### PR TITLE
chore(weave): exclude weave-query build folder from pre-commit check.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
           [types-pkg-resources==0.1.3, types-all, wandb>=0.15.5, wandb<0.19.0]
         # Note: You have to update pyproject.toml[tool.mypy] too!
         args: ["--config-file=pyproject.toml", "."]
-        exclude: (.*pyi$)|(tests)|(examples)|(.github/scripts/validate_docs_coverage.py)
+        exclude: (.*pyi$)|(tests)|(examples)|(build)|(.github/scripts/validate_docs_coverage.py)
         always_run: true
         pass_filenames: false
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -320,7 +320,7 @@ reportCallIssue = false
 [tool.mypy]
 warn_unused_configs = true
 # Note: You have to update .pre-commit-config.yaml too!
-exclude = [".*pyi$", "tests", "examples"]
+exclude = [".*pyi$", "tests", "examples", "build"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]


### PR DESCRIPTION
## Description

I have been constantly seeing a local run of `nox -e lint` generates way more errors than CI. while the pre-commit check on CI passes cleanly. 

It turned out that there is a `weave_query/build/` folder somehow created locally which contains some files which the `mypy` checker doesn't like. I believe this folder doesn't exist on CI run. 

## Testing

Locally verified. 
