### PR TITLE
fix(weave): prevent deferred import bug in openai postprocessor

### DIFF
--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -7,6 +7,21 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 from urllib.parse import urlparse
 
+# Do not import this module directly, it should only be invoked
+from openai._legacy_response import LegacyAPIResponse
+from openai._response import APIResponse
+from openai.types.chat import ChatCompletion, ChatCompletionChunk
+from openai.types.chat.chat_completion_chunk import (
+    ChoiceDeltaFunctionCall,
+    ChoiceDeltaToolCall,
+    ChoiceDeltaToolCallFunction,
+)
+from openai.types.chat.chat_completion_message import FunctionCall
+from openai.types.chat.chat_completion_message_tool_call import (
+    ChatCompletionMessageToolCall,
+    Function,
+)
+
 import weave
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
@@ -24,7 +39,6 @@ from weave.utils.stream_metrics import (
 )
 
 if TYPE_CHECKING:
-    from openai.types.chat import ChatCompletionChunk
     from openai.types.responses import Response, ResponseStreamEvent
 
 _openai_patcher: MultiPatcher | None = None
@@ -37,45 +51,20 @@ def maybe_unwrap_api_response(value: Any) -> Any:
     We take a very conservative approach to only unwrap the types we know about.
     """
     maybe_value: Any = None
-    try:
-        from openai._legacy_response import LegacyAPIResponse
 
-        if isinstance(value, LegacyAPIResponse):
-            maybe_value = value.parse()
-    except:
-        pass
+    if isinstance(value, LegacyAPIResponse):
+        maybe_value = value.parse()
 
-    try:
-        from openai._response import APIResponse
+    if isinstance(value, APIResponse):
+        maybe_value = value.parse()
 
-        if isinstance(value, APIResponse):
-            maybe_value = value.parse()
-    except:
-        pass
-
-    try:
-        from openai.types.chat import ChatCompletion, ChatCompletionChunk
-
-        if isinstance(maybe_value, (ChatCompletion, ChatCompletionChunk)):
-            return maybe_value
-    except:
-        pass
+    if isinstance(maybe_value, (ChatCompletion, ChatCompletionChunk)):
+        return maybe_value
 
     return value
 
 
 def openai_on_finish_post_processor(value: ChatCompletionChunk | None) -> dict | None:
-    from openai.types.chat import ChatCompletion, ChatCompletionChunk
-    from openai.types.chat.chat_completion_chunk import (
-        ChoiceDeltaFunctionCall,
-        ChoiceDeltaToolCall,
-    )
-    from openai.types.chat.chat_completion_message import FunctionCall
-    from openai.types.chat.chat_completion_message_tool_call import (
-        ChatCompletionMessageToolCall,
-        Function,
-    )
-
     value = maybe_unwrap_api_response(value)
 
     def _get_function_call(
@@ -171,13 +160,6 @@ def openai_accumulator(
     skip_last: bool = False,
     stream_start_time: float | None = None,
 ) -> ChatCompletionChunk:
-    from openai.types.chat import ChatCompletionChunk
-    from openai.types.chat.chat_completion_chunk import (
-        ChoiceDeltaFunctionCall,
-        ChoiceDeltaToolCall,
-        ChoiceDeltaToolCallFunction,
-    )
-
     def _process_chunk(
         chunk: ChatCompletionChunk, acc_choices: list[dict] | None = None
     ) -> list[dict]:


### PR DESCRIPTION
## Description

This PR removes all lazy imports from the openai autopatch integration and moves the imports to the module level. The module `openai_sdk.py` is only imported by the autopatcher and only runs if `openai` is found in `sys.modules`, so this does not inadvertently make `openai` a required dependency of `weave`. I tested this by importing `weave` and running `weave.init` in a python environment without `openai` installed.

This is also a win because the wrapper functions don't need to run that import over and over again for every completion.

Also fixes a yet unexplained bug. Lazy imports of some types from the openai sdk fail in our postprocessor when stremaing is enabled and weave is imported after openai in the user code.

Eg
```
import openai
import weave

weave.init(...)
client = openai.Client()

response = client.chat.completions.create(
    stream=True,
    model="gpt-4o-mini",
    messages=[
        {"role": "system", "content": "You are a helpful assistant."},
        {"role": "user", "content": "Tell me a joke."},
    ],
)
```

will fail with
```
weave: Error closing iterator, call data may be incomplete:
weave: Traceback (most recent call last):
weave:   File "/Users/ben/core/services/weave-python/weave-public/weave/trace/op.py", line 1429, in _call_on_close_once
weave:     self._on_close()  # type: ignore
weave:     ^^^^^^^^^^^^^^^^
weave:   File "/Users/ben/core/services/weave-python/weave-public/weave/trace/op.py", line 1637, in on_close
weave:     on_finish(acc.get_state(), None)
weave:   File "/Users/ben/core/services/weave-python/weave-public/weave/trace/op.py", line 1681, in wrapped_on_finish
weave:     value = on_finish_post_processor(value)
weave:             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
weave:   File "/Users/ben/core/services/weave-python/weave-public/weave/integrations/openai/openai_sdk.py", line 68, in openai_on_finish_post_processor
weave:     from openai.types.chat import ChatCompletion, ChatCompletionChunk
weave: ModuleNotFoundError: import of openai.types.chat halted; None in sys.modules
weave:  (subsequent messages of this type will be suppressed)
```

Somehow these conditions lead to the lazy imports failing- and the `sys.modules` for all `openai.types.chat.*` are observably `None` in the runtime. This PR prevents the bug from occurring, but the root cause of the bug is unclear.