### PR TITLE
docs(weave): Fixes Dataset name field for downstream TS reference docs

### DIFF
--- a/sdks/node/src/dataset.ts
+++ b/sdks/node/src/dataset.ts
@@ -30,7 +30,7 @@ export type DatasetRow = Record<string, any> & {
  * @example
  * // Create a dataset
  * const dataset = new Dataset({
- *   id: 'grammar-dataset',
+ *   name: 'grammar-dataset',
  *   rows: [
  *     { id: '0', sentence: "He no likes ice cream.", correction: "He doesn't like ice cream." },
  *     { id: '1', sentence: "She goed to the store.", correction: "She went to the store." },


### PR DESCRIPTION
## Description
Resolves [DOCS-1721](https://wandb.atlassian.net/browse/DOCS-1721). The TS reference docs incorrectly use the `id` field when they should be using the `name` field to name a dataset. This corrects that.


[DOCS-1721]: https://wandb.atlassian.net/browse/DOCS-1721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ