### PR TITLE
fix(weave): object creation breaks sdk due to object_id

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -355,6 +355,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         res = self.obj_create_batch(obj_creation_batch)
 
         for result in res:
+            if result.object_id is None:
+                raise RuntimeError("Otel Export - Expected object_id but got None")
+
             op_ref_uri = ri.InternalOpRef(
                 project_id=req.project_id,
                 name=result.object_id,

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -555,7 +555,7 @@ class ObjCreateReq(BaseModelStrict):
 
 class ObjCreateRes(BaseModel):
     digest: str
-    object_id: str
+    object_id: Optional[str] = None
 
 
 class ObjReadReq(BaseModelStrict):


### PR DESCRIPTION
## Description

All older server version instances are breaking due to non-optional parameter added in obj_create_batch PR. This fixes it. docs are not required

