### PR TITLE
fix(weave): OOM error during costs query

### DIFF
--- a/tests/trace_server/query_builder/test_costs_query.py
+++ b/tests/trace_server/query_builder/test_costs_query.py
@@ -100,9 +100,9 @@ def test_query_light_column_with_costs() -> None:
                     OR (llm_token_prices.pricing_level_id = {pb_4:String}))) )
             -- Final Select, which just selects the correct fields, and adds a costs object
             SELECT
-                id,
-                started_at,
-                if( any(llm_id) = 'weave_dummy_llm_id' or any(llm_token_prices.id) == '',
+                ranked_prices.id,
+                ranked_prices.started_at,
+                if( any(ranked_prices.llm_id) = 'weave_dummy_llm_id' or any(llm_token_prices.id) == '',
                 any(all_calls.summary_dump),
                 concat(
                     left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1),
@@ -113,23 +113,23 @@ def test_query_light_column_with_costs() -> None:
                             arrayStringConcat(
                                 groupUniqArray(
                                     concat(
-                                        '"', toString(llm_id), '":{',
-                                        '"prompt_tokens":', toString(prompt_tokens), ',',
-                                        '"completion_tokens":', toString(completion_tokens), ',',
-                                        '"requests":', toString(requests), ',',
-                                        '"total_tokens":', toString(total_tokens), ',',
-                                        '"prompt_token_cost":', toString(prompt_token_cost), ',',
-                                        '"completion_token_cost":', toString(completion_token_cost), ',',
-                                        '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',',
-                                        '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
-                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit),  '",',
-                                        '"completion_token_cost_unit":"', toString(completion_token_cost_unit),  '",',
-                                        '"effective_date":"', toString(effective_date),  '",',
-                                        '"provider_id":"', toString(provider_id),  '",',
-                                        '"pricing_level":"', toString(pricing_level),  '",',
-                                        '"pricing_level_id":"', toString(pricing_level_id),  '",',
-                                        '"created_by":"', toString(created_by),  '",',
-                                        '"created_at":"', toString(created_at),
+                                        '"', toString(ranked_prices.llm_id), '":{',
+                                        '"prompt_tokens":', toString(ranked_prices.prompt_tokens), ',',
+                                        '"completion_tokens":', toString(ranked_prices.completion_tokens), ',',
+                                        '"requests":', toString(ranked_prices.requests), ',',
+                                        '"total_tokens":', toString(ranked_prices.total_tokens), ',',
+                                        '"prompt_token_cost":', toString(ranked_prices.prompt_token_cost), ',',
+                                        '"completion_token_cost":', toString(ranked_prices.completion_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString(ranked_prices.prompt_tokens * ranked_prices.prompt_token_cost), ',',
+                                        '"completion_tokens_total_cost":', toString(ranked_prices.completion_tokens * ranked_prices.completion_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(ranked_prices.prompt_token_cost_unit),  '",',
+                                        '"completion_token_cost_unit":"', toString(ranked_prices.completion_token_cost_unit),  '",',
+                                        '"effective_date":"', toString(ranked_prices.effective_date),  '",',
+                                        '"provider_id":"', toString(ranked_prices.provider_id),  '",',
+                                        '"pricing_level":"', toString(ranked_prices.pricing_level),  '",',
+                                        '"pricing_level_id":"', toString(ranked_prices.pricing_level_id),  '",',
+                                        '"created_by":"', toString(ranked_prices.created_by),  '",',
+                                        '"created_at":"', toString(ranked_prices.created_at),
                                     '"}'
                                     )
                                 ), ','
@@ -141,7 +141,7 @@ def test_query_light_column_with_costs() -> None:
             FROM ranked_prices
             JOIN all_calls ON ranked_prices.id = all_calls.id
             WHERE (rank = {pb_5:UInt64})
-            GROUP BY id, started_at
+            GROUP BY ranked_prices.id, ranked_prices.started_at
         """,
         {
             "pb_0": ["a", "b"],
@@ -238,17 +238,17 @@ def test_query_with_costs_and_attributes_order() -> None:
                                             AND ((llm_token_prices.pricing_level_id = {pb_1:String})
                                                  OR (llm_token_prices.pricing_level_id = {pb_2:String})
                                                  OR (llm_token_prices.pricing_level_id = {pb_3:String})))) -- Final Select, which just selects the correct fields, and adds a costs object
-        SELECT id,
-               started_at,
-               attributes_dump,
-               if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(all_calls.summary_dump), concat(left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }') , '}')) AS summary_dump
+        SELECT ranked_prices.id,
+               ranked_prices.started_at,
+               ranked_prices.attributes_dump,
+               if(any(ranked_prices.llm_id) = 'weave_dummy_llm_id'
+                  or any(llm_token_prices.id) == '', any(all_calls.summary_dump), concat(left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(ranked_prices.llm_id), '":{', '"prompt_tokens":', toString(ranked_prices.prompt_tokens), ',', '"completion_tokens":', toString(ranked_prices.completion_tokens), ',', '"requests":', toString(ranked_prices.requests), ',', '"total_tokens":', toString(ranked_prices.total_tokens), ',', '"prompt_token_cost":', toString(ranked_prices.prompt_token_cost), ',', '"completion_token_cost":', toString(ranked_prices.completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(ranked_prices.prompt_tokens * ranked_prices.prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(ranked_prices.completion_tokens * ranked_prices.completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(ranked_prices.prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(ranked_prices.completion_token_cost_unit), '",', '"effective_date":"', toString(ranked_prices.effective_date), '",', '"provider_id":"', toString(ranked_prices.provider_id), '",', '"pricing_level":"', toString(ranked_prices.pricing_level), '",', '"pricing_level_id":"', toString(ranked_prices.pricing_level_id), '",', '"created_by":"', toString(ranked_prices.created_by), '",', '"created_at":"', toString(ranked_prices.created_at), '"}')), ','), '} }') , '}')) AS summary_dump
         FROM ranked_prices
         JOIN all_calls ON ranked_prices.id = all_calls.id
         WHERE (rank = {pb_4:UInt64})
-        GROUP BY id,
-                 started_at,
-                 attributes_dump
+        GROUP BY ranked_prices.id,
+                 ranked_prices.started_at,
+                 ranked_prices.attributes_dump
             ORDER BY (NOT (JSONType(any(ranked_prices.attributes_dump)) = 'Null'
                            OR JSONType(any(ranked_prices.attributes_dump)) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(ranked_prices.attributes_dump), '$'), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(ranked_prices.attributes_dump), '$'), 'null'), '')) ASC
             """,
@@ -348,16 +348,16 @@ def test_query_with_costs_and_feedback_order() -> None:
                                             AND ((llm_token_prices.pricing_level_id = {pb_5:String})
                                                  OR (llm_token_prices.pricing_level_id = {pb_6:String})
                                                  OR (llm_token_prices.pricing_level_id = {pb_7:String})))) -- Final Select, which just selects the correct fields, and adds a costs object
-        SELECT id,
-               started_at,
-               if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(all_calls.summary_dump), concat(left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
+        SELECT ranked_prices.id,
+               ranked_prices.started_at,
+               if(any(ranked_prices.llm_id) = 'weave_dummy_llm_id'
+                  or any(llm_token_prices.id) == '', any(all_calls.summary_dump), concat(left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(ranked_prices.llm_id), '":{', '"prompt_tokens":', toString(ranked_prices.prompt_tokens), ',', '"completion_tokens":', toString(ranked_prices.completion_tokens), ',', '"requests":', toString(ranked_prices.requests), ',', '"total_tokens":', toString(ranked_prices.total_tokens), ',', '"prompt_token_cost":', toString(ranked_prices.prompt_token_cost), ',', '"completion_token_cost":', toString(ranked_prices.completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(ranked_prices.prompt_tokens * ranked_prices.prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(ranked_prices.completion_tokens * ranked_prices.completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(ranked_prices.prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(ranked_prices.completion_token_cost_unit), '",', '"effective_date":"', toString(ranked_prices.effective_date), '",', '"provider_id":"', toString(ranked_prices.provider_id), '",', '"pricing_level":"', toString(ranked_prices.pricing_level), '",', '"pricing_level_id":"', toString(ranked_prices.pricing_level_id), '",', '"created_by":"', toString(ranked_prices.created_by), '",', '"created_at":"', toString(ranked_prices.created_at), '"}')), ','), '} }'), '}')) AS summary_dump
         FROM ranked_prices
         JOIN all_calls ON ranked_prices.id = all_calls.id
         LEFT JOIN (SELECT * FROM feedback WHERE feedback.project_id = {pb_4:String} ) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_4:String}, '/call/', ranked_prices.id))
         WHERE (rank = {pb_8:UInt64})
-        GROUP BY id,
-                 started_at
+        GROUP BY ranked_prices.id,
+                 ranked_prices.started_at
         ORDER BY (NOT (JSONType(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_1:String}, {pb_2:String}) = 'Null'
                        OR JSONType(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_1:String}, {pb_2:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_3:String}), 'null'), '')) DESC, toString(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_3:String}), 'null'), '')) DESC
         """,
@@ -463,17 +463,17 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
                                             AND ((llm_token_prices.pricing_level_id = {pb_3:String})
                                                  OR (llm_token_prices.pricing_level_id = {pb_4:String})
                                                  OR (llm_token_prices.pricing_level_id = {pb_5:String})))) -- Final Select, which just selects the correct fields, and adds a costs object
-        SELECT id,
-               started_at,
-               attributes_dump,
-               if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(all_calls.summary_dump), concat(left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }') , '}')) AS summary_dump
+        SELECT ranked_prices.id,
+               ranked_prices.started_at,
+               ranked_prices.attributes_dump,
+               if(any(ranked_prices.llm_id) = 'weave_dummy_llm_id'
+                  or any(llm_token_prices.id) == '', any(all_calls.summary_dump), concat(left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(ranked_prices.llm_id), '":{', '"prompt_tokens":', toString(ranked_prices.prompt_tokens), ',', '"completion_tokens":', toString(ranked_prices.completion_tokens), ',', '"requests":', toString(ranked_prices.requests), ',', '"total_tokens":', toString(ranked_prices.total_tokens), ',', '"prompt_token_cost":', toString(ranked_prices.prompt_token_cost), ',', '"completion_token_cost":', toString(ranked_prices.completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(ranked_prices.prompt_tokens * ranked_prices.prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(ranked_prices.completion_tokens * ranked_prices.completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(ranked_prices.prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(ranked_prices.completion_token_cost_unit), '",', '"effective_date":"', toString(ranked_prices.effective_date), '",', '"provider_id":"', toString(ranked_prices.provider_id), '",', '"pricing_level":"', toString(ranked_prices.pricing_level), '",', '"pricing_level_id":"', toString(ranked_prices.pricing_level_id), '",', '"created_by":"', toString(ranked_prices.created_by), '",', '"created_at":"', toString(ranked_prices.created_at), '"}')), ','), '} }') , '}')) AS summary_dump
         FROM ranked_prices
         JOIN all_calls ON ranked_prices.id = all_calls.id
         WHERE (rank = {pb_6:UInt64})
-        GROUP BY id,
-                 started_at,
-                 attributes_dump
+        GROUP BY ranked_prices.id,
+                 ranked_prices.started_at,
+                 ranked_prices.attributes_dump
         ORDER BY (NOT (JSONType(any(ranked_prices.attributes_dump), {pb_0:String}) = 'Null'
                        OR JSONType(any(ranked_prices.attributes_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(ranked_prices.attributes_dump), {pb_1:String}), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(ranked_prices.attributes_dump), {pb_1:String}), 'null'), '')) ASC
         """,

--- a/tests/trace_server/query_builder/test_costs_query.py
+++ b/tests/trace_server/query_builder/test_costs_query.py
@@ -45,7 +45,8 @@ def test_query_light_column_with_costs() -> None:
             llm_usage AS (
                 -- From the all_calls we get the usage data for LLMs
                 SELECT
-                    *,
+                    id,
+                    started_at,
                     ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                     arrayJoin(
                         if(
@@ -102,9 +103,9 @@ def test_query_light_column_with_costs() -> None:
                 id,
                 started_at,
                 if( any(llm_id) = 'weave_dummy_llm_id' or any(llm_token_prices.id) == '',
-                any(summary_dump),
+                any(all_calls.summary_dump),
                 concat(
-                    left(any(summary_dump), length(any(summary_dump)) - 1),
+                    left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1),
                     ',"weave":{',
                         '"costs":',
                         concat(
@@ -138,6 +139,7 @@ def test_query_light_column_with_costs() -> None:
                     '}' )
                 ) AS summary_dump
             FROM ranked_prices
+            JOIN all_calls ON ranked_prices.id = all_calls.id
             WHERE (rank = {pb_5:UInt64})
             GROUP BY id, started_at
         """,
@@ -192,7 +194,9 @@ def test_query_with_costs_and_attributes_order() -> None:
                             OR JSONType(any(calls_merged.attributes_dump)) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC),
              llm_usage AS
             (-- From the all_calls we get the usage data for LLMs
-             SELECT *,
+             SELECT id,
+                    started_at,
+                    attributes_dump,
                     ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                     arrayJoin(if(usage_raw != ''
                                  and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
@@ -238,8 +242,9 @@ def test_query_with_costs_and_attributes_order() -> None:
                started_at,
                attributes_dump,
                if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }') , '}')) AS summary_dump
+                  or any(llm_token_prices.id) == '', any(all_calls.summary_dump), concat(left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }') , '}')) AS summary_dump
         FROM ranked_prices
+        JOIN all_calls ON ranked_prices.id = all_calls.id
         WHERE (rank = {pb_4:UInt64})
         GROUP BY id,
                  started_at,
@@ -300,7 +305,8 @@ def test_query_with_costs_and_feedback_order() -> None:
                             OR JSONType(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_1:String}, {pb_2:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_3:String}), 'null'), '')) DESC, toString(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_3:String}), 'null'), '')) DESC),
              llm_usage AS
             (-- From the all_calls we get the usage data for LLMs
-             SELECT *,
+             SELECT id,
+                    started_at,
                     ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                     arrayJoin(if(usage_raw != ''
                                  and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
@@ -345,8 +351,9 @@ def test_query_with_costs_and_feedback_order() -> None:
         SELECT id,
                started_at,
                if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
+                  or any(llm_token_prices.id) == '', any(all_calls.summary_dump), concat(left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
         FROM ranked_prices
+        JOIN all_calls ON ranked_prices.id = all_calls.id
         LEFT JOIN (SELECT * FROM feedback WHERE feedback.project_id = {pb_4:String} ) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_4:String}, '/call/', ranked_prices.id))
         WHERE (rank = {pb_8:UInt64})
         GROUP BY id,
@@ -412,7 +419,9 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
                                 OR JSONType(any(calls_merged.attributes_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')) ASC),
              llm_usage AS
             (-- From the all_calls we get the usage data for LLMs
-             SELECT *,
+             SELECT id,
+                    started_at,
+                    attributes_dump,
                     ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                     arrayJoin(if(usage_raw != ''
                                  and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
@@ -458,8 +467,9 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
                started_at,
                attributes_dump,
                if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }') , '}')) AS summary_dump
+                  or any(llm_token_prices.id) == '', any(all_calls.summary_dump), concat(left(any(all_calls.summary_dump), length(any(all_calls.summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }') , '}')) AS summary_dump
         FROM ranked_prices
+        JOIN all_calls ON ranked_prices.id = all_calls.id
         WHERE (rank = {pb_6:UInt64})
         GROUP BY id,
                  started_at,

--- a/weave/trace_server/token_costs.py
+++ b/weave/trace_server/token_costs.py
@@ -185,8 +185,14 @@ def get_llm_usage(
     # carrying it through row-multiplying CTEs (arrayJoin + LEFT JOIN).
     # summary_dump is still read from the source table for usage_raw extraction,
     # but not included in the output columns.
+    # Also filter out fields that aren't in calls_merged (e.g. total_storage_size_bytes
+    # which comes from optional JOINs and doesn't exist in this CTE).
     if select_fields is not None:
-        llm_fields = [f for f in select_fields if f != "summary_dump"]
+        valid_columns = {col.name for col in get_calls_merged_columns()}
+        llm_fields = [
+            f for f in select_fields
+            if f != "summary_dump" and f in valid_columns
+        ]
         # Ensure id and started_at are always present (needed by downstream CTEs)
         for required in ("id", "started_at"):
             if required not in llm_fields:
@@ -389,19 +395,26 @@ def get_ranked_prices(
 """
 
 
-def _build_cost_summary_dump_snippet(all_calls_alias: str | None = None) -> str:
+def _build_cost_summary_dump_snippet(
+    all_calls_alias: str | None = None,
+    prices_alias: str = "ranked_prices",
+) -> str:
     """Build the SQL snippet for adding costs to summary_dump.
 
     Args:
         all_calls_alias: When provided, qualifies summary_dump references with this
             alias (e.g. "all_calls.summary_dump") so it reads from the original
             all_calls CTE rather than from ranked_prices (which no longer carries it).
+        prices_alias: Table alias for qualifying cost/usage field references to avoid
+            ambiguity when other tables (e.g. feedback) are joined. Defaults to
+            "ranked_prices".
 
     Returns:
         SQL expression for the summary_dump field with costs
     """
     # Build the qualified reference to summary_dump
     sd = f"{all_calls_alias}.summary_dump" if all_calls_alias else "summary_dump"
+    p = prices_alias  # shorthand for qualifying fields
 
     # These two objects are used to construct the costs object
     cost_string_fields = [
@@ -425,20 +438,20 @@ def _build_cost_summary_dump_snippet(all_calls_alias: str | None = None) -> str:
     numeric_fields_str = " ".join(
         [
             *[
-                f""" '"{field}":', toString({field}), ',', """
+                f""" '"{field}":', toString({p}.{field}), ',', """
                 for field in cost_numeric_fields
             ],
             # These numeric fields are derived or mapped to another name
-            """
-            '"prompt_token_cost":', toString(prompt_token_cost), ',',
-            '"completion_token_cost":', toString(completion_token_cost), ',',
-            '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',',
-            '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+            f"""
+            '"prompt_token_cost":', toString({p}.prompt_token_cost), ',',
+            '"completion_token_cost":', toString({p}.completion_token_cost), ',',
+            '"prompt_tokens_total_cost":', toString({p}.prompt_tokens * {p}.prompt_token_cost), ',',
+            '"completion_tokens_total_cost":', toString({p}.completion_tokens * {p}.completion_token_cost), ',',
         """,
         ]
     )
     string_fields_str = """ '",', """.join(
-        [f""" '"{field}":"', toString({field}), """ for field in cost_string_fields]
+        [f""" '"{field}":"', toString({p}.{field}), """ for field in cost_string_fields]
     )
 
     cost_snippet = f"""
@@ -449,7 +462,7 @@ def _build_cost_summary_dump_snippet(all_calls_alias: str | None = None) -> str:
             arrayStringConcat(
                 groupUniqArray(
                     concat(
-                        '"', toString(llm_id), '":{{',
+                        '"', toString({p}.llm_id), '":{{',
                         {numeric_fields_str}
                         {string_fields_str}
                     '"}}'
@@ -462,7 +475,7 @@ def _build_cost_summary_dump_snippet(all_calls_alias: str | None = None) -> str:
 
     # If no cost was found dont add a costs object
     return f"""
-    if( any(llm_id) = '{DUMMY_LLM_ID}' or any(llm_token_prices.id) == '',
+    if( any({p}.llm_id) = '{DUMMY_LLM_ID}' or any(llm_token_prices.id) == '',
     any({sd}),
     concat(
         left(any({sd}), length(any({sd})) - 1),
@@ -612,7 +625,21 @@ def get_cost_final_select(
         Complete SQL SELECT statement
     """
     final_fields = _prepare_final_select_fields(select_fields, order_fields)
-    fields_str = ", ".join(final_fields)
+
+    # When joining all_calls back, qualify field names to avoid ambiguity.
+    # Fields that exist in calls_merged flow through ranked_prices; fields from
+    # optional JOINs (e.g. total_storage_size_bytes) only exist in all_calls.
+    if all_calls_alias:
+        calls_merged_field_names = {col.name for col in get_calls_merged_columns()}
+        qualified_fields = []
+        for f in final_fields:
+            if f in calls_merged_field_names:
+                qualified_fields.append(f"ranked_prices.{f}")
+            else:
+                qualified_fields.append(f"{all_calls_alias}.{f}")
+    else:
+        qualified_fields = final_fields
+    fields_str = ", ".join(qualified_fields)
 
     # Build SELECT clause with cost calculation
     summary_dump = _build_cost_summary_dump_snippet(all_calls_alias=all_calls_alias)
@@ -632,7 +659,7 @@ def get_cost_final_select(
         feedback_join = "\n" + _build_feedback_join(pb, project_id, "ranked_prices")
 
     where_clause = f"WHERE (rank = {{{pb.add_param(1)}:UInt64}})"
-    group_by = f"GROUP BY {', '.join(final_fields)}"
+    group_by = f"GROUP BY {', '.join(qualified_fields)}"
     order_by = ""
     if order_fields:
         order_parts = [of.as_sql(pb, "ranked_prices") for of in order_fields]


### PR DESCRIPTION
## Description

- Fixes WB-31150

The costs query caused OOM errors because summary_dump was duplicated through llm_usage via arrayJoin and ranked_prices via LEFT JOIN

This excludes summary_dump from the llm_usage output and joined it back from all_calls in the final SELECT where it's only needed once per call.
