### PR TITLE
chore(weave): ignore claude worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ gha-creds-*.json
 .coverage
 .nox
 .venv
+.claude/worktrees
 .weave_client_dropped_items_log.jsonl
 *.log
 */file::memory:?cache=shared


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Claude really wants to put worktrees in this path, any reason not to add this to gitignore? I think it's fine. 

## Testing

no functional change

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wandb/weave/pull/6505" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
