### PR TITLE
chore(weave): Manually bump weave to 0.52.14-dev0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -383,7 +383,7 @@ module = "weave_query.*"
 ignore_errors = true
 
 [tool.bumpversion]
-current_version = "0.52.13-dev0"
+current_version = "0.52.14-dev0"
 parse = """(?x)
     (?P<major>0|[1-9]\\d*)\\.
     (?P<minor>0|[1-9]\\d*)\\.

--- a/weave/version.py
+++ b/weave/version.py
@@ -44,4 +44,4 @@ https://github.com/callowayproject/bump-my-version. Additional configuration can
 
 """
 
-VERSION = "0.52.13-dev0"
+VERSION = "0.52.14-dev0"


### PR DESCRIPTION
Manually bump to to `0.52.14-dev0` to resolve version bumping issues