### PR TITLE
Griffin/fix bufstream producer errors

### DIFF
--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -47,7 +47,11 @@ class KafkaProducer(ConfluentKafkaProducer):
         config = {
             "bootstrap.servers": _make_broker_host(),
             "client.id": socket.gethostname(),
-            "message.timeout.ms": 500,
+            "retries": 1,
+            "retry.backoff.ms": 100,
+            # this is large to accommodate large call batches, with only 1
+            # retry to prevent continued failures when timeout is due to size
+            "request.timeout.ms": 5000,  # per attempt deadline
             **_make_auth_config(),
             **additional_kafka_config,
         }

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -44,14 +44,22 @@ class KafkaProducer(ConfluentKafkaProducer):
         if additional_kafka_config is None:
             additional_kafka_config = {}
 
+        num_retries = 1
+        request_retry_backoff_ms = 100
+        # per attempt deadline, this is large to accommodate large call batches,
+        # with only 1 retry to prevent continued failures when timeout is due to size
+        request_timeout_ms = 5000
+        # worst case total request time hardcap
+        total_timeout_ms = (
+            request_timeout_ms * (num_retries + 1) + request_retry_backoff_ms
+        )
         config = {
             "bootstrap.servers": _make_broker_host(),
             "client.id": socket.gethostname(),
+            "request.timeout.ms": request_timeout_ms,
+            "message.timeout.ms": total_timeout_ms,
             "retries": 1,
-            "retry.backoff.ms": 100,
-            # this is large to accommodate large call batches, with only 1
-            # retry to prevent continued failures when timeout is due to size
-            "request.timeout.ms": 5000,  # per attempt deadline
+            "retry.backoff.ms": request_retry_backoff_ms,
             **_make_auth_config(),
             **additional_kafka_config,
         }


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->


Example [error logs](https://us5.datadoghq.com/logs?query=-source%3Acloudrun%20-%22GET%20%2A%22%20-%22POST%20%2A%22%20-%22OPTIONS%20%2A%22%20service%3Aweave-trace%20env%3Aprod%20status%3Aerror&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1750786916902&to_ts=1750787816902&live=true) in prod. We currently have an "extremely aggressive" (according to chat5) timeout on the bufstream producer in prod, which fails to flush large call batches. Despite the `500ms` timeout, we retry up to at least 5 times. Lets increase the timeout considerably, and lower the retries to just 1 retry. 

## Testing

Locally, with existing impl:
```bash
>>>> _insert_complete_calls_batch 993
%5|1759429032.752|REQTMOUT|Griffin-Tarpenning-LQLGY47606#producer-4| [thrd:LOCalHoST:9092/1257328465]: LOCalHoST:9092/1257328465: Timed out ProduceRequest in flight (after 826ms, timeout #0)
%5|1759429032.752|REQTMOUT|Griffin-Tarpenning-LQLGY47606#producer-4| [thrd:LOCalHoST:9092/1257328465]: LOCalHoST:9092/1257328465: Timed out ProduceRequest in flight (after 820ms, timeout #1)
%5|1759429032.752|REQTMOUT|Griffin-Tarpenning-LQLGY47606#producer-4| [thrd:LOCalHoST:9092/1257328465]: LOCalHoST:9092/1257328465: Timed out ProduceRequest in flight (after 815ms, timeout #2)
%5|1759429032.752|REQTMOUT|Griffin-Tarpenning-LQLGY47606#producer-4| [thrd:LOCalHoST:9092/1257328465]: LOCalHoST:9092/1257328465: Timed out ProduceRequest in flight (after 809ms, timeout #3)
%5|1759429032.752|REQTMOUT|Griffin-Tarpenning-LQLGY47606#producer-4| [thrd:LOCalHoST:9092/1257328465]: LOCalHoST:9092/1257328465: Timed out ProduceRequest in flight (after 804ms, timeout #4)
%4|1759429032.752|REQTMOUT|Griffin-Tarpenning-LQLGY47606#producer-4| [thrd:LOCalHoST:9092/1257328465]: LOCalHoST:9092/1257328465: Timed out 16 in-flight, 0 retry-queued, 0 out-queue, 0 partially-sent requests
%3|1759429032.752|FAIL|Griffin-Tarpenning-LQLGY47606#producer-4| [thrd:LOCalHoST:9092/1257328465]: LOCalHoST:9092/1257328465: 16 request(s) timed out: disconnect (average rtt 481.117ms) (after 1016ms in state UP)
```

Then with increased timeout, no failed produces. 