### PR TITLE
chore(weave): update server check logic in conftest

### DIFF
--- a/tests/trace_server/conftest_lib/clickhouse_server.py
+++ b/tests/trace_server/conftest_lib/clickhouse_server.py
@@ -22,7 +22,7 @@ def ensure_clickhouse_db_container_running(
 
     The fixture handles cleanup by stopping the Docker container when the test session ends.
     """
-    server_up = check_server_up(host, port, 0)
+    server_up = check_server_up(host, port, 1)
     started_container = None
 
     if not server_up:


### PR DESCRIPTION
## Description

This fixes a use case for local development, sometimes I would prefer launching a secondary clickhouse instance all by myself at port 8124. It avoids having the test launch the default instance at 8123 and erase the local dev data. 

In this scenario I want the `check_server_up(host, port, 1)` to actually do the check at least once during start up. hence the fix.

## Testing

Validate the tests now pass
