### PR TITLE
feat(weave): Add option to show storage size in get_calls

### DIFF
--- a/weave/trace/call.py
+++ b/weave/trace/call.py
@@ -75,6 +75,11 @@ class Call:
     wb_run_step: int | None = None
     wb_run_step_end: int | None = None
 
+    # Size of metadata storage for this call (only populated when requested)
+    storage_size_bytes: int | None = None
+    # Total size of metadata storage for the entire trace (only populated when requested)
+    total_storage_size_bytes: int | None = None
+
     # These are the live children during logging
     _children: list[Call] = dataclasses.field(default_factory=list)
     _feedback: RefFeedbackQuery | None = None
@@ -332,6 +337,8 @@ def _make_calls_iterator(
     query: Query | None = None,
     include_costs: bool = False,
     include_feedback: bool = False,
+    include_storage_size: bool = False,
+    include_total_storage_size: bool = False,
     columns: list[str] | None = None,
     expand_columns: list[str] | None = None,
     return_expanded_column_values: bool = True,
@@ -353,6 +360,8 @@ def _make_calls_iterator(
                     limit=limit,
                     include_costs=include_costs,
                     include_feedback=include_feedback,
+                    include_storage_size=include_storage_size,
+                    include_total_storage_size=include_total_storage_size,
                     query=query,
                     sort_by=sort_by,
                     columns=columns,
@@ -422,6 +431,8 @@ def make_client_call(
         wb_run_id=server_call.wb_run_id,
         wb_run_step=server_call.wb_run_step,
         wb_run_step_end=server_call.wb_run_step_end,
+        storage_size_bytes=server_call.storage_size_bytes,
+        total_storage_size_bytes=server_call.total_storage_size_bytes,
     )
     if isinstance(call.attributes, AttributesDict):
         call.attributes.freeze()

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -529,6 +529,8 @@ class WeaveClient:
         query: QueryLike | None = None,
         include_costs: bool = False,
         include_feedback: bool = False,
+        include_storage_size: bool = False,
+        include_total_storage_size: bool = False,
         columns: list[str] | None = None,
         expand_columns: list[str] | None = None,
         return_expanded_column_values: bool = True,
@@ -551,6 +553,8 @@ class WeaveClient:
             `query`: A mongo-like expression for advanced filtering. Not all Mongo operators are supported.
             `include_costs`: If True, includes token/cost info in `summary.weave`.
             `include_feedback`: If True, includes feedback in `summary.weave.feedback`.
+            `include_storage_size`: If True, includes storage_size_bytes for each call.
+            `include_total_storage_size`: If True, includes total_storage_size_bytes (trace total) for each call.
             `columns`: List of fields to return per call. Reducing this can significantly improve performance.
                     (Some fields like `id`, `trace_id`, `op_name`, and `started_at` are always included.)
             `scored_by`: Filter by one or more scorers (name or ref URI). Multiple scorers are AND-ed.
@@ -585,6 +589,8 @@ class WeaveClient:
             query=query,
             include_costs=include_costs,
             include_feedback=include_feedback,
+            include_storage_size=include_storage_size,
+            include_total_storage_size=include_total_storage_size,
             columns=columns,
             expand_columns=expand_columns,
             return_expanded_column_values=return_expanded_column_values,
@@ -597,6 +603,8 @@ class WeaveClient:
         call_id: str,
         include_costs: bool = False,
         include_feedback: bool = False,
+        include_storage_size: bool = False,
+        include_total_storage_size: bool = False,
         columns: list[str] | None = None,
     ) -> WeaveObject:
         """Get a single call by its ID.
@@ -605,6 +613,8 @@ class WeaveClient:
             call_id: The ID of the call to get.
             include_costs: If true, cost info is included at summary.weave
             include_feedback: If true, feedback info is included at summary.weave.feedback
+            include_storage_size: If true, storage_size_bytes is included for the call.
+            include_total_storage_size: If true, total_storage_size_bytes (trace total) is included.
             columns: A list of columns to include in the response. If None,
                all columns are included. Specifying fewer columns may be more performant.
                Some columns are always included: id, project_id, trace_id, op_name, started_at
@@ -619,6 +629,8 @@ class WeaveClient:
                     filter=CallsFilter(call_ids=[call_id]),
                     include_costs=include_costs,
                     include_feedback=include_feedback,
+                    include_storage_size=include_storage_size,
+                    include_total_storage_size=include_total_storage_size,
                     columns=columns,
                 )
             )


### PR DESCRIPTION
Adds new params to `get_calls` to expose how much storage is being used.

```py
calls = client.get_calls(include_total_storage_size=True, include_storage_size=True)
```

To get just the storage data:
```py
calls = client.get_calls(
    include_total_storage_size=True,
    include_storage_size=True,
    columns=["id", "storage_size_bytes", "total_storage_size_bytes"],
)
```