### PR TITLE
feat(weave): Input and output parsing for logfire pydantic ai instrumentation

### DIFF
--- a/weave/trace_server/opentelemetry/constants.py
+++ b/weave/trace_server/opentelemetry/constants.py
@@ -53,7 +53,7 @@ INPUT_KEYS = [
     "input.value",  # From OpenInference standard
     "mlflow.spanInputs",  # From MLFlow's tracking format
     "gen_ai.input.messages",  # Logfire V2 - see logfire pydantic instrumentation notes
-    "pydantic_ai.all_messages",  # Includes all messages for Pydantic AI agent run 
+    "pydantic_ai.all_messages",  # Includes all messages for Pydantic AI agent run
     "traceloop.entity.input",  # From Traceloop's conventions
     "gcp.vertex.agent.tool_call_args",  # From Google's Vertex AI
     "gcp.vertex.agent.llm_request",  # From Google's Vertex AI
@@ -70,7 +70,7 @@ OUTPUT_KEYS = [
     "output.value",  # From OpenInference standard - highest priority
     "gen_ai.output.messages",  # Logfire v2 - see logfire pydantic instrumentation notes
     "mlflow.spanOutputs",  # From MLFlow's tracking format
-    "final_result", # Output for PydanticAI agent run
+    "final_result",  # Output for PydanticAI agent run
     "gen_ai.content.completion",  # From OpenLit project's format
     "traceloop.entity.output",  # From Traceloop's conventions
     "gcp.vertex.agent.tool_response",  # From Google's Vertex AI


### PR DESCRIPTION
## Description


- Fixes WB-29948
- DOCS-1964

Adds input and output parsing for logfire's pydantic ai instrumentation. See https://github.com/pydantic/logfire/blob/0782da9c021a54246cc46429c28627c9d9a480e8/logfire/_internal/main.py#L1067

## Testing

Tested in UI
<img width="1882" height="646" alt="image" src="https://github.com/user-attachments/assets/0f49bc64-10a6-4c24-82a0-055567d2e0f5" />

<img width="1882" height="646" alt="image" src="https://github.com/user-attachments/assets/7e34e03e-ab70-417d-a6d1-ed54273cda5f" />
