### PR TITLE
Improve graceful failure handling for rate limits and server errors

### DIFF
--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -85,10 +85,10 @@ if sys.version_info < (3, 10):
 logger = logging.getLogger(__name__)
 
 
-CALL_CREATE_MSG = "Error creating call:\n{}"
-ASYNC_CALL_CREATE_MSG = "Error creating async call:\n{}"
-ON_OUTPUT_MSG = "Error capturing call output:\n{}"
-UNINITIALIZED_MSG = "Warning: Traces will not be logged. Call weave.init to log your traces to a project.\n"
+CALL_CREATE_MSG = "Failed to log call to Weave server (your code will continue to run). Error details:\n{}"
+ASYNC_CALL_CREATE_MSG = "Failed to log async call to Weave server (your code will continue to run). Error details:\n{}"
+ON_OUTPUT_MSG = "Failed to capture call output for logging (your code will continue to run). Error details:\n{}"
+UNINITIALIZED_MSG = "Weave tracing is not initialized. Call weave.init(<project_name>) to enable tracing.\n"
 
 
 class DisplayNameFuncError(ValueError): ...


### PR DESCRIPTION
## Summary
- Improved error messages to be less alarming when rate limits or server errors occur
- Changed log levels from `error` to `warning`/`info` for non-critical failures
- Added specific context for rate limit (429) and server errors (5xx)

## Motivation
When the Weave server encounters rate limits or is temporarily unavailable, `weave.op` should not crash the user's program. The existing implementation already had proper retry logic with exponential backoff, but the error messages were alarming and could confuse users. This PR improves the user experience by making it clear that their code will continue to run normally, just without tracing.

## Changes
1. **Updated error message constants in `op.py`**:
   - Changed messages to clarify that "your code will continue to run"
   - Made the uninitialized warning clearer

2. **Improved retry logging in `retry.py`**:
   - Added specific context for rate limits and server errors
   - Changed failure messages to be less alarming

3. **Updated batch error logging in `http_utils.py`**:
   - Changed from `logger.error` to `logger.warning` for dropped batches
   - Added specific messages for 429 and 5xx errors
   - Made it clear that code execution continues

## Testing
Tested manually with simulated rate limits and server errors. The decorated functions continue to work correctly even when:
- The Weave server returns 429 (rate limit)
- The Weave server returns 5xx (server errors)
- Network connection is refused
- Request timeouts occur

## User Impact
Users will see clearer, less alarming messages when temporary issues occur with the Weave server. Their code will continue to run without interruption, and they'll understand that only the tracing/logging functionality is affected.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>