### PR TITLE
fix(weave): for feedback or multi-value types, rely on groupArrayIf

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -3583,6 +3583,49 @@ def test_calls_stream_feedback(client):
     } in call2_payloads
 
 
+def test_feedback_filter_finds_minority_reaction(client):
+    """Regression test-ish: filtering by emoji must check all reactions, not pick one arbitrarily.
+
+    previously `anyIf` (clickhouse) / `LIMIT 1` (sqlite) would pick one reaction per call, leading to unpredictable results when filtering by reaction.
+    this test has a 10% chance of passing on the original implementation, but will always pass on the groupArrayIf implementation.
+    """
+
+    @weave.op
+    def my_op(x):
+        return x
+
+    my_op(1)
+
+    calls = list(my_op.calls())
+    assert len(calls) == 1
+
+    # add 10 👎 and 1 👍 — anyIf will almost always pick a 👎
+    for _ in range(10):
+        calls[0].feedback.add_reaction("👎")
+    calls[0].feedback.add_reaction("👍")
+
+    project_id = get_client_project_id(client)
+    res = client.server.calls_query_stream(
+        tsi.CallsQueryReq(
+            project_id=project_id,
+            query=tsi.Query.model_validate(
+                {
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "feedback.[wandb.reaction.1].payload.emoji"},
+                            {"$literal": "👍"},
+                        ]
+                    }
+                }
+            ),
+        )
+    )
+    results = list(res)
+
+    assert len(results) == 1
+    assert results[0].id == calls[0].id
+
+
 def test_inline_dataclass_generates_no_refs_in_function(client):
     @dataclasses.dataclass
     class A:

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4232,3 +4232,158 @@ def test_status_sort_calls_complete_uses_sentinels() -> None:
             "pb_8": "project",
         },
     )
+
+
+def test_query_with_reaction_eq_filter_calls_merged() -> None:
+    """Test that reaction emoji filter uses groupArrayIf + has() instead of anyIf."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {"$getField": "feedback.[wandb.reaction.1].payload.emoji"},
+                    {"$literal": "👎"},
+                ]
+            }
+        )
+    )
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id
+        FROM
+            calls_merged
+                    LEFT JOIN (
+                SELECT * FROM feedback WHERE feedback.project_id = {pb_3:String}
+            ) AS feedback ON (
+            feedback.weave_ref = concat('weave-trace-internal:///',
+            {pb_3:String},
+            '/call/',
+            calls_merged.id))
+        PREWHERE
+            calls_merged.project_id = {pb_3:String}
+        GROUP BY
+            (calls_merged.project_id,
+            calls_merged.id)
+        HAVING
+            ((has(groupArrayIf(coalesce(nullIf(JSON_VALUE(feedback.payload_dump,
+            {pb_1:String}), 'null'), ''),
+            feedback.feedback_type = {pb_0:String}
+            AND coalesce(nullIf(JSON_VALUE(feedback.payload_dump,
+            {pb_1:String}), 'null'), '') != ''), {pb_2:String}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.started_at) IS NULL)))))
+        """,
+        {
+            "pb_0": "wandb.reaction.1",
+            "pb_1": '$."emoji"',
+            "pb_2": "👎",
+            "pb_3": "project",
+        },
+    )
+
+
+def test_query_with_note_contains_filter_calls_merged() -> None:
+    """Test that note text filter uses arrayExists instead of position on anyIf."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.ContainsOperation.model_validate(
+            {
+                "$contains": {
+                    "input": {"$getField": "feedback.[wandb.note.1].payload.note"},
+                    "substr": {"$literal": "bad output"},
+                    "case_insensitive": False,
+                }
+            }
+        )
+    )
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id
+        FROM
+            calls_merged
+                    LEFT JOIN (
+                SELECT * FROM feedback WHERE feedback.project_id = {pb_3:String}
+            ) AS feedback ON (
+            feedback.weave_ref = concat('weave-trace-internal:///',
+            {pb_3:String},
+            '/call/',
+            calls_merged.id))
+        PREWHERE
+            calls_merged.project_id = {pb_3:String}
+        GROUP BY
+            (calls_merged.project_id,
+            calls_merged.id)
+        HAVING
+            ((arrayExists(x -> position(x, {pb_2:String}) > 0,
+            groupArrayIf(coalesce(nullIf(JSON_VALUE(feedback.payload_dump,
+            {pb_1:String}), 'null'), ''),
+            feedback.feedback_type = {pb_0:String}
+            AND coalesce(nullIf(JSON_VALUE(feedback.payload_dump,
+            {pb_1:String}), 'null'), '') != '')))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.started_at) IS NULL)))))
+        """,
+        {
+            "pb_0": "wandb.note.1",
+            "pb_1": '$."note"',
+            "pb_2": "bad output",
+            "pb_3": "project",
+        },
+    )
+
+
+def test_query_with_annotation_filter_still_uses_anyif() -> None:
+    """Regression test: annotation feedback (single-value) still uses anyIf, not groupArrayIf."""
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$getField": "feedback.[wandb.annotation.rating].payload.value"
+                    },
+                    {"$literal": "good"},
+                ]
+            }
+        )
+    )
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id
+        FROM
+            calls_merged
+                    LEFT JOIN (
+                SELECT * FROM feedback WHERE feedback.project_id = {pb_3:String}
+            ) AS feedback ON (
+            feedback.weave_ref = concat('weave-trace-internal:///',
+            {pb_3:String},
+            '/call/',
+            calls_merged.id))
+        PREWHERE
+            calls_merged.project_id = {pb_3:String}
+        GROUP BY
+            (calls_merged.project_id,
+            calls_merged.id)
+        HAVING
+            (((coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump,
+            feedback.feedback_type = {pb_0:String}),
+            {pb_1:String}), 'null'), '') = {pb_2:String}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                    AND ((NOT ((any(calls_merged.started_at) IS NULL)))))
+        """,
+        {
+            "pb_0": "wandb.annotation.rating",
+            "pb_1": '$."value"',
+            "pb_2": "good",
+            "pb_3": "project",
+        },
+    )

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4346,9 +4346,7 @@ def test_query_with_annotation_filter_still_uses_anyif() -> None:
         tsi_query.EqOperation.model_validate(
             {
                 "$eq": [
-                    {
-                        "$getField": "feedback.[wandb.annotation.rating].payload.value"
-                    },
+                    {"$getField": "feedback.[wandb.annotation.rating].payload.value"},
                     {"$literal": "good"},
                 ]
             }

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -65,6 +65,7 @@ from weave.trace_server.calls_query_builder.utils import (
 from weave.trace_server.common_interface import SortBy
 from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.interface import query as tsi_query
+from weave.trace_server.interface.feedback_types import MULTI_VALUE_FEEDBACK_TYPES
 from weave.trace_server.orm import (
     ParamBuilder,
     clickhouse_cast,
@@ -301,6 +302,11 @@ class CallsMergedFeedbackPayloadField(CallsMergedField):
     def is_feedback_field(self) -> bool:
         return True
 
+    @property
+    def is_multi_value(self) -> bool:
+        """Whether this feedback type can have multiple entries per call."""
+        return self.feedback_type in MULTI_VALUE_FEEDBACK_TYPES
+
     @classmethod
     def from_path(cls, path: str) -> Self:
         """Expected format: `[feedback.type].dot.path`.
@@ -374,6 +380,25 @@ class CallsMergedFeedbackPayloadField(CallsMergedField):
         if not self.extra_path:
             return res
         return json_dump_field_as_sql(pb, "feedback", res, self.extra_path, cast)
+
+    def as_array_sql(self, pb: ParamBuilder) -> str:
+        """Build a groupArrayIf expression collecting all values for this feedback field.
+
+        Used for multi-value feedback types (reactions, notes) where a call can
+        have multiple entries. Extracts and collects all non-empty values from
+        the feedback rows into an array for has()/arrayExists().
+        """
+        inner = f"feedback.{self.field}"
+        type_param = pb.add_param(self.feedback_type)
+        type_cond = f"feedback.feedback_type = {param_slot(type_param, 'String')}"
+
+        if self.extra_path:
+            extracted = json_dump_field_as_sql(
+                pb, "feedback", inner, self.extra_path, None
+            )
+            return f"groupArrayIf({extracted}, {type_cond} AND {extracted} != '')"
+        else:
+            return f"groupArrayIf({inner}, {type_cond})"
 
     def as_select_sql(
         self, pb: ParamBuilder, table_alias: str, use_agg_fn: bool = True, **kwargs: Any
@@ -2103,6 +2128,22 @@ def _extract_field_name(operand: "tsi_query.Operand") -> str | None:
     return None
 
 
+def _get_multi_value_feedback_field(
+    operand: tsi_query.Operand,
+) -> CallsMergedFeedbackPayloadField | None:
+    """If the operand is a GetField referencing a multi-value feedback field, return it."""
+    field_name = _extract_field_name(operand)
+    if not field_name or not field_name.startswith("feedback."):
+        return None
+    structured_field = get_field_by_name(field_name)
+    if (
+        isinstance(structured_field, CallsMergedFeedbackPayloadField)
+        and structured_field.is_multi_value
+    ):
+        return structured_field
+    return None
+
+
 def process_query_to_conditions(
     query: tsi.Query,
     param_builder: ParamBuilder,
@@ -2138,31 +2179,44 @@ def process_query_to_conditions(
             cond = f"(NOT ({operand_part}))"
         elif isinstance(operation, tsi_query.EqOperation):
             ops = _maybe_convert_datetime_operands(operation.eq_)
-            lhs_part = process_operand(ops[0])
-            if (
-                isinstance(ops[1], tsi_query.LiteralOperation)
-                and ops[1].literal_ is None
-            ):
-                # For calls_complete, sentinel fields use equality checks
-                # against the sentinel value instead of IS NULL.
-                field_name = _extract_field_name(ops[0])
-                sentinel = (
-                    ch_sentinel_values.get_sentinel_value(field_name)
-                    if use_sentinels and field_name
-                    else None
-                )
-                if sentinel is not None:
-                    assert field_name is not None
-                    sentinel_type = ch_sentinel_values.sentinel_ch_type(field_name)
-                    sentinel_slot = param_builder.add(
-                        sentinel, param_type=sentinel_type
-                    )
-                    cond = f"({lhs_part} = {sentinel_slot})"
+            mv_field = _get_multi_value_feedback_field(ops[0]) if use_agg_fn else None
+            if mv_field is not None:
+                array_expr = mv_field.as_array_sql(param_builder)
+                raw_fields_used[mv_field.feedback_type] = mv_field
+                if (
+                    isinstance(ops[1], tsi_query.LiteralOperation)
+                    and ops[1].literal_ is None
+                ):
+                    cond = f"(length({array_expr}) = 0)"
                 else:
-                    cond = f"({lhs_part} IS NULL)"
+                    rhs_part = process_operand(ops[1])
+                    cond = f"has({array_expr}, {rhs_part})"
             else:
-                rhs_part = process_operand(ops[1])
-                cond = f"({lhs_part} = {rhs_part})"
+                lhs_part = process_operand(ops[0])
+                if (
+                    isinstance(ops[1], tsi_query.LiteralOperation)
+                    and ops[1].literal_ is None
+                ):
+                    # For calls_complete, sentinel fields use equality checks
+                    # against the sentinel value instead of IS NULL.
+                    field_name = _extract_field_name(ops[0])
+                    sentinel = (
+                        ch_sentinel_values.get_sentinel_value(field_name)
+                        if use_sentinels and field_name
+                        else None
+                    )
+                    if sentinel is not None:
+                        assert field_name is not None
+                        sentinel_type = ch_sentinel_values.sentinel_ch_type(field_name)
+                        sentinel_slot = param_builder.add(
+                            sentinel, param_type=sentinel_type
+                        )
+                        cond = f"({lhs_part} = {sentinel_slot})"
+                    else:
+                        cond = f"({lhs_part} IS NULL)"
+                else:
+                    rhs_part = process_operand(ops[1])
+                    cond = f"({lhs_part} = {rhs_part})"
         elif isinstance(operation, tsi_query.GtOperation):
             ops = _maybe_convert_datetime_operands(operation.gt_)
             lhs_part = process_operand(ops[0])
@@ -2188,12 +2242,27 @@ def process_query_to_conditions(
             rhs_part = ",".join(process_operand(op) for op in operation.in_[1])
             cond = f"({lhs_part} IN ({rhs_part}))"
         elif isinstance(operation, tsi_query.ContainsOperation):
-            lhs_part = process_operand(operation.contains_.input)
-            rhs_part = process_operand(operation.contains_.substr)
-            position_operation = "position"
-            if operation.contains_.case_insensitive:
-                position_operation = "positionCaseInsensitive"
-            cond = f"{position_operation}({lhs_part}, {rhs_part}) > 0"
+            # Multi-value feedback fields need arrayExists instead of position
+            mv_field = (
+                _get_multi_value_feedback_field(operation.contains_.input)
+                if use_agg_fn
+                else None
+            )
+            if mv_field is not None:
+                array_expr = mv_field.as_array_sql(param_builder)
+                rhs_part = process_operand(operation.contains_.substr)
+                raw_fields_used[mv_field.feedback_type] = mv_field
+                position_operation = "position"
+                if operation.contains_.case_insensitive:
+                    position_operation = "positionCaseInsensitive"
+                cond = f"arrayExists(x -> {position_operation}(x, {rhs_part}) > 0, {array_expr})"
+            else:
+                lhs_part = process_operand(operation.contains_.input)
+                rhs_part = process_operand(operation.contains_.substr)
+                position_operation = "position"
+                if operation.contains_.case_insensitive:
+                    position_operation = "positionCaseInsensitive"
+                cond = f"{position_operation}({lhs_part}, {rhs_part}) > 0"
         else:
             raise TypeError(f"Unknown operation type: {operation}")
 

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -2242,7 +2242,6 @@ def process_query_to_conditions(
             rhs_part = ",".join(process_operand(op) for op in operation.in_[1])
             cond = f"({lhs_part} IN ({rhs_part}))"
         elif isinstance(operation, tsi_query.ContainsOperation):
-            # Multi-value feedback fields need arrayExists instead of position
             mv_field = (
                 _get_multi_value_feedback_field(operation.contains_.input)
                 if use_agg_fn

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -18,6 +18,7 @@ from weave.trace_server.interface.builtin_object_classes.annotation_spec import 
 from weave.trace_server.interface.feedback_types import (
     ANNOTATION_FEEDBACK_TYPE_PREFIX,
     FEEDBACK_PAYLOAD_SCHEMAS,
+    REACTION_FEEDBACK_TYPE,
     RUNNABLE_FEEDBACK_TYPE_PREFIX,
     AnnotationPayloadSchema,
     RunnablePayloadSchema,
@@ -69,7 +70,7 @@ def process_feedback_payload(
     """
     processed_payload = feedback_req.payload.copy()
 
-    if feedback_req.feedback_type == "wandb.reaction.1":
+    if feedback_req.feedback_type == REACTION_FEEDBACK_TYPE:
         em = feedback_req.payload["emoji"]
         if emoji.emoji_count(em) != 1:
             raise InvalidRequest(

--- a/weave/trace_server/interface/feedback_types.py
+++ b/weave/trace_server/interface/feedback_types.py
@@ -13,9 +13,17 @@ class FeedbackPayloadNoteReq(BaseModel):
     note: str = Field(min_length=1, max_length=MAX_FEEDBACK_NOTE_LENGTH)
 
 
+REACTION_FEEDBACK_TYPE = "wandb.reaction.1"
+NOTE_FEEDBACK_TYPE = "wandb.note.1"
+
+# Feedback types where multiple entries can exist per call per type.
+# When filtering on these, we use groupArrayIf (collect all values) + has()
+# instead of anyIf (pick one arbitrary value), which could miss matches.
+MULTI_VALUE_FEEDBACK_TYPES = {REACTION_FEEDBACK_TYPE, NOTE_FEEDBACK_TYPE}
+
 FEEDBACK_PAYLOAD_SCHEMAS: dict[str, type[BaseModel]] = {
-    "wandb.reaction.1": FeedbackPayloadReactionReq,
-    "wandb.note.1": FeedbackPayloadNoteReq,
+    REACTION_FEEDBACK_TYPE: FeedbackPayloadReactionReq,
+    NOTE_FEEDBACK_TYPE: FeedbackPayloadNoteReq,
 }
 
 ANNOTATION_FEEDBACK_TYPE_PREFIX = "wandb.annotation"

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -50,7 +50,10 @@ from weave.trace_server.feedback import (
 )
 from weave.trace_server.ids import generate_id
 from weave.trace_server.interface import query as tsi_query
-from weave.trace_server.interface.feedback_types import RUNNABLE_FEEDBACK_TYPE_PREFIX
+from weave.trace_server.interface.feedback_types import (
+    MULTI_VALUE_FEEDBACK_TYPES,
+    RUNNABLE_FEEDBACK_TYPE_PREFIX,
+)
 from weave.trace_server.methods.evaluation_status import evaluation_status
 from weave.trace_server.methods.sqlite_feedback_stats import (
     sqlite_feedback_payload_schema,
@@ -1016,11 +1019,18 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                     cond = f"(NOT ({operand_part}))"
                 elif isinstance(operation, tsi_query.EqOperation):
                     lhs_part = process_operand(operation.eq_[0])
+                    is_multi_value_feedback = _is_multi_value_feedback_operand(
+                        operation.eq_[0]
+                    )
                     if (
                         isinstance(operation.eq_[1], tsi_query.LiteralOperation)
                         and operation.eq_[1].literal_ is None
                     ):
                         cond = f"({lhs_part} IS NULL)"
+                    elif is_multi_value_feedback:
+                        # Multi-value: GROUP_CONCAT result, use INSTR to find value
+                        rhs_part = process_operand(operation.eq_[1])
+                        cond = f"instr({lhs_part}, {rhs_part})"
                     else:
                         rhs_part = process_operand(operation.eq_[1])
                         cond = f"({lhs_part} = {rhs_part})"
@@ -5045,8 +5055,8 @@ def _build_feedback_subquery(field: str) -> str:
         escaped = feedback_type.replace("'", "''")
         type_filter = f" AND feedback_type = '{escaped}'"
 
-    if feedback_type == "*":
-        # For wildcard, concatenate values from all feedback rows so filters
+    if feedback_type == "*" or feedback_type in MULTI_VALUE_FEEDBACK_TYPES:
+        # Concatenate values from all matching feedback rows so filters
         # can search across every entry.
         return (
             f"(SELECT GROUP_CONCAT({value_expr}, ',') FROM feedback"
@@ -5059,3 +5069,12 @@ def _build_feedback_subquery(field: str) -> str:
             f" WHERE feedback.weave_ref = 'weave-trace-internal:///' || calls.project_id || '/call/' || calls.id"
             f"{type_filter} LIMIT 1)"
         )
+
+
+def _is_multi_value_feedback_operand(operand: tsi_query.Operand) -> bool:
+    """Check if an operand references a multi-value feedback field."""
+    if not isinstance(operand, tsi_query.GetFieldOperator):
+        return False
+    return any(
+        f"feedback.[{ft}]" in operand.get_field_ for ft in MULTI_VALUE_FEEDBACK_TYPES
+    )


### PR DESCRIPTION
## Description

- Fixes [Jira ticket](https://coreweave.atlassian.net/browse/WB-32768)

- Filtering calls on feedback was previously unpredictable, since we relied on `anyIf` to check reactions/notes, which were multi-value per call.
- So if you had a call with both a '👍🏽'  and a '👎🏽', and you wanted to filter by all '👎🏽', its possible the call would not be returned if the `anyIf` randomly selected the  '👍🏽' from the row.

## Testing
- Unit tests
- QA tests
