### PR TITLE
Griffin/custom wb stats query

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -3923,3 +3923,33 @@ def test_table_create_from_digests(network_proxy_client):
     assert shuffled_res.digest != original_digest, (
         f"Different row order should produce different digest: {shuffled_res.digest} vs {original_digest}"
     )
+
+
+def test_calls_query_with_wb_run_id_not_null(client, monkeypatch):
+    """Test optimized stats query for wb_run_id not null."""
+    # Mock wandb to simulate a run
+    import weave.trace.weave_client as wc
+
+    mock_run_id = "entity/project/test_run_123"
+    monkeypatch.setattr(wc, "safe_current_wb_run_id", lambda: mock_run_id)
+
+    @weave.op
+    def test_op(x: int) -> int:
+        return x * 2
+
+    # Create a call with wb_run_id
+    test_op(5)
+    client.flush()
+
+    # Query for calls with wb_run_id not null using limit=1 to trigger optimization
+    query = tsi.Query(
+        **{
+            "$expr": {
+                "$not": [{"$eq": [{"$getField": "wb_run_id"}, {"$literal": None}]}]
+            }
+        }
+    )
+    calls = list(client.get_calls(query=query, limit=1))
+
+    assert len(calls) == 1
+    assert calls[0].wb_run_id == mock_run_id

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1689,7 +1689,6 @@ def optimized_wb_run_id_not_null_query(
             WHERE calls_merged.project_id = {param_slot(project_id_param, "String")}
                 AND calls_merged.wb_run_id IS NOT NULL
                 AND calls_merged.deleted_at IS NULL
-                AND calls_merged.started_at IS NOT NULL
             LIMIT 1
         )
     """
@@ -1710,9 +1709,7 @@ def try_optimized_stats_query(
         and req.query is None
         and not req.include_total_storage_size
     ):
-        return optimized_project_contains_call_query(
-            req.project_id, param_builder, table_name="calls_complete"
-        )
+        return optimized_project_contains_call_query(req.project_id, param_builder)
 
     # Pattern 2: Query with wb_run_id check (limit=1, query present, minimal filter)
     # Covers common case: checking for runs with wb_run_id not null

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -40,7 +40,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     QueryBuilderField,
     build_calls_query_stats_query,
     combine_conditions,
-    optimized_project_contains_call_query,
+    try_optimized_stats_query,
 )
 from weave.trace_server.clickhouse_schema import (
     ALL_CALL_INSERT_COLUMNS,
@@ -339,25 +339,17 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
         """
         pb = ParamBuilder()
 
-        # Special case when limit=1 and there is no filter or query,
-        # construct highly optimized query that returns early
-        if (
-            req.limit == 1
-            and req.filter is None
-            and req.query is None
-            and not req.include_total_storage_size
-        ):
-            query = optimized_project_contains_call_query(req.project_id, pb)
-            raw_res = self._query(query, pb.get_params())
-            rows = raw_res.result_rows
-            count = rows[0][0]
+        # Try optimized special case queries first
+        if opt_query := try_optimized_stats_query(req, pb):
+            raw_res = self._query(opt_query, pb.get_params())
+            count = raw_res.result_rows[0][0] if raw_res.result_rows else 0
             return tsi.CallsQueryStatsRes(
                 count=count,
                 total_storage_size_bytes=None,
             )
 
+        # Fall back to general query
         query, columns = build_calls_query_stats_query(req, pb)
-
         raw_res = self._query(query, pb.get_params())
 
         res_dict = (


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-28058](https://wandb.atlassian.net/browse/WB-28058)

This is technically not correct, and will not filter out deleted rows that have not been properly aggregated in the background by clickhouse. However, because this is already just a rough heuristic, I think it's way better to be fast and right 99% of the time instead of always slow. 

## Testing

adds test
