### PR TITLE
chore(weave): otel shadow writes to calls_complete

### DIFF
--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -89,6 +89,14 @@ class ProjectVersionResolver:
                 )
         return _global_resolver
 
+    def do_OTEL_shadow_write(self) -> bool:
+        """Determine if OTEL shadow write should be performed.
+
+        Returns:
+            True if OTEL shadow write should be performed, False otherwise.
+        """
+        return self._mode != ProjectVersionMode.OFF
+
     def _apply_mode(
         self, resolved_version: ProjectVersion, is_write: bool
     ) -> ProjectVersion:
@@ -152,6 +160,9 @@ class ProjectVersionResolver:
         if self._mode == ProjectVersionMode.CALLS_MERGED_READ and not is_write:
             return ProjectVersion.CALLS_MERGED_VERSION
 
+        if self._mode == ProjectVersionMode.CALLS_COMPLETE_READ and not is_write:
+            return ProjectVersion.CALLS_COMPLETE_VERSION
+
         version = self._resolve_version_sync(project_id)
         return self._apply_mode(version, is_write)
 
@@ -179,6 +190,9 @@ class ProjectVersionResolver:
 
         if self._mode == ProjectVersionMode.CALLS_MERGED_READ and not is_write:
             return ProjectVersion.CALLS_MERGED_VERSION
+
+        if self._mode == ProjectVersionMode.CALLS_COMPLETE_READ and not is_write:
+            return ProjectVersion.CALLS_COMPLETE_VERSION
 
         # Since we don't have an async ClickHouse client, we need to run
         # the sync version in a thread to avoid blocking the event loop

--- a/weave/trace_server/project_version/types.py
+++ b/weave/trace_server/project_version/types.py
@@ -42,14 +42,16 @@ class ProjectVersionMode(str, Enum):
     """Modes for controlling project version resolution behavior.
 
     AUTO: Default behavior - uses table to determine project version.
-    CALLS_MERGED: Forces all reads/writes to calls_merged table (queries DB for perf measurement).
+    CALLS_MERGED: Forces all reads/writes to calls_merged table.
     CALLS_MERGED_READ: Forces reads to calls_merged table, writes use determined version.
+    CALLS_COMPLETE_READ: Forces reads to calls_complete table, writes use determined version.
     OFF: Skips DB queries entirely, returns CALLS_MERGED_VERSION immediately.
     """
 
     AUTO = "auto"
     CALLS_MERGED = "calls_merged"
     CALLS_MERGED_READ = "calls_merged_read"
+    CALLS_COMPLETE_READ = "calls_complete_read"
     OFF = "off"
 
     @classmethod


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Shadow service for writing to `calls_complete` when doing OTEL exports. We can test performance by comparing projects and confirming the shape of the data is kosher. 

## Testing

todo
