### PR TITLE
chore(weave): parallel table uploads by default

### DIFF
--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -178,7 +178,7 @@ class UserSettings(BaseModel):
     Can be overridden with the environment variable `WEAVE_ENABLE_DISK_FALLBACK`
     """
 
-    use_parallel_table_upload: bool = False
+    use_parallel_table_upload: bool = True
     """
     Toggles parallel table upload chunking.
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This has been opt in, but has been soaking for a while, we should make it default on. 

## Testing

A month of testing in prod with the flag. 
