### PR TITLE
chore(weave): Only run CI on min and max supported python versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -213,9 +213,6 @@ jobs:
         python-version-major: ["3"]
         python-version-minor: [
             "9",
-            "10",
-            "11",
-            "12",
             "13",
             #
           ]
@@ -254,9 +251,6 @@ jobs:
         python-version-major: ["3"]
         python-version-minor: [
             "9",
-            "10",
-            "11",
-            "12",
             "13",
             #
           ]


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-27281

In future, we'll add a nightly shard to run all versions
https://github.com/wandb/weave/pull/5395