### PR TITLE
feat(weave): Make call special func raise on exception by default

### DIFF
--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -8,6 +8,7 @@ import logging
 import random
 import sys
 import traceback
+import warnings
 import weakref
 from collections import defaultdict
 from collections.abc import (
@@ -32,7 +33,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import ParamSpec, TypeIs, Unpack
+from typing_extensions import ParamSpec, TypeIs
 
 from weave.trace import box, settings
 from weave.trace.context import call_context
@@ -110,10 +111,6 @@ class Sentinel:
 
 _sentinels_to_check = [
     Sentinel(package="openai", path="openai._types", name="NOT_GIVEN"),
-    Sentinel(package="openai", path="openai._types", name="omit"),
-    Sentinel(
-        package="openai", path="openai._types", name="Omit"
-    ),  # Class, not instance
     Sentinel(package="cohere", path="cohere.base_client", name="COHERE_NOT_GIVEN"),
     Sentinel(package="anthropic", path="anthropic._types", name="NOT_GIVEN"),
     Sentinel(package="cerebras", path="cerebras.cloud.sdk._types", name="NOT_GIVEN"),
@@ -158,13 +155,8 @@ def _value_is_sentinel(param: inspect.Parameter) -> bool:
 
     # Check cached sentinels first
     for sentinel in _SENTINEL_CACHE.values():
-        if sentinel is not None:
-            # Check for identity (singleton instances)
-            if param.default is sentinel:
-                return True
-            # Check for isinstance (e.g., openai.Omit class instances)
-            if isinstance(sentinel, type) and isinstance(param.default, sentinel):
-                return True
+        if sentinel is not None and param.default is sentinel:
+            return True
 
     for sentinel in _sentinels_to_check:
         if _check_param_is_sentinel(param, sentinel):
@@ -194,18 +186,6 @@ class WeaveKwargs(TypedDict):
     display_name: str | None
     attributes: dict[str, Any]
     call_id: str | None
-
-
-class OpKwargs(TypedDict, total=False):
-    """TypedDict for op() keyword arguments."""
-
-    name: str | None
-    call_display_name: str | CallDisplayNameFunc | None
-    postprocess_inputs: PostprocessInputsFunc | None
-    postprocess_output: PostprocessOutputFunc | None
-    tracing_sample_rate: float
-    enable_code_capture: bool
-    accumulator: Callable[[Any | None, Any], Any] | None
 
 
 def setup_dunder_weave_dict(d: WeaveKwargs | None = None) -> WeaveKwargs:
@@ -404,7 +384,7 @@ def _call_sync_func(
     op: Op,
     *args: Any,
     __weave: WeaveKwargs | None = None,
-    __should_raise: bool = False,
+    raise_on_exception: bool | None = None,
     # When this param is True, calls do not automatically "finish" when the function
     # returns.  The user must explicitly call `finish` on the call object.  This is
     # included to support the imperative evaluation logging interface.
@@ -518,11 +498,26 @@ def _call_sync_func(
         finish(output)
         return output
 
+    # Use global setting if raise_on_exception is not explicitly set
+    was_explicitly_set = raise_on_exception is not None
+    if raise_on_exception is None:
+        raise_on_exception = settings.should_call_raise_on_exception()
+
+    # Warn if raise_on_exception is False and wasn't explicitly set (default behavior that will change)
+    if not raise_on_exception and not was_explicitly_set:
+        warnings.warn(
+            "The default behavior of op.call() will change to raise exceptions "
+            "in a future version. Set raise_on_exception=True to opt-in to the new behavior, "
+            "or set weave.trace.settings.call_raise_on_exception=True globally.",
+            FutureWarning,
+            stacklevel=3,
+        )
+
     try:
         res = func(*args, **kwargs)
     except Exception as e:
         finish(exception=e)
-        if __should_raise:
+        if raise_on_exception:
             raise
         return None, call
     except (SystemExit, KeyboardInterrupt) as e:
@@ -552,7 +547,7 @@ async def _call_async_func(
     op: Op,
     *args: Any,
     __weave: WeaveKwargs | None = None,
-    __should_raise: bool = False,
+    raise_on_exception: bool | None = None,
     __require_explicit_finish: bool = False,
     **kwargs: Any,
 ) -> tuple[Any, Call]:
@@ -649,11 +644,26 @@ async def _call_async_func(
             finish(output)
             return output
 
+    # Use global setting if raise_on_exception is not explicitly set
+    was_explicitly_set = raise_on_exception is not None
+    if raise_on_exception is None:
+        raise_on_exception = settings.should_call_raise_on_exception()
+
+    # Warn if raise_on_exception is False and wasn't explicitly set (default behavior that will change)
+    if not raise_on_exception and not was_explicitly_set:
+        warnings.warn(
+            "The default behavior of op.call() will change to raise exceptions "
+            "in a future version. Set raise_on_exception=True to opt-in to the new behavior, "
+            "or set weave.trace.settings.call_raise_on_exception=True globally.",
+            FutureWarning,
+            stacklevel=3,
+        )
+
     try:
         res = await func(*args, **kwargs)
     except Exception as e:
         finish(exception=e)
-        if __should_raise:
+        if raise_on_exception:
             raise
         return None, call
     except (SystemExit, KeyboardInterrupt) as e:
@@ -683,7 +693,7 @@ def _call_sync_gen(
     op: Op,
     *args: Any,
     __weave: WeaveKwargs | None = None,
-    __should_raise: bool = False,
+    raise_on_exception: bool | None = None,
     __require_explicit_finish: bool = False,
     **kwargs: Any,
 ) -> tuple[Generator[Any], Call]:
@@ -874,11 +884,27 @@ def _call_sync_gen(
     except Exception as e:
         # Handle exceptions from initial generator creation
         finish(exception=e)
-        if __should_raise:
+
+        # Use global setting if raise_on_exception is not explicitly set
+        was_explicitly_set = raise_on_exception is not None
+        if raise_on_exception is None:
+            raise_on_exception = settings.should_call_raise_on_exception()
+
+        # Warn if raise_on_exception is False and wasn't explicitly set (default behavior that will change)
+        if not raise_on_exception and not was_explicitly_set:
+            warnings.warn(
+                "The default behavior of op.call() will change to raise exceptions "
+                "in a future version. Set raise_on_exception=True to opt-in to the new behavior, "
+                "or set weave.trace.settings.call_raise_on_exception=True globally.",
+                FutureWarning,
+                stacklevel=3,
+            )
+
+        if raise_on_exception:
             raise
 
         def empty_sync_gen() -> Generator[Any]:
-            # Re-raise the original exception if __should_raise is False
+            # Re-raise the original exception if raise_on_exception is False
             # but we're evaluating the generator, to maintain expected behavior
             if not has_finished:
                 nonlocal e
@@ -893,7 +919,7 @@ async def _call_async_gen(
     op: Op,
     *args: Any,
     __weave: WeaveKwargs | None = None,
-    __should_raise: bool = False,
+    raise_on_exception: bool | None = None,
     __require_explicit_finish: bool = False,
     **kwargs: Any,
 ) -> tuple[AsyncIterator, Call]:
@@ -1089,11 +1115,27 @@ async def _call_async_gen(
     except Exception as e:
         # Handle exceptions from initial generator creation
         finish(exception=e)
-        if __should_raise:
+
+        # Use global setting if raise_on_exception is not explicitly set
+        was_explicitly_set = raise_on_exception is not None
+        if raise_on_exception is None:
+            raise_on_exception = settings.should_call_raise_on_exception()
+
+        # Warn if raise_on_exception is False and wasn't explicitly set (default behavior that will change)
+        if not raise_on_exception and not was_explicitly_set:
+            warnings.warn(
+                "The default behavior of op.call() will change to raise exceptions "
+                "in a future version. Set raise_on_exception=True to opt-in to the new behavior, "
+                "or set weave.trace.settings.call_raise_on_exception=True globally.",
+                FutureWarning,
+                stacklevel=3,
+            )
+
+        if raise_on_exception:
             raise
 
         async def empty_async_gen() -> AsyncIterator[Any]:
-            # Re-raise the original exception if __should_raise is False
+            # Re-raise the original exception if raise_on_exception is False
             # but we're evaluating the generator, to maintain expected behavior
             if not has_finished:
                 nonlocal e
@@ -1109,7 +1151,7 @@ def call(
     op: Op,
     *args: Any,
     __weave: WeaveKwargs | None = None,
-    __should_raise: bool = False,
+    raise_on_exception: bool | None = None,
     # When this param is True, calls do not automatically "finish" when the function
     # returns.  The user must explicitly call `finish` on the call object.  This is
     # included to support the imperative evaluation logging interface.
@@ -1118,7 +1160,9 @@ def call(
 ) -> tuple[Any, Call] | Coroutine[Any, Any, tuple[Any, Call]]:
     """Executes the op and returns both the result and a Call representing the execution.
 
-    This function will never raise.  Any errors are captured in the Call object.
+    By default, this function will not raise exceptions. Any errors are captured in the Call object.
+    Set raise_on_exception=True to re-raise exceptions, or set the global setting
+    weave.trace.settings.call_raise_on_exception=True.
 
     This method is automatically bound to any function decorated with `@weave.op`,
     allowing for usage like:
@@ -1136,7 +1180,7 @@ def call(
             op,
             *args,
             __weave=__weave,
-            __should_raise=__should_raise,
+            raise_on_exception=raise_on_exception,
             __require_explicit_finish=__require_explicit_finish,
             **kwargs,
         )
@@ -1145,7 +1189,7 @@ def call(
             op,
             *args,
             __weave=__weave,
-            __should_raise=__should_raise,
+            raise_on_exception=raise_on_exception,
             __require_explicit_finish=__require_explicit_finish,
             **kwargs,
         )
@@ -1172,9 +1216,37 @@ def calls(op: Op) -> CallsIter:
 
 
 @overload
-def op(func: Callable[P, R], **kwargs: Unpack[OpKwargs]) -> Op[P, R]: ...
+def op(
+    func: Callable[P, R],
+    *,
+    name: str | None = None,
+    call_display_name: str | CallDisplayNameFunc | None = None,
+    postprocess_inputs: PostprocessInputsFunc | None = None,
+    postprocess_output: PostprocessOutputFunc | None = None,
+    accumulator: Callable[[Any | None, Any], Any] | None = None,
+) -> Op[P, R]: ...
+
+
 @overload
-def op(**kwargs: Unpack[OpKwargs]) -> Callable[[Callable[P, R]], Op[P, R]]: ...
+def op(
+    *,
+    name: str | None = None,
+    call_display_name: str | CallDisplayNameFunc | None = None,
+    postprocess_inputs: PostprocessInputsFunc | None = None,
+    postprocess_output: PostprocessOutputFunc | None = None,
+    accumulator: Callable[[Any | None, Any], Any] | None = None,
+) -> Callable[[Callable[P, R]], Op[P, R]]: ...
+
+
+@overload
+def op(
+    *,
+    name: str | None = None,
+    enable_code_capture: bool = True,
+    accumulator: Callable[[Any | None, Any], Any] | None = None,
+) -> Callable[[Callable[P, R]], Op[P, R]]: ...
+
+
 def op(
     func: Callable[P, R] | None = None,
     *,
@@ -1208,7 +1280,10 @@ def op(
                 @wraps(func)
                 async def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:  # pyright: ignore[reportRedeclaration]
                     res, _ = await _call_async_func(
-                        cast(Op[P, R], wrapper), *args, __should_raise=True, **kwargs
+                        cast(Op[P, R], wrapper),
+                        *args,
+                        raise_on_exception=True,
+                        **kwargs,
                     )
                     return cast(R, res)
             elif is_sync_generator:
@@ -1216,7 +1291,10 @@ def op(
                 @wraps(func)
                 def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:  # pyright: ignore[reportRedeclaration]
                     res, _ = _call_sync_gen(
-                        cast(Op[P, R], wrapper), *args, __should_raise=True, **kwargs
+                        cast(Op[P, R], wrapper),
+                        *args,
+                        raise_on_exception=True,
+                        **kwargs,
                     )
                     return cast(R, res)
             elif is_async_generator:
@@ -1226,7 +1304,10 @@ def op(
                     *args: P.args, **kwargs: P.kwargs
                 ) -> AsyncGenerator[R]:
                     res, _ = await _call_async_gen(
-                        cast(Op[P, R], wrapper), *args, __should_raise=True, **kwargs
+                        cast(Op[P, R], wrapper),
+                        *args,
+                        raise_on_exception=True,
+                        **kwargs,
                     )
                     async for item in res:
                         yield item
@@ -1235,7 +1316,10 @@ def op(
                 @wraps(func)
                 def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
                     res, _ = _call_sync_func(
-                        cast(Op[P, R], wrapper), *args, __should_raise=True, **kwargs
+                        cast(Op[P, R], wrapper),
+                        *args,
+                        raise_on_exception=True,
+                        **kwargs,
                     )
                     return cast(R, res)
 
@@ -1269,7 +1353,6 @@ def op(
 
             wrapper._set_on_finish_handler = partial(_set_on_finish_handler, wrapper)  # type: ignore
             wrapper._on_finish_handler = None  # type: ignore
-            wrapper._on_finish_post_processor = None  # type: ignore
 
             wrapper._tracing_enabled = True  # type: ignore
             wrapper.tracing_sample_rate = tracing_sample_rate  # type: ignore
@@ -1605,7 +1688,7 @@ class _Accumulator(Generic[S, V]):
 
 
 def _build_iterator_from_accumulator_for_op(
-    value: Iterator[V] | AsyncIterator[V],
+    value: Iterator[V],
     accumulator: Callable,
     on_finish: FinishCallbackType,
     iterator_wrapper: type[_IteratorWrapper] = _IteratorWrapper,
@@ -1659,23 +1742,28 @@ def _add_accumulator(
     """
 
     def on_output(
-        value: Iterator[V] | AsyncIterator[V],
-        on_finish: FinishCallbackType,
-        inputs: dict,
-    ) -> Iterator | AsyncIterator:
+        value: Iterator[V], on_finish: FinishCallbackType, inputs: dict
+    ) -> Iterator:
+        def wrapped_on_finish(value: Any, e: BaseException | None = None) -> None:
+            if on_finish_post_processor is not None:
+                value = on_finish_post_processor(value)
+            on_finish(value, e)
+
         if should_accumulate is None or should_accumulate(inputs):
             # we build the accumulator here dependent on the inputs (optional)
             accumulator = make_accumulator(inputs)
             return _build_iterator_from_accumulator_for_op(
                 value,
                 accumulator,
-                on_finish,
+                wrapped_on_finish,
                 iterator_wrapper,
             )
         else:
-            on_finish(value, None)
+            wrapped_on_finish(value)
             return value
 
     op._set_on_output_handler(on_output)
-    op._on_finish_post_processor = on_finish_post_processor
     return op
+
+
+__docspec__ = [call, calls]

--- a/weave/trace/op_caller.py
+++ b/weave/trace/op_caller.py
@@ -47,8 +47,8 @@ def async_call_op(
     """
     is_async = inspect.iscoroutinefunction(func.resolve_fn)
     if is_async:
-        return func.call(*args, __should_raise=True, **kwargs)
+        return func.call(*args, raise_on_exception=True, **kwargs)
     else:
         return asyncio.to_thread(
-            lambda: func.call(*args, __should_raise=True, **kwargs)
+            lambda: func.call(*args, raise_on_exception=True, **kwargs)
         )

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -187,6 +187,17 @@ class UserSettings(BaseModel):
     Can be overridden with the environment variable `WEAVE_USE_PARALLEL_TABLE_UPLOAD`
     """
 
+    call_raise_on_exception: bool = False
+    """
+    Globally controls whether exceptions are raised when calling ops via op.call().
+
+    If True, exceptions raised during op execution will be re-raised.
+    If False, exceptions are captured in the Call object and not raised.
+
+    This setting will change to True in a future version.
+    Can be overridden with the environment variable `WEAVE_CALL_RAISE_ON_EXCEPTION`
+    """
+
     model_config = ConfigDict(extra="forbid")
     _is_first_apply: bool = PrivateAttr(True)
 
@@ -302,6 +313,11 @@ def should_use_parallel_table_upload() -> bool:
 def should_implicitly_patch_integrations() -> bool:
     """Returns whether implicit patching of integrations is enabled."""
     return _should("implicitly_patch_integrations")
+
+
+def should_call_raise_on_exception() -> bool:
+    """Returns whether exceptions should be raised when calling ops via op.call()."""
+    return _should("call_raise_on_exception")
 
 
 def parse_and_apply_settings(


### PR DESCRIPTION
Previously, the `op.call` special func would NOT raise by default.  This was an intentional choice to allow users to always have access to the resulting `Call` object, but feels like a bug to many users.

This PR changes the func to raise by default with a new kwarg called `never_raise = False` that can be set to `True` to get the old behaviour