### PR TITLE
feat(weave): Add settings flag to `LLMAsAJudgeScorer` for audio inclusion

### DIFF
--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -140,13 +140,14 @@ library_cases = [
             },
             {
                 "object_id": "LLMAsAJudgeScorer",
-                "digest": "uCyQ5g10zJ2wLecCEYNAfm45MbWH1823FJ6ZGv9Gpco",
+                "digest": "MSQK8lv8o63D3en3XvEkkTZqFXmFTc7usQ02zlKUWcE",
                 "exp_val": {
                     "_type": "LLMAsAJudgeScorer",
                     "name": None,
                     "description": None,
                     "column_map": None,
                     "model": "weave:///shawn/test-project/object/LLMStructuredCompletionModel:eZuAYazYqoSTeGwAR6G4e5RMQ1XEDo0AADq60hKTn9o",
+                    "include_audio_output": False,
                     "scoring_prompt": "Here are the inputs: {inputs}. Here is the output: {output}. Is the output correct?",
                     "score": "weave:///shawn/test-project/op/LLMAsAJudgeScorer.score:3DXMPEFwP04oJ362x6sxQIqQmVYYX2jB4Kg5EF2SF60",
                     "summarize": "weave:///shawn/test-project/op/Scorer.summarize:lMo39TTtMo50nRj7gWzUJUXXbuX3D3VXkRRMuOTdCHU",

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -81,7 +81,7 @@ library_cases = [
             "dataset": "weave:///shawn/test-project/object/Dataset:N0VKaX8wr9kF9QQzM7mSQz3yKrJJjTiJi4c9Bt7RSTA",
             "scorers": [
                 "weave:///shawn/test-project/object/MyScorer:K1OwZ5OGLRYNboUzGHPhnyR0W6PqWj431ieXWISYiyA",
-                "weave:///shawn/test-project/object/LLMAsAJudgeScorer:uCyQ5g10zJ2wLecCEYNAfm45MbWH1823FJ6ZGv9Gpco",
+                "weave:///shawn/test-project/object/LLMAsAJudgeScorer:MSQK8lv8o63D3en3XvEkkTZqFXmFTc7usQ02zlKUWcE",
             ],
             "preprocess_model_input": None,
             "trials": 1,

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -81,7 +81,7 @@ library_cases = [
             "dataset": "weave:///shawn/test-project/object/Dataset:N0VKaX8wr9kF9QQzM7mSQz3yKrJJjTiJi4c9Bt7RSTA",
             "scorers": [
                 "weave:///shawn/test-project/object/MyScorer:K1OwZ5OGLRYNboUzGHPhnyR0W6PqWj431ieXWISYiyA",
-                "weave:///shawn/test-project/object/LLMAsAJudgeScorer:uCyQ5g10zJ2wLecCEYNAfm45MbWH1823FJ6ZGv9Gpco",
+                "weave:///shawn/test-project/object/LLMAsAJudgeScorer:MSQK8lv8o63D3en3XvEkkTZqFXmFTc7usQ02zlKUWcE",
             ],
             "preprocess_model_input": None,
             "trials": 1,
@@ -140,7 +140,7 @@ library_cases = [
             },
             {
                 "object_id": "LLMAsAJudgeScorer",
-                "digest": "uCyQ5g10zJ2wLecCEYNAfm45MbWH1823FJ6ZGv9Gpco",
+                "digest": "MSQK8lv8o63D3en3XvEkkTZqFXmFTc7usQ02zlKUWcE",
                 "exp_val": {
                     "_type": "LLMAsAJudgeScorer",
                     "name": None,

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -73,7 +73,7 @@ library_cases = [
         id="Library Objects - Scorer, Evaluation, Dataset, LLMAsAJudgeScorer, LLMStructuredCompletionModel",
         runtime_object_factory=lambda: make_evaluation(),
         inline_call_param=False,
-        is_legacy=False,
+        is_legacy=True,
         exp_json={
             "_type": "Evaluation",
             "name": None,

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -81,7 +81,7 @@ library_cases = [
             "dataset": "weave:///shawn/test-project/object/Dataset:N0VKaX8wr9kF9QQzM7mSQz3yKrJJjTiJi4c9Bt7RSTA",
             "scorers": [
                 "weave:///shawn/test-project/object/MyScorer:K1OwZ5OGLRYNboUzGHPhnyR0W6PqWj431ieXWISYiyA",
-                "weave:///shawn/test-project/object/LLMAsAJudgeScorer:MSQK8lv8o63D3en3XvEkkTZqFXmFTc7usQ02zlKUWcE",
+                "weave:///shawn/test-project/object/LLMAsAJudgeScorer:uCyQ5g10zJ2wLecCEYNAfm45MbWH1823FJ6ZGv9Gpco",
             ],
             "preprocess_model_input": None,
             "trials": 1,
@@ -140,7 +140,7 @@ library_cases = [
             },
             {
                 "object_id": "LLMAsAJudgeScorer",
-                "digest": "MSQK8lv8o63D3en3XvEkkTZqFXmFTc7usQ02zlKUWcE",
+                "digest": "uCyQ5g10zJ2wLecCEYNAfm45MbWH1823FJ6ZGv9Gpco",
                 "exp_val": {
                     "_type": "LLMAsAJudgeScorer",
                     "name": None,

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -81,7 +81,7 @@ library_cases = [
             "dataset": "weave:///shawn/test-project/object/Dataset:N0VKaX8wr9kF9QQzM7mSQz3yKrJJjTiJi4c9Bt7RSTA",
             "scorers": [
                 "weave:///shawn/test-project/object/MyScorer:K1OwZ5OGLRYNboUzGHPhnyR0W6PqWj431ieXWISYiyA",
-                "weave:///shawn/test-project/object/LLMAsAJudgeScorer:MSQK8lv8o63D3en3XvEkkTZqFXmFTc7usQ02zlKUWcE",
+                "weave:///shawn/test-project/object/LLMAsAJudgeScorer:xYbeX9MvQj7UKXa9zb61Oa6lSvb9DydZmdYagYiYKSU",
             ],
             "preprocess_model_input": None,
             "trials": 1,
@@ -140,7 +140,7 @@ library_cases = [
             },
             {
                 "object_id": "LLMAsAJudgeScorer",
-                "digest": "MSQK8lv8o63D3en3XvEkkTZqFXmFTc7usQ02zlKUWcE",
+                "digest": "xYbeX9MvQj7UKXa9zb61Oa6lSvb9DydZmdYagYiYKSU",
                 "exp_val": {
                     "_type": "LLMAsAJudgeScorer",
                     "name": None,

--- a/weave/scorers/llm_as_a_judge_scorer.py
+++ b/weave/scorers/llm_as_a_judge_scorer.py
@@ -12,6 +12,7 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 class LLMAsAJudgeScorer(Scorer):
     model: LLMStructuredCompletionModel
     scoring_prompt: str
+    include_op_audio_output: bool = False
 
     @op
     def score(self, *, output: str, **kwargs: Any) -> Any:

--- a/weave/scorers/llm_as_a_judge_scorer.py
+++ b/weave/scorers/llm_as_a_judge_scorer.py
@@ -12,7 +12,7 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 class LLMAsAJudgeScorer(Scorer):
     model: LLMStructuredCompletionModel
     scoring_prompt: str
-    include_call_audio_output: bool = False
+    include_audio_output: bool = False
 
     @op
     def score(self, *, output: str, **kwargs: Any) -> Any:

--- a/weave/scorers/llm_as_a_judge_scorer.py
+++ b/weave/scorers/llm_as_a_judge_scorer.py
@@ -12,7 +12,7 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 class LLMAsAJudgeScorer(Scorer):
     model: LLMStructuredCompletionModel
     scoring_prompt: str
-    include_op_audio_output: bool = False
+    include_call_audio_output: bool = False
 
     @op
     def score(self, *, output: str, **kwargs: Any) -> Any:


### PR DESCRIPTION
## Description

This PR adds a settings flag to `LLMAsAJudgeScorer`. The `inclue_audio_output` is used by `scoring_worker.py` to determine whether to include any audio output of the scored call in the scoring completion request.

Associated core PR: https://github.com/wandb/core/pull/34747

## Testing

How was this PR tested?

Local dev and QA.