### PR TITLE
fix(weave): Raise errors in completion create stream

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5913,36 +5913,23 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         prompt = getattr(req.inputs, "prompt", None)
         template_vars = getattr(req.inputs, "template_vars", None)
 
-        try:
-            # Use helper to resolve prompt, combine messages, and apply template vars
-            combined_messages, initial_messages = resolve_and_apply_prompt(
-                prompt=prompt,
-                messages=getattr(req.inputs, "messages", None),
-                template_vars=template_vars,
-                project_id=req.project_id,
-                obj_read_func=self.obj_read,
-            )
-        except Exception as e:
-            logger.exception("Failed to resolve and apply prompt")
-
-            # Yield error as single chunk then stop.
-            def _single_error_iter(err: Exception) -> Iterator[dict[str, str]]:
-                yield {"error": f"Failed to resolve and apply prompt: {err!s}"}
-
-            return _single_error_iter(e)
+        # Use helper to resolve prompt, combine messages, and apply template vars.
+        # Raises on failure — callers (trace_server.py) let this propagate to
+        # FastAPI's exception handlers for a proper error response.
+        combined_messages, initial_messages = resolve_and_apply_prompt(
+            prompt=prompt,
+            messages=getattr(req.inputs, "messages", None),
+            template_vars=template_vars,
+            project_id=req.project_id,
+            obj_read_func=self.obj_read,
+        )
 
         # --- Shared setup logic (copy of completions_create up to litellm call)
         model_info = self._model_to_provider_info_map.get(req.inputs.model)
-        try:
-            completion_model_info = _setup_completion_model_info(
-                model_info, req, self.obj_read
-            )
-        except Exception as e:
-            # Yield error as single chunk then stop.
-            def _single_error_iter(err: Exception) -> Iterator[dict[str, str]]:
-                yield {"error": str(err)}
-
-            return _single_error_iter(e)
+        # Raises on failure (e.g. missing secret, unrecognised model).
+        completion_model_info = _setup_completion_model_info(
+            model_info, req, self.obj_read
+        )
 
         model_name = completion_model_info.model_name
         api_key = completion_model_info.api_key
@@ -7545,6 +7532,9 @@ def _setup_completion_model_info(
             vertex_credentials=None,
         )
     elif model_info:
+        raise InvalidRequest(
+            f"No secret fetcher found, cannot fetch API key for model {model_name}"
+        )
         secret_name = model_info.get("api_key_name")
         if not secret_name:
             raise InvalidRequest(f"No secret name found for model {model_name}")

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7675,9 +7675,6 @@ def _setup_completion_model_info(
             vertex_credentials=None,
         )
     elif model_info:
-        raise InvalidRequest(
-            f"No secret fetcher found, cannot fetch API key for model {model_name}"
-        )
         secret_name = model_info.get("api_key_name")
         if not secret_name:
             raise InvalidRequest(f"No secret name found for model {model_name}")

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -7707,9 +7707,6 @@ def _setup_completion_model_info(
             vertex_credentials=None,
         )
     elif model_info:
-        raise InvalidRequest(
-            f"No secret fetcher found, cannot fetch API key for model {model_name}"
-        )
         secret_name = model_info.get("api_key_name")
         if not secret_name:
             raise InvalidRequest(f"No secret name found for model {model_name}")

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6046,15 +6046,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         except Exception as e:
             logger.exception("Failed to resolve prompt (streaming)")
             err = f"Failed to resolve and apply prompt: {e!s}"
+            weave_call_id: str | None = None
             if req.track_llm_call and start_time_tracked is not None:
-                self._record_tracked_completions_create_failure(
+                weave_call_id = self._record_tracked_completions_create_failure(
                     req,
                     start_time=start_time_tracked,
                     end_time=datetime.datetime.now(),
                     error_message=err,
                     initial_messages=initial_messages,
                 )
-            return iter([{"error": err}])
+            return _setup_error_chunks(weave_call_id, err)
 
         # --- Shared setup logic (copy of completions_create up to litellm call)
         model_info = self._model_to_provider_info_map.get(req.inputs.model)
@@ -6064,15 +6065,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             )
         except Exception as e:
             err = str(e)
+            weave_call_id = None
             if req.track_llm_call and start_time_tracked is not None:
-                self._record_tracked_completions_create_failure(
+                weave_call_id = self._record_tracked_completions_create_failure(
                     req,
                     start_time=start_time_tracked,
                     end_time=datetime.datetime.now(),
                     error_message=err,
                     initial_messages=initial_messages,
                 )
-            return iter([{"error": err}])
+            return _setup_error_chunks(weave_call_id, err)
 
         model_name = completion_model_info.model_name
         api_key = completion_model_info.api_key
@@ -7449,6 +7451,25 @@ def _process_tool_call_delta(
                 ]
 
 
+def _setup_error_chunks(
+    weave_call_id: str | None,
+    error_message: str,
+) -> Iterator[dict[str, Any]]:
+    """Yield a single error chunk for setup failures (errors before streaming begins).
+
+    The error chunk is always the first (and only) chunk so that
+    StreamingResponseWithStatusCode can set HTTP 500 before committing response
+    headers.  When weave_call_id is available it is embedded directly in the
+    error chunk under ``_meta`` so that the client can extract it from the 500
+    response body without needing a separate 200-status _meta chunk (which would
+    irrecoverably commit the HTTP response as 200 before the error arrives).
+    """
+    chunk: dict[str, Any] = {"error": error_message}
+    if weave_call_id:
+        chunk["_meta"] = {"weave_call_id": weave_call_id}
+    yield chunk
+
+
 def _create_tracked_stream_wrapper(
     insert_call: Callable[[CallEndCHInsertable], None],
     chunk_iter: Iterator[dict[str, Any]],
@@ -7476,8 +7497,15 @@ def _create_tracked_stream_wrapper(
         ] = {}  # Track finish reasons by choice index
         aggregated_metadata: dict[str, Any] = {}
 
+        stream_exception: str | None = None
         try:
             for chunk in chunk_iter:
+                # Capture error dicts from the LLM provider so the finally block
+                # can persist the exception on the call record even when the
+                # provider signals errors as a yielded chunk rather than raising.
+                if isinstance(chunk, dict) and chunk.get("error"):
+                    stream_exception = str(chunk["error"])
+
                 yield chunk  # Yield to client immediately
 
                 if not isinstance(chunk, dict):
@@ -7526,6 +7554,9 @@ def _create_tracked_stream_wrapper(
                                     reasoning_content_delta
                                 )
 
+        except Exception as e:
+            stream_exception = str(e)
+            raise
         finally:
             # Build final aggregated output with all choices
             if choice_contents or choice_tool_calls or choice_reasoning_content:
@@ -7554,6 +7585,7 @@ def _create_tracked_stream_wrapper(
                 ended_at=datetime.datetime.now(),
                 output=aggregated_output,
                 summary=summary,
+                exception=stream_exception,
             )
             end_call = _end_call_for_insert_to_ch_insertable_end_call(end)
             insert_call(end_call)
@@ -7675,6 +7707,9 @@ def _setup_completion_model_info(
             vertex_credentials=None,
         )
     elif model_info:
+        raise InvalidRequest(
+            f"No secret fetcher found, cannot fetch API key for model {model_name}"
+        )
         secret_name = model_info.get("api_key_name")
         if not secret_name:
             raise InvalidRequest(f"No secret name found for model {model_name}")

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5753,6 +5753,98 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.ActionsExecuteBatchRes()
 
+    def _record_tracked_completions_create_failure(
+        self,
+        req: tsi.CompletionsCreateReq,
+        *,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        error_message: str,
+        initial_messages: list,
+    ) -> str:
+        """Persist a failed completions_create to ClickHouse when ``track_llm_call`` is enabled.
+
+        Mirrors the success-path insert (calls_complete vs calls_merged) so failures
+        before ``lite_llm_completion`` still produce a trace row with ``exception`` set.
+
+        Args:
+            req: The completions request (inputs are restored from ``initial_messages`` for storage).
+            start_time: When the completion attempt started.
+            end_time: When the failure was recorded.
+            error_message: String stored on the call as ``exception`` and in ``output.error``.
+            initial_messages: Original user messages to store in ``inputs`` (same as success path).
+
+        Returns:
+            The generated ``call_id`` for ``weave_call_id`` in the API response.
+        """
+        req.inputs.messages = initial_messages
+        write_target = self.table_routing_resolver.resolve_v2_write_target(
+            req.project_id,
+            self.ch_client,
+        )
+        call_id = generate_id()
+        trace_id = req.trace_id or generate_id()
+        parent_id = req.parent_id
+        summary: tsi.SummaryInsertMap = {}
+        response_payload: dict[str, Any] = {"error": error_message}
+
+        inputs_dump = {
+            **req.inputs.model_dump(exclude_none=True, exclude={"vertex_credentials"})
+        }
+
+        if write_target == WriteTarget.CALLS_COMPLETE:
+            completed = tsi.CompletedCallSchemaForInsert(
+                project_id=req.project_id,
+                id=call_id,
+                trace_id=trace_id,
+                parent_id=parent_id,
+                op_name=COMPLETIONS_CREATE_OP_NAME,
+                started_at=start_time,
+                ended_at=end_time,
+                attributes={},
+                inputs=inputs_dump,
+                output=response_payload,
+                summary=summary,
+                exception=error_message,
+                wb_user_id=req.wb_user_id,
+            )
+            ch_call = _complete_call_to_ch_insertable(completed)
+            self._insert_call_complete(ch_call)
+        else:
+            start = tsi.StartedCallSchemaForInsert(
+                project_id=req.project_id,
+                id=call_id,
+                trace_id=trace_id,
+                parent_id=parent_id,
+                wb_user_id=req.wb_user_id,
+                op_name=COMPLETIONS_CREATE_OP_NAME,
+                started_at=start_time,
+                inputs=inputs_dump,
+                attributes={},
+            )
+            start_call = _start_call_for_insert_to_ch_insertable_start_call(start)
+            end = tsi.EndedCallSchemaForInsert(
+                project_id=req.project_id,
+                id=start_call.id,
+                ended_at=end_time,
+                output=response_payload,
+                summary=summary,
+            )
+            end.exception = error_message
+            end_call = _end_call_for_insert_to_ch_insertable_end_call(end)
+            calls: list[CallStartCHInsertable | CallEndCHInsertable] = [
+                start_call,
+                end_call,
+            ]
+            batch_data = []
+            for call in calls:
+                call_dict = call.model_dump()
+                values = [call_dict.get(col) for col in ALL_CALL_INSERT_COLUMNS]
+                batch_data.append(values)
+            self._insert_call_batch(batch_data)
+
+        return call_id
+
     def completions_create(
         self, req: tsi.CompletionsCreateReq
     ) -> tsi.CompletionsCreateRes:
@@ -5762,6 +5854,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Initialize initial_messages with the original messages
         initial_messages = getattr(req.inputs, "messages", None) or []
+
+        # When tracking is on, record wall time for early failures (prompt / setup).
+        start_time_tracked = datetime.datetime.now() if req.track_llm_call else None
 
         if prompt:
             try:
@@ -5777,8 +5872,19 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
             except Exception as e:
                 logger.exception("Failed to resolve prompt")
+                err = f"Failed to resolve and apply prompt: {e!s}"
+                weave_call_id: str | None = None
+                if req.track_llm_call and start_time_tracked is not None:
+                    weave_call_id = self._record_tracked_completions_create_failure(
+                        req,
+                        start_time=start_time_tracked,
+                        end_time=datetime.datetime.now(),
+                        error_message=err,
+                        initial_messages=initial_messages,
+                    )
                 return tsi.CompletionsCreateRes(
-                    response={"error": f"Failed to resolve prompt: {e!s}"}
+                    response={"error": err},
+                    weave_call_id=weave_call_id,
                 )
 
         # Use shared setup logic
@@ -5788,7 +5894,20 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 model_info, req, self.obj_read
             )
         except Exception as e:
-            return tsi.CompletionsCreateRes(response={"error": str(e)})
+            err = str(e)
+            weave_call_id = None
+            if req.track_llm_call and start_time_tracked is not None:
+                weave_call_id = self._record_tracked_completions_create_failure(
+                    req,
+                    start_time=start_time_tracked,
+                    end_time=datetime.datetime.now(),
+                    error_message=err,
+                    initial_messages=initial_messages,
+                )
+            return tsi.CompletionsCreateRes(
+                response={"error": err},
+                weave_call_id=weave_call_id,
+            )
 
         model_name = completion_model_info.model_name
 
@@ -5913,23 +6032,47 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         prompt = getattr(req.inputs, "prompt", None)
         template_vars = getattr(req.inputs, "template_vars", None)
 
-        # Use helper to resolve prompt, combine messages, and apply template vars.
-        # Raises on failure — callers (trace_server.py) let this propagate to
-        # FastAPI's exception handlers for a proper error response.
-        combined_messages, initial_messages = resolve_and_apply_prompt(
-            prompt=prompt,
-            messages=getattr(req.inputs, "messages", None),
-            template_vars=template_vars,
-            project_id=req.project_id,
-            obj_read_func=self.obj_read,
-        )
+        initial_messages = getattr(req.inputs, "messages", None) or []
+        start_time_tracked = datetime.datetime.now() if req.track_llm_call else None
+
+        try:
+            combined_messages, initial_messages = resolve_and_apply_prompt(
+                prompt=prompt,
+                messages=getattr(req.inputs, "messages", None),
+                template_vars=template_vars,
+                project_id=req.project_id,
+                obj_read_func=self.obj_read,
+            )
+        except Exception as e:
+            logger.exception("Failed to resolve prompt (streaming)")
+            err = f"Failed to resolve and apply prompt: {e!s}"
+            if req.track_llm_call and start_time_tracked is not None:
+                self._record_tracked_completions_create_failure(
+                    req,
+                    start_time=start_time_tracked,
+                    end_time=datetime.datetime.now(),
+                    error_message=err,
+                    initial_messages=initial_messages,
+                )
+            return iter([{"error": err}])
 
         # --- Shared setup logic (copy of completions_create up to litellm call)
         model_info = self._model_to_provider_info_map.get(req.inputs.model)
-        # Raises on failure (e.g. missing secret, unrecognised model).
-        completion_model_info = _setup_completion_model_info(
-            model_info, req, self.obj_read
-        )
+        try:
+            completion_model_info = _setup_completion_model_info(
+                model_info, req, self.obj_read
+            )
+        except Exception as e:
+            err = str(e)
+            if req.track_llm_call and start_time_tracked is not None:
+                self._record_tracked_completions_create_failure(
+                    req,
+                    start_time=start_time_tracked,
+                    end_time=datetime.datetime.now(),
+                    error_message=err,
+                    initial_messages=initial_messages,
+                )
+            return iter([{"error": err}])
 
         model_name = completion_model_info.model_name
         api_key = completion_model_info.api_key


### PR DESCRIPTION
## Description

https://wandb.atlassian.net/browse/WB-32221

Before we would swallow errors
Return 200 
and not save the error on the call

properly return 500, save the error message on the call, and return
<img width="496" height="369" alt="Screenshot 2026-03-19 at 12 44 34 PM" src="https://github.com/user-attachments/assets/d5b8d3f9-565b-4ce6-9469-ead4f27d9fd7" />

we also properly return weave call ids so you can see the errored trace in the playground 
<img width="980" height="82" alt="Screenshot 2026-03-19 at 12 44 55 PM" src="https://github.com/user-attachments/assets/ab95f339-7904-4375-81fb-ed1cc774c008" />


## Testing

manually, added some tests on core side
