### PR TITLE
fix(weave): dedupe concurrent op saves

### DIFF
--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -1,4 +1,5 @@
 import asyncio
+import threading
 
 import pytest
 
@@ -6,6 +7,8 @@ import weave
 from tests.conftest import LATENCY_TOL
 from weave import Dataset, Evaluation, Model
 from weave.scorers import MultiTaskBinaryClassificationF1
+from weave.trace.ref_util import get_ref, remove_ref
+from weave.trace.weave_client import WeaveClient
 
 dataset_rows = [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
 dataset = Dataset(rows=dataset_rows)
@@ -119,6 +122,68 @@ def test_evaluate_both_styles(client):
         "score_oldstyle": {"true_count": 1, "true_fraction": 0.5},
         "score_newstyle": {"true_count": 1, "true_fraction": 0.5},
         "model_latency": {"mean": pytest.approx(0, abs=LATENCY_TOL)},
+    }
+
+
+@pytest.mark.disable_logging_error_check
+def test_evaluate_both_styles_saves_each_function_scorer_once(client, monkeypatch):
+    expanded_rows = [dict(row) for _ in range(5) for row in dataset_rows]
+    evaluation = Evaluation(
+        dataset=expanded_rows,
+        scorers=[score_oldstyle, score_newstyle],
+    )
+    model = EvalModel()
+
+    # These scorer Ops live at module scope, so clear any ref from earlier tests.
+    remove_ref(score_oldstyle)
+    remove_ref(score_newstyle)
+
+    save_counts = {
+        score_oldstyle.name: 0,
+        score_newstyle.name: 0,
+    }
+    save_counts_lock = threading.Lock()
+    concurrent_first_save_gates = {
+        id(score_oldstyle): {"waiting": 0, "release": threading.Event()},
+        id(score_newstyle): {"waiting": 0, "release": threading.Event()},
+    }
+    gate_lock = threading.Lock()
+    original_save_object_basic = WeaveClient._save_object_basic.__get__(
+        client, type(client)
+    )
+
+    def tracking_save_object_basic(val, name=None, branch="latest"):
+        if val is score_oldstyle or val is score_newstyle:
+            if get_ref(val) is None:
+                gate_state = concurrent_first_save_gates[id(val)]
+                with gate_lock:
+                    gate_state["waiting"] += 1
+                    if gate_state["waiting"] == 2:
+                        gate_state["release"].set()
+                gate_state["release"].wait(timeout=0.5)
+            with save_counts_lock:
+                save_counts[val.name] += 1
+        return original_save_object_basic(val, name=name, branch=branch)
+
+    monkeypatch.setattr(client, "_save_object_basic", tracking_save_object_basic)
+    monkeypatch.setenv("WEAVE_PARALLELISM", "20")
+
+    client.set_autoflush(False)
+    try:
+        result = asyncio.run(evaluation.evaluate(model))
+        client.flush()
+    finally:
+        client.set_autoflush(True)
+
+    assert result == {
+        "model_output": {"mean": 9.5},
+        "score_oldstyle": {"true_count": 5, "true_fraction": 0.5},
+        "score_newstyle": {"true_count": 5, "true_fraction": 0.5},
+        "model_latency": {"mean": pytest.approx(0, abs=LATENCY_TOL)},
+    }
+    assert save_counts == {
+        score_oldstyle.name: 1,
+        score_newstyle.name: 1,
     }
 
 

--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -99,13 +99,21 @@ def test_evaluate_rows_only(client):
     assert result == expected_eval_result
 
 
+@pytest.mark.flaky(reruns=3)
 def test_evaluate_both_styles(client):
+    client.set_autoflush(False)
     evaluation = Evaluation(
         dataset=dataset_rows,
         scorers=[score_oldstyle, score_newstyle],
     )
     model = EvalModel()
-    result = asyncio.run(evaluation.evaluate(model))
+    try:
+        result = asyncio.run(evaluation.evaluate(model))
+        # Flush once after the evaluation to avoid per-op autoflush contention
+        # in the calls_complete ClickHouse path.
+        client.flush()
+    finally:
+        client.set_autoflush(True)
     assert result == {
         "model_output": {"mean": 9.5},
         "score_oldstyle": {"true_count": 1, "true_fraction": 0.5},

--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -5,13 +5,20 @@ import pytest
 
 import weave
 from tests.conftest import LATENCY_TOL
-from weave import Dataset, Evaluation, Model
+from weave import Evaluation, Model
 from weave.scorers import MultiTaskBinaryClassificationF1
 from weave.trace.ref_util import get_ref, remove_ref
 from weave.trace.weave_client import WeaveClient
 
-dataset_rows = [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
-dataset = Dataset(rows=dataset_rows)
+
+@pytest.fixture
+def dataset_rows():
+    return [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
+
+
+@pytest.fixture
+def expanded_dataset_rows(dataset_rows):
+    return [dict(row) for _ in range(5) for row in dataset_rows]
 
 
 expected_eval_result = {
@@ -42,7 +49,41 @@ def example_to_model_input(example):
     return {"input": example["input"]}
 
 
-def test_evaluate_callable_as_model(client):
+def _install_concurrent_first_save_tracker(
+    client: WeaveClient, monkeypatch: pytest.MonkeyPatch, *tracked_ops
+) -> dict[str, int]:
+    """Force first-time saves of shared ops to overlap and count real save attempts."""
+    save_counts = {op.name: 0 for op in tracked_ops}
+    save_counts_lock = threading.Lock()
+    first_save_gates = {
+        id(op): {"waiting": 0, "release": threading.Event()} for op in tracked_ops
+    }
+    tracked_ops_by_id = {id(op): op for op in tracked_ops}
+    gate_lock = threading.Lock()
+    original_save_object_basic = WeaveClient._save_object_basic.__get__(
+        client, type(client)
+    )
+
+    def tracking_save_object_basic(val, name=None, branch="latest"):
+        tracked_op = tracked_ops_by_id.get(id(val))
+        if tracked_op is not None:
+            # Hold the first unsaved call for each scorer until a second caller arrives.
+            if get_ref(val) is None:
+                gate_state = first_save_gates[id(val)]
+                with gate_lock:
+                    gate_state["waiting"] += 1
+                    if gate_state["waiting"] == 2:
+                        gate_state["release"].set()
+                gate_state["release"].wait(timeout=0.5)
+            with save_counts_lock:
+                save_counts[tracked_op.name] += 1
+        return original_save_object_basic(val, name=name, branch=branch)
+
+    monkeypatch.setattr(client, "_save_object_basic", tracking_save_object_basic)
+    return save_counts
+
+
+def test_evaluate_callable_as_model(client, dataset_rows):
     @weave.op
     async def model_predict(input) -> str:
         return eval(input)
@@ -55,7 +96,7 @@ def test_evaluate_callable_as_model(client):
     assert result == expected_eval_result
 
 
-def test_predict_can_receive_other_params(client):
+def test_predict_can_receive_other_params(client, dataset_rows):
     @weave.op
     async def model_predict(input, target) -> str:
         return eval(input) + target
@@ -74,7 +115,7 @@ def test_predict_can_receive_other_params(client):
     }
 
 
-def test_can_preprocess_model_input(client):
+def test_can_preprocess_model_input(client, dataset_rows):
     @weave.op
     async def model_predict(x) -> str:
         return eval(x)
@@ -92,7 +133,7 @@ def test_can_preprocess_model_input(client):
     assert result == expected_eval_result
 
 
-def test_evaluate_rows_only(client):
+def test_evaluate_rows_only(client, dataset_rows):
     evaluation = Evaluation(
         dataset=dataset_rows,
         scorers=[score_oldstyle],
@@ -102,7 +143,8 @@ def test_evaluate_rows_only(client):
     assert result == expected_eval_result
 
 
-def test_evaluate_both_styles(client):
+@pytest.mark.asyncio
+async def test_evaluate_both_styles(client, dataset_rows):
     client.set_autoflush(False)
     evaluation = Evaluation(
         dataset=dataset_rows,
@@ -110,7 +152,7 @@ def test_evaluate_both_styles(client):
     )
     model = EvalModel()
     try:
-        result = asyncio.run(evaluation.evaluate(model))
+        result = await evaluation.evaluate(model)
         # Flush once after the evaluation to avoid per-op autoflush contention
         # in the calls_complete ClickHouse path.
         client.flush()
@@ -125,10 +167,12 @@ def test_evaluate_both_styles(client):
 
 
 @pytest.mark.disable_logging_error_check
-def test_evaluate_both_styles_saves_each_function_scorer_once(client, monkeypatch):
-    expanded_rows = [dict(row) for _ in range(5) for row in dataset_rows]
+@pytest.mark.asyncio
+async def test_evaluate_both_styles_saves_each_function_scorer_once(
+    client, monkeypatch, expanded_dataset_rows
+):
     evaluation = Evaluation(
-        dataset=expanded_rows,
+        dataset=expanded_dataset_rows,
         scorers=[score_oldstyle, score_newstyle],
     )
     model = EvalModel()
@@ -137,39 +181,14 @@ def test_evaluate_both_styles_saves_each_function_scorer_once(client, monkeypatc
     remove_ref(score_oldstyle)
     remove_ref(score_newstyle)
 
-    save_counts = {
-        score_oldstyle.name: 0,
-        score_newstyle.name: 0,
-    }
-    save_counts_lock = threading.Lock()
-    concurrent_first_save_gates = {
-        id(score_oldstyle): {"waiting": 0, "release": threading.Event()},
-        id(score_newstyle): {"waiting": 0, "release": threading.Event()},
-    }
-    gate_lock = threading.Lock()
-    original_save_object_basic = WeaveClient._save_object_basic.__get__(
-        client, type(client)
+    save_counts = _install_concurrent_first_save_tracker(
+        client, monkeypatch, score_oldstyle, score_newstyle
     )
-
-    def tracking_save_object_basic(val, name=None, branch="latest"):
-        if val is score_oldstyle or val is score_newstyle:
-            if get_ref(val) is None:
-                gate_state = concurrent_first_save_gates[id(val)]
-                with gate_lock:
-                    gate_state["waiting"] += 1
-                    if gate_state["waiting"] == 2:
-                        gate_state["release"].set()
-                gate_state["release"].wait(timeout=0.5)
-            with save_counts_lock:
-                save_counts[val.name] += 1
-        return original_save_object_basic(val, name=name, branch=branch)
-
-    monkeypatch.setattr(client, "_save_object_basic", tracking_save_object_basic)
     monkeypatch.setenv("WEAVE_PARALLELISM", "20")
 
     client.set_autoflush(False)
     try:
-        result = asyncio.run(evaluation.evaluate(model))
+        result = await evaluation.evaluate(model)
         client.flush()
     finally:
         client.set_autoflush(True)
@@ -186,7 +205,7 @@ def test_evaluate_both_styles_saves_each_function_scorer_once(client, monkeypatc
     }
 
 
-def test_evaluate_other_model_method_names():
+def test_evaluate_other_model_method_names(dataset_rows):
     class EvalModel(Model):
         @weave.op
         async def infer(self, input) -> str:
@@ -201,7 +220,7 @@ def test_evaluate_other_model_method_names():
     assert result == expected_eval_result
 
 
-def test_score_as_class(client):
+def test_score_as_class(client, dataset_rows):
     class MyScorerOldstyle(weave.Scorer):
         @weave.op
         def score(self, model_output, target):
@@ -222,7 +241,7 @@ def test_score_as_class(client):
     }
 
 
-def test_score_with_custom_summarize(client):
+def test_score_with_custom_summarize(client, dataset_rows):
     class MyScorerOldstyle(weave.Scorer):
         @weave.op
         def summarize(self, score_rows):

--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -102,7 +102,6 @@ def test_evaluate_rows_only(client):
     assert result == expected_eval_result
 
 
-@pytest.mark.flaky(reruns=3)
 def test_evaluate_both_styles(client):
     client.set_autoflush(False)
     evaluation = Evaluation(

--- a/tests/trace/test_server_object_creation_utils.py
+++ b/tests/trace/test_server_object_creation_utils.py
@@ -5,10 +5,14 @@ as the SDK.  Ideally they would be placed next to the trace_server tests, but
 the client serialization requires a client object to serialize.
 """
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
 import weave
 from weave.evaluation.eval import Evaluation
 from weave.flow.scorer import Scorer
 from weave.trace.object_record import pydantic_object_record
+from weave.trace.ref_util import remove_ref
 from weave.trace.serialization.serialize import to_json
 from weave.trace.weave_client import WeaveClient, map_to_refs
 from weave.trace_server import object_creation_utils
@@ -27,6 +31,45 @@ def test_helper_serializes_op_same_way_as_sdk(client: WeaveClient) -> None:
         sdk_val["files"][object_creation_utils.OP_SOURCE_FILE_NAME]
     )
     assert helper_val == sdk_val
+
+
+def test_concurrent_save_op_reuses_single_inflight_save(
+    client: WeaveClient, monkeypatch
+) -> None:
+    @weave.op
+    def test_op(x: int) -> int:
+        return x + 1
+
+    remove_ref(test_op)
+
+    save_call_count = 0
+    save_call_count_lock = threading.Lock()
+    release = threading.Event()
+    waiting = 0
+    waiting_lock = threading.Lock()
+    original_save_object_basic = WeaveClient._save_object_basic.__get__(
+        client, type(client)
+    )
+
+    def tracked_save_object_basic(val, name=None, branch="latest"):
+        nonlocal save_call_count, waiting
+        if val is test_op:
+            with save_call_count_lock:
+                save_call_count += 1
+            with waiting_lock:
+                waiting += 1
+                if waiting == 2:
+                    release.set()
+            release.wait(timeout=0.5)
+        return original_save_object_basic(val, name=name, branch=branch)
+
+    monkeypatch.setattr(client, "_save_object_basic", tracked_save_object_basic)
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        refs = list(executor.map(lambda _: client._save_op(test_op), range(4)))
+
+    assert save_call_count == 1
+    assert [ref.uri for ref in refs] == [refs[0].uri] * 4
 
 
 def test_helper_serializes_dataset_same_way_as_sdk(client: WeaveClient) -> None:

--- a/tests/trace/test_server_object_creation_utils.py
+++ b/tests/trace/test_server_object_creation_utils.py
@@ -8,6 +8,8 @@ the client serialization requires a client object to serialize.
 import threading
 from concurrent.futures import ThreadPoolExecutor
 
+import pytest
+
 import weave
 from weave.evaluation.eval import Evaluation
 from weave.flow.scorer import Scorer
@@ -44,32 +46,72 @@ def test_concurrent_save_op_reuses_single_inflight_save(
 
     save_call_count = 0
     save_call_count_lock = threading.Lock()
-    release = threading.Event()
-    waiting = 0
-    waiting_lock = threading.Lock()
+    creator_entered_save = threading.Event()
+    allow_creator_to_finish = threading.Event()
+    start_barrier = threading.Barrier(5)
     original_save_object_basic = WeaveClient._save_object_basic.__get__(
         client, type(client)
     )
 
     def tracked_save_object_basic(val, name=None, branch="latest"):
-        nonlocal save_call_count, waiting
+        nonlocal save_call_count
         if val is test_op:
             with save_call_count_lock:
                 save_call_count += 1
-            with waiting_lock:
-                waiting += 1
-                if waiting == 2:
-                    release.set()
-            release.wait(timeout=0.5)
+            creator_entered_save.set()
+            allow_creator_to_finish.wait()
         return original_save_object_basic(val, name=name, branch=branch)
 
     monkeypatch.setattr(client, "_save_object_basic", tracked_save_object_basic)
 
+    def save_once():
+        # Release all callers into `_save_op` at once while the creator thread
+        # is blocked in `_save_object_basic`, forcing the inflight join path.
+        start_barrier.wait()
+        return client._save_op(test_op)
+
     with ThreadPoolExecutor(max_workers=4) as executor:
-        refs = list(executor.map(lambda _: client._save_op(test_op), range(4)))
+        futures = [executor.submit(save_once) for _ in range(4)]
+        start_barrier.wait()
+        assert creator_entered_save.wait(timeout=1)
+        assert all(not future.done() for future in futures)
+        allow_creator_to_finish.set()
+        refs = [future.result(timeout=1) for future in futures]
 
     assert save_call_count == 1
     assert [ref.uri for ref in refs] == [refs[0].uri] * 4
+
+
+def test_concurrent_save_op_rejects_conflicting_names(
+    client: WeaveClient, monkeypatch
+) -> None:
+    @weave.op
+    def test_op(x: int) -> int:
+        return x + 1
+
+    remove_ref(test_op)
+
+    creator_entered_save = threading.Event()
+    allow_creator_to_finish = threading.Event()
+    original_save_object_basic = WeaveClient._save_object_basic.__get__(
+        client, type(client)
+    )
+
+    def tracked_save_object_basic(val, name=None, branch="latest"):
+        if val is test_op:
+            creator_entered_save.set()
+            allow_creator_to_finish.wait()
+        return original_save_object_basic(val, name=name, branch=branch)
+
+    monkeypatch.setattr(client, "_save_object_basic", tracked_save_object_basic)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        first_save = executor.submit(client._save_op, test_op, "first_name")
+        assert creator_entered_save.wait(timeout=1)
+        with pytest.raises(ValueError, match="conflicting names"):
+            client._save_op(test_op, name="second_name")
+        allow_creator_to_finish.set()
+        assert first_save.result(timeout=1).name == "first_name"
 
 
 def test_helper_serializes_dataset_same_way_as_sdk(client: WeaveClient) -> None:

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future
 from functools import cached_property
+from threading import Lock
 from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 import pydantic
@@ -175,6 +176,12 @@ if TYPE_CHECKING:
 ALLOW_MIXED_PROJECT_REFS = False
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class _InflightOpSave:
+    name: str
+    future: Future[ObjectRef]
 
 
 class NoInternalProjectIDError(Exception):
@@ -366,6 +373,8 @@ class WeaveClient:
         self.future_executor = FutureExecutor(max_workers=parallelism_main)
         self.future_executor_fastlane = FutureExecutor(max_workers=parallelism_upload)
         self.ensure_project_exists = ensure_project_exists
+        self._inflight_op_saves_lock = Lock()
+        self._inflight_op_saves: dict[int, _InflightOpSave] = {}
 
         if ensure_project_exists:
             resp = self.server.ensure_project_exists(entity, project)
@@ -2137,7 +2146,59 @@ class WeaveClient:
         if name is None:
             name = op.name
 
-        return self._save_object_basic(op, name)
+        name = sanitize_object_name(name)
+
+        def get_existing_ref() -> ObjectRef | None:
+            if (ref := get_ref(op)) is None:
+                return None
+            if ALLOW_MIXED_PROJECT_REFS:
+                return ref
+            if ref.project == self.project and ref.entity == self.entity:
+                return ref
+            remove_ref(op)
+            return None
+
+        if existing_ref := get_existing_ref():
+            return existing_ref
+
+        op_id = id(op)
+        created_future: Future[ObjectRef] | None = None
+        inflight_future: Future[ObjectRef]
+
+        with self._inflight_op_saves_lock:
+            if existing_ref := get_existing_ref():
+                return existing_ref
+
+            if inflight := self._inflight_op_saves.get(op_id):
+                if inflight.name != name:
+                    raise ValueError(
+                        f"Concurrent saves of op {op!r} used conflicting names: "
+                        f"{inflight.name!r} vs {name!r}"
+                    )
+                inflight_future = inflight.future
+            else:
+                inflight_future = Future()
+                self._inflight_op_saves[op_id] = _InflightOpSave(
+                    name=name, future=inflight_future
+                )
+                created_future = inflight_future
+
+        if created_future is None:
+            return inflight_future.result()
+
+        try:
+            ref = self._save_object_basic(op, name)
+        except Exception as exc:
+            created_future.set_exception(exc)
+            raise
+        else:
+            created_future.set_result(ref)
+            return ref
+        finally:
+            with self._inflight_op_saves_lock:
+                inflight = self._inflight_op_saves.get(op_id)
+                if inflight is not None and inflight.future is created_future:
+                    del self._inflight_op_saves[op_id]
 
     def _send_table_create(self, rows: list[Any]) -> TableCreateRes:
         compute_digests = self._should_compute_client_digests()

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -179,7 +179,7 @@ logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass
-class _InflightOpSave:
+class InflightOpSave:
     name: str
     future: Future[ObjectRef]
 
@@ -374,7 +374,7 @@ class WeaveClient:
         self.future_executor_fastlane = FutureExecutor(max_workers=parallelism_upload)
         self.ensure_project_exists = ensure_project_exists
         self._inflight_op_saves_lock = Lock()
-        self._inflight_op_saves: dict[int, _InflightOpSave] = {}
+        self._inflight_op_saves: dict[int, InflightOpSave] = {}
 
         if ensure_project_exists:
             resp = self.server.ensure_project_exists(entity, project)
@@ -2147,18 +2147,7 @@ class WeaveClient:
             name = op.name
 
         name = sanitize_object_name(name)
-
-        def get_existing_ref() -> ObjectRef | None:
-            if (ref := get_ref(op)) is None:
-                return None
-            if ALLOW_MIXED_PROJECT_REFS:
-                return ref
-            if ref.project == self.project and ref.entity == self.entity:
-                return ref
-            remove_ref(op)
-            return None
-
-        if existing_ref := get_existing_ref():
+        if existing_ref := self._get_existing_op_ref(op):
             return existing_ref
 
         op_id = id(op)
@@ -2166,7 +2155,7 @@ class WeaveClient:
         inflight_future: Future[ObjectRef]
 
         with self._inflight_op_saves_lock:
-            if existing_ref := get_existing_ref():
+            if existing_ref := self._get_existing_op_ref(op):
                 return existing_ref
 
             if inflight := self._inflight_op_saves.get(op_id):
@@ -2178,7 +2167,9 @@ class WeaveClient:
                 inflight_future = inflight.future
             else:
                 inflight_future = Future()
-                self._inflight_op_saves[op_id] = _InflightOpSave(
+                # Only one thread should perform the actual save for a shared
+                # Op object. Other threads join this future and reuse the ref.
+                self._inflight_op_saves[op_id] = InflightOpSave(
                     name=name, future=inflight_future
                 )
                 created_future = inflight_future
@@ -2199,6 +2190,17 @@ class WeaveClient:
                 inflight = self._inflight_op_saves.get(op_id)
                 if inflight is not None and inflight.future is created_future:
                     del self._inflight_op_saves[op_id]
+
+    def _get_existing_op_ref(self, op: Op) -> ObjectRef | None:
+        """Return the current-project ref for an op, clearing stale refs."""
+        if (ref := get_ref(op)) is None:
+            return None
+        if ALLOW_MIXED_PROJECT_REFS:
+            return ref
+        if ref.project == self.project and ref.entity == self.entity:
+            return ref
+        remove_ref(op)
+        return None
 
     def _send_table_create(self, rows: list[Any]) -> TableCreateRes:
         compute_digests = self._should_compute_client_digests()


### PR DESCRIPTION
## Summary

Fix a concurrency bug in op saving that was surfacing as a flaky evaluation teardown failure.

During `Evaluation.evaluate(...)`, parallel scorer execution could race on the same shared function scorer op. Multiple workers could observe that scorer op as unsaved and all call `_save_object_basic`, leading to redundant saves of the same op and occasionally destabilizing later background ref resolution.

This PR makes `_save_op` singleflight per client: one caller performs the save, concurrent callers wait and reuse the same ref.

Original failure ([GitHub Actions job](https://github.com/wandb/weave/actions/runs/23918560565/job/69758718183?pr=6523)):
```
ERROR    weave.trace.concurrent.futures:futures.py:192 Task failed: AttributeError: 'list' object has no attribute 'result'
```

## Root Cause

The flake was exposing a check-then-act race:

- evaluation rows are processed concurrently
- function scorers are shared module-scope `@weave.op` objects
- multiple threads could see `get_ref(op) is None` at the same time
- each thread could then independently call `_save_object_basic(op, ...)`

A deterministic reproducer added in this PR showed that exact behavior on both SQLite and ClickHouse. Before the fix, each scorer op was being saved 11 times in a single evaluation run. After the fix, each scorer is saved once.

That repeated-save race is the most plausible root cause of the rarer teardown error: the evaluation itself completed, but a later background task tripped over unstable async/ref state.

## Options Considered

1. Keep the test-only mitigation
- Disable autoflush around the flaky test and rely on reruns.
- Rejected because it reduces noise without fixing the race.

2. Redesign ref ownership entirely
- Move ref state off Python op objects and into a client-scoped cache.
- Better long term, but much larger than needed for this bug.

3. Add singleflight to op saves
- Make concurrent saves of the same Python op object collapse to one underlying save.
- Chosen because it directly addresses the observed race while preserving current semantics.

## Decision And Fix

`WeaveClient._save_op` now:

- returns an existing same-project ref immediately when present
- tracks in-flight saves per client, keyed by Python object identity
- lets one thread own the save while concurrent callers wait for the same future
- raises on conflicting concurrent names instead of silently picking one
- always clears the in-flight entry in `finally`

This keeps synchronization at the ownership layer for op saving rather than leaking it into evaluation.

## Why This Fix Works

The bug was not “evaluation is flaky”. The bug was “saving the same op object is not concurrency-safe”.

This change closes that race for ops:

- one caller performs the save
- all concurrent callers reuse the same in-flight result
- the shared op object ends up with one stable ref instead of several competing save attempts

This is a correctness fix, not just a flake-rate reduction.

## Tests

Added:
- an evaluation-level reproducer that forces concurrent scorer saves and asserts each scorer is saved once
- a focused `_save_op` concurrency test that asserts one underlying save is reused by concurrent callers