### PR TITLE
chore(weave): Move memray profiling to nightly tests

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -134,6 +134,7 @@ jobs:
         env:
           WEAVE_SENTRY_ENV: ci
           CI: 1
+          WEAVE_USE_MEMRAY: 1
           WB_SERVER_HOST: http://wandbservice
           WF_CLICKHOUSE_HOST: weave_clickhouse
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1

--- a/noxfile.py
+++ b/noxfile.py
@@ -188,8 +188,9 @@ def tests(session, shard):
         "--cov-branch",
     ]
 
-    # Memray not working with trace_server shard atm
-    if shard != "trace_server":
+    # Memray profiling is optional and controlled via environment variable
+    # (not working with trace_server shard atm)
+    if os.getenv("WEAVE_USE_MEMRAY") == "1" and shard != "trace_server":
         pytest_args.extend(
             [
                 "--memray",


### PR DESCRIPTION
This minimizes spurious CI failures where memray causes a segfault