### PR TITLE
fix(weave): unpin LlamaIndex dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,8 +149,7 @@ langchain_nvidia_ai_endpoints = [
 litellm = ["litellm>=1.36.1", "openai>=1.99.9,<1.100.0"]
 # temporary max pin b/c 0.12.50 changes call structure and therefor tests
 llamaindex = [
-  "llama-index>=0.10.35,<0.12.50",
-  "llama-index-core<0.12.50",
+  "llama-index>=0.10.35",
   "openai>=1.99.9,<1.100.0",
 ]
 mistral = ["mistralai>=1.0.0"]


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

Our CI started failing when llama-index==0.12.50 introduced a breaking change. As a stopgap, this PR initially pinned llama-index to <0.12.50. The upstream maintainers have since shipped a patch release that resolves the issue introduced in 0.12.50. This PR updates the dependency to the fixed version and removes the temporary <0.12.50 constraint.

## Testing

How was this PR tested?
