### PR TITLE
docs(weave): How to silence link printing using `.init()`

### DIFF
--- a/docs/docs/guides/core-types/env-vars.md
+++ b/docs/docs/guides/core-types/env-vars.md
@@ -22,7 +22,7 @@ os.environ["WEAVE_PRINT_CALL_LINK"] = "false"
 |----------|------|---------|-------------|
 | `WANDB_API_KEY` | `string` | `None` | If set, automatically log into W&B Weave without being prompted for your API key. To generate an API key, log in to your W&B account and go to [https://wandb.ai/authorize](https://wandb.ai/authorize). |
 | `WEAVE_DISABLED` | `bool` | `false` | When set to `true`, disables all Weave tracing. Weave ops will behave like regular functions. |
-| `WEAVE_PRINT_CALL_LINK` | `bool` | `true` | Controls whether to print a link to the Weave UI when calling a Weave op. |
+| `WEAVE_PRINT_CALL_LINK` | `bool` | `true` | Controls whether to print a link to the Weave UI when calling a Weave op. You can also set this directly in your code by configuring the `settings` argurment for `weave.init()` like this: `weave.init("your-project-name", settings={"print_call_link": False})` |
 | `WEAVE_LOG_LEVEL` | `str` | `INFO` | Controls the log level of the weave logger.
 | `WEAVE_CAPTURE_CODE` | `bool` | `true` | Controls whether to save code for ops so they can be reloaded for later use. |
 | `WEAVE_DEBUG_HTTP` | `bool` | `false` | When set to `true`, turns on HTTP request and response logging for debugging. |


### PR DESCRIPTION
Resolves [DOCS-1474](https://wandb.atlassian.net/browse/DOCS-1474). Updates the environment variables page with information about how to disable link printing using the equivalent `weave.init(settings)` argument.

[DOCS-1474]: https://wandb.atlassian.net/browse/DOCS-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ