### PR TITLE
fix(weave): trace failed op argument binding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,11 @@ npm run test
 - Include meaningful error messages
 - Add error handling tests
 
+### Tracing Behavior
+
+- `@weave.op` should emit an error call span even when input argument binding fails (for example, unexpected keyword arguments that raise `OpCallError`).
+- For binding failures, traced inputs should preserve raw user-provided values (`kwargs` and positional args mapped best-effort, with fallback keys like `_arg0` for unnamed extras).
+
 ### Integration Testing
 
 - Since autopatching was removed from `weave.init()`, integration tests must explicitly patch their integrations

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -312,11 +312,39 @@ def _default_on_input_handler(func: Op, args: tuple, kwargs: dict) -> ProcessedI
     )
 
 
+def _raw_call_inputs_for_failed_binding(
+    func: Op, args: tuple[Any, ...], kwargs: dict[str, Any]
+) -> dict[str, Any]:
+    """Capture user-provided inputs without signature binding."""
+    inputs: dict[str, Any] = dict(kwargs)
+    sig = inspect.signature(func)
+    params = list(sig.parameters.values())
+
+    for index, value in enumerate(args):
+        fallback_name = f"_arg{index}"
+        input_name = fallback_name
+
+        if index < len(params):
+            param = params[index]
+            if param.kind in (
+                inspect.Parameter.POSITIONAL_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            ):
+                input_name = param.name
+
+        if input_name in inputs:
+            input_name = fallback_name
+        inputs[input_name] = value
+
+    return inputs
+
+
 def _create_call(
     func: Op,
     *args: Any,
     __weave: WeaveKwargs | None = None,
     use_stack: bool = True,
+    _inputs_override: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> Call:
     """Create a call object for the given op.
@@ -334,12 +362,15 @@ def _create_call(
     """
     client = weave_client_context.require_weave_client()
 
-    pargs = None
-    if func._on_input_handler is not None:
-        pargs = func._on_input_handler(func, args, kwargs)
-    if not pargs:
-        pargs = _default_on_input_handler(func, args, kwargs)
-    inputs_with_defaults = pargs.inputs
+    if _inputs_override is None:
+        pargs = None
+        if func._on_input_handler is not None:
+            pargs = func._on_input_handler(func, args, kwargs)
+        if not pargs:
+            pargs = _default_on_input_handler(func, args, kwargs)
+        inputs_with_defaults = pargs.inputs
+    else:
+        inputs_with_defaults = dict(_inputs_override)
 
     # This should probably be configurable, but for now we redact the api_key
     if "api_key" in inputs_with_defaults:
@@ -370,6 +401,26 @@ def _create_call(
         use_stack=use_stack,
         _call_id_override=preferred_call_id,
     )
+
+
+def _record_call_for_input_error(
+    op: Op,
+    error: OpCallError,
+    __weave: WeaveKwargs,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+) -> None:
+    """Best-effort tracing for input binding failures."""
+    try:
+        call = _create_call(
+            op,
+            __weave=__weave,
+            _inputs_override=_raw_call_inputs_for_failed_binding(op, args, kwargs),
+        )
+        client = weave_client_context.require_weave_client()
+        client.finish_call(call, exception=error, op=op)
+    except Exception:
+        log_once(logger.error, CALL_CREATE_MSG.format(traceback.format_exc()))
 
 
 def is_tracing_setting_disabled() -> bool:
@@ -456,6 +507,7 @@ def _call_sync_func(
     try:
         call = _create_call(op, *args, __weave=__weave, **kwargs)
     except OpCallError as e:
+        _record_call_for_input_error(op, e, __weave, args, kwargs)
         raise e
     except Exception as e:
         if get_raise_on_captured_errors():
@@ -599,6 +651,7 @@ async def _call_async_func(
     try:
         call = _create_call(op, *args, __weave=__weave, **kwargs)
     except OpCallError as e:
+        _record_call_for_input_error(op, e, __weave, args, kwargs)
         raise e
     except Exception as e:
         if get_raise_on_captured_errors():
@@ -731,7 +784,8 @@ def _call_sync_gen(
         # For generators, use_stack=False because we push when iteration starts,
         # not when the call is created. This avoids double-pushing.
         call = _create_call(op, *args, __weave=__weave, use_stack=False, **kwargs)
-    except OpCallError:
+    except OpCallError as e:
+        _record_call_for_input_error(op, e, __weave, args, kwargs)
         raise
     except Exception:
         if get_raise_on_captured_errors():
@@ -943,7 +997,8 @@ async def _call_async_gen(
         # For generators, use_stack=False because we push when iteration starts,
         # not when the call is created. This avoids double-pushing.
         call = _create_call(op, *args, __weave=__weave, use_stack=False, **kwargs)
-    except OpCallError:
+    except OpCallError as e:
+        _record_call_for_input_error(op, e, __weave, args, kwargs)
         raise
     except Exception:
         if get_raise_on_captured_errors():


### PR DESCRIPTION
This is one of a series of pr's I am producing from different Coding agents for comparison for fixing the same bug: Fixes [WB-30436](https://wandb.atlassian.net/browse/WB-30436)

## Agent
Conductor: OpenAi GPT-5.3-Codex Thinking: High

## Comparison Prs:
#6083 

## Summary

Fixes [WB-30436](https://wandb.atlassian.net/browse/WB-30436)

- trace `OpCallError` argument-binding failures by creating and finishing an error call span
- preserve raw user-provided inputs when binding fails so bad tool arguments remain visible in traces
- add a regression test that asserts incorrect kwargs still produce an error call
- document this tracing behavior in `AGENTS.md`

## Testing
- `python -m compileall weave/trace/op.py tests/trace/test_op_decorator_behaviour.py`
- could not run `nox`/`pytest` in this workspace because those modules are not installed in the active Python environment

## Notes
- no user-facing API changes; behavior only affects internal tracing for failed op invocations


[WB-30436]: https://wandb.atlassian.net/browse/WB-30436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-30436]: https://wandb.atlassian.net/browse/WB-30436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ