### PR TITLE
fix(weave): avoid returning same call multiple times if it has multiple feedbacks

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -3583,52 +3583,6 @@ def test_calls_stream_feedback(client):
     } in call2_payloads
 
 
-def test_feedback_filter_does_not_duplicate_calls(client):
-    """Regression test: filtering by feedback should not return duplicate calls.
-
-    When feedback LEFT JOINs the calls table, a call with multiple feedback
-    entries produces multiple joined rows. Without deduplication, the same call
-    appears multiple times in the results.
-    """
-
-    @weave.op
-    def my_op(x):
-        return x
-
-    my_op(1)
-    my_op(2)
-
-    calls = list(my_op.calls())
-    assert len(calls) == 2
-
-    project_id = get_client_project_id(client)
-
-    # multiple feedbacks on same call should trigger row multiplication in LEFT JOIN
-    calls[0].feedback.add_reaction("👍")
-    calls[0].feedback.add_reaction("👍")
-
-    res = client.server.calls_query_stream(
-        tsi.CallsQueryReq(
-            project_id=project_id,
-            query=tsi.Query.model_validate(
-                {
-                    "$expr": {
-                        "$eq": [
-                            {"$getField": "feedback.[wandb.reaction.1].payload.emoji"},
-                            {"$literal": "👍"},
-                        ]
-                    }
-                }
-            ),
-        )
-    )
-    results = list(res)
-
-    # call should be deduped and appear once in result set.
-    assert len(results) == 1
-    assert results[0].id == calls[0].id
-
-
 def test_inline_dataclass_generates_no_refs_in_function(client):
     @dataclasses.dataclass
     class A:

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -3583,6 +3583,52 @@ def test_calls_stream_feedback(client):
     } in call2_payloads
 
 
+def test_feedback_filter_does_not_duplicate_calls(client):
+    """Regression test: filtering by feedback should not return duplicate calls.
+
+    When feedback LEFT JOINs the calls table, a call with multiple feedback
+    entries produces multiple joined rows. Without deduplication, the same call
+    appears multiple times in the results.
+    """
+
+    @weave.op
+    def my_op(x):
+        return x
+
+    my_op(1)
+    my_op(2)
+
+    calls = list(my_op.calls())
+    assert len(calls) == 2
+
+    project_id = get_client_project_id(client)
+
+    # multiple feedbacks on same call should trigger row multiplication in LEFT JOIN
+    calls[0].feedback.add_reaction("👍")
+    calls[0].feedback.add_reaction("👍")
+
+    res = client.server.calls_query_stream(
+        tsi.CallsQueryReq(
+            project_id=project_id,
+            query=tsi.Query.model_validate(
+                {
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "feedback.[wandb.reaction.1].payload.emoji"},
+                            {"$literal": "👍"},
+                        ]
+                    }
+                }
+            ),
+        )
+    )
+    results = list(res)
+
+    # call should be deduped and appear once in result set.
+    assert len(results) == 1
+    assert results[0].id == calls[0].id
+
+
 def test_inline_dataclass_generates_no_refs_in_function(client):
     @dataclasses.dataclass
     class A:

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -711,7 +711,7 @@ def test_query_with_simple_feedback_sort_and_filter() -> None:
 
 
 def test_query_with_simple_feedback_filter_calls_complete() -> None:
-    """Test feedback filter on calls_complete uses DISTINCT to avoid row duplication."""
+    """Test feedback filter on calls_complete table - should NOT use GROUP BY or aggregation."""
     cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
     cq.add_field("id")
     cq.add_condition(
@@ -3332,7 +3332,7 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
 
 
 def test_query_with_simple_feedback_sort_calls_complete() -> None:
-    """Ensure feedback sorting uses calls_complete with DISTINCT for dedup."""
+    """Ensure feedback sorting uses calls_complete."""
     cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
     cq.add_field("id")
     cq.add_order("feedback.[wandb.runnable.my_op].payload.output.expected", "desc")

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -711,7 +711,7 @@ def test_query_with_simple_feedback_sort_and_filter() -> None:
 
 
 def test_query_with_simple_feedback_filter_calls_complete() -> None:
-    """Test feedback filter on calls_complete table - should NOT use GROUP BY or aggregation."""
+    """Test feedback filter on calls_complete uses DISTINCT to avoid row duplication."""
     cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
     cq.add_field("id")
     cq.add_condition(
@@ -731,7 +731,7 @@ def test_query_with_simple_feedback_filter_calls_complete() -> None:
     assert_sql(
         cq,
         """
-        SELECT
+        SELECT DISTINCT
             calls_complete.id AS id
         FROM
             calls_complete
@@ -3332,14 +3332,14 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
 
 
 def test_query_with_simple_feedback_sort_calls_complete() -> None:
-    """Ensure feedback sorting uses calls_complete."""
+    """Ensure feedback sorting uses calls_complete with DISTINCT for dedup."""
     cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
     cq.add_field("id")
     cq.add_order("feedback.[wandb.runnable.my_op].payload.output.expected", "desc")
     assert_sql(
         cq,
         """
-            SELECT
+            SELECT DISTINCT
                 calls_complete.id AS id
             FROM
                 calls_complete
@@ -3456,7 +3456,7 @@ def test_calls_complete_with_feedback_filter() -> None:
     assert_sql(
         cq,
         """
-        SELECT
+        SELECT DISTINCT
             calls_complete.id AS id
         FROM
             calls_complete
@@ -3891,6 +3891,58 @@ def test_stats_query_calls_complete_flat_with_total_storage_size() -> None:
             "pb_0": SENTINEL_DATETIME,
             "pb_1": "project",
             "pb_2": "",
+        },
+        read_table=ReadTable.CALLS_COMPLETE,
+    )
+
+
+def test_stats_query_calls_complete_with_feedback_filter_uses_count_distinct() -> None:
+    """Stats query on calls_complete with feedback filter uses COUNT(DISTINCT id).
+
+    Feedback LEFT JOIN can multiply rows on calls_complete. The data query uses
+    SELECT DISTINCT to deduplicate; the stats query must use COUNT(DISTINCT id)
+    so the count matches the actual number of rows returned.
+    """
+    req = tsi.CallsQueryStatsReq(
+        project_id="project",
+        query=tsi.Query.model_validate(
+            {
+                "$expr": {
+                    "$eq": [
+                        {
+                            "$getField": "feedback.[wandb.annotation.rating].payload.value"
+                        },
+                        {"$literal": "good"},
+                    ]
+                }
+            }
+        ),
+    )
+    assert_stats_sql(
+        req,
+        """
+        SELECT count(DISTINCT calls_complete.id) AS count
+        FROM calls_complete
+        LEFT JOIN (
+            SELECT * FROM feedback WHERE feedback.project_id = {pb_4:String}
+        ) AS feedback ON (
+            feedback.weave_ref = concat('weave-trace-internal:///',
+            {pb_4:String},
+            '/call/',
+            calls_complete.id))
+        PREWHERE calls_complete.project_id = {pb_4:String}
+        WHERE 1
+          AND (((coalesce(nullIf(JSON_VALUE(CASE WHEN feedback.feedback_type = {pb_0:String}
+            THEN feedback.payload_dump END,
+            {pb_1:String}), 'null'), '') = {pb_2:String}))
+       AND ((calls_complete.deleted_at = {pb_3:DateTime64(3)})))
+        """,
+        {
+            "pb_0": "wandb.annotation.rating",
+            "pb_1": '$."value"',
+            "pb_2": "good",
+            "pb_3": SENTINEL_DATETIME,
+            "pb_4": "project",
         },
         read_table=ReadTable.CALLS_COMPLETE,
     )

--- a/tests/trace_server/query_builder/test_costs_query.py
+++ b/tests/trace_server/query_builder/test_costs_query.py
@@ -913,7 +913,7 @@ def test_query_calls_complete_with_costs_and_feedback_order() -> None:
         cq,
         """
         WITH all_calls AS
-          (SELECT calls_complete.id AS id,
+          (SELECT DISTINCT calls_complete.id AS id,
                   calls_complete.started_at AS started_at
            FROM calls_complete
            LEFT JOIN

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -1814,3 +1814,76 @@ def test_call_start_v2_converts_wb_run_id(trace_server, clickhouse_trace_server)
     started_call = _find_call_by_id(calls, call_id)
     assert started_call is not None
     assert started_call.wb_run_id == ext_run_id
+
+
+def test_feedback_filter_does_not_duplicate_calls_complete(
+    trace_server, clickhouse_trace_server
+):
+    """Regression test: feedback filter on calls_complete must not return duplicate calls.
+
+    On calls_complete there is no GROUP BY, so a feedback LEFT JOIN multiplies
+    rows when a call has multiple feedback entries. Without SELECT DISTINCT,
+    the same call appears once per matching feedback row.
+    """
+    project_id = f"{TEST_ENTITY}/calls_complete_feedback_dedup"
+    internal_project_id = b64(project_id)
+
+    # Insert a call directly into calls_complete (bypasses routing)
+    call_id = _insert_complete_call(
+        clickhouse_trace_server.ch_client, internal_project_id
+    )
+    reset_project_residence_cache()
+
+    # verify we are reading from calls_complete
+    resolver = clickhouse_trace_server.table_routing_resolver
+    read_table = resolver.resolve_read_table(
+        internal_project_id, clickhouse_trace_server.ch_client
+    )
+    assert read_table == ReadTable.CALLS_COMPLETE
+
+    # add 2 feedback entries to the same call
+    call_ref = f"weave-trace-internal:///{internal_project_id}/call/{call_id}"
+    trace_server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=call_ref,
+            feedback_type="wandb.reaction.1",
+            payload={"emoji": "👍"},
+            wb_user_id="user_alice",
+        )
+    )
+    trace_server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=call_ref,
+            feedback_type="wandb.reaction.1",
+            payload={"emoji": "👍"},
+            wb_user_id="user_bob",
+        )
+    )
+
+    # this should return 1 item in result set
+    results = list(
+        trace_server.calls_query_stream(
+            tsi.CallsQueryReq(
+                project_id=project_id,
+                query=tsi.Query.model_validate(
+                    {
+                        "$expr": {
+                            "$eq": [
+                                {
+                                    "$getField": "feedback.[wandb.reaction.1].payload.emoji"
+                                },
+                                {"$literal": "👍"},
+                            ]
+                        }
+                    }
+                ),
+            )
+        )
+    )
+
+    assert len(results) == 1, (
+        f"Expected 1 call but got {len(results)} — feedback LEFT JOIN is duplicating rows"
+    )
+    assert results[0].id == call_id

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -1828,7 +1828,6 @@ def test_feedback_filter_does_not_duplicate_calls_complete(
     project_id = f"{TEST_ENTITY}/calls_complete_feedback_dedup"
     internal_project_id = b64(project_id)
 
-    # Insert a call directly into calls_complete (bypasses routing)
     call_id = _insert_complete_call(
         clickhouse_trace_server.ch_client, internal_project_id
     )

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -116,6 +116,13 @@ class OrderLimitOffsetResult(NamedTuple):
     needs_feedback: bool
 
 
+class QueryBodyResult(NamedTuple):
+    """Result from building the query body (FROM through OFFSET)."""
+
+    sql: str
+    needs_feedback_join: bool
+
+
 def maybe_agg(expr: str, use_agg_fn: bool) -> str:
     """Wrap expression in any() aggregate function if needed."""
     return f"any({expr})" if use_agg_fn else expr
@@ -1668,7 +1675,7 @@ class CallsQuery(BaseModel):
         id_subquery_name: str | None = None,
         field_to_object_join_alias_map: dict[str, str] | None = None,
         expand_columns: list[str] | None = None,
-    ) -> str:
+    ) -> QueryBodyResult:
         """Build the SQL query body: everything from FROM through OFFSET.
 
         This method builds filters, JOINs, WHERE/PREWHERE, GROUP BY, ORDER BY,
@@ -1707,6 +1714,9 @@ class CallsQuery(BaseModel):
             field_to_object_join_alias_map=field_to_object_join_alias_map,
             id_subquery_name=id_subquery_name,
         )
+        needs_feedback_join = (
+            filter_result.needs_feedback or order_result.needs_feedback
+        )
         group_by_sql = ""
         if self.read_table == ReadTable.CALLS_MERGED:
             group_by_sql = f"GROUP BY ({table_alias}.project_id, {table_alias}.id)"
@@ -1737,7 +1747,7 @@ class CallsQuery(BaseModel):
         if self.eval_root_ids and self.read_table == ReadTable.CALLS_MERGED:
             having_sql = self._build_eval_subtree_having(having_sql, pb, table_alias)
 
-        return f"""FROM {table_alias}
+        sql = f"""FROM {table_alias}
         {joins.to_sql()}
         PREWHERE {table_alias}.project_id = {param_slot(project_param, "String")}
         {where_clause}
@@ -1746,6 +1756,7 @@ class CallsQuery(BaseModel):
         {order_result.order_by_sql}
         {order_result.limit_sql}
         {order_result.offset_sql}"""
+        return QueryBodyResult(sql=sql, needs_feedback_join=needs_feedback_join)
 
     def _as_sql_base_format(
         self,
@@ -1776,16 +1787,23 @@ class CallsQuery(BaseModel):
             )
             for field in self.select_fields
         )
-        body = self._build_query_body(
+        body_result = self._build_query_body(
             pb,
             table_alias,
             id_subquery_name,
             field_to_object_join_alias_map,
             expand_columns,
         )
+        # On calls_complete, feedback LEFT JOIN can multiply rows, so use DISTINCT to de-dup.
+        distinct = ""
+        if (
+            self.read_table == ReadTable.CALLS_COMPLETE
+            and body_result.needs_feedback_join
+        ):
+            distinct = "DISTINCT"
         raw_sql = f"""
-        SELECT {select_fields_sql}
-        {body}
+        SELECT {distinct} {select_fields_sql}
+        {body_result.sql}
         """
         return safely_format_sql(raw_sql, logger)
 
@@ -2852,9 +2870,11 @@ def _build_calls_complete_stats_query(
 
     # Build the query body (FROM, JOINs, WHERE, etc.) — reuses all existing
     # filter/condition/join abstractions without CTE optimization overhead
-    body = cq._build_query_body(param_builder, table_name)
+    body_result = cq._build_query_body(param_builder, table_name)
 
     # Build the aggregate SELECT clause
+    # When feedback JOIN is present, use COUNT(DISTINCT id) to avoid counting
+    # duplicate rows from the JOIN.
     stats_parts: list[str] = []
     for col_name, col_agg in aggregated_columns.items():
         if col_name == "total_storage_size_bytes":
@@ -2871,13 +2891,15 @@ def _build_calls_complete_stats_query(
                 f"ELSE NULL END"
             )
             stats_parts.append(f"sum(coalesce({total_storage_expr}, 0)) AS {col_name}")
+        elif body_result.needs_feedback_join and col_name == "count":
+            stats_parts.append(f"count(DISTINCT {table_name}.id) AS {col_name}")
         else:
             stats_parts.append(f"{col_agg} AS {col_name}")
     stats_select = ", ".join(stats_parts)
 
     raw_sql = f"""
     SELECT {stats_select}
-    {body}
+    {body_result.sql}
     """
     return safely_format_sql(raw_sql, logger)
 

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1058,6 +1058,11 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
 
             def process_operand(operand: tsi_query.Operand) -> str:
                 if isinstance(operand, tsi_query.LiteralOperation):
+                    # Use SQL string literals instead of json.dumps, which wraps strings in
+                    # double quotes that don't match json_extract() output.
+                    if isinstance(operand.literal_, str):
+                        escaped = operand.literal_.replace("'", "''")
+                        return f"'{escaped}'"
                     return json.dumps(operand.literal_)
                 elif isinstance(operand, tsi_query.GetFieldOperator):
                     if operand.get_field_.startswith("feedback."):


### PR DESCRIPTION
## Description

- Fixes: [Jira Ticket](https://coreweave.atlassian.net/browse/WB-33100)

Small bug where if the same call has multiple feedbacks, the call is returned multiple times.
This occurs due to a `LEFT JOIN` between the `calls_complete` and the `feedback` table.

This is not an issue on calls_merged as data is de-duped thanks to the `GROUP BY (project_id, id)` 

This PR adds a `DISTINCT` to calls_complete query when we do a join on the `feedback` table.


## Before

https://github.com/user-attachments/assets/3deff179-763b-4673-9862-69778ce5a91d

## After

<img width="1672" height="571" alt="Screenshot 2026-04-10 at 2 13 10 PM" src="https://github.com/user-attachments/assets/b2059968-a7ba-4469-b66b-2dd3df9a4154" />

## Testing

- Unit tests
- QA testing
