### PR TITLE
feat(weave): Support properly retrieving a dataset back in TS SDK

### DIFF
--- a/sdks/node/src/__tests__/dataset.test.ts
+++ b/sdks/node/src/__tests__/dataset.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for Dataset and Table lazy loading
+ */
+
+import {Dataset} from '../dataset';
+import {ObjectRef} from '../weaveObject';
+import {InMemoryTraceServer} from '../inMemoryTraceServer';
+import {initWithCustomTraceServer} from './clientMock';
+import {requireGlobalClient} from '../clientApi';
+
+describe('Dataset', () => {
+  let traceServer: InMemoryTraceServer;
+  const projectId = 'wandb/test-project';
+
+  beforeEach(() => {
+    traceServer = new InMemoryTraceServer();
+    initWithCustomTraceServer(projectId, traceServer);
+  });
+
+  test('hello world', () => {
+    expect(1 + 1).toBe(2);
+  });
+
+  test('round trip: create dataset and read it back', async () => {
+    const client = requireGlobalClient();
+
+    // Create a dataset with some rows
+    const originalRows = [
+      {id: 1, name: 'Alice', score: 0.95},
+      {id: 2, name: 'Bob', score: 0.87},
+      {id: 3, name: 'Charlie', score: 0.92},
+    ];
+
+    const dataset = new Dataset({
+      name: 'test-dataset',
+      description: 'A test dataset',
+      rows: originalRows,
+    });
+
+    // Save the dataset
+    const ref = await dataset.save();
+
+    expect(ref).toBeInstanceOf(ObjectRef);
+    expect(ref.projectId).toBe(projectId);
+    expect(ref.objectId).toBe('test-dataset');
+
+    // Read the dataset back
+    const retrievedDataset = await client.get(ref);
+
+    expect(retrievedDataset).toBeInstanceOf(Dataset);
+    expect(retrievedDataset.name).toBe('test-dataset');
+    expect(retrievedDataset.description).toBe('A test dataset');
+
+    // Check that rows are loaded and accessible synchronously
+    expect(retrievedDataset.length).toBe(3);
+
+    const rows = retrievedDataset.rows.rows;
+    expect(rows).toHaveLength(3);
+    expect(rows[0]).toMatchObject({id: 1, name: 'Alice', score: 0.95});
+    expect(rows[1]).toMatchObject({id: 2, name: 'Bob', score: 0.87});
+    expect(rows[2]).toMatchObject({id: 3, name: 'Charlie', score: 0.92});
+
+    // Test getRow method
+    const row0 = retrievedDataset.getRow(0);
+    expect(row0).toMatchObject({id: 1, name: 'Alice', score: 0.95});
+
+    // Test table.row method
+    const tableRow1 = retrievedDataset.rows.row(1);
+    expect(tableRow1).toMatchObject({id: 2, name: 'Bob', score: 0.87});
+
+    // Verify __savedRef is attached to rows
+    expect(rows[0].__savedRef).toBeDefined();
+    expect(rows[1].__savedRef).toBeDefined();
+  });
+});

--- a/sdks/node/src/__tests__/evaluationLogger.test.ts
+++ b/sdks/node/src/__tests__/evaluationLogger.test.ts
@@ -73,7 +73,7 @@ describe('EvaluationLogger - Basic Functionality', () => {
   });
 
   // Test: Fire-and-forget with chained calls - true synchronous API
-  test.only('fire-and-forget usage with multple threads', async () => {
+  test('fire-and-forget usage with multple threads', async () => {
     const evalLogger = new EvaluationLogger({name: 'test-eval'});
 
     // True fire-and-forget: synchronous, no await needed!

--- a/sdks/node/src/inMemoryTraceServer.ts
+++ b/sdks/node/src/inMemoryTraceServer.ts
@@ -44,10 +44,17 @@ interface File {
   content: Blob;
 }
 
+interface Table {
+  project_id: string;
+  digest: string;
+  rows: Array<{digest: string; val: any}>;
+}
+
 export class InMemoryTraceServer {
   private _calls: Call[] = [];
   private _objs: Obj[] = [];
   private _files: File[] = [];
+  private _tables: Table[] = [];
   private _lastCallCount: number = 0;
   private _lastChangeTime: number = Date.now();
 
@@ -144,6 +151,80 @@ export class InMemoryTraceServer {
       return {
         data: {
           digest: digest,
+        },
+      };
+    },
+
+    objReadObjReadPost: async (req: {
+      project_id: string;
+      object_id: string;
+      digest?: string;
+    }) => {
+      const obj = this._objs.find(
+        o =>
+          o.project_id === req.project_id &&
+          o.object_id === req.object_id &&
+          (req.digest ? o.digest === req.digest : o.is_latest === 1)
+      );
+
+      if (!obj) {
+        throw new Error(
+          `Object not found: ${req.project_id}/${req.object_id}${req.digest ? ':' + req.digest : ''}`
+        );
+      }
+
+      return {
+        data: {
+          obj: obj,
+        },
+      };
+    },
+  };
+
+  table = {
+    tableCreateTableCreatePost: async (req: {
+      table: {project_id: string; rows: any[]};
+    }) => {
+      const digest = this.generateDigest(req.table.rows);
+
+      // Create row entries with individual digests
+      const rows = req.table.rows.map(rowVal => ({
+        digest: this.generateDigest(rowVal),
+        val: rowVal,
+      }));
+
+      const newTable: Table = {
+        project_id: req.table.project_id,
+        digest: digest,
+        rows: rows,
+      };
+
+      this._tables.push(newTable);
+
+      return {
+        data: {
+          digest: digest,
+        },
+      };
+    },
+
+    tableQueryTableQueryPost: async (req: {
+      project_id: string;
+      digest: string;
+    }) => {
+      const table = this._tables.find(
+        t => t.project_id === req.project_id && t.digest === req.digest
+      );
+
+      if (!table) {
+        throw new Error(
+          `Table not found: ${req.project_id}/table/${req.digest}`
+        );
+      }
+
+      return {
+        data: {
+          rows: table.rows,
         },
       };
     },

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -12,7 +12,7 @@ export {wrapOpenAI} from './integrations';
 export {weaveAudio, weaveImage, WeaveAudio, WeaveImage} from './media';
 export {op} from './op';
 export * from './types';
-export {WeaveObject} from './weaveObject';
+export {WeaveObject, ObjectRef} from './weaveObject';
 export {MessagesPrompt, StringPrompt} from './prompt';
 import './utils/commonJSLoader';
 import './integrations/hooks';

--- a/sdks/node/src/table.ts
+++ b/sdks/node/src/table.ts
@@ -1,3 +1,5 @@
+import {parseTableRefUri} from './uriParser';
+
 export class TableRef {
   constructor(
     public projectId: string,
@@ -6,6 +8,15 @@ export class TableRef {
 
   public uri() {
     return `weave:///${this.projectId}/table/${this.digest}`;
+  }
+
+  /**
+   * Parse a table ref URI string into a TableRef object.
+   * Format: weave:///entity/project/table/digest
+   */
+  static parseUri(uri: string): TableRef {
+    const parsed = parseTableRefUri(uri);
+    return new TableRef(parsed.projectId, parsed.digest);
   }
 }
 
@@ -26,21 +37,84 @@ type TableRow = Record<string, any> & {
 };
 
 export class Table<R extends TableRow = TableRow> {
+  private _rows: R[];
   __savedRef?: TableRef | Promise<TableRef>;
 
-  constructor(public rows: R[]) {}
+  constructor(rows: R[] | string | TableRef) {
+    if (Array.isArray(rows)) {
+      this._rows = rows;
+    } else {
+      // Store ref info but rows not loaded yet
+      this._rows = [];
+      // Store the ref for later loading
+      if (typeof rows === 'string') {
+        this.__savedRef = Promise.resolve(TableRef.parseUri(rows));
+      } else {
+        this.__savedRef = Promise.resolve(rows);
+      }
+    }
+  }
+
+  /**
+   * Load table rows from the server if they haven't been loaded yet.
+   * This method should be called after constructing a Table with a ref.
+   * After loading, rows can be accessed synchronously via getRows(), length, etc.
+   */
+  async load(): Promise<void> {
+    // If rows already loaded (array passed to constructor), nothing to do
+    if (this._rows.length > 0) {
+      return;
+    }
+
+    // If no saved ref, nothing to load
+    if (!this.__savedRef) {
+      return;
+    }
+
+    const tableRef = await this.__savedRef;
+
+    const {requireGlobalClient} = await import('./clientApi');
+    const client = requireGlobalClient();
+
+    // Fetch table data from server
+    const response = await client.traceServerApi.table.tableQueryTableQueryPost(
+      {
+        project_id: tableRef.projectId,
+        digest: tableRef.digest,
+      }
+    );
+
+    // Convert to rows with __savedRef
+    this._rows = response.data.rows.map((row: any) => {
+      const rowData = row.val as R;
+      rowData.__savedRef = new TableRowRef(
+        tableRef.projectId,
+        tableRef.digest,
+        row.digest
+      );
+      return rowData;
+    });
+  }
+
+  /**
+   * Get all rows synchronously.
+   * Note: If table was constructed with a ref, you must call load() first.
+   */
+  get rows(): R[] {
+    return this._rows;
+  }
 
   get length(): number {
-    return this.rows.length;
+    return this._rows.length;
   }
 
   async *[Symbol.asyncIterator](): AsyncIterator<R> {
-    for (let i = 0; i < this.length; i++) {
-      yield this.row(i);
+    for (let i = 0; i < this._rows.length; i++) {
+      yield this._rows[i];
     }
   }
 
   row(index: number): R {
-    return this.rows[index];
+    return this._rows[index];
   }
 }

--- a/sdks/node/src/uriParser.ts
+++ b/sdks/node/src/uriParser.ts
@@ -1,0 +1,124 @@
+/**
+ * Utility for parsing Weave ref URIs.
+ *
+ * Supports parsing different types of Weave refs:
+ * - Table refs: weave:///entity/project/table/digest
+ * - Object refs: weave:///entity/project/object/name:digest
+ * - Op refs: weave:///entity/project/op/name:digest
+ * - Call refs: weave:///entity/project/call/id
+ */
+
+export type ParsedWeaveUri =
+  | {
+      type: 'table';
+      entity: string;
+      project: string;
+      digest: string;
+    }
+  | {
+      type: 'object';
+      entity: string;
+      project: string;
+      name: string;
+      digest: string;
+    }
+  | {
+      type: 'op';
+      entity: string;
+      project: string;
+      name: string;
+      digest: string;
+    }
+  | {
+      type: 'call';
+      entity: string;
+      project: string;
+      id: string;
+    };
+
+/**
+ * Parse a Weave URI into its components.
+ *
+ * @param uri - The weave:/// URI string to parse
+ * @returns Parsed URI components or null if invalid
+ *
+ * @example
+ * ```typescript
+ * const parsed = parseWeaveUri('weave:///wandb/project/table/abc123...');
+ * if (parsed && parsed.type === 'table') {
+ *   console.log(parsed.digest);  // 'abc123...'
+ * }
+ * ```
+ */
+export function parseWeaveUri(uri: string): ParsedWeaveUri | null {
+  // Format: weave:///entity/project/type/...
+  const match = uri.match(/^weave:\/\/\/([^/]+)\/([^/]+)\/([^/]+)\/(.+)$/);
+
+  if (!match) {
+    return null;
+  }
+
+  const [, entity, project, type, rest] = match;
+
+  if (type === 'table') {
+    // weave:///entity/project/table/digest
+    return {
+      type: 'table',
+      entity,
+      project,
+      digest: rest,
+    };
+  } else if (type === 'object' || type === 'op') {
+    // weave:///entity/project/object/name:digest
+    // weave:///entity/project/op/name:digest
+    const [nameVersion] = rest.split('/');
+    const [name, digest = 'latest'] = nameVersion.split(':');
+
+    return {
+      type: type as 'object' | 'op',
+      entity,
+      project,
+      name,
+      digest,
+    };
+  } else if (type === 'call') {
+    // weave:///entity/project/call/id
+    const [id] = rest.split('/');
+    return {
+      type: 'call',
+      entity,
+      project,
+      id,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Parse a table ref URI specifically.
+ * Throws an error if the URI is not a valid table ref.
+ *
+ * @param uri - The weave:/// URI string to parse
+ * @returns Parsed table ref components
+ * @throws Error if URI is not a valid table ref
+ */
+export function parseTableRefUri(uri: string): {
+  entity: string;
+  project: string;
+  projectId: string;
+  digest: string;
+} {
+  const parsed = parseWeaveUri(uri);
+
+  if (!parsed || parsed.type !== 'table') {
+    throw new Error(`Invalid table ref URI: ${uri}`);
+  }
+
+  return {
+    entity: parsed.entity,
+    project: parsed.project,
+    projectId: `${parsed.entity}/${parsed.project}`,
+    digest: parsed.digest,
+  };
+}

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -344,12 +344,18 @@ export class WeaveClient {
 
       obj.__savedRef = ref;
 
-      // TODO: The table row refs are not correct
+      // Load table rows if they are a ref
+      await obj.rows.load();
+
       return obj;
     } else if (t == 'Table') {
       const {rows} = val;
       let obj = new Table(rows);
       obj.__savedRef = ref;
+
+      // Load table rows if they are a ref
+      await obj.load();
+
       return obj;
     } else if (t == 'CustomWeaveType') {
       const typeName = val.weave_type.type;


### PR DESCRIPTION
## Description

- Implements loading for Dataset and Table objects in the TypeScript SDK
- Adds URI parsing utilities for Weave references

This PR adds support for loading of Dataset and Table objects, allowing them to be retrieved from the server on demand. It includes a new URI parser for handling different types of Weave references 

The implementation ensures that dataset rows can be accessed synchronously after loading.

The PR also extends the InMemoryTraceServer to support table operations for testing scenarios. 

## Testing

- Added comprehensive tests for Dataset creation and retrieval
- Implemented round-trip testing to verify data integrity
- Extended InMemoryTraceServer to support table operations for testing

## Docs:
https://github.com/wandb/docs/pull/1809
