### PR TITLE
chore(weave): update api key length check

### DIFF
--- a/tests/compat/wandb/test_login.py
+++ b/tests/compat/wandb/test_login.py
@@ -40,17 +40,17 @@ class HostAndBaseURL:
 def api_key(request):
     """Parametrized fixture for different API key formats."""
     if request.param == "valid-saas":
+        return "a" * 86
+    elif request.param == "valid-saas-legacy":
         return "a" * 40
     elif request.param == "valid-onprem":
+        return "local-" + "b" * 86
+    elif request.param == "valid-onprem-legacy":
         return "local-" + "b" * 40
     elif request.param == "invalid-too-short":
         return "short"
-    elif request.param == "invalid-too-long":
-        return "a" * 41
     elif request.param == "invalid-onprem-too-short":
-        return "local-short"
-    elif request.param == "invalid-onprem-too-long":
-        return "local-" + "c" * 41
+        return "local-short-" + "c" * 39
 
     raise ValueError(f"Invalid API key type: {request.param}")
 
@@ -79,12 +79,15 @@ def host_and_base_url(request):
     return HostAndBaseURL(host, base_url)
 
 
-all_valid_keys = ["valid-saas", "valid-onprem"]
+all_valid_keys = [
+    "valid-saas",
+    "valid-saas-legacy",
+    "valid-onprem",
+    "valid-onprem-legacy",
+]
 all_invalid_keys = [
     "invalid-too-short",
-    "invalid-too-long",
     "invalid-onprem-too-short",
-    "invalid-onprem-too-long",
 ]
 all_hosts = ["saas", "aws", "gcp", "azure", "onprem"]
 

--- a/weave/compat/wandb/wandb_thin/login.py
+++ b/weave/compat/wandb/wandb_thin/login.py
@@ -357,13 +357,14 @@ def _validate_api_key(api_key: str) -> None:
         >>> _validate_api_key("short")  # Raises ValueError
     """
     if "-" in api_key:  # on-prem style
-        _, key = api_key.split("-", 1)
+        parts = api_key.split("-")
+        key = parts[-1]
     else:  # normal style
         key = api_key
 
-    if len(key) != 40:
+    if len(key) < 40:
         raise ValueError(
-            f"API key must be 40 characters long, yours was {len(key)}"
+            f"API key must be at least 40 characters long, yours was {len(key)}"
         ) from None
 
 


### PR DESCRIPTION
## Description

New wandb API keys will be longer than 40 chars. 
This change updates the api key check to support them.

## Testing

How was this PR tested?
