### PR TITLE
chore(weave): auto-detect distributed tables from cluster shard count

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -212,7 +212,9 @@ def test_use_distributed_mode_auto_detect_paths():
     # 1. Env var unset + replicated + multi-shard -> auto-detected True, cached.
     mock_client = _mock_client(shard_count=3)
     with (
-        patch.object(chts.ClickHouseTraceServer, "_mint_client", return_value=mock_client),
+        patch.object(
+            chts.ClickHouseTraceServer, "_mint_client", return_value=mock_client
+        ),
         patch(
             "weave.trace_server.environment.wf_clickhouse_use_distributed_tables",
             return_value=None,
@@ -236,14 +238,14 @@ def test_use_distributed_mode_auto_detect_paths():
             if c.args and c.args[0] == CLUSTER_SHARD_COUNT_QUERY
         ]
         assert len(cluster_calls) == 1
-        assert cluster_calls[0].kwargs["parameters"] == {
-            "cluster_name": "auto_cluster"
-        }
+        assert cluster_calls[0].kwargs["parameters"] == {"cluster_name": "auto_cluster"}
 
     # 2. Env var unset + non-replicated -> False, no system.clusters query.
     mock_client = _mock_client(shard_count=99)
     with (
-        patch.object(chts.ClickHouseTraceServer, "_mint_client", return_value=mock_client),
+        patch.object(
+            chts.ClickHouseTraceServer, "_mint_client", return_value=mock_client
+        ),
         patch(
             "weave.trace_server.environment.wf_clickhouse_use_distributed_tables",
             return_value=None,
@@ -260,7 +262,9 @@ def test_use_distributed_mode_auto_detect_paths():
     # 3. Env var unset + replicated + single shard -> False.
     mock_client = _mock_client(shard_count=1)
     with (
-        patch.object(chts.ClickHouseTraceServer, "_mint_client", return_value=mock_client),
+        patch.object(
+            chts.ClickHouseTraceServer, "_mint_client", return_value=mock_client
+        ),
         patch(
             "weave.trace_server.environment.wf_clickhouse_use_distributed_tables",
             return_value=None,

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -198,6 +198,86 @@ def test_clickhouse_distributed_mode_properties():
         assert server._get_calls_complete_table_name() == "calls_complete"
 
 
+def test_use_distributed_mode_auto_detect_paths():
+    """Cover the new auto-detect resolution: env unset, replicated gate, caching."""
+    from weave.trace_server.database_engine import CLUSTER_SHARD_COUNT_QUERY
+
+    def _mock_client(shard_count: int) -> MagicMock:
+        shard_result = Mock()
+        shard_result.result_rows = [(shard_count,)]
+        client = MagicMock()
+        client.query.return_value = shard_result
+        return client
+
+    # 1. Env var unset + replicated + multi-shard -> auto-detected True, cached.
+    mock_client = _mock_client(shard_count=3)
+    with (
+        patch.object(chts.ClickHouseTraceServer, "_mint_client", return_value=mock_client),
+        patch(
+            "weave.trace_server.environment.wf_clickhouse_use_distributed_tables",
+            return_value=None,
+        ),
+        patch(
+            "weave.trace_server.environment.wf_clickhouse_replicated",
+            return_value=True,
+        ),
+        patch(
+            "weave.trace_server.environment.wf_clickhouse_replicated_cluster",
+            return_value="auto_cluster",
+        ),
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host")
+        assert server.use_distributed_mode is True
+        # Repeated access uses the cache; system.clusters is queried exactly once.
+        assert server.use_distributed_mode is True
+        cluster_calls = [
+            c
+            for c in mock_client.query.call_args_list
+            if c.args and c.args[0] == CLUSTER_SHARD_COUNT_QUERY
+        ]
+        assert len(cluster_calls) == 1
+        assert cluster_calls[0].kwargs["parameters"] == {
+            "cluster_name": "auto_cluster"
+        }
+
+    # 2. Env var unset + non-replicated -> False, no system.clusters query.
+    mock_client = _mock_client(shard_count=99)
+    with (
+        patch.object(chts.ClickHouseTraceServer, "_mint_client", return_value=mock_client),
+        patch(
+            "weave.trace_server.environment.wf_clickhouse_use_distributed_tables",
+            return_value=None,
+        ),
+        patch(
+            "weave.trace_server.environment.wf_clickhouse_replicated",
+            return_value=False,
+        ),
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host")
+        assert server.use_distributed_mode is False
+        assert mock_client.query.call_count == 0
+
+    # 3. Env var unset + replicated + single shard -> False.
+    mock_client = _mock_client(shard_count=1)
+    with (
+        patch.object(chts.ClickHouseTraceServer, "_mint_client", return_value=mock_client),
+        patch(
+            "weave.trace_server.environment.wf_clickhouse_use_distributed_tables",
+            return_value=None,
+        ),
+        patch(
+            "weave.trace_server.environment.wf_clickhouse_replicated",
+            return_value=True,
+        ),
+        patch(
+            "weave.trace_server.environment.wf_clickhouse_replicated_cluster",
+            return_value=None,
+        ),
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host")
+        assert server.use_distributed_mode is False
+
+
 def test_completions_create_stream_custom_provider():
     """Test completions_create_stream for a custom provider (no call tracking)."""
     # Mock chunks to be returned by the stream

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -22,22 +22,28 @@ DEFAULT_MIGRATION_DIR = os.path.abspath(
 )
 
 
-def _make_ch_client(database_engine: str = "Atomic") -> Mock:
-    """Create a mock CH client that returns *database_engine* for system.databases queries.
+def _make_ch_client(
+    database_engine: str = "Atomic", shard_count: int = 0
+) -> Mock:
+    """Create a mock CH client that returns *database_engine* for system.databases
+    queries and *shard_count* for system.clusters queries.
 
-    Only ``system.databases`` queries are stubbed; all other ``query()`` calls
-    fall through to the default Mock behaviour so they don't silently return
-    engine data for unrelated code paths.
+    Other ``query()`` calls fall through to the default Mock behaviour so they
+    don't silently return engine data for unrelated code paths.
     """
     ch_client = Mock()
     ch_client.database = "test_db"
 
     engine_result = Mock()
     engine_result.result_rows = [(database_engine,)]
+    shard_result = Mock()
+    shard_result.result_rows = [(shard_count,)]
 
     def _query_side_effect(sql, *args, **kwargs):
         if "system.databases" in sql:
             return engine_result
+        if "system.clusters" in sql:
+            return shard_result
         return Mock()
 
     ch_client.query.side_effect = _query_side_effect
@@ -1264,3 +1270,133 @@ def test_is_transient_ch_error():
     assert not _is_transient_ch_error(DatabaseError("some other error"))
     assert not _is_transient_ch_error(DatabaseError(""))
     assert not _is_transient_ch_error(ConnectionError("not a db error"))
+
+
+def _make_shard_count_ch_client(
+    shard_count: int | None = None,
+    raise_on_clusters: Exception | None = None,
+) -> Mock:
+    """Mock CH client that answers system.databases (engine) and system.clusters
+    (shard count) queries.
+    """
+    ch_client = Mock()
+    ch_client.database = "test_db"
+
+    engine_result = Mock()
+    engine_result.result_rows = [("Atomic",)]
+
+    def _query_side_effect(sql, *args, **kwargs):
+        if "system.clusters" in sql:
+            if raise_on_clusters is not None:
+                raise raise_on_clusters
+            shard_result = Mock()
+            shard_result.result_rows = [(shard_count,)]
+            return shard_result
+        if "system.databases" in sql:
+            return engine_result
+        return Mock()
+
+    ch_client.query.side_effect = _query_side_effect
+    return ch_client
+
+
+@pytest.mark.parametrize(
+    ("shard_count", "expected_use_distributed", "expected_class"),
+    [
+        (3, True, DistributedClickHouseTraceServerMigrator),
+        (1, False, ReplicatedClickHouseTraceServerMigrator),
+        (0, False, ReplicatedClickHouseTraceServerMigrator),
+    ],
+)
+def test_get_migrator_auto_detects_use_distributed_when_replicated(
+    shard_count, expected_use_distributed, expected_class
+):
+    """When use_distributed is None and replicated=True, auto-detect from system.clusters."""
+    ch_client = _make_shard_count_ch_client(shard_count=shard_count)
+    migrator = trace_server_migrator.get_clickhouse_trace_server_migrator(
+        ch_client,
+        replicated=True,
+        replicated_cluster="test_cluster",
+        replicated_path="/clickhouse/tables/{db}",
+    )
+    assert isinstance(migrator, expected_class)
+    cluster_queries = [
+        c
+        for c in ch_client.query.call_args_list
+        if "system.clusters" in c.args[0]
+    ]
+    assert len(cluster_queries) == 1
+    assert cluster_queries[0].kwargs["parameters"] == {"cluster_name": "test_cluster"}
+
+
+def test_get_migrator_no_auto_detect_when_not_replicated():
+    """When use_distributed is None and replicated=False, system.clusters is never queried."""
+    ch_client = _make_shard_count_ch_client(shard_count=10)  # would imply distributed
+    migrator = trace_server_migrator.get_clickhouse_trace_server_migrator(ch_client)
+    assert isinstance(migrator, CloudClickHouseTraceServerMigrator)
+    assert all(
+        "system.clusters" not in c.args[0] for c in ch_client.query.call_args_list
+    )
+
+
+def test_get_migrator_auto_detect_falls_back_when_query_fails():
+    """If system.clusters query fails, fall back to use_distributed=False."""
+    ch_client = _make_shard_count_ch_client(
+        raise_on_clusters=DatabaseError("Code: 497. Not enough privileges")
+    )
+    migrator = trace_server_migrator.get_clickhouse_trace_server_migrator(
+        ch_client,
+        replicated=True,
+        replicated_cluster="test_cluster",
+        replicated_path="/clickhouse/tables/{db}",
+    )
+    assert isinstance(migrator, ReplicatedClickHouseTraceServerMigrator)
+
+
+def test_get_migrator_explicit_use_distributed_skips_auto_detect():
+    """An explicit True/False bypasses the system.clusters query entirely."""
+    ch_client = _make_shard_count_ch_client(shard_count=10)
+    trace_server_migrator.get_clickhouse_trace_server_migrator(
+        ch_client,
+        replicated=True,
+        use_distributed=False,
+        replicated_cluster="test_cluster",
+        replicated_path="/clickhouse/tables/{db}",
+    )
+    assert all(
+        "system.clusters" not in c.args[0] for c in ch_client.query.call_args_list
+    )
+
+
+def test_auto_detect_use_distributed_helper():
+    """Direct coverage for the auto_detect_use_distributed helper."""
+    from weave.trace_server.database_engine import (
+        EngineDiscoveryError,
+        auto_detect_use_distributed,
+        detect_cluster_shard_count,
+    )
+
+    # Multi-shard -> True
+    ch = _make_shard_count_ch_client(shard_count=4)
+    assert auto_detect_use_distributed(ch, "c") is True
+    assert detect_cluster_shard_count(ch, "c") == 4
+
+    # Single shard -> False
+    ch = _make_shard_count_ch_client(shard_count=1)
+    assert auto_detect_use_distributed(ch, "c") is False
+
+    # Cluster not found (count = 0) -> False
+    ch = _make_shard_count_ch_client(shard_count=0)
+    assert auto_detect_use_distributed(ch, "c") is False
+
+    # Query failure -> warning + False from the helper, EngineDiscoveryError
+    # from the lower-level shard counter.
+    ch = _make_shard_count_ch_client(
+        raise_on_clusters=DatabaseError("Code: 497. Not enough privileges")
+    )
+    assert auto_detect_use_distributed(ch, "c") is False
+    ch = _make_shard_count_ch_client(
+        raise_on_clusters=DatabaseError("Code: 497. Not enough privileges")
+    )
+    with pytest.raises(EngineDiscoveryError, match="system.clusters"):
+        detect_cluster_shard_count(ch, "c")

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -22,9 +22,7 @@ DEFAULT_MIGRATION_DIR = os.path.abspath(
 )
 
 
-def _make_ch_client(
-    database_engine: str = "Atomic", shard_count: int = 0
-) -> Mock:
+def _make_ch_client(database_engine: str = "Atomic", shard_count: int = 0) -> Mock:
     """Create a mock CH client that returns *database_engine* for system.databases
     queries and *shard_count* for system.clusters queries.
 
@@ -1321,9 +1319,7 @@ def test_get_migrator_auto_detects_use_distributed_when_replicated(
     )
     assert isinstance(migrator, expected_class)
     cluster_queries = [
-        c
-        for c in ch_client.query.call_args_list
-        if "system.clusters" in c.args[0]
+        c for c in ch_client.query.call_args_list if "system.clusters" in c.args[0]
     ]
     assert len(cluster_queries) == 1
     assert cluster_queries[0].kwargs["parameters"] == {"cluster_name": "test_cluster"}

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -132,10 +132,17 @@ from weave.trace_server.clickhouse_schema import (
     SelectableCHObjSchema,
     TagCHInsertable,
 )
+from weave.trace_server.clickhouse_trace_server_migrator import (
+    DEFAULT_REPLICATED_CLUSTER,
+)
 from weave.trace_server.common_interface import AnnotationQueueItemsFilter
 from weave.trace_server.constants import (
     COMPLETIONS_CREATE_OP_NAME,
     IMAGE_GENERATION_CREATE_OP_NAME,
+)
+from weave.trace_server.database_engine import (
+    EngineDiscoveryError,
+    detect_cluster_shard_count,
 )
 from weave.trace_server.datadog import (
     generator_trace,
@@ -340,6 +347,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._op_ref_cache_lock = threading.Lock()
         self._placeholder_file_projects: set[str] = set()
         self._database_ensured = False
+        # Cached result of distributed-mode auto-detection (None = not yet resolved).
+        # Once resolved by querying system.clusters, the bool is stored here so
+        # we don't re-query on every call to use_distributed_mode.
+        self._use_distributed_cached: bool | None = None
 
         if wf_env.wf_clickhouse_disable_lightweight_update():
             logger.warning(
@@ -458,12 +469,47 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def use_distributed_mode(self) -> bool:
         """Check if ClickHouse is configured to use distributed tables.
 
-        Returns the value from WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES environment variable.
-
-        Returns:
-            bool: True if using distributed tables, False otherwise.
+        Resolution order:
+        1. If WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES is explicitly set → use that.
+        2. Otherwise, auto-detect by querying system.clusters for the shard
+           count of the configured cluster (>1 shard → distributed).
+        3. Cache the result so we only query system.clusters once.
         """
-        return wf_env.wf_clickhouse_use_distributed_tables()
+        # Fast path: already resolved and cached.
+        if self._use_distributed_cached is not None:
+            return self._use_distributed_cached
+
+        # Check the env var — returns None when unset (= auto-detect).
+        env_value = wf_env.wf_clickhouse_use_distributed_tables()
+        if env_value is not None:
+            # Explicit override from env var — cache and return.
+            self._use_distributed_cached = env_value
+            return env_value
+
+        # Auto-detect: query system.clusters for the shard count.
+        cluster = (
+            wf_env.wf_clickhouse_replicated_cluster() or DEFAULT_REPLICATED_CLUSTER
+        )
+        try:
+            shard_count = detect_cluster_shard_count(self.ch_client, cluster)
+            result = shard_count > 1
+            logger.info(
+                "Auto-detected %d shard(s) for cluster '%s' → use_distributed=%s",
+                shard_count,
+                cluster,
+                result,
+            )
+        except EngineDiscoveryError:
+            logger.warning(
+                "Could not auto-detect shard count for cluster '%s' — "
+                "defaulting to use_distributed=False. Set "
+                "WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES explicitly to override.",
+                cluster,
+            )
+            result = False
+
+        self._use_distributed_cached = result
+        return result
 
     @property
     def clickhouse_cluster_name(self) -> str | None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -132,17 +132,14 @@ from weave.trace_server.clickhouse_schema import (
     SelectableCHObjSchema,
     TagCHInsertable,
 )
-from weave.trace_server.clickhouse_trace_server_migrator import (
-    DEFAULT_REPLICATED_CLUSTER,
-)
 from weave.trace_server.common_interface import AnnotationQueueItemsFilter
 from weave.trace_server.constants import (
     COMPLETIONS_CREATE_OP_NAME,
     IMAGE_GENERATION_CREATE_OP_NAME,
 )
 from weave.trace_server.database_engine import (
-    EngineDiscoveryError,
-    detect_cluster_shard_count,
+    DEFAULT_REPLICATED_CLUSTER,
+    auto_detect_use_distributed,
 )
 from weave.trace_server.datadog import (
     generator_trace,
@@ -347,9 +344,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._op_ref_cache_lock = threading.Lock()
         self._placeholder_file_projects: set[str] = set()
         self._database_ensured = False
-        # Cached result of distributed-mode auto-detection (None = not yet resolved).
-        # Once resolved by querying system.clusters, the bool is stored here so
-        # we don't re-query on every call to use_distributed_mode.
+        # Cached result of distributed-mode resolution. None until first read.
         self._use_distributed_cached: bool | None = None
 
         if wf_env.wf_clickhouse_disable_lightweight_update():
@@ -470,46 +465,35 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         """Check if ClickHouse is configured to use distributed tables.
 
         Resolution order:
-        1. If WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES is explicitly set → use that.
-        2. Otherwise, auto-detect by querying system.clusters for the shard
-           count of the configured cluster (>1 shard → distributed).
-        3. Cache the result so we only query system.clusters once.
+        1. Cached result from a previous call.
+        2. WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES env var if explicitly set.
+        3. Auto-detect by querying system.clusters for the shard count
+           (>1 shard means distributed). Only fires under replicated mode,
+           since distributed tables sit on top of replicated ones.
         """
-        # Fast path: already resolved and cached.
         if self._use_distributed_cached is not None:
             return self._use_distributed_cached
+        with self._init_lock:
+            if self._use_distributed_cached is not None:
+                return self._use_distributed_cached
 
-        # Check the env var — returns None when unset (= auto-detect).
-        env_value = wf_env.wf_clickhouse_use_distributed_tables()
-        if env_value is not None:
-            # Explicit override from env var — cache and return.
-            self._use_distributed_cached = env_value
-            return env_value
+            env_value = wf_env.wf_clickhouse_use_distributed_tables()
+            if env_value is not None:
+                self._use_distributed_cached = env_value
+                return env_value
 
-        # Auto-detect: query system.clusters for the shard count.
-        cluster = (
-            wf_env.wf_clickhouse_replicated_cluster() or DEFAULT_REPLICATED_CLUSTER
-        )
-        try:
-            shard_count = detect_cluster_shard_count(self.ch_client, cluster)
-            result = shard_count > 1
-            logger.info(
-                "Auto-detected %d shard(s) for cluster '%s' → use_distributed=%s",
-                shard_count,
-                cluster,
-                result,
+            # Auto-detect only makes sense for replicated deployments. A non-
+            # replicated single-node setup has no cluster to query.
+            if not wf_env.wf_clickhouse_replicated():
+                self._use_distributed_cached = False
+                return False
+
+            cluster = (
+                wf_env.wf_clickhouse_replicated_cluster() or DEFAULT_REPLICATED_CLUSTER
             )
-        except EngineDiscoveryError:
-            logger.warning(
-                "Could not auto-detect shard count for cluster '%s' — "
-                "defaulting to use_distributed=False. Set "
-                "WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES explicitly to override.",
-                cluster,
-            )
-            result = False
-
-        self._use_distributed_cached = result
-        return result
+            result = auto_detect_use_distributed(self.ch_client, cluster)
+            self._use_distributed_cached = result
+            return result
 
     @property
     def clickhouse_cluster_name(self) -> str | None:

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -94,6 +94,7 @@ from weave.trace_server.costs.insert_costs import insert_costs, should_insert_co
 from weave.trace_server.database_engine import (
     ENGINE_DISCOVERY_MAX_WAIT_SECONDS,
     EngineDiscoveryError,
+    detect_cluster_shard_count,
     wait_for_database_engine,
 )
 from weave.trace_server.environment import wf_clickhouse_calls_shard_key
@@ -1226,7 +1227,11 @@ def get_clickhouse_trace_server_migrator(
         replicated: Whether to use replicated tables
         replicated_path: ZooKeeper path for replication
         replicated_cluster: Cluster name for replication
-        use_distributed: Whether to use distributed tables (requires replicated=True)
+        use_distributed: Whether to use distributed tables on top of replicated
+            tables. Pass ``None`` (the default) to auto-detect from the cluster's
+            shard count in ``system.clusters``. Pass ``True``/``False`` to
+            override auto-detection (e.g. via the
+            ``WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES`` env var).
         management_db: Database name for migration management
         migration_dir: Absolute path to a directory containing `*.up.sql` / `*.down.sql`
         post_migration_hook: Optional callable run after migrations; defaults to the Weave costs backfill hook (pass None to disable)
@@ -1238,7 +1243,40 @@ def get_clickhouse_trace_server_migrator(
         MigrationError: If configuration is invalid (e.g., use_distributed without replicated)
     """
     replicated = False if replicated is None else replicated
-    use_distributed = False if use_distributed is None else use_distributed
+
+    # --- Auto-detect distributed mode from cluster shard count ---
+    # When use_distributed is None (no explicit env var / CLI flag), we query
+    # system.clusters to count the shards. >1 shard means data is partitioned
+    # across nodes and we need Distributed engine tables.
+    # An explicit True/False always wins — auto-detect only fires for None.
+    if use_distributed is None and replicated:
+        cluster = replicated_cluster or DEFAULT_REPLICATED_CLUSTER
+        try:
+            shard_count = detect_cluster_shard_count(ch_client, cluster)
+            # >1 shard → distributed tables needed to fan queries across shards.
+            # 0 means the cluster wasn't found (misconfigured or single-node);
+            # 1 means single-shard replicated — no distributed tables needed.
+            use_distributed = shard_count > 1
+            logger.info(
+                "Auto-detected %d shard(s) for cluster '%s' → use_distributed=%s",
+                shard_count,
+                cluster,
+                use_distributed,
+            )
+        except EngineDiscoveryError:
+            # If we can't query system.clusters (e.g. permissions), fall back
+            # to non-distributed mode and let the operator know.
+            logger.warning(
+                "Could not auto-detect shard count for cluster '%s' from "
+                "system.clusters — defaulting to use_distributed=False. "
+                "Set WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES explicitly to "
+                "override.",
+                cluster,
+            )
+            use_distributed = False
+    elif use_distributed is None:
+        # Not replicated → distributed tables don't apply.
+        use_distributed = False
 
     logger.info(
         "ClickHouseTraceServerMigrator initialized with: "

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -92,9 +92,10 @@ from tenacity import (
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.costs.insert_costs import insert_costs, should_insert_costs
 from weave.trace_server.database_engine import (
+    DEFAULT_REPLICATED_CLUSTER,
     ENGINE_DISCOVERY_MAX_WAIT_SECONDS,
     EngineDiscoveryError,
-    detect_cluster_shard_count,
+    auto_detect_use_distributed,
     wait_for_database_engine,
 )
 from weave.trace_server.environment import wf_clickhouse_calls_shard_key
@@ -125,7 +126,6 @@ def _is_transient_ch_error(exc: BaseException) -> bool:
 # These settings are only used when `replicated` mode is enabled for
 # self managed clickhouse instances.
 DEFAULT_REPLICATED_PATH = "/clickhouse/tables/{db}"
-DEFAULT_REPLICATED_CLUSTER = "weave_cluster"
 
 # Constants for table naming conventions
 VIEW_SUFFIX = "_view"
@@ -1228,10 +1228,10 @@ def get_clickhouse_trace_server_migrator(
         replicated_path: ZooKeeper path for replication
         replicated_cluster: Cluster name for replication
         use_distributed: Whether to use distributed tables on top of replicated
-            tables. Pass ``None`` (the default) to auto-detect from the cluster's
-            shard count in ``system.clusters``. Pass ``True``/``False`` to
-            override auto-detection (e.g. via the
-            ``WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES`` env var).
+            tables. Pass `None` (the default) to auto-detect from the cluster's
+            shard count in `system.clusters`. Pass `True`/`False` to override
+            auto-detection (e.g. via the `WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES`
+            env var).
         management_db: Database name for migration management
         migration_dir: Absolute path to a directory containing `*.up.sql` / `*.down.sql`
         post_migration_hook: Optional callable run after migrations; defaults to the Weave costs backfill hook (pass None to disable)
@@ -1244,39 +1244,14 @@ def get_clickhouse_trace_server_migrator(
     """
     replicated = False if replicated is None else replicated
 
-    # --- Auto-detect distributed mode from cluster shard count ---
-    # When use_distributed is None (no explicit env var / CLI flag), we query
-    # system.clusters to count the shards. >1 shard means data is partitioned
-    # across nodes and we need Distributed engine tables.
-    # An explicit True/False always wins — auto-detect only fires for None.
-    if use_distributed is None and replicated:
-        cluster = replicated_cluster or DEFAULT_REPLICATED_CLUSTER
-        try:
-            shard_count = detect_cluster_shard_count(ch_client, cluster)
-            # >1 shard → distributed tables needed to fan queries across shards.
-            # 0 means the cluster wasn't found (misconfigured or single-node);
-            # 1 means single-shard replicated — no distributed tables needed.
-            use_distributed = shard_count > 1
-            logger.info(
-                "Auto-detected %d shard(s) for cluster '%s' → use_distributed=%s",
-                shard_count,
-                cluster,
-                use_distributed,
-            )
-        except EngineDiscoveryError:
-            # If we can't query system.clusters (e.g. permissions), fall back
-            # to non-distributed mode and let the operator know.
-            logger.warning(
-                "Could not auto-detect shard count for cluster '%s' from "
-                "system.clusters — defaulting to use_distributed=False. "
-                "Set WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES explicitly to "
-                "override.",
-                cluster,
-            )
+    # An explicit True/False from the env var or CLI flag always wins.
+    # When None and replication is on, auto-detect from the cluster shard count.
+    if use_distributed is None:
+        if replicated:
+            cluster = replicated_cluster or DEFAULT_REPLICATED_CLUSTER
+            use_distributed = auto_detect_use_distributed(ch_client, cluster)
+        else:
             use_distributed = False
-    elif use_distributed is None:
-        # Not replicated → distributed tables don't apply.
-        use_distributed = False
 
     logger.info(
         "ClickHouseTraceServerMigrator initialized with: "

--- a/weave/trace_server/database_engine.py
+++ b/weave/trace_server/database_engine.py
@@ -1,20 +1,21 @@
 """ClickHouse database engine and cluster discovery for the migrator.
 
-Queries ``system.databases`` to determine whether a database uses the
+Queries `system.databases` to determine whether a database uses the
 Replicated engine (DDL auto-replicated, ON CLUSTER forbidden) or the
 default Atomic engine (explicit ON CLUSTER + ReplicatedMergeTree required).
 
-Queries ``system.clusters`` to detect the number of shards in a cluster,
+Queries `system.clusters` to detect the number of shards in a cluster,
 which is used to auto-detect whether distributed tables are needed
 (shards > 1 means data is split across nodes and requires Distributed engine tables).
 
-Handles the metadata-visibility lag that can occur after ``CREATE DATABASE``
+Handles the metadata-visibility lag that can occur after `CREATE DATABASE`
 by polling with exponential back-off.
 """
 
 import logging
 
 from clickhouse_connect.driver.client import Client as CHClient
+from clickhouse_connect.driver.exceptions import DatabaseError
 from tenacity import (
     RetryError,
     Retrying,
@@ -31,13 +32,15 @@ ENGINE_DISCOVERY_INITIAL_DELAY_SECONDS = 0.1
 ENGINE_DISCOVERY_MAX_WAIT_SECONDS = 3.0
 ENGINE_DISCOVERY_MAX_DELAY_SECONDS = 0.8
 
+# Default cluster name used by replicated/distributed Weave deployments
+# when WF_CLICKHOUSE_REPLICATED_CLUSTER is unset.
+DEFAULT_REPLICATED_CLUSTER = "weave_cluster"
+
 ENGINE_QUERY = "SELECT engine FROM system.databases WHERE name = %(db_name)s"
 
-# Query to count distinct shards in a ClickHouse cluster.
 # system.clusters contains one row per (shard, replica) pair, so counting
-# distinct shard_num gives us the number of shards.
-# A cluster with >1 shard needs Distributed engine tables to route queries
-# across shards; a single-shard cluster only needs replicated tables.
+# distinct shard_num gives the number of shards. >1 shard needs Distributed
+# engine tables; a single-shard cluster only needs replicated tables.
 CLUSTER_SHARD_COUNT_QUERY = (
     "SELECT count(DISTINCT shard_num) FROM system.clusters"
     " WHERE cluster = %(cluster_name)s"
@@ -136,48 +139,55 @@ def detect_cluster_shard_count(
     ch_client: CHClient,
     cluster_name: str,
 ) -> int:
-    """Return the number of distinct shards in *cluster_name*.
+    """Return the number of distinct shards in `cluster_name`.
 
-    Queries ClickHouse's ``system.clusters`` table which contains one row
-    per (shard, replica) pair. Counting distinct ``shard_num`` tells us
-    how many shards the cluster is configured with:
+    `count(DISTINCT shard_num)` always returns one row with one int. If the
+    cluster name is not in `system.clusters` the count is 0.
 
-    - **1 shard**: all replicas hold the same data → distributed tables
-      are unnecessary, plain ReplicatedMergeTree is sufficient.
-    - **>1 shards**: data is partitioned across nodes → Distributed engine
-      tables are needed to fan out queries and route inserts.
-
-    Returns 0 if the cluster name is not found (e.g. single-node setup
-    with no cluster configured).
-
-    Raises ``EngineDiscoveryError`` if the query fails (e.g. missing
-    SELECT access on ``system.clusters``).
+    Raises `EngineDiscoveryError` if the query fails (e.g. missing SELECT
+    access on `system.clusters`).
     """
     try:
         result = ch_client.query(
             CLUSTER_SHARD_COUNT_QUERY,
             parameters={"cluster_name": cluster_name},
         )
-    except Exception as exc:
+    except DatabaseError as exc:
         raise EngineDiscoveryError(
             f"Could not query system.clusters for cluster `{cluster_name}`. "
             "Auto-detection of distributed mode requires SELECT access to "
             f"system.clusters. Underlying error: {exc}"
         ) from exc
 
-    # Extract the scalar count from the result.
-    # Result shape: [[count]] — a single row with a single column.
-    result_rows = getattr(result, "result_rows", None)
-    if not isinstance(result_rows, list | tuple) or not result_rows:
-        # No rows means the cluster name wasn't found in system.clusters.
-        return 0
+    return int(result.result_rows[0][0])
 
-    first_row = result_rows[0]
-    if not isinstance(first_row, list | tuple) or not first_row:
-        return 0
 
-    count = first_row[0]
-    # Guard against None (e.g. from a mock or unexpected query result).
-    if count is None:
-        return 0
-    return int(count)
+def auto_detect_use_distributed(
+    ch_client: CHClient,
+    cluster_name: str,
+) -> bool:
+    """Decide whether to use distributed tables based on the cluster's shard count.
+
+    Returns True when `cluster_name` has more than one shard. On query failure
+    (`EngineDiscoveryError`), logs a warning and returns False so callers can
+    proceed in non-distributed mode.
+    """
+    try:
+        shard_count = detect_cluster_shard_count(ch_client, cluster_name)
+    except EngineDiscoveryError:
+        logger.warning(
+            "Could not auto-detect shard count for cluster '%s' from "
+            "system.clusters. Defaulting to use_distributed=False. Set "
+            "WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES explicitly to override.",
+            cluster_name,
+        )
+        return False
+
+    use_distributed = shard_count > 1
+    logger.info(
+        "Auto-detected %d shard(s) for cluster '%s' -> use_distributed=%s",
+        shard_count,
+        cluster_name,
+        use_distributed,
+    )
+    return use_distributed

--- a/weave/trace_server/database_engine.py
+++ b/weave/trace_server/database_engine.py
@@ -177,4 +177,7 @@ def detect_cluster_shard_count(
         return 0
 
     count = first_row[0]
+    # Guard against None (e.g. from a mock or unexpected query result).
+    if count is None:
+        return 0
     return int(count)

--- a/weave/trace_server/database_engine.py
+++ b/weave/trace_server/database_engine.py
@@ -1,8 +1,12 @@
-"""ClickHouse database engine discovery for the migrator.
+"""ClickHouse database engine and cluster discovery for the migrator.
 
 Queries ``system.databases`` to determine whether a database uses the
 Replicated engine (DDL auto-replicated, ON CLUSTER forbidden) or the
 default Atomic engine (explicit ON CLUSTER + ReplicatedMergeTree required).
+
+Queries ``system.clusters`` to detect the number of shards in a cluster,
+which is used to auto-detect whether distributed tables are needed
+(shards > 1 means data is split across nodes and requires Distributed engine tables).
 
 Handles the metadata-visibility lag that can occur after ``CREATE DATABASE``
 by polling with exponential back-off.
@@ -28,6 +32,16 @@ ENGINE_DISCOVERY_MAX_WAIT_SECONDS = 3.0
 ENGINE_DISCOVERY_MAX_DELAY_SECONDS = 0.8
 
 ENGINE_QUERY = "SELECT engine FROM system.databases WHERE name = %(db_name)s"
+
+# Query to count distinct shards in a ClickHouse cluster.
+# system.clusters contains one row per (shard, replica) pair, so counting
+# distinct shard_num gives us the number of shards.
+# A cluster with >1 shard needs Distributed engine tables to route queries
+# across shards; a single-shard cluster only needs replicated tables.
+CLUSTER_SHARD_COUNT_QUERY = (
+    "SELECT count(DISTINCT shard_num) FROM system.clusters"
+    " WHERE cluster = %(cluster_name)s"
+)
 
 
 class EngineDiscoveryError(RuntimeError):
@@ -116,3 +130,51 @@ def wait_for_database_engine(
         )
 
     return engine
+
+
+def detect_cluster_shard_count(
+    ch_client: CHClient,
+    cluster_name: str,
+) -> int:
+    """Return the number of distinct shards in *cluster_name*.
+
+    Queries ClickHouse's ``system.clusters`` table which contains one row
+    per (shard, replica) pair. Counting distinct ``shard_num`` tells us
+    how many shards the cluster is configured with:
+
+    - **1 shard**: all replicas hold the same data → distributed tables
+      are unnecessary, plain ReplicatedMergeTree is sufficient.
+    - **>1 shards**: data is partitioned across nodes → Distributed engine
+      tables are needed to fan out queries and route inserts.
+
+    Returns 0 if the cluster name is not found (e.g. single-node setup
+    with no cluster configured).
+
+    Raises ``EngineDiscoveryError`` if the query fails (e.g. missing
+    SELECT access on ``system.clusters``).
+    """
+    try:
+        result = ch_client.query(
+            CLUSTER_SHARD_COUNT_QUERY,
+            parameters={"cluster_name": cluster_name},
+        )
+    except Exception as exc:
+        raise EngineDiscoveryError(
+            f"Could not query system.clusters for cluster `{cluster_name}`. "
+            "Auto-detection of distributed mode requires SELECT access to "
+            f"system.clusters. Underlying error: {exc}"
+        ) from exc
+
+    # Extract the scalar count from the result.
+    # Result shape: [[count]] — a single row with a single column.
+    result_rows = getattr(result, "result_rows", None)
+    if not isinstance(result_rows, list | tuple) or not result_rows:
+        # No rows means the cluster name wasn't found in system.clusters.
+        return 0
+
+    first_row = result_rows[0]
+    if not isinstance(first_row, list | tuple) or not first_row:
+        return 0
+
+    count = first_row[0]
+    return int(count)

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -177,12 +177,21 @@ def wf_clickhouse_replicated_cluster() -> str | None:
     return os.environ.get("WF_CLICKHOUSE_REPLICATED_CLUSTER")
 
 
-def wf_clickhouse_use_distributed_tables() -> bool:
-    """Whether to use distributed tables on top of replicated tables."""
-    return (
-        os.environ.get("WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES", "false").lower()
-        == "true"
-    )
+def wf_clickhouse_use_distributed_tables() -> bool | None:
+    """Whether to use distributed tables on top of replicated tables.
+
+    Returns:
+        True/False: explicit override from the env var.
+        None: env var is not set — caller should auto-detect by querying
+              system.clusters for the shard count.
+    """
+    # When the env var is not set at all, return None to signal
+    # "auto-detect from the cluster configuration."
+    # When explicitly set to "true"/"false"/"1"/"0", honour that as an override.
+    raw = os.environ.get("WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES")
+    if raw is None:
+        return None
+    return raw.lower() in {"true", "1"}
 
 
 VALID_CALLS_SHARD_KEYS = frozenset({"trace_id", "id", "project_id"})

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -182,12 +182,9 @@ def wf_clickhouse_use_distributed_tables() -> bool | None:
 
     Returns:
         True/False: explicit override from the env var.
-        None: env var is not set — caller should auto-detect by querying
+        None: env var is not set; caller should auto-detect by querying
               system.clusters for the shard count.
     """
-    # When the env var is not set at all, return None to signal
-    # "auto-detect from the cluster configuration."
-    # When explicitly set to "true"/"false"/"1"/"0", honour that as an override.
     raw = os.environ.get("WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES")
     if raw is None:
         return None


### PR DESCRIPTION
## Summary
- Auto-detect whether distributed tables are needed by querying `system.clusters` for the cluster's shard count, instead of requiring `WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES` to be explicitly set.
- When the env var is unset: >1 shard → distributed mode, 1 shard → replicated only, 0 shards (cluster not found) → non-distributed.
- Explicit `true`/`false` env var still overrides auto-detection.

## Changes
- **`database_engine.py`**: Added `detect_cluster_shard_count()` — queries `system.clusters` for distinct shard count.
- **`environment.py`**: `wf_clickhouse_use_distributed_tables()` now returns `bool | None` — `None` when env var is unset (signals auto-detect).
- **`clickhouse_trace_server_migrator.py`**: Factory function auto-detects when `use_distributed=None` and `replicated=True`. Falls back to `False` on query failure.
- **`clickhouse_trace_server_batched.py`**: `use_distributed_mode` property auto-detects and caches the result.

## Test plan
- [ ] Verify on a multi-shard cluster: migrator auto-selects `DistributedClickHouseTraceServerMigrator`
- [ ] Verify on a single-shard cluster: migrator auto-selects `ReplicatedClickHouseTraceServerMigrator`
- [ ] Verify explicit `WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES=true` still overrides to distributed
- [ ] Verify explicit `WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES=false` still overrides to non-distributed

🤖 Generated with [Claude Code](https://claude.com/claude-code)