### PR TITLE
docs(weave): Add endpoints for dedicated instances

### DIFF
--- a/docs/docs/guides/integrations/agno.md
+++ b/docs/docs/guides/integrations/agno.md
@@ -34,7 +34,7 @@ It is recommended that you store sensitive environment variables like your API k
 
 #### Required configuration
 
-- **Endpoint:** `https://trace.wandb.ai/otel/v1/traces`
+- **Endpoint:** `https://trace.wandb.ai/otel/v1/traces`. If you are using a dedicated Weave instance, the URL follows this pattern instead: `{YOUR_WEAVE_HOST}/traces/otel/v1/traces`
 - **Headers:**
   - `Authorization`: Basic auth using your W&B API key
   - `project_id`: Your W&B entity/project name (e.g., `myteam/myproject`)

--- a/docs/docs/guides/integrations/google_adk.md
+++ b/docs/docs/guides/integrations/google_adk.md
@@ -34,7 +34,7 @@ It is recommended that you store sensitive environment variables like your API k
 
 ### Required configuration
 
-- **Endpoint:** `https://trace.wandb.ai/otel/v1/traces`
+- **Endpoint:** `https://trace.wandb.ai/otel/v1/traces`. If you are using a dedicated Weave instance, the URL follows this pattern instead: `{YOUR_WEAVE_HOST}/traces/otel/v1/traces`
 - **Headers:**
   - `Authorization`: Basic auth using your W&B API key
   - `project_id`: Your W&B entity/project name (e.g., `myteam/myproject`)

--- a/docs/docs/guides/integrations/pydantic_ai.md
+++ b/docs/docs/guides/integrations/pydantic_ai.md
@@ -27,7 +27,7 @@ It is recommended that you store sensitive environment variables like your API k
 
 ### Required configuration
 
-- **Endpoint:** `https://trace.wandb.ai/otel/v1/traces`
+- **Endpoint:** `https://trace.wandb.ai/otel/v1/traces`. If you are using a dedicated Weave instance, the URL follows this pattern instead: `{YOUR_WEAVE_HOST}/traces/otel/v1/traces`
 - **Headers:**
   - `Authorization`: Basic auth using your W&B API key
   - `project_id`: Your W&B entity/project name (e.g., `myteam/myproject`)


### PR DESCRIPTION
## Description
Resolves DOCS-1748. Adds the URL pattern to a few integration docs that users need to use if they are trying to access traces from a dedicated instance.