### PR TITLE
test(weave): update weave SDK version in wandb/core for tests on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,3 +37,32 @@ jobs:
       - name: upload distribution
         uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !inputs.is_test }}
+
+  # this job exists so that there's some traceability between weave SDk releases
+  # and potential build failures in core.
+  notify-core:
+    name: notify wandb/core of release
+    runs-on: ubuntu-latest
+    if: "!inputs.is_test"
+    needs: [build-release]
+
+    steps:
+      - name: Create GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.WANDBOT_3000_APP_ID }}
+          private-key: ${{ secrets.WANDBOT_3000_PRIVATE_KEY }}
+
+      - name: Repository dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: "${{ steps.app-token.outputs.token }}"
+          repository: wandb/core
+          event-type: weave-sdk-released
+          client-payload: |-
+            {
+              "ref_name": "${{ github.ref_name }}",
+              "actor": "${{ github.actor }}",
+              "actor_id": "${{ github.actor_id }}"
+            }


### PR DESCRIPTION
Update `weave` reference in wandb/core for integration tests when the weave sdk is released.

Sending half of https://github.com/wandb/core/pull/33810