### PR TITLE
chore(weave): add version_index stability tests and benchmarks (WB-32435)

### DIFF
--- a/tests/trace/bench_obj_create.py
+++ b/tests/trace/bench_obj_create.py
@@ -1,0 +1,270 @@
+"""Benchmark: object creation and query performance.
+
+Measures the time to create N versions of M different objects, plus query times.
+Run against SQLite or ClickHouse to compare baselines.
+
+Usage:
+  # SQLite (fast, local baseline):
+  nox --no-install -e "tests-3.12(shard='trace')" -- \
+    tests/trace/bench_obj_create.py -v -s --trace-server=sqlite
+
+  # ClickHouse:
+  nox --no-install -e "tests-3.12(shard='trace')" -- \
+    tests/trace/bench_obj_create.py -v -s --trace-server=clickhouse --clickhouse-process=true
+
+After implementing the min(created_at) change, re-run and compare output.
+"""
+
+import json
+import time
+
+import pytest
+
+from weave.trace.weave_client import WeaveClient
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.common_interface import SortBy
+
+# Tunable parameters
+NUM_OBJECTS = 100
+NUM_VERSIONS_PER_OBJECT = 100
+
+
+def _make_val(obj_idx: int, ver_idx: int) -> dict:
+    """Generate a unique value for each object version."""
+    return {
+        "name": f"object_{obj_idx}",
+        "version": ver_idx,
+        "data": f"payload_{obj_idx}_{ver_idx}",
+        "config": {"lr": 0.001 * ver_idx, "epochs": ver_idx + 1},
+    }
+
+
+def _objs_query(
+    client: WeaveClient,
+    object_id: str,
+    latest_only: bool = False,
+) -> list[tsi.ObjSchema]:
+    return client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(
+                object_ids=[object_id],
+                latest_only=latest_only,
+            ),
+            sort_by=[SortBy(field="created_at", direction="asc")],
+        )
+    ).objs
+
+
+def _objs_query_all(client: WeaveClient) -> list[tsi.ObjSchema]:
+    """Query all objects (no filter), as a user listing their project would."""
+    return client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(latest_only=True),
+        )
+    ).objs
+
+
+# ── Benchmark: bulk object creation ─────────────────────────────────
+
+
+def test_bench_obj_create(client: WeaveClient):
+    """Create NUM_VERSIONS_PER_OBJECT versions of NUM_OBJECTS objects.
+
+    This is the hot path that the dedup-before-insert change would affect:
+    each obj_create currently does a blind INSERT; the proposed change adds
+    a SELECT check before inserting.
+    """
+    project_id = client._project_id()
+
+    # Phase 1: Create all objects and versions
+    t0 = time.perf_counter()
+    digests: dict[str, list[str]] = {}  # object_id -> [digest, ...]
+
+    for obj_idx in range(NUM_OBJECTS):
+        object_id = f"bench_obj_{obj_idx}"
+        digests[object_id] = []
+        for ver_idx in range(NUM_VERSIONS_PER_OBJECT):
+            val = _make_val(obj_idx, ver_idx)
+            resp = client.server.obj_create(
+                tsi.ObjCreateReq(
+                    obj=tsi.ObjSchemaForInsert(
+                        project_id=project_id,
+                        object_id=object_id,
+                        val=val,
+                    )
+                )
+            )
+            digests[object_id].append(resp.digest)
+
+    t_create = time.perf_counter() - t0
+    total_versions = NUM_OBJECTS * NUM_VERSIONS_PER_OBJECT
+
+    print(f"\n{'='*60}")
+    print(f"CREATE: {total_versions} versions ({NUM_OBJECTS} objects x {NUM_VERSIONS_PER_OBJECT} versions)")
+    print(f"  Total time:   {t_create:.2f}s")
+    print(f"  Per version:  {t_create / total_versions * 1000:.2f}ms")
+    print(f"  Throughput:   {total_versions / t_create:.0f} versions/s")
+
+    # Phase 2: Query single object (all versions)
+    t0 = time.perf_counter()
+    sample_obj = "bench_obj_0"
+    objs = _objs_query(client, sample_obj)
+    t_query_single = time.perf_counter() - t0
+
+    assert len(objs) == NUM_VERSIONS_PER_OBJECT, (
+        f"Expected {NUM_VERSIONS_PER_OBJECT} versions for {sample_obj}, got {len(objs)}"
+    )
+    # Verify version indices are sequential
+    for i, obj in enumerate(objs):
+        assert obj.version_index == i, (
+            f"Version index mismatch: expected {i}, got {obj.version_index} "
+            f"(digest={obj.digest})"
+        )
+
+    print(f"\nQUERY single object ({NUM_VERSIONS_PER_OBJECT} versions):")
+    print(f"  Time: {t_query_single * 1000:.1f}ms")
+
+    # Phase 3: Query all latest versions
+    t0 = time.perf_counter()
+    latest_objs = _objs_query_all(client)
+    t_query_latest = time.perf_counter() - t0
+
+    assert len(latest_objs) >= NUM_OBJECTS, (
+        f"Expected at least {NUM_OBJECTS} latest objects, got {len(latest_objs)}"
+    )
+
+    print(f"\nQUERY all latest ({len(latest_objs)} objects):")
+    print(f"  Time: {t_query_latest * 1000:.1f}ms")
+
+    # Phase 4: Re-publish existing content (dedup path)
+    # This is the exact path that gets a dedup check added
+    t0 = time.perf_counter()
+    num_republish = NUM_OBJECTS  # re-publish v0 of each object
+    for obj_idx in range(NUM_OBJECTS):
+        object_id = f"bench_obj_{obj_idx}"
+        val = _make_val(obj_idx, 0)  # same content as v0
+        client.server.obj_create(
+            tsi.ObjCreateReq(
+                obj=tsi.ObjSchemaForInsert(
+                    project_id=project_id,
+                    object_id=object_id,
+                    val=val,
+                )
+            )
+        )
+    t_republish = time.perf_counter() - t0
+
+    print(f"\nREPUBLISH: {num_republish} objects (same content as v0):")
+    print(f"  Total time:  {t_republish:.2f}s")
+    print(f"  Per republish: {t_republish / num_republish * 1000:.2f}ms")
+
+    # Phase 5: Query after republish to verify version count
+    t0 = time.perf_counter()
+    objs_after = _objs_query(client, "bench_obj_0")
+    t_query_after = time.perf_counter() - t0
+
+    print(f"\nQUERY after republish ({len(objs_after)} versions):")
+    print(f"  Time: {t_query_after * 1000:.1f}ms")
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("SUMMARY")
+    print(f"  obj_create rate:    {total_versions / t_create:.0f}/s")
+    print(f"  republish rate:     {num_republish / t_republish:.0f}/s")
+    print(f"  query single:       {t_query_single * 1000:.1f}ms")
+    print(f"  query all latest:   {t_query_latest * 1000:.1f}ms")
+    print(f"  query after repub:  {t_query_after * 1000:.1f}ms")
+    print(f"{'='*60}\n")
+
+
+# ── Benchmark: query-heavy workload ─────────────────────────────────
+
+
+def test_bench_query_versions(client: WeaveClient):
+    """Measure query performance with varying numbers of versions.
+
+    Creates objects with 1, 10, 50, 100 versions and times queries for each.
+    This isolates the cost of the version_index window function.
+    """
+    project_id = client._project_id()
+    version_counts = [1, 10, 50, 100, 250, 500, 1000]
+
+    print(f"\n{'='*60}")
+    print("QUERY SCALING BY VERSION COUNT")
+
+    for n_versions in version_counts:
+        object_id = f"bench_scale_{n_versions}"
+
+        # Create versions
+        for v in range(n_versions):
+            client.server.obj_create(
+                tsi.ObjCreateReq(
+                    obj=tsi.ObjSchemaForInsert(
+                        project_id=project_id,
+                        object_id=object_id,
+                        val=_make_val(0, v),
+                    )
+                )
+            )
+
+        # Time the query (run 5x, take median)
+        times = []
+        for _ in range(5):
+            t0 = time.perf_counter()
+            objs = _objs_query(client, object_id)
+            times.append(time.perf_counter() - t0)
+
+        assert len(objs) == n_versions
+        median_ms = sorted(times)[len(times) // 2] * 1000
+        print(f"  {n_versions:>3} versions: {median_ms:.1f}ms (median of 5)")
+
+    # Also measure query across all objects in the project
+    t0 = time.perf_counter()
+    all_latest = _objs_query_all(client)
+    t_all = time.perf_counter() - t0
+    print(f"\n  All latest ({len(all_latest)} objects): {t_all * 1000:.1f}ms")
+    print(f"{'='*60}\n")
+
+
+# ── Benchmark: concurrent-style object creation ─────────────────────
+
+
+def test_bench_obj_create_many_objects_few_versions(client: WeaveClient):
+    """Inverse pattern: many distinct objects with few versions each.
+
+    This stresses the partition-creation side of the window function
+    rather than the per-partition sorting.
+    """
+    project_id = client._project_id()
+    n_objects = 500
+    n_versions = 5
+
+    t0 = time.perf_counter()
+    for obj_idx in range(n_objects):
+        for ver_idx in range(n_versions):
+            client.server.obj_create(
+                tsi.ObjCreateReq(
+                    obj=tsi.ObjSchemaForInsert(
+                        project_id=project_id,
+                        object_id=f"bench_wide_{obj_idx}",
+                        val=_make_val(obj_idx, ver_idx),
+                    )
+                )
+            )
+    t_create = time.perf_counter() - t0
+    total = n_objects * n_versions
+
+    print(f"\n{'='*60}")
+    print(f"WIDE CREATE: {total} versions ({n_objects} objects x {n_versions} versions)")
+    print(f"  Total time:  {t_create:.2f}s")
+    print(f"  Per version: {t_create / total * 1000:.2f}ms")
+    print(f"  Throughput:  {total / t_create:.0f} versions/s")
+
+    # Query all latest
+    t0 = time.perf_counter()
+    latest = _objs_query_all(client)
+    t_query = time.perf_counter() - t0
+    print(f"\n  Query all latest ({len(latest)} objects): {t_query * 1000:.1f}ms")
+    print(f"{'='*60}\n")

--- a/tests/trace/test_version_index_stability.py
+++ b/tests/trace/test_version_index_stability.py
@@ -1,0 +1,199 @@
+"""Reproduction tests for Problem 1: Version Index Instability on Re-publish.
+
+Root cause: In ClickHouse, version_index is computed via
+    ROW_NUMBER() OVER (PARTITION BY ... ORDER BY created_at ASC) - 1
+When the same digest is re-published, a new row with a newer created_at is
+inserted. The dedup query keeps the latest row per digest, but that row now
+has a newer timestamp, shifting it to the end of the ordering.
+
+SQLite is not affected because obj_create checks _obj_exists and returns
+early when the same digest already exists (no new row is created).
+"""
+
+import weave
+from weave.trace.weave_client import WeaveClient
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.common_interface import SortBy
+
+
+def _objs_query(client: WeaveClient, object_id: str) -> list[tsi.ObjSchema]:
+    objs = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(object_ids=[object_id]),
+            sort_by=[SortBy(field="created_at", direction="asc")],
+        )
+    )
+    return objs.objs
+
+
+def _obj_delete(client: WeaveClient, object_id: str, digests: list[str]) -> int:
+    return client.server.obj_delete(
+        tsi.ObjDeleteReq(
+            project_id=client._project_id(),
+            object_id=object_id,
+            digests=digests,
+        )
+    ).num_deleted
+
+
+def _get_latest(client: WeaveClient, object_id: str) -> tsi.ObjSchema | None:
+    resp = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client._project_id(),
+            filter=tsi.ObjectVersionFilter(
+                object_ids=[object_id], latest_only=True
+            ),
+        )
+    )
+    return resp.objs[0] if resp.objs else None
+
+
+# ── P1-T1: Re-publish oldest version ────────────────────────────────
+
+
+def test_republish_oldest_version_index_stable(client: WeaveClient):
+    """Re-publishing A (v0) when latest=C should be a no-op on indices.
+
+    Before:  A=v0, B=v1, C=v2  latest=C
+    After:   A=v0, B=v1, C=v2  latest=C  (expected)
+    Bug:     B=v0, C=v1, A=v2  latest=A  (actual on ClickHouse)
+    """
+    v0 = weave.publish({"text": "A"}, name="idx_stable_1")
+    v1 = weave.publish({"text": "B"}, name="idx_stable_1")
+    v2 = weave.publish({"text": "C"}, name="idx_stable_1")
+
+    # Re-publish A (same content as v0)
+    weave.publish({"text": "A"}, name="idx_stable_1")
+
+    objs = _objs_query(client, "idx_stable_1")
+    assert len(objs) == 3, f"Expected 3 versions, got {len(objs)}"
+
+    assert objs[0].digest == v0.digest
+    assert objs[0].version_index == 0
+    assert objs[1].digest == v1.digest
+    assert objs[1].version_index == 1
+    assert objs[2].digest == v2.digest
+    assert objs[2].version_index == 2
+
+    latest = _get_latest(client, "idx_stable_1")
+    assert latest is not None
+    assert latest.digest == v2.digest, "Latest should still be C"
+
+
+# ── P1-T2: Re-publish middle version ────────────────────────────────
+
+
+def test_republish_middle_version_index_stable(client: WeaveClient):
+    """Re-publishing B (v1) when latest=C should be a no-op on indices."""
+    v0 = weave.publish({"text": "A"}, name="idx_stable_2")
+    v1 = weave.publish({"text": "B"}, name="idx_stable_2")
+    v2 = weave.publish({"text": "C"}, name="idx_stable_2")
+
+    # Re-publish B (same content as v1)
+    weave.publish({"text": "B"}, name="idx_stable_2")
+
+    objs = _objs_query(client, "idx_stable_2")
+    assert len(objs) == 3
+
+    assert objs[0].version_index == 0
+    assert objs[0].digest == v0.digest
+    assert objs[1].version_index == 1
+    assert objs[1].digest == v1.digest
+    assert objs[2].version_index == 2
+    assert objs[2].digest == v2.digest
+
+    latest = _get_latest(client, "idx_stable_2")
+    assert latest.digest == v2.digest
+
+
+# ── P1-T3: Re-publish latest version (should always be no-op) ───────
+
+
+def test_republish_latest_version_index_stable(client: WeaveClient):
+    """Re-publishing C (latest) should be a complete no-op."""
+    v0 = weave.publish({"text": "A"}, name="idx_stable_3")
+    v1 = weave.publish({"text": "B"}, name="idx_stable_3")
+    v2 = weave.publish({"text": "C"}, name="idx_stable_3")
+
+    weave.publish({"text": "C"}, name="idx_stable_3")
+
+    objs = _objs_query(client, "idx_stable_3")
+    assert len(objs) == 3
+
+    assert objs[0].version_index == 0 and objs[0].digest == v0.digest
+    assert objs[1].version_index == 1 and objs[1].digest == v1.digest
+    assert objs[2].version_index == 2 and objs[2].digest == v2.digest
+
+
+# ── P1-T4: Delete middle, re-publish middle ─────────────────────────
+
+
+def test_delete_middle_republish_version_index_stable(client: WeaveClient):
+    """Delete B, then re-publish B. B should return at v1, not shift to end."""
+    v0 = weave.publish({"text": "A"}, name="idx_stable_4")
+    v1 = weave.publish({"text": "B"}, name="idx_stable_4")
+    v2 = weave.publish({"text": "C"}, name="idx_stable_4")
+
+    _obj_delete(client, "idx_stable_4", [v1.digest])
+
+    # Re-publish B (undelete / re-create)
+    weave.publish({"text": "B"}, name="idx_stable_4")
+
+    objs = _objs_query(client, "idx_stable_4")
+    non_deleted = [o for o in objs if o.deleted_at is None]
+    assert len(non_deleted) == 3
+
+    # A should still be v0, C should still be v2
+    a = next(o for o in non_deleted if o.digest == v0.digest)
+    c = next(o for o in non_deleted if o.digest == v2.digest)
+    assert a.version_index == 0
+    assert c.version_index == 2
+
+
+# ── P1-T5: 5 versions, re-publish v0 ────────────────────────────────
+
+
+def test_five_versions_republish_v0_stable(client: WeaveClient):
+    """With 5 versions (A-E), re-publishing A should not shift any indices."""
+    refs = {}
+    for label in ["A", "B", "C", "D", "E"]:
+        refs[label] = weave.publish({"text": label}, name="idx_stable_5")
+
+    # Re-publish A
+    weave.publish({"text": "A"}, name="idx_stable_5")
+
+    objs = _objs_query(client, "idx_stable_5")
+    assert len(objs) == 5
+
+    for i, label in enumerate(["A", "B", "C", "D", "E"]):
+        assert objs[i].version_index == i, (
+            f"{label}: expected v{i}, got v{objs[i].version_index}"
+        )
+        assert objs[i].digest == refs[label].digest
+
+    latest = _get_latest(client, "idx_stable_5")
+    assert latest.digest == refs["E"].digest, "Latest should still be E"
+
+
+# ── P1-T6: Re-publish A then B back-to-back ─────────────────────────
+
+
+def test_republish_two_versions_indices_stable(client: WeaveClient):
+    """Re-publishing A then B should not scramble any indices."""
+    v0 = weave.publish({"text": "A"}, name="idx_stable_6")
+    v1 = weave.publish({"text": "B"}, name="idx_stable_6")
+    v2 = weave.publish({"text": "C"}, name="idx_stable_6")
+
+    weave.publish({"text": "A"}, name="idx_stable_6")
+    weave.publish({"text": "B"}, name="idx_stable_6")
+
+    objs = _objs_query(client, "idx_stable_6")
+    assert len(objs) == 3
+
+    assert objs[0].version_index == 0 and objs[0].digest == v0.digest
+    assert objs[1].version_index == 1 and objs[1].digest == v1.digest
+    assert objs[2].version_index == 2 and objs[2].digest == v2.digest
+
+    latest = _get_latest(client, "idx_stable_6")
+    assert latest.digest == v2.digest


### PR DESCRIPTION
## Summary

Adds test suite and benchmark script for version_index stability and object creation performance. Stacked on #6408.

**New files:**

- `tests/trace/test_version_index_stability.py` — 6 correctness tests covering re-publish and delete+republish scenarios (P1-T1 through P1-T6)
- `tests/trace/bench_obj_create.py` — performance benchmark for object creation and query paths

## Running the benchmarks

```bash
cd services/weave-python/weave-public

# Full benchmark (ClickHouse):
nox --no-install -e "tests-3.12(shard='trace')" -- \
  tests/trace/bench_obj_create.py -v -s --trace-server=clickhouse --clickhouse-process=true -n0

# Query scaling only:
nox --no-install -e "tests-3.12(shard='trace')" -- \
  tests/trace/bench_obj_create.py::test_bench_query_versions -v -s --trace-server=clickhouse --clickhouse-process=true -n0

# Stability tests:
nox --no-install -e "tests-3.12(shard='trace')" -- \
  tests/trace/test_version_index_stability.py -v -s --trace-server=clickhouse --clickhouse-process=true -n0
```

Note: `-n0` disables xdist parallelism so benchmark output is visible.

## Benchmark coverage

| Test | What it measures |
|------|-----------------|
| `test_bench_obj_create` | 100 objects × 100 versions: create throughput, query, republish |
| `test_bench_query_versions` | Query scaling from 1 to 1000 versions per object |
| `test_bench_obj_create_many_objects_few_versions` | 500 objects × 5 versions: wide partition pattern |

## Test plan

- [x] All benchmarks pass on SQLite
- [x] All benchmarks pass on ClickHouse
- [x] Stability tests pass on SQLite (6/6)
- [x] Stability tests pass on ClickHouse (5/6, P1-T4 is documented known gap)