### PR TITLE
fix(weave): sanitize string passed as model name to EvaluationLogger

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -605,3 +605,15 @@ def test_evaluation_logger_with_custom_attributes(client):
 
     calls = client.get_calls()
     assert calls[0].attributes["custom_attribute"] == "value"
+
+
+@pytest.mark.parametrize("model_name", ["for", "42", "a-b-c", "!"])
+def test_evaluation_invalid_model_name_fixable(model_name):
+    # Should not raise
+    weave.EvaluationLogger(model=model_name)
+
+
+@pytest.mark.parametrize("model_name", [""])
+def test_evaluation_invalid_model_name_not_fixable(model_name):
+    with pytest.raises(ValueError):
+        weave.EvaluationLogger(model=model_name)

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -107,12 +107,32 @@ def _set_current_summary(summary: dict) -> Iterator[None]:
         current_summary.reset(token)
 
 
+def _sanitize_class_name(name: str) -> str:
+    """Return a valid Python class name based on a string."""
+    # Remove characters that are not alphanumeric or underscore
+    class_name = re.sub(r"\W", "", name)
+    if not class_name:
+        return "GeneratedClass"
+
+    # Ensure it starts with a letter or underscore (prepend "C" if not)
+    first_char = class_name[0]
+    if not first_char.isalpha() and first_char != "_":
+        class_name = "C" + class_name
+
+    # Avoid Python keywords
+    if keyword.iskeyword(class_name):
+        class_name += "Class"
+
+    return class_name
+
+
 def _cast_to_cls(type_: type[T]) -> Callable[[str | dict | T], T]:
     def _convert_to_cls_inner(value: str | dict | T) -> T:
         if isinstance(value, str):
-            cls_name = value
-
             # Dynamically create the class if the user only provides a name
+            cls_name = _sanitize_class_name(value)
+
+            # Sanitization should have ensured a valid class name, but double check for safety
             cls_name = _validate_class_name(cls_name, type_.__name__)
 
             pydantic_config_dict = {

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -111,7 +111,7 @@ def _sanitize_class_name(name: str) -> str:
     """Return a valid Python class name based on a string."""
     # Remove characters that are not alphanumeric or underscore
     class_name = re.sub(r"\W", "", name)
-    if not class_name:
+    if class_name == "":
         return "GeneratedClass"
 
     # Ensure it starts with a letter or underscore (prepend "C" if not)


### PR DESCRIPTION
## Description

See https://weightsandbiases.slack.com/archives/C03BSTEBD7F/p1756247631879479

Passing a string as the "model" parameter to EvaluationLogger that was not a valid class name would raise a ValidationError.
```
Traceback (most recent call last):
  File "/Users/jamie/source/jcr/suprot_2025-08-25/infdoc.py", line 112, in <module>
    evaluate_model(model, dataset)
  File "/Users/jamie/source/jcr/suprot_2025-08-25/infdoc.py", line 70, in evaluate_model
    eval_logger = EvaluationLogger(
                  ^^^^^^^^^^^^^^^^^
  File "/Users/jamie/source/jcr/suprot_2025-08-25/.venv/lib/python3.12/site-packages/pydantic/main.py", line 214, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for EvaluationLogger
```

This PR attempts to sanitize the name instead.

## Testing

Added unit tests