### PR TITLE
chore(weave): API to support queue item state change

### DIFF
--- a/weave/trace_server/annotation_queues_query_builder.py
+++ b/weave/trace_server/annotation_queues_query_builder.py
@@ -437,6 +437,7 @@ def make_queue_items_query(
     # enum value (the one with the lowest numeric code), which is 'unstarted'. This naturally
     # handles the case where no annotator has worked on an item yet.
     # Cast annotation_state enum to String so it can be compared with string filters
+    # Also get the wb_user_id of the annotator who owns the most recent state
     inner_query = f"""
     SELECT
         qi.id,
@@ -453,7 +454,8 @@ def make_queue_items_query(
         any(qi.created_by) as created_by,
         any(qi.updated_at) as updated_at,
         any(qi.deleted_at) as deleted_at,
-        toString(argMax(p.annotation_state, p.updated_at)) as annotation_state
+        toString(argMax(p.annotation_state, p.updated_at)) as annotation_state,
+        argMax(p.annotator_id, p.updated_at) as annotator_user_id
     FROM annotation_queue_items qi
     LEFT JOIN annotator_queue_items_progress p
         ON p.queue_item_id = qi.id

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -76,6 +76,7 @@ from weave.trace_server.clickhouse_schema import (
     ObjRefListType,
     SelectableCHObjSchema,
 )
+from weave.trace_server.common_interface import AnnotationQueueItemsFilter
 from weave.trace_server.constants import (
     COMPLETIONS_CREATE_OP_NAME,
     IMAGE_GENERATION_CREATE_OP_NAME,
@@ -1778,6 +1779,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     updated_at=row["updated_at"],
                     deleted_at=row["deleted_at"],
                     position_in_queue=row.get("position_in_queue"),
+                    annotator_user_id=row.get("annotator_user_id"),
                 )
             )
 
@@ -1814,6 +1816,171 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             )
 
         return tsi.AnnotationQueuesStatsRes(stats=stats)
+
+    def annotator_queue_items_progress_update(
+        self, req: tsi.AnnotatorQueueItemsProgressUpdateReq
+    ) -> tsi.AnnotatorQueueItemsProgressUpdateRes:
+        """Update annotation state for a queue item using ClickHouse lightweight update.
+
+        Validates state transitions:
+        - Allowed: (absence) -> 'in_progress', 'completed' or 'skipped'
+        - Allowed: 'in_progress' -> 'completed' or 'skipped'
+        - Rejected: any other transition (including updating to 'in_progress' when record exists)
+        """
+        # Validate annotation_state
+        allowed_states = {"completed", "skipped", "in_progress"}
+        if req.annotation_state not in allowed_states:
+            raise ValueError(
+                f"Invalid annotation_state '{req.annotation_state}'. "
+                f"Must be one of: {', '.join(sorted(allowed_states))}"
+            )
+
+        # Get the annotator ID from the session
+        annotator_id = req.wb_user_id
+        if not annotator_id:
+            raise ValueError("wb_user_id is required")
+
+        pb = ParamBuilder()
+        project_id_param = pb.add(req.project_id)
+        queue_id_param = pb.add(req.queue_id)
+        item_id_param = pb.add(req.item_id)
+        annotator_id_param = pb.add(annotator_id)
+
+        # First, check current state and validate the queue item exists
+        check_query = f"""
+        SELECT
+            annotation_state,
+            COUNT(*) as record_exists
+        FROM annotator_queue_items_progress
+        WHERE project_id = {project_id_param}
+          AND queue_item_id = {item_id_param}
+          AND annotator_id = {annotator_id_param}
+          AND deleted_at IS NULL
+        GROUP BY annotation_state
+        """
+
+        check_result = self.ch_client.query(check_query, parameters=pb.get_params())
+        current_state = None
+        has_record = False
+
+        for row in check_result.named_results():
+            current_state = row["annotation_state"]
+            has_record = row["record_exists"] > 0
+            break
+
+        # Special handling for 'in_progress': only allow when no record exists
+        if req.annotation_state == "in_progress" and has_record:
+            raise ValueError(
+                "Cannot transition to 'in_progress' when a record already exists. "
+                "'in_progress' can only be set on new items."
+            )
+
+        # Validate state transition for other states
+        # Record exists - only allow transition from 'in_progress' or 'unstarted'
+        if (
+            current_state is not None
+            and req.annotation_state != "in_progress"
+            and current_state not in ("in_progress", "unstarted")
+        ):
+            raise ValueError(
+                f"Invalid state transition from '{current_state}' to '{req.annotation_state}'. "
+                f"Only transitions from 'in_progress' or 'unstarted' are allowed."
+            )
+
+        # Also verify the queue item exists in annotation_queue_items
+        item_check_query = f"""
+        SELECT id
+        FROM annotation_queue_items
+        WHERE id = {item_id_param}
+          AND project_id = {project_id_param}
+          AND queue_id = {queue_id_param}
+          AND deleted_at IS NULL
+        LIMIT 1
+        """
+
+        item_check_result = self.ch_client.query(
+            item_check_query, parameters=pb.get_params()
+        )
+        if not list(item_check_result.named_results()):
+            raise ValueError(
+                f"Queue item '{req.item_id}' not found in queue '{req.queue_id}'"
+            )
+
+        new_state_param = pb.add(req.annotation_state)
+        now = datetime.datetime.now(datetime.timezone.utc)
+        now_param = pb.add(now)
+
+        if has_record:
+            # Use ClickHouse lightweight UPDATE for existing record
+            update_query = f"""
+            UPDATE annotator_queue_items_progress
+            SET
+                annotation_state = {new_state_param},
+                updated_at = {now_param}
+            WHERE project_id = {project_id_param}
+              AND queue_item_id = {item_id_param}
+              AND annotator_id = {annotator_id_param}
+              AND deleted_at IS NULL
+            """
+            self.ch_client.command(update_query, parameters=pb.get_params())
+        else:
+            # Create new record
+            progress_id = generate_id()
+            progress_id_param = pb.add(progress_id)
+
+            insert_query = f"""
+            INSERT INTO annotator_queue_items_progress
+                (id, project_id, queue_item_id, queue_id, annotator_id,
+                 annotation_state, created_at, updated_at, deleted_at)
+            VALUES
+                ({progress_id_param}, {project_id_param}, {item_id_param},
+                 {queue_id_param}, {annotator_id_param}, {new_state_param},
+                 {now_param}, {now_param}, NULL)
+            """
+            self.ch_client.command(insert_query, parameters=pb.get_params())
+
+        # Fetch and return the updated queue item
+        # We need to re-query to get the aggregated annotation_state
+        pb_fetch = ParamBuilder()
+        fetch_query = make_queue_items_query(
+            project_id=req.project_id,
+            queue_id=req.queue_id,
+            pb=pb_fetch,
+            filter=AnnotationQueueItemsFilter(id=req.item_id),
+            sort_by=None,
+            limit=1,
+            offset=None,
+            include_position=False,
+        )
+
+        fetch_result = self.ch_client.query(
+            fetch_query, parameters=pb_fetch.get_params()
+        )
+
+        for row in fetch_result.named_results():
+            item = tsi.AnnotationQueueItemSchema(
+                id=row["id"],
+                project_id=row["project_id"],
+                queue_id=row["queue_id"],
+                call_id=row["call_id"],
+                call_started_at=row["call_started_at"],
+                call_ended_at=row["call_ended_at"],
+                call_op_name=row["call_op_name"],
+                call_trace_id=row["call_trace_id"],
+                display_fields=row["display_fields"],
+                added_by=row["added_by"],
+                annotation_state=row["annotation_state"],
+                created_at=row["created_at"],
+                created_by=row["created_by"],
+                updated_at=row["updated_at"],
+                deleted_at=row["deleted_at"],
+                position_in_queue=None,
+                annotator_user_id=row.get("annotator_user_id"),
+            )
+            return tsi.AnnotatorQueueItemsProgressUpdateRes(item=item)
+
+        # This shouldn't happen if our logic is correct
+        raise ValueError(f"Failed to fetch updated item '{req.item_id}'")
 
     def op_create(self, req: tsi.OpCreateReq) -> tsi.OpCreateRes:
         """Create an op object by delegating to obj_create.

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -475,6 +475,16 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         return self._ref_apply(self._internal_trace_server.annotation_queues_stats, req)
 
+    def annotator_queue_items_progress_update(
+        self, req: tsi.AnnotatorQueueItemsProgressUpdateReq
+    ) -> tsi.AnnotatorQueueItemsProgressUpdateRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        if req.wb_user_id is not None:
+            req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
+        return self._ref_apply(
+            self._internal_trace_server.annotator_queue_items_progress_update, req
+        )
+
     def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         if req.wb_user_id is not None:

--- a/weave/trace_server/http_service_interface.py
+++ b/weave/trace_server/http_service_interface.py
@@ -9,7 +9,6 @@ include all parameters for internal use.
 from pydantic import Field
 
 from weave.trace_server.common_interface import (
-    WB_USER_ID_DESCRIPTION,
     AnnotationQueueItemsFilter,
     BaseModelStrict,
     SortBy,
@@ -25,7 +24,6 @@ class AnnotationQueueAddCallsBody(BaseModelStrict):
         examples=[["input.prompt", "output.text"]],
         description="JSON paths to display to annotators",
     )
-    wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)
 
 
 class AnnotationQueueItemsQueryBody(BaseModelStrict):
@@ -45,4 +43,17 @@ class AnnotationQueueItemsQueryBody(BaseModelStrict):
     include_position: bool = Field(
         default=False,
         description="Include position_in_queue field (1-based index in full queue)",
+    )
+
+
+class AnnotationQueueItemProgressUpdateBody(BaseModelStrict):
+    """Request body for updating annotation progress (queue_id and item_id come from path).
+
+    Note: wb_user_id is not included in the body - it's set server-side from the authenticated session.
+    """
+
+    project_id: str = Field(examples=["entity/project"])
+    annotation_state: str = Field(
+        examples=["in_progress", "completed", "skipped"],
+        description="New state: 'in_progress', 'completed', or 'skipped'",
     )

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -508,6 +508,8 @@ def python_value_to_ch_type(value: typing.Any) -> str:
         return "UInt64"
     elif isinstance(value, float):
         return "Float64"
+    elif isinstance(value, datetime.datetime):
+        return "DateTime64(3)"
     elif value is None:
         return "Nullable(String)"
     else:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1687,6 +1687,12 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         """Annotation queues not supported in SQLite."""
         raise NotImplementedError("Annotation queues are not supported in SQLite")
 
+    def annotator_queue_items_progress_update(
+        self, req: tsi.AnnotatorQueueItemsProgressUpdateReq
+    ) -> tsi.AnnotatorQueueItemsProgressUpdateRes:
+        """Annotation queues not supported in SQLite."""
+        raise NotImplementedError("Annotation queues are not supported in SQLite")
+
     def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
         if self._evaluate_model_dispatcher is None:
             raise ValueError("Evaluate model dispatcher is not set")

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1192,6 +1192,9 @@ class AnnotationQueueItemSchema(BaseModel):
     display_fields: list[str]  # JSON paths like ['input.prompt', 'output.text']
     added_by: str | None = None  # wb_user_id (nullable)
     annotation_state: AnnotationState
+    annotator_user_id: str | None = (
+        None  # wb_user_id of annotator who owns the most recent state (nullable)
+    )
     created_at: datetime.datetime
     created_by: str  # wb_user_id
     updated_at: datetime.datetime
@@ -1208,6 +1211,7 @@ class AnnotationQueueAddCallsReq(his.AnnotationQueueAddCallsBody):
     """
 
     queue_id: str = Field(examples=["550e8400-e29b-41d4-a716-446655440000"])
+    wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)
 
 
 class AnnotationQueueAddCallsRes(BaseModel):
@@ -1266,6 +1270,31 @@ class AnnotationQueuesStatsRes(BaseModel):
     """Response with stats for multiple annotation queues."""
 
     stats: list[AnnotationQueueStatsSchema]
+
+
+class AnnotatorQueueItemsProgressUpdateReq(BaseModelStrict):
+    """Request to update the annotation state of a queue item for the current annotator.
+
+    Valid state transitions:
+    - (absence) -> 'in_progress': Mark item as in progress (only when no record exists)
+    - (absence) -> 'completed' or 'skipped': Directly complete/skip item
+    - 'in_progress' or 'unstarted' -> 'completed' or 'skipped': Complete/skip started item
+    """
+
+    project_id: str = Field(examples=["entity/project"])
+    queue_id: str = Field(examples=["550e8400-e29b-41d4-a716-446655440000"])
+    item_id: str = Field(examples=["550e8400-e29b-41d4-a716-446655440001"])
+    annotation_state: str = Field(
+        examples=["in_progress", "completed", "skipped"],
+        description="New state: 'in_progress', 'completed', or 'skipped'",
+    )
+    wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)
+
+
+class AnnotatorQueueItemsProgressUpdateRes(BaseModel):
+    """Response from updating annotation state."""
+
+    item: AnnotationQueueItemSchema
 
 
 # Thread API
@@ -2229,6 +2258,10 @@ class TraceServerInterface(Protocol):
     def annotation_queue_items_query(
         self, req: AnnotationQueueItemsQueryReq
     ) -> AnnotationQueueItemsQueryRes: ...
+
+    def annotator_queue_items_progress_update(
+        self, req: AnnotatorQueueItemsProgressUpdateReq
+    ) -> AnnotatorQueueItemsProgressUpdateRes: ...
 
     # Evaluation API
     def evaluate_model(self, req: EvaluateModelReq) -> EvaluateModelRes: ...

--- a/weave/trace_server_bindings/caching_middleware_trace_server.py
+++ b/weave/trace_server_bindings/caching_middleware_trace_server.py
@@ -546,6 +546,11 @@ class CachingMiddlewareTraceServer(TraceServerClientInterface):
     ) -> tsi.AnnotationQueuesStatsRes:
         return self._next_trace_server.annotation_queues_stats(req)
 
+    def annotator_queue_items_progress_update(
+        self, req: tsi.AnnotatorQueueItemsProgressUpdateReq
+    ) -> tsi.AnnotatorQueueItemsProgressUpdateRes:
+        return self._next_trace_server.annotator_queue_items_progress_update(req)
+
     def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:
         return self._next_trace_server.evaluate_model(req)
 

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -738,7 +738,6 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             project_id=req.project_id,
             call_ids=req.call_ids,
             display_fields=req.display_fields,
-            wb_user_id=req.wb_user_id,
         )
         return self._generic_request(
             f"/annotation_queues/{req.queue_id}/items",
@@ -774,6 +773,22 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             req,
             tsi.AnnotationQueuesStatsReq,
             tsi.AnnotationQueuesStatsRes,
+        )
+
+    def annotator_queue_items_progress_update(
+        self, req: tsi.AnnotatorQueueItemsProgressUpdateReq
+    ) -> tsi.AnnotatorQueueItemsProgressUpdateRes:
+        # Convert to Body type to exclude queue_id, item_id, and wb_user_id from request body
+        # (queue_id and item_id are in the URL path, wb_user_id is set server-side from auth)
+        body = his.AnnotationQueueItemProgressUpdateBody(
+            project_id=req.project_id,
+            annotation_state=req.annotation_state,
+        )
+        return self._generic_request(
+            f"/annotation_queues/{req.queue_id}/items/{req.item_id}/progress",
+            body,
+            his.AnnotationQueueItemProgressUpdateBody,
+            tsi.AnnotatorQueueItemsProgressUpdateRes,
         )
 
     def evaluate_model(self, req: tsi.EvaluateModelReq) -> tsi.EvaluateModelRes:


### PR DESCRIPTION
## Description

- https://wandb.atlassian.net/browse/WB-30068

Adds a new API endpoint `annotator_queue_items_progress_update` that allows annotators to update the state of annotation queue items. The endpoint supports transitioning items through the annotation workflow:

- Mark items as "in_progress" when starting work
- Mark items as "completed" when finished
- Mark items as "skipped" when not applicable

The implementation includes validation for state transitions and updates queue statistics accordingly.

## Testing

Added comprehensive test suite covering:
- Basic state transitions (unstarted → completed, unstarted → skipped)
- In-progress workflow (unstarted → in_progress → completed)
- Invalid state transitions
- Integration with queue statistics
- Error handling for invalid inputs