### PR TITLE
chore(weave): Bump version to 0.9.3 and export new prompt types

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weave",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "AI development toolkit",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -12,5 +12,6 @@ export {weaveAudio, weaveImage, WeaveAudio, WeaveImage} from './media';
 export {op} from './op';
 export * from './types';
 export {WeaveObject} from './weaveObject';
+export {MessagesPrompt, StringPrompt} from './prompt';
 import './utils/commonJSLoader';
 import './integrations/hooks';


### PR DESCRIPTION
## Description

- Bumps Node SDK version from 0.9.2 to 0.9.3
- Exports `MessagesPrompt` and `StringPrompt` classes from the prompt module

## Testing

Verified that the exported prompt classes are accessible when importing the package.