### PR TITLE
fix(weave): OTEL traces missing user id

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -220,7 +220,7 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         for resource_spans in traces_data:
             for scope_spans in resource_spans.scope_spans:
                 for span in scope_spans.spans:
-                    start_call, end_call = span.to_call(req.project_id)
+                    start_call, end_call = span.to_call(req.project_id, req.wb_user_id)
                     calls.extend(
                         [
                             {

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -282,7 +282,7 @@ class Span:
         )
 
     def to_call(
-        self, project_id: str
+        self, project_id: str, wb_user_id: Optional[str]
     ) -> tuple[tsi.StartedCallSchemaForInsert, tsi.EndedCallSchemaForInsert]:
         events = [SpanEvent(e.as_dict()) for e in self.events]
         usage = get_weave_usage(self.attributes) or {}
@@ -385,7 +385,7 @@ class Span:
             attributes=attributes,
             inputs=inputs,
             display_name=display_name,
-            wb_user_id=None,
+            wb_user_id=wb_user_id,
             wb_run_id=None,
             turn_id=turn_id,
             thread_id=thread_id,

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -282,7 +282,7 @@ class Span:
         )
 
     def to_call(
-        self, project_id: str, wb_user_id: Optional[str]
+        self, project_id: str, wb_user_id: Optional[str] = None
     ) -> tuple[tsi.StartedCallSchemaForInsert, tsi.EndedCallSchemaForInsert]:
         events = [SpanEvent(e.as_dict()) for e in self.events]
         usage = get_weave_usage(self.attributes) or {}


### PR DESCRIPTION
## Description


- Fixes WB-27757

Passes user id to call conversion for span so that it is associated with the call

## Testing

manually
