### PR TITLE
chore(weave): Adds a missing field in the saved view schema

### DIFF
--- a/weave/trace_server/interface/builtin_object_classes/saved_view.py
+++ b/weave/trace_server/interface/builtin_object_classes/saved_view.py
@@ -49,6 +49,7 @@ class SavedViewDefinition(BaseModel):
 
     pin: Optional[Pin] = Field(default=None)
     sort_by: Optional[list[tsi.SortBy]] = Field(default=None)
+    page: Optional[int] = Field(default=None)
     page_size: Optional[int] = Field(default=None)
     charts: Optional[list[ChartConfig]] = Field(default=None)
 


### PR DESCRIPTION
## Description

This is a required change by PR https://github.com/wandb/core/pull/34330

