### PR TITLE
chore(weave): Remove BaseModel from leaderboard

### DIFF
--- a/weave/flow/leaderboard.py
+++ b/weave/flow/leaderboard.py
@@ -1,6 +1,7 @@
-from typing import Any
+from __future__ import annotations
 
-from pydantic import BaseModel
+from dataclasses import dataclass
+from typing import Any
 
 from weave.trace.refs import OpRef
 from weave.trace.weave_client import WeaveClient, get_ref
@@ -9,16 +10,19 @@ from weave.trace_server.trace_server_interface import CallsFilter
 from weave.utils.project_id import from_project_id
 
 
-class LeaderboardModelEvaluationResult(BaseModel):
+@dataclass
+class LeaderboardModelEvaluationResult:
     evaluate_call_ref: str
     value: Any
 
 
-class ModelScoresForColumn(BaseModel):
+@dataclass
+class ModelScoresForColumn:
     scores: list[LeaderboardModelEvaluationResult]
 
 
-class LeaderboardModelResult(BaseModel):
+@dataclass
+class LeaderboardModelResult:
     model_ref: str
     column_scores: list[ModelScoresForColumn]
 


### PR DESCRIPTION
We don't need to use BaseModel here.  Using a dataclass is fine, and less expensive