### PR TITLE
feat(weave): Add new CRUD endpoints for interacting with Ops

### DIFF
--- a/tests/trace/test_server_object_creation_utils.py
+++ b/tests/trace/test_server_object_creation_utils.py
@@ -1,0 +1,26 @@
+"""Tests for object_creation_utils.py utilities.
+
+These tests verify that the helper functions serialize objects in the same way
+as the SDK.  Ideally they would be placed next to the trace_server tests, but
+the client serialization requires a client object to serialize.
+"""
+
+import weave
+from weave.trace.serialization.serialize import to_json
+from weave.trace.weave_client import WeaveClient
+from weave.trace_server import object_creation_utils
+
+
+def test_helper_serializes_op_same_way_as_sdk(client: WeaveClient) -> None:
+    """Test that helpers serialize an Op the same way as SDK."""
+
+    @weave.op
+    def test_op(x: int) -> int:
+        return x + 1
+
+    # Serialize the Op using the SDK's to_json function
+    sdk_val = to_json(test_op, client._project_id(), client)
+    helper_val = object_creation_utils.build_op_val(
+        sdk_val["files"][object_creation_utils.OP_SOURCE_FILE_NAME]
+    )
+    assert helper_val == sdk_val

--- a/tests/trace_server/test_op_v2_api.py
+++ b/tests/trace_server/test_op_v2_api.py
@@ -1,0 +1,440 @@
+"""Tests for Op V2 API endpoints.
+
+Tests verify that the Op V2 API correctly creates, reads, lists, and deletes op objects.
+"""
+
+import pytest
+
+from tests.trace_server.conftest import TEST_ENTITY
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.errors import NotFoundError, ObjectDeletedError
+
+
+def test_op_create_v2_basic(trace_server):
+    """Test creating a basic op object."""
+    project_id = f"{TEST_ENTITY}/test_op_create_v2_basic"
+
+    # Create an op
+    create_req = tsi.OpCreateV2Req(
+        project_id=project_id,
+        name="my_function",
+        description=None,
+        source_code="def my_function(x: int) -> int:\n    return x * 2",
+    )
+    create_res = trace_server.op_create_v2(create_req)
+
+    assert create_res.digest is not None
+    assert create_res.object_id == "my_function"
+    assert create_res.version_index == 0
+
+
+def test_op_create_v2_without_source_code(trace_server):
+    """Test creating an op without providing source code (uses placeholder)."""
+    project_id = f"{TEST_ENTITY}/test_op_create_v2_no_source"
+
+    # Create an op without source code
+    create_req = tsi.OpCreateV2Req(
+        project_id=project_id,
+        name="my_op_no_source",
+        description=None,
+        source_code=None,
+    )
+    create_res = trace_server.op_create_v2(create_req)
+
+    assert create_res.digest is not None
+    assert create_res.object_id == "my_op_no_source"
+    assert create_res.version_index == 0
+
+
+def test_op_read_v2_basic(trace_server):
+    """Test reading a specific op object."""
+    project_id = f"{TEST_ENTITY}/test_op_read_v2_basic"
+
+    # Create an op
+    source_code = "def read_test(x: int) -> int:\n    return x + 1"
+    create_req = tsi.OpCreateV2Req(
+        project_id=project_id,
+        name="read_test",
+        description=None,
+        source_code=source_code,
+    )
+    create_res = trace_server.op_create_v2(create_req)
+
+    # Read the op back
+    read_req = tsi.OpReadV2Req(
+        project_id=project_id,
+        object_id="read_test",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.op_read_v2(read_req)
+
+    assert read_res.object_id == "read_test"
+    assert read_res.digest == create_res.digest
+    assert read_res.version_index == 0
+    assert read_res.code == source_code
+    assert read_res.created_at is not None
+
+
+def test_op_read_v2_not_found(trace_server):
+    """Test reading a non-existent op raises NotFoundError."""
+    project_id = f"{TEST_ENTITY}/test_op_read_v2_not_found"
+
+    read_req = tsi.OpReadV2Req(
+        project_id=project_id,
+        object_id="nonexistent_op",
+        digest="fake_digest_1234567890",
+    )
+
+    with pytest.raises(NotFoundError):
+        trace_server.op_read_v2(read_req)
+
+
+def test_op_list_v2_basic(trace_server):
+    """Test listing all ops in a project."""
+    project_id = f"{TEST_ENTITY}/test_op_list_v2_basic"
+
+    # Create multiple ops
+    op_names = ["op_a", "op_b", "op_c"]
+    for name in op_names:
+        create_req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name=name,
+            description=None,
+            source_code=f"def {name}():\n    pass",
+        )
+        trace_server.op_create_v2(create_req)
+
+    # List all ops
+    list_req = tsi.OpListV2Req(project_id=project_id)
+    ops = list(trace_server.op_list_v2(list_req))
+
+    assert len(ops) == 3
+    op_names_returned = {op.object_id for op in ops}
+    assert op_names_returned == {"op_a", "op_b", "op_c"}
+
+    # Verify all ops have code loaded
+    for op in ops:
+        assert op.code
+        assert "def " in op.code
+        assert op.created_at is not None
+
+
+def test_op_list_v2_with_limit(trace_server):
+    """Test listing ops with a limit."""
+    project_id = f"{TEST_ENTITY}/test_op_list_v2_limit"
+
+    # Create multiple ops
+    for i in range(5):
+        create_req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name=f"op_{i}",
+            description=None,
+            source_code=f"def op_{i}():\n    pass",
+        )
+        trace_server.op_create_v2(create_req)
+
+    # List with a limit
+    list_req = tsi.OpListV2Req(project_id=project_id, limit=3)
+    ops = list(trace_server.op_list_v2(list_req))
+
+    assert len(ops) == 3
+
+
+def test_op_list_v2_with_offset(trace_server):
+    """Test listing ops with an offset."""
+    project_id = f"{TEST_ENTITY}/test_op_list_v2_offset"
+
+    # Create multiple ops
+    for i in range(5):
+        create_req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name=f"op_{i}",
+            description=None,
+            source_code=f"def op_{i}():\n    pass",
+        )
+        trace_server.op_create_v2(create_req)
+
+    # List with an offset
+    list_req = tsi.OpListV2Req(project_id=project_id, offset=2)
+    ops = list(trace_server.op_list_v2(list_req))
+
+    assert len(ops) == 3
+
+
+def test_op_list_v2_with_limit_and_offset(trace_server):
+    """Test listing ops with both limit and offset for pagination."""
+    project_id = f"{TEST_ENTITY}/test_op_list_v2_pagination"
+
+    # Create multiple ops
+    for i in range(10):
+        create_req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name=f"op_{i}",
+            description=None,
+            source_code=f"def op_{i}():\n    pass",
+        )
+        trace_server.op_create_v2(create_req)
+
+    # First page
+    list_req1 = tsi.OpListV2Req(project_id=project_id, limit=3, offset=0)
+    ops1 = list(trace_server.op_list_v2(list_req1))
+    assert len(ops1) == 3
+
+    # Second page
+    list_req2 = tsi.OpListV2Req(project_id=project_id, limit=3, offset=3)
+    ops2 = list(trace_server.op_list_v2(list_req2))
+    assert len(ops2) == 3
+
+    # Verify different ops on different pages
+    ops1_ids = {op.object_id for op in ops1}
+    ops2_ids = {op.object_id for op in ops2}
+    assert len(ops1_ids & ops2_ids) == 0  # No overlap
+
+
+def test_op_list_v2_empty_project(trace_server):
+    """Test listing ops in a project with no ops."""
+    project_id = f"{TEST_ENTITY}/test_op_list_v2_empty"
+
+    list_req = tsi.OpListV2Req(project_id=project_id)
+    ops = list(trace_server.op_list_v2(list_req))
+
+    assert len(ops) == 0
+
+
+def test_op_delete_v2_single_version(trace_server):
+    """Test deleting a single version of an op."""
+    project_id = f"{TEST_ENTITY}/test_op_delete_v2_single"
+
+    # Create an op
+    create_req = tsi.OpCreateV2Req(
+        project_id=project_id,
+        name="delete_test",
+        description=None,
+        source_code="def delete_test():\n    pass",
+    )
+    create_res = trace_server.op_create_v2(create_req)
+
+    # Delete the specific version
+    delete_req = tsi.OpDeleteV2Req(
+        project_id=project_id,
+        object_id="delete_test",
+        digests=[create_res.digest],
+    )
+    delete_res = trace_server.op_delete_v2(delete_req)
+
+    assert delete_res.num_deleted == 1
+
+    # Verify the op is deleted (should raise ObjectDeletedError)
+    read_req = tsi.OpReadV2Req(
+        project_id=project_id,
+        object_id="delete_test",
+        digest=create_res.digest,
+    )
+    with pytest.raises(ObjectDeletedError):
+        trace_server.op_read_v2(read_req)
+
+
+def test_op_delete_v2_all_versions(trace_server):
+    """Test deleting all versions of an op (no digests specified)."""
+    project_id = f"{TEST_ENTITY}/test_op_delete_v2_all"
+
+    # Create multiple versions of the same op
+    digests = []
+    for i in range(3):
+        create_req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name="versioned_op",
+            description=None,
+            source_code=f"def versioned_op():\n    return {i}",
+        )
+        create_res = trace_server.op_create_v2(create_req)
+        digests.append(create_res.digest)
+
+    # Delete all versions (no digests specified)
+    delete_req = tsi.OpDeleteV2Req(
+        project_id=project_id,
+        object_id="versioned_op",
+        digests=None,
+    )
+    delete_res = trace_server.op_delete_v2(delete_req)
+
+    assert delete_res.num_deleted == 3
+
+
+def test_op_delete_v2_multiple_versions(trace_server):
+    """Test deleting multiple specific versions of an op."""
+    project_id = f"{TEST_ENTITY}/test_op_delete_v2_multiple"
+
+    # Create multiple versions
+    digests = []
+    for i in range(4):
+        create_req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name="multi_version_op",
+            description=None,
+            source_code=f"def multi_version_op():\n    return {i}",
+        )
+        create_res = trace_server.op_create_v2(create_req)
+        digests.append(create_res.digest)
+
+    # Delete the first two versions
+    delete_req = tsi.OpDeleteV2Req(
+        project_id=project_id,
+        object_id="multi_version_op",
+        digests=digests[:2],
+    )
+    delete_res = trace_server.op_delete_v2(delete_req)
+
+    assert delete_res.num_deleted == 2
+
+    # Verify the first two are deleted
+    for digest in digests[:2]:
+        read_req = tsi.OpReadV2Req(
+            project_id=project_id,
+            object_id="multi_version_op",
+            digest=digest,
+        )
+        with pytest.raises(ObjectDeletedError):
+            trace_server.op_read_v2(read_req)
+
+    # Verify the last two still exist
+    for digest in digests[2:]:
+        read_req = tsi.OpReadV2Req(
+            project_id=project_id,
+            object_id="multi_version_op",
+            digest=digest,
+        )
+        read_res = trace_server.op_read_v2(read_req)
+        assert read_res.digest == digest
+
+
+def test_op_delete_v2_not_found(trace_server):
+    """Test deleting a non-existent op raises NotFoundError."""
+    project_id = f"{TEST_ENTITY}/test_op_delete_v2_not_found"
+
+    delete_req = tsi.OpDeleteV2Req(
+        project_id=project_id,
+        object_id="nonexistent_op",
+        digests=["fake_digest"],
+    )
+
+    with pytest.raises(NotFoundError):
+        trace_server.op_delete_v2(delete_req)
+
+
+def test_op_versioning(trace_server):
+    """Test that creating multiple versions of an op increments version_index."""
+    project_id = f"{TEST_ENTITY}/test_op_versioning"
+
+    # Create multiple versions of the same op
+    versions = []
+    for i in range(3):
+        create_req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name="versioned_function",
+            description=None,
+            source_code=f"def versioned_function():\n    return {i}",
+        )
+        create_res = trace_server.op_create_v2(create_req)
+        versions.append(create_res)
+
+    # Verify version indices increment
+    assert versions[0].version_index == 0
+    assert versions[1].version_index == 1
+    assert versions[2].version_index == 2
+
+    # Verify all versions are distinct
+    assert len({v.digest for v in versions}) == 3
+
+
+def test_op_code_with_special_characters(trace_server):
+    """Test creating and reading an op with special characters in source code."""
+    project_id = f"{TEST_ENTITY}/test_op_special_chars"
+
+    # Create an op with special characters
+    source_code = """def special_function(x: str) -> str:
+    '''This function has "quotes" and 'apostrophes'.'''
+    return f"Result: {x} with special chars: \n\t\r"
+"""
+    create_req = tsi.OpCreateV2Req(
+        project_id=project_id,
+        name="special_function",
+        description=None,
+        source_code=source_code,
+    )
+    create_res = trace_server.op_create_v2(create_req)
+
+    # Read it back and verify the code is preserved
+    read_req = tsi.OpReadV2Req(
+        project_id=project_id,
+        object_id="special_function",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.op_read_v2(read_req)
+
+    assert read_res.code == source_code
+
+
+def test_op_code_with_unicode(trace_server):
+    """Test creating and reading an op with unicode characters in source code."""
+    project_id = f"{TEST_ENTITY}/test_op_unicode"
+
+    # Create an op with unicode
+    source_code = """def unicode_function():
+    '''This function has unicode: 你好世界 🚀 café'''
+    return "unicode test"
+"""
+    create_req = tsi.OpCreateV2Req(
+        project_id=project_id,
+        name="unicode_function",
+        description=None,
+        source_code=source_code,
+    )
+    create_res = trace_server.op_create_v2(create_req)
+
+    # Read it back and verify the unicode is preserved
+    read_req = tsi.OpReadV2Req(
+        project_id=project_id,
+        object_id="unicode_function",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.op_read_v2(read_req)
+
+    assert read_res.code == source_code
+    assert "你好世界" in read_res.code
+    assert "🚀" in read_res.code
+    assert "café" in read_res.code
+
+
+def test_op_list_after_deletion(trace_server):
+    """Test that deleted ops don't appear in list results."""
+    project_id = f"{TEST_ENTITY}/test_op_list_after_deletion"
+
+    # Create three ops
+    op_names = ["op_keep_1", "op_delete", "op_keep_2"]
+    digests = {}
+    for name in op_names:
+        create_req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name=name,
+            description=None,
+            source_code=f"def {name}():\n    pass",
+        )
+        create_res = trace_server.op_create_v2(create_req)
+        digests[name] = create_res.digest
+
+    # Delete one op
+    delete_req = tsi.OpDeleteV2Req(
+        project_id=project_id,
+        object_id="op_delete",
+        digests=None,
+    )
+    trace_server.op_delete_v2(delete_req)
+
+    # List ops - should only see the two that weren't deleted
+    list_req = tsi.OpListV2Req(project_id=project_id)
+    ops = list(trace_server.op_list_v2(list_req))
+
+    op_names_returned = {op.object_id for op in ops}
+    assert op_names_returned == {"op_keep_1", "op_keep_2"}
+    assert "op_delete" not in op_names_returned

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1700,9 +1700,9 @@ class WeaveClient:
                 if hasattr(server, "_next_trace_server"):
                     server = server._next_trace_server
 
-                assert hasattr(server, "_generic_request_executor")
-                assert hasattr(server._generic_request_executor, "__wrapped__")
-                return server._generic_request_executor.__wrapped__(
+                assert hasattr(server, "_post_request_executor")
+                assert hasattr(server._post_request_executor, "__wrapped__")
+                return server._post_request_executor.__wrapped__(
                     server, "/table/create_from_digests", req
                 )
 

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -13,7 +13,9 @@ from weave.trace import (
 )
 from weave.trace.context import weave_client_context as weave_client_context
 from weave.trace.settings import should_redact_pii, use_server_cache
-from weave.trace_server.trace_server_interface import TraceServerInterface
+from weave.trace_server.trace_server_interface import (
+    FullTraceServerInterface,
+)
 from weave.trace_server_bindings import remote_http_trace_server
 from weave.trace_server_bindings.caching_middleware_trace_server import (
     CachingMiddlewareTraceServer,
@@ -137,7 +139,7 @@ def init_weave(
         raise RuntimeError(
             "Weave is not available on the server.  Please contact support."
         )
-    server: TraceServerInterface = remote_server
+    server: FullTraceServerInterface = remote_server
     if use_server_cache():
         server = CachingMiddlewareTraceServer.from_env(server)
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -22,10 +22,17 @@ from clickhouse_connect.driver.summary import QuerySummary
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import (
     ExportTraceServiceRequest,
 )
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
 
 from weave.trace_server import clickhouse_trace_server_migrator as wf_migrator
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import environment as wf_env
+from weave.trace_server import object_creation_utils
 from weave.trace_server import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.actions_worker.dispatcher import execute_batch
@@ -157,7 +164,7 @@ logger.setLevel(logging.INFO)
 _CH_POOL_MANAGER = get_pool_manager(maxsize=50, num_pools=2)
 
 
-class ClickHouseTraceServer(tsi.TraceServerInterface):
+class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def __init__(
         self,
         *,
@@ -1264,6 +1271,255 @@ class ClickHouseTraceServer(tsi.TraceServerInterface):
                 p50_turn_duration_ms=p50_turn_duration_ms,
                 p99_turn_duration_ms=p99_turn_duration_ms,
             )
+
+    def op_create_v2(self, req: tsi.OpCreateV2Req) -> tsi.OpCreateV2Res:
+        """Create an op object by delegating to obj_create.
+
+        Args:
+            req: OpCreateV2Req containing project_id, name, description, and source_code
+
+        Returns:
+            OpCreateV2Res with digest, object_id, version_index, and op_ref
+        """
+        # Create the obj.py file that the SDK would have created
+        source_code = req.source_code or object_creation_utils.PLACEHOLDER_OP_SOURCE
+        source_file_req = tsi.FileCreateReq(
+            project_id=req.project_id,
+            name=object_creation_utils.OP_SOURCE_FILE_NAME,
+            content=source_code.encode("utf-8"),
+        )
+        source_file_res = self.file_create(source_file_req)
+
+        # Create the op "val" that the SDK would have created
+        # Note: We store just the digest string, matching SDK's to_json output
+        op_val = object_creation_utils.build_op_val(source_file_res.digest)
+        obj_req = tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=req.project_id,
+                object_id=req.name,
+                val=op_val,
+                wb_user_id=None,
+            )
+        )
+        obj_result = self.obj_create(obj_req)
+
+        # Query the object back to get its version index (this may not be
+        # immediately available, so we retry a few times)
+        obj_read_req = tsi.ObjReadReq(
+            project_id=req.project_id,
+            object_id=req.name,
+            digest=obj_result.digest,
+        )
+        obj_read_res = self._obj_read_with_retry(obj_read_req)
+
+        return tsi.OpCreateV2Res(
+            digest=obj_result.digest,
+            object_id=req.name,
+            version_index=obj_read_res.obj.version_index,
+        )
+
+    def op_read_v2(self, req: tsi.OpReadV2Req) -> tsi.OpReadV2Res:
+        """Get a specific op object by delegating to obj_read with op filtering.
+
+        Returns the actual source code of the op.
+        """
+        # Query for the ops
+        object_query_builder = ObjectMetadataQueryBuilder(req.project_id)
+        object_query_builder.add_is_op_condition(True)
+        object_query_builder.add_object_ids_condition([req.object_id])
+        object_query_builder.add_digests_conditions(req.digest)
+        object_query_builder.set_include_deleted(include_deleted=True)
+        objs = self._select_objs_query(object_query_builder)
+        if len(objs) == 0:
+            raise NotFoundError(f"Op {req.object_id}:{req.digest} not found")
+
+        # There should not be multiple ops returned, but in case there are, just
+        # return the first one.
+        obj = objs[0]
+        if obj.deleted_at is not None:
+            raise ObjectDeletedError(
+                f"Op {req.object_id}:v{obj.version_index} was deleted at {obj.deleted_at}",
+                deleted_at=obj.deleted_at,
+            )
+
+        # For ops, the object_id is the function name since ops don't have
+        # a "name" field in their val object. Ops are stored as CustomWeaveType
+        # objects with files containing source code.
+        code = ""
+
+        val = json.loads(obj.val_dump)
+
+        # Check if this is a file-based op
+        if not isinstance(val, dict):
+            raise TypeError(f"Op {req.object_id}:{req.digest} has invalid val: {val}")
+
+        if val.get("_type") != "CustomWeaveType":
+            raise TypeError(f"Op {req.object_id}:{req.digest} has invalid val: {val}")
+
+        files = val.get("files", {})
+        if object_creation_utils.OP_SOURCE_FILE_NAME in files:
+            # Files dict maps filename to digest string
+            file_digest = files[object_creation_utils.OP_SOURCE_FILE_NAME]
+
+            # Load the actual source code
+            try:
+                file_content_res = self.file_content_read(
+                    tsi.FileContentReadReq(
+                        project_id=req.project_id, digest=file_digest
+                    )
+                )
+                code = file_content_res.content.decode("utf-8")
+            except Exception:
+                # If we can't read the file, leave code empty
+                pass
+
+        return tsi.OpReadV2Res(
+            object_id=obj.object_id,
+            digest=obj.digest,
+            version_index=obj.version_index,
+            created_at=_ensure_datetimes_have_tz(obj.created_at),
+            code=code,
+        )
+
+    def op_list_v2(self, req: tsi.OpListV2Req) -> Iterator[tsi.OpReadV2Res]:
+        """List op objects in a project by delegating to objs_query with op filtering."""
+        # Query the objects
+        op_filter = tsi.ObjectVersionFilter(is_op=True)
+
+        complex_query = req.limit is not None or req.offset is not None
+        if complex_query:
+            object_query_builder = ObjectMetadataQueryBuilder(req.project_id)
+            object_query_builder.add_is_op_condition(True)
+            object_query_builder.set_include_deleted(include_deleted=False)
+
+            if req.limit is not None:
+                object_query_builder.set_limit(req.limit)
+            if req.offset is not None:
+                object_query_builder.set_offset(req.offset)
+
+            # Sort by latest first (most recent version first)
+            object_query_builder.add_order("object_id", "asc")
+            object_query_builder.add_order("version_index", "desc")
+
+            objs = self._select_objs_query(object_query_builder, metadata_only=False)
+        else:
+            # Use objs_query for simpler cases without custom sorting
+            obj_query_req = tsi.ObjQueryReq(
+                project_id=req.project_id,
+                filter=op_filter,
+                metadata_only=False,
+            )
+            obj_res = self.objs_query(obj_query_req)
+            objs = obj_res.objs
+
+        # Yield back a descriptive metadata object for each op
+        for obj in objs:
+            code = ""
+
+            # Extract file reference from the val if it's a file-based op
+
+            try:
+                if complex_query:
+                    val = json.loads(obj.val_dump)
+                else:
+                    val = obj.val
+                if isinstance(val, dict) and val.get("_type") == "CustomWeaveType":
+                    files = val.get("files", {})
+                    if object_creation_utils.OP_SOURCE_FILE_NAME in files:
+                        file_digest = files[object_creation_utils.OP_SOURCE_FILE_NAME]
+
+                        # Load the actual source code
+                        try:
+                            file_content_res = self.file_content_read(
+                                tsi.FileContentReadReq(
+                                    project_id=req.project_id, digest=file_digest
+                                )
+                            )
+                            code = file_content_res.content.decode("utf-8")
+                        except Exception:
+                            # If we can't read the file, leave code empty
+                            pass
+            except Exception:
+                pass  # If parsing fails, leave code empty
+
+            yield tsi.OpReadV2Res(
+                object_id=obj.object_id,
+                digest=obj.digest,
+                version_index=obj.version_index,
+                created_at=_ensure_datetimes_have_tz(obj.created_at),
+                code=code,
+            )
+
+    def op_delete_v2(self, req: tsi.OpDeleteV2Req) -> tsi.OpDeleteV2Res:
+        """Delete op object versions by delegating to obj_delete with op filtering."""
+        # First verify that the objects are indeed ops by querying them
+        object_query_builder = ObjectMetadataQueryBuilder(req.project_id)
+        object_query_builder.add_is_op_condition(True)
+        object_query_builder.add_object_ids_condition([req.object_id])
+        metadata_only = True
+        if req.digests:
+            object_query_builder.add_digests_conditions(*req.digests)
+            metadata_only = False
+
+        object_versions = self._select_objs_query(object_query_builder, metadata_only)
+
+        # If no op objects found, raise NotFoundError
+        if len(object_versions) == 0:
+            raise NotFoundError(
+                f"Op object {req.object_id} ({req.digests}) not found when deleting."
+            )
+
+        # Verify we found all requested digests if they were specified
+        if req.digests:
+            given_digests = set(req.digests)
+            found_digests = {obj.digest for obj in object_versions}
+            if len(given_digests) != len(found_digests):
+                raise NotFoundError(
+                    f"Delete request contains {len(req.digests)} digests, but found {len(found_digests)} objects to delete. Diff digests: {given_digests - found_digests}"
+                )
+
+        # Now delegate to obj_delete to perform the actual deletion
+        obj_delete_req = tsi.ObjDeleteReq(
+            project_id=req.project_id,
+            object_id=req.object_id,
+            digests=req.digests,
+        )
+
+        obj_delete_res = self.obj_delete(obj_delete_req)
+
+        return tsi.OpDeleteV2Res(num_deleted=obj_delete_res.num_deleted)
+
+    def _obj_read_with_retry(
+        self, req: tsi.ObjReadReq, max_retries: int = 10, initial_delay: float = 0.05
+    ) -> tsi.ObjReadRes:
+        """Read an object with retry logic to handle race conditions.
+
+        After creating an object, ClickHouse may not immediately make it available
+        for reading due to eventual consistency. This method retries with exponential
+        backoff to handle this race condition.
+
+        Args:
+            req: The object read request
+            max_retries: Maximum number of retry attempts (default 10)
+            initial_delay: Initial delay in seconds (default 0.05, i.e., 50ms)
+
+        Returns:
+            ObjReadRes with the object data
+
+        Raises:
+            NotFoundError: If the object is not found after all retries
+        """
+
+        @retry(
+            stop=stop_after_attempt(max_retries),
+            wait=wait_exponential(multiplier=1, min=initial_delay, max=1.0),
+            retry=retry_if_exception_type(NotFoundError),
+            reraise=True,
+        )
+        def _read() -> tsi.ObjReadRes:
+            return self.obj_read(req)
+
+        return _read()
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._parsed_refs_read_batch")
     def _parsed_refs_read_batch(

--- a/weave/trace_server/object_creation_utils.py
+++ b/weave/trace_server/object_creation_utils.py
@@ -1,0 +1,38 @@
+"""Utils for creating object payloads that are similar to what the SDK would create."""
+
+from __future__ import annotations
+
+from typing import Any
+
+OP_SOURCE_FILE_NAME = "obj.py"
+PLACEHOLDER_OP_SOURCE = """def func(*args, **kwargs):
+    ... # Code-capture unavailable for this op
+"""
+
+
+def build_op_val(file_digest: str, load_op: str | None = None) -> dict[str, Any]:
+    """Build the op value structure with a file digest (post-file-upload).
+
+    This creates the structure that matches what the SDK produces after file upload,
+    where the files dict contains digest strings rather than content bytes.
+
+    Args:
+        file_digest: The digest of the uploaded source file
+        load_op: Optional URI of the load_op (for non-Op custom types)
+
+    Returns:
+        Dictionary with the complete structure for an Op object ready for storage
+
+    Examples:
+        >>> result = build_op_val_with_file_digest("abc123")
+        >>> result["files"][OP_SOURCE_FILE_NAME]
+        'abc123'
+    """
+    result = {
+        "_type": "CustomWeaveType",
+        "weave_type": {"type": "Op"},
+        "files": {OP_SOURCE_FILE_NAME: file_digest},
+    }
+    if load_op is not None:
+        result["load_op"] = load_op
+    return result

--- a/weave/trace_server/reference/server.py
+++ b/weave/trace_server/reference/server.py
@@ -8,6 +8,7 @@ from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from weave.trace_server.reference.generate import (
     ServiceDependency,
     generate_routes,
+    generate_routes_v2,
     noop_trace_server_factory,
 )
 
@@ -25,8 +26,10 @@ def authenticate(
 
 server_dependency = ServiceDependency(service_factory=noop_trace_server_factory)
 trace_service_router = generate_routes(APIRouter(), server_dependency)
+v2_router = generate_routes_v2(APIRouter(prefix="/v2"), server_dependency)
 app = FastAPI()
 app.include_router(trace_service_router, dependencies=[Depends(authenticate)])
+app.include_router(v2_router, dependencies=[Depends(authenticate)])
 
 if __name__ == "__main__":
     import uvicorn

--- a/weave/trace_server/trace_service.py
+++ b/weave/trace_server/trace_service.py
@@ -2,7 +2,9 @@ from typing import Protocol
 
 from pydantic import BaseModel
 
-from weave.trace_server.trace_server_interface import TraceServerInterface
+from weave.trace_server.trace_server_interface import (
+    FullTraceServerInterface,
+)
 
 
 class ServerInfoRes(BaseModel):
@@ -21,7 +23,7 @@ class TraceService(Protocol):
     that consumes this interface and provides a convenient FastAPI router.
     """
 
-    trace_server_interface: TraceServerInterface
+    trace_server_interface: FullTraceServerInterface
 
     def server_info(self) -> ServerInfoRes: ...
     def read_root(self) -> dict[str, str]: ...

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -58,7 +58,7 @@ CACHE_DIR_PREFIX = "weave_trace_server_cache"
 CACHE_KEY_SUFFIX = "v_" + version.VERSION
 
 
-class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
+class CachingMiddlewareTraceServer(tsi.FullTraceServerInterface):
     """A middleware trace server that provides caching functionality.
 
     This server wraps another trace server and caches responses to improve performance.
@@ -71,12 +71,12 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
         _cache_recorder: Metrics tracking cache hits, misses, errors and skips
     """
 
-    _next_trace_server: tsi.TraceServerInterface
+    _next_trace_server: tsi.FullTraceServerInterface
     _cache_prefix: str
 
     def __init__(
         self,
-        next_trace_server: tsi.TraceServerInterface,
+        next_trace_server: tsi.FullTraceServerInterface,
         cache_dir: str | None = None,
         size_limit: int = 1_000_000_000,
     ):
@@ -100,7 +100,7 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
         """Cleanup method called when object is destroyed."""
         try:
             self._cache.close()
-        except Exception as e:
+        except Exception:
             logger.exception("Error closing cache")
 
     def get_call_processor(self) -> AsyncBatchProcessor | None:
@@ -120,7 +120,7 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
         return None
 
     @classmethod
-    def from_env(cls, next_trace_server: tsi.TraceServerInterface) -> Self:
+    def from_env(cls, next_trace_server: tsi.FullTraceServerInterface) -> Self:
         cache_dir = server_cache_dir()
         size_limit = server_cache_size_limit()
         return cls(next_trace_server, cache_dir, size_limit)
@@ -209,7 +209,7 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
         """
         try:
             cache_key = self._make_cache_key(namespace, make_cache_key(req))
-        except Exception as e:
+        except Exception:
             logger.exception("Error creating cache key")
             return func(req)
 
@@ -218,7 +218,7 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
         if cached_json_value is not None:
             try:
                 return deserialize(cached_json_value)
-            except Exception as e:
+            except Exception:
                 logger.exception("Error deserializing cached value")
                 # Remove corrupted cache entry
                 self._safe_cache_delete(cache_key)
@@ -230,7 +230,7 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
         try:
             json_value_to_cache = serialize(res)
             self._safe_cache_set(cache_key, json_value_to_cache)
-        except Exception as e:
+        except Exception:
             logger.exception("Error serializing value for cache")
 
         return res
@@ -386,7 +386,7 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
                             self._make_cache_key("refs_read_batch", needed_ref),
                             needed_val,
                         )
-                except Exception as e:
+                except Exception:
                     logger.exception("Error parsing ref for caching")
 
         return tsi.RefsReadBatchRes(vals=final_results)
@@ -530,6 +530,24 @@ class CachingMiddlewareTraceServer(tsi.TraceServerInterface):
         self, req: tsi.EvaluationStatusReq
     ) -> tsi.EvaluationStatusRes:
         return self._next_trace_server.evaluation_status(req)
+
+    # === V2 APIs ===
+
+    def op_create_v2(self, req: tsi.OpCreateV2Req) -> tsi.OpCreateV2Res:
+        return self._next_trace_server.op_create_v2(req)
+
+    def op_read_v2(self, req: tsi.OpReadV2Req) -> tsi.OpReadV2Res:
+        if not digest_is_cacheable(req.digest):
+            return self._next_trace_server.op_read_v2(req)
+        return self._with_cache_pydantic(
+            self._next_trace_server.op_read_v2, req, tsi.OpReadV2Res
+        )
+
+    def op_list_v2(self, req: tsi.OpListV2Req) -> Iterator[tsi.OpReadV2Res]:
+        return self._next_trace_server.op_list_v2(req)
+
+    def op_delete_v2(self, req: tsi.OpDeleteV2Req) -> tsi.OpDeleteV2Res:
+        return self._next_trace_server.op_delete_v2(req)
 
 
 def pydantic_bytes_safe_dump(obj: BaseModel) -> str:

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -248,7 +248,7 @@ def check_endpoint_exists(
 
     Args:
         func: The function to test (e.g., server.table_create_from_digests or
-              server._generic_request_executor.__wrapped__)
+              server._post_request_executor.__wrapped__)
         test_req: A test request to use for checking the function
         cache_key: Optional cache key. If not provided, uses id(func)
 

--- a/weave/utils/http_requests.py
+++ b/weave/utils/http_requests.py
@@ -171,3 +171,12 @@ def post(
 ) -> Response:
     """Send a POST request with optional logging."""
     return session.post(url, data=data, json=json, **kwargs)
+
+
+def delete(
+    url: str,
+    params: Optional[dict[str, Any]] = None,
+    **kwargs: Any,
+) -> Response:
+    """Send a DELETE request with optional logging."""
+    return session.delete(url, params=params, **kwargs)


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-28278

This PR adds CRUD endpoints for interacting with Ops as part of the V2 Evals API.

For this POC, the implementation simply delegates to the existing Objects endpoints.  There is some logic to generate the same payloads as the client would normally create.

Pairs with https://github.com/wandb/core/pull/35081