### PR TITLE
chore(weave): Add --ruff-only flag to lint to run just the fast ruff checks

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -29,8 +29,17 @@ def lint(session):
     session.install("pre-commit", "jupyter")
     dry_run = session.posargs and "dry-run" in session.posargs
     all_files = session.posargs and "--all-files" in session.posargs
+    ruff_only = session.posargs and "--ruff-only" in session.posargs
 
-    if dry_run:
+    if ruff_only:
+        # Run only ruff checks on all files
+        session.run(
+            "pre-commit", "run", "--hook-stage=pre-push", "ruff-check", "--all-files"
+        )
+        session.run(
+            "pre-commit", "run", "--hook-stage=pre-push", "ruff-format", "--all-files"
+        )
+    elif dry_run:
         session.run(
             "pre-commit",
             "run",


### PR DESCRIPTION
Adds a flag to only run the fast checks