### PR TITLE
feat(weave): Defer moviepy patching until import

### DIFF
--- a/weave/initialization/__init__.py
+++ b/weave/initialization/__init__.py
@@ -1,7 +1,7 @@
-from .moviepy_video_thread_safety import apply_threadsafe_patch_to_moviepy_video
+from .moviepy_video_thread_safety import install_moviepy_import_hook
 from .pil_image_thread_safety import apply_threadsafe_patch_to_pil_image
 
 apply_threadsafe_patch_to_pil_image()
-apply_threadsafe_patch_to_moviepy_video()
+install_moviepy_import_hook()
 
 __all__: list[str] = []


### PR DESCRIPTION
## Summary
- Defers moviepy patching until moviepy.editor is actually imported by user code
- Previously patching was applied eagerly during weave initialization, even when moviepy was never used
- Improves initialization performance when moviepy is not needed

## Changes Made
- Replace eager `apply_threadsafe_patch_to_moviepy_video()` call with `install_moviepy_import_hook()`
- Add new `install_moviepy_import_hook()` function that installs an import hook
- Import hook detects when `moviepy.editor` is imported and applies the patch at that time
- Maintains all existing thread-safety guarantees when moviepy is actually used

## Implementation Details
The implementation uses Python's import hook system to intercept imports:
- Replaces the built-in `__import__` function with a wrapper
- Detects when `moviepy.editor` is imported
- Applies the existing thread-safety patch at that moment
- Handles both dict and module forms of `__builtins__` for compatibility

## Test plan
- [x] Verify import hook installation works correctly
- [x] Verify patch is applied when moviepy.editor is imported
- [x] Verify existing moviepy functionality continues to work
- [ ] Run existing moviepy tests to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)