### PR TITLE
chore(weave): add migration for cache token cost columns

### DIFF
--- a/weave/trace_server/migrations/027_add_cache_token_costs.down.sql
+++ b/weave/trace_server/migrations/027_add_cache_token_costs.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE llm_token_prices DROP COLUMN IF EXISTS cache_read_input_token_cost;
+ALTER TABLE llm_token_prices DROP COLUMN IF EXISTS cache_creation_input_token_cost;

--- a/weave/trace_server/migrations/027_add_cache_token_costs.up.sql
+++ b/weave/trace_server/migrations/027_add_cache_token_costs.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE llm_token_prices ADD COLUMN IF NOT EXISTS cache_read_input_token_cost Float DEFAULT 0;
+ALTER TABLE llm_token_prices ADD COLUMN IF NOT EXISTS cache_creation_input_token_cost Float DEFAULT 0;


### PR DESCRIPTION
## Summary
- Adds `cache_read_input_token_cost` and `cache_creation_input_token_cost` columns to `llm_token_prices` table
- These columns support per-token pricing for cached tokens (e.g., Anthropic prompt caching, OpenAI cached completions)
- Migration is backwards-compatible: new columns default to 0

Split from #6507.

## Test plan
- [ ] Verify migration applies cleanly on ClickHouse
- [ ] Verify down migration drops columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)