### PR TITLE
fix(weave): remove lazy imports from patch integration wrappers

### DIFF
--- a/weave/integrations/anthropic/anthropic_sdk.py
+++ b/weave/integrations/anthropic/anthropic_sdk.py
@@ -5,6 +5,21 @@ from collections.abc import AsyncIterator, Iterator
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 
+from anthropic.lib.streaming._types import MessageStopEvent
+from anthropic.types import (
+    Message,
+    MessageStreamEvent,
+    RawContentBlockDeltaEvent,
+    RawMessageDeltaEvent,
+    TextBlock,
+    Usage,
+)
+from anthropic.types.beta import (
+    BetaRawContentBlockDeltaEvent,
+    BetaRawMessageDeltaEvent,
+    BetaRawMessageStopEvent,
+)
+
 import weave
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
@@ -12,7 +27,6 @@ from weave.trace.op import _add_accumulator, _IteratorWrapper
 
 if TYPE_CHECKING:
     from anthropic.lib.streaming import MessageStream
-    from anthropic.types import Message, MessageStreamEvent
 
 _anthropic_patcher: MultiPatcher | None = None
 
@@ -21,18 +35,6 @@ def anthropic_accumulator(
     acc: Message | None,
     value: MessageStreamEvent,
 ) -> Message:
-    from anthropic.types import (
-        Message,
-        RawContentBlockDeltaEvent,
-        RawMessageDeltaEvent,
-        TextBlock,
-        Usage,
-    )
-    from anthropic.types.beta import (
-        BetaRawContentBlockDeltaEvent,
-        BetaRawMessageDeltaEvent,
-    )
-
     if acc is None:
         if hasattr(value, "message"):
             acc = Message(
@@ -127,9 +129,6 @@ def anthropic_stream_accumulator(
     acc: Message | None,
     value: MessageStream,
 ) -> Message:
-    from anthropic.lib.streaming._types import MessageStopEvent
-    from anthropic.types.beta import BetaRawMessageStopEvent
-
     if acc is None:
         acc = ""
     if isinstance(value, (MessageStopEvent, BetaRawMessageStopEvent)):

--- a/weave/integrations/cohere/cohere_sdk.py
+++ b/weave/integrations/cohere/cohere_sdk.py
@@ -4,14 +4,21 @@ import importlib
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 
+from cohere.types.assistant_message_response import AssistantMessageResponse
+from cohere.types.assistant_message_response_content_item import (
+    TextAssistantMessageResponseContentItem,
+)
+from cohere.types.non_streamed_chat_response import NonStreamedChatResponse
+from cohere.types.usage import Usage
+from cohere.v2.types.v2chat_response import V2ChatResponse
+
 import weave
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import _add_accumulator
 
 if TYPE_CHECKING:
-    from cohere.types.non_streamed_chat_response import NonStreamedChatResponse
-    from cohere.v2.types.v2chat_response import V2ChatResponse
+    pass
 
 
 _cohere_patcher: MultiPatcher | None = None
@@ -38,12 +45,6 @@ def cohere_accumulator(acc: dict | None, value: Any) -> NonStreamedChatResponse:
 
 
 def cohere_accumulator_v2(acc: V2ChatResponse | None, value: Any) -> V2ChatResponse:
-    from cohere.types.assistant_message_response import AssistantMessageResponse
-    from cohere.types.assistant_message_response_content_item import (
-        TextAssistantMessageResponseContentItem,
-    )
-    from cohere.v2.types.v2chat_response import V2ChatResponse
-
     if acc is None:
         # Initialize accumulator with basic structure
         acc = V2ChatResponse(
@@ -126,8 +127,6 @@ def cohere_wrapper_v2(settings: OpSettings) -> Callable:
                 response = fn(*args, **kwargs)
 
                 try:
-                    from cohere.types.usage import Usage
-
                     # Extract usage information from meta and populate the usage field
                     if hasattr(response, "meta") and response.meta:
                         response.usage = Usage(
@@ -156,8 +155,6 @@ def cohere_wrapper_async_v2(settings: OpSettings) -> Callable:
                 response = await fn(*args, **kwargs)
 
                 try:
-                    from cohere.types.usage import Usage
-
                     # Extract usage information from meta and populate the usage field
                     if hasattr(response, "meta") and response.meta:
                         response.usage = Usage(

--- a/weave/integrations/groq/groq_sdk.py
+++ b/weave/integrations/groq/groq_sdk.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 import importlib
 from typing import TYPE_CHECKING, Callable
 
+from groq.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
+from groq.types.chat.chat_completion import Choice
+from groq.types.chat.chat_completion_chunk import Choice as ChoiceChunk
+from groq.types.completion_usage import CompletionUsage
+
 import weave
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import _add_accumulator
 
 if TYPE_CHECKING:
-    from groq.types.chat import ChatCompletion, ChatCompletionChunk
+    pass
 
 
 _groq_patcher: MultiPatcher | None = None
@@ -18,11 +23,6 @@ _groq_patcher: MultiPatcher | None = None
 def groq_accumulator(
     acc: ChatCompletion | None, value: ChatCompletionChunk
 ) -> ChatCompletion:
-    from groq.types.chat import ChatCompletion, ChatCompletionMessage
-    from groq.types.chat.chat_completion import Choice
-    from groq.types.chat.chat_completion_chunk import Choice as ChoiceChunk
-    from groq.types.completion_usage import CompletionUsage
-
     if acc is None:
         choices = []
         for choice in value.choices:

--- a/weave/integrations/mistral/mistral_sdk.py
+++ b/weave/integrations/mistral/mistral_sdk.py
@@ -3,16 +3,21 @@ from __future__ import annotations
 import importlib
 from typing import TYPE_CHECKING, Callable
 
+from mistralai.models import (
+    AssistantMessage,
+    ChatCompletionChoice,
+    ChatCompletionResponse,
+    CompletionEvent,
+    UsageInfo,
+)
+
 import weave
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import _add_accumulator
 
 if TYPE_CHECKING:
-    from mistralai.models import (
-        ChatCompletionResponse,
-        CompletionEvent,
-    )
+    pass
 
 _mistral_patcher: MultiPatcher | None = None
 
@@ -21,14 +26,6 @@ def mistral_accumulator(
     acc: ChatCompletionResponse | None,
     value: CompletionEvent,
 ) -> ChatCompletionResponse:
-    # This import should be safe at this point
-    from mistralai.models import (
-        AssistantMessage,
-        ChatCompletionChoice,
-        ChatCompletionResponse,
-        UsageInfo,
-    )
-
     value = value.data
     if acc is None:
         acc = ChatCompletionResponse(

--- a/weave/integrations/vertexai/vertexai_sdk.py
+++ b/weave/integrations/vertexai/vertexai_sdk.py
@@ -4,6 +4,12 @@ import importlib
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable
 
+from google.cloud.aiplatform_v1beta1.types import content as gapic_content_types
+from google.cloud.aiplatform_v1beta1.types import (
+    prediction_service as gapic_prediction_service_types,
+)
+from vertexai.generative_models import GenerationResponse
+
 import weave
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
@@ -12,7 +18,7 @@ from weave.trace.op import _add_accumulator
 from weave.trace.serialization.serialize import dictify
 
 if TYPE_CHECKING:
-    from vertexai.generative_models import GenerationResponse
+    pass
 
 
 _vertexai_patcher: MultiPatcher | None = None
@@ -33,12 +39,6 @@ def vertexai_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
 def vertexai_accumulator(
     acc: GenerationResponse | None, value: GenerationResponse
 ) -> GenerationResponse:
-    from google.cloud.aiplatform_v1beta1.types import content as gapic_content_types
-    from google.cloud.aiplatform_v1beta1.types import (
-        prediction_service as gapic_prediction_service_types,
-    )
-    from vertexai.generative_models import GenerationResponse
-
     if acc is None:
         return value
 


### PR DESCRIPTION
## Description

This PR builds on https://github.com/wandb/weave/pull/5600 and removes lazy type imports from the groq, mistral, anthropic, cohere, and vertex ai integrations.

## Testing

Tested that moving the imports to the module level does not cause `import weave` or `weave.init` to fail when the dependencies are not installed. This works because the modules we are importing from are only imported if the dependencies are detected in `sys.modules`