### PR TITLE
chore(weave): Correctly link non-server tests to the matrix checks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -234,11 +234,12 @@ jobs:
 
     needs:
       - trace-tests
+      - trace_no_server
 
     runs-on: ubuntu-latest
 
     steps:
-      - name: Passes if all trace-tests jobs succeeded
+      - name: Passes if all trace-tests and trace_no_server jobs succeeded
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
@@ -365,11 +366,12 @@ jobs:
 
     needs:
       - windows_trace_tests
+      - windows_trace_no_server
 
     runs-on: ubuntu-latest
 
     steps:
-      - name: Passes if all windows-trace-tests jobs succeeded
+      - name: Passes if all windows_trace_tests and windows_trace_no_server jobs succeeded
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}


### PR DESCRIPTION
The `trace_no_server` and `windows_trace_no_server` matrix tests were not linked to their respective buckets, meaning CI would not block on their failure. This is now fixed

Before

<img width="465" height="582" alt="Screenshot 2025-11-19 at 11 45 32" src="https://github.com/user-attachments/assets/67163107-4367-4a37-8ffd-4f55f60d2fca" />

After
<img width="440" height="549" alt="Screenshot 2025-11-19 at 11 47 26" src="https://github.com/user-attachments/assets/ac3caf80-c671-48f1-9dc3-f61ac3922ae6" />

