### PR TITLE
feat(weave): Implement client-side mutation-tracking API

### DIFF
--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -138,6 +138,10 @@ class TableRef(Ref):
 
 @dataclass(frozen=True)
 class RefWithExtra(Ref):
+    @property
+    def extra(self) -> tuple[str, ...]:
+        raise NotImplementedError
+
     def with_extra(self, extra: tuple[str | Future[str], ...]) -> Self:
         params = self.as_param_dict()
         params["_extra"] = self._extra + tuple(extra)  # type: ignore

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -136,7 +136,9 @@ class Traceable:
             return
 
         # Mutations are only meaningful for objects rooted at object refs.
-        if not isinstance(root.ref, ObjectRef) and not isinstance(root._base_ref, ObjectRef):
+        if not isinstance(root.ref, ObjectRef) and not isinstance(
+            root._base_ref, ObjectRef
+        ):
             return
 
         path = self._mutation_path()

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 import operator
 import typing
-from collections.abc import Generator, Iterator, Sequence
+from collections.abc import Generator, Iterable, Iterator, Sequence
 from copy import deepcopy
 from typing import Any, Literal, Optional, SupportsIndex
 
@@ -199,10 +199,11 @@ class Traceable:
             self.ref = new_ref
             self._base_ref = None
             self._is_dirty = False
-            return new_ref
         except Exception:
             self.mutations = original_mutations
             raise
+        else:
+            return new_ref
 
     def unwrap(self) -> Any: ...
 
@@ -695,11 +696,15 @@ class WeaveList(Traceable, list):
 
         super().append(item)
 
-    def extend(self, iterable: Any) -> None:
+    def extend(self, iterable: Iterable[Any]) -> None:
         for item in iterable:
             self.append(item)
 
-    def __iadd__(self, x: Any) -> "WeaveList":
+    def __add__(self, x: Iterable[Any], /) -> "WeaveList":
+        values = super().__add__(list(x))
+        return WeaveList(values, server=self.server, ref=None)
+
+    def __iadd__(self, x: Iterable[Any], /) -> "WeaveList":
         self.extend(x)
         return self
 

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -117,13 +117,46 @@ def unwrap(val: Any) -> Any:
 class Traceable:
     ref: RefWithExtra | None
     mutations: list[Mutation] | None = None
+    _base_ref: ObjectRef | None = None
     root: "Traceable"
     parent: Optional["Traceable"] = None
     server: TraceServerInterface
     _is_dirty: bool = False
 
+    def _mutation_path(self) -> tuple[str, ...]:
+        if isinstance(self.ref, RefWithExtra):
+            return self.ref.extra
+        if isinstance(self._base_ref, RefWithExtra):
+            return self._base_ref.extra
+        return ()
+
+    def _record_mutation(self, operation: MutationOperation, *args: Any) -> None:
+        root = self.root
+        if not isinstance(root, Traceable):
+            return
+
+        # Mutations are only meaningful for objects rooted at object refs.
+        if not isinstance(root.ref, ObjectRef) and not isinstance(root._base_ref, ObjectRef):
+            return
+
+        path = self._mutation_path()
+        root.add_mutation(path, operation, *args)
+
     def _mark_dirty(self) -> None:
         """Recursively mark this object and its ancestors as dirty and removes their refs."""
+        if self._base_ref is None and isinstance(self.ref, ObjectRef):
+            self._base_ref = self.ref
+
+        # Preserve the root object ref so Traceable.save() can still publish a new version
+        # after dirtying nulls out refs.
+        root = self.root
+        if (
+            isinstance(root, Traceable)
+            and root._base_ref is None
+            and isinstance(root.ref, ObjectRef)
+        ):
+            root._base_ref = root.ref
+
         self._is_dirty = True
         self.ref = None
         if (
@@ -142,17 +175,32 @@ class Traceable:
         self.mutations.append(make_mutation(path, operation, args))
 
     def save(self) -> ObjectRef:
-        if not isinstance(self.ref, ObjectRef):
-            raise TypeError("Can only save from object refs")
         if self.root is not self:
             raise ValueError("Can only save from root object")
+
+        root_ref = self.ref if isinstance(self.ref, ObjectRef) else self._base_ref
+        if not isinstance(root_ref, ObjectRef):
+            raise TypeError("Can only save from object refs")
+
+        if not self._is_dirty:
+            return root_ref
+
         if self.mutations is None:
             raise ValueError("No mutations to save")
 
-        mutations = self.mutations
+        # Preserve the mutation list in case publishing fails.
+        original_mutations = self.mutations
         self.mutations = None
-        raise NotImplementedError("Traceable.save not implemented")
-        # return self.server.mutate(self.ref, mutations)
+        try:
+            wc = require_weave_client()
+            new_ref = wc._save_object(self, root_ref.name)
+            self.ref = new_ref
+            self._base_ref = None
+            self._is_dirty = False
+            return new_ref
+        except Exception:
+            self.mutations = original_mutations
+            raise
 
     def unwrap(self) -> Any: ...
 
@@ -270,11 +318,13 @@ class WeaveObject(Traceable):
             "server",
             "root",
             "mutations",
+            "_base_ref",
             "_is_dirty",
             "parent",
         ]:
             return object.__setattr__(self, __name, __value)
         else:
+            self._record_mutation("setattr", __name, unwrap(__value))
             self._mark_dirty()
             if isinstance(__value, Traceable):
                 __value.parent = self
@@ -570,6 +620,7 @@ class WeaveTable(Traceable):
         rows = self._inefficiently_materialize_rows_as_list()
         if not isinstance(val, dict):
             raise TypeError("Can only append dicts to tables")
+        self._record_mutation("append", unwrap(val))
         self._mark_dirty()
         rows.append(val)
 
@@ -627,6 +678,7 @@ class WeaveList(Traceable, list):
         # Though this ostensibly only marks the parent (list) as dirty, siblings
         # will also get new refs because their old refs are relative to the parent
         # (the element refs will be extras of the new parent ref)
+        self._record_mutation("setitem", str(index), unwrap(value))
         self._mark_dirty()
         if isinstance(value, Traceable):
             value.parent = self
@@ -634,11 +686,20 @@ class WeaveList(Traceable, list):
         super().__setitem__(index, value)
 
     def append(self, item: Any) -> None:
+        self._record_mutation("append", unwrap(item))
         self._mark_dirty()
         if isinstance(item, Traceable):
             item.parent = self
 
         super().append(item)
+
+    def extend(self, iterable: Any) -> None:
+        for item in iterable:
+            self.append(item)
+
+    def __iadd__(self, x: Any) -> "WeaveList":
+        self.extend(x)
+        return self
 
     def __iter__(self) -> Iterator[Any]:
         for i in range(len(self)):
@@ -704,6 +765,7 @@ class WeaveDict(Traceable, dict):
         # Though this ostensibly only marks the parent (dict) as dirty, siblings
         # will also get new refs because their old refs are relative to the parent
         # (the element refs will be extras of the new parent ref)
+        self._record_mutation("setitem", key, unwrap(value))
         self._mark_dirty()
         if isinstance(value, Traceable):
             value.parent = self

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -83,7 +83,7 @@ from weave.trace.settings import (
 from weave.trace.table import Table
 from weave.trace.table_upload_chunking import ChunkingConfig, TableChunkManager
 from weave.trace.util import log_once
-from weave.trace.vals import WeaveObject, WeaveTable, make_trace_obj
+from weave.trace.vals import WeaveDict, WeaveList, WeaveObject, WeaveTable, make_trace_obj
 from weave.trace.wandb_run_context import (
     WandbRunContext,
     check_wandb_run_matches,
@@ -266,6 +266,10 @@ def map_to_refs(obj: Any) -> Any:
         return obj.ref
     elif isinstance(obj, WeaveTable):
         return obj.ref
+    elif isinstance(obj, WeaveList):
+        return [map_to_refs(v) for v in list.__iter__(obj)]
+    elif isinstance(obj, WeaveDict):
+        return {k: map_to_refs(v) for k, v in dict.items(obj)}
     elif isinstance_namedtuple(obj):
         return {k: map_to_refs(v) for k, v in obj._asdict().items()}
     elif isinstance(obj, (list, tuple)):

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -83,7 +83,13 @@ from weave.trace.settings import (
 from weave.trace.table import Table
 from weave.trace.table_upload_chunking import ChunkingConfig, TableChunkManager
 from weave.trace.util import log_once
-from weave.trace.vals import WeaveDict, WeaveList, WeaveObject, WeaveTable, make_trace_obj
+from weave.trace.vals import (
+    WeaveDict,
+    WeaveList,
+    WeaveObject,
+    WeaveTable,
+    make_trace_obj,
+)
 from weave.trace.wandb_run_context import (
     WandbRunContext,
     check_wandb_run_matches,


### PR DESCRIPTION
This PR completes the client-side implementation of mutations API by adding `Traceable.save` and implementing the relevant wiring

There is no user-facing impact today as it's not defined on the server yet, but it will be useful later to improve upload perf