### PR TITLE
chore(weave): skip failing langchain tests on Win 

### DIFF
--- a/tests/integrations/langchain/langchain_test.py
+++ b/tests/integrations/langchain/langchain_test.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from collections.abc import Generator
 from unittest.mock import patch
 
@@ -233,6 +234,10 @@ def assert_correct_calls_for_chain_batch(calls: list[Call]) -> None:
     allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Currently not working on Windows",
+)
 def test_simple_chain_batch(client: WeaveClient) -> None:
     from langchain_core.prompts import PromptTemplate
     from langchain_openai import ChatOpenAI
@@ -301,6 +306,10 @@ def assert_correct_calls_for_chain_batch_from_op(calls: list[Call]) -> None:
     filter_headers=["authorization"],
     allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
+)
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="Currently not working on Windows",
 )
 def test_simple_chain_batch_inside_op(client: WeaveClient) -> None:
     # This test is the same as test_simple_chain_batch, but ensures things work when nested in an op


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-NNNNN
- Fixes #NNNN

This PR for now skips the failing tests on windows platform.


## Testing

How was this PR tested?
