### PR TITLE
feat(weave): Add option to only return calls with feedback attached

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -656,7 +656,9 @@ def test_get_calls_require_feedback(client):
     call_ids_with_feedback = {call.id for call in calls_with_feedback}
 
     # Should have exactly 2 calls (call1 and call3)
-    assert len(call_ids_with_feedback) == 2, f"Expected 2 calls with feedback, got {len(call_ids_with_feedback)}"
+    assert len(call_ids_with_feedback) == 2, (
+        f"Expected 2 calls with feedback, got {len(call_ids_with_feedback)}"
+    )
 
     # Should include call1 and call3
     assert call1.id in call_ids_with_feedback

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -581,7 +581,10 @@ class WeaveClient:
             # Query feedback table with both weave_ref AND payload to filter out empty feedback
             feedback_req = FeedbackQueryReq(
                 project_id=self._project_id(),
-                fields=["weave_ref", "payload"],  # Fetch payload to check if it's populated
+                fields=[
+                    "weave_ref",
+                    "payload",  # Fetch payload to check if it's populated
+                ],
             )
             feedback_res = self.server.feedback_query(feedback_req)
 
@@ -591,10 +594,10 @@ class WeaveClient:
                 payload = item.get("payload")
                 # Only include feedback that has a non-null, non-empty payload
                 if payload is not None and payload != {}:
-                    ref = item.get("weave_ref", "")
-                    if "/call/" in ref:
-                        call_id = ref.split("/call/")[-1]
-                        call_ids_with_feedback.add(call_id)
+                    ref_str = item.get("weave_ref", "")
+                    ref = Ref.maybe_parse_uri(ref_str)
+                    if isinstance(ref, CallRef):
+                        call_ids_with_feedback.add(ref.id)
 
             # Filter by call_ids
             if not call_ids_with_feedback:


### PR DESCRIPTION
New API:
```py
client.get_calls(require_feedback=True)
```

Returns only the subset of calls that contain feedback records