### PR TITLE
chore(weave): use clickhouse UPDATE clause for call deletion/updates

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -865,7 +865,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
         try:
-            return self._calls_delete_mutate(req.project_id, req.call_ids, req.wb_user_id)
+            return self._calls_delete_mutate(
+                req.project_id, req.call_ids, req.wb_user_id, "calls_merged"
+            )
         except Exception as e:
             logger.warning(f"Error deleting calls with mutate: {e}")
 
@@ -887,12 +889,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return tsi.CallsDeleteRes(num_deleted=len(all_descendants))
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._calls_delete_mutate")
-    def _calls_delete_mutate(self, project_id: str, call_ids: list[str], wb_user_id: str) -> tsi.CallsDeleteRes:
+    def _calls_delete_mutate(
+        self, project_id: str, call_ids: list[str], wb_user_id: str, table_name: str
+    ) -> tsi.CallsDeleteRes:
         """Use the new fancy clickhouse UPDATE clause to delete the table directly."""
-        query = """UPDATE calls_merged
-            SET deleted_at = {deleted_at:DateTime64(3)}, wb_user_id = {wb_user_id:String}
-            WHERE project_id = {project_id:String}
-                AND id IN ({call_ids:String[]})
+        query = f"""UPDATE {table_name}
+            SET deleted_at = {{deleted_at:DateTime64(3)}}, wb_user_id = {{wb_user_id:String}}
+            WHERE project_id = {{project_id:String}}
+                AND id IN {{call_ids:String[]}}
         """
         self.ch_client.command(
             query,
@@ -922,7 +926,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Try new update path, if fails fallback to insertion
         try:
-            return self._call_update_mutate(req)
+            return self._call_update_mutate(
+                req.display_name,
+                req.wb_user_id,
+                req.project_id,
+                req.call_id,
+                "calls_merged",
+            )
         except Exception as e:
             logger.warning(f"Error updating call with mutate: {e}")
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This pr moves call deletion and display name updates onto the new clickhouse `UPDATE` path. This is a new feature, both for us and clickhouse, so in this pr it is implemented with blanket try/catch that falls back to the existing method. 

This does NOT use the new tables, and is intended to gauge the performance impact of these new methods.

## Testing

TODO qa: also, this is **BLOCKED** on setting the beta flag by clickhouse team for prod.