### PR TITLE
feat(weave): Add new CRUD endpoints for interacting with Datasets

### DIFF
--- a/tests/trace/test_server_object_creation_utils.py
+++ b/tests/trace/test_server_object_creation_utils.py
@@ -6,8 +6,9 @@ the client serialization requires a client object to serialize.
 """
 
 import weave
+from weave.trace.object_record import pydantic_object_record
 from weave.trace.serialization.serialize import to_json
-from weave.trace.weave_client import WeaveClient
+from weave.trace.weave_client import WeaveClient, map_to_refs
 from weave.trace_server import object_creation_utils
 
 
@@ -23,4 +24,46 @@ def test_helper_serializes_op_same_way_as_sdk(client: WeaveClient) -> None:
     helper_val = object_creation_utils.build_op_val(
         sdk_val["files"][object_creation_utils.OP_SOURCE_FILE_NAME]
     )
+    assert helper_val == sdk_val
+
+
+def test_helper_serializes_dataset_same_way_as_sdk(client: WeaveClient) -> None:
+    """Test that helpers serialize a Dataset the same way as SDK."""
+    # Create a test dataset
+    dataset = weave.Dataset(
+        name="test_dataset",
+        description="Test dataset for serialization",
+        rows=[
+            {"id": 1, "value": "first"},
+            {"id": 2, "value": "second"},
+            {"id": 3, "value": "third"},
+        ],
+    )
+
+    # Note: Unlike Op which has custom serialization, Dataset is a pydantic
+    # model that gets converted to an ObjectRecord. We need to simulate the
+    # actual save process:
+
+    # 1. Save the table to get a table reference
+    client._save_table(dataset.rows)
+
+    # 2. Convert to ObjectRecord (what gets serialized)
+    obj_rec = pydantic_object_record(dataset)
+
+    # 3. Map nested objects to their refs (table -> table ref)
+    mapped_obj_rec = map_to_refs(obj_rec)
+
+    # 4. Finally serialize
+    sdk_val = to_json(mapped_obj_rec, client._project_id(), client)
+
+    # Extract the table reference URI from the serialized data
+    table_ref_uri = sdk_val["rows"]
+
+    # Build the dataset value using the helper function
+    helper_val = object_creation_utils.build_dataset_val(
+        name=dataset.name,
+        description=dataset.description,
+        table_ref=table_ref_uri,
+    )
+
     assert helper_val == sdk_val

--- a/tests/trace_server/test_dataset_v2_api.py
+++ b/tests/trace_server/test_dataset_v2_api.py
@@ -1,0 +1,516 @@
+"""Tests for Dataset V2 API endpoints.
+
+Tests verify that the Dataset V2 API correctly creates, reads, lists, and deletes dataset objects.
+"""
+
+import pytest
+
+from tests.trace_server.conftest import TEST_ENTITY
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.errors import NotFoundError, ObjectDeletedError
+
+
+def test_dataset_create_v2_basic(trace_server):
+    """Test creating a basic dataset object."""
+    project_id = f"{TEST_ENTITY}/test_dataset_create_v2_basic"
+
+    # Create a dataset
+    rows = [
+        {"id": 1, "value": "a"},
+        {"id": 2, "value": "b"},
+        {"id": 3, "value": "c"},
+    ]
+    create_req = tsi.DatasetCreateV2Req(
+        project_id=project_id,
+        name="my_dataset",
+        description="A test dataset",
+        rows=rows,
+    )
+    create_res = trace_server.dataset_create_v2(create_req)
+
+    assert create_res.digest is not None
+    assert create_res.object_id == "dataset_my_dataset"
+    assert create_res.version_index == 0
+
+
+def test_dataset_create_v2_without_description(trace_server):
+    """Test creating a dataset without providing a description."""
+    project_id = f"{TEST_ENTITY}/test_dataset_create_v2_no_desc"
+
+    # Create a dataset without description
+    rows = [{"x": 1, "y": 2}]
+    create_req = tsi.DatasetCreateV2Req(
+        project_id=project_id,
+        name="dataset_no_desc",
+        description=None,
+        rows=rows,
+    )
+    create_res = trace_server.dataset_create_v2(create_req)
+
+    assert create_res.digest is not None
+    assert create_res.object_id == "dataset_dataset_no_desc"
+    assert create_res.version_index == 0
+
+
+def test_dataset_read_v2_basic(trace_server):
+    """Test reading a specific dataset object."""
+    project_id = f"{TEST_ENTITY}/test_dataset_read_v2_basic"
+
+    # Create a dataset
+    rows = [
+        {"name": "Alice", "age": 30},
+        {"name": "Bob", "age": 25},
+    ]
+    create_req = tsi.DatasetCreateV2Req(
+        project_id=project_id,
+        name="people",
+        description="A dataset of people",
+        rows=rows,
+    )
+    create_res = trace_server.dataset_create_v2(create_req)
+
+    # Read the dataset back
+    read_req = tsi.DatasetReadV2Req(
+        project_id=project_id,
+        object_id="dataset_people",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.dataset_read_v2(read_req)
+
+    assert read_res.object_id == "dataset_people"
+    assert read_res.digest == create_res.digest
+    assert read_res.version_index == 0
+    assert read_res.name == "people"
+    assert read_res.description == "A dataset of people"
+    assert read_res.created_at is not None
+    # Verify rows is a string reference, not the actual data
+    assert isinstance(read_res.rows, str)
+    assert read_res.rows.startswith("weave:///")
+
+
+def test_dataset_read_v2_not_found(trace_server):
+    """Test reading a non-existent dataset raises NotFoundError."""
+    project_id = f"{TEST_ENTITY}/test_dataset_read_v2_not_found"
+
+    read_req = tsi.DatasetReadV2Req(
+        project_id=project_id,
+        object_id="nonexistent_dataset",
+        digest="fake_digest_1234567890",
+    )
+
+    with pytest.raises(NotFoundError):
+        trace_server.dataset_read_v2(read_req)
+
+
+def test_dataset_list_v2_basic(trace_server):
+    """Test listing all datasets in a project."""
+    project_id = f"{TEST_ENTITY}/test_dataset_list_v2_basic"
+
+    # Create multiple datasets
+    dataset_names = ["dataset_a", "dataset_b", "dataset_c"]
+    for name in dataset_names:
+        create_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name=name,
+            description=f"Dataset {name}",
+            rows=[{"id": 1, "name": name}],
+        )
+        trace_server.dataset_create_v2(create_req)
+
+    # List all datasets
+    list_req = tsi.DatasetListV2Req(project_id=project_id)
+    datasets = list(trace_server.dataset_list_v2(list_req))
+
+    assert len(datasets) == 3
+    dataset_names_returned = {ds.name for ds in datasets}
+    assert dataset_names_returned == {"dataset_a", "dataset_b", "dataset_c"}
+
+    # Verify all datasets have rows references (not actual data)
+    for ds in datasets:
+        assert isinstance(ds.rows, str)
+        assert ds.rows.startswith("weave:///")
+        assert ds.created_at is not None
+
+
+def test_dataset_list_v2_with_limit(trace_server):
+    """Test listing datasets with a limit."""
+    project_id = f"{TEST_ENTITY}/test_dataset_list_v2_limit"
+
+    # Create multiple datasets
+    for i in range(5):
+        create_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name=f"dataset_{i}",
+            description=None,
+            rows=[{"value": i}],
+        )
+        trace_server.dataset_create_v2(create_req)
+
+    # List with a limit
+    list_req = tsi.DatasetListV2Req(project_id=project_id, limit=3)
+    datasets = list(trace_server.dataset_list_v2(list_req))
+
+    assert len(datasets) == 3
+
+
+def test_dataset_list_v2_with_offset(trace_server):
+    """Test listing datasets with an offset."""
+    project_id = f"{TEST_ENTITY}/test_dataset_list_v2_offset"
+
+    # Create multiple datasets
+    for i in range(5):
+        create_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name=f"dataset_{i}",
+            description=None,
+            rows=[{"value": i}],
+        )
+        trace_server.dataset_create_v2(create_req)
+
+    # List with an offset
+    list_req = tsi.DatasetListV2Req(project_id=project_id, offset=2)
+    datasets = list(trace_server.dataset_list_v2(list_req))
+
+    assert len(datasets) == 3
+
+
+def test_dataset_list_v2_with_limit_and_offset(trace_server):
+    """Test listing datasets with both limit and offset for pagination."""
+    project_id = f"{TEST_ENTITY}/test_dataset_list_v2_pagination"
+
+    # Create multiple datasets
+    for i in range(10):
+        create_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name=f"dataset_{i}",
+            description=None,
+            rows=[{"value": i}],
+        )
+        trace_server.dataset_create_v2(create_req)
+
+    # First page
+    list_req1 = tsi.DatasetListV2Req(project_id=project_id, limit=3, offset=0)
+    datasets1 = list(trace_server.dataset_list_v2(list_req1))
+    assert len(datasets1) == 3
+
+    # Second page
+    list_req2 = tsi.DatasetListV2Req(project_id=project_id, limit=3, offset=3)
+    datasets2 = list(trace_server.dataset_list_v2(list_req2))
+    assert len(datasets2) == 3
+
+    # Verify different datasets on different pages
+    datasets1_names = {ds.name for ds in datasets1}
+    datasets2_names = {ds.name for ds in datasets2}
+    assert len(datasets1_names & datasets2_names) == 0  # No overlap
+
+
+def test_dataset_list_v2_empty_project(trace_server):
+    """Test listing datasets in a project with no datasets."""
+    project_id = f"{TEST_ENTITY}/test_dataset_list_v2_empty"
+
+    list_req = tsi.DatasetListV2Req(project_id=project_id)
+    datasets = list(trace_server.dataset_list_v2(list_req))
+
+    assert len(datasets) == 0
+
+
+def test_dataset_delete_v2_single_version(trace_server):
+    """Test deleting a single version of a dataset."""
+    project_id = f"{TEST_ENTITY}/test_dataset_delete_v2_single"
+
+    # Create a dataset
+    create_req = tsi.DatasetCreateV2Req(
+        project_id=project_id,
+        name="delete_test",
+        description=None,
+        rows=[{"id": 1}],
+    )
+    create_res = trace_server.dataset_create_v2(create_req)
+
+    # Delete the specific version
+    delete_req = tsi.DatasetDeleteV2Req(
+        project_id=project_id,
+        object_id="dataset_delete_test",
+        digests=[create_res.digest],
+    )
+    delete_res = trace_server.dataset_delete_v2(delete_req)
+
+    assert delete_res.num_deleted == 1
+
+    # Verify the dataset is deleted (should raise ObjectDeletedError)
+    read_req = tsi.DatasetReadV2Req(
+        project_id=project_id,
+        object_id="dataset_delete_test",
+        digest=create_res.digest,
+    )
+    with pytest.raises(ObjectDeletedError):
+        trace_server.dataset_read_v2(read_req)
+
+
+def test_dataset_delete_v2_all_versions(trace_server):
+    """Test deleting all versions of a dataset (no digests specified)."""
+    project_id = f"{TEST_ENTITY}/test_dataset_delete_v2_all"
+
+    # Create multiple versions of the same dataset
+    digests = []
+    for i in range(3):
+        create_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="versioned_dataset",
+            description=None,
+            rows=[{"version": i}],
+        )
+        create_res = trace_server.dataset_create_v2(create_req)
+        digests.append(create_res.digest)
+
+    # Delete all versions (no digests specified)
+    delete_req = tsi.DatasetDeleteV2Req(
+        project_id=project_id,
+        object_id="dataset_versioned_dataset",
+        digests=None,
+    )
+    delete_res = trace_server.dataset_delete_v2(delete_req)
+
+    assert delete_res.num_deleted == 3
+
+
+def test_dataset_delete_v2_multiple_versions(trace_server):
+    """Test deleting multiple specific versions of a dataset."""
+    project_id = f"{TEST_ENTITY}/test_dataset_delete_v2_multiple"
+
+    # Create multiple versions
+    digests = []
+    for i in range(4):
+        create_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="multi_version_dataset",
+            description=None,
+            rows=[{"version": i}],
+        )
+        create_res = trace_server.dataset_create_v2(create_req)
+        digests.append(create_res.digest)
+
+    # Delete the first two versions
+    delete_req = tsi.DatasetDeleteV2Req(
+        project_id=project_id,
+        object_id="dataset_multi_version_dataset",
+        digests=digests[:2],
+    )
+    delete_res = trace_server.dataset_delete_v2(delete_req)
+
+    assert delete_res.num_deleted == 2
+
+    # Verify the first two are deleted
+    for digest in digests[:2]:
+        read_req = tsi.DatasetReadV2Req(
+            project_id=project_id,
+            object_id="dataset_multi_version_dataset",
+            digest=digest,
+        )
+        with pytest.raises(ObjectDeletedError):
+            trace_server.dataset_read_v2(read_req)
+
+    # Verify the last two still exist
+    for digest in digests[2:]:
+        read_req = tsi.DatasetReadV2Req(
+            project_id=project_id,
+            object_id="dataset_multi_version_dataset",
+            digest=digest,
+        )
+        read_res = trace_server.dataset_read_v2(read_req)
+        assert read_res.digest == digest
+
+
+def test_dataset_delete_v2_not_found(trace_server):
+    """Test deleting a non-existent dataset raises NotFoundError."""
+    project_id = f"{TEST_ENTITY}/test_dataset_delete_v2_not_found"
+
+    delete_req = tsi.DatasetDeleteV2Req(
+        project_id=project_id,
+        object_id="nonexistent_dataset",
+        digests=["fake_digest"],
+    )
+
+    with pytest.raises(NotFoundError):
+        trace_server.dataset_delete_v2(delete_req)
+
+
+def test_dataset_versioning(trace_server):
+    """Test that creating multiple versions of a dataset increments version_index."""
+    project_id = f"{TEST_ENTITY}/test_dataset_versioning"
+
+    # Create multiple versions of the same dataset
+    versions = []
+    for i in range(3):
+        create_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="versioned_dataset",
+            description=f"Version {i}",
+            rows=[{"value": i}],
+        )
+        create_res = trace_server.dataset_create_v2(create_req)
+        versions.append(create_res)
+
+    # Verify version indices increment
+    assert versions[0].version_index == 0
+    assert versions[1].version_index == 1
+    assert versions[2].version_index == 2
+
+    # Verify all versions are distinct
+    assert len({v.digest for v in versions}) == 3
+
+
+def test_dataset_with_special_characters(trace_server):
+    """Test creating and reading a dataset with special characters in data."""
+    project_id = f"{TEST_ENTITY}/test_dataset_special_chars"
+
+    # Create a dataset with special characters
+    rows = [
+        {"text": "This has \"quotes\" and 'apostrophes'"},
+        {"text": "Line breaks:\n\tand tabs"},
+        {"text": "Unicode: 你好世界 🚀"},
+    ]
+    create_req = tsi.DatasetCreateV2Req(
+        project_id=project_id,
+        name="special_chars",
+        description='Dataset with "special" characters',
+        rows=rows,
+    )
+    create_res = trace_server.dataset_create_v2(create_req)
+
+    # Read it back and verify metadata is preserved
+    read_req = tsi.DatasetReadV2Req(
+        project_id=project_id,
+        object_id="dataset_special_chars",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.dataset_read_v2(read_req)
+
+    assert read_res.name == "special_chars"
+    assert read_res.description == 'Dataset with "special" characters'
+    # The rows should still be a reference
+    assert isinstance(read_res.rows, str)
+    assert read_res.rows.startswith("weave:///")
+
+
+def test_dataset_with_unicode(trace_server):
+    """Test creating and reading a dataset with unicode characters."""
+    project_id = f"{TEST_ENTITY}/test_dataset_unicode"
+
+    # Create a dataset with unicode
+    rows = [
+        {"language": "Chinese", "greeting": "你好世界"},
+        {"language": "Japanese", "greeting": "こんにちは"},
+        {"language": "Emoji", "greeting": "🚀 🌟 ✨"},
+    ]
+    create_req = tsi.DatasetCreateV2Req(
+        project_id=project_id,
+        name="unicode_dataset",
+        description="Unicode greetings 🌍",
+        rows=rows,
+    )
+    create_res = trace_server.dataset_create_v2(create_req)
+
+    # Read it back and verify metadata is preserved
+    read_req = tsi.DatasetReadV2Req(
+        project_id=project_id,
+        object_id="dataset_unicode_dataset",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.dataset_read_v2(read_req)
+
+    assert read_res.name == "unicode_dataset"
+    assert read_res.description == "Unicode greetings 🌍"
+    assert "🌍" in read_res.description
+
+
+def test_dataset_list_after_deletion(trace_server):
+    """Test that deleted datasets don't appear in list results."""
+    project_id = f"{TEST_ENTITY}/test_dataset_list_after_deletion"
+
+    # Create three datasets
+    dataset_names = ["keep_1", "delete_me", "keep_2"]
+    digests = {}
+    for name in dataset_names:
+        create_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name=name,
+            description=None,
+            rows=[{"id": 1}],
+        )
+        create_res = trace_server.dataset_create_v2(create_req)
+        digests[name] = create_res.digest
+
+    # Delete one dataset
+    delete_req = tsi.DatasetDeleteV2Req(
+        project_id=project_id,
+        object_id="dataset_delete_me",
+        digests=None,
+    )
+    trace_server.dataset_delete_v2(delete_req)
+
+    # List datasets - should only see the two that weren't deleted
+    list_req = tsi.DatasetListV2Req(project_id=project_id)
+    datasets = list(trace_server.dataset_list_v2(list_req))
+
+    dataset_names_returned = {ds.name for ds in datasets}
+    assert dataset_names_returned == {"keep_1", "keep_2"}
+    assert "delete_me" not in dataset_names_returned
+
+
+def test_dataset_empty_rows(trace_server):
+    """Test creating a dataset with empty rows."""
+    project_id = f"{TEST_ENTITY}/test_dataset_empty_rows"
+
+    # Create a dataset with empty rows
+    create_req = tsi.DatasetCreateV2Req(
+        project_id=project_id,
+        name="empty_dataset",
+        description="A dataset with no rows",
+        rows=[],
+    )
+    create_res = trace_server.dataset_create_v2(create_req)
+
+    assert create_res.digest is not None
+    assert create_res.object_id == "dataset_empty_dataset"
+
+    # Read it back
+    read_req = tsi.DatasetReadV2Req(
+        project_id=project_id,
+        object_id="dataset_empty_dataset",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.dataset_read_v2(read_req)
+
+    assert read_res.name == "empty_dataset"
+    assert isinstance(read_res.rows, str)
+
+
+def test_dataset_large_rows(trace_server):
+    """Test creating a dataset with many rows."""
+    project_id = f"{TEST_ENTITY}/test_dataset_large_rows"
+
+    # Create a dataset with 100 rows
+    rows = [{"id": i, "value": f"value_{i}", "data": i * 2} for i in range(100)]
+    create_req = tsi.DatasetCreateV2Req(
+        project_id=project_id,
+        name="large_dataset",
+        description="A dataset with 100 rows",
+        rows=rows,
+    )
+    create_res = trace_server.dataset_create_v2(create_req)
+
+    assert create_res.digest is not None
+
+    # Read it back
+    read_req = tsi.DatasetReadV2Req(
+        project_id=project_id,
+        object_id="dataset_large_dataset",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.dataset_read_v2(read_req)
+
+    assert read_res.name == "large_dataset"
+    # The rows should still be a reference (not the actual 100 rows)
+    assert isinstance(read_res.rows, str)
+    assert read_res.rows.startswith("weave:///")

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1489,6 +1489,144 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.OpDeleteV2Res(num_deleted=obj_delete_res.num_deleted)
 
+    def dataset_create_v2(self, req: tsi.DatasetCreateV2Req) -> tsi.DatasetCreateV2Res:
+        """Create a dataset object by first creating a table for rows, then creating the dataset object.
+
+        The dataset object references the table containing the actual row data.
+        """
+        # Create a safe ID for the dataset
+        safe_name = object_creation_utils.make_safe_name(req.name)
+        dataset_id = f"dataset_{safe_name}"
+
+        # Create a table and get its ref
+        table_req = tsi.TableCreateReq(
+            table=tsi.TableSchemaForInsert(
+                project_id=req.project_id,
+                rows=req.rows,
+            )
+        )
+        table_res = self.table_create(table_req)
+        table_ref = ri.InternalTableRef(
+            project_id=req.project_id,
+            digest=table_res.digest,
+        ).uri()
+
+        # Create the dataset object
+        dataset_val = object_creation_utils.build_dataset_val(
+            name=req.name,
+            description=req.description,
+            table_ref=table_ref,
+        )
+        obj_req = tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=req.project_id,
+                object_id=dataset_id,
+                val=dataset_val,
+                wb_user_id=None,
+            )
+        )
+        obj_result = self.obj_create(obj_req)
+
+        # Query the object back to get its version index (this may not be
+        # immediately available, so we retry a few times)
+        obj_read_req = tsi.ObjReadReq(
+            project_id=req.project_id,
+            object_id=dataset_id,
+            digest=obj_result.digest,
+        )
+        obj_read_res = self._obj_read_with_retry(obj_read_req)
+
+        return tsi.DatasetCreateV2Res(
+            digest=obj_result.digest,
+            object_id=dataset_id,
+            version_index=obj_read_res.obj.version_index,
+        )
+
+    def dataset_read_v2(self, req: tsi.DatasetReadV2Req) -> tsi.DatasetReadV2Res:
+        """Get a dataset object by delegating to obj_read with retry logic.
+
+        Returns the rows reference as a string.
+        """
+        obj_req = tsi.ObjReadReq(
+            project_id=req.project_id,
+            object_id=req.object_id,
+            digest=req.digest,
+        )
+        result = self._obj_read_with_retry(obj_req)
+        val = result.obj.val
+
+        # Extract name, description, and rows ref from val data
+        name = val.get("name")
+        description = val.get("description")
+        rows_ref = val.get("rows", "")
+
+        # Create the response with all required fields
+        return tsi.DatasetReadV2Res(
+            object_id=result.obj.object_id,
+            digest=result.obj.digest,
+            version_index=result.obj.version_index,
+            created_at=result.obj.created_at,
+            name=name,
+            description=description,
+            rows=rows_ref,
+        )
+
+    def dataset_list_v2(
+        self, req: tsi.DatasetListV2Req
+    ) -> Iterator[tsi.DatasetReadV2Res]:
+        """List dataset objects by delegating to objs_query with Dataset filtering.
+
+        Returns the rows reference as a string.
+        """
+        # Query the objects
+        dataset_filter = tsi.ObjectVersionFilter(base_object_classes=["Dataset"])
+        obj_query_req = tsi.ObjQueryReq(
+            project_id=req.project_id,
+            filter=dataset_filter,
+            limit=req.limit,
+            offset=req.offset,
+        )
+        obj_res = self.objs_query(obj_query_req)
+
+        # Yield back a descriptive metadata object for each dataset
+        for obj in obj_res.objs:
+            if not hasattr(obj, "val") or not obj.val:
+                logger.warning(
+                    f"Skipping dataset object {obj.object_id} with digest {obj.digest}: missing or empty val"
+                )
+                continue
+
+            val = obj.val
+            if not isinstance(val, dict):
+                logger.warning(
+                    f"Skipping dataset object {obj.object_id} with digest {obj.digest}: val is not a dict"
+                )
+                continue
+
+            name = val.get("name")
+            description = val.get("description")
+            rows_ref = val.get("rows", "")
+
+            yield tsi.DatasetReadV2Res(
+                object_id=obj.object_id,
+                digest=obj.digest,
+                version_index=obj.version_index,
+                created_at=obj.created_at,
+                name=name,
+                description=description,
+                rows=rows_ref,
+            )
+
+    def dataset_delete_v2(self, req: tsi.DatasetDeleteV2Req) -> tsi.DatasetDeleteV2Res:
+        """Delete dataset objects by delegating to obj_delete."""
+        obj_delete_req = tsi.ObjDeleteReq(
+            project_id=req.project_id,
+            object_id=req.object_id,
+            digests=req.digests,
+        )
+        result = self.obj_delete(obj_delete_req)
+        return tsi.DatasetDeleteV2Res(num_deleted=result.num_deleted)
+
     def _obj_read_with_retry(
         self, req: tsi.ObjReadReq, max_retries: int = 10, initial_delay: float = 0.05
     ) -> tsi.ObjReadRes:

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -481,3 +481,21 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     def op_delete_v2(self, req: tsi.OpDeleteV2Req) -> tsi.OpDeleteV2Res:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(self._internal_trace_server.op_delete_v2, req)
+
+    def dataset_create_v2(self, req: tsi.DatasetCreateV2Req) -> tsi.DatasetCreateV2Res:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.dataset_create_v2, req)
+
+    def dataset_read_v2(self, req: tsi.DatasetReadV2Req) -> tsi.DatasetReadV2Res:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.dataset_read_v2, req)
+
+    def dataset_list_v2(
+        self, req: tsi.DatasetListV2Req
+    ) -> Iterator[tsi.DatasetReadV2Res]:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._stream_ref_apply(self._internal_trace_server.dataset_list_v2, req)
+
+    def dataset_delete_v2(self, req: tsi.DatasetDeleteV2Req) -> tsi.DatasetDeleteV2Res:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.dataset_delete_v2, req)

--- a/weave/trace_server/object_creation_utils.py
+++ b/weave/trace_server/object_creation_utils.py
@@ -10,6 +10,26 @@ PLACEHOLDER_OP_SOURCE = """def func(*args, **kwargs):
 """
 
 
+def make_safe_name(name: str | None) -> str:
+    """Convert a name to a safe identifier format.
+
+    Args:
+        name: The name to sanitize
+
+    Returns:
+        A safe identifier with spaces and slashes replaced by underscores, lowercased
+
+    Examples:
+        >>> make_safe_name("My Dataset")
+        'my_dataset'
+        >>> make_safe_name("user/model")
+        'user_model'
+    """
+    if name is None:
+        name = "unknown"
+    return name.replace(" ", "_").replace("/", "_").lower()
+
+
 def build_op_val(file_digest: str, load_op: str | None = None) -> dict[str, Any]:
     """Build the op value structure with a file digest (post-file-upload).
 
@@ -36,3 +56,33 @@ def build_op_val(file_digest: str, load_op: str | None = None) -> dict[str, Any]
     if load_op is not None:
         result["load_op"] = load_op
     return result
+
+
+def build_dataset_val(
+    table_ref: str, name: str | None = None, description: str | None = None
+) -> dict[str, Any]:
+    """Build the value dictionary for a Dataset object.
+
+    Args:
+        name: The dataset name
+        description: Optional description
+        table_ref: Reference to the table containing the dataset rows
+
+    Returns:
+        Dictionary representing the dataset object value
+    """
+    if name is None:
+        name = "Dataset"
+
+    return {
+        "_type": "Dataset",
+        "_class_name": "Dataset",
+        "_bases": ["Object", "BaseModel"],
+        "name": name,
+        "description": description,
+        "rows": table_ref,
+    }
+
+
+def build_table_ref(entity: str, project: str, digest: str) -> str:
+    return f"weave:///{entity}/{project}/table/{digest}"

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1325,6 +1325,82 @@ class OpDeleteV2Res(BaseModel):
     )
 
 
+class DatasetCreateV2Body(BaseModel):
+    name: Optional[str] = Field(
+        None,
+        description="The name of this dataset.  Datasets with the same name will be versioned together.",
+    )
+    description: Optional[str] = Field(
+        None,
+        description="A description of this dataset",
+    )
+    rows: list[dict[str, Any]] = Field(..., description="Dataset rows")
+
+
+class DatasetCreateV2Req(DatasetCreateV2Body):
+    project_id: str = Field(
+        ..., description="The `entity/project` where this dataset will be saved"
+    )
+
+
+class DatasetCreateV2Res(BaseModel):
+    digest: str = Field(..., description="The digest of the created dataset")
+    object_id: str = Field(..., description="The ID of the created dataset")
+    version_index: int = Field(
+        ..., description="The version index of the created dataset"
+    )
+
+
+class DatasetReadV2Req(BaseModel):
+    project_id: str = Field(
+        ..., description="The `entity/project` where this dataset is saved"
+    )
+    object_id: str = Field(..., description="The dataset ID")
+    digest: str = Field(..., description="The digest of the dataset object")
+
+
+class DatasetReadV2Res(BaseModel):
+    object_id: str = Field(..., description="The dataset ID")
+    digest: str = Field(..., description="The digest of the dataset object")
+    version_index: int = Field(..., description="The version index of the object")
+    created_at: datetime.datetime = Field(
+        ..., description="When the object was created"
+    )
+    name: str = Field(..., description="The name of the dataset")
+    description: Optional[str] = Field(None, description="Description of the dataset")
+    rows: str = Field(
+        ...,
+        description="Reference to the dataset rows data",
+    )
+
+
+class DatasetListV2Req(BaseModel):
+    project_id: str = Field(
+        ..., description="The `entity/project` where these datasets are saved"
+    )
+    limit: Optional[int] = Field(
+        default=None, description="Maximum number of datasets to return"
+    )
+    offset: Optional[int] = Field(
+        default=None, description="Number of datasets to skip"
+    )
+
+
+class DatasetDeleteV2Req(BaseModelStrict):
+    project_id: str = Field(
+        ..., description="The `entity/project` where this dataset is saved"
+    )
+    object_id: str = Field(..., description="The dataset ID")
+    digests: Optional[list[str]] = Field(
+        default=None,
+        description="List of digests to delete. If not provided, all digests for the dataset will be deleted.",
+    )
+
+
+class DatasetDeleteV2Res(BaseModel):
+    num_deleted: int = Field(..., description="Number of d  ataset versions deleted")
+
+
 class TraceServerInterface(Protocol):
     def ensure_project_exists(
         self, entity: str, project: str
@@ -1438,6 +1514,12 @@ class TraceServerInterfaceV2(Protocol):
     def op_read_v2(self, req: OpReadV2Req) -> OpReadV2Res: ...
     def op_list_v2(self, req: OpListV2Req) -> Iterator[OpReadV2Res]: ...
     def op_delete_v2(self, req: OpDeleteV2Req) -> OpDeleteV2Res: ...
+
+    # Datasets
+    def dataset_create_v2(self, req: DatasetCreateV2Req) -> DatasetCreateV2Res: ...
+    def dataset_read_v2(self, req: DatasetReadV2Req) -> DatasetReadV2Res: ...
+    def dataset_list_v2(self, req: DatasetListV2Req) -> Iterator[DatasetReadV2Res]: ...
+    def dataset_delete_v2(self, req: DatasetDeleteV2Req) -> DatasetDeleteV2Res: ...
 
 
 class FullTraceServerInterface(TraceServerInterface, TraceServerInterfaceV2, Protocol):

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -549,6 +549,24 @@ class CachingMiddlewareTraceServer(tsi.FullTraceServerInterface):
     def op_delete_v2(self, req: tsi.OpDeleteV2Req) -> tsi.OpDeleteV2Res:
         return self._next_trace_server.op_delete_v2(req)
 
+    def dataset_create_v2(self, req: tsi.DatasetCreateV2Req) -> tsi.DatasetCreateV2Res:
+        return self._next_trace_server.dataset_create_v2(req)
+
+    def dataset_read_v2(self, req: tsi.DatasetReadV2Req) -> tsi.DatasetReadV2Res:
+        if not digest_is_cacheable(req.digest):
+            return self._next_trace_server.dataset_read_v2(req)
+        return self._with_cache_pydantic(
+            self._next_trace_server.dataset_read_v2, req, tsi.DatasetReadV2Res
+        )
+
+    def dataset_list_v2(
+        self, req: tsi.DatasetListV2Req
+    ) -> Iterator[tsi.DatasetReadV2Res]:
+        return self._next_trace_server.dataset_list_v2(req)
+
+    def dataset_delete_v2(self, req: tsi.DatasetDeleteV2Req) -> tsi.DatasetDeleteV2Res:
+        return self._next_trace_server.dataset_delete_v2(req)
+
 
 def pydantic_bytes_safe_dump(obj: BaseModel) -> str:
     raw_dict = obj.model_dump()


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-28279

This PR adds CRUD endpoints for interacting with Datasets as part of the V2 Evals API.

For this POC, the implementation simply delegates to the existing Objects endpoints.  There is some logic to generate the same payloads as the client would normally create.

Notably, this PR does not implement endpoints for interacting with the Dataset's rows.  That feature will come later!

Pairs with https://github.com/wandb/core/pull/35094