### PR TITLE
chore(weave): consolidate trace_server tests to reduce CI time

### DIFF
--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -349,9 +349,7 @@ def test_custom_provider_completions_create(client):
                 model_id="test-model",
                 model_name="test-model",
             )
-            slash_mock_read = create_mock_obj_read(
-                slash_provider_obj, slash_model_obj
-            )
+            slash_mock_read = create_mock_obj_read(slash_provider_obj, slash_model_obj)
 
             slash_inputs = {
                 "model": slash_model_name,
@@ -432,9 +430,7 @@ def test_custom_provider_error_handling(client):
                         "project_id": client.project_id,
                         "inputs": {
                             "model": "invalid-model-format",
-                            "messages": [
-                                {"role": "user", "content": "Hello, world!"}
-                            ],
+                            "messages": [{"role": "user", "content": "Hello, world!"}],
                         },
                     }
                 )

--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -45,19 +45,6 @@ def create_provider_obj(
     extra_headers: dict | None = None,
     return_type: str = "openai",
 ) -> tsi.ObjSchema:
-    """Create a Provider object for testing.
-
-    Args:
-        project_id: The project ID
-        provider_id: The provider ID
-        base_url: The base URL for the provider's API
-        api_key_name: The name of the API key secret
-        extra_headers: Additional headers to include in requests
-        return_type: The return type for the provider
-
-    Returns:
-        tsi.ObjSchema: A provider object
-    """
     provider = Provider(
         base_url=base_url,
         api_key_name=api_key_name,
@@ -87,18 +74,6 @@ def create_provider_model_obj(
     model_name: str | None = None,
     max_tokens: int = 4096,
 ) -> tsi.ObjSchema:
-    """Create a ProviderModel object for testing.
-
-    Args:
-        project_id: The project ID
-        provider_id: The provider ID
-        model_id: The model ID
-        model_name: The actual model name to use (defaults to model_id)
-        max_tokens: Maximum tokens for the model
-
-    Returns:
-        tsi.ObjSchema: A provider model object
-    """
     provider_model = ProviderModel(
         name=model_name or model_id,
         provider=provider_id,
@@ -126,17 +101,6 @@ def create_mock_completion_response(
     completion_tokens: int = 5,
     prompt_tokens: int = 11,
 ) -> dict:
-    """Create a mock completion response for testing.
-
-    Args:
-        model_name: The name of the model
-        content: The response content
-        completion_tokens: Number of completion tokens
-        prompt_tokens: Number of prompt tokens
-
-    Returns:
-        dict: A mock completion response
-    """
     return {
         "id": f"chatcmpl-{uuid.uuid4()}",
         "created": 1730235604,
@@ -169,14 +133,6 @@ def create_mock_completion_response(
 
 
 def setup_test_environment(mock_secret_fetcher=None):
-    """Set up the test environment with a secret fetcher.
-
-    Args:
-        mock_secret_fetcher: Optional custom secret fetcher to use
-
-    Returns:
-        tuple: (secret_fetcher, context_token)
-    """
     mock_secret_fetcher = mock_secret_fetcher or DummySecretFetcher()
     token = _secret_fetcher_context.set(mock_secret_fetcher)
     return mock_secret_fetcher, token
@@ -185,16 +141,6 @@ def setup_test_environment(mock_secret_fetcher=None):
 def create_mock_obj_read(
     provider_obj: tsi.ObjSchema, provider_model_obj: tsi.ObjSchema
 ):
-    """Create a mock obj_read function for testing.
-
-    Args:
-        provider_obj: The provider object configuration
-        provider_model_obj: The provider model object configuration
-
-    Returns:
-        function: A mock obj_read function
-    """
-
     def mock_obj_read(req):
         if req.object_id == provider_obj.object_id:
             return tsi.ObjReadRes(obj=provider_obj)
@@ -206,18 +152,7 @@ def create_mock_obj_read(
 
 
 def test_custom_provider_model_classes():
-    """Test the model classes for Provider and ProviderModel.
-
-    This test verifies that:
-    1. Provider class can be instantiated with correct configuration
-    2. Provider attributes are properly set and accessible
-    3. ProviderModel class can be instantiated with correct configuration
-    4. ProviderModel attributes are properly set and accessible
-
-    The test checks both required and optional fields, ensuring they are
-    properly typed and accessible through the model instances.
-    """
-    # Test Provider class initialization and attribute access
+    """Test the model classes for Provider and ProviderModel."""
     provider = Provider(
         base_url="https://api.example.com",
         api_key_name="EXAMPLE_API_KEY",
@@ -225,364 +160,39 @@ def test_custom_provider_model_classes():
         return_type=ProviderReturnType.OPENAI,
     )
 
-    # Verify Provider attributes
-    assert provider.base_url == "https://api.example.com", (
-        f"Provider base_url mismatch. Expected 'https://api.example.com', "
-        f"got '{provider.base_url}'"
-    )
-    assert provider.api_key_name == "EXAMPLE_API_KEY", (
-        f"Provider api_key_name mismatch. Expected 'EXAMPLE_API_KEY', "
-        f"got '{provider.api_key_name}'"
-    )
-    assert provider.extra_headers == {"X-Custom-Header": "value"}, (
-        f"Provider extra_headers mismatch. Expected {{'X-Custom-Header': 'value'}}, "
-        f"got {provider.extra_headers}"
-    )
-    assert provider.return_type == ProviderReturnType.OPENAI, (
-        f"Provider return_type mismatch. Expected {ProviderReturnType.OPENAI}, "
-        f"got {provider.return_type}"
-    )
+    assert provider.base_url == "https://api.example.com"
+    assert provider.api_key_name == "EXAMPLE_API_KEY"
+    assert provider.extra_headers == {"X-Custom-Header": "value"}
+    assert provider.return_type == ProviderReturnType.OPENAI
 
-    # Test ProviderModel class initialization and attribute access
     provider_model = ProviderModel(
         provider="provider_id",
         max_tokens=4096,
     )
 
-    # Verify ProviderModel attributes
-    assert provider_model.provider == "provider_id", (
-        f"ProviderModel provider mismatch. Expected 'provider_id', "
-        f"got '{provider_model.provider}'"
-    )
-    assert provider_model.max_tokens == 4096, (
-        f"ProviderModel max_tokens mismatch. Expected 4096, "
-        f"got {provider_model.max_tokens}"
-    )
-
-
-def test_custom_provider_completions_create(client):
-    """Test the completions_create endpoint with a custom provider.
-
-    This test verifies the complete flow of creating a completion using a custom provider:
-    1. Provider and model object creation with correct configuration
-    2. Proper request handling and parameter passing to LiteLLM
-    3. Response transformation and validation
-    4. Usage tracking and logging of the completion call
-
-    The test mocks:
-    - Object read operations to simulate provider/model configuration
-    - LiteLLM completion call to simulate API response
-    - Secret fetching for API keys
-
-    Args:
-        client: The test client fixture providing access to the completion endpoint
-    """
-    is_sqlite = client_is_sqlite(client)
-    if is_sqlite:
-        # no need to test in sqlite
-        return
-
-    # Create unique provider ID and model ID for test isolation
-    provider_id = f"test-provider-{uuid.uuid4()}"
-    model_id = "test-model"
-    model_name = f"custom::{provider_id}::{model_id}"
-
-    # Create a Provider object with test configuration
-    provider_obj = create_provider_obj(
-        project_id=client.project_id,
-        provider_id=provider_id,
-        extra_headers={"X-Custom-Header": "value"},
-    )
-
-    # Create a ProviderModel object with test configuration
-    provider_model_obj = create_provider_model_obj(
-        project_id=client.project_id,
-        provider_id=provider_id,
-        model_id=model_id,
-        model_name=model_id,  # Use the actual model name part only
-    )
-
-    # Mock responses for obj_read calls to return our test configurations
-    mock_obj_read = create_mock_obj_read(provider_obj, provider_model_obj)
-
-    # Create test input with a simple chat message
-    inputs = {
-        "model": model_name,
-        "messages": [{"role": "user", "content": "Hello, world!"}],
-    }
-
-    # Mock response from LiteLLM to simulate successful API call
-    mock_response = create_mock_completion_response(model_name=model_name)
-
-    # Run test with tracing disabled to avoid interference
-    with with_tracing_disabled():
-        # Set up the secret fetcher
-        mock_secret_fetcher, token = setup_test_environment()
-        try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
-                with patch("litellm.completion") as mock_completion:
-                    mock_completion.return_value = ModelResponse.model_validate(
-                        mock_response
-                    )
-
-                    res = client.server.completions_create(
-                        tsi.CompletionsCreateReq.model_validate(
-                            {
-                                "project_id": client.project_id,
-                                "inputs": inputs,
-                            }
-                        )
-                    )
-
-            # Verify the response matches our mock
-            assert res.response == mock_response, (
-                f"Response mismatch. Expected {mock_response}, got {res.response}"
-            )
-
-            # Verify LiteLLM was called with correct parameters
-            mock_completion.assert_called_once()
-            call_args = mock_completion.call_args[1]
-            expected_litellm_model = (
-                f"openai/{model_id}"  # Implementation prefixes with "openai/"
-            )
-            assert call_args["model"] == expected_litellm_model, (
-                f"Model name mismatch. Expected '{expected_litellm_model}', got '{call_args['model']}'"
-            )
-            assert call_args["messages"] == inputs["messages"], (
-                f"Messages mismatch. Expected {inputs['messages']}, "
-                f"got {call_args['messages']}"
-            )
-            assert call_args["api_key"] == "DUMMY_SECRET_VALUE", (
-                f"API key mismatch. Expected 'DUMMY_SECRET_VALUE', "
-                f"got '{call_args['api_key']}'"
-            )
-            assert call_args["api_base"] == "https://api.example.com", (
-                f"API base URL mismatch. Expected 'https://api.example.com', "
-                f"got '{call_args['api_base']}'"
-            )
-            assert call_args["extra_headers"] == {"X-Custom-Header": "value"}, (
-                f"Extra headers mismatch. Expected {{'X-Custom-Header': 'value'}}, "
-                f"got {call_args['extra_headers']}"
-            )
-
-            # Verify the call was properly logged
-            calls = list(client.get_calls())
-            assert len(calls) == 1, f"Expected 1 logged call, got {len(calls)}"
-            assert calls[0].output == res.response, (
-                f"Logged output mismatch. Expected {res.response}, "
-                f"got {calls[0].output}"
-            )
-            # The usage key in the summary uses the provider/model format, not the custom format
-            expected_usage_key = f"{provider_id}/{model_id}"
-            assert (
-                calls[0].summary["usage"][expected_usage_key] == res.response["usage"]
-            ), (
-                f"Usage summary mismatch. Expected {res.response['usage']}, "
-                f"got {calls[0].summary['usage'][expected_usage_key]}"
-            )
-            # The implementation modifies req.inputs.model before logging, so we expect the transformed model name
-            expected_logged_inputs = inputs.copy()
-            expected_logged_inputs["model"] = f"openai/{model_id}"
-            assert calls[0].inputs == expected_logged_inputs, (
-                f"Logged inputs mismatch. Expected {expected_logged_inputs}, got {calls[0].inputs}"
-            )
-            assert calls[0].op_name == "weave.completions_create", (
-                f"Operation name mismatch. Expected 'weave.completions_create', "
-                f"got {calls[0].op_name}"
-            )
-        finally:
-            _secret_fetcher_context.reset(token)
-
-
-def test_custom_provider_ollama_model(client):
-    """Test handling of ollama models that need special prefixing."""
-    is_sqlite = client_is_sqlite(client)
-    if is_sqlite:
-        # no need to test in sqlite
-        return
-
-    # Create provider ID and model ID for testing
-    provider_id = f"test-ollama-{uuid.uuid4()}"
-    model_id = "llama2"
-    model_name = f"custom::{provider_id}::{model_id}"
-
-    # Create a Provider object with Ollama-specific configuration
-    provider_obj = create_provider_obj(
-        project_id=client.project_id,
-        provider_id=provider_id,
-        base_url="http://localhost:11434",
-        api_key_name="OLLAMA_API_KEY",
-        extra_headers={},
-    )
-
-    # Create a ProviderModel object with Ollama-specific configuration
-    provider_model_obj = create_provider_model_obj(
-        project_id=client.project_id,
-        provider_id=provider_id,
-        model_id=model_id,
-        model_name="llama2",  # Note: this will be prefixed with ollama/
-    )
-
-    # Mock responses for obj_read calls
-    mock_obj_read = create_mock_obj_read(provider_obj, provider_model_obj)
-
-    # Create test input
-    inputs = {
-        "model": model_name,
-        "messages": [{"role": "user", "content": "Hello, world!"}],
-    }
-
-    # Mock response from LiteLLM with Ollama-specific details
-    mock_response = create_mock_completion_response(
-        model_name="ollama/llama2",
-        content="Hello from Ollama!",
-        completion_tokens=4,
-        prompt_tokens=11,
-    )
-
-    with with_tracing_disabled():
-        # Set up the secret fetcher
-        mock_secret_fetcher, token = setup_test_environment()
-        try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
-                with patch("litellm.completion") as mock_completion:
-                    mock_completion.return_value = ModelResponse.model_validate(
-                        mock_response
-                    )
-                    res = client.server.completions_create(
-                        tsi.CompletionsCreateReq.model_validate(
-                            {
-                                "project_id": client.project_id,
-                                "inputs": inputs,
-                            }
-                        )
-                    )
-
-            # Verify the correct response is returned
-            assert res.response == mock_response
-
-            # Verify the litellm.completion was called with the right parameters
-            mock_completion.assert_called_once()
-            call_args = mock_completion.call_args[1]
-            assert call_args["model"] == "ollama/llama2"  # Should add ollama/ prefix
-            assert call_args["api_key"] == "DUMMY_SECRET_VALUE"
-            assert call_args["api_base"] == "http://localhost:11434"
-        finally:
-            _secret_fetcher_context.reset(token)
-
-
-def test_custom_provider_trailing_slash_normalization(client):
-    """Test that trailing slashes in base_url are stripped to prevent redirect issues.
-
-    When a base_url has a trailing slash, HTTP servers often redirect to the
-    canonical URL without the slash using 301/302. These redirects cause most
-    HTTP clients to change POST to GET, breaking the API call.
-
-    This test verifies that trailing slashes are stripped before making the request.
-    """
-    is_sqlite = client_is_sqlite(client)
-    if is_sqlite:
-        # no need to test in sqlite
-        return
-
-    # Create provider ID and model ID for testing
-    provider_id = f"test-trailing-slash-{uuid.uuid4()}"
-    model_id = "test-model"
-    model_name = f"custom::{provider_id}::{model_id}"
-
-    # Create a Provider object with a trailing slash in base_url
-    provider_obj = create_provider_obj(
-        project_id=client.project_id,
-        provider_id=provider_id,
-        base_url="http://localhost:11434/",  # Note the trailing slash
-        api_key_name="TEST_API_KEY",
-        extra_headers={},
-    )
-
-    # Create a ProviderModel object
-    provider_model_obj = create_provider_model_obj(
-        project_id=client.project_id,
-        provider_id=provider_id,
-        model_id=model_id,
-        model_name=model_id,
-    )
-
-    # Mock responses for obj_read calls
-    mock_obj_read = create_mock_obj_read(provider_obj, provider_model_obj)
-
-    # Create test input
-    inputs = {
-        "model": model_name,
-        "messages": [{"role": "user", "content": "Hello, world!"}],
-    }
-
-    # Mock response from LiteLLM
-    mock_response = create_mock_completion_response(
-        model_name=model_id,
-        content="Hello!",
-    )
-
-    with with_tracing_disabled():
-        mock_secret_fetcher, token = setup_test_environment()
-        try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
-                with patch("litellm.completion") as mock_completion:
-                    mock_completion.return_value = ModelResponse.model_validate(
-                        mock_response
-                    )
-                    client.server.completions_create(
-                        tsi.CompletionsCreateReq.model_validate(
-                            {
-                                "project_id": client.project_id,
-                                "inputs": inputs,
-                            }
-                        )
-                    )
-
-            # Verify the trailing slash was stripped from api_base
-            mock_completion.assert_called_once()
-            call_args = mock_completion.call_args[1]
-            assert call_args["api_base"] == "http://localhost:11434", (
-                f"Expected trailing slash to be stripped. Got '{call_args['api_base']}'"
-            )
-        finally:
-            _secret_fetcher_context.reset(token)
+    assert provider_model.provider == "provider_id"
+    assert provider_model.max_tokens == 4096
 
 
 def test_get_custom_provider_info():
     """Test the get_custom_provider_info function directly."""
-    # Set up test data
     project_id = "test-project"
-    model_name = "test-provider-test-model"  # object_id format expected by get_custom_provider_info
+    model_name = "test-provider-test-model"
 
-    # Create a Provider object with explicit extra headers
     provider_obj = create_provider_obj(
         project_id=project_id,
         provider_id="test-provider",
         extra_headers={"X-Custom-Header": "value"},
     )
 
-    # Create a ProviderModel object
     provider_model_obj = create_provider_model_obj(
         project_id=project_id, provider_id="test-provider", model_id="test-model"
     )
 
-    # Mock the obj_read_func
     mock_obj_read = create_mock_obj_read(provider_obj, provider_model_obj)
 
-    # Set up the secret fetcher
     mock_secret_fetcher, token = setup_test_environment()
     try:
-        # Call the function
         provider_info = get_custom_provider_info(
             project_id=project_id,
             provider_name="test-provider",
@@ -590,7 +200,6 @@ def test_get_custom_provider_info():
             obj_read_func=mock_obj_read,
         )
 
-        # Verify the results
         assert provider_info.base_url == "https://api.example.com"
         assert provider_info.api_key == "DUMMY_SECRET_VALUE"
         assert provider_info.extra_headers == {"X-Custom-Header": "value"}
@@ -600,85 +209,237 @@ def test_get_custom_provider_info():
         _secret_fetcher_context.reset(token)
 
 
-def test_error_handling_custom_provider(client):
-    """Test error handling for custom provider."""
+def test_custom_provider_completions_create(client):
+    """Test completions_create with custom provider: standard, ollama, and trailing slash."""
     is_sqlite = client_is_sqlite(client)
     if is_sqlite:
-        # no need to test in sqlite
         return
 
-    # Create provider ID and model ID for testing
-    provider_id = f"test-error-{uuid.uuid4()}"
+    # --- Standard custom provider completion ---
+    provider_id = f"test-provider-{uuid.uuid4()}"
     model_id = "test-model"
     model_name = f"custom::{provider_id}::{model_id}"
 
-    # Create test input
+    provider_obj = create_provider_obj(
+        project_id=client.project_id,
+        provider_id=provider_id,
+        extra_headers={"X-Custom-Header": "value"},
+    )
+    provider_model_obj = create_provider_model_obj(
+        project_id=client.project_id,
+        provider_id=provider_id,
+        model_id=model_id,
+        model_name=model_id,
+    )
+    mock_obj_read = create_mock_obj_read(provider_obj, provider_model_obj)
+
     inputs = {
         "model": model_name,
         "messages": [{"role": "user", "content": "Hello, world!"}],
     }
-
-    # Mock obj_read to raise an exception
-    def mock_obj_read(req):
-        raise NotFoundError("Test error fetching provider")
+    mock_response = create_mock_completion_response(model_name=model_name)
 
     with with_tracing_disabled():
-        # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
             with patch(
                 "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
             ) as mock_read:
                 mock_read.side_effect = mock_obj_read
+                with patch("litellm.completion") as mock_completion:
+                    mock_completion.return_value = ModelResponse.model_validate(
+                        mock_response
+                    )
+                    res = client.server.completions_create(
+                        tsi.CompletionsCreateReq.model_validate(
+                            {
+                                "project_id": client.project_id,
+                                "inputs": inputs,
+                            }
+                        )
+                    )
+
+            assert res.response == mock_response
+            mock_completion.assert_called_once()
+            call_args = mock_completion.call_args[1]
+            assert call_args["model"] == f"openai/{model_id}"
+            assert call_args["messages"] == inputs["messages"]
+            assert call_args["api_key"] == "DUMMY_SECRET_VALUE"
+            assert call_args["api_base"] == "https://api.example.com"
+            assert call_args["extra_headers"] == {"X-Custom-Header": "value"}
+
+            calls = list(client.get_calls())
+            assert len(calls) == 1
+            assert calls[0].output == res.response
+            expected_usage_key = f"{provider_id}/{model_id}"
+            assert (
+                calls[0].summary["usage"][expected_usage_key] == res.response["usage"]
+            )
+            assert calls[0].op_name == "weave.completions_create"
+
+            # --- Ollama model (special prefix) ---
+            ollama_provider_id = f"test-ollama-{uuid.uuid4()}"
+            ollama_model_name = f"custom::{ollama_provider_id}::llama2"
+
+            ollama_provider_obj = create_provider_obj(
+                project_id=client.project_id,
+                provider_id=ollama_provider_id,
+                base_url="http://localhost:11434",
+                api_key_name="OLLAMA_API_KEY",
+                extra_headers={},
+            )
+            ollama_model_obj = create_provider_model_obj(
+                project_id=client.project_id,
+                provider_id=ollama_provider_id,
+                model_id="llama2",
+                model_name="llama2",
+            )
+            ollama_mock_read = create_mock_obj_read(
+                ollama_provider_obj, ollama_model_obj
+            )
+
+            ollama_inputs = {
+                "model": ollama_model_name,
+                "messages": [{"role": "user", "content": "Hello, world!"}],
+            }
+            ollama_response = create_mock_completion_response(
+                model_name="ollama/llama2",
+                content="Hello from Ollama!",
+                completion_tokens=4,
+                prompt_tokens=11,
+            )
+
+            with patch(
+                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
+            ) as mock_read:
+                mock_read.side_effect = ollama_mock_read
+                with patch("litellm.completion") as mock_completion:
+                    mock_completion.return_value = ModelResponse.model_validate(
+                        ollama_response
+                    )
+                    res = client.server.completions_create(
+                        tsi.CompletionsCreateReq.model_validate(
+                            {
+                                "project_id": client.project_id,
+                                "inputs": ollama_inputs,
+                            }
+                        )
+                    )
+
+            assert res.response == ollama_response
+            mock_completion.assert_called_once()
+            call_args = mock_completion.call_args[1]
+            assert call_args["model"] == "ollama/llama2"
+            assert call_args["api_base"] == "http://localhost:11434"
+
+            # --- Trailing slash normalization ---
+            slash_provider_id = f"test-trailing-slash-{uuid.uuid4()}"
+            slash_model_name = f"custom::{slash_provider_id}::test-model"
+
+            slash_provider_obj = create_provider_obj(
+                project_id=client.project_id,
+                provider_id=slash_provider_id,
+                base_url="http://localhost:11434/",
+                api_key_name="TEST_API_KEY",
+                extra_headers={},
+            )
+            slash_model_obj = create_provider_model_obj(
+                project_id=client.project_id,
+                provider_id=slash_provider_id,
+                model_id="test-model",
+                model_name="test-model",
+            )
+            slash_mock_read = create_mock_obj_read(
+                slash_provider_obj, slash_model_obj
+            )
+
+            slash_inputs = {
+                "model": slash_model_name,
+                "messages": [{"role": "user", "content": "Hello, world!"}],
+            }
+            slash_response = create_mock_completion_response(
+                model_name="test-model", content="Hello!"
+            )
+
+            with patch(
+                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
+            ) as mock_read:
+                mock_read.side_effect = slash_mock_read
+                with patch("litellm.completion") as mock_completion:
+                    mock_completion.return_value = ModelResponse.model_validate(
+                        slash_response
+                    )
+                    client.server.completions_create(
+                        tsi.CompletionsCreateReq.model_validate(
+                            {
+                                "project_id": client.project_id,
+                                "inputs": slash_inputs,
+                            }
+                        )
+                    )
+
+            mock_completion.assert_called_once()
+            call_args = mock_completion.call_args[1]
+            assert call_args["api_base"] == "http://localhost:11434"
+        finally:
+            _secret_fetcher_context.reset(token)
+
+
+def test_custom_provider_error_handling(client):
+    """Test error handling for custom provider: missing provider and invalid format."""
+    is_sqlite = client_is_sqlite(client)
+    if is_sqlite:
+        return
+
+    with with_tracing_disabled():
+        mock_secret_fetcher, token = setup_test_environment()
+        try:
+            # Provider not found
+            provider_id = f"test-error-{uuid.uuid4()}"
+            model_name = f"custom::{provider_id}::test-model"
+
+            def mock_obj_read_error(req):
+                raise NotFoundError("Test error fetching provider")
+
+            with patch(
+                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
+            ) as mock_read:
+                mock_read.side_effect = mock_obj_read_error
                 res = client.server.completions_create(
                     tsi.CompletionsCreateReq.model_validate(
                         {
                             "project_id": client.project_id,
-                            "inputs": inputs,
+                            "inputs": {
+                                "model": model_name,
+                                "messages": [
+                                    {"role": "user", "content": "Hello, world!"}
+                                ],
+                            },
                         }
                     )
                 )
 
-            # Verify error is returned in the response
             assert "error" in res.response
             assert (
                 "Failed to fetch provider model information: Test error fetching provider"
                 in res.response["error"]
             )
-        finally:
-            _secret_fetcher_context.reset(token)
 
-
-def test_custom_provider_invalid_model_format(client):
-    """Test error handling for invalid model format."""
-    is_sqlite = client_is_sqlite(client)
-    if is_sqlite:
-        # no need to test in sqlite
-        return
-
-    # Use an invalid model format (no slash)
-    model_name = "invalid-model-format"
-
-    # Create test input
-    inputs = {
-        "model": model_name,
-        "messages": [{"role": "user", "content": "Hello, world!"}],
-    }
-
-    with with_tracing_disabled():
-        # Set up the secret fetcher
-        mock_secret_fetcher, token = setup_test_environment()
-        try:
+            # Invalid model format (no custom:: prefix)
             res = client.server.completions_create(
                 tsi.CompletionsCreateReq.model_validate(
                     {
                         "project_id": client.project_id,
-                        "inputs": inputs,
+                        "inputs": {
+                            "model": "invalid-model-format",
+                            "messages": [
+                                {"role": "user", "content": "Hello, world!"}
+                            ],
+                        },
                     }
                 )
             )
 
-            # Verify error is returned in the response
             assert "error" in res.response
             assert "LLM Provider NOT provided" in res.response["error"]
         finally:

--- a/tests/trace_server/test_dataset_v2_api.py
+++ b/tests/trace_server/test_dataset_v2_api.py
@@ -147,17 +147,13 @@ def test_dataset_list_and_pagination(trace_server):
 
     # Limit
     datasets = list(
-        trace_server.dataset_list(
-            tsi.DatasetListReq(project_id=project_id, limit=3)
-        )
+        trace_server.dataset_list(tsi.DatasetListReq(project_id=project_id, limit=3))
     )
     assert len(datasets) == 3
 
     # Offset
     datasets = list(
-        trace_server.dataset_list(
-            tsi.DatasetListReq(project_id=project_id, offset=7)
-        )
+        trace_server.dataset_list(tsi.DatasetListReq(project_id=project_id, offset=7))
     )
     assert len(datasets) == 3
 
@@ -316,9 +312,7 @@ def test_dataset_list_after_deletion(trace_server):
         )
 
     trace_server.dataset_delete(
-        tsi.DatasetDeleteReq(
-            project_id=project_id, object_id="delete_me", digests=None
-        )
+        tsi.DatasetDeleteReq(project_id=project_id, object_id="delete_me", digests=None)
     )
 
     datasets = list(

--- a/tests/trace_server/test_dataset_v2_api.py
+++ b/tests/trace_server/test_dataset_v2_api.py
@@ -10,507 +10,375 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 
 
-def test_dataset_create_basic(trace_server):
-    """Test creating a basic dataset object."""
-    project_id = f"{TEST_ENTITY}/test_dataset_create_basic"
+def test_dataset_create_and_read(trace_server):
+    """Test creating datasets (with and without description) and reading them back."""
+    project_id = f"{TEST_ENTITY}/test_dataset_create_and_read"
 
-    # Create a dataset
-    rows = [
-        {"id": 1, "value": "a"},
-        {"id": 2, "value": "b"},
-        {"id": 3, "value": "c"},
-    ]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="my_dataset",
-        description="A test dataset",
-        rows=rows,
-    )
-    create_res = trace_server.dataset_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "my_dataset"
-    assert create_res.version_index == 0
-
-
-def test_dataset_create_without_description(trace_server):
-    """Test creating a dataset without providing a description."""
-    project_id = f"{TEST_ENTITY}/test_dataset_create_no_desc"
-
-    # Create a dataset without description
-    rows = [{"x": 1, "y": 2}]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="dataset_no_desc",
-        description=None,
-        rows=rows,
-    )
-    create_res = trace_server.dataset_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "dataset_no_desc"
-    assert create_res.version_index == 0
-
-
-def test_dataset_read_basic(trace_server):
-    """Test reading a specific dataset object."""
-    project_id = f"{TEST_ENTITY}/test_dataset_read_basic"
-
-    # Create a dataset
+    # Create with description
     rows = [
         {"name": "Alice", "age": 30},
         {"name": "Bob", "age": 25},
     ]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="people",
-        description="A dataset of people",
-        rows=rows,
+    create_res = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id,
+            name="people",
+            description="A dataset of people",
+            rows=rows,
+        )
     )
-    create_res = trace_server.dataset_create(create_req)
+    assert create_res.digest is not None
+    assert create_res.object_id == "people"
+    assert create_res.version_index == 0
 
-    # Read the dataset back
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="people",
-        digest=create_res.digest,
+    # Read it back
+    read_res = trace_server.dataset_read(
+        tsi.DatasetReadReq(
+            project_id=project_id,
+            object_id="people",
+            digest=create_res.digest,
+        )
     )
-    read_res = trace_server.dataset_read(read_req)
-
     assert read_res.object_id == "people"
     assert read_res.digest == create_res.digest
     assert read_res.version_index == 0
     assert read_res.name == "people"
     assert read_res.description == "A dataset of people"
     assert read_res.created_at is not None
-    # Verify rows is a string reference, not the actual data
     assert isinstance(read_res.rows, str)
     assert read_res.rows.startswith("weave:///")
 
-
-def test_dataset_read_not_found(trace_server):
-    """Test reading a non-existent dataset raises NotFoundError."""
-    project_id = f"{TEST_ENTITY}/test_dataset_read_not_found"
-
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="nonexistent_dataset",
-        digest="fake_digest_1234567890",
-    )
-
-    with pytest.raises(NotFoundError):
-        trace_server.dataset_read(read_req)
-
-
-def test_dataset_list_basic(trace_server):
-    """Test listing all datasets in a project."""
-    project_id = f"{TEST_ENTITY}/test_dataset_list_basic"
-
-    # Create multiple datasets
-    dataset_names = ["dataset_a", "dataset_b", "dataset_c"]
-    for name in dataset_names:
-        create_req = tsi.DatasetCreateReq(
+    # Create without description
+    create_res2 = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
             project_id=project_id,
-            name=name,
-            description=f"Dataset {name}",
-            rows=[{"id": 1, "name": name}],
+            name="dataset_no_desc",
+            description=None,
+            rows=[{"x": 1, "y": 2}],
         )
-        trace_server.dataset_create(create_req)
+    )
+    assert create_res2.digest is not None
+    assert create_res2.object_id == "dataset_no_desc"
+    assert create_res2.version_index == 0
 
-    # List all datasets
-    list_req = tsi.DatasetListReq(project_id=project_id)
-    datasets = list(trace_server.dataset_list(list_req))
+    # Create with empty rows
+    create_res3 = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id,
+            name="empty_dataset",
+            description="A dataset with no rows",
+            rows=[],
+        )
+    )
+    assert create_res3.digest is not None
+    read_res3 = trace_server.dataset_read(
+        tsi.DatasetReadReq(
+            project_id=project_id,
+            object_id="empty_dataset",
+            digest=create_res3.digest,
+        )
+    )
+    assert read_res3.name == "empty_dataset"
+    assert isinstance(read_res3.rows, str)
 
-    assert len(datasets) == 3
-    dataset_names_returned = {ds.name for ds in datasets}
-    assert dataset_names_returned == {"dataset_a", "dataset_b", "dataset_c"}
+    # Create with many rows
+    large_rows = [{"id": i, "value": f"value_{i}", "data": i * 2} for i in range(100)]
+    create_res4 = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id,
+            name="large_dataset",
+            description="A dataset with 100 rows",
+            rows=large_rows,
+        )
+    )
+    assert create_res4.digest is not None
+    read_res4 = trace_server.dataset_read(
+        tsi.DatasetReadReq(
+            project_id=project_id,
+            object_id="large_dataset",
+            digest=create_res4.digest,
+        )
+    )
+    assert read_res4.name == "large_dataset"
+    assert isinstance(read_res4.rows, str)
+    assert read_res4.rows.startswith("weave:///")
 
-    # Verify all datasets have rows references (not actual data)
+    # Read not found
+    with pytest.raises(NotFoundError):
+        trace_server.dataset_read(
+            tsi.DatasetReadReq(
+                project_id=project_id,
+                object_id="nonexistent_dataset",
+                digest="fake_digest_1234567890",
+            )
+        )
+
+
+def test_dataset_list_and_pagination(trace_server):
+    """Test listing datasets with limit, offset, and empty project."""
+    project_id = f"{TEST_ENTITY}/test_dataset_list_pagination"
+
+    # Empty project
+    datasets = list(
+        trace_server.dataset_list(tsi.DatasetListReq(project_id=project_id))
+    )
+    assert len(datasets) == 0
+
+    # Create 10 datasets
+    for i in range(10):
+        trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id,
+                name=f"dataset_{i}",
+                description=None,
+                rows=[{"value": i}],
+            )
+        )
+
+    # List all
+    datasets = list(
+        trace_server.dataset_list(tsi.DatasetListReq(project_id=project_id))
+    )
+    assert len(datasets) == 10
     for ds in datasets:
         assert isinstance(ds.rows, str)
         assert ds.rows.startswith("weave:///")
         assert ds.created_at is not None
 
-
-def test_dataset_list_with_limit(trace_server):
-    """Test listing datasets with a limit."""
-    project_id = f"{TEST_ENTITY}/test_dataset_list_limit"
-
-    # Create multiple datasets
-    for i in range(5):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name=f"dataset_{i}",
-            description=None,
-            rows=[{"value": i}],
+    # Limit
+    datasets = list(
+        trace_server.dataset_list(
+            tsi.DatasetListReq(project_id=project_id, limit=3)
         )
-        trace_server.dataset_create(create_req)
-
-    # List with a limit
-    list_req = tsi.DatasetListReq(project_id=project_id, limit=3)
-    datasets = list(trace_server.dataset_list(list_req))
-
+    )
     assert len(datasets) == 3
 
-
-def test_dataset_list_with_offset(trace_server):
-    """Test listing datasets with an offset."""
-    project_id = f"{TEST_ENTITY}/test_dataset_list_offset"
-
-    # Create multiple datasets
-    for i in range(5):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name=f"dataset_{i}",
-            description=None,
-            rows=[{"value": i}],
+    # Offset
+    datasets = list(
+        trace_server.dataset_list(
+            tsi.DatasetListReq(project_id=project_id, offset=7)
         )
-        trace_server.dataset_create(create_req)
-
-    # List with an offset
-    list_req = tsi.DatasetListReq(project_id=project_id, offset=2)
-    datasets = list(trace_server.dataset_list(list_req))
-
+    )
     assert len(datasets) == 3
 
-
-def test_dataset_list_with_limit_and_offset(trace_server):
-    """Test listing datasets with both limit and offset for pagination."""
-    project_id = f"{TEST_ENTITY}/test_dataset_list_pagination"
-
-    # Create multiple datasets
-    for i in range(10):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name=f"dataset_{i}",
-            description=None,
-            rows=[{"value": i}],
+    # Limit + offset pagination
+    page1 = list(
+        trace_server.dataset_list(
+            tsi.DatasetListReq(project_id=project_id, limit=3, offset=0)
         )
-        trace_server.dataset_create(create_req)
-
-    # First page
-    list_req1 = tsi.DatasetListReq(project_id=project_id, limit=3, offset=0)
-    datasets1 = list(trace_server.dataset_list(list_req1))
-    assert len(datasets1) == 3
-
-    # Second page
-    list_req2 = tsi.DatasetListReq(project_id=project_id, limit=3, offset=3)
-    datasets2 = list(trace_server.dataset_list(list_req2))
-    assert len(datasets2) == 3
-
-    # Verify different datasets on different pages
-    datasets1_names = {ds.name for ds in datasets1}
-    datasets2_names = {ds.name for ds in datasets2}
-    assert len(datasets1_names & datasets2_names) == 0  # No overlap
-
-
-def test_dataset_list_empty_project(trace_server):
-    """Test listing datasets in a project with no datasets."""
-    project_id = f"{TEST_ENTITY}/test_dataset_list_empty"
-
-    list_req = tsi.DatasetListReq(project_id=project_id)
-    datasets = list(trace_server.dataset_list(list_req))
-
-    assert len(datasets) == 0
-
-
-def test_dataset_delete_single_version(trace_server):
-    """Test deleting a single version of a dataset."""
-    project_id = f"{TEST_ENTITY}/test_dataset_delete_single"
-
-    # Create a dataset
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="delete_test",
-        description=None,
-        rows=[{"id": 1}],
     )
-    create_res = trace_server.dataset_create(create_req)
-
-    # Delete the specific version
-    delete_req = tsi.DatasetDeleteReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digests=[create_res.digest],
-    )
-    delete_res = trace_server.dataset_delete(delete_req)
-
-    assert delete_res.num_deleted == 1
-
-    # Verify the dataset is deleted (should raise ObjectDeletedError)
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digest=create_res.digest,
-    )
-    with pytest.raises(ObjectDeletedError):
-        trace_server.dataset_read(read_req)
-
-
-def test_dataset_delete_all_versions(trace_server):
-    """Test deleting all versions of a dataset (no digests specified)."""
-    project_id = f"{TEST_ENTITY}/test_dataset_delete_all"
-
-    # Create multiple versions of the same dataset
-    digests = []
-    for i in range(3):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name="versioned_dataset",
-            description=None,
-            rows=[{"version": i}],
+    page2 = list(
+        trace_server.dataset_list(
+            tsi.DatasetListReq(project_id=project_id, limit=3, offset=3)
         )
-        create_res = trace_server.dataset_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete all versions (no digests specified)
-    delete_req = tsi.DatasetDeleteReq(
-        project_id=project_id,
-        object_id="versioned_dataset",
-        digests=None,
     )
-    delete_res = trace_server.dataset_delete(delete_req)
-
-    assert delete_res.num_deleted == 3
-
-
-def test_dataset_delete_multiple_versions(trace_server):
-    """Test deleting multiple specific versions of a dataset."""
-    project_id = f"{TEST_ENTITY}/test_dataset_delete_multiple"
-
-    # Create multiple versions
-    digests = []
-    for i in range(4):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name="multi_version_dataset",
-            description=None,
-            rows=[{"version": i}],
-        )
-        create_res = trace_server.dataset_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete the first two versions
-    delete_req = tsi.DatasetDeleteReq(
-        project_id=project_id,
-        object_id="multi_version_dataset",
-        digests=digests[:2],
-    )
-    delete_res = trace_server.dataset_delete(delete_req)
-
-    assert delete_res.num_deleted == 2
-
-    # Verify the first two are deleted
-    for digest in digests[:2]:
-        read_req = tsi.DatasetReadReq(
-            project_id=project_id,
-            object_id="multi_version_dataset",
-            digest=digest,
-        )
-        with pytest.raises(ObjectDeletedError):
-            trace_server.dataset_read(read_req)
-
-    # Verify the last two still exist
-    for digest in digests[2:]:
-        read_req = tsi.DatasetReadReq(
-            project_id=project_id,
-            object_id="multi_version_dataset",
-            digest=digest,
-        )
-        read_res = trace_server.dataset_read(read_req)
-        assert read_res.digest == digest
-
-
-def test_dataset_delete_not_found(trace_server):
-    """Test deleting a non-existent dataset raises NotFoundError."""
-    project_id = f"{TEST_ENTITY}/test_dataset_delete_not_found"
-
-    delete_req = tsi.DatasetDeleteReq(
-        project_id=project_id,
-        object_id="nonexistent_dataset",
-        digests=["fake_digest"],
-    )
-
-    with pytest.raises(NotFoundError):
-        trace_server.dataset_delete(delete_req)
+    assert len(page1) == 3
+    assert len(page2) == 3
+    page1_names = {ds.name for ds in page1}
+    page2_names = {ds.name for ds in page2}
+    assert len(page1_names & page2_names) == 0
 
 
 def test_dataset_versioning(trace_server):
-    """Test that creating multiple versions of a dataset increments version_index."""
+    """Test version_index increments and all versions are distinct."""
     project_id = f"{TEST_ENTITY}/test_dataset_versioning"
 
-    # Create multiple versions of the same dataset
     versions = []
     for i in range(3):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name="versioned_dataset",
-            description=f"Version {i}",
-            rows=[{"value": i}],
+        create_res = trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id,
+                name="versioned_dataset",
+                description=f"Version {i}",
+                rows=[{"value": i}],
+            )
         )
-        create_res = trace_server.dataset_create(create_req)
         versions.append(create_res)
 
-    # Verify version indices increment
     assert versions[0].version_index == 0
     assert versions[1].version_index == 1
     assert versions[2].version_index == 2
-
-    # Verify all versions are distinct
     assert len({v.digest for v in versions}) == 3
 
 
-def test_dataset_with_special_characters(trace_server):
-    """Test creating and reading a dataset with special characters in data."""
-    project_id = f"{TEST_ENTITY}/test_dataset_special_chars"
+def test_dataset_delete(trace_server):
+    """Test deleting datasets: single version, all versions, multiple versions, not found."""
+    project_id = f"{TEST_ENTITY}/test_dataset_delete"
 
-    # Create a dataset with special characters
-    rows = [
-        {"text": "This has \"quotes\" and 'apostrophes'"},
-        {"text": "Line breaks:\n\tand tabs"},
-        {"text": "Unicode: 你好世界 🚀"},
-    ]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="special_chars",
-        description='Dataset with "special" characters',
-        rows=rows,
+    # Delete single version
+    create_res = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id,
+            name="delete_single",
+            description=None,
+            rows=[{"id": 1}],
+        )
     )
-    create_res = trace_server.dataset_create(create_req)
-
-    # Read it back and verify metadata is preserved
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="special_chars",
-        digest=create_res.digest,
+    delete_res = trace_server.dataset_delete(
+        tsi.DatasetDeleteReq(
+            project_id=project_id,
+            object_id="delete_single",
+            digests=[create_res.digest],
+        )
     )
-    read_res = trace_server.dataset_read(read_req)
+    assert delete_res.num_deleted == 1
+    with pytest.raises(ObjectDeletedError):
+        trace_server.dataset_read(
+            tsi.DatasetReadReq(
+                project_id=project_id,
+                object_id="delete_single",
+                digest=create_res.digest,
+            )
+        )
 
-    assert read_res.name == "special_chars"
-    assert read_res.description == 'Dataset with "special" characters'
-    # The rows should still be a reference
-    assert isinstance(read_res.rows, str)
-    assert read_res.rows.startswith("weave:///")
-
-
-def test_dataset_with_unicode(trace_server):
-    """Test creating and reading a dataset with unicode characters."""
-    project_id = f"{TEST_ENTITY}/test_dataset_unicode"
-
-    # Create a dataset with unicode
-    rows = [
-        {"language": "Chinese", "greeting": "你好世界"},
-        {"language": "Japanese", "greeting": "こんにちは"},
-        {"language": "Emoji", "greeting": "🚀 🌟 ✨"},
-    ]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="unicode_dataset",
-        description="Unicode greetings 🌍",
-        rows=rows,
+    # Delete all versions
+    digests = []
+    for i in range(3):
+        res = trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id,
+                name="delete_all",
+                description=None,
+                rows=[{"version": i}],
+            )
+        )
+        digests.append(res.digest)
+    delete_res = trace_server.dataset_delete(
+        tsi.DatasetDeleteReq(
+            project_id=project_id, object_id="delete_all", digests=None
+        )
     )
-    create_res = trace_server.dataset_create(create_req)
+    assert delete_res.num_deleted == 3
 
-    # Read it back and verify metadata is preserved
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="unicode_dataset",
-        digest=create_res.digest,
+    # Delete multiple specific versions (keep some)
+    digests = []
+    for i in range(4):
+        res = trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id,
+                name="delete_multi",
+                description=None,
+                rows=[{"version": i}],
+            )
+        )
+        digests.append(res.digest)
+    delete_res = trace_server.dataset_delete(
+        tsi.DatasetDeleteReq(
+            project_id=project_id,
+            object_id="delete_multi",
+            digests=digests[:2],
+        )
     )
-    read_res = trace_server.dataset_read(read_req)
+    assert delete_res.num_deleted == 2
+    for digest in digests[:2]:
+        with pytest.raises(ObjectDeletedError):
+            trace_server.dataset_read(
+                tsi.DatasetReadReq(
+                    project_id=project_id,
+                    object_id="delete_multi",
+                    digest=digest,
+                )
+            )
+    for digest in digests[2:]:
+        read_res = trace_server.dataset_read(
+            tsi.DatasetReadReq(
+                project_id=project_id,
+                object_id="delete_multi",
+                digest=digest,
+            )
+        )
+        assert read_res.digest == digest
 
-    assert read_res.name == "unicode_dataset"
-    assert read_res.description == "Unicode greetings 🌍"
-    assert "🌍" in read_res.description
+    # Delete not found
+    with pytest.raises(NotFoundError):
+        trace_server.dataset_delete(
+            tsi.DatasetDeleteReq(
+                project_id=project_id,
+                object_id="nonexistent_dataset",
+                digests=["fake_digest"],
+            )
+        )
 
 
 def test_dataset_list_after_deletion(trace_server):
     """Test that deleted datasets don't appear in list results."""
     project_id = f"{TEST_ENTITY}/test_dataset_list_after_deletion"
 
-    # Create three datasets
     dataset_names = ["keep_1", "delete_me", "keep_2"]
-    digests = {}
     for name in dataset_names:
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name=name,
-            description=None,
-            rows=[{"id": 1}],
+        trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id,
+                name=name,
+                description=None,
+                rows=[{"id": 1}],
+            )
         )
-        create_res = trace_server.dataset_create(create_req)
-        digests[name] = create_res.digest
 
-    # Delete one dataset
-    delete_req = tsi.DatasetDeleteReq(
-        project_id=project_id,
-        object_id="delete_me",
-        digests=None,
+    trace_server.dataset_delete(
+        tsi.DatasetDeleteReq(
+            project_id=project_id, object_id="delete_me", digests=None
+        )
     )
-    trace_server.dataset_delete(delete_req)
 
-    # List datasets - should only see the two that weren't deleted
-    list_req = tsi.DatasetListReq(project_id=project_id)
-    datasets = list(trace_server.dataset_list(list_req))
-
+    datasets = list(
+        trace_server.dataset_list(tsi.DatasetListReq(project_id=project_id))
+    )
     dataset_names_returned = {ds.name for ds in datasets}
     assert dataset_names_returned == {"keep_1", "keep_2"}
-    assert "delete_me" not in dataset_names_returned
 
 
-def test_dataset_empty_rows(trace_server):
-    """Test creating a dataset with empty rows."""
-    project_id = f"{TEST_ENTITY}/test_dataset_empty_rows"
+def test_dataset_special_characters_and_unicode(trace_server):
+    """Test creating and reading datasets with special characters and unicode."""
+    project_id = f"{TEST_ENTITY}/test_dataset_special_chars"
 
-    # Create a dataset with empty rows
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="empty_dataset",
-        description="A dataset with no rows",
-        rows=[],
+    # Special characters
+    rows = [
+        {"text": "This has \"quotes\" and 'apostrophes'"},
+        {"text": "Line breaks:\n\tand tabs"},
+        {"text": "Unicode: 你好世界 🚀"},
+    ]
+    create_res = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id,
+            name="special_chars",
+            description='Dataset with "special" characters',
+            rows=rows,
+        )
     )
-    create_res = trace_server.dataset_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "empty_dataset"
-
-    # Read it back
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="empty_dataset",
-        digest=create_res.digest,
+    read_res = trace_server.dataset_read(
+        tsi.DatasetReadReq(
+            project_id=project_id,
+            object_id="special_chars",
+            digest=create_res.digest,
+        )
     )
-    read_res = trace_server.dataset_read(read_req)
-
-    assert read_res.name == "empty_dataset"
-    assert isinstance(read_res.rows, str)
-
-
-def test_dataset_large_rows(trace_server):
-    """Test creating a dataset with many rows."""
-    project_id = f"{TEST_ENTITY}/test_dataset_large_rows"
-
-    # Create a dataset with 100 rows
-    rows = [{"id": i, "value": f"value_{i}", "data": i * 2} for i in range(100)]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="large_dataset",
-        description="A dataset with 100 rows",
-        rows=rows,
-    )
-    create_res = trace_server.dataset_create(create_req)
-
-    assert create_res.digest is not None
-
-    # Read it back
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="large_dataset",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.dataset_read(read_req)
-
-    assert read_res.name == "large_dataset"
-    # The rows should still be a reference (not the actual 100 rows)
+    assert read_res.name == "special_chars"
+    assert read_res.description == 'Dataset with "special" characters'
     assert isinstance(read_res.rows, str)
     assert read_res.rows.startswith("weave:///")
+
+    # Unicode
+    unicode_rows = [
+        {"language": "Chinese", "greeting": "你好世界"},
+        {"language": "Japanese", "greeting": "こんにちは"},
+        {"language": "Emoji", "greeting": "🚀 🌟 ✨"},
+    ]
+    create_res2 = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id,
+            name="unicode_dataset",
+            description="Unicode greetings 🌍",
+            rows=unicode_rows,
+        )
+    )
+    read_res2 = trace_server.dataset_read(
+        tsi.DatasetReadReq(
+            project_id=project_id,
+            object_id="unicode_dataset",
+            digest=create_res2.digest,
+        )
+    )
+    assert read_res2.name == "unicode_dataset"
+    assert read_res2.description == "Unicode greetings 🌍"
+    assert "🌍" in read_res2.description

--- a/tests/trace_server/test_digest_validation.py
+++ b/tests/trace_server/test_digest_validation.py
@@ -35,94 +35,91 @@ def test_validate_expected_digest_mismatch_raises() -> None:
         validate_expected_digest(expected="wrong", actual="abc123", label="test")
 
 
-@pytest.mark.trace_server
-class TestFileCreateExpectedDigest:
-    def test_no_expected_digest(self, client) -> None:
-        """file_create without expected_digest succeeds (fallback path)."""
-        req = FileCreateReq(
+def test_expected_digest_on_create_endpoints(client) -> None:
+    """Test expected_digest validation on file_create, obj_create, and table_create."""
+    from weave.trace_server.sqlite_trace_server import compute_file_digest
+
+    # --- FileCreateReq ---
+    # No expected_digest (fallback path)
+    res = client.server.file_create(
+        FileCreateReq(
             project_id=client.project_id,
             name="test.txt",
             content=b"hello world",
         )
-        res = client.server.file_create(req)
-        assert res.digest is not None
+    )
+    assert res.digest is not None
 
-    def test_correct_expected_digest(self, client) -> None:
-        """file_create with correct expected_digest succeeds."""
-        from weave.trace_server.sqlite_trace_server import compute_file_digest
-
-        content = b"hello world"
-        digest = compute_file_digest(content)
-        req = FileCreateReq(
+    # Correct expected_digest
+    content = b"hello world"
+    digest = compute_file_digest(content)
+    res = client.server.file_create(
+        FileCreateReq(
             project_id=client.project_id,
             name="test.txt",
             content=content,
             expected_digest=digest,
         )
-        res = client.server.file_create(req)
-        assert res.digest == digest
+    )
+    assert res.digest == digest
 
-    def test_wrong_expected_digest(self, client) -> None:
-        """file_create with wrong expected_digest raises DigestMismatchError."""
-        req = FileCreateReq(
-            project_id=client.project_id,
-            name="test.txt",
-            content=b"hello world",
-            expected_digest="wrong_digest",
+    # Wrong expected_digest
+    with pytest.raises(DigestMismatchError):
+        client.server.file_create(
+            FileCreateReq(
+                project_id=client.project_id,
+                name="test.txt",
+                content=b"hello world",
+                expected_digest="wrong_digest",
+            )
         )
-        with pytest.raises(DigestMismatchError):
-            client.server.file_create(req)
 
-
-@pytest.mark.trace_server
-class TestObjCreateExpectedDigest:
-    def test_no_expected_digest(self, client) -> None:
-        """obj_create without expected_digest succeeds (fallback path)."""
-        req = ObjCreateReq(
+    # --- ObjCreateReq ---
+    # No expected_digest
+    res = client.server.obj_create(
+        ObjCreateReq(
             obj=ObjSchemaForInsert(
                 project_id=client.project_id,
                 object_id="test_obj",
                 val={"key": "value"},
             )
         )
-        res = client.server.obj_create(req)
-        assert res.digest is not None
+    )
+    assert res.digest is not None
 
-    def test_wrong_expected_digest(self, client) -> None:
-        """obj_create with wrong expected_digest raises DigestMismatchError."""
-        req = ObjCreateReq(
-            obj=ObjSchemaForInsert(
-                project_id=client.project_id,
-                object_id="test_obj",
-                val={"key": "value"},
-                expected_digest="wrong_digest",
+    # Wrong expected_digest
+    with pytest.raises(DigestMismatchError):
+        client.server.obj_create(
+            ObjCreateReq(
+                obj=ObjSchemaForInsert(
+                    project_id=client.project_id,
+                    object_id="test_obj",
+                    val={"key": "value"},
+                    expected_digest="wrong_digest",
+                )
             )
         )
-        with pytest.raises(DigestMismatchError):
-            client.server.obj_create(req)
 
-
-@pytest.mark.trace_server
-class TestTableCreateExpectedDigest:
-    def test_no_expected_digest(self, client) -> None:
-        """table_create without expected_digest succeeds (fallback path)."""
-        req = TableCreateReq(
+    # --- TableCreateReq ---
+    # No expected_digest
+    res = client.server.table_create(
+        TableCreateReq(
             table=TableSchemaForInsert(
                 project_id=client.project_id,
                 rows=[{"val": {"a": 1}}, {"val": {"a": 2}}],
             )
         )
-        res = client.server.table_create(req)
-        assert res.digest is not None
+    )
+    assert res.digest is not None
 
-    def test_wrong_expected_digest(self, client) -> None:
-        """table_create with wrong expected_digest raises DigestMismatchError."""
-        req = TableCreateReq(
-            table=TableSchemaForInsert(
-                project_id=client.project_id,
-                rows=[{"val": {"a": 1}}, {"val": {"a": 2}}],
-                expected_digest="wrong_digest",
+    # Wrong expected_digest
+    with pytest.raises(DigestMismatchError):
+        client.server.table_create(
+            TableCreateReq(
+                table=TableSchemaForInsert(
+                    project_id=client.project_id,
+                    rows=[{"val": {"a": 1}}, {"val": {"a": 2}}],
+                    expected_digest="wrong_digest",
+                )
             )
         )
-        with pytest.raises(DigestMismatchError):
-            client.server.table_create(req)

--- a/tests/trace_server/test_op_v2_api.py
+++ b/tests/trace_server/test_op_v2_api.py
@@ -103,14 +103,10 @@ def test_op_list_and_pagination(trace_server):
 
     # Limit + offset pagination
     page1 = list(
-        trace_server.op_list(
-            tsi.OpListReq(project_id=project_id, limit=3, offset=0)
-        )
+        trace_server.op_list(tsi.OpListReq(project_id=project_id, limit=3, offset=0))
     )
     page2 = list(
-        trace_server.op_list(
-            tsi.OpListReq(project_id=project_id, limit=3, offset=3)
-        )
+        trace_server.op_list(tsi.OpListReq(project_id=project_id, limit=3, offset=3))
     )
     assert len(page1) == 3
     assert len(page2) == 3
@@ -184,9 +180,7 @@ def test_op_delete(trace_server):
         )
         digests.append(res.digest)
     delete_res = trace_server.op_delete(
-        tsi.OpDeleteReq(
-            project_id=project_id, object_id="delete_all", digests=None
-        )
+        tsi.OpDeleteReq(project_id=project_id, object_id="delete_all", digests=None)
     )
     assert delete_res.num_deleted == 3
 
@@ -256,9 +250,7 @@ def test_op_list_after_deletion(trace_server):
         )
 
     trace_server.op_delete(
-        tsi.OpDeleteReq(
-            project_id=project_id, object_id="op_delete", digests=None
-        )
+        tsi.OpDeleteReq(project_id=project_id, object_id="op_delete", digests=None)
     )
 
     ops = list(trace_server.op_list(tsi.OpListReq(project_id=project_id)))

--- a/tests/trace_server/test_op_v2_api.py
+++ b/tests/trace_server/test_op_v2_api.py
@@ -10,431 +10,309 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 
 
-def test_op_create_basic(trace_server):
-    """Test creating a basic op object."""
-    project_id = f"{TEST_ENTITY}/test_op_create_basic"
+def test_op_create_and_read(trace_server):
+    """Test creating ops (with and without source code) and reading them back."""
+    project_id = f"{TEST_ENTITY}/test_op_create_and_read"
 
-    # Create an op
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="my_function",
-        description=None,
-        source_code="def my_function(x: int) -> int:\n    return x * 2",
+    # Create with source code
+    source_code = "def my_function(x: int) -> int:\n    return x * 2"
+    create_res = trace_server.op_create(
+        tsi.OpCreateReq(
+            project_id=project_id,
+            name="my_function",
+            description=None,
+            source_code=source_code,
+        )
     )
-    create_res = trace_server.op_create(create_req)
-
     assert create_res.digest is not None
     assert create_res.object_id == "my_function"
     assert create_res.version_index == 0
 
-
-def test_op_create_without_source_code(trace_server):
-    """Test creating an op without providing source code (uses placeholder)."""
-    project_id = f"{TEST_ENTITY}/test_op_create_no_source"
-
-    # Create an op without source code
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="my_op_no_source",
-        description=None,
-        source_code=None,
+    # Read it back
+    read_res = trace_server.op_read(
+        tsi.OpReadReq(
+            project_id=project_id,
+            object_id="my_function",
+            digest=create_res.digest,
+        )
     )
-    create_res = trace_server.op_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "my_op_no_source"
-    assert create_res.version_index == 0
-
-
-def test_op_read_basic(trace_server):
-    """Test reading a specific op object."""
-    project_id = f"{TEST_ENTITY}/test_op_read_basic"
-
-    # Create an op
-    source_code = "def read_test(x: int) -> int:\n    return x + 1"
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="read_test",
-        description=None,
-        source_code=source_code,
-    )
-    create_res = trace_server.op_create(create_req)
-
-    # Read the op back
-    read_req = tsi.OpReadReq(
-        project_id=project_id,
-        object_id="read_test",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.op_read(read_req)
-
-    assert read_res.object_id == "read_test"
+    assert read_res.object_id == "my_function"
     assert read_res.digest == create_res.digest
     assert read_res.version_index == 0
     assert read_res.code == source_code
     assert read_res.created_at is not None
 
-
-def test_op_read_not_found(trace_server):
-    """Test reading a non-existent op raises NotFoundError."""
-    project_id = f"{TEST_ENTITY}/test_op_read_not_found"
-
-    read_req = tsi.OpReadReq(
-        project_id=project_id,
-        object_id="nonexistent_op",
-        digest="fake_digest_1234567890",
-    )
-
-    with pytest.raises(NotFoundError):
-        trace_server.op_read(read_req)
-
-
-def test_op_list_basic(trace_server):
-    """Test listing all ops in a project."""
-    project_id = f"{TEST_ENTITY}/test_op_list_basic"
-
-    # Create multiple ops
-    op_names = ["op_a", "op_b", "op_c"]
-    for name in op_names:
-        create_req = tsi.OpCreateReq(
+    # Create without source code
+    create_res2 = trace_server.op_create(
+        tsi.OpCreateReq(
             project_id=project_id,
-            name=name,
+            name="my_op_no_source",
             description=None,
-            source_code=f"def {name}():\n    pass",
+            source_code=None,
         )
-        trace_server.op_create(create_req)
+    )
+    assert create_res2.digest is not None
+    assert create_res2.object_id == "my_op_no_source"
+    assert create_res2.version_index == 0
 
-    # List all ops
-    list_req = tsi.OpListReq(project_id=project_id)
-    ops = list(trace_server.op_list(list_req))
+    # Read not found
+    with pytest.raises(NotFoundError):
+        trace_server.op_read(
+            tsi.OpReadReq(
+                project_id=project_id,
+                object_id="nonexistent_op",
+                digest="fake_digest_1234567890",
+            )
+        )
 
-    assert len(ops) == 3
-    op_names_returned = {op.object_id for op in ops}
-    assert op_names_returned == {"op_a", "op_b", "op_c"}
 
-    # Verify all ops have code loaded
+def test_op_list_and_pagination(trace_server):
+    """Test listing ops with limit, offset, and empty project."""
+    project_id = f"{TEST_ENTITY}/test_op_list_pagination"
+
+    # Empty project
+    ops = list(trace_server.op_list(tsi.OpListReq(project_id=project_id)))
+    assert len(ops) == 0
+
+    # Create 10 ops
+    for i in range(10):
+        trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=project_id,
+                name=f"op_{i}",
+                description=None,
+                source_code=f"def op_{i}():\n    pass",
+            )
+        )
+
+    # List all
+    ops = list(trace_server.op_list(tsi.OpListReq(project_id=project_id)))
+    assert len(ops) == 10
     for op in ops:
         assert op.code
         assert "def " in op.code
         assert op.created_at is not None
 
-
-def test_op_list_with_limit(trace_server):
-    """Test listing ops with a limit."""
-    project_id = f"{TEST_ENTITY}/test_op_list_limit"
-
-    # Create multiple ops
-    for i in range(5):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name=f"op_{i}",
-            description=None,
-            source_code=f"def op_{i}():\n    pass",
-        )
-        trace_server.op_create(create_req)
-
-    # List with a limit
-    list_req = tsi.OpListReq(project_id=project_id, limit=3)
-    ops = list(trace_server.op_list(list_req))
-
+    # Limit
+    ops = list(trace_server.op_list(tsi.OpListReq(project_id=project_id, limit=3)))
     assert len(ops) == 3
 
-
-def test_op_list_with_offset(trace_server):
-    """Test listing ops with an offset."""
-    project_id = f"{TEST_ENTITY}/test_op_list_offset"
-
-    # Create multiple ops
-    for i in range(5):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name=f"op_{i}",
-            description=None,
-            source_code=f"def op_{i}():\n    pass",
-        )
-        trace_server.op_create(create_req)
-
-    # List with an offset
-    list_req = tsi.OpListReq(project_id=project_id, offset=2)
-    ops = list(trace_server.op_list(list_req))
-
+    # Offset
+    ops = list(trace_server.op_list(tsi.OpListReq(project_id=project_id, offset=7)))
     assert len(ops) == 3
 
-
-def test_op_list_with_limit_and_offset(trace_server):
-    """Test listing ops with both limit and offset for pagination."""
-    project_id = f"{TEST_ENTITY}/test_op_list_pagination"
-
-    # Create multiple ops
-    for i in range(10):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name=f"op_{i}",
-            description=None,
-            source_code=f"def op_{i}():\n    pass",
+    # Limit + offset pagination
+    page1 = list(
+        trace_server.op_list(
+            tsi.OpListReq(project_id=project_id, limit=3, offset=0)
         )
-        trace_server.op_create(create_req)
-
-    # First page
-    list_req1 = tsi.OpListReq(project_id=project_id, limit=3, offset=0)
-    ops1 = list(trace_server.op_list(list_req1))
-    assert len(ops1) == 3
-
-    # Second page
-    list_req2 = tsi.OpListReq(project_id=project_id, limit=3, offset=3)
-    ops2 = list(trace_server.op_list(list_req2))
-    assert len(ops2) == 3
-
-    # Verify different ops on different pages
-    ops1_ids = {op.object_id for op in ops1}
-    ops2_ids = {op.object_id for op in ops2}
-    assert len(ops1_ids & ops2_ids) == 0  # No overlap
-
-
-def test_op_list_empty_project(trace_server):
-    """Test listing ops in a project with no ops."""
-    project_id = f"{TEST_ENTITY}/test_op_list_empty"
-
-    list_req = tsi.OpListReq(project_id=project_id)
-    ops = list(trace_server.op_list(list_req))
-
-    assert len(ops) == 0
-
-
-def test_op_delete_single_version(trace_server):
-    """Test deleting a single version of an op."""
-    project_id = f"{TEST_ENTITY}/test_op_delete_single"
-
-    # Create an op
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="delete_test",
-        description=None,
-        source_code="def delete_test():\n    pass",
     )
-    create_res = trace_server.op_create(create_req)
-
-    # Delete the specific version
-    delete_req = tsi.OpDeleteReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digests=[create_res.digest],
-    )
-    delete_res = trace_server.op_delete(delete_req)
-
-    assert delete_res.num_deleted == 1
-
-    # Verify the op is deleted (should raise ObjectDeletedError)
-    read_req = tsi.OpReadReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digest=create_res.digest,
-    )
-    with pytest.raises(ObjectDeletedError):
-        trace_server.op_read(read_req)
-
-
-def test_op_delete_all_versions(trace_server):
-    """Test deleting all versions of an op (no digests specified)."""
-    project_id = f"{TEST_ENTITY}/test_op_delete_all"
-
-    # Create multiple versions of the same op
-    digests = []
-    for i in range(3):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name="versioned_op",
-            description=None,
-            source_code=f"def versioned_op():\n    return {i}",
+    page2 = list(
+        trace_server.op_list(
+            tsi.OpListReq(project_id=project_id, limit=3, offset=3)
         )
-        create_res = trace_server.op_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete all versions (no digests specified)
-    delete_req = tsi.OpDeleteReq(
-        project_id=project_id,
-        object_id="versioned_op",
-        digests=None,
     )
-    delete_res = trace_server.op_delete(delete_req)
-
-    assert delete_res.num_deleted == 3
-
-
-def test_op_delete_multiple_versions(trace_server):
-    """Test deleting multiple specific versions of an op."""
-    project_id = f"{TEST_ENTITY}/test_op_delete_multiple"
-
-    # Create multiple versions
-    digests = []
-    for i in range(4):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name="multi_version_op",
-            description=None,
-            source_code=f"def multi_version_op():\n    return {i}",
-        )
-        create_res = trace_server.op_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete the first two versions
-    delete_req = tsi.OpDeleteReq(
-        project_id=project_id,
-        object_id="multi_version_op",
-        digests=digests[:2],
-    )
-    delete_res = trace_server.op_delete(delete_req)
-
-    assert delete_res.num_deleted == 2
-
-    # Verify the first two are deleted
-    for digest in digests[:2]:
-        read_req = tsi.OpReadReq(
-            project_id=project_id,
-            object_id="multi_version_op",
-            digest=digest,
-        )
-        with pytest.raises(ObjectDeletedError):
-            trace_server.op_read(read_req)
-
-    # Verify the last two still exist
-    for digest in digests[2:]:
-        read_req = tsi.OpReadReq(
-            project_id=project_id,
-            object_id="multi_version_op",
-            digest=digest,
-        )
-        read_res = trace_server.op_read(read_req)
-        assert read_res.digest == digest
-
-
-def test_op_delete_not_found(trace_server):
-    """Test deleting a non-existent op raises NotFoundError."""
-    project_id = f"{TEST_ENTITY}/test_op_delete_not_found"
-
-    delete_req = tsi.OpDeleteReq(
-        project_id=project_id,
-        object_id="nonexistent_op",
-        digests=["fake_digest"],
-    )
-
-    with pytest.raises(NotFoundError):
-        trace_server.op_delete(delete_req)
+    assert len(page1) == 3
+    assert len(page2) == 3
+    page1_ids = {op.object_id for op in page1}
+    page2_ids = {op.object_id for op in page2}
+    assert len(page1_ids & page2_ids) == 0
 
 
 def test_op_versioning(trace_server):
-    """Test that creating multiple versions of an op increments version_index."""
+    """Test version_index increments and all versions are distinct."""
     project_id = f"{TEST_ENTITY}/test_op_versioning"
 
-    # Create multiple versions of the same op
     versions = []
     for i in range(3):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name="versioned_function",
-            description=None,
-            source_code=f"def versioned_function():\n    return {i}",
+        create_res = trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=project_id,
+                name="versioned_function",
+                description=None,
+                source_code=f"def versioned_function():\n    return {i}",
+            )
         )
-        create_res = trace_server.op_create(create_req)
         versions.append(create_res)
 
-    # Verify version indices increment
     assert versions[0].version_index == 0
     assert versions[1].version_index == 1
     assert versions[2].version_index == 2
-
-    # Verify all versions are distinct
     assert len({v.digest for v in versions}) == 3
 
 
-def test_op_code_with_special_characters(trace_server):
-    """Test creating and reading an op with special characters in source code."""
-    project_id = f"{TEST_ENTITY}/test_op_special_chars"
+def test_op_delete(trace_server):
+    """Test deleting ops: single version, all versions, multiple versions, not found."""
+    project_id = f"{TEST_ENTITY}/test_op_delete"
 
-    # Create an op with special characters
-    source_code = """def special_function(x: str) -> str:
-    '''This function has "quotes" and 'apostrophes'.'''
-    return f"Result: {x} with special chars: \n\t\r"
-"""
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="special_function",
-        description=None,
-        source_code=source_code,
+    # Delete single version
+    create_res = trace_server.op_create(
+        tsi.OpCreateReq(
+            project_id=project_id,
+            name="delete_single",
+            description=None,
+            source_code="def delete_single():\n    pass",
+        )
     )
-    create_res = trace_server.op_create(create_req)
-
-    # Read it back and verify the code is preserved
-    read_req = tsi.OpReadReq(
-        project_id=project_id,
-        object_id="special_function",
-        digest=create_res.digest,
+    delete_res = trace_server.op_delete(
+        tsi.OpDeleteReq(
+            project_id=project_id,
+            object_id="delete_single",
+            digests=[create_res.digest],
+        )
     )
-    read_res = trace_server.op_read(read_req)
+    assert delete_res.num_deleted == 1
+    with pytest.raises(ObjectDeletedError):
+        trace_server.op_read(
+            tsi.OpReadReq(
+                project_id=project_id,
+                object_id="delete_single",
+                digest=create_res.digest,
+            )
+        )
 
-    assert read_res.code == source_code
-
-
-def test_op_code_with_unicode(trace_server):
-    """Test creating and reading an op with unicode characters in source code."""
-    project_id = f"{TEST_ENTITY}/test_op_unicode"
-
-    # Create an op with unicode
-    source_code = """def unicode_function():
-    '''This function has unicode: 你好世界 🚀 café'''
-    return "unicode test"
-"""
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="unicode_function",
-        description=None,
-        source_code=source_code,
+    # Delete all versions
+    digests = []
+    for i in range(3):
+        res = trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=project_id,
+                name="delete_all",
+                description=None,
+                source_code=f"def delete_all():\n    return {i}",
+            )
+        )
+        digests.append(res.digest)
+    delete_res = trace_server.op_delete(
+        tsi.OpDeleteReq(
+            project_id=project_id, object_id="delete_all", digests=None
+        )
     )
-    create_res = trace_server.op_create(create_req)
+    assert delete_res.num_deleted == 3
 
-    # Read it back and verify the unicode is preserved
-    read_req = tsi.OpReadReq(
-        project_id=project_id,
-        object_id="unicode_function",
-        digest=create_res.digest,
+    # Delete multiple specific versions (keep some)
+    digests = []
+    for i in range(4):
+        res = trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=project_id,
+                name="delete_multi",
+                description=None,
+                source_code=f"def delete_multi():\n    return {i}",
+            )
+        )
+        digests.append(res.digest)
+    delete_res = trace_server.op_delete(
+        tsi.OpDeleteReq(
+            project_id=project_id,
+            object_id="delete_multi",
+            digests=digests[:2],
+        )
     )
-    read_res = trace_server.op_read(read_req)
+    assert delete_res.num_deleted == 2
+    for digest in digests[:2]:
+        with pytest.raises(ObjectDeletedError):
+            trace_server.op_read(
+                tsi.OpReadReq(
+                    project_id=project_id,
+                    object_id="delete_multi",
+                    digest=digest,
+                )
+            )
+    for digest in digests[2:]:
+        read_res = trace_server.op_read(
+            tsi.OpReadReq(
+                project_id=project_id,
+                object_id="delete_multi",
+                digest=digest,
+            )
+        )
+        assert read_res.digest == digest
 
-    assert read_res.code == source_code
-    assert "你好世界" in read_res.code
-    assert "🚀" in read_res.code
-    assert "café" in read_res.code
+    # Delete not found
+    with pytest.raises(NotFoundError):
+        trace_server.op_delete(
+            tsi.OpDeleteReq(
+                project_id=project_id,
+                object_id="nonexistent_op",
+                digests=["fake_digest"],
+            )
+        )
 
 
 def test_op_list_after_deletion(trace_server):
     """Test that deleted ops don't appear in list results."""
     project_id = f"{TEST_ENTITY}/test_op_list_after_deletion"
 
-    # Create three ops
     op_names = ["op_keep_1", "op_delete", "op_keep_2"]
-    digests = {}
     for name in op_names:
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name=name,
-            description=None,
-            source_code=f"def {name}():\n    pass",
+        trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=project_id,
+                name=name,
+                description=None,
+                source_code=f"def {name}():\n    pass",
+            )
         )
-        create_res = trace_server.op_create(create_req)
-        digests[name] = create_res.digest
 
-    # Delete one op
-    delete_req = tsi.OpDeleteReq(
-        project_id=project_id,
-        object_id="op_delete",
-        digests=None,
+    trace_server.op_delete(
+        tsi.OpDeleteReq(
+            project_id=project_id, object_id="op_delete", digests=None
+        )
     )
-    trace_server.op_delete(delete_req)
 
-    # List ops - should only see the two that weren't deleted
-    list_req = tsi.OpListReq(project_id=project_id)
-    ops = list(trace_server.op_list(list_req))
-
+    ops = list(trace_server.op_list(tsi.OpListReq(project_id=project_id)))
     op_names_returned = {op.object_id for op in ops}
     assert op_names_returned == {"op_keep_1", "op_keep_2"}
-    assert "op_delete" not in op_names_returned
+
+
+def test_op_special_characters_and_unicode(trace_server):
+    """Test creating and reading ops with special characters and unicode."""
+    project_id = f"{TEST_ENTITY}/test_op_special_chars"
+
+    # Special characters
+    source_special = """def special_function(x: str) -> str:
+    '''This function has "quotes" and 'apostrophes'.'''
+    return f"Result: {x} with special chars: \n\t\r"
+"""
+    create_res = trace_server.op_create(
+        tsi.OpCreateReq(
+            project_id=project_id,
+            name="special_function",
+            description=None,
+            source_code=source_special,
+        )
+    )
+    read_res = trace_server.op_read(
+        tsi.OpReadReq(
+            project_id=project_id,
+            object_id="special_function",
+            digest=create_res.digest,
+        )
+    )
+    assert read_res.code == source_special
+
+    # Unicode
+    source_unicode = """def unicode_function():
+    '''This function has unicode: 你好世界 🚀 café'''
+    return "unicode test"
+"""
+    create_res = trace_server.op_create(
+        tsi.OpCreateReq(
+            project_id=project_id,
+            name="unicode_function",
+            description=None,
+            source_code=source_unicode,
+        )
+    )
+    read_res = trace_server.op_read(
+        tsi.OpReadReq(
+            project_id=project_id,
+            object_id="unicode_function",
+            digest=create_res.digest,
+        )
+    )
+    assert read_res.code == source_unicode
+    assert "你好世界" in read_res.code
+    assert "🚀" in read_res.code
+    assert "café" in read_res.code

--- a/tests/trace_server/test_scorer_v2_api.py
+++ b/tests/trace_server/test_scorer_v2_api.py
@@ -10,463 +10,336 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 
 
-def test_scorer_create_basic(trace_server):
-    """Test creating a basic scorer object."""
-    project_id = f"{TEST_ENTITY}/test_scorer_create_basic"
+def test_scorer_create_and_read(trace_server):
+    """Test creating scorers (with and without description) and reading them back."""
+    project_id = f"{TEST_ENTITY}/test_scorer_create_and_read"
 
-    # Create a scorer
-    op_source_code = """
-def score(output: str, target: str) -> dict:
-    return {"correct": output == target}
-"""
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="exact_match",
-        description="A simple exact match scorer",
-        op_source_code=op_source_code,
-    )
-    create_res = trace_server.scorer_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "exact_match"
-    assert create_res.version_index == 0
-    # Verify scorer returns a reference string
-    assert isinstance(create_res.scorer, str)
-    assert create_res.scorer.startswith("weave:///")
-
-
-def test_scorer_create_without_description(trace_server):
-    """Test creating a scorer without providing a description."""
-    project_id = f"{TEST_ENTITY}/test_scorer_create_no_desc"
-
-    # Create a scorer without description
-    op_source_code = """
-def score(output: str) -> dict:
-    return {"length": len(output)}
-"""
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="length_scorer",
-        description=None,
-        op_source_code=op_source_code,
-    )
-    create_res = trace_server.scorer_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "length_scorer"
-    assert create_res.version_index == 0
-    assert isinstance(create_res.scorer, str)
-
-
-def test_scorer_read_basic(trace_server):
-    """Test reading a specific scorer object."""
-    project_id = f"{TEST_ENTITY}/test_scorer_read_basic"
-
-    # Create a scorer
+    # Create with description
     op_source_code = """
 def score(output: str, target: str) -> dict:
     return {"correct": output.lower() == target.lower()}
 """
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="case_insensitive_match",
-        description="Case insensitive match scorer",
-        op_source_code=op_source_code,
+    create_res = trace_server.scorer_create(
+        tsi.ScorerCreateReq(
+            project_id=project_id,
+            name="case_insensitive_match",
+            description="Case insensitive match scorer",
+            op_source_code=op_source_code,
+        )
     )
-    create_res = trace_server.scorer_create(create_req)
+    assert create_res.digest is not None
+    assert create_res.object_id == "case_insensitive_match"
+    assert create_res.version_index == 0
+    assert isinstance(create_res.scorer, str)
+    assert create_res.scorer.startswith("weave:///")
 
-    # Read the scorer back
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="case_insensitive_match",
-        digest=create_res.digest,
+    # Read it back
+    read_res = trace_server.scorer_read(
+        tsi.ScorerReadReq(
+            project_id=project_id,
+            object_id="case_insensitive_match",
+            digest=create_res.digest,
+        )
     )
-    read_res = trace_server.scorer_read(read_req)
-
     assert read_res.object_id == "case_insensitive_match"
     assert read_res.digest == create_res.digest
     assert read_res.version_index == 0
     assert read_res.name == "case_insensitive_match"
     assert read_res.description == "Case insensitive match scorer"
     assert read_res.created_at is not None
-    # Verify score_op is a reference string
     assert isinstance(read_res.score_op, str)
     assert read_res.score_op.startswith("weave:///") or len(read_res.score_op) > 0
 
-
-def test_scorer_read_not_found(trace_server):
-    """Test reading a non-existent scorer raises NotFoundError."""
-    project_id = f"{TEST_ENTITY}/test_scorer_read_not_found"
-
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="nonexistent_scorer",
-        digest="fake_digest_1234567890",
-    )
-
-    with pytest.raises(NotFoundError):
-        trace_server.scorer_read(read_req)
-
-
-def test_scorer_list_basic(trace_server):
-    """Test listing all scorers in a project."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_basic"
-
-    # Create multiple scorers
-    scorer_names = ["scorer_a", "scorer_b", "scorer_c"]
-    for name in scorer_names:
-        create_req = tsi.ScorerCreateReq(
+    # Create without description
+    create_res2 = trace_server.scorer_create(
+        tsi.ScorerCreateReq(
             project_id=project_id,
-            name=name,
-            description=f"Scorer {name}",
-            op_source_code=f'def score():\n    return {{"score": "{name}"}}',
+            name="length_scorer",
+            description=None,
+            op_source_code='def score(output: str) -> dict:\n    return {"length": len(output)}',
         )
-        trace_server.scorer_create(create_req)
+    )
+    assert create_res2.digest is not None
+    assert create_res2.object_id == "length_scorer"
+    assert isinstance(create_res2.scorer, str)
 
-    # List all scorers
-    list_req = tsi.ScorerListReq(project_id=project_id)
-    scorers = list(trace_server.scorer_list(list_req))
+    # Read not found
+    with pytest.raises(NotFoundError):
+        trace_server.scorer_read(
+            tsi.ScorerReadReq(
+                project_id=project_id,
+                object_id="nonexistent_scorer",
+                digest="fake_digest_1234567890",
+            )
+        )
 
-    assert len(scorers) == 3
-    scorer_names_returned = {s.name for s in scorers}
-    assert scorer_names_returned == {"scorer_a", "scorer_b", "scorer_c"}
 
-    # Verify all scorers have score_op references
+def test_scorer_list_and_pagination(trace_server):
+    """Test listing scorers with limit, offset, and empty project."""
+    project_id = f"{TEST_ENTITY}/test_scorer_list_pagination"
+
+    # Empty project
+    scorers = list(
+        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id))
+    )
+    assert len(scorers) == 0
+
+    # Create 10 scorers
+    for i in range(10):
+        trace_server.scorer_create(
+            tsi.ScorerCreateReq(
+                project_id=project_id,
+                name=f"scorer_{i}",
+                description=None,
+                op_source_code=f'def score():\n    return {{"value": {i}}}',
+            )
+        )
+
+    # List all
+    scorers = list(
+        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id))
+    )
+    assert len(scorers) == 10
     for scorer in scorers:
         assert scorer.score_op
         assert scorer.created_at is not None
 
-
-def test_scorer_list_with_limit(trace_server):
-    """Test listing scorers with a limit."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_limit"
-
-    # Create multiple scorers
-    for i in range(5):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name=f"scorer_{i}",
-            description=None,
-            op_source_code=f'def score():\n    return {{"value": {i}}}',
+    # Limit
+    scorers = list(
+        trace_server.scorer_list(
+            tsi.ScorerListReq(project_id=project_id, limit=3)
         )
-        trace_server.scorer_create(create_req)
-
-    # List with a limit
-    list_req = tsi.ScorerListReq(project_id=project_id, limit=3)
-    scorers = list(trace_server.scorer_list(list_req))
-
+    )
     assert len(scorers) == 3
 
-
-def test_scorer_list_with_offset(trace_server):
-    """Test listing scorers with an offset."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_offset"
-
-    # Create multiple scorers
-    for i in range(5):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name=f"scorer_{i}",
-            description=None,
-            op_source_code=f'def score():\n    return {{"value": {i}}}',
+    # Offset
+    scorers = list(
+        trace_server.scorer_list(
+            tsi.ScorerListReq(project_id=project_id, offset=7)
         )
-        trace_server.scorer_create(create_req)
-
-    # List with an offset
-    list_req = tsi.ScorerListReq(project_id=project_id, offset=2)
-    scorers = list(trace_server.scorer_list(list_req))
-
+    )
     assert len(scorers) == 3
 
-
-def test_scorer_list_with_limit_and_offset(trace_server):
-    """Test listing scorers with both limit and offset for pagination."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_pagination"
-
-    # Create multiple scorers
-    for i in range(10):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name=f"scorer_{i}",
-            description=None,
-            op_source_code=f'def score():\n    return {{"value": {i}}}',
+    # Limit + offset pagination
+    page1 = list(
+        trace_server.scorer_list(
+            tsi.ScorerListReq(project_id=project_id, limit=3, offset=0)
         )
-        trace_server.scorer_create(create_req)
-
-    # First page
-    list_req1 = tsi.ScorerListReq(project_id=project_id, limit=3, offset=0)
-    scorers1 = list(trace_server.scorer_list(list_req1))
-    assert len(scorers1) == 3
-
-    # Second page
-    list_req2 = tsi.ScorerListReq(project_id=project_id, limit=3, offset=3)
-    scorers2 = list(trace_server.scorer_list(list_req2))
-    assert len(scorers2) == 3
-
-    # Verify different scorers on different pages
-    scorers1_names = {s.name for s in scorers1}
-    scorers2_names = {s.name for s in scorers2}
-    assert len(scorers1_names & scorers2_names) == 0  # No overlap
-
-
-def test_scorer_list_empty_project(trace_server):
-    """Test listing scorers in a project with no scorers."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_empty"
-
-    list_req = tsi.ScorerListReq(project_id=project_id)
-    scorers = list(trace_server.scorer_list(list_req))
-
-    assert len(scorers) == 0
-
-
-def test_scorer_delete_single_version(trace_server):
-    """Test deleting a single version of a scorer."""
-    project_id = f"{TEST_ENTITY}/test_scorer_delete_single"
-
-    # Create a scorer
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="delete_test",
-        description=None,
-        op_source_code='def score():\n    return {"score": 1}',
     )
-    create_res = trace_server.scorer_create(create_req)
-
-    # Delete the specific version
-    delete_req = tsi.ScorerDeleteReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digests=[create_res.digest],
-    )
-    delete_res = trace_server.scorer_delete(delete_req)
-
-    assert delete_res.num_deleted == 1
-
-    # Verify the scorer is deleted (should raise ObjectDeletedError)
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digest=create_res.digest,
-    )
-    with pytest.raises(ObjectDeletedError):
-        trace_server.scorer_read(read_req)
-
-
-def test_scorer_delete_all_versions(trace_server):
-    """Test deleting all versions of a scorer (no digests specified)."""
-    project_id = f"{TEST_ENTITY}/test_scorer_delete_all"
-
-    # Create multiple versions of the same scorer
-    digests = []
-    for i in range(3):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name="versioned_scorer",
-            description=None,
-            op_source_code=f'def score():\n    return {{"version": {i}}}',
+    page2 = list(
+        trace_server.scorer_list(
+            tsi.ScorerListReq(project_id=project_id, limit=3, offset=3)
         )
-        create_res = trace_server.scorer_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete all versions (no digests specified)
-    delete_req = tsi.ScorerDeleteReq(
-        project_id=project_id,
-        object_id="versioned_scorer",
-        digests=None,
     )
-    delete_res = trace_server.scorer_delete(delete_req)
-
-    assert delete_res.num_deleted == 3
-
-
-def test_scorer_delete_multiple_versions(trace_server):
-    """Test deleting multiple specific versions of a scorer."""
-    project_id = f"{TEST_ENTITY}/test_scorer_delete_multiple"
-
-    # Create multiple versions
-    digests = []
-    for i in range(4):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name="multi_version_scorer",
-            description=None,
-            op_source_code=f'def score():\n    return {{"version": {i}}}',
-        )
-        create_res = trace_server.scorer_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete the first two versions
-    delete_req = tsi.ScorerDeleteReq(
-        project_id=project_id,
-        object_id="multi_version_scorer",
-        digests=digests[:2],
-    )
-    delete_res = trace_server.scorer_delete(delete_req)
-
-    assert delete_res.num_deleted == 2
-
-    # Verify the first two are deleted
-    for digest in digests[:2]:
-        read_req = tsi.ScorerReadReq(
-            project_id=project_id,
-            object_id="multi_version_scorer",
-            digest=digest,
-        )
-        with pytest.raises(ObjectDeletedError):
-            trace_server.scorer_read(read_req)
-
-    # Verify the last two still exist
-    for digest in digests[2:]:
-        read_req = tsi.ScorerReadReq(
-            project_id=project_id,
-            object_id="multi_version_scorer",
-            digest=digest,
-        )
-        read_res = trace_server.scorer_read(read_req)
-        assert read_res.digest == digest
-
-
-def test_scorer_delete_not_found(trace_server):
-    """Test deleting a non-existent scorer raises NotFoundError."""
-    project_id = f"{TEST_ENTITY}/test_scorer_delete_not_found"
-
-    delete_req = tsi.ScorerDeleteReq(
-        project_id=project_id,
-        object_id="nonexistent_scorer",
-        digests=["fake_digest"],
-    )
-
-    with pytest.raises(NotFoundError):
-        trace_server.scorer_delete(delete_req)
+    assert len(page1) == 3
+    assert len(page2) == 3
+    page1_names = {s.name for s in page1}
+    page2_names = {s.name for s in page2}
+    assert len(page1_names & page2_names) == 0
 
 
 def test_scorer_versioning(trace_server):
-    """Test that creating multiple versions of a scorer increments version_index."""
+    """Test version_index increments and all versions are distinct."""
     project_id = f"{TEST_ENTITY}/test_scorer_versioning"
 
-    # Create multiple versions of the same scorer
     versions = []
     for i in range(3):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name="versioned_scorer",
-            description=f"Version {i}",
-            op_source_code=f'def score():\n    return {{"version": {i}}}',
+        create_res = trace_server.scorer_create(
+            tsi.ScorerCreateReq(
+                project_id=project_id,
+                name="versioned_scorer",
+                description=f"Version {i}",
+                op_source_code=f'def score():\n    return {{"version": {i}}}',
+            )
         )
-        create_res = trace_server.scorer_create(create_req)
         versions.append(create_res)
 
-    # Verify version indices increment
     assert versions[0].version_index == 0
     assert versions[1].version_index == 1
     assert versions[2].version_index == 2
-
-    # Verify all versions are distinct
     assert len({v.digest for v in versions}) == 3
 
 
-def test_scorer_with_special_characters(trace_server):
-    """Test creating and reading a scorer with special characters in code."""
-    project_id = f"{TEST_ENTITY}/test_scorer_special_chars"
+def test_scorer_delete(trace_server):
+    """Test deleting scorers: single version, all versions, multiple versions, not found."""
+    project_id = f"{TEST_ENTITY}/test_scorer_delete"
 
-    # Create a scorer with special characters
-    op_source_code = """
-def score(output: str) -> dict:
-    '''This scorer has "quotes" and 'apostrophes'.'''
-    return {"result": f"Output: {output} with special chars: \\n\\t"}
-"""
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="special_chars",
-        description='Scorer with "special" characters',
-        op_source_code=op_source_code,
+    # Delete single version
+    create_res = trace_server.scorer_create(
+        tsi.ScorerCreateReq(
+            project_id=project_id,
+            name="delete_single",
+            description=None,
+            op_source_code='def score():\n    return {"score": 1}',
+        )
     )
-    create_res = trace_server.scorer_create(create_req)
-
-    # Read it back and verify metadata is preserved
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="special_chars",
-        digest=create_res.digest,
+    delete_res = trace_server.scorer_delete(
+        tsi.ScorerDeleteReq(
+            project_id=project_id,
+            object_id="delete_single",
+            digests=[create_res.digest],
+        )
     )
-    read_res = trace_server.scorer_read(read_req)
+    assert delete_res.num_deleted == 1
+    with pytest.raises(ObjectDeletedError):
+        trace_server.scorer_read(
+            tsi.ScorerReadReq(
+                project_id=project_id,
+                object_id="delete_single",
+                digest=create_res.digest,
+            )
+        )
 
-    assert read_res.name == "special_chars"
-    assert read_res.description == 'Scorer with "special" characters'
-    assert read_res.score_op  # Should have a reference
-
-
-def test_scorer_with_unicode(trace_server):
-    """Test creating and reading a scorer with unicode characters."""
-    project_id = f"{TEST_ENTITY}/test_scorer_unicode"
-
-    # Create a scorer with unicode
-    op_source_code = """
-def score(output: str) -> dict:
-    '''This scorer has unicode: 你好世界 🚀'''
-    return {"greeting": "你好世界"}
-"""
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="unicode_scorer",
-        description="Unicode scorer 🌍",
-        op_source_code=op_source_code,
+    # Delete all versions
+    digests = []
+    for i in range(3):
+        res = trace_server.scorer_create(
+            tsi.ScorerCreateReq(
+                project_id=project_id,
+                name="delete_all",
+                description=None,
+                op_source_code=f'def score():\n    return {{"version": {i}}}',
+            )
+        )
+        digests.append(res.digest)
+    delete_res = trace_server.scorer_delete(
+        tsi.ScorerDeleteReq(
+            project_id=project_id, object_id="delete_all", digests=None
+        )
     )
-    create_res = trace_server.scorer_create(create_req)
+    assert delete_res.num_deleted == 3
 
-    # Read it back and verify metadata is preserved
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="unicode_scorer",
-        digest=create_res.digest,
+    # Delete multiple specific versions (keep some)
+    digests = []
+    for i in range(4):
+        res = trace_server.scorer_create(
+            tsi.ScorerCreateReq(
+                project_id=project_id,
+                name="delete_multi",
+                description=None,
+                op_source_code=f'def score():\n    return {{"version": {i}}}',
+            )
+        )
+        digests.append(res.digest)
+    delete_res = trace_server.scorer_delete(
+        tsi.ScorerDeleteReq(
+            project_id=project_id,
+            object_id="delete_multi",
+            digests=digests[:2],
+        )
     )
-    read_res = trace_server.scorer_read(read_req)
+    assert delete_res.num_deleted == 2
+    for digest in digests[:2]:
+        with pytest.raises(ObjectDeletedError):
+            trace_server.scorer_read(
+                tsi.ScorerReadReq(
+                    project_id=project_id,
+                    object_id="delete_multi",
+                    digest=digest,
+                )
+            )
+    for digest in digests[2:]:
+        read_res = trace_server.scorer_read(
+            tsi.ScorerReadReq(
+                project_id=project_id,
+                object_id="delete_multi",
+                digest=digest,
+            )
+        )
+        assert read_res.digest == digest
 
-    assert read_res.name == "unicode_scorer"
-    assert read_res.description == "Unicode scorer 🌍"
-    assert "🌍" in read_res.description
+    # Delete not found
+    with pytest.raises(NotFoundError):
+        trace_server.scorer_delete(
+            tsi.ScorerDeleteReq(
+                project_id=project_id,
+                object_id="nonexistent_scorer",
+                digests=["fake_digest"],
+            )
+        )
 
 
 def test_scorer_list_after_deletion(trace_server):
     """Test that deleted scorers don't appear in list results."""
     project_id = f"{TEST_ENTITY}/test_scorer_list_after_deletion"
 
-    # Create three scorers
     scorer_names = ["keep_1", "delete_me", "keep_2"]
-    digests = {}
     for name in scorer_names:
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name=name,
-            description=None,
-            op_source_code='def score():\n    return {"score": 1}',
+        trace_server.scorer_create(
+            tsi.ScorerCreateReq(
+                project_id=project_id,
+                name=name,
+                description=None,
+                op_source_code='def score():\n    return {"score": 1}',
+            )
         )
-        create_res = trace_server.scorer_create(create_req)
-        digests[name] = create_res.digest
 
-    # Delete one scorer
-    delete_req = tsi.ScorerDeleteReq(
-        project_id=project_id,
-        object_id="delete_me",
-        digests=None,
+    trace_server.scorer_delete(
+        tsi.ScorerDeleteReq(
+            project_id=project_id, object_id="delete_me", digests=None
+        )
     )
-    trace_server.scorer_delete(delete_req)
 
-    # List scorers - should only see the two that weren't deleted
-    list_req = tsi.ScorerListReq(project_id=project_id)
-    scorers = list(trace_server.scorer_list(list_req))
-
+    scorers = list(
+        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id))
+    )
     scorer_names_returned = {s.name for s in scorers}
     assert scorer_names_returned == {"keep_1", "keep_2"}
-    assert "delete_me" not in scorer_names_returned
 
 
-def test_scorer_complex_source_code(trace_server):
-    """Test creating a scorer with complex multi-line source code."""
-    project_id = f"{TEST_ENTITY}/test_scorer_complex_code"
+def test_scorer_special_characters_and_complex_code(trace_server):
+    """Test scorers with special characters, unicode, and complex source code."""
+    project_id = f"{TEST_ENTITY}/test_scorer_special_chars"
 
-    # Create a scorer with complex code
-    op_source_code = """
+    # Special characters
+    create_res = trace_server.scorer_create(
+        tsi.ScorerCreateReq(
+            project_id=project_id,
+            name="special_chars",
+            description='Scorer with "special" characters',
+            op_source_code="""
+def score(output: str) -> dict:
+    '''This scorer has "quotes" and 'apostrophes'.'''
+    return {"result": f"Output: {output} with special chars: \\n\\t"}
+""",
+        )
+    )
+    read_res = trace_server.scorer_read(
+        tsi.ScorerReadReq(
+            project_id=project_id,
+            object_id="special_chars",
+            digest=create_res.digest,
+        )
+    )
+    assert read_res.name == "special_chars"
+    assert read_res.description == 'Scorer with "special" characters'
+    assert read_res.score_op
+
+    # Unicode
+    create_res2 = trace_server.scorer_create(
+        tsi.ScorerCreateReq(
+            project_id=project_id,
+            name="unicode_scorer",
+            description="Unicode scorer 🌍",
+            op_source_code="""
+def score(output: str) -> dict:
+    '''This scorer has unicode: 你好世界 🚀'''
+    return {"greeting": "你好世界"}
+""",
+        )
+    )
+    read_res2 = trace_server.scorer_read(
+        tsi.ScorerReadReq(
+            project_id=project_id,
+            object_id="unicode_scorer",
+            digest=create_res2.digest,
+        )
+    )
+    assert read_res2.name == "unicode_scorer"
+    assert "🌍" in read_res2.description
+
+    # Complex multi-line code
+    complex_code = """
 import json
 from typing import Any
 
@@ -474,14 +347,12 @@ def score(output: str, target: str) -> dict:
     '''
     Complex scoring function with multiple operations.
     '''
-    # Parse outputs
     try:
         output_data = json.loads(output)
         target_data = json.loads(target)
     except json.JSONDecodeError:
         return {"error": "Invalid JSON", "score": 0.0}
 
-    # Calculate similarity
     matches = 0
     total = len(target_data)
 
@@ -497,27 +368,24 @@ def score(output: str, target: str) -> dict:
         "total": total
     }
 """
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="json_similarity",
-        description="Complex JSON similarity scorer",
-        op_source_code=op_source_code,
+    create_res3 = trace_server.scorer_create(
+        tsi.ScorerCreateReq(
+            project_id=project_id,
+            name="json_similarity",
+            description="Complex JSON similarity scorer",
+            op_source_code=complex_code,
+        )
     )
-    create_res = trace_server.scorer_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "json_similarity"
-
-    # Read it back
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="json_similarity",
-        digest=create_res.digest,
+    assert create_res3.digest is not None
+    read_res3 = trace_server.scorer_read(
+        tsi.ScorerReadReq(
+            project_id=project_id,
+            object_id="json_similarity",
+            digest=create_res3.digest,
+        )
     )
-    read_res = trace_server.scorer_read(read_req)
-
-    assert read_res.name == "json_similarity"
-    assert read_res.description == "Complex JSON similarity scorer"
+    assert read_res3.name == "json_similarity"
+    assert read_res3.description == "Complex JSON similarity scorer"
 
 
 def test_scorer_list_with_missing_name_in_val(trace_server):
@@ -530,27 +398,26 @@ def test_scorer_list_with_missing_name_in_val(trace_server):
     project_id = f"{TEST_ENTITY}/test_scorer_list_missing_name"
 
     # Directly create a Scorer object whose val dict has no "name" key.
-    obj_create_req = tsi.ObjCreateReq(
-        obj=tsi.ObjSchemaForInsert(
-            project_id=project_id,
-            object_id="nameless_scorer",
-            val={
-                "_type": "Scorer",
-                "_class_name": "Scorer",
-                "_bases": ["Scorer", "Object", "BaseModel"],
-                "description": "A scorer with no name in val",
-                "score": "",
-            },
-            set_base_object_class="Scorer",
+    trace_server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=project_id,
+                object_id="nameless_scorer",
+                val={
+                    "_type": "Scorer",
+                    "_class_name": "Scorer",
+                    "_bases": ["Scorer", "Object", "BaseModel"],
+                    "description": "A scorer with no name in val",
+                    "score": "",
+                },
+                set_base_object_class="Scorer",
+            )
         )
     )
-    trace_server.obj_create(obj_create_req)
 
-    # List scorers - should not raise ValidationError
-    list_req = tsi.ScorerListReq(project_id=project_id)
-    scorers = list(trace_server.scorer_list(list_req))
-
+    scorers = list(
+        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id))
+    )
     assert len(scorers) == 1
-    # name should fall back to object_id
     assert scorers[0].name == "nameless_scorer"
     assert scorers[0].object_id == "nameless_scorer"

--- a/tests/trace_server/test_scorer_v2_api.py
+++ b/tests/trace_server/test_scorer_v2_api.py
@@ -79,9 +79,7 @@ def test_scorer_list_and_pagination(trace_server):
     project_id = f"{TEST_ENTITY}/test_scorer_list_pagination"
 
     # Empty project
-    scorers = list(
-        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id))
-    )
+    scorers = list(trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id)))
     assert len(scorers) == 0
 
     # Create 10 scorers
@@ -96,9 +94,7 @@ def test_scorer_list_and_pagination(trace_server):
         )
 
     # List all
-    scorers = list(
-        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id))
-    )
+    scorers = list(trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id)))
     assert len(scorers) == 10
     for scorer in scorers:
         assert scorer.score_op
@@ -106,17 +102,13 @@ def test_scorer_list_and_pagination(trace_server):
 
     # Limit
     scorers = list(
-        trace_server.scorer_list(
-            tsi.ScorerListReq(project_id=project_id, limit=3)
-        )
+        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id, limit=3))
     )
     assert len(scorers) == 3
 
     # Offset
     scorers = list(
-        trace_server.scorer_list(
-            tsi.ScorerListReq(project_id=project_id, offset=7)
-        )
+        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id, offset=7))
     )
     assert len(scorers) == 3
 
@@ -203,9 +195,7 @@ def test_scorer_delete(trace_server):
         )
         digests.append(res.digest)
     delete_res = trace_server.scorer_delete(
-        tsi.ScorerDeleteReq(
-            project_id=project_id, object_id="delete_all", digests=None
-        )
+        tsi.ScorerDeleteReq(project_id=project_id, object_id="delete_all", digests=None)
     )
     assert delete_res.num_deleted == 3
 
@@ -275,14 +265,10 @@ def test_scorer_list_after_deletion(trace_server):
         )
 
     trace_server.scorer_delete(
-        tsi.ScorerDeleteReq(
-            project_id=project_id, object_id="delete_me", digests=None
-        )
+        tsi.ScorerDeleteReq(project_id=project_id, object_id="delete_me", digests=None)
     )
 
-    scorers = list(
-        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id))
-    )
+    scorers = list(trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id)))
     scorer_names_returned = {s.name for s in scorers}
     assert scorer_names_returned == {"keep_1", "keep_2"}
 
@@ -415,9 +401,7 @@ def test_scorer_list_with_missing_name_in_val(trace_server):
         )
     )
 
-    scorers = list(
-        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id))
-    )
+    scorers = list(trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id)))
     assert len(scorers) == 1
     assert scorers[0].name == "nameless_scorer"
     assert scorers[0].object_id == "nameless_scorer"

--- a/weave/integrations/openai_realtime/state_exporter.py
+++ b/weave/integrations/openai_realtime/state_exporter.py
@@ -843,11 +843,7 @@ class StateExporter(BaseModel):
                     pass
 
             def _cb() -> None:
-                try:
-                    self._advance_fifo()
-                finally:
-                    # If more remain and head not ready, a new timer will be scheduled
-                    pass
+                self._advance_fifo()
 
             self.fifo_timer = threading.Timer(FIFO_TIMER_INTERVAL_SECONDS, _cb)
             self.fifo_timer.start()

--- a/weave/trace/serialization/op_type.py
+++ b/weave/trace/serialization/op_type.py
@@ -317,7 +317,7 @@ def get_code_deps_safe(
         fn: The Python function to analyze.
 
     Returns:
-        tupe: A tuple containing
+        tuple: A tuple containing
             import_code: str, the code that should be included in the generated code to ensure all
                 dependencies are available for the function body.
             code: str, the function body code.
@@ -405,26 +405,20 @@ def _get_code_deps(
                     code.append(get_source_notebook_safe(var_value))
 
                     warnings += fn_warnings
+            # For now, if the function is in another module.
+            # we just import it. This is ok for libraries, but not
+            # if the user has functions declared within their
+            # package but outside of the op module.
+            elif is_op(var_value):
+                warnings.append(
+                    f"Cross-module op dependencies are not yet serializable {var_value}"
+                )
             else:
-                # For now, if the function is in another module.
-                # we just import it. This is ok for libraries, but not
-                # if the user has functions declared within their
-                # package but outside of the op module.
-                if var_value.__module__.split(".")[0] == fn.__module__.split(".")[0]:
-                    pass
+                import_line = f"from {var_value.__module__} import {var_value.__name__}"
+                if var_value.__name__ != var_name:
+                    import_line += f" as {var_name}"
 
-                if is_op(var_value):
-                    warnings.append(
-                        f"Cross-module op dependencies are not yet serializable {var_value}"
-                    )
-                else:
-                    import_line = (
-                        f"from {var_value.__module__} import {var_value.__name__}"
-                    )
-                    if var_value.__name__ != var_name:
-                        import_line += f" as {var_name}"
-
-                    import_code.append(import_line)
+                import_code.append(import_line)
 
         else:
             # Code saving for Ops using TypedDict and NotRequired was failing on Python 3.9


### PR DESCRIPTION
## Summary

- Consolidates small, independent trace_server tests that each spin up a fresh ClickHouse DB into fewer tests with more assertions
- **45 fewer DB setups** across 5 test files, estimated ~45s savings on the ClickHouse CI run

### Changes per file

| File | Before | After |
|------|--------|-------|
| test_op_v2_api | 17 tests | 6 tests |
| test_dataset_v2_api | 19 tests | 6 tests |
| test_scorer_v2_api | 19 tests | 7 tests |
| test_digest_validation | 7 DB tests | 1 DB test |
| test_custom_provider | 4 DB tests | 2 DB tests |

All assertions are preserved — no coverage loss. Unit tests (no DB fixture) are unchanged.