### PR TITLE
chore(weave): replicated ClickHouse CI test run for trace shard

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -287,6 +287,87 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  trace-server-replicated-tests:
+    name: Trace server replicated ClickHouse tests
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version-major: ["3"]
+        python-version-minor: ["12"]
+      fail-fast: false
+    services:
+      wandbservice:
+        image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
+        credentials:
+          username: _json_key
+          password: ${{ secrets.gcp_wb_sa_key }}
+        env:
+          CI: 1
+          WANDB_ENABLE_TEST_CONTAINER: true
+          LOGGING_ENABLED: true
+        ports:
+          - "8080:8080"
+          - "8083:8083"
+          - "9015:9015"
+        options: >-
+          --health-cmd "wget -q -O /dev/null http://localhost:8080/healthz || exit 1"
+          --health-interval=5s
+          --health-timeout=3s
+          --health-start-period=10s
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Start ClickHouse with embedded Keeper
+        run: |
+          docker run -d --rm \
+            -e CLICKHOUSE_DB=default \
+            -e CLICKHOUSE_USER=default \
+            -e "CLICKHOUSE_PASSWORD=" \
+            -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
+            -p 8123:8123 \
+            -v ${{ github.workspace }}/tests/trace_server/conftest_lib/clickhouse_keeper_config.xml:/etc/clickhouse-server/config.d/keeper.xml \
+            --name weave-test-keeper-replicated \
+            --ulimit nofile=262144:262144 \
+            clickhouse/clickhouse-server:25.11.2.24
+          # Wait for server to be healthy
+          for i in $(seq 1 30); do
+            wget -q -O- 'http://localhost:8123/ping' && break || sleep 1
+          done
+      - name: Install SQLite dev package
+        run: sudo apt update && sudo apt install -y libsqlite3-dev
+      - name: Install Libmagic dependency package
+        run: sudo apt update && sudo apt install -y libmagic1
+      - name: Set up Python ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox uv
+      - name: Run nox (Replicated ClickHouse Trace Server)
+        env:
+          WEAVE_SENTRY_ENV: ci
+          CI: 1
+          WB_SERVER_HOST: http://wandbservice
+          WF_CLICKHOUSE_HOST: localhost
+          WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
+          DD_TRACE_ENABLED: false
+          OPENAI_API_KEY: sk-1234567890abcdef1234567890abcdef
+        run: |
+          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server')" -- \
+            -m "trace_server and not skip_clickhouse_client" \
+            --clickhouse-replicated
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          flags: trace-server-replicated
+          name: trace-server-replicated-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   trace-tests-matrix-check: # This job does nothing and is only used for the branch protection
     if: always()
 
@@ -294,6 +375,7 @@ jobs:
       - trace-tests
       - trace_no_server
       - trace-server-migrator-tests
+      - trace-server-replicated-tests
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -359,12 +359,14 @@ jobs:
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace')" -- \
             -m "trace_server and not skip_clickhouse_client" \
             --clickhouse-replicated \
-            --ignore=tests/trace/test_obj_tags_aliases.py \
-            --ignore=tests/trace/test_client_server_caching.py \
-            --ignore=tests/trace/test_custom_objs.py \
-            --ignore=tests/trace/test_deepcopy.py \
-            --ignore=tests/trace/test_op_argument_forms.py \
-            --ignore=tests/trace/test_op_accumulator.py
+            tests/trace/test_weave_client.py \
+            tests/trace/test_weave_client_mutations.py \
+            tests/trace/test_client_annotation_queues.py \
+            tests/trace/test_feedback.py \
+            tests/trace/test_log_call.py \
+            tests/trace/test_client_trace.py \
+            tests/trace/test_queue_filtering.py \
+            tests/trace_server/test_calls_complete.py
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -358,7 +358,8 @@ jobs:
         run: |
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace')" -- \
             -m "trace_server and not skip_clickhouse_client" \
-            --clickhouse-replicated
+            --clickhouse-replicated \
+            --ignore=tests/trace/test_obj_tags_aliases.py  # TODO: remove once these tests are consolidated (132 tests, all obj reads/writes, no CH mutations)
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -287,10 +287,10 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  trace-server-replicated-tests:
-    name: Replicated ClickHouse trace_server tests
+  trace-replicated-tests:
+    name: Replicated ClickHouse trace tests
     timeout-minutes: 15
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8-cores
     strategy:
       matrix:
         python-version-major: ["3"]
@@ -356,16 +356,15 @@ jobs:
           DD_TRACE_ENABLED: false
           OPENAI_API_KEY: sk-1234567890abcdef1234567890abcdef
         run: |
-          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server')" -- \
+          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace')" -- \
             -m "trace_server and not skip_clickhouse_client" \
-            --clickhouse-replicated \
-            --ignore=tests/trace_server/query_builder
+            --clickhouse-replicated
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
-          flags: trace-server-replicated
-          name: trace-server-replicated-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+          flags: trace-replicated
+          name: trace-replicated-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -376,7 +375,7 @@ jobs:
       - trace-tests
       - trace_no_server
       - trace-server-migrator-tests
-      - trace-server-replicated-tests
+      - trace-replicated-tests
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -358,7 +358,8 @@ jobs:
         run: |
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server')" -- \
             -m "trace_server and not skip_clickhouse_client" \
-            --clickhouse-replicated
+            --clickhouse-replicated \
+            --ignore=tests/trace_server/query_builder
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -288,13 +288,16 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   trace-server-replicated-tests:
-    name: Trace server replicated ClickHouse tests
+    name: Replicated ClickHouse tests (${{ matrix.nox-shard }})
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version-major: ["3"]
         python-version-minor: ["12"]
+        nox-shard:
+          - "trace_server"
+          - "trace_calls_complete_only"
       fail-fast: false
     services:
       wandbservice:
@@ -346,31 +349,18 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install nox uv
-      - name: Run nox (Replicated ClickHouse Trace Server)
+      - name: Run nox (Replicated ClickHouse)
         env:
           WEAVE_SENTRY_ENV: ci
           CI: 1
           WB_SERVER_HOST: http://wandbservice
           WF_CLICKHOUSE_HOST: localhost
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
+          WEAVE_USE_CALLS_COMPLETE: ${{ matrix.nox-shard == 'trace_calls_complete_only' && 'true' || '' }}
           DD_TRACE_ENABLED: false
           OPENAI_API_KEY: sk-1234567890abcdef1234567890abcdef
         run: |
-          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server')" -- \
-            -m "trace_server and not skip_clickhouse_client" \
-            --clickhouse-replicated
-      - name: Run nox (Replicated ClickHouse Calls Complete)
-        env:
-          WEAVE_SENTRY_ENV: ci
-          CI: 1
-          WB_SERVER_HOST: http://wandbservice
-          WF_CLICKHOUSE_HOST: localhost
-          WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
-          WEAVE_USE_CALLS_COMPLETE: "true"
-          DD_TRACE_ENABLED: false
-          OPENAI_API_KEY: sk-1234567890abcdef1234567890abcdef
-        run: |
-          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_calls_complete_only')" -- \
+          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.nox-shard }}')" -- \
             -m "trace_server and not skip_clickhouse_client" \
             --clickhouse-replicated
       - name: Upload coverage reports to Codecov
@@ -378,7 +368,7 @@ jobs:
         with:
           files: ./coverage.xml
           flags: trace-server-replicated
-          name: trace-server-replicated-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+          name: trace-server-replicated-${{ matrix.nox-shard }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -290,7 +290,7 @@ jobs:
   trace-replicated-tests:
     name: Replicated ClickHouse trace tests
     timeout-minutes: 30
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
         python-version-major: ["3"]
@@ -359,7 +359,12 @@ jobs:
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace')" -- \
             -m "trace_server and not skip_clickhouse_client" \
             --clickhouse-replicated \
-            --ignore=tests/trace/test_obj_tags_aliases.py  # TODO: remove once these tests are consolidated (132 tests, all obj reads/writes, no CH mutations)
+            --ignore=tests/trace/test_obj_tags_aliases.py \
+            --ignore=tests/trace/test_client_server_caching.py \
+            --ignore=tests/trace/test_custom_objs.py \
+            --ignore=tests/trace/test_deepcopy.py \
+            --ignore=tests/trace/test_op_argument_forms.py \
+            --ignore=tests/trace/test_op_accumulator.py
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -359,6 +359,20 @@ jobs:
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server')" -- \
             -m "trace_server and not skip_clickhouse_client" \
             --clickhouse-replicated
+      - name: Run nox (Replicated ClickHouse Calls Complete)
+        env:
+          WEAVE_SENTRY_ENV: ci
+          CI: 1
+          WB_SERVER_HOST: http://wandbservice
+          WF_CLICKHOUSE_HOST: localhost
+          WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
+          WEAVE_USE_CALLS_COMPLETE: "true"
+          DD_TRACE_ENABLED: false
+          OPENAI_API_KEY: sk-1234567890abcdef1234567890abcdef
+        run: |
+          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_calls_complete_only')" -- \
+            -m "trace_server and not skip_clickhouse_client" \
+            --clickhouse-replicated
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -289,7 +289,7 @@ jobs:
 
   trace-replicated-tests:
     name: Replicated ClickHouse trace tests
-    timeout-minutes: 15
+    timeout-minutes: 30
     runs-on: ubuntu-latest-8-cores
     strategy:
       matrix:
@@ -376,7 +376,7 @@ jobs:
       - trace-tests
       - trace_no_server
       - trace-server-migrator-tests
-      - trace-replicated-tests
+      # trace-replicated-tests is intentionally non-blocking — informational only
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -288,16 +288,13 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   trace-server-replicated-tests:
-    name: Replicated ClickHouse tests (${{ matrix.nox-shard }})
+    name: Replicated ClickHouse trace_server tests
     timeout-minutes: 15
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version-major: ["3"]
         python-version-minor: ["12"]
-        nox-shard:
-          - "trace_server"
-          - "trace_calls_complete_only"
       fail-fast: false
     services:
       wandbservice:
@@ -356,11 +353,10 @@ jobs:
           WB_SERVER_HOST: http://wandbservice
           WF_CLICKHOUSE_HOST: localhost
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
-          WEAVE_USE_CALLS_COMPLETE: ${{ matrix.nox-shard == 'trace_calls_complete_only' && 'true' || '' }}
           DD_TRACE_ENABLED: false
           OPENAI_API_KEY: sk-1234567890abcdef1234567890abcdef
         run: |
-          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.nox-shard }}')" -- \
+          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server')" -- \
             -m "trace_server and not skip_clickhouse_client" \
             --clickhouse-replicated
       - name: Upload coverage reports to Codecov
@@ -368,7 +364,7 @@ jobs:
         with:
           files: ./coverage.xml
           flags: trace-server-replicated
-          name: trace-server-replicated-${{ matrix.nox-shard }}
+          name: trace-server-replicated-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -383,7 +383,7 @@ jobs:
       - trace-tests
       - trace_no_server
       - trace-server-migrator-tests
-      # trace-replicated-tests is intentionally non-blocking — informational only
+      - trace-replicated-tests
 
     runs-on: ubuntu-latest
 

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -69,6 +69,12 @@ def pytest_addoption(parser):
             default="remote",
             help="Specify the remote HTTP trace server implementation: remote or stainless",
         )
+        parser.addoption(
+            "--clickhouse-replicated",
+            action="store_true",
+            default=False,
+            help="Run ClickHouse tests in replicated mode (requires Keeper-enabled CH)",
+        )
     except ValueError:
         pass
 
@@ -134,6 +140,10 @@ def _get_worker_db_suffix(request, default: str = "_test") -> str:
     return f"_w{worker_id.replace('gw', '')}"
 
 
+REPLICATED_CLUSTER = "weave_cluster"
+REPLICATED_PATH = "/clickhouse/tables/{db}"
+
+
 # Tables with migration-seeded data that should NOT be truncated between tests.
 SEED_DATA_TABLES = frozenset({"llm_token_prices"})
 
@@ -196,6 +206,8 @@ def _ch_session_server(
         yield None
         return
 
+    use_replicated = request.config.getoption("--clickhouse-replicated", default=False)
+
     host, port = next(ensure_clickhouse_db())
     db_suffix = _get_worker_db_suffix(request)
 
@@ -205,6 +217,17 @@ def _ch_session_server(
     management_db = f"db_management{db_suffix}"
 
     os.environ["WF_CLICKHOUSE_DATABASE"] = unique_db
+
+    # Set replicated env vars so the batched server picks them up at runtime
+    saved_env: dict[str, str | None] = {}
+    if use_replicated:
+        for key, val in [
+            ("WF_CLICKHOUSE_REPLICATED", "true"),
+            ("WF_CLICKHOUSE_REPLICATED_CLUSTER", REPLICATED_CLUSTER),
+            ("WF_CLICKHOUSE_REPLICATED_PATH", REPLICATED_PATH),
+        ]:
+            saved_env[key] = os.environ.get(key)
+            os.environ[key] = val
 
     id_converter = DummyIdConverter()
     ch_server = clickhouse_trace_server_batched.ClickHouseTraceServer(
@@ -223,7 +246,11 @@ def _ch_session_server(
 
     def patched_run_migrations():
         migrator = wf_migrator.get_clickhouse_trace_server_migrator(
-            ch_server._mint_client(), management_db=management_db
+            ch_server._mint_client(),
+            management_db=management_db,
+            replicated=use_replicated,
+            replicated_cluster=REPLICATED_CLUSTER if use_replicated else None,
+            replicated_path=REPLICATED_PATH if use_replicated else None,
         )
         migrator.apply_migrations(ch_server._database)
 
@@ -244,6 +271,13 @@ def _ch_session_server(
         os.environ.pop("WF_CLICKHOUSE_DATABASE", None)
     else:
         os.environ["WF_CLICKHOUSE_DATABASE"] = original_db
+
+    # Restore replicated env vars
+    for key, original_val in saved_env.items():
+        if original_val is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = original_val
 
     # Session cleanup: drop databases
     try:

--- a/tests/trace_server/conftest_lib/clickhouse_server.py
+++ b/tests/trace_server/conftest_lib/clickhouse_server.py
@@ -89,6 +89,86 @@ def ensure_clickhouse_db_container_running(host: str, port: int) -> Callable[[],
     return cleanup
 
 
+def ensure_clickhouse_db_keeper_container_running(
+    host: str, port: int
+) -> Callable[[], None]:
+    """Start a ClickHouse container with embedded Keeper for replicated-mode tests.
+
+    Uses the same clickhouse_keeper_config.xml as the migrator functional tests
+    to enable Keeper, cluster definitions, and macros needed for ReplicatedMergeTree.
+    """
+    server_up = check_server_up(host, port, 1)
+    started_container = None
+
+    if not server_up:
+        container_name = "weave-python-test-clickhouse-keeper"
+
+        subprocess.run(
+            ["docker", "stop", container_name], capture_output=True, check=False
+        )
+        subprocess.run(
+            ["docker", "rm", container_name], capture_output=True, check=False
+        )
+
+        # Resolve the keeper config path relative to this file
+        config_path = os.path.join(
+            os.path.dirname(__file__), "clickhouse_keeper_config.xml"
+        )
+
+        process = subprocess.Popen(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--rm",
+                "-e",
+                "CLICKHOUSE_DB=default",
+                "-e",
+                "CLICKHOUSE_USER=default",
+                "-e",
+                "CLICKHOUSE_PASSWORD=",
+                "-e",
+                "CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1",
+                "-p",
+                f"{port}:8123",
+                "-v",
+                f"{config_path}:/etc/clickhouse-server/config.d/keeper.xml",
+                "--name",
+                container_name,
+                "--ulimit",
+                "nofile=262144:262144",
+                "clickhouse/clickhouse-server:25.11.2.24",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        stdout, stderr = process.communicate()
+        if process.returncode != 0:
+            pytest.fail(
+                f"Failed to start ClickHouse Keeper container: {stderr.decode()}"
+            )
+
+        started_container = container_name
+
+        server_up = check_server_up(host, port)
+        if not server_up:
+            subprocess.run(
+                ["docker", "stop", container_name], capture_output=True, check=False
+            )
+            pytest.fail(
+                f"ClickHouse Keeper server failed to become healthy on {host}:{port}"
+            )
+
+    def cleanup():
+        if started_container:
+            subprocess.run(
+                ["docker", "stop", started_container], capture_output=True, check=False
+            )
+
+    return cleanup
+
+
 def ensure_clickhouse_db_process_running(host: str, port: int) -> Callable[[], None]:
     """ClickHouse server fixture that automatically starts a server process if one isn't already running.
 
@@ -187,7 +267,15 @@ def ensure_clickhouse_db(
         if os.environ.get("CI"):
             yield host, port
             return
-        if request.config.getoption("--clickhouse-process") == "true":
+        use_replicated = request.config.getoption(
+            "--clickhouse-replicated", default=False
+        )
+        if use_replicated:
+            cleanup = ensure_clickhouse_db_keeper_container_running(
+                host=host,
+                port=port,
+            )
+        elif request.config.getoption("--clickhouse-process") == "true":
             cleanup = ensure_clickhouse_db_process_running(
                 host=host,
                 port=port,


### PR DESCRIPTION
## Summary

Adds CI coverage for replicated ClickHouse mode — the mode that broke in #6574 and had zero test coverage.

- New `--clickhouse-replicated` pytest flag configures the test CH server in replicated mode (Keeper-enabled, `ReplicatedMergeTree` tables, `WF_CLICKHOUSE_REPLICATED_CLUSTER` set)
- Runs the `trace` shard (end-to-end client->server->CH tests) on an 8-core runner with pytest-xdist parallel workers
- Python 3.12 only

**Non blocking, because it takes forever**

## Overhead

+1 `ubuntu-latest-8-cores` runner, ~30 min timeout.