### PR TITLE
chore(weave): Make dependabot work with our CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -202,8 +202,7 @@ updates:
       - "wandb/weave-team"
     # Add prefix to PR titles
     commit-message:
-      prefix: "deps"
-      include: "scope"
+      prefix: "chore(deps)"
     # Ignore major version updates by default - these will need manual review
     ignore:
       - dependency-name: "*"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -198,12 +198,14 @@ jobs:
           WB_SERVER_HOST: http://wandbservice
           WF_CLICKHOUSE_HOST: weave_clickhouse
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
-          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # Use dummy API keys when secrets aren't available (e.g., Dependabot PRs)
+          # Tests use VCR recordings so real keys aren't needed
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY || 'DUMMY_API_KEY' }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY || 'DUMMY_API_KEY' }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY || 'DUMMY_API_KEY' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || 'DUMMY_API_KEY' }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY || 'DUMMY_API_KEY' }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'DUMMY_API_KEY' }}
           DD_TRACE_ENABLED: false
         run: |
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.nox-shard }}')" -- \
@@ -343,12 +345,14 @@ jobs:
           WB_SERVER_HOST: http://localhost
           WF_CLICKHOUSE_HOST: localhost
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
-          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
-          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY }}
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          # Use dummy API keys when secrets aren't available (e.g., Dependabot PRs)
+          # Tests use VCR recordings so real keys aren't needed
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY || 'DUMMY_API_KEY' }}
+          GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY || 'DUMMY_API_KEY' }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY || 'DUMMY_API_KEY' }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY || 'DUMMY_API_KEY' }}
+          MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY || 'DUMMY_API_KEY' }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'DUMMY_API_KEY' }}
           DD_TRACE_ENABLED: false
         run: |
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.nox-shard }}')" -- -m "trace_server" --trace-server=sqlite


### PR DESCRIPTION
https://wandb.atlassian.net/browse/WB-30517

---

This PR tries to make dependabot work with our CI.

Currently there are 2 failure modes:
1. The PR title is wrong (this changes it from `deps -> chore`)
2. Our integration tests require can require an API key to be present.  This is not actually required because everything is mocked with `pytest-recording`, but the API key check still happens.  To fix this, we'll instead pass a dummy api key.
```
FAILED tests/integrations/anthropic/anthropic_test.py::test_anthropic - TypeError: "Could not resolve authentication method. Expected either api_key or auth_token to be set. Or for one of the `X-Api-Key` or `Authorization` headers to be explicitly omitted"
```