### PR TITLE
feat(weave): Add new CRUD endpoints for interacting with Scorers

### DIFF
--- a/tests/trace/test_server_object_creation_utils.py
+++ b/tests/trace/test_server_object_creation_utils.py
@@ -6,6 +6,7 @@ the client serialization requires a client object to serialize.
 """
 
 import weave
+from weave.flow.scorer import Scorer
 from weave.trace.object_record import pydantic_object_record
 from weave.trace.serialization.serialize import to_json
 from weave.trace.weave_client import WeaveClient, map_to_refs
@@ -64,6 +65,56 @@ def test_helper_serializes_dataset_same_way_as_sdk(client: WeaveClient) -> None:
         name=dataset.name,
         description=dataset.description,
         table_ref=table_ref_uri,
+    )
+
+    assert helper_val == sdk_val
+
+
+def test_helper_serializes_scorer_same_way_as_sdk(client: WeaveClient) -> None:
+    """Test that helpers serialize a Scorer with the correct structure.
+
+    Note: The helper creates base Scorer objects (not custom subclasses),
+    so we compare the data fields rather than type metadata.
+    """
+
+    class TestScorer(Scorer):
+        @weave.op
+        def score(self, *, output, **kwargs):  # type: ignore
+            return {"score": len(output)}
+
+    scorer = TestScorer(name="test_scorer", description="Test scorer for serialization")
+
+    # Like Dataset, Scorer is a pydantic model that gets converted to an ObjectRecord.
+    # We need to simulate the actual save process:
+
+    # 1. Save the score op to get a reference
+    client._save_op(scorer.score)
+
+    # 2. Save the summarize op to get a reference
+    client._save_op(scorer.summarize)
+
+    # 3. Convert to ObjectRecord (what gets serialized)
+    obj_rec = pydantic_object_record(scorer)
+
+    # 4. Map nested objects to their refs (score op -> score op ref, summarize op -> summarize op ref)
+    mapped_obj_rec = map_to_refs(obj_rec)
+
+    # 5. Finally serialize
+    sdk_val = to_json(mapped_obj_rec, client._project_id(), client)
+
+    # Extract the score op reference URI and summarize op ref from the serialized data
+    score_op_ref_uri = sdk_val["score"]
+    summarize_op_ref_uri = sdk_val["summarize"]
+    column_map = sdk_val.get("column_map")
+
+    # Build the scorer value using the helper function
+    helper_val = object_creation_utils.build_scorer_val(
+        name=scorer.name,
+        description=scorer.description,
+        score_op_ref=score_op_ref_uri,
+        summarize_op_ref=summarize_op_ref_uri,
+        column_map=column_map,
+        class_name=scorer.__class__.__name__,
     )
 
     assert helper_val == sdk_val

--- a/tests/trace_server/test_scorer_v2_api.py
+++ b/tests/trace_server/test_scorer_v2_api.py
@@ -1,0 +1,520 @@
+"""Tests for Scorer V2 API endpoints.
+
+Tests verify that the Scorer V2 API correctly creates, reads, lists, and deletes scorer objects.
+"""
+
+import pytest
+
+from tests.trace_server.conftest import TEST_ENTITY
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.errors import NotFoundError, ObjectDeletedError
+
+
+def test_scorer_create_v2_basic(trace_server):
+    """Test creating a basic scorer object."""
+    project_id = f"{TEST_ENTITY}/test_scorer_create_v2_basic"
+
+    # Create a scorer
+    op_source_code = """
+def score(output: str, target: str) -> dict:
+    return {"correct": output == target}
+"""
+    create_req = tsi.ScorerCreateV2Req(
+        project_id=project_id,
+        name="exact_match",
+        description="A simple exact match scorer",
+        op_source_code=op_source_code,
+    )
+    create_res = trace_server.scorer_create_v2(create_req)
+
+    assert create_res.digest is not None
+    assert create_res.object_id == "scorer_exact_match"
+    assert create_res.version_index == 0
+    # Verify scorer returns a reference string
+    assert isinstance(create_res.scorer, str)
+    assert create_res.scorer.startswith("weave:///")
+
+
+def test_scorer_create_v2_without_description(trace_server):
+    """Test creating a scorer without providing a description."""
+    project_id = f"{TEST_ENTITY}/test_scorer_create_v2_no_desc"
+
+    # Create a scorer without description
+    op_source_code = """
+def score(output: str) -> dict:
+    return {"length": len(output)}
+"""
+    create_req = tsi.ScorerCreateV2Req(
+        project_id=project_id,
+        name="length_scorer",
+        description=None,
+        op_source_code=op_source_code,
+    )
+    create_res = trace_server.scorer_create_v2(create_req)
+
+    assert create_res.digest is not None
+    assert create_res.object_id == "scorer_length_scorer"
+    assert create_res.version_index == 0
+    assert isinstance(create_res.scorer, str)
+
+
+def test_scorer_read_v2_basic(trace_server):
+    """Test reading a specific scorer object."""
+    project_id = f"{TEST_ENTITY}/test_scorer_read_v2_basic"
+
+    # Create a scorer
+    op_source_code = """
+def score(output: str, target: str) -> dict:
+    return {"correct": output.lower() == target.lower()}
+"""
+    create_req = tsi.ScorerCreateV2Req(
+        project_id=project_id,
+        name="case_insensitive_match",
+        description="Case insensitive match scorer",
+        op_source_code=op_source_code,
+    )
+    create_res = trace_server.scorer_create_v2(create_req)
+
+    # Read the scorer back
+    read_req = tsi.ScorerReadV2Req(
+        project_id=project_id,
+        object_id="scorer_case_insensitive_match",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.scorer_read_v2(read_req)
+
+    assert read_res.object_id == "scorer_case_insensitive_match"
+    assert read_res.digest == create_res.digest
+    assert read_res.version_index == 0
+    assert read_res.name == "case_insensitive_match"
+    assert read_res.description == "Case insensitive match scorer"
+    assert read_res.created_at is not None
+    # Verify score_op is a reference string
+    assert isinstance(read_res.score_op, str)
+    assert read_res.score_op.startswith("weave:///") or len(read_res.score_op) > 0
+
+
+def test_scorer_read_v2_not_found(trace_server):
+    """Test reading a non-existent scorer raises NotFoundError."""
+    project_id = f"{TEST_ENTITY}/test_scorer_read_v2_not_found"
+
+    read_req = tsi.ScorerReadV2Req(
+        project_id=project_id,
+        object_id="nonexistent_scorer",
+        digest="fake_digest_1234567890",
+    )
+
+    with pytest.raises(NotFoundError):
+        trace_server.scorer_read_v2(read_req)
+
+
+def test_scorer_list_v2_basic(trace_server):
+    """Test listing all scorers in a project."""
+    project_id = f"{TEST_ENTITY}/test_scorer_list_v2_basic"
+
+    # Create multiple scorers
+    scorer_names = ["scorer_a", "scorer_b", "scorer_c"]
+    for name in scorer_names:
+        create_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name=name,
+            description=f"Scorer {name}",
+            op_source_code=f'def score():\n    return {{"score": "{name}"}}',
+        )
+        trace_server.scorer_create_v2(create_req)
+
+    # List all scorers
+    list_req = tsi.ScorerListV2Req(project_id=project_id)
+    scorers = list(trace_server.scorer_list_v2(list_req))
+
+    assert len(scorers) == 3
+    scorer_names_returned = {s.name for s in scorers}
+    assert scorer_names_returned == {"scorer_a", "scorer_b", "scorer_c"}
+
+    # Verify all scorers have score_op references
+    for scorer in scorers:
+        assert scorer.score_op
+        assert scorer.created_at is not None
+
+
+def test_scorer_list_v2_with_limit(trace_server):
+    """Test listing scorers with a limit."""
+    project_id = f"{TEST_ENTITY}/test_scorer_list_v2_limit"
+
+    # Create multiple scorers
+    for i in range(5):
+        create_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name=f"scorer_{i}",
+            description=None,
+            op_source_code=f'def score():\n    return {{"value": {i}}}',
+        )
+        trace_server.scorer_create_v2(create_req)
+
+    # List with a limit
+    list_req = tsi.ScorerListV2Req(project_id=project_id, limit=3)
+    scorers = list(trace_server.scorer_list_v2(list_req))
+
+    assert len(scorers) == 3
+
+
+def test_scorer_list_v2_with_offset(trace_server):
+    """Test listing scorers with an offset."""
+    project_id = f"{TEST_ENTITY}/test_scorer_list_v2_offset"
+
+    # Create multiple scorers
+    for i in range(5):
+        create_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name=f"scorer_{i}",
+            description=None,
+            op_source_code=f'def score():\n    return {{"value": {i}}}',
+        )
+        trace_server.scorer_create_v2(create_req)
+
+    # List with an offset
+    list_req = tsi.ScorerListV2Req(project_id=project_id, offset=2)
+    scorers = list(trace_server.scorer_list_v2(list_req))
+
+    assert len(scorers) == 3
+
+
+def test_scorer_list_v2_with_limit_and_offset(trace_server):
+    """Test listing scorers with both limit and offset for pagination."""
+    project_id = f"{TEST_ENTITY}/test_scorer_list_v2_pagination"
+
+    # Create multiple scorers
+    for i in range(10):
+        create_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name=f"scorer_{i}",
+            description=None,
+            op_source_code=f'def score():\n    return {{"value": {i}}}',
+        )
+        trace_server.scorer_create_v2(create_req)
+
+    # First page
+    list_req1 = tsi.ScorerListV2Req(project_id=project_id, limit=3, offset=0)
+    scorers1 = list(trace_server.scorer_list_v2(list_req1))
+    assert len(scorers1) == 3
+
+    # Second page
+    list_req2 = tsi.ScorerListV2Req(project_id=project_id, limit=3, offset=3)
+    scorers2 = list(trace_server.scorer_list_v2(list_req2))
+    assert len(scorers2) == 3
+
+    # Verify different scorers on different pages
+    scorers1_names = {s.name for s in scorers1}
+    scorers2_names = {s.name for s in scorers2}
+    assert len(scorers1_names & scorers2_names) == 0  # No overlap
+
+
+def test_scorer_list_v2_empty_project(trace_server):
+    """Test listing scorers in a project with no scorers."""
+    project_id = f"{TEST_ENTITY}/test_scorer_list_v2_empty"
+
+    list_req = tsi.ScorerListV2Req(project_id=project_id)
+    scorers = list(trace_server.scorer_list_v2(list_req))
+
+    assert len(scorers) == 0
+
+
+def test_scorer_delete_v2_single_version(trace_server):
+    """Test deleting a single version of a scorer."""
+    project_id = f"{TEST_ENTITY}/test_scorer_delete_v2_single"
+
+    # Create a scorer
+    create_req = tsi.ScorerCreateV2Req(
+        project_id=project_id,
+        name="delete_test",
+        description=None,
+        op_source_code='def score():\n    return {"score": 1}',
+    )
+    create_res = trace_server.scorer_create_v2(create_req)
+
+    # Delete the specific version
+    delete_req = tsi.ScorerDeleteV2Req(
+        project_id=project_id,
+        object_id="scorer_delete_test",
+        digests=[create_res.digest],
+    )
+    delete_res = trace_server.scorer_delete_v2(delete_req)
+
+    assert delete_res.num_deleted == 1
+
+    # Verify the scorer is deleted (should raise ObjectDeletedError)
+    read_req = tsi.ScorerReadV2Req(
+        project_id=project_id,
+        object_id="scorer_delete_test",
+        digest=create_res.digest,
+    )
+    with pytest.raises(ObjectDeletedError):
+        trace_server.scorer_read_v2(read_req)
+
+
+def test_scorer_delete_v2_all_versions(trace_server):
+    """Test deleting all versions of a scorer (no digests specified)."""
+    project_id = f"{TEST_ENTITY}/test_scorer_delete_v2_all"
+
+    # Create multiple versions of the same scorer
+    digests = []
+    for i in range(3):
+        create_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name="versioned_scorer",
+            description=None,
+            op_source_code=f'def score():\n    return {{"version": {i}}}',
+        )
+        create_res = trace_server.scorer_create_v2(create_req)
+        digests.append(create_res.digest)
+
+    # Delete all versions (no digests specified)
+    delete_req = tsi.ScorerDeleteV2Req(
+        project_id=project_id,
+        object_id="scorer_versioned_scorer",
+        digests=None,
+    )
+    delete_res = trace_server.scorer_delete_v2(delete_req)
+
+    assert delete_res.num_deleted == 3
+
+
+def test_scorer_delete_v2_multiple_versions(trace_server):
+    """Test deleting multiple specific versions of a scorer."""
+    project_id = f"{TEST_ENTITY}/test_scorer_delete_v2_multiple"
+
+    # Create multiple versions
+    digests = []
+    for i in range(4):
+        create_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name="multi_version_scorer",
+            description=None,
+            op_source_code=f'def score():\n    return {{"version": {i}}}',
+        )
+        create_res = trace_server.scorer_create_v2(create_req)
+        digests.append(create_res.digest)
+
+    # Delete the first two versions
+    delete_req = tsi.ScorerDeleteV2Req(
+        project_id=project_id,
+        object_id="scorer_multi_version_scorer",
+        digests=digests[:2],
+    )
+    delete_res = trace_server.scorer_delete_v2(delete_req)
+
+    assert delete_res.num_deleted == 2
+
+    # Verify the first two are deleted
+    for digest in digests[:2]:
+        read_req = tsi.ScorerReadV2Req(
+            project_id=project_id,
+            object_id="scorer_multi_version_scorer",
+            digest=digest,
+        )
+        with pytest.raises(ObjectDeletedError):
+            trace_server.scorer_read_v2(read_req)
+
+    # Verify the last two still exist
+    for digest in digests[2:]:
+        read_req = tsi.ScorerReadV2Req(
+            project_id=project_id,
+            object_id="scorer_multi_version_scorer",
+            digest=digest,
+        )
+        read_res = trace_server.scorer_read_v2(read_req)
+        assert read_res.digest == digest
+
+
+def test_scorer_delete_v2_not_found(trace_server):
+    """Test deleting a non-existent scorer raises NotFoundError."""
+    project_id = f"{TEST_ENTITY}/test_scorer_delete_v2_not_found"
+
+    delete_req = tsi.ScorerDeleteV2Req(
+        project_id=project_id,
+        object_id="nonexistent_scorer",
+        digests=["fake_digest"],
+    )
+
+    with pytest.raises(NotFoundError):
+        trace_server.scorer_delete_v2(delete_req)
+
+
+def test_scorer_versioning(trace_server):
+    """Test that creating multiple versions of a scorer increments version_index."""
+    project_id = f"{TEST_ENTITY}/test_scorer_versioning"
+
+    # Create multiple versions of the same scorer
+    versions = []
+    for i in range(3):
+        create_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name="versioned_scorer",
+            description=f"Version {i}",
+            op_source_code=f'def score():\n    return {{"version": {i}}}',
+        )
+        create_res = trace_server.scorer_create_v2(create_req)
+        versions.append(create_res)
+
+    # Verify version indices increment
+    assert versions[0].version_index == 0
+    assert versions[1].version_index == 1
+    assert versions[2].version_index == 2
+
+    # Verify all versions are distinct
+    assert len({v.digest for v in versions}) == 3
+
+
+def test_scorer_with_special_characters(trace_server):
+    """Test creating and reading a scorer with special characters in code."""
+    project_id = f"{TEST_ENTITY}/test_scorer_special_chars"
+
+    # Create a scorer with special characters
+    op_source_code = """
+def score(output: str) -> dict:
+    '''This scorer has "quotes" and 'apostrophes'.'''
+    return {"result": f"Output: {output} with special chars: \\n\\t"}
+"""
+    create_req = tsi.ScorerCreateV2Req(
+        project_id=project_id,
+        name="special_chars",
+        description='Scorer with "special" characters',
+        op_source_code=op_source_code,
+    )
+    create_res = trace_server.scorer_create_v2(create_req)
+
+    # Read it back and verify metadata is preserved
+    read_req = tsi.ScorerReadV2Req(
+        project_id=project_id,
+        object_id="scorer_special_chars",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.scorer_read_v2(read_req)
+
+    assert read_res.name == "special_chars"
+    assert read_res.description == 'Scorer with "special" characters'
+    assert read_res.score_op  # Should have a reference
+
+
+def test_scorer_with_unicode(trace_server):
+    """Test creating and reading a scorer with unicode characters."""
+    project_id = f"{TEST_ENTITY}/test_scorer_unicode"
+
+    # Create a scorer with unicode
+    op_source_code = """
+def score(output: str) -> dict:
+    '''This scorer has unicode: 你好世界 🚀'''
+    return {"greeting": "你好世界"}
+"""
+    create_req = tsi.ScorerCreateV2Req(
+        project_id=project_id,
+        name="unicode_scorer",
+        description="Unicode scorer 🌍",
+        op_source_code=op_source_code,
+    )
+    create_res = trace_server.scorer_create_v2(create_req)
+
+    # Read it back and verify metadata is preserved
+    read_req = tsi.ScorerReadV2Req(
+        project_id=project_id,
+        object_id="scorer_unicode_scorer",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.scorer_read_v2(read_req)
+
+    assert read_res.name == "unicode_scorer"
+    assert read_res.description == "Unicode scorer 🌍"
+    assert "🌍" in read_res.description
+
+
+def test_scorer_list_after_deletion(trace_server):
+    """Test that deleted scorers don't appear in list results."""
+    project_id = f"{TEST_ENTITY}/test_scorer_list_after_deletion"
+
+    # Create three scorers
+    scorer_names = ["keep_1", "delete_me", "keep_2"]
+    digests = {}
+    for name in scorer_names:
+        create_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name=name,
+            description=None,
+            op_source_code='def score():\n    return {"score": 1}',
+        )
+        create_res = trace_server.scorer_create_v2(create_req)
+        digests[name] = create_res.digest
+
+    # Delete one scorer
+    delete_req = tsi.ScorerDeleteV2Req(
+        project_id=project_id,
+        object_id="scorer_delete_me",
+        digests=None,
+    )
+    trace_server.scorer_delete_v2(delete_req)
+
+    # List scorers - should only see the two that weren't deleted
+    list_req = tsi.ScorerListV2Req(project_id=project_id)
+    scorers = list(trace_server.scorer_list_v2(list_req))
+
+    scorer_names_returned = {s.name for s in scorers}
+    assert scorer_names_returned == {"keep_1", "keep_2"}
+    assert "delete_me" not in scorer_names_returned
+
+
+def test_scorer_complex_source_code(trace_server):
+    """Test creating a scorer with complex multi-line source code."""
+    project_id = f"{TEST_ENTITY}/test_scorer_complex_code"
+
+    # Create a scorer with complex code
+    op_source_code = """
+import json
+from typing import Any
+
+def score(output: str, target: str) -> dict:
+    '''
+    Complex scoring function with multiple operations.
+    '''
+    # Parse outputs
+    try:
+        output_data = json.loads(output)
+        target_data = json.loads(target)
+    except json.JSONDecodeError:
+        return {"error": "Invalid JSON", "score": 0.0}
+
+    # Calculate similarity
+    matches = 0
+    total = len(target_data)
+
+    for key, value in target_data.items():
+        if key in output_data and output_data[key] == value:
+            matches += 1
+
+    score = matches / total if total > 0 else 0.0
+
+    return {
+        "score": score,
+        "matches": matches,
+        "total": total
+    }
+"""
+    create_req = tsi.ScorerCreateV2Req(
+        project_id=project_id,
+        name="json_similarity",
+        description="Complex JSON similarity scorer",
+        op_source_code=op_source_code,
+    )
+    create_res = trace_server.scorer_create_v2(create_req)
+
+    assert create_res.digest is not None
+    assert create_res.object_id == "scorer_json_similarity"
+
+    # Read it back
+    read_req = tsi.ScorerReadV2Req(
+        project_id=project_id,
+        object_id="scorer_json_similarity",
+        digest=create_res.digest,
+    )
+    read_res = trace_server.scorer_read_v2(read_req)
+
+    assert read_res.name == "json_similarity"
+    assert read_res.description == "Complex JSON similarity scorer"

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -499,3 +499,19 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     def dataset_delete_v2(self, req: tsi.DatasetDeleteV2Req) -> tsi.DatasetDeleteV2Res:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(self._internal_trace_server.dataset_delete_v2, req)
+
+    def scorer_create_v2(self, req: tsi.ScorerCreateV2Req) -> tsi.ScorerCreateV2Res:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.scorer_create_v2, req)
+
+    def scorer_read_v2(self, req: tsi.ScorerReadV2Req) -> tsi.ScorerReadV2Res:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.scorer_read_v2, req)
+
+    def scorer_list_v2(self, req: tsi.ScorerListV2Req) -> Iterator[tsi.ScorerReadV2Res]:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._stream_ref_apply(self._internal_trace_server.scorer_list_v2, req)
+
+    def scorer_delete_v2(self, req: tsi.ScorerDeleteV2Req) -> tsi.ScorerDeleteV2Res:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.scorer_delete_v2, req)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1924,6 +1924,141 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         result = self.obj_delete(obj_delete_req)
         return tsi.DatasetDeleteV2Res(num_deleted=result.num_deleted)
 
+    def scorer_create_v2(self, req: tsi.ScorerCreateV2Req) -> tsi.ScorerCreateV2Res:
+        """Create a scorer object by first creating its score op, then creating the scorer object.
+
+        The scorer object references the op that implements the scoring logic.
+        """
+        # Generate a safe ID for the scorer
+        safe_name = object_creation_utils.make_safe_name(req.name)
+        scorer_id = f"scorer_{safe_name}"
+
+        # Create the score op first
+        score_op_req = tsi.OpCreateV2Req(
+            project_id=req.project_id,
+            name=f"{scorer_id}_score",
+            source_code=req.op_source_code,
+        )
+        score_op_res = self.op_create_v2(score_op_req)
+        score_op_ref = score_op_res.digest
+
+        # Create the default summarize op
+        summarize_op_req = tsi.OpCreateV2Req(
+            project_id=req.project_id,
+            name=f"{scorer_id}_summarize",
+            source_code=object_creation_utils.PLACEHOLDER_SCORER_SUMMARIZE_OP_SOURCE,
+        )
+        summarize_op_res = self.op_create_v2(summarize_op_req)
+        summarize_op_ref = summarize_op_res.digest
+
+        # Create the scorer object using shared utility for val
+        scorer_val = object_creation_utils.build_scorer_val(
+            name=req.name,
+            description=req.description,
+            score_op_ref=score_op_ref,
+            summarize_op_ref=summarize_op_ref,
+        )
+
+        obj_req = tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=req.project_id,
+                object_id=scorer_id,
+                val=scorer_val,
+                wb_user_id=None,
+            )
+        )
+        obj_result = self.obj_create(obj_req)
+
+        # Query back to get version_index
+        obj_read_req = tsi.ObjReadReq(
+            project_id=req.project_id,
+            object_id=scorer_id,
+            digest=obj_result.digest,
+        )
+        obj_read_res = self.obj_read(obj_read_req)
+
+        # Construct the scorer reference using InternalObjectRef
+        scorer_ref = ri.InternalObjectRef(
+            project_id=req.project_id,
+            name=scorer_id,
+            version=obj_result.digest,
+        ).uri()
+
+        return tsi.ScorerCreateV2Res(
+            digest=obj_result.digest,
+            object_id=scorer_id,
+            version_index=obj_read_res.obj.version_index,
+            scorer=scorer_ref,
+        )
+
+    def scorer_read_v2(self, req: tsi.ScorerReadV2Req) -> tsi.ScorerReadV2Res:
+        """Get scorer objects by delegating to obj_read."""
+        obj_req = tsi.ObjReadReq(
+            project_id=req.project_id,
+            object_id=req.object_id,
+            digest=req.digest,
+        )
+        result = self.obj_read(obj_req)
+        val = result.obj.val
+
+        # Extract name and description from val data
+        name = val.get("name", result.obj.object_id)
+        description = val.get("description")
+
+        # Create the response with all required fields
+        return tsi.ScorerReadV2Res(
+            object_id=result.obj.object_id,
+            digest=result.obj.digest,
+            version_index=result.obj.version_index,
+            created_at=result.obj.created_at,
+            name=name,
+            description=description,
+            score_op=val.get("score", ""),
+        )
+
+    def scorer_list_v2(self, req: tsi.ScorerListV2Req) -> Iterator[tsi.ScorerReadV2Res]:
+        """List scorer objects by delegating to objs_query with Scorer filtering."""
+        obj_query_req = tsi.ObjQueryReq(
+            project_id=req.project_id,
+            filter=tsi.ObjectVersionFilter(base_object_classes=["Scorer"]),
+            limit=req.limit,
+            offset=req.offset,
+        )
+        result = self.objs_query(obj_query_req)
+
+        for obj in result.objs:
+            # Extract name, description, and score_op from val data
+            name = obj.object_id  # fallback to object_id
+            description = None
+            score_op = ""
+
+            if hasattr(obj, "val") and obj.val:
+                val = obj.val
+                if isinstance(val, dict):
+                    name = val.get("name", obj.object_id)
+                    description = val.get("description")
+                    score_op = val.get("score", "")
+
+            yield tsi.ScorerReadV2Res(
+                object_id=obj.object_id,
+                digest=obj.digest,
+                version_index=obj.version_index,
+                created_at=obj.created_at,
+                name=name,
+                description=description,
+                score_op=score_op,
+            )
+
+    def scorer_delete_v2(self, req: tsi.ScorerDeleteV2Req) -> tsi.ScorerDeleteV2Res:
+        """Delete scorer objects by delegating to obj_delete."""
+        obj_delete_req = tsi.ObjDeleteReq(
+            project_id=req.project_id,
+            object_id=req.object_id,
+            digests=req.digests,
+        )
+        result = self.obj_delete(obj_delete_req)
+        return tsi.ScorerDeleteV2Res(num_deleted=result.num_deleted)
+
     def _table_row_read(self, project_id: str, row_digest: str) -> tsi.TableRowSchema:
         conn, cursor = get_conn_cursor(self.db_path)
         # Now get the rows

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1401,6 +1401,87 @@ class DatasetDeleteV2Res(BaseModel):
     num_deleted: int = Field(..., description="Number of d  ataset versions deleted")
 
 
+class ScorerCreateV2Body(BaseModel):
+    name: str = Field(
+        ...,
+        description="The name of this scorer.  Scorers with the same name will be versioned together.",
+    )
+    description: Optional[str] = Field(
+        None,
+        description="A description of this scorer",
+    )
+    op_source_code: str = Field(
+        ...,
+        description="Complete source code for the Scorer.score op including imports",
+    )
+
+
+class ScorerCreateV2Req(ScorerCreateV2Body):
+    project_id: str = Field(
+        ..., description="The `entity/project` where this scorer will be saved"
+    )
+
+
+class ScorerCreateV2Res(BaseModel):
+    digest: str = Field(..., description="The digest of the created scorer")
+    object_id: str = Field(..., description="The ID of the created scorer")
+    version_index: int = Field(
+        ..., description="The version index of the created scorer"
+    )
+    scorer: str = Field(
+        ...,
+        description="Full reference to the created scorer",
+    )
+
+
+class ScorerReadV2Req(BaseModel):
+    project_id: str = Field(
+        ..., description="The `entity/project` where this scorer is saved"
+    )
+    object_id: str = Field(..., description="The scorer ID")
+    digest: str = Field(..., description="The digest of the scorer")
+
+
+class ScorerReadV2Res(BaseModel):
+    object_id: str = Field(..., description="The scorer ID")
+    digest: str = Field(..., description="The digest of the scorer")
+    version_index: int = Field(..., description="The version index of the object")
+    created_at: datetime.datetime = Field(
+        ..., description="When the scorer was created"
+    )
+    name: str = Field(..., description="The name of the scorer")
+    description: Optional[str] = Field(None, description="Description of the scorer")
+    score_op: str = Field(
+        ...,
+        description="The Scorer.score op reference",
+    )
+
+
+class ScorerListV2Req(BaseModel):
+    project_id: str = Field(
+        ..., description="The `entity/project` where these scorers are saved"
+    )
+    limit: Optional[int] = Field(
+        default=None, description="Maximum number of scorers to return"
+    )
+    offset: Optional[int] = Field(default=None, description="Number of scorers to skip")
+
+
+class ScorerDeleteV2Req(BaseModelStrict):
+    project_id: str = Field(
+        ..., description="The `entity/project` where this scorer is saved"
+    )
+    object_id: str = Field(..., description="The scorer ID")
+    digests: Optional[list[str]] = Field(
+        default=None,
+        description="List of digests to delete. If not provided, all digests for the scorer will be deleted",
+    )
+
+
+class ScorerDeleteV2Res(BaseModel):
+    num_deleted: int = Field(..., description="Number of scorer versions deleted")
+
+
 class TraceServerInterface(Protocol):
     def ensure_project_exists(
         self, entity: str, project: str
@@ -1520,6 +1601,12 @@ class TraceServerInterfaceV2(Protocol):
     def dataset_read_v2(self, req: DatasetReadV2Req) -> DatasetReadV2Res: ...
     def dataset_list_v2(self, req: DatasetListV2Req) -> Iterator[DatasetReadV2Res]: ...
     def dataset_delete_v2(self, req: DatasetDeleteV2Req) -> DatasetDeleteV2Res: ...
+
+    # Scorers
+    def scorer_create_v2(self, req: ScorerCreateV2Req) -> ScorerCreateV2Res: ...
+    def scorer_read_v2(self, req: ScorerReadV2Req) -> ScorerReadV2Res: ...
+    def scorer_list_v2(self, req: ScorerListV2Req) -> Iterator[ScorerReadV2Res]: ...
+    def scorer_delete_v2(self, req: ScorerDeleteV2Req) -> ScorerDeleteV2Res: ...
 
 
 class FullTraceServerInterface(TraceServerInterface, TraceServerInterfaceV2, Protocol):

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -567,6 +567,18 @@ class CachingMiddlewareTraceServer(tsi.FullTraceServerInterface):
     def dataset_delete_v2(self, req: tsi.DatasetDeleteV2Req) -> tsi.DatasetDeleteV2Res:
         return self._next_trace_server.dataset_delete_v2(req)
 
+    def scorer_create_v2(self, req: tsi.ScorerCreateV2Req) -> tsi.ScorerCreateV2Res:
+        return self._next_trace_server.scorer_create_v2(req)
+
+    def scorer_read_v2(self, req: tsi.ScorerReadV2Req) -> tsi.ScorerReadV2Res:
+        return self._next_trace_server.scorer_read_v2(req)
+
+    def scorer_list_v2(self, req: tsi.ScorerListV2Req) -> Iterator[tsi.ScorerReadV2Res]:
+        return self._next_trace_server.scorer_list_v2(req)
+
+    def scorer_delete_v2(self, req: tsi.ScorerDeleteV2Req) -> tsi.ScorerDeleteV2Res:
+        return self._next_trace_server.scorer_delete_v2(req)
+
 
 def pydantic_bytes_safe_dump(obj: BaseModel) -> str:
     raw_dict = obj.model_dump()


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-28280

This PR adds CRUD endpoints for interacting with Scorers as part of the V2 Evals API.

For this POC, the implementation simply delegates to the existing Objects endpoints.  There is some logic to generate the same payloads as the client would normally create.

Pairs with https://github.com/wandb/core/pull/35112