### PR TITLE
fix(weave): Remove chars causing op creation to fail

### DIFF
--- a/tests/trace/test_server_object_creation_utils.py
+++ b/tests/trace/test_server_object_creation_utils.py
@@ -228,4 +228,6 @@ def test_make_safe_name_with_angle_brackets() -> None:
             return x + 1
 
         # Verify the op was successfully created
-        assert test_op.name == "opname", f"Op creation failed for input '{test_input}': got name '{test_op.name}'"
+        assert test_op.name == "opname", (
+            f"Op creation failed for input '{test_input}': got name '{test_op.name}'"
+        )

--- a/weave/trace_server/object_creation_utils.py
+++ b/weave/trace_server/object_creation_utils.py
@@ -88,7 +88,13 @@ def make_safe_name(name: str | None) -> str:
     """
     if name is None:
         name = "unknown"
-    return name.replace(" ", "_").replace("/", "_").replace("<", "").replace(">", "").lower()
+    return (
+        name.replace(" ", "_")
+        .replace("/", "_")
+        .replace("<", "")
+        .replace(">", "")
+        .lower()
+    )
 
 
 def make_object_id(name: str | None, default: str) -> str:


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes WB-29975

Customer ran into issue exporting to weave through intermediate collector. Turns out it was unrelated to OTEL but was instead an issue with chars that break op creation not being removed by the safe name method.

docs are not required

## Testing

Validated full e2e flow and can ingest with this change.
