### PR TITLE
chore(weave): fix the http client auth issue

### DIFF
--- a/weave/utils/http_requests.py
+++ b/weave/utils/http_requests.py
@@ -180,8 +180,10 @@ def get(
 ) -> Response:
     """Send a GET request with optional logging."""
     if stream:
+        # Extract auth since build_request doesn't accept it
+        auth = kwargs.pop("auth", None)
         request = client.build_request("GET", url, params=params, **kwargs)
-        return client.send(request, stream=True)
+        return client.send(request, auth=auth, stream=True)
     return client.get(url, params=params, **kwargs)
 
 
@@ -195,8 +197,10 @@ def post(
 ) -> Response:
     """Send a POST request with optional logging."""
     if stream:
+        # Extract auth since build_request doesn't accept it
+        auth = kwargs.pop("auth", None)
         request = client.build_request("POST", url, data=data, json=json, **kwargs)
-        return client.send(request, stream=True)
+        return client.send(request, auth=auth, stream=True)
     return client.post(url, data=data, json=json, **kwargs)
 
 
@@ -209,6 +213,8 @@ def delete(
 ) -> Response:
     """Send a DELETE request with optional logging."""
     if stream:
+        # Extract auth since build_request doesn't accept it
+        auth = kwargs.pop("auth", None)
         request = client.build_request("DELETE", url, params=params, **kwargs)
-        return client.send(request, stream=True)
+        return client.send(request, auth=auth, stream=True)
     return client.delete(url, params=params, **kwargs)


### PR DESCRIPTION
## Description

- Fixes a bug in HTTP streaming requests

https://wandb.atlassian.net/browse/WB-29691

This PR fixes an issue with authentication in streaming HTTP requests. The `build_request` method doesn't accept the `auth` parameter, so we now extract it from kwargs and pass it directly to the `send` method for GET, POST, and DELETE requests when streaming is enabled.

## Testing

Tested by verifying that authenticated streaming requests now work correctly for all HTTP methods.