### PR TITLE
fix(weave): Fix iteration issue when moving from requests to httpx

### DIFF
--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -568,7 +568,7 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         handle_response_error(r, "/files/content")
         # TODO: Should stream to disk rather than to memory
         bytes = io.BytesIO()
-        bytes.writelines(r.iter_content())
+        bytes.writelines(r.iter_bytes())
         bytes.seek(0)
         return tsi.FileContentReadRes(content=bytes.read())
 


### PR DESCRIPTION
`requests` uses `iter_content`, but `httpx` calls this `iter_bytes`