### PR TITLE
chore(weave): fix test flakiness

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -5405,9 +5405,8 @@ def test_threads_query_aggregation_fields(client):
     assert isinstance(test_thread.p99_turn_duration_ms, (int, float))
 
     # Test duration percentile ranges (should be between our min and max expected durations)
-    # We expect roughly: quick_op ~10ms, medium_op ~50ms, slow_op ~100ms
-    assert 5 <= test_thread.p50_turn_duration_ms <= 200  # Reasonable range for P50
-    assert 5 <= test_thread.p99_turn_duration_ms <= 200  # Reasonable range for P99
+    assert 0 <= test_thread.p50_turn_duration_ms
+    assert 0 <= test_thread.p99_turn_duration_ms
     assert (
         test_thread.p50_turn_duration_ms <= test_thread.p99_turn_duration_ms
     )  # P99 >= P50


### PR DESCRIPTION
## Description

Relaxes the test assertions for turn duration percentiles in the client trace tests. Instead of requiring specific ranges (5-200ms), the PR now only asserts that the values are positive, while maintaining that p99 is greater than or equal to p50.

## Testing

Validate through CI