### PR TITLE
chore(weave): Pin pydantic to unblock CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = ["version"]
 dependencies = [
   "wandb>=0.17.1",
   "sentry-sdk>=2.0.0,<3.0.0",
-  "pydantic>=2.0.0",
+  "pydantic>=2.0.0,<2.12.0",
   "packaging>=21.0",          # For version parsing in integrations
   "tenacity>=8.3.0,!=8.4.0",  # Excluding 8.4.0 because it had a bug on import of AsyncRetrying
   "click",                    # Used for terminal/stdio printing


### PR DESCRIPTION
Pins `pydantic<2.12.0` as the latest version seems to break a lot of things