### PR TITLE
fix(weave): Ascii encode error for content

### DIFF
--- a/tests/trace/type_handlers/Content/content_test.py
+++ b/tests/trace/type_handlers/Content/content_test.py
@@ -3,14 +3,13 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from util import generate_media
 
 import weave
 from weave import Dataset
 from weave.trace.table import Table
 from weave.trace.weave_client import WeaveClient
 from weave.type_wrappers.Content.content import Content
-
-from .util import generate_media
 
 
 @pytest.fixture(scope="session")

--- a/tests/trace/type_handlers/Content/content_test.py
+++ b/tests/trace/type_handlers/Content/content_test.py
@@ -3,13 +3,14 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from util import generate_media
 
 import weave
 from weave import Dataset
 from weave.trace.table import Table
 from weave.trace.weave_client import WeaveClient
 from weave.type_wrappers.Content.content import Content
+
+from .util import generate_media
 
 
 @pytest.fixture(scope="session")
@@ -498,3 +499,30 @@ class TestWeaveContent:
         assert content_text_no_ext.data == b""
         assert content_text_no_ext.extension == ".txt"  # Default for text
         assert content_text_no_ext.size == 0
+
+    def test_emoji_content(self):
+        doc = """
+My Awesome Emoji Document 👋
+This is a simple document to show how you can use emojis in Markdown. It's a great way to add some personality and visual interest to your text! 🥳
+
+I'm feeling pretty happy about it. 😄
+
+My Goals for Today 🚀
+Here is a list of things I want to accomplish:
+
+✅ Finish my first task.
+
+💡 Come up with a brilliant new idea.
+
+🍕 Grab a slice of pizza for lunch.
+
+🎉 Celebrate a small victory!
+
+That's all for now. Have a great day! ☀️
+"""
+        # First do it with the correct constructor
+        content = Content.from_text(doc, extension=".md")
+        assert content.mimetype == "text/markdown"
+        # Next guess from annotated value
+        content = Content._from_guess(doc, extension=".md")
+        assert content.mimetype == "text/markdown"

--- a/weave/type_wrappers/Content/utils.py
+++ b/weave/type_wrappers/Content/utils.py
@@ -54,9 +54,12 @@ def is_valid_b64(input: str | bytes) -> bool:
     if len(input) == 0:
         return False
 
-    # Normalize to bytes
+    # Normalize to bytes and verify it is not unicode
     if isinstance(input, str):
-        input = input.encode("ascii")
+        try:
+            input = input.encode("ascii")
+        except UnicodeEncodeError:
+            return False
     try:
         base64.b64decode(input, validate=True)
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes [WB-27106](https://wandb.atlassian.net/browse/WB-27106)

Attempting the `_from_guess` method used for annotations would cause the text to attempt to be encoded to ascii, which raised an uncaught error during the check if a string is valid base64. This allows HTML and Markdown or any other text with unicode characters like emojis to work with Content.

## Testing

Adds regression test


[WB-27106]: https://wandb.atlassian.net/browse/WB-27106?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ