### PR TITLE
fix: Improve __dirname handling for CommonJS and ESM

### DIFF
--- a/sdks/node/src/utils/userAgent.ts
+++ b/sdks/node/src/utils/userAgent.ts
@@ -1,10 +1,21 @@
 import {existsSync, readFileSync} from 'fs';
-import {join} from 'path';
+import {dirname, join} from 'path';
+import {fileURLToPath} from 'url';
 
 export let packageVersion: string;
 
-const twoLevelsUp = join(__dirname, '..', '..', 'package.json');
-const oneLevelUp = join(__dirname, '..', 'package.json');
+// Get current directory, handling both CommonJS and ESM
+let currentDir: string;
+try {
+  // CommonJS
+  currentDir = __dirname;
+} catch {
+  // ESM fallback
+  currentDir = dirname(fileURLToPath(import.meta.url));
+}
+
+const twoLevelsUp = join(currentDir, '..', '..', 'package.json');
+const oneLevelUp = join(currentDir, '..', 'package.json');
 
 if (existsSync(twoLevelsUp)) {
   // This is the case in the built npm package


### PR DESCRIPTION
This changes the `__dirname` logic to handle commonjs and esm.

For context, I wanted to get this running in a cloudflare worker, which led to this error:

```
  Uncaught ReferenceError: __dirname is not defined at null.<anonymous>
```