### PR TITLE
fix(weave): drop calls from bufstream produce after max (10k)

### DIFF
--- a/tests/trace_server/test_environment.py
+++ b/tests/trace_server/test_environment.py
@@ -15,7 +15,7 @@ def test_kafka_producer_max_buffer_size():
     os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"] = "10"
     assert kafka_producer_max_buffer_size() == 10
     os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"] = "10.5"
-    assert kafka_producer_max_buffer_size() == None
+    assert kafka_producer_max_buffer_size() is None
     os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"] = "invalid"
     assert kafka_producer_max_buffer_size() is None
     del os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"]

--- a/tests/trace_server/test_environment.py
+++ b/tests/trace_server/test_environment.py
@@ -1,0 +1,21 @@
+import os
+
+import pytest
+
+from weave.trace_server.environment import kafka_producer_max_buffer_size
+
+
+@pytest.mark.disable_logging_error_check
+def test_kafka_producer_max_buffer_size():
+    assert kafka_producer_max_buffer_size() is None
+    os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"] = "10000"
+    assert kafka_producer_max_buffer_size() == 10000
+    os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"] = ""
+    assert kafka_producer_max_buffer_size() is None
+    os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"] = "10"
+    assert kafka_producer_max_buffer_size() == 10
+    os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"] = "10.5"
+    assert kafka_producer_max_buffer_size() == None
+    os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"] = "invalid"
+    assert kafka_producer_max_buffer_size() is None
+    del os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"]

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -27,6 +27,12 @@ def kafka_client_password() -> Optional[str]:
     return os.environ.get("KAFKA_CLIENT_PASSWORD")
 
 
+def kafka_producer_max_buffer_size() -> int:
+    """The maximum number of messages in the Kafka producer buffer."""
+    # Default to 10000 messages if not specified
+    return int(os.environ.get("KAFKA_PRODUCER_MAX_BUFFER_SIZE", 10000))
+
+
 # Scoring worker settings
 
 

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -27,10 +27,16 @@ def kafka_client_password() -> Optional[str]:
     return os.environ.get("KAFKA_CLIENT_PASSWORD")
 
 
-def kafka_producer_max_buffer_size() -> int:
+def kafka_producer_max_buffer_size() -> Optional[int]:
     """The maximum number of messages in the Kafka producer buffer."""
-    # Default to 10000 messages if not specified
-    return int(os.environ.get("KAFKA_PRODUCER_MAX_BUFFER_SIZE", 10000))
+    size = os.environ.get("KAFKA_PRODUCER_MAX_BUFFER_SIZE")
+    if size is None:
+        return None
+    try:
+        return int(size)
+    except ValueError:
+        logger.exception(f"KAFKA_PRODUCER_MAX_BUFFER_SIZE value '{size}' is not valid")
+        return None
 
 
 # Scoring worker settings


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-27534](https://wandb.atlassian.net/browse/WB-27534)

Max buffer size on the trace server kafka queue. Warn if at 50%. Drop call from queue push at 100%. Call will still be inserted, but not eligible for online scoring. 

## Testing

how do we test scoring worker stuff? 


[WB-27534]: https://wandb.atlassian.net/browse/WB-27534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ