### PR TITLE
chore(weave): more datadog reporting on types of calls queries

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -640,7 +640,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # We put summary_dump last so that when we compute the costs and summary its in the right place
         if req.include_costs:
-            set_current_span_dd_tags({"cost_query": 'true'})
+            set_current_span_dd_tags({"include_costs": "true"})
             summary_columns = ["summary", "summary_dump"]
             columns = [
                 *[col for col in columns if col not in summary_columns],
@@ -680,9 +680,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         include_feedback = req.include_feedback or False
 
         if include_feedback:
-            set_current_span_dd_tags({"feedback_query": 'true'})
+            set_current_span_dd_tags({"include_feedback": "true"})
         if expand_columns:
-            set_current_span_dd_tags({"expand_columns": 'true'})
+            set_current_span_dd_tags({"expand_columns": "true"})
 
         def row_to_call_schema_dict(row: tuple[Any, ...]) -> dict[str, Any]:
             return _ch_call_dict_to_call_schema_dict(


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Adds a couple tags to more easily correlate problematic/slow queries in datadog. Include flags for cost query, feedback query, and expand column query. 

We might want these tags on the root, but for now on the stream call feels okay.

## Testing

<img width="1406" height="734" alt="image" src="https://github.com/user-attachments/assets/d09c1395-261e-4426-8154-9c8510bfd2f1" />
