### PR TITLE
test(weave): skip calls query builder unit tests in clickhouse CI

### DIFF
--- a/tests/trace_server/query_builder/conftest.py
+++ b/tests/trace_server/query_builder/conftest.py
@@ -3,6 +3,7 @@ import pytest
 
 def pytest_collection_modifyitems(items):
     # These are SQL-generation unit tests; keep them in the SQLite trace_server run
-    # and exclude the whole directory from the ClickHouse CI shard.
+    # and exclude only this directory from the ClickHouse CI shard.
     for item in items:
-        item.add_marker(pytest.mark.skip_clickhouse_client)
+        if "query_builder" in item.path.parts:
+            item.add_marker(pytest.mark.skip_clickhouse_client)

--- a/tests/trace_server/query_builder/conftest.py
+++ b/tests/trace_server/query_builder/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        item.add_marker(pytest.mark.skip_clickhouse_client)

--- a/tests/trace_server/query_builder/conftest.py
+++ b/tests/trace_server/query_builder/conftest.py
@@ -1,9 +1,15 @@
 import pytest
 
 
-def pytest_collection_modifyitems(items):
-    # These are SQL-generation unit tests; keep them in the SQLite trace_server run
-    # and exclude only this directory from the ClickHouse CI shard.
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Skip query_builder tests when running with ClickHouse client.
+
+    pytest_collection_modifyitems is a pytest hook that receives ALL collected
+    tests for the session, not just tests in this directory — so we filter by
+    path. See: https://docs.pytest.org/en/stable/reference/reference.html#pytest.hookspec.pytest_collection_modifyitems
+    """
     for item in items:
         if "query_builder" in item.path.parts:
             item.add_marker(pytest.mark.skip_clickhouse_client)

--- a/tests/trace_server/query_builder/conftest.py
+++ b/tests/trace_server/query_builder/conftest.py
@@ -2,5 +2,7 @@ import pytest
 
 
 def pytest_collection_modifyitems(items):
+    # These are SQL-generation unit tests; keep them in the SQLite trace_server run
+    # and exclude the whole directory from the ClickHouse CI shard.
     for item in items:
         item.add_marker(pytest.mark.skip_clickhouse_client)

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -22,8 +22,6 @@ from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.project_version.types import ReadTable
 
-pytestmark = pytest.mark.skip_clickhouse_client
-
 
 @pytest.mark.parametrize(
     ("read_table", "expected_table"),

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -22,6 +22,8 @@ from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.project_version.types import ReadTable
 
+pytestmark = pytest.mark.skip_clickhouse_client
+
 
 @pytest.mark.parametrize(
     ("read_table", "expected_table"),


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Skip the entire `tests/trace_server/query_builder` directory in the ClickHouse `trace_server` CI shard. These are SQL-generation unit tests and are already covered in the SQLite `trace_server` run.

Measured on the latest completed `Trace nox tests (3, 13, trace_server)` job for `master` vs this branch's skip-change run:
- ClickHouse step: `6m 21s` on `master` -> `5m 4s` on this branch, saving `1m 17s` (`%20`)

## Testing

test only change

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wandb/weave/pull/6593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
