### PR TITLE
fix(weave): Accept HTTP/HTTPS/ALL_PROXY env vars with HTTPX client

### DIFF
--- a/weave/utils/http_requests.py
+++ b/weave/utils/http_requests.py
@@ -164,8 +164,14 @@ def _get_http_timeout() -> float:
     return http_timeout()
 
 
+def _get_proxy_from_env() -> str | None:
+    return os.getenv("HTTPS_PROXY") or os.getenv("HTTP_PROXY") or os.getenv("ALL_PROXY")
+
+
 client = httpx.Client(
-    transport=LoggingHTTPTransport(),
+    # HTTPX doesn't read proxy env vars when a custom transport is provided,
+    # so we need to read them manually and pass them here.
+    transport=LoggingHTTPTransport(proxy=_get_proxy_from_env()),
     timeout=_get_http_timeout(),
     limits=httpx.Limits(max_connections=None, max_keepalive_connections=None),
 )


### PR DESCRIPTION
Internal Tracking: https://wandb.atlassian.net/browse/WB-30252
Related PR: https://github.com/wandb/weave/pull/5901
Related Issue: https://github.com/wandb/weave/issues/5849

---

We recently switched over to HTTPX from requests as our main requests lib.  HTTPX ignores env vars when a custom transport is provided, which is causing issues for users behind corp firewalls.  This PR explicitly passes the env vars to work around this issue.
