### PR TITLE
chore(weave): session-scoped ClickHouse fixture for faster CI

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -17,6 +17,7 @@ from tests.trace_server.workers.evaluate_model_test_worker import (
     EvaluateModelTestDispatcher,
 )
 from weave.trace_server import clickhouse_trace_server_batched
+from weave.trace_server import clickhouse_trace_server_migrator as wf_migrator
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.project_version import project_version
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
@@ -120,11 +121,15 @@ def reset_project_version_cache():
     project_version.reset_project_residence_cache()
 
 
-def _get_worker_db_suffix(request) -> str:
-    """Get database suffix for pytest-xdist worker isolation."""
+def _get_worker_db_suffix(request, default: str = "_test") -> str:
+    """Get database suffix for pytest-xdist worker isolation.
+
+    Returns worker-specific suffix like '_w0' for xdist, or `default` for
+    single-process runs.
+    """
     worker_input = getattr(request.config, "workerinput", None)
     if worker_input is None:
-        return ""
+        return default
     worker_id = worker_input.get("workerid", "master")
     return f"_w{worker_id.replace('gw', '')}"
 
@@ -167,16 +172,11 @@ def _reset_server_state(server: ClickHouseTraceServer) -> None:
     # Reset file storage client so tests that mock env vars get a fresh client
     server._file_storage_client = None
     server._file_storage_client_initialized = False
-    # Clear batch queues (thread-local, clear for current thread)
-    tl = server._thread_local
-    if hasattr(tl, "call_batch"):
-        tl.call_batch.clear()
-    if hasattr(tl, "file_batch"):
-        tl.file_batch.clear()
-    if hasattr(tl, "calls_complete_batch"):
-        tl.calls_complete_batch.clear()
-    if hasattr(tl, "flush_immediately"):
-        tl.flush_immediately = False
+    # Reset batch queues (thread-local, for current thread)
+    server._call_batch = []
+    server._file_batch = []
+    server._calls_complete_batch = []
+    server._flush_immediately = False
 
 
 @pytest.fixture(scope="session")
@@ -198,8 +198,6 @@ def _ch_session_server(
 
     host, port = next(ensure_clickhouse_db())
     db_suffix = _get_worker_db_suffix(request)
-    if not db_suffix:
-        db_suffix = "_test"
 
     original_db = os.environ.get("WF_CLICKHOUSE_DATABASE")
     base_db = original_db or "default"
@@ -222,8 +220,6 @@ def _ch_session_server(
     ch_server.ch_client.command(f"DROP DATABASE IF EXISTS {management_db}")
     ch_server.ch_client.command(f"DROP DATABASE IF EXISTS {unique_db}")
     ch_server._database_ensured = False
-
-    import weave.trace_server.clickhouse_trace_server_migrator as wf_migrator
 
     def patched_run_migrations():
         migrator = wf_migrator.get_clickhouse_trace_server_migrator(

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -19,6 +19,7 @@ from tests.trace_server.workers.evaluate_model_test_worker import (
 from weave.trace_server import clickhouse_trace_server_batched
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.project_version import project_version
+from weave.trace_server.project_version.types import CallsStorageServerMode
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
 from weave.trace_server.sqlite_trace_server import SqliteTraceServer
 
@@ -26,12 +27,14 @@ pytest_plugins = ["tests.trace_server.conftest_lib.clickhouse_server"]
 
 
 @dataclass(frozen=True)
-class ClickHouseServerCleanup:
-    """Tracks ClickHouse server resources that need cleanup after tests."""
+class ClickHouseSessionState:
+    """Holds the session-scoped ClickHouse server and its database names."""
 
     server: clickhouse_trace_server_batched.ClickHouseTraceServer
     management_db: str
     unique_db: str
+    # Tables that should be truncated between tests (excludes views)
+    truncatable_tables: list[str]
 
 
 def pytest_addoption(parser):
@@ -127,102 +130,161 @@ def _get_worker_db_suffix(request) -> str:
     return f"_w{worker_id.replace('gw', '')}"
 
 
-@pytest.fixture
-def get_ch_trace_server(
+def _discover_truncatable_tables(ch_client, database: str) -> list[str]:
+    """Query system.tables to find non-view tables that can be truncated."""
+    result = ch_client.query(
+        "SELECT name FROM system.tables "
+        f"WHERE database = '{database}' "
+        "AND engine NOT IN ('View', 'MaterializedView') "
+        "ORDER BY name"
+    )
+    return [row[0] for row in result.result_rows]
+
+
+def _truncate_all_tables(ch_client, database: str, tables: list[str]) -> None:
+    """Truncate all data tables in the database for test isolation."""
+    for table in tables:
+        ch_client.command(f"TRUNCATE TABLE {database}.{table}")
+
+
+def _reset_server_state(server: ClickHouseTraceServer) -> None:
+    """Reset cached/accumulated state on a ClickHouseTraceServer instance."""
+    # Clear op ref cache
+    server._op_ref_cache.clear()
+    # Clear placeholder file projects set
+    server._placeholder_file_projects.clear()
+    # Reset table routing mode (tests may set it to AUTO)
+    server.table_routing_resolver._mode = CallsStorageServerMode.from_env()
+    # Clear batch queues (thread-local, clear for current thread)
+    tl = server._thread_local
+    if hasattr(tl, "call_batch"):
+        tl.call_batch.clear()
+    if hasattr(tl, "file_batch"):
+        tl.file_batch.clear()
+    if hasattr(tl, "calls_complete_batch"):
+        tl.calls_complete_batch.clear()
+    if hasattr(tl, "flush_immediately"):
+        tl.flush_immediately = False
+
+
+@pytest.fixture(scope="session")
+def _ch_session_server(
     ensure_clickhouse_db,
     request,
+) -> ClickHouseSessionState | None:
+    """Session-scoped ClickHouse server: created once, migrated once.
+
+    Returns None if ClickHouse is not the selected backend, so that
+    function-scoped fixtures can fall through to the old path if needed.
+    """
+    # Only set up if we'll actually use clickhouse
+    trace_server_flag = request.config.getoption("--trace-server", default="clickhouse")
+    use_sqlite = request.config.getoption("--sqlite", default=False)
+    if use_sqlite or trace_server_flag == "sqlite":
+        yield None
+        return
+
+    host, port = next(ensure_clickhouse_db())
+    db_suffix = _get_worker_db_suffix(request)
+    if not db_suffix:
+        db_suffix = "_test"
+
+    original_db = os.environ.get("WF_CLICKHOUSE_DATABASE")
+    base_db = original_db or "default"
+    unique_db = f"{base_db}{db_suffix}"
+    management_db = f"db_management{db_suffix}"
+
+    os.environ["WF_CLICKHOUSE_DATABASE"] = unique_db
+
+    id_converter = DummyIdConverter()
+    ch_server = clickhouse_trace_server_batched.ClickHouseTraceServer(
+        host=host,
+        port=port,
+        database=unique_db,
+        evaluate_model_dispatcher=EvaluateModelTestDispatcher(
+            id_converter=id_converter
+        ),
+    )
+
+    # Drop and recreate from scratch once
+    ch_server.ch_client.command(f"DROP DATABASE IF EXISTS {management_db}")
+    ch_server.ch_client.command(f"DROP DATABASE IF EXISTS {unique_db}")
+    ch_server._database_ensured = False
+
+    import weave.trace_server.clickhouse_trace_server_migrator as wf_migrator
+
+    def patched_run_migrations():
+        migrator = wf_migrator.get_clickhouse_trace_server_migrator(
+            ch_server._mint_client(), management_db=management_db
+        )
+        migrator.apply_migrations(ch_server._database)
+
+    ch_server._run_migrations = patched_run_migrations  # type: ignore[assignment]
+    ch_server._run_migrations()
+
+    truncatable = _discover_truncatable_tables(ch_server.ch_client, unique_db)
+
+    yield ClickHouseSessionState(
+        server=ch_server,
+        management_db=management_db,
+        unique_db=unique_db,
+        truncatable_tables=truncatable,
+    )
+
+    # Restore env
+    if original_db is None:
+        os.environ.pop("WF_CLICKHOUSE_DATABASE", None)
+    else:
+        os.environ["WF_CLICKHOUSE_DATABASE"] = original_db
+
+    # Session cleanup: drop databases
+    try:
+        ch_server.ch_client.command(f"DROP DATABASE IF EXISTS {management_db}")
+    except Exception:
+        pass
+    try:
+        ch_server.ch_client.command(f"DROP DATABASE IF EXISTS {unique_db}")
+    except Exception:
+        pass
+    try:
+        ch_server.ch_client.close()
+    except Exception:
+        pass
+
+
+@pytest.fixture
+def get_ch_trace_server(
+    _ch_session_server: ClickHouseSessionState | None,
+    request,
 ) -> Callable[[], UserInjectingExternalTraceServer]:
-    servers_to_cleanup: list[ClickHouseServerCleanup] = []
+    """Function-scoped CH fixture factory. Reuses session-scoped DB, truncates between tests."""
 
     def ch_trace_server_inner() -> UserInjectingExternalTraceServer:
-        host, port = next(ensure_clickhouse_db())
-        db_suffix = _get_worker_db_suffix(request)
+        if _ch_session_server is None:
+            pytest.skip("ClickHouse session not available")
 
-        # Always add a test-specific suffix to prevent collision with other databases
-        if not db_suffix:
-            db_suffix = "_test"
+        state = _ch_session_server
+        server = state.server
 
-        # Store original environment variable
-        original_db = os.environ.get("WF_CLICKHOUSE_DATABASE")
-        base_db = original_db or "default"
-        unique_db = f"{base_db}{db_suffix}"
-        management_db = f"db_management{db_suffix}"
+        # Truncate all tables for a clean slate
+        _truncate_all_tables(
+            server.ch_client, state.unique_db, state.truncatable_tables
+        )
 
-        # Set worker-specific database name
-        os.environ["WF_CLICKHOUSE_DATABASE"] = unique_db
+        # Reset any accumulated in-memory state
+        _reset_server_state(server)
 
-        try:
-            id_converter = DummyIdConverter()
-            ch_server = clickhouse_trace_server_batched.ClickHouseTraceServer(
-                host=host,
-                port=port,
-                database=unique_db,
-                evaluate_model_dispatcher=EvaluateModelTestDispatcher(
-                    id_converter=id_converter
-                ),
-            )
+        # Force synchronous writes so tests see data immediately
+        server._flush_immediately = True
 
-            # Track server for cleanup
-            servers_to_cleanup.append(
-                ClickHouseServerCleanup(
-                    server=ch_server,
-                    management_db=management_db,
-                    unique_db=unique_db,
-                )
-            )
+        # Wrap in the external adapter (fresh id_converter per test)
+        id_converter = DummyIdConverter()
+        server._evaluate_model_dispatcher = EvaluateModelTestDispatcher(
+            id_converter=id_converter
+        )
+        return externalize_trace_server(server, TEST_ENTITY, id_converter=id_converter)
 
-            # Clean up any existing worker-specific databases
-            ch_server.ch_client.command(f"DROP DATABASE IF EXISTS {management_db}")
-            ch_server.ch_client.command(f"DROP DATABASE IF EXISTS {unique_db}")
-            ch_server._database_ensured = False
-
-            # Patch _run_migrations to use worker-specific management database
-            def patched_run_migrations():
-                import weave.trace_server.clickhouse_trace_server_migrator as wf_migrator
-
-                migrator = wf_migrator.get_clickhouse_trace_server_migrator(
-                    ch_server._mint_client(), management_db=management_db
-                )
-                migrator.apply_migrations(ch_server._database)
-
-            ch_server._run_migrations = patched_run_migrations  # type: ignore[assignment]
-            ch_server._run_migrations()
-
-            result = externalize_trace_server(
-                ch_server, TEST_ENTITY, id_converter=id_converter
-            )
-            return result
-        finally:
-            # Restore original database name
-            if original_db is None:
-                os.environ.pop("WF_CLICKHOUSE_DATABASE", None)
-            else:
-                os.environ["WF_CLICKHOUSE_DATABASE"] = original_db
-
-    yield ch_trace_server_inner
-
-    # Cleanup after all tests using this fixture complete
-    for server_config in servers_to_cleanup:
-        ch_client = getattr(server_config.server, "ch_client", None)
-        if not ch_client:
-            continue
-
-        # Drop test databases (best effort)
-        try:
-            ch_client.command(f"DROP DATABASE IF EXISTS {server_config.management_db}")
-        except Exception:
-            pass
-
-        try:
-            ch_client.command(f"DROP DATABASE IF EXISTS {server_config.unique_db}")
-        except Exception:
-            pass
-
-        # Close client connection (best effort)
-        try:
-            ch_client.close()
-        except Exception:
-            pass
+    return ch_trace_server_inner
 
 
 @pytest.fixture

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -130,6 +130,10 @@ def _get_worker_db_suffix(request) -> str:
     return f"_w{worker_id.replace('gw', '')}"
 
 
+# Tables with migration-seeded data that should NOT be truncated between tests.
+SEED_DATA_TABLES = frozenset({"llm_token_prices"})
+
+
 def _discover_truncatable_tables(ch_client, database: str) -> list[str]:
     """Query system.tables to find non-view tables that can be truncated."""
     result = ch_client.query(
@@ -138,7 +142,7 @@ def _discover_truncatable_tables(ch_client, database: str) -> list[str]:
         "AND engine NOT IN ('View', 'MaterializedView') "
         "ORDER BY name"
     )
-    return [row[0] for row in result.result_rows]
+    return [row[0] for row in result.result_rows if row[0] not in SEED_DATA_TABLES]
 
 
 def _truncate_all_tables(ch_client, database: str, tables: list[str]) -> None:
@@ -155,6 +159,9 @@ def _reset_server_state(server: ClickHouseTraceServer) -> None:
     server._placeholder_file_projects.clear()
     # Reset table routing mode (tests may set it to AUTO)
     server.table_routing_resolver._mode = CallsStorageServerMode.from_env()
+    # Reset file storage client so tests that mock env vars get a fresh client
+    server._file_storage_client = None
+    server._file_storage_client_initialized = False
     # Clear batch queues (thread-local, clear for current thread)
     tl = server._thread_local
     if hasattr(tl, "call_batch"):

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -19,7 +19,6 @@ from tests.trace_server.workers.evaluate_model_test_worker import (
 from weave.trace_server import clickhouse_trace_server_batched
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.project_version import project_version
-from weave.trace_server.project_version.types import CallsStorageServerMode
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
 from weave.trace_server.sqlite_trace_server import SqliteTraceServer
 
@@ -157,8 +156,9 @@ def _reset_server_state(server: ClickHouseTraceServer) -> None:
     server._op_ref_cache.clear()
     # Clear placeholder file projects set
     server._placeholder_file_projects.clear()
-    # Reset table routing mode (tests may set it to AUTO)
-    server.table_routing_resolver._mode = CallsStorageServerMode.from_env()
+    # Reset table routing resolver to None so it's lazily re-created
+    # (tests may have set _mode to AUTO or accessed the resolver)
+    server._table_routing_resolver = None
     # Reset file storage client so tests that mock env vars get a fresh client
     server._file_storage_client = None
     server._file_storage_client_initialized = False

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -151,7 +151,12 @@ def _truncate_all_tables(ch_client, database: str, tables: list[str]) -> None:
 
 
 def _reset_server_state(server: ClickHouseTraceServer) -> None:
-    """Reset cached/accumulated state on a ClickHouseTraceServer instance."""
+    """Reset cached/accumulated state on a ClickHouseTraceServer instance.
+
+    IMPORTANT: If you add new cached/mutable state to ClickHouseTraceServer,
+    you must reset it here too — otherwise it will leak between tests and cause
+    hard-to-debug order-dependent failures.
+    """
     # Clear op ref cache
     server._op_ref_cache.clear()
     # Clear placeholder file projects set

--- a/tests/trace_server/test_trace_server_conftest.py
+++ b/tests/trace_server/test_trace_server_conftest.py
@@ -24,22 +24,46 @@ def test_skip_clickhouse_client(
     assert get_trace_server_flag(request) != "clickhouse"
 
 
-# The exact count of instance attributes on ClickHouseTraceServer.__init__.
-# If this changes, someone added or removed state. The test below will fail
-# and force them to check whether _reset_server_state needs updating.
-EXPECTED_ATTR_COUNT = 19
+# All instance attributes set in ClickHouseTraceServer.__init__.
+# Instrumentation (ddtrace, coverage) may add extras — those are ignored.
+# If you add a new attribute to __init__, add it here AND decide whether
+# _reset_server_state in conftest.py needs to reset it between tests.
+KNOWN_SERVER_ATTRS = frozenset(
+    {
+        "_database",
+        "_database_ensured",
+        "_evaluate_model_dispatcher",
+        "_file_storage_client",
+        "_file_storage_client_initialized",
+        "_host",
+        "_init_lock",
+        "_kafka_producer",
+        "_model_to_provider_info_map",
+        "_op_ref_cache",
+        "_op_ref_cache_lock",
+        "_password",
+        "_placeholder_file_projects",
+        "_port",
+        "_run_migrations",
+        "_table_routing_resolver",
+        "_thread_local",
+        "_use_async_insert",
+        "_user",
+        "ch_client",
+    }
+)
 
 
 def test_reset_server_state_covers_all_attrs(ch_server):
-    """Canary: fails when ClickHouseTraceServer gains/loses instance attributes.
+    """Fails when ClickHouseTraceServer gains new instance attributes.
 
-    This doesn't know *which* attributes need resetting — it just notices when
-    the set changes so the author is forced to check _reset_server_state.
+    Instrumentation attrs (ddtrace, coverage) are ignored — only attrs
+    missing from KNOWN_SERVER_ATTRS trigger failure.
     """
-    attr_count = len([a for a in ch_server.__dict__ if not a.startswith("__")])
-    assert attr_count == EXPECTED_ATTR_COUNT, (
-        f"ClickHouseTraceServer has {attr_count} instance attributes "
-        f"(expected {EXPECTED_ATTR_COUNT}). If you added/removed state, "
-        f"check whether _reset_server_state in conftest.py needs updating, "
-        f"then update EXPECTED_ATTR_COUNT."
+    actual = {a for a in ch_server.__dict__ if not a.startswith("__")}
+    unknown = actual - KNOWN_SERVER_ATTRS
+    assert not unknown, (
+        f"ClickHouseTraceServer has new attributes: {unknown}. "
+        f"Add them to KNOWN_SERVER_ATTRS in this file, and check whether "
+        f"_reset_server_state in conftest.py needs to reset them."
     )

--- a/tests/trace_server/test_trace_server_conftest.py
+++ b/tests/trace_server/test_trace_server_conftest.py
@@ -22,3 +22,24 @@ def test_skip_clickhouse_client(
 ):
     assert isinstance(trace_server, UserInjectingExternalTraceServer)
     assert get_trace_server_flag(request) != "clickhouse"
+
+
+# The exact count of instance attributes on ClickHouseTraceServer.__init__.
+# If this changes, someone added or removed state. The test below will fail
+# and force them to check whether _reset_server_state needs updating.
+EXPECTED_ATTR_COUNT = 19
+
+
+def test_reset_server_state_covers_all_attrs(ch_server):
+    """Canary: fails when ClickHouseTraceServer gains/loses instance attributes.
+
+    This doesn't know *which* attributes need resetting — it just notices when
+    the set changes so the author is forced to check _reset_server_state.
+    """
+    attr_count = len([a for a in ch_server.__dict__ if not a.startswith("__")])
+    assert attr_count == EXPECTED_ATTR_COUNT, (
+        f"ClickHouseTraceServer has {attr_count} instance attributes "
+        f"(expected {EXPECTED_ATTR_COUNT}). If you added/removed state, "
+        f"check whether _reset_server_state in conftest.py needs updating, "
+        f"then update EXPECTED_ATTR_COUNT."
+    )

--- a/tests/trace_server/test_trace_server_conftest.py
+++ b/tests/trace_server/test_trace_server_conftest.py
@@ -49,7 +49,6 @@ KNOWN_SERVER_ATTRS = frozenset(
         "_thread_local",
         "_use_async_insert",
         "_user",
-        "ch_client",
     }
 )
 
@@ -60,7 +59,12 @@ def test_reset_server_state_covers_all_attrs(ch_server):
     Instrumentation attrs (ddtrace, coverage) are ignored — only attrs
     missing from KNOWN_SERVER_ATTRS trigger failure.
     """
-    actual = {a for a in ch_server.__dict__ if not a.startswith("__")}
+    # Only check underscore-prefixed attrs (real app state).
+    # Instrumentation (ddtrace) injects public-name wrappers like
+    # 'objs_query', 'file_create' etc. — ignore those.
+    actual = {
+        a for a in ch_server.__dict__ if a.startswith("_") and not a.startswith("__")
+    }
     unknown = actual - KNOWN_SERVER_ATTRS
     assert not unknown, (
         f"ClickHouseTraceServer has new attributes: {unknown}. "


### PR DESCRIPTION
## Summary

Replaces per-test DB creation + 28 migrations (~1s each) with a single session-scoped DB that truncates tables between tests (~0.03s each).

**CI results (ClickHouse runs):**

| Shard | Baseline | This PR (3.10 / 3.11 / 3.13) | Improvement |
|-------|----------|-------------------------------|-------------|
| trace_server | 6m10s | 3m36s / 2m59s / 3m20s | ~50% faster |
| trace (-n8 xdist) | 7m56s | 3m10s / 3m06s / 3m07s | ~61% faster |

All 180 CI checks pass.