### PR TITLE
chore(weave): add eval and dataset selector fields on saved views

### DIFF
--- a/scripts/generate_base_object_schemas.py
+++ b/scripts/generate_base_object_schemas.py
@@ -9,6 +9,7 @@ from weave.trace_server.interface.builtin_object_classes.builtin_object_registry
 
 OUTPUT_DIR = (
     Path(__file__).parent.parent
+    / "weave"
     / "trace_server"
     / "interface"
     / "builtin_object_classes"

--- a/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
+++ b/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
@@ -129,6 +129,7 @@
           "title": "Description"
         },
         "field_schema": {
+          "additionalProperties": true,
           "default": {},
           "description": "Expected to be valid JSON Schema. Can be provided as a dict, a Pydantic model class, a tuple of a primitive type and a Pydantic Field, or primitive type",
           "examples": [
@@ -1247,6 +1248,7 @@
           "anyOf": [
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1417,6 +1419,7 @@
           "type": "string"
         },
         "response_schema": {
+          "additionalProperties": true,
           "title": "Response Schema",
           "type": "object"
         }
@@ -1443,6 +1446,7 @@
             },
             {
               "items": {
+                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1469,6 +1473,7 @@
         "function_call": {
           "anyOf": [
             {
+              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1930,6 +1935,18 @@
           "default": null,
           "title": "Sort By"
         },
+        "page": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Page"
+        },
         "page_size": {
           "anyOf": [
             {
@@ -1956,6 +1973,30 @@
           ],
           "default": null,
           "title": "Charts"
+        },
+        "dataset_selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dataset Selector"
+        },
+        "evaluation_selector": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Evaluation Selector"
         }
       },
       "title": "SavedViewDefinition",

--- a/weave/trace_server/interface/builtin_object_classes/saved_view.py
+++ b/weave/trace_server/interface/builtin_object_classes/saved_view.py
@@ -53,6 +53,13 @@ class SavedViewDefinition(BaseModel):
     page_size: Optional[int] = Field(default=None)
     charts: Optional[list[ChartConfig]] = Field(default=None)
 
+    # Evaluations calls table has dataset and evaluation object
+    # selectors that can be used to filter down evals to those using these objects.
+    # The selector is an object ref where the version can either be a digest or `*`
+    # to match all versions.
+    dataset_selector: Optional[str] = Field(default=None)
+    evaluation_selector: Optional[str] = Field(default=None)
+
 
 class SavedView(base_object_def.BaseObject):
     # "traces" or "evaluations", type is str for extensibility


### PR DESCRIPTION
## Description

Updates the `SavedViewDefinition` model to include new fields for dataset and evaluation selectors, which can filter evaluations based on specific objects. Also adds a `page` field for pagination support. Additionally, adds `additionalProperties: true` to several schema definitions to allow for more flexible object structures.
