### PR TITLE
feat(weave): Implement fromUri method for ObjectRef to create instances from Weave URIs

### DIFF
--- a/sdks/node/src/__tests__/dataset.test.ts
+++ b/sdks/node/src/__tests__/dataset.test.ts
@@ -44,8 +44,10 @@ describe('Dataset', () => {
     expect(ref.projectId).toBe(projectId);
     expect(ref.objectId).toBe('test-dataset');
 
-    // Read the dataset back
-    const retrievedDataset = await client.get(ref);
+    // Read the dataset back using the factory method
+    const uri = `weave:///${projectId}/object/test-dataset:${ref.digest}`;
+    const refFromUri = ObjectRef.fromUri(uri);
+    const retrievedDataset = await client.get(refFromUri);
 
     expect(retrievedDataset).toBeInstanceOf(Dataset);
     expect(retrievedDataset.name).toBe('test-dataset');

--- a/sdks/node/src/weaveObject.ts
+++ b/sdks/node/src/weaveObject.ts
@@ -1,6 +1,7 @@
 import {requireGlobalClient} from './clientApi';
 import {isOp} from './op';
 import {getGlobalDomain} from './urls';
+import {parseWeaveUri} from './uriParser';
 
 export interface Callable {}
 
@@ -29,6 +30,29 @@ export class ObjectRef {
   ) {}
 
   // TODO: Add extra
+
+  /**
+   * Creates an ObjectRef from a Weave URI string.
+   *
+   * @param uri - A Weave URI in the format: weave:///entity/project/object/name:digest
+   * @returns A new ObjectRef instance
+   * @throws Error if the URI format is invalid or not an object ref
+   *
+   * @example
+   * const ref = ObjectRef.fromUri('weave:///my-entity/my-project/object/my-dataset:abc123');
+   */
+  public static fromUri(uri: string): ObjectRef {
+    const parsed = parseWeaveUri(uri);
+
+    if (!parsed || parsed.type !== 'object') {
+      throw new Error(
+        `Invalid object ref URI: ${uri}. Expected format: weave:///entity/project/object/name:digest`
+      );
+    }
+
+    const projectId = `${parsed.entity}/${parsed.project}`;
+    return new ObjectRef(projectId, parsed.name, parsed.digest);
+  }
 
   public uri() {
     return `weave:///${this.projectId}/object/${this.objectId}:${this.digest}`;


### PR DESCRIPTION
## Description

- Adds `ObjectRef.fromUri()` static factory method to create an ObjectRef from a Weave URI string. This is more convenient and realistic to use for end users.
- Updates the dataset test to demonstrate using the new factory method to retrieve a dataset

## Testing

The implementation was tested by updating the existing dataset test to use the new `ObjectRef.fromUri()` method to retrieve a dataset from a URI. Tests still pass.

## Docs:

https://github.com/wandb/docs/pull/1809