### PR TITLE
chore(weave): add header depth to saved view definition

### DIFF
--- a/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
+++ b/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
@@ -129,7 +129,6 @@
           "title": "Description"
         },
         "field_schema": {
-          "additionalProperties": true,
           "default": {},
           "description": "Expected to be valid JSON Schema. Can be provided as a dict, a Pydantic model class, a tuple of a primitive type and a Pydantic Field, or primitive type",
           "examples": [
@@ -1322,7 +1321,6 @@
           "anyOf": [
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1493,7 +1491,6 @@
           "type": "string"
         },
         "response_schema": {
-          "additionalProperties": true,
           "title": "Response Schema",
           "type": "object"
         }
@@ -1520,7 +1517,6 @@
             },
             {
               "items": {
-                "additionalProperties": true,
                 "type": "object"
               },
               "type": "array"
@@ -1547,7 +1543,6 @@
         "function_call": {
           "anyOf": [
             {
-              "additionalProperties": true,
               "type": "object"
             },
             {
@@ -1982,6 +1977,18 @@
           ],
           "default": null,
           "title": "Columns"
+        },
+        "header_depth": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Header Depth"
         },
         "pin": {
           "anyOf": [

--- a/weave/trace_server/interface/builtin_object_classes/saved_view.py
+++ b/weave/trace_server/interface/builtin_object_classes/saved_view.py
@@ -46,6 +46,7 @@ class SavedViewDefinition(BaseModel):
     # columns is specifying exactly which columns to include
     # including order.
     columns: Optional[list[Column]] = Field(default=None)
+    header_depth: Optional[int] = Field(default=None)
 
     pin: Optional[Pin] = Field(default=None)
     sort_by: Optional[list[tsi.SortBy]] = Field(default=None)


### PR DESCRIPTION
## Description

- Added `header_depth` field to `SavedViewDefinition` model

This PR is required by https://github.com/wandb/core/pull/36000
