### PR TITLE
feat(weave): implement cache token cost calculations

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -1697,6 +1697,12 @@ def test_summary_tokens_cost(client):
             "pricing_level": "default",
             "pricing_level_id": "default",
             "created_by": "system",
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens_total_cost": 0.0,
+            "cache_creation_input_tokens_total_cost": 0.0,
+            "cache_read_input_token_cost": 0.0,
+            "cache_creation_input_token_cost": 0.0,
         }
     )
 
@@ -1716,6 +1722,12 @@ def test_summary_tokens_cost(client):
             "pricing_level": "default",
             "pricing_level_id": "default",
             "created_by": "system",
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens_total_cost": 0.0,
+            "cache_creation_input_tokens_total_cost": 0.0,
+            "cache_read_input_token_cost": 0.0,
+            "cache_creation_input_token_cost": 0.0,
         }
     )
 

--- a/tests/trace_server/costs/test_insert_costs.py
+++ b/tests/trace_server/costs/test_insert_costs.py
@@ -37,6 +37,8 @@ class TestInsertCosts(unittest.TestCase):
                 "llm_model_1",
                 0.01,
                 0.02,
+                0,
+                0,
                 datetime.strptime("2023-10-01 12:00:00", "%Y-%m-%d %H:%M:%S").replace(
                     tzinfo=timezone.utc
                 ),
@@ -45,6 +47,8 @@ class TestInsertCosts(unittest.TestCase):
                 "llm_model_3",
                 0.02,
                 0.03,
+                0,
+                0,
                 datetime.strptime("2023-10-02 13:30:00", "%Y-%m-%d %H:%M:%S").replace(
                     tzinfo=timezone.utc
                 ),

--- a/tests/trace_server/costs/test_insert_costs.py
+++ b/tests/trace_server/costs/test_insert_costs.py
@@ -122,6 +122,8 @@ class TestInsertCosts(unittest.TestCase):
                     "USD",
                     cost.get("output", 0),
                     "USD",
+                    cost.get("cache_read_input", 0),
+                    cost.get("cache_creation_input", 0),
                     "system",
                     created_at,
                 )
@@ -142,6 +144,8 @@ class TestInsertCosts(unittest.TestCase):
                 "prompt_token_cost_unit",
                 "completion_token_cost",
                 "completion_token_cost_unit",
+                "cache_read_input_token_cost",
+                "cache_creation_input_token_cost",
                 "created_by",
                 "created_at",
             ],

--- a/tests/trace_server/query_builder/test_costs_query.py
+++ b/tests/trace_server/query_builder/test_costs_query.py
@@ -53,14 +53,16 @@ def test_query_light_column_with_costs() -> None:
                         if(
                             usage_raw != '' and usage_raw != '{}',
                             JSONExtractKeysAndValuesRaw(usage_raw),
-                            [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')]
+                            [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')]
                         )
                     ) AS kv,
                     kv.1 AS llm_id,
                     JSONExtractInt(kv.2, 'requests') AS requests,
                     (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
                     (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-                    JSONExtractInt(kv.2, 'total_tokens') AS total_tokens
+                    JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+                    JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+                    JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
                 FROM all_calls),
             ranked_prices AS (
                 -- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
@@ -74,6 +76,8 @@ def test_query_light_column_with_costs() -> None:
                     llm_token_prices.effective_date,
                     llm_token_prices.prompt_token_cost,
                     llm_token_prices.completion_token_cost,
+                    llm_token_prices.cache_read_input_token_cost,
+                    llm_token_prices.cache_creation_input_token_cost,
                     llm_token_prices.prompt_token_cost_unit,
                     llm_token_prices.completion_token_cost_unit,
                     llm_token_prices.created_by,
@@ -119,10 +123,16 @@ def test_query_light_column_with_costs() -> None:
                                         '"completion_tokens":', toString(completion_tokens), ',',
                                         '"requests":', toString(requests), ',',
                                         '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
                                         '"prompt_token_cost":', toString(prompt_token_cost), ',',
                                         '"completion_token_cost":', toString(completion_token_cost), ',',
-                                        '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',',
                                         '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
                                         '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit),  '",',
                                         '"completion_token_cost_unit":"', toString(completion_token_cost_unit),  '",',
                                         '"effective_date":"', toString(effective_date),  '",',
@@ -213,12 +223,14 @@ def test_query_with_costs_and_attributes_order() -> None:
  SELECT *,
         ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
         arrayJoin(if(usage_raw != ''
-                     and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
+                     and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
         kv.1 AS llm_id,
         JSONExtractInt(kv.2, 'requests') AS requests,
         (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
         (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-        JSONExtractInt(kv.2, 'total_tokens') AS total_tokens
+        JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+        JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+        JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
    FROM all_calls),
      ranked_prices AS
   (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
@@ -231,6 +243,8 @@ def test_query_with_costs_and_attributes_order() -> None:
         llm_token_prices.effective_date,
         llm_token_prices.prompt_token_cost,
         llm_token_prices.completion_token_cost,
+        llm_token_prices.cache_read_input_token_cost,
+        llm_token_prices.cache_creation_input_token_cost,
         llm_token_prices.prompt_token_cost_unit,
         llm_token_prices.completion_token_cost_unit,
         llm_token_prices.created_by,
@@ -260,7 +274,16 @@ SELECT id,
        attributes_dump,
        `summary.weave.status`,
        if(any(llm_id) = 'weave_dummy_llm_id'
-          or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
+          or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
+                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
 FROM ranked_prices
 WHERE (rank = {pb_9:UInt64})
 GROUP BY id,
@@ -325,12 +348,14 @@ def test_query_with_costs_and_dynamic_summary_order() -> None:
  SELECT *,
         ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
         arrayJoin(if(usage_raw != ''
-                     and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
+                     and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
         kv.1 AS llm_id,
         JSONExtractInt(kv.2, 'requests') AS requests,
         (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
         (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-        JSONExtractInt(kv.2, 'total_tokens') AS total_tokens
+        JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+        JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+        JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
    FROM all_calls),
      ranked_prices AS
   (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
@@ -343,6 +368,8 @@ def test_query_with_costs_and_dynamic_summary_order() -> None:
         llm_token_prices.effective_date,
         llm_token_prices.prompt_token_cost,
         llm_token_prices.completion_token_cost,
+        llm_token_prices.cache_read_input_token_cost,
+        llm_token_prices.cache_creation_input_token_cost,
         llm_token_prices.prompt_token_cost_unit,
         llm_token_prices.completion_token_cost_unit,
         llm_token_prices.created_by,
@@ -370,7 +397,16 @@ def test_query_with_costs_and_dynamic_summary_order() -> None:
 SELECT id,
        started_at,
        if(any(llm_id) = 'weave_dummy_llm_id'
-          or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
+          or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
+                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
 FROM ranked_prices
 WHERE (rank = {pb_6:UInt64})
 GROUP BY id,
@@ -435,12 +471,14 @@ def test_query_with_costs_and_feedback_order() -> None:
              SELECT *,
                     ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                     arrayJoin(if(usage_raw != ''
-                                 and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
+                                 and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
                     kv.1 AS llm_id,
                     JSONExtractInt(kv.2, 'requests') AS requests,
                     (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
                     (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-                    JSONExtractInt(kv.2, 'total_tokens') AS total_tokens
+                    JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+                    JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+                    JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
              FROM all_calls),
              ranked_prices AS
             (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
@@ -453,6 +491,8 @@ def test_query_with_costs_and_feedback_order() -> None:
                     llm_token_prices.effective_date,
                     llm_token_prices.prompt_token_cost,
                     llm_token_prices.completion_token_cost,
+                    llm_token_prices.cache_read_input_token_cost,
+                    llm_token_prices.cache_creation_input_token_cost,
                     llm_token_prices.prompt_token_cost_unit,
                     llm_token_prices.completion_token_cost_unit,
                     llm_token_prices.created_by,
@@ -477,7 +517,16 @@ def test_query_with_costs_and_feedback_order() -> None:
         SELECT id,
                started_at,
                if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
+                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
+                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
         FROM ranked_prices
         LEFT JOIN (SELECT * FROM feedback WHERE feedback.project_id = {pb_4:String} ) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_4:String}, '/call/', ranked_prices.id))
         WHERE (rank = {pb_8:UInt64})
@@ -547,12 +596,14 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
              SELECT *,
                     ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                     arrayJoin(if(usage_raw != ''
-                                 and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
+                                 and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
                     kv.1 AS llm_id,
                     JSONExtractInt(kv.2, 'requests') AS requests,
                     (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
                     (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-                    JSONExtractInt(kv.2, 'total_tokens') AS total_tokens
+                    JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+                    JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+                    JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
              FROM all_calls),
              ranked_prices AS
             (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
@@ -565,6 +616,8 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
                     llm_token_prices.effective_date,
                     llm_token_prices.prompt_token_cost,
                     llm_token_prices.completion_token_cost,
+                    llm_token_prices.cache_read_input_token_cost,
+                    llm_token_prices.cache_creation_input_token_cost,
                     llm_token_prices.prompt_token_cost_unit,
                     llm_token_prices.completion_token_cost_unit,
                     llm_token_prices.created_by,
@@ -590,7 +643,16 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
                started_at,
                attributes_dump,
                if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }') , '}')) AS summary_dump
+                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
+                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }') , '}')) AS summary_dump
         FROM ranked_prices
         WHERE (rank = {pb_6:UInt64})
         GROUP BY id,
@@ -647,12 +709,14 @@ def test_query_calls_complete_with_costs_light_fields() -> None:
          SELECT *,
                 ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                 arrayJoin(if(usage_raw != ''
-                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
+                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
                 kv.1 AS llm_id,
                 JSONExtractInt(kv.2, 'requests') AS requests,
                 (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
                 (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens
+                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+                JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+                JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
            FROM all_calls),
              ranked_prices AS
           (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
@@ -665,6 +729,8 @@ def test_query_calls_complete_with_costs_light_fields() -> None:
                 llm_token_prices.effective_date,
                 llm_token_prices.prompt_token_cost,
                 llm_token_prices.completion_token_cost,
+                llm_token_prices.cache_read_input_token_cost,
+                llm_token_prices.cache_creation_input_token_cost,
                 llm_token_prices.prompt_token_cost_unit,
                 llm_token_prices.completion_token_cost_unit,
                 llm_token_prices.created_by,
@@ -689,7 +755,16 @@ def test_query_calls_complete_with_costs_light_fields() -> None:
         SELECT id,
                started_at,
                if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
+                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
+                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
         FROM ranked_prices
         WHERE (rank = {pb_6:UInt64})
         GROUP BY id,
@@ -740,12 +815,14 @@ def test_query_calls_complete_with_costs_and_attributes_order() -> None:
          SELECT *,
                 ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                 arrayJoin(if(usage_raw != ''
-                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
+                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
                 kv.1 AS llm_id,
                 JSONExtractInt(kv.2, 'requests') AS requests,
                 (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
                 (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens
+                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+                JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+                JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
            FROM all_calls),
              ranked_prices AS
           (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
@@ -758,6 +835,8 @@ def test_query_calls_complete_with_costs_and_attributes_order() -> None:
                 llm_token_prices.effective_date,
                 llm_token_prices.prompt_token_cost,
                 llm_token_prices.completion_token_cost,
+                llm_token_prices.cache_read_input_token_cost,
+                llm_token_prices.cache_creation_input_token_cost,
                 llm_token_prices.prompt_token_cost_unit,
                 llm_token_prices.completion_token_cost_unit,
                 llm_token_prices.created_by,
@@ -783,7 +862,16 @@ def test_query_calls_complete_with_costs_and_attributes_order() -> None:
                started_at,
                attributes_dump,
                if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }') , '}')) AS summary_dump
+                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
+                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }') , '}')) AS summary_dump
         FROM ranked_prices
         WHERE (rank = {pb_7:UInt64})
         GROUP BY id,
@@ -849,12 +937,14 @@ def test_query_calls_complete_with_costs_and_feedback_order() -> None:
          SELECT *,
                 ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                 arrayJoin(if(usage_raw != ''
-                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
+                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
                 kv.1 AS llm_id,
                 JSONExtractInt(kv.2, 'requests') AS requests,
                 (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
                 (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens
+                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+                JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+                JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
            FROM all_calls),
              ranked_prices AS
           (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
@@ -867,6 +957,8 @@ def test_query_calls_complete_with_costs_and_feedback_order() -> None:
                 llm_token_prices.effective_date,
                 llm_token_prices.prompt_token_cost,
                 llm_token_prices.completion_token_cost,
+                llm_token_prices.cache_read_input_token_cost,
+                llm_token_prices.cache_creation_input_token_cost,
                 llm_token_prices.prompt_token_cost_unit,
                 llm_token_prices.completion_token_cost_unit,
                 llm_token_prices.created_by,
@@ -891,7 +983,16 @@ def test_query_calls_complete_with_costs_and_feedback_order() -> None:
         SELECT id,
                started_at,
                if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
+                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
+                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
         FROM ranked_prices
         LEFT JOIN (SELECT * FROM feedback WHERE feedback.project_id = {pb_5:String} ) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_5:String}, '/call/', ranked_prices.id))
         WHERE (rank = {pb_9:UInt64})
@@ -953,12 +1054,14 @@ def test_query_with_costs_and_summary_weave_trace_name_field() -> None:
          SELECT *,
                 ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                 arrayJoin(if(usage_raw != ''
-                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
+                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
                 kv.1 AS llm_id,
                 JSONExtractInt(kv.2, 'requests') AS requests,
                 (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
                 (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens
+                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+                JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+                JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
            FROM all_calls),
              ranked_prices AS
           (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
@@ -971,6 +1074,8 @@ def test_query_with_costs_and_summary_weave_trace_name_field() -> None:
                 llm_token_prices.effective_date,
                 llm_token_prices.prompt_token_cost,
                 llm_token_prices.completion_token_cost,
+                llm_token_prices.cache_read_input_token_cost,
+                llm_token_prices.cache_creation_input_token_cost,
                 llm_token_prices.prompt_token_cost_unit,
                 llm_token_prices.completion_token_cost_unit,
                 llm_token_prices.created_by,
@@ -996,7 +1101,16 @@ def test_query_with_costs_and_summary_weave_trace_name_field() -> None:
                `summary.weave.trace_name`,
                started_at,
                if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
+                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
+                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
         FROM ranked_prices
         WHERE (rank = {pb_4:UInt64})
         GROUP BY id,
@@ -1055,12 +1169,14 @@ def test_query_calls_complete_with_costs_and_trace_name_order() -> None:
          SELECT *,
                 ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
                 arrayJoin(if(usage_raw != ''
-                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0}')])) AS kv,
+                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
                 kv.1 AS llm_id,
                 JSONExtractInt(kv.2, 'requests') AS requests,
                 (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
                 (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens
+                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+                JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+                JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
            FROM all_calls),
              ranked_prices AS
           (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
@@ -1073,6 +1189,8 @@ def test_query_calls_complete_with_costs_and_trace_name_order() -> None:
                 llm_token_prices.effective_date,
                 llm_token_prices.prompt_token_cost,
                 llm_token_prices.completion_token_cost,
+                llm_token_prices.cache_read_input_token_cost,
+                llm_token_prices.cache_creation_input_token_cost,
                 llm_token_prices.prompt_token_cost_unit,
                 llm_token_prices.completion_token_cost_unit,
                 llm_token_prices.created_by,
@@ -1098,7 +1216,16 @@ def test_query_calls_complete_with_costs_and_trace_name_order() -> None:
                started_at,
                `summary.weave.trace_name`,
                if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',', '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',', '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',', '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
+                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
+                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
         FROM ranked_prices
         WHERE (rank = {pb_7:UInt64})
         GROUP BY id,

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -1494,6 +1494,12 @@ class TestSemanticConventionParsing:
                 "pricing_level": "default",
                 "pricing_level_id": "default",
                 "created_by": "system",
+                "cache_read_input_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens_total_cost": 0,
+                "cache_creation_input_tokens_total_cost": 0,
+                "cache_read_input_token_cost": 0,
+                "cache_creation_input_token_cost": 0,
             }
         )
 

--- a/tests/trace_server/test_trace_usage.py
+++ b/tests/trace_server/test_trace_usage.py
@@ -15,10 +15,16 @@ _REQUIRED_COST_FIELDS = (
     "output_tokens",
     "requests",
     "total_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
     "prompt_tokens_total_cost",
     "completion_tokens_total_cost",
+    "cache_read_input_tokens_total_cost",
+    "cache_creation_input_tokens_total_cost",
     "prompt_token_cost",
     "completion_token_cost",
+    "cache_read_input_token_cost",
+    "cache_creation_input_token_cost",
     "prompt_token_cost_unit",
     "completion_token_cost_unit",
     "effective_date",
@@ -778,3 +784,83 @@ def test_calls_usage_handles_missing_usage(
     assert usage.completion_tokens == expected_root[1]
     assert usage.total_tokens == expected_root[2]
     assert usage.requests == expected_root[3]
+
+
+def test_aggregate_usage_with_cache_tokens_rolls_up() -> None:
+    """Cache token counts and costs are extracted, rolled up, and merged correctly."""
+    root_id = "root"
+    child_id = "child"
+
+    calls = [
+        _make_call(
+            root_id,
+            None,
+            _usage_summary(
+                {
+                    "claude-3.5-sonnet": {
+                        "input_tokens": 100,
+                        "output_tokens": 50,
+                        "cache_read_input_tokens": 80,
+                        "cache_creation_input_tokens": 20,
+                        "requests": 1,
+                    }
+                },
+                costs={
+                    "claude-3.5-sonnet": {
+                        "prompt_tokens_total_cost": 0.3,
+                        "completion_tokens_total_cost": 0.15,
+                        "cache_read_input_tokens_total_cost": 0.04,
+                        "cache_creation_input_tokens_total_cost": 0.05,
+                    }
+                },
+            ),
+        ),
+        _make_call(
+            child_id,
+            root_id,
+            _usage_summary(
+                {
+                    "claude-3.5-sonnet": {
+                        "input_tokens": 60,
+                        "output_tokens": 30,
+                        "cache_read_input_tokens": 40,
+                        "cache_creation_input_tokens": 10,
+                        "requests": 1,
+                    }
+                },
+                costs={
+                    "claude-3.5-sonnet": {
+                        "prompt_tokens_total_cost": 0.18,
+                        "completion_tokens_total_cost": 0.09,
+                        "cache_read_input_tokens_total_cost": 0.02,
+                        "cache_creation_input_tokens_total_cost": 0.0,
+                    }
+                },
+            ),
+        ),
+    ]
+
+    # Token counts roll up
+    result = usage_utils.aggregate_usage_with_descendants(calls, include_costs=True)
+    root_usage = result[root_id]["claude-3.5-sonnet"]
+    assert root_usage.prompt_tokens == 160
+    assert root_usage.completion_tokens == 80
+    assert root_usage.cache_read_input_tokens == 120
+    assert root_usage.cache_creation_input_tokens == 30
+    assert root_usage.requests == 2
+
+    # Costs roll up
+    assert root_usage.cache_read_input_tokens_total_cost == pytest.approx(0.06)
+    assert root_usage.cache_creation_input_tokens_total_cost == pytest.approx(0.05)
+
+    child_usage = result[child_id]["claude-3.5-sonnet"]
+    assert child_usage.cache_read_input_tokens == 40
+    assert child_usage.cache_creation_input_tokens == 10
+
+    # Without costs flag, cost fields are None
+    result_no_costs = usage_utils.aggregate_usage_with_descendants(
+        calls, include_costs=False
+    )
+    root_no_costs = result_no_costs[root_id]["claude-3.5-sonnet"]
+    assert root_no_costs.cache_read_input_tokens_total_cost is None
+    assert root_no_costs.cache_creation_input_tokens_total_cost is None

--- a/weave/trace_server/calls_query_builder/usage_query_builder.py
+++ b/weave/trace_server/calls_query_builder/usage_query_builder.py
@@ -71,6 +71,8 @@ def _get_usage_metric_extraction_sql(metric: str, json_col: str) -> str:
             ifNull(toFloat64OrNull(JSONExtractRaw({json_col}, 'completion_tokens')), 0) +
             ifNull(toFloat64OrNull(JSONExtractRaw({json_col}, 'output_tokens')), 0)
         )"""
+    elif metric in {"cache_read_input_tokens", "cache_creation_input_tokens"}:
+        return f"ifNull(toFloat64OrNull(JSONExtractRaw({json_col}, '{metric}')), 0)"
     else:
         return f"toFloat64OrNull(JSONExtractRaw({json_col}, '{metric}'))"
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1089,11 +1089,23 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         prices: dict[str, dict[str, float]] = {}
         for row in result.result_rows:
-            llm_id, prompt_cost, completion_cost = row
+            (
+                llm_id,
+                prompt_cost,
+                completion_cost,
+                cache_read_cost,
+                cache_creation_cost,
+            ) = row
             prices[llm_id] = {
                 "prompt_token_cost": float(prompt_cost) if prompt_cost else 0.0,
                 "completion_token_cost": float(completion_cost)
                 if completion_cost
+                else 0.0,
+                "cache_read_input_token_cost": float(cache_read_cost)
+                if cache_read_cost
+                else 0.0,
+                "cache_creation_input_token_cost": float(cache_creation_cost)
+                if cache_creation_cost
                 else 0.0,
             }
         return prices
@@ -1126,22 +1138,42 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             model_prices = prices.get(model, {})
             prompt_cost = model_prices.get("prompt_token_cost", 0.0)
             completion_cost = model_prices.get("completion_token_cost", 0.0)
+            cache_read_cost = model_prices.get("cache_read_input_token_cost", 0.0)
+            cache_creation_cost = model_prices.get(
+                "cache_creation_input_token_cost", 0.0
+            )
 
             input_tokens = bucket.get("sum_input_tokens", 0) or 0
             output_tokens = bucket.get("sum_output_tokens", 0) or 0
+            cache_read_tokens = bucket.get("sum_cache_read_input_tokens", 0) or 0
+            cache_creation_tokens = (
+                bucket.get("sum_cache_creation_input_tokens", 0) or 0
+            )
+
+            # Subtract cache tokens from input: they are billed at cache
+            # rates, not the regular prompt rate.
+            net_input_tokens = (
+                input_tokens - cache_read_tokens - cache_creation_tokens
+            )
 
             if "input_cost" in requested_cost_metrics:
-                bucket["sum_input_cost"] = input_tokens * prompt_cost
+                bucket["sum_input_cost"] = net_input_tokens * prompt_cost
 
             if "output_cost" in requested_cost_metrics:
                 bucket["sum_output_cost"] = output_tokens * completion_cost
 
             if "total_cost" in requested_cost_metrics:
-                input_cost = bucket.get("sum_input_cost", input_tokens * prompt_cost)
+                input_cost = bucket.get(
+                    "sum_input_cost", net_input_tokens * prompt_cost
+                )
                 output_cost = bucket.get(
                     "sum_output_cost", output_tokens * completion_cost
                 )
-                bucket["sum_total_cost"] = input_cost + output_cost
+                cache_read_total = cache_read_tokens * cache_read_cost
+                cache_creation_total = cache_creation_tokens * cache_creation_cost
+                bucket["sum_total_cost"] = (
+                    input_cost + output_cost + cache_read_total + cache_creation_total
+                )
 
     def call_stats(self, req: tsi.CallStatsReq) -> tsi.CallStatsRes:
         """Return call statistics grouped by bucket with requested aggregations.
@@ -5742,6 +5774,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 ),
                 "prompt_token_cost": cost.prompt_token_cost,
                 "completion_token_cost": cost.completion_token_cost,
+                "cache_read_input_token_cost": cost.cache_read_input_token_cost,
+                "cache_creation_input_token_cost": cost.cache_creation_input_token_cost,
                 "prompt_token_cost_unit": cost.prompt_token_cost_unit,
                 "completion_token_cost_unit": cost.completion_token_cost_unit,
             }

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1152,9 +1152,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
             # Subtract cache tokens from input: they are billed at cache
             # rates, not the regular prompt rate.
-            net_input_tokens = (
-                input_tokens - cache_read_tokens - cache_creation_tokens
-            )
+            net_input_tokens = input_tokens - cache_read_tokens - cache_creation_tokens
 
             if "input_cost" in requested_cost_metrics:
                 bucket["sum_input_cost"] = net_input_tokens * prompt_cost

--- a/weave/trace_server/costs/insert_costs.py
+++ b/weave/trace_server/costs/insert_costs.py
@@ -21,13 +21,15 @@ logger.setLevel(logging.INFO)
 
 def get_current_costs(
     client: Client,
-) -> list[tuple[str, float, float, datetime]]:
+) -> list[tuple[str, float, float, float, float, datetime]]:
     current_costs = client.query(
         f"""
         SELECT
             llm_id,
             prompt_token_cost,
             completion_token_cost,
+            cache_read_input_token_cost,
+            cache_creation_input_token_cost,
             effective_date
         FROM llm_token_prices
         WHERE
@@ -128,6 +130,8 @@ def filter_out_current_costs(
         llm_id,
         prompt_token_cost,
         completion_token_cost,
+        cache_read_input_token_cost,
+        cache_creation_input_token_cost,
         effective_date,
     ) in current_costs:
         if llm_id not in new_costs:
@@ -136,10 +140,22 @@ def filter_out_current_costs(
         filtered_costs = []
         for cost in new_costs[llm_id]:
             # Filter out costs that already exist in the database by comparing
-            # the prompt and completion token costs with a relative tolerance
+            # the prompt, completion, and cache token costs with a relative tolerance
             if not (
                 math.isclose(prompt_token_cost, cost["input"], rel_tol=1e-7)
                 and math.isclose(completion_token_cost, cost["output"], rel_tol=1e-7)
+                and math.isclose(
+                    cache_read_input_token_cost,
+                    cost.get("cache_read_input", 0),
+                    rel_tol=1e-7,
+                    abs_tol=1e-12,
+                )
+                and math.isclose(
+                    cache_creation_input_token_cost,
+                    cost.get("cache_creation_input", 0),
+                    rel_tol=1e-7,
+                    abs_tol=1e-12,
+                )
                 and effective_date_str == cost["created_at"]
             ):
                 filtered_costs.append(cost)

--- a/weave/trace_server/costs/insert_costs.py
+++ b/weave/trace_server/costs/insert_costs.py
@@ -42,6 +42,8 @@ def get_current_costs(
 class CostDetails(TypedDict):
     input: float
     output: float
+    cache_read_input: float
+    cache_creation_input: float
     provider: str
     created_at: str
 
@@ -69,6 +71,8 @@ def insert_costs_into_db(client: Client, data: dict[str, list[CostDetails]]) -> 
             provider_id = cost.get("provider", "default")
             input_token_cost = cost.get("input", 0)
             output_token_cost = cost.get("output", 0)
+            cache_read_input_token_cost = cost.get("cache_read_input", 0)
+            cache_creation_input_token_cost = cost.get("cache_creation_input", 0)
             date_str = cost.get(
                 "created_at", datetime.now().strftime("%Y-%m-%d %H:%M:%S")
             )
@@ -87,6 +91,8 @@ def insert_costs_into_db(client: Client, data: dict[str, list[CostDetails]]) -> 
                     "USD",
                     output_token_cost,
                     "USD",
+                    cache_read_input_token_cost,
+                    cache_creation_input_token_cost,
                     "system",
                     created_at,
                 ),
@@ -106,6 +112,8 @@ def insert_costs_into_db(client: Client, data: dict[str, list[CostDetails]]) -> 
             "prompt_token_cost_unit",
             "completion_token_cost",
             "completion_token_cost_unit",
+            "cache_read_input_token_cost",
+            "cache_creation_input_token_cost",
             "created_by",
             "created_at",
         ],

--- a/weave/trace_server/migrations/027_add_cache_token_costs.down.sql
+++ b/weave/trace_server/migrations/027_add_cache_token_costs.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE llm_token_prices DROP COLUMN IF EXISTS cache_read_input_token_cost;
+ALTER TABLE llm_token_prices DROP COLUMN IF EXISTS cache_creation_input_token_cost;

--- a/weave/trace_server/migrations/027_add_cache_token_costs.up.sql
+++ b/weave/trace_server/migrations/027_add_cache_token_costs.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE llm_token_prices ADD COLUMN IF NOT EXISTS cache_read_input_token_cost Float DEFAULT 0;
+ALTER TABLE llm_token_prices ADD COLUMN IF NOT EXISTS cache_creation_input_token_cost Float DEFAULT 0;

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -239,6 +239,12 @@ def _cost_usage_from_summary(
             "requests": _safe_int_for_costs(usage.get("requests")),
             # Match ClickHouse: keep total_tokens as-reported rather than deriving it.
             "total_tokens": _safe_int_for_costs(usage.get("total_tokens")),
+            "cache_read_input_tokens": _safe_int_for_costs(
+                usage.get("cache_read_input_tokens")
+            ),
+            "cache_creation_input_tokens": _safe_int_for_costs(
+                usage.get("cache_creation_input_tokens")
+            ),
         }
     return normalized_usage
 
@@ -437,6 +443,8 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                 effective_date TEXT NOT NULL,
                 prompt_token_cost REAL NOT NULL,
                 completion_token_cost REAL NOT NULL,
+                cache_read_input_token_cost REAL NOT NULL DEFAULT 0,
+                cache_creation_input_token_cost REAL NOT NULL DEFAULT 0,
                 prompt_token_cost_unit TEXT NOT NULL,
                 completion_token_cost_unit TEXT NOT NULL,
                 created_by TEXT NOT NULL,
@@ -671,6 +679,8 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                 row["effective_date"],
                 row["prompt_token_cost"],
                 row["completion_token_cost"],
+                row.get("cache_read_input_token_cost", 0),
+                row.get("cache_creation_input_token_cost", 0),
                 row["prompt_token_cost_unit"],
                 row["completion_token_cost_unit"],
                 row["created_by"],
@@ -689,11 +699,13 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                 effective_date,
                 prompt_token_cost,
                 completion_token_cost,
+                cache_read_input_token_cost,
+                cache_creation_input_token_cost,
                 prompt_token_cost_unit,
                 completion_token_cost_unit,
                 created_by,
                 created_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             default_rows,
         )
@@ -767,6 +779,8 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                 effective_date,
                 prompt_token_cost,
                 completion_token_cost,
+                cache_read_input_token_cost,
+                cache_creation_input_token_cost,
                 prompt_token_cost_unit,
                 completion_token_cost_unit,
                 created_by,
@@ -800,6 +814,8 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                         "effective_date",
                         "prompt_token_cost",
                         "completion_token_cost",
+                        "cache_read_input_token_cost",
+                        "cache_creation_input_token_cost",
                         "prompt_token_cost_unit",
                         "completion_token_cost_unit",
                         "created_by",
@@ -836,18 +852,43 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
 
                 prompt_cost = float(best_row["prompt_token_cost"] or 0.0)
                 completion_cost = float(best_row["completion_token_cost"] or 0.0)
+                cache_read_cost = float(
+                    best_row.get("cache_read_input_token_cost") or 0.0
+                )
+                cache_creation_cost = float(
+                    best_row.get("cache_creation_input_token_cost") or 0.0
+                )
                 prompt_tokens = usage["prompt_tokens"]
                 completion_tokens = usage["completion_tokens"]
+                cache_read_input_tokens = usage.get("cache_read_input_tokens", 0)
+                cache_creation_input_tokens = usage.get(
+                    "cache_creation_input_tokens", 0
+                )
 
                 call_costs[llm_id] = {
                     "prompt_tokens": prompt_tokens,
                     "completion_tokens": completion_tokens,
+                    "cache_read_input_tokens": cache_read_input_tokens,
+                    "cache_creation_input_tokens": cache_creation_input_tokens,
                     "requests": usage["requests"],
                     "total_tokens": usage["total_tokens"],
-                    "prompt_tokens_total_cost": prompt_tokens * prompt_cost,
+                    # Subtract cached tokens: they are billed at the cache
+                    # rate, not the regular input rate.
+                    "prompt_tokens_total_cost": (
+                        prompt_tokens
+                        - cache_read_input_tokens
+                        - cache_creation_input_tokens
+                    )
+                    * prompt_cost,
                     "completion_tokens_total_cost": completion_tokens * completion_cost,
+                    "cache_read_input_tokens_total_cost": cache_read_input_tokens
+                    * cache_read_cost,
+                    "cache_creation_input_tokens_total_cost": cache_creation_input_tokens
+                    * cache_creation_cost,
                     "prompt_token_cost": prompt_cost,
                     "completion_token_cost": completion_cost,
+                    "cache_read_input_token_cost": cache_read_cost,
+                    "cache_creation_input_token_cost": cache_creation_cost,
                     "prompt_token_cost_unit": best_row["prompt_token_cost_unit"],
                     "completion_token_cost_unit": best_row[
                         "completion_token_cost_unit"

--- a/weave/trace_server/token_costs.py
+++ b/weave/trace_server/token_costs.py
@@ -24,9 +24,7 @@ if TYPE_CHECKING:
     from weave.trace_server.calls_query_builder.calls_query_builder import OrderField
 
 DUMMY_LLM_ID = "weave_dummy_llm_id"
-DUMMY_LLM_USAGE = (
-    '{"requests": 0, "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}'
-)
+DUMMY_LLM_USAGE = '{"requests": 0, "prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0, "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0}'
 ESCAPED_DUMMY_LLM_USAGE = DUMMY_LLM_USAGE.replace('"', '\\"')
 
 
@@ -42,6 +40,8 @@ LLM_USAGE_COLUMNS = [
     Column(name="prompt_tokens", type="float"),
     Column(name="completion_tokens", type="float"),
     Column(name="total_tokens", type="float"),
+    Column(name="cache_read_input_tokens", type="float"),
+    Column(name="cache_creation_input_tokens", type="float"),
 ]
 
 
@@ -54,6 +54,8 @@ LLM_TOKEN_PRICES_COLUMNS = [
     Column(name="effective_date", type="datetime"),
     Column(name="prompt_token_cost", type="float"),
     Column(name="completion_token_cost", type="float"),
+    Column(name="cache_read_input_token_cost", type="float"),
+    Column(name="cache_creation_input_token_cost", type="float"),
     Column(name="prompt_token_cost_unit", type="string"),
     Column(name="completion_token_cost_unit", type="string"),
     Column(name="created_by", type="string"),
@@ -81,12 +83,14 @@ def build_model_prices_query(
         SQL string and parameters dict.
     """
     sql = f"""
-    SELECT llm_id, prompt_token_cost, completion_token_cost
+    SELECT llm_id, prompt_token_cost, completion_token_cost, cache_read_input_token_cost, cache_creation_input_token_cost
     FROM (
         SELECT
             llm_id,
             prompt_token_cost,
             completion_token_cost,
+            cache_read_input_token_cost,
+            cache_creation_input_token_cost,
             ROW_NUMBER() OVER (
                 PARTITION BY llm_id
                 ORDER BY
@@ -174,6 +178,8 @@ def get_llm_usage(param_builder: ParamBuilder, table_alias: str) -> PreparedSele
         Column(name="prompt_tokens", type="float"),
         Column(name="completion_tokens", type="float"),
         Column(name="total_tokens", type="float"),
+        Column(name="cache_read_input_tokens", type="float"),
+        Column(name="cache_creation_input_tokens", type="float"),
     ]
 
     all_calls_table = Table(table_alias, cols)
@@ -197,6 +203,10 @@ def get_llm_usage(param_builder: ParamBuilder, table_alias: str) -> PreparedSele
     prompt_tokens = """(if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens"""
     completion_tokens = """(if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens"""
     total_tokens = "JSONExtractInt(kv.2, 'total_tokens') AS total_tokens"
+    cache_read_input_tokens = (
+        "JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens"
+    )
+    cache_creation_input_tokens = "JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens"
 
     select_query = (
         all_calls_table.select()
@@ -210,6 +220,8 @@ def get_llm_usage(param_builder: ParamBuilder, table_alias: str) -> PreparedSele
                 prompt_tokens,
                 completion_tokens,
                 total_tokens,
+                cache_read_input_tokens,
+                cache_creation_input_tokens,
             ]
         )
     )
@@ -396,6 +408,8 @@ def _build_cost_summary_dump_snippet() -> str:
         "completion_tokens",
         "requests",
         "total_tokens",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
     ]
 
     numeric_fields_str = " ".join(
@@ -404,12 +418,18 @@ def _build_cost_summary_dump_snippet() -> str:
                 f""" '"{field}":', toString({field}), ',', """
                 for field in cost_numeric_fields
             ],
-            # These numeric fields are derived or mapped to another name
+            # These numeric fields are derived or mapped to another name.
+            # prompt_tokens_total_cost subtracts cache_read_input_tokens because
+            # cached tokens are billed at the cache rate, not the regular input rate.
             """
             '"prompt_token_cost":', toString(prompt_token_cost), ',',
             '"completion_token_cost":', toString(completion_token_cost), ',',
-            '"prompt_tokens_total_cost":', toString(prompt_tokens * prompt_token_cost), ',',
+            '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+            '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+            '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',',
             '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+            '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+            '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
         """,
         ]
     )

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1448,6 +1448,8 @@ class FilesStatsRes(BaseModel):
 class CostCreateInput(BaseModelStrict):
     prompt_token_cost: float
     completion_token_cost: float
+    cache_read_input_token_cost: float = 0
+    cache_creation_input_token_cost: float = 0
     prompt_token_cost_unit: str | None = Field(
         "USD", description="The unit of the cost for the prompt tokens"
     )
@@ -3059,6 +3061,8 @@ UsageMetric = Literal[
     "input_tokens",
     "output_tokens",
     "total_tokens",
+    "cache_read_input_tokens",
+    "cache_creation_input_tokens",
     "input_cost",
     "output_cost",
     "total_cost",
@@ -3069,11 +3073,15 @@ Token metrics are extracted from summary.usage[model]:
 - input_tokens: Sum of prompt_tokens (OpenAI) and input_tokens (Anthropic/others)
 - output_tokens: Sum of completion_tokens (OpenAI) and output_tokens (Anthropic/others)
 - total_tokens: Total tokens (input + output)
+- cache_read_input_tokens: Tokens read from prompt cache (all providers)
+- cache_creation_input_tokens: Tokens used to create prompt cache (Anthropic)
 
-Cost metrics are computed post-query by multiplying token counts by prices from llm_token_prices:
-- input_cost: input_tokens * prompt_token_cost
+Cost metrics are computed post-query by multiplying token counts by prices from llm_token_prices.
+Cache tokens are subtracted from input before applying the prompt rate (they are billed
+at their own cache rates instead):
+- input_cost: (input_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost
 - output_cost: output_tokens * completion_token_cost
-- total_cost: input_cost + output_cost
+- total_cost: input_cost + output_cost + cache_read_cost + cache_creation_cost
 """
 
 
@@ -3191,9 +3199,13 @@ class LLMAggregatedUsage(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+    cache_read_input_tokens: int = 0
+    cache_creation_input_tokens: int = 0
     # Cost fields - only populated when include_costs=True
     prompt_tokens_total_cost: float | None = None
     completion_tokens_total_cost: float | None = None
+    cache_read_input_tokens_total_cost: float | None = None
+    cache_creation_input_tokens_total_cost: float | None = None
 
 
 # --- /trace/usage endpoint (per-call usage with descendant rollup) ---

--- a/weave/trace_server/usage_utils.py
+++ b/weave/trace_server/usage_utils.py
@@ -106,15 +106,23 @@ def _extract_call_usage(
         )
         requests = _safe_int(usage.get("requests"))
         total_tokens = _safe_int(usage.get("total_tokens"))
+        cache_read_input_tokens = _safe_int(usage.get("cache_read_input_tokens"))
+        cache_creation_input_tokens = _safe_int(
+            usage.get("cache_creation_input_tokens")
+        )
         if total_tokens == 0:
             total_tokens = prompt_tokens + completion_tokens
 
         # Costs are optional and only populated when requested.
         prompt_cost: float | None = None
         completion_cost: float | None = None
+        cache_read_cost: float | None = None
+        cache_creation_cost: float | None = None
         if include_costs:
             prompt_cost = 0.0
             completion_cost = 0.0
+            cache_read_cost = 0.0
+            cache_creation_cost = 0.0
             cost_entry = (
                 costs_map.get(model_name) if isinstance(costs_map, dict) else {}
             )
@@ -123,6 +131,12 @@ def _extract_call_usage(
                 completion_cost = _safe_float(
                     cost_entry.get("completion_tokens_total_cost")
                 )
+                cache_read_cost = _safe_float(
+                    cost_entry.get("cache_read_input_tokens_total_cost")
+                )
+                cache_creation_cost = _safe_float(
+                    cost_entry.get("cache_creation_input_tokens_total_cost")
+                )
 
         # Only store entries that contain any usage (or cost when requested).
         usage_obj = tsi.LLMAggregatedUsage(
@@ -130,8 +144,12 @@ def _extract_call_usage(
             prompt_tokens=prompt_tokens,
             completion_tokens=completion_tokens,
             total_tokens=total_tokens,
+            cache_read_input_tokens=cache_read_input_tokens,
+            cache_creation_input_tokens=cache_creation_input_tokens,
             prompt_tokens_total_cost=prompt_cost,
             completion_tokens_total_cost=completion_cost,
+            cache_read_input_tokens_total_cost=cache_read_cost,
+            cache_creation_input_tokens_total_cost=cache_creation_cost,
         )
 
         if _has_usage(usage_obj, include_costs):
@@ -154,6 +172,8 @@ def _merge_usage(
             existing.prompt_tokens += usage.prompt_tokens
             existing.completion_tokens += usage.completion_tokens
             existing.total_tokens += usage.total_tokens
+            existing.cache_read_input_tokens += usage.cache_read_input_tokens
+            existing.cache_creation_input_tokens += usage.cache_creation_input_tokens
 
             if include_costs:
                 existing.prompt_tokens_total_cost = (
@@ -162,6 +182,12 @@ def _merge_usage(
                 existing.completion_tokens_total_cost = (
                     existing.completion_tokens_total_cost or 0.0
                 ) + (usage.completion_tokens_total_cost or 0.0)
+                existing.cache_read_input_tokens_total_cost = (
+                    existing.cache_read_input_tokens_total_cost or 0.0
+                ) + (usage.cache_read_input_tokens_total_cost or 0.0)
+                existing.cache_creation_input_tokens_total_cost = (
+                    existing.cache_creation_input_tokens_total_cost or 0.0
+                ) + (usage.cache_creation_input_tokens_total_cost or 0.0)
 
 
 def _safe_int(value: Any) -> int:
@@ -179,16 +205,23 @@ def _safe_float(value: Any) -> float:
 
 
 def _has_usage(usage: tsi.LLMAggregatedUsage, include_costs: bool) -> bool:
-    if (
+    has_tokens = (
         usage.requests
         or usage.prompt_tokens
         or usage.completion_tokens
         or usage.total_tokens
-    ):
+    )
+    has_cache_tokens = (
+        usage.cache_read_input_tokens or usage.cache_creation_input_tokens
+    )
+    if has_tokens or has_cache_tokens:
         return True
     if include_costs:
-        return bool(
-            (usage.prompt_tokens_total_cost or 0.0)
-            or (usage.completion_tokens_total_cost or 0.0)
+        has_cost = (usage.prompt_tokens_total_cost or 0.0) or (
+            usage.completion_tokens_total_cost or 0.0
         )
+        has_cache_cost = (usage.cache_read_input_tokens_total_cost or 0.0) or (
+            usage.cache_creation_input_tokens_total_cost or 0.0
+        )
+        return bool(has_cost or has_cache_cost)
     return False


### PR DESCRIPTION
## Summary
- Adds cache token cost support across ClickHouse SQL, SQLite, and stats endpoints
- Cache tokens (read + creation) are subtracted from input tokens before applying the prompt rate, then billed separately at their own cache rates
- Fixes double-charging bug where cache tokens were billed at both regular and cache rates
- Updates all cost-related test assertions to include the new cache token fields

Split from #6507. Depends on #6555 (migrations).

## Changed files
- `weave/trace_server/token_costs.py` — ClickHouse SQL cost formula
- `weave/trace_server/sqlite_trace_server.py` — SQLite cost calculation + usage extraction
- `weave/trace_server/clickhouse_trace_server_batched.py` — Stats endpoint cost computation
- `weave/trace_server/costs/insert_costs.py` — Cost insertion with cache columns
- `weave/trace_server/usage_utils.py` — Usage aggregation
- `weave/trace_server/calls_query_builder/usage_query_builder.py` — Query builder
- `weave/trace_server/trace_server_interface.py` — Updated UsageMetric docstring
- Tests updated: `test_weave_client`, `test_costs_query`, `test_insert_costs`, `test_opentelemetry`, `test_trace_usage`

## Test plan
- [x] All 10 cost query SQL assertion tests pass
- [x] Insert costs test passes with new columns
- [x] `test_summary_tokens_cost` passes (SQLite)
- [x] `test_opentelemetry_cost_calculation` passes
- [ ] ClickHouse integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)