### PR TITLE
fix(weave): dictification issue in the smolagents integration

### DIFF
--- a/weave/integrations/smolagents/smolagents_sdk.py
+++ b/weave/integrations/smolagents/smolagents_sdk.py
@@ -14,15 +14,26 @@ _smolagents_patcher: MultiPatcher | None = None
 
 def smolagents_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
     if "self" in inputs:
-        dictified_self = dictify(inputs["self"])
-        # Make sure that the object type is rendered correctly in the Weave UI
-        if "__class__" not in dictified_self:
-            dictified_self["__class__"] = {
-                "module": inputs["self"].__class__.__module__,
-                "qualname": inputs["self"].__class__.__qualname__,
-                "name": inputs["self"].__class__.__name__,
+        try:
+            dictified_self = dictify(inputs["self"])
+            # Make sure that the object type is rendered correctly in the Weave UI
+            if "__class__" not in dictified_self:
+                dictified_self["__class__"] = {
+                    "module": inputs["self"].__class__.__module__,
+                    "qualname": inputs["self"].__class__.__qualname__,
+                    "name": inputs["self"].__class__.__name__,
+                }
+            inputs["self"] = dictified_self
+        except (ValueError, Exception):
+            # If dictify fails (e.g., to_dict() raises an exception),
+            # fall back to a minimal representation with just the class info
+            inputs["self"] = {
+                "__class__": {
+                    "module": inputs["self"].__class__.__module__,
+                    "qualname": inputs["self"].__class__.__qualname__,
+                    "name": inputs["self"].__class__.__name__,
+                }
             }
-        inputs["self"] = dictified_self
     return inputs
 
 


### PR DESCRIPTION
## Description

This PR handles the case where the `dictify` function fails for certain `smolagents` objects.

## Testing

This PR was tested using the following snippet:

```python
import weave
from smolagents import DuckDuckGoSearchTool, OpenAIServerModel, ToolCallingAgent

# Initialize Weave
weave.init(project_name="smolagents")

# Define your LLM provider supported by Smolagents
model = OpenAIServerModel(model_id="gpt-4o")

# Define a DuckDuckGo web search tool based on your query
search_tool = DuckDuckGoSearchTool()

# Define a tool-calling agent
agent = ToolCallingAgent(tools=[search_tool], model=model)
answer = agent.run(
    "Get me just the title of the page at url 'https://wandb.ai/geekyrakshit/story-illustration/reports/Building-a-GenAI-assisted-automatic-story-illustrator--Vmlldzo5MTYxNTkw'?"
)
```
