### PR TITLE
chore(weave): add _test suffix to ch db in tests

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -128,6 +128,10 @@ def get_ch_trace_server(
         host, port = next(ensure_clickhouse_db())
         db_suffix = _get_worker_db_suffix(request)
 
+        # Always add a test-specific suffix to prevent collision with other databases
+        if not db_suffix:
+            db_suffix = "_test"
+
         # Store original environment variable
         original_db = os.environ.get("WF_CLICKHOUSE_DATABASE")
         base_db = original_db or "default"


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

[WB-29971](https://wandb.atlassian.net/browse/WB-29971)

Naively add '_test' to db name during tests. 

## Testing

Manually point the tests at clickhouse being run by tilt. Run test. Then query for existing data. 
<img width="1728" height="588" alt="image" src="https://github.com/user-attachments/assets/b31f92d3-2807-40f9-a215-7ac2a5926bd8" />



[WB-29971]: https://wandb.atlassian.net/browse/WB-29971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ