### PR TITLE
fix(weave): Actually patch OpenAI Agents SDK

### DIFF
--- a/weave/integrations/patch.py
+++ b/weave/integrations/patch.py
@@ -294,7 +294,7 @@ INTEGRATION_MODULE_MAPPING: dict[str, Callable[[], None]] = {
     "mcp": patch_mcp,
     "langchain_nvidia_ai_endpoints": patch_nvidia,
     "smolagents": patch_smolagents,
-    "openai_agents": patch_openai_agents,
+    "agents": patch_openai_agents,
     "verdict": patch_verdict,
     "verifiers": patch_verifiers,
     "autogen": patch_autogen,


### PR DESCRIPTION
Previously, we looked for `openai_agents`, but that's not what the package is actually called!  So patching doesn't actually happen automatically.