### PR TITLE
chore(weave): speed up slow sqlite trace tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,9 +20,12 @@ from weave.trace.context import weave_client_context
 from weave.trace.context.call_context import set_call_stack
 from weave.trace.settings import UserSettings, parse_and_apply_settings
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server_bindings import remote_http_trace_server
+from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.trace_server_bindings.caching_middleware_trace_server import (
     CachingMiddlewareTraceServer,
 )
+from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
 from weave.trace_server_bindings.remote_http_trace_server import RemoteHTTPTraceServer
 
 pytest_plugins = ["tests.trace_server.conftest"]
@@ -434,7 +437,7 @@ def client_creator(zero_stack, request, trace_server, caching_client_isolation):
 
 
 @pytest.fixture
-def network_proxy_client(client):
+def network_proxy_client(client, monkeypatch):
     """This fixture is used to test the `RemoteHTTPTraceServer` class. There is
     almost no logic in this class, other than a little batching, so we typically
     skip it for simplicity. However, we can use this fixture to test such logic.
@@ -551,6 +554,25 @@ def network_proxy_client(client):
 
         orig_post = weave.utils.http_requests.post
         weave.utils.http_requests.post = post
+
+        def make_fast_async_batch_processor(*args, **kwargs):
+            kwargs.setdefault("min_batch_interval", 0)
+            return AsyncBatchProcessor(*args, **kwargs)
+
+        def make_fast_call_batch_processor(*args, **kwargs):
+            kwargs.setdefault("min_batch_interval", 0)
+            return CallBatchProcessor(*args, **kwargs)
+
+        monkeypatch.setattr(
+            remote_http_trace_server,
+            "AsyncBatchProcessor",
+            make_fast_async_batch_processor,
+        )
+        monkeypatch.setattr(
+            remote_http_trace_server,
+            "CallBatchProcessor",
+            make_fast_call_batch_processor,
+        )
 
         remote_client = RemoteHTTPTraceServer(
             trace_server_url="",

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -347,12 +347,11 @@ def test_retry_max_attempts_env(caplog) -> None:
 def test_retry_max_interval_settings(client_creator, caplog, monkeypatch) -> None:
     caplog.set_level(logging.INFO, logger="weave.utils.retry")
 
-    original_wait = tenacity.wait_exponential_jitter
     call_args = []
 
     def mock_wait_exponential_jitter(initial=0, max=None):
         call_args.append(max)
-        return original_wait(initial=initial, max=max)
+        return tenacity.wait_none()
 
     monkeypatch.setattr(
         tenacity, "wait_exponential_jitter", mock_wait_exponential_jitter

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -3942,7 +3942,6 @@ def test_feedback_batching(network_proxy_client):
 
     # make sure we aren't actually waiting for 10 feedbacks, should be quick
     assert time.time() - start < 0.5, "Feedback creation took too long"
-    assert client.server.get_feedback_processor() is not None
 
     # Flush to ensure all feedback is processed
     client.flush()

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -3942,7 +3942,9 @@ def test_feedback_batching(network_proxy_client):
     # Flush to ensure all feedback is processed
     client.flush()
 
-    feedback_create_records = [req for route, req in records if route == "feedback_create"]
+    feedback_create_records = [
+        req for route, req in records if route == "feedback_create"
+    ]
 
     assert remote_client.get_feedback_processor() is not None
     assert len(feedback_create_records) == 0, (

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -3928,10 +3928,9 @@ def test_feedback_batching(network_proxy_client):
     client.flush()
 
     test_call = client.get_calls()[0]
-    client.server.attribute_access_log = []
+    records.clear()
 
     feedback_items = []
-    start = time.time()
     for i in range(10):
         id = test_call.feedback.add(
             feedback_type=f"test_feedback_{i}",
@@ -3940,17 +3939,15 @@ def test_feedback_batching(network_proxy_client):
         assert id is not None
         feedback_items.append(id)
 
-    # make sure we aren't actually waiting for 10 feedbacks, should be quick
-    assert time.time() - start < 0.5, "Feedback creation took too long"
-
     # Flush to ensure all feedback is processed
     client.flush()
 
-    log = client.server.attribute_access_log
-    feedback_creates = [l for l in log if l == "feedback_create"]
+    feedback_create_records = [req for route, req in records if route == "feedback_create"]
 
-    assert_err = f"Expected 0 feedback creates, got {len(feedback_creates)}"
-    assert len(feedback_creates) == 0, assert_err
+    assert remote_client.get_feedback_processor() is not None
+    assert len(feedback_create_records) == 0, (
+        f"Expected 0 feedback_create requests, got {len(feedback_create_records)}"
+    )
 
     # Query feedback to verify all items were created
     all_feedback = list(test_call.feedback)


### PR DESCRIPTION
## Summary
- start `network_proxy_client` batch processors with `min_batch_interval=0` in tests
- make `test_retry_max_interval_settings` validate retry wiring without real backoff sleeps
- replace the `test_feedback_batching` wall-clock assertion with deterministic batching assertions
- targeted tests go from `9.85s` -> `0.84s`

Also fix flake ([GitHub Actions](https://github.com/wandb/weave/actions/runs/24353587927/job/71114419966?pr=6585)):
`FAILED tests/trace/test_weave_client.py::test_feedback_batching - AssertionError: Feedback creation took too long`

## Before / After
Before:
- `test_feedback_batching`: `6.02s`
- `test_retry_max_interval_settings`: `3.83s`

After:
- `test_feedback_batching`: `0.80s`
- `test_retry_max_interval_settings`: `0.04s`
