### PR TITLE
fix(weave): better feedback field validation

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -726,7 +726,6 @@ def test_feedback_query_bad_json_path(client) -> None:
 
     # Try to query for a field that doesn't exist in the feedback table schema
     # "inputs" is not a valid column or JSON field in the feedback table
-    # This should now properly raise a ValueError due to the improved prefix validation
     with pytest.raises(ValueError, match="Unknown field: inputs.message_id"):
         client.server.feedback_query(
             FeedbackQueryReq(

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -722,7 +722,7 @@ def test_feedback_query_bad_json_path(client) -> None:
 
     # Add feedback with a known structure
     trace_object = client.get_call(call.id)
-    feedback_id = trace_object.feedback.add_note("test note")
+    trace_object.feedback.add_note("test note")
 
     # Try to query for a field that doesn't exist in the feedback table schema
     # "inputs" is not a valid column or JSON field in the feedback table

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -223,7 +223,10 @@ class Select:
     action: Action
 
     _project_id: typing.Optional[str]
+    # Fields from the user that must be transformed to internal field names
+    # like "inputs.my_field" or "payload.value"
     _fields: typing.Optional[list[str]]
+    # Fields that we have constructed internally, like cost query fields
     _raw_sql_fields: typing.Optional[list[str]]
     _query: typing.Optional[tsi.Query]
     _order_by: typing.Optional[list[tsi.SortBy]]

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -562,11 +562,14 @@ def _transform_external_field_to_internal_field(
         and field != "*"
         and field.lower() != "count(*)"
         and not any(
-            # Checks that a column is in the field, allows prefixed columns to be used
-            substr in unprefixed_field.lower()
-            for substr in all_columns
+            # Check if field starts with a valid column name as prefix
+            unprefixed_field.lower().startswith(col_name.lower() + ".")
+            for col_name in all_columns
         )
     ):
+        # add back table prefix when erroring
+        if table_prefix:
+            field = f"{table_prefix}.{field}"
         raise ValueError(f"Unknown field: {field}")
 
     raw_fields_used.add(unprefixed_field)

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -224,6 +224,7 @@ class Select:
 
     _project_id: typing.Optional[str]
     _fields: typing.Optional[list[str]]
+    _raw_sql_fields: typing.Optional[list[str]]
     _query: typing.Optional[tsi.Query]
     _order_by: typing.Optional[list[tsi.SortBy]]
     _limit: typing.Optional[int]
@@ -238,6 +239,7 @@ class Select:
 
         self._project_id = None
         self._fields = []
+        self._raw_sql_fields = []
         self._query = None
         self._order_by = None
         self._limit = None
@@ -258,6 +260,11 @@ class Select:
 
     def fields(self, fields: typing.Optional[list[str]]) -> "Select":
         self._fields = fields
+        return self
+
+    def raw_sql_fields(self, raw_fields: typing.Optional[list[str]]) -> "Select":
+        """Add raw SQL expressions that don't need external-to-internal field transformation."""
+        self._raw_sql_fields = raw_fields or []
         return self
 
     def where(self, query: typing.Optional[tsi.Query]) -> "Select":
@@ -312,6 +319,9 @@ class Select:
                 )[0]
                 for f in fieldnames
             ]
+            # Add raw SQL fields without transformation
+            if self._raw_sql_fields:
+                internal_fields.extend(self._raw_sql_fields)
             joined_fields = ", ".join(internal_fields)
             sql = f"SELECT {joined_fields}\n"
         elif self.action == "DELETE":

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -266,7 +266,13 @@ class Select:
         return self
 
     def raw_sql_fields(self, raw_fields: typing.Optional[list[str]]) -> "Select":
-        """Add raw SQL expressions that don't need external-to-internal field transformation."""
+        """Add raw SQL expressions that don't need external-to-internal field transformation.
+
+        Example: fields like cost query fields that are aggregations and custom-defined
+
+        Using raw_sql_fields cirucumvents some basic field validation, do not use
+           user-controlled fields without handling validation before adding.
+        """
         self._raw_sql_fields = raw_fields or []
         return self
 

--- a/weave/trace_server/token_costs.py
+++ b/weave/trace_server/token_costs.py
@@ -144,17 +144,20 @@ def get_llm_usage(param_builder: ParamBuilder, table_alias: str) -> PreparedSele
     completion_tokens = """if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'output_tokens')) AS completion_tokens"""
     total_tokens = "JSONExtractInt(kv.2, 'total_tokens') AS total_tokens"
 
-    select_query = all_calls_table.select().fields(
-        [
-            "*",
-            usage_raw,
-            kv,
-            llm_id,
-            requests,
-            prompt_tokens,
-            completion_tokens,
-            total_tokens,
-        ]
+    select_query = (
+        all_calls_table.select()
+        .fields(["*"])
+        .raw_sql_fields(
+            [
+                usage_raw,
+                kv,
+                llm_id,
+                requests,
+                prompt_tokens,
+                completion_tokens,
+                total_tokens,
+            ]
+        )
     )
 
     prepared_query = select_query.prepare(
@@ -239,7 +242,8 @@ def get_ranked_prices(
 
     select_query = (
         llm_usage_table.select()
-        .fields(["*", *ltp_fields, row_number_clause])
+        .fields(["*", *ltp_fields])
+        .raw_sql_fields([row_number_clause])
         .join(
             LLM_TOKEN_PRICES_TABLE,
             tsi.Query(
@@ -421,7 +425,8 @@ def final_call_select_with_cost(
 
     final_query = (
         ranked_price_table.select()
-        .fields([*final_select_fields, summary_dump_snippet])
+        .fields(final_select_fields)
+        .raw_sql_fields([summary_dump_snippet])
         .where(
             tsi.Query(**{"$expr": {"$eq": [{"$getField": "rank"}, {"$literal": 1}]}})
         )


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-27642](https://wandb.atlassian.net/browse/WB-27642)

Fixes bug in field validation logic that was allowing any param with a column substring to hit the db. 

To do so we needed to add a way of bypassing the `_transform_external_field_to_internal_field` which gets called on more than just external fields it turns out. All of the cost/token query fields are hitting this function, which really makes zero sense!

## Testing

add test 

and tested locally, costs appear fine:
<img width="673" height="808" alt="Screenshot 2025-09-25 at 9 13 34 AM" src="https://github.com/user-attachments/assets/6aae4886-43e0-4360-8de2-3c9f0a9aebf1" />



[WB-27642]: https://wandb.atlassian.net/browse/WB-27642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ