### PR TITLE
fix(weave): Allow markdown to be stored in files

### DIFF
--- a/tests/trace/data_serialization/test_cases/media_cases.py
+++ b/tests/trace/data_serialization/test_cases/media_cases.py
@@ -31,6 +31,10 @@ video_file_path = os.path.join(
 VIDEO_BYTES = open(video_file_path, "rb").read()
 
 
+def markdown_equality_check(a, b):
+    return a.markup == b.markup and a.code_theme == b.code_theme
+
+
 media_cases = [
     # Datetime
     SerializationTestCase(
@@ -40,6 +44,247 @@ media_cases = [
         ),
         inline_call_param=True,
         is_legacy=False,
+        exp_json={
+            "_type": "CustomWeaveType",
+            "weave_type": {"type": "datetime.datetime"},
+            "load_op": "weave:///shawn/test-project/op/load_datetime.datetime:7HTt9V46gIXwlrAFunI2MPmOxF9CXOapvMuTRBJYiXY",
+            "val": "2025-01-01T00:00:00+00:00",
+        },
+        exp_objects=[
+            {
+                "object_id": "load_datetime.datetime",
+                "digest": "7HTt9V46gIXwlrAFunI2MPmOxF9CXOapvMuTRBJYiXY",
+                "exp_val": {
+                    "_type": "CustomWeaveType",
+                    "weave_type": {"type": "Op"},
+                    "files": {"obj.py": "N4DNKMmxsQXSUwJUHgNuDJboXqRyYTI8UvLtmYvCBQE"},
+                },
+            }
+        ],
+        exp_files=[
+            {
+                "digest": "N4DNKMmxsQXSUwJUHgNuDJboXqRyYTI8UvLtmYvCBQE",
+                "exp_content": b'import weave\nfrom weave.trace.serialization.mem_artifact import MemTraceFilesArtifact\nfrom typing import Any\nimport datetime\n\n@weave.op()\ndef load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> datetime.datetime:\n    """Deserialize an ISO format string back to a datetime object with timezone."""\n    return datetime.datetime.fromisoformat(val)\n',
+            }
+        ],
+    ),
+    # Image (PIL.Image.Image)
+    SerializationTestCase(
+        id="image",
+        runtime_object_factory=lambda: Image.new("RGB", (10, 10), "red"),
+        inline_call_param=True,
+        is_legacy=False,
+        exp_json={
+            "_type": "CustomWeaveType",
+            "weave_type": {"type": "PIL.Image.Image"},
+            "files": {"image.png": "Ac3YO5daeesZTxBfXf7DAKaQZ5IZysk2HvclN8sfwxQ"},
+            "load_op": "weave:///shawn/test-project/op/load_PIL.Image.Image:jhxXm8LUXTL8B8nfSGFXQdOLhpuzJYtbW59ZxhUFgoI",
+        },
+        exp_objects=[
+            {
+                "object_id": "load_PIL.Image.Image",
+                "digest": "jhxXm8LUXTL8B8nfSGFXQdOLhpuzJYtbW59ZxhUFgoI",
+                "exp_val": {
+                    "_type": "CustomWeaveType",
+                    "weave_type": {"type": "Op"},
+                    "files": {"obj.py": "oxqbCLXF1PsVGFKXZgXHGIuFqlgDG69IwQFUQsGzfHw"},
+                },
+            }
+        ],
+        exp_files=[
+            {
+                "digest": "oxqbCLXF1PsVGFKXZgXHGIuFqlgDG69IwQFUQsGzfHw",
+                "exp_content": b'import weave\nfrom weave.trace.serialization.mem_artifact import MemTraceFilesArtifact\nfrom typing import Any\nfrom weave.utils.iterators import first\nimport PIL.Image as Image\n\n@weave.op()\ndef load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> Image.Image:\n    # Today, we assume there can only be 1 image in the artifact.\n    filename = first(artifact.path_contents)\n    if not filename.startswith("image."):\n        raise ValueError(f"Expected filename to start with \'image.\', got {filename}")\n\n    path = artifact.path(filename)\n    return Image.open(path)\n',
+            },
+            {
+                "digest": "Ac3YO5daeesZTxBfXf7DAKaQZ5IZysk2HvclN8sfwxQ",
+                "exp_content": b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\n\x00\x00\x00\n\x08\x02\x00\x00\x00\x02PX\xea\x00\x00\x00\x12IDATx\x9cc\xfc\xcf\x80\x0f0\xe1\x95\x1d\xb1\xd2\x00A,\x01\x13\xb1\ns\x13\x00\x00\x00\x00IEND\xaeB`\x82",
+            },
+        ],
+        equality_check=lambda a, b: a.tobytes() == b.tobytes(),
+    ),
+    # Audio (weave.type_handlers.Audio.audio.Audio)
+    SerializationTestCase(
+        id="audio",
+        runtime_object_factory=lambda: wave.open(audio_file_path, "rb"),
+        inline_call_param=True,
+        is_legacy=False,
+        exp_json={
+            "_type": "CustomWeaveType",
+            "weave_type": {"type": "weave.type_handlers.Audio.audio.Audio"},
+            "files": {
+                "_metadata.json": "k3eN5qEgVIyMLbUc8sQrx1LRU0gxf7l6dD9LIoSoa0M",
+                "audio.wav": "xfOhnNfgQxRzgWZ6DC1QEGt9vrJWcathymKPPZQmmIw",
+            },
+            "load_op": "weave:///shawn/test-project/op/load_weave.type_handlers.Audio.audio.Audio:rhUJYHAtujfj6PiXSjwdygp1066f006hM3HRZFpvYdI",
+        },
+        exp_objects=[
+            {
+                "object_id": "load_weave.type_handlers.Audio.audio.Audio",
+                "digest": "rhUJYHAtujfj6PiXSjwdygp1066f006hM3HRZFpvYdI",
+                "exp_val": {
+                    "_type": "CustomWeaveType",
+                    "weave_type": {"type": "Op"},
+                    "files": {"obj.py": "SKG0fb7fynxh9xNkLYDMfRrYbEI1iqoNJYB5mrXqn5k"},
+                },
+            }
+        ],
+        exp_files=[
+            {
+                "digest": "SKG0fb7fynxh9xNkLYDMfRrYbEI1iqoNJYB5mrXqn5k",
+                "exp_content": b'import weave\nfrom typing import Any\nimport json\nimport wave\nfrom typing import Generic\nfrom typing import Literal as SUPPORTED_FORMATS_TYPE\nimport base64\nfrom typing import cast\nfrom pathlib._local import Path\nimport os\n\nMETADATA_FILE_NAME = "_metadata.json"\n\nAUDIO_FILE_PREFIX = "audio."\n\nT = "~T"\n\ndef try_decode(data: str | bytes) -> bytes:\n    """Attempt to decode data as base64 or convert to bytes.\n\n    This function tries to decode the input as base64 first. If that fails,\n    it will return the data as bytes, converting if needed.\n\n    Args:\n        data: Input data as string or bytes, potentially base64 encoded\n\n    Returns:\n        bytes: The decoded data as bytes\n    """\n    try:\n        data = base64.b64decode(data, validate=True)\n    except binascii.Error:\n        pass\n\n    if isinstance(data, str):\n        data = data.encode("utf-8")\n\n    return data\n\nSUPPORTED_FORMATS = [\n    "mp3",\n    "wav"\n]\n\ndef get_format_from_filename(filename: str) -> str:\n    """Get the file format from a filename.\n\n    Args:\n        filename: The filename to extract the format from\n    Returns:\n        The format string or None if no extension is found\n    """\n    # Get last dot position\n    last_dot = filename.rfind(".")\n\n    # If there\'s no dot or it\'s the last character, return None\n    if last_dot == -1 or last_dot == len(filename) - 1:\n        return ""\n\n    return filename[last_dot + 1 :].lower()\n\nclass Audio(Generic[T]):\n    """A class representing audio data in a supported format (wav or mp3).\n\n    This class handles audio data storage and provides methods for loading from\n    different sources and exporting to files.\n\n    Attributes:\n        format: The audio format (currently supports \'wav\' or \'mp3\')\n        data: The raw audio data as bytes\n\n    Args:\n        data: The audio data (bytes or base64 encoded string)\n        format: The audio format (\'wav\' or \'mp3\')\n        validate_base64: Whether to attempt base64 decoding of the input data\n\n    Raises:\n        ValueError: If audio data is empty or format is not supported\n    """\n\n    # File Format\n    format: SUPPORTED_FORMATS_TYPE\n\n    # Raw audio data bytes\n    data: bytes\n\n    def __init__(\n        self,\n        data: bytes,\n        format: SUPPORTED_FORMATS_TYPE,\n        validate_base64: bool = True,\n    ) -> None:\n        if len(data) == 0:\n            raise ValueError("Audio data cannot be empty")\n\n        if validate_base64:\n            data = try_decode(data)\n\n        self.data = data\n        self.format = format\n\n    @classmethod\n    def from_data(cls, data: str | bytes, format: str) -> Audio:\n        """Create an Audio object from raw data and specified format.\n\n        Args:\n            data: Audio data as bytes or base64 encoded string\n            format: Audio format (\'wav\' or \'mp3\')\n\n        Returns:\n            Audio: A new Audio instance\n\n        Raises:\n            ValueError: If format is not supported\n        """\n        data = try_decode(data)\n        if format not in list(map(str, SUPPORTED_FORMATS)):\n            raise ValueError("Unknown format {format}, must be one of: mp3 or wav")\n\n        # We already attempted to decode it as base64 and coerced to bytes so we can skip that step\n        return cls(\n            data=data,\n            format=cast(SUPPORTED_FORMATS_TYPE, format),\n            validate_base64=False,\n        )\n\n    @classmethod\n    def from_path(cls, path: str | bytes | Path | os.PathLike) -> Audio:\n        """Create an Audio object from a file path.\n\n        Args:\n            path: Path to an audio file (must have .wav or .mp3 extension)\n\n        Returns:\n            Audio: A new Audio instance loaded from the file\n\n        Raises:\n            ValueError: If file doesn\'t exist or has unsupported extension\n        """\n        if isinstance(path, bytes):\n            path = path.decode()\n\n        if not os.path.exists(path):\n            raise ValueError(f"File {path} does not exist")\n\n        format_str = get_format_from_filename(str(path))\n        if format_str not in list(map(str, SUPPORTED_FORMATS)):\n            raise ValueError(\n                f"Invalid file path {path}, file must end in one of: mp3 or wav"\n            )\n\n        data = open(path, "rb").read()\n        return cls(data=data, format=cast(SUPPORTED_FORMATS_TYPE, format_str))\n\n    def export(self, path: str | bytes | Path | os.PathLike) -> None:\n        """Export audio data to a file.\n\n        Args:\n            path: Path where the audio file should be written\n        """\n        with open(path, "wb") as f:\n            f.write(self.data)\n\n@weave.op()\ndef load(\n    artifact: MemTraceFilesArtifact, name: str, val: Any\n) -> wave.Wave_read | Audio:\n    """Load an audio object from a trace files artifact.\n\n    Args:\n        artifact: The artifact containing the audio data\n        name: Name of the audio file in the artifact\n\n    Returns:\n        Either a wave.Wave_read object or an Audio object, depending on the stored type\n\n    Raises:\n        ValueError: If no audio is found in the artifact\n    """\n    pytype = None\n    if artifact.path_contents.get(METADATA_FILE_NAME):\n        with open(artifact.path(METADATA_FILE_NAME)) as f:\n            pytype = json.load(f).get("_type")\n\n    for filename in artifact.path_contents:\n        path = artifact.path(filename)\n        if filename.startswith(AUDIO_FILE_PREFIX):\n            if (\n                pytype is None and filename.endswith(".wav")\n            ) or pytype == "wave.Wave_read":\n                return wave.open(path, "rb")\n            return Audio.from_path(path=path)\n\n    raise ValueError("No audio found for artifact")\n',
+            },
+            {
+                "digest": "k3eN5qEgVIyMLbUc8sQrx1LRU0gxf7l6dD9LIoSoa0M",
+                "exp_content": b'{"_type": "wave.Wave_read"}',
+            },
+            {
+                "digest": "xfOhnNfgQxRzgWZ6DC1QEGt9vrJWcathymKPPZQmmIw",
+                "exp_content": AUDIO_BYTES,
+            },
+        ],
+        equality_check=lambda a, b: a.readframes(10) == b.readframes(10),
+        python_version_code_capture=(3, 13),
+    ),
+    # Markdown
+    # Here, we put both inline and file cases together so that the ref on Markdown
+    # doesn't screw up parallel tests.
+    SerializationTestCase(
+        id="markdown",
+        runtime_object_factory=lambda: {
+            "inline": weave.Markdown("a" * 1024),
+            "file": weave.Markdown("# Hello, world!"),
+        },
+        inline_call_param=True,
+        is_legacy=False,
+        exp_json={
+            "inline": {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "rich.markdown.Markdown"},
+                "files": {"markup.md": "LtyYaEfiCbQBbhQabchxbTIHNQ9BaWk4LUMVOb8pLko"},
+                "val": {"code_theme": "monokai"},
+                "load_op": "weave:///shawn/test-project/op/load_rich.markdown.Markdown:c3wm9zZXbUKJB0FG5IYJfsmZ20zvQyMhcT0q30XgX84",
+            },
+            "file": {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "rich.markdown.Markdown"},
+                "val": {"markup": "# Hello, world!", "code_theme": "monokai"},
+                "load_op": "weave:///shawn/test-project/op/load_rich.markdown.Markdown:c3wm9zZXbUKJB0FG5IYJfsmZ20zvQyMhcT0q30XgX84",
+            },
+        },
+        exp_objects=[
+            {
+                "object_id": "load_rich.markdown.Markdown",
+                "digest": "c3wm9zZXbUKJB0FG5IYJfsmZ20zvQyMhcT0q30XgX84",
+                "exp_val": {
+                    "_type": "CustomWeaveType",
+                    "weave_type": {"type": "Op"},
+                    "files": {"obj.py": "ZlYsZB0XaBa8O0kLSbW6sMAnaoJmztqBevEAxxERDLc"},
+                },
+            }
+        ],
+        exp_files=[
+            {
+                "digest": "LtyYaEfiCbQBbhQabchxbTIHNQ9BaWk4LUMVOb8pLko",
+                "exp_content": b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            },
+            {
+                "digest": "ZlYsZB0XaBa8O0kLSbW6sMAnaoJmztqBevEAxxERDLc",
+                "exp_content": b'import weave\nfrom typing import Any\nfrom rich.markdown import Markdown\n\n@weave.op()\ndef load(artifact: "MemTraceFilesArtifact", name: str, val: Any) -> Markdown:\n    """Load markdown from file and metadata."""\n    if "markup" in val:\n        markup = val["markup"]\n    else:\n        with artifact.open("markup.md", binary=False) as f:\n            markup = f.read()\n\n    kwargs = {}\n    if val and isinstance(val, dict) and "code_theme" in val:\n        kwargs["code_theme"] = val["code_theme"]\n\n    return Markdown(markup=markup, **kwargs)\n',
+            },
+        ],
+        equality_check=lambda a, b: markdown_equality_check(a["inline"], b["inline"])
+        and markdown_equality_check(a["file"], b["file"]),
+        python_version_code_capture=(3, 13),
+    ),
+    # Video
+    SerializationTestCase(
+        id="video",
+        runtime_object_factory=lambda: VideoFileClip(video_file_path),
+        inline_call_param=True,
+        is_legacy=False,
+        exp_json={
+            "_type": "CustomWeaveType",
+            "weave_type": {"type": "moviepy.video.VideoClip.VideoClip"},
+            "files": {"video.mp4": "Aoxws9QUryX0YiZ8ScTAyi4YzX2SO5QHTsLsYABBMjc"},
+            "load_op": "weave:///shawn/test-project/op/load_moviepy.video.VideoClip.VideoClip:f93jTm5UMbq6MbX2082R4jxb7V2iBrEputpkcMfdWMg",
+        },
+        exp_objects=[
+            {
+                "object_id": "load_moviepy.video.VideoClip.VideoClip",
+                "digest": "f93jTm5UMbq6MbX2082R4jxb7V2iBrEputpkcMfdWMg",
+                "exp_val": {
+                    "_type": "CustomWeaveType",
+                    "weave_type": {"type": "Op"},
+                    "files": {"obj.py": "ce83ho6fagyOt61OqowrsJxbb3B3HZOeeZAykGhXjYI"},
+                },
+            }
+        ],
+        exp_files=[
+            {
+                "digest": "ce83ho6fagyOt61OqowrsJxbb3B3HZOeeZAykGhXjYI",
+                "exp_content": b'from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact\nfrom typing import Any\nimport importlib\nimport weave.trace.serialization.serializer as serializer\nfrom enum import Enum\nimport shutil\nfrom typing import TypeIs\n\n_registered = true\n\ndef _dependencies_met() -> bool:\n    """Check if the dependencies are met.  This import is deferred to avoid\n    an expensive module import at the top level.\n    """\n    import sys\n\n    # First check if already imported\n    if "moviepy" in sys.modules:\n        return True\n    # Otherwise check if it can be imported\n    try:\n        return importlib.util.find_spec("moviepy") is not None\n    except (ValueError, ImportError):\n        return False\n\nclass VideoFormat(str, Enum):\n    """These are NOT the list of formats we accept from the user\n    Rather, these are the list of formats we can save to weave servers\n    If we detect that the file is in these formats, we copy it over directly\n    Otherwise, we encode it to one of these formats using ffmpeg (mp4 by default).\n    """\n\n    GIF = "gif"\n    MP4 = "mp4"\n    WEBM = "webm"\n    UNSUPPORTED = "unsupported"\n\n    def __str__(self) -> str:\n        return self.value\n\n    @classmethod\n    def _missing_(cls, value: Any) -> VideoFormat:\n        return cls.UNSUPPORTED\n\ndef get_format_from_filename(filename: str) -> VideoFormat:\n    """Get the file format from a filename.\n\n    Args:\n        filename: The filename to extract the format from\n\n    Returns:\n        The format string or None if no extension is found\n    """\n    # Get last dot position\n    last_dot = filename.rfind(".")\n\n    # If there\'s no dot or it\'s the last character, return None\n    if last_dot == -1 or last_dot == len(filename) - 1:\n        return VideoFormat.UNSUPPORTED\n\n    # Get the extension without the dot\n    return VideoFormat(filename[last_dot + 1 :])\n\nDEFAULT_VIDEO_FORMAT = "mp4"\n\ndef write_video(fp: str, clip: VideoClip) -> None:\n    """Takes a filepath and a VideoClip and writes the video to the file.\n    errors if the file does not end in a supported video extension.\n    """\n    try:\n        fps = clip.fps or 24\n    except Exception as _:\n        fps = 24\n\n    audio = clip.audio\n    fmt_str = get_format_from_filename(fp)\n    fmt = VideoFormat(fmt_str)\n\n    if fmt == VideoFormat.UNSUPPORTED:\n        raise ValueError(f"Unsupported video format: {fmt_str}")\n\n    if fmt == VideoFormat.GIF:\n        clip.write_gif(fp, fps=fps)\n        return\n    if fmt == VideoFormat.WEBM:\n        codec = "libvpx"\n    else:\n        codec = "libx264"\n\n    clip.write_videofile(\n        fp,\n        fps=fps,\n        codec=codec,\n        audio=audio,\n        verbose=False,\n        logger=None,\n    )\n\ndef _save_video_file_clip(obj: VideoFileClip, artifact: MemTraceFilesArtifact) -> None:\n    """Save a VideoFileClip to the artifact.\n\n    Args:\n        obj: The VideoFileClip\n        artifact: The artifact to save to\n        name: Ignored, see comment below\n    """\n    video_format = get_format_from_filename(obj.filename)\n\n    # Check if the format is known/supported. If not, set to unsupported\n    fmt = VideoFormat(video_format)\n    ext = fmt.value\n\n    if fmt == VideoFormat.UNSUPPORTED:\n        ext = DEFAULT_VIDEO_FORMAT.value\n\n    with artifact.writeable_file_path(f"video.{ext}") as fp:\n        if fmt == VideoFormat.UNSUPPORTED:\n            # If the format is unsupported, we need to convert it\n            write_video(fp, obj)\n        else:\n            # Copy the file directly if it\'s a supported format\n            shutil.copy(obj.filename, fp)\n\nDEFAULT_VIDEO_FORMAT = "mp4"\n\ndef _save_non_file_clip(obj: VideoClip, artifact: MemTraceFilesArtifact) -> None:\n    ext = DEFAULT_VIDEO_FORMAT.value\n    with artifact.writeable_file_path(f"video.{ext}") as fp:\n        # If the format is unsupported, we need to convert it\n        write_video(fp, obj)\n\ndef save(\n    obj: VideoClip,\n    artifact: MemTraceFilesArtifact,\n    name: str,\n) -> None:\n    """Save a VideoClip to the artifact.\n\n    Args:\n        obj: The VideoClip or VideoWithPreview to save\n        artifact: The artifact to save to\n        name: Ignored, see comment below\n    """\n    _ensure_registered()\n    from moviepy.editor import VideoFileClip\n\n    is_video_file = isinstance(obj, VideoFileClip)\n\n    try:\n        if is_video_file:\n            _save_video_file_clip(obj, artifact)\n        else:\n            _save_non_file_clip(obj, artifact)\n    except Exception as e:\n        raise ValueError(f"Failed to write video file with error: {e}") from e\n\ndef load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> VideoClip:\n    """Load a VideoClip from the artifact.\n\n    Args:\n        artifact: The artifact to load from\n        name: Ignored, consistent with save method\n\n    Returns:\n        The loaded VideoClip\n    """\n    _ensure_registered()\n    from moviepy.editor import VideoFileClip\n\n    # Assume there can only be 1 video in the artifact\n    for filename in artifact.path_contents:\n        path = artifact.path(filename)\n        if filename.startswith("video."):\n            return VideoFileClip(path)\n\n    raise ValueError("No video or found for artifact")\n\ndef is_video_clip_instance(obj: Any) -> TypeIs[VideoClip]:\n    """Check if the object is any subclass of VideoClip."""\n    _ensure_registered()\n    from moviepy.editor import VideoClip\n\n    return isinstance(obj, VideoClip)\n\ndef _ensure_registered() -> None:\n    """Ensure the video type handler is registered if MoviePy is available."""\n    global _registered\n    if not _registered and _dependencies_met():\n        from moviepy.editor import VideoClip\n\n        serializer.register_serializer(VideoClip, save, load, is_video_clip_instance)\n        _registered = True\n\n@serializer.op()\ndef load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> VideoClip:\n    """Load a VideoClip from the artifact.\n\n    Args:\n        artifact: The artifact to load from\n        name: Ignored, consistent with save method\n\n    Returns:\n        The loaded VideoClip\n    """\n    _ensure_registered()\n    from moviepy.editor import VideoFileClip\n\n    # Assume there can only be 1 video in the artifact\n    for filename in artifact.path_contents:\n        path = artifact.path(filename)\n        if filename.startswith("video."):\n            return VideoFileClip(path)\n\n    raise ValueError("No video or found for artifact")\n',
+            },
+            {
+                "digest": "Aoxws9QUryX0YiZ8ScTAyi4YzX2SO5QHTsLsYABBMjc",
+                "exp_content": VIDEO_BYTES,
+            },
+        ],
+        equality_check=lambda a, b: a.duration
+        == b.duration,  # could do better, but this is a good start
+        python_version_code_capture=(3, 13),
+    ),
+    # Content
+    ## WAV Content
+    SerializationTestCase(
+        id="content: WAV",
+        runtime_object_factory=lambda: Content.from_path(audio_file_path),
+        inline_call_param=True,
+        is_legacy=False,
+        exp_json={
+            "_type": "CustomWeaveType",
+            "weave_type": {"type": "weave.type_wrappers.Content.content.Content"},
+            "files": {
+                "content": "xfOhnNfgQxRzgWZ6DC1QEGt9vrJWcathymKPPZQmmIw",
+                "metadata.json": "0tY4LYkQE9BXzCQDItzaUoFLd3lesQ0RkuHNMuXQJIk",
+            },
+            "load_op": "weave:///shawn/test-project/op/load_weave.type_wrappers.Content.content.Content:eZCocNGYXrXPrJMWO0MECHxVUOWlrWSma9iGydnlxE0",
+        },
+        exp_objects=[
+            {
+                "object_id": "load_weave.type_wrappers.Content.content.Content",
+                "digest": "eZCocNGYXrXPrJMWO0MECHxVUOWlrWSma9iGydnlxE0",
+                "exp_val": {
+                    "_type": "CustomWeaveType",
+                    "weave_type": {"type": "Op"},
+                    "files": {"obj.py": "YafOZjnk1XBoGDQRvrGNadv8zLKrhM36QGJB92Bf8Ps"},
+                },
+            }
+        ],
+        exp_files=[
+            {
+                "digest": "0tY4LYkQE9BXzCQDItzaUoFLd3lesQ0RkuHNMuXQJIk",
+                "exp_content": b'{"size": 88244, "mimetype": "audio/x-wav", "digest": "c5f3a19cd7e043147381667a0c2d50106b7dbeb25671ab61ca628f3d9426988c", "filename": "audio.wav", "content_type": "file", "input_type": "str", "encoding": "utf-8", "metadata": null, "extension": ".wav"}',
+            },
+            {
+                "digest": "xfOhnNfgQxRzgWZ6DC1QEGt9vrJWcathymKPPZQmmIw",
+                "exp_content": AUDIO_BYTES,
+            },
+            {
+                "digest": "YafOZjnk1XBoGDQRvrGNadv8zLKrhM36QGJB92Bf8Ps",
+                "exp_content": b'import weave\nfrom weave.trace.serialization.mem_artifact import MemTraceFilesArtifact\nfrom typing import Any\nimport json\n\n@weave.op()\ndef load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> Content:\n    from weave.type_wrappers.Content.content import Content\n    from weave.type_wrappers.Content.content_types import (\n        ResolvedContentArgs,\n        ResolvedContentArgsWithoutData,\n    )\n\n    metadata_path = artifact.path("metadata.json")\n\n    with open(metadata_path) as f:\n        metadata: ResolvedContentArgsWithoutData = json.load(f)\n\n    with open(artifact.path("content"), "rb") as f:\n        data = f.read()\n\n    resolved_args: ResolvedContentArgs = {"data": data, **metadata}\n\n    return Content._from_resolved_args(resolved_args)\n',
+            },
+        ],
+        equality_check=lambda a, b: a.digest == b.digest,
+    ),
+    # LEGACY CASES
+    SerializationTestCase(
+        id="datetime (legacy)",
+        runtime_object_factory=lambda: datetime(
+            2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc
+        ),
+        inline_call_param=True,
+        is_legacy=True,
         exp_json={
             "_type": "CustomWeaveType",
             "load_op": "weave:///shawn/test-project/op/load_datetime.datetime:vBlX1uTKCGWJCbt7bmYHsvnse0lidjCeSGVQjE44Evc",
@@ -64,33 +309,32 @@ media_cases = [
             }
         ],
     ),
-    # Image (PIL.Image.Image)
     SerializationTestCase(
-        id="image",
+        id="image (legacy)",
         runtime_object_factory=lambda: Image.new("RGB", (10, 10), "red"),
-        inline_call_param=True,
-        is_legacy=False,
+        inline_call_param=False,
+        is_legacy=True,
         exp_json={
             "_type": "CustomWeaveType",
             "weave_type": {"type": "PIL.Image.Image"},
             "files": {"image.png": "Ac3YO5daeesZTxBfXf7DAKaQZ5IZysk2HvclN8sfwxQ"},
-            "load_op": "weave:///shawn/test-project/op/load_PIL.Image.Image:XTwpuNcfNiGtjAaWpDPfMSflzS7JYxJNd6FYk1TAfeA",
+            "load_op": "weave:///shawn/test-project/op/load_PIL.Image.Image:jhxXm8LUXTL8B8nfSGFXQdOLhpuzJYtbW59ZxhUFgoI",
         },
         exp_objects=[
             {
                 "object_id": "load_PIL.Image.Image",
-                "digest": "XTwpuNcfNiGtjAaWpDPfMSflzS7JYxJNd6FYk1TAfeA",
+                "digest": "jhxXm8LUXTL8B8nfSGFXQdOLhpuzJYtbW59ZxhUFgoI",
                 "exp_val": {
                     "_type": "CustomWeaveType",
                     "weave_type": {"type": "Op"},
-                    "files": {"obj.py": "ReUEgimaLvoco8RMDnTr4tTo26SXYwVz61tJHoDJ1CI"},
+                    "files": {"obj.py": "oxqbCLXF1PsVGFKXZgXHGIuFqlgDG69IwQFUQsGzfHw"},
                 },
             }
         ],
         exp_files=[
             {
-                "digest": "ReUEgimaLvoco8RMDnTr4tTo26SXYwVz61tJHoDJ1CI",
-                "exp_content": b'import weave\nfrom weave.trace.serialization.mem_artifact import MemTraceFilesArtifact\nfrom weave.utils.iterators import first\nimport PIL.Image as Image\n\n@weave.op()\ndef load(artifact: MemTraceFilesArtifact, name: str) -> Image.Image:\n    # Today, we assume there can only be 1 image in the artifact.\n    filename = first(artifact.path_contents)\n    if not filename.startswith("image."):\n        raise ValueError(f"Expected filename to start with \'image.\', got {filename}")\n\n    path = artifact.path(filename)\n    return Image.open(path)\n',
+                "digest": "oxqbCLXF1PsVGFKXZgXHGIuFqlgDG69IwQFUQsGzfHw",
+                "exp_content": b'import weave\nfrom weave.trace.serialization.mem_artifact import MemTraceFilesArtifact\nfrom typing import Any\nfrom weave.utils.iterators import first\nimport PIL.Image as Image\n\n@weave.op()\ndef load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> Image.Image:\n    # Today, we assume there can only be 1 image in the artifact.\n    filename = first(artifact.path_contents)\n    if not filename.startswith("image."):\n        raise ValueError(f"Expected filename to start with \'image.\', got {filename}")\n\n    path = artifact.path(filename)\n    return Image.open(path)\n',
             },
             {
                 "digest": "Ac3YO5daeesZTxBfXf7DAKaQZ5IZysk2HvclN8sfwxQ",
@@ -99,12 +343,11 @@ media_cases = [
         ],
         equality_check=lambda a, b: a.tobytes() == b.tobytes(),
     ),
-    # Audio (weave.type_handlers.Audio.audio.Audio)
     SerializationTestCase(
-        id="audio",
+        id="audio (legacy)",
         runtime_object_factory=lambda: wave.open(audio_file_path, "rb"),
         inline_call_param=True,
-        is_legacy=False,
+        is_legacy=True,
         exp_json={
             "_type": "CustomWeaveType",
             "weave_type": {"type": "weave.type_handlers.Audio.audio.Audio"},
@@ -142,12 +385,11 @@ media_cases = [
         equality_check=lambda a, b: a.readframes(10) == b.readframes(10),
         python_version_code_capture=(3, 13),
     ),
-    # Markdown
     SerializationTestCase(
-        id="markdown",
+        id="markdown (legacy)",
         runtime_object_factory=lambda: weave.Markdown("# Hello, world!"),
         inline_call_param=True,
-        is_legacy=False,
+        is_legacy=True,
         exp_json={
             "_type": "CustomWeaveType",
             "load_op": "weave:///shawn/test-project/op/load_rich.markdown.Markdown:ZJrNtY2McTqdAZdfBmciQV1TyCouPS8ED400FQFE4JE",
@@ -171,16 +413,14 @@ media_cases = [
                 "exp_content": b"import weave\nfrom typing import TypedDict\nfrom typing import NotRequired\nfrom rich.markdown import Markdown\n\nclass SerializedMarkdown(TypedDict):\n    markup: str\n    code_theme: NotRequired[str]\n\n@weave.op()\ndef load(encoded: SerializedMarkdown) -> Markdown:\n    return Markdown(**encoded)\n",
             }
         ],
-        equality_check=lambda a, b: a.markup == b.markup
-        and a.code_theme == b.code_theme,
+        equality_check=markdown_equality_check,
         python_version_code_capture=(3, 13),
     ),
-    # Video
     SerializationTestCase(
-        id="video",
+        id="video (legacy)",
         runtime_object_factory=lambda: VideoFileClip(video_file_path),
         inline_call_param=True,
-        is_legacy=False,
+        is_legacy=True,
         exp_json={
             "_type": "CustomWeaveType",
             "weave_type": {"type": "moviepy.video.VideoClip.VideoClip"},
@@ -212,13 +452,11 @@ media_cases = [
         == b.duration,  # could do better, but this is a good start
         python_version_code_capture=(3, 13),
     ),
-    # Content
-    ## WAV Content
     SerializationTestCase(
-        id="content: WAV",
+        id="content: WAV (legacy)",
         runtime_object_factory=lambda: Content.from_path(audio_file_path),
         inline_call_param=True,
-        is_legacy=False,
+        is_legacy=True,
         exp_json={
             "_type": "CustomWeaveType",
             "weave_type": {"type": "weave.type_wrappers.Content.content.Content"},

--- a/tests/trace/test_custom_objs.py
+++ b/tests/trace/test_custom_objs.py
@@ -6,8 +6,7 @@ from PIL import Image
 import weave
 from weave.trace.serialization.custom_objs import (
     KNOWN_TYPES,
-    decode_custom_files_obj,
-    decode_custom_inline_obj,
+    decode_custom_obj,
     encode_custom_obj,
 )
 
@@ -22,14 +21,12 @@ def test_encode_custom_obj_unknown_type(client):
     assert encode_custom_obj(unknown) is None
 
 
-def test_decode_custom_files_obj_known_type(client):
+def test_decode_custom_obj_known_type(client):
     img = Image.new("RGB", (100, 100))
     encoded = encode_custom_obj(img)
 
     # Even though something is wrong with the deserializer op, we can still decode
-    decoded = decode_custom_files_obj(
-        encoded["weave_type"], encoded["files"], "weave:///totally/invalid/uri"
-    )
+    decoded = decode_custom_obj(encoded)
 
     assert isinstance(decoded, Image.Image)
     assert decoded.tobytes() == img.tobytes()
@@ -44,7 +41,7 @@ def test_inline_custom_obj(client):
     assert "load_op" in encoded
     assert encoded["val"] == "2025-03-07T00:00:00+00:00"
 
-    decoded = decode_custom_inline_obj(encoded)
+    decoded = decode_custom_obj(encoded)
     assert isinstance(decoded, datetime)
     dt_with_tz = dt.replace(tzinfo=timezone.utc)
     assert decoded == dt_with_tz

--- a/weave/trace/env.py
+++ b/weave/trace/env.py
@@ -55,12 +55,19 @@ def wandb_frontend_base_url() -> str:
     return public_url if public_url != "" else wandb_base_url()
 
 
+MTSAAS_TRACE_URL = "https://trace.wandb.ai"
+
+
 def weave_trace_server_url() -> str:
     base_url = wandb_frontend_base_url()
-    default = "https://trace.wandb.ai"
+    default = MTSAAS_TRACE_URL
     if base_url != "https://api.wandb.ai":
         default = base_url + "/traces"
     return os.getenv("WF_TRACE_SERVER_URL", default)
+
+
+def is_mtsaas() -> bool:
+    return weave_trace_server_url() == MTSAAS_TRACE_URL
 
 
 def _wandb_api_key_via_env() -> str | None:

--- a/weave/trace/serialization/README.md
+++ b/weave/trace/serialization/README.md
@@ -52,7 +52,7 @@ The entrypoint for custom object serialization is `weave/trace/serialization/cus
 
 1. `encode_custom_obj()`, which encodes custom objects using registered serializers (both inline and file-based)
 2. `decode_custom_inline_obj()`, which decodes custom inline objects using the appropriate serializer
-3. `decode_custom_files_obj()`, which decodes custom file-based objects using the appropriate serializer
+3. `decode_custom_obj()`, which decodes custom file-based objects using the appropriate serializer
 
 #### Custom Object Serialization Flow
 
@@ -68,7 +68,7 @@ flowchart TD
         Serializer -->|Write to files| MemArtifact["MemTraceFilesArtifact"]
 
         MemArtifact -->|Read from files| Deserializer["Registered Serializer (load method)"]
-        Deserializer --> DecodeCustomObj["decode_custom_files_obj()"]
+        Deserializer --> DecodeCustomObj["decode_custom_obj()"]
     end
 
     DecodeCustomObj --> FromJson["from_json()"]

--- a/weave/trace/serialization/custom_objs.py
+++ b/weave/trace/serialization/custom_objs.py
@@ -1,22 +1,51 @@
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping
-from typing import Any, Callable
+from typing import Any, Literal, TypedDict
 
 from weave.trace.context.weave_client_context import require_weave_client
-from weave.trace.op import is_op, op
+from weave.trace.op import op
 from weave.trace.op_protocol import Op
-from weave.trace.refs import ObjectRef, OpRef
+from weave.trace.refs import ObjectRef
 from weave.trace.serialization import (
     op_type,  # noqa: F401, Must import this to register op save/load
 )
 from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact
 from weave.trace.serialization.serializer import (
+    AllLoadCallables,
     get_serializer_by_id,
     get_serializer_for_obj,
-    is_file_save,
-    is_inline_save,
+    is_probably_legacy_file_load,
+    is_probably_legacy_inline_load,
 )
+from weave.trace_server.trace_server_interface import (
+    FileContentReadReq,
+    TraceServerInterface,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class WeaveTypeDict(TypedDict):
+    type: str
+
+
+class _EncodedCustomObjDictRequired(TypedDict):
+    _type: Literal["CustomWeaveType"]
+    weave_type: WeaveTypeDict
+    load_op: str | None
+
+
+class _EncodedCustomObjDictOptional(TypedDict, total=False):
+    val: Any
+    files: Mapping[str, str | bytes]
+
+
+class EncodedCustomObjDict(
+    _EncodedCustomObjDictRequired, _EncodedCustomObjDictOptional
+):
+    pass
 
 
 class DecodeCustomObjectError(Exception):
@@ -37,7 +66,7 @@ KNOWN_TYPES = {
 }
 
 
-def encode_custom_obj(obj: Any) -> dict | None:
+def encode_custom_obj(obj: Any) -> EncodedCustomObjDict | None:
     serializer = get_serializer_for_obj(obj)
     if serializer is None:
         # We silently return None right now. We could warn here. This object
@@ -56,80 +85,96 @@ def encode_custom_obj(obj: Any) -> dict | None:
             # We don't want to actually trace the load_instance op,
             # just save it.
             serializer.load._tracing_enabled = False  # type: ignore
-        # Save the load_instance_op
-        wc = require_weave_client()
 
-        # TODO(PR): this can fail right? Or does it return None?
-        # Calculating this URL is blocking, but we only have to pay it once per custom type
-        load_instance_op_ref = wc._save_op(serializer.load, "load_" + serializer.id())  # type: ignore
-        load_op_uri = load_instance_op_ref.uri()
+        if serializer.publish_load_op:
+            # Save the load_instance_op
+            wc = require_weave_client()
 
-    encoded = {
+            # TODO(PR): this can fail right? Or does it return None?
+            # Calculating this URL is blocking, but we only have to pay it once per custom type
+            load_instance_op_ref = wc._save_op(
+                serializer.load, "load_" + serializer.id()
+            )  # type: ignore
+            load_op_uri = load_instance_op_ref.uri()
+
+    encoded: EncodedCustomObjDict = {
         "_type": "CustomWeaveType",
         "weave_type": {"type": serializer.id()},
         "load_op": load_op_uri,
     }
 
-    # If the save method just takes one argument, it is an inline serializer
-    if is_inline_save(serializer.save):
-        encoded["val"] = serializer.save(obj)
-    elif is_file_save(serializer.save):
-        art = MemTraceFilesArtifact()
-        serializer.save(obj, art, "obj")
+    art = MemTraceFilesArtifact()
+    val = serializer.save(obj, art, "obj")
+    if art.path_contents:
         encoded_path_contents = {
             k: (v.encode("utf-8") if isinstance(v, str) else v)  # type: ignore
             for k, v in art.path_contents.items()
         }
         encoded["files"] = encoded_path_contents
-    else:
-        raise ValueError(
-            f"Serializer save function could not be identified as inline or file-based: {type(serializer.save)}"
-        )
+    if val is not None:
+        encoded["val"] = val
+
     return encoded
 
 
-def decode_custom_inline_obj(obj: dict) -> Any:
-    type_ = obj["weave_type"]["type"]
-    if type_ in KNOWN_TYPES:
-        serializer = get_serializer_by_id(type_)
-        if serializer is not None:
-            if is_op(serializer.load):
-                # We would expect this to be already set to False, but
-                # just in case.
-                serializer.load._tracing_enabled = False  # type: ignore
-            return serializer.load(obj["val"])
-
-    load_op_uri = obj.get("load_op")
-    if load_op_uri is None:
-        raise ValueError(f"No serializer found for `{type_}`")
-
-    op_ref = OpRef.parse_uri(load_op_uri)
-    wc = require_weave_client()
-    load_instance_op = wc.get(op_ref)
-    if load_instance_op is None:
-        raise ValueError(
-            f"Failed to load op needed to decode object of type `{type_}`. See logs above for more information."
+def _load_custom_obj_files(
+    project_id: str, server: TraceServerInterface, file_digests: dict
+) -> dict[str, bytes]:
+    loaded_files: dict[str, bytes] = {}
+    for name, digest in file_digests.items():
+        file_response = server.file_content_read(
+            FileContentReadReq(project_id=project_id, digest=digest)
         )
+        loaded_files[name] = file_response.content
+    return loaded_files
 
-    load_instance_op._tracing_enabled = False  # type: ignore
-    return load_instance_op(obj.get("val"))
+
+def maybe_attach_art(res: Any, art: MemTraceFilesArtifact) -> None:
+    """Attach the artifact to the result if possible.
+    This is a best-effort approach to attach the artifact to the result.
+
+    I am pretty sure this is just used in a legacy code capture case
+    """
+    try:
+        res.art = art
+    except Exception:
+        logger.debug("Failed to attach artifact to result", exc_info=True)
+        pass
 
 
-def _decode_custom_files_obj(
+def _load_custom_obj(
     encoded_path_contents: Mapping[str, str | bytes],
-    load_instance_op: Callable[..., Any],
+    val: Any | None,
+    load_instance_op: AllLoadCallables,
 ) -> Any:
     # Disables tracing so that calls to loading data itself don't get traced
     load_instance_op._tracing_enabled = False  # type: ignore
     art = MemTraceFilesArtifact(encoded_path_contents, metadata={})
-    res = load_instance_op(art, "obj")
-    res.art = art
+    if is_probably_legacy_file_load(load_instance_op):
+        res = load_instance_op(art, "obj")
+    elif is_probably_legacy_inline_load(load_instance_op):
+        res = load_instance_op(val)
+    else:
+        # Modern, current path
+        res = load_instance_op(art, "obj", val)
+
+    maybe_attach_art(res, art)
     return res
 
 
-def decode_custom_files_obj(
-    weave_type: dict,
+def decode_custom_obj(encoded: EncodedCustomObjDict) -> Any:
+    return _decode_custom_obj(
+        encoded["weave_type"],
+        encoded.get("files", {}),
+        encoded.get("val"),
+        encoded.get("load_op"),
+    )
+
+
+def _decode_custom_obj(
+    weave_type: WeaveTypeDict,
     encoded_path_contents: Mapping[str, str | bytes],
+    val: Any | None,
     load_instance_op_uri: str | None = None,
 ) -> Any:
     type_ = weave_type["type"]
@@ -139,13 +184,15 @@ def decode_custom_files_obj(
     if type_ in KNOWN_TYPES:
         serializer = get_serializer_by_id(type_)
         if serializer is not None:
-            found_serializer = True
             load_instance_op = serializer.load
 
             try:
-                return _decode_custom_files_obj(encoded_path_contents, load_instance_op)
+                res = _load_custom_obj(encoded_path_contents, val, load_instance_op)
+                found_serializer = True
             except Exception as e:
                 pass
+            else:
+                return res
 
     # Otherwise, fall back to load_instance_op
     if not found_serializer:
@@ -161,7 +208,7 @@ def decode_custom_files_obj(
             )
 
     try:
-        return _decode_custom_files_obj(encoded_path_contents, load_instance_op)
+        return _load_custom_obj(encoded_path_contents, val, load_instance_op)
     except Exception as e:
         raise DecodeCustomObjectError(
             f"Failed to decode object of type `{type_}`. See logs above for more information."

--- a/weave/trace/serialization/op_type.py
+++ b/weave/trace/serialization/op_type.py
@@ -603,6 +603,7 @@ def save_instance(obj: Op, artifact: MemTraceFilesArtifact, name: str) -> None:
 def load_instance(
     artifact: MemTraceFilesArtifact,
     name: str,
+    val: Any,
 ) -> Op | None:
     file_name = f"{name}.py"
     module_path = artifact.path(file_name)

--- a/weave/type_handlers/Audio/audio.py
+++ b/weave/type_handlers/Audio/audio.py
@@ -232,7 +232,9 @@ def save(
         obj.export(fp)
 
 
-def load(artifact: MemTraceFilesArtifact, name: str) -> wave.Wave_read | Audio:
+def load(
+    artifact: MemTraceFilesArtifact, name: str, val: Any
+) -> wave.Wave_read | Audio:
     """Load an audio object from a trace files artifact.
 
     Args:

--- a/weave/type_handlers/Content/content.py
+++ b/weave/type_handlers/Content/content.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from weave.type_wrappers.Content.content import Content
@@ -21,7 +21,7 @@ def save(obj: Content, artifact: MemTraceFilesArtifact, name: str) -> None:
         json.dump(metadata, f)
 
 
-def load(artifact: MemTraceFilesArtifact, name: str) -> Content:
+def load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> Content:
     from weave.type_wrappers.Content.content import Content
     from weave.type_wrappers.Content.content_types import (
         ResolvedContentArgs,

--- a/weave/type_handlers/DateTime/datetime.py
+++ b/weave/type_handlers/DateTime/datetime.py
@@ -1,9 +1,11 @@
 import datetime
+from typing import Any
 
 from weave.trace.serialization import serializer
+from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact
 
 
-def save(obj: datetime.datetime) -> str:
+def save(obj: datetime.datetime, artifact: MemTraceFilesArtifact, name: str) -> str:
     """Serialize a datetime object to ISO format with timezone information.
     If the datetime object is naive (has no timezone), it will be assumed to be UTC.
 
@@ -14,9 +16,9 @@ def save(obj: datetime.datetime) -> str:
     return obj.isoformat()
 
 
-def load(encoded: str) -> datetime.datetime:
+def load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> datetime.datetime:
     """Deserialize an ISO format string back to a datetime object with timezone."""
-    return datetime.datetime.fromisoformat(encoded)
+    return datetime.datetime.fromisoformat(val)
 
 
 def register() -> None:

--- a/weave/type_handlers/File/file.py
+++ b/weave/type_handlers/File/file.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 
 from typing_extensions import deprecated
 
@@ -99,7 +100,7 @@ def save(obj: File, artifact: MemTraceFilesArtifact, name: str) -> None:
     save_content(content, artifact, name)
 
 
-def load(artifact: MemTraceFilesArtifact, name: str) -> File:
+def load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> File:
     metadata_path = artifact.path("metadata.json")
     with open(metadata_path) as f:
         metadata = json.load(f)

--- a/weave/type_handlers/Image/image.py
+++ b/weave/type_handlers/Image/image.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from weave.trace.serialization import serializer
 from weave.trace.serialization.custom_objs import MemTraceFilesArtifact
@@ -56,7 +57,7 @@ def save(obj: Image.Image, artifact: MemTraceFilesArtifact, name: str) -> None:
         obj.save(f, format=ext_to_pil_format[ext])  # type: ignore
 
 
-def load(artifact: MemTraceFilesArtifact, name: str) -> Image.Image:
+def load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> Image.Image:
     # Today, we assume there can only be 1 image in the artifact.
     filename = first(artifact.path_contents)
     if not filename.startswith("image."):

--- a/weave/type_handlers/Markdown/markdown.py
+++ b/weave/type_handlers/Markdown/markdown.py
@@ -1,8 +1,12 @@
-from typing import Any, TypedDict
+from typing import TYPE_CHECKING, Any, Optional
 
-from typing_extensions import NotRequired
-
+from weave.trace.env import is_mtsaas
 from weave.trace.serialization import serializer
+
+INLINE_MARKDOWN_THRESHOLD = 1024
+
+if TYPE_CHECKING:
+    from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact
 
 # Try to import rich Markdown, but make it optional
 try:
@@ -19,23 +23,45 @@ except ImportError:
             self.code_theme = code_theme
 
 
-# TODO: Serialize "justify" and "hyperlinks" attributes?
-class SerializedMarkdown(TypedDict):
-    markup: str
-    code_theme: NotRequired[str]
+def save(
+    obj: Markdown, artifact: "MemTraceFilesArtifact", name: str
+) -> Optional[dict[str, Any]]:
+    """Save markdown content as file, return metadata."""
+    use_file = len(obj.markup) >= INLINE_MARKDOWN_THRESHOLD
 
+    # We only use files for markdown on MTSAAS for now (until the new UI is rolled out to all customers)
+    use_file = use_file and is_mtsaas()
 
-def save(obj: Markdown) -> SerializedMarkdown:
-    d: SerializedMarkdown = {
-        "markup": obj.markup,
-    }
+    result = {}
+
+    if use_file:
+        with artifact.new_file("markup.md", binary=False) as f:
+            f.write(obj.markup)
+    else:
+        result["markup"] = obj.markup
+
+    # Return metadata if present
     if obj.code_theme:
-        d["code_theme"] = obj.code_theme
-    return d
+        result["code_theme"] = obj.code_theme
+
+    if result:
+        return result
+    return None
 
 
-def load(encoded: SerializedMarkdown) -> Markdown:
-    return Markdown(**encoded)
+def load(artifact: "MemTraceFilesArtifact", name: str, val: Any) -> Markdown:
+    """Load markdown from file and metadata."""
+    if "markup" in val:
+        markup = val["markup"]
+    else:
+        with artifact.open("markup.md", binary=False) as f:
+            markup = f.read()
+
+    kwargs = {}
+    if val and isinstance(val, dict) and "code_theme" in val:
+        kwargs["code_theme"] = val["code_theme"]
+
+    return Markdown(markup=markup, **kwargs)
 
 
 def register() -> None:

--- a/weave/type_handlers/Video/video.py
+++ b/weave/type_handlers/Video/video.py
@@ -171,7 +171,7 @@ def save(
         raise ValueError(f"Failed to write video file with error: {e}") from e
 
 
-def load(artifact: MemTraceFilesArtifact, name: str) -> VideoClip:
+def load(artifact: MemTraceFilesArtifact, name: str, val: Any) -> VideoClip:
     """Load a VideoClip from the artifact.
 
     Args:


### PR DESCRIPTION
Copy of https://github.com/wandb/weave/pull/5545

Currently our custom type serialization layer suffers from a fractured design between "inline" and "file" based payloads. This implementation has a number of problems:
1. "inline" objects typically has referred to when we put data "inline" as opposed to in saved objects - this use of "inline" is a different concept
2. There is no reason that a serializer can't use both files and values (in fact, we want to do in many cases where there is a bigger file and a smaller metadata payload).

This Pr implements a simplified pattern that combines these approaches, allowing serializers to choose if they want to use files, metadata, or both. This simplifies the code path and supports backwards compatibility.

Further, it makes Markdown use this new approach. Relies on https://github.com/wandb/core/pull/35135 being shipped first to support this new layout.
