### PR TITLE
docs(weave): fix standalone eval code snippet

### DIFF
--- a/docs/docs/guides/core-types/evaluations.md
+++ b/docs/docs/guides/core-types/evaluations.md
@@ -212,7 +212,7 @@ def function_to_evaluate(question: str):
     # here's where you would add your LLM call and return the output
     return  {'generated_text': 'some response' + question}
 
-asyncio.run(evaluation.evaluate(function_to_evaluate("What is the capitol of France?")))
+asyncio.run(evaluation.evaluate(function_to_evaluate))
 ```
 
 ![Evals hero](../../../static/img/evals-hero.png)


### PR DESCRIPTION
## Description

https://weave-docs.wandb.ai/guides/core-types/evaluations/#full-evaluation-code-sample <- this runnable code snippet for getting started with evals produces this error:
```
Traceback (most recent call last):
  File "/Users/ben/core/services/weave-python/weave-public/test.py", line 45, in <module>
    asyncio.run(evaluation.evaluate(function_to_evaluate("What is the capitol of France?")))
  File "/Users/ben/.pyenv/versions/3.11.9/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/ben/.pyenv/versions/3.11.9/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/.pyenv/versions/3.11.9/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/ben/core/services/weave-python/weave-public/weave/trace/op.py", line 1217, in wrapper
    res, _ = await _call_async_func(
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/core/services/weave-python/weave-public/weave/trace/op.py", line 632, in _call_async_func
    res = await func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/core/services/weave-python/weave-public/weave/evaluation/eval.py", line 280, in evaluate
    eval_results = await self.get_eval_results(model)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ben/core/services/weave-python/weave-public/weave/evaluation/eval.py", line 238, in get_eval_results
    raise ValueError(INVALID_MODEL_ERROR)
ValueError: `Evaluation.evaluate` requires a `Model` or `Op` instance as the `model` argument. If you are using a function, wrap it with `weave.op` to create an `Op` instance.
```

Because the last line passes the result of invoking an op instead of the op itself to `evaluation.evaluate`. This PR fixes that.