### PR TITLE
chore(weave): Better autopatching for common langchain imports

### DIFF
--- a/weave/integrations/patch.py
+++ b/weave/integrations/patch.py
@@ -254,6 +254,7 @@ def patch_langchain() -> None:
 
     if langchain_patcher.attempt_patch():
         _PATCHED_INTEGRATIONS.add("langchain")
+        _PATCHED_INTEGRATIONS.add("langchain_core")
 
 
 def patch_llamaindex() -> None:
@@ -300,6 +301,7 @@ INTEGRATION_MODULE_MAPPING: dict[str, Callable[[], None]] = {
     "verifiers": patch_verifiers,
     "autogen": patch_autogen,
     "langchain": patch_langchain,
+    "langchain_core": patch_langchain,
     "llama_index": patch_llamaindex,
     "openai_realtime": patch_openai_realtime,
 }


### PR DESCRIPTION
Additionally patches `langchain_core` which is used in most places where users use langchain