### PR TITLE
fix(weave): respect HTTP_PROXY/HTTPS_PROXY environment variables in httpx.Client

### DIFF
--- a/weave/utils/http_requests.py
+++ b/weave/utils/http_requests.py
@@ -164,8 +164,15 @@ def _get_http_timeout() -> float:
     return http_timeout()
 
 
+proxy_url = (
+    os.environ.get("HTTPS_PROXY")
+    or os.environ.get("https_proxy")
+    or os.environ.get("HTTP_PROXY")
+    or os.environ.get("http_proxy")
+)
+
 client = httpx.Client(
-    transport=LoggingHTTPTransport(),
+    transport=LoggingHTTPTransport(proxy=proxy_url),
     timeout=_get_http_timeout(),
     limits=httpx.Limits(max_connections=None, max_keepalive_connections=None),
 )


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

- Fixes #5849 
