### PR TITLE
fix(weave): handle another integration patching case

### DIFF
--- a/tests/integrations/test_patcher.py
+++ b/tests/integrations/test_patcher.py
@@ -36,9 +36,22 @@ def test_symbol_patcher_invalid_module():
 
 
 def test_symbol_patcher_invalid_attr():
+    # Attempt to patch a non-existent class in an existent module
     patcher = SymbolPatcher(
         lambda: importlib.import_module("tests.test_patcher_module.example_class"),
         "NotARealExampleClass.example_fn",
+        lambda original_fn: lambda self: 43,
+    )
+    # Should not raise, but should fail to patch
+    assert not patcher.attempt_patch()
+    assert not patcher.undo_patch()
+
+
+def test_symbol_patcher_invalid_attr_method():
+    # Attempt to patch a non-existent method on an existent class
+    patcher = SymbolPatcher(
+        lambda: importlib.import_module("tests.test_patcher_module.example_class"),
+        "ExampleClass.not_a_real_example_fn",
         lambda original_fn: lambda self: 43,
     )
     # Should not raise, but should fail to patch

--- a/weave/integrations/patcher.py
+++ b/weave/integrations/patcher.py
@@ -92,11 +92,15 @@ class SymbolPatcher(Patcher):
 
     def attempt_patch(self) -> bool:
         if self._original_value:
+            # Already patched
             return True
         target = self._get_symbol_target()
         if target is None:
             return False
-        original_value = getattr(target.base_symbol, target.attr)
+        try:
+            original_value = getattr(target.base_symbol, target.attr)
+        except AttributeError:
+            return False
         try:
             new_val = self._make_new_value(original_value)
         except Exception:


### PR DESCRIPTION
## Description

Fixes https://wandb.atlassian.net/browse/WB-27312

This came up with https://github.com/wandb/weave/pull/5403 and our latest Weave SDK release. People using it with openai <= 1.91.0 will see patching errors like the following:

```
weave: Error patching - some logs may not be captured
weave: Traceback (most recent call last):
weave:   File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/integrations/patcher.py", line 36, in attempt_patch
weave:     result = patcher.attempt_patch()
weave:              ^^^^^^^^^^^^^^^^^^^^^^^
weave:   File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/integrations/patcher.py", line 99, in attempt_patch
weave:     original_value = getattr(target.base_symbol, target.attr)
weave:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
weave: AttributeError: type object 'Completions' has no attribute 'parse'
weave: Error patching - some logs may not be captured
weave: Traceback (most recent call last):
weave:   File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/integrations/patcher.py", line 36, in attempt_patch
weave:     result = patcher.attempt_patch()
weave:              ^^^^^^^^^^^^^^^^^^^^^^^
weave:   File "/Users/jamie/source/wandb/core/services/weave-python/weave-public/weave/integrations/patcher.py", line 99, in attempt_patch
weave:     original_value = getattr(target.base_symbol, target.attr)
weave:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
weave: AttributeError: type object 'AsyncCompletions' has no attribute 'parse'
```

We should probably revisit our package level constraints on the openai version. Still, reading our patching code it seems the intention is to quietly move on when the module/class in question does not exist, so this change does that for missing method too.

Something to consider for the future might be to add more detailed debug level logging about patching. This might include logging information about the version of the target library.

## Testing

Add a unit test