### PR TITLE
fix(weave): use fresh CH session for write-target resolution to prevent SESSION_IS_LOCKED

### DIFF
--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -304,7 +304,7 @@ def test_calls_complete_routing_by_residence(
     )
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server.ch_client,
+        clickhouse_trace_server._mint_client,
     )
     if read_table == ReadTable.CALLS_MERGED:
         expected_call_ids = {call.id, *merged_call_ids}
@@ -399,7 +399,7 @@ def test_calls_complete_routing_both_residence_state(
     # Verify resolver detects BOTH residence
     resolver = clickhouse_trace_server.table_routing_resolver
     residence = resolver._get_residence(
-        internal_project_id, clickhouse_trace_server.ch_client
+        internal_project_id, clickhouse_trace_server._mint_client
     )
     assert residence == ProjectDataResidence.BOTH, (
         f"Expected BOTH residence, got {residence}"
@@ -409,7 +409,7 @@ def test_calls_complete_routing_both_residence_state(
     # PART 3: Verify read routing in BOTH state
     # =========================================================================
     read_table = resolver.resolve_read_table(
-        internal_project_id, clickhouse_trace_server.ch_client
+        internal_project_id, clickhouse_trace_server._mint_client
     )
     assert read_table == ReadTable.CALLS_COMPLETE, (
         "BOTH residence should route reads to calls_complete"
@@ -428,7 +428,7 @@ def test_calls_complete_routing_both_residence_state(
     # =========================================================================
     # V2 writes should go to calls_complete
     v2_write_target = resolver.resolve_v2_write_target(
-        internal_project_id, clickhouse_trace_server.ch_client
+        internal_project_id, clickhouse_trace_server._mint_client
     )
     assert v2_write_target == WriteTarget.CALLS_COMPLETE, (
         "BOTH residence should route V2 writes to calls_complete"
@@ -515,7 +515,7 @@ def test_calls_complete_routing_both_residence_state(
     # V1 write target should be COMPLETE (signaling error should be raised)
     # because BOTH state has calls_complete data
     v1_write_target = resolver.resolve_v1_write_target(
-        internal_project_id, clickhouse_trace_server.ch_client
+        internal_project_id, clickhouse_trace_server._mint_client
     )
     assert v1_write_target == WriteTarget.CALLS_COMPLETE, (
         "V1 write target should be CALLS_COMPLETE for BOTH state to trigger error"
@@ -760,7 +760,7 @@ def test_call_start_end_v2_writes_calls_complete_for_empty_project(
     # Verify read-side returns the call with correct data
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server.ch_client,
+        clickhouse_trace_server._mint_client,
     )
     expected_call_ids = {call_id}
     calls = _fetch_calls_stream(trace_server, project_id)
@@ -998,7 +998,7 @@ def test_calls_query_routing_by_residence(
 
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server.ch_client,
+        clickhouse_trace_server._mint_client,
     )
     if seed_complete:
         assert read_table == ReadTable.CALLS_COMPLETE
@@ -1139,7 +1139,7 @@ def test_calls_complete_query_with_status_filter(trace_server, clickhouse_trace_
     # Verify we're reading from calls_complete
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server.ch_client,
+        clickhouse_trace_server._mint_client,
     )
     assert read_table == ReadTable.CALLS_COMPLETE
 
@@ -1432,7 +1432,7 @@ def test_project_stats_with_calls_complete(trace_server, clickhouse_trace_server
     # Verify we're reading from calls_complete
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server.ch_client,
+        clickhouse_trace_server._mint_client,
     )
     assert read_table == ReadTable.CALLS_COMPLETE
 
@@ -1518,10 +1518,10 @@ def test_project_stats_uses_correct_stats_table_based_on_residence(
 
     # Verify project residences
     read_table1 = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
-        internal_project1_id, clickhouse_trace_server.ch_client
+        internal_project1_id, clickhouse_trace_server._mint_client
     )
     read_table2 = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
-        internal_project2_id, clickhouse_trace_server.ch_client
+        internal_project2_id, clickhouse_trace_server._mint_client
     )
 
     assert read_table1 == ReadTable.CALLS_MERGED
@@ -1635,7 +1635,7 @@ def test_call_stats_with_calls_complete(trace_server, clickhouse_trace_server):
     # Verify we're reading from calls_complete
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server.ch_client,
+        clickhouse_trace_server._mint_client,
     )
     assert read_table == ReadTable.CALLS_COMPLETE
 

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -284,9 +284,13 @@ class TestLLMCompletionStreaming(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures before each test."""
-        self.server = chts.ClickHouseTraceServer(host="test_host")
         mock_ch_client = MagicMock()
         mock_ch_client.query.return_value = MagicMock(result_rows=[[0, 0]])
+        self._mint_patcher = patch.object(
+            chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+        )
+        self._mint_patcher.start()
+        self.server = chts.ClickHouseTraceServer(host="test_host")
         self.server._thread_local.ch_client = mock_ch_client
         self.mock_secret_fetcher = MagicMock()
         self.mock_secret_fetcher.fetch.return_value = {
@@ -299,6 +303,7 @@ class TestLLMCompletionStreaming(unittest.TestCase):
         self.token = _secret_fetcher_context.set(self.mock_secret_fetcher)
 
     def tearDown(self):
+        self._mint_patcher.stop()
         _secret_fetcher_context.reset(self.token)
 
     def test_basic_streaming_completion(self):
@@ -1308,11 +1313,14 @@ class TestResolveAndApplyPrompt(unittest.TestCase):
 @pytest.fixture
 def completions_mock_server():
     """Create a mock ClickHouseTraceServer for completions tests."""
-    server = chts.ClickHouseTraceServer(host="test_host")
     mock_ch_client = MagicMock()
     mock_ch_client.query.return_value = MagicMock(result_rows=[[0, 0]])
-    server._thread_local.ch_client = mock_ch_client
-    return server
+    with patch.object(
+        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host")
+        server._thread_local.ch_client = mock_ch_client
+        yield server
 
 
 @pytest.fixture

--- a/tests/trace_server/test_project_version.py
+++ b/tests/trace_server/test_project_version.py
@@ -33,16 +33,30 @@ def insert_call(ch_client, table: str, project_id: str):
 
 @contextmanager
 def count_queries(ch_client):
+    """Count CH queries made through the given client.
+
+    Returns a (get_count, mint_client) tuple. mint_client is a factory that
+    returns the counted client (with close() suppressed so the resolver
+    doesn't tear it down).
+    """
     call_count = 0
     original_query = ch_client.query
+    original_close = ch_client.close
 
     def counting_query(*args, **kwargs):
         nonlocal call_count
         call_count += 1
         return original_query(*args, **kwargs)
 
-    with patch.object(ch_client, "query", side_effect=counting_query):
-        yield lambda: call_count
+    with (
+        patch.object(ch_client, "query", side_effect=counting_query),
+        patch.object(ch_client, "close"),
+    ):
+
+        def _mint() -> type(ch_client):
+            return ch_client
+
+        yield lambda: call_count, _mint
 
 
 @pytest.mark.parametrize(
@@ -115,15 +129,15 @@ def test_version_resolution_by_table_contents(
         insert_call(ch_server.ch_client, table, project_id)
 
     assert (
-        resolver.resolve_read_table(project_id, ch_server.ch_client)
+        resolver.resolve_read_table(project_id, ch_server._mint_client)
         == expected_read_table
     )
     assert (
-        resolver.resolve_v1_write_target(project_id, ch_server.ch_client)
+        resolver.resolve_v1_write_target(project_id, ch_server._mint_client)
         == expected_v1_write_target
     )
     assert (
-        resolver.resolve_v2_write_target(project_id, ch_server.ch_client)
+        resolver.resolve_v2_write_target(project_id, ch_server._mint_client)
         == expected_v2_write_target
     )
 
@@ -153,22 +167,22 @@ def test_caching_behavior(client, trace_server):
     cached_proj = make_project_id("cached_project")
     insert_call(ch_server.ch_client, "calls_complete", cached_proj)
 
-    with count_queries(ch_server.ch_client) as get_count:
-        table1 = resolver.resolve_read_table(cached_proj, ch_server.ch_client)
+    with count_queries(ch_server.ch_client) as (get_count, mint):
+        table1 = resolver.resolve_read_table(cached_proj, mint)
         assert table1 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
-        table2 = resolver.resolve_read_table(cached_proj, ch_server.ch_client)
+        table2 = resolver.resolve_read_table(cached_proj, mint)
         assert table2 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
     empty_proj = make_project_id("empty_not_cached")
-    with count_queries(ch_server.ch_client) as get_count:
-        table1 = resolver.resolve_read_table(empty_proj, ch_server.ch_client)
+    with count_queries(ch_server.ch_client) as (get_count, mint):
+        table1 = resolver.resolve_read_table(empty_proj, mint)
         assert table1 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
-        table2 = resolver.resolve_read_table(empty_proj, ch_server.ch_client)
+        table2 = resolver.resolve_read_table(empty_proj, mint)
         assert table2 == ReadTable.CALLS_COMPLETE
         assert get_count() == 2
 
@@ -184,20 +198,20 @@ def test_mode_off_and_force_legacy(client, trace_server):
     insert_call(ch_server.ch_client, "calls_complete", project_id)
 
     resolver._mode = CallsStorageServerMode.OFF
-    with count_queries(ch_server.ch_client) as get_count:
-        table = resolver.resolve_read_table(project_id, ch_server.ch_client)
+    with count_queries(ch_server.ch_client) as (get_count, mint):
+        table = resolver.resolve_read_table(project_id, mint)
         assert table == ReadTable.CALLS_MERGED
         assert get_count() == 0
 
     resolver._mode = CallsStorageServerMode.FORCE_LEGACY
     # FORCE_LEGACY performs the query but returns MERGED
-    with count_queries(ch_server.ch_client) as get_count:
-        table = resolver.resolve_read_table(project_id, ch_server.ch_client)
+    with count_queries(ch_server.ch_client) as (get_count, mint):
+        table = resolver.resolve_read_table(project_id, mint)
         assert table == ReadTable.CALLS_MERGED
         assert get_count() == 1
 
     resolver._mode = CallsStorageServerMode.AUTO
-    table = resolver.resolve_read_table(project_id, ch_server.ch_client)
+    table = resolver.resolve_read_table(project_id, ch_server._mint_client)
     assert table == ReadTable.CALLS_COMPLETE
 
 
@@ -232,18 +246,18 @@ def test_resolver_as_trace_server_member(client, trace_server):
     project_id = make_project_id("trace_server_member")
     insert_call(ch_server.ch_client, "calls_complete", project_id)
 
-    with count_queries(ch_server.ch_client) as get_count:
+    with count_queries(ch_server.ch_client) as (get_count, mint):
         resolver1._mode = CallsStorageServerMode.AUTO
-        table = resolver1.resolve_read_table(project_id, ch_server.ch_client)
+        table = resolver1.resolve_read_table(project_id, mint)
         assert table == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
         # Subsequent requests hit the cache
-        table2 = resolver1.resolve_read_table(project_id, ch_server.ch_client)
+        table2 = resolver1.resolve_read_table(project_id, mint)
         assert table2 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
-        table3 = resolver2.resolve_read_table(project_id, ch_server.ch_client)
+        table3 = resolver2.resolve_read_table(project_id, mint)
         assert table3 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1496,7 +1496,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     ) -> Iterator[tsi.CallSchema]:
         """Fetch direct children of eval root IDs and optionally their children."""
         read_table = self.table_routing_resolver.resolve_read_table(
-            project_id, self.ch_client
+            project_id, self._mint_client
         )
         columns = sorted(
             [*REQUIRED_CALL_COLUMNS, *ALL_CALL_JSON_COLUMNS, "parent_id", "ended_at"]

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -454,6 +454,20 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._table_routing_resolver = TableRoutingResolver()
             return self._table_routing_resolver
 
+    def _resolve_v2_write_target(self, project_id: str) -> WriteTarget:
+        """Resolve write target using a fresh CH session to avoid session locking."""
+        with self.with_new_client():
+            return self.table_routing_resolver.resolve_v2_write_target(
+                project_id, self.ch_client
+            )
+
+    def _resolve_v1_write_target(self, project_id: str) -> WriteTarget:
+        """Resolve v1 write target using a fresh CH session to avoid session locking."""
+        with self.with_new_client():
+            return self.table_routing_resolver.resolve_v1_write_target(
+                project_id, self.ch_client
+            )
+
     @property
     def use_distributed_mode(self) -> bool:
         """Check if ClickHouse is configured to use distributed tables.
@@ -653,10 +667,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 for op_name, op_ref_uri in cached_op_refs.items():
                     self._op_ref_cache[req.project_id, op_name] = op_ref_uri
 
-        write_target = self.table_routing_resolver.resolve_v2_write_target(
-            req.project_id,
-            self.ch_client,
-        )
+        write_target = self._resolve_v2_write_target(req.project_id)
 
         # Build event callbacks (same for both write targets)
         event_callbacks = [
@@ -783,10 +794,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ch_call = start_call_for_insert_to_ch_insertable(req.start)
 
         # Check write target - v1 call_start cannot write to calls_complete
-        write_target = self.table_routing_resolver.resolve_v1_write_target(
-            ch_call.project_id,
-            self.ch_client,
-        )
+        write_target = self._resolve_v1_write_target(ch_call.project_id)
         if write_target == WriteTarget.CALLS_COMPLETE:
             raise CallsCompleteModeRequired(ch_call.project_id)
 
@@ -812,10 +820,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ch_call = end_call_for_insert_to_ch_insertable(req.end)
 
         # Check write target - v1 call_end cannot write to calls_complete
-        write_target = self.table_routing_resolver.resolve_v1_write_target(
-            ch_call.project_id,
-            self.ch_client,
-        )
+        write_target = self._resolve_v1_write_target(ch_call.project_id)
         if write_target == WriteTarget.CALLS_COMPLETE:
             raise CallsCompleteModeRequired(ch_call.project_id)
 
@@ -868,9 +873,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 # calls in the batch, subsequent calls just hit the in-memory cache. This
                 # is here for technical correctness, in case we relax project_id target
                 # constraints intra-batch
-                write_target = self.table_routing_resolver.resolve_v2_write_target(
-                    processed_complete_call.project_id,
-                    self.ch_client,
+                write_target = self._resolve_v2_write_target(
+                    processed_complete_call.project_id
                 )
 
                 ch_call = complete_call_to_ch_insertable(processed_complete_call)
@@ -897,10 +901,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         start_req = process_call_req_to_content(tsi.CallStartReq(start=req.start), self)
         ch_start = start_call_for_insert_to_ch_insertable(start_req.start)
 
-        write_target = self.table_routing_resolver.resolve_v2_write_target(
-            ch_start.project_id,
-            self.ch_client,
-        )
+        write_target = self._resolve_v2_write_target(ch_start.project_id)
         if write_target == WriteTarget.CALLS_COMPLETE:
             ch_complete_start = start_call_insertable_to_complete_start(ch_start)
             self._insert_call_complete(ch_complete_start)
@@ -924,10 +925,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         """
         req = process_call_req_to_content(req, self)
 
-        write_target = self.table_routing_resolver.resolve_v2_write_target(
-            req.end.project_id,
-            self.ch_client,
-        )
+        write_target = self._resolve_v2_write_target(req.end.project_id)
 
         # If writing to calls_complete, perform lightweight UPDATE
         if write_target == WriteTarget.CALLS_COMPLETE:
@@ -1658,10 +1656,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             all_calls=all_calls,
         )
 
-        write_target = self.table_routing_resolver.resolve_v1_write_target(
-            req.project_id,
-            self.ch_client,
-        )
+        write_target = self._resolve_v1_write_target(req.project_id)
         if write_target == WriteTarget.CALLS_COMPLETE:
             self._delete_calls_complete(req.project_id, all_descendants)
             return tsi.CallsDeleteRes(num_deleted=len(all_descendants))
@@ -1715,10 +1710,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         assert_non_null_wb_user_id(req)
         self._ensure_valid_update_field(req)
 
-        write_target = self.table_routing_resolver.resolve_v1_write_target(
-            req.project_id,
-            self.ch_client,
-        )
+        write_target = self._resolve_v1_write_target(req.project_id)
         if write_target == WriteTarget.CALLS_COMPLETE:
             self._update_calls_complete(req.project_id, req.call_id, req.display_name)
             return tsi.CallUpdateRes()
@@ -6025,10 +6017,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if not req.track_llm_call:
             return tsi.CompletionsCreateRes(response=res.response)
 
-        write_target = self.table_routing_resolver.resolve_v2_write_target(
-            req.project_id,
-            self.ch_client,
-        )
+        write_target = self._resolve_v2_write_target(req.project_id)
 
         req.inputs.messages = initial_messages
         call_id = generate_id()
@@ -6170,10 +6159,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         start_call: CallStartCHInsertable | None = None
         write_target: WriteTarget | None = None
         if req.track_llm_call:
-            write_target = self.table_routing_resolver.resolve_v2_write_target(
-                req.project_id,
-                self.ch_client,
-            )
+            write_target = self._resolve_v2_write_target(req.project_id)
             # Prepare inputs for tracking: use original messages (with template syntax)
             # and include prompt and template_vars
             tracked_inputs = req.inputs.model_dump(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -454,20 +454,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._table_routing_resolver = TableRoutingResolver()
             return self._table_routing_resolver
 
-    def _resolve_v2_write_target(self, project_id: str) -> WriteTarget:
-        """Resolve write target using a fresh CH session to avoid session locking."""
-        with self.with_new_client():
-            return self.table_routing_resolver.resolve_v2_write_target(
-                project_id, self.ch_client
-            )
-
-    def _resolve_v1_write_target(self, project_id: str) -> WriteTarget:
-        """Resolve v1 write target using a fresh CH session to avoid session locking."""
-        with self.with_new_client():
-            return self.table_routing_resolver.resolve_v1_write_target(
-                project_id, self.ch_client
-            )
-
     @property
     def use_distributed_mode(self) -> bool:
         """Check if ClickHouse is configured to use distributed tables.
@@ -667,7 +653,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 for op_name, op_ref_uri in cached_op_refs.items():
                     self._op_ref_cache[req.project_id, op_name] = op_ref_uri
 
-        write_target = self._resolve_v2_write_target(req.project_id)
+        write_target = self.table_routing_resolver.resolve_v2_write_target(
+            req.project_id, self._mint_client
+        )
 
         # Build event callbacks (same for both write targets)
         event_callbacks = [
@@ -794,7 +782,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ch_call = start_call_for_insert_to_ch_insertable(req.start)
 
         # Check write target - v1 call_start cannot write to calls_complete
-        write_target = self._resolve_v1_write_target(ch_call.project_id)
+        write_target = self.table_routing_resolver.resolve_v1_write_target(
+            ch_call.project_id, self._mint_client
+        )
         if write_target == WriteTarget.CALLS_COMPLETE:
             raise CallsCompleteModeRequired(ch_call.project_id)
 
@@ -820,7 +810,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ch_call = end_call_for_insert_to_ch_insertable(req.end)
 
         # Check write target - v1 call_end cannot write to calls_complete
-        write_target = self._resolve_v1_write_target(ch_call.project_id)
+        write_target = self.table_routing_resolver.resolve_v1_write_target(
+            ch_call.project_id, self._mint_client
+        )
         if write_target == WriteTarget.CALLS_COMPLETE:
             raise CallsCompleteModeRequired(ch_call.project_id)
 
@@ -873,8 +865,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 # calls in the batch, subsequent calls just hit the in-memory cache. This
                 # is here for technical correctness, in case we relax project_id target
                 # constraints intra-batch
-                write_target = self._resolve_v2_write_target(
-                    processed_complete_call.project_id
+                write_target = self.table_routing_resolver.resolve_v2_write_target(
+                    processed_complete_call.project_id, self._mint_client
                 )
 
                 ch_call = complete_call_to_ch_insertable(processed_complete_call)
@@ -901,7 +893,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         start_req = process_call_req_to_content(tsi.CallStartReq(start=req.start), self)
         ch_start = start_call_for_insert_to_ch_insertable(start_req.start)
 
-        write_target = self._resolve_v2_write_target(ch_start.project_id)
+        write_target = self.table_routing_resolver.resolve_v2_write_target(
+            ch_start.project_id, self._mint_client
+        )
         if write_target == WriteTarget.CALLS_COMPLETE:
             ch_complete_start = start_call_insertable_to_complete_start(ch_start)
             self._insert_call_complete(ch_complete_start)
@@ -925,7 +919,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         """
         req = process_call_req_to_content(req, self)
 
-        write_target = self._resolve_v2_write_target(req.end.project_id)
+        write_target = self.table_routing_resolver.resolve_v2_write_target(
+            req.end.project_id, self._mint_client
+        )
 
         # If writing to calls_complete, perform lightweight UPDATE
         if write_target == WriteTarget.CALLS_COMPLETE:
@@ -1046,7 +1042,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         aggregate statistics that are not directly queryable from the calls themselves.
         """
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self.ch_client
+            req.project_id, self._mint_client
         )
         pb = ParamBuilder()
         query, columns = build_calls_stats_query(req, pb, read_table)
@@ -1188,7 +1184,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Resolve which table to read from based on project data residence
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self.ch_client
+            req.project_id, self._mint_client
         )
 
         token_metrics, requested_cost_metrics = split_usage_metrics(req.usage_metrics)
@@ -1359,7 +1355,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
         """Returns a stream of calls that match the given query."""
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self.ch_client
+            req.project_id, self._mint_client
         )
         settings = None
         cq = CallsQuery(
@@ -1656,7 +1652,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             all_calls=all_calls,
         )
 
-        write_target = self._resolve_v1_write_target(req.project_id)
+        write_target = self.table_routing_resolver.resolve_v1_write_target(
+            req.project_id, self._mint_client
+        )
         if write_target == WriteTarget.CALLS_COMPLETE:
             self._delete_calls_complete(req.project_id, all_descendants)
             return tsi.CallsDeleteRes(num_deleted=len(all_descendants))
@@ -1710,7 +1708,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         assert_non_null_wb_user_id(req)
         self._ensure_valid_update_field(req)
 
-        write_target = self._resolve_v1_write_target(req.project_id)
+        write_target = self.table_routing_resolver.resolve_v1_write_target(
+            req.project_id, self._mint_client
+        )
         if write_target == WriteTarget.CALLS_COMPLETE:
             self._update_calls_complete(req.project_id, req.call_id, req.display_name)
             return tsi.CallUpdateRes()
@@ -2582,7 +2582,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Resolve which table to read from based on project data residence
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self.ch_client
+            req.project_id, self._mint_client
         )
 
         pb = ParamBuilder()
@@ -2609,7 +2609,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     ) -> Iterator[tsi.ThreadSchema]:
         """Stream threads with aggregated statistics sorted by last activity."""
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self.ch_client
+            req.project_id, self._mint_client
         )
         pb = ParamBuilder()
 
@@ -2952,7 +2952,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Step 0: Determine which table to query based on project data residence
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self.ch_client
+            req.project_id, self._mint_client
         )
 
         # Step 1: Check for existing calls (duplicate prevention)
@@ -6017,7 +6017,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if not req.track_llm_call:
             return tsi.CompletionsCreateRes(response=res.response)
 
-        write_target = self._resolve_v2_write_target(req.project_id)
+        write_target = self.table_routing_resolver.resolve_v2_write_target(
+            req.project_id, self._mint_client
+        )
 
         req.inputs.messages = initial_messages
         call_id = generate_id()
@@ -6159,7 +6161,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         start_call: CallStartCHInsertable | None = None
         write_target: WriteTarget | None = None
         if req.track_llm_call:
-            write_target = self._resolve_v2_write_target(req.project_id)
+            write_target = self.table_routing_resolver.resolve_v2_write_target(
+                req.project_id, self._mint_client
+            )
             # Prepare inputs for tracking: use original messages (with template syntax)
             # and include prompt and template_vars
             tracked_inputs = req.inputs.model_dump(

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -1,5 +1,6 @@
 import logging
 import threading
+from collections.abc import Callable
 
 import ddtrace
 from cachetools import LRUCache
@@ -15,6 +16,10 @@ from weave.trace_server.project_version.types import (
     ReadTable,
     WriteTarget,
 )
+
+# Factory callable that creates a fresh CH client. The consumer
+# (e.g. _get_residence) is responsible for closing the returned client.
+MintClient = Callable[[], CHClient]
 
 logger = logging.getLogger(__name__)
 
@@ -48,14 +53,21 @@ class TableRoutingResolver:
         self._mode = CallsStorageServerMode.from_env()
 
     def _get_residence(
-        self, project_id: str, ch_client: CHClient
+        self, project_id: str, mint_client: MintClient
     ) -> ProjectDataResidence:
         with _project_residence_cache_lock:
             cached = _project_residence_cache.get(project_id)
         if cached is not None:
             return cached
 
-        residence = get_project_data_residence(project_id, ch_client)
+        # Mint a fresh client so the residence query runs on its own CH
+        # session, preventing SESSION_IS_LOCKED when the caller subsequently
+        # performs inserts on the main thread-local session.
+        client = mint_client()
+        try:
+            residence = get_project_data_residence(project_id, client)
+        finally:
+            client.close()
 
         # Log warning if we detect dual residency - data should only ever be in
         # calls_merged OR calls_complete, not both. This is handled gracefully but
@@ -77,12 +89,14 @@ class TableRoutingResolver:
         return residence
 
     @ddtrace.tracer.wrap(name="table_routing.resolve_read_table")
-    def resolve_read_table(self, project_id: str, ch_client: CHClient) -> ReadTable:
+    def resolve_read_table(
+        self, project_id: str, mint_client: MintClient
+    ) -> ReadTable:
         """Resolve which table to read from for a given project."""
         if self._mode == CallsStorageServerMode.OFF:
             return ReadTable.CALLS_MERGED
 
-        residence = self._get_residence(project_id, ch_client)
+        residence = self._get_residence(project_id, mint_client)
         set_current_span_dd_tags(
             {
                 "project_version.residence": residence.value,
@@ -109,7 +123,7 @@ class TableRoutingResolver:
     def resolve_v1_write_target(
         self,
         project_id: str,
-        ch_client: CHClient,
+        mint_client: MintClient,
     ) -> WriteTarget:
         """Resolve write target for V1 (legacy) API calls.
 
@@ -119,7 +133,7 @@ class TableRoutingResolver:
 
         Args:
             project_id: The internal project ID.
-            ch_client: ClickHouse client instance.
+            mint_client: Factory that creates a fresh CH client with its own session.
 
         Returns:
             WriteTarget indicating which table to write to.
@@ -127,7 +141,7 @@ class TableRoutingResolver:
         if self._mode == CallsStorageServerMode.OFF:
             return WriteTarget.CALLS_MERGED
 
-        residence = self._get_residence(project_id, ch_client)
+        residence = self._get_residence(project_id, mint_client)
         set_current_span_dd_tags(
             {
                 "project_version.residence": residence.value,
@@ -154,7 +168,7 @@ class TableRoutingResolver:
     def resolve_v2_write_target(
         self,
         project_id: str,
-        ch_client: CHClient,
+        mint_client: MintClient,
     ) -> WriteTarget:
         """Resolve write target for V2 API calls.
 
@@ -162,7 +176,7 @@ class TableRoutingResolver:
 
         Args:
             project_id: The internal project ID.
-            ch_client: ClickHouse client instance.
+            mint_client: Factory that creates a fresh CH client with its own session.
 
         Returns:
             WriteTarget indicating which table to write to.
@@ -170,7 +184,7 @@ class TableRoutingResolver:
         if self._mode == CallsStorageServerMode.OFF:
             return WriteTarget.CALLS_MERGED
 
-        residence = self._get_residence(project_id, ch_client)
+        residence = self._get_residence(project_id, mint_client)
         set_current_span_dd_tags(
             {
                 "project_version.residence": residence.value,

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -89,9 +89,7 @@ class TableRoutingResolver:
         return residence
 
     @ddtrace.tracer.wrap(name="table_routing.resolve_read_table")
-    def resolve_read_table(
-        self, project_id: str, mint_client: MintClient
-    ) -> ReadTable:
+    def resolve_read_table(self, project_id: str, mint_client: MintClient) -> ReadTable:
         """Resolve which table to read from for a given project."""
         if self._mode == CallsStorageServerMode.OFF:
             return ReadTable.CALLS_MERGED


### PR DESCRIPTION
https://coreweave.atlassian.net/browse/WB-30704

## Summary

- Seeing `SESSION_IS_LOCKED (373)` errors on the `upsert_batch` / write paths in production against CH Cloud
- Root cause: `resolve_v{1,2}_write_target` does a `ch_client.query()` (on residence cache miss) using the same thread-local session that subsequent inserts use. With CH Cloud's load balancer and the shared `_CH_POOL_MANAGER`, these can route through different HTTP connections where the session lock hasn't fully cleared
- Same fix pattern as 463e92daed (`query_stream` path): mint a fresh client with its own session for the residence query so it never conflicts with mutations
- Added `_resolve_v2_write_target` / `_resolve_v1_write_target` helpers that encapsulate the `with_new_client()` pattern, applied to all 10 call sites