### PR TITLE
chore(weave): fix flaky gcp duplicate write test

### DIFF
--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -7,6 +7,7 @@ specific setup requirements.
 
 import base64
 import os
+import time
 from unittest import mock
 
 import boto3
@@ -241,6 +242,7 @@ class TestGCSStorage:
         blob = bucket.blob(res.digest)
         assert blob.download_as_bytes() == TEST_CONTENT
 
+    @pytest.mark.flaky(reruns=3)
     @pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
     def test_gcp_storage_skips_duplicate_write(self, client: WeaveClient):
         """Test that writing the same content twice skips the second write.
@@ -305,6 +307,9 @@ class TestGCSStorage:
             assert upload_count == 1
             # Both should return the same digest
             assert res1.digest == res2.digest
+
+            # Allow the file row insert to become visible before readback.
+            time.sleep(0.2)
 
             # Verify we can still read the content
             file = client.server.file_content_read(


### PR DESCRIPTION
## Summary

Add a short visibility wait and rerun marker to the flaky GCS duplicate-write test so immediate readback no longer races ClickHouse file metadata visibility.

Original failure (https://github.com/wandb/weave/actions/runs/24200757326/job/70643355894?pr=6542):
```
weave.trace_server.errors.NotFoundError: File with digest MV9b23bQeMQ7isAGTkoBZGErH853yGk0WYyUx1iU7dM not found
```

## Testing

Test-only change.
uvx ruff check tests/trace/test_server_file_storage.py
nox --no-install -e "tests-3.12(shard=trace)" -- tests/trace/test_server_file_storage.py::TestGCSStorage::test_gcp_storage_skips_duplicate_write --trace-server=clickhouse --clickhouse-process=true