### PR TITLE
chore(weave): Fix nightly tests

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -30,7 +30,7 @@ jobs:
           ]
         shard:
           [
-            "trace123",
+            "trace",
             "flow",
             "trace_server",
             "trace_server_bindings",


### PR DESCRIPTION
Trace shards were recently combined, but I forgot to update the nightly tests