### PR TITLE
fix(weave): Ensure serialization issues do not crash the user program and only prevent logging to weave

### DIFF
--- a/tests/trace/test_pathological_serialize.py
+++ b/tests/trace/test_pathological_serialize.py
@@ -1,8 +1,4 @@
-"""Test that broken serialization doesn't crash.
-
-These tests document that to_json currently crashes on pathological input.
-The fix should make these tests pass by falling back gracefully.
-"""
+"""Test that broken serialization doesn't crash."""
 
 from __future__ import annotations
 
@@ -37,19 +33,13 @@ def mock_client():
     return MagicMock()
 
 
-def test_to_json_broken_dict_should_not_crash(mock_client) -> None:
-    """to_json should handle dict subclasses with broken items() gracefully."""
-    bad_obj = BrokenDict()
-
-    # Currently crashes - this test will pass once the bug is fixed
-    result = to_json(bad_obj, "test/project", mock_client, use_dictify=True)
-    assert result is not None
+def test_to_json_broken_dict_does_not_crash(mock_client) -> None:
+    """to_json handles dict subclasses with broken items() gracefully."""
+    result = to_json(BrokenDict(), "test/project", mock_client, use_dictify=True)
+    assert result == "{}"  # Falls back to string repr
 
 
-def test_to_json_broken_namedtuple_should_not_crash(mock_client) -> None:
-    """to_json should handle namedtuples with broken _asdict() gracefully."""
-    bad_obj = BrokenNamedTuple()
-
-    # Currently crashes - this test will pass once the bug is fixed
-    result = to_json(bad_obj, "test/project", mock_client, use_dictify=True)
-    assert result is not None
+def test_to_json_broken_namedtuple_does_not_crash(mock_client) -> None:
+    """to_json handles namedtuples with broken _asdict() gracefully."""
+    result = to_json(BrokenNamedTuple(), "test/project", mock_client, use_dictify=True)
+    assert result == "(1, 2)"  # Falls back to string repr

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -61,14 +61,23 @@ def to_json(
             res[k] = to_json(v, project_id, client, use_dictify)
         return res
     elif isinstance_namedtuple(obj):
-        return {
-            k: to_json(v, project_id, client, use_dictify)
-            for k, v in obj._asdict().items()
-        }
+        try:
+            return {
+                k: to_json(v, project_id, client, use_dictify)
+                for k, v in obj._asdict().items()
+            }
+        except Exception:
+            return fallback_encode(obj)
     elif isinstance(obj, (list, tuple)):
         return [to_json(v, project_id, client, use_dictify) for v in obj]
     elif isinstance(obj, dict):
-        return {k: to_json(v, project_id, client, use_dictify) for k, v in obj.items()}
+        try:
+            return {
+                k: to_json(v, project_id, client, use_dictify)
+                for k, v in obj.items()
+            }
+        except Exception:
+            return fallback_encode(obj)
     elif is_pydantic_model_class(obj):
         return obj.model_json_schema()
 


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-30498

Op serialization is complex, but it should never crash the user's program.  This PR adds some tests to ensure that wonky serialization only prevents logging and never crashes the user's code