### PR TITLE
chore(weave): API for querying queue items

### DIFF
--- a/weave/trace_server/annotation_queues_query_builder.py
+++ b/weave/trace_server/annotation_queues_query_builder.py
@@ -15,34 +15,50 @@ VALID_QUEUE_SORT_FIELDS = {
     "updated_at",
 }
 
+# Valid sort fields for annotation queue items
+VALID_QUEUE_ITEM_SORT_FIELDS = {
+    "call_started_at",
+    "call_op_name",
+    "created_at",
+    "updated_at",
+}
+
 VALID_SORT_DIRECTIONS = {"asc", "desc"}
 
 
-def _make_sort_clause(sort_by: list[tsi.SortBy] | None) -> str:
-    """Build ORDER BY clause from sort_by list.
+def _make_sort_clause(
+    sort_by: list[tsi.SortBy] | None,
+    valid_fields: set[str],
+    default: str,
+    table_prefix: str = "",
+) -> str:
+    """Build sort field list from sort_by list.
 
     Args:
         sort_by: List of SortBy objects
+        valid_fields: Set of valid field names for sorting
+        default: Default sort field list (without ORDER BY prefix)
+        table_prefix: Optional table alias prefix (e.g., "qi." for joins)
 
     Returns:
-        ORDER BY clause string, or default "ORDER BY created_at DESC" if no valid sorts
+        Sort field list string (e.g., "created_at ASC, id ASC"), or default if no valid sorts.
+        Always appends 'id ASC' as final tiebreaker for stable, deterministic sorting.
     """
     if not sort_by:
-        return "ORDER BY created_at DESC"
+        return default
 
     sort_clauses = []
     for sort in sort_by:
-        if (
-            sort.field in VALID_QUEUE_SORT_FIELDS
-            and sort.direction in VALID_SORT_DIRECTIONS
-        ):
-            sort_clause = f"{sort.field} {sort.direction.upper()}"
+        if sort.field in valid_fields and sort.direction in VALID_SORT_DIRECTIONS:
+            sort_clause = f"{table_prefix}{sort.field} {sort.direction.upper()}"
             sort_clauses.append(sort_clause)
 
     if not sort_clauses:
-        return "ORDER BY created_at DESC"
+        return default
 
-    return "ORDER BY " + ", ".join(sort_clauses)
+    # Always append id ASC as tiebreaker for stable sorting
+    sort_clauses.append(f"{table_prefix}id ASC")
+    return ", ".join(sort_clauses)
 
 
 def make_queues_query(
@@ -86,7 +102,9 @@ def make_queues_query(
     where_clause = " AND ".join(where_clauses)
 
     # Build sort clause
-    sort_clause = _make_sort_clause(sort_by)
+    sort_fields = _make_sort_clause(
+        sort_by, VALID_QUEUE_SORT_FIELDS, "created_at DESC, id ASC"
+    )
 
     query = f"""
     SELECT
@@ -101,7 +119,7 @@ def make_queues_query(
         deleted_at
     FROM annotation_queues
     WHERE {where_clause}
-    {sort_clause}
+    ORDER BY {sort_fields}
     """
 
     if limit is not None:
@@ -337,3 +355,154 @@ def make_queues_stats_query(
     """
 
     return query
+
+
+def make_queue_items_query(
+    project_id: str,
+    queue_id: str,
+    pb: ParamBuilder,
+    *,
+    filter: tsi.AnnotationQueueItemsFilter | None = None,
+    sort_by: list[tsi.SortBy] | None = None,
+    limit: int | None = None,
+    offset: int | None = None,
+    include_position: bool = False,
+) -> str:
+    """Generate a query to fetch items in an annotation queue.
+
+    Joins with annotator_queue_items_progress to include annotation state.
+    If no progress record exists, the state is 'unstarted'.
+    If progress records exist (possibly from multiple annotators), returns the most recent state.
+
+    Args:
+        project_id: The project ID to filter by
+        queue_id: The queue ID to filter by
+        pb: Parameter builder for safe SQL parameter injection
+        filter: Optional filter object for filtering results
+        sort_by: Optional list of sort specifications
+        limit: Maximum number of items to return
+        offset: Number of items to skip
+        include_position: If True, include position_in_queue field (1-based index)
+
+    Returns:
+        SQL query string for queue items query
+    """
+    project_id_param = pb.add_param(project_id)
+    queue_id_param = pb.add_param(queue_id)
+
+    # Build base WHERE clause for project and queue filtering
+    where_clauses = [
+        f"qi.project_id = {{{project_id_param}: String}}",
+        f"qi.queue_id = {{{queue_id_param}: String}}",
+        "qi.deleted_at IS NULL",
+    ]
+
+    # Add filters that can be applied directly on queue_items table
+    if filter is not None:
+        if filter.call_id is not None:
+            param = pb.add(filter.call_id, None, "String")
+            where_clauses.append(f"qi.call_id = {param}")
+
+        if filter.call_op_name is not None:
+            param = pb.add(filter.call_op_name, None, "String")
+            where_clauses.append(f"qi.call_op_name = {param}")
+
+        if filter.call_trace_id is not None:
+            param = pb.add(filter.call_trace_id, None, "String")
+            where_clauses.append(f"qi.call_trace_id = {param}")
+
+        if filter.added_by is not None:
+            param = pb.add(filter.added_by, None, "String")
+            where_clauses.append(f"qi.added_by = {param}")
+
+    where_clause = " AND ".join(where_clauses)
+
+    # Build sort field list (default to created_at ASC, id ASC for queue items)
+    # _make_sort_clause always adds id ASC as tiebreaker for deterministic ordering
+    sort_fields = _make_sort_clause(
+        sort_by,
+        VALID_QUEUE_ITEM_SORT_FIELDS,
+        "created_at ASC, id ASC",
+        table_prefix="",  # No prefix needed since we select from subquery
+    )
+
+    # LEFT JOIN with progress table to get annotation state
+    # Using argMax to get the most recent annotation_state when multiple annotators have worked on the item
+    # Using any() for qi fields since they're functionally dependent on qi.id (same for all rows with same id)
+    # The annotation_state enum includes 'unstarted' as the lowest numeric value (0).
+    # When no progress records exist in the LEFT JOIN, ClickHouse's argMax() returns the default
+    # enum value (the one with the lowest numeric code), which is 'unstarted'. This naturally
+    # handles the case where no annotator has worked on an item yet.
+    # Cast annotation_state enum to String so it can be compared with string filters
+    inner_query = f"""
+    SELECT
+        qi.id,
+        any(qi.project_id) as project_id,
+        any(qi.queue_id) as queue_id,
+        any(qi.call_id) as call_id,
+        any(qi.call_started_at) as call_started_at,
+        any(qi.call_ended_at) as call_ended_at,
+        any(qi.call_op_name) as call_op_name,
+        any(qi.call_trace_id) as call_trace_id,
+        any(qi.display_fields) as display_fields,
+        any(qi.added_by) as added_by,
+        any(qi.created_at) as created_at,
+        any(qi.created_by) as created_by,
+        any(qi.updated_at) as updated_at,
+        any(qi.deleted_at) as deleted_at,
+        toString(argMax(p.annotation_state, p.updated_at)) as annotation_state
+    FROM annotation_queue_items qi
+    LEFT JOIN annotator_queue_items_progress p
+        ON p.queue_item_id = qi.id
+        AND p.project_id = qi.project_id
+        AND p.deleted_at IS NULL
+    WHERE {where_clause}
+    GROUP BY qi.id
+    """
+
+    # If include_position is requested, wrap the query with ROW_NUMBER()
+    # to compute position in the full queue (1-based)
+    # Note: We use the same ORDER BY for both ROW_NUMBER and the outer query to ensure
+    # position numbers match the display order. While this may look like double sorting,
+    # it's necessary because the SQL standard doesn't guarantee that window function
+    # ordering is preserved in the final result. Modern query planners can often optimize
+    # away the redundant sort when they detect the data is already ordered.
+    if include_position:
+        # Reuse sort_fields directly - no string manipulation needed!
+        # This ensures position numbering matches the final display order
+        inner_query = f"""
+        SELECT
+            *,
+            ROW_NUMBER() OVER (ORDER BY {sort_fields}) as position_in_queue
+        FROM (
+            {inner_query}
+        )
+        """
+
+    # If there's an annotation_states filter, we need to wrap in outer query
+    # since annotation_state is computed by the aggregation
+    if (
+        filter is not None
+        and filter.annotation_states is not None
+        and len(filter.annotation_states) > 0
+    ):
+        param = pb.add(filter.annotation_states, None, "Array(String)")
+        sql_query = f"""
+        SELECT * FROM (
+            {inner_query}
+        )
+        WHERE annotation_state IN {param}
+        ORDER BY {sort_fields}
+        """
+    else:
+        sql_query = f"{inner_query}\nORDER BY {sort_fields}"
+
+    if limit is not None:
+        limit_param = pb.add_param(limit)
+        sql_query += f" LIMIT {{{limit_param}: Int64}}"
+
+    if offset is not None:
+        offset_param = pb.add_param(offset)
+        sql_query += f" OFFSET {{{offset_param}: Int64}}"
+
+    return sql_query

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -461,6 +461,14 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             self._internal_trace_server.annotation_queue_add_calls, req
         )
 
+    def annotation_queue_items_query(
+        self, req: tsi.AnnotationQueueItemsQueryReq
+    ) -> tsi.AnnotationQueueItemsQueryRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(
+            self._internal_trace_server.annotation_queue_items_query, req
+        )
+
     def annotation_queues_stats(
         self, req: tsi.AnnotationQueuesStatsReq
     ) -> tsi.AnnotationQueuesStatsRes:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1674,6 +1674,12 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         """Annotation queues not supported in SQLite."""
         raise NotImplementedError("Annotation queues are not supported in SQLite")
 
+    def annotation_queue_items_query(
+        self, req: tsi.AnnotationQueueItemsQueryReq
+    ) -> tsi.AnnotationQueueItemsQueryRes:
+        """Annotation queues not supported in SQLite."""
+        raise NotImplementedError("Annotation queues are not supported in SQLite")
+
     def annotation_queues_stats(
         self, req: tsi.AnnotationQueuesStatsReq
     ) -> tsi.AnnotationQueuesStatsRes:

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -536,6 +536,11 @@ class CachingMiddlewareTraceServer(TraceServerClientInterface):
     ) -> tsi.AnnotationQueueAddCallsRes:
         return self._next_trace_server.annotation_queue_add_calls(req)
 
+    def annotation_queue_items_query(
+        self, req: tsi.AnnotationQueueItemsQueryReq
+    ) -> tsi.AnnotationQueueItemsQueryRes:
+        return self._next_trace_server.annotation_queue_items_query(req)
+
     def annotation_queues_stats(
         self, req: tsi.AnnotationQueuesStatsReq
     ) -> tsi.AnnotationQueuesStatsRes:

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -737,6 +737,16 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             tsi.AnnotationQueueAddCallsRes,
         )
 
+    def annotation_queue_items_query(
+        self, req: tsi.AnnotationQueueItemsQueryReq
+    ) -> tsi.AnnotationQueueItemsQueryRes:
+        return self._generic_request(
+            "/annotation_queue/items/query",
+            req,
+            tsi.AnnotationQueueItemsQueryReq,
+            tsi.AnnotationQueueItemsQueryRes,
+        )
+
     def annotation_queues_stats(
         self, req: tsi.AnnotationQueuesStatsReq
     ) -> tsi.AnnotationQueuesStatsRes:


### PR DESCRIPTION
# Add Annotation Queue Items Query API

This PR adds backend and frontend support for querying annotation queue items with pagination and sorting capabilities.

## Backend Changes

### New API Endpoint: `annotation_queue_items_query`

**Type Definitions**

- Added `AnnotationQueueItemsQueryReq` and `AnnotationQueueItemsQueryRes` to trace server interface
- Updated `AnnotationQueueItemSchema` to include all necessary fields for displaying queue items

**Query Builder** (`annotation_queues_query_builder.py`)

- Added `make_queue_items_query` function with support for:
    - Filtering by project and queue ID
    - Pagination (limit/offset)
    - Sorting by multiple fields: `call_started_at`, `call_op_name`, `created_at`, `updated_at`
    - **Deterministic ordering**: Uses `ORDER BY created_at ASC, id ASC` as default to ensure stable pagination when multiple items have identical timestamps

**Implementation Across Trace Server Layers**

- `clickhouse_trace_server_batched.py` - Main ClickHouse implementation
- `external_to_internal_trace_server_adapter.py` - ID conversion adapter layer
- `caching_middleware_trace_server.py` - Passthrough caching middleware
- `remote_http_trace_server.py` - HTTP client implementation

### Schema Cleanup

- **Removed** **`added_at`** **field**: Eliminated redundant timestamp field, using `created_at` instead

### Testing

**New Test Coverage**

- `test_annotation_queue_items_query_basic` - Basic query functionality
- `test_annotation_queue_items_query_with_pagination` - Pagination with limit/offset
- `test_annotation_queue_items_query_with_sorting` - Custom sort orders
- `test_annotation_queue_items_query_empty_queue` - Empty queue edge case
- `test_annotation_queue_items_query_with_multiple_sort_fields` - Multi-field sorting

## Related Work

This PR builds on the annotation queues feature introduced in earlier commits and prepares the foundation for the upcoming annotation review interface where users will interact with queued calls to provide feedback and annotations.