### PR TITLE
chore(weave): allow conditional migrations by group key

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -1,10 +1,15 @@
+import os
 import types
 from unittest.mock import Mock, call, patch
 
 import pytest
 
 from weave.trace_server import clickhouse_trace_server_migrator as trace_server_migrator
-from weave.trace_server.clickhouse_trace_server_migrator import MigrationError
+from weave.trace_server.clickhouse_trace_server_migrator import (
+    MigrationError,
+    MigrationInfo,
+    MigrationStatus,
+)
 
 
 @pytest.fixture
@@ -229,3 +234,198 @@ def test_format_replicated_sql_non_mergetree(mock_costs, migrator):
 
     for sql in test_cases:
         assert migrator._format_replicated_sql(sql) == sql
+
+
+def test_get_migrations_parsing(tmp_path):
+    # Setup migration files
+    migration_dir = tmp_path / "migrations"
+    migration_dir.mkdir()
+
+    files = [
+        "1_init.up.sql",
+        "1_init.down.sql",
+        "2_feature.experimental.up.sql",
+        "2_feature.experimental.down.sql",
+        "3_complex.alpha_beta.up.sql",
+        "3_complex.alpha_beta.down.sql",
+        "4_legacy.up.sql",
+        "4_legacy.down.sql",
+    ]
+    for f in files:
+        (migration_dir / f).write_text("")
+
+    ch_client = Mock()
+    migrator = trace_server_migrator.ClickHouseTraceServerMigrator(ch_client)
+
+    # Mock where the migrator looks for files
+    with (
+        patch("os.path.dirname", return_value=str(tmp_path)),
+        patch("os.path.join", side_effect=os.path.join),
+        patch("os.listdir", return_value=files),
+    ):
+        migration_map = migrator._get_migrations()
+
+        assert len(migration_map) == 4
+
+        # Check standard migration
+        assert migration_map[1].up == "1_init.up.sql"
+        assert migration_map[1].keys == []
+
+        # Check single key
+        assert migration_map[2].up == "2_feature.experimental.up.sql"
+        assert set(migration_map[2].keys) == {"experimental"}
+
+        # Check multiple keys
+        assert migration_map[3].up == "3_complex.alpha_beta.up.sql"
+        assert set(migration_map[3].keys) == {"alpha", "beta"}
+
+        # Check legacy style (implied no keys)
+        assert migration_map[4].up == "4_legacy.up.sql"
+        assert migration_map[4].keys == []
+
+
+def test_apply_migrations_skips_mismatch_keys(mock_costs, migrator, tmp_path):
+    # Setup
+    migrator._get_migration_status = Mock(
+        return_value=MigrationStatus(
+            db_name="test_db",
+            curr_version=0,
+            partially_applied_version=None,
+        )
+    )
+
+    # Mock migration map with keys
+    migrator._get_migrations = Mock(
+        return_value={
+            1: MigrationInfo(up="1_init.up.sql", down="1_init.down.sql", keys=[]),
+            2: MigrationInfo(
+                up="2_exp.experimental.up.sql",
+                down="2_exp.experimental.down.sql",
+                keys=["experimental"],
+            ),
+            3: MigrationInfo(
+                up="3_beta.beta.up.sql",
+                down="3_beta.beta.down.sql",
+                keys=["beta"],
+            ),
+        }
+    )
+
+    migrator._determine_migrations_to_apply = Mock(
+        return_value=[
+            (1, "1_init.up.sql"),
+            (2, "2_exp.experimental.up.sql"),
+            (3, "3_beta.beta.up.sql"),
+        ]
+    )
+
+    migrator._update_migration_status = Mock()
+
+    # Make _apply_migration simulate the status update side effect
+    def apply_side_effect(target_db, target_version, migration_file):
+        migrator._update_migration_status(target_db, target_version, is_start=True)
+        migrator._update_migration_status(target_db, target_version, is_start=False)
+
+    migrator._apply_migration = Mock(side_effect=apply_side_effect)
+
+    # CASE 1: No keys in env var
+    migrator.migration_keys = []
+    migrator.apply_migrations("test_db", target_version=3)
+
+    # Check 1 ran
+    migrator._apply_migration.assert_any_call("test_db", 1, "1_init.up.sql")
+
+    # Check 2 skipped (not called)
+    with pytest.raises(AssertionError):
+        migrator._apply_migration.assert_any_call(
+            "test_db", 2, "2_exp.experimental.up.sql"
+        )
+
+    # Check 3 skipped
+    with pytest.raises(AssertionError):
+        migrator._apply_migration.assert_any_call("test_db", 3, "3_beta.beta.up.sql")
+
+    # Check version updates happen for ALL (skipped ones too)
+    calls = migrator._update_migration_status.call_args_list
+    versions_updated = []
+    for c in calls:
+        args, kwargs = c
+        if args[0] != "test_db":
+            continue
+
+        is_start = kwargs.get("is_start")
+        if is_start is None and len(args) > 2:
+            is_start = args[2]
+
+        if is_start is False:
+            versions_updated.append(args[1])
+
+    assert 1 in versions_updated
+    assert 2 in versions_updated
+    assert 3 in versions_updated
+
+
+def test_apply_migrations_matches_keys(mock_costs, migrator):
+    # Setup
+    migrator._get_migration_status = Mock(
+        return_value=MigrationStatus(
+            db_name="test_db",
+            curr_version=0,
+            partially_applied_version=None,
+        )
+    )
+    migrator._get_migrations = Mock(
+        return_value={
+            1: MigrationInfo(up="1.up.sql", keys=[]),
+            2: MigrationInfo(up="2.exp.up.sql", keys=["experimental"]),
+        }
+    )
+    migrator._determine_migrations_to_apply = Mock(
+        return_value=[(1, "1.up.sql"), (2, "2.exp.up.sql")]
+    )
+    migrator._apply_migration = Mock()
+    migrator._update_migration_status = Mock()
+
+    # CASE 2: Env var has 'experimental'
+    migrator.migration_keys = ["experimental"]
+    migrator.apply_migrations("test_db", target_version=2)
+
+    # Should run both
+    migrator._apply_migration.assert_any_call("test_db", 1, "1.up.sql")
+    migrator._apply_migration.assert_any_call("test_db", 2, "2.exp.up.sql")
+
+
+def test_apply_migrations_partial_keys(mock_costs, migrator):
+    # Setup
+    migrator._get_migration_status = Mock(
+        return_value=MigrationStatus(
+            db_name="test_db",
+            curr_version=0,
+            partially_applied_version=None,
+        )
+    )
+    migrator._get_migrations = Mock(
+        return_value={
+            1: MigrationInfo(up="1.up.sql", keys=["alpha", "beta"]),
+        }
+    )
+    migrator._determine_migrations_to_apply = Mock(return_value=[(1, "1.up.sql")])
+    migrator._apply_migration = Mock()
+    migrator._update_migration_status = Mock()
+
+    # CASE 3: Env var has 'alpha' (one of the keys)
+    migrator.migration_keys = ["alpha"]
+    migrator.apply_migrations("test_db", target_version=1)
+
+    # Should run because alpha matches
+    migrator._apply_migration.assert_called_with("test_db", 1, "1.up.sql")
+
+    # CASE 4: Env var has 'gamma' (no match)
+    migrator._apply_migration.reset_mock()
+    migrator.migration_keys = ["gamma"]
+    migrator.apply_migrations("test_db", target_version=1)
+
+    # Should skip
+    migrator._apply_migration.assert_not_called()
+    # But should update version
+    assert migrator._update_migration_status.call_count > 0


### PR DESCRIPTION
# Description

## ClickHouse Migration Keys

### Overview

Migration keys allow selective application of database migrations based on the environment. This is useful for deploying experimental features or phased rollouts without affecting the main database schema.

### Usage

_Naming Convention_
Format: `<index>_<name>.<key1>_<key2>.up.sql`

- **Standard Migration (Always Runs):** `001_init.up.sql`
- **Keyed Migration (Runs if Key Matches):** `002_feature.experimental.up.sql`
- **Multi-Key Migration (Runs if ANY Key Matches):** `003_complex.alpha_beta.up.sql`

_Activating Keys_
Set the environment variable `WEAVE_CH_MIGRATION_KEY` with a comma-separated list of active keys.

```bash
export WEAVE_CH_MIGRATION_KEY="experimental,beta"
```

### Behavior

- **Match:** If a migration has keys and at least one matches `WEAVE_CH_MIGRATION_KEY`, the migration SQL executes.
- **Mismatch:** If a migration has keys and none match, the migration is **skipped**.
    - **Important:** The database version is still incremented to maintain the sequence.
- **No Keys:** Standard migrations (no keys in filename) always run.

### FAQ

**Q: What happens if I skip a migration and later enable the key?**
A: The migration will effectively be "skipped" forever on that database instance because the version number was already incremented. You must manually apply the SQL if needed later, or reset the database.

**Q: Can I have multiple keys on one file?**
A: Yes. `003_foo.alpha_beta.up.sql` runs if `alpha` OR `beta` is active.

**Q: Does the order matter?**
A: Yes. Migrations are always processed in index order. Keys only determine execution, not order.

### Pitfalls & Best Practices

- **Avoid modifying existing schemas in keyed migrations.** Only add new tables or columns that are independent.
- **Do not reuse indices.** Each migration file must have a unique index, regardless of keys.
- **Database consistency.** Since skipped migrations increment the version, ensure your application code handles the potential absence of "skipped" schema elements gracefully if the key is not enabled.