### PR TITLE
chore(weave): strip large payloads to content, dont drop

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -3915,6 +3915,52 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
     assert large_calls[0].inputs == json.loads(ENTITY_TOO_LARGE_PAYLOAD)
 
 
+def test_many_medium_strings_offloaded_not_dropped(client, monkeypatch):
+    """A column of many medium strings (none over MAX_CHARS) must be offloaded,
+    not stripped wholesale. Without progressive offloading the first pass offloads
+    nothing and the entire column is replaced with ENTITY_TOO_LARGE_PAYLOAD.
+    """
+    if client_is_sqlite(client):
+        return
+
+    # Limit is 10KB; no single string exceeds MAX (50k), so the first pass
+    # offloads nothing. The MIN (1k) pass must offload the medium strings.
+    monkeypatch.setattr(
+        weave.trace_server.clickhouse_trace_server_settings,
+        "PROACTIVE_OFFLOAD_BYTES_LIMIT",
+        10 * 1024,
+    )
+    monkeypatch.setattr(
+        weave.trace_server.clickhouse_trace_server_settings,
+        "LARGE_STRING_OFFLOAD_MAX_CHARS",
+        50 * 1024,
+    )
+    monkeypatch.setattr(
+        weave.trace_server.clickhouse_trace_server_settings,
+        "LARGE_STRING_OFFLOAD_MIN_CHARS",
+        1024,
+    )
+
+    medium = "m" * 2048
+    data = {f"field_{i}": medium for i in range(20)}  # ~40KB, no single huge leaf
+
+    @weave.op
+    def test_op_medium(input_data: dict):
+        return input_data
+
+    test_op_medium(data)
+
+    calls = list(test_op_medium.calls())
+    assert len(calls) == 1
+    # Every medium string is preserved as a Content object, not dropped.
+    assert calls[0].inputs["input_data"] != json.loads(ENTITY_TOO_LARGE_PAYLOAD)
+    assert calls[0].output != json.loads(ENTITY_TOO_LARGE_PAYLOAD)
+    for i in range(20):
+        offloaded = calls[0].inputs["input_data"][f"field_{i}"]
+        assert isinstance(offloaded, Content)
+        assert offloaded.data == medium.encode("utf-8")
+
+
 def test_weave_finish_unsets_client(client, monkeypatch):
     @weave.op
     def foo():

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1,7 +1,6 @@
 import dataclasses
 import datetime
 import json
-import logging
 import platform
 import random
 import sys
@@ -53,7 +52,7 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.clickhouse_trace_server_settings import ENTITY_TOO_LARGE_PAYLOAD
 from weave.trace_server.common_interface import SortBy
-from weave.trace_server.errors import InsertTooLarge, InvalidFieldError, InvalidRequest
+from weave.trace_server.errors import InvalidFieldError, InvalidRequest
 from weave.trace_server.ids import generate_id
 from weave.trace_server.token_costs import COST_OBJECT_NAME
 from weave.trace_server.validation_util import CHValidationError
@@ -3770,34 +3769,18 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
         # no need to strip in sqlite
         return
 
-    caplog.set_level(logging.INFO)
-
-    original_insert_call_batch = weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer._insert_call_batch
     max_size = 10 * 1024
 
-    # Patch _insert_call_batch to raise InsertTooLarge
-    def mock_insert_call_batch(self, batch):
-        # mock raise insert error
-        if len(str(batch)) > max_size:
-            raise InsertTooLarge(
-                "Database insertion failed. Record too large. "
-                "A likely cause is that a single row or cell exceeded "
-                "the limit. If logging images, save them as `Image.PIL`."
-            )
-        original_insert_call_batch(self, batch)
-
+    # Lower the proactive offload threshold so our 10KB test data triggers it.
     monkeypatch.setattr(
         weave.trace_server.clickhouse_trace_server_settings,
-        "CLICKHOUSE_SINGLE_ROW_INSERT_BYTES_LIMIT",
+        "PROACTIVE_OFFLOAD_BYTES_LIMIT",
         max_size,
     )
-    monkeypatch.setattr(
-        weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer,
-        "_insert_call_batch",
-        mock_insert_call_batch,
-    )
 
-    # Use a dictionary that will exceed our new 10KB limit
+    # Use a dictionary that will exceed our new 10KB limit.
+    # Dict values are small ints (no large string leaves to offload),
+    # so the fallback replaces the whole column with ENTITY_TOO_LARGE_PAYLOAD.
     data = {"dictionary": {f"{i}": i for i in range(max_size // 10)}}
 
     @weave.op
@@ -3811,10 +3794,9 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
     assert calls[0].output == json.loads(ENTITY_TOO_LARGE_PAYLOAD)
     assert calls[0].inputs == json.loads(ENTITY_TOO_LARGE_PAYLOAD)
 
-    # now test for inputs/output as raw string
-    # With Phase 1 of _offload_large_values, large string leaf values are
-    # offloaded to Content storage (preserving data) instead of being replaced
-    # with ENTITY_TOO_LARGE_PAYLOAD.
+    # Now test for inputs/output as raw string.
+    # Large string leaf values are offloaded to Content storage (preserving
+    # data) instead of being replaced with ENTITY_TOO_LARGE_PAYLOAD.
     @weave.op
     def test_op_str(input_data: str):
         return input_data
@@ -3851,15 +3833,6 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
     assert len(calls[0].inputs["input_data"]) == 1
     assert isinstance(calls[0].inputs["input_data"][0], Content)
     assert calls[0].inputs["input_data"][0].data == str_data.encode("utf-8")
-
-    # Verify retry was logged at INFO level (new behavior uses content offloading)
-    info_messages = [
-        record.message for record in caplog.records if record.levelname == "INFO"
-    ]
-    assert any(
-        "Retrying with large values offloaded to content storage" in msg
-        for msg in info_messages
-    )
 
     # test that when inputs + output > max_size but input < max_size
     # we only strip the inputs

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1,6 +1,7 @@
 import dataclasses
 import datetime
 import json
+import logging
 import platform
 import random
 import sys
@@ -56,6 +57,7 @@ from weave.trace_server.errors import InsertTooLarge, InvalidFieldError, Invalid
 from weave.trace_server.ids import generate_id
 from weave.trace_server.token_costs import COST_OBJECT_NAME
 from weave.trace_server.validation_util import CHValidationError
+from weave.type_wrappers.Content.content import Content
 from weave.utils.project_id import from_project_id, to_project_id
 
 ## Hacky interface compatibility helpers
@@ -3768,6 +3770,8 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
         # no need to strip in sqlite
         return
 
+    caplog.set_level(logging.INFO)
+
     original_insert_call_batch = weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer._insert_call_batch
     max_size = 10 * 1024
 
@@ -3808,34 +3812,54 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
     assert calls[0].inputs == json.loads(ENTITY_TOO_LARGE_PAYLOAD)
 
     # now test for inputs/output as raw string
+    # With Phase 1 of _offload_large_values, large string leaf values are
+    # offloaded to Content storage (preserving data) instead of being replaced
+    # with ENTITY_TOO_LARGE_PAYLOAD.
     @weave.op
     def test_op_str(input_data: str):
         return input_data
 
-    test_op_str(json.dumps(data))
+    str_data = json.dumps(data)
+    test_op_str(str_data)
 
     calls = list(test_op_str.calls())
     assert len(calls) == 1
-    assert calls[0].output == json.loads(ENTITY_TOO_LARGE_PAYLOAD)
-    assert calls[0].inputs == json.loads(ENTITY_TOO_LARGE_PAYLOAD)
+    # Output string is offloaded to Content storage
+    assert isinstance(calls[0].output, Content)
+    assert calls[0].output.data == str_data.encode("utf-8")
+    # Input string value is offloaded to Content storage within the inputs dict
+    assert isinstance(calls[0].inputs["input_data"], Content)
+    assert calls[0].inputs["input_data"].data == str_data.encode("utf-8")
 
-    # and now list
+    # and now list — large strings within lists are also offloaded to Content
     @weave.op
     def test_op_list(input_data: list[str]):
         return input_data
 
-    test_op_list([json.dumps(data)])
+    list_data = [json.dumps(data)]
+    test_op_list(list_data)
 
     calls = list(test_op_list.calls())
     assert len(calls) == 1
-    assert calls[0].output == json.loads(ENTITY_TOO_LARGE_PAYLOAD)
-    assert calls[0].inputs == json.loads(ENTITY_TOO_LARGE_PAYLOAD)
+    # Output list elements with large strings are offloaded to Content storage
+    assert isinstance(calls[0].output, list)
+    assert len(calls[0].output) == 1
+    assert isinstance(calls[0].output[0], Content)
+    assert calls[0].output[0].data == str_data.encode("utf-8")
+    # Input list elements are similarly offloaded
+    assert isinstance(calls[0].inputs["input_data"], list)
+    assert len(calls[0].inputs["input_data"]) == 1
+    assert isinstance(calls[0].inputs["input_data"][0], Content)
+    assert calls[0].inputs["input_data"][0].data == str_data.encode("utf-8")
 
-    error_messages = [
-        record.message for record in caplog.records if record.levelname == "ERROR"
+    # Verify retry was logged at INFO level (new behavior uses content offloading)
+    info_messages = [
+        record.message for record in caplog.records if record.levelname == "INFO"
     ]
-    for error_message in error_messages:
-        assert "Retrying with large objects stripped" in error_message
+    assert any(
+        "Retrying with large values offloaded to content storage" in msg
+        for msg in info_messages
+    )
 
     # test that when inputs + output > max_size but input < max_size
     # we only strip the inputs

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -3781,7 +3781,7 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
     )
     monkeypatch.setattr(
         weave.trace_server.clickhouse_trace_server_settings,
-        "LARGE_STRING_OFFLOAD_MIN_CHARS",
+        "LARGE_STRING_OFFLOAD_MAX_CHARS",
         1024,
     )
 

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -3772,10 +3772,17 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
     max_size = 10 * 1024
 
     # Lower the proactive offload threshold so our 10KB test data triggers it.
+    # Also lower the per-string offload threshold so individual strings in the
+    # test data are large enough to be offloaded to Content storage.
     monkeypatch.setattr(
         weave.trace_server.clickhouse_trace_server_settings,
         "PROACTIVE_OFFLOAD_BYTES_LIMIT",
         max_size,
+    )
+    monkeypatch.setattr(
+        weave.trace_server.clickhouse_trace_server_settings,
+        "LARGE_STRING_OFFLOAD_MIN_CHARS",
+        1024,
     )
 
     # Use a dictionary that will exceed our new 10KB limit.

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -183,7 +183,7 @@ def test_large_string_offloading():
     # -- basic threshold: large converted, small/exact untouched --
     ts = _mock_ts(num_files=2)
     r = replace_large_strings_with_content_objects(
-        {"lg": large, "sm": small, "eq": exact}, "proj", ts, min_chars=threshold
+        {"lg": large, "sm": small, "eq": exact}, "proj", ts, max_chars=threshold
     )
     assert _is_content_ref(r["lg"])
     assert r["sm"] == small  # below threshold
@@ -197,7 +197,7 @@ def test_large_string_offloading():
         {"outer": {"inner": deep, "sib": "short"}, "list": ["tiny", deep]},
         "proj",
         ts,
-        min_chars=threshold,
+        max_chars=threshold,
     )
     assert _is_content_ref(r["outer"]["inner"])
     assert r["outer"]["sib"] == "short"  # small sibling untouched
@@ -210,7 +210,7 @@ def test_large_string_offloading():
     primitives = {"int": 42, "float": 3.14, "bool": True, "none": None}
     assert (
         replace_large_strings_with_content_objects(
-            primitives, "proj", ts, min_chars=threshold
+            primitives, "proj", ts, max_chars=threshold
         )
         == primitives
     )
@@ -219,11 +219,11 @@ def test_large_string_offloading():
     # -- empty structures --
     ts = _mock_ts()
     assert (
-        replace_large_strings_with_content_objects({}, "p", ts, min_chars=threshold)
+        replace_large_strings_with_content_objects({}, "p", ts, max_chars=threshold)
         == {}
     )
     assert (
-        replace_large_strings_with_content_objects([], "p", ts, min_chars=threshold)
+        replace_large_strings_with_content_objects([], "p", ts, max_chars=threshold)
         == []
     )
 
@@ -237,7 +237,7 @@ def test_large_string_offloading():
         },
         "proj",
         ts,
-        min_chars=threshold,
+        max_chars=threshold,
     )
     for k in ("a", "b", "c"):
         assert _is_content_ref(r[k])
@@ -246,7 +246,7 @@ def test_large_string_offloading():
     # -- stored metadata is text/plain --
     ts = _mock_ts()
     replace_large_strings_with_content_objects(
-        {"f": "hello " * (threshold // 6 + 1)}, "proj", ts, min_chars=threshold
+        {"f": "hello " * (threshold // 6 + 1)}, "proj", ts, max_chars=threshold
     )
     meta = json.loads(ts.file_create.call_args_list[1][0][0].content)
     assert meta["mimetype"] == "text/plain"
@@ -256,7 +256,7 @@ def test_large_string_offloading():
     broken_ts = MagicMock()
     broken_ts.file_create = MagicMock(side_effect=RuntimeError("boom"))
     r = replace_large_strings_with_content_objects(
-        {"f": large}, "proj", broken_ts, min_chars=threshold
+        {"f": large}, "proj", broken_ts, max_chars=threshold
     )
     assert r["f"] == large  # original preserved
 

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.base64_content_conversion import (
     AUTO_CONVERSION_MIN_SIZE,
     is_base64,
@@ -18,6 +19,7 @@ from weave.trace_server.base64_content_conversion import (
     replace_large_strings_with_content_objects,
     store_content_object,
 )
+from weave.trace_server.clickhouse_trace_server_batched import _offload_oversized_row
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallStartReq,
@@ -259,6 +261,40 @@ def test_large_string_offloading():
         {"f": large}, "proj", broken_ts, max_chars=threshold
     )
     assert r["f"] == large  # original preserved
+
+
+def test_offload_oversized_row_progressive(monkeypatch):
+    """A column of many medium strings (none over MAX_CHARS) is offloaded via the
+    escalating MIN_CHARS pass instead of being stripped to ENTITY_TOO_LARGE_PAYLOAD,
+    while a column with no offloadable string leaves falls back to a full strip.
+    """
+    row_limit = 10 * 1024
+    monkeypatch.setattr(ch_settings, "LARGE_STRING_OFFLOAD_MAX_CHARS", 50 * 1024)
+    monkeypatch.setattr(ch_settings, "LARGE_STRING_OFFLOAD_MIN_CHARS", 1024)
+
+    # 20 medium strings, each under MAX (50k) but over MIN (1k); ~40 KiB total.
+    medium = {f"f{i}": "m" * 2048 for i in range(20)}
+    dump = json.dumps(medium)
+    ts = _mock_ts(num_files=40)  # 20 leaves * (content + metadata)
+    row, offloaded, stripped = _offload_oversized_row(
+        [dump, "proj"], [(0, len(dump.encode()))], len(dump.encode()), row_limit, 1, ts
+    )
+    parsed = json.loads(row[0])
+    assert offloaded == 1
+    assert stripped == 0
+    assert all(_is_content_ref(parsed[f"f{i}"]) for i in range(20))
+
+    # No offloadable string leaves (small ints) -> strip the whole column.
+    ints = {str(i): i for i in range(2000)}
+    dump = json.dumps(ints)
+    ts = _mock_ts(num_files=2)
+    row, offloaded, stripped = _offload_oversized_row(
+        [dump, "proj"], [(0, len(dump.encode()))], len(dump.encode()), row_limit, 1, ts
+    )
+    assert offloaded == 0
+    assert stripped == 1
+    assert row[0] == ch_settings.ENTITY_TOO_LARGE_PAYLOAD
+    ts.file_create.assert_not_called()
 
 
 class TestStandaloneBase64Detection:

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -163,7 +163,7 @@ def test_base64_and_data_uri_content_conversion():
     assert _is_content_ref(out["audio"])
     assert out["label"] == "ok"
     wav_meta = json.loads(ts.file_create.call_args_list[1][0][0].content)
-    assert wav_meta["mimetype"] in ("audio/wav", "audio/x-wav", "audio/wave")
+    assert wav_meta["mimetype"] in {"audio/wav", "audio/x-wav", "audio/wave"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -1,7 +1,10 @@
-"""Tests for base64 content conversion functionality (updated for new API)."""
+"""Tests for content conversion: base64/data-URI detection, Content object storage,
+and large-string offloading to file storage.
+"""
 
 import base64
 import json
+from datetime import datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,6 +15,7 @@ from weave.trace_server.base64_content_conversion import (
     is_data_uri,
     process_call_req_to_content,
     replace_base64_with_content_objects,
+    replace_large_strings_with_content_objects,
     store_content_object,
 )
 from weave.trace_server.trace_server_interface import (
@@ -23,204 +27,238 @@ from weave.trace_server.trace_server_interface import (
 )
 from weave.type_wrappers.Content.content import Content
 
-# Test data size larger than AUTO_CONVERSION_MIN_SIZE to trigger conversion
 LARGE_TEST_DATA_SIZE = AUTO_CONVERSION_MIN_SIZE + 10
+_TEST_MIN_BYTES = 100
 
 
-class TestBase64AndDataURIDetection:
-    """Test detection heuristics for data URIs only (raw base64 no longer auto-encoded)."""
-
-    def test_is_data_uri_valid(self):
-        """Valid base64 data URIs are detected."""
-        test_data = b"Hello, World!"
-        b64_data = base64.b64encode(test_data).decode("ascii")
-        data_uri = f"data:text/plain;base64,{b64_data}"
-        assert is_data_uri(data_uri)
-
-    def test_is_data_uri_invalid(self):
-        """Invalid data URIs are rejected."""
-        assert not is_data_uri("not a data uri")
-        assert not is_data_uri("data:text/plain,not base64")
+def _mock_ts(num_files: int = 2) -> MagicMock:
+    """Return a mock trace server whose file_create returns sequential digests."""
+    ts = MagicMock()
+    ts.file_create = MagicMock(
+        side_effect=[FileCreateRes(digest=f"digest_{i}") for i in range(num_files)]
+    )
+    return ts
 
 
-class TestContentObjectStorage:
-    """Test Content object storage and structure."""
+def _is_content_ref(val: object) -> bool:
+    """True if val looks like a stored Content object reference dict."""
+    return (
+        isinstance(val, dict)
+        and val.get("_type") == "CustomWeaveType"
+        and val.get("weave_type", {}).get("type")
+        == "weave.type_wrappers.Content.content.Content"
+        and set(val.get("files", {}).keys()) == {"content", "metadata.json"}
+    )
 
-    def test_store_content_object(self):
-        """Test storing a Content object persists content and metadata files."""
-        # Mock trace server
-        trace_server = MagicMock()
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest"),
-                FileCreateRes(digest="metadata_digest"),
-            ]
+
+# ---------------------------------------------------------------------------
+# Base64 / data-URI detection, storage, and replacement
+# ---------------------------------------------------------------------------
+
+
+def test_base64_and_data_uri_content_conversion():
+    """End-to-end: detection heuristics, Content storage, replacement in dicts/lists,
+    process_call_req_to_content, and standalone base64 edge cases.
+    """
+    # -- data-URI detection --
+    b64_hello = base64.b64encode(b"Hello, World!").decode("ascii")
+    assert is_data_uri(f"data:text/plain;base64,{b64_hello}")
+    assert not is_data_uri("not a data uri")
+    assert not is_data_uri("data:text/plain,not base64")
+
+    # -- store_content_object structure --
+    ts = _mock_ts()
+    content_obj = Content.from_bytes(b"Test content")
+    result = store_content_object(content_obj, "test_project", ts)
+
+    assert _is_content_ref(result)
+    assert result["files"]["content"] == "digest_0"
+    assert result["files"]["metadata.json"] == "digest_1"
+    assert ts.file_create.call_count == 2
+
+    # first call stores raw content bytes, second stores metadata JSON
+    content_call = ts.file_create.call_args_list[0][0][0]
+    assert content_call.project_id == "test_project"
+    assert content_call.content == b"Test content"
+    metadata = json.loads(ts.file_create.call_args_list[1][0][0].content)
+    assert metadata["mimetype"] == content_obj.mimetype
+
+    # -- replace in dicts: data URIs converted, raw base64 left alone --
+    ts = _mock_ts(num_files=4)
+    big = b"a" * LARGE_TEST_DATA_SIZE
+    b64_big = base64.b64encode(big).decode("ascii")
+
+    out = replace_base64_with_content_objects(
+        {
+            "plain": "normal string",
+            "raw_b64": b64_big,  # standalone base64 -> NOT replaced
+            "nested": {"uri": f"data:image/png;base64,{b64_big}"},
+        },
+        "proj",
+        ts,
+    )
+    assert out["plain"] == "normal string"
+    assert out["raw_b64"] == b64_big  # raw base64 stays as-is
+    assert _is_content_ref(out["nested"]["uri"])
+
+    # -- replace in lists --
+    ts = _mock_ts(num_files=4)
+    out = replace_base64_with_content_objects(
+        ["keep", b64_big, {"k": f"data:text/plain;base64,{b64_big}"}],
+        "proj",
+        ts,
+    )
+    assert out[0] == "keep"
+    assert out[1] == b64_big  # raw base64 unchanged
+    assert _is_content_ref(out[2]["k"])
+
+    # -- process_call_req_to_content for CallStartReq and CallEndReq --
+    ts = _mock_ts(num_files=4)
+    start_req = CallStartReq(
+        start=StartedCallSchemaForInsert(
+            project_id="proj",
+            op_name="op",
+            started_at=datetime.utcnow(),
+            attributes={},
+            inputs={
+                "image": f"data:image/png;base64,{b64_big}",
+                "text": "Some normal text",
+            },
         )
+    )
+    processed = process_call_req_to_content(start_req, ts)
+    assert processed.start.inputs["text"] == "Some normal text"
+    assert _is_content_ref(processed.start.inputs["image"])
 
-        test_data = b"Test content"
-        project_id = "test_project"
-
-        content_obj = Content.from_bytes(test_data)
-        result = store_content_object(content_obj, project_id, trace_server)
-
-        # Verify structure
-        assert result["_type"] == "CustomWeaveType"
-        assert (
-            result["weave_type"]["type"]
-            == "weave.type_wrappers.Content.content.Content"
+    long_b64 = base64.b64encode(b"y" * LARGE_TEST_DATA_SIZE).decode("ascii")
+    end_req = CallEndReq(
+        end=EndedCallSchemaForInsert(
+            project_id="proj",
+            id="call-id",
+            ended_at=datetime.utcnow(),
+            summary={"usage": {}, "status_counts": {}},
+            output=long_b64,
         )
-        assert "files" in result
-        assert result["files"]["content"] == "content_digest"
-        assert result["files"]["metadata.json"] == "metadata_digest"
+    )
+    processed_end = process_call_req_to_content(end_req, ts)
+    assert processed_end.end.output == long_b64  # raw b64, not a data URI
 
-        # Verify file_create was called
-        assert trace_server.file_create.call_count == 2
-        calls = trace_server.file_create.call_args_list
+    # -- non-media base64 strings stay untouched --
+    ts = MagicMock()
+    for b64_str in ("aaaa", "aGVsbG8=", "dGVzdCBtZXNzYWdl", "YQ==", "SGVsbG8gV29ybGQh"):
+        assert is_base64(b64_str)
+        r = replace_base64_with_content_objects({"f": b64_str}, "proj", ts)
+        assert r["f"] == b64_str  # text/plain or octet-stream -> skip
+    assert ts.file_create.call_count == 0
 
-        # First call for content
-        content_call = calls[0][0][0]
-        assert content_call.project_id == project_id
-        assert content_call.name == "content"
-        assert content_call.content == test_data
+    # -- WAV-file base64 IS converted (audio mimetype detected) --
+    ts = _mock_ts(num_files=2)
+    wav = _build_minimal_wav(LARGE_TEST_DATA_SIZE)
+    wav_b64 = base64.b64encode(wav).decode("ascii")
+    assert is_base64(wav_b64)
 
-        # Second call for metadata
-        metadata_call = calls[1][0][0]
-        assert metadata_call.project_id == project_id
-        assert metadata_call.name == "metadata.json"
-        metadata = json.loads(metadata_call.content)
-        # Ensure key metadata fields are present and correct
-        assert metadata["mimetype"] == content_obj.mimetype
-        assert metadata["size"] == content_obj.size
-        assert metadata["filename"] == content_obj.filename
+    out = replace_base64_with_content_objects(
+        {"audio": wav_b64, "label": "ok"}, "proj", ts
+    )
+    assert _is_content_ref(out["audio"])
+    assert out["label"] == "ok"
+    wav_meta = json.loads(ts.file_create.call_args_list[1][0][0].content)
+    assert wav_meta["mimetype"] in ("audio/wav", "audio/x-wav", "audio/wave")
 
 
-class TestBase64Replacement:
-    """Test base64 replacement in data structures."""
+# ---------------------------------------------------------------------------
+# Large-string offloading (replace_large_strings_with_content_objects)
+# ---------------------------------------------------------------------------
 
-    def test_replace_data_uri_in_dict_only(self):
-        """Only base64 data URIs are replaced; raw base64 is left untouched."""
-        # Mock trace server
-        trace_server = MagicMock()
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest1"),
-                FileCreateRes(digest="metadata_digest1"),
-                FileCreateRes(digest="content_digest2"),
-                FileCreateRes(digest="metadata_digest2"),
-            ]
+
+def test_large_string_offloading():
+    """Covers threshold behaviour, recursion into nested structures, non-string
+    passthrough, metadata correctness, and graceful failure.
+    """
+    threshold = _TEST_MIN_BYTES
+    large = "x" * (threshold + 1)
+    small = "x" * (threshold - 1)
+    exact = "x" * threshold
+
+    # -- basic threshold: large converted, small/exact untouched --
+    ts = _mock_ts(num_files=2)
+    r = replace_large_strings_with_content_objects(
+        {"lg": large, "sm": small, "eq": exact}, "proj", ts, min_chars=threshold
+    )
+    assert _is_content_ref(r["lg"])
+    assert r["sm"] == small  # below threshold
+    assert r["eq"] == exact  # at threshold (not strictly greater)
+    assert ts.file_create.call_count == 2  # 1 content + 1 metadata
+
+    # -- nested dicts and lists --
+    ts = _mock_ts(num_files=6)
+    deep = "y" * (threshold + 1)
+    r = replace_large_strings_with_content_objects(
+        {"outer": {"inner": deep, "sib": "short"}, "list": ["tiny", deep]},
+        "proj",
+        ts,
+        min_chars=threshold,
+    )
+    assert _is_content_ref(r["outer"]["inner"])
+    assert r["outer"]["sib"] == "short"  # small sibling untouched
+    assert r["list"][0] == "tiny"
+    assert _is_content_ref(r["list"][1])
+    assert ts.file_create.call_count == 4  # 2 content objects x 2 files each
+
+    # -- non-string primitives pass through unchanged --
+    ts = _mock_ts()
+    primitives = {"int": 42, "float": 3.14, "bool": True, "none": None}
+    assert (
+        replace_large_strings_with_content_objects(
+            primitives, "proj", ts, min_chars=threshold
         )
+        == primitives
+    )
+    assert ts.file_create.call_count == 0
 
-        test_data = b"a" * LARGE_TEST_DATA_SIZE
-        b64_data = base64.b64encode(test_data).decode("ascii")
+    # -- empty structures --
+    ts = _mock_ts()
+    assert (
+        replace_large_strings_with_content_objects({}, "p", ts, min_chars=threshold)
+        == {}
+    )
+    assert (
+        replace_large_strings_with_content_objects([], "p", ts, min_chars=threshold)
+        == []
+    )
 
-        input_data = {
-            "field1": "normal string",
-            "field2": b64_data,  # raw base64 should remain unchanged
-            "nested": {"field3": f"data:image/png;base64,{b64_data}"},
-        }
+    # -- multiple large strings each get their own Content object --
+    ts = _mock_ts(num_files=6)
+    r = replace_large_strings_with_content_objects(
+        {
+            "a": "a" * (threshold + 1),
+            "b": "b" * (threshold + 1),
+            "c": "c" * (threshold + 1),
+        },
+        "proj",
+        ts,
+        min_chars=threshold,
+    )
+    for k in ("a", "b", "c"):
+        assert _is_content_ref(r[k])
+    assert ts.file_create.call_count == 6
 
-        result = replace_base64_with_content_objects(
-            input_data, "test_project", trace_server
-        )
+    # -- stored metadata is text/plain --
+    ts = _mock_ts()
+    replace_large_strings_with_content_objects(
+        {"f": "hello " * (threshold // 6 + 1)}, "proj", ts, min_chars=threshold
+    )
+    meta = json.loads(ts.file_create.call_args_list[1][0][0].content)
+    assert meta["mimetype"] == "text/plain"
+    assert meta["content_type"] == "text"
 
-        # Check normal string is unchanged
-        assert result["field1"] == "normal string"
-
-        # Check standalone base64 is NOT replaced
-        assert result["field2"] == b64_data
-
-        # Check data URI was replaced
-        assert isinstance(result["nested"]["field3"], dict)
-        assert result["nested"]["field3"]["_type"] == "CustomWeaveType"
-        assert set(result["nested"]["field3"]["files"].keys()) == {
-            "content",
-            "metadata.json",
-        }
-
-    def test_replace_data_uri_in_list_only(self):
-        """Only base64 data URIs are replaced in lists; raw base64 is left untouched."""
-        # Mock trace server
-        trace_server = MagicMock()
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest1"),
-                FileCreateRes(digest="metadata_digest1"),
-                FileCreateRes(digest="content_digest2"),
-                FileCreateRes(digest="metadata_digest2"),
-            ]
-        )
-
-        test_data = b"a" * LARGE_TEST_DATA_SIZE
-        b64_data = base64.b64encode(test_data).decode("ascii")
-
-        input_data = [
-            "normal string",
-            b64_data,  # raw base64 should remain unchanged
-            {"nested": f"data:text/plain;base64,{b64_data}"},
-        ]
-
-        result = replace_base64_with_content_objects(
-            input_data, "test_project", trace_server
-        )
-
-        # Check list structure is preserved
-        assert len(result) == 3
-        assert result[0] == "normal string"
-        # Raw base64 remains a string
-        assert result[1] == b64_data
-        assert isinstance(result[2]["nested"], dict)
-        assert result[2]["nested"]["_type"] == "CustomWeaveType"
-
-    def test_process_call_req_to_content_start_and_end(self):
-        """Test the main entry point for processing CallStartReq and CallEndReq."""
-        # Mock trace server
-        trace_server = MagicMock()
-        # Two files for start (content + metadata), two for end
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest_start"),
-                FileCreateRes(digest="metadata_digest_start"),
-                FileCreateRes(digest="content_digest_end"),
-                FileCreateRes(digest="metadata_digest_end"),
-            ]
-        )
-
-        test_data = b"x" * LARGE_TEST_DATA_SIZE
-        b64_data = base64.b64encode(test_data).decode("ascii")
-
-        # Start request with data URI in inputs
-        start_req = CallStartReq(
-            start=StartedCallSchemaForInsert(
-                project_id="proj",
-                op_name="op",
-                started_at=__import__("datetime").datetime.utcnow(),
-                attributes={},
-                inputs={
-                    "image": f"data:image/png;base64,{b64_data}",
-                    "text": "Some normal text",
-                },
-            )
-        )
-
-        processed_start = process_call_req_to_content(start_req, trace_server)
-        assert processed_start.start.inputs["text"] == "Some normal text"
-        assert isinstance(processed_start.start.inputs["image"], dict)
-        assert processed_start.start.inputs["image"]["_type"] == "CustomWeaveType"
-
-        long_bytes = b"y" * LARGE_TEST_DATA_SIZE
-        long_b64 = base64.b64encode(long_bytes).decode("ascii")
-        end_req = CallEndReq(
-            end=EndedCallSchemaForInsert(
-                project_id="proj",
-                id="call-id",
-                ended_at=__import__("datetime").datetime.utcnow(),
-                summary={"usage": {}, "status_counts": {}},
-                output=long_b64,
-            )
-        )
-
-        processed_end = process_call_req_to_content(end_req, trace_server)
-        assert processed_end.end.output == long_b64
+    # -- graceful failure: broken storage returns original string --
+    broken_ts = MagicMock()
+    broken_ts.file_create = MagicMock(side_effect=RuntimeError("boom"))
+    r = replace_large_strings_with_content_objects(
+        {"f": large}, "proj", broken_ts, min_chars=threshold
+    )
+    assert r["f"] == large  # original preserved
 
 
 class TestStandaloneBase64Detection:
@@ -514,6 +552,31 @@ class TestThresholdAndStructuralIdentity:
         # unchanged regardless of the SDK copy.
         assert processed.start.inputs == inputs_before
         assert trace_server.file_create.call_count == 0
+
+
+def _build_minimal_wav(data_size: int) -> bytes:
+    """Build a minimal valid WAV file with *data_size* bytes of silence."""
+    wav = bytearray()
+    wav.extend(b"RIFF")
+    size_pos = len(wav)
+    wav.extend(b"\x00\x00\x00\x00")  # placeholder
+    wav.extend(b"WAVE")
+    # fmt chunk
+    wav.extend(b"fmt ")
+    wav.extend((16).to_bytes(4, "little"))
+    wav.extend((1).to_bytes(2, "little"))  # PCM
+    wav.extend((1).to_bytes(2, "little"))  # mono
+    wav.extend((44100).to_bytes(4, "little"))
+    wav.extend((88200).to_bytes(4, "little"))
+    wav.extend((2).to_bytes(2, "little"))
+    wav.extend((16).to_bytes(2, "little"))
+    # data chunk
+    wav.extend(b"data")
+    wav.extend(data_size.to_bytes(4, "little"))
+    wav.extend(b"\x00" * data_size)
+    # patch RIFF size
+    wav[size_pos : size_pos + 4] = (len(wav) - 8).to_bytes(4, "little")
+    return bytes(wav)
 
 
 if __name__ == "__main__":

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -212,12 +212,12 @@ def replace_large_strings_with_content_objects(
     vals: T,
     project_id: str,
     trace_server: TraceServerInterface,
-    min_chars: int,
+    max_chars: int,
 ) -> T:
     """Recursively replace large string values with Content objects in file storage.
 
     Walks the value tree and converts any string leaf whose character count exceeds
-    ``min_chars`` into a Content object stored via the trace server's file storage.
+    ``max_chars`` into a Content object stored via the trace server's file storage.
     The original string is preserved as ``text/plain`` content, and a Content
     reference dict is returned in its place.
 
@@ -231,7 +231,7 @@ def replace_large_strings_with_content_objects(
             return {k: _visit(v) for k, v in val.items()}
         elif isinstance(val, list):
             return [_visit(v) for v in val]
-        elif isinstance(val, str) and len(val) > min_chars:
+        elif isinstance(val, str) and len(val) > max_chars:
             try:
                 content: Content[Any] = Content.from_text(val)
                 return store_content_object(content, project_id, trace_server)
@@ -240,6 +240,7 @@ def replace_large_strings_with_content_objects(
                     "Failed to offload large string (%d chars) to content storage: %s",
                     len(val),
                     e,
+                    exc_info=True,
                 )
                 return val
         return val

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -233,7 +233,7 @@ def replace_large_strings_with_content_objects(
             return [_visit(v) for v in val]
         elif isinstance(val, str) and len(val) > min_chars:
             try:
-                content = Content.from_text(val)
+                content: Content[Any] = Content.from_text(val)
                 return store_content_object(content, project_id, trace_server)
             except Exception as e:
                 logger.warning(

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -1,7 +1,10 @@
-"""Base64 content conversion utilities for trace server.
+"""Content conversion utilities for trace server.
 
-This module handles automatic detection and replacement of base64 encoded content
-with content objects stored in bucket storage.
+This module handles automatic detection and replacement of large or encoded content
+with Content objects stored in bucket storage. Supports:
+- Base64 encoded strings (detected by pattern matching)
+- Data URI strings (e.g., data:image/png;base64,...)
+- Arbitrary large strings (offloaded when payloads exceed ClickHouse row limits)
 """
 
 import json
@@ -44,12 +47,15 @@ AUTO_CONVERSION_MIN_SIZE = 8192  # 8 KiB
 
 
 def is_base64(value: str) -> bool:
-    """Huerestic to quickly check if a string is likely base64.
-    We do not decode here because Content already does decode based 'true' validation
+    """Heuristic to quickly check if a string is likely base64.
+
+    We do not decode here because Content already does decode-based validation.
+
     Args:
-        value: String to check
+        value: String to check.
+
     Returns:
-        True if the string is possibly valid base64
+        True if the string is possibly valid base64.
     """
     return BASE64_PATTERN.match(value) is not None
 
@@ -75,14 +81,12 @@ def store_content_object(
     """Create a proper Content object structure and store its files.
 
     Args:
-        data: Raw byte content
-        original_schema: The schema to restore the original base64 string
-        mimetype: MIME type of the content
-        project_id: Project ID for storage
-        trace_server: Trace server instance for file storage
+        content_obj: Content wrapper holding the raw bytes and metadata.
+        project_id: Project ID for storage.
+        trace_server: Trace server instance for file storage.
 
     Returns:
-        Dict representing the Content object in the proper format
+        Dict representing the Content object in the proper format.
     """
     content_data = content_obj.data
     content_metadata = json.dumps(content_obj.model_dump(exclude={"data"})).encode(
@@ -198,6 +202,46 @@ def replace_base64_with_content_objects(
                     )
 
             return val
+        return val
+
+    return _visit(vals)
+
+
+@ddtrace.tracer.wrap(name="replace_large_strings_with_content_objects")
+def replace_large_strings_with_content_objects(
+    vals: T,
+    project_id: str,
+    trace_server: TraceServerInterface,
+    min_chars: int,
+) -> T:
+    """Recursively replace large string values with Content objects in file storage.
+
+    Walks the value tree and converts any string leaf whose character count exceeds
+    ``min_chars`` into a Content object stored via the trace server's file storage.
+    The original string is preserved as ``text/plain`` content, and a Content
+    reference dict is returned in its place.
+
+    Note: the threshold is measured in *characters* (``len(val)``), not bytes.
+    For ASCII-dominated content this is equivalent; for multi-byte UTF-8 strings
+    the character count is a safe lower bound on byte size.
+    """
+
+    def _visit(val: Any) -> Any:
+        if isinstance(val, dict):
+            return {k: _visit(v) for k, v in val.items()}
+        elif isinstance(val, list):
+            return [_visit(v) for v in val]
+        elif isinstance(val, str) and len(val) > min_chars:
+            try:
+                content = Content.from_text(val)
+                return store_content_object(content, project_id, trace_server)
+            except Exception as e:
+                logger.warning(
+                    "Failed to offload large string (%d chars) to content storage: %s",
+                    len(val),
+                    e,
+                )
+                return val
         return val
 
     return _visit(vals)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -174,6 +174,7 @@ from weave.trace_server.datadog import (
 from weave.trace_server.digest_validation import validate_expected_digest
 from weave.trace_server.errors import (
     CallsCompleteModeRequired,
+    InsertTooLarge,
     InvalidRequest,
     MissingLLMApiKeyError,
     NotFoundError,
@@ -337,6 +338,11 @@ OP_REF_CACHE_TTL_SECONDS = 300
 
 # Max error messages to include in OTel export partial success responses
 MAX_OTEL_ERROR_MESSAGES = 20
+
+# UTF-8 encodes a character as at most 4 bytes, so `chars * 4` is a cheap upper
+# bound on a string's byte size. Used to skip the expensive byte-encode in the
+# offload gate for rows that are safely under the limit.
+MAX_UTF8_BYTES_PER_CHAR = 4
 
 # Cache size for ref expansion during call streaming
 REF_EXPANSION_CACHE_SIZE = 1000
@@ -718,11 +724,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         retention_days = get_project_retention_days(req.project_id, self.ch_client)
         rows = self._otel_build_rows(calls, retention_days, write_target)
         if write_target == WriteTarget.CALLS_COMPLETE:
-            rows = self._offload_large_values(rows, ALL_CALL_COMPLETE_INSERT_COLUMNS)
-            self._insert_call_complete_batch(rows)
+            self._offload_and_insert(
+                rows, ALL_CALL_COMPLETE_INSERT_COLUMNS, self._insert_call_complete_batch
+            )
         else:
-            rows = self._offload_large_values(rows, ALL_CALL_INSERT_COLUMNS)
-            self._insert_call_batch(rows)
+            self._offload_and_insert(
+                rows, ALL_CALL_INSERT_COLUMNS, self._insert_call_batch
+            )
 
         # Run callbacks and flush
         for cb in event_callbacks:
@@ -7251,10 +7259,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._flush_calls")
     def _flush_calls(self) -> None:
         try:
-            batch = self._offload_large_values(
-                self._call_batch, ALL_CALL_INSERT_COLUMNS
+            self._offload_and_insert(
+                self._call_batch, ALL_CALL_INSERT_COLUMNS, self._insert_call_batch
             )
-            self._insert_call_batch(batch)
         finally:
             self._call_batch = []
 
@@ -7335,12 +7342,36 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if not self._calls_complete_batch:
             return
         try:
-            batch = self._offload_large_values(
-                self._calls_complete_batch, ALL_CALL_COMPLETE_INSERT_COLUMNS
+            self._offload_and_insert(
+                self._calls_complete_batch,
+                ALL_CALL_COMPLETE_INSERT_COLUMNS,
+                self._insert_call_complete_batch,
             )
-            self._insert_call_complete_batch(batch)
         finally:
             self._calls_complete_batch = []
+
+    def _offload_and_insert(
+        self,
+        batch: list[list[Any]],
+        column_names: list[str],
+        insert_fn: Callable[[list[list[Any]]], None],
+    ) -> None:
+        """Offload oversized rows, then insert; fall back to one-by-one on overflow.
+
+        The proactive offload targets PROACTIVE_OFFLOAD_BYTES_LIMIT over the JSON
+        columns only, while ClickHouse's real ceiling covers the whole row. If a
+        row still trips InsertTooLarge we insert one at a time so a single
+        pathological row cannot fail the entire batch.
+        """
+        batch = self._offload_large_values(batch, column_names)
+        try:
+            insert_fn(batch)
+        except InsertTooLarge:
+            logger.warning(
+                "Row exceeded ClickHouse limit after offload; inserting one-by-one."
+            )
+            for row in batch:
+                insert_fn([row])
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._offload_large_values")
     def _offload_large_values(
@@ -7381,6 +7412,17 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         row_limit = ch_settings.PROACTIVE_OFFLOAD_BYTES_LIMIT
 
         for item in batch:
+            # Cheap upper bound first: `chars * 4` >= utf-8 byte size, so a row
+            # under the limit by that measure cannot exceed it. This skips the
+            # full byte-encode for the common small-row path (master did no
+            # measurement here at all). Columns may be None (nullable).
+            total_chars = sum(
+                len(item[i]) for i in json_column_indices if item[i] is not None
+            )
+            if total_chars * MAX_UTF8_BYTES_PER_CHAR <= row_limit:
+                final_batch.append(item)
+                continue
+
             json_idx_size_pairs = [(i, num_bytes(item[i])) for i in json_column_indices]
             total_json_bytes = sum(size for _, size in json_idx_size_pairs)
 
@@ -7441,6 +7483,16 @@ def _offload_oversized_row(
     stripped_count = 0
     entity_too_large_payload_byte_size = num_bytes(ch_settings.ENTITY_TOO_LARGE_PAYLOAD)
 
+    # Read live (not at import) so settings overrides apply; descending so we
+    # offload the largest leaves first and escalate to smaller ones.
+    offload_char_thresholds = sorted(
+        {
+            ch_settings.LARGE_STRING_OFFLOAD_MAX_CHARS,
+            ch_settings.LARGE_STRING_OFFLOAD_MIN_CHARS,
+        },
+        reverse=True,
+    )
+
     sorted_pairs = sorted(json_idx_size_pairs, key=lambda x: x[1], reverse=True)
 
     for col_idx, original_size in sorted_pairs:
@@ -7449,20 +7501,28 @@ def _offload_oversized_row(
 
         current_col_size = original_size
 
-        new_dump = _try_offload_json_column(
-            row[col_idx],
-            row[project_id_idx],
-            trace_server,
-            max_chars=ch_settings.LARGE_STRING_OFFLOAD_MAX_CHARS,
-        )
-        if new_dump is not None:
-            new_size = num_bytes(new_dump)
-            if new_size < current_col_size:
-                row[col_idx] = new_dump
-                total_json_bytes -= current_col_size - new_size
-                current_col_size = new_size
-                offloaded_count += 1
+        # Offload progressively smaller leaves until the column fits. A column
+        # made of many medium strings (none over MAX_CHARS) would otherwise
+        # offload nothing and get stripped wholesale, losing user data.
+        for max_chars in offload_char_thresholds:
+            if total_json_bytes <= row_limit:
+                break
+            new_dump = _try_offload_json_column(
+                row[col_idx],
+                row[project_id_idx],
+                trace_server,
+                max_chars=max_chars,
+            )
+            if new_dump is not None:
+                new_size = num_bytes(new_dump)
+                if new_size < current_col_size:
+                    row[col_idx] = new_dump
+                    total_json_bytes -= current_col_size - new_size
+                    current_col_size = new_size
+                    offloaded_count += 1
 
+        # Last resort: the column is still over budget (e.g. file storage is
+        # unavailable, or the bytes are not in offloadable string leaves).
         if total_json_bytes > row_limit:
             row[col_idx] = ch_settings.ENTITY_TOO_LARGE_PAYLOAD
             total_json_bytes -= current_col_size - entity_too_large_payload_byte_size

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -719,8 +719,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         retention_days = get_project_retention_days(req.project_id, self.ch_client)
         rows = self._otel_build_rows(calls, retention_days, write_target)
         if write_target == WriteTarget.CALLS_COMPLETE:
+            rows = self._offload_large_values(rows, ALL_CALL_COMPLETE_INSERT_COLUMNS)
             self._insert_call_complete_batch(rows)
         else:
+            rows = self._offload_large_values(rows, ALL_CALL_INSERT_COLUMNS)
             self._insert_call_batch(rows)
 
         # Run callbacks and flush
@@ -7250,9 +7252,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._flush_calls")
     def _flush_calls(self) -> None:
         try:
-            self._insert_call_batch(self._call_batch)
-        except InsertTooLarge:
-            logger.info("Retrying with large values offloaded to content storage.")
             batch = self._offload_large_values(
                 self._call_batch, ALL_CALL_INSERT_COLUMNS
             )
@@ -7336,13 +7335,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         """Flush the calls_complete batch to the database."""
         if not self._calls_complete_batch:
             return
-
         try:
-            self._insert_call_complete_batch(self._calls_complete_batch)
-        except InsertTooLarge:
-            logger.info(
-                "Retrying calls_complete with large values offloaded to content storage."
-            )
             batch = self._offload_large_values(
                 self._calls_complete_batch, ALL_CALL_COMPLETE_INSERT_COLUMNS
             )
@@ -7352,20 +7345,26 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._offload_large_values")
     def _offload_large_values(
-        self, batch: list[list[Any]], column_names: list[str]
+        self,
+        batch: list[list[Any]],
+        column_names: list[str],
     ) -> list[list[Any]]:
-        """Offload large string values from JSON columns to file storage as Content objects.
+        """Offload large string values from JSON columns to file storage.
 
-        When a row's combined JSON column size exceeds the ClickHouse row limit,
-        this method processes each oversized column (largest first) in two phases:
+        Called before every batch insert (call_start/call_end, calls_complete,
+        and OTEL export).  When a row's combined JSON column size exceeds
+        ``PROACTIVE_OFFLOAD_BYTES_LIMIT`` (1 MiB), each oversized column
+        (largest first) is processed in two steps:
 
-        1. **Content offloading** -- parse the JSON, replace large string leaf values
-           with Content object references stored in file storage, and re-serialize.
-           This preserves the data structure and user data.
-        2. **Error-payload fallback** -- if offloading alone does not reduce the column
-           enough, replace the entire column with ``ENTITY_TOO_LARGE_PAYLOAD``.
+        1. **Content offloading** -- parse the JSON, replace large string leaf
+           values with Content object references stored in file storage, and
+           re-serialize.  This preserves the data structure and user data.
+        2. **Error-payload fallback** -- if offloading alone does not reduce
+           the column enough, replace the entire column with
+           ``ENTITY_TOO_LARGE_PAYLOAD``.
 
-        Only JSON dump columns (inputs, output, attributes, summary) are considered.
+        Only JSON dump columns (inputs, output, attributes, summary) are
+        considered.
 
         Args:
             batch: List of rows, where each row is a list of column values.
@@ -7383,11 +7382,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         entity_too_large_payload_byte_size = num_bytes(
             ch_settings.ENTITY_TOO_LARGE_PAYLOAD
         )
-        row_limit = ch_settings.CLICKHOUSE_SINGLE_ROW_INSERT_BYTES_LIMIT
+        row_limit = ch_settings.PROACTIVE_OFFLOAD_BYTES_LIMIT
 
         for item in batch:
             json_idx_size_pairs = [(i, num_bytes(item[i])) for i in json_column_indices]
             total_json_bytes = sum(size for _, size in json_idx_size_pairs)
+
+            if total_json_bytes <= row_limit:
+                final_batch.append(item)
+                continue
 
             processed_item = list(item)
             sorted_json_idx_size_pairs = sorted(
@@ -7400,7 +7403,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
                 current_col_size = original_size
 
-                # Phase 1: try to offload large strings to Content objects
+                # Try to offload large strings to Content objects
                 new_dump = _try_offload_json_column(
                     processed_item[col_idx],
                     processed_item[project_id_idx],
@@ -7415,7 +7418,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                         current_col_size = new_size
                         offloaded_count += 1
 
-                # Phase 2: if still over the limit, replace entire column
+                # If still over the limit, replace entire column
                 if total_json_bytes > row_limit:
                     processed_item[col_idx] = ch_settings.ENTITY_TOO_LARGE_PAYLOAD
                     total_json_bytes -= (

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -83,6 +83,7 @@ from weave.trace_server.agents.types import (
 from weave.trace_server.base64_content_conversion import (
     process_call_req_to_content,
     process_complete_call_to_content,
+    replace_large_strings_with_content_objects,
 )
 from weave.trace_server.call_stats_helpers import (
     rows_to_bucket_dicts,
@@ -7251,11 +7252,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         try:
             self._insert_call_batch(self._call_batch)
         except InsertTooLarge:
-            logger.info("Retrying with large objects stripped.")
-            batch = self._strip_large_values(self._call_batch)
-            # Insert rows one at a time after stripping large values
-            for row in batch:
-                self._insert_call_batch([row])
+            logger.info("Retrying with large values offloaded to content storage.")
+            batch = self._offload_large_values(
+                self._call_batch, ALL_CALL_INSERT_COLUMNS
+            )
+            self._insert_call_batch(batch)
         finally:
             self._call_batch = []
 
@@ -7339,64 +7340,131 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         try:
             self._insert_call_complete_batch(self._calls_complete_batch)
         except InsertTooLarge:
-            # Try 1 by 1
-            for row in self._calls_complete_batch:
-                self._insert_call_complete_batch([row])
+            logger.info(
+                "Retrying calls_complete with large values offloaded to content storage."
+            )
+            batch = self._offload_large_values(
+                self._calls_complete_batch, ALL_CALL_COMPLETE_INSERT_COLUMNS
+            )
+            self._insert_call_complete_batch(batch)
         finally:
             self._calls_complete_batch = []
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._strip_large_values")
-    def _strip_large_values(self, batch: list[list[Any]]) -> list[list[Any]]:
-        """Iterate through the batch and replace large JSON values with placeholders.
+    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._offload_large_values")
+    def _offload_large_values(
+        self, batch: list[list[Any]], column_names: list[str]
+    ) -> list[list[Any]]:
+        """Offload large string values from JSON columns to file storage as Content objects.
 
-        Only considers JSON dump columns and ensures their combined size stays under
-        the limit by selectively replacing the largest values.
+        When a row's combined JSON column size exceeds the ClickHouse row limit,
+        this method processes each oversized column (largest first) in two phases:
+
+        1. **Content offloading** -- parse the JSON, replace large string leaf values
+           with Content object references stored in file storage, and re-serialize.
+           This preserves the data structure and user data.
+        2. **Error-payload fallback** -- if offloading alone does not reduce the column
+           enough, replace the entire column with ``ENTITY_TOO_LARGE_PAYLOAD``.
+
+        Only JSON dump columns (inputs, output, attributes, summary) are considered.
+
+        Args:
+            batch: List of rows, where each row is a list of column values.
+            column_names: Column name list matching the row layout (e.g.
+                ``ALL_CALL_INSERT_COLUMNS`` or ``ALL_CALL_COMPLETE_INSERT_COLUMNS``).
         """
+        offloaded_count = 0
         stripped_count = 0
         final_batch = []
 
+        project_id_idx = column_names.index("project_id")
         json_column_indices = [
-            ALL_CALL_INSERT_COLUMNS.index(f"{col}_dump")
-            for col in ALL_CALL_JSON_COLUMNS
+            column_names.index(f"{col}_dump") for col in ALL_CALL_JSON_COLUMNS
         ]
         entity_too_large_payload_byte_size = num_bytes(
             ch_settings.ENTITY_TOO_LARGE_PAYLOAD
         )
+        row_limit = ch_settings.CLICKHOUSE_SINGLE_ROW_INSERT_BYTES_LIMIT
 
         for item in batch:
-            # Calculate only JSON dump bytes
             json_idx_size_pairs = [(i, num_bytes(item[i])) for i in json_column_indices]
             total_json_bytes = sum(size for _, size in json_idx_size_pairs)
 
-            # If over limit, try to optimize by selectively stripping largest JSON values
-            stripped_item = list(item)
+            processed_item = list(item)
             sorted_json_idx_size_pairs = sorted(
                 json_idx_size_pairs, key=lambda x: x[1], reverse=True
             )
 
-            # Try to get under the limit by replacing largest JSON values
-            for col_idx, size in sorted_json_idx_size_pairs:
-                if (
-                    total_json_bytes
-                    <= ch_settings.CLICKHOUSE_SINGLE_ROW_INSERT_BYTES_LIMIT
-                ):
+            for col_idx, original_size in sorted_json_idx_size_pairs:
+                if total_json_bytes <= row_limit:
                     break
 
-                # Replace this large JSON value with placeholder, update running size
-                stripped_item[col_idx] = ch_settings.ENTITY_TOO_LARGE_PAYLOAD
-                total_json_bytes -= size - entity_too_large_payload_byte_size
-                stripped_count += 1
+                current_col_size = original_size
 
-            final_batch.append(stripped_item)
+                # Phase 1: try to offload large strings to Content objects
+                new_dump = _try_offload_json_column(
+                    processed_item[col_idx],
+                    processed_item[project_id_idx],
+                    self,
+                    min_chars=ch_settings.LARGE_STRING_OFFLOAD_MIN_CHARS,
+                )
+                if new_dump is not None:
+                    new_size = num_bytes(new_dump)
+                    if new_size < current_col_size:
+                        processed_item[col_idx] = new_dump
+                        total_json_bytes -= current_col_size - new_size
+                        current_col_size = new_size
+                        offloaded_count += 1
+
+                # Phase 2: if still over the limit, replace entire column
+                if total_json_bytes > row_limit:
+                    processed_item[col_idx] = ch_settings.ENTITY_TOO_LARGE_PAYLOAD
+                    total_json_bytes -= (
+                        current_col_size - entity_too_large_payload_byte_size
+                    )
+                    stripped_count += 1
+
+            final_batch.append(processed_item)
 
         set_current_span_dd_tags(
             {
-                "clickhouse_trace_server_batched._strip_large_values.stripped_count": str(
+                "clickhouse_trace_server_batched._offload_large_values.offloaded_count": str(
+                    offloaded_count
+                ),
+                "clickhouse_trace_server_batched._offload_large_values.stripped_count": str(
                     stripped_count
-                )
+                ),
             }
         )
         return final_batch
+
+
+def _try_offload_json_column(
+    json_dump: str,
+    project_id: str,
+    trace_server: tsi.TraceServerInterface,
+    min_chars: int,
+) -> str | None:
+    """Try to reduce a JSON column by offloading large string leaves to Content storage.
+
+    Parses the JSON dump, replaces string values whose character count exceeds
+    ``min_chars`` with Content object references stored in file storage, and
+    re-serializes.
+    """
+    try:
+        parsed = json.loads(json_dump)
+        processed = replace_large_strings_with_content_objects(
+            parsed,
+            project_id,
+            trace_server,
+            min_chars=min_chars,
+        )
+        return json.dumps(processed)
+    except Exception:
+        logger.warning(
+            "Content offload failed for JSON column",
+            exc_info=True,
+        )
+        return None
 
 
 def _update_metadata_from_chunk(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7379,9 +7379,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         json_column_indices = [
             column_names.index(f"{col}_dump") for col in ALL_CALL_JSON_COLUMNS
         ]
-        entity_too_large_payload_byte_size = num_bytes(
-            ch_settings.ENTITY_TOO_LARGE_PAYLOAD
-        )
         row_limit = ch_settings.PROACTIVE_OFFLOAD_BYTES_LIMIT
 
         for item in batch:
@@ -7392,40 +7389,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 final_batch.append(item)
                 continue
 
-            processed_item = list(item)
-            sorted_json_idx_size_pairs = sorted(
-                json_idx_size_pairs, key=lambda x: x[1], reverse=True
+            processed_item, row_offloaded, row_stripped = _offload_oversized_row(
+                list(item),
+                json_idx_size_pairs,
+                total_json_bytes,
+                row_limit,
+                project_id_idx,
+                self,
             )
-
-            for col_idx, original_size in sorted_json_idx_size_pairs:
-                if total_json_bytes <= row_limit:
-                    break
-
-                current_col_size = original_size
-
-                # Try to offload large strings to Content objects
-                new_dump = _try_offload_json_column(
-                    processed_item[col_idx],
-                    processed_item[project_id_idx],
-                    self,
-                    min_chars=ch_settings.LARGE_STRING_OFFLOAD_MIN_CHARS,
-                )
-                if new_dump is not None:
-                    new_size = num_bytes(new_dump)
-                    if new_size < current_col_size:
-                        processed_item[col_idx] = new_dump
-                        total_json_bytes -= current_col_size - new_size
-                        current_col_size = new_size
-                        offloaded_count += 1
-
-                # If still over the limit, replace entire column
-                if total_json_bytes > row_limit:
-                    processed_item[col_idx] = ch_settings.ENTITY_TOO_LARGE_PAYLOAD
-                    total_json_bytes -= (
-                        current_col_size - entity_too_large_payload_byte_size
-                    )
-                    stripped_count += 1
-
+            offloaded_count += row_offloaded
+            stripped_count += row_stripped
             final_batch.append(processed_item)
 
         set_current_span_dd_tags(
@@ -7441,16 +7414,76 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return final_batch
 
 
+def _offload_oversized_row(
+    row: list[Any],
+    json_idx_size_pairs: list[tuple[int, int]],
+    total_json_bytes: int,
+    row_limit: int,
+    project_id_idx: int,
+    trace_server: tsi.TraceServerInterface,
+) -> tuple[list[Any], int, int]:
+    """Process a single oversized row by offloading or stripping its JSON columns.
+
+    Iterates through JSON columns (largest first), attempting content offloading
+    first, then falling back to replacing the column with an error payload.
+
+    Args:
+        row: Mutable list of column values for this row.
+        json_idx_size_pairs: (column_index, byte_size) pairs for JSON columns.
+        total_json_bytes: Current total byte size of all JSON columns in the row.
+        row_limit: Maximum allowed total JSON bytes per row.
+        project_id_idx: Index of the project_id column in the row.
+        trace_server: Trace server instance for file storage.
+
+    Returns:
+        Tuple of (processed_row, offloaded_count, stripped_count).
+    """
+    offloaded_count = 0
+    stripped_count = 0
+    entity_too_large_payload_byte_size = num_bytes(
+        ch_settings.ENTITY_TOO_LARGE_PAYLOAD
+    )
+
+    sorted_pairs = sorted(json_idx_size_pairs, key=lambda x: x[1], reverse=True)
+
+    for col_idx, original_size in sorted_pairs:
+        if total_json_bytes <= row_limit:
+            break
+
+        current_col_size = original_size
+
+        new_dump = _try_offload_json_column(
+            row[col_idx],
+            row[project_id_idx],
+            trace_server,
+            max_chars=ch_settings.LARGE_STRING_OFFLOAD_MAX_CHARS,
+        )
+        if new_dump is not None:
+            new_size = num_bytes(new_dump)
+            if new_size < current_col_size:
+                row[col_idx] = new_dump
+                total_json_bytes -= current_col_size - new_size
+                current_col_size = new_size
+                offloaded_count += 1
+
+        if total_json_bytes > row_limit:
+            row[col_idx] = ch_settings.ENTITY_TOO_LARGE_PAYLOAD
+            total_json_bytes -= current_col_size - entity_too_large_payload_byte_size
+            stripped_count += 1
+
+    return row, offloaded_count, stripped_count
+
+
 def _try_offload_json_column(
     json_dump: str,
     project_id: str,
     trace_server: tsi.TraceServerInterface,
-    min_chars: int,
+    max_chars: int,
 ) -> str | None:
     """Try to reduce a JSON column by offloading large string leaves to Content storage.
 
     Parses the JSON dump, replaces string values whose character count exceeds
-    ``min_chars`` with Content object references stored in file storage, and
+    ``max_chars`` with Content object references stored in file storage, and
     re-serializes.
     """
     try:
@@ -7459,7 +7492,7 @@ def _try_offload_json_column(
             parsed,
             project_id,
             trace_server,
-            min_chars=min_chars,
+            max_chars=max_chars,
         )
         return json.dumps(processed)
     except Exception:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -174,7 +174,6 @@ from weave.trace_server.datadog import (
 from weave.trace_server.digest_validation import validate_expected_digest
 from weave.trace_server.errors import (
     CallsCompleteModeRequired,
-    InsertTooLarge,
     InvalidRequest,
     MissingLLMApiKeyError,
     NotFoundError,
@@ -7440,9 +7439,7 @@ def _offload_oversized_row(
     """
     offloaded_count = 0
     stripped_count = 0
-    entity_too_large_payload_byte_size = num_bytes(
-        ch_settings.ENTITY_TOO_LARGE_PAYLOAD
-    )
+    entity_too_large_payload_byte_size = num_bytes(ch_settings.ENTITY_TOO_LARGE_PAYLOAD)
 
     sorted_pairs = sorted(json_idx_size_pairs, key=lambda x: x[1], reverse=True)
 

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -24,6 +24,14 @@ CLICKHOUSE_SINGLE_ROW_INSERT_BYTES_LIMIT = 3.5 * 1024 * 1024  # 3.5 MiB
 CLICKHOUSE_MAX_FEEDBACK_PAYLOAD_SIZE = 1 * 1024 * 1024  # 1 MiB
 ENTITY_TOO_LARGE_PAYLOAD = '{"_weave": {"error":"<EXCEEDS_LIMITS>"}}'
 
+# Minimum string length (in characters) to offload to Content storage when a row
+# exceeds CLICKHOUSE_SINGLE_ROW_INSERT_BYTES_LIMIT.  Strings shorter than this
+# threshold are left inline; longer ones are stored as Content objects in file
+# storage so the row can fit within ClickHouse limits without data loss.
+# Note: measured in characters (len()), not bytes -- equivalent for ASCII content
+# and a safe lower bound for multi-byte UTF-8 strings.
+LARGE_STRING_OFFLOAD_MIN_CHARS = 10 * 1024  # 10k characters
+
 
 # Table naming conventions for distributed mode
 # In distributed mode, local tables use this suffix (e.g., "calls_complete_local")

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -31,11 +31,12 @@ ENTITY_TOO_LARGE_PAYLOAD = '{"_weave": {"error":"<EXCEEDS_LIMITS>"}}'
 # ENTITY_TOO_LARGE_PAYLOAD so the row fits within ClickHouse limits.
 PROACTIVE_OFFLOAD_BYTES_LIMIT = 1 * 1024 * 1024  # 1 MiB
 
-# Minimum string length (in characters) to offload to Content storage when a row
-# exceeds the offload threshold. Strings shorter than this are left inline;
-# longer ones are stored as Content objects in file storage so the row can fit
-# within limits without data loss.
+# String-length thresholds (in characters) for offloading to Content storage when
+# a row exceeds the byte limit. We first offload only the largest strings (MAX),
+# and escalate to smaller strings (MIN) only if the column is still over budget,
+# so a column made of many medium strings is preserved rather than dropped.
 LARGE_STRING_OFFLOAD_MAX_CHARS = 100 * 1024  # 100k characters
+LARGE_STRING_OFFLOAD_MIN_CHARS = 8 * 1024  # 8k characters
 
 
 # Table naming conventions for distributed mode

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -35,7 +35,7 @@ PROACTIVE_OFFLOAD_BYTES_LIMIT = 1 * 1024 * 1024  # 1 MiB
 # exceeds the offload threshold.  Strings shorter than this are left inline;
 # longer ones are stored as Content objects in file storage so the row can fit
 # within limits without data loss.
-LARGE_STRING_OFFLOAD_MIN_CHARS = 100 * 1024  # 100k characters
+LARGE_STRING_OFFLOAD_MAX_CHARS = 100 * 1024  # 100k characters
 
 
 # Table naming conventions for distributed mode

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -32,7 +32,7 @@ ENTITY_TOO_LARGE_PAYLOAD = '{"_weave": {"error":"<EXCEEDS_LIMITS>"}}'
 PROACTIVE_OFFLOAD_BYTES_LIMIT = 1 * 1024 * 1024  # 1 MiB
 
 # Minimum string length (in characters) to offload to Content storage when a row
-# exceeds the offload threshold.  Strings shorter than this are left inline;
+# exceeds the offload threshold. Strings shorter than this are left inline;
 # longer ones are stored as Content objects in file storage so the row can fit
 # within limits without data loss.
 LARGE_STRING_OFFLOAD_MAX_CHARS = 100 * 1024  # 100k characters

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -24,13 +24,18 @@ CLICKHOUSE_SINGLE_ROW_INSERT_BYTES_LIMIT = 3.5 * 1024 * 1024  # 3.5 MiB
 CLICKHOUSE_MAX_FEEDBACK_PAYLOAD_SIZE = 1 * 1024 * 1024  # 1 MiB
 ENTITY_TOO_LARGE_PAYLOAD = '{"_weave": {"error":"<EXCEEDS_LIMITS>"}}'
 
+# Payload offloading threshold.  Before every batch insert (call_start/call_end,
+# calls_complete, and OTEL export), each row's total JSON payload is measured.
+# When it exceeds this limit, large string leaves are offloaded to Content
+# storage (file storage) and, as a last resort, entire columns are replaced with
+# ENTITY_TOO_LARGE_PAYLOAD so the row fits within ClickHouse limits.
+PROACTIVE_OFFLOAD_BYTES_LIMIT = 1 * 1024 * 1024  # 1 MiB
+
 # Minimum string length (in characters) to offload to Content storage when a row
-# exceeds CLICKHOUSE_SINGLE_ROW_INSERT_BYTES_LIMIT.  Strings shorter than this
-# threshold are left inline; longer ones are stored as Content objects in file
-# storage so the row can fit within ClickHouse limits without data loss.
-# Note: measured in characters (len()), not bytes -- equivalent for ASCII content
-# and a safe lower bound for multi-byte UTF-8 strings.
-LARGE_STRING_OFFLOAD_MIN_CHARS = 10 * 1024  # 10k characters
+# exceeds the offload threshold.  Strings shorter than this are left inline;
+# longer ones are stored as Content objects in file storage so the row can fit
+# within limits without data loss.
+LARGE_STRING_OFFLOAD_MIN_CHARS = 100 * 1024  # 100k characters
 
 
 # Table naming conventions for distributed mode


### PR DESCRIPTION
## Summary
- Stop dropping oversized call payloads: offload large string leaves to Content (file) storage before insert, stripping to the `<EXCEEDS_LIMITS>` sentinel only as a last resort.
- Runs proactively before every insert (calls / calls_complete / OTEL) at a 1 MiB JSON budget; offloads progressively (large then medium leaves) so payloads made of many medium strings are preserved, not dropped.
- Keeps the `InsertTooLarge` -> row-by-row fallback so a single oversized row can't fail the whole batch.

## Performance
A cheap `chars * 4` upper bound skips the full byte-encode on the common small-row path (master did no measurement here at all). Heavy ~80 KiB trace rows: ~3.9 -> ~0.7 us/row on the offload gate.

## Testing
offload functional tests in clickhouse mode + unit coverage for progressive offload and the strip fallback.