### PR TITLE
chore(weave): make distributed db_mangement table name unique

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -520,11 +520,10 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
     def _create_management_table_sql(self) -> str:
         """Generate SQL to create the management table in distributed mode.
 
-        In distributed mode, the management table should be replicated but NOT sharded.
-        All shards need to see the same migration state.
+        Unlike data tables (which use {shard} in the ZK path to separate data per shard),
+        the management table uses a shared path so all nodes replicate the same state.
+        We use {shard}-{replica} for the replica ID since {replica} alone repeats across shards.
         """
-        # Use a fixed path without {shard} macro so all nodes replicate the same data
-        # Use {replica} only (not {shard}-{replica}) to ensure it's truly shared
         return f"""
             CREATE TABLE IF NOT EXISTS {self.management_db}.migrations ON CLUSTER {self.replicated_cluster}
             (
@@ -532,7 +531,7 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
                 curr_version UInt64,
                 partially_applied_version UInt64 NULL,
             )
-            ENGINE = ReplicatedMergeTree('/clickhouse/tables/shared/{self.management_db}/migrations', '{{replica}}')
+            ENGINE = ReplicatedMergeTree('/clickhouse/tables/shared/{self.management_db}/migrations', '{{shard}}-{{replica}}')
             ORDER BY (db_name)
         """
 
@@ -851,6 +850,15 @@ def get_clickhouse_trace_server_migrator(
     """
     replicated = False if replicated is None else replicated
     use_distributed = False if use_distributed is None else use_distributed
+
+    logger.info(
+        f"ClickHouseTraceServerMigrator initialized with: "
+        f"replicated={replicated}, "
+        f"use_distributed={use_distributed}, "
+        f"replicated_cluster={replicated_cluster}, "
+        f"replicated_path={replicated_path}, "
+        f"management_db={management_db}"
+    )
 
     # Validate configuration
     if use_distributed and not replicated:


### PR DESCRIPTION
## Description

This is a fix for the migration path to spin up distributed replicated self managed instances, we actually need a fully unique name in the zookeeper entry for each shard-replica. this pr adds a comment to that effect and the fix in the db_mangement table ddl. And adds a log line. 

## Testing

locally
```
Running cmd: make migrate_local
./migrate_local.sh
INFO:weave.trace_server.clickhouse_trace_server_migrator:ClickHouseTraceServerMigrator initialized with: replicated=True, use_distributed=True, replicated_cluster=weavecluster, replicated_path=None, management_db=db_management
INFO:weave.trace_server.clickhouse_trace_server_migrator:2026-01-06 14:50:15 DistributedClickHouseTraceServerMigrator initialized
INFO:weave.trace_server.clickhouse_trace_server_migrator:2026-01-06 14:50:15 ReplicatedClickHouseTraceServerMigrator initialized with: replicated_cluster=weavecluster, replicated_path=/clickhouse/tables/{db}, management_db=db_management
INFO:weave.trace_server.clickhouse_trace_server_migrator:`default` migration status: {'db_name': 'default', 'curr_version': 0, 'partially_applied_version': None}
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migrations to apply: [(1, '001_init.up.sql'), (2, '002_add_deleted_at.up.sql'), (3, '003_feedback.up.sql'), (4, '004_add_display_name.up.sql'), (5, '005_add_cost.up.sql'), (6, '006_seed_costs.up.sql'), (7, '007_add_refs_to_feedback.up.sql'), (8, '008_stats_views.up.sql'), (9, '009_increase_call_timestamp_resolution.up.sql'), (10, '010_add_user_to_objects.up.sql'), (11, '011_add_file_bucket_storage.up.sql'), (12, '012_add_sortable_timestamp.up.sql'), (13, '013_add_wb_run_step.up.sql'), (14, '014_add_leaf_object_class.up.sql'), (15, '015_add_thread_id.up.sql'), (16, '016_add_thread_id_to_stats.up.sql'), (17, '017_add_turn_id.up.sql'), (18, '018_add_wb_run_id_idx.up.sql'), (19, '019_add_wb_run_step_end.up.sql'), (20, '020_add_otel_column.up.sql'), (21, '021_fix_otel_stats.up.sql'), (22, '022_calls_complete.up.sql')]
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 001_init.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 001_init.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 002_add_deleted_at.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 002_add_deleted_at.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 003_feedback.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 003_feedback.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 004_add_display_name.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 004_add_display_name.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 005_add_cost.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 005_add_cost.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 006_seed_costs.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 006_seed_costs.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 007_add_refs_to_feedback.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 007_add_refs_to_feedback.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 008_stats_views.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 008_stats_views.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 009_increase_call_timestamp_resolution.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 009_increase_call_timestamp_resolution.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 010_add_user_to_objects.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 010_add_user_to_objects.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 011_add_file_bucket_storage.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 011_add_file_bucket_storage.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 012_add_sortable_timestamp.up.sql to `default`
WARNING:weave.trace_server.clickhouse_trace_server_migrator:Skipping MATERIALIZE command (not supported in distributed mode): -- Matialize the column
ALTER TABLE calls_merged MATERIALIZE COLUMN sortable_datetime
WARNING:weave.trace_server.clickhouse_trace_server_migrator:Skipping MATERIALIZE command (not supported in distributed mode): -- Materialize the index, actually generating index marks for all the granules
ALTER TABLE calls_merged MATERIALIZE INDEX idx_sortable_datetime
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 012_add_sortable_timestamp.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 013_add_wb_run_step.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 013_add_wb_run_step.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 014_add_leaf_object_class.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 014_add_leaf_object_class.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 015_add_thread_id.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 015_add_thread_id.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 016_add_thread_id_to_stats.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 016_add_thread_id_to_stats.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 017_add_turn_id.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 017_add_turn_id.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 018_add_wb_run_id_idx.up.sql to `default`
WARNING:weave.trace_server.clickhouse_trace_server_migrator:Skipping MATERIALIZE command (not supported in distributed mode): -- Materialize the index, actually generating index marks for all the granules
ALTER TABLE calls_merged MATERIALIZE INDEX idx_wb_run_id
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 018_add_wb_run_id_idx.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 019_add_wb_run_step_end.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 019_add_wb_run_step_end.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 020_add_otel_column.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 020_add_otel_column.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 021_fix_otel_stats.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 021_fix_otel_stats.up.sql applied to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Applying migration 022_calls_complete.up.sql to `default`
INFO:weave.trace_server.clickhouse_trace_server_migrator:Migration 022_calls_complete.up.sql applied to `default`
INFO:weave.trace_server.costs.insert_costs:Loaded 2153 costs from json
INFO:weave.trace_server.costs.insert_costs:There are 2153 costs to insert, after filtering out existing costs
INFO:weave.trace_server.costs.insert_costs:Inserted 2153 costs
Running cmd: make trace_server
```

And crucially idempotent
```
Running cmd: make migrate_local
./migrate_local.sh
INFO:weave.trace_server.clickhouse_trace_server_migrator:ClickHouseTraceServerMigrator initialized with: replicated=True, use_distributed=True, replicated_cluster=weavecluster, replicated_path=None, management_db=db_management
INFO:weave.trace_server.clickhouse_trace_server_migrator:2026-01-06 15:11:40 DistributedClickHouseTraceServerMigrator initialized
INFO:weave.trace_server.clickhouse_trace_server_migrator:2026-01-06 15:11:40 ReplicatedClickHouseTraceServerMigrator initialized with: replicated_cluster=weavecluster, replicated_path=/clickhouse/tables/{db}, management_db=db_management
INFO:weave.trace_server.clickhouse_trace_server_migrator:`default` migration status: {'db_name': 'default', 'curr_version': 22, 'partially_applied_version': None}
INFO:weave.trace_server.clickhouse_trace_server_migrator:No migrations to apply to `default`
INFO:weave.trace_server.costs.insert_costs:Loaded 2153 costs from json
INFO:weave.trace_server.costs.insert_costs:There are 0 costs to insert, after filtering out existing costs
Running cmd: make trace_server
```