### PR TITLE
chore(weave): remove duplicate call_ids filter from query generation

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -22,8 +22,6 @@ from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.project_version.types import ReadTable
 
-pytestmark = pytest.mark.skip_clickhouse_client
-
 
 @pytest.mark.parametrize(
     ("read_table", "expected_table"),

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4036,11 +4036,14 @@ def test_not_eq_none_display_name_calls_complete() -> None:
 
 
 def test_hardcoded_filters_calls_complete() -> None:
-    """Verify thread_ids, turn_ids, parent_ids, wb_run_ids use sentinel null checks on calls_complete."""
+    """Verify hardcoded filters on calls_complete: sentinel null checks and
+    call_ids appears exactly once (in WHERE, not duplicated in filter conditions).
+    """
     cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
     cq.add_field("id")
     cq.hardcoded_filter = HardCodedFilter(
         filter={
+            "call_ids": ["call_aaa"],
             "thread_ids": ["thread_123"],
             "turn_ids": ["turn_456"],
             "parent_ids": ["parent_aaa", "parent_bbb"],
@@ -4051,8 +4054,9 @@ def test_hardcoded_filters_calls_complete() -> None:
         cq,
         """
         SELECT calls_complete.id AS id
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_13:String}
-        WHERE (calls_complete.wb_run_id IN {pb_9:Array(String)}
+        FROM calls_complete PREWHERE calls_complete.project_id = {pb_14:String}
+        WHERE (calls_complete.id IN {pb_13:Array(String)})
+          AND (calls_complete.wb_run_id IN {pb_9:Array(String)}
                OR calls_complete.wb_run_id = {pb_10:String})
           AND (calls_complete.parent_id IN {pb_11:Array(String)}
                OR calls_complete.parent_id = {pb_12:String})
@@ -4080,37 +4084,9 @@ def test_hardcoded_filters_calls_complete() -> None:
             "pb_10": "",
             "pb_11": ["parent_aaa", "parent_bbb"],
             "pb_12": "",
-            "pb_13": "project",
+            "pb_13": ["call_aaa"],
+            "pb_14": "project",
         },
-    )
-
-
-@pytest.mark.parametrize(
-    ("read_table", "expected_table"),
-    [
-        (ReadTable.CALLS_MERGED, "calls_merged"),
-        (ReadTable.CALLS_COMPLETE, "calls_complete"),
-    ],
-)
-def test_call_ids_filter_not_duplicated(
-    read_table: ReadTable, expected_table: str
-) -> None:
-    """call_ids should appear exactly once in the query, not duplicated across
-    WHERE optimization and filter conditions.
-    """
-    cq = CallsQuery(project_id="project", read_table=read_table)
-    cq.add_field("id")
-    cq.set_hardcoded_filter(
-        HardCodedFilter(filter=tsi.CallsFilter(call_ids=["test-call-id-123"]))
-    )
-
-    pb = ParamBuilder("pb")
-    query = cq.as_sql(pb)
-
-    id_in_count = query.count("id IN")
-    assert id_in_count == 1, (
-        f"Expected 'id IN' exactly once but found {id_in_count} times "
-        f"in {read_table} query.\nQuery:\n{query}"
     )
 
 

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4085,6 +4085,36 @@ def test_hardcoded_filters_calls_complete() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("read_table", "expected_table"),
+    [
+        (ReadTable.CALLS_MERGED, "calls_merged"),
+        (ReadTable.CALLS_COMPLETE, "calls_complete"),
+    ],
+)
+def test_call_ids_filter_not_duplicated(
+    read_table: ReadTable, expected_table: str
+) -> None:
+    """call_ids should appear exactly once in the query, not duplicated across
+    WHERE optimization and filter conditions."""
+    cq = CallsQuery(project_id="project", read_table=read_table)
+    cq.add_field("id")
+    cq.set_hardcoded_filter(
+        HardCodedFilter(
+            filter=tsi.CallsFilter(call_ids=["test-call-id-123"])
+        )
+    )
+
+    pb = ParamBuilder("pb")
+    query = cq.as_sql(pb)
+
+    id_in_count = query.count("id IN")
+    assert id_in_count == 1, (
+        f"Expected 'id IN' exactly once but found {id_in_count} times "
+        f"in {read_table} query.\nQuery:\n{query}"
+    )
+
+
 def test_status_sort_calls_complete_uses_sentinels() -> None:
     """Verify status computation sort uses sentinel checks on calls_complete."""
     cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -22,6 +22,8 @@ from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.project_version.types import ReadTable
 
+pytestmark = pytest.mark.skip_clickhouse_client
+
 
 @pytest.mark.parametrize(
     ("read_table", "expected_table"),

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4096,13 +4096,12 @@ def test_call_ids_filter_not_duplicated(
     read_table: ReadTable, expected_table: str
 ) -> None:
     """call_ids should appear exactly once in the query, not duplicated across
-    WHERE optimization and filter conditions."""
+    WHERE optimization and filter conditions.
+    """
     cq = CallsQuery(project_id="project", read_table=read_table)
     cq.add_field("id")
     cq.set_hardcoded_filter(
-        HardCodedFilter(
-            filter=tsi.CallsFilter(call_ids=["test-call-id-123"])
-        )
+        HardCodedFilter(filter=tsi.CallsFilter(call_ids=["test-call-id-123"]))
     )
 
     pb = ParamBuilder("pb")

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1365,7 +1365,9 @@ class CallsQuery(BaseModel):
         # to avoid duplicate id IN filters in the generated SQL.
         id_mask = ""
         if self.hardcoded_filter and self.hardcoded_filter.filter.call_ids:
-            assert_parameter_length_less_than_max("call_ids", len(self.hardcoded_filter.filter.call_ids))
+            assert_parameter_length_less_than_max(
+                "call_ids", len(self.hardcoded_filter.filter.call_ids)
+            )
             id_mask = f"AND ({table_alias}.id IN {param_slot(pb.add_param(self.hardcoded_filter.filter.call_ids), 'Array(String)')})"
 
         return WhereFilters(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1361,9 +1361,11 @@ class CallsQuery(BaseModel):
         if id_subquery_name is not None:
             id_subquery = f"AND ({table_alias}.id IN {id_subquery_name})"
 
-        # special optimization for call_ids filter
+        # call_ids is handled exclusively here (not in process_calls_filter_to_conditions)
+        # to avoid duplicate id IN filters in the generated SQL.
         id_mask = ""
         if self.hardcoded_filter and self.hardcoded_filter.filter.call_ids:
+            assert_parameter_length_less_than_max("call_ids", len(self.hardcoded_filter.filter.call_ids))
             id_mask = f"AND ({table_alias}.id IN {param_slot(pb.add_param(self.hardcoded_filter.filter.call_ids), 'Array(String)')})"
 
         return WhereFilters(
@@ -2680,11 +2682,9 @@ def process_calls_filter_to_conditions(
             f"{get_field_sql('parent_id')} IN {param_slot(param_builder.add_param(filter.parent_ids), 'Array(String)')}"
         )
 
-    if filter.call_ids:
-        assert_parameter_length_less_than_max("call_ids", len(filter.call_ids))
-        conditions.append(
-            f"{get_field_sql('id')} IN {param_slot(param_builder.add_param(filter.call_ids), 'Array(String)')}"
-        )
+    # Note: call_ids is intentionally NOT handled here — it is pushed into
+    # the WHERE clause as an id_mask optimization by
+    # _build_where_clause_optimizations to avoid duplicate id IN filters.
 
     if filter.thread_ids is not None:
         assert_parameter_length_less_than_max("thread_ids", len(filter.thread_ids))


### PR DESCRIPTION
## Summary
- `call_ids` was added to the SQL query twice: once by `_build_where_clause_optimizations` (WHERE id_mask) and again by `process_calls_filter_to_conditions` (via `hardcoded_filter.as_sql`). Removed the duplicate from `process_calls_filter_to_conditions`.
- Moved length validation into the WHERE optimization path so it remains the single owner of the `call_ids` filter.
- Red-green TDD: commit `f336170` adds the failing test, commit `e148214` fixes it.

## Testing
- unit
