### PR TITLE
fix(weave): Don't capture `openai._types.Omit` sentinels

### DIFF
--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -111,7 +111,9 @@ class Sentinel:
 _sentinels_to_check = [
     Sentinel(package="openai", path="openai._types", name="NOT_GIVEN"),
     Sentinel(package="openai", path="openai._types", name="omit"),
-    Sentinel(package="openai", path="openai._types", name="Omit"),  # Class, not instance
+    Sentinel(
+        package="openai", path="openai._types", name="Omit"
+    ),  # Class, not instance
     Sentinel(package="cohere", path="cohere.base_client", name="COHERE_NOT_GIVEN"),
     Sentinel(package="anthropic", path="anthropic._types", name="NOT_GIVEN"),
     Sentinel(package="cerebras", path="cerebras.cloud.sdk._types", name="NOT_GIVEN"),


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-28121

Adds `Omit` to the sentinel list that we ignore tracking for because it's noisy.


## Before
<img width="843" height="767" alt="image" src="https://github.com/user-attachments/assets/4e8a5499-f1f3-4ec9-bccf-7829ec689153" />

## After
<img width="517" height="796" alt="image" src="https://github.com/user-attachments/assets/26a1cd7e-05a7-4bc8-bebf-7b6945cadade" />
