### PR TITLE
chore(weave): Add skills to bump and release weave

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: bump-version
+description: Bump the Weave Python SDK version for release. Use when preparing a new release.
+---
+
+# Bump Python SDK Version
+
+This replicates the GitHub Actions `bump-python-sdk-version` workflow.
+
+## What this does
+
+1. Drops the pre-release tag (e.g., `0.52.24-dev0` -> `0.52.24`) and creates a git tag
+2. Bumps to the next pre-release version (e.g., `0.52.24` -> `0.52.25-dev0`)
+
+## Instructions
+
+Run the bump version script with a dry-run first to preview changes:
+
+```bash
+uv run ./scripts/bump_python_sdk_version.py --dry-run
+```
+
+If the user confirms they want to proceed, run without `--dry-run`:
+
+```bash
+uv run ./scripts/bump_python_sdk_version.py
+```
+
+After the version bump completes, remind the user of next steps:
+1. Review the commits: `git log -2`
+2. Push changes: `git push && git push --tags`
+
+## Requirements
+
+- Git working directory must be clean (no uncommitted changes)
+- Must be run from the repository root

--- a/.claude/skills/publish-pypi/SKILL.md
+++ b/.claude/skills/publish-pypi/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: publish-pypi
+description: Build and publish the Weave Python SDK to PyPI. Use when releasing a new version.
+---
+
+# Publish to PyPI
+
+This replicates the GitHub Actions `publish-pypi-release` workflow.
+
+## Arguments
+
+- `$ARGUMENTS` can be `test` to publish to Test PyPI, or empty for production PyPI
+
+## Instructions
+
+First, run a dry-run to build and verify the package:
+
+```bash
+uv run ./scripts/publish_pypi_release.py --dry-run
+```
+
+If the user wants to publish to **Test PyPI** (or `$ARGUMENTS` contains "test"):
+
+```bash
+uv run ./scripts/publish_pypi_release.py --test
+```
+
+If the user wants to publish to **production PyPI**:
+
+```bash
+uv run ./scripts/publish_pypi_release.py
+```
+
+## Authentication
+
+Before publishing, ensure the user has set up authentication. Options:
+- `TWINE_API_KEY` environment variable (recommended for production)
+- `TWINE_TEST_API_KEY` environment variable (for Test PyPI)
+- `.pypirc` file in home directory
+
+If authentication fails, help the user set up their credentials.
+
+## After Publishing
+
+Remind the user to verify the package:
+- Test PyPI: https://test.pypi.org/project/weave/
+- Production PyPI: https://pypi.org/project/weave/

--- a/scripts/bump_python_sdk_version.py
+++ b/scripts/bump_python_sdk_version.py
@@ -1,0 +1,93 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "bump-my-version>=0.28.0",
+# ]
+# ///
+"""Bump the Python SDK version for release.
+
+This script replicates the GitHub Actions workflow `bump-python-sdk-version`.
+It performs two steps:
+1. Drop the pre-release tag (e.g., X.Y.Z-dev0 -> X.Y.Z) and tag this commit
+2. Bump to the next pre-release version (e.g., X.Y.Z -> X.Y.(Z+1)-dev0)
+
+Usage:
+    uv run scripts/bump_python_sdk_version.py [--dry-run]
+
+Options:
+    --dry-run   Show what would happen without making changes
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+
+
+def run_command(cmd: list[str], dry_run: bool = False) -> None:
+    """Run a command, printing it first."""
+    print(f"Running: {' '.join(cmd)}")
+    if not dry_run:
+        result = subprocess.run(cmd, check=False)
+        if result.returncode != 0:
+            print(f"Command failed with return code {result.returncode}")
+            sys.exit(result.returncode)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Bump the Python SDK version for release."
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would happen without making changes",
+    )
+    args = parser.parse_args()
+
+    dry_run_flag = ["--dry-run"] if args.dry_run else []
+
+    print("Step 1: Drop pre-release tag (e.g., X.Y.Z-dev0 -> X.Y.Z)")
+    print("        This creates the release commit and tag.")
+    run_command(
+        [
+            "bump-my-version",
+            "bump",
+            "pre_l",
+            "./weave/version.py",
+            "--tag",
+            "--commit",
+            *dry_run_flag,
+        ],
+        dry_run=False,  # Let bump-my-version handle --dry-run
+    )
+
+    print()
+    print("Step 2: Bump to next pre-release version (e.g., X.Y.Z -> X.Y.(Z+1)-dev0)")
+    print("        This starts the next development cycle.")
+    run_command(
+        [
+            "bump-my-version",
+            "bump",
+            "patch",
+            "./weave/version.py",
+            "--commit",
+            *dry_run_flag,
+        ],
+        dry_run=False,  # Let bump-my-version handle --dry-run
+    )
+
+    print()
+    if args.dry_run:
+        print("Dry run complete. No changes were made.")
+    else:
+        print("Version bump complete!")
+        print()
+        print("Next steps:")
+        print("  1. Review the commits: git log -2")
+        print("  2. Push changes: git push && git push --tags")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/publish_pypi_release.py
+++ b/scripts/publish_pypi_release.py
@@ -1,0 +1,142 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "twine>=5.0.0",
+#     "build>=1.0.0",
+# ]
+# ///
+"""Build and publish the Python SDK to PyPI.
+
+This script replicates the GitHub Actions workflow `publish-pypi-release`.
+It builds the distribution and uploads it to PyPI (or Test PyPI).
+
+Usage:
+    uv run scripts/publish_pypi_release.py [--test] [--dry-run]
+
+Options:
+    --test      Upload to Test PyPI instead of production PyPI
+    --dry-run   Build only, don't upload
+
+Authentication:
+    For uploading, you need PyPI credentials. Options:
+    1. Set TWINE_USERNAME and TWINE_PASSWORD environment variables
+    2. Set TWINE_API_KEY environment variable (recommended)
+    3. Use a .pypirc file in your home directory
+    4. Be prompted interactively
+
+    For Test PyPI, use TWINE_TEST_USERNAME/TWINE_TEST_PASSWORD or
+    TWINE_TEST_API_KEY environment variables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_command(cmd: list[str], env: dict[str, str] | None = None) -> int:
+    """Run a command, printing it first."""
+    print(f"Running: {' '.join(cmd)}")
+    result = subprocess.run(cmd, check=False, env=env)
+    return result.returncode
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Build and publish the Python SDK to PyPI."
+    )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="Upload to Test PyPI instead of production PyPI",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Build only, don't upload",
+    )
+    args = parser.parse_args()
+
+    # Find the project root (where pyproject.toml is)
+    script_dir = Path(__file__).parent
+    project_root = script_dir.parent
+
+    dist_dir = project_root / "dist"
+
+    # Clean dist directory
+    if dist_dir.exists():
+        print(f"Cleaning {dist_dir}")
+        shutil.rmtree(dist_dir)
+
+    # Build the distribution
+    print()
+    print("Building distribution...")
+    ret = run_command(["uv", "build"], env={**os.environ, "PWD": str(project_root)})
+    if ret != 0:
+        print("Build failed!")
+        sys.exit(ret)
+
+    # List built files
+    print()
+    print("Built files:")
+    for f in dist_dir.iterdir():
+        print(f"  {f.name}")
+
+    if args.dry_run:
+        print()
+        print("Dry run complete. Distribution built but not uploaded.")
+        return
+
+    # Upload to PyPI
+    print()
+    if args.test:
+        print("Uploading to Test PyPI...")
+        repository_url = "https://test.pypi.org/legacy/"
+
+        # Check for test-specific credentials
+        env = os.environ.copy()
+        if "TWINE_TEST_API_KEY" in env:
+            env["TWINE_PASSWORD"] = env["TWINE_TEST_API_KEY"]
+            env["TWINE_USERNAME"] = "__token__"
+        elif "TWINE_TEST_USERNAME" in env:
+            env["TWINE_USERNAME"] = env["TWINE_TEST_USERNAME"]
+            if "TWINE_TEST_PASSWORD" in env:
+                env["TWINE_PASSWORD"] = env["TWINE_TEST_PASSWORD"]
+    else:
+        print("Uploading to PyPI...")
+        repository_url = "https://upload.pypi.org/legacy/"
+        env = os.environ.copy()
+
+        # Use API key if available
+        if "TWINE_API_KEY" in env:
+            env["TWINE_PASSWORD"] = env["TWINE_API_KEY"]
+            env["TWINE_USERNAME"] = "__token__"
+
+    upload_cmd = [
+        "twine",
+        "upload",
+        "--repository-url",
+        repository_url,
+        "--verbose",
+        str(dist_dir / "*"),
+    ]
+
+    ret = run_command(upload_cmd, env=env)
+    if ret != 0:
+        print("Upload failed!")
+        sys.exit(ret)
+
+    print()
+    print("Upload complete!")
+    if args.test:
+        print("Check your package at: https://test.pypi.org/project/weave/")
+    else:
+        print("Check your package at: https://pypi.org/project/weave/")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds two claude skills:
1. `bump-version`, which is the equivalent of the `bump-python-sdk-version` GHA; and
2. `publish-pypi`, which is the equivalent of the `publish-pypi-release` GHA.

Now you can trigger a bump and release with claude code

---

## Example

<img width="1099" height="1160" alt="image" src="https://github.com/user-attachments/assets/3edf9344-b9d9-4b3f-8fdb-2f0d4529e791" />
