### PR TITLE
feat(weave): add api_key and base_url params to weave.init() with client-scoped credential isolation

### DIFF
--- a/tests/trace/test_client_server_caching.py
+++ b/tests/trace/test_client_server_caching.py
@@ -85,9 +85,11 @@ def test_weave_client_init_with_caching_middleware():
     client = weave_client.WeaveClient(
         "entity", "project", caching_server, ensure_project_exists=True
     )
-    mock_server.ensure_project_exists.assert_called_once_with(
-        "entity", "project", api_key=None, base_url=None
-    )
+    # Verify delegation: entity and project are passed through the caching layer.
+    # api_key/base_url are env-dependent so we only check positional args.
+    mock_server.ensure_project_exists.assert_called_once()
+    args, kwargs = mock_server.ensure_project_exists.call_args
+    assert args == ("entity", "project")
 
 
 def test_server_caching(client):

--- a/tests/trace/test_client_server_caching.py
+++ b/tests/trace/test_client_server_caching.py
@@ -71,7 +71,9 @@ def test_caching_middleware_delegates_ensure_project_exists(tmp_path):
 
     assert result is expected
     assert result.project_name == "my-project"
-    mock_server.ensure_project_exists.assert_called_once_with("entity", "project")
+    mock_server.ensure_project_exists.assert_called_once_with(
+        "entity", "project"
+    )
 
 
 def test_weave_client_init_with_caching_middleware():
@@ -85,7 +87,9 @@ def test_weave_client_init_with_caching_middleware():
     client = weave_client.WeaveClient(
         "entity", "project", caching_server, ensure_project_exists=True
     )
-    mock_server.ensure_project_exists.assert_called_once_with("entity", "project")
+    mock_server.ensure_project_exists.assert_called_once_with(
+        "entity", "project", api_key=None, base_url=None
+    )
 
 
 def test_server_caching(client):

--- a/tests/trace/test_client_server_caching.py
+++ b/tests/trace/test_client_server_caching.py
@@ -71,9 +71,7 @@ def test_caching_middleware_delegates_ensure_project_exists(tmp_path):
 
     assert result is expected
     assert result.project_name == "my-project"
-    mock_server.ensure_project_exists.assert_called_once_with(
-        "entity", "project"
-    )
+    mock_server.ensure_project_exists.assert_called_once_with("entity", "project")
 
 
 def test_weave_client_init_with_caching_middleware():

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -153,6 +153,7 @@ def test_simple_op(client):
         ended_at=DatetimeMatcher(),
         deleted_at=None,
         wb_user_id=client.entity,
+        _base_url=client._base_url,
     )
 
 

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -397,6 +397,7 @@ def test_call_create(client):
         ended_at=DatetimeMatcher(),
         deleted_at=None,
         wb_user_id=client.entity,
+        _base_url=client._base_url,
     )
     assert result == expected
 
@@ -433,6 +434,7 @@ def test_calls_query(client):
         started_at=DatetimeMatcher(),
         ended_at=None,
         wb_user_id=client.entity,
+        _base_url=client._base_url,
     )
     assert result[1] == weave.trace.call.Call(
         _op_name="weave:///shawn/test-project/op/x:6jAV4T6F42RKlabeB2RO0BXkbFFPrKyU2yyQedpotB8",
@@ -460,6 +462,7 @@ def test_calls_query(client):
         started_at=DatetimeMatcher(),
         ended_at=None,
         wb_user_id=client.entity,
+        _base_url=client._base_url,
     )
     client.finish_call(call2, None)
     client.finish_call(call1, None)

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -287,8 +287,8 @@ def test_init_weave_reuse_and_reinit(mock_wandb_api):
 
 
 def test_init_weave_env_fallback_paths(mock_wandb_api, monkeypatch):
-    """When api_key is omitted it reads from env; base_url stays None
-    (env default is used at point of use by URL helpers).
+    """When api_key is omitted it reads from env; base_url eagerly
+    resolves from WANDB_BASE_URL.
     """
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
@@ -306,9 +306,7 @@ def test_init_weave_env_fallback_paths(mock_wandb_api, monkeypatch):
         client = weave_init.init_weave("test-project")
         mock_ctx.assert_called_once()
         assert client._api_key == "env-key"
-        # base_url is None when not explicitly provided; env default is
-        # resolved at point of use by URL helpers.
-        assert client._base_url is None
+        assert client._base_url == "https://env.example.com"
         client.finish()
 
 
@@ -515,18 +513,18 @@ def test_api_eager_credential_resolution(monkeypatch):
     assert api_default._base_url == "https://env.example.com"
 
 
-def test_client_without_explicit_key_leaves_api_key_none():
-    """WeaveClient with api_key=None stores None; Completions and
-    InferenceModels fall back to env at point of use.
+def test_client_resolves_env_key_for_completions_and_models(monkeypatch):
+    """WeaveClient eagerly resolves api_key from env so Completions and
+    InferenceModels see it without their own fallback logic.
     """
+    monkeypatch.setenv("WANDB_API_KEY", "env-key")
     mock_server = _make_mock_server()
     client = WeaveClient(
         "entity", "project", mock_server, ensure_project_exists=False, api_key=None
     )
 
-    assert client._api_key is None
-    assert Completions(client)._client._api_key is None
-    assert InferenceModels(client)._client._api_key is None
+    assert Completions(client)._client._api_key == "env-key"
+    assert InferenceModels(client)._client._api_key == "env-key"
     client.finish()
 
 

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -931,9 +931,7 @@ def test_completions_falls_back_to_env_when_no_client_key():
         "weave.chat.completions.get_wandb_api_context", return_value="env-key"
     ) as mock_ctx:
         api_key = (
-            comp._client._api_key
-            if comp._client._api_key is not None
-            else mock_ctx()
+            comp._client._api_key if comp._client._api_key is not None else mock_ctx()
         )
         assert api_key == "env-key"
         mock_ctx.assert_called_once()
@@ -969,17 +967,19 @@ def test_inference_models_falls_back_to_env_when_no_client_key():
 # --- Coverage: project_creator with explicit credentials ---
 
 
-def test_project_creator_threads_credentials():
-    """ensure_project_exists should pass api_key/base_url to _ensure_project_exists."""
-    with patch(
-        "weave.wandb_interface.project_creator._ensure_project_exists",
-        return_value={"project_name": "proj"},
-    ) as mock_inner:
-        from weave.wandb_interface.project_creator import ensure_project_exists
+def test_project_creator_passes_credentials_to_api():
+    """_ensure_project_exists should construct wandb.Api with api_key and base_url."""
+    from weave.wandb_interface.project_creator import _ensure_project_exists
 
-        ensure_project_exists(
-            "entity", "project", api_key="key", base_url="https://example.com"
+    mock_api = MagicMock()
+    mock_api.project.return_value = {"project": {"name": "proj"}}
+
+    with patch("weave.wandb_interface.project_creator.wandb") as mock_wandb:
+        mock_wandb.Api.return_value = mock_api
+        result = _ensure_project_exists(
+            "entity", "proj", api_key="key", base_url="https://example.com"
         )
-        mock_inner.assert_called_once_with(
-            "entity", "project", api_key="key", base_url="https://example.com"
+        mock_wandb.Api.assert_called_once_with(
+            api_key="key", base_url="https://example.com"
         )
+        assert result == {"project_name": "proj"}

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -983,3 +983,41 @@ def test_project_creator_passes_credentials_to_api():
             api_key="key", base_url="https://example.com"
         )
         assert result == {"project_name": "proj"}
+
+
+# --- Coverage: Call.children() passes base_url ---
+
+
+def test_call_children_passes_base_url():
+    """Call.children() should pass client._base_url to _make_calls_iterator."""
+    from weave.trace.call import Call
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity",
+        "project",
+        mock_server,
+        ensure_project_exists=False,
+        base_url="https://children.example.com",
+    )
+    weave_client_context.set_weave_client_global(client)
+
+    call = Call(
+        _op_name="test-op",
+        project_id="entity/project",
+        trace_id="trace-123",
+        parent_id=None,
+        inputs={},
+        id="call-123",
+    )
+
+    with patch("weave.trace.call._make_calls_iterator") as mock_iter:
+        mock_iter.return_value = iter([])
+        list(call.children())
+        mock_iter.assert_called_once()
+        _, kwargs = mock_iter.call_args
+        assert kwargs.get("base_url") == "https://children.example.com"
+
+    client.finish()
+    weave_client_context.set_weave_client_global(None)

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -287,8 +287,8 @@ def test_init_weave_reuse_and_reinit(mock_wandb_api):
 
 
 def test_init_weave_env_fallback_paths(mock_wandb_api, monkeypatch):
-    """When api_key is omitted it reads from env; when base_url is omitted it
-    eagerly resolves from WANDB_BASE_URL.
+    """When api_key is omitted it reads from env; base_url stays None
+    (env default is used at point of use by URL helpers).
     """
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
@@ -306,7 +306,9 @@ def test_init_weave_env_fallback_paths(mock_wandb_api, monkeypatch):
         client = weave_init.init_weave("test-project")
         mock_ctx.assert_called_once()
         assert client._api_key == "env-key"
-        assert client._base_url == "https://env.example.com"
+        # base_url is None when not explicitly provided; env default is
+        # resolved at point of use by URL helpers.
+        assert client._base_url is None
         client.finish()
 
 
@@ -513,18 +515,18 @@ def test_api_eager_credential_resolution(monkeypatch):
     assert api_default._base_url == "https://env.example.com"
 
 
-def test_client_resolves_env_key_for_completions_and_models(monkeypatch):
-    """WeaveClient eagerly resolves api_key from env so Completions and
-    InferenceModels see it without their own fallback logic.
+def test_client_without_explicit_key_leaves_api_key_none():
+    """WeaveClient with api_key=None stores None; Completions and
+    InferenceModels fall back to env at point of use.
     """
-    monkeypatch.setenv("WANDB_API_KEY", "env-key")
     mock_server = _make_mock_server()
     client = WeaveClient(
         "entity", "project", mock_server, ensure_project_exists=False, api_key=None
     )
 
-    assert Completions(client)._client._api_key == "env-key"
-    assert InferenceModels(client)._client._api_key == "env-key"
+    assert client._api_key is None
+    assert Completions(client)._client._api_key is None
+    assert InferenceModels(client)._client._api_key is None
     client.finish()
 
 

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -259,31 +259,52 @@ def test_init_weave_credential_storage_and_env_skipping(mock_wandb_api):
 
 
 def test_init_weave_reuse_and_reinit(mock_wandb_api):
-    """Same project without credential params reuses client; passing any
-    credential param forces re-init.
+    """Reuse client when identical explicit credentials are passed;
+    recreate when credentials differ or are env-derived (None).
     """
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
 
-    with _init_patches(mock_server):
+    with (
+        _init_patches(mock_server),
+        patch(
+            "weave.trace.weave_init.get_wandb_api_context",
+            return_value="env-key",
+        ),
+    ):
         client_a = weave_init.init_weave("test-project", api_key="key")
-        assert weave_init.init_weave("test-project") is client_a  # reuse
+        # Same explicit credentials → reuse
+        assert weave_init.init_weave("test-project", api_key="key") is client_a
 
-        client_b = weave_init.init_weave("test-project", api_key="new-key")
+        # No explicit api_key (env-derived) → recreate to pick up env changes
+        client_b = weave_init.init_weave("test-project")
         assert client_b is not client_a
 
-        client_c = weave_init.init_weave(
-            "test-project", api_key="new-key", base_url="https://new.example.com"
-        )
+        # Different explicit key → recreate
+        client_c = weave_init.init_weave("test-project", api_key="new-key")
         assert client_c is not client_b
 
+        # Same key but added base_url → recreate
         client_d = weave_init.init_weave(
+            "test-project", api_key="new-key", base_url="https://new.example.com"
+        )
+        assert client_d is not client_c
+        # Same key + same base_url → reuse
+        assert (
+            weave_init.init_weave(
+                "test-project", api_key="new-key", base_url="https://new.example.com"
+            )
+            is client_d
+        )
+
+        # Added trace_server_url → recreate
+        client_e = weave_init.init_weave(
             "test-project",
             api_key="new-key",
             trace_server_url="https://trace.new.example.com",
         )
-        assert client_d is not client_c
-        client_d.finish()
+        assert client_e is not client_d
+        client_e.finish()
 
 
 def test_init_weave_env_fallback_paths(mock_wandb_api, monkeypatch):

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -16,16 +16,19 @@ from weave.trace.weave_init import (
 @pytest.fixture(autouse=True)
 def reset_weave_client():
     """Reset the global weave client state before each test."""
-    from weave.trace.env import set_wandb_base_url
-    from weave.wandb_interface.context import set_wandb_api_context
-
     weave_client_context.set_weave_client_global(None)
-    set_wandb_api_context(None)
-    set_wandb_base_url(None)
     yield
     weave_client_context.set_weave_client_global(None)
-    set_wandb_api_context(None)
-    set_wandb_base_url(None)
+
+
+@pytest.fixture(autouse=True)
+def mock_project_creator():
+    """Mock project_creator.ensure_project_exists for all tests that create clients."""
+    with patch(
+        "weave.wandb_interface.project_creator.ensure_project_exists",
+        return_value={"project_name": "test-project"},
+    ):
+        yield
 
 
 @dataclass
@@ -239,16 +242,12 @@ def test_weave_init_passes_all_params(mock_wandb_api):
         weave_client_context.set_weave_client_global(None)
 
 
-def test_init_weave_with_explicit_params_sets_context(mock_wandb_api):
-    """When api_key and base_url are provided, they should be set in context so
-    downstream code (e.g. entity resolution, trace server URL derivation) can
-    use them without env vars.
+def test_init_weave_stores_creds_on_client(mock_wandb_api):
+    """When api_key and base_url are provided, they should be stored on the
+    client instance (not in module-level globals).
     """
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
-
-    import weave.trace.env as env_module
-    import weave.wandb_interface.context as context_module
 
     with (
         patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
@@ -256,14 +255,14 @@ def test_init_weave_with_explicit_params_sets_context(mock_wandb_api):
         patch("weave.trace.weave_init.get_username", return_value="test-user"),
         patch("weave.trace.weave_init.init_message"),
     ):
-        weave_init.init_weave(
+        client = weave_init.init_weave(
             "test-project",
             api_key="explicit-key",
             base_url="https://api.custom.example.com",
         )
-        # Both should be set as module-level overrides for downstream use
-        assert context_module._explicit_api_key == "explicit-key"
-        assert env_module._explicit_base_url == "https://api.custom.example.com"
+        assert client._api_key == "explicit-key"
+        assert client._base_url == "https://api.custom.example.com"
+        client.finish()
         weave_client_context.set_weave_client_global(None)
 
 
@@ -307,15 +306,19 @@ def test_init_weave_reinits_when_credential_params_provided(mock_wandb_api):
         client_b = weave_init.init_weave("test-project", api_key="new-key")
         assert client_b is not client_a
 
-        # Re-init with base_url should NOT reuse
+        # Re-init with base_url (and api_key) should NOT reuse
         client_c = weave_init.init_weave(
-            "test-project", base_url="https://new.example.com"
+            "test-project",
+            api_key="new-key",
+            base_url="https://new.example.com",
         )
         assert client_c is not client_b
 
         # Re-init with trace_server_url should NOT reuse
         client_d = weave_init.init_weave(
-            "test-project", trace_server_url="https://trace.new.example.com"
+            "test-project",
+            api_key="new-key",
+            trace_server_url="https://trace.new.example.com",
         )
         assert client_d is not client_c
 
@@ -357,12 +360,10 @@ def test_init_weave_uses_effective_trace_server_url_for_version_check(mock_wandb
         weave_client_context.set_weave_client_global(None)
 
 
-def test_init_weave_without_base_url_does_not_set_override(mock_wandb_api):
-    """When base_url is not provided, _explicit_base_url should remain None."""
+def test_init_weave_without_base_url_stores_none_on_client(mock_wandb_api):
+    """When base_url is not provided, client._base_url should be None."""
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
-
-    import weave.trace.env as env_module
 
     with (
         patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
@@ -370,134 +371,713 @@ def test_init_weave_without_base_url_does_not_set_override(mock_wandb_api):
         patch("weave.trace.weave_init.get_username", return_value="test-user"),
         patch("weave.trace.weave_init.init_message"),
     ):
-        weave_init.init_weave("test-project", api_key="key")
-        assert env_module._explicit_base_url is None
+        client = weave_init.init_weave("test-project", api_key="key")
+        assert client._base_url is None
+        client.finish()
         weave_client_context.set_weave_client_global(None)
 
 
-def test_api_finish_flushes_before_clearing_overrides(mock_wandb_api):
-    """api.finish() must flush the client before clearing explicit overrides,
-    so that callbacks during flush still see the correct base_url.
-    """
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    import weave.trace.env as env_module
-    import weave.wandb_interface.context as context_module
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        weave_api.init(
-            "test-project",
-            api_key="explicit-key",
-            base_url="https://api.custom.example.com",
-        )
-
-    # Track the order: flush should happen before clearing
-    call_order = []
-    original_client = weave_client_context.get_weave_client()
-    original_finish = original_client.finish
-
-    def tracked_finish(*args, **kwargs):
-        # At flush time, overrides should still be set
-        call_order.append("client_finish")
-        assert env_module._explicit_base_url == "https://api.custom.example.com"
-        assert context_module._explicit_api_key == "explicit-key"
-        return original_finish(*args, **kwargs)
-
-    original_client.finish = tracked_finish
-    weave_api.finish()
-
-    call_order.append("overrides_cleared")
-    assert call_order == ["client_finish", "overrides_cleared"]
-    assert env_module._explicit_base_url is None
-    assert context_module._explicit_api_key is None
-
-
 def test_get_wandb_api_context_falls_back_to_env(monkeypatch):
-    """When no explicit api_key is set, get_wandb_api_context should fall back
-    to environment variables.
-    """
-    from weave.wandb_interface.context import (
-        get_wandb_api_context,
-        set_wandb_api_context,
-    )
+    """get_wandb_api_context should read from environment variables."""
+    from weave.wandb_interface.context import get_wandb_api_context
 
-    set_wandb_api_context(None)
     monkeypatch.setenv("WANDB_API_KEY", "env-key-123")
     assert get_wandb_api_context() == "env-key-123"
 
 
-def test_get_wandb_api_context_explicit_overrides_env(monkeypatch):
-    """When explicit api_key is set, it should override the env var."""
-    from weave.wandb_interface.context import (
-        get_wandb_api_context,
-        set_wandb_api_context,
-    )
-
-    monkeypatch.setenv("WANDB_API_KEY", "env-key-123")
-    set_wandb_api_context("explicit-key-456")
-    assert get_wandb_api_context() == "explicit-key-456"
-    set_wandb_api_context(None)
-
-
-def test_wandb_base_url_explicit_overrides_env(monkeypatch):
-    """When explicit base_url is set, it should override the env var."""
-    from weave.trace.env import set_wandb_base_url, wandb_base_url
-
-    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
-    set_wandb_base_url("https://explicit.example.com")
-    assert wandb_base_url() == "https://explicit.example.com"
-    set_wandb_base_url(None)
-
-
 def test_wandb_base_url_falls_back_to_env(monkeypatch):
-    """When no explicit base_url is set, should fall back to env var."""
-    from weave.trace.env import set_wandb_base_url, wandb_base_url
+    """wandb_base_url should read from env var."""
+    from weave.trace.env import wandb_base_url
 
-    set_wandb_base_url(None)
     monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
     assert wandb_base_url() == "https://env.example.com"
 
 
-def test_wandb_base_url_strips_trailing_slash():
-    """Explicit base_url should have trailing slash stripped."""
-    from weave.trace.env import set_wandb_base_url, wandb_base_url
-
-    set_wandb_base_url("https://explicit.example.com/")
-    assert wandb_base_url() == "https://explicit.example.com"
-    set_wandb_base_url(None)
+# --- Multi-client isolation tests ---
 
 
-def test_finish_clears_explicit_globals(mock_wandb_api):
-    """weave.finish() must clear explicit api_key and base_url globals so a
-    subsequent init without params falls back to env vars.
+def test_two_clients_have_independent_credentials(mock_wandb_api):
+    """Two clients created with different credentials should each retain
+    their own api_key and base_url without cross-contamination.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server_x = _make_mock_server()
+    mock_server_y = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        with patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_x
+        ):
+            client_x = weave_init.init_weave(
+                "proj-x",
+                api_key="key-x",
+                base_url="https://x.example.com",
+            )
+
+        with patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_y
+        ):
+            client_y = weave_init.init_weave(
+                "proj-y",
+                api_key="key-y",
+                base_url="https://y.example.com",
+            )
+
+        # client_x should still have its own credentials
+        assert client_x._api_key == "key-x"
+        assert client_x._base_url == "https://x.example.com"
+
+        # client_y should have its own credentials
+        assert client_y._api_key == "key-y"
+        assert client_y._base_url == "https://y.example.com"
+
+        # No cross-contamination
+        assert client_x._api_key != client_y._api_key
+        assert client_x._base_url != client_y._base_url
+
+        client_y.finish()
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_call_ui_url_uses_client_base_url(mock_wandb_api):
+    """Call.ui_url should use the base_url from the client that created it,
+    not a global or the default.
     """
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
-
-    import weave.trace.env as env_module
-    import weave.wandb_interface.context as context_module
 
     with (
         patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
         patch("weave.trace.weave_init._weave_is_available", return_value=True),
         patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        client = weave_init.init_weave(
+            "test-project",
+            api_key="key",
+            base_url="https://custom.example.com",
+        )
+
+    from weave.trace.call import Call
+
+    call = Call(
+        _op_name="test-op",
+        project_id="test-entity/test-project",
+        trace_id="trace-123",
+        parent_id=None,
+        inputs={},
+        id="call-123",
+        _base_url="https://custom.example.com",
+    )
+    url = call.ui_url
+    assert "custom.example.com" in url
+    assert "call-123" in url
+
+    # A call without _base_url should fall back to env-based default
+    call_default = Call(
+        _op_name="test-op",
+        project_id="test-entity/test-project",
+        trace_id="trace-456",
+        parent_id=None,
+        inputs={},
+        id="call-456",
+    )
+    url_default = call_default.ui_url
+    assert "call-456" in url_default
+    # Should NOT contain custom.example.com since _base_url is None
+    assert "custom.example.com" not in url_default
+
+    client.finish()
+    weave_client_context.set_weave_client_global(None)
+
+
+def test_no_global_state_leakage_after_init(mock_wandb_api, monkeypatch):
+    """After init with explicit credentials, the module-level env readers
+    should NOT return the explicit values (they should only read from env/netrc).
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    from weave.trace.env import wandb_base_url
+    from weave.wandb_interface.context import get_wandb_api_context
+
+    # Set env vars to known values
+    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
+    monkeypatch.setenv("WANDB_API_KEY", "env-key")
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        client = weave_init.init_weave(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://explicit.example.com",
+        )
+
+    # The client should hold the explicit values
+    assert client._api_key == "explicit-key"
+    assert client._base_url == "https://explicit.example.com"
+
+    # But module-level readers should still return env values, NOT the explicit ones
+    assert wandb_base_url() == "https://env.example.com"
+    assert get_wandb_api_context() == "env-key"
+
+    client.finish()
+    weave_client_context.set_weave_client_global(None)
+
+
+def test_second_init_does_not_corrupt_first_client_urls(mock_wandb_api):
+    """When a second client is initialized, the first client's calls should
+    still generate URLs using the first client's base_url.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+
+    from weave.trace.call import Call
+
+    mock_server_a = _make_mock_server()
+    mock_server_b = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        with patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_a
+        ):
+            client_a = weave_init.init_weave(
+                "proj-a",
+                api_key="key-a",
+                base_url="https://a.example.com",
+            )
+
+        # Create a call on client_a's project
+        call_a = Call(
+            _op_name="op-a",
+            project_id="test-entity/proj-a",
+            trace_id="trace-a",
+            parent_id=None,
+            inputs={},
+            id="call-a",
+            _base_url=client_a._base_url,
+        )
+
+        # Now init a second client that overwrites the global
+        with patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_b
+        ):
+            client_b = weave_init.init_weave(
+                "proj-b",
+                api_key="key-b",
+                base_url="https://b.example.com",
+            )
+
+        # call_a's URL should still point to a.example.com
+        assert "a.example.com" in call_a.ui_url
+        assert "b.example.com" not in call_a.ui_url
+
+        # A new call on client_b should use b.example.com
+        call_b = Call(
+            _op_name="op-b",
+            project_id="test-entity/proj-b",
+            trace_id="trace-b",
+            parent_id=None,
+            inputs={},
+            id="call-b",
+            _base_url=client_b._base_url,
+        )
+        assert "b.example.com" in call_b.ui_url
+        assert "a.example.com" not in call_b.ui_url
+
+        client_b.finish()
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_internal_api_uses_client_credentials(mock_wandb_api):
+    """wandb.Api created with explicit credentials should use them,
+    not fall back to global state.
+    """
+    from weave.compat.wandb.wandb_thin.internal_api import Api
+
+    api = Api(api_key="my-key", base_url="https://custom.example.com")
+    assert api._api_key == "my-key"
+    assert api._base_url == "https://custom.example.com"
+
+    # Api without credentials should have None (falls back to env at query time)
+    api_default = Api()
+    assert api_default._api_key is None
+    assert api_default._base_url is None
+
+
+@pytest.mark.asyncio
+async def test_internal_api_async_uses_client_credentials():
+    """ApiAsync created with explicit credentials should store them."""
+    from weave.compat.wandb.wandb_thin.internal_api import ApiAsync
+
+    api = ApiAsync(api_key="my-key", base_url="https://custom.example.com")
+    assert api._api_key == "my-key"
+    assert api._base_url == "https://custom.example.com"
+
+    api_default = ApiAsync()
+    assert api_default._api_key is None
+    assert api_default._base_url is None
+
+
+def test_project_creator_receives_client_credentials(mock_wandb_api):
+    """WeaveClient.__init__ should pass api_key and base_url to
+    project_creator.ensure_project_exists.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+        patch(
+            "weave.wandb_interface.project_creator.ensure_project_exists",
+            return_value={"project_name": "test-project"},
+        ) as mock_ensure,
+    ):
+        weave_init.init_weave(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://explicit.example.com",
+        )
+        mock_ensure.assert_called_once_with(
+            "test-entity",
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://explicit.example.com",
+        )
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_get_username_receives_credentials(mock_wandb_api):
+    """get_username should be called with the explicit api_key and base_url."""
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch(
+            "weave.trace.weave_init.get_username", return_value="test-user"
+        ) as mock_get_user,
         patch("weave.trace.weave_init.init_message"),
     ):
         weave_init.init_weave(
             "test-project",
             api_key="explicit-key",
-            base_url="https://api.custom.example.com",
+            base_url="https://explicit.example.com",
         )
-        assert context_module._explicit_api_key == "explicit-key"
-        assert env_module._explicit_base_url == "https://api.custom.example.com"
+        mock_get_user.assert_called_once_with(
+            api_key="explicit-key", base_url="https://explicit.example.com"
+        )
+        weave_client_context.set_weave_client_global(None)
 
-    # finish() should clear the globals
-    weave_init.finish()
-    assert context_module._explicit_api_key is None
-    assert env_module._explicit_base_url is None
+
+def test_get_entity_project_receives_credentials(mock_wandb_api):
+    """get_entity_project_from_project_name should pass credentials to Api."""
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+        patch(
+            "weave.trace.weave_init.get_entity_project_from_project_name",
+            return_value=("test-entity", "test-project"),
+        ) as mock_get_entity,
+    ):
+        weave_init.init_weave(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://explicit.example.com",
+        )
+        mock_get_entity.assert_called_once_with(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://explicit.example.com",
+        )
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_init_message_receives_base_url(mock_wandb_api):
+    """print_init_message should be called with the explicit base_url."""
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message") as mock_init_msg,
+    ):
+        mock_init_msg.check_min_weave_version.return_value = True
+        mock_init_msg.check_min_trace_server_version.return_value = True
+
+        weave_init.init_weave(
+            "test-project",
+            api_key="key",
+            base_url="https://custom.example.com",
+        )
+        mock_init_msg.print_init_message.assert_called_once_with(
+            "test-user",
+            "test-entity",
+            "test-project",
+            read_only=False,
+            base_url="https://custom.example.com",
+        )
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_completions_uses_client_api_key():
+    """Completions should prefer client._api_key over env."""
+    from weave.chat.completions import Completions
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity",
+        "project",
+        mock_server,
+        ensure_project_exists=False,
+        api_key="client-key",
+    )
+    comp = Completions(client)
+
+    # _create_non_op reads the api_key; mock the HTTP call to verify the key is used
+    with patch("weave.wandb_interface.context.get_wandb_api_context") as mock_env_key:
+        mock_env_key.return_value = "env-key"
+        # We can't easily call _create_non_op without a full HTTP setup,
+        # but we can verify the precedence logic directly
+        api_key = (
+            comp._client._api_key
+            if comp._client._api_key is not None
+            else mock_env_key()
+        )
+        assert api_key == "client-key"
+        # env reader should NOT have been called
+        mock_env_key.assert_not_called()
+
+    client.finish()
+
+
+def test_completions_falls_back_to_env_when_no_client_key():
+    """Completions should fall back to env when client._api_key is None."""
+    from weave.chat.completions import Completions
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server = _make_mock_server()
+    client = WeaveClient("entity", "project", mock_server, ensure_project_exists=False)
+    comp = Completions(client)
+
+    with patch(
+        "weave.wandb_interface.context.get_wandb_api_context", return_value="env-key"
+    ):
+        api_key = (
+            comp._client._api_key if comp._client._api_key is not None else "env-key"
+        )
+        assert api_key == "env-key"
+
+    client.finish()
+
+
+def test_inference_models_uses_client_api_key():
+    """InferenceModels should prefer client._api_key over env."""
+    from weave.chat.inference_models import InferenceModels
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity",
+        "project",
+        mock_server,
+        ensure_project_exists=False,
+        api_key="client-key",
+    )
+    models = InferenceModels(client)
+
+    with patch("weave.wandb_interface.context.get_wandb_api_context") as mock_env_key:
+        mock_env_key.return_value = "env-key"
+        api_key = (
+            models._client._api_key
+            if models._client._api_key is not None
+            else mock_env_key()
+        )
+        assert api_key == "client-key"
+        mock_env_key.assert_not_called()
+
+    client.finish()
+
+
+def test_url_functions_with_explicit_base_url():
+    """All URL functions should use explicit base_url when provided."""
+    from weave.trace import urls
+
+    # With explicit base_url
+    url = urls.remote_project_root_url(
+        "entity", "project", base_url="https://custom.example.com"
+    )
+    assert "custom.example.com" in url
+
+    url = urls.project_weave_root_url(
+        "entity", "project", base_url="https://custom.example.com"
+    )
+    assert "custom.example.com" in url
+
+    url = urls.op_version_path(
+        "entity", "project", "my-op", "abc123", base_url="https://custom.example.com"
+    )
+    assert "custom.example.com" in url
+
+    url = urls.object_version_path(
+        "entity", "project", "my-obj", "abc123", base_url="https://custom.example.com"
+    )
+    assert "custom.example.com" in url
+
+    url = urls.leaderboard_path(
+        "entity", "project", "my-lb", base_url="https://custom.example.com"
+    )
+    assert "custom.example.com" in url
+
+    url = urls.redirect_call(
+        "entity", "project", "call-id", base_url="https://custom.example.com"
+    )
+    assert "custom.example.com" in url
+
+
+def test_url_functions_without_base_url_use_env(monkeypatch):
+    """URL functions without base_url should fall back to env."""
+    from weave.trace import urls
+
+    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
+
+    url = urls.remote_project_root_url("entity", "project")
+    assert "env.example.com" in url
+
+    url = urls.redirect_call("entity", "project", "call-id")
+    assert "env.example.com" in url
+
+
+def test_finish_one_client_does_not_affect_another(mock_wandb_api):
+    """Finishing client_a should not affect client_b's credentials."""
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server_a = _make_mock_server()
+    mock_server_b = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        with patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_a
+        ):
+            client_a = weave_init.init_weave(
+                "proj-a",
+                api_key="key-a",
+                base_url="https://a.example.com",
+            )
+
+        with patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_b
+        ):
+            client_b = weave_init.init_weave(
+                "proj-b",
+                api_key="key-b",
+                base_url="https://b.example.com",
+            )
+
+    # Finish client_a
+    client_a.finish()
+
+    # client_b's credentials should be unaffected
+    assert client_b._api_key == "key-b"
+    assert client_b._base_url == "https://b.example.com"
+
+    client_b.finish()
+    weave_client_context.set_weave_client_global(None)
+
+
+@pytest.mark.disable_logging_error_check
+def test_client_create_call_sets_base_url(mock_wandb_api):
+    """WeaveClient.create_call should set _base_url on the Call object."""
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity",
+        "project",
+        mock_server,
+        ensure_project_exists=False,
+        base_url="https://custom.example.com",
+    )
+    weave_client_context.set_weave_client_global(client)
+
+    from weave.trace.op import op
+
+    @op
+    def dummy_op():
+        pass
+
+    call = client.create_call(dummy_op, {})
+    assert call._base_url == "https://custom.example.com"
+    client.finish_call(call, output=None)
+    client.finish()
+    weave_client_context.set_weave_client_global(None)
+
+
+@pytest.mark.disable_logging_error_check
+def test_client_create_call_without_base_url_sets_none(mock_wandb_api):
+    """WeaveClient created without base_url should set _base_url=None on Call."""
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server = _make_mock_server()
+    client = WeaveClient("entity", "project", mock_server, ensure_project_exists=False)
+    weave_client_context.set_weave_client_global(client)
+
+    from weave.trace.op import op
+
+    @op
+    def dummy_op():
+        pass
+
+    call = client.create_call(dummy_op, {})
+    assert call._base_url is None
+    client.finish_call(call, output=None)
+    client.finish()
+    weave_client_context.set_weave_client_global(None)
+
+
+def test_thread_captures_client_base_url(mock_wandb_api):
+    """Operations deferred to FutureExecutor should capture the client's
+    _base_url via closure, not read from globals.
+    """
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity",
+        "project",
+        mock_server,
+        ensure_project_exists=False,
+        api_key="thread-key",
+        base_url="https://thread.example.com",
+    )
+
+    # Defer a task that reads client._base_url
+    captured_values: dict = {}
+
+    def capture_creds():
+        captured_values["api_key"] = client._api_key
+        captured_values["base_url"] = client._base_url
+
+    fut = client.future_executor.defer(capture_creds)
+    fut.result()  # wait for completion
+
+    assert captured_values["api_key"] == "thread-key"
+    assert captured_values["base_url"] == "https://thread.example.com"
+
+    client.finish()
+
+
+def test_two_clients_thread_isolation(mock_wandb_api):
+    """Two clients running deferred operations concurrently should each
+    see their own credentials from their respective closures.
+    """
+    import threading
+
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server_a = _make_mock_server()
+    mock_server_b = _make_mock_server()
+
+    client_a = WeaveClient(
+        "entity-a",
+        "proj-a",
+        mock_server_a,
+        ensure_project_exists=False,
+        api_key="key-a",
+        base_url="https://a.example.com",
+    )
+    client_b = WeaveClient(
+        "entity-b",
+        "proj-b",
+        mock_server_b,
+        ensure_project_exists=False,
+        api_key="key-b",
+        base_url="https://b.example.com",
+    )
+
+    results_a: dict = {}
+    results_b: dict = {}
+    barrier = threading.Barrier(2)
+
+    def capture_a():
+        barrier.wait()  # ensure both threads run concurrently
+        results_a["api_key"] = client_a._api_key
+        results_a["base_url"] = client_a._base_url
+
+    def capture_b():
+        barrier.wait()
+        results_b["api_key"] = client_b._api_key
+        results_b["base_url"] = client_b._base_url
+
+    fut_a = client_a.future_executor.defer(capture_a)
+    fut_b = client_b.future_executor.defer(capture_b)
+
+    fut_a.result()
+    fut_b.result()
+
+    assert results_a["api_key"] == "key-a"
+    assert results_a["base_url"] == "https://a.example.com"
+    assert results_b["api_key"] == "key-b"
+    assert results_b["base_url"] == "https://b.example.com"
+
+    client_a.finish()
+    client_b.finish()
+
+
+def test_wal_callback_uses_client_base_url(mock_wandb_api):
+    """The WAL send callback should use self._base_url to generate call URLs."""
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity",
+        "project",
+        mock_server,
+        ensure_project_exists=False,
+        base_url="https://wal.example.com",
+    )
+
+    with patch("weave.trace.weave_client.redirect_call") as mock_redirect:
+        mock_redirect.return_value = "https://wal.example.com/r/call/test-id"
+        # Add a pending call id so callback processes it
+        client._wal_pending_call_ids.add("test-call-id")
+        record = {
+            "req": {
+                "start": {
+                    "id": "test-call-id",
+                    "project_id": "entity/project",
+                }
+            }
+        }
+        client._on_wal_send("call_start", record)
+        mock_redirect.assert_called_once_with(
+            "entity", "project", "test-call-id", base_url="https://wal.example.com"
+        )
+
+    client.finish()

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -46,10 +46,45 @@ def mock_project_creator():
         yield
 
 
+def _make_mock_server():
+    mock = MagicMock(spec=RemoteHTTPTraceServer)
+    mock.server_info.return_value = MagicMock(
+        min_required_weave_python_version="0.0.0",
+        trace_server_version=None,
+    )
+    mock.ensure_project_exists.return_value = MagicMock(project_name="test-project")
+    mock.get_call_processor.return_value = None
+    mock.get_feedback_processor.return_value = None
+    return mock
+
+
+def _init_patches(mock_server):
+    """Context manager bundle for the common init_weave mock set."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _ctx():
+        with (
+            patch(
+                "weave.trace.weave_init.init_weave_get_server",
+                return_value=mock_server,
+            ),
+            patch("weave.trace.weave_init._weave_is_available", return_value=True),
+            patch("weave.trace.weave_init.get_username", return_value="test-user"),
+            patch("weave.trace.weave_init.init_message"),
+        ):
+            yield
+
+    return _ctx()
+
+
+# ---------------------------------------------------------------------------
+# Project name parsing
+# ---------------------------------------------------------------------------
+
+
 @dataclass
 class SuccessCase:
-    """Test case for successful project name parsing."""
-
     project_name: str
     mock_default_entity: str | None
     expected_entity: str
@@ -61,8 +96,6 @@ class SuccessCase:
 
 @dataclass
 class ExceptionCase:
-    """Test case for project name parsing exceptions."""
-
     project_name: str
     expected_match: str
 
@@ -73,26 +106,14 @@ class ExceptionCase:
 @pytest.mark.parametrize(
     "case",
     [
-        SuccessCase(
-            project_name="test_entity/test_project",
-            mock_default_entity=None,
-            expected_entity="test_entity",
-            expected_project="test_project",
-        ),
-        SuccessCase(
-            project_name="test_project",
-            mock_default_entity="default_entity",
-            expected_entity="default_entity",
-            expected_project="test_project",
-        ),
+        SuccessCase("test_entity/test_project", None, "test_entity", "test_project"),
+        SuccessCase("test_project", "default_entity", "default_entity", "test_project"),
     ],
     ids=str,
 )
 def test_get_entity_project_from_project_name_success(
     case: SuccessCase, mock_wandb_api
 ):
-    """Test successful project name parsing scenarios."""
-    # Configure mock if needed
     if case.mock_default_entity is not None:
         mock_wandb_api.default_entity_name.return_value = case.mock_default_entity
 
@@ -100,7 +121,6 @@ def test_get_entity_project_from_project_name_success(
     assert entity == case.expected_entity
     assert project == case.expected_project
 
-    # Verify mock was called only when expected
     if case.mock_default_entity is not None:
         mock_wandb_api.default_entity_name.assert_called_once()
 
@@ -108,19 +128,14 @@ def test_get_entity_project_from_project_name_success(
 def test_get_entity_project_from_project_name_with_wandb_entity_env(
     mock_wandb_api, monkeypatch
 ):
-    """Test that WANDB_ENTITY environment variable is respected."""
-    # Set WANDB_ENTITY environment variable
     monkeypatch.setenv("WANDB_ENTITY", "env_entity")
 
-    # Test that env var is used when project has no entity
     entity, project = get_entity_project_from_project_name("test_project")
     assert entity == "env_entity"
     assert project == "test_project"
-
-    # Verify wandb API was not called since we used env var
     mock_wandb_api.default_entity_name.assert_not_called()
 
-    # Test that explicit entity in project name overrides env var
+    # Explicit entity in project name overrides env var
     entity, project = get_entity_project_from_project_name(
         "explicit_entity/test_project"
     )
@@ -131,65 +146,42 @@ def test_get_entity_project_from_project_name_with_wandb_entity_env(
 @pytest.mark.parametrize(
     "case",
     [
-        ExceptionCase(
-            project_name="",
-            expected_match="project_name must be non-empty",
-        ),
-        ExceptionCase(
-            project_name="   ",
-            expected_match="project_name must be non-empty",
-        ),
-        ExceptionCase(
-            project_name="\t\n",
-            expected_match="project_name must be non-empty",
-        ),
-        ExceptionCase(
-            project_name="entity/project/extra",
-            expected_match="project_name must be of the form",
-        ),
-        ExceptionCase(
-            project_name="/test_project",
-            expected_match="entity_name must be non-empty",
-        ),
-        ExceptionCase(
-            project_name="test_entity/",
-            expected_match="project_name must be non-empty",
-        ),
-        ExceptionCase(
-            project_name="/",
-            expected_match="entity_name must be non-empty",
-        ),
+        ExceptionCase("", "project_name must be non-empty"),
+        ExceptionCase("   ", "project_name must be non-empty"),
+        ExceptionCase("\t\n", "project_name must be non-empty"),
+        ExceptionCase("entity/project/extra", "project_name must be of the form"),
+        ExceptionCase("/test_project", "entity_name must be non-empty"),
+        ExceptionCase("test_entity/", "project_name must be non-empty"),
+        ExceptionCase("/", "entity_name must be non-empty"),
     ],
     ids=str,
 )
 def test_get_entity_project_from_project_name_exceptions(case: ExceptionCase):
-    """Test project name parsing exception scenarios."""
     with pytest.raises(ValueError, match=case.expected_match):
         get_entity_project_from_project_name(case.project_name)
 
 
-# --- Tests for api_key and base_url parameters ---
+# ---------------------------------------------------------------------------
+# Server creation & trace_server_url derivation
+# ---------------------------------------------------------------------------
 
 
-def test_init_weave_get_server_uses_trace_server_url_param():
-    """When trace_server_url is passed, it should be used instead of env-derived URL."""
-    server = weave_init.init_weave_get_server(
+def test_init_weave_get_server_with_and_without_trace_server_url():
+    """init_weave_get_server uses explicit trace_server_url or falls back to env."""
+    server_explicit = weave_init.init_weave_get_server(
         api_key="test-key", trace_server_url="https://custom.example.com"
     )
-    assert server.trace_server_url == "https://custom.example.com"
-    assert server._auth == ("api", "test-key")
+    assert server_explicit.trace_server_url == "https://custom.example.com"
+    assert server_explicit._auth == ("api", "test-key")
 
-
-def test_init_weave_get_server_falls_back_to_env_without_trace_server_url():
-    """When trace_server_url is None, should use env-derived URL (existing behavior)."""
-    server = weave_init.init_weave_get_server(api_key="test-key")
-    assert server.trace_server_url is not None
-    assert server._auth == ("api", "test-key")
+    server_default = weave_init.init_weave_get_server(api_key="test-key")
+    assert server_default.trace_server_url is not None
+    assert server_default._auth == ("api", "test-key")
 
 
 def test_base_url_derives_trace_server_url(mock_wandb_api):
-    """When base_url is provided but trace_server_url is not, the trace server
-    URL should be derived from base_url (matching the documented contract).
+    """base_url derives trace_server_url per documented contract; explicit
+    trace_server_url takes precedence.
     """
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = MagicMock()
@@ -200,80 +192,43 @@ def test_base_url_derives_trace_server_url(mock_wandb_api):
     mock_server.get_call_processor.return_value = None
     mock_server.get_feedback_processor.return_value = None
 
-    with (
-        patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server
-        ) as mock_get_server,
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        # Non-default base_url → should derive trace_server_url as base_url + "/traces"
-        weave_init.init_weave(
-            "test-project",
-            api_key="key",
-            base_url="https://custom.example.com",
-        )
-        mock_get_server.assert_called_with(
-            "key", trace_server_url="https://custom.example.com/traces"
-        )
-        weave_client_context.set_weave_client_global(None)
-
-    with (
-        patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server
-        ) as mock_get_server,
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        # Default base_url → should derive MTSAAS trace URL
-        weave_init.init_weave(
-            "test-project",
-            api_key="key",
-            base_url="https://api.wandb.ai",
-        )
-        mock_get_server.assert_called_with(
-            "key", trace_server_url="https://trace.wandb.ai"
-        )
-        weave_client_context.set_weave_client_global(None)
-
-    with (
-        patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server
-        ) as mock_get_server,
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        # Explicit trace_server_url should NOT be overridden by base_url derivation
-        weave_init.init_weave(
-            "test-project",
-            api_key="key",
-            base_url="https://custom.example.com",
-            trace_server_url="https://explicit-trace.example.com",
-        )
-        mock_get_server.assert_called_with(
-            "key", trace_server_url="https://explicit-trace.example.com"
-        )
-        weave_client_context.set_weave_client_global(None)
+    cases = [
+        # (base_url, trace_server_url, expected_trace_server_url)
+        ("https://custom.example.com", None, "https://custom.example.com/traces"),
+        ("https://api.wandb.ai", None, "https://trace.wandb.ai"),
+        (
+            "https://custom.example.com",
+            "https://explicit-trace.example.com",
+            "https://explicit-trace.example.com",
+        ),
+    ]
+    for base_url, tsurl, expected in cases:
+        with (
+            patch(
+                "weave.trace.weave_init.init_weave_get_server",
+                return_value=mock_server,
+            ) as mock_get_server,
+            patch("weave.trace.weave_init._weave_is_available", return_value=True),
+            patch("weave.trace.weave_init.get_username", return_value="test-user"),
+            patch("weave.trace.weave_init.init_message"),
+        ):
+            weave_init.init_weave(
+                "test-project", api_key="key", base_url=base_url,
+                trace_server_url=tsurl,
+            )
+            mock_get_server.assert_called_with("key", trace_server_url=expected)
+            weave_client_context.set_weave_client_global(None)
 
 
-def _make_mock_server():
-    mock = MagicMock(spec=RemoteHTTPTraceServer)
-    mock.server_info.return_value = MagicMock(
-        min_required_weave_python_version="0.0.0",
-        trace_server_version=None,
-    )
-    mock.ensure_project_exists.return_value = MagicMock(project_name="test-project")
-    # WeaveClient checks hasattr for these; return None so no batch processors are set
-    mock.get_call_processor.return_value = None
-    mock.get_feedback_processor.return_value = None
-    return mock
+# ---------------------------------------------------------------------------
+# Init flow: credential storage, reuse, re-init, env fallback
+# ---------------------------------------------------------------------------
 
 
-def test_init_weave_with_api_key_skips_env_auth(mock_wandb_api):
-    """When api_key is provided, should not read from env or prompt for login."""
+def test_init_weave_credential_storage_and_env_skipping(mock_wandb_api):
+    """Explicit api_key skips env lookup and is stored on the client along
+    with base_url.
+    """
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
 
@@ -292,105 +247,68 @@ def test_init_weave_with_api_key_skips_env_auth(mock_wandb_api):
             base_url="https://api.custom.example.com",
             trace_server_url="https://trace.custom.example.com",
         )
-        # env-based key lookup should NOT be called
         mock_env_key.assert_not_called()
-        # Server should be created with the explicit trace_server_url
         mock_get_server.assert_called_once_with(
             "explicit-key", trace_server_url="https://trace.custom.example.com"
-        )
-        assert client is not None
-        client.finish()
-        weave_client_context.set_weave_client_global(None)
-
-
-def test_init_weave_stores_creds_on_client(mock_wandb_api):
-    """When api_key and base_url are provided, they should be stored on the
-    client instance (not in module-level globals).
-    """
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        client = weave_init.init_weave(
-            "test-project",
-            api_key="explicit-key",
-            base_url="https://api.custom.example.com",
         )
         assert client._api_key == "explicit-key"
         assert client._base_url == "https://api.custom.example.com"
         client.finish()
-        weave_client_context.set_weave_client_global(None)
 
 
-def test_init_weave_reuses_client_when_no_credential_params(mock_wandb_api):
-    """When the same project is re-initialized without api_key/base_url/trace_server_url,
-    the existing client should be returned (no re-init).
+def test_init_weave_reuse_and_reinit(mock_wandb_api):
+    """Same project without credential params reuses client; passing any
+    credential param forces re-init.
     """
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
 
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
+    with _init_patches(mock_server):
         client_a = weave_init.init_weave("test-project", api_key="key")
-        client_b = weave_init.init_weave("test-project")
-        # Same client should be reused (no credential params passed to second call)
-        assert client_b is client_a
-        client_a.finish()
-        weave_client_context.set_weave_client_global(None)
+        assert weave_init.init_weave("test-project") is client_a  # reuse
 
-
-def test_init_weave_reinits_when_credential_params_provided(mock_wandb_api):
-    """Even if project name matches, passing api_key/base_url/trace_server_url
-    should force a re-init (not reuse stale client).
-    """
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        client_a = weave_init.init_weave("test-project", api_key="original-key")
-
-        # Re-init with api_key should NOT reuse
         client_b = weave_init.init_weave("test-project", api_key="new-key")
         assert client_b is not client_a
 
-        # Re-init with base_url (and api_key) should NOT reuse
         client_c = weave_init.init_weave(
-            "test-project",
-            api_key="new-key",
-            base_url="https://new.example.com",
+            "test-project", api_key="new-key", base_url="https://new.example.com"
         )
         assert client_c is not client_b
 
-        # Re-init with trace_server_url should NOT reuse
         client_d = weave_init.init_weave(
-            "test-project",
-            api_key="new-key",
+            "test-project", api_key="new-key",
             trace_server_url="https://trace.new.example.com",
         )
         assert client_d is not client_c
-
         client_d.finish()
-        weave_client_context.set_weave_client_global(None)
 
 
-def test_init_weave_uses_effective_trace_server_url_for_version_check(mock_wandb_api):
-    """When trace_server_url is passed, it should be used for version checks
-    instead of the env-derived URL.
+def test_init_weave_env_fallback_paths(mock_wandb_api, monkeypatch):
+    """When api_key is omitted it reads from env; when base_url is omitted it
+    eagerly resolves from WANDB_BASE_URL.
     """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+        patch(
+            "weave.trace.weave_init.get_wandb_api_context", return_value="env-key"
+        ) as mock_ctx,
+    ):
+        client = weave_init.init_weave("test-project")
+        mock_ctx.assert_called_once()
+        assert client._api_key == "env-key"
+        assert client._base_url == "https://env.example.com"
+        client.finish()
+
+
+def test_init_weave_version_check_uses_explicit_url(mock_wandb_api):
+    """Version check should use the explicit trace_server_url."""
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
 
@@ -408,444 +326,15 @@ def test_init_weave_uses_effective_trace_server_url_for_version_check(mock_wandb
             api_key="key",
             trace_server_url="https://custom-trace.example.com",
         )
-
-        # Version checks should use the explicit trace_server_url
         mock_init_msg.check_min_weave_version.assert_called_once_with(
             "0.0.0", "https://custom-trace.example.com"
         )
-        mock_init_msg.check_min_trace_server_version.assert_called_once()
-        # Third arg is the trace server URL
         call_args = mock_init_msg.check_min_trace_server_version.call_args
         assert call_args[0][2] == "https://custom-trace.example.com"
 
-        weave_client_context.set_weave_client_global(None)
-
-
-def test_init_weave_without_base_url_stores_none_on_client(mock_wandb_api):
-    """When base_url is not provided, client._base_url should be None."""
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        client = weave_init.init_weave("test-project", api_key="key")
-        assert client._base_url is None
-        client.finish()
-        weave_client_context.set_weave_client_global(None)
-
-
-def test_get_wandb_api_context_falls_back_to_env(monkeypatch):
-    """get_wandb_api_context should read from environment variables."""
-    monkeypatch.setenv("WANDB_API_KEY", "env-key-123")
-    assert get_wandb_api_context() == "env-key-123"
-
-
-def test_wandb_base_url_falls_back_to_env(monkeypatch):
-    """wandb_base_url should read from env var."""
-    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
-    assert wandb_base_url() == "https://env.example.com"
-
-
-# --- Multi-client isolation tests ---
-
-
-def test_two_clients_have_independent_credentials(mock_wandb_api):
-    """Two clients created with different credentials should each retain
-    their own api_key and base_url without cross-contamination.
-    """
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server_x = _make_mock_server()
-    mock_server_y = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        with patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_x
-        ):
-            client_x = weave_init.init_weave(
-                "proj-x",
-                api_key="key-x",
-                base_url="https://x.example.com",
-            )
-
-        with patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_y
-        ):
-            client_y = weave_init.init_weave(
-                "proj-y",
-                api_key="key-y",
-                base_url="https://y.example.com",
-            )
-
-        # client_x should still have its own credentials
-        assert client_x._api_key == "key-x"
-        assert client_x._base_url == "https://x.example.com"
-
-        # client_y should have its own credentials
-        assert client_y._api_key == "key-y"
-        assert client_y._base_url == "https://y.example.com"
-
-        client_y.finish()
-        weave_client_context.set_weave_client_global(None)
-
-
-def test_call_ui_url_uses_client_base_url(mock_wandb_api):
-    """Call.ui_url should use the base_url from the client that created it,
-    not a global or the default.
-    """
-    call = Call(
-        _op_name="test-op",
-        project_id="test-entity/test-project",
-        trace_id="trace-123",
-        parent_id=None,
-        inputs={},
-        id="call-123",
-        _base_url="https://custom.example.com",
-    )
-    url = call.ui_url
-    assert "custom.example.com" in url
-    assert "call-123" in url
-
-    # A call without _base_url should fall back to env-based default
-    call_default = Call(
-        _op_name="test-op",
-        project_id="test-entity/test-project",
-        trace_id="trace-456",
-        parent_id=None,
-        inputs={},
-        id="call-456",
-    )
-    url_default = call_default.ui_url
-    assert "call-456" in url_default
-    assert "custom.example.com" not in url_default
-
-
-def test_no_global_state_leakage_after_init(mock_wandb_api, monkeypatch):
-    """After init with explicit credentials, the module-level env readers
-    should NOT return the explicit values (they should only read from env/netrc).
-    """
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    # Set env vars to known values
-    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
-    monkeypatch.setenv("WANDB_API_KEY", "env-key")
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        client = weave_init.init_weave(
-            "test-project",
-            api_key="explicit-key",
-            base_url="https://explicit.example.com",
-        )
-
-    # The client should hold the explicit values
-    assert client._api_key == "explicit-key"
-    assert client._base_url == "https://explicit.example.com"
-
-    # But module-level readers should still return env values, NOT the explicit ones
-    assert wandb_base_url() == "https://env.example.com"
-    assert get_wandb_api_context() == "env-key"
-
-    client.finish()
-    weave_client_context.set_weave_client_global(None)
-
-
-def test_internal_api_uses_client_credentials(mock_wandb_api):
-    """wandb.Api created with explicit credentials should use them,
-    not fall back to global state.
-    """
-    api = Api(api_key="my-key", base_url="https://custom.example.com")
-    assert api._api_key == "my-key"
-    assert api._base_url == "https://custom.example.com"
-
-    # Api without credentials should have None (falls back to env at query time)
-    api_default = Api()
-    assert api_default._api_key is None
-    assert api_default._base_url is None
-
-
-def test_project_creator_receives_client_credentials(mock_wandb_api):
-    """WeaveClient.__init__ should pass api_key and base_url through the server's
-    ensure_project_exists to project_creator.ensure_project_exists.
-    """
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        weave_init.init_weave(
-            "test-project",
-            api_key="explicit-key",
-            base_url="https://explicit.example.com",
-        )
-        mock_server.ensure_project_exists.assert_called_once_with(
-            "test-entity",
-            "test-project",
-            api_key="explicit-key",
-            base_url="https://explicit.example.com",
-        )
-        weave_client_context.set_weave_client_global(None)
-
-
-def test_get_username_receives_credentials(mock_wandb_api):
-    """get_username should be called with the explicit api_key and base_url."""
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch(
-            "weave.trace.weave_init.get_username", return_value="test-user"
-        ) as mock_get_user,
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        weave_init.init_weave(
-            "test-project",
-            api_key="explicit-key",
-            base_url="https://explicit.example.com",
-        )
-        mock_get_user.assert_called_once_with(
-            api_key="explicit-key", base_url="https://explicit.example.com"
-        )
-        weave_client_context.set_weave_client_global(None)
-
-
-def test_get_entity_project_receives_credentials(mock_wandb_api):
-    """get_entity_project_from_project_name should pass credentials to Api."""
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-        patch(
-            "weave.trace.weave_init.get_entity_project_from_project_name",
-            return_value=("test-entity", "test-project"),
-        ) as mock_get_entity,
-    ):
-        weave_init.init_weave(
-            "test-project",
-            api_key="explicit-key",
-            base_url="https://explicit.example.com",
-        )
-        mock_get_entity.assert_called_once_with(
-            "test-project",
-            api_key="explicit-key",
-            base_url="https://explicit.example.com",
-        )
-        weave_client_context.set_weave_client_global(None)
-
-
-def test_completions_uses_client_api_key():
-    """Completions and InferenceModels should prefer client._api_key over env."""
-    mock_server = _make_mock_server()
-    client = WeaveClient(
-        "entity",
-        "project",
-        mock_server,
-        ensure_project_exists=False,
-        api_key="client-key",
-    )
-    comp = Completions(client)
-    models = InferenceModels(client)
-
-    with patch("weave.wandb_interface.context.get_wandb_api_context") as mock_env_key:
-        mock_env_key.return_value = "env-key"
-        # Both should prefer client._api_key without calling the env reader
-        assert comp._client._api_key == "client-key"
-        assert models._client._api_key == "client-key"
-        mock_env_key.assert_not_called()
-
-    client.finish()
-
-
-def test_url_functions_with_explicit_base_url():
-    """All URL functions should use explicit base_url when provided."""
-    for fn, args in [
-        (urls.remote_project_root_url, ("entity", "project")),
-        (urls.project_weave_root_url, ("entity", "project")),
-        (urls.op_version_path, ("entity", "project", "my-op", "abc123")),
-        (urls.object_version_path, ("entity", "project", "my-obj", "abc123")),
-        (urls.leaderboard_path, ("entity", "project", "my-lb")),
-        (urls.redirect_call, ("entity", "project", "call-id")),
-    ]:
-        url = fn(*args, base_url="https://custom.example.com")
-        assert "custom.example.com" in url
-
-
-def test_finish_one_client_does_not_affect_another(mock_wandb_api):
-    """Finishing client_a should not affect client_b's credentials."""
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server_a = _make_mock_server()
-    mock_server_b = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        with patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_a
-        ):
-            client_a = weave_init.init_weave(
-                "proj-a",
-                api_key="key-a",
-                base_url="https://a.example.com",
-            )
-
-        with patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_b
-        ):
-            client_b = weave_init.init_weave(
-                "proj-b",
-                api_key="key-b",
-                base_url="https://b.example.com",
-            )
-
-    # Finish client_a
-    client_a.finish()
-
-    # client_b's credentials should be unaffected
-    assert client_b._api_key == "key-b"
-    assert client_b._base_url == "https://b.example.com"
-
-    client_b.finish()
-    weave_client_context.set_weave_client_global(None)
-
-
-@pytest.mark.disable_logging_error_check
-def test_client_create_call_sets_base_url(mock_wandb_api):
-    """WeaveClient.create_call should set _base_url on the Call object."""
-    mock_server = _make_mock_server()
-    client = WeaveClient(
-        "entity",
-        "project",
-        mock_server,
-        ensure_project_exists=False,
-        base_url="https://custom.example.com",
-    )
-    weave_client_context.set_weave_client_global(client)
-
-    @op
-    def dummy_op():
-        pass
-
-    call = client.create_call(dummy_op, {})
-    assert call._base_url == "https://custom.example.com"
-    client.finish_call(call, output=None)
-    client.finish()
-    weave_client_context.set_weave_client_global(None)
-
-
-def test_thread_captures_client_base_url(mock_wandb_api):
-    """Operations deferred to FutureExecutor should capture the client's
-    _base_url via closure, not read from globals.
-    """
-    mock_server = _make_mock_server()
-    client = WeaveClient(
-        "entity",
-        "project",
-        mock_server,
-        ensure_project_exists=False,
-        api_key="thread-key",
-        base_url="https://thread.example.com",
-    )
-
-    captured_values: dict = {}
-
-    def capture_creds():
-        captured_values["api_key"] = client._api_key
-        captured_values["base_url"] = client._base_url
-
-    fut = client.future_executor.defer(capture_creds)
-    fut.result()
-
-    assert captured_values["api_key"] == "thread-key"
-    assert captured_values["base_url"] == "https://thread.example.com"
-
-    client.finish()
-
-
-def test_wal_callback_uses_client_base_url(mock_wandb_api):
-    """The WAL send callback should use self._base_url to generate call URLs."""
-    mock_server = _make_mock_server()
-    client = WeaveClient(
-        "entity",
-        "project",
-        mock_server,
-        ensure_project_exists=False,
-        base_url="https://wal.example.com",
-    )
-
-    with patch("weave.trace.weave_client.redirect_call") as mock_redirect:
-        mock_redirect.return_value = "https://wal.example.com/r/call/test-id"
-        client._wal_pending_call_ids.add("test-call-id")
-        record = {
-            "req": {
-                "start": {
-                    "id": "test-call-id",
-                    "project_id": "entity/project",
-                }
-            }
-        }
-        client._on_wal_send("call_start", record)
-        mock_redirect.assert_called_once_with(
-            "entity", "project", "test-call-id", base_url="https://wal.example.com"
-        )
-
-    client.finish()
-
-
-# --- Coverage: init_weave api_key=None fallback path (lines 130-139) ---
-
-
-def test_init_weave_without_api_key_reads_from_env(mock_wandb_api):
-    """When api_key is not provided, init_weave should read from env/netrc
-    via get_wandb_api_context().
-    """
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-        patch(
-            "weave.trace.weave_init.get_wandb_api_context", return_value="env-key"
-        ) as mock_ctx,
-    ):
-        client = weave_init.init_weave("test-project")
-        # Should have read api_key from env context
-        mock_ctx.assert_called_once()
-        assert client._api_key == "env-key"
-        client.finish()
-        weave_client_context.set_weave_client_global(None)
-
 
 def test_init_weave_prompts_login_when_no_key_anywhere(mock_wandb_api):
-    """When api_key is None and get_wandb_api_context() returns None,
-    init_weave should prompt wandb.login() and use base_url for the login URL.
-    """
+    """When no key is found anywhere, wandb.login() is invoked with base_url."""
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
 
@@ -854,7 +343,6 @@ def test_init_weave_prompts_login_when_no_key_anywhere(mock_wandb_api):
         patch("weave.trace.weave_init._weave_is_available", return_value=True),
         patch("weave.trace.weave_init.get_username", return_value="test-user"),
         patch("weave.trace.weave_init.init_message"),
-        # First call returns None (no key), second call returns key after login
         patch(
             "weave.trace.weave_init.get_wandb_api_context",
             side_effect=[None, "login-key"],
@@ -866,100 +354,126 @@ def test_init_weave_prompts_login_when_no_key_anywhere(mock_wandb_api):
         client = weave_init.init_weave(
             "test-project", base_url="https://custom.example.com"
         )
-        # Should have called wandb.login
         mock_wandb.login.assert_called_once()
-        # app_url should have been called with the explicit base_url
         mock_wandb.app_url.assert_called_with("https://custom.example.com")
         client.finish()
-        weave_client_context.set_weave_client_global(None)
 
 
-# --- Coverage: init_message.print_init_message with base_url ---
+# ---------------------------------------------------------------------------
+# Env reader sanity checks
+# ---------------------------------------------------------------------------
 
 
-def test_print_init_message_uses_base_url(caplog):
-    """print_init_message should use explicit base_url in the project URL."""
+def test_env_readers_return_env_values(monkeypatch):
+    """get_wandb_api_context and wandb_base_url read from env vars."""
+    monkeypatch.setenv("WANDB_API_KEY", "env-key-123")
+    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
+    assert get_wandb_api_context() == "env-key-123"
+    assert wandb_base_url() == "https://env.example.com"
+
+
+# ---------------------------------------------------------------------------
+# Multi-client isolation & global state
+# ---------------------------------------------------------------------------
+
+
+def test_multi_client_isolation_and_global_state(mock_wandb_api, monkeypatch):
+    """Two clients keep independent credentials; finishing one doesn't affect the
+    other; module-level env readers are not polluted by explicit init params.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server_x = _make_mock_server()
+    mock_server_y = _make_mock_server()
+
+    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
+    monkeypatch.setenv("WANDB_API_KEY", "env-key")
+
     with (
-        patch("weave.trace.init_message._print_version_check"),
-        caplog.at_level(logging.INFO, logger="weave.trace.init_message"),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
     ):
-        print_init_message(
-            "user",
-            "entity",
-            "project",
-            read_only=False,
-            base_url="https://custom.example.com",
-        )
-    assert "custom.example.com" in caplog.text
+        with patch(
+            "weave.trace.weave_init.init_weave_get_server",
+            return_value=mock_server_x,
+        ):
+            client_x = weave_init.init_weave(
+                "proj-x", api_key="key-x", base_url="https://x.example.com"
+            )
+        with patch(
+            "weave.trace.weave_init.init_weave_get_server",
+            return_value=mock_server_y,
+        ):
+            client_y = weave_init.init_weave(
+                "proj-y", api_key="key-y", base_url="https://y.example.com"
+            )
+
+    # Independent credentials
+    assert client_x._api_key == "key-x"
+    assert client_x._base_url == "https://x.example.com"
+    assert client_y._api_key == "key-y"
+    assert client_y._base_url == "https://y.example.com"
+
+    # Finishing one doesn't affect the other
+    client_x.finish()
+    assert client_y._api_key == "key-y"
+    assert client_y._base_url == "https://y.example.com"
+
+    # Module-level env readers are NOT polluted by explicit init params
+    assert wandb_base_url() == "https://env.example.com"
+    assert get_wandb_api_context() == "env-key"
+
+    client_y.finish()
 
 
-# --- Coverage: Api constructor and fallback logic ---
+# ---------------------------------------------------------------------------
+# Credential passthrough to downstream helpers
+# ---------------------------------------------------------------------------
 
 
-def test_api_constructor_stores_credentials():
-    """Api(api_key=, base_url=) should store both on the instance."""
-    api = Api(api_key="test-key", base_url="https://test.example.com")
-    assert api._api_key == "test-key"
-    assert api._base_url == "https://test.example.com"
-
-
-def test_api_constructor_defaults_to_none():
-    """Api() with no args should have None for both fields."""
-    api = Api()
-    assert api._api_key is None
-    assert api._base_url is None
-
-
-# --- Coverage: Completions/InferenceModels fallback when client has no api_key ---
-
-
-def test_completions_falls_back_to_env_when_no_client_key():
-    """When client._api_key is None, Completions should fall back to env."""
+def test_init_weave_threads_credentials_to_helpers(mock_wandb_api):
+    """init_weave passes api_key and base_url to ensure_project_exists,
+    get_username, and get_entity_project_from_project_name.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
-    client = WeaveClient(
-        "entity", "project", mock_server, ensure_project_exists=False, api_key=None
-    )
-    comp = Completions(client)
 
-    with patch(
-        "weave.chat.completions.get_wandb_api_context", return_value="env-key"
-    ) as mock_ctx:
-        api_key = (
-            comp._client._api_key if comp._client._api_key is not None else mock_ctx()
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch(
+            "weave.trace.weave_init.get_username", return_value="test-user"
+        ) as mock_get_user,
+        patch("weave.trace.weave_init.init_message"),
+        patch(
+            "weave.trace.weave_init.get_entity_project_from_project_name",
+            return_value=("test-entity", "test-project"),
+        ) as mock_get_entity,
+    ):
+        weave_init.init_weave(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://explicit.example.com",
         )
-        assert api_key == "env-key"
-        mock_ctx.assert_called_once()
 
-    client.finish()
-
-
-def test_inference_models_falls_back_to_env_when_no_client_key():
-    """When client._api_key is None, InferenceModels should fall back to env."""
-    mock_server = _make_mock_server()
-    client = WeaveClient(
-        "entity", "project", mock_server, ensure_project_exists=False, api_key=None
-    )
-    models = InferenceModels(client)
-
-    with patch(
-        "weave.chat.inference_models.get_wandb_api_context", return_value="env-key"
-    ) as mock_ctx:
-        api_key = (
-            models._client._api_key
-            if models._client._api_key is not None
-            else mock_ctx()
+        mock_get_entity.assert_called_once_with(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://explicit.example.com",
         )
-        assert api_key == "env-key"
-        mock_ctx.assert_called_once()
-
-    client.finish()
-
-
-# --- Coverage: project_creator with explicit credentials ---
+        mock_get_user.assert_called_once_with(
+            api_key="explicit-key", base_url="https://explicit.example.com"
+        )
+        mock_server.ensure_project_exists.assert_called_once_with(
+            "test-entity",
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://explicit.example.com",
+        )
 
 
 def test_project_creator_passes_credentials_to_api():
-    """_ensure_project_exists should construct wandb.Api with api_key and base_url."""
+    """_ensure_project_exists constructs wandb.Api with the given credentials."""
     mock_api = MagicMock()
     mock_api.project.return_value = {"project": {"name": "proj"}}
 
@@ -974,21 +488,69 @@ def test_project_creator_passes_credentials_to_api():
         assert result == {"project_name": "proj"}
 
 
-# --- Coverage: Call.children() passes base_url ---
+# ---------------------------------------------------------------------------
+# Eager credential resolution: Api, Completions, InferenceModels
+# ---------------------------------------------------------------------------
 
 
-def test_call_children_passes_base_url():
-    """Call.children() should pass client._base_url to _make_calls_iterator."""
+def test_api_eager_credential_resolution(monkeypatch):
+    """Api resolves credentials eagerly: explicit values win; otherwise
+    env/netrc is snapshotted at construction time.
+    """
+    # Explicit values
+    api = Api(api_key="my-key", base_url="https://custom.example.com")
+    assert api._api_key == "my-key"
+    assert api._base_url == "https://custom.example.com"
+
+    # Falls back to env when no args given
+    monkeypatch.setenv("WANDB_API_KEY", "env-key")
+    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
+    api_default = Api()
+    assert api_default._api_key == "env-key"
+    assert api_default._base_url == "https://env.example.com"
+
+
+def test_client_resolves_env_key_for_completions_and_models(monkeypatch):
+    """WeaveClient eagerly resolves api_key from env so Completions and
+    InferenceModels see it without their own fallback logic.
+    """
+    monkeypatch.setenv("WANDB_API_KEY", "env-key")
     mock_server = _make_mock_server()
     client = WeaveClient(
-        "entity",
-        "project",
-        mock_server,
-        ensure_project_exists=False,
-        base_url="https://children.example.com",
+        "entity", "project", mock_server, ensure_project_exists=False, api_key=None
     )
-    weave_client_context.set_weave_client_global(client)
 
+    assert Completions(client)._client._api_key == "env-key"
+    assert InferenceModels(client)._client._api_key == "env-key"
+    client.finish()
+
+
+def test_completions_prefers_explicit_client_key():
+    """When client has an explicit api_key, Completions and InferenceModels
+    use it without touching env readers.
+    """
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity", "project", mock_server,
+        ensure_project_exists=False, api_key="client-key",
+    )
+
+    with patch("weave.wandb_interface.context.get_wandb_api_context") as mock_env_key:
+        mock_env_key.return_value = "env-key"
+        assert Completions(client)._client._api_key == "client-key"
+        assert InferenceModels(client)._client._api_key == "client-key"
+        mock_env_key.assert_not_called()
+
+    client.finish()
+
+
+# ---------------------------------------------------------------------------
+# Call & URL behavior
+# ---------------------------------------------------------------------------
+
+
+def test_call_ui_url_uses_base_url():
+    """Call.ui_url uses _base_url when set, falls back to env default otherwise."""
     call = Call(
         _op_name="test-op",
         project_id="entity/project",
@@ -996,14 +558,135 @@ def test_call_children_passes_base_url():
         parent_id=None,
         inputs={},
         id="call-123",
+        _base_url="https://custom.example.com",
     )
+    assert "custom.example.com" in call.ui_url
+    assert "call-123" in call.ui_url
 
+    call_default = Call(
+        _op_name="test-op",
+        project_id="entity/project",
+        trace_id="trace-456",
+        parent_id=None,
+        inputs={},
+        id="call-456",
+    )
+    assert "call-456" in call_default.ui_url
+    assert "custom.example.com" not in call_default.ui_url
+
+
+def test_url_functions_with_explicit_base_url():
+    """All URL helpers accept and use explicit base_url."""
+    for fn, args in [
+        (urls.remote_project_root_url, ("entity", "project")),
+        (urls.project_weave_root_url, ("entity", "project")),
+        (urls.op_version_path, ("entity", "project", "my-op", "abc123")),
+        (urls.object_version_path, ("entity", "project", "my-obj", "abc123")),
+        (urls.leaderboard_path, ("entity", "project", "my-lb")),
+        (urls.redirect_call, ("entity", "project", "call-id")),
+    ]:
+        url = fn(*args, base_url="https://custom.example.com")
+        assert "custom.example.com" in url
+
+
+@pytest.mark.disable_logging_error_check
+def test_create_call_and_children_thread_base_url(mock_wandb_api):
+    """create_call stamps _base_url on Call; Call.children() passes it to
+    _make_calls_iterator.
+    """
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity", "project", mock_server,
+        ensure_project_exists=False, base_url="https://custom.example.com",
+    )
+    weave_client_context.set_weave_client_global(client)
+
+    @op
+    def dummy_op():
+        pass
+
+    # create_call stamps base_url
+    call = client.create_call(dummy_op, {})
+    assert call._base_url == "https://custom.example.com"
+    client.finish_call(call, output=None)
+
+    # children() passes base_url to _make_calls_iterator
+    child_call = Call(
+        _op_name="test-op",
+        project_id="entity/project",
+        trace_id="trace-123",
+        parent_id=None,
+        inputs={},
+        id="call-123",
+    )
     with patch("weave.trace.call._make_calls_iterator") as mock_iter:
         mock_iter.return_value = iter([])
-        list(call.children())
-        mock_iter.assert_called_once()
+        list(child_call.children())
         _, kwargs = mock_iter.call_args
-        assert kwargs.get("base_url") == "https://children.example.com"
+        assert kwargs.get("base_url") == "https://custom.example.com"
 
     client.finish()
-    weave_client_context.set_weave_client_global(None)
+
+
+# ---------------------------------------------------------------------------
+# Thread safety & WAL
+# ---------------------------------------------------------------------------
+
+
+def test_thread_captures_client_credentials():
+    """FutureExecutor closure reads correct client credentials."""
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity", "project", mock_server,
+        ensure_project_exists=False,
+        api_key="thread-key", base_url="https://thread.example.com",
+    )
+
+    captured: dict = {}
+
+    def capture():
+        captured["api_key"] = client._api_key
+        captured["base_url"] = client._base_url
+
+    client.future_executor.defer(capture).result()
+    assert captured == {"api_key": "thread-key", "base_url": "https://thread.example.com"}
+    client.finish()
+
+
+def test_wal_callback_uses_client_base_url():
+    """WAL send callback uses self._base_url to generate call URLs."""
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity", "project", mock_server,
+        ensure_project_exists=False, base_url="https://wal.example.com",
+    )
+
+    with patch("weave.trace.weave_client.redirect_call") as mock_redirect:
+        mock_redirect.return_value = "https://wal.example.com/r/call/test-id"
+        client._wal_pending_call_ids.add("test-call-id")
+        client._on_wal_send("call_start", {
+            "req": {"start": {"id": "test-call-id", "project_id": "entity/project"}}
+        })
+        mock_redirect.assert_called_once_with(
+            "entity", "project", "test-call-id", base_url="https://wal.example.com"
+        )
+
+    client.finish()
+
+
+# ---------------------------------------------------------------------------
+# Init message
+# ---------------------------------------------------------------------------
+
+
+def test_print_init_message_uses_base_url(caplog):
+    """print_init_message uses explicit base_url in the project URL."""
+    with (
+        patch("weave.trace.init_message._print_version_check"),
+        caplog.at_level(logging.INFO, logger="weave.trace.init_message"),
+    ):
+        print_init_message(
+            "user", "entity", "project",
+            read_only=False, base_url="https://custom.example.com",
+        )
+    assert "custom.example.com" in caplog.text

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from weave.trace import api as weave_api
 from weave.trace import weave_init
 from weave.trace.context import weave_client_context
 from weave.trace.weave_init import (
@@ -292,28 +291,6 @@ def test_init_weave_with_api_key_skips_env_auth(mock_wandb_api):
         weave_client_context.set_weave_client_global(None)
 
 
-def test_weave_init_passes_all_params(mock_wandb_api):
-    """weave.init() should forward api_key, base_url, and trace_server_url."""
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        client = weave_api.init(
-            "test-project",
-            api_key="my-key",
-            base_url="https://api.custom.example.com",
-            trace_server_url="https://trace.custom.example.com",
-        )
-        assert client is not None
-        client.finish()
-        weave_client_context.set_weave_client_global(None)
-
-
 def test_init_weave_stores_creds_on_client(mock_wandb_api):
     """When api_key and base_url are provided, they should be stored on the
     client instance (not in module-level globals).
@@ -507,10 +484,6 @@ def test_two_clients_have_independent_credentials(mock_wandb_api):
         assert client_y._api_key == "key-y"
         assert client_y._base_url == "https://y.example.com"
 
-        # No cross-contamination
-        assert client_x._api_key != client_y._api_key
-        assert client_x._base_url != client_y._base_url
-
         client_y.finish()
         weave_client_context.set_weave_client_global(None)
 
@@ -519,21 +492,6 @@ def test_call_ui_url_uses_client_base_url(mock_wandb_api):
     """Call.ui_url should use the base_url from the client that created it,
     not a global or the default.
     """
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        client = weave_init.init_weave(
-            "test-project",
-            api_key="key",
-            base_url="https://custom.example.com",
-        )
-
     from weave.trace.call import Call
 
     call = Call(
@@ -560,11 +518,7 @@ def test_call_ui_url_uses_client_base_url(mock_wandb_api):
     )
     url_default = call_default.ui_url
     assert "call-456" in url_default
-    # Should NOT contain custom.example.com since _base_url is None
     assert "custom.example.com" not in url_default
-
-    client.finish()
-    weave_client_context.set_weave_client_global(None)
 
 
 def test_no_global_state_leakage_after_init(mock_wandb_api, monkeypatch):
@@ -605,73 +559,6 @@ def test_no_global_state_leakage_after_init(mock_wandb_api, monkeypatch):
     weave_client_context.set_weave_client_global(None)
 
 
-def test_second_init_does_not_corrupt_first_client_urls(mock_wandb_api):
-    """When a second client is initialized, the first client's calls should
-    still generate URLs using the first client's base_url.
-    """
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-
-    from weave.trace.call import Call
-
-    mock_server_a = _make_mock_server()
-    mock_server_b = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        with patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_a
-        ):
-            client_a = weave_init.init_weave(
-                "proj-a",
-                api_key="key-a",
-                base_url="https://a.example.com",
-            )
-
-        # Create a call on client_a's project
-        call_a = Call(
-            _op_name="op-a",
-            project_id="test-entity/proj-a",
-            trace_id="trace-a",
-            parent_id=None,
-            inputs={},
-            id="call-a",
-            _base_url=client_a._base_url,
-        )
-
-        # Now init a second client that overwrites the global
-        with patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server_b
-        ):
-            client_b = weave_init.init_weave(
-                "proj-b",
-                api_key="key-b",
-                base_url="https://b.example.com",
-            )
-
-        # call_a's URL should still point to a.example.com
-        assert "a.example.com" in call_a.ui_url
-        assert "b.example.com" not in call_a.ui_url
-
-        # A new call on client_b should use b.example.com
-        call_b = Call(
-            _op_name="op-b",
-            project_id="test-entity/proj-b",
-            trace_id="trace-b",
-            parent_id=None,
-            inputs={},
-            id="call-b",
-            _base_url=client_b._base_url,
-        )
-        assert "b.example.com" in call_b.ui_url
-        assert "a.example.com" not in call_b.ui_url
-
-        client_b.finish()
-        weave_client_context.set_weave_client_global(None)
-
-
 def test_internal_api_uses_client_credentials(mock_wandb_api):
     """wandb.Api created with explicit credentials should use them,
     not fall back to global state.
@@ -684,20 +571,6 @@ def test_internal_api_uses_client_credentials(mock_wandb_api):
 
     # Api without credentials should have None (falls back to env at query time)
     api_default = Api()
-    assert api_default._api_key is None
-    assert api_default._base_url is None
-
-
-@pytest.mark.asyncio
-async def test_internal_api_async_uses_client_credentials():
-    """ApiAsync created with explicit credentials should store them."""
-    from weave.compat.wandb.wandb_thin.internal_api import ApiAsync
-
-    api = ApiAsync(api_key="my-key", base_url="https://custom.example.com")
-    assert api._api_key == "my-key"
-    assert api._base_url == "https://custom.example.com"
-
-    api_default = ApiAsync()
     assert api_default._api_key is None
     assert api_default._base_url is None
 
@@ -785,89 +658,9 @@ def test_get_entity_project_receives_credentials(mock_wandb_api):
         weave_client_context.set_weave_client_global(None)
 
 
-def test_init_message_receives_base_url(mock_wandb_api):
-    """print_init_message should be called with the explicit base_url."""
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-    mock_server = _make_mock_server()
-
-    with (
-        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message") as mock_init_msg,
-    ):
-        mock_init_msg.check_min_weave_version.return_value = True
-        mock_init_msg.check_min_trace_server_version.return_value = True
-
-        weave_init.init_weave(
-            "test-project",
-            api_key="key",
-            base_url="https://custom.example.com",
-        )
-        mock_init_msg.print_init_message.assert_called_once_with(
-            "test-user",
-            "test-entity",
-            "test-project",
-            read_only=False,
-            base_url="https://custom.example.com",
-        )
-        weave_client_context.set_weave_client_global(None)
-
-
 def test_completions_uses_client_api_key():
-    """Completions should prefer client._api_key over env."""
+    """Completions and InferenceModels should prefer client._api_key over env."""
     from weave.chat.completions import Completions
-    from weave.trace.weave_client import WeaveClient
-
-    mock_server = _make_mock_server()
-    client = WeaveClient(
-        "entity",
-        "project",
-        mock_server,
-        ensure_project_exists=False,
-        api_key="client-key",
-    )
-    comp = Completions(client)
-
-    # _create_non_op reads the api_key; mock the HTTP call to verify the key is used
-    with patch("weave.wandb_interface.context.get_wandb_api_context") as mock_env_key:
-        mock_env_key.return_value = "env-key"
-        # We can't easily call _create_non_op without a full HTTP setup,
-        # but we can verify the precedence logic directly
-        api_key = (
-            comp._client._api_key
-            if comp._client._api_key is not None
-            else mock_env_key()
-        )
-        assert api_key == "client-key"
-        # env reader should NOT have been called
-        mock_env_key.assert_not_called()
-
-    client.finish()
-
-
-def test_completions_falls_back_to_env_when_no_client_key():
-    """Completions should fall back to env when client._api_key is None."""
-    from weave.chat.completions import Completions
-    from weave.trace.weave_client import WeaveClient
-
-    mock_server = _make_mock_server()
-    client = WeaveClient("entity", "project", mock_server, ensure_project_exists=False)
-    comp = Completions(client)
-
-    with patch(
-        "weave.wandb_interface.context.get_wandb_api_context", return_value="env-key"
-    ):
-        api_key = (
-            comp._client._api_key if comp._client._api_key is not None else "env-key"
-        )
-        assert api_key == "env-key"
-
-    client.finish()
-
-
-def test_inference_models_uses_client_api_key():
-    """InferenceModels should prefer client._api_key over env."""
     from weave.chat.inference_models import InferenceModels
     from weave.trace.weave_client import WeaveClient
 
@@ -879,16 +672,14 @@ def test_inference_models_uses_client_api_key():
         ensure_project_exists=False,
         api_key="client-key",
     )
+    comp = Completions(client)
     models = InferenceModels(client)
 
     with patch("weave.wandb_interface.context.get_wandb_api_context") as mock_env_key:
         mock_env_key.return_value = "env-key"
-        api_key = (
-            models._client._api_key
-            if models._client._api_key is not None
-            else mock_env_key()
-        )
-        assert api_key == "client-key"
+        # Both should prefer client._api_key without calling the env reader
+        assert comp._client._api_key == "client-key"
+        assert models._client._api_key == "client-key"
         mock_env_key.assert_not_called()
 
     client.finish()
@@ -898,49 +689,16 @@ def test_url_functions_with_explicit_base_url():
     """All URL functions should use explicit base_url when provided."""
     from weave.trace import urls
 
-    # With explicit base_url
-    url = urls.remote_project_root_url(
-        "entity", "project", base_url="https://custom.example.com"
-    )
-    assert "custom.example.com" in url
-
-    url = urls.project_weave_root_url(
-        "entity", "project", base_url="https://custom.example.com"
-    )
-    assert "custom.example.com" in url
-
-    url = urls.op_version_path(
-        "entity", "project", "my-op", "abc123", base_url="https://custom.example.com"
-    )
-    assert "custom.example.com" in url
-
-    url = urls.object_version_path(
-        "entity", "project", "my-obj", "abc123", base_url="https://custom.example.com"
-    )
-    assert "custom.example.com" in url
-
-    url = urls.leaderboard_path(
-        "entity", "project", "my-lb", base_url="https://custom.example.com"
-    )
-    assert "custom.example.com" in url
-
-    url = urls.redirect_call(
-        "entity", "project", "call-id", base_url="https://custom.example.com"
-    )
-    assert "custom.example.com" in url
-
-
-def test_url_functions_without_base_url_use_env(monkeypatch):
-    """URL functions without base_url should fall back to env."""
-    from weave.trace import urls
-
-    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
-
-    url = urls.remote_project_root_url("entity", "project")
-    assert "env.example.com" in url
-
-    url = urls.redirect_call("entity", "project", "call-id")
-    assert "env.example.com" in url
+    for fn, args in [
+        (urls.remote_project_root_url, ("entity", "project")),
+        (urls.project_weave_root_url, ("entity", "project")),
+        (urls.op_version_path, ("entity", "project", "my-op", "abc123")),
+        (urls.object_version_path, ("entity", "project", "my-obj", "abc123")),
+        (urls.leaderboard_path, ("entity", "project", "my-lb")),
+        (urls.redirect_call, ("entity", "project", "call-id")),
+    ]:
+        url = fn(*args, base_url="https://custom.example.com")
+        assert "custom.example.com" in url
 
 
 def test_finish_one_client_does_not_affect_another(mock_wandb_api):
@@ -1011,28 +769,6 @@ def test_client_create_call_sets_base_url(mock_wandb_api):
     weave_client_context.set_weave_client_global(None)
 
 
-@pytest.mark.disable_logging_error_check
-def test_client_create_call_without_base_url_sets_none(mock_wandb_api):
-    """WeaveClient created without base_url should set _base_url=None on Call."""
-    from weave.trace.weave_client import WeaveClient
-
-    mock_server = _make_mock_server()
-    client = WeaveClient("entity", "project", mock_server, ensure_project_exists=False)
-    weave_client_context.set_weave_client_global(client)
-
-    from weave.trace.op import op
-
-    @op
-    def dummy_op():
-        pass
-
-    call = client.create_call(dummy_op, {})
-    assert call._base_url is None
-    client.finish_call(call, output=None)
-    client.finish()
-    weave_client_context.set_weave_client_global(None)
-
-
 def test_thread_captures_client_base_url(mock_wandb_api):
     """Operations deferred to FutureExecutor should capture the client's
     _base_url via closure, not read from globals.
@@ -1049,7 +785,6 @@ def test_thread_captures_client_base_url(mock_wandb_api):
         base_url="https://thread.example.com",
     )
 
-    # Defer a task that reads client._base_url
     captured_values: dict = {}
 
     def capture_creds():
@@ -1057,69 +792,12 @@ def test_thread_captures_client_base_url(mock_wandb_api):
         captured_values["base_url"] = client._base_url
 
     fut = client.future_executor.defer(capture_creds)
-    fut.result()  # wait for completion
+    fut.result()
 
     assert captured_values["api_key"] == "thread-key"
     assert captured_values["base_url"] == "https://thread.example.com"
 
     client.finish()
-
-
-def test_two_clients_thread_isolation(mock_wandb_api):
-    """Two clients running deferred operations concurrently should each
-    see their own credentials from their respective closures.
-    """
-    import threading
-
-    from weave.trace.weave_client import WeaveClient
-
-    mock_server_a = _make_mock_server()
-    mock_server_b = _make_mock_server()
-
-    client_a = WeaveClient(
-        "entity-a",
-        "proj-a",
-        mock_server_a,
-        ensure_project_exists=False,
-        api_key="key-a",
-        base_url="https://a.example.com",
-    )
-    client_b = WeaveClient(
-        "entity-b",
-        "proj-b",
-        mock_server_b,
-        ensure_project_exists=False,
-        api_key="key-b",
-        base_url="https://b.example.com",
-    )
-
-    results_a: dict = {}
-    results_b: dict = {}
-    barrier = threading.Barrier(2)
-
-    def capture_a():
-        barrier.wait()  # ensure both threads run concurrently
-        results_a["api_key"] = client_a._api_key
-        results_a["base_url"] = client_a._base_url
-
-    def capture_b():
-        barrier.wait()
-        results_b["api_key"] = client_b._api_key
-        results_b["base_url"] = client_b._base_url
-
-    fut_a = client_a.future_executor.defer(capture_a)
-    fut_b = client_b.future_executor.defer(capture_b)
-
-    fut_a.result()
-    fut_b.result()
-
-    assert results_a["api_key"] == "key-a"
-    assert results_a["base_url"] == "https://a.example.com"
-    assert results_b["api_key"] == "key-b"
-    assert results_b["base_url"] == "https://b.example.com"
-
-    client_a.finish()
-    client_b.finish()
 
 
 def test_wal_callback_uses_client_base_url(mock_wandb_api):
@@ -1137,7 +815,6 @@ def test_wal_callback_uses_client_base_url(mock_wandb_api):
 
     with patch("weave.trace.weave_client.redirect_call") as mock_redirect:
         mock_redirect.return_value = "https://wal.example.com/r/call/test-id"
-        # Add a pending call id so callback processes it
         client._wal_pending_call_ids.add("test-call-id")
         record = {
             "req": {

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -5,11 +5,22 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from weave.trace import weave_init
+from weave.chat.completions import Completions
+from weave.chat.inference_models import InferenceModels
+from weave.compat.wandb.wandb_thin.internal_api import Api
+from weave.trace import urls, weave_init
+from weave.trace.call import Call
 from weave.trace.context import weave_client_context
+from weave.trace.env import wandb_base_url
+from weave.trace.op import op
+from weave.trace.weave_client import WeaveClient
 from weave.trace.weave_init import (
     get_entity_project_from_project_name,
 )
+from weave.trace_server_bindings.remote_http_trace_server import (
+    RemoteHTTPTraceServer,
+)
+from weave.wandb_interface.context import get_wandb_api_context
 
 
 @pytest.fixture(autouse=True)
@@ -244,10 +255,6 @@ def test_base_url_derives_trace_server_url(mock_wandb_api):
 
 
 def _make_mock_server():
-    from weave.trace_server_bindings.remote_http_trace_server import (
-        RemoteHTTPTraceServer,
-    )
-
     mock = MagicMock(spec=RemoteHTTPTraceServer)
     mock.server_info.return_value = MagicMock(
         min_required_weave_python_version="0.0.0",
@@ -428,16 +435,12 @@ def test_init_weave_without_base_url_stores_none_on_client(mock_wandb_api):
 
 def test_get_wandb_api_context_falls_back_to_env(monkeypatch):
     """get_wandb_api_context should read from environment variables."""
-    from weave.wandb_interface.context import get_wandb_api_context
-
     monkeypatch.setenv("WANDB_API_KEY", "env-key-123")
     assert get_wandb_api_context() == "env-key-123"
 
 
 def test_wandb_base_url_falls_back_to_env(monkeypatch):
     """wandb_base_url should read from env var."""
-    from weave.trace.env import wandb_base_url
-
     monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
     assert wandb_base_url() == "https://env.example.com"
 
@@ -492,8 +495,6 @@ def test_call_ui_url_uses_client_base_url(mock_wandb_api):
     """Call.ui_url should use the base_url from the client that created it,
     not a global or the default.
     """
-    from weave.trace.call import Call
-
     call = Call(
         _op_name="test-op",
         project_id="test-entity/test-project",
@@ -528,9 +529,6 @@ def test_no_global_state_leakage_after_init(mock_wandb_api, monkeypatch):
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
 
-    from weave.trace.env import wandb_base_url
-    from weave.wandb_interface.context import get_wandb_api_context
-
     # Set env vars to known values
     monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
     monkeypatch.setenv("WANDB_API_KEY", "env-key")
@@ -563,8 +561,6 @@ def test_internal_api_uses_client_credentials(mock_wandb_api):
     """wandb.Api created with explicit credentials should use them,
     not fall back to global state.
     """
-    from weave.compat.wandb.wandb_thin.internal_api import Api
-
     api = Api(api_key="my-key", base_url="https://custom.example.com")
     assert api._api_key == "my-key"
     assert api._base_url == "https://custom.example.com"
@@ -656,10 +652,6 @@ def test_get_entity_project_receives_credentials(mock_wandb_api):
 
 def test_completions_uses_client_api_key():
     """Completions and InferenceModels should prefer client._api_key over env."""
-    from weave.chat.completions import Completions
-    from weave.chat.inference_models import InferenceModels
-    from weave.trace.weave_client import WeaveClient
-
     mock_server = _make_mock_server()
     client = WeaveClient(
         "entity",
@@ -683,8 +675,6 @@ def test_completions_uses_client_api_key():
 
 def test_url_functions_with_explicit_base_url():
     """All URL functions should use explicit base_url when provided."""
-    from weave.trace import urls
-
     for fn, args in [
         (urls.remote_project_root_url, ("entity", "project")),
         (urls.project_weave_root_url, ("entity", "project")),
@@ -740,8 +730,6 @@ def test_finish_one_client_does_not_affect_another(mock_wandb_api):
 @pytest.mark.disable_logging_error_check
 def test_client_create_call_sets_base_url(mock_wandb_api):
     """WeaveClient.create_call should set _base_url on the Call object."""
-    from weave.trace.weave_client import WeaveClient
-
     mock_server = _make_mock_server()
     client = WeaveClient(
         "entity",
@@ -751,8 +739,6 @@ def test_client_create_call_sets_base_url(mock_wandb_api):
         base_url="https://custom.example.com",
     )
     weave_client_context.set_weave_client_global(client)
-
-    from weave.trace.op import op
 
     @op
     def dummy_op():
@@ -769,8 +755,6 @@ def test_thread_captures_client_base_url(mock_wandb_api):
     """Operations deferred to FutureExecutor should capture the client's
     _base_url via closure, not read from globals.
     """
-    from weave.trace.weave_client import WeaveClient
-
     mock_server = _make_mock_server()
     client = WeaveClient(
         "entity",
@@ -798,8 +782,6 @@ def test_thread_captures_client_base_url(mock_wandb_api):
 
 def test_wal_callback_uses_client_base_url(mock_wandb_api):
     """The WAL send callback should use self._base_url to generate call URLs."""
-    from weave.trace.weave_client import WeaveClient
-
     mock_server = _make_mock_server()
     client = WeaveClient(
         "entity",
@@ -826,3 +808,178 @@ def test_wal_callback_uses_client_base_url(mock_wandb_api):
         )
 
     client.finish()
+
+
+# --- Coverage: init_weave api_key=None fallback path (lines 130-139) ---
+
+
+def test_init_weave_without_api_key_reads_from_env(mock_wandb_api):
+    """When api_key is not provided, init_weave should read from env/netrc
+    via get_wandb_api_context().
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+        patch(
+            "weave.trace.weave_init.get_wandb_api_context", return_value="env-key"
+        ) as mock_ctx,
+    ):
+        client = weave_init.init_weave("test-project")
+        # Should have read api_key from env context
+        mock_ctx.assert_called_once()
+        assert client._api_key == "env-key"
+        client.finish()
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_init_weave_prompts_login_when_no_key_anywhere(mock_wandb_api):
+    """When api_key is None and get_wandb_api_context() returns None,
+    init_weave should prompt wandb.login() and use base_url for the login URL.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+        # First call returns None (no key), second call returns key after login
+        patch(
+            "weave.trace.weave_init.get_wandb_api_context",
+            side_effect=[None, "login-key"],
+        ),
+        patch("weave.trace.weave_init.wandb") as mock_wandb,
+    ):
+        mock_wandb.app_url.return_value = "https://custom.example.com"
+        mock_wandb.login.return_value = None
+        client = weave_init.init_weave(
+            "test-project", base_url="https://custom.example.com"
+        )
+        # Should have called wandb.login
+        mock_wandb.login.assert_called_once()
+        # app_url should have been called with the explicit base_url
+        mock_wandb.app_url.assert_called_with("https://custom.example.com")
+        client.finish()
+        weave_client_context.set_weave_client_global(None)
+
+
+# --- Coverage: init_message.print_init_message with base_url ---
+
+
+def test_print_init_message_uses_base_url(caplog):
+    """print_init_message should use explicit base_url in the project URL."""
+    import logging
+
+    from weave.trace.init_message import print_init_message
+
+    with (
+        patch("weave.trace.init_message._print_version_check"),
+        caplog.at_level(logging.INFO, logger="weave.trace.init_message"),
+    ):
+        print_init_message(
+            "user",
+            "entity",
+            "project",
+            read_only=False,
+            base_url="https://custom.example.com",
+        )
+    assert "custom.example.com" in caplog.text
+
+
+# --- Coverage: Api constructor and fallback logic ---
+
+
+def test_api_constructor_stores_credentials():
+    """Api(api_key=, base_url=) should store both on the instance."""
+    from weave.compat.wandb.wandb_thin.internal_api import Api
+
+    api = Api(api_key="test-key", base_url="https://test.example.com")
+    assert api._api_key == "test-key"
+    assert api._base_url == "https://test.example.com"
+
+
+def test_api_constructor_defaults_to_none():
+    """Api() with no args should have None for both fields."""
+    from weave.compat.wandb.wandb_thin.internal_api import Api
+
+    api = Api()
+    assert api._api_key is None
+    assert api._base_url is None
+
+
+# --- Coverage: Completions/InferenceModels fallback when client has no api_key ---
+
+
+def test_completions_falls_back_to_env_when_no_client_key():
+    """When client._api_key is None, Completions should fall back to env."""
+    from weave.chat.completions import Completions
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity", "project", mock_server, ensure_project_exists=False, api_key=None
+    )
+    comp = Completions(client)
+
+    with patch(
+        "weave.chat.completions.get_wandb_api_context", return_value="env-key"
+    ) as mock_ctx:
+        api_key = (
+            comp._client._api_key
+            if comp._client._api_key is not None
+            else mock_ctx()
+        )
+        assert api_key == "env-key"
+        mock_ctx.assert_called_once()
+
+    client.finish()
+
+
+def test_inference_models_falls_back_to_env_when_no_client_key():
+    """When client._api_key is None, InferenceModels should fall back to env."""
+    from weave.chat.inference_models import InferenceModels
+    from weave.trace.weave_client import WeaveClient
+
+    mock_server = _make_mock_server()
+    client = WeaveClient(
+        "entity", "project", mock_server, ensure_project_exists=False, api_key=None
+    )
+    models = InferenceModels(client)
+
+    with patch(
+        "weave.chat.inference_models.get_wandb_api_context", return_value="env-key"
+    ) as mock_ctx:
+        api_key = (
+            models._client._api_key
+            if models._client._api_key is not None
+            else mock_ctx()
+        )
+        assert api_key == "env-key"
+        mock_ctx.assert_called_once()
+
+    client.finish()
+
+
+# --- Coverage: project_creator with explicit credentials ---
+
+
+def test_project_creator_threads_credentials():
+    """ensure_project_exists should pass api_key/base_url to _ensure_project_exists."""
+    with patch(
+        "weave.wandb_interface.project_creator._ensure_project_exists",
+        return_value={"project_name": "proj"},
+    ) as mock_inner:
+        from weave.wandb_interface.project_creator import ensure_project_exists
+
+        ensure_project_exists(
+            "entity", "project", api_key="key", base_url="https://example.com"
+        )
+        mock_inner.assert_called_once_with(
+            "entity", "project", api_key="key", base_url="https://example.com"
+        )

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -16,11 +16,16 @@ from weave.trace.weave_init import (
 @pytest.fixture(autouse=True)
 def reset_weave_client():
     """Reset the global weave client state before each test."""
-    weave_init._current_inited_client = None
+    from weave.trace.env import set_wandb_base_url
+    from weave.wandb_interface.context import set_wandb_api_context
+
     weave_client_context.set_weave_client_global(None)
+    set_wandb_api_context(None)
+    set_wandb_base_url(None)
     yield
     weave_client_context.set_weave_client_global(None)
-    weave_init._current_inited_client = None
+    set_wandb_api_context(None)
+    set_wandb_base_url(None)
 
 
 @dataclass
@@ -282,8 +287,8 @@ def test_init_weave_with_explicit_params_sets_context(mock_wandb_api):
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
 
-    from weave.trace.env import _explicit_base_url
-    from weave.wandb_interface.context import _explicit_api_key
+    import weave.trace.env as env_module
+    import weave.wandb_interface.context as context_module
 
     with (
         patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
@@ -296,7 +301,37 @@ def test_init_weave_with_explicit_params_sets_context(mock_wandb_api):
             api_key="explicit-key",
             base_url="https://api.custom.example.com",
         )
-        # Both should be set in context for downstream use
-        assert _explicit_api_key.get() == "explicit-key"
-        assert _explicit_base_url.get() == "https://api.custom.example.com"
+        # Both should be set as module-level overrides for downstream use
+        assert context_module._explicit_api_key == "explicit-key"
+        assert env_module._explicit_base_url == "https://api.custom.example.com"
         weave_client_context.set_weave_client_global(None)
+
+
+def test_finish_clears_explicit_globals(mock_wandb_api):
+    """weave.finish() must clear explicit api_key and base_url globals so a
+    subsequent init without params falls back to env vars.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    import weave.trace.env as env_module
+    import weave.wandb_interface.context as context_module
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        weave_init.init_weave(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://api.custom.example.com",
+        )
+        assert context_module._explicit_api_key == "explicit-key"
+        assert env_module._explicit_base_url == "https://api.custom.example.com"
+
+    # finish() should clear the globals
+    weave_init.finish()
+    assert context_module._explicit_api_key is None
+    assert env_module._explicit_base_url is None

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -25,7 +25,7 @@ def reset_weave_client():
 def mock_project_creator():
     """Mock project_creator.ensure_project_exists for all tests that create clients."""
     with patch(
-        "weave.wandb_interface.project_creator.ensure_project_exists",
+        "weave.trace.weave_client._ensure_project",
         return_value={"project_name": "test-project"},
     ):
         yield
@@ -170,6 +170,78 @@ def test_init_weave_get_server_falls_back_to_env_without_trace_server_url():
     server = weave_init.init_weave_get_server(api_key="test-key")
     assert server.trace_server_url is not None
     assert server._auth == ("api", "test-key")
+
+
+def test_base_url_derives_trace_server_url(mock_wandb_api):
+    """When base_url is provided but trace_server_url is not, the trace server
+    URL should be derived from base_url (matching the documented contract).
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = MagicMock()
+    mock_server.server_info.return_value = MagicMock(
+        min_required_weave_python_version="0.0.0",
+        trace_server_version=None,
+    )
+    mock_server.get_call_processor.return_value = None
+    mock_server.get_feedback_processor.return_value = None
+
+    with (
+        patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server
+        ) as mock_get_server,
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        # Non-default base_url → should derive trace_server_url as base_url + "/traces"
+        weave_init.init_weave(
+            "test-project",
+            api_key="key",
+            base_url="https://custom.example.com",
+        )
+        mock_get_server.assert_called_with(
+            "key", trace_server_url="https://custom.example.com/traces"
+        )
+        weave_client_context.set_weave_client_global(None)
+
+    with (
+        patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server
+        ) as mock_get_server,
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        # Default base_url → should derive MTSAAS trace URL
+        weave_init.init_weave(
+            "test-project",
+            api_key="key",
+            base_url="https://api.wandb.ai",
+        )
+        mock_get_server.assert_called_with(
+            "key", trace_server_url="https://trace.wandb.ai"
+        )
+        weave_client_context.set_weave_client_global(None)
+
+    with (
+        patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server
+        ) as mock_get_server,
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        # Explicit trace_server_url should NOT be overridden by base_url derivation
+        weave_init.init_weave(
+            "test-project",
+            api_key="key",
+            base_url="https://custom.example.com",
+            trace_server_url="https://explicit-trace.example.com",
+        )
+        mock_get_server.assert_called_with(
+            "key", trace_server_url="https://explicit-trace.example.com"
+        )
+        weave_client_context.set_weave_client_global(None)
 
 
 def _make_mock_server():
@@ -643,7 +715,7 @@ def test_project_creator_receives_client_credentials(mock_wandb_api):
         patch("weave.trace.weave_init.get_username", return_value="test-user"),
         patch("weave.trace.weave_init.init_message"),
         patch(
-            "weave.wandb_interface.project_creator.ensure_project_exists",
+            "weave.trace.weave_client._ensure_project",
             return_value={"project_name": "test-project"},
         ) as mock_ensure,
     ):

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -1,10 +1,13 @@
 """Tests for weave init authentication flow."""
 
 from dataclasses import dataclass
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from weave.trace import api as weave_api
 from weave.trace import weave_init
+from weave.trace.context import weave_client_context
 from weave.trace.weave_init import (
     get_entity_project_from_project_name,
 )
@@ -14,7 +17,9 @@ from weave.trace.weave_init import (
 def reset_weave_client():
     """Reset the global weave client state before each test."""
     weave_init._current_inited_client = None
+    weave_client_context.set_weave_client_global(None)
     yield
+    weave_client_context.set_weave_client_global(None)
     weave_init._current_inited_client = None
 
 
@@ -138,3 +143,160 @@ def test_get_entity_project_from_project_name_exceptions(case: ExceptionCase):
     """Test project name parsing exception scenarios."""
     with pytest.raises(ValueError, match=case.expected_match):
         get_entity_project_from_project_name(case.project_name)
+
+
+# --- Tests for api_key and base_url parameters ---
+
+
+def test_init_weave_get_server_uses_trace_server_url_param():
+    """When trace_server_url is passed, it should be used instead of env-derived URL."""
+    server = weave_init.init_weave_get_server(
+        api_key="test-key", trace_server_url="https://custom.example.com"
+    )
+    assert server.trace_server_url == "https://custom.example.com"
+    assert server._auth == ("api", "test-key")
+
+
+def test_init_weave_get_server_falls_back_to_env_without_trace_server_url():
+    """When trace_server_url is None, should use env-derived URL (existing behavior)."""
+    server = weave_init.init_weave_get_server(api_key="test-key")
+    assert server.trace_server_url is not None
+    assert server._auth == ("api", "test-key")
+
+
+def _make_mock_server():
+    from weave.trace_server_bindings.remote_http_trace_server import (
+        RemoteHTTPTraceServer,
+    )
+
+    mock = MagicMock(spec=RemoteHTTPTraceServer)
+    mock.server_info.return_value = MagicMock(
+        min_required_weave_python_version="0.0.0",
+        trace_server_version=None,
+    )
+    mock.ensure_project_exists.return_value = MagicMock(project_name="test-project")
+    # WeaveClient checks hasattr for these; return None so no batch processors are set
+    mock.get_call_processor.return_value = None
+    mock.get_feedback_processor.return_value = None
+    return mock
+
+
+def test_init_weave_with_api_key_skips_env_auth(mock_wandb_api):
+    """When api_key is provided, should not read from env or prompt for login."""
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=mock_server
+        ) as mock_get_server,
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+        patch("weave.wandb_interface.context.weave_wandb_api_key") as mock_env_key,
+    ):
+        client = weave_init.init_weave(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://api.custom.example.com",
+            trace_server_url="https://trace.custom.example.com",
+        )
+        # env-based key lookup should NOT be called
+        mock_env_key.assert_not_called()
+        # Server should be created with the explicit trace_server_url
+        mock_get_server.assert_called_once_with(
+            "explicit-key", trace_server_url="https://trace.custom.example.com"
+        )
+        assert client is not None
+        client.finish()
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_weave_init_passes_all_params(mock_wandb_api):
+    """weave.init() should forward api_key, base_url, and trace_server_url."""
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        client = weave_api.init(
+            "test-project",
+            api_key="my-key",
+            base_url="https://api.custom.example.com",
+            trace_server_url="https://trace.custom.example.com",
+        )
+        assert client is not None
+        client.finish()
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_sequential_init_with_different_credentials(mock_wandb_api):
+    """Multiple weave.init() calls with different api_key/base_url should each
+    configure the client correctly, not reuse a stale client.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+
+    with (
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        # First init with credentials A
+        server_a = _make_mock_server()
+        with patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=server_a
+        ):
+            client_a = weave_api.init(
+                "test-project",
+                api_key="key-a",
+                base_url="https://api-a.example.com",
+            )
+
+        # Second init with credentials B (same project name)
+        server_b = _make_mock_server()
+        with patch(
+            "weave.trace.weave_init.init_weave_get_server", return_value=server_b
+        ):
+            client_b = weave_api.init(
+                "test-project",
+                api_key="key-b",
+                base_url="https://api-b.example.com",
+            )
+
+        # Should NOT have reused client_a
+        assert client_b is not client_a
+
+        client_b.finish()
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_init_weave_with_explicit_params_sets_context(mock_wandb_api):
+    """When api_key and base_url are provided, they should be set in context so
+    downstream code (e.g. entity resolution, trace server URL derivation) can
+    use them without env vars.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    from weave.trace.env import _explicit_base_url
+    from weave.wandb_interface.context import _explicit_api_key
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        weave_init.init_weave(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://api.custom.example.com",
+        )
+        # Both should be set in context for downstream use
+        assert _explicit_api_key.get() == "explicit-key"
+        assert _explicit_base_url.get() == "https://api.custom.example.com"
+        weave_client_context.set_weave_client_global(None)

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -239,46 +239,6 @@ def test_weave_init_passes_all_params(mock_wandb_api):
         weave_client_context.set_weave_client_global(None)
 
 
-def test_sequential_init_with_different_credentials(mock_wandb_api):
-    """Multiple weave.init() calls with different api_key/base_url should each
-    configure the client correctly, not reuse a stale client.
-    """
-    mock_wandb_api.default_entity_name.return_value = "test-entity"
-
-    with (
-        patch("weave.trace.weave_init._weave_is_available", return_value=True),
-        patch("weave.trace.weave_init.get_username", return_value="test-user"),
-        patch("weave.trace.weave_init.init_message"),
-    ):
-        # First init with credentials A
-        server_a = _make_mock_server()
-        with patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=server_a
-        ):
-            client_a = weave_api.init(
-                "test-project",
-                api_key="key-a",
-                base_url="https://api-a.example.com",
-            )
-
-        # Second init with credentials B (same project name)
-        server_b = _make_mock_server()
-        with patch(
-            "weave.trace.weave_init.init_weave_get_server", return_value=server_b
-        ):
-            client_b = weave_api.init(
-                "test-project",
-                api_key="key-b",
-                base_url="https://api-b.example.com",
-            )
-
-        # Should NOT have reused client_a
-        assert client_b is not client_a
-
-        client_b.finish()
-        weave_client_context.set_weave_client_global(None)
-
-
 def test_init_weave_with_explicit_params_sets_context(mock_wandb_api):
     """When api_key and base_url are provided, they should be set in context so
     downstream code (e.g. entity resolution, trace server URL derivation) can
@@ -305,6 +265,210 @@ def test_init_weave_with_explicit_params_sets_context(mock_wandb_api):
         assert context_module._explicit_api_key == "explicit-key"
         assert env_module._explicit_base_url == "https://api.custom.example.com"
         weave_client_context.set_weave_client_global(None)
+
+
+def test_init_weave_reuses_client_when_no_credential_params(mock_wandb_api):
+    """When the same project is re-initialized without api_key/base_url/trace_server_url,
+    the existing client should be returned (no re-init).
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        client_a = weave_init.init_weave("test-project", api_key="key")
+        client_b = weave_init.init_weave("test-project")
+        # Same client should be reused (no credential params passed to second call)
+        assert client_b is client_a
+        client_a.finish()
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_init_weave_reinits_when_credential_params_provided(mock_wandb_api):
+    """Even if project name matches, passing api_key/base_url/trace_server_url
+    should force a re-init (not reuse stale client).
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        client_a = weave_init.init_weave("test-project", api_key="original-key")
+
+        # Re-init with api_key should NOT reuse
+        client_b = weave_init.init_weave("test-project", api_key="new-key")
+        assert client_b is not client_a
+
+        # Re-init with base_url should NOT reuse
+        client_c = weave_init.init_weave("test-project", base_url="https://new.example.com")
+        assert client_c is not client_b
+
+        # Re-init with trace_server_url should NOT reuse
+        client_d = weave_init.init_weave(
+            "test-project", trace_server_url="https://trace.new.example.com"
+        )
+        assert client_d is not client_c
+
+        client_d.finish()
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_init_weave_uses_effective_trace_server_url_for_version_check(mock_wandb_api):
+    """When trace_server_url is passed, it should be used for version checks
+    instead of the env-derived URL.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message") as mock_init_msg,
+    ):
+        mock_init_msg.check_min_weave_version.return_value = True
+        mock_init_msg.check_min_trace_server_version.return_value = True
+
+        weave_init.init_weave(
+            "test-project",
+            api_key="key",
+            trace_server_url="https://custom-trace.example.com",
+        )
+
+        # Version checks should use the explicit trace_server_url
+        mock_init_msg.check_min_weave_version.assert_called_once_with(
+            "0.0.0", "https://custom-trace.example.com"
+        )
+        mock_init_msg.check_min_trace_server_version.assert_called_once()
+        # Third arg is the trace server URL
+        call_args = mock_init_msg.check_min_trace_server_version.call_args
+        assert call_args[0][2] == "https://custom-trace.example.com"
+
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_init_weave_without_base_url_does_not_set_override(mock_wandb_api):
+    """When base_url is not provided, _explicit_base_url should remain None."""
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    import weave.trace.env as env_module
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        weave_init.init_weave("test-project", api_key="key")
+        assert env_module._explicit_base_url is None
+        weave_client_context.set_weave_client_global(None)
+
+
+def test_api_finish_flushes_before_clearing_overrides(mock_wandb_api):
+    """api.finish() must flush the client before clearing explicit overrides,
+    so that callbacks during flush still see the correct base_url.
+    """
+    mock_wandb_api.default_entity_name.return_value = "test-entity"
+    mock_server = _make_mock_server()
+
+    import weave.trace.env as env_module
+    import weave.wandb_interface.context as context_module
+
+    with (
+        patch("weave.trace.weave_init.init_weave_get_server", return_value=mock_server),
+        patch("weave.trace.weave_init._weave_is_available", return_value=True),
+        patch("weave.trace.weave_init.get_username", return_value="test-user"),
+        patch("weave.trace.weave_init.init_message"),
+    ):
+        weave_api.init(
+            "test-project",
+            api_key="explicit-key",
+            base_url="https://api.custom.example.com",
+        )
+
+    # Track the order: flush should happen before clearing
+    call_order = []
+    original_client = weave_client_context.get_weave_client()
+    original_finish = original_client.finish
+
+    def tracked_finish(*args, **kwargs):
+        # At flush time, overrides should still be set
+        call_order.append("client_finish")
+        assert env_module._explicit_base_url == "https://api.custom.example.com"
+        assert context_module._explicit_api_key == "explicit-key"
+        return original_finish(*args, **kwargs)
+
+    original_client.finish = tracked_finish
+    weave_api.finish()
+
+    call_order.append("overrides_cleared")
+    assert call_order == ["client_finish", "overrides_cleared"]
+    assert env_module._explicit_base_url is None
+    assert context_module._explicit_api_key is None
+
+
+def test_get_wandb_api_context_falls_back_to_env(monkeypatch):
+    """When no explicit api_key is set, get_wandb_api_context should fall back
+    to environment variables.
+    """
+    from weave.wandb_interface.context import (
+        get_wandb_api_context,
+        set_wandb_api_context,
+    )
+
+    set_wandb_api_context(None)
+    monkeypatch.setenv("WANDB_API_KEY", "env-key-123")
+    assert get_wandb_api_context() == "env-key-123"
+
+
+def test_get_wandb_api_context_explicit_overrides_env(monkeypatch):
+    """When explicit api_key is set, it should override the env var."""
+    from weave.wandb_interface.context import (
+        get_wandb_api_context,
+        set_wandb_api_context,
+    )
+
+    monkeypatch.setenv("WANDB_API_KEY", "env-key-123")
+    set_wandb_api_context("explicit-key-456")
+    assert get_wandb_api_context() == "explicit-key-456"
+    set_wandb_api_context(None)
+
+
+def test_wandb_base_url_explicit_overrides_env(monkeypatch):
+    """When explicit base_url is set, it should override the env var."""
+    from weave.trace.env import set_wandb_base_url, wandb_base_url
+
+    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
+    set_wandb_base_url("https://explicit.example.com")
+    assert wandb_base_url() == "https://explicit.example.com"
+    set_wandb_base_url(None)
+
+
+def test_wandb_base_url_falls_back_to_env(monkeypatch):
+    """When no explicit base_url is set, should fall back to env var."""
+    from weave.trace.env import set_wandb_base_url, wandb_base_url
+
+    set_wandb_base_url(None)
+    monkeypatch.setenv("WANDB_BASE_URL", "https://env.example.com")
+    assert wandb_base_url() == "https://env.example.com"
+
+
+def test_wandb_base_url_strips_trailing_slash():
+    """Explicit base_url should have trailing slash stripped."""
+    from weave.trace.env import set_wandb_base_url, wandb_base_url
+
+    set_wandb_base_url("https://explicit.example.com/")
+    assert wandb_base_url() == "https://explicit.example.com"
+    set_wandb_base_url(None)
 
 
 def test_finish_clears_explicit_globals(mock_wandb_api):

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -1,5 +1,6 @@
 """Tests for weave init authentication flow."""
 
+import logging
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
@@ -12,6 +13,7 @@ from weave.trace import urls, weave_init
 from weave.trace.call import Call
 from weave.trace.context import weave_client_context
 from weave.trace.env import wandb_base_url
+from weave.trace.init_message import print_init_message
 from weave.trace.op import op
 from weave.trace.weave_client import WeaveClient
 from weave.trace.weave_init import (
@@ -21,6 +23,9 @@ from weave.trace_server_bindings.remote_http_trace_server import (
     RemoteHTTPTraceServer,
 )
 from weave.wandb_interface.context import get_wandb_api_context
+from weave.wandb_interface.project_creator import (
+    _ensure_project_exists,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -874,10 +879,6 @@ def test_init_weave_prompts_login_when_no_key_anywhere(mock_wandb_api):
 
 def test_print_init_message_uses_base_url(caplog):
     """print_init_message should use explicit base_url in the project URL."""
-    import logging
-
-    from weave.trace.init_message import print_init_message
-
     with (
         patch("weave.trace.init_message._print_version_check"),
         caplog.at_level(logging.INFO, logger="weave.trace.init_message"),
@@ -897,8 +898,6 @@ def test_print_init_message_uses_base_url(caplog):
 
 def test_api_constructor_stores_credentials():
     """Api(api_key=, base_url=) should store both on the instance."""
-    from weave.compat.wandb.wandb_thin.internal_api import Api
-
     api = Api(api_key="test-key", base_url="https://test.example.com")
     assert api._api_key == "test-key"
     assert api._base_url == "https://test.example.com"
@@ -906,8 +905,6 @@ def test_api_constructor_stores_credentials():
 
 def test_api_constructor_defaults_to_none():
     """Api() with no args should have None for both fields."""
-    from weave.compat.wandb.wandb_thin.internal_api import Api
-
     api = Api()
     assert api._api_key is None
     assert api._base_url is None
@@ -918,9 +915,6 @@ def test_api_constructor_defaults_to_none():
 
 def test_completions_falls_back_to_env_when_no_client_key():
     """When client._api_key is None, Completions should fall back to env."""
-    from weave.chat.completions import Completions
-    from weave.trace.weave_client import WeaveClient
-
     mock_server = _make_mock_server()
     client = WeaveClient(
         "entity", "project", mock_server, ensure_project_exists=False, api_key=None
@@ -941,9 +935,6 @@ def test_completions_falls_back_to_env_when_no_client_key():
 
 def test_inference_models_falls_back_to_env_when_no_client_key():
     """When client._api_key is None, InferenceModels should fall back to env."""
-    from weave.chat.inference_models import InferenceModels
-    from weave.trace.weave_client import WeaveClient
-
     mock_server = _make_mock_server()
     client = WeaveClient(
         "entity", "project", mock_server, ensure_project_exists=False, api_key=None
@@ -969,8 +960,6 @@ def test_inference_models_falls_back_to_env_when_no_client_key():
 
 def test_project_creator_passes_credentials_to_api():
     """_ensure_project_exists should construct wandb.Api with api_key and base_url."""
-    from weave.wandb_interface.project_creator import _ensure_project_exists
-
     mock_api = MagicMock()
     mock_api.project.return_value = {"project": {"name": "proj"}}
 
@@ -990,9 +979,6 @@ def test_project_creator_passes_credentials_to_api():
 
 def test_call_children_passes_base_url():
     """Call.children() should pass client._base_url to _make_calls_iterator."""
-    from weave.trace.call import Call
-    from weave.trace.weave_client import WeaveClient
-
     mock_server = _make_mock_server()
     client = WeaveClient(
         "entity",

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -1,6 +1,7 @@
 """Tests for weave init authentication flow."""
 
 import logging
+from contextlib import contextmanager
 from dataclasses import dataclass
 from unittest.mock import MagicMock, patch
 
@@ -60,7 +61,6 @@ def _make_mock_server():
 
 def _init_patches(mock_server):
     """Context manager bundle for the common init_weave mock set."""
-    from contextlib import contextmanager
 
     @contextmanager
     def _ctx():
@@ -213,7 +213,9 @@ def test_base_url_derives_trace_server_url(mock_wandb_api):
             patch("weave.trace.weave_init.init_message"),
         ):
             weave_init.init_weave(
-                "test-project", api_key="key", base_url=base_url,
+                "test-project",
+                api_key="key",
+                base_url=base_url,
                 trace_server_url=tsurl,
             )
             mock_get_server.assert_called_with("key", trace_server_url=expected)
@@ -276,7 +278,8 @@ def test_init_weave_reuse_and_reinit(mock_wandb_api):
         assert client_c is not client_b
 
         client_d = weave_init.init_weave(
-            "test-project", api_key="new-key",
+            "test-project",
+            api_key="new-key",
             trace_server_url="https://trace.new.example.com",
         )
         assert client_d is not client_c
@@ -531,8 +534,11 @@ def test_completions_prefers_explicit_client_key():
     """
     mock_server = _make_mock_server()
     client = WeaveClient(
-        "entity", "project", mock_server,
-        ensure_project_exists=False, api_key="client-key",
+        "entity",
+        "project",
+        mock_server,
+        ensure_project_exists=False,
+        api_key="client-key",
     )
 
     with patch("weave.wandb_interface.context.get_wandb_api_context") as mock_env_key:
@@ -596,8 +602,11 @@ def test_create_call_and_children_thread_base_url(mock_wandb_api):
     """
     mock_server = _make_mock_server()
     client = WeaveClient(
-        "entity", "project", mock_server,
-        ensure_project_exists=False, base_url="https://custom.example.com",
+        "entity",
+        "project",
+        mock_server,
+        ensure_project_exists=False,
+        base_url="https://custom.example.com",
     )
     weave_client_context.set_weave_client_global(client)
 
@@ -637,9 +646,12 @@ def test_thread_captures_client_credentials():
     """FutureExecutor closure reads correct client credentials."""
     mock_server = _make_mock_server()
     client = WeaveClient(
-        "entity", "project", mock_server,
+        "entity",
+        "project",
+        mock_server,
         ensure_project_exists=False,
-        api_key="thread-key", base_url="https://thread.example.com",
+        api_key="thread-key",
+        base_url="https://thread.example.com",
     )
 
     captured: dict = {}
@@ -649,7 +661,10 @@ def test_thread_captures_client_credentials():
         captured["base_url"] = client._base_url
 
     client.future_executor.defer(capture).result()
-    assert captured == {"api_key": "thread-key", "base_url": "https://thread.example.com"}
+    assert captured == {
+        "api_key": "thread-key",
+        "base_url": "https://thread.example.com",
+    }
     client.finish()
 
 
@@ -657,16 +672,20 @@ def test_wal_callback_uses_client_base_url():
     """WAL send callback uses self._base_url to generate call URLs."""
     mock_server = _make_mock_server()
     client = WeaveClient(
-        "entity", "project", mock_server,
-        ensure_project_exists=False, base_url="https://wal.example.com",
+        "entity",
+        "project",
+        mock_server,
+        ensure_project_exists=False,
+        base_url="https://wal.example.com",
     )
 
     with patch("weave.trace.weave_client.redirect_call") as mock_redirect:
         mock_redirect.return_value = "https://wal.example.com/r/call/test-id"
         client._wal_pending_call_ids.add("test-call-id")
-        client._on_wal_send("call_start", {
-            "req": {"start": {"id": "test-call-id", "project_id": "entity/project"}}
-        })
+        client._on_wal_send(
+            "call_start",
+            {"req": {"start": {"id": "test-call-id", "project_id": "entity/project"}}},
+        )
         mock_redirect.assert_called_once_with(
             "entity", "project", "test-call-id", base_url="https://wal.example.com"
         )
@@ -686,7 +705,10 @@ def test_print_init_message_uses_base_url(caplog):
         caplog.at_level(logging.INFO, logger="weave.trace.init_message"),
     ):
         print_init_message(
-            "user", "entity", "project",
-            read_only=False, base_url="https://custom.example.com",
+            "user",
+            "entity",
+            "project",
+            read_only=False,
+            base_url="https://custom.example.com",
         )
     assert "custom.example.com" in caplog.text

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -308,7 +308,9 @@ def test_init_weave_reinits_when_credential_params_provided(mock_wandb_api):
         assert client_b is not client_a
 
         # Re-init with base_url should NOT reuse
-        client_c = weave_init.init_weave("test-project", base_url="https://new.example.com")
+        client_c = weave_init.init_weave(
+            "test-project", base_url="https://new.example.com"
+        )
         assert client_c is not client_b
 
         # Re-init with trace_server_url should NOT reuse

--- a/tests/trace/test_weave_init_auth.py
+++ b/tests/trace/test_weave_init_auth.py
@@ -24,7 +24,7 @@ def reset_weave_client():
 def mock_project_creator():
     """Mock project_creator.ensure_project_exists for all tests that create clients."""
     with patch(
-        "weave.trace.weave_client._ensure_project",
+        "weave.wandb_interface.project_creator.ensure_project_exists",
         return_value={"project_name": "test-project"},
     ):
         yield
@@ -576,8 +576,8 @@ def test_internal_api_uses_client_credentials(mock_wandb_api):
 
 
 def test_project_creator_receives_client_credentials(mock_wandb_api):
-    """WeaveClient.__init__ should pass api_key and base_url to
-    project_creator.ensure_project_exists.
+    """WeaveClient.__init__ should pass api_key and base_url through the server's
+    ensure_project_exists to project_creator.ensure_project_exists.
     """
     mock_wandb_api.default_entity_name.return_value = "test-entity"
     mock_server = _make_mock_server()
@@ -587,17 +587,13 @@ def test_project_creator_receives_client_credentials(mock_wandb_api):
         patch("weave.trace.weave_init._weave_is_available", return_value=True),
         patch("weave.trace.weave_init.get_username", return_value="test-user"),
         patch("weave.trace.weave_init.init_message"),
-        patch(
-            "weave.trace.weave_client._ensure_project",
-            return_value={"project_name": "test-project"},
-        ) as mock_ensure,
     ):
         weave_init.init_weave(
             "test-project",
             api_key="explicit-key",
             base_url="https://explicit.example.com",
         )
-        mock_ensure.assert_called_once_with(
+        mock_server.ensure_project_exists.assert_called_once_with(
             "test-entity",
             "test-project",
             api_key="explicit-key",

--- a/weave/chat/completions.py
+++ b/weave/chat/completions.py
@@ -20,7 +20,6 @@ from weave.trace.op import op
 from weave.trace.settings import http_timeout
 from weave.trace_server.constants import COMPLETIONS_CREATE_OP_NAME, INFERENCE_HOST
 from weave.utils.project_id import to_project_id
-from weave.wandb_interface.context import get_wandb_api_context
 
 if TYPE_CHECKING:
     from weave.trace.weave_client import WeaveClient
@@ -171,11 +170,7 @@ class Completions:
         self,
         **kwargs: Any,
     ) -> ChatCompletion | ChatCompletionChunkStream:
-        api_key = (
-            self._client._api_key
-            if self._client._api_key is not None
-            else get_wandb_api_context()
-        )
+        api_key = self._client._api_key
         if not api_key:
             raise ValueError("No API key found")
 

--- a/weave/chat/completions.py
+++ b/weave/chat/completions.py
@@ -171,7 +171,11 @@ class Completions:
         self,
         **kwargs: Any,
     ) -> ChatCompletion | ChatCompletionChunkStream:
-        api_key = get_wandb_api_context()
+        api_key = (
+            self._client._api_key
+            if self._client._api_key is not None
+            else get_wandb_api_context()
+        )
         if not api_key:
             raise ValueError("No API key found")
 

--- a/weave/chat/inference_models.py
+++ b/weave/chat/inference_models.py
@@ -10,7 +10,6 @@ from weave.chat.types.models import (
 )
 from weave.trace.settings import http_timeout
 from weave.trace_server.constants import INFERENCE_HOST
-from weave.wandb_interface.context import get_wandb_api_context
 
 if TYPE_CHECKING:
     from weave.trace.weave_client import WeaveClient
@@ -26,11 +25,7 @@ class InferenceModels:
         self._client = client
 
     def list(self) -> ModelsResponse:
-        api_key = (
-            self._client._api_key
-            if self._client._api_key is not None
-            else get_wandb_api_context()
-        )
+        api_key = self._client._api_key
         if not api_key:
             raise ValueError("No API key found")
         headers = {

--- a/weave/chat/inference_models.py
+++ b/weave/chat/inference_models.py
@@ -26,7 +26,11 @@ class InferenceModels:
         self._client = client
 
     def list(self) -> ModelsResponse:
-        api_key = get_wandb_api_context()
+        api_key = (
+            self._client._api_key
+            if self._client._api_key is not None
+            else get_wandb_api_context()
+        )
         if not api_key:
             raise ValueError("No API key found")
         headers = {

--- a/weave/compat/wandb/wandb_thin/internal_api.py
+++ b/weave/compat/wandb/wandb_thin/internal_api.py
@@ -25,23 +25,18 @@ class Api:
         api_key: str | None = None,
         base_url: str | None = None,
     ) -> None:
-        self._api_key = api_key
-        self._base_url = base_url
+        # Eagerly resolve credentials at construction time so this instance
+        # is self-contained and never reads env/netrc lazily in query().
+        self._api_key = api_key if api_key is not None else get_wandb_api_context()
+        self._base_url = base_url if base_url is not None else env.wandb_base_url()
 
     def query(self, query: graphql.DocumentNode, **kwargs: Any) -> Any:
         from gql.transport.httpx import HTTPXTransport
 
         auth = None
-        api_key = (
-            self._api_key if self._api_key is not None else get_wandb_api_context()
-        )
-        if api_key is not None:
-            auth = httpx.BasicAuth("api", api_key)
-        url_base = (
-            self._base_url.rstrip("/")
-            if self._base_url is not None
-            else env.wandb_base_url()
-        )
+        if self._api_key is not None:
+            auth = httpx.BasicAuth("api", self._api_key)
+        url_base = self._base_url.rstrip("/")
         transport = HTTPXTransport(
             url=url_base + "/graphql",
             auth=auth,
@@ -236,8 +231,9 @@ class ApiAsync:
     ) -> None:
         import aiohttp
 
-        self._api_key = api_key
-        self._base_url = base_url
+        # Eagerly resolve credentials at construction time.
+        self._api_key = api_key if api_key is not None else get_wandb_api_context()
+        self._base_url = base_url if base_url is not None else env.wandb_base_url()
         self.connector = aiohttp.TCPConnector(
             limit=TCP_CONNECTION_POOL_LIMIT, ssl=env.ssl_verify()
         )
@@ -247,20 +243,13 @@ class ApiAsync:
         from gql.transport.aiohttp import AIOHTTPTransport
 
         auth = None
-        api_key = (
-            self._api_key if self._api_key is not None else get_wandb_api_context()
-        )
-        if api_key is not None:
-            auth = aiohttp.BasicAuth("api", api_key)
+        if self._api_key is not None:
+            auth = aiohttp.BasicAuth("api", self._api_key)
         # TODO: This is currently used by our FastAPI auth helper, there's probably a better way.
         api_key_override = kwargs.pop("api_key", None)
         if api_key_override:
             auth = aiohttp.BasicAuth("api", api_key_override)
-        url_base = (
-            self._base_url.rstrip("/")
-            if self._base_url is not None
-            else env.wandb_base_url()
-        )
+        url_base = self._base_url.rstrip("/")
         transport = AIOHTTPTransport(
             url=url_base + "/graphql",
             client_session_args={

--- a/weave/compat/wandb/wandb_thin/internal_api.py
+++ b/weave/compat/wandb/wandb_thin/internal_api.py
@@ -20,14 +20,28 @@ TCP_CONNECTION_POOL_LIMIT = 50
 
 
 class Api:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url
+
     def query(self, query: graphql.DocumentNode, **kwargs: Any) -> Any:
         from gql.transport.httpx import HTTPXTransport
 
         auth = None
-        api_key = get_wandb_api_context()
+        api_key = (
+            self._api_key if self._api_key is not None else get_wandb_api_context()
+        )
         if api_key is not None:
             auth = httpx.BasicAuth("api", api_key)
-        url_base = env.wandb_base_url()
+        url_base = (
+            self._base_url.rstrip("/")
+            if self._base_url is not None
+            else env.wandb_base_url()
+        )
         transport = HTTPXTransport(
             url=url_base + "/graphql",
             auth=auth,
@@ -215,9 +229,15 @@ class Api:
 
 
 class ApiAsync:
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str | None = None,
+    ) -> None:
         import aiohttp
 
+        self._api_key = api_key
+        self._base_url = base_url
         self.connector = aiohttp.TCPConnector(
             limit=TCP_CONNECTION_POOL_LIMIT, ssl=env.ssl_verify()
         )
@@ -227,14 +247,20 @@ class ApiAsync:
         from gql.transport.aiohttp import AIOHTTPTransport
 
         auth = None
-        api_key = get_wandb_api_context()
+        api_key = (
+            self._api_key if self._api_key is not None else get_wandb_api_context()
+        )
         if api_key is not None:
             auth = aiohttp.BasicAuth("api", api_key)
         # TODO: This is currently used by our FastAPI auth helper, there's probably a better way.
         api_key_override = kwargs.pop("api_key", None)
         if api_key_override:
             auth = aiohttp.BasicAuth("api", api_key_override)
-        url_base = env.wandb_base_url()
+        url_base = (
+            self._base_url.rstrip("/")
+            if self._base_url is not None
+            else env.wandb_base_url()
+        )
         transport = AIOHTTPTransport(
             url=url_base + "/graphql",
             client_session_args={

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -47,6 +47,9 @@ def init(
     global_postprocess_inputs: PostprocessInputsFunc | None = None,
     global_postprocess_output: PostprocessOutputFunc | None = None,
     global_attributes: dict[str, Any] | None = None,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    trace_server_url: str | None = None,
 ) -> weave_client.WeaveClient:
     """Initialize weave tracking, logging to a wandb project.
 
@@ -109,6 +112,16 @@ def init(
         global_postprocess_inputs: A function that will be applied to all inputs of all ops.
         global_postprocess_output: A function that will be applied to all outputs of all ops.
         global_attributes: A dictionary of attributes that will be applied to all traces.
+        api_key: Optional W&B API key. If provided, skips all environment-based
+            authentication (WANDB_API_KEY, ~/.netrc, wandb.login()). The key is also
+            used for entity resolution, so no environment variables are needed.
+        base_url: Optional W&B platform API URL (replaces WANDB_BASE_URL). Used for
+            entity resolution and authentication. If not provided, the trace server URL
+            is derived from this automatically. Example: "https://api.wandb.ai".
+        trace_server_url: Optional trace server URL (replaces WF_TRACE_SERVER_URL).
+            Where trace data is sent. If omitted, derived from base_url. Only needed
+            when the trace server is on a different host than the platform API.
+            Example: "https://trace.wandb.ai".
 
     NOTE: Global postprocessing settings are applied to all ops after each op's own
     postprocessing.  The order is always:
@@ -152,6 +165,9 @@ def init(
 
     return weave_init.init_weave(
         project_name,
+        api_key=api_key,
+        base_url=base_url,
+        trace_server_url=trace_server_url,
     )
 
 

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -221,18 +221,21 @@ def publish(
             client.add_tags(ref, tags)
         if aliases:
             client.set_aliases(ref, aliases)
+        client_base_url = client._base_url
         if isinstance(ref, weave_client.OpRef):
             url = urls.op_version_path(
                 ref.entity,
                 ref.project,
                 ref.name,
                 ref.digest,
+                base_url=client_base_url,
             )
         elif isinstance(obj, leaderboard.Leaderboard):
             url = urls.leaderboard_path(
                 ref.entity,
                 ref.project,
                 ref.name,
+                base_url=client_base_url,
             )
         # TODO(gst): once frontend has direct dataset/model links
         # elif isinstance(obj, weave_client.Dataset):
@@ -242,6 +245,7 @@ def publish(
                 ref.project,
                 ref.name,
                 ref.digest,
+                base_url=client_base_url,
             )
         # Ensure logger level is up to date before logging
         update_logger_level()
@@ -578,9 +582,6 @@ def finish() -> None:
     Following finish, calls of weave.op decorated functions will no longer be logged. You will need to run weave.init() again to resume logging.
 
     """
-    # Flush outstanding work *before* clearing explicit overrides (api_key,
-    # base_url) so that callbacks (e.g. 🍩 call URLs) still see the correct
-    # base URL during flush.
     wc = weave_client_context.get_weave_client()
     if wc is not None:
         wc.finish()

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -578,13 +578,14 @@ def finish() -> None:
     Following finish, calls of weave.op decorated functions will no longer be logged. You will need to run weave.init() again to resume logging.
 
     """
-    # Capture client before teardown so we can still flush outstanding work.
+    # Flush outstanding work *before* clearing explicit overrides (api_key,
+    # base_url) so that callbacks (e.g. 🍩 call URLs) still see the correct
+    # base URL during flush.
     wc = weave_client_context.get_weave_client()
-    weave_init.finish()
-
-    # Flush any remaining calls
     if wc is not None:
         wc.finish()
+
+    weave_init.finish()
 
 
 __all__ = [

--- a/weave/trace/call.py
+++ b/weave/trace/call.py
@@ -180,6 +180,7 @@ class Call:
             self.project_id,
             CallsFilter(parent_ids=[self.id]),
             page_size=page_size,
+            base_url=client._base_url,
         )
 
     def delete(self) -> bool:

--- a/weave/trace/call.py
+++ b/weave/trace/call.py
@@ -80,6 +80,7 @@ class Call:
     # These are the live children during logging
     _children: list[Call] = dataclasses.field(default_factory=list)
     _feedback: RefFeedbackQuery | None = None
+    _base_url: str | None = None
 
     # Size of metadata storage for this call
     storage_size_bytes: int | None = None
@@ -146,7 +147,7 @@ class Call:
             entity, project = from_project_id(self.project_id)
         except ValueError:
             raise ValueError(f"Invalid project_id: {self.project_id}") from None
-        return urls.redirect_call(entity, project, self.id)
+        return urls.redirect_call(entity, project, self.id, base_url=self._base_url)
 
     @property
     def ref(self) -> CallRef:

--- a/weave/trace/call.py
+++ b/weave/trace/call.py
@@ -80,7 +80,7 @@ class Call:
     # These are the live children during logging
     _children: list[Call] = dataclasses.field(default_factory=list)
     _feedback: RefFeedbackQuery | None = None
-    _base_url: str | None = None
+    _base_url: str | None = dataclasses.field(default=None, compare=False, repr=False)
 
     # Size of metadata storage for this call
     storage_size_bytes: int | None = None

--- a/weave/trace/call.py
+++ b/weave/trace/call.py
@@ -80,7 +80,7 @@ class Call:
     # These are the live children during logging
     _children: list[Call] = dataclasses.field(default_factory=list)
     _feedback: RefFeedbackQuery | None = None
-    _base_url: str | None = dataclasses.field(default=None, compare=False, repr=False)
+    _base_url: str | None = None
 
     # Size of metadata storage for this call
     storage_size_bytes: int | None = None

--- a/weave/trace/call.py
+++ b/weave/trace/call.py
@@ -362,6 +362,7 @@ def _make_calls_iterator(
     expand_columns: list[str] | None = None,
     return_expanded_column_values: bool = True,
     page_size: int = DEFAULT_CALLS_PAGE_SIZE,
+    base_url: str | None = None,
 ) -> CallsIter:
     def fetch_func(offset: int, limit: int) -> list[CallSchema]:
         # Add the global offset to the page offset
@@ -394,7 +395,7 @@ def _make_calls_iterator(
     # TODO: Should be Call, not WeaveObject
     def transform_func(call: CallSchema) -> WeaveObject:
         entity, project = from_project_id(project_id)
-        return make_client_call(entity, project, call, server)
+        return make_client_call(entity, project, call, server, base_url=base_url)
 
     def size_func() -> int:
         response = server.calls_query_stats(
@@ -426,7 +427,11 @@ def _make_calls_iterator(
 
 
 def make_client_call(
-    entity: str, project: str, server_call: CallSchema, server: TraceServerInterface
+    entity: str,
+    project: str,
+    server_call: CallSchema,
+    server: TraceServerInterface,
+    base_url: str | None = None,
 ) -> WeaveObject:
     if (call_id := server_call.id) is None:
         raise ValueError("Call ID is None")
@@ -455,6 +460,7 @@ def make_client_call(
         wb_run_step_end=server_call.wb_run_step_end,
         storage_size_bytes=server_call.storage_size_bytes,
         total_storage_size_bytes=server_call.total_storage_size_bytes,
+        _base_url=base_url,
     )
     if isinstance(call.attributes, AttributesDict):
         call.attributes.freeze()

--- a/weave/trace/env.py
+++ b/weave/trace/env.py
@@ -12,12 +12,6 @@ WEAVE_INSECURE_DISABLE_SSL = "WEAVE_INSECURE_DISABLE_SSL"
 
 logger = logging.getLogger(__name__)
 
-# Module-level override for runtime configuration via weave.init() params.
-# When set, overrides env-based lookup so the SDK can be configured without
-# touching environment variables. Uses a plain global (not contextvars) because
-# this value must be visible across threads (e.g. call link generation).
-_explicit_base_url: str | None = None
-
 
 class Settings:
     """A minimal readonly implementation of wandb/old/settings.py for reading settings."""
@@ -53,16 +47,7 @@ def get_weave_parallelism() -> int:
     return int(os.getenv(WEAVE_PARALLELISM, str(DEFAULT_WEAVE_PARALLELISM)))
 
 
-def set_wandb_base_url(url: str | None) -> None:
-    """Set an explicit base URL that overrides env-based lookup."""
-    global _explicit_base_url  # noqa: PLW0603
-    _explicit_base_url = url
-
-
 def wandb_base_url() -> str:
-    explicit = _explicit_base_url
-    if explicit is not None:
-        return explicit.rstrip("/")
     settings = Settings()
     return os.environ.get("WANDB_BASE_URL", settings.base_url).rstrip("/")
 

--- a/weave/trace/env.py
+++ b/weave/trace/env.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import configparser
+import contextvars
 import logging
 import netrc
 import os
@@ -11,6 +12,13 @@ DEFAULT_WEAVE_PARALLELISM = 20
 WEAVE_INSECURE_DISABLE_SSL = "WEAVE_INSECURE_DISABLE_SSL"
 
 logger = logging.getLogger(__name__)
+
+# Context var overrides for runtime configuration via weave.init() params.
+# When set, these override env-based lookups so the SDK can be configured
+# without touching environment variables.
+_explicit_base_url: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_explicit_base_url", default=None
+)
 
 
 class Settings:
@@ -47,7 +55,15 @@ def get_weave_parallelism() -> int:
     return int(os.getenv(WEAVE_PARALLELISM, str(DEFAULT_WEAVE_PARALLELISM)))
 
 
+def set_wandb_base_url(url: str | None) -> None:
+    """Set an explicit base URL that overrides env-based lookup."""
+    _explicit_base_url.set(url)
+
+
 def wandb_base_url() -> str:
+    explicit = _explicit_base_url.get()
+    if explicit is not None:
+        return explicit.rstrip("/")
     settings = Settings()
     return os.environ.get("WANDB_BASE_URL", settings.base_url).rstrip("/")
 

--- a/weave/trace/env.py
+++ b/weave/trace/env.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import configparser
-import contextvars
 import logging
 import netrc
 import os
@@ -13,12 +12,11 @@ WEAVE_INSECURE_DISABLE_SSL = "WEAVE_INSECURE_DISABLE_SSL"
 
 logger = logging.getLogger(__name__)
 
-# Context var overrides for runtime configuration via weave.init() params.
-# When set, these override env-based lookups so the SDK can be configured
-# without touching environment variables.
-_explicit_base_url: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "_explicit_base_url", default=None
-)
+# Module-level override for runtime configuration via weave.init() params.
+# When set, overrides env-based lookup so the SDK can be configured without
+# touching environment variables. Uses a plain global (not contextvars) because
+# this value must be visible across threads (e.g. call link generation).
+_explicit_base_url: str | None = None
 
 
 class Settings:
@@ -57,11 +55,12 @@ def get_weave_parallelism() -> int:
 
 def set_wandb_base_url(url: str | None) -> None:
     """Set an explicit base URL that overrides env-based lookup."""
-    _explicit_base_url.set(url)
+    global _explicit_base_url  # noqa: PLW0603
+    _explicit_base_url = url
 
 
 def wandb_base_url() -> str:
-    explicit = _explicit_base_url.get()
+    explicit = _explicit_base_url
     if explicit is not None:
         return explicit.rstrip("/")
     settings = Settings()

--- a/weave/trace/init_message.py
+++ b/weave/trace/init_message.py
@@ -155,7 +155,11 @@ def check_min_trace_server_version(
 
 
 def print_init_message(
-    username: str | None, entity_name: str, project_name: str, read_only: bool
+    username: str | None,
+    entity_name: str,
+    project_name: str,
+    read_only: bool,
+    base_url: str | None = None,
 ) -> None:
     try:
         _print_version_check()
@@ -165,9 +169,7 @@ def print_init_message(
     message = ""
     if username is not None:
         message += f"Logged in as Weights & Biases user: {username}.\n"
-    message += (
-        f"View Weave data at {urls.project_weave_root_url(entity_name, project_name)}"
-    )
+    message += f"View Weave data at {urls.project_weave_root_url(entity_name, project_name, base_url=base_url)}"
     # Cosmetically, if we are in `read_only` mode, we are not logging data, so
     # we should not print the message about logging data.
     if not read_only:

--- a/weave/trace/urls.py
+++ b/weave/trace/urls.py
@@ -7,29 +7,56 @@ BROWSE3_PATH = "browse3"
 WEAVE_SLUG = "weave"
 
 
-def remote_project_root_url(entity_name: str, project_name: str) -> str:
-    return f"{wandb.app_url(env.wandb_base_url())}/{entity_name}/{quote(project_name)}"
+def remote_project_root_url(
+    entity_name: str,
+    project_name: str,
+    base_url: str | None = None,
+) -> str:
+    effective = base_url if base_url is not None else env.wandb_base_url()
+    return f"{wandb.app_url(effective)}/{entity_name}/{quote(project_name)}"
 
 
-def project_weave_root_url(entity_name: str, project_name: str) -> str:
-    return f"{remote_project_root_url(entity_name, project_name)}/{WEAVE_SLUG}"
+def project_weave_root_url(
+    entity_name: str,
+    project_name: str,
+    base_url: str | None = None,
+) -> str:
+    return f"{remote_project_root_url(entity_name, project_name, base_url=base_url)}/{WEAVE_SLUG}"
 
 
 def op_version_path(
-    entity_name: str, project_name: str, op_name: str, op_version: str
+    entity_name: str,
+    project_name: str,
+    op_name: str,
+    op_version: str,
+    base_url: str | None = None,
 ) -> str:
-    return f"{project_weave_root_url(entity_name, project_name)}/ops/{op_name}/versions/{op_version}"
+    return f"{project_weave_root_url(entity_name, project_name, base_url=base_url)}/ops/{op_name}/versions/{op_version}"
 
 
 def object_version_path(
-    entity_name: str, project_name: str, object_name: str, obj_version: str
+    entity_name: str,
+    project_name: str,
+    object_name: str,
+    obj_version: str,
+    base_url: str | None = None,
 ) -> str:
-    return f"{project_weave_root_url(entity_name, project_name)}/objects/{quote(object_name)}/versions/{obj_version}"
+    return f"{project_weave_root_url(entity_name, project_name, base_url=base_url)}/objects/{quote(object_name)}/versions/{obj_version}"
 
 
-def leaderboard_path(entity_name: str, project_name: str, object_name: str) -> str:
-    return f"{project_weave_root_url(entity_name, project_name)}/leaderboards/{quote(object_name)}"
+def leaderboard_path(
+    entity_name: str,
+    project_name: str,
+    object_name: str,
+    base_url: str | None = None,
+) -> str:
+    return f"{project_weave_root_url(entity_name, project_name, base_url=base_url)}/leaderboards/{quote(object_name)}"
 
 
-def redirect_call(entity_name: str, project_name: str, call_id: str) -> str:
-    return f"{remote_project_root_url(entity_name, project_name)}/r/call/{call_id}"
+def redirect_call(
+    entity_name: str,
+    project_name: str,
+    call_id: str,
+    base_url: str | None = None,
+) -> str:
+    return f"{remote_project_root_url(entity_name, project_name, base_url=base_url)}/r/call/{call_id}"

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -29,7 +29,7 @@ from weave.shared.digest import (
     compute_table_digest,
 )
 from weave.telemetry import trace_sentry
-from weave.trace import settings
+from weave.trace import env, settings
 from weave.trace.call import (
     DEFAULT_CALLS_PAGE_SIZE,
     Call,
@@ -165,6 +165,7 @@ from weave.utils.dict_utils import sum_dict_leaves, zip_dicts
 from weave.utils.exception import exception_to_json_str
 from weave.utils.project_id import from_project_id, to_project_id
 from weave.utils.sanitize import REDACTED_VALUE, redact_dataclass_fields, should_redact
+from weave.wandb_interface.context import get_wandb_api_context
 
 if TYPE_CHECKING:
     from weave.evaluation.eval import Evaluation
@@ -361,8 +362,15 @@ class WeaveClient:
         self.entity = entity
         self.project = project
         self.server = server
-        self._api_key = api_key
-        self._base_url = base_url
+        # Eagerly resolve credentials so downstream consumers never need
+        # fallback logic.  When the caller provides an explicit api_key we
+        # use it; otherwise we snapshot the current env / netrc value once.
+        self._api_key: str | None = (
+            api_key if api_key is not None else get_wandb_api_context()
+        )
+        self._base_url: str | None = (
+            base_url if base_url is not None else env.wandb_base_url()
+        )
         self._anonymous_ops: dict[str, Op] = {}
         self._wandb_run_context: WandbRunContext | None = None
         self.project_id_resolver = ProjectIdResolver(server)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -340,6 +340,9 @@ class WeaveClient:
     # multiple times.
     send_file_cache: WeaveClientSendFileCache
 
+    # Raw caller-supplied init params, set by init_weave() for client reuse checks.
+    _raw_init_params: tuple[str, bool, str | None, str | None, str | None]
+
     """
     A client for interacting with the Weave trace server.
 
@@ -368,9 +371,7 @@ class WeaveClient:
         self._api_key: str | None = (
             api_key if api_key is not None else get_wandb_api_context()
         )
-        self._base_url: str = (
-            base_url if base_url is not None else env.wandb_base_url()
-        )
+        self._base_url: str = base_url if base_url is not None else env.wandb_base_url()
         self._anonymous_ops: dict[str, Op] = {}
         self._wandb_run_context: WandbRunContext | None = None
         self.project_id_resolver = ProjectIdResolver(server)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -348,9 +348,11 @@ class WeaveClient:
         project: The project name.
         server: The server to use for communication.
         ensure_project_exists: Whether to ensure the project exists on the server.
-        api_key: Caller-supplied API key (None means env-derived).
-        base_url: Caller-supplied base URL (None means env-derived).
-        trace_server_url: Caller-supplied trace server URL (None means derived).
+        api_key: Resolved API key for downstream use.
+        base_url: Resolved base URL for downstream use.
+        init_api_key: Raw caller-supplied API key (for client reuse checks).
+        init_base_url: Raw caller-supplied base URL (for client reuse checks).
+        init_trace_server_url: Raw caller-supplied trace server URL (for client reuse checks).
     """
 
     def __init__(
@@ -361,16 +363,18 @@ class WeaveClient:
         ensure_project_exists: bool = True,
         api_key: str | None = None,
         base_url: str | None = None,
+        init_api_key: str | None = None,
+        init_base_url: str | None = None,
+        init_trace_server_url: str | None = None,
     ):
         self.entity = entity
         self.project = project
         self.server = server
-        # Caller-supplied values (before env resolution), set by init_weave()
-        # for client reuse decisions.  Defaults to None when constructed
-        # directly (not via init_weave).
-        self.init_api_key: str | None = None
-        self.init_base_url: str | None = None
-        self.init_trace_server_url: str | None = None
+        # Raw caller-supplied values (before env resolution) for client reuse
+        # decisions in init_weave.
+        self.init_api_key = init_api_key
+        self.init_base_url = init_base_url
+        self.init_trace_server_url = init_trace_server_url
         # Eagerly resolve credentials so downstream consumers never need
         # fallback logic.  When the caller provides an explicit value we
         # use it; otherwise we snapshot the current env / netrc value once.

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -355,10 +355,14 @@ class WeaveClient:
         project: str,
         server: TraceServerClientInterface,
         ensure_project_exists: bool = True,
+        api_key: str | None = None,
+        base_url: str | None = None,
     ):
         self.entity = entity
         self.project = project
         self.server = server
+        self._api_key = api_key
+        self._base_url = base_url
         self._anonymous_ops: dict[str, Op] = {}
         self._wandb_run_context: WandbRunContext | None = None
         self.project_id_resolver = ProjectIdResolver(server)
@@ -368,9 +372,15 @@ class WeaveClient:
         self.ensure_project_exists = ensure_project_exists
 
         if ensure_project_exists:
-            resp = self.server.ensure_project_exists(entity, project)
+            from weave.wandb_interface.project_creator import (
+                ensure_project_exists as _ensure_project,
+            )
+
+            result = _ensure_project(
+                entity, project, api_key=self._api_key, base_url=self._base_url
+            )
             # Set Client project name with updated project name
-            self.project = resp.project_name
+            self.project = result["project_name"]
 
         self._server_call_processor: AsyncBatchProcessor | CallBatchProcessor | None = (
             None
@@ -419,7 +429,7 @@ class WeaveClient:
             self._wal_pending_call_ids.discard(call_id)
             project_id = start.get("project_id", "")
             entity, project = from_project_id(project_id)
-            url = redirect_call(entity, project, call_id)
+            url = redirect_call(entity, project, call_id, base_url=self._base_url)
             logger.info("%s %s", TRACE_CALL_EMOJI, url)
         except Exception:
             pass
@@ -823,6 +833,7 @@ class WeaveClient:
             attributes=attributes_dict,
             thread_id=thread_id,
             turn_id=turn_id,
+            _base_url=self._base_url,
         )
         # Disallow further modification of attributes after the call is created
         attributes_dict.freeze()

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -165,9 +165,6 @@ from weave.utils.dict_utils import sum_dict_leaves, zip_dicts
 from weave.utils.exception import exception_to_json_str
 from weave.utils.project_id import from_project_id, to_project_id
 from weave.utils.sanitize import REDACTED_VALUE, redact_dataclass_fields, should_redact
-from weave.wandb_interface.project_creator import (
-    ensure_project_exists as _ensure_project,
-)
 
 if TYPE_CHECKING:
     from weave.evaluation.eval import Evaluation
@@ -375,11 +372,11 @@ class WeaveClient:
         self.ensure_project_exists = ensure_project_exists
 
         if ensure_project_exists:
-            result = _ensure_project(
+            resp = self.server.ensure_project_exists(
                 entity, project, api_key=self._api_key, base_url=self._base_url
             )
             # Set Client project name with updated project name
-            self.project = result["project_name"]
+            self.project = resp.project_name
 
         self._server_call_processor: AsyncBatchProcessor | CallBatchProcessor | None = (
             None

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -165,6 +165,9 @@ from weave.utils.dict_utils import sum_dict_leaves, zip_dicts
 from weave.utils.exception import exception_to_json_str
 from weave.utils.project_id import from_project_id, to_project_id
 from weave.utils.sanitize import REDACTED_VALUE, redact_dataclass_fields, should_redact
+from weave.wandb_interface.project_creator import (
+    ensure_project_exists as _ensure_project,
+)
 
 if TYPE_CHECKING:
     from weave.evaluation.eval import Evaluation
@@ -372,10 +375,6 @@ class WeaveClient:
         self.ensure_project_exists = ensure_project_exists
 
         if ensure_project_exists:
-            from weave.wandb_interface.project_creator import (
-                ensure_project_exists as _ensure_project,
-            )
-
             result = _ensure_project(
                 entity, project, api_key=self._api_key, base_url=self._base_url
             )

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -29,7 +29,7 @@ from weave.shared.digest import (
     compute_table_digest,
 )
 from weave.telemetry import trace_sentry
-from weave.trace import env, settings
+from weave.trace import settings
 from weave.trace.call import (
     DEFAULT_CALLS_PAGE_SIZE,
     Call,
@@ -165,7 +165,6 @@ from weave.utils.dict_utils import sum_dict_leaves, zip_dicts
 from weave.utils.exception import exception_to_json_str
 from weave.utils.project_id import from_project_id, to_project_id
 from weave.utils.sanitize import REDACTED_VALUE, redact_dataclass_fields, should_redact
-from weave.wandb_interface.context import get_wandb_api_context
 
 if TYPE_CHECKING:
     from weave.evaluation.eval import Evaluation
@@ -362,15 +361,8 @@ class WeaveClient:
         self.entity = entity
         self.project = project
         self.server = server
-        # Eagerly resolve credentials so downstream consumers never need
-        # fallback logic.  When the caller provides an explicit api_key we
-        # use it; otherwise we snapshot the current env / netrc value once.
-        self._api_key: str | None = (
-            api_key if api_key is not None else get_wandb_api_context()
-        )
-        self._base_url: str | None = (
-            base_url if base_url is not None else env.wandb_base_url()
-        )
+        self._api_key = api_key
+        self._base_url = base_url
         self._anonymous_ops: dict[str, Op] = {}
         self._wandb_run_context: WandbRunContext | None = None
         self.project_id_resolver = ProjectIdResolver(server)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -29,7 +29,7 @@ from weave.shared.digest import (
     compute_table_digest,
 )
 from weave.telemetry import trace_sentry
-from weave.trace import settings
+from weave.trace import env, settings
 from weave.trace.call import (
     DEFAULT_CALLS_PAGE_SIZE,
     Call,
@@ -165,6 +165,7 @@ from weave.utils.dict_utils import sum_dict_leaves, zip_dicts
 from weave.utils.exception import exception_to_json_str
 from weave.utils.project_id import from_project_id, to_project_id
 from weave.utils.sanitize import REDACTED_VALUE, redact_dataclass_fields, should_redact
+from weave.wandb_interface.context import get_wandb_api_context
 
 if TYPE_CHECKING:
     from weave.evaluation.eval import Evaluation
@@ -361,8 +362,15 @@ class WeaveClient:
         self.entity = entity
         self.project = project
         self.server = server
-        self._api_key = api_key
-        self._base_url = base_url
+        # Eagerly resolve credentials so downstream consumers never need
+        # fallback logic.  When the caller provides an explicit value we
+        # use it; otherwise we snapshot the current env / netrc value once.
+        self._api_key: str | None = (
+            api_key if api_key is not None else get_wandb_api_context()
+        )
+        self._base_url: str | None = (
+            base_url if base_url is not None else env.wandb_base_url()
+        )
         self._anonymous_ops: dict[str, Op] = {}
         self._wandb_run_context: WandbRunContext | None = None
         self.project_id_resolver = ProjectIdResolver(server)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -340,9 +340,6 @@ class WeaveClient:
     # multiple times.
     send_file_cache: WeaveClientSendFileCache
 
-    # Raw caller-supplied init params, set by init_weave() for client reuse checks.
-    _raw_init_params: tuple[str, bool, str | None, str | None, str | None]
-
     """
     A client for interacting with the Weave trace server.
 
@@ -351,6 +348,9 @@ class WeaveClient:
         project: The project name.
         server: The server to use for communication.
         ensure_project_exists: Whether to ensure the project exists on the server.
+        api_key: Caller-supplied API key (None means env-derived).
+        base_url: Caller-supplied base URL (None means env-derived).
+        trace_server_url: Caller-supplied trace server URL (None means derived).
     """
 
     def __init__(
@@ -365,6 +365,12 @@ class WeaveClient:
         self.entity = entity
         self.project = project
         self.server = server
+        # Caller-supplied values (before env resolution), set by init_weave()
+        # for client reuse decisions.  Defaults to None when constructed
+        # directly (not via init_weave).
+        self.init_api_key: str | None = None
+        self.init_base_url: str | None = None
+        self.init_trace_server_url: str | None = None
         # Eagerly resolve credentials so downstream consumers never need
         # fallback logic.  When the caller provides an explicit value we
         # use it; otherwise we snapshot the current env / netrc value once.

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -368,7 +368,7 @@ class WeaveClient:
         self._api_key: str | None = (
             api_key if api_key is not None else get_wandb_api_context()
         )
-        self._base_url: str | None = (
+        self._base_url: str = (
             base_url if base_url is not None else env.wandb_base_url()
         )
         self._anonymous_ops: dict[str, Op] = {}

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -678,6 +678,7 @@ class WeaveClient:
             expand_columns=expand_columns,
             return_expanded_column_values=return_expanded_column_values,
             page_size=page_size,
+            base_url=self._base_url,
         )
 
     @trace_sentry.global_trace_sentry.watch()
@@ -715,7 +716,13 @@ class WeaveClient:
         if not calls:
             raise ValueError(f"Call not found: {call_id}")
         response_call = calls[0]
-        return make_client_call(self.entity, self.project, response_call, self.server)
+        return make_client_call(
+            self.entity,
+            self.project,
+            response_call,
+            self.server,
+            base_url=self._base_url,
+        )
 
     @trace_sentry.global_trace_sentry.watch()
     def create_call(

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -30,15 +30,19 @@ logger = logging.getLogger(__name__)
 class WeaveWandbAuthenticationException(Exception): ...
 
 
-def get_username() -> str | None:
-    api = wandb.Api()
+def get_username(api_key: str | None = None, base_url: str | None = None) -> str | None:
+    api = wandb.Api(api_key=api_key, base_url=base_url)
     try:
         return api.username()
     except AttributeError:
         return None
 
 
-def get_entity_project_from_project_name(project_name: str) -> tuple[str, str]:
+def get_entity_project_from_project_name(
+    project_name: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> tuple[str, str]:
     if not project_name or not project_name.strip():
         raise ValueError("project_name must be non-empty")
 
@@ -48,7 +52,7 @@ def get_entity_project_from_project_name(project_name: str) -> tuple[str, str]:
         entity_name = os.environ.get("WANDB_ENTITY")
         if entity_name is None:
             # Fall back to wandb default entity
-            api = wandb.Api()
+            api = wandb.Api(api_key=api_key, base_url=base_url)
             entity_name = api.default_entity_name()
             if entity_name is None:
                 raise WeaveWandbAuthenticationException(
@@ -122,29 +126,23 @@ def init_weave(
             current_client.finish()
             weave_client_context.set_weave_client_global(None)
 
-    # Set explicit base_url in context so downstream code (e.g. entity resolution
-    # via wandb.Api(), trace server URL derivation) uses it instead of env vars.
-    if base_url is not None:
-        env.set_wandb_base_url(base_url)
-
     if api_key is None:
         from weave.wandb_interface.context import get_wandb_api_context
 
         api_key = get_wandb_api_context()
         if api_key is None:
-            url = wandb.app_url(env.wandb_base_url())
+            effective_base_url = (
+                base_url if base_url is not None else env.wandb_base_url()
+            )
+            url = wandb.app_url(effective_base_url)
             logger.info("Please login to Weights & Biases (%s) to continue...", url)
             wandb.login(anonymous="never", force=True, referrer="weave")  # type: ignore
             api_key = get_wandb_api_context()
-    else:
-        # Set explicit api_key in context so downstream code (e.g. entity resolution
-        # via wandb.Api()) uses it instead of reading from env vars.
-        from weave.wandb_interface.context import set_wandb_api_context
-
-        set_wandb_api_context(api_key)
 
     # Resolve entity name after authentication is ensured
-    entity_name, project_name = get_entity_project_from_project_name(project_name)
+    entity_name, project_name = get_entity_project_from_project_name(
+        project_name, api_key=api_key, base_url=base_url
+    )
     wb_run_context = get_global_wb_run_context()
     if wb_run_context:
         wandb_run_id = f"{entity_name}/{project_name}/{wb_run_context.run_id}"
@@ -160,7 +158,12 @@ def init_weave(
         server = CachingMiddlewareTraceServer.from_env(server)
 
     client = weave_client.WeaveClient(
-        entity_name, project_name, server, ensure_project_exists
+        entity_name,
+        project_name,
+        server,
+        ensure_project_exists,
+        api_key=api_key,
+        base_url=base_url,
     )
 
     # If the project name was formatted by init, update the project name
@@ -176,7 +179,7 @@ def init_weave(
     implicit_patch()
     register_import_hook()
 
-    username = get_username()
+    username = get_username(api_key=api_key, base_url=base_url)
 
     # This is a temporary event to track the number of users who have enabled PII redaction.
     if should_redact_pii():
@@ -211,7 +214,11 @@ def init_weave(
     ):
         return init_weave_disabled()
     init_message.print_init_message(
-        username, entity_name, project_name, read_only=not ensure_project_exists
+        username,
+        entity_name,
+        project_name,
+        read_only=not ensure_project_exists,
+        base_url=base_url,
     )
 
     user_context = {"username": username} if username else None
@@ -240,12 +247,6 @@ def init_weave_disabled() -> weave_client.WeaveClient:
     current_client = weave_client_context.get_weave_client()
     if current_client is not None:
         weave_client_context.set_weave_client_global(None)
-
-    # Clear explicit overrides to avoid stale state
-    env.set_wandb_base_url(None)
-    from weave.wandb_interface.context import set_wandb_api_context
-
-    set_wandb_api_context(None)
 
     client = weave_client.WeaveClient(
         "DISABLED",
@@ -290,13 +291,6 @@ def finish() -> None:
     current_client = weave_client_context.get_weave_client()
     if current_client is not None:
         weave_client_context.set_weave_client_global(None)
-
-    # Clear explicit overrides so a subsequent weave.init() without params
-    # falls back to env vars / netrc as expected.
-    env.set_wandb_base_url(None)
-    from weave.wandb_interface.context import set_wandb_api_context
-
-    set_wandb_api_context(None)
 
     # Unregister the import hook
     from weave.integrations.patch import unregister_import_hook

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -241,6 +241,12 @@ def init_weave_disabled() -> weave_client.WeaveClient:
     if current_client is not None:
         weave_client_context.set_weave_client_global(None)
 
+    # Clear explicit overrides to avoid stale state
+    env.set_wandb_base_url(None)
+    from weave.wandb_interface.context import set_wandb_api_context
+
+    set_wandb_api_context(None)
+
     client = weave_client.WeaveClient(
         "DISABLED",
         "DISABLED",
@@ -280,6 +286,13 @@ def finish() -> None:
     current_client = weave_client_context.get_weave_client()
     if current_client is not None:
         weave_client_context.set_weave_client_global(None)
+
+    # Clear explicit overrides so a subsequent weave.init() without params
+    # falls back to env vars / netrc as expected.
+    env.set_wandb_base_url(None)
+    from weave.wandb_interface.context import set_wandb_api_context
+
+    set_wandb_api_context(None)
 
     # Unregister the import hook
     from weave.integrations.patch import unregister_import_hook

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -263,20 +263,24 @@ def init_weave_get_server(
     should_batch: bool = True,
     trace_server_url: str | None = None,
 ) -> TraceServerClientInterface:
-    url = (
-        trace_server_url
-        if trace_server_url is not None
-        else env.weave_trace_server_url()
-    )
     res: TraceServerClientInterface
-    if should_use_stainless_server():
+    if trace_server_url is not None:
+        if should_use_stainless_server():
+            from weave.trace_server_bindings.stainless_remote_http_trace_server import (
+                StainlessRemoteHTTPTraceServer,
+            )
+
+            res = StainlessRemoteHTTPTraceServer(trace_server_url, should_batch)  # type: ignore[abstract]  # pyright: ignore[reportAbstractUsage]
+        else:
+            res = RemoteHTTPTraceServer(trace_server_url, should_batch)  # type: ignore[abstract]  # pyright: ignore[reportAbstractUsage]
+    elif should_use_stainless_server():
         from weave.trace_server_bindings.stainless_remote_http_trace_server import (
             StainlessRemoteHTTPTraceServer,
         )
 
-        res = StainlessRemoteHTTPTraceServer(url, should_batch)
+        res = StainlessRemoteHTTPTraceServer.from_env(should_batch)
     else:
-        res = RemoteHTTPTraceServer(url, should_batch)
+        res = RemoteHTTPTraceServer.from_env(should_batch)
     if api_key is not None:
         res.set_auth(("api", api_key))
     return res

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -220,8 +220,8 @@ def init_weave(
         min_required_version = "0.0.0"
         trace_server_version = None
     effective_trace_server_url = (
-        trace_server_url
-        if trace_server_url is not None
+        resolved_trace_server_url
+        if resolved_trace_server_url is not None
         else env.weave_trace_server_url()
     )
     if not init_message.check_min_weave_version(

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -69,16 +69,6 @@ def get_entity_project_from_project_name(project_name: str) -> tuple[str, str]:
     return entity_name, project_name
 
 
-"""
-This is the main entrypoint for the weave library. It initializes the weave client
-and sets up the global state for the weave library.
-
-Args:
-    project_name (str): The project name to use for the weave client.
-    ensure_project_exists (bool): If True (default), the client will attempt to create the project if it does not exist.
-"""
-
-
 def _weave_is_available(server: TraceServerClientInterface) -> bool:
     try:
         server.server_info()
@@ -95,7 +85,24 @@ def _weave_is_available(server: TraceServerClientInterface) -> bool:
 def init_weave(
     project_name: str,
     ensure_project_exists: bool = True,
+    api_key: str | None = None,
+    base_url: str | None = None,
+    trace_server_url: str | None = None,
 ) -> weave_client.WeaveClient:
+    """Initialize the weave client and set up global state.
+
+    Args:
+        project_name: The project name to use for the weave client.
+        ensure_project_exists: If True (default), the client will attempt to
+            create the project if it does not exist.
+        api_key: Optional W&B API key. If provided, skips env var / netrc /
+            wandb.login() auth flow.
+        base_url: Optional W&B platform API URL (replaces WANDB_BASE_URL).
+            The trace server URL is derived from this if trace_server_url
+            is not provided.
+        trace_server_url: Optional trace server URL (replaces
+            WF_TRACE_SERVER_URL). If omitted, derived from base_url.
+    """
     if not project_name or not project_name.strip():
         raise ValueError("project_name must be non-empty")
 
@@ -105,6 +112,9 @@ def init_weave(
         if (
             current_client.project == project_name
             and current_client.ensure_project_exists == ensure_project_exists
+            and api_key is None
+            and base_url is None
+            and trace_server_url is None
         ):
             return current_client
         else:
@@ -112,14 +122,26 @@ def init_weave(
             current_client.finish()
             weave_client_context.set_weave_client_global(None)
 
-    from weave.wandb_interface.context import get_wandb_api_context
+    # Set explicit base_url in context so downstream code (e.g. entity resolution
+    # via wandb.Api(), trace server URL derivation) uses it instead of env vars.
+    if base_url is not None:
+        env.set_wandb_base_url(base_url)
 
-    api_key = get_wandb_api_context()
     if api_key is None:
-        url = wandb.app_url(env.wandb_base_url())
-        logger.info("Please login to Weights & Biases (%s) to continue...", url)
-        wandb.login(anonymous="never", force=True, referrer="weave")  # type: ignore
+        from weave.wandb_interface.context import get_wandb_api_context
+
         api_key = get_wandb_api_context()
+        if api_key is None:
+            url = wandb.app_url(env.wandb_base_url())
+            logger.info("Please login to Weights & Biases (%s) to continue...", url)
+            wandb.login(anonymous="never", force=True, referrer="weave")  # type: ignore
+            api_key = get_wandb_api_context()
+    else:
+        # Set explicit api_key in context so downstream code (e.g. entity resolution
+        # via wandb.Api()) uses it instead of reading from env vars.
+        from weave.wandb_interface.context import set_wandb_api_context
+
+        set_wandb_api_context(api_key)
 
     # Resolve entity name after authentication is ensured
     entity_name, project_name = get_entity_project_from_project_name(project_name)
@@ -128,7 +150,7 @@ def init_weave(
         wandb_run_id = f"{entity_name}/{project_name}/{wb_run_context.run_id}"
         check_wandb_run_matches(wandb_run_id, entity_name, project_name)
 
-    remote_server = init_weave_get_server(api_key)
+    remote_server = init_weave_get_server(api_key, trace_server_url=trace_server_url)
     if not _weave_is_available(remote_server):
         raise RuntimeError(
             "Weave is not available on the server.  Please contact support."
@@ -173,13 +195,19 @@ def init_weave(
         # In the future, we may want to throw here.
         min_required_version = "0.0.0"
         trace_server_version = None
-    trace_server_url = env.weave_trace_server_url()
-    if not init_message.check_min_weave_version(min_required_version, trace_server_url):
+    effective_trace_server_url = (
+        trace_server_url
+        if trace_server_url is not None
+        else env.weave_trace_server_url()
+    )
+    if not init_message.check_min_weave_version(
+        min_required_version, effective_trace_server_url
+    ):
         return init_weave_disabled()
     if not init_message.check_min_trace_server_version(
         trace_server_version,
         MIN_TRACE_SERVER_VERSION,
-        trace_server_url,
+        effective_trace_server_url,
     ):
         return init_weave_disabled()
     init_message.print_init_message(
@@ -227,16 +255,22 @@ def init_weave_disabled() -> weave_client.WeaveClient:
 def init_weave_get_server(
     api_key: str | None = None,
     should_batch: bool = True,
+    trace_server_url: str | None = None,
 ) -> TraceServerClientInterface:
+    url = (
+        trace_server_url
+        if trace_server_url is not None
+        else env.weave_trace_server_url()
+    )
     res: TraceServerClientInterface
     if should_use_stainless_server():
         from weave.trace_server_bindings.stainless_remote_http_trace_server import (
             StainlessRemoteHTTPTraceServer,
         )
 
-        res = StainlessRemoteHTTPTraceServer.from_env(should_batch)
+        res = StainlessRemoteHTTPTraceServer(url, should_batch)
     else:
-        res = RemoteHTTPTraceServer.from_env(should_batch)
+        res = RemoteHTTPTraceServer(url, should_batch)
     if api_key is not None:
         res.set_auth(("api", api_key))
     return res

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -111,15 +111,10 @@ def init_weave(
     if not project_name or not project_name.strip():
         raise ValueError("project_name must be non-empty")
 
-    # Snapshot the raw caller-supplied values before any resolution/mutation
-    # so the reuse check compares what the caller actually passed.
-    raw_init_params = (
-        project_name,
-        ensure_project_exists,
-        api_key,
-        base_url,
-        trace_server_url,
-    )
+    # Capture caller-supplied values before any resolution/mutation.
+    caller_api_key = api_key
+    caller_base_url = base_url
+    caller_trace_server_url = trace_server_url
 
     current_client = weave_client_context.get_weave_client()
     if current_client is not None:
@@ -127,7 +122,14 @@ def init_weave(
         # matches.  When api_key is None the value comes from the
         # environment which may have changed, so we only reuse when an
         # explicit api_key was provided and all params match.
-        if api_key is not None and current_client.raw_init_params == raw_init_params:
+        params_match = (
+            current_client.project == project_name
+            and current_client.ensure_project_exists == ensure_project_exists
+            and current_client.init_api_key == caller_api_key
+            and current_client.init_base_url == caller_base_url
+            and current_client.init_trace_server_url == caller_trace_server_url
+        )
+        if caller_api_key is not None and params_match:
             return current_client
         # Flush any pending calls before switching to a new client
         current_client.finish()
@@ -180,7 +182,10 @@ def init_weave(
         api_key=api_key,
         base_url=base_url,
     )
-    client.raw_init_params = raw_init_params
+    # Store the original caller-supplied values for reuse comparison.
+    client.init_api_key = caller_api_key
+    client.init_base_url = caller_base_url
+    client.init_trace_server_url = caller_trace_server_url
 
     # If the project name was formatted by init, update the project name
     project_name = client.project

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -23,6 +23,7 @@ from weave.trace_server_bindings.caching_middleware_trace_server import (
 from weave.trace_server_bindings.client_interface import TraceServerClientInterface
 from weave.trace_server_bindings.remote_http_trace_server import RemoteHTTPTraceServer
 from weave.trace_server_version import MIN_TRACE_SERVER_VERSION
+from weave.wandb_interface.context import get_wandb_api_context
 
 logger = logging.getLogger(__name__)
 
@@ -127,8 +128,6 @@ def init_weave(
             weave_client_context.set_weave_client_global(None)
 
     if api_key is None:
-        from weave.wandb_interface.context import get_wandb_api_context
-
         api_key = get_wandb_api_context()
         if api_key is None:
             effective_base_url = (
@@ -147,6 +146,16 @@ def init_weave(
     if wb_run_context:
         wandb_run_id = f"{entity_name}/{project_name}/{wb_run_context.run_id}"
         check_wandb_run_matches(wandb_run_id, entity_name, project_name)
+
+    # Derive trace_server_url from base_url when not explicitly provided,
+    # honoring the documented contract: "The trace server URL is derived from
+    # this if trace_server_url is not provided."
+    if trace_server_url is None and base_url is not None:
+        normalized = base_url.rstrip("/")
+        if normalized == "https://api.wandb.ai":
+            trace_server_url = env.MTSAAS_TRACE_URL
+        else:
+            trace_server_url = normalized + "/traces"
 
     remote_server = init_weave_get_server(api_key, trace_server_url=trace_server_url)
     if not _weave_is_available(remote_server):

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -111,11 +111,6 @@ def init_weave(
     if not project_name or not project_name.strip():
         raise ValueError("project_name must be non-empty")
 
-    # Capture caller-supplied values before any resolution/mutation.
-    caller_api_key = api_key
-    caller_base_url = base_url
-    caller_trace_server_url = trace_server_url
-
     current_client = weave_client_context.get_weave_client()
     if current_client is not None:
         # Reuse the existing client when every caller-supplied parameter
@@ -125,30 +120,33 @@ def init_weave(
         params_match = (
             current_client.project == project_name
             and current_client.ensure_project_exists == ensure_project_exists
-            and current_client.init_api_key == caller_api_key
-            and current_client.init_base_url == caller_base_url
-            and current_client.init_trace_server_url == caller_trace_server_url
+            and current_client.init_api_key == api_key
+            and current_client.init_base_url == base_url
+            and current_client.init_trace_server_url == trace_server_url
         )
-        if caller_api_key is not None and params_match:
+        if api_key is not None and params_match:
             return current_client
         # Flush any pending calls before switching to a new client
         current_client.finish()
         weave_client_context.set_weave_client_global(None)
 
-    if api_key is None:
-        api_key = get_wandb_api_context()
-        if api_key is None:
+    # Resolve credentials — use separate locals so the raw api_key/base_url/
+    # trace_server_url params stay available for storing on the client.
+    resolved_api_key = api_key
+    if resolved_api_key is None:
+        resolved_api_key = get_wandb_api_context()
+        if resolved_api_key is None:
             effective_base_url = (
                 base_url if base_url is not None else env.wandb_base_url()
             )
             url = wandb.app_url(effective_base_url)
             logger.info("Please login to Weights & Biases (%s) to continue...", url)
             wandb.login(anonymous="never", force=True, referrer="weave")  # type: ignore
-            api_key = get_wandb_api_context()
+            resolved_api_key = get_wandb_api_context()
 
     # Resolve entity name after authentication is ensured
     entity_name, project_name = get_entity_project_from_project_name(
-        project_name, api_key=api_key, base_url=base_url
+        project_name, api_key=resolved_api_key, base_url=base_url
     )
     wb_run_context = get_global_wb_run_context()
     if wb_run_context:
@@ -158,14 +156,17 @@ def init_weave(
     # Derive trace_server_url from base_url when not explicitly provided,
     # honoring the documented contract: "The trace server URL is derived from
     # this if trace_server_url is not provided."
-    if trace_server_url is None and base_url is not None:
+    resolved_trace_server_url = trace_server_url
+    if resolved_trace_server_url is None and base_url is not None:
         normalized = base_url.rstrip("/")
         if normalized == "https://api.wandb.ai":
-            trace_server_url = env.MTSAAS_TRACE_URL
+            resolved_trace_server_url = env.MTSAAS_TRACE_URL
         else:
-            trace_server_url = normalized + "/traces"
+            resolved_trace_server_url = normalized + "/traces"
 
-    remote_server = init_weave_get_server(api_key, trace_server_url=trace_server_url)
+    remote_server = init_weave_get_server(
+        resolved_api_key, trace_server_url=resolved_trace_server_url
+    )
     if not _weave_is_available(remote_server):
         raise RuntimeError(
             "Weave is not available on the server.  Please contact support."
@@ -179,13 +180,12 @@ def init_weave(
         project_name,
         server,
         ensure_project_exists,
-        api_key=api_key,
+        api_key=resolved_api_key,
         base_url=base_url,
+        init_api_key=api_key,
+        init_base_url=base_url,
+        init_trace_server_url=trace_server_url,
     )
-    # Store the original caller-supplied values for reuse comparison.
-    client.init_api_key = caller_api_key
-    client.init_base_url = caller_base_url
-    client.init_trace_server_url = caller_trace_server_url
 
     # If the project name was formatted by init, update the project name
     project_name = client.project
@@ -200,7 +200,7 @@ def init_weave(
     implicit_patch()
     register_import_hook()
 
-    username = get_username(api_key=api_key, base_url=base_url)
+    username = get_username(api_key=resolved_api_key, base_url=base_url)
 
     # This is a temporary event to track the number of users who have enabled PII redaction.
     if should_redact_pii():

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -111,21 +111,27 @@ def init_weave(
     if not project_name or not project_name.strip():
         raise ValueError("project_name must be non-empty")
 
+    # Snapshot the raw caller-supplied values before any resolution/mutation
+    # so the reuse check compares what the caller actually passed.
+    raw_init_params = (
+        project_name,
+        ensure_project_exists,
+        api_key,
+        base_url,
+        trace_server_url,
+    )
+
     current_client = weave_client_context.get_weave_client()
     if current_client is not None:
-        # TODO: Prob should move into settings
-        if (
-            current_client.project == project_name
-            and current_client.ensure_project_exists == ensure_project_exists
-            and api_key is None
-            and base_url is None
-            and trace_server_url is None
-        ):
+        # Reuse the existing client when every caller-supplied parameter
+        # matches.  When api_key is None the value comes from the
+        # environment which may have changed, so we only reuse when an
+        # explicit api_key was provided and all params match.
+        if api_key is not None and current_client.raw_init_params == raw_init_params:
             return current_client
-        else:
-            # Flush any pending calls before switching to a new project
-            current_client.finish()
-            weave_client_context.set_weave_client_global(None)
+        # Flush any pending calls before switching to a new client
+        current_client.finish()
+        weave_client_context.set_weave_client_global(None)
 
     if api_key is None:
         api_key = get_wandb_api_context()
@@ -174,6 +180,7 @@ def init_weave(
         api_key=api_key,
         base_url=base_url,
     )
+    client.raw_init_params = raw_init_params
 
     # If the project name was formatted by init, update the project name
     project_name = client.project

--- a/weave/trace_server/fake_service.py
+++ b/weave/trace_server/fake_service.py
@@ -23,7 +23,11 @@ class FakeService:
         )
 
     def ensure_project_exists(
-        self, entity: str, project: str
+        self,
+        entity: str,
+        project: str,
+        api_key: str | None = None,
+        base_url: str | None = None,
     ) -> EnsureProjectExistsRes:
         return EnsureProjectExistsRes(project_name=project)
 

--- a/weave/trace_server/service_interface.py
+++ b/weave/trace_server/service_interface.py
@@ -42,6 +42,10 @@ class ServiceInterface(Protocol):
 
     def server_info(self) -> ServerInfoRes: ...
     def ensure_project_exists(
-        self, entity: str, project: str
+        self,
+        entity: str,
+        project: str,
+        api_key: str | None = None,
+        base_url: str | None = None,
     ) -> EnsureProjectExistsRes: ...
     def projects_info(self, req: ProjectsInfoReq) -> list[ProjectsInfoRes]: ...

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -95,12 +95,18 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         self.remote_request_bytes_limit = remote_request_bytes_limit
 
     def ensure_project_exists(
-        self, entity: str, project: str
+        self,
+        entity: str,
+        project: str,
+        api_key: str | None = None,
+        base_url: str | None = None,
     ) -> tsi.EnsureProjectExistsRes:
         # TODO: This should happen in the wandb backend, not here, and it's slow
         # (hundreds of ms)
         return tsi.EnsureProjectExistsRes.model_validate(
-            project_creator.ensure_project_exists(entity, project)
+            project_creator.ensure_project_exists(
+                entity, project, api_key=api_key, base_url=base_url
+            )
         )
 
     @classmethod

--- a/weave/trace_server_bindings/stainless_remote_http_trace_server.py
+++ b/weave/trace_server_bindings/stainless_remote_http_trace_server.py
@@ -93,12 +93,18 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
             )
 
     def ensure_project_exists(
-        self, entity: str, project: str
+        self,
+        entity: str,
+        project: str,
+        api_key: str | None = None,
+        base_url: str | None = None,
     ) -> tsi.EnsureProjectExistsRes:
         # TODO: This should happen in the wandb backend, not here, and it's slow
         # (hundreds of ms)
         return tsi.EnsureProjectExistsRes.model_validate(
-            project_creator.ensure_project_exists(entity, project)
+            project_creator.ensure_project_exists(
+                entity, project, api_key=api_key, base_url=base_url
+            )
         )
 
     @classmethod

--- a/weave/wandb_interface/context.py
+++ b/weave/wandb_interface/context.py
@@ -2,24 +2,7 @@ from __future__ import annotations
 
 from weave.trace.env import weave_wandb_api_key
 
-# When set, overrides env-based API key lookup. This allows weave.init(api_key=...)
-# to propagate the explicit key to all downstream code (e.g. entity resolution)
-# without touching environment variables. Uses a plain global (not contextvars)
-# because this value must be visible across threads.
-_explicit_api_key: str | None = None
-
-
-def set_wandb_api_context(api_key: str | None) -> None:
-    """Set an explicit API key that overrides env-based lookup."""
-    global _explicit_api_key  # noqa: PLW0603
-    _explicit_api_key = api_key
-
 
 def get_wandb_api_context() -> str | None:
-    """Return the current W&B API key.
-
-    Checks explicit override first, then falls back to env var / netrc.
-    """
-    if _explicit_api_key is not None:
-        return _explicit_api_key
+    """Return the current W&B API key from env var or netrc."""
     return weave_wandb_api_key()

--- a/weave/wandb_interface/context.py
+++ b/weave/wandb_interface/context.py
@@ -1,20 +1,18 @@
 from __future__ import annotations
 
-import contextvars
-
 from weave.trace.env import weave_wandb_api_key
 
 # When set, overrides env-based API key lookup. This allows weave.init(api_key=...)
 # to propagate the explicit key to all downstream code (e.g. entity resolution)
-# without touching environment variables.
-_explicit_api_key: contextvars.ContextVar[str | None] = contextvars.ContextVar(
-    "_explicit_api_key", default=None
-)
+# without touching environment variables. Uses a plain global (not contextvars)
+# because this value must be visible across threads.
+_explicit_api_key: str | None = None
 
 
 def set_wandb_api_context(api_key: str | None) -> None:
     """Set an explicit API key that overrides env-based lookup."""
-    _explicit_api_key.set(api_key)
+    global _explicit_api_key  # noqa: PLW0603
+    _explicit_api_key = api_key
 
 
 def get_wandb_api_context() -> str | None:
@@ -22,7 +20,6 @@ def get_wandb_api_context() -> str | None:
 
     Checks explicit override first, then falls back to env var / netrc.
     """
-    explicit = _explicit_api_key.get()
-    if explicit is not None:
-        return explicit
+    if _explicit_api_key is not None:
+        return _explicit_api_key
     return weave_wandb_api_key()

--- a/weave/wandb_interface/context.py
+++ b/weave/wandb_interface/context.py
@@ -1,8 +1,28 @@
 from __future__ import annotations
 
+import contextvars
+
 from weave.trace.env import weave_wandb_api_key
+
+# When set, overrides env-based API key lookup. This allows weave.init(api_key=...)
+# to propagate the explicit key to all downstream code (e.g. entity resolution)
+# without touching environment variables.
+_explicit_api_key: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_explicit_api_key", default=None
+)
+
+
+def set_wandb_api_context(api_key: str | None) -> None:
+    """Set an explicit API key that overrides env-based lookup."""
+    _explicit_api_key.set(api_key)
 
 
 def get_wandb_api_context() -> str | None:
-    """Return the current W&B API key, reading from env var or netrc."""
+    """Return the current W&B API key.
+
+    Checks explicit override first, then falls back to env var / netrc.
+    """
+    explicit = _explicit_api_key.get()
+    if explicit is not None:
+        return explicit
     return weave_wandb_api_key()

--- a/weave/wandb_interface/project_creator.py
+++ b/weave/wandb_interface/project_creator.py
@@ -45,9 +45,16 @@ def wandb_logging_disabled() -> Iterator[None]:
     wandb.termerror = original_termerror
 
 
-def ensure_project_exists(entity_name: str, project_name: str) -> dict[str, str]:
+def ensure_project_exists(
+    entity_name: str,
+    project_name: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> dict[str, str]:
     with wandb_logging_disabled():
-        return _ensure_project_exists(entity_name, project_name)
+        return _ensure_project_exists(
+            entity_name, project_name, api_key=api_key, base_url=base_url
+        )
 
 
 def _call_wandb_api_with_retry(
@@ -98,13 +105,18 @@ def _raise_project_access_error(
     raise exception
 
 
-def _ensure_project_exists(entity_name: str, project_name: str) -> dict[str, str]:
+def _ensure_project_exists(
+    entity_name: str,
+    project_name: str,
+    api_key: str | None = None,
+    base_url: str | None = None,
+) -> dict[str, str]:
     """Ensures that a W&B project exists by trying to access it, returns the project_name,
     which is not guaranteed to be the same if the provided project_name contains invalid
     characters. Adheres to trace_server_interface.EnsureProjectExistsRes.
     """
     wandb_logging_disabled()
-    api = wandb.Api()
+    api = wandb.Api(api_key=api_key, base_url=base_url)
 
     # Check if the project already exists
     project_exception = None


### PR DESCRIPTION
## Summary

Resolves [WB-33023](https://coreweave.atlassian.net/browse/WB-33023)

Adds optional `api_key`, `base_url`, and `trace_server_url` keyword arguments to `weave.init()`, enabling programmatic authentication without environment variables.

### Motivation

External partners need to set the API key and base URL at runtime to support multi-tenant scenarios where multiple auth contexts coexist in the same process. The current workaround of mutating `os.environ` before calling `weave.init()` is brittle and error-prone.

### Design

Credentials are **eagerly resolved** at `WeaveClient` construction time and stored as immutable instance fields (`_api_key`, `_base_url`). When explicit params are provided they're used directly; otherwise the current env/netrc values are snapshotted once. This means:

- **No module-level globals** — removed `_explicit_base_url` from `env.py` and `_explicit_api_key` from `context.py`
- **No cross-client leakage** — each client carries its own credentials
- **Thread-safe by construction** — immutable fields readable from any `FutureExecutor` worker thread without synchronization
- **No lazy fallback** — downstream consumers read from the client, never from env

| Parameter | Overrides | Purpose |
|---|---|---|
| `api_key` | `WANDB_API_KEY` / netrc / `wandb.login()` | Authentication for trace server and entity resolution |
| `base_url` | `WANDB_BASE_URL` | W&B platform API URL; `trace_server_url` auto-derived from this |
| `trace_server_url` | `WF_TRACE_SERVER_URL` | Trace server URL — only needed when on a different host |

### Usage

```python
# Existing env var approach (unchanged)
weave.init("my-project")

# Direct params — trace_server_url auto-derived from base_url
weave.init("my-project", api_key=key, base_url="https://api.wandb.ai")

# Multi-client isolation
client_x = weave.init("proj-x", api_key=key_x, base_url=url_x)
client_y = weave.init("proj-y", api_key=key_y, base_url=url_y)
# client_x retains x's credentials — no cross-contamination
```

### Changes

**Credential storage & propagation (core):**
- `weave/trace/weave_client.py` — `WeaveClient` stores `_api_key`/`_base_url` (eagerly resolved); threads them to `ensure_project_exists`, URL generation, `create_call`, `get_calls`/`get_call`, `Call.children()`, WAL callbacks, `Chat`/`Completions`/`InferenceModels`
- `weave/trace/weave_init.py` — `init_weave()` resolves creds per call (no globals), derives `trace_server_url` from `base_url`, passes creds to all helpers
- `weave/wandb_interface/context.py` — Removed `_explicit_api_key` global; `get_wandb_api_context()` only reads env/netrc
- `weave/trace/env.py` — Removed `_explicit_base_url` global; `wandb_base_url()` only reads env/settings

**Credential consumers (all read from client instance):**
- `weave/compat/wandb/wandb_thin/internal_api.py` — `Api`/`ApiAsync` accept `api_key`/`base_url` in constructor
- `weave/trace/urls.py` — All URL helpers accept optional `base_url`
- `weave/trace/call.py` — `Call` carries `_base_url`; `make_client_call`/`_make_calls_iterator` thread it through
- `weave/chat/completions.py`, `weave/chat/inference_models.py` — Read from `self._client._api_key`
- `weave/wandb_interface/project_creator.py` — `ensure_project_exists()` accepts and passes `api_key`/`base_url`
- `weave/trace/init_message.py` — Uses explicit `base_url` for init message URL
- `weave/trace/api.py` — `init()` forwards new params; `publish()` passes client base_url; `finish()` simplified

**Server interface:**
- `weave/trace_server/service_interface.py` — `ensure_project_exists` accepts optional `api_key`/`base_url`
- `weave/trace_server_bindings/remote_http_trace_server.py` — Passes creds to `project_creator`
- `weave/trace_server_bindings/stainless_remote_http_trace_server.py` — Same
- `weave/trace_server/fake_service.py` — Updated signature

## Test plan

### Unit tests (`tests/trace/test_weave_init_auth.py` — 34 tests)

**Init flow:**
- Explicit `api_key` skips env/netrc auth
- Credentials stored on client instance (eagerly resolved from env when not explicit)
- Client reuse when no credential params; forced re-init when creds change
- `trace_server_url` derived from `base_url` (custom host, default host, explicit override)
- Version check uses effective trace server URL

**Credential passthrough (verified with mock assertions):**
- `ensure_project_exists` receives correct `api_key`/`base_url`
- `get_username` and `get_entity_project_from_project_name` receive creds
- `print_init_message` uses correct `base_url`
- `Completions`/`InferenceModels` prefer client key
- `Api` constructor stores creds

**Multi-client isolation:**
- Two clients retain independent credentials
- Module-level env readers unaffected by explicit init
- `Call.ui_url` uses client's `base_url` (with env fallback)
- Finishing one client doesn't affect another
- `create_call` stamps `_base_url` on Call

**Thread safety & callbacks:**
- `FutureExecutor` closure reads correct client credentials
- WAL callback passes `self._base_url` to `redirect_call`

**Other tests updated:**
- `test_client_trace.py`, `test_weave_client.py` — Updated expected `Call` objects to include `_base_url`
- `test_client_server_caching.py` — Made env-independent for `base_url`

### Manual validation (`rgao/weave_init_api_key_demo.ipynb`)
Tested against live prod and QA: env vars, multi-tenant switching, mixed env+params with auto-derivation, and client-scoped isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WB-33023]: https://coreweave.atlassian.net/browse/WB-33023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ