### PR TITLE
chore(weave): Set no:ddtrace for pytest

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -205,6 +205,8 @@ def tests(session: nox.Session, shard: str):
     # Add sharding logic for trace1, trace2, trace3
     pytest_args = [
         "pytest",
+        "-p",
+        "no:ddtrace",  # Disable ddtrace pytest plugin to prevent hangs during initialization
         "--durations=20",
         "--strict-markers",
         "--cov=weave",


### PR DESCRIPTION
This is an experimental change that will hopefully reduce test flake.

The hypothesis is that there is a bad interaction between `ddtrace` and `pytest-xdist` which can cause the container to hang or deadlock