### PR TITLE
fix(weave): Patch non-beta OpenAI methods

### DIFF
--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -752,10 +752,10 @@ def get_openai_patcher(
         update={"name": base.name or "openai.chat.completions.create"}
     )
     completions_parse_settings = base.model_copy(
-        update={"name": base.name or "openai.beta.chat.completions.parse"}
+        update={"name": base.name or "openai.chat.completions.parse"}
     )
     async_completions_parse_settings = base.model_copy(
-        update={"name": base.name or "openai.beta.chat.completions.parse"}
+        update={"name": base.name or "openai.chat.completions.parse"}
     )
     moderation_create_settings = base.model_copy(
         update={"name": base.name or "openai.moderations.create"}
@@ -794,6 +794,17 @@ def get_openai_patcher(
                 "AsyncCompletions.create",
                 create_wrapper_async(settings=async_completions_create_settings),
             ),
+            SymbolPatcher(
+                lambda: importlib.import_module("openai.resources.chat.completions"),
+                "Completions.parse",
+                create_wrapper_sync(settings=completions_parse_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("openai.resources.chat.completions"),
+                "AsyncCompletions.parse",
+                create_wrapper_async(settings=async_completions_parse_settings),
+            ),
+            # Beta methods were removed in 1.92.0
             SymbolPatcher(
                 lambda: importlib.import_module(
                     "openai.resources.beta.chat.completions"


### PR DESCRIPTION
## Description

In OpenAI [v1.92.0](https://github.com/openai/openai-python/releases/tag/v1.92.0) the `parse` method was [moved out of beta](https://github.com/openai/openai-python/commit/0e358ed66b317038705fb38958a449d284f3cb88).

Our OpenAI integration was only checking for this parse method where it no longer existed, so parse calls were not getting tracked at all.

After:

Trace exists with token usage.
<img width="2520" height="1090" alt="image" src="https://github.com/user-attachments/assets/210c0a1a-8a9c-4cb8-8d98-e102f32aa6dd" />


## Testing

How was this PR tested?
