### PR TITLE
feat(weave): Support context propagation in EvaluationLogger

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -272,10 +272,7 @@ def test_evaluation_version_reuse(
 
         for row in user_dataset:
             output = user_model(row["a"], row["b"])
-            # Convert TypedDict to dict to avoid type errors
-            inputs_dict = dict(row)
-            pred = ev.log_prediction(inputs=inputs_dict, output=output)
-
+            pred = ev.log_prediction(inputs=row, output=output)
             score_result = output > 2
             pred.log_score(scorer="greater_than_2_scorer", score=score_result)
             pred.finish()
@@ -744,41 +741,34 @@ def test_evaluation_logger_set_view_string(client):
 
 def test_cost_propagation_with_child_calls(client):
     """Test that cost data from child calls propagates to parent predict_and_score call."""
-    ev = EvaluationLogger()
 
-    # Log a prediction
+    @weave.op
+    def mock_llm_call(prompt: str) -> dict:
+        return {
+            "model": "gpt-4",
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 20,
+                "total_tokens": 30,
+            },
+            "content": "response",
+        }
+
+    ev = EvaluationLogger()
     pred = ev.log_prediction(inputs={"question": "Hello"}, output="Hi there!")
 
     # Add a child call with usage/cost data to the predict_call
     # This simulates calling an LLM within the prediction
     with call_context.set_call_stack([pred.predict_call]):
-        # Create a mock op that returns usage data
-        @weave.op
-        def mock_llm_call(prompt: str) -> dict:
-            return {
-                "model": "gpt-4",
-                "usage": {
-                    "prompt_tokens": 10,
-                    "completion_tokens": 20,
-                    "total_tokens": 30,
-                },
-                "content": "response",
-            }
-
         mock_llm_call("test prompt")
 
-    # Finish the prediction
     pred.finish()
-
-    # Log summary to finalize the evaluation
     ev.log_summary({"test": "complete"})
 
     client.flush()
 
     # Get all calls and verify cost propagation
     calls = client.get_calls()
-
-    # Find the predict_and_score_call
     predict_and_score_call = None
     for call in calls:
         if op_name_from_call(call) == "Evaluation.predict_and_score":
@@ -797,31 +787,40 @@ def test_cost_propagation_with_child_calls(client):
     assert predict_and_score_call.summary["usage"]["gpt-4"]["requests"] == 1
 
 
-def test_finish_with_output_override(client):
-    """Test that passing output to finish() overrides the initial output."""
+def test_log_prediction_context_manager(client):
+    """Test using PredictionContext as a context manager with automatic call stack management."""
+
+    @weave.op
+    def calculate_answer(question: str) -> dict:
+        return {
+            "model": "gpt-4",
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 3,
+                "total_tokens": 8,
+            },
+            "answer": 4,
+        }
+
     ev = EvaluationLogger()
 
-    # Log a prediction with placeholder output
-    pred = ev.log_prediction(inputs={"question": "Hello"}, output="placeholder")
+    # When output is None, log_prediction returns PredictionContext
+    with ev.log_prediction(inputs={"question": "What is 2+2?"}) as pred:
+        # Operations here automatically become children of pred.predict_call
+        result = calculate_answer("What is 2+2?")
 
-    # Add a child call that generates the real output
-    with call_context.set_call_stack([pred.predict_call]):
+        # Set the output
+        pred.output = result["answer"]
 
-        @weave.op
-        def generate_response(prompt: str) -> str:
-            return "This is the real response!"
+        # Log scores
+        pred.log_score("correctness", 1.0)
 
-        actual_output = generate_response("Hello")
+        # finish() is called automatically on exit and call stack is restored
 
-    # Finish with the actual output
-    pred.finish(output=actual_output)
+    ev.log_summary({"avg_score": 1.0})
 
-    # Log summary
-    ev.log_summary({"test": "complete"})
-
+    # Verify everything was logged correctly
     client.flush()
-
-    # Verify the output was overridden
     calls = client.get_calls()
 
     predict_call = None
@@ -835,6 +834,101 @@ def test_finish_with_output_override(client):
     assert predict_call is not None
     assert predict_and_score_call is not None
 
-    # Both should have the actual output, not the placeholder
-    assert predict_call.output == "This is the real response!"
-    assert predict_and_score_call.output["output"] == "This is the real response!"
+    # Verify the output was set correctly
+    assert predict_call.output == 4
+    assert predict_and_score_call.output["output"] == 4
+
+    # Verify scores were logged
+    assert predict_and_score_call.output["scores"]["correctness"] == 1.0
+
+    # Verify cost data propagated
+    assert predict_and_score_call.summary is not None
+    assert "usage" in predict_and_score_call.summary
+    assert "gpt-4" in predict_and_score_call.summary["usage"]
+    assert predict_and_score_call.summary["usage"]["gpt-4"]["total_tokens"] == 8
+
+
+def test_log_score_context_manager(client):
+    """Test using log_score as a context manager for complex scoring."""
+
+    @weave.op
+    def analyze_quality(text: str) -> float:
+        """Mock quality analysis that returns a score."""
+        return 0.95
+
+    ev = EvaluationLogger()
+
+    with ev.log_prediction(inputs={"question": "What is AI?"}) as pred:
+        pred.output = "AI is artificial intelligence"
+
+        # Direct score logging
+        pred.log_score("correctness", 1.0)
+
+        # Context manager score logging
+        with pred.log_score("quality") as score:
+            # Operations here become children of the score call
+            quality_result = analyze_quality(pred.output)
+            score.value = quality_result
+
+    ev.log_summary({"avg_score": 0.975})
+    client.flush()
+
+    # Verify everything was logged correctly
+    calls = client.get_calls()
+
+    # Find the predict_and_score_call
+    predict_and_score_call = None
+    quality_scorer_call = None
+    for call in calls:
+        if op_name_from_call(call) == "Evaluation.predict_and_score":
+            predict_and_score_call = call
+        elif op_name_from_call(call) == "quality":
+            quality_scorer_call = call
+
+    assert predict_and_score_call is not None
+    assert quality_scorer_call is not None
+
+    # Verify both scores were logged
+    assert predict_and_score_call.output["scores"]["correctness"] == 1.0
+    assert predict_and_score_call.output["scores"]["quality"] == 0.95
+
+    # Verify the analyze_quality op was called
+    analyze_calls = [c for c in calls if op_name_from_call(c) == "analyze_quality"]
+    assert len(analyze_calls) == 1, (
+        f"Should have exactly one analyze_quality call, found {len(analyze_calls)}"
+    )
+    analyze_call = analyze_calls[0]
+
+    # The analyze_quality call's parent should be the quality scorer call
+    assert analyze_call.parent_id == quality_scorer_call.id, (
+        f"analyze_quality parent should be quality scorer, but got {analyze_call.parent_id}"
+    )
+
+
+def test_none_as_valid_score_value(client):
+    """Test that None can be used as a valid score value."""
+    ev = EvaluationLogger()
+
+    # Log prediction with None as output
+    pred = ev.log_prediction(inputs={"q": "test"}, output=None)
+
+    # Log a None score (e.g., scoring failed)
+    pred.log_score("correctness", None)
+    pred.log_score("quality", 0.5)
+
+    pred.finish()
+    ev.log_summary({})
+
+    client.flush()
+    calls = client.get_calls()
+
+    predict_and_score_call = None
+    for call in calls:
+        if op_name_from_call(call) == "Evaluation.predict_and_score":
+            predict_and_score_call = call
+            break
+
+    assert predict_and_score_call is not None
+    # Verify None score was recorded
+    assert predict_and_score_call.output["scores"]["correctness"] is None
+    assert predict_and_score_call.output["scores"]["quality"] == 0.5

--- a/weave/utils/sentinel.py
+++ b/weave/utils/sentinel.py
@@ -1,0 +1,12 @@
+"""Sentinel values for distinguishing 'not provided' from None or other values."""
+
+
+class _NotSetType:
+    """Sentinel type to distinguish 'not provided' from None or other values."""
+
+    def __repr__(self) -> str:
+        return "<NOT_SET>"
+
+
+# Sentinel value to distinguish "not provided" from None
+NOT_SET = _NotSetType()


### PR DESCRIPTION
This changes `EvaluationLogger` to defer finishing calls so summary stats can be accurately computed.  It also introduces a new context manager API for nesting calls under a given `predict` or `score` call

See before and after results for the snippet below:
```py
import openai
import weave

client = weave.init("nested-imperative-evaluation")
oai = openai.OpenAI()

ev = weave.EvaluationLogger()

user_prompt = "Tell me a joke"
with ev.log_prediction(inputs={"user_prompt": user_prompt}) as pred:
    result = oai.chat.completions.create(
        model="gpt-5-mini",
        messages=[{"role": "user", "content": user_prompt}],
    )

    # Set the output of the "predict" call
    pred.output = result.choices[0].message.content

    # Log scores
    pred.log_score("correctness", 1.0)
    pred.log_score("ambiguity", 0.3)
    with pred.log_score("llm_judge") as score:
        result = oai.chat.completions.create(
            model="gpt-4o-mini",
            messages=[
                {"role": "system", "content": "Rate how funny the joke is from 1-5"},
                {"role": "user", "content": pred.output},
            ],
        )
        score.value = result.choices[0].message.content

ev.log_summary({"avg_score": 1.0})

```

## Before
<img width="390" height="263" alt="image" src="https://github.com/user-attachments/assets/7aff8cc0-cc0a-4e78-a2d0-5fb20c44b336" />


## After
<img width="808" height="320" alt="image" src="https://github.com/user-attachments/assets/e45213d3-580b-4e95-b219-5e47f9bd1de8" />

