### PR TITLE
feat(weave): add api_key and base_url params to weave.init()

### DIFF
--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -16,11 +16,16 @@ from weave.trace.weave_init import (
 @pytest.fixture(autouse=True)
 def reset_weave_client():
     """Reset the global weave client state before each test."""
-    weave_init._current_inited_client = None
+    from weave.trace.env import set_wandb_base_url
+    from weave.wandb_interface.context import set_wandb_api_context
+
     weave_client_context.set_weave_client_global(None)
+    set_wandb_api_context(None)
+    set_wandb_base_url(None)
     yield
     weave_client_context.set_weave_client_global(None)
-    weave_init._current_inited_client = None
+    set_wandb_api_context(None)
+    set_wandb_base_url(None)
 
 
 @dataclass
@@ -282,8 +287,8 @@ def test_init_weave_with_explicit_params_sets_context(mock_wandb_api):
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
 
-    from weave.trace.env import _explicit_base_url
-    from weave.wandb_interface.context import _explicit_api_key
+    import weave.trace.env as env_module
+    import weave.wandb_interface.context as context_module
 
     with (
         patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
@@ -296,7 +301,37 @@ def test_init_weave_with_explicit_params_sets_context(mock_wandb_api):
             api_key="explicit-key",
             base_url="https://api.custom.example.com",
         )
-        # Both should be set in context for downstream use
-        assert _explicit_api_key.get() == "explicit-key"
-        assert _explicit_base_url.get() == "https://api.custom.example.com"
+        # Both should be set as module-level overrides for downstream use
+        assert context_module._explicit_api_key == "explicit-key"
+        assert env_module._explicit_base_url == "https://api.custom.example.com"
         weave_client_context.set_weave_client_global(None)
+
+
+def test_finish_clears_explicit_globals(mock_wandb_api):
+    """weave.finish() must clear explicit api_key and base_url globals so a
+    subsequent init without params falls back to env vars.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    import weave.trace.env as env_module
+    import weave.wandb_interface.context as context_module
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        weave_init.init_weave(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://api.custom.example.com",
+        )
+        assert context_module._explicit_api_key == "explicit-key"
+        assert env_module._explicit_base_url == "https://api.custom.example.com"
+
+    # finish() should clear the globals
+    weave_init.finish()
+    assert context_module._explicit_api_key is None
+    assert env_module._explicit_base_url is None

--- a/weave/trace/env.py
+++ b/weave/trace/env.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import configparser
-import contextvars
 import logging
 import netrc
 import os
@@ -13,12 +12,11 @@ WEAVE_INSECURE_DISABLE_SSL = "WEAVE_INSECURE_DISABLE_SSL"
 
 logger = logging.getLogger(__name__)
 
-# Context var overrides for runtime configuration via weave.init() params.
-# When set, these override env-based lookups so the SDK can be configured
-# without touching environment variables.
-_explicit_base_url: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "_explicit_base_url", default=None
-)
+# Module-level override for runtime configuration via weave.init() params.
+# When set, overrides env-based lookup so the SDK can be configured without
+# touching environment variables. Uses a plain global (not contextvars) because
+# this value must be visible across threads (e.g. call link generation).
+_explicit_base_url: str | None = None
 
 
 class Settings:
@@ -57,11 +55,12 @@ def get_weave_parallelism() -> int:
 
 def set_wandb_base_url(url: str | None) -> None:
     """Set an explicit base URL that overrides env-based lookup."""
-    _explicit_base_url.set(url)
+    global _explicit_base_url  # noqa: PLW0603
+    _explicit_base_url = url
 
 
 def wandb_base_url() -> str:
-    explicit = _explicit_base_url.get()
+    explicit = _explicit_base_url
     if explicit is not None:
         return explicit.rstrip("/")
     settings = Settings()

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -241,6 +241,12 @@ def init_weave_disabled() -> weave_client.WeaveClient:
     if current_client is not None:
         weave_client_context.set_weave_client_global(None)
 
+    # Clear explicit overrides to avoid stale state
+    env.set_wandb_base_url(None)
+    from weave.wandb_interface.context import set_wandb_api_context
+
+    set_wandb_api_context(None)
+
     client = weave_client.WeaveClient(
         "DISABLED",
         "DISABLED",
@@ -280,6 +286,13 @@ def finish() -> None:
     current_client = weave_client_context.get_weave_client()
     if current_client is not None:
         weave_client_context.set_weave_client_global(None)
+
+    # Clear explicit overrides so a subsequent weave.init() without params
+    # falls back to env vars / netrc as expected.
+    env.set_wandb_base_url(None)
+    from weave.wandb_interface.context import set_wandb_api_context
+
+    set_wandb_api_context(None)
 
     # Unregister the import hook
     from weave.integrations.patch import unregister_import_hook

--- a/weave/wandb_interface/context.py
+++ b/weave/wandb_interface/context.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
-import contextvars
-
 from weave.trace.env import weave_wandb_api_key
 
 # When set, overrides env-based API key lookup. This allows weave.init(api_key=...)
 # to propagate the explicit key to all downstream code (e.g. entity resolution)
-# without touching environment variables.
-_explicit_api_key: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "_explicit_api_key", default=None
-)
+# without touching environment variables. Uses a plain global (not contextvars)
+# because this value must be visible across threads.
+_explicit_api_key: str | None = None
 
 
 def set_wandb_api_context(api_key: str | None) -> None:
     """Set an explicit API key that overrides env-based lookup."""
-    _explicit_api_key.set(api_key)
+    global _explicit_api_key  # noqa: PLW0603
+    _explicit_api_key = api_key
 
 
 def get_wandb_api_context() -> str | None:
@@ -22,7 +20,6 @@ def get_wandb_api_context() -> str | None:
 
     Checks explicit override first, then falls back to env var / netrc.
     """
-    explicit = _explicit_api_key.get()
-    if explicit is not None:
-        return explicit
+    if _explicit_api_key is not None:
+        return _explicit_api_key
     return weave_wandb_api_key()


### PR DESCRIPTION
## Summary

Resolves [WB-33023](https://coreweave.atlassian.net/browse/WB-33023)

- Adds optional `api_key`, `base_url`, and `trace_server_url` keyword arguments to `weave.init()`, allowing callers to configure authentication and trace server URL programmatically instead of relying solely on environment variables
- When `api_key` is provided, the SDK skips the env var / netrc / `wandb.login()` auth flow entirely and sets the key in context for downstream use (e.g. entity resolution)
- When `base_url` is provided, it overrides `WANDB_BASE_URL` for entity resolution and platform API calls
- When `trace_server_url` is provided, it overrides `WF_TRACE_SERVER_URL` and the default URL derivation from `base_url`
- Sequential `weave.init()` calls with different credentials properly re-initialize rather than reusing a stale client
- Existing env-based behavior is fully preserved when these params are omitted
- Fixed `api.finish()` to flush the client **before** clearing explicit overrides, so 🍩 call URLs show the correct host during flush

### Motivation

External partners need to set the API key and base URL at runtime — not just via env vars — to support multi-tenant scenarios where multiple auth contexts coexist in the same process. The current workaround of temporarily mutating `os.environ` before calling `weave.init()` is brittle and error-prone, especially since `WF_TRACE_SERVER_URL` must be set before `import weave` for it to take effect.

### Design

Three separate parameters give callers precise control:

| Parameter | Overrides | Purpose |
|---|---|---|
| `api_key` | `WANDB_API_KEY` / netrc / `wandb.login()` | Authentication — passed to the trace server and stored in context for entity resolution |
| `base_url` | `WANDB_BASE_URL` | W&B platform API URL — used for entity resolution; trace server URL is derived from this if `trace_server_url` is omitted |
| `trace_server_url` | `WF_TRACE_SERVER_URL` | Trace server URL — only needed when the trace server is on a different host than the platform API |

### Usage

Both env var and direct parameter approaches are supported:

```python
# Option 1: Environment variables (existing behavior, unchanged)
os.environ["WANDB_API_KEY"] = api_key
os.environ["WF_TRACE_SERVER_URL"] = trace_server_url
weave.init(project_name=project)

# Option 2: Direct params — minimal
weave.init(project_name=project, api_key=api_key, base_url=base_url)

# Option 3: Direct params — explicit trace server
weave.init(
    project_name=project,
    api_key=api_key,
    base_url=base_url,
    trace_server_url=trace_server_url,
)
```

### Files changed

- **`weave/trace/api.py`** — `init()` accepts and forwards the three new params; `finish()` reordered to flush before clearing overrides
- **`weave/trace/weave_init.py`** — `init_weave()` and `init_weave_get_server()` use explicit params when provided, falling back to env-based behavior otherwise; stale-client check accounts for credential changes
- **`weave/trace/env.py`** — `set_wandb_base_url()` / `wandb_base_url()` support an explicit override
- **`weave/wandb_interface/context.py`** — `set_wandb_api_context()` / `get_wandb_api_context()` support an explicit API key override

## Test plan

### Unit tests

- [x] `test_init_weave_get_server_uses_trace_server_url_param` — trace_server_url overrides env-derived URL
- [x] `test_init_weave_get_server_falls_back_to_env_without_trace_server_url` — existing behavior preserved
- [x] `test_init_weave_with_api_key_skips_env_auth` — env/netrc auth not called when api_key provided
- [x] `test_weave_init_passes_all_params` — public API forwards all three params correctly
- [x] `test_sequential_init_with_different_credentials` — multiple init calls don't reuse stale client
- [x] `test_init_weave_with_explicit_params_sets_context` — api_key and base_url are propagated to module-level context for downstream use
- [ ] CI passes

### Manual validation (notebook: `rgao/weave_init_api_key_demo.ipynb`)

Tested three scenarios end-to-end against live prod and QA environments:

**1. Env var approach (existing behavior)**
- Set `WANDB_API_KEY`, `WANDB_BASE_URL`, `WF_TRACE_SERVER_URL` via `os.environ`
- Called `weave.init("hello-world-team/qa-proj")` with no direct params
- ✅ Traces landed in QA project, correct 🍩 URLs (`https://app.qa.wandb.ai/...`)

**2. Direct params — multi-tenant switching**
- Looped over two tenants (`coreweave1` → prod, `qa` → QA) with different `api_key`/`base_url`/`trace_server_url`
- Called `weave.init()` with direct params for each tenant, no env vars set
- ✅ Each tenant's traces landed in the correct project
- ✅ 🍩 URLs showed correct hosts (`https://wandb.ai/...` for prod, `https://app.qa.wandb.ai/...` for QA)
- ✅ Sequential `weave.init()` calls properly re-initialized (no stale client reuse)

**3. Mixed — env vars set + direct params override**
- Set env vars pointing to QA, then called `weave.init()` with direct params pointing to prod
- Without `trace_server_url` param: ❌ Expected 403 — prod API key sent to QA trace server (env var `WF_TRACE_SERVER_URL` won since param was omitted)
- With `trace_server_url` param: ✅ All three params fully overrode env vars, traces landed in prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WB-33023]: https://coreweave.atlassian.net/browse/WB-33023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ