### PR TITLE
chore(weave): bump ts SDK version to 0.10.1

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "weave",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "AI development toolkit",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description

Simply version bump. The new version has already been released to NPM.

## Testing

New version is tested locally. EvalLogger works as expected.
