### PR TITLE
fix(weave): patch memory leak in openai agents tracing processor

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -135,6 +135,7 @@ jobs:
             "mistral",
             "notdiamond",
             "openai",
+            "openai_agents",
             "verifiers_test",
             "vertexai",
             "pandas_test",


### PR DESCRIPTION
## Description

Prevents unbounded memory consumption by the `WeaveTracingProcessor` that plugs into the `openai-agents` sdk. The processor was keeping an infinitely growing list of processed data in its internal state. This PR updates the processor to clear items from internal state after they are processed and flush all data on shutdown.

Adds a test to assert that the internal state updates as we expect. Also adds the `openai_agents` shard to the list of shards we run in CI. The tests for the openai agents integration defined by https://github.com/wandb/weave/pull/3882 have actually never run in CI 