### PR TITLE
docs(weave): fix OpenRouter name

### DIFF
--- a/docs/docs/guides/integrations/index.md
+++ b/docs/docs/guides/integrations/index.md
@@ -63,7 +63,7 @@ LLM providers are the vendors that offer access to large language models for gen
 - **[MistralAI](/guides/integrations/mistral)**
 - **[NVIDIA NIM](/guides/integrations/nvidia_nim)**
 - **[OpenAI](/guides/integrations/openai)**
-- **[Open Router](/guides/integrations/openrouter)**
+- **[OpenRouter](/guides/integrations/openrouter)**
 - **[Together AI](/guides/integrations/together_ai)**
 
 **[Local Models](/guides/integrations/local_models)**: For when you're running models on your own infrastructure.

--- a/docs/docs/guides/integrations/openrouter.md
+++ b/docs/docs/guides/integrations/openrouter.md
@@ -1,12 +1,12 @@
-# Open Router
+# OpenRouter
 
 import DefaultEntityNote from '../../../src/components/DefaultEntityNote.mdx';
 
 Openrouter.ai is a unified interface for many LLMs, supporting both foundational models like OpenAI GPT-4, Anthropic Claude, Google Gemini but also open source models like LLama-3, Mixtral and [many more](https://openrouter.ai/models), some models are even offered for free. 
 
-Open Router offers a Rest API and an OpenAI SDK compatibility ([docs](https://docs.together.ai/docs/openai-api-compatibility)) which Weave automatically detects and integrates with (see Open Router [quick start](https://openrouter.ai/docs/quick-start) for more details).
+OpenRouter offers a Rest API and an OpenAI SDK compatibility ([docs](https://docs.together.ai/docs/openai-api-compatibility)) which Weave automatically detects and integrates with (see OpenRouter [quick start](https://openrouter.ai/docs/quick-start) for more details).
 
-To switch your OpenAI SDK code to Open Router, switch out the API key to your [Open Router API](https://openrouter.ai/docs/api-keys) key, `base_url` to `https://openrouter.ai/api/v1`, and model to one of their many [chat models](https://openrouter.ai/docs/models). When you call `weave.init()`, provide a project name for your traces. <DefaultEntityNote variant="inline" />
+To switch your OpenAI SDK code to OpenRouter, switch out the API key to your [OpenRouter API](https://openrouter.ai/docs/api-keys) key, `base_url` to `https://openrouter.ai/api/v1`, and model to one of their many [chat models](https://openrouter.ai/docs/models). When you call `weave.init()`, provide a project name for your traces. <DefaultEntityNote variant="inline" />
 
 ```python
 import os


### PR DESCRIPTION
## Description

The proper name for this company is "OpenRouter" without a space.
https://openrouter.ai/about

## Testing

yarn start