### PR TITLE
chore(weave): add TTL settings LRU cache module

### DIFF
--- a/tests/trace_server/test_ttl_settings.py
+++ b/tests/trace_server/test_ttl_settings.py
@@ -1,7 +1,7 @@
 """Scenario-focused tests for weave.trace_server.ttl_settings."""
 
 import datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -94,9 +94,12 @@ def test_get_project_retention_days_l1_cache():
     assert first == 90
     assert second == 90
     assert ch_client.query.call_count == 1
-    query_arg = ch_client.query.call_args[0][0]
-    assert "argMax(retention_days, updated_at)" in query_arg
-    assert "FINAL" not in query_arg
+    assert ch_client.query.call_args == call(
+        "SELECT argMax(retention_days, updated_at) "
+        "FROM project_ttl_settings "
+        "WHERE project_id = {project_id:String}",
+        parameters={"project_id": "entity/project"},
+    )
 
     # Different project with no rows → 0 (no TTL configured)
     ch_empty = _make_ch_client([])

--- a/tests/trace_server/test_ttl_settings.py
+++ b/tests/trace_server/test_ttl_settings.py
@@ -1,0 +1,178 @@
+"""Scenario-focused tests for weave.trace_server.ttl_settings."""
+
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from weave.trace_server.ttl_settings import (
+    EXPIRE_AT_NEVER,
+    REDIS_TTL_EXPIRY_SECS,
+    _ttl_cache_key,
+    compute_expire_at,
+    get_project_retention_days,
+    invalidate_ttl_cache,
+    reset_ttl_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    """Ensure cache is empty before and after each test."""
+    reset_ttl_cache()
+    yield
+    reset_ttl_cache()
+
+
+class _FakeRedis:
+    """Minimal dict-backed Redis mock for testing L2 cache."""
+
+    def __init__(self):
+        self._store: dict[str, tuple[str, int | None]] = {}
+
+    def get(self, key: str) -> str | None:
+        entry = self._store.get(key)
+        return entry[0] if entry else None
+
+    def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self._store[key] = (value, ex)
+
+    def delete(self, key: str) -> None:
+        self._store.pop(key, None)
+
+
+def _make_ch_client(rows):
+    """Build a mock ClickHouse client that returns given rows."""
+    mock_result = MagicMock()
+    mock_result.row_count = len(rows)
+    mock_result.first_row = rows[0] if rows else None
+    client = MagicMock()
+    client.query.return_value = mock_result
+    return client
+
+
+def test_compute_expire_at():
+    """Zero → sentinel, positive + naive → UTC, positive + aware → preserved, negative → minutes."""
+    # retention_days=0 returns the far-future UTC sentinel
+    result_zero = compute_expire_at(0, datetime.datetime(2025, 1, 1))
+    assert result_zero == EXPIRE_AT_NEVER
+    assert result_zero.tzinfo == datetime.timezone.utc
+
+    # Positive days with naive datetime normalizes to UTC
+    result_positive_naive = compute_expire_at(
+        90, datetime.datetime(2025, 1, 1, 12, 0, 0)
+    )
+    assert result_positive_naive == datetime.datetime(
+        2025, 4, 1, 12, 0, 0, tzinfo=datetime.timezone.utc
+    )
+    assert result_positive_naive.tzinfo == datetime.timezone.utc
+
+    # Positive days with aware datetime preserves original timezone
+    tz_minus7 = datetime.timezone(datetime.timedelta(hours=-7))
+    result_positive_aware = compute_expire_at(
+        30, datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=tz_minus7)
+    )
+    assert result_positive_aware == datetime.datetime(
+        2025, 1, 31, 12, 0, 0, tzinfo=tz_minus7
+    )
+    assert result_positive_aware.tzinfo == tz_minus7
+
+    # Negative retention_days encodes minutes (e.g. -5 = 5 minutes)
+    result_negative = compute_expire_at(-5, datetime.datetime(2025, 6, 15, 10, 0, 0))
+    assert result_negative == datetime.datetime(
+        2025, 6, 15, 10, 5, 0, tzinfo=datetime.timezone.utc
+    )
+
+
+def test_get_project_retention_days_l1_cache():
+    """L1 caching: single CH query for repeated lookups, zero on CH miss."""
+    ch_client = _make_ch_client([[90]])
+
+    first = get_project_retention_days("entity/project", ch_client)
+    second = get_project_retention_days("entity/project", ch_client)
+
+    assert first == 90
+    assert second == 90
+    assert ch_client.query.call_count == 1
+    query_arg = ch_client.query.call_args[0][0]
+    assert "argMax(retention_days, updated_at)" in query_arg
+    assert "FINAL" not in query_arg
+
+    # Different project with no rows → 0 (no TTL configured)
+    ch_empty = _make_ch_client([])
+    assert get_project_retention_days("entity/no-ttl", ch_empty) == 0
+
+
+@pytest.mark.disable_logging_error_check
+def test_get_project_retention_days_redis_l2_cache():
+    """L2 read, L2 populate after CH hit, and graceful Redis failure fallback."""
+    redis = _FakeRedis()
+
+    # Pre-populated Redis → serves from L2, no CH query, then L1 on repeat
+    ch_not_reached = _make_ch_client([[999]])
+    redis.set(_ttl_cache_key("entity/proj"), "45", ex=300)
+
+    first = get_project_retention_days(
+        "entity/proj", ch_not_reached, redis_client=redis
+    )
+    second = get_project_retention_days(
+        "entity/proj", ch_not_reached, redis_client=redis
+    )
+    assert first == 45
+    assert second == 45
+    assert ch_not_reached.query.call_count == 0
+
+    # Cold Redis → CH query populates both L2 and L1
+    redis_cold = _FakeRedis()
+    ch_client = _make_ch_client([[60]])
+    result = get_project_retention_days(
+        "entity/other", ch_client, redis_client=redis_cold
+    )
+    assert result == 60
+    assert ch_client.query.call_count == 1
+    key = _ttl_cache_key("entity/other")
+    assert redis_cold.get(key) == "60"
+    assert redis_cold._store[key][1] == REDIS_TTL_EXPIRY_SECS
+
+    # Broken Redis → falls back to CH transparently
+    broken_redis = MagicMock()
+    broken_redis.get.side_effect = ConnectionError("Redis down")
+    broken_redis.set.side_effect = ConnectionError("Redis down")
+    ch_fallback = _make_ch_client([[77]])
+    assert (
+        get_project_retention_days(
+            "entity/broken-redis", ch_fallback, redis_client=broken_redis
+        )
+        == 77
+    )
+    assert ch_fallback.query.call_count == 1
+
+
+@pytest.mark.disable_logging_error_check
+def test_invalidate_ttl_cache():
+    """Invalidation clears L1+L2, forces refetch, and swallows Redis errors."""
+    ch_client = _make_ch_client([[90]])
+    redis = _FakeRedis()
+    key = _ttl_cache_key("entity/proj")
+
+    # Populate both cache layers
+    original = get_project_retention_days("entity/proj", ch_client, redis_client=redis)
+    cached = get_project_retention_days("entity/proj", ch_client, redis_client=redis)
+    assert original == 90
+    assert cached == 90
+    assert redis.get(key) == "90"
+    assert ch_client.query.call_count == 1
+
+    # Invalidate and verify refetch picks up new value
+    ch_client.query.return_value.first_row = [30]
+    invalidate_ttl_cache("entity/proj", redis_client=redis)
+    assert redis.get(key) is None
+
+    refreshed = get_project_retention_days("entity/proj", ch_client, redis_client=redis)
+    assert refreshed == 30
+    assert ch_client.query.call_count == 2
+
+    # Broken Redis on delete → no exception raised
+    broken_redis = MagicMock()
+    broken_redis.delete.side_effect = ConnectionError("Redis down")
+    invalidate_ttl_cache("entity/proj", redis_client=broken_redis)

--- a/weave/trace_server/clickhouse_schema.py
+++ b/weave/trace_server/clickhouse_schema.py
@@ -6,7 +6,7 @@ from weave.shared import refs_internal as ri
 from weave.trace_server import validation
 
 # Sentinel value meaning "never expire". Matches the CH column default.
-EXPIRE_AT_NEVER = datetime.datetime(2100, 1, 1)
+EXPIRE_AT_NEVER = datetime.datetime(2100, 1, 1, tzinfo=datetime.timezone.utc)
 
 # =============================================================================
 # Base Classes for ClickHouse Call Schemas

--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -3,7 +3,13 @@
 Provides a cached lookup of per-project retention settings from ClickHouse,
 and helpers to compute the expire_at timestamp for new inserts.
 
-Two-layer cache: L1 in-process TTLCache, L2 Redis (optional).
+Two-layer cache over per-project retention_days:
+  L1: in-process, time-based eviction via cachetools.TTLCache
+  L2: Redis (optional)
+
+Noun overload warning: the cached *value* is itself a TTL setting
+(retention_days). "TTLCache" here refers to the L1 eviction strategy, not the
+value being cached.
 """
 
 from __future__ import annotations
@@ -45,8 +51,9 @@ def get_project_retention_days(
 ) -> int:
     """Return retention_days for a project (0 = no TTL / infinite). Cached.
 
-    Read path: L1 (TTLCache) -> L2 (Redis, optional) -> L3 (ClickHouse argMax).
-    On CH miss (no row), returns 0 (no TTL configured).
+    Read path: L1 (in-process) -> L2 (Redis, optional) -> SOT (ClickHouse argMax).
+    A fall-through to SOT is a full cache miss; on CH miss (no row), returns 0
+    (no TTL configured).
     """
     cached = _l1_get(project_id)
     if cached is not None:
@@ -60,9 +67,9 @@ def get_project_retention_days(
             set_current_span_dd_tags({"ttl.cache_hit": "L2"})
             return redis_val
 
-    retention_days = _l3_query(ch_client, project_id)
+    retention_days = _query_source_of_truth(ch_client, project_id)
     set_current_span_dd_tags(
-        {"ttl.cache_hit": "L3", "ttl.retention_days": retention_days}
+        {"ttl.cache_hit": "SOT", "ttl.retention_days": retention_days}
     )
 
     if redis_client is not None:
@@ -164,7 +171,7 @@ def _l2_delete(redis_client: redis.Redis, project_id: str) -> None:
         logger.exception("Redis L2 cache delete failed for project %s", project_id)
 
 
-def _l3_query(ch_client: CHClient, project_id: str) -> int:
+def _query_source_of_truth(ch_client: CHClient, project_id: str) -> int:
     """Query ClickHouse for the latest retention_days via argMax. Returns 0 on miss."""
     result = ch_client.query(
         "SELECT argMax(retention_days, updated_at) "

--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -1,0 +1,177 @@
+"""TTL (Time-To-Live) settings cache for per-project call data retention.
+
+Provides a cached lookup of per-project retention settings from ClickHouse,
+and helpers to compute the expire_at timestamp for new inserts.
+
+Two-layer cache: L1 in-process TTLCache, L2 Redis (optional).
+"""
+
+from __future__ import annotations
+
+import datetime
+import logging
+import threading
+
+import ddtrace
+import redis
+from cachetools import TTLCache
+from clickhouse_connect.driver.client import Client as CHClient
+
+from weave.trace_server.clickhouse_schema import EXPIRE_AT_NEVER
+from weave.trace_server.datadog import set_current_span_dd_tags
+
+logger = logging.getLogger(__name__)
+
+PROJECT_TTL_CACHE_SIZE = 10_000
+# 5 minutes; bounds staleness in multi-instance deploys
+PROJECT_TTL_CACHE_TTL_SECS = 300
+
+REDIS_TTL_KEY_PREFIX = "weave:project_ttl:"
+REDIS_TTL_EXPIRY_SECS = 300
+
+# Global cache shared across all threads. Keyed by project_id.
+# Value is retention_days (int). 0 means no TTL (sentinel 2100-01-01).
+_project_ttl_cache: TTLCache[str, int] = TTLCache(
+    maxsize=PROJECT_TTL_CACHE_SIZE, ttl=PROJECT_TTL_CACHE_TTL_SECS
+)
+_project_ttl_cache_lock = threading.Lock()
+
+
+@ddtrace.tracer.wrap(name="ttl_settings.get_project_retention_days")
+def get_project_retention_days(
+    project_id: str,
+    ch_client: CHClient,
+    redis_client: redis.Redis | None = None,
+) -> int:
+    """Return retention_days for a project (0 = no TTL / infinite). Cached.
+
+    Read path: L1 (TTLCache) -> L2 (Redis, optional) -> L3 (ClickHouse argMax).
+    On CH miss (no row), returns 0 (no TTL configured).
+    """
+    cached = _l1_get(project_id)
+    if cached is not None:
+        set_current_span_dd_tags({"ttl.cache_hit": "L1"})
+        return cached
+
+    if redis_client is not None:
+        redis_val = _l2_get(redis_client, project_id)
+        if redis_val is not None:
+            _l1_set(project_id, redis_val)
+            set_current_span_dd_tags({"ttl.cache_hit": "L2"})
+            return redis_val
+
+    retention_days = _l3_query(ch_client, project_id)
+    set_current_span_dd_tags(
+        {"ttl.cache_hit": "L3", "ttl.retention_days": retention_days}
+    )
+
+    if redis_client is not None:
+        _l2_set(redis_client, project_id, retention_days)
+    _l1_set(project_id, retention_days)
+
+    return retention_days
+
+
+def compute_expire_at(
+    retention_days: int, started_at: datetime.datetime
+) -> datetime.datetime:
+    """Compute the expire_at timestamp for a call.
+
+    If retention_days == 0, returns the far-future sentinel (2100-01-01 UTC),
+    meaning the row will never expire. Otherwise returns
+    started_at + timedelta(days=retention_days).
+    """
+    if retention_days == 0:
+        return EXPIRE_AT_NEVER
+
+    anchor = started_at
+    if anchor.tzinfo is None:
+        anchor = anchor.replace(tzinfo=datetime.timezone.utc)
+
+    if retention_days > 0:
+        return anchor + datetime.timedelta(days=retention_days)
+    # Negative values encode minutes-based retention (e.g. -5 = 5 minutes) for admin/testing use only
+    return anchor + datetime.timedelta(minutes=-retention_days)
+
+
+def invalidate_ttl_cache(
+    project_id: str, redis_client: redis.Redis | None = None
+) -> None:
+    """Remove a project from the TTL cache (both L1 and L2).
+
+    Call this after updating a project's TTL settings so the next
+    insert picks up the new value.
+    """
+    with _project_ttl_cache_lock:
+        _project_ttl_cache.pop(project_id, None)
+    if redis_client is not None:
+        _l2_delete(redis_client, project_id)
+
+
+def reset_ttl_cache() -> None:
+    """Clear the entire TTL cache. Primarily for testing."""
+    with _project_ttl_cache_lock:
+        _project_ttl_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Cache-layer helpers
+# ---------------------------------------------------------------------------
+
+
+def _ttl_cache_key(project_id: str) -> str:
+    return f"{REDIS_TTL_KEY_PREFIX}{project_id}"
+
+
+def _l1_get(project_id: str) -> int | None:
+    """Read from the in-process TTLCache."""
+    with _project_ttl_cache_lock:
+        return _project_ttl_cache.get(project_id)
+
+
+def _l1_set(project_id: str, retention_days: int) -> None:
+    """Write to the in-process TTLCache."""
+    with _project_ttl_cache_lock:
+        _project_ttl_cache[project_id] = retention_days
+
+
+def _l2_get(redis_client: redis.Redis, project_id: str) -> int | None:
+    """Try to read retention_days from Redis. Returns None on miss or error."""
+    try:
+        val = redis_client.get(_ttl_cache_key(project_id))
+        if val is not None:
+            return int(val)
+    except Exception:
+        logger.exception("Redis L2 cache read failed for project %s", project_id)
+    return None
+
+
+def _l2_set(redis_client: redis.Redis, project_id: str, retention_days: int) -> None:
+    """Try to write retention_days to Redis with TTL. Logs errors but does not raise."""
+    try:
+        redis_client.set(
+            _ttl_cache_key(project_id), str(retention_days), ex=REDIS_TTL_EXPIRY_SECS
+        )
+    except Exception:
+        logger.exception("Redis L2 cache write failed for project %s", project_id)
+
+
+def _l2_delete(redis_client: redis.Redis, project_id: str) -> None:
+    """Try to delete a key from Redis. Logs errors but does not raise."""
+    try:
+        redis_client.delete(_ttl_cache_key(project_id))
+    except Exception:
+        logger.exception("Redis L2 cache delete failed for project %s", project_id)
+
+
+def _l3_query(ch_client: CHClient, project_id: str) -> int:
+    """Query ClickHouse for the latest retention_days via argMax. Returns 0 on miss."""
+    result = ch_client.query(
+        "SELECT argMax(retention_days, updated_at) "
+        "FROM project_ttl_settings "
+        "WHERE project_id = {project_id:String}",
+        parameters={"project_id": project_id},
+    )
+    if result.row_count == 0:
+        return 0
+    return int(result.first_row[0])

--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -51,9 +51,9 @@ def get_project_retention_days(
 ) -> int:
     """Return retention_days for a project (0 = no TTL / infinite). Cached.
 
-    Read path: L1 (in-process) -> L2 (Redis, optional) -> SOT (ClickHouse argMax).
-    A fall-through to SOT is a full cache miss; on CH miss (no row), returns 0
-    (no TTL configured).
+    Read path: L1 (in-process) -> L2 (Redis, optional) -> ClickHouse (argMax).
+    A fall-through to ClickHouse is a full cache miss; if ClickHouse has no
+    row for the project, returns 0 (no TTL configured).
     """
     cached = _l1_get(project_id)
     if cached is not None:
@@ -67,9 +67,9 @@ def get_project_retention_days(
             set_current_span_dd_tags({"ttl.cache_hit": "L2"})
             return redis_val
 
-    retention_days = _query_source_of_truth(ch_client, project_id)
+    retention_days = _query_clickhouse(ch_client, project_id)
     set_current_span_dd_tags(
-        {"ttl.cache_hit": "SOT", "ttl.retention_days": retention_days}
+        {"ttl.cache_hit": "clickhouse", "ttl.retention_days": retention_days}
     )
 
     if redis_client is not None:
@@ -171,7 +171,7 @@ def _l2_delete(redis_client: redis.Redis, project_id: str) -> None:
         logger.exception("Redis L2 cache delete failed for project %s", project_id)
 
 
-def _query_source_of_truth(ch_client: CHClient, project_id: str) -> int:
+def _query_clickhouse(ch_client: CHClient, project_id: str) -> int:
     """Query ClickHouse for the latest retention_days via argMax. Returns 0 on miss."""
     result = ch_client.query(
         "SELECT argMax(retention_days, updated_at) "


### PR DESCRIPTION
## Summary

- Two-layer TTL settings cache (L1 in-process TTLCache, L2 Redis) for per-project retention lookups
- argMax-based ClickHouse query avoids FINAL, with graceful Redis failure fallback
- `compute_expire_at` helper handles zero/positive/negative retention_days
- Datadog tracing on cache hits (L1/L2/L3 tags)

NO hot code path changes, this new code should not be hit yet. 