### PR TITLE
fix(weave): guard kafka flush with env check

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -478,7 +478,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.kafka_producer.flush")
     def _flush_kafka_producer(self) -> None:
-        self.kafka_producer.flush()
+        if wf_env.wf_enable_online_eval():
+            self.kafka_producer.flush()
 
     @contextmanager
     def call_batch(self) -> Iterator[None]:


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

https://wandb.atlassian.net/browse/WB-30074

We are not checking if online evals is enabled when flushing, this could be causing errors in existing deployments that do not have bufstream setup.

## Testing

todo qa 
