### PR TITLE
fix(weave): create trace spans for argument binding failures in weave.op

### DIFF
--- a/tests/trace/test_op_decorator_behaviour.py
+++ b/tests/trace/test_op_decorator_behaviour.py
@@ -142,6 +142,12 @@ def test_sync_method_call(client, weave_obj, py_obj):
     with pytest.raises(OpCallError):
         res2, call2 = py_obj.method.call(1)
 
+    # Verify a trace span was created for the failed call
+    calls = list(client.get_calls())
+    error_calls = [c for c in calls if c.exception is not None]
+    assert len(error_calls) == 1
+    assert "OpCallError" in error_calls[0].exception or "Error calling" in error_calls[0].exception
+
 
 @pytest.mark.asyncio
 async def test_async_method(client, weave_obj, py_obj):
@@ -176,6 +182,12 @@ async def test_async_method_call(client, weave_obj, py_obj):
 
     with pytest.raises(OpCallError):
         res2, call2 = await py_obj.amethod.call(1)
+
+    # Verify a trace span was created for the failed call
+    calls = list(client.get_calls())
+    error_calls = [c for c in calls if c.exception is not None]
+    assert len(error_calls) == 1
+    assert "OpCallError" in error_calls[0].exception or "Error calling" in error_calls[0].exception
 
 
 def test_sync_func_patching_passes_inspection(func):
@@ -489,3 +501,127 @@ def test_op_kind_and_color_attributes():
     result = setup_dunder_weave_dict(llm_func)
     assert result["attributes"]["weave"]["kind"] == "llm"
     assert result["attributes"]["weave"]["color"] == "green"
+
+
+def test_sync_func_wrong_kwargs_creates_span(client):
+    """Test that calling a sync op with wrong kwargs creates a trace span with error."""
+
+    @op
+    def my_func(a: int, b: str) -> str:
+        return f"{a}-{b}"
+
+    with pytest.raises(OpCallError):
+        my_func(wrong_param="hello")
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    assert calls[0].exception is not None
+    assert "Error calling" in calls[0].exception
+    assert calls[0].inputs == {"wrong_param": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_async_func_wrong_kwargs_creates_span(client):
+    """Test that calling an async op with wrong kwargs creates a trace span with error."""
+
+    @op
+    async def my_async_func(a: int, b: str) -> str:
+        return f"{a}-{b}"
+
+    with pytest.raises(OpCallError):
+        await my_async_func(wrong_param="hello")
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    assert calls[0].exception is not None
+    assert "Error calling" in calls[0].exception
+    assert calls[0].inputs == {"wrong_param": "hello"}
+
+
+def test_sync_gen_wrong_kwargs_creates_span(client):
+    """Test that calling a sync generator op with wrong kwargs creates a trace span."""
+
+    @op
+    def my_gen(a: int) -> int:
+        yield a
+
+    with pytest.raises(OpCallError):
+        my_gen(wrong_param="hello")
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    assert calls[0].exception is not None
+    assert "Error calling" in calls[0].exception
+    assert calls[0].inputs == {"wrong_param": "hello"}
+
+
+@pytest.mark.asyncio
+async def test_async_gen_wrong_kwargs_creates_span(client):
+    """Test that calling an async generator op with wrong kwargs creates a trace span."""
+
+    @op
+    async def my_async_gen(a: int):
+        yield a
+
+    with pytest.raises(OpCallError):
+        async for _ in my_async_gen(wrong_param="hello"):
+            pass
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    assert calls[0].exception is not None
+    assert "Error calling" in calls[0].exception
+    assert calls[0].inputs == {"wrong_param": "hello"}
+
+
+def test_bind_error_span_records_exception_details(client):
+    """Test that the span created for a bind error records the exception details."""
+
+    @op
+    def add(x: int, y: int) -> int:
+        return x + y
+
+    with pytest.raises(OpCallError):
+        add(x=1, z=2)  # 'z' is wrong, should be 'y'
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    call = calls[0]
+    assert call.exception is not None
+    assert "z" in call.exception or "unexpected keyword" in call.exception
+    assert call.inputs == {"x": 1, "z": 2}
+    assert call.output is None
+
+
+def test_bind_error_with_positional_args_creates_span(client):
+    """Test that positional args are captured in the span when binding fails."""
+
+    @op
+    def my_func(a: int, b: str) -> str:
+        return f"{a}-{b}"
+
+    with pytest.raises(OpCallError):
+        my_func(1, 2, 3)  # too many positional args
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    assert calls[0].exception is not None
+    assert "arg_0" in calls[0].inputs
+    assert calls[0].inputs["arg_0"] == 1
+
+
+def test_bind_error_with_weave_attributes_creates_span(client):
+    """Test that weave attributes are included in the span when binding fails."""
+
+    @op
+    def my_func(a: int) -> int:
+        return a
+
+    with weave.attributes({"env": "test"}):
+        with pytest.raises(OpCallError):
+            my_func(wrong=1)
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    assert calls[0].exception is not None
+    assert calls[0].inputs == {"wrong": 1}

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -372,6 +372,53 @@ def _create_call(
     )
 
 
+def _handle_op_call_error(
+    op: Op,
+    e: OpCallError,
+    args: tuple,
+    kwargs: dict,
+    weave_kwargs: WeaveKwargs | None = None,
+    use_stack: bool = True,
+) -> None:
+    """Create and finish a trace span for an op that failed argument binding."""
+    try:
+        client = weave_client_context.require_weave_client()
+        parent_call = call_context.get_current_call()
+
+        raw_inputs = {f"arg_{i}": a for i, a in enumerate(args)}
+        raw_inputs.update(kwargs)
+
+        call_time_display_name = (
+            weave_kwargs.get("display_name") if weave_kwargs else None
+        )
+        call_attrs = weave_kwargs.get("attributes") if weave_kwargs else None
+
+        from weave.trace.serialization.serialize import dictify
+
+        attributes = dictify(call_attributes.get())
+        if call_attrs is not None:
+            attributes = {**attributes, **call_attrs}
+
+        preferred_call_id = weave_kwargs.get("call_id") if weave_kwargs else None
+
+        error_call = client.create_call(
+            op,
+            raw_inputs,
+            parent_call,
+            display_name=call_time_display_name or op.call_display_name,
+            attributes=attributes,
+            use_stack=use_stack,
+            _call_id_override=preferred_call_id,
+        )
+        client.finish_call(error_call, None, e, op=op)
+
+        current_call = call_context.get_current_call()
+        if current_call and current_call.id == error_call.id:
+            call_context.pop_call(error_call.id)
+    except Exception:
+        logger.debug("Failed to create span for OpCallError", exc_info=True)
+
+
 def is_tracing_setting_disabled() -> bool:
     if settings.should_disable_weave():
         return True
@@ -456,7 +503,8 @@ def _call_sync_func(
     try:
         call = _create_call(op, *args, __weave=__weave, **kwargs)
     except OpCallError as e:
-        raise e
+        _handle_op_call_error(op, e, args, kwargs, weave_kwargs=__weave)
+        raise
     except Exception as e:
         if get_raise_on_captured_errors():
             raise
@@ -599,7 +647,8 @@ async def _call_async_func(
     try:
         call = _create_call(op, *args, __weave=__weave, **kwargs)
     except OpCallError as e:
-        raise e
+        _handle_op_call_error(op, e, args, kwargs, weave_kwargs=__weave)
+        raise
     except Exception as e:
         if get_raise_on_captured_errors():
             raise
@@ -731,7 +780,10 @@ def _call_sync_gen(
         # For generators, use_stack=False because we push when iteration starts,
         # not when the call is created. This avoids double-pushing.
         call = _create_call(op, *args, __weave=__weave, use_stack=False, **kwargs)
-    except OpCallError:
+    except OpCallError as e:
+        _handle_op_call_error(
+            op, e, args, kwargs, weave_kwargs=__weave, use_stack=False
+        )
         raise
     except Exception:
         if get_raise_on_captured_errors():
@@ -943,7 +995,10 @@ async def _call_async_gen(
         # For generators, use_stack=False because we push when iteration starts,
         # not when the call is created. This avoids double-pushing.
         call = _create_call(op, *args, __weave=__weave, use_stack=False, **kwargs)
-    except OpCallError:
+    except OpCallError as e:
+        _handle_op_call_error(
+            op, e, args, kwargs, weave_kwargs=__weave, use_stack=False
+        )
         raise
     except Exception:
         if get_raise_on_captured_errors():


### PR DESCRIPTION
This is one of a series of pr's I am producing from different Coding agents for comparison for fixing the same bug: Fixes [WB-30436](https://wandb.atlassian.net/browse/WB-30436)

## Agent
Conductor: Claude Opus 4.6 Thinking w/plan

## Comparison PRs
#6084 

## Summary

Fixes [WB-30436](https://wandb.atlassian.net/browse/WB-30436)

- When a `@weave.op` decorated function is called with wrong arguments (e.g., LLM sends wrong parameter names), `sig.bind()` fails with `TypeError` which gets wrapped in `OpCallError`. Previously this error was raised **before** a Call object was created, so no trace span appeared in the UI, making debugging agent behavior difficult.
- Added a `_handle_op_call_error` helper that catches `OpCallError` in all 4 `_call_*` functions (sync, async, sync gen, async gen), creates a Call with the raw kwargs as inputs, finishes it with the error, then re-raises. The helper is wrapped in try/except so tracing errors never mask the original error.
- Updated existing tests and added 5 new tests covering all function types and error detail recording.

## Test plan
- [x] All 33 tests in `tests/trace/test_op_decorator_behaviour.py` pass
- [x] All 208 broader op tests pass (`tests/trace/ -k "op"`)
- [x] `OpCallError` is still raised to the caller
- [x] Trace span shows raw inputs and the exception
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WB-30436]: https://wandb.atlassian.net/browse/WB-30436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ