### PR TITLE
feat(weave): Add new CRUD endpoints for interacting with Evaluations

### DIFF
--- a/tests/trace/test_trace_server_v2_api.py
+++ b/tests/trace/test_trace_server_v2_api.py
@@ -1,0 +1,706 @@
+"""Tests for Trace Server V2 API endpoints.
+
+This module tests the V2 API endpoints for:
+- Ops (create, read, list, delete)
+- Datasets (create, read, list, delete)
+- Scorers (create, read, list, delete)
+- Evaluations (create, read, list, delete)
+
+The tests run against both SQLite and ClickHouse backends.
+"""
+
+from weave.trace_server import trace_server_interface as tsi
+
+
+class TestOpsV2API:
+    """Tests for Ops V2 API endpoints."""
+
+    def test_op_create_v2(self, client):
+        """Test creating an op via V2 API."""
+        project_id = client._project_id()
+
+        # Create an op
+        req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name="test_op",
+            source_code="def test_op():\n    return 42",
+        )
+        res = client.server.op_create_v2(req)
+
+        # Verify response
+        assert res.object_id == "test_op"
+        assert res.digest is not None
+        assert res.version_index == 0
+
+    def test_op_read_v2(self, client):
+        """Test reading an op via V2 API."""
+        project_id = client._project_id()
+
+        # Create an op first
+        source_code = "def my_test_op():\n    return 'hello world'"
+        create_req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name="readable_op",
+            source_code=source_code,
+        )
+        create_res = client.server.op_create_v2(create_req)
+
+        # Read the op
+        read_req = tsi.OpReadV2Req(
+            project_id=project_id,
+            object_id="readable_op",
+            digest=create_res.digest,
+        )
+        read_res = client.server.op_read_v2(read_req)
+
+        # Verify response
+        assert read_res.object_id == "readable_op"
+        assert read_res.digest == create_res.digest
+        assert read_res.version_index == 0
+        assert read_res.code == source_code
+        assert read_res.created_at is not None
+
+    def test_op_list_v2(self, client):
+        """Test listing ops via V2 API."""
+        project_id = client._project_id()
+
+        # Create multiple ops
+        for i in range(3):
+            req = tsi.OpCreateV2Req(
+                project_id=project_id,
+                name=f"list_test_op_{i}",
+                source_code=f"def op_{i}():\n    return {i}",
+            )
+            client.server.op_create_v2(req)
+
+        # List ops
+        list_req = tsi.OpListV2Req(project_id=project_id)
+        ops = list(client.server.op_list_v2(list_req))
+
+        # Verify we get at least our 3 ops
+        assert len(ops) >= 3
+        op_names = [op.object_id for op in ops]
+        assert "list_test_op_0" in op_names
+        assert "list_test_op_1" in op_names
+        assert "list_test_op_2" in op_names
+
+    def test_op_list_v2_with_limit(self, client):
+        """Test listing ops with limit via V2 API."""
+        project_id = client._project_id()
+
+        # Create multiple ops
+        for i in range(5):
+            req = tsi.OpCreateV2Req(
+                project_id=project_id,
+                name=f"limit_test_op_{i}",
+                source_code=f"def op_{i}():\n    return {i}",
+            )
+            client.server.op_create_v2(req)
+
+        # List ops with limit
+        list_req = tsi.OpListV2Req(project_id=project_id, limit=2)
+        ops = list(client.server.op_list_v2(list_req))
+
+        # Verify limit is respected
+        assert len(ops) == 2
+
+    def test_op_delete_v2(self, client):
+        """Test deleting an op via V2 API."""
+        project_id = client._project_id()
+
+        # Create an op
+        create_req = tsi.OpCreateV2Req(
+            project_id=project_id,
+            name="deletable_op",
+            source_code="def deletable():\n    pass",
+        )
+        create_res = client.server.op_create_v2(create_req)
+
+        # Delete the op
+        delete_req = tsi.OpDeleteV2Req(
+            project_id=project_id,
+            object_id="deletable_op",
+            digests=[create_res.digest],
+        )
+        delete_res = client.server.op_delete_v2(delete_req)
+
+        # Verify deletion
+        assert delete_res.num_deleted == 1
+
+    def test_op_delete_v2_all_versions(self, client):
+        """Test deleting all versions of an op via V2 API."""
+        project_id = client._project_id()
+
+        # Create multiple versions
+        digests = []
+        for i in range(3):
+            create_req = tsi.OpCreateV2Req(
+                project_id=project_id,
+                name="multi_version_op",
+                source_code=f"def multi_version():\n    return {i}",
+            )
+            create_res = client.server.op_create_v2(create_req)
+            digests.append(create_res.digest)
+
+        # Delete all versions (None means delete all)
+        delete_req = tsi.OpDeleteV2Req(
+            project_id=project_id,
+            object_id="multi_version_op",
+            digests=None,
+        )
+        delete_res = client.server.op_delete_v2(delete_req)
+
+        # Verify all versions deleted
+        assert delete_res.num_deleted == 3
+
+
+class TestDatasetsV2API:
+    """Tests for Datasets V2 API endpoints."""
+
+    def test_dataset_create_v2(self, client):
+        """Test creating a dataset via V2 API."""
+        project_id = client._project_id()
+
+        # Create a dataset
+        req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="test_dataset",
+            description="A test dataset",
+            rows=[
+                {"input": "hello", "output": "world"},
+                {"input": "foo", "output": "bar"},
+            ],
+        )
+        res = client.server.dataset_create_v2(req)
+
+        # Verify response
+        assert res.object_id.startswith("dataset_")
+        assert res.digest is not None
+        assert res.version_index == 0
+
+    def test_dataset_read_v2(self, client):
+        """Test reading a dataset via V2 API."""
+        project_id = client._project_id()
+
+        # Create a dataset first
+        rows = [
+            {"question": "What is 2+2?", "answer": "4"},
+            {"question": "What is the capital of France?", "answer": "Paris"},
+        ]
+        create_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="readable_dataset",
+            description="Test dataset for reading",
+            rows=rows,
+        )
+        create_res = client.server.dataset_create_v2(create_req)
+
+        # Read the dataset
+        read_req = tsi.DatasetReadV2Req(
+            project_id=project_id,
+            object_id=create_res.object_id,
+            digest=create_res.digest,
+        )
+        read_res = client.server.dataset_read_v2(read_req)
+
+        # Verify response
+        assert read_res.object_id == create_res.object_id
+        assert read_res.digest == create_res.digest
+        assert read_res.version_index == 0
+        assert read_res.name == "readable_dataset"
+        assert read_res.description == "Test dataset for reading"
+        assert read_res.rows is not None  # Field is 'rows', not 'rows_ref'
+        assert read_res.created_at is not None
+
+    def test_dataset_list_v2(self, client):
+        """Test listing datasets via V2 API."""
+        project_id = client._project_id()
+
+        # Create multiple datasets
+        for i in range(3):
+            req = tsi.DatasetCreateV2Req(
+                project_id=project_id,
+                name=f"list_dataset_{i}",
+                rows=[{"value": i}],
+            )
+            client.server.dataset_create_v2(req)
+
+        # List datasets
+        list_req = tsi.DatasetListV2Req(project_id=project_id)
+        datasets = list(client.server.dataset_list_v2(list_req))
+
+        # Verify we get at least our 3 datasets
+        assert len(datasets) >= 3
+        dataset_names = [ds.name for ds in datasets]
+        assert "list_dataset_0" in dataset_names
+        assert "list_dataset_1" in dataset_names
+        assert "list_dataset_2" in dataset_names
+
+    def test_dataset_delete_v2(self, client):
+        """Test deleting a dataset via V2 API."""
+        project_id = client._project_id()
+
+        # Create a dataset
+        create_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="deletable_dataset",
+            rows=[{"data": "test"}],
+        )
+        create_res = client.server.dataset_create_v2(create_req)
+
+        # Delete the dataset
+        delete_req = tsi.DatasetDeleteV2Req(
+            project_id=project_id,
+            object_id=create_res.object_id,
+            digests=[create_res.digest],
+        )
+        delete_res = client.server.dataset_delete_v2(delete_req)
+
+        # Verify deletion
+        assert delete_res.num_deleted == 1
+
+
+class TestScorersV2API:
+    """Tests for Scorers V2 API endpoints."""
+
+    def test_scorer_create_v2(self, client):
+        """Test creating a scorer via V2 API."""
+        project_id = client._project_id()
+
+        # Create a scorer
+        req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name="test_scorer",
+            description="A test scorer",
+            op_source_code="def score(output, target):\n    return output == target",
+        )
+        res = client.server.scorer_create_v2(req)
+
+        # Verify response
+        assert res.object_id.startswith("scorer_")
+        assert res.digest is not None
+        assert res.version_index == 0
+
+    def test_scorer_read_v2(self, client):
+        """Test reading a scorer via V2 API."""
+        project_id = client._project_id()
+
+        # Create a scorer first
+        source_code = (
+            "def accuracy_score(output, target):\n    return int(output == target)"
+        )
+        create_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name="accuracy_scorer",
+            description="Measures accuracy",
+            op_source_code=source_code,
+        )
+        create_res = client.server.scorer_create_v2(create_req)
+
+        # Read the scorer
+        read_req = tsi.ScorerReadV2Req(
+            project_id=project_id,
+            object_id=create_res.object_id,
+            digest=create_res.digest,
+        )
+        read_res = client.server.scorer_read_v2(read_req)
+
+        # Verify response
+        assert read_res.object_id == create_res.object_id
+        assert read_res.digest == create_res.digest
+        assert read_res.version_index == 0
+        assert read_res.name == "accuracy_scorer"
+        assert read_res.description == "Measures accuracy"
+        assert (
+            read_res.score_op is not None
+        )  # ScorerReadV2Res has 'score_op', not 'code'
+        assert read_res.created_at is not None
+
+    def test_scorer_list_v2(self, client):
+        """Test listing scorers via V2 API."""
+        project_id = client._project_id()
+
+        # Create multiple scorers
+        for i in range(3):
+            req = tsi.ScorerCreateV2Req(
+                project_id=project_id,
+                name=f"list_scorer_{i}",
+                op_source_code=f"def scorer_{i}():\n    return {i}",
+            )
+            client.server.scorer_create_v2(req)
+
+        # List scorers
+        list_req = tsi.ScorerListV2Req(project_id=project_id)
+        scorers = list(client.server.scorer_list_v2(list_req))
+
+        # Verify we get at least our 3 scorers
+        assert len(scorers) >= 3
+        scorer_names = [s.name for s in scorers]
+        assert "list_scorer_0" in scorer_names
+        assert "list_scorer_1" in scorer_names
+        assert "list_scorer_2" in scorer_names
+
+    def test_scorer_delete_v2(self, client):
+        """Test deleting a scorer via V2 API."""
+        project_id = client._project_id()
+
+        # Create a scorer
+        create_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name="deletable_scorer",
+            op_source_code="def deletable():\n    pass",
+        )
+        create_res = client.server.scorer_create_v2(create_req)
+
+        # Delete the scorer
+        delete_req = tsi.ScorerDeleteV2Req(
+            project_id=project_id,
+            object_id=create_res.object_id,
+            digests=[create_res.digest],
+        )
+        delete_res = client.server.scorer_delete_v2(delete_req)
+
+        # Verify deletion
+        assert delete_res.num_deleted == 1
+
+
+class TestEvaluationsV2API:
+    """Tests for Evaluations V2 API endpoints."""
+
+    def test_evaluation_create_v2(self, client):
+        """Test creating an evaluation via V2 API."""
+        project_id = client._project_id()
+
+        # First create a dataset
+        dataset_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="eval_dataset",
+            rows=[{"input": "test", "output": "result"}],
+        )
+        dataset_res = client.server.dataset_create_v2(dataset_req)
+
+        # Create dataset ref
+        entity, project = project_id.split("/")
+        dataset_ref = f"weave:///{entity}/{project}/object/{dataset_res.object_id}:{dataset_res.digest}"
+
+        # Create an evaluation
+        req = tsi.EvaluationCreateV2Req(
+            project_id=project_id,
+            name="test_evaluation",
+            description="A test evaluation",
+            dataset=dataset_ref,
+            scorers=[],
+            trials=1,
+        )
+        res = client.server.evaluation_create_v2(req)
+
+        # Verify response
+        assert res.object_id == "test_evaluation"  # Evaluations use name as object_id
+        assert res.digest is not None
+        assert res.version_index == 0
+        assert res.evaluation_ref is not None
+
+    def test_evaluation_read_v2(self, client):
+        """Test reading an evaluation via V2 API."""
+        project_id = client._project_id()
+
+        # Create dataset and evaluation first
+        dataset_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="read_eval_dataset",
+            rows=[{"data": "value"}],
+        )
+        dataset_res = client.server.dataset_create_v2(dataset_req)
+
+        entity, project = project_id.split("/")
+        dataset_ref = f"weave:///{entity}/{project}/object/{dataset_res.object_id}:{dataset_res.digest}"
+
+        eval_req = tsi.EvaluationCreateV2Req(
+            project_id=project_id,
+            name="readable_evaluation",
+            description="Test eval for reading",
+            dataset=dataset_ref,
+            scorers=[],
+            trials=2,
+            evaluation_name="custom_eval_name",
+        )
+        eval_res = client.server.evaluation_create_v2(eval_req)
+
+        # Read the evaluation
+        read_req = tsi.EvaluationReadV2Req(
+            project_id=project_id,
+            object_id=eval_res.object_id,
+            digest=eval_res.digest,
+        )
+        read_res = client.server.evaluation_read_v2(read_req)
+
+        # Verify response
+        assert read_res.object_id == eval_res.object_id
+        assert read_res.digest == eval_res.digest
+        assert read_res.version_index == 0
+        assert read_res.name == "readable_evaluation"
+        assert read_res.description == "Test eval for reading"
+        assert read_res.dataset == dataset_ref
+        assert read_res.scorers == []
+        assert read_res.trials == 2
+        assert read_res.evaluation_name == "custom_eval_name"
+        assert read_res.evaluate_op is not None
+        assert read_res.predict_and_score_op is not None
+        assert read_res.summarize_op is not None
+        assert read_res.created_at is not None
+
+    def test_evaluation_list_v2(self, client):
+        """Test listing evaluations via V2 API."""
+        project_id = client._project_id()
+
+        # Create dataset
+        dataset_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="list_eval_dataset",
+            rows=[{"x": 1}],
+        )
+        dataset_res = client.server.dataset_create_v2(dataset_req)
+
+        entity, project = project_id.split("/")
+        dataset_ref = f"weave:///{entity}/{project}/object/{dataset_res.object_id}:{dataset_res.digest}"
+
+        # Create multiple evaluations
+        for i in range(3):
+            req = tsi.EvaluationCreateV2Req(
+                project_id=project_id,
+                name=f"list_evaluation_{i}",
+                dataset=dataset_ref,
+                scorers=[],
+            )
+            client.server.evaluation_create_v2(req)
+
+        # List evaluations
+        list_req = tsi.EvaluationListV2Req(project_id=project_id)
+        evaluations = list(client.server.evaluation_list_v2(list_req))
+
+        # Verify we get at least our 3 evaluations
+        assert len(evaluations) >= 3
+        eval_names = [ev.name for ev in evaluations]
+        assert "list_evaluation_0" in eval_names
+        assert "list_evaluation_1" in eval_names
+        assert "list_evaluation_2" in eval_names
+
+    def test_evaluation_delete_v2(self, client):
+        """Test deleting an evaluation via V2 API."""
+        project_id = client._project_id()
+
+        # Create dataset and evaluation
+        dataset_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="delete_eval_dataset",
+            rows=[{"data": "test"}],
+        )
+        dataset_res = client.server.dataset_create_v2(dataset_req)
+
+        entity, project = project_id.split("/")
+        dataset_ref = f"weave:///{entity}/{project}/object/{dataset_res.object_id}:{dataset_res.digest}"
+
+        eval_req = tsi.EvaluationCreateV2Req(
+            project_id=project_id,
+            name="deletable_evaluation",
+            dataset=dataset_ref,
+            scorers=[],
+        )
+        eval_res = client.server.evaluation_create_v2(eval_req)
+
+        # Delete the evaluation
+        delete_req = tsi.EvaluationDeleteV2Req(
+            project_id=project_id,
+            object_id=eval_res.object_id,
+            digests=[eval_res.digest],
+        )
+        delete_res = client.server.evaluation_delete_v2(delete_req)
+
+        # Verify deletion
+        assert delete_res.num_deleted == 1
+
+    def test_evaluation_with_scorers(self, client):
+        """Test creating an evaluation with scorers."""
+        project_id = client._project_id()
+
+        # Create dataset
+        dataset_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="scorer_eval_dataset",
+            rows=[{"input": "test", "expected": "output"}],
+        )
+        dataset_res = client.server.dataset_create_v2(dataset_req)
+
+        # Create scorers
+        scorer_req1 = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name="scorer_1",
+            op_source_code="def score1():\n    return 1",
+        )
+        scorer_res1 = client.server.scorer_create_v2(scorer_req1)
+
+        scorer_req2 = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name="scorer_2",
+            op_source_code="def score2():\n    return 2",
+        )
+        scorer_res2 = client.server.scorer_create_v2(scorer_req2)
+
+        # Build refs
+        entity, project = project_id.split("/")
+        dataset_ref = f"weave:///{entity}/{project}/object/{dataset_res.object_id}:{dataset_res.digest}"
+        scorer_ref1 = f"weave:///{entity}/{project}/object/{scorer_res1.object_id}:{scorer_res1.digest}"
+        scorer_ref2 = f"weave:///{entity}/{project}/object/{scorer_res2.object_id}:{scorer_res2.digest}"
+
+        # Create evaluation with scorers
+        eval_req = tsi.EvaluationCreateV2Req(
+            project_id=project_id,
+            name="eval_with_scorers",
+            dataset=dataset_ref,
+            scorers=[scorer_ref1, scorer_ref2],
+        )
+        eval_res = client.server.evaluation_create_v2(eval_req)
+
+        # Read it back and verify scorers
+        read_req = tsi.EvaluationReadV2Req(
+            project_id=project_id,
+            object_id=eval_res.object_id,
+            digest=eval_res.digest,
+        )
+        read_res = client.server.evaluation_read_v2(read_req)
+
+        assert len(read_res.scorers) == 2
+        assert scorer_ref1 in read_res.scorers
+        assert scorer_ref2 in read_res.scorers
+
+
+class TestV2APIIntegration:
+    """Integration tests for V2 API endpoints."""
+
+    def test_complete_evaluation_workflow(self, client):
+        """Test a complete workflow: create dataset, scorers, and evaluation."""
+        project_id = client._project_id()
+        entity, project = project_id.split("/")
+
+        # Step 1: Create a dataset
+        dataset_req = tsi.DatasetCreateV2Req(
+            project_id=project_id,
+            name="workflow_dataset",
+            description="Dataset for workflow test",
+            rows=[
+                {"question": "What is 2+2?", "answer": "4"},
+                {"question": "What is 3+3?", "answer": "6"},
+            ],
+        )
+        dataset_res = client.server.dataset_create_v2(dataset_req)
+        dataset_ref = f"weave:///{entity}/{project}/object/{dataset_res.object_id}:{dataset_res.digest}"
+
+        # Step 2: Create scorers
+        exact_match_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name="exact_match",
+            description="Checks for exact match",
+            op_source_code="def score(output, answer):\n    return output == answer",
+        )
+        exact_match_res = client.server.scorer_create_v2(exact_match_req)
+        exact_match_ref = f"weave:///{entity}/{project}/object/{exact_match_res.object_id}:{exact_match_res.digest}"
+
+        length_req = tsi.ScorerCreateV2Req(
+            project_id=project_id,
+            name="length_check",
+            description="Checks answer length",
+            op_source_code="def score(output):\n    return len(output)",
+        )
+        length_res = client.server.scorer_create_v2(length_req)
+        length_ref = f"weave:///{entity}/{project}/object/{length_res.object_id}:{length_res.digest}"
+
+        # Step 3: Create evaluation
+        eval_req = tsi.EvaluationCreateV2Req(
+            project_id=project_id,
+            name="math_evaluation",
+            description="Evaluates math questions",
+            dataset=dataset_ref,
+            scorers=[exact_match_ref, length_ref],
+            trials=3,
+            evaluation_name="Math Quiz v1",
+        )
+        eval_res = client.server.evaluation_create_v2(eval_req)
+
+        # Step 4: Verify all components exist and are linked
+        # Read evaluation
+        eval_read_req = tsi.EvaluationReadV2Req(
+            project_id=project_id,
+            object_id=eval_res.object_id,
+            digest=eval_res.digest,
+        )
+        eval_read_res = client.server.evaluation_read_v2(eval_read_req)
+
+        assert eval_read_res.name == "math_evaluation"
+        assert eval_read_res.dataset == dataset_ref
+        assert len(eval_read_res.scorers) == 2
+        assert exact_match_ref in eval_read_res.scorers
+        assert length_ref in eval_read_res.scorers
+        assert eval_read_res.trials == 3
+        assert eval_read_res.evaluation_name == "Math Quiz v1"
+
+        # Verify we can read the dataset
+        dataset_read_req = tsi.DatasetReadV2Req(
+            project_id=project_id,
+            object_id=dataset_res.object_id,
+            digest=dataset_res.digest,
+        )
+        dataset_read_res = client.server.dataset_read_v2(dataset_read_req)
+        assert dataset_read_res.name == "workflow_dataset"
+
+        # Verify we can read the scorers
+        scorer1_read_req = tsi.ScorerReadV2Req(
+            project_id=project_id,
+            object_id=exact_match_res.object_id,
+            digest=exact_match_res.digest,
+        )
+        scorer1_read_res = client.server.scorer_read_v2(scorer1_read_req)
+        assert scorer1_read_res.name == "exact_match"
+
+        scorer2_read_req = tsi.ScorerReadV2Req(
+            project_id=project_id,
+            object_id=length_res.object_id,
+            digest=length_res.digest,
+        )
+        scorer2_read_res = client.server.scorer_read_v2(scorer2_read_req)
+        assert scorer2_read_res.name == "length_check"
+
+    def test_versioning_workflow(self, client):
+        """Test that versioning works correctly across V2 API."""
+        project_id = client._project_id()
+
+        # Create multiple versions of the same op
+        versions = []
+        for i in range(3):
+            req = tsi.OpCreateV2Req(
+                project_id=project_id,
+                name="versioned_op",
+                source_code=f"def versioned():\n    return {i}",
+            )
+            res = client.server.op_create_v2(req)
+            versions.append(res)
+
+        # Verify version indexes
+        assert versions[0].version_index == 0
+        assert versions[1].version_index == 1
+        assert versions[2].version_index == 2
+
+        # Verify all versions have different digests
+        assert versions[0].digest != versions[1].digest
+        assert versions[1].digest != versions[2].digest
+        assert versions[0].digest != versions[2].digest
+
+        # Verify we can read each version
+        for version in versions:
+            read_req = tsi.OpReadV2Req(
+                project_id=project_id,
+                object_id="versioned_op",
+                digest=version.digest,
+            )
+            read_res = client.server.op_read_v2(read_req)
+            assert read_res.digest == version.digest
+            assert read_res.version_index == version.version_index

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1763,6 +1763,178 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         result = self.obj_delete(obj_delete_req)
         return tsi.ScorerDeleteV2Res(num_deleted=result.num_deleted)
 
+    def evaluation_create_v2(
+        self, req: tsi.EvaluationCreateV2Req
+    ) -> tsi.EvaluationCreateV2Res:
+        """Create an evaluation object.
+
+        Creates placeholder ops for evaluate, predict_and_score, and summarize methods.
+        """
+        # Create a safe ID for the evaluation
+        if req.name is None:
+            evaluation_id = "Evaluation"
+        else:
+            evaluation_id = object_creation_utils.make_safe_name(req.name)
+
+        # Create placeholder evaluate op
+        evaluate_op_req = tsi.OpCreateV2Req(
+            project_id=req.project_id,
+            name=f"{evaluation_id}.evaluate",
+            source_code=object_creation_utils.PLACEHOLDER_EVALUATE_OP_SOURCE,
+        )
+        evaluate_op_res = self.op_create_v2(evaluate_op_req)
+        evaluate_ref = evaluate_op_res.digest
+
+        # Create placeholder predict_and_score op
+        predict_and_score_op_req = tsi.OpCreateV2Req(
+            project_id=req.project_id,
+            name=f"{evaluation_id}.predict_and_score",
+            source_code=object_creation_utils.PLACEHOLDER_PREDICT_AND_SCORE_OP_SOURCE,
+        )
+        predict_and_score_op_res = self.op_create_v2(predict_and_score_op_req)
+        predict_and_score_ref = predict_and_score_op_res.digest
+
+        # Create placeholder summarize op
+        summarize_op_req = tsi.OpCreateV2Req(
+            project_id=req.project_id,
+            name=f"{evaluation_id}.summarize",
+            source_code=object_creation_utils.PLACEHOLDER_EVALUATION_SUMMARIZE_OP_SOURCE,
+        )
+        summarize_op_res = self.op_create_v2(summarize_op_req)
+        summarize_ref = summarize_op_res.digest
+
+        # Create the evaluation object
+        evaluation_val = object_creation_utils.build_evaluation_val(
+            name=req.name,
+            dataset_ref=req.dataset,
+            trials=req.trials,
+            description=req.description,
+            scorer_refs=req.scorers,
+            evaluation_name=req.evaluation_name,
+            metadata=None,
+            preprocess_model_input=None,
+            eval_attributes=req.eval_attributes,
+            evaluate_ref=evaluate_ref,
+            predict_and_score_ref=predict_and_score_ref,
+            summarize_ref=summarize_ref,
+        )
+        obj_req = tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=req.project_id,
+                object_id=evaluation_id,
+                val=evaluation_val,
+                wb_user_id=None,
+            )
+        )
+        obj_result = self.obj_create(obj_req)
+
+        # Query the object back to get its version index (this may not be
+        # immediately available, so we retry a few times)
+        obj_read_req = tsi.ObjReadReq(
+            project_id=req.project_id,
+            object_id=evaluation_id,
+            digest=obj_result.digest,
+        )
+        obj_read_res = self._obj_read_with_retry(obj_read_req)
+
+        # Get the ref and return the create result
+        evaluation_ref = ri.InternalObjectRef(
+            project_id=req.project_id,
+            name=evaluation_id,
+            version=obj_result.digest,
+        ).uri()
+        return tsi.EvaluationCreateV2Res(
+            digest=obj_result.digest,
+            object_id=evaluation_id,
+            version_index=obj_read_res.obj.version_index,
+            evaluation_ref=evaluation_ref,
+        )
+
+    def evaluation_read_v2(
+        self, req: tsi.EvaluationReadV2Req
+    ) -> tsi.EvaluationReadV2Res:
+        """Get an evaluation object by delegating to obj_read with retry logic."""
+        obj_req = tsi.ObjReadReq(
+            project_id=req.project_id,
+            object_id=req.object_id,
+            digest=req.digest,
+        )
+        result = self._obj_read_with_retry(obj_req)
+        val = result.obj.val
+
+        # Extract name and description from val data
+        name = val.get("name")
+        description = val.get("description")
+
+        # Create the response with all required fields
+        return tsi.EvaluationReadV2Res(
+            object_id=result.obj.object_id,
+            digest=result.obj.digest,
+            version_index=result.obj.version_index,
+            created_at=result.obj.created_at,
+            name=name,
+            description=description,
+            dataset=val.get("dataset", ""),
+            scorers=val.get("scorers", []),
+            trials=val.get("trials", 1),
+            evaluation_name=val.get("evaluation_name"),
+            evaluate_op=val.get("evaluate", ""),
+            predict_and_score_op=val.get("predict_and_score", ""),
+            summarize_op=val.get("summarize", ""),
+        )
+
+    def evaluation_list_v2(
+        self, req: tsi.EvaluationListV2Req
+    ) -> Iterator[tsi.EvaluationReadV2Res]:
+        """List evaluation objects by delegating to objs_query with Evaluation filtering."""
+        # Query the objects
+        obj_query_req = tsi.ObjQueryReq(
+            project_id=req.project_id,
+            filter=tsi.ObjectVersionFilter(base_object_classes=["Evaluation"]),
+            limit=req.limit,
+            offset=req.offset,
+        )
+        result = self.objs_query(obj_query_req)
+
+        # Yield back a descriptive metadata object for each evaluation
+        for obj in result.objs:
+            val = obj.val if hasattr(obj, "val") and obj.val else {}
+
+            name = val.get("name") if isinstance(val, dict) else None
+            description = val.get("description") if isinstance(val, dict) else None
+
+            yield tsi.EvaluationReadV2Res(
+                object_id=obj.object_id,
+                digest=obj.digest,
+                version_index=obj.version_index,
+                created_at=obj.created_at,
+                name=name,
+                description=description,
+                dataset=val.get("dataset", "") if isinstance(val, dict) else "",
+                scorers=val.get("scorers", []) if isinstance(val, dict) else [],
+                trials=val.get("trials", 1) if isinstance(val, dict) else 1,
+                evaluation_name=val.get("evaluation_name")
+                if isinstance(val, dict)
+                else None,
+                evaluate_op=val.get("evaluate", "") if isinstance(val, dict) else "",
+                predict_and_score_op=val.get("predict_and_score", "")
+                if isinstance(val, dict)
+                else "",
+                summarize_op=val.get("summarize", "") if isinstance(val, dict) else "",
+            )
+
+    def evaluation_delete_v2(
+        self, req: tsi.EvaluationDeleteV2Req
+    ) -> tsi.EvaluationDeleteV2Res:
+        """Delete evaluation objects by delegating to obj_delete."""
+        obj_delete_req = tsi.ObjDeleteReq(
+            project_id=req.project_id,
+            object_id=req.object_id,
+            digests=req.digests,
+        )
+        result = self.obj_delete(obj_delete_req)
+        return tsi.EvaluationDeleteV2Res(num_deleted=result.num_deleted)
+
     def _obj_read_with_retry(
         self, req: tsi.ObjReadReq, max_retries: int = 10, initial_delay: float = 0.05
     ) -> tsi.ObjReadRes:

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -515,3 +515,29 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
     def scorer_delete_v2(self, req: tsi.ScorerDeleteV2Req) -> tsi.ScorerDeleteV2Res:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(self._internal_trace_server.scorer_delete_v2, req)
+
+    def evaluation_create_v2(
+        self, req: tsi.EvaluationCreateV2Req
+    ) -> tsi.EvaluationCreateV2Res:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.evaluation_create_v2, req)
+
+    def evaluation_read_v2(
+        self, req: tsi.EvaluationReadV2Req
+    ) -> tsi.EvaluationReadV2Res:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.evaluation_read_v2, req)
+
+    def evaluation_list_v2(
+        self, req: tsi.EvaluationListV2Req
+    ) -> Iterator[tsi.EvaluationReadV2Res]:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._stream_ref_apply(
+            self._internal_trace_server.evaluation_list_v2, req
+        )
+
+    def evaluation_delete_v2(
+        self, req: tsi.EvaluationDeleteV2Req
+    ) -> tsi.EvaluationDeleteV2Res:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(self._internal_trace_server.evaluation_delete_v2, req)

--- a/weave/trace_server/object_creation_utils.py
+++ b/weave/trace_server/object_creation_utils.py
@@ -13,6 +13,27 @@ PLACEHOLDER_SCORER_SUMMARIZE_OP_SOURCE = """def summarize(score_rows: list) -> d
     from weave.flow.scorer import auto_summarize
     return auto_summarize(score_rows)
 """
+PLACEHOLDER_EVALUATE_OP_SOURCE = """import weave
+@weave.op()
+def evaluate(evaluation, model):
+    \"\"\"Placeholder evaluate function.\"\"\"
+    # TODO: Implement actual evaluation logic
+    return {"status": "not_implemented"}
+"""
+PLACEHOLDER_PREDICT_AND_SCORE_OP_SOURCE = """import weave
+@weave.op()
+def predict_and_score(evaluation, example):
+    \"\"\"Placeholder predict_and_score function.\"\"\"
+    # TODO: Implement actual predict and score logic
+    return {"prediction": None, "scores": {}}
+"""
+PLACEHOLDER_EVALUATION_SUMMARIZE_OP_SOURCE = """import weave
+@weave.op()
+def summarize(evaluation_results):
+    \"\"\"Placeholder summarize function.\"\"\"
+    # TODO: Implement actual summarization logic
+    return {"summary": "not_implemented"}
+"""
 
 
 def make_safe_name(name: str | None) -> str:
@@ -135,3 +156,66 @@ def build_scorer_val(
         "summarize": summarize_op_ref,
         "column_map": column_map,
     }
+
+
+def build_evaluation_val(
+    name: str,
+    dataset_ref: str,
+    trials: int,
+    description: str | None,
+    scorer_refs: list[str] | None,
+    evaluation_name: str | None,
+    metadata: dict[str, Any] | None,
+    preprocess_model_input: str | None,
+    evaluate_ref: str,
+    predict_and_score_ref: str,
+    summarize_ref: str,
+    class_name: str = "Evaluation",
+    eval_attributes: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the value dictionary for an Evaluation object.
+
+    Args:
+        name: The evaluation name
+        dataset_ref: Reference to the dataset (weave:// URI)
+        trials: Number of trials to run
+        description: Optional description of the evaluation
+        scorer_refs: Optional list of scorer references (weave:// URIs)
+        evaluation_name: Optional name for the evaluation run
+        metadata: Optional metadata for the evaluation
+        preprocess_model_input: Optional reference to a function that preprocesses model inputs
+        evaluate_ref: Reference to the op implementing the evaluate method
+        predict_and_score_ref: Reference to the op implementing the predict_and_score method
+        summarize_ref: Reference to the op implementing the summarize method
+        class_name: The class name (defaults to "Evaluation" for base evaluations, or a custom name for subclasses)
+        eval_attributes: Optional attributes for the evaluation
+
+    Returns:
+        Dictionary representing the evaluation object value
+    """
+    if class_name == "Evaluation":
+        bases = ["Object", "BaseModel"]
+    else:
+        bases = ["Evaluation", "Object", "BaseModel"]
+
+    result = {
+        "_type": class_name,
+        "_class_name": class_name,
+        "_bases": bases,
+        "name": name,
+        "description": description,
+        "dataset": dataset_ref,
+        "scorers": scorer_refs or [],
+        "trials": trials,
+        "evaluation_name": evaluation_name,
+        "metadata": metadata,
+        "preprocess_model_input": preprocess_model_input,
+        "evaluate": evaluate_ref,
+        "predict_and_score": predict_and_score_ref,
+        "summarize": summarize_ref,
+    }
+
+    if eval_attributes is not None:
+        result.update(eval_attributes)
+
+    return result

--- a/weave/trace_server/reference/generate.py
+++ b/weave/trace_server/reference/generate.py
@@ -25,6 +25,7 @@ THREADS_TAG_NAME = "Threads"
 V2_OPS_TAG_NAME = "V2 -- Ops"
 V2_DATASETS_TAG_NAME = "V2 -- Datasets"
 V2_SCORERS_TAG_NAME = "V2 -- Scorers"
+V2_EVALUATIONS_TAG_NAME = "V2 -- Evaluations"
 
 
 class AuthParams(NamedTuple):
@@ -362,6 +363,85 @@ def generate_routes_v2(
             project_id=project_id, object_id=object_id, digests=digests
         )
         return service.trace_server_interface.scorer_delete_v2(req)
+
+    @router.post(
+        "{entity}/{project}/evaluations",
+        tags=[V2_EVALUATIONS_TAG_NAME],
+    )
+    def evaluation_create_v2(
+        req: tsi.EvaluationCreateV2Req,
+        service: weave.trace_server.trace_service.TraceService = Depends(get_service),  # noqa: B008
+    ) -> tsi.EvaluationCreateV2Res:
+        """Create an evaluation object."""
+        return service.trace_server_interface.evaluation_create_v2(req)
+
+    @router.get(
+        "{entity}/{project}/evaluations/{object_id}/versions/{digest}",
+        tags=[V2_EVALUATIONS_TAG_NAME],
+    )
+    def evaluation_read_v2(
+        entity: str,
+        project: str,
+        object_id: str,
+        digest: str,
+        service: weave.trace_server.trace_service.TraceService = Depends(get_service),  # noqa: B008
+    ) -> tsi.EvaluationReadV2Res:
+        """Get an evaluation object."""
+        project_id = f"{entity}/{project}"
+        req = tsi.EvaluationReadV2Req(
+            project_id=project_id, object_id=object_id, digest=digest
+        )
+        return service.trace_server_interface.evaluation_read_v2(req)
+
+    @router.get(
+        "{entity}/{project}/evaluations",
+        tags=[V2_EVALUATIONS_TAG_NAME],
+        response_class=StreamingResponse,
+        responses={
+            200: {
+                "description": "Stream of data in JSONL format",
+                "content": {
+                    "application/jsonl": {
+                        "schema": {
+                            "type": "array",
+                            "items": {"$ref": "#/components/schemas/Schema"},
+                        }
+                    }
+                },
+            }
+        },
+    )
+    def evaluation_list_v2(
+        entity: str,
+        project: str,
+        limit: int | None = None,
+        offset: int | None = None,
+        service: weave.trace_server.trace_service.TraceService = Depends(get_service),  # noqa: B008
+    ) -> StreamingResponse:
+        """List evaluation objects."""
+        project_id = f"{entity}/{project}"
+        req = tsi.EvaluationListV2Req(project_id=project_id, limit=limit, offset=offset)
+        return StreamingResponse(
+            service.trace_server_interface.evaluation_list_v2(req),
+            media_type="application/jsonl",
+        )
+
+    @router.delete(
+        "{entity}/{project}/evaluations/{object_id}", tags=[V2_EVALUATIONS_TAG_NAME]
+    )
+    def evaluation_delete_v2(
+        entity: str,
+        project: str,
+        object_id: str,
+        digests: list[str] | None = None,
+        service: weave.trace_server.trace_service.TraceService = Depends(get_service),  # noqa: B008
+    ) -> tsi.EvaluationDeleteV2Res:
+        """Delete an evaluation object."""
+        project_id = f"{entity}/{project}"
+        req = tsi.EvaluationDeleteV2Req(
+            project_id=project_id, object_id=object_id, digests=digests
+        )
+        return service.trace_server_interface.evaluation_delete_v2(req)
 
     return router
 

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1482,6 +1482,112 @@ class ScorerDeleteV2Res(BaseModel):
     num_deleted: int = Field(..., description="Number of scorer versions deleted")
 
 
+class EvaluationCreateV2Body(BaseModel):
+    name: str = Field(
+        ...,
+        description="The name of this evaluation.  Evaluations with the same name will be versioned together.",
+    )
+    description: Optional[str] = Field(
+        None,
+        description="A description of this evaluation",
+    )
+
+    dataset: str = Field(..., description="Reference to the dataset (weave:// URI)")
+    scorers: Optional[list[str]] = Field(
+        None, description="List of scorer references (weave:// URIs)"
+    )
+
+    trials: int = Field(default=1, description="Number of trials to run")
+    evaluation_name: Optional[str] = Field(
+        None, description="Name for the evaluation run"
+    )
+    eval_attributes: Optional[dict[str, Any]] = Field(
+        None, description="Optional attributes for the evaluation"
+    )
+
+
+class EvaluationCreateV2Req(EvaluationCreateV2Body):
+    project_id: str = Field(
+        ..., description="The `entity/project` where this evaluation will be saved"
+    )
+
+
+class EvaluationCreateV2Res(BaseModel):
+    digest: str = Field(..., description="The digest of the created evaluation")
+    object_id: str = Field(..., description="The ID of the created evaluation")
+    version_index: int = Field(
+        ..., description="The version index of the created evaluation"
+    )
+    evaluation_ref: str = Field(
+        ..., description="Full reference to the created evaluation"
+    )
+
+
+class EvaluationReadV2Req(BaseModel):
+    project_id: str = Field(
+        ..., description="The `entity/project` where this evaluation is saved"
+    )
+    object_id: str = Field(..., description="The evaluation ID")
+    digest: str = Field(..., description="The digest of the evaluation")
+
+
+class EvaluationReadV2Res(BaseModel):
+    object_id: str = Field(..., description="The evaluation ID")
+    digest: str = Field(..., description="The digest of the evaluation")
+    version_index: int = Field(..., description="The version index of the evaluation")
+    created_at: datetime.datetime = Field(
+        ..., description="When the evaluation was created"
+    )
+    name: str = Field(..., description="The name of the evaluation")
+    description: Optional[str] = Field(
+        None, description="A description of the evaluation"
+    )
+    dataset: str = Field(..., description="Dataset reference (weave:// URI)")
+    scorers: list[str] = Field(
+        ..., description="List of scorer references (weave:// URIs)"
+    )
+    trials: int = Field(..., description="Number of trials")
+    evaluation_name: Optional[str] = Field(
+        None, description="Name for the evaluation run"
+    )
+    evaluate_op: Optional[str] = Field(
+        None, description="Evaluate op reference (weave:// URI)"
+    )
+    predict_and_score_op: Optional[str] = Field(
+        None, description="Predict and score op reference (weave:// URI)"
+    )
+    summarize_op: Optional[str] = Field(
+        None, description="Summarize op reference (weave:// URI)"
+    )
+
+
+class EvaluationListV2Req(BaseModel):
+    project_id: str = Field(
+        ..., description="The `entity/project` where these evaluations are saved"
+    )
+    limit: Optional[int] = Field(
+        default=None, description="Maximum number of evaluations to return"
+    )
+    offset: Optional[int] = Field(
+        default=None, description="Number of evaluations to skip"
+    )
+
+
+class EvaluationDeleteV2Req(BaseModel):
+    project_id: str = Field(
+        ..., description="The `entity/project` where this evaluation is saved"
+    )
+    object_id: str = Field(..., description="The evaluation ID")
+    digests: Optional[list[str]] = Field(
+        default=None,
+        description="List of digests to delete. If not provided, all digests for the evaluation will be deleted.",
+    )
+
+
+class EvaluationDeleteV2Res(BaseModel):
+    num_deleted: int = Field(..., description="Number of evaluation versions deleted")
+
+
 class TraceServerInterface(Protocol):
     def ensure_project_exists(
         self, entity: str, project: str
@@ -1607,6 +1713,18 @@ class TraceServerInterfaceV2(Protocol):
     def scorer_read_v2(self, req: ScorerReadV2Req) -> ScorerReadV2Res: ...
     def scorer_list_v2(self, req: ScorerListV2Req) -> Iterator[ScorerReadV2Res]: ...
     def scorer_delete_v2(self, req: ScorerDeleteV2Req) -> ScorerDeleteV2Res: ...
+
+    # Evaluations
+    def evaluation_create_v2(
+        self, req: EvaluationCreateV2Req
+    ) -> EvaluationCreateV2Res: ...
+    def evaluation_read_v2(self, req: EvaluationReadV2Req) -> EvaluationReadV2Res: ...
+    def evaluation_list_v2(
+        self, req: EvaluationListV2Req
+    ) -> Iterator[EvaluationReadV2Res]: ...
+    def evaluation_delete_v2(
+        self, req: EvaluationDeleteV2Req
+    ) -> EvaluationDeleteV2Res: ...
 
 
 class FullTraceServerInterface(TraceServerInterface, TraceServerInterfaceV2, Protocol):

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -579,6 +579,26 @@ class CachingMiddlewareTraceServer(tsi.FullTraceServerInterface):
     def scorer_delete_v2(self, req: tsi.ScorerDeleteV2Req) -> tsi.ScorerDeleteV2Res:
         return self._next_trace_server.scorer_delete_v2(req)
 
+    def evaluation_create_v2(
+        self, req: tsi.EvaluationCreateV2Req
+    ) -> tsi.EvaluationCreateV2Res:
+        return self._next_trace_server.evaluation_create_v2(req)
+
+    def evaluation_read_v2(
+        self, req: tsi.EvaluationReadV2Req
+    ) -> tsi.EvaluationReadV2Res:
+        return self._next_trace_server.evaluation_read_v2(req)
+
+    def evaluation_list_v2(
+        self, req: tsi.EvaluationListV2Req
+    ) -> Iterator[tsi.EvaluationReadV2Res]:
+        return self._next_trace_server.evaluation_list_v2(req)
+
+    def evaluation_delete_v2(
+        self, req: tsi.EvaluationDeleteV2Req
+    ) -> tsi.EvaluationDeleteV2Res:
+        return self._next_trace_server.evaluation_delete_v2(req)
+
 
 def pydantic_bytes_safe_dump(obj: BaseModel) -> str:
     raw_dict = obj.model_dump()


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-28281

This PR adds CRUD endpoints for interacting with Evaluations as part of the V2 Evals API.

For this POC, the implementation simply delegates to the existing Objects endpoints.  There is some logic to generate the same payloads as the client would normally create.

Notably, this PR does not implement endpoints for interacting with the Evaluation's calls.  That feature will come later!

Pairs with https://github.com/wandb/core/pull/35136