### PR TITLE
chore(weave): Move ref methods to the Ref objects themselves

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -35,7 +35,7 @@ from weave.trace.context.weave_client_context import (
     get_weave_client,
     set_weave_client_global,
 )
-from weave.trace.refs import parse_uri
+from weave.trace.refs import Ref
 from weave.trace.vals import MissingSelfInstanceError
 from weave.trace.weave_client import sanitize_object_name
 from weave.trace_server import trace_server_interface as tsi
@@ -4157,7 +4157,7 @@ def test_obj_query_with_storage_size_clickhouse(client):
     assert queried_obj.size_bytes == 257  # Should have some size due to the test data
 
     # Test that a table is created and its size is correct
-    table_ref = parse_uri(queried_obj.val["rows"])
+    table_ref = Ref.parse_uri(queried_obj.val["rows"])
     res = client.server.table_query_stats_batch(
         tsi.TableQueryStatsBatchReq(
             project_id=client._project_id(),

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -35,7 +35,7 @@ from weave.trace.context.weave_client_context import (
     get_weave_client,
     set_weave_client_global,
 )
-from weave.trace.refs import Ref
+from weave.trace.refs import TableRef
 from weave.trace.vals import MissingSelfInstanceError
 from weave.trace.weave_client import sanitize_object_name
 from weave.trace_server import trace_server_interface as tsi
@@ -4157,7 +4157,7 @@ def test_obj_query_with_storage_size_clickhouse(client):
     assert queried_obj.size_bytes == 257  # Should have some size due to the test data
 
     # Test that a table is created and its size is correct
-    table_ref = Ref.parse_uri(queried_obj.val["rows"])
+    table_ref = TableRef.parse_uri(queried_obj.val["rows"])
     res = client.server.table_query_stats_batch(
         tsi.TableQueryStatsBatchReq(
             project_id=client._project_id(),

--- a/tests/trace/test_op_decorator_behaviour.py
+++ b/tests/trace/test_op_decorator_behaviour.py
@@ -5,7 +5,7 @@ import pytest
 
 import weave
 from weave.trace.op import OpCallError, is_op, op
-from weave.trace.refs import ObjectRef, parse_uri
+from weave.trace.refs import ObjectRef, Ref
 from weave.trace.vals import MissingSelfInstanceError
 from weave.trace.weave_client import Call
 
@@ -417,7 +417,7 @@ def test_op_name(client):
     calls = list(client.get_calls())
     call = calls[0]
 
-    parsed = parse_uri(call.op_name)
+    parsed = Ref.parse_uri(call.op_name)
     assert parsed.name == "custom_name"
 
 

--- a/tests/trace/testutil.py
+++ b/tests/trace/testutil.py
@@ -1,6 +1,6 @@
 from typing import Any, Optional
 
-from weave.trace.refs import ObjectRef, OpRef, parse_uri
+from weave.trace.refs import ObjectRef, OpRef, Ref
 
 
 class ObjectRefStrMatcher:
@@ -21,7 +21,7 @@ class ObjectRefStrMatcher:
         self.extra = extra
 
     def __eq__(self, other: Any) -> bool:
-        other_ref = parse_uri(other)
+        other_ref = Ref.parse_uri(other)
         if not isinstance(other_ref, ObjectRef):
             return False
         if self.entity is not None and self.entity != other_ref.entity:

--- a/tests/trace_server/test_refs.py
+++ b/tests/trace_server/test_refs.py
@@ -56,7 +56,7 @@ def test_ref_parsing_external_sanitized():
     exp_ref = f"{refs_internal.WEAVE_SCHEME}:///{ref_start.entity}/{ref_start.project}/object/{ref_start.name}:{ref_start.digest}/{ref_start.extra[0]}/{quote(ref_start.extra[1])}"
     assert ref_str == exp_ref
 
-    parsed = refs.parse_uri(ref_str)
+    parsed = refs.Ref.parse_uri(ref_str)
     assert parsed == ref_start
 
 

--- a/weave/flow/saved_view.py
+++ b/weave/flow/saved_view.py
@@ -12,7 +12,7 @@ from weave.trace.api import ref as weave_ref
 from weave.trace.context import weave_client_context
 from weave.trace.display.grid import Grid
 from weave.trace.display.rich import pydantic_util
-from weave.trace.refs import ObjectRef, parse_op_uri
+from weave.trace.refs import ObjectRef, OpRef
 from weave.trace.traverse import ObjectPath, get_paths
 from weave.trace.vals import WeaveObject
 from weave.trace.weave_client import CallsIter
@@ -481,7 +481,7 @@ def render_status(value: Any) -> str:
 
 def render_cell(path: ObjectPath, value: Any) -> str:
     if path.elements[0] == "op_name":
-        op_ref = parse_op_uri(value)
+        op_ref = OpRef.parse_uri(value)
         return op_ref.name
     if path == ObjectPath(["summary", "weave", "status"]):
         return render_status(value)

--- a/weave/integrations/integration_utilities.py
+++ b/weave/integrations/integration_utilities.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from concurrent.futures import Future
 from typing import Any, Union
 
-from weave.trace.refs import OpRef, Ref
+from weave.trace.refs import OpRef
 from weave.trace.weave_client import Call, CallsIter
 from weave.trace_server.constants import MAX_OP_NAME_LENGTH
 
@@ -83,9 +83,8 @@ def flatten_calls(calls: Union[Iterable[Call], CallsIter], *, depth: int = 0) ->
 def flattened_calls_to_names(flattened_calls: list) -> list:
     lst = []
     for call, depth in flattened_calls:
-        ref = Ref.parse_uri(call.op_name)
-        assert isinstance(ref, OpRef)
-        lst.append((ref.name, depth))
+        op_ref = OpRef.parse_uri(call.op_name)
+        lst.append((op_ref.name, depth))
     return lst
 
 

--- a/weave/integrations/integration_utilities.py
+++ b/weave/integrations/integration_utilities.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from concurrent.futures import Future
 from typing import Any, Union
 
-from weave.trace.refs import OpRef, parse_uri
+from weave.trace.refs import OpRef, Ref
 from weave.trace.weave_client import Call, CallsIter
 from weave.trace_server.constants import MAX_OP_NAME_LENGTH
 
@@ -83,7 +83,7 @@ def flatten_calls(calls: Union[Iterable[Call], CallsIter], *, depth: int = 0) ->
 def flattened_calls_to_names(flattened_calls: list) -> list:
     lst = []
     for call, depth in flattened_calls:
-        ref = parse_uri(call.op_name)
+        ref = Ref.parse_uri(call.op_name)
         assert isinstance(ref, OpRef)
         lst.append((ref.name, depth))
     return lst

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -186,10 +186,10 @@ def ref(location: str) -> ObjectRef:
             name, version = location.split(":")
         location = str(client._ref_uri(name, version, "obj"))
 
-    uri = Ref.parse_uri(location)
-    if not isinstance(uri, ObjectRef):
+    ref = Ref.parse_uri(location)
+    if not isinstance(ref, ObjectRef):
         raise TypeError("Expected an object ref")
-    return uri
+    return ref
 
 
 def get(uri: str | ObjectRef) -> Any:

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -20,7 +20,7 @@ from weave.trace.context import weave_client_context as weave_client_context
 from weave.trace.context.call_context import get_current_call, require_current_call
 from weave.trace.display.term import configure_logger
 from weave.trace.op import PostprocessInputsFunc, PostprocessOutputFunc, as_op, op
-from weave.trace.refs import ObjectRef, parse_uri
+from weave.trace.refs import ObjectRef, Ref
 from weave.trace.settings import (
     UserSettings,
     parse_and_apply_settings,
@@ -186,7 +186,7 @@ def ref(location: str) -> ObjectRef:
             name, version = location.split(":")
         location = str(client._ref_uri(name, version, "obj"))
 
-    uri = parse_uri(location)
+    uri = Ref.parse_uri(location)
     if not isinstance(uri, ObjectRef):
         raise TypeError("Expected an object ref")
     return uri
@@ -350,7 +350,6 @@ __all__ = [
     "get_current_call",
     "init",
     "op",
-    "parse_uri",
     "publish",
     "ref",
     "require_current_call",

--- a/weave/trace/display/rich/refs.py
+++ b/weave/trace/display/rich/refs.py
@@ -27,7 +27,9 @@ class Refs(AbstractRichContainer[str]):
         return [Ref.parse_uri(ref) for ref in self.items]
 
     def call_refs(self) -> "Refs":
-        return Refs(ref for ref in self.items if isinstance(Ref.parse_uri(ref), CallRef))
+        return Refs(
+            ref for ref in self.items if isinstance(Ref.parse_uri(ref), CallRef)
+        )
 
     # TODO: Perhaps there should be a Calls that extends AbstractRichContainer
     def calls(self) -> list[WeaveObject]:

--- a/weave/trace/display/rich/refs.py
+++ b/weave/trace/display/rich/refs.py
@@ -7,7 +7,7 @@ from rich.table import Table
 
 from weave.trace.context import weave_client_context as weave_client_context
 from weave.trace.display.rich.container import AbstractRichContainer
-from weave.trace.refs import AnyRef, CallRef, parse_uri
+from weave.trace.refs import AnyRef, CallRef, Ref
 from weave.trace.vals import WeaveObject
 
 
@@ -24,17 +24,17 @@ class Refs(AbstractRichContainer[str]):
         return [item]
 
     def parsed(self) -> list[AnyRef]:
-        return [parse_uri(ref) for ref in self.items]
+        return [Ref.parse_uri(ref) for ref in self.items]
 
     def call_refs(self) -> "Refs":
-        return Refs(ref for ref in self.items if isinstance(parse_uri(ref), CallRef))
+        return Refs(ref for ref in self.items if isinstance(Ref.parse_uri(ref), CallRef))
 
     # TODO: Perhaps there should be a Calls that extends AbstractRichContainer
     def calls(self) -> list[WeaveObject]:
         client = weave_client_context.require_weave_client()
         objs = []
         for ref in self.call_refs():
-            parsed = parse_uri(ref)
+            parsed = Ref.parse_uri(ref)
             assert isinstance(parsed, CallRef)
             objs.append(client.get_call(parsed.id))
         return objs

--- a/weave/trace/feedback.py
+++ b/weave/trace/feedback.py
@@ -13,7 +13,7 @@ from weave.trace.context import weave_client_context as weave_client_context
 from weave.trace.display.rich import pydantic_util
 from weave.trace.display.rich.container import AbstractRichContainer
 from weave.trace.display.rich.refs import Refs
-from weave.trace.refs import parse_object_uri, parse_uri
+from weave.trace.refs import ObjectRef, Ref
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.interface.query import Query
 
@@ -171,7 +171,7 @@ class RefFeedbackQuery(FeedbackQuery):
     weave_ref: str
 
     def __init__(self, ref: str) -> None:
-        parsed_ref = parse_uri(ref)
+        parsed_ref = Ref.parse_uri(ref)
         query = {
             "$expr": {
                 "$eq": [
@@ -203,7 +203,7 @@ class RefFeedbackQuery(FeedbackQuery):
         )
         if annotation_ref:
             try:
-                parse_object_uri(annotation_ref)
+                ObjectRef.parse_uri(annotation_ref)
             except TypeError:
                 raise TypeError(
                     "annotation_ref must be a valid object ref, eg weave:///<entity>/<project>/object/<name>:<digest>"

--- a/weave/trace/feedback.py
+++ b/weave/trace/feedback.py
@@ -173,7 +173,7 @@ class RefFeedbackQuery(FeedbackQuery):
     def __init__(self, ref: str) -> None:
         parsed_ref = Ref.parse_uri(ref)
         # All ref types have entity and project attributes
-        if not hasattr(parsed_ref, 'entity') or not hasattr(parsed_ref, 'project'):
+        if not hasattr(parsed_ref, "entity") or not hasattr(parsed_ref, "project"):
             raise ValueError(f"Invalid ref type: {type(parsed_ref)}")
         query = {
             "$expr": {

--- a/weave/trace/feedback.py
+++ b/weave/trace/feedback.py
@@ -172,6 +172,9 @@ class RefFeedbackQuery(FeedbackQuery):
 
     def __init__(self, ref: str) -> None:
         parsed_ref = Ref.parse_uri(ref)
+        # All ref types have entity and project attributes
+        if not hasattr(parsed_ref, 'entity') or not hasattr(parsed_ref, 'project'):
+            raise ValueError(f"Invalid ref type: {type(parsed_ref)}")
         query = {
             "$expr": {
                 "$eq": [
@@ -181,8 +184,8 @@ class RefFeedbackQuery(FeedbackQuery):
             }
         }
         super().__init__(
-            entity=parsed_ref.entity,
-            project=parsed_ref.project,
+            entity=parsed_ref.entity,  # type: ignore
+            project=parsed_ref.project,  # type: ignore
             query=Query(**query),
         )
         self.weave_ref = ref

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -127,10 +127,10 @@ class TableRef(Ref):
     def uri(self) -> str:
         return f"weave:///{self.entity}/{self.project}/table/{self.digest}"
 
-    @classmethod
-    def parse_uri(cls, uri: str) -> Self:
-        if not isinstance(parsed := Ref.parse_uri(uri), cls):
-            raise TypeError(f"URI is not for a {cls.__name__}: {uri}")
+    @staticmethod
+    def parse_uri(uri: str) -> TableRef:
+        if not isinstance(parsed := Ref.parse_uri(uri), TableRef):
+            raise TypeError(f"URI is not for a Table: {uri}")
         return parsed
 
 
@@ -256,10 +256,10 @@ class ObjectRef(RefWithExtra):
         if gc is not None:
             gc.delete_object_version(self)
 
-    @classmethod
-    def parse_uri(cls, uri: str) -> Self:
-        if not isinstance(parsed := Ref.parse_uri(uri), cls):
-            raise TypeError(f"URI is not for an {cls.__name__}: {uri}")
+    @staticmethod
+    def parse_uri(uri: str) -> ObjectRef:
+        if not isinstance(parsed := Ref.parse_uri(uri), ObjectRef):
+            raise TypeError(f"URI is not for an Object: {uri}")
         return parsed
 
 
@@ -278,10 +278,10 @@ class OpRef(ObjectRef):
         if gc is not None:
             gc.delete_op_version(self)
 
-    @classmethod
-    def parse_uri(cls, uri: str) -> Self:
-        if not isinstance(parsed := Ref.parse_uri(uri), cls):
-            raise TypeError(f"URI is not for an {cls.__name__}: {uri}")
+    @staticmethod
+    def parse_uri(uri: str) -> OpRef:
+        if not isinstance(parsed := Ref.parse_uri(uri), OpRef):
+            raise TypeError(f"URI is not for an Op: {uri}")
         return parsed
 
 
@@ -310,10 +310,10 @@ class CallRef(RefWithExtra):
             u += "/" + "/".join(refs_internal.extra_value_quoter(e) for e in self.extra)
         return u
 
-    @classmethod
-    def parse_uri(cls, uri: str) -> Self:
-        if not isinstance(parsed := Ref.parse_uri(uri), cls):
-            raise TypeError(f"URI is not for a {cls.__name__}: {uri}")
+    @staticmethod
+    def parse_uri(uri: str) -> CallRef:
+        if not isinstance(parsed := Ref.parse_uri(uri), CallRef):
+            raise TypeError(f"URI is not for a Call: {uri}")
         return parsed
 
 

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -335,19 +335,3 @@ def parse_name_version(name_version: str) -> tuple[str, str]:
         return name, version
     return name_version, "latest"
 
-
-# Legacy function names for backward compatibility
-def parse_uri(uri: str) -> AnyRef:
-    return Ref.parse_uri(uri)
-
-
-def parse_op_uri(uri: str) -> OpRef:
-    return OpRef.parse_uri(uri)
-
-
-def parse_object_uri(uri: str) -> ObjectRef:
-    return ObjectRef.parse_uri(uri)
-
-
-def maybe_parse_uri(s: str) -> AnyRef | None:
-    return Ref.maybe_parse_uri(s)

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -35,8 +35,8 @@ class Ref:
         memo[id(self)] = res
         return res
 
-    @classmethod
-    def parse_uri(cls, uri: str) -> Self:
+    @staticmethod
+    def parse_uri(uri: str) -> AnyRef:
         if not uri.startswith("weave:///"):
             raise ValueError(f"Invalid URI: {uri}")
         path = uri[len("weave:///") :]
@@ -65,10 +65,10 @@ class Ref:
         else:
             raise ValueError(f"Unknown ref kind: {kind}")
 
-    @classmethod
-    def maybe_parse_uri(cls, s: str) -> Self | None:
+    @staticmethod
+    def maybe_parse_uri(s: str) -> AnyRef | None:
         try:
-            return cls.parse_uri(s)
+            return Ref.parse_uri(s)
         except ValueError:
             return None
 
@@ -129,8 +129,8 @@ class TableRef(Ref):
 
     @classmethod
     def parse_uri(cls, uri: str) -> Self:
-        if not isinstance(parsed := Ref.parse_uri(uri), TableRef):
-            raise TypeError(f"URI is not for a Table: {uri}")
+        if not isinstance(parsed := Ref.parse_uri(uri), cls):
+            raise TypeError(f"URI is not for a {cls.__name__}: {uri}")
         return parsed
 
 
@@ -258,8 +258,8 @@ class ObjectRef(RefWithExtra):
 
     @classmethod
     def parse_uri(cls, uri: str) -> Self:
-        if not isinstance(parsed := Ref.parse_uri(uri), ObjectRef):
-            raise TypeError(f"URI is not for an Object: {uri}")
+        if not isinstance(parsed := Ref.parse_uri(uri), cls):
+            raise TypeError(f"URI is not for an {cls.__name__}: {uri}")
         return parsed
 
 
@@ -280,8 +280,8 @@ class OpRef(ObjectRef):
 
     @classmethod
     def parse_uri(cls, uri: str) -> Self:
-        if not isinstance(parsed := Ref.parse_uri(uri), OpRef):
-            raise TypeError(f"URI is not for an Op: {uri}")
+        if not isinstance(parsed := Ref.parse_uri(uri), cls):
+            raise TypeError(f"URI is not for an {cls.__name__}: {uri}")
         return parsed
 
 
@@ -312,8 +312,8 @@ class CallRef(RefWithExtra):
 
     @classmethod
     def parse_uri(cls, uri: str) -> Self:
-        if not isinstance(parsed := Ref.parse_uri(uri), CallRef):
-            raise TypeError(f"URI is not for a Call: {uri}")
+        if not isinstance(parsed := Ref.parse_uri(uri), cls):
+            raise TypeError(f"URI is not for a {cls.__name__}: {uri}")
         return parsed
 
 

--- a/weave/trace/serialization/custom_objs.py
+++ b/weave/trace/serialization/custom_objs.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 
 from weave.trace.context.weave_client_context import require_weave_client
 from weave.trace.op import Op, is_op, op
-from weave.trace.refs import ObjectRef, OpRef, parse_uri
+from weave.trace.refs import ObjectRef, OpRef, Ref
 from weave.trace.serialization import (
     op_type,  # noqa: F401, Must import this to register op save/load
 )
@@ -102,7 +102,7 @@ def decode_custom_inline_obj(obj: dict) -> Any:
     if load_op_uri is None:
         raise ValueError(f"No serializer found for `{type_}`")
 
-    ref = parse_uri(load_op_uri)
+    ref = Ref.parse_uri(load_op_uri)
     if not isinstance(ref, OpRef):
         raise TypeError(f"Expected OpRef, got `{type(ref)}`")
 
@@ -154,7 +154,7 @@ def decode_custom_files_obj(
         if load_instance_op_uri is None:
             raise ValueError(f"No serializer found for `{type_}`")
 
-        ref = parse_uri(load_instance_op_uri)
+        ref = Ref.parse_uri(load_instance_op_uri)
         if not isinstance(ref, ObjectRef):
             raise TypeError(f"Expected ObjectRef, got `{type(ref)}`")
 

--- a/weave/trace/serialization/custom_objs.py
+++ b/weave/trace/serialization/custom_objs.py
@@ -5,7 +5,7 @@ from typing import Any, Callable
 
 from weave.trace.context.weave_client_context import require_weave_client
 from weave.trace.op import Op, is_op, op
-from weave.trace.refs import ObjectRef, OpRef, Ref
+from weave.trace.refs import ObjectRef, OpRef
 from weave.trace.serialization import (
     op_type,  # noqa: F401, Must import this to register op save/load
 )
@@ -102,12 +102,9 @@ def decode_custom_inline_obj(obj: dict) -> Any:
     if load_op_uri is None:
         raise ValueError(f"No serializer found for `{type_}`")
 
-    ref = Ref.parse_uri(load_op_uri)
-    if not isinstance(ref, OpRef):
-        raise TypeError(f"Expected OpRef, got `{type(ref)}`")
-
+    op_ref = OpRef.parse_uri(load_op_uri)
     wc = require_weave_client()
-    load_instance_op = wc.get(ref)
+    load_instance_op = wc.get(op_ref)
     if load_instance_op is None:
         raise ValueError(
             f"Failed to load op needed to decode object of type `{type_}`. See logs above for more information."
@@ -154,12 +151,9 @@ def decode_custom_files_obj(
         if load_instance_op_uri is None:
             raise ValueError(f"No serializer found for `{type_}`")
 
-        ref = Ref.parse_uri(load_instance_op_uri)
-        if not isinstance(ref, ObjectRef):
-            raise TypeError(f"Expected ObjectRef, got `{type(ref)}`")
-
+        obj_ref = ObjectRef.parse_uri(load_instance_op_uri)
         wc = require_weave_client()
-        load_instance_op = wc.get(ref)
+        load_instance_op = wc.get(obj_ref)
         if load_instance_op is None:
             raise ValueError(
                 f"Failed to load op needed to decode object of type `{type_}`. See logs above for more information."

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from weave.trace.object_record import ObjectRecord
-from weave.trace.refs import ObjectRef, TableRef, Ref
+from weave.trace.refs import ObjectRef, Ref, TableRef
 from weave.trace.serialization import custom_objs
 from weave.trace.serialization.dictifiable import try_to_dict
 from weave.trace_server.trace_server_interface import (

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel
 
 from weave.trace.object_record import ObjectRecord
-from weave.trace.refs import ObjectRef, TableRef, parse_uri
+from weave.trace.refs import ObjectRef, TableRef, Ref
 from weave.trace.serialization import custom_objs
 from weave.trace.serialization.dictifiable import try_to_dict
 from weave.trace_server.trace_server_interface import (
@@ -328,6 +328,6 @@ def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
             {k: from_json(v, project_id, server) for k, v in obj.items()}
         )
     elif isinstance(obj, str) and obj.startswith("weave://"):
-        return parse_uri(obj)
+        return Ref.parse_uri(obj)
 
     return obj

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1695,12 +1695,8 @@ class WeaveClient:
         - Should we somehow include supervision (ie. the ground truth) in the payload?
         """
         # Parse the refs (acts as validation)
-        call_ref = Ref.parse_uri(weave_ref_uri)
-        if not isinstance(call_ref, CallRef):
-            raise TypeError(f"Invalid call ref: {weave_ref_uri}")
-        scorer_call_ref = Ref.parse_uri(call_ref_uri)
-        if not isinstance(scorer_call_ref, CallRef):
-            raise TypeError(f"Invalid scorer call ref: {call_ref_uri}")
+        call_ref = CallRef.parse_uri(weave_ref_uri)  # noqa: RUF100
+        scorer_call_ref = CallRef.parse_uri(call_ref_uri)  # # noqa: RUF100
         runnable_ref = Ref.parse_uri(runnable_ref_uri)
         if not isinstance(runnable_ref, (OpRef, ObjectRef)):
             raise TypeError(f"Invalid scorer op ref: {runnable_ref_uri}")

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -60,9 +60,6 @@ from weave.trace.refs import (
     OpRef,
     Ref,
     TableRef,
-    maybe_parse_uri,
-    parse_op_uri,
-    parse_uri,
 )
 from weave.trace.serialization.serialize import (
     from_json,
@@ -246,7 +243,7 @@ def _add_scored_by_to_calls_query(
     if query is not None:
         exprs.append(query["$expr"])
     for name in scored_by:
-        ref = maybe_parse_uri(name)
+        ref = Ref.maybe_parse_uri(name)
         if ref and isinstance(ref, ObjectRef):
             uri = name
             scorer_name = ref.name
@@ -431,7 +428,7 @@ class Call:
         This is different from `op_name` which is usually the ref of the op.
         """
         if self.op_name.startswith("weave:///"):
-            ref = parse_op_uri(self.op_name)
+            ref = OpRef.parse_uri(self.op_name)
             return ref.name
 
         return self.op_name
@@ -1698,13 +1695,13 @@ class WeaveClient:
         - Should we somehow include supervision (ie. the ground truth) in the payload?
         """
         # Parse the refs (acts as validation)
-        call_ref = parse_uri(weave_ref_uri)
+        call_ref = Ref.parse_uri(weave_ref_uri)
         if not isinstance(call_ref, CallRef):
             raise TypeError(f"Invalid call ref: {weave_ref_uri}")
-        scorer_call_ref = parse_uri(call_ref_uri)
+        scorer_call_ref = Ref.parse_uri(call_ref_uri)
         if not isinstance(scorer_call_ref, CallRef):
             raise TypeError(f"Invalid scorer call ref: {call_ref_uri}")
-        runnable_ref = parse_uri(runnable_ref_uri)
+        runnable_ref = Ref.parse_uri(runnable_ref_uri)
         if not isinstance(runnable_ref, (OpRef, ObjectRef)):
             raise TypeError(f"Invalid scorer op ref: {runnable_ref_uri}")
 

--- a/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
+++ b/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
@@ -8,7 +8,7 @@ import weave
 from weave.evaluation.eval import Evaluation
 from weave.scorers.llm_as_a_judge_scorer import LLMAsAJudgeScorer
 from weave.trace.context.weave_client_context import require_weave_client
-from weave.trace.refs import parse_uri
+from weave.trace.refs import Ref
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server.interface.builtin_object_classes.llm_structured_model import (
     LLMStructuredCompletionModel,
@@ -50,7 +50,7 @@ def _evaluate_model(args: EvaluateModelArgs) -> None:
 
 @ddtrace.tracer.wrap(name="evaluate_model_worker.evaluate_model.get_valid_evaluation")
 def _get_valid_evaluation(client: WeaveClient, evaluation_ref: str) -> Evaluation:
-    loaded_evaluation = client.get(parse_uri(evaluation_ref))
+    loaded_evaluation = client.get(Ref.parse_uri(evaluation_ref))
 
     if not isinstance(loaded_evaluation, Evaluation):
         raise TypeError(
@@ -74,7 +74,7 @@ def _get_valid_evaluation(client: WeaveClient, evaluation_ref: str) -> Evaluatio
 def _get_valid_model(
     client: WeaveClient, model_ref: str
 ) -> LLMStructuredCompletionModel:
-    loaded_model = client.get(parse_uri(model_ref))
+    loaded_model = client.get(Ref.parse_uri(model_ref))
 
     if not isinstance(loaded_model, LLMStructuredCompletionModel):
         raise TypeError(

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from typing_extensions import Self
 
 from weave import version
-from weave.trace.refs import ObjectRef, parse_uri
+from weave.trace.refs import ObjectRef, Ref
 from weave.trace.settings import (
     server_cache_dir,
     server_cache_size_limit,
@@ -381,7 +381,7 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
 
                 # Only cache if the ref has a cacheable digest
                 try:
-                    parsed_ref = parse_uri(needed_ref)
+                    parsed_ref = Ref.parse_uri(needed_ref)
                     if isinstance(parsed_ref, ObjectRef) and digest_is_cacheable(
                         parsed_ref.digest
                     ):


### PR DESCRIPTION
Moves ref methods on to the Ref objects themselves, which is more descriptive in some cases