### PR TITLE
chore(weave): all inserts use async inserts, every 1000ms (not 2s)

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -4,6 +4,8 @@ This module contains all configuration constants, type definitions, and column
 specifications used by the ClickHouse trace server implementation.
 """
 
+from typing import Any
+
 from weave.trace_server import environment as wf_env
 
 # File and batch processing settings
@@ -54,3 +56,12 @@ CLICKHOUSE_ASYNC_INSERT_SETTINGS = {
     # Max time between buffer flushes
     "async_insert_busy_timeout_ms": 1000,
 }
+
+
+def update_settings_for_async_insert(
+    settings: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    merged_settings = CLICKHOUSE_ASYNC_INSERT_SETTINGS.copy()
+    if settings is not None:
+        merged_settings.update(settings)
+    return merged_settings


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

This pr 
- moves all clickhouse inserts to be async inserts. `call_parts` is already async and it had a wonderful impact on the db, let's move all inserts to use the buffer flush.
     - includes: `table_rows`, `tables`, `object_versions`, and `feedback`
- set `async_insert_busy_timeout_ms = 1000` (from `2000`)

## Testing

object insert:
<img width="749" height="747" alt="image" src="https://github.com/user-attachments/assets/cdb1225e-a9ac-4861-939f-116bd596ad3e" />

calls insert:
<img width="992" height="696" alt="Screenshot 2025-11-17 at 1 30 31 PM" src="https://github.com/user-attachments/assets/25dc4665-9401-433b-9217-513fecd89834" />

db impact: positive, hard to know the total impact without seeing larger traffic like in prod.
<img width="713" height="213" alt="Screenshot 2025-11-17 at 1 42 29 PM" src="https://github.com/user-attachments/assets/7d5d58d0-51b2-4c3e-a894-eebd541adc63" />