### PR TITLE
chore(weave): don't allow empty env var override netrc value

### DIFF
--- a/weave/trace/env.py
+++ b/weave/trace/env.py
@@ -97,7 +97,7 @@ def _wandb_api_key_via_netrc_file(filepath: str) -> str | None:
 
 def weave_wandb_api_key() -> str | None:
     env_api_key = _wandb_api_key_via_env()
-    if env_api_key is not None:
+    if env_api_key is not None and env_api_key != "":
         return env_api_key
 
     return _wandb_api_key_via_netrc()


### PR DESCRIPTION
Fixes https://wandb.atlassian.net/browse/WB-28705
## Description

- Fixes an issue where empty API keys from environment variables were being used instead of falling back to netrc

This PR enhances the API key retrieval logic in `weave_wandb_api_key()` by checking if the environment variable API key is not only non-None but also non-empty before using it. This ensures that empty strings in environment variables don't prevent the system from properly falling back to the netrc file for authentication.

**It’s a common pattern to forward env vars into a docker container with -e XXX.  If XXX doesn’t have a value on the host, it will be passed in as an empty string.**

## Testing

Tested by verifying that when WANDB_API_KEY is set to an empty string, the function correctly falls back to checking the netrc file for credentials.