### PR TITLE
fix(weave): calls stats existence query works w/ new ch version

### DIFF
--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1599,15 +1599,14 @@ def optimized_project_contains_call_query(
     """Returns a query that checks if the project contains any calls."""
     return safely_format_sql(
         f"""SELECT
-    CASE
-        WHEN EXISTS (
-            SELECT 1
-            FROM calls_merged
-            WHERE project_id = {param_slot(param_builder.add_param(project_id), "String")}
-        )
-        THEN 1
-        ELSE 0
-        END AS has_any
+    toUInt8(count()) AS has_any
+    FROM
+    (
+        SELECT 1
+        FROM calls_merged
+        WHERE project_id = {param_slot(param_builder.add_param(project_id), "String")}
+        LIMIT 1
+    )
     """,
         logger,
     )


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-27450](https://wandb.atlassian.net/browse/WB-27450)

New clickhouse version: `25.8.2.29` breaks the weave data existence check special query! All projects with both wandb and weave data will not show _any_ weave data if this ch version hits prod without a change. 

Currently, all dev environments testing with the most recent clickhouse version will suffer the above issue. 

This pr re-writes the stats query to not use `multiIf` and `Exists`, the later of which has had pretty extensive work done on it in the most recent ch release, possibly causing this issues. 

## Testing

<img width="535" height="405" alt="Screenshot 2025-09-04 at 2 18 14 PM" src="https://github.com/user-attachments/assets/5ada2722-f62d-4d2e-939f-fed5e317d3ee" />


[WB-27450]: https://wandb.atlassian.net/browse/WB-27450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ