### PR TITLE
fix log_summary function

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -474,7 +474,7 @@ def test_evaluation_no_auto_summarize(client):
     calls = client.get_calls()
     # assert len(calls) == 1
     summarize_call = calls[4]
-    assert summarize_call.output == {"output": {}}
+    assert summarize_call.output == {}
 
 
 def test_evaluation_fail_with_exception(client):
@@ -504,8 +504,6 @@ def test_evaluation_no_auto_summarize_with_custom_dict(client):
     # assert len(calls) == 1
     summarize_call = calls[4]
     assert summarize_call.output == {
-        "something": 1,
-        "else": 2,
         "output": {"something": 1, "else": 2},
     }
 

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -585,6 +585,7 @@ class EvaluationLogger(BaseModel):
         self,
         summary: dict | None = None,
         auto_summarize: bool = True,
+        summary_key: str = "output",
     ) -> None:
         """Log a summary dict to the Evaluation.
 
@@ -595,23 +596,20 @@ class EvaluationLogger(BaseModel):
             logger.warning("(NO-OP): Evaluation already finalized, cannot log summary.")
             return
 
-        if summary is None:
-            summary = {}
-
         # Calculate summary
         if auto_summarize:
             data_to_summarize = [
                 pred._captured_scores for pred in self._accumulated_predictions
             ]
-            summary_data = auto_summarize_fn(data_to_summarize)
+            auto_summary_data = auto_summarize_fn(data_to_summarize)
         else:
-            summary_data = summary
+            auto_summary_data = {}
 
         final_summary = {}
-        if summary_data:
-            final_summary = summary_data
+        if auto_summary_data:
+            final_summary = auto_summary_data
         if summary is not None:
-            final_summary = {**final_summary, "output": summary}
+            final_summary = {**final_summary, summary_key: summary}
 
         # Call the summarize op
         assert self._evaluate_call is not None, (


### PR DESCRIPTION
## Description
  1. Fixed `summary` None check: summary None check logic does not always get executed
  2. Eliminated duplication: When `auto_summarize=False`, user summary only appears under the specified key -> note that this is imcompatible with old version, but it makes more sense to remove duplication?
  3. Added customization: New `summary_key` parameter (default: "output") allows custom key names (otherwise weave ui shows 'output' under 'output')

## Testing

How was this PR tested?
Modified the related tests