### PR TITLE
feat(weave): user code can define custom content to display on a call page

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -9,6 +9,7 @@ import weave
 from weave.evaluation.eval_imperative import EvaluationLogger, Model, Scorer
 from weave.integrations.integration_utilities import op_name_from_call
 from weave.trace.context import call_context
+from weave.trace.serialization.serialize import to_json
 from weave.trace_server.trace_server_interface import ObjectVersionFilter
 
 
@@ -701,3 +702,41 @@ def test_evaluation_logger_with_predefined_scorers(client, caplog):
     # verify we can get the eval object separately by ref and see metadata
     eval_object = ev._pseudo_evaluation.ref.get()
     assert eval_object.metadata["scorers"] == ["accuracy", "precision"]
+
+
+def test_evaluation_logger_set_view(client):
+    """Ensure set_view stores content metadata on evaluation summary."""
+    ev = weave.EvaluationLogger()
+    content = weave.Content.from_text("# hello", mimetype="text/markdown")
+    content2 = weave.Content.from_text("<h1>hello world</h1>", mimetype="text/html")
+
+    ev.set_view("report", content)
+    ev.set_view("report2", content2)
+    ev.finish()
+    client.flush()
+
+    evaluate_call = client.get_calls()[0]
+    assert evaluate_call.summary["weave"] is not None
+    assert "views" in evaluate_call.summary["weave"]
+    views = evaluate_call.summary["weave"]["views"]
+    assert len(views) == 2
+    assert views["report"] == to_json(content, client._project_id(), client)
+    assert views["report2"] == to_json(content2, client._project_id(), client)
+
+
+def test_evaluation_logger_set_view_string(client):
+    """Ensure string inputs are accepted for evaluation views."""
+    ev = weave.EvaluationLogger()
+    ev.set_view("view", "<h1>Eval</h1>", extension="html")
+    ev.finish()
+    client.flush()
+
+    evaluate_call = client.get_calls()[0]
+    assert evaluate_call.summary
+    assert evaluate_call.summary["weave"] is not None
+    views = evaluate_call.summary["weave"]["views"]
+    stored = dict(views["view"])
+
+    assert stored["_type"] == "CustomWeaveType"
+    assert stored["weave_type"]["type"] == "weave.type_wrappers.Content.content.Content"
+    assert stored["files"]["content"]

--- a/tests/trace/test_current_call.py
+++ b/tests/trace/test_current_call.py
@@ -2,6 +2,7 @@ import pytest
 
 import weave
 from weave.trace.context import call_context
+from weave.trace.serialization.serialize import to_json
 from weave.trace.weave_client import RESERVED_SUMMARY_STATUS_COUNTS_KEY
 from weave.trace_server import trace_server_interface as tsi
 
@@ -69,3 +70,65 @@ def test_call_summary_deep_merge(client):
     summary = calls[0].summary
     assert summary["nested"]["foo"] == 1
     assert summary[RESERVED_SUMMARY_STATUS_COUNTS_KEY][tsi.TraceStatus.SUCCESS] == 1
+
+
+def test_set_view_inside_op(client):
+    """Verify weave.set_view stores serialized content on op call summary."""
+    markdown_view = weave.Content.from_text("# Report", mimetype="text/markdown")
+    html_view = weave.Content.from_text("<p>Hi</p>", mimetype="text/html")
+
+    @weave.op
+    def my_op_with_views() -> str:
+        """Op that attaches two views to its call summary.
+
+        Returns:
+            str: Constant string to keep output simple.
+
+        Examples:
+            >>> my_op_with_views()
+            'ok'
+        """
+        weave.set_view("markdown", markdown_view)
+        weave.set_view("html", html_view)
+        return "ok"
+
+    result = my_op_with_views()
+    assert result == "ok"
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.summary["weave"] is not None
+    assert "views" in call.summary["weave"]
+    views = call.summary["weave"]["views"]
+    assert len(views) == 2
+    assert views["markdown"] == to_json(
+        markdown_view,
+        client._project_id(),
+        client,
+    )
+    assert views["html"] == to_json(
+        html_view,
+        client._project_id(),
+        client,
+    )
+
+
+def test_set_view_string_content(client):
+    """Verify weave.set_view accepts raw string content."""
+
+    @weave.op
+    def op_with_string_view() -> None:
+        """Attach a markdown view using plain string input."""
+        weave.set_view("md", "# Report", extension="md")
+
+    op_with_string_view()
+
+    call = client.get_calls()[0]
+    assert call.summary["weave"] is not None
+    views = call.summary["weave"]["views"]
+    stored = dict(views["md"])
+
+    assert stored["_type"] == "CustomWeaveType"
+    assert stored["weave_type"]["type"] == "weave.type_wrappers.Content.content.Content"
+    assert stored["files"]["content"]

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -94,5 +94,6 @@ __all__ = [
     "publish",
     "ref",
     "require_current_call",
+    "set_view",
     "thread",
 ]

--- a/weave/trace/view_utils.py
+++ b/weave/trace/view_utils.py
@@ -1,0 +1,136 @@
+"""Utilities for attaching Content-backed views to trace calls."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from weave.trace.call import Call
+from weave.trace.serialization.serialize import to_json
+from weave.trace.weave_client import WeaveClient
+from weave.type_wrappers.Content.content import Content
+
+
+def resolve_view_content(
+    content: Content | str,
+    *,
+    extension: str | None = None,
+    mimetype: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    encoding: str = "utf-8",
+) -> Content:
+    """Return a ``weave.Content`` for the provided content input.
+
+    Args:
+        content: Either a preconstructed ``weave.Content`` instance or a text
+            string to encode as content.
+        extension: Optional file extension (e.g. ``"md"`` or ``".html"``)
+            used when the ``content`` argument is a string.
+        mimetype: Explicit MIME type override for string content.
+        metadata: Optional metadata to attach when constructing content from a
+            string.
+        encoding: Text encoding to use when converting string content.
+
+    Returns:
+        A ``weave.Content`` instance that can be serialized into the call
+        summary.
+
+    Raises:
+        TypeError: If ``content`` is neither a string nor a ``weave.Content``.
+
+    Examples:
+        >>> resolve_view_content("# Title", extension="md").mimetype
+        'text/markdown'
+    """
+    if isinstance(content, Content):
+        result = content
+    else:
+        result = Content._from_guess(
+            content,
+            extension=extension,
+            mimetype=mimetype,
+        )
+
+    updates: dict[str, Any] = {}
+    if metadata is not None:
+        updates["metadata"] = metadata
+    if encoding is not None:
+        updates["encoding"] = encoding
+
+    if len(updates) > 0:
+        result = result.model_copy(update=updates)
+
+    return result
+
+
+def set_call_view(
+    *,
+    call: Call,
+    client: WeaveClient,
+    name: str,
+    content: Content | str,
+    extension: str | None = None,
+    mimetype: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    encoding: str = "utf-8",
+) -> None:
+    """Attach serialized content to the provided call's summary under `weave.views`.
+
+    Args:
+        call: The call whose summary should receive the view entry.
+        client: The active ``WeaveClient`` used for serialization.
+        name: Key to store the view under within ``summary.weave.views``.
+        content: ``weave.Content`` or raw text to serialize into the view.
+        extension: Optional file extension used when converting text content.
+        mimetype: Optional MIME type applied when converting text content.
+        metadata: Optional metadata for newly created ``Content`` objects.
+        encoding: Encoding used when converting string content to bytes.
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If ``name`` is not a non-empty string.
+
+    Examples:
+        >>> from weave.trace.call import Call
+        >>> call = Call(None, "proj", None, {})  # doctest: +SKIP
+        >>> set_call_view(  # doctest: +SKIP
+        ...     call=call,
+        ...     client=client,
+        ...     name="report",
+        ...     content="<h1>Hello</h1>",
+        ...     extension="html",
+        ... )
+    """
+    content_obj = resolve_view_content(
+        content,
+        extension=extension,
+        mimetype=mimetype,
+        metadata=metadata,
+        encoding=encoding,
+    )
+
+    if call.summary is None:
+        call.summary = {}
+
+    summary = call.summary
+
+    weave_bucket = summary.get("weave")
+    if not isinstance(weave_bucket, dict):
+        weave_bucket = {}
+        summary["weave"] = weave_bucket
+
+    legacy_views = summary.get("views")
+    if isinstance(legacy_views, dict):
+        summary.pop("views", None)
+    views = weave_bucket.get("views")
+
+    if not isinstance(views, dict):
+        views = {}
+        weave_bucket["views"] = views
+
+    if isinstance(legacy_views, dict):
+        views.update(legacy_views)
+
+    project_id = client._project_id()
+    views[name] = to_json(content_obj, project_id, client, use_dictify=False)


### PR DESCRIPTION
## Description

Adds `weave.set_view` to the primary api. Adds `EvaluationLogger.set_view` to the imperative eval logger api.

The parameter and return signature is the same for both. They accept a view `name` and `weave.Content` to display.

Content is persisted to the file backend and the json manifest is dumped into `summary.weave.views.<view_name>`.

This frontend PR adds rendering for these custom views to a new default tab for the call page: https://github.com/wandb/core/pull/34732

## Testing

Added unit tests to verify the summary is populated with the `Content` json dump when called in an op or the imperative eval method, passed either by a `Content` object or a string with an extension or mimetype specified.
