### PR TITLE
docs(weave): Adds new Limits and Expected Behaviors

### DIFF
--- a/docs/docs/details/limits.md
+++ b/docs/docs/details/limits.md
@@ -11,7 +11,7 @@
 
 * [Dedicated Weave instances](../../guides/platform/weave-self-managed) use a different OpenTelemetry ingress URL. Use `{WANDB_HOST}/traces/otel/v1/traces` to access your traces on a dedicated instance. For example, if your host your instance at `acme.wandb.io`, trace information is accessible at `https://acme.wandb.io/traces/otel/v1/traces`.
 
-* Weave sometimes truncates large trace data objects. This occurs because default trace output is a raw, custom Python object that Weave doesn’t know how to serialize. To ensure that large trace data isn't cut off, define a dictionary of strings to return all trace data, like this: 
+* Weave sometimes truncates large trace data objects. This occurs because default trace output is a raw, custom Python object that Weave doesn’t know how to serialize. To return all of your trace data, define a dictionary of strings, like this: 
 
     ```python
     import weave

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -231,6 +231,7 @@ const sidebars: SidebarsConfig = {
       label: "🛠️ Tools & Resources",
       ...CATEGORY_SECTION_HEADER_MIXIN,
       items: [
+        "details/limits",
         "guides/core-types/env-vars",
         "guides/troubleshooting",
         "guides/tracking/faqs",


### PR DESCRIPTION
## Description
Resolves [DOCS-1244](https://wandb.atlassian.net/browse/DOCS-1244) and partially resolves [DOCS-1748](https://wandb.atlassian.net/browse/DOCS-1748).

This PR adds a new Limits and Expected Behaviors page. The new page is designed to document Weave's limitations, known issues, and behaviors that may initially seem counterintuitive to users. The page is in a new directory called **Details**. This is a new section that I intend to flesh out more in the coming weeks.


[DOCS-1244]: https://wandb.atlassian.net/browse/DOCS-1244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DOCS-1748]: https://wandb.atlassian.net/browse/DOCS-1748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ