### PR TITLE
feat(weave): add CallViewSpec for rich evaluation reports

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -10,7 +10,6 @@ import weave
 from weave.evaluation.eval_imperative import EvaluationLogger, Model, Scorer
 from weave.integrations.integration_utilities import op_name_from_call
 from weave.trace.context import call_context
-from weave.trace.serialization.serialize import to_json
 from weave.trace_server.trace_server_interface import ObjectVersionFilter
 
 
@@ -703,7 +702,7 @@ def test_evaluation_logger_with_predefined_scorers(client, caplog):
 
 
 def test_evaluation_logger_set_view(client):
-    """Ensure set_view stores content metadata on evaluation summary."""
+    """Ensure set_view stores content in CallViewSpec via view_spec_ref."""
     ev = weave.EvaluationLogger()
     content = weave.Content.from_text("# hello", mimetype="text/markdown")
     content2 = weave.Content.from_text("<h1>hello world</h1>", mimetype="text/html")
@@ -714,12 +713,15 @@ def test_evaluation_logger_set_view(client):
     client.flush()
 
     evaluate_call = client.get_calls()[0]
-    assert evaluate_call.summary["weave"] is not None
-    assert "views" in evaluate_call.summary["weave"]
-    views = evaluate_call.summary["weave"]["views"]
-    assert len(views) == 2
-    assert views["report"] == to_json(content, client._project_id(), client)
-    assert views["report2"] == to_json(content2, client._project_id(), client)
+    # Views are now stored via view_spec_ref, not in summary
+    assert evaluate_call.view_spec_ref is not None
+    view_spec = weave.ref(evaluate_call.view_spec_ref).get()
+    assert len(view_spec.views) == 2
+    assert "report" in view_spec.views
+    assert "report2" in view_spec.views
+    # Verify the view items have content type
+    assert view_spec.views["report"].type == "content"
+    assert view_spec.views["report2"].type == "content"
 
 
 def test_evaluation_logger_set_view_string(client):
@@ -730,14 +732,17 @@ def test_evaluation_logger_set_view_string(client):
     client.flush()
 
     evaluate_call = client.get_calls()[0]
-    assert evaluate_call.summary
-    assert evaluate_call.summary["weave"] is not None
-    views = evaluate_call.summary["weave"]["views"]
-    stored = dict(views["view"])
+    # Views are now stored via view_spec_ref
+    assert evaluate_call.view_spec_ref is not None
+    view_spec = weave.ref(evaluate_call.view_spec_ref).get()
+    assert "view" in view_spec.views
+    # String content gets converted to ContentViewItem
+    assert view_spec.views["view"].type == "content"
+    # Verify the content is base64 encoded HTML
+    import base64
 
-    assert stored["_type"] == "CustomWeaveType"
-    assert stored["weave_type"]["type"] == "weave.type_wrappers.Content.content.Content"
-    assert stored["files"]["content"]
+    content_bytes = base64.b64decode(view_spec.views["view"].data)
+    assert b"<h1>Eval</h1>" in content_bytes
 
 
 def test_cost_propagation_with_child_calls(client):

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -207,6 +207,7 @@ def test_trace_server_call_start_and_end(client):
         "total_storage_size_bytes": None,
         "thread_id": None,
         "turn_id": None,
+        "view_spec_ref": None,
     }
 
     end = tsi.EndedCallSchemaForInsert(
@@ -259,6 +260,7 @@ def test_trace_server_call_start_and_end(client):
         "total_storage_size_bytes": None,
         "thread_id": None,
         "turn_id": None,
+        "view_spec_ref": None,
     }
 
 

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -32,6 +32,7 @@ from weave.initialization import *
 from weave.object.obj import Object
 from weave.prompt.prompt import EasyPrompt, MessagesPrompt, Prompt, StringPrompt
 from weave.trace.log_call import log_call
+from weave.trace.table import Table
 from weave.trace.util import Thread as Thread
 from weave.trace.util import ThreadPoolExecutor as ThreadPoolExecutor
 from weave.type_handlers.Audio.audio import Audio
@@ -62,6 +63,7 @@ __all__ = [
     "SavedView",
     "Scorer",
     "StringPrompt",
+    "Table",
     "attributes",
     "finish",
     "get",

--- a/weave/trace/call.py
+++ b/weave/trace/call.py
@@ -75,9 +75,15 @@ class Call:
     wb_run_step: int | None = None
     wb_run_step_end: int | None = None
 
+    # Reference to a CallViewSpec object containing view configurations
+    view_spec_ref: str | None = None
+
     # These are the live children during logging
     _children: list[Call] = dataclasses.field(default_factory=list)
     _feedback: RefFeedbackQuery | None = None
+
+    # Pending views to be saved as CallViewSpec object at call_end
+    _pending_views: dict[str, Any] = dataclasses.field(default_factory=dict)
 
     # Size of metadata storage for this call
     storage_size_bytes: int | None = None
@@ -432,6 +438,7 @@ def make_client_call(
         wb_run_id=server_call.wb_run_id,
         wb_run_step=server_call.wb_run_step,
         wb_run_step_end=server_call.wb_run_step_end,
+        view_spec_ref=server_call.view_spec_ref,
         storage_size_bytes=server_call.storage_size_bytes,
         total_storage_size_bytes=server_call.total_storage_size_bytes,
     )

--- a/weave/trace/view_utils.py
+++ b/weave/trace/view_utils.py
@@ -2,12 +2,35 @@
 
 from __future__ import annotations
 
-from typing import Any
+import base64
+from typing import TYPE_CHECKING, Any
 
 from weave.trace.call import Call
+from weave.trace.refs import ObjectRef
 from weave.trace.serialization.serialize import to_json
-from weave.trace.weave_client import WeaveClient
+from weave.trace.table import Table
+from weave.trace_server.interface.builtin_object_classes.call_view_spec import (
+    CallViewSpec,
+    ContentViewItem,
+    ObjectRefViewItem,
+    SavedViewDefinitionItem,
+)
+from weave.trace_server.interface.builtin_object_classes.call_view_spec import (
+    ViewItem as CallViewSpecItem,
+)
 from weave.type_wrappers.Content.content import Content
+
+if TYPE_CHECKING:
+    from weave.flow.saved_view import SavedView as SDKSavedView
+    from weave.trace.weave_client import WeaveClient
+
+    # Type aliases for type checking - includes SavedView
+    ViewItem = Content | str | Table | ObjectRef | SDKSavedView
+    ViewSpec = ViewItem | list[ViewItem]
+else:
+    # At runtime, use Any since SDKSavedView causes circular import
+    ViewItem = Any
+    ViewSpec = Any
 
 
 def resolve_view_content(
@@ -62,24 +85,207 @@ def resolve_view_content(
     return result
 
 
+def serialize_view_item(
+    item: ViewItem,
+    project_id: str,
+    client: WeaveClient,
+    *,
+    extension: str | None = None,
+    mimetype: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    encoding: str = "utf-8",
+) -> dict[str, Any] | str:
+    """Serialize a single view item to JSON.
+
+    Args:
+        item: A Content, string, or Table to serialize.
+        project_id: The project ID for serialization context.
+        client: The WeaveClient for serialization.
+        extension: Optional file extension for string content.
+        mimetype: Optional MIME type for string content.
+        metadata: Optional metadata for string content.
+        encoding: Encoding for string content.
+
+    Returns:
+        A JSON-serializable dictionary or string (for Table refs).
+    """
+    if isinstance(item, Table):
+        # Publish the table and return its ref URI
+        table_ref = client._save_table(item)
+        return table_ref.uri()
+    elif isinstance(item, (Content, str)):
+        content_obj = resolve_view_content(
+            item,
+            extension=extension,
+            mimetype=mimetype,
+            metadata=metadata,
+            encoding=encoding,
+        )
+        return to_json(content_obj, project_id, client, use_dictify=False)
+    else:
+        raise TypeError(f"Unsupported view item type: {type(item)}")
+
+
+def serialize_view_spec(
+    spec: ViewSpec,
+    project_id: str,
+    client: WeaveClient,
+    *,
+    extension: str | None = None,
+    mimetype: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    encoding: str = "utf-8",
+) -> dict[str, Any] | str | list[dict[str, Any] | str]:
+    """Serialize a view specification to JSON.
+
+    Args:
+        spec: A single view item or list of view items.
+        project_id: The project ID for serialization context.
+        client: The WeaveClient for serialization.
+        extension: Optional file extension for string content.
+        mimetype: Optional MIME type for string content.
+        metadata: Optional metadata for string content.
+        encoding: Encoding for string content.
+
+    Returns:
+        A JSON-serializable dictionary, string (for Table refs), or list of these.
+    """
+    if isinstance(spec, list):
+        return [serialize_view_item(item, project_id, client) for item in spec]
+    else:
+        return serialize_view_item(
+            spec,
+            project_id,
+            client,
+            extension=extension,
+            mimetype=mimetype,
+            metadata=metadata,
+            encoding=encoding,
+        )
+
+
+def _sdk_view_item_to_call_view_spec_item(
+    item: ViewItem,
+    client: WeaveClient,
+    *,
+    extension: str | None = None,
+    mimetype: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    encoding: str = "utf-8",
+) -> CallViewSpecItem:
+    """Convert an SDK view item to a CallViewSpec item for storage.
+
+    Args:
+        item: A Content, string, Table, ObjectRef, or SavedView to convert.
+        client: The WeaveClient for saving tables.
+        extension: Optional file extension for string content.
+        mimetype: Optional MIME type for string content.
+        metadata: Optional metadata for string content.
+        encoding: Encoding for string content.
+
+    Returns:
+        A CallViewSpec item (ContentViewItem, ObjectRefViewItem, or
+        SavedViewDefinitionItem).
+    """
+    # Import here to avoid circular imports
+    from weave.flow.saved_view import SavedView as SDKSavedView
+
+    if isinstance(item, Table):
+        # Publish the table and return its ref URI as an object ref
+        table_ref = client._save_table(item)
+        return ObjectRefViewItem(uri=table_ref.uri())
+    elif isinstance(item, SDKSavedView):
+        # Embed the SavedView definition directly in the CallViewSpec
+        # This avoids needing to save the SavedView as a separate object
+        return SavedViewDefinitionItem(
+            label=item.base.label,
+            definition=item.base.definition,
+        )
+    elif isinstance(item, ObjectRef):
+        # Store object references as URI strings
+        return ObjectRefViewItem(uri=item.uri())
+    elif isinstance(item, (Content, str)):
+        content_obj = resolve_view_content(
+            item,
+            extension=extension,
+            mimetype=mimetype,
+            metadata=metadata,
+            encoding=encoding,
+        )
+        # Encode content data as base64
+        data_bytes = (
+            content_obj.data
+            if isinstance(content_obj.data, bytes)
+            else content_obj.data.encode(content_obj.encoding or "utf-8")
+        )
+        return ContentViewItem(
+            mimetype=content_obj.mimetype,
+            encoding=content_obj.encoding,
+            data=base64.b64encode(data_bytes).decode("ascii"),
+            metadata=content_obj.metadata,
+        )
+    else:
+        raise TypeError(f"Unsupported view item type: {type(item)}")
+
+
+def _sdk_view_spec_to_call_view_spec_item(
+    spec: ViewSpec,
+    client: WeaveClient,
+    *,
+    extension: str | None = None,
+    mimetype: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    encoding: str = "utf-8",
+) -> CallViewSpecItem | list[CallViewSpecItem]:
+    """Convert an SDK view spec to CallViewSpec item(s).
+
+    Args:
+        spec: A single view item or list of view items.
+        client: The WeaveClient for saving tables.
+        extension: Optional file extension for string content.
+        mimetype: Optional MIME type for string content.
+        metadata: Optional metadata for string content.
+        encoding: Encoding for string content.
+
+    Returns:
+        A CallViewSpec item or list of items.
+    """
+    if isinstance(spec, list):
+        return [_sdk_view_item_to_call_view_spec_item(item, client) for item in spec]
+    else:
+        return _sdk_view_item_to_call_view_spec_item(
+            spec,
+            client,
+            extension=extension,
+            mimetype=mimetype,
+            metadata=metadata,
+            encoding=encoding,
+        )
+
+
 def set_call_view(
     *,
     call: Call,
     client: WeaveClient,
     name: str,
-    content: Content | str,
+    content: ViewSpec,
     extension: str | None = None,
     mimetype: str | None = None,
     metadata: dict[str, Any] | None = None,
     encoding: str = "utf-8",
 ) -> None:
-    """Attach serialized content to the provided call's summary under `weave.views`.
+    """Attach a view to the call's pending views for later storage as CallViewSpec.
+
+    Views are stored in the call's _pending_views dict and will be converted to
+    a CallViewSpec object when the call is finished. This allows deduplication
+    of identical view configurations across calls.
 
     Args:
-        call: The call whose summary should receive the view entry.
+        call: The call whose pending views should receive the view entry.
         client: The active ``WeaveClient`` used for serialization.
-        name: Key to store the view under within ``summary.weave.views``.
-        content: ``weave.Content`` or raw text to serialize into the view.
+        name: Key to store the view under.
+        content: A ``weave.Content``, raw text, ``Table``, ``ObjectRef``, or list of
+            these to serialize into the view.
         extension: Optional file extension used when converting text content.
         mimetype: Optional MIME type applied when converting text content.
         metadata: Optional metadata for newly created ``Content`` objects.
@@ -102,35 +308,46 @@ def set_call_view(
         ...     extension="html",
         ... )
     """
-    content_obj = resolve_view_content(
+    # Store the converted view item in _pending_views
+    call._pending_views[name] = _sdk_view_spec_to_call_view_spec_item(
         content,
+        client,
         extension=extension,
         mimetype=mimetype,
         metadata=metadata,
         encoding=encoding,
     )
 
-    if call.summary is None:
-        call.summary = {}
 
-    summary = call.summary
+def build_and_save_call_view_spec(
+    call: Call,
+    client: WeaveClient,
+) -> str | None:
+    """Build a CallViewSpec from pending views and save it as an object.
 
-    weave_bucket = summary.get("weave")
-    if not isinstance(weave_bucket, dict):
-        weave_bucket = {}
-        summary["weave"] = weave_bucket
+    This function collects all pending views from the call, creates a CallViewSpec
+    object, and saves it to the project. The returned ref URI can be used as the
+    view_spec_ref in the call_end request.
 
-    legacy_views = summary.get("views")
-    if isinstance(legacy_views, dict):
-        summary.pop("views", None)
-    views = weave_bucket.get("views")
+    Args:
+        call: The call with pending views to save.
+        client: The WeaveClient for saving the object.
 
-    if not isinstance(views, dict):
-        views = {}
-        weave_bucket["views"] = views
+    Returns:
+        The view_spec_ref URI string, or None if no views are pending.
+    """
+    if not call._pending_views:
+        return None
 
-    if isinstance(legacy_views, dict):
-        views.update(legacy_views)
+    # Convert pending views dict values to the proper union type
+    views_dict: dict[str, CallViewSpecItem | list[CallViewSpecItem]] = {}
+    for name, item in call._pending_views.items():
+        views_dict[name] = item
 
-    project_id = client._project_id()
-    views[name] = to_json(content_obj, project_id, client, use_dictify=False)
+    # Create the CallViewSpec object
+    view_spec = CallViewSpec(views=views_dict)
+
+    # Save as a versioned object - content-addressed storage will deduplicate
+    ref: ObjectRef = client._save_object(view_spec, name="CallViewSpec")
+
+    return ref.uri()

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -84,6 +84,7 @@ from weave.trace.table import Table
 from weave.trace.table_upload_chunking import ChunkingConfig, TableChunkManager
 from weave.trace.util import log_once
 from weave.trace.vals import WeaveObject, WeaveTable, make_trace_obj
+from weave.trace.view_utils import build_and_save_call_view_spec
 from weave.trace.wandb_run_context import (
     WandbRunContext,
     check_wandb_run_matches,
@@ -981,6 +982,9 @@ class WeaveClient:
                 wb_run_context_end.step if wb_run_context_end else None
             )
 
+            # Build and save CallViewSpec if there are pending views
+            view_spec_ref = build_and_save_call_view_spec(call, self)
+
             call_end_req = CallEndReq(
                 end=EndedCallSchemaForInsertWithStartedAt(
                     project_id=project_id,
@@ -991,6 +995,7 @@ class WeaveClient:
                     summary=merged_summary,
                     exception=exception_str,
                     wb_run_step_end=current_wb_run_step_end,
+                    view_spec_ref=view_spec_ref,
                 )
             )
             bytes_size = len(call_end_req.model_dump_json())

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1569,6 +1569,7 @@ ALLOWED_CALL_FIELDS = {
         join_table_name=ROLLED_UP_CALL_MERGED_STATS_TABLE_NAME,
     ),
     "otel_dump": CallsMergedAggField(field="otel_dump", agg_fn="any"),
+    "view_spec_ref": CallsMergedAggField(field="view_spec_ref", agg_fn="any"),
 }
 
 DISALLOWED_FILTERING_FIELDS = {"storage_size_bytes", "total_storage_size_bytes"}

--- a/weave/trace_server/clickhouse_schema.py
+++ b/weave/trace_server/clickhouse_schema.py
@@ -79,6 +79,7 @@ class CallEndCHInsertable(CallBaseCHInsertable):
     summary_dump: str
     output_dump: str
     wb_run_step_end: int | None = None
+    view_spec_ref: str | None = None
 
     _wb_run_step_end_v = field_validator("wb_run_step_end")(
         validation.wb_run_step_validator
@@ -122,6 +123,7 @@ class CallCompleteCHInsertable(
     summary_dump: str
     otel_dump: str | None = None
     wb_run_step_end: int | None = None
+    view_spec_ref: str | None = None
 
     _wb_run_step_end_v = field_validator("wb_run_step_end")(
         validation.wb_run_step_validator
@@ -163,6 +165,8 @@ class SelectableCHCallSchema(BaseModel):
     wb_run_id: str | None = None
     wb_run_step: int | None = None
     wb_run_step_end: int | None = None
+
+    view_spec_ref: str | None = None
 
     deleted_at: datetime.datetime | None = None
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6150,6 +6150,7 @@ def _ch_call_dict_to_call_schema_dict(ch_call_dict: dict) -> dict:
         "display_name": display_name,
         "storage_size_bytes": ch_call_dict.get("storage_size_bytes"),
         "total_storage_size_bytes": ch_call_dict.get("total_storage_size_bytes"),
+        "view_spec_ref": ch_call_dict.get("view_spec_ref"),
     }
 
 
@@ -6298,6 +6299,7 @@ def _end_call_for_insert_to_ch_insertable_end_call(
         output_dump=_any_value_to_dump(output),
         output_refs=output_refs,
         wb_run_step_end=end_call.wb_run_step_end,
+        view_spec_ref=end_call.view_spec_ref,
     )
 
 
@@ -6378,6 +6380,7 @@ def _complete_call_to_ch_insertable(
         wb_run_id=complete_call.wb_run_id,
         wb_run_step=complete_call.wb_run_step,
         wb_run_step_end=complete_call.wb_run_step_end,
+        view_spec_ref=complete_call.view_spec_ref,
     )
 
 

--- a/weave/trace_server/interface/builtin_object_classes/builtin_object_registry.py
+++ b/weave/trace_server/interface/builtin_object_classes/builtin_object_registry.py
@@ -5,6 +5,9 @@ from weave.trace_server.interface.builtin_object_classes.annotation_spec import 
 from weave.trace_server.interface.builtin_object_classes.base_object_def import (
     BaseObject,
 )
+from weave.trace_server.interface.builtin_object_classes.call_view_spec import (
+    CallViewSpec,
+)
 from weave.trace_server.interface.builtin_object_classes.comparison_view import (
     ComparisonView,
 )
@@ -50,3 +53,4 @@ register_base_object(SavedView)
 register_base_object(ComparisonView)
 register_base_object(LLMStructuredCompletionModel)
 register_base_object(ChartConfig)
+register_base_object(CallViewSpec)

--- a/weave/trace_server/interface/builtin_object_classes/call_view_spec.py
+++ b/weave/trace_server/interface/builtin_object_classes/call_view_spec.py
@@ -1,0 +1,92 @@
+"""CallViewSpec builtin type for storing view configurations attached to calls."""
+
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field
+
+from weave.trace_server.interface.builtin_object_classes import base_object_def
+from weave.trace_server.interface.builtin_object_classes.saved_view import (
+    SavedViewDefinition,
+)
+
+
+class ContentViewItem(BaseModel):
+    """Serialized Content object for display in call views.
+
+    Represents rich content like markdown, HTML, or other text formats
+    that can be rendered in the UI.
+    """
+
+    type: Literal["content"] = "content"
+    mimetype: str
+    encoding: str | None = None
+    data: str  # base64 encoded content
+    metadata: dict[str, Any] | None = None
+
+
+class ObjectRefViewItem(BaseModel):
+    """Reference to a Weave object for display in call views.
+
+    Stores a URI reference to a saved object (e.g., SavedView) that
+    can be resolved and rendered by the UI.
+    """
+
+    type: Literal["object_ref"] = "object_ref"
+    # Named 'uri' not 'ref' to avoid collision with ObjectRef 'ref' attribute pattern
+    uri: str  # Object URI (e.g., weave:///entity/project/object/SavedView:digest)
+
+
+class SavedViewDefinitionItem(BaseModel):
+    """Embedded SavedView definition for display in call views.
+
+    Stores the view definition directly in the CallViewSpec rather than
+    requiring a separate SavedView object to be saved and referenced.
+    This simplifies the user workflow by eliminating the need to save
+    a SavedView object before attaching it to a call.
+    """
+
+    type: Literal["saved_view_definition"] = "saved_view_definition"
+    label: str  # Display label for the view
+    definition: SavedViewDefinition
+
+
+# Union of all view item types with discriminator for proper deserialization
+ViewItem = Annotated[
+    ContentViewItem | ObjectRefViewItem | SavedViewDefinitionItem,
+    Field(discriminator="type"),
+]
+
+
+class CallViewSpec(base_object_def.BaseObject):
+    """View specification attached to a call.
+
+    Contains a mapping of view names to their specifications. Each view
+    can be a single item or a list of items that will be rendered together.
+
+    The view spec is stored as a versioned object, enabling deduplication
+    when the same view configuration is used across multiple calls.
+
+    Examples:
+        >>> spec = CallViewSpec(
+        ...     views={
+        ...         "report": ContentViewItem(
+        ...             mimetype="text/markdown",
+        ...             data="IyBIZWxsbw==",  # base64 "# Hello"
+        ...         ),
+        ...     }
+        ... )
+    """
+
+    views: dict[str, ViewItem | list[ViewItem]] = Field(
+        default_factory=dict,
+        description="Mapping of view names to view item(s)",
+    )
+
+
+__all__ = [
+    "CallViewSpec",
+    "ContentViewItem",
+    "ObjectRefViewItem",
+    "SavedViewDefinitionItem",
+    "ViewItem",
+]

--- a/weave/trace_server/migrations/024_add_view_spec_ref.down.sql
+++ b/weave/trace_server/migrations/024_add_view_spec_ref.down.sql
@@ -1,0 +1,113 @@
+/*
+    Rollback view_spec_ref column from call tables.
+*/
+
+-- Rollback calls_complete_stats_view
+ALTER TABLE calls_complete_stats_view MODIFY QUERY
+SELECT
+    calls_complete.project_id,
+    calls_complete.id,
+    anySimpleState(calls_complete.trace_id) as trace_id,
+    anySimpleState(calls_complete.parent_id) as parent_id,
+    anySimpleState(calls_complete.op_name) as op_name,
+    anySimpleState(calls_complete.started_at) as started_at,
+    anySimpleState(calls_complete.ended_at) as ended_at,
+    anySimpleState(length(calls_complete.attributes_dump)) as attributes_size_bytes,
+    anySimpleState(length(calls_complete.inputs_dump)) as inputs_size_bytes,
+    anySimpleState(length(calls_complete.output_dump)) as output_size_bytes,
+    anySimpleState(length(calls_complete.summary_dump)) as summary_size_bytes,
+    anySimpleState(length(calls_complete.exception)) as exception_size_bytes,
+    anySimpleState(length(calls_complete.otel_dump)) as otel_size_bytes,
+    anySimpleState(calls_complete.wb_user_id) as wb_user_id,
+    anySimpleState(calls_complete.wb_run_id) as wb_run_id,
+    anySimpleState(calls_complete.wb_run_step) as wb_run_step,
+    anySimpleState(calls_complete.wb_run_step_end) as wb_run_step_end,
+    anySimpleState(calls_complete.thread_id) as thread_id,
+    anySimpleState(calls_complete.turn_id) as turn_id,
+    minSimpleState(calls_complete.created_at) as created_at,
+    maxSimpleState(calls_complete.updated_at) as updated_at,
+    argMaxState(calls_complete.display_name, calls_complete.created_at) as display_name
+FROM calls_complete
+GROUP BY
+    calls_complete.project_id,
+    calls_complete.id;
+
+-- Remove view_spec_ref from calls_complete_stats table
+ALTER TABLE calls_complete_stats
+    DROP COLUMN view_spec_ref;
+
+-- Rollback stats materialized view to remove view_spec_ref
+ALTER TABLE calls_merged_stats_view MODIFY QUERY
+SELECT
+    call_parts.project_id,
+    call_parts.id,
+    anySimpleState(call_parts.trace_id) as trace_id,
+    anySimpleState(call_parts.parent_id) as parent_id,
+    anySimpleState(call_parts.thread_id) as thread_id,
+    anySimpleState(call_parts.turn_id) as turn_id,
+    anySimpleState(call_parts.op_name) as op_name,
+    anySimpleState(call_parts.started_at) as started_at,
+    anySimpleState(length(call_parts.attributes_dump)) as attributes_size_bytes,
+    anySimpleState(length(call_parts.inputs_dump)) as inputs_size_bytes,
+    anySimpleState(call_parts.ended_at) as ended_at,
+    anySimpleState(length(call_parts.output_dump)) as output_size_bytes,
+    anySimpleState(length(call_parts.summary_dump)) as summary_size_bytes,
+    anySimpleState(length(call_parts.exception)) as exception_size_bytes,
+    anySimpleState(call_parts.wb_user_id) as wb_user_id,
+    anySimpleState(call_parts.wb_run_id) as wb_run_id,
+    anySimpleState(call_parts.wb_run_step) as wb_run_step,
+    anySimpleState(call_parts.wb_run_step_end) as wb_run_step_end,
+    anySimpleState(call_parts.deleted_at) as deleted_at,
+    maxSimpleState(call_parts.created_at) as updated_at,
+    argMaxState(call_parts.display_name, call_parts.created_at) as display_name,
+    anySimpleState(call_parts.otel_dump) as otel_dump
+FROM call_parts
+GROUP BY
+    call_parts.project_id,
+    call_parts.id;
+
+-- Remove view_spec_ref from stats table
+ALTER TABLE calls_merged_stats
+    DROP COLUMN view_spec_ref;
+
+-- Remove view_spec_ref from calls_complete table
+ALTER TABLE calls_complete
+    DROP COLUMN view_spec_ref;
+
+-- Rollback materialized view to remove view_spec_ref
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleState(wb_run_step) as wb_run_step,
+        anySimpleState(wb_run_step_end) as wb_run_step_end,
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(thread_id) as thread_id,
+        anySimpleState(turn_id) as turn_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        anySimpleState(deleted_at) as deleted_at,
+        argMaxState(display_name, call_parts.created_at) as display_name,
+        anySimpleState(coalesce(call_parts.started_at, call_parts.ended_at, call_parts.created_at)) as sortable_datetime,
+        anySimpleState(otel_dump) as otel_dump
+    FROM call_parts
+    GROUP BY project_id,
+        id;
+
+-- Remove view_spec_ref from aggregated calls table
+ALTER TABLE calls_merged
+    DROP COLUMN view_spec_ref;
+
+-- Remove view_spec_ref from raw call parts table
+ALTER TABLE call_parts
+    DROP COLUMN view_spec_ref;

--- a/weave/trace_server/migrations/024_add_view_spec_ref.up.sql
+++ b/weave/trace_server/migrations/024_add_view_spec_ref.up.sql
@@ -1,0 +1,123 @@
+/*
+    Add view_spec_ref column to call tables.
+
+    This column stores a reference to a CallViewSpec object that contains
+    view configurations attached to a call. The reference is a string in the
+    format: weave-trace-internal:///project_id/object/name:digest
+
+    The view_spec_ref is only set at call_end time, so we use anySimpleState
+    for aggregation (not argMaxState like display_name which can be updated).
+*/
+
+-- Add view_spec_ref to raw call parts table
+ALTER TABLE call_parts
+    ADD COLUMN view_spec_ref Nullable(String) DEFAULT NULL;
+
+-- Add view_spec_ref to aggregated calls table
+ALTER TABLE calls_merged
+    ADD COLUMN view_spec_ref SimpleAggregateFunction(any, Nullable(String));
+
+-- Update materialized view to include view_spec_ref
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleState(wb_run_step) as wb_run_step,
+        anySimpleState(wb_run_step_end) as wb_run_step_end,
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(thread_id) as thread_id,
+        anySimpleState(turn_id) as turn_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        anySimpleState(deleted_at) as deleted_at,
+        argMaxState(display_name, call_parts.created_at) as display_name,
+        anySimpleState(coalesce(call_parts.started_at, call_parts.ended_at, call_parts.created_at)) as sortable_datetime,
+        anySimpleState(otel_dump) as otel_dump,
+        anySimpleState(view_spec_ref) as view_spec_ref
+    FROM call_parts
+    GROUP BY project_id,
+        id;
+
+-- Add view_spec_ref to calls_complete table
+ALTER TABLE calls_complete
+    ADD COLUMN view_spec_ref Nullable(String) DEFAULT NULL;
+
+-- Add view_spec_ref to stats table
+ALTER TABLE calls_merged_stats
+    ADD COLUMN view_spec_ref SimpleAggregateFunction(any, Nullable(String));
+
+-- Update stats materialized view
+ALTER TABLE calls_merged_stats_view MODIFY QUERY
+SELECT
+    call_parts.project_id,
+    call_parts.id,
+    anySimpleState(call_parts.trace_id) as trace_id,
+    anySimpleState(call_parts.parent_id) as parent_id,
+    anySimpleState(call_parts.thread_id) as thread_id,
+    anySimpleState(call_parts.turn_id) as turn_id,
+    anySimpleState(call_parts.op_name) as op_name,
+    anySimpleState(call_parts.started_at) as started_at,
+    anySimpleState(length(call_parts.attributes_dump)) as attributes_size_bytes,
+    anySimpleState(length(call_parts.inputs_dump)) as inputs_size_bytes,
+    anySimpleState(call_parts.ended_at) as ended_at,
+    anySimpleState(length(call_parts.output_dump)) as output_size_bytes,
+    anySimpleState(length(call_parts.summary_dump)) as summary_size_bytes,
+    anySimpleState(length(call_parts.exception)) as exception_size_bytes,
+    anySimpleState(call_parts.wb_user_id) as wb_user_id,
+    anySimpleState(call_parts.wb_run_id) as wb_run_id,
+    anySimpleState(call_parts.wb_run_step) as wb_run_step,
+    anySimpleState(call_parts.wb_run_step_end) as wb_run_step_end,
+    anySimpleState(call_parts.deleted_at) as deleted_at,
+    maxSimpleState(call_parts.created_at) as updated_at,
+    argMaxState(call_parts.display_name, call_parts.created_at) as display_name,
+    anySimpleState(call_parts.otel_dump) as otel_dump,
+    anySimpleState(call_parts.view_spec_ref) as view_spec_ref
+FROM call_parts
+GROUP BY
+    call_parts.project_id,
+    call_parts.id;
+
+-- Add view_spec_ref to calls_complete_stats table
+ALTER TABLE calls_complete_stats
+    ADD COLUMN view_spec_ref SimpleAggregateFunction(any, Nullable(String));
+
+-- Update calls_complete_stats_view
+ALTER TABLE calls_complete_stats_view MODIFY QUERY
+SELECT
+    calls_complete.project_id,
+    calls_complete.id,
+    anySimpleState(calls_complete.trace_id) as trace_id,
+    anySimpleState(calls_complete.parent_id) as parent_id,
+    anySimpleState(calls_complete.op_name) as op_name,
+    anySimpleState(calls_complete.started_at) as started_at,
+    anySimpleState(calls_complete.ended_at) as ended_at,
+    anySimpleState(length(calls_complete.attributes_dump)) as attributes_size_bytes,
+    anySimpleState(length(calls_complete.inputs_dump)) as inputs_size_bytes,
+    anySimpleState(length(calls_complete.output_dump)) as output_size_bytes,
+    anySimpleState(length(calls_complete.summary_dump)) as summary_size_bytes,
+    anySimpleState(length(calls_complete.exception)) as exception_size_bytes,
+    anySimpleState(length(calls_complete.otel_dump)) as otel_size_bytes,
+    anySimpleState(calls_complete.wb_user_id) as wb_user_id,
+    anySimpleState(calls_complete.wb_run_id) as wb_run_id,
+    anySimpleState(calls_complete.wb_run_step) as wb_run_step,
+    anySimpleState(calls_complete.wb_run_step_end) as wb_run_step_end,
+    anySimpleState(calls_complete.thread_id) as thread_id,
+    anySimpleState(calls_complete.turn_id) as turn_id,
+    minSimpleState(calls_complete.created_at) as created_at,
+    maxSimpleState(calls_complete.updated_at) as updated_at,
+    argMaxState(calls_complete.display_name, calls_complete.created_at) as display_name,
+    anySimpleState(calls_complete.view_spec_ref) as view_spec_ref
+FROM calls_complete
+GROUP BY
+    calls_complete.project_id,
+    calls_complete.id;

--- a/weave/trace_server/object_creation_utils.py
+++ b/weave/trace_server/object_creation_utils.py
@@ -275,6 +275,7 @@ def build_evaluation_val(
     summarize_ref: str,
     class_name: str = "Evaluation",
     eval_attributes: dict[str, Any] | None = None,
+    on_complete: str | None = None,
 ) -> dict[str, Any]:
     """Build the value dictionary for an Evaluation object.
 
@@ -292,6 +293,7 @@ def build_evaluation_val(
         summarize_ref: Reference to the op implementing the summarize method
         class_name: The class name (defaults to "Evaluation" for base evaluations, or a custom name for subclasses)
         eval_attributes: Optional attributes for the evaluation
+        on_complete: Optional callback reference for post-evaluation actions
 
     Returns:
         Dictionary representing the evaluation object value
@@ -313,6 +315,7 @@ def build_evaluation_val(
         "evaluation_name": evaluation_name,
         "metadata": metadata,
         "preprocess_model_input": preprocess_model_input,
+        "on_complete": on_complete,
         "evaluate": evaluate_ref,
         "predict_and_score": predict_and_score_ref,
         "summarize": summarize_ref,

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -182,7 +182,8 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                 wb_run_step_end INTEGER,
                 deleted_at TEXT,
                 display_name TEXT,
-                otel_dump TEXT
+                otel_dump TEXT,
+                view_spec_ref TEXT
             )
         """
         )
@@ -324,7 +325,8 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                     output = ?,
                     output_refs = ?,
                     summary = ?,
-                    wb_run_step_end = ?
+                    wb_run_step_end = ?,
+                    view_spec_ref = ?
                 WHERE id = ?""",
                 (
                     req.end.ended_at.isoformat(),
@@ -335,6 +337,7 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                     ),
                     json.dumps(req.end.summary),
                     req.end.wb_run_step_end,
+                    req.end.view_spec_ref,
                     req.end.id,
                 ),
             )

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -127,6 +127,9 @@ class CallSchema(BaseModel):
     wb_run_step: int | None = None
     wb_run_step_end: int | None = None
 
+    # Reference to a CallViewSpec object containing view configurations
+    view_spec_ref: str | None = None
+
     deleted_at: datetime.datetime | None = None
 
     # Size of metadata storage for this call
@@ -197,6 +200,9 @@ class EndedCallSchemaForInsert(BaseModel):
     # WB Metadata
     wb_run_step_end: int | None = None
 
+    # Reference to a CallViewSpec object containing view configurations
+    view_spec_ref: str | None = None
+
     @field_serializer("summary")
     def serialize_typed_dicts(self, v: dict[str, Any]) -> dict[str, Any]:
         return dict(v)
@@ -251,6 +257,9 @@ class CompletedCallSchemaForInsert(BaseModel):
     wb_run_id: str | None = None
     wb_run_step: int | None = None
     wb_run_step_end: int | None = None
+
+    # Reference to a CallViewSpec object containing view configurations
+    view_spec_ref: str | None = None
 
     @field_serializer("attributes", "summary", when_used="unless-none")
     def serialize_typed_dicts(self, v: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

This consolidates the CallViewSpec feature for attaching rich views to calls, particularly useful for evaluation reports.

### Schema Changes
- Add `view_spec_ref` column to call schema for linking to view specifications

### CallViewSpec Types (3 item types)
- `ContentViewItem`: Rich content (HTML, markdown, images) with base64 encoding
- `ObjectRefViewItem`: References to any weave object/table by URI
- `SavedViewDefinitionItem`: Embedded table view configurations

### SDK Features
- `weave.set_view()` for attaching views to the current call
- SavedView definitions embedded directly in CallViewSpec (no separate save needed)
- Support for Content, strings, Tables, ObjectRefs, and SavedViews as view items

### Evaluation Integration
- `on_complete` callback for Evaluation class
- Create custom reports with charts, tables, and filtered views
- Filter SavedViews by trace_id, op name, and output fields

### SavedView Enhancements
- `filter_op()` method for filtering by operation name
- `add_filter()` for field-level filtering with operators (is, isNot, etc.)
- `set_columns()` for configuring visible columns
- Proper query serialization for trace filters

## Test Plan
- [ ] Run existing tests
- [ ] Test evaluation with custom report views
- [ ] Verify SavedView filtering works correctly