### PR TITLE
chore(weave): bump ClickHouse version to 25.10 in nightly run

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -80,7 +80,7 @@ jobs:
         ports:
           - "10000:10000"
       weave_clickhouse:
-        image: clickhouse/clickhouse-server:25.4
+        image: clickhouse/clickhouse-server:25.10
         env:
           CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
           CLICKHOUSE_USER: default


### PR DESCRIPTION
## Description

- Updates the ClickHouse server image version from 25.4 to 25.10 in the nightly tests GitHub workflow

25.10 is the production CH version.

## Testing
The PR is the test.