### PR TITLE
feat(weave): add integration with verifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,7 @@ autogen_tests = [
   "autogen-ext[openai]>=0.5.7",
   "openai>=1.99.9,<1.100.0",
 ]
-verifiers = ["verifiers>=0.1.3.post0"]
+verifiers = ["verifiers>=0.1.3.post0", "nltk", "textarena"]
 
 test = [
   "nox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ autogen_tests = [
   "autogen-ext[openai]>=0.5.7",
   "openai>=1.99.9,<1.100.0",
 ]
+verifiers = ["verifiers>=0.1.3.post0"]
 
 test = [
   "nox",

--- a/weave/integrations/__init__.py
+++ b/weave/integrations/__init__.py
@@ -20,6 +20,7 @@ __all__ = [
     "patch_nvidia",
     "patch_openai",
     "patch_openai_agents",
+    "patch_verifiers",
     "patch_smolagents",
     "patch_verdict",
     "patch_vertexai",

--- a/weave/integrations/__init__.py
+++ b/weave/integrations/__init__.py
@@ -20,8 +20,8 @@ __all__ = [
     "patch_nvidia",
     "patch_openai",
     "patch_openai_agents",
-    "patch_verifiers",
     "patch_smolagents",
     "patch_verdict",
+    "patch_verifiers",
     "patch_vertexai",
 ]

--- a/weave/integrations/patch.py
+++ b/weave/integrations/patch.py
@@ -227,6 +227,16 @@ def patch_verdict(settings: Optional[IntegrationSettings] = None) -> None:
         _PATCHED_INTEGRATIONS.add("verdict")
 
 
+def patch_verifiers(settings: Optional[IntegrationSettings] = None) -> None:
+    """Enable Weave tracing for Verifiers."""
+    from weave.integrations.verifiers.verifiers import get_verifiers_patcher
+
+    if settings is None:
+        settings = IntegrationSettings()
+    if get_verifiers_patcher(settings).attempt_patch():
+        _PATCHED_INTEGRATIONS.add("verifiers")
+
+
 def patch_autogen(settings: Optional[IntegrationSettings] = None) -> None:
     """Enable Weave tracing for AutoGen."""
     from weave.integrations.autogen import get_autogen_patcher
@@ -277,6 +287,7 @@ INTEGRATION_MODULE_MAPPING: dict[str, Callable[[], None]] = {
     "smolagents": patch_smolagents,
     "openai_agents": patch_openai_agents,
     "verdict": patch_verdict,
+    "verifiers": patch_verifiers,
     "autogen": patch_autogen,
     "langchain": patch_langchain,
     "llama_index": patch_llamaindex,

--- a/weave/integrations/verifiers/verifiers.py
+++ b/weave/integrations/verifiers/verifiers.py
@@ -12,6 +12,7 @@ _verifiers_patcher: Optional[MultiPatcher] = None
 
 
 def _verifiers_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
+    """Normalize `self` for clearer display in the UI."""
     if "self" in inputs:
         cls = inputs["self"].__class__
         inputs["self"] = {
@@ -28,6 +29,8 @@ def _verifiers_wrapper(settings: OpSettings) -> Callable:
     """Return a sync wrapper that converts a function into a Weave op."""
     def wrapper(fn: Callable) -> Callable:
         op_kwargs = settings.model_dump()
+        if not op_kwargs.get("postprocess_inputs"):
+            op_kwargs["postprocess_inputs"] = _verifiers_postprocess_inputs
         return weave.op(fn, **op_kwargs)
 
     return wrapper
@@ -37,11 +40,57 @@ def _verifiers_wrapper_async(settings: OpSettings) -> Callable:
     """Return an async-aware wrapper factory that awaits the original function."""
     def wrapper(fn: Callable) -> Callable:
         op_kwargs = settings.model_dump()
+        if not op_kwargs.get("postprocess_inputs"):
+            op_kwargs["postprocess_inputs"] = _verifiers_postprocess_inputs
         @wraps(fn)
         async def _inner(*args: Any, **kwargs: Any) -> Any:
             return await fn(*args, **kwargs)
 
         return weave.op(_inner, **op_kwargs)
+
+    return wrapper
+
+
+def _wrap_parser_init(settings: OpSettings) -> Callable[[Callable], Callable]:
+    def wrapper(original_init: Callable) -> Callable:
+        @wraps(original_init)
+        def _inner(self: Any, *args: Any, **kwargs: Any) -> Any:
+            result = original_init(self, *args, **kwargs)
+            extract_fn = getattr(self, "extract_fn", None)
+            if callable(extract_fn):
+                op_kwargs = settings.model_dump()
+                if not op_kwargs.get("name"):
+                    op_kwargs["name"] = f"verifiers.{self.__class__.__name__}.extract_fn"
+                try:
+                    self.extract_fn = weave.op(extract_fn, **op_kwargs)
+                except Exception:
+                    # If wrapping fails, leave the original in place
+                    pass
+            return result
+
+        return _inner
+
+    return wrapper
+
+
+def _wrap_method_returning_callable(settings: OpSettings) -> Callable[[Callable], Callable]:
+    def wrapper(original_method: Callable) -> Callable:
+        @wraps(original_method)
+        def _inner(self: Any, *args: Any, **kwargs: Any) -> Callable:
+            returned = original_method(self, *args, **kwargs)
+            if callable(returned):
+                op_kwargs = settings.model_dump()
+                if not op_kwargs.get("name"):
+                    op_kwargs["name"] = (
+                        f"verifiers.{self.__class__.__name__}.format_reward"
+                    )
+                try:
+                    return weave.op(returned, **op_kwargs)
+                except Exception:
+                    return returned
+            return returned
+
+        return _inner
 
     return wrapper
 
@@ -75,26 +124,27 @@ def get_verifiers_patcher(
     generate_settings = base.model_copy(
         update={"name": base.name or "verifiers.Environment.generate"}
     )
+    score_rollouts_settings = base.model_copy(
+        update={"name": base.name or "verifiers.Rubric.score_rollouts"}
+    )
+    score_rollout_settings = base.model_copy(
+        update={"name": base.name or "verifiers.Rubric.score_rollout"}
+    )
 
     _verifiers_patcher = MultiPatcher(
         [
-            # Model calls
-            SymbolPatcher(
-                lambda: importlib.import_module("verifiers.envs.environment"),
-                "Environment.get_model_response",
-                _verifiers_wrapper_async(settings=get_model_response_settings),
-            ),
-            # Rollouts and batching
-            SymbolPatcher(
-                lambda: importlib.import_module("verifiers.envs.multiturn_env"),
-                "MultiTurnEnv.rollout",
-                _verifiers_wrapper_async(settings=rollout_settings),
-            ),
+            # Environment
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.environment"),
                 "Environment.evaluate",
                 _verifiers_wrapper(evaluate_settings),
             ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.environment"),
+                "Environment.get_model_response",
+                _verifiers_wrapper_async(settings=get_model_response_settings),
+            ),
+
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.environment"),
                 "Environment.a_generate",
@@ -105,6 +155,56 @@ def get_verifiers_patcher(
                 "Environment.generate",
                 _verifiers_wrapper(settings=generate_settings),
             ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.multiturn_env"),
+                "MultiTurnEnv.rollout",
+                _verifiers_wrapper_async(settings=rollout_settings),
+            ),
+            # Rubric
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.rubrics.rubric"),
+                "Rubric.score_rollouts",
+                _verifiers_wrapper_async(settings=score_rollouts_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.rubrics.rubric"),
+                "Rubric.score_rollout",
+                _verifiers_wrapper_async(settings=score_rollout_settings),
+            ),
+            # Parsers: base
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.parser"),
+                "Parser.__init__",
+                _wrap_parser_init(settings=base.model_copy(update={"name": base.name or "verifiers.Parser.extract_fn"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.parser"),
+                "Parser.parse",
+                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.Parser.parse"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.parser"),
+                "Parser.parse_answer",
+                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.Parser.parse_answer"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.parser"),
+                "Parser.get_format_reward_func",
+                _wrap_method_returning_callable(settings=base.model_copy(update={"name": base.name or "verifiers.Parser.format_reward"})),
+            ),
+
+            # Parsers: ThinkParser
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.think_parser"),
+                "ThinkParser.parse",
+                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.ThinkParser.parse"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.think_parser"),
+                "ThinkParser.get_format_reward_func",
+                _wrap_method_returning_callable(settings=base.model_copy(update={"name": base.name or "verifiers.ThinkParser.format_reward"})),
+            ),
+            # TODO(ayulockin): Add XMLParser
         ]
     )
 

--- a/weave/integrations/verifiers/verifiers.py
+++ b/weave/integrations/verifiers/verifiers.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import importlib
 from functools import wraps
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import weave
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 
-_verifiers_patcher: Optional[MultiPatcher] = None
+_verifiers_patcher: MultiPatcher | None = None
 
 
 def _verifiers_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
@@ -27,6 +27,7 @@ def _verifiers_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
 
 def _verifiers_wrapper(settings: OpSettings) -> Callable:
     """Return a sync wrapper that converts a function into a Weave op."""
+
     def wrapper(fn: Callable) -> Callable:
         op_kwargs = settings.model_dump()
         if not op_kwargs.get("postprocess_inputs"):
@@ -38,10 +39,12 @@ def _verifiers_wrapper(settings: OpSettings) -> Callable:
 
 def _verifiers_wrapper_async(settings: OpSettings) -> Callable:
     """Return an async-aware wrapper factory that awaits the original function."""
+
     def wrapper(fn: Callable) -> Callable:
         op_kwargs = settings.model_dump()
         if not op_kwargs.get("postprocess_inputs"):
             op_kwargs["postprocess_inputs"] = _verifiers_postprocess_inputs
+
         @wraps(fn)
         async def _inner(*args: Any, **kwargs: Any) -> Any:
             return await fn(*args, **kwargs)
@@ -60,7 +63,9 @@ def _wrap_parser_init(settings: OpSettings) -> Callable[[Callable], Callable]:
             if callable(extract_fn):
                 op_kwargs = settings.model_dump()
                 if not op_kwargs.get("name"):
-                    op_kwargs["name"] = f"verifiers.{self.__class__.__name__}.extract_fn"
+                    op_kwargs["name"] = (
+                        f"verifiers.{self.__class__.__name__}.extract_fn"
+                    )
                 try:
                     self.extract_fn = weave.op(extract_fn, **op_kwargs)
                 except Exception:
@@ -73,7 +78,9 @@ def _wrap_parser_init(settings: OpSettings) -> Callable[[Callable], Callable]:
     return wrapper
 
 
-def _wrap_method_returning_callable(settings: OpSettings) -> Callable[[Callable], Callable]:
+def _wrap_method_returning_callable(
+    settings: OpSettings,
+) -> Callable[[Callable], Callable]:
     def wrapper(original_method: Callable) -> Callable:
         @wraps(original_method)
         def _inner(self: Any, *args: Any, **kwargs: Any) -> Callable:
@@ -113,7 +120,9 @@ def get_verifiers_patcher(
         update={"name": base.name or "verifiers.Environment.get_model_response"}
     )
     rollout_settings = base.model_copy(
-        update={"name": base.name or "verifiers.envs.multiturn_env.MultiTurnEnv.rollout"}
+        update={
+            "name": base.name or "verifiers.envs.multiturn_env.MultiTurnEnv.rollout"
+        }
     )
     evaluate_settings = base.model_copy(
         update={"name": base.name or "verifiers.Environment.evaluate"}
@@ -154,74 +163,121 @@ def get_verifiers_patcher(
                 "Environment.generate",
                 _verifiers_wrapper(settings=generate_settings),
             ),
-
             # Multi-turn core rollout
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.multiturn_env"),
                 "MultiTurnEnv.rollout",
                 _verifiers_wrapper_async(settings=rollout_settings),
             ),
-
             # EnvGroup routing
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.env_group"),
                 "EnvGroup.rollout",
-                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.EnvGroup.rollout"})),
+                _verifiers_wrapper_async(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.EnvGroup.rollout"}
+                    )
+                ),
             ),
-
             # SingleTurnEnv
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.singleturn_env"),
                 "SingleTurnEnv.env_response",
-                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.SingleTurnEnv.env_response"})),
+                _verifiers_wrapper_async(
+                    settings=base.model_copy(
+                        update={
+                            "name": base.name or "verifiers.SingleTurnEnv.env_response"
+                        }
+                    )
+                ),
             ),
-
             # ToolEnv (tool-use)
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.tool_env"),
                 "ToolEnv.is_completed",
-                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.ToolEnv.is_completed"})),
+                _verifiers_wrapper_async(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.ToolEnv.is_completed"}
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.tool_env"),
                 "ToolEnv.env_response",
-                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.ToolEnv.env_response"})),
+                _verifiers_wrapper_async(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.ToolEnv.env_response"}
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.tool_env"),
                 "ToolEnv.call_tool",
-                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.ToolEnv.call_tool"})),
+                _verifiers_wrapper_async(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.ToolEnv.call_tool"}
+                    )
+                ),
             ),
-
             # StatefulToolEnv
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.stateful_tool_env"),
                 "StatefulToolEnv.update_tool_args",
-                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.StatefulToolEnv.update_tool_args"})),
+                _verifiers_wrapper(
+                    settings=base.model_copy(
+                        update={
+                            "name": base.name
+                            or "verifiers.StatefulToolEnv.update_tool_args"
+                        }
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.stateful_tool_env"),
                 "StatefulToolEnv.call_tool",
-                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.StatefulToolEnv.call_tool"})),
+                _verifiers_wrapper_async(
+                    settings=base.model_copy(
+                        update={
+                            "name": base.name or "verifiers.StatefulToolEnv.call_tool"
+                        }
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.stateful_tool_env"),
                 "StatefulToolEnv.env_response",
-                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.StatefulToolEnv.env_response"})),
+                _verifiers_wrapper_async(
+                    settings=base.model_copy(
+                        update={
+                            "name": base.name
+                            or "verifiers.StatefulToolEnv.env_response"
+                        }
+                    )
+                ),
             ),
-
             # TextArenaEnv
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.textarena_env"),
                 "TextArenaEnv.is_completed",
-                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.TextArenaEnv.is_completed"})),
+                _verifiers_wrapper_async(
+                    settings=base.model_copy(
+                        update={
+                            "name": base.name or "verifiers.TextArenaEnv.is_completed"
+                        }
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.textarena_env"),
                 "TextArenaEnv.env_response",
-                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.TextArenaEnv.env_response"})),
+                _verifiers_wrapper_async(
+                    settings=base.model_copy(
+                        update={
+                            "name": base.name or "verifiers.TextArenaEnv.env_response"
+                        }
+                    )
+                ),
             ),
-
             # Rubric
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.rubrics.rubric"),
@@ -233,66 +289,113 @@ def get_verifiers_patcher(
                 "Rubric.score_rollout",
                 _verifiers_wrapper_async(settings=score_rollout_settings),
             ),
-
             # Parsers: base
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.parser"),
                 "Parser.__init__",
-                _wrap_parser_init(settings=base.model_copy(update={"name": base.name or "verifiers.Parser.extract_fn"})),
+                _wrap_parser_init(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.Parser.extract_fn"}
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.parser"),
                 "Parser.parse",
-                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.Parser.parse"})),
+                _verifiers_wrapper(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.Parser.parse"}
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.parser"),
                 "Parser.get_format_reward_func",
-                _wrap_method_returning_callable(settings=base.model_copy(update={"name": base.name or "verifiers.Parser.format_reward"})),
+                _wrap_method_returning_callable(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.Parser.format_reward"}
+                    )
+                ),
             ),
-
             # Parsers: ThinkParser
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.think_parser"),
                 "ThinkParser.parse",
-                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.ThinkParser.parse"})),
+                _verifiers_wrapper(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.ThinkParser.parse"}
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.think_parser"),
                 "ThinkParser.get_format_reward_func",
-                _wrap_method_returning_callable(settings=base.model_copy(update={"name": base.name or "verifiers.ThinkParser.format_reward"})),
+                _wrap_method_returning_callable(
+                    settings=base.model_copy(
+                        update={
+                            "name": base.name or "verifiers.ThinkParser.format_reward"
+                        }
+                    )
+                ),
             ),
-
             # Parsers: XMLParser
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.xml_parser"),
                 "XMLParser.parse",
-                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.parse"})),
+                _verifiers_wrapper(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.XMLParser.parse"}
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.xml_parser"),
                 "XMLParser.parse_answer",
-                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.parse_answer"})),
+                _verifiers_wrapper(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.XMLParser.parse_answer"}
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.xml_parser"),
                 "XMLParser.get_format_reward_func",
-                _wrap_method_returning_callable(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.format_reward"})),
+                _wrap_method_returning_callable(
+                    settings=base.model_copy(
+                        update={
+                            "name": base.name or "verifiers.XMLParser.format_reward"
+                        }
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.xml_parser"),
                 "XMLParser.get_fields",
-                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.get_fields"})),
+                _verifiers_wrapper(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.XMLParser.get_fields"}
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.xml_parser"),
                 "XMLParser.format",
-                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.format"})),
+                _verifiers_wrapper(
+                    settings=base.model_copy(
+                        update={"name": base.name or "verifiers.XMLParser.format"}
+                    )
+                ),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.xml_parser"),
                 "XMLParser.get_format_str",
-                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.get_format_str"})),
+                _verifiers_wrapper(
+                    settings=base.model_copy(
+                        update={
+                            "name": base.name or "verifiers.XMLParser.get_format_str"
+                        }
+                    )
+                ),
             ),
         ]
     )

--- a/weave/integrations/verifiers/verifiers.py
+++ b/weave/integrations/verifiers/verifiers.py
@@ -133,7 +133,7 @@ def get_verifiers_patcher(
 
     _verifiers_patcher = MultiPatcher(
         [
-            # Environment
+            # Environment (core)
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.environment"),
                 "Environment.evaluate",
@@ -144,7 +144,6 @@ def get_verifiers_patcher(
                 "Environment.get_model_response",
                 _verifiers_wrapper_async(settings=get_model_response_settings),
             ),
-
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.environment"),
                 "Environment.a_generate",
@@ -155,11 +154,74 @@ def get_verifiers_patcher(
                 "Environment.generate",
                 _verifiers_wrapper(settings=generate_settings),
             ),
+
+            # Multi-turn core rollout
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.multiturn_env"),
                 "MultiTurnEnv.rollout",
                 _verifiers_wrapper_async(settings=rollout_settings),
             ),
+
+            # EnvGroup routing
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.env_group"),
+                "EnvGroup.rollout",
+                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.EnvGroup.rollout"})),
+            ),
+
+            # SingleTurnEnv
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.singleturn_env"),
+                "SingleTurnEnv.env_response",
+                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.SingleTurnEnv.env_response"})),
+            ),
+
+            # ToolEnv (tool-use)
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.tool_env"),
+                "ToolEnv.is_completed",
+                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.ToolEnv.is_completed"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.tool_env"),
+                "ToolEnv.env_response",
+                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.ToolEnv.env_response"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.tool_env"),
+                "ToolEnv.call_tool",
+                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.ToolEnv.call_tool"})),
+            ),
+
+            # StatefulToolEnv
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.stateful_tool_env"),
+                "StatefulToolEnv.update_tool_args",
+                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.StatefulToolEnv.update_tool_args"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.stateful_tool_env"),
+                "StatefulToolEnv.call_tool",
+                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.StatefulToolEnv.call_tool"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.stateful_tool_env"),
+                "StatefulToolEnv.env_response",
+                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.StatefulToolEnv.env_response"})),
+            ),
+
+            # TextArenaEnv
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.textarena_env"),
+                "TextArenaEnv.is_completed",
+                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.TextArenaEnv.is_completed"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.textarena_env"),
+                "TextArenaEnv.env_response",
+                _verifiers_wrapper_async(settings=base.model_copy(update={"name": base.name or "verifiers.TextArenaEnv.env_response"})),
+            ),
+
             # Rubric
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.rubrics.rubric"),
@@ -171,6 +233,7 @@ def get_verifiers_patcher(
                 "Rubric.score_rollout",
                 _verifiers_wrapper_async(settings=score_rollout_settings),
             ),
+
             # Parsers: base
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.parser"),
@@ -181,11 +244,6 @@ def get_verifiers_patcher(
                 lambda: importlib.import_module("verifiers.parsers.parser"),
                 "Parser.parse",
                 _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.Parser.parse"})),
-            ),
-            SymbolPatcher(
-                lambda: importlib.import_module("verifiers.parsers.parser"),
-                "Parser.parse_answer",
-                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.Parser.parse_answer"})),
             ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.parsers.parser"),
@@ -204,7 +262,38 @@ def get_verifiers_patcher(
                 "ThinkParser.get_format_reward_func",
                 _wrap_method_returning_callable(settings=base.model_copy(update={"name": base.name or "verifiers.ThinkParser.format_reward"})),
             ),
-            # TODO(ayulockin): Add XMLParser
+
+            # Parsers: XMLParser
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.xml_parser"),
+                "XMLParser.parse",
+                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.parse"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.xml_parser"),
+                "XMLParser.parse_answer",
+                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.parse_answer"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.xml_parser"),
+                "XMLParser.get_format_reward_func",
+                _wrap_method_returning_callable(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.format_reward"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.xml_parser"),
+                "XMLParser.get_fields",
+                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.get_fields"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.xml_parser"),
+                "XMLParser.format",
+                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.format"})),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.parsers.xml_parser"),
+                "XMLParser.get_format_str",
+                _verifiers_wrapper(settings=base.model_copy(update={"name": base.name or "verifiers.XMLParser.get_format_str"})),
+            ),
         ]
     )
 

--- a/weave/integrations/verifiers/verifiers.py
+++ b/weave/integrations/verifiers/verifiers.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+from typing import Any, Callable, Optional
+
+import weave
+from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
+from weave.trace.autopatch import IntegrationSettings, OpSettings
+
+_verifiers_patcher: Optional[MultiPatcher] = None
+
+
+def _verifiers_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
+    if "self" in inputs:
+        cls = inputs["self"].__class__
+        inputs["self"] = {
+            "__class__": {
+                "module": cls.__module__,
+                "qualname": getattr(cls, "__qualname__", cls.__name__),
+                "name": cls.__name__,
+            }
+        }
+    return inputs
+
+
+def _verifiers_wrapper(settings: OpSettings) -> Callable:
+    def wrapper(fn: Callable) -> Callable:
+        op_kwargs = settings.model_dump()
+        return weave.op(fn, **op_kwargs)
+
+    return wrapper
+
+
+def get_verifiers_patcher(
+    settings: IntegrationSettings | None = None,
+) -> MultiPatcher | NoOpPatcher:
+    if settings is None:
+        settings = IntegrationSettings()
+
+    if not settings.enabled:
+        return NoOpPatcher()
+
+    global _verifiers_patcher
+    if _verifiers_patcher is not None:
+        return _verifiers_patcher
+
+    base: OpSettings = settings.op_settings
+    evaluate_settings = base.model_copy(
+        update={"name": base.name or "verifiers.Environment.evaluate"}
+    )
+
+    _verifiers_patcher = MultiPatcher(
+        [
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.environment"),
+                "Environment.evaluate",
+                _verifiers_wrapper(evaluate_settings),
+            ),
+        ]
+    )
+
+    return _verifiers_patcher

--- a/weave/integrations/verifiers/verifiers.py
+++ b/weave/integrations/verifiers/verifiers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from functools import wraps
 from typing import Any, Callable, Optional
 
 import weave
@@ -24,9 +25,23 @@ def _verifiers_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
 
 
 def _verifiers_wrapper(settings: OpSettings) -> Callable:
+    """Return a sync wrapper that converts a function into a Weave op."""
     def wrapper(fn: Callable) -> Callable:
         op_kwargs = settings.model_dump()
         return weave.op(fn, **op_kwargs)
+
+    return wrapper
+
+
+def _verifiers_wrapper_async(settings: OpSettings) -> Callable:
+    """Return an async-aware wrapper factory that awaits the original function."""
+    def wrapper(fn: Callable) -> Callable:
+        op_kwargs = settings.model_dump()
+        @wraps(fn)
+        async def _inner(*args: Any, **kwargs: Any) -> Any:
+            return await fn(*args, **kwargs)
+
+        return weave.op(_inner, **op_kwargs)
 
     return wrapper
 
@@ -45,16 +60,50 @@ def get_verifiers_patcher(
         return _verifiers_patcher
 
     base: OpSettings = settings.op_settings
+    get_model_response_settings = base.model_copy(
+        update={"name": base.name or "verifiers.Environment.get_model_response"}
+    )
+    rollout_settings = base.model_copy(
+        update={"name": base.name or "verifiers.envs.multiturn_env.MultiTurnEnv.rollout"}
+    )
     evaluate_settings = base.model_copy(
         update={"name": base.name or "verifiers.Environment.evaluate"}
+    )
+    a_generate_settings = base.model_copy(
+        update={"name": base.name or "verifiers.Environment.a_generate"}
+    )
+    generate_settings = base.model_copy(
+        update={"name": base.name or "verifiers.Environment.generate"}
     )
 
     _verifiers_patcher = MultiPatcher(
         [
+            # Model calls
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.environment"),
+                "Environment.get_model_response",
+                _verifiers_wrapper_async(settings=get_model_response_settings),
+            ),
+            # Rollouts and batching
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.multiturn_env"),
+                "MultiTurnEnv.rollout",
+                _verifiers_wrapper_async(settings=rollout_settings),
+            ),
             SymbolPatcher(
                 lambda: importlib.import_module("verifiers.envs.environment"),
                 "Environment.evaluate",
                 _verifiers_wrapper(evaluate_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.environment"),
+                "Environment.a_generate",
+                _verifiers_wrapper_async(settings=a_generate_settings),
+            ),
+            SymbolPatcher(
+                lambda: importlib.import_module("verifiers.envs.environment"),
+                "Environment.generate",
+                _verifiers_wrapper(settings=generate_settings),
             ),
         ]
     )


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

This PR patches relevant methods from the `verifiers` library. Upon successful installation of the library  and an envirnment (`gsm8k` in this case) one can run evaluation like this. 

```
import weave
weave.init("verifiers-dev")

import verifiers as vf
from openai import OpenAI

# Load your environment
env = vf.load_environment("gsm8k")

# Test with a model
client = OpenAI()
results = env.evaluate(
    client, "gpt-4.1-mini",
    num_examples=5,
    rollouts_per_example=2,
    max_concurrent=32,
)
```

Note that the result is a trace timeline and not "weave eval view". The verifiers lib flatten the input by copying the same `input` `rollouts_per_example` times. The scoring is done after all the rollouts are generated.

Here's a screenshot of a trace timeline:

<img width="536" height="890" alt="image" src="https://github.com/user-attachments/assets/3ee7233f-e474-40be-87fc-42f473b0333c" />

Check out the trace [here](https://wandb.ai/ayut/verifiers-dev/weave/traces?filter=%7B%22opVersionRefs%22%3A%5B%22weave%3A%2F%2F%2Fayut%2Fverifiers-dev%2Fop%2Fverifiers.Environment.evaluate%3A*%22%5D%7D&peekPath=%2Fayut%2Fverifiers-dev%2Fcalls%2F01993581-b8b6-7574-912b-f2e970c3ad35%3FdescendentCallId%3D01993581-b8c6-78c0-a50a-010b5249743d).

## Testing

I have not added tests yet. I plan to keep it minimal for this iteration. 