### PR TITLE
chore(weave): Make dependabot work with our CI(2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -202,7 +202,7 @@ updates:
       - "wandb/weave-team"
     # Add prefix to PR titles
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "chore(weave)"
     # Ignore major version updates by default - these will need manual review
     ignore:
       - dependency-name: "*"

--- a/.github/workflows/weave-node-tests.yaml
+++ b/.github/workflows/weave-node-tests.yaml
@@ -29,4 +29,5 @@ jobs:
         run: pnpm test
         working-directory: sdks/node
         env:
-          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          # Use dummy API key when secrets aren't available (e.g., Dependabot PRs)
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY || 'DUMMY_API_KEY' }}


### PR DESCRIPTION
Extends https://github.com/wandb/weave/pull/5940

This fixes the node tests that may be missing a `WANDB_API_KEY`