### PR TITLE
fix(weave): markdown not rendering when rich not installed

### DIFF
--- a/weave/type_handlers/Markdown/markdown.py
+++ b/weave/type_handlers/Markdown/markdown.py
@@ -14,7 +14,7 @@ except ImportError:
 
     # Create a dummy Markdown class for when rich is not available
     class Markdown:  # type: ignore[no-redef]
-        def __init__(self, markup: str, code_theme: str = "ansi_dark", **kwargs: Any):
+        def __init__(self, markup: str, code_theme: str = "monokai", **kwargs: Any):
             self.markup = markup
             self.code_theme = code_theme
 
@@ -39,5 +39,4 @@ def load(encoded: SerializedMarkdown) -> Markdown:
 
 
 def register() -> None:
-    if RICH_MARKDOWN_AVAILABLE:
-        serializer.register_serializer(Markdown, save, load)
+    serializer.register_serializer(Markdown, save, load)


### PR DESCRIPTION
## Description

When rich is not installed we implement our own simple Markdown class, however we were not registering a serializer for it, so it was just getting serialized as a string.

Also changed the default value of the `code_theme` to match `rich.markdown.Markdown`
https://github.com/Textualize/rich/blob/master/rich/markdown.py#L537

See also internal companion PR: https://github.com/wandb/core/pull/33920

## Testing

How was this PR tested?
