### PR TITLE
chore(weave): speed up table partitioning test

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -1563,6 +1563,7 @@ def test_table_partitioning(network_proxy_client, use_parallel_table_upload):
         server=remote_client,
         ensure_project_exists=False,
     )
+    client.set_autoflush(False)
 
     # Create a Table object and save it to trigger chunking logic
     table_obj = weave_client.Table(rows)
@@ -1572,6 +1573,7 @@ def test_table_partitioning(network_proxy_client, use_parallel_table_upload):
     _ENDPOINT_CACHE.discard("table_create_from_digests")
 
     saved_table = client.save(table_obj, "table")
+    client.flush()
 
     assert saved_table.table_ref._digest == exp_digest
 


### PR DESCRIPTION
## Summary
- disable `TestOnlyFlushingWeaveClient` autoflush inside `test_table_partitioning`
- do one explicit `client.flush()` after `client.save(...)`
- test goes from `57s` -> `38s`

## Why This Was Slow
`test_table_partitioning` was using `TestOnlyFlushingWeaveClient`, which flushes after every public method call. That client-side flush waits on the remote HTTP trace server batch processors, and `AsyncBatchProcessor` uses a `1.0s` `min_batch_interval` sleep between batches. In practice, this test was spending most of its time waiting on repeated test harness flushes rather than exercising SQLite table partitioning logic.

## Before / After

Before:
- `test_table_partitioning[False]`: `18.08s`
- `test_table_partitioning[True]`: `15.07s`
- pytest total: `57.03s`
- wall clock: `69.16s`

After:
- `test_table_partitioning[False]`: `2.01s`
- `test_table_partitioning[True]`: `1.00s`
- pytest total: `38.93s`
- wall clock: `57.78s`

Focused slow-path check:
- `test_table_partitioning[False]`: `20.08s` -> `2.01s`