### PR TITLE
fix(weave): use delimiter and custom:: prefix for custom providers

### DIFF
--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -338,9 +338,9 @@ def test_custom_provider_completions_create(client):
                     )
 
             # Verify the response matches our mock
-            assert (
-                res.response == mock_response
-            ), f"Response mismatch. Expected {mock_response}, got {res.response}"
+            assert res.response == mock_response, (
+                f"Response mismatch. Expected {mock_response}, got {res.response}"
+            )
 
             # Verify LiteLLM was called with correct parameters
             mock_completion.assert_called_once()
@@ -348,9 +348,9 @@ def test_custom_provider_completions_create(client):
             expected_litellm_model = (
                 f"openai/{model_id}"  # Implementation prefixes with "openai/"
             )
-            assert (
-                call_args["model"] == expected_litellm_model
-            ), f"Model name mismatch. Expected '{expected_litellm_model}', got '{call_args['model']}'"
+            assert call_args["model"] == expected_litellm_model, (
+                f"Model name mismatch. Expected '{expected_litellm_model}', got '{call_args['model']}'"
+            )
             assert call_args["messages"] == inputs["messages"], (
                 f"Messages mismatch. Expected {inputs['messages']}, "
                 f"got {call_args['messages']}"
@@ -386,9 +386,9 @@ def test_custom_provider_completions_create(client):
             # The implementation modifies req.inputs.model before logging, so we expect the transformed model name
             expected_logged_inputs = inputs.copy()
             expected_logged_inputs["model"] = f"openai/{model_id}"
-            assert (
-                calls[0].inputs == expected_logged_inputs
-            ), f"Logged inputs mismatch. Expected {expected_logged_inputs}, got {calls[0].inputs}"
+            assert calls[0].inputs == expected_logged_inputs, (
+                f"Logged inputs mismatch. Expected {expected_logged_inputs}, got {calls[0].inputs}"
+            )
             assert calls[0].op_name == "weave.completions_create", (
                 f"Operation name mismatch. Expected 'weave.completions_create', "
                 f"got {calls[0].op_name}"

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2915,15 +2915,11 @@ def _create_tracked_stream_wrapper(
 
             # Prepare summary and end call
             summary: dict[str, Any] = {}
-            if (
-                aggregated_output
-                and "usage" in aggregated_output
-                and model_name is not None
-            ):
-                summary["usage"] = {model_name: aggregated_output["usage"]}
-
             if aggregated_output is not None and model_name is not None:
                 aggregated_output["model"] = model_name
+
+                if "usage" in aggregated_output:
+                    summary["usage"] = {model_name: aggregated_output["usage"]}
 
             end = tsi.EndedCallSchemaForInsert(
                 project_id=project_id,

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -31,6 +31,7 @@ import threading
 from collections import defaultdict
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
+from re import sub
 from typing import Any, Callable, Optional, Union, cast
 from zoneinfo import ZoneInfo
 
@@ -2005,9 +2006,14 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         # --- Shared setup logic (copy of completions_create up to litellm call)
         model_info = self._model_to_provider_info_map.get(req.inputs.model)
         try:
-            model_name, api_key, provider, base_url, extra_headers, return_type = (
-                _setup_completion_model_info(model_info, req, self.obj_read)
-            )
+            (
+                model_name,
+                api_key,
+                provider,
+                base_url,
+                extra_headers,
+                return_type,
+            ) = _setup_completion_model_info(model_info, req, self.obj_read)
         except Exception as e:
             # Yield error as single chunk then stop.
             def _single_error_iter(e: Exception) -> Iterator[dict[str, str]]:
@@ -2018,12 +2024,14 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         # Track start call if requested
         start_call: Optional[CallStartCHInsertable] = None
         if req.track_llm_call:
+            inputs = req.inputs.model_dump(exclude_none=True)
+            inputs["model"] = model_name
             start = tsi.StartedCallSchemaForInsert(
                 project_id=req.project_id,
                 wb_user_id=req.wb_user_id,
                 op_name=COMPLETIONS_CREATE_OP_NAME,
                 started_at=datetime.datetime.now(),
-                inputs={**req.inputs.model_dump(exclude_none=True)},
+                inputs={**inputs},
                 attributes={},
             )
             start_call = _start_call_for_insert_to_ch_insertable_start_call(start)
@@ -2046,7 +2054,11 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
 
         # Otherwise, wrap the iterator with tracking
         return _create_tracked_stream_wrapper(
-            self._insert_call, chunk_iter, start_call, model_name, req.project_id
+            self._insert_call,
+            chunk_iter,
+            start_call,
+            model_name,
+            req.project_id,
         )
 
     def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
@@ -2905,6 +2917,8 @@ def _create_tracked_stream_wrapper(
             summary: dict[str, Any] = {}
             if aggregated_output and "usage" in aggregated_output:
                 summary["usage"] = {model_name: aggregated_output["usage"]}
+            if model_name is not None:
+                aggregated_output["model"] = model_name
 
             end = tsi.EndedCallSchemaForInsert(
                 project_id=project_id,
@@ -2936,6 +2950,9 @@ def _setup_completion_model_info(
     extra_headers: dict[str, str] = {}
     return_type: Optional[str] = None
 
+    # Check for explicit custom provider prefix
+    is_explicit_custom = model_name.startswith("custom::")
+
     is_coreweave = (
         model_info and model_info.get("litellm_provider") == "coreweave"
     ) or model_name.startswith("coreweave/")
@@ -2951,6 +2968,59 @@ def _setup_completion_model_info(
             extra_headers = req.inputs.extra_headers
             req.inputs.extra_headers = None
         return_type = "openai"
+    elif is_explicit_custom:
+        # Custom provider path - model_name format: custom::<provider>::<model>
+        # Parse provider and model names, create sanitized object_id for lookup
+        name_part = model_name.replace("custom::", "")
+
+        if "::" in name_part:
+            # Format: custom::<provider>::<model>
+            provider_name, model_name_part = name_part.split("::", 1)
+
+            # Create sanitized object_id to match what was created during provider setup
+
+            sanitized_provider = _sanitize_name_for_object_id(provider_name)
+            sanitized_model = _sanitize_name_for_object_id(model_name_part)
+            sanitized_object_id = f"{sanitized_provider}-{sanitized_model}"
+        else:
+            # Fallback: assume it's already in object_id format
+            # Extract names from object_id (this is a fallback case)
+            parts = name_part.split("-", 1) if "-" in name_part else [name_part, ""]
+            provider_name = parts[0]  # May be sanitized
+            model_name_part = parts[1] if len(parts) > 1 else ""
+            sanitized_provider = provider_name  # Already sanitized
+            sanitized_object_id = name_part
+
+        custom_provider_info = get_custom_provider_info(
+            project_id=req.project_id,
+            provider_name=sanitized_provider,
+            model_name=sanitized_object_id,
+            obj_read_func=obj_read,
+        )
+
+        base_url = custom_provider_info.base_url
+        final_model_name = custom_provider_info.actual_model_name
+        provider_model_name = (
+            f"{provider_name}/{final_model_name}"
+            if "::" in name_part
+            else final_model_name
+        )
+
+        # prefix the model name with "ollama/" if it is an ollama model else with openai/
+        req.inputs.model = (
+            "ollama/" + final_model_name
+            if "ollama" in provider_name.lower()
+            else "openai/" + final_model_name
+        )
+
+        return (
+            provider_model_name,
+            custom_provider_info.api_key,
+            "custom",  # return "custom" as provider
+            base_url,
+            custom_provider_info.extra_headers,
+            custom_provider_info.return_type,
+        )
     elif model_info:
         secret_name = model_info.get("api_key_name")
         if not secret_name:
@@ -2970,25 +3040,16 @@ def _setup_completion_model_info(
                 f"No API key {secret_name} found for model {model_name}",
                 api_key_name=secret_name,
             )
-    else:
-        # Custom provider path
-        custom_provider_info = get_custom_provider_info(
-            project_id=req.project_id,
-            model_name=model_name,
-            obj_read_func=obj_read,
-        )
 
-        base_url = custom_provider_info.base_url
-        api_key = custom_provider_info.api_key
-        extra_headers = custom_provider_info.extra_headers
-        return_type = custom_provider_info.return_type
-        actual_model_name = custom_provider_info.actual_model_name
+    return (
+        model_name,
+        api_key,
+        provider,
+        base_url,
+        extra_headers,
+        return_type,
+    )
 
-        provider = "custom"
-        req.inputs.model = (
-            "ollama/" + actual_model_name
-            if "ollama" in model_name
-            else actual_model_name
-        )
 
-    return model_name, api_key, provider, base_url, extra_headers, return_type
+def _sanitize_name_for_object_id(name: str) -> str:
+    return sub(r"[^a-zA-Z0-9_-]", "_", name)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -3037,9 +3037,7 @@ def _setup_completion_model_info(
                 f"No secret fetcher found, cannot fetch API key for model {model_name}"
             )
 
-        api_key: Optional[str] = (
-            secret_fetcher.fetch(secret_name).get("secrets", {}).get(secret_name)
-        )
+        api_key = secret_fetcher.fetch(secret_name).get("secrets", {}).get(secret_name)
         provider = model_info.get("litellm_provider", "openai")
 
         if not api_key and provider not in ("bedrock", "bedrock_converse"):


### PR DESCRIPTION
## Description

Allows the usage of '/' and ':' in provider and custom model names unblocking ollama and openrotuer custom model usage
Changes to accept a custom:: prefix from the frontend on custom provider requests instead of just guessing at it

## Testing

created and hit local ollama models and sent reqeusts to openrouter 
