### PR TITLE
feat(weave): add key for root level attributes to filter on

### DIFF
--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -102,6 +102,7 @@ USAGE_KEYS = {
 }
 
 # ATTRIBUTE_KEYS: Maps common LLM call metadata attributes to the types of attributes expected in weave traces
+# Exception is wandb.attributes which populates its keys to the root level
 # This is used to populate the `attributes_dump` column in clickhouse
 # Legacy: Prior to dumping, the full span is dumped under another key not listed here called `otel_span`
 # Now: we inject the otel_span key into attributes at runtime, data is dumped to a special `otel_dump` column
@@ -134,6 +135,7 @@ WB_KEYS = {
     # Custom display name for the call in the UI
     "display_name": ["wandb.display_name"],
     "thread_id": ["gcp.vertex.agent.session_id", "wandb.thread_id"],
+    "attributes": ["wandb.attributes"],
     "wb_run_id": ["wandb.wb_run_id"],
     "wb_run_step": ["wandb.wb_run_step"],
     "wb_run_step_end": ["wandb.wb_run_step_end"],

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -338,7 +338,11 @@ class Span:
         has_outputs = isinstance(outputs, int) or len(outputs) > 0
         has_usage = len(usage) > 0
 
-        # We failed to load any of the Weave attributes, dump all attributes
+        # Load user defined attributes - tagging system
+        if custom_attributes := wandb_attributes.get("attributes"):
+            attributes.update(custom_attributes)
+
+        # We failed to load any weave or user defined attributes, dump all attributes
         if not has_attributes and not has_inputs and not has_outputs and not has_usage:
             attributes = to_json_serializable(self.attributes)
 


### PR DESCRIPTION
## Description

keys under wandb.attributes will be populated to the top level

<img width="3456" height="1740" alt="image" src="https://github.com/user-attachments/assets/8f83b7f0-196d-48b5-9667-2050b079770a" />

