### PR TITLE
chore(weave): add squash migration for fresh database installs

### DIFF
--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -8,6 +8,7 @@ import time
 import uuid
 
 from weave.trace_server.clickhouse_trace_server_migrator import (
+    SQUASH_MIGRATION_VERSION,
     get_clickhouse_trace_server_migrator,
 )
 
@@ -254,7 +255,8 @@ def test_all_production_down_migrations_replicated(ch_client):
     # ALTER TABLE UPDATE mutations are async; wait for them to settle
     _sync_mutations(ch_client, mgmt_db, "migrations")
 
-    # Migrate all the way back down
+    # Migrate all the way back down (squash does not affect down migrations)
+    migrator.use_squash_migration = False
     migrator.apply_migrations(target_db, target_version=0)
 
 
@@ -286,3 +288,135 @@ def test_all_production_down_migrations_distributed(ch_client):
 
     # Migrate all the way back down
     migrator.apply_migrations(target_db, target_version=0)
+
+
+# ---------------------------------------------------------------------------
+# Squash migration tests
+# ---------------------------------------------------------------------------
+
+# Tables created by intermediate migration steps (e.g., rename dances) that
+# exist in the sequential path but NOT in the squash path.
+_MIGRATION_ARTIFACT_TABLES = {"calls_complete_old"}
+
+
+def _get_all_tables(ch_client, db_name: str) -> list[str]:
+    """Return sorted list of table/view names in a database."""
+    result = ch_client.query(
+        f"SELECT name FROM system.tables WHERE database = '{db_name}' ORDER BY name"
+    )
+    return [row[0] for row in result.result_rows]
+
+
+def _get_create_table_normalized(ch_client, db_name: str, table_name: str) -> str:
+    """Return SHOW CREATE TABLE output with the database name replaced."""
+    result = ch_client.query(f"SHOW CREATE TABLE {db_name}.{table_name}")
+    ddl = result.result_rows[0][0]
+    return ddl.replace(db_name, "TARGET_DB")
+
+
+def test_squash_migration_version_matches_migration_count(ch_client):
+    """SQUASH_MIGRATION_VERSION must equal the number of individual migrations."""
+    mgmt_db = _unique_name("db_mgmt_count")
+    target_db = _unique_name("count")
+    ch_client.track_db(mgmt_db)
+    ch_client.track_db(target_db)
+
+    migrator = get_clickhouse_trace_server_migrator(
+        ch_client,
+        replicated=False,
+        management_db=mgmt_db,
+        migration_dir=_PROD_MIGRATION_DIR,
+        post_migration_hook=None,
+    )
+    migration_map = migrator._get_migrations()
+    assert SQUASH_MIGRATION_VERSION == len(migration_map), (
+        f"SQUASH_MIGRATION_VERSION ({SQUASH_MIGRATION_VERSION}) != "
+        f"migration count ({len(migration_map)}). "
+        f"Update SQUASH_MIGRATION_VERSION after adding a new migration."
+    )
+
+
+def test_squash_migration_matches_sequential(ch_client):
+    """Squash migration produces the same schema as running all migrations."""
+    # --- Path A: sequential (squash disabled) ---
+    mgmt_db_seq = _unique_name("db_mgmt_seq")
+    target_db_seq = _unique_name("seq")
+    ch_client.track_db(mgmt_db_seq)
+    ch_client.track_db(target_db_seq)
+
+    migrator_seq = get_clickhouse_trace_server_migrator(
+        ch_client,
+        replicated=False,
+        management_db=mgmt_db_seq,
+        migration_dir=_PROD_MIGRATION_DIR,
+        post_migration_hook=None,
+    )
+    migrator_seq.use_squash_migration = False
+    migrator_seq.apply_migrations(target_db_seq)
+
+    # --- Path B: squash ---
+    mgmt_db_squash = _unique_name("db_mgmt_squash")
+    target_db_squash = _unique_name("squash")
+    ch_client.track_db(mgmt_db_squash)
+    ch_client.track_db(target_db_squash)
+
+    migrator_squash = get_clickhouse_trace_server_migrator(
+        ch_client,
+        replicated=False,
+        management_db=mgmt_db_squash,
+        migration_dir=_PROD_MIGRATION_DIR,
+        post_migration_hook=None,
+    )
+    migrator_squash.apply_migrations(target_db_squash)
+
+    # --- Compare schemas ---
+    tables_seq = _get_all_tables(ch_client, target_db_seq)
+    tables_squash = _get_all_tables(ch_client, target_db_squash)
+
+    # Filter out migration artifacts from the sequential path
+    tables_seq_filtered = [t for t in tables_seq if t not in _MIGRATION_ARTIFACT_TABLES]
+
+    assert tables_seq_filtered == tables_squash, (
+        f"Table sets differ.\n"
+        f"  Sequential only: {set(tables_seq_filtered) - set(tables_squash)}\n"
+        f"  Squash only:     {set(tables_squash) - set(tables_seq_filtered)}"
+    )
+
+    for table_name in tables_squash:
+        ddl_seq = _get_create_table_normalized(ch_client, target_db_seq, table_name)
+        ddl_squash = _get_create_table_normalized(
+            ch_client, target_db_squash, table_name
+        )
+        assert ddl_seq == ddl_squash, (
+            f"Schema mismatch for `{table_name}`:\n"
+            f"--- sequential ---\n{ddl_seq}\n"
+            f"--- squash ---\n{ddl_squash}"
+        )
+
+
+def test_squash_migration_sets_correct_version(ch_client):
+    """After squash, db_management records SQUASH_MIGRATION_VERSION."""
+    mgmt_db = _unique_name("db_mgmt_ver")
+    target_db = _unique_name("ver")
+    ch_client.track_db(mgmt_db)
+    ch_client.track_db(target_db)
+
+    migrator = get_clickhouse_trace_server_migrator(
+        ch_client,
+        replicated=False,
+        management_db=mgmt_db,
+        migration_dir=_PROD_MIGRATION_DIR,
+        post_migration_hook=None,
+    )
+    migrator.apply_migrations(target_db)
+
+    _sync_mutations(ch_client, mgmt_db, "migrations")
+
+    result = ch_client.query(
+        f"SELECT curr_version, partially_applied_version "
+        f"FROM {mgmt_db}.migrations WHERE db_name = '{target_db}'"
+    )
+    assert len(result.result_rows) == 1
+    curr_version, partial = result.result_rows[0]
+    assert curr_version == SQUASH_MIGRATION_VERSION
+    assert partial is None

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -135,6 +135,13 @@ VIEW_SUFFIX = "_view"
 # individual migrations (SQUASH_MIGRATION_VERSION+1 … latest).
 SQUASH_MIGRATION_VERSION = 28
 
+# Migration files that seed data and must also be applied after the squash
+# migration creates the schema.  Migration 006 seeds default LLM token prices
+# with effective_date = now().  The post-migration hook later adds any NEWER
+# entries from cost_checkpoint.json but deduplicates against what's already
+# present, so the 006 rows remain authoritative (their now()-based date wins).
+SQUASH_SEED_MIGRATIONS = ("006_seed_costs.up.sql",)
+
 # Schema for the migration tracking table (shared across all migrator variants)
 _MIGRATIONS_TABLE_COLUMNS = """
     db_name String,
@@ -243,7 +250,12 @@ class BaseClickHouseTraceServerMigrator(ABC):
         return None
 
     def _apply_squash_migration(self, target_db: str, squash_path: str) -> int:
-        """Apply the squash migration and return the version it represents."""
+        """Apply the squash migration and return the version it represents.
+
+        After creating the schema, any data-seeding migrations listed in
+        ``SQUASH_SEED_MIGRATIONS`` are replayed so that the database state
+        matches the sequential migration path exactly.
+        """
         logger.info(
             "Applying squash migration (version %s) to `%s`",
             SQUASH_MIGRATION_VERSION,
@@ -258,6 +270,18 @@ class BaseClickHouseTraceServerMigrator(ABC):
         migration_sub_commands = migration_sql.split(";")
         for command in migration_sub_commands:
             self._execute_migration_command(target_db, command)
+
+        # Replay data-seeding migrations that the squash DDL intentionally
+        # omits (e.g. cost seed data from migration 006).
+        for seed_file in SQUASH_SEED_MIGRATIONS:
+            seed_path = os.path.join(self.migration_dir, seed_file)
+            if os.path.isfile(seed_path):
+                logger.info("Seeding data from %s", seed_file)
+                with open(seed_path, encoding="utf-8") as f:
+                    seed_sql = f.read()
+                for command in seed_sql.split(";"):
+                    self._execute_migration_command(target_db, command)
+
         self._update_migration_status(
             target_db, SQUASH_MIGRATION_VERSION, is_start=False
         )

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -129,6 +129,12 @@ DEFAULT_REPLICATED_CLUSTER = "weave_cluster"
 # Constants for table naming conventions
 VIEW_SUFFIX = "_view"
 
+# The migration version that the squash file represents. Must match the highest
+# numbered migration file.  When the squash is applied on a fresh database the
+# migrator records this as the current version, then applies any remaining
+# individual migrations (SQUASH_MIGRATION_VERSION+1 … latest).
+SQUASH_MIGRATION_VERSION = 28
+
 # Schema for the migration tracking table (shared across all migrator variants)
 _MIGRATIONS_TABLE_COLUMNS = """
     db_name String,
@@ -173,6 +179,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
     management_db: str
     migration_dir: str
     post_migration_hook: PostMigrationHook | None
+    use_squash_migration: bool
 
     def __init__(
         self,
@@ -187,6 +194,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
         self.management_db = management_db
         self.migration_dir = self._resolve_migration_dir(migration_dir)
         self.post_migration_hook = post_migration_hook
+        self.use_squash_migration = True
         self._initialize_migration_db()
 
     def _uses_replicated_db_engine(self, db_name: str) -> bool:
@@ -221,6 +229,46 @@ class BaseClickHouseTraceServerMigrator(ABC):
             raise MigrationError(f"Migration directory not found: {migration_dir}")
         return migration_dir
 
+    def _get_squash_migration_path(self) -> str | None:
+        """Return path to squash migration file if it exists, None otherwise.
+
+        The squash file lives alongside the migrations directory as
+        ``squash_migration.sql``.
+        """
+        squash_path = os.path.join(
+            os.path.dirname(self.migration_dir), "squash_migration.sql"
+        )
+        if os.path.isfile(squash_path):
+            return squash_path
+        return None
+
+    def _apply_squash_migration(self, target_db: str, squash_path: str) -> int:
+        """Apply the squash migration and return the version it represents."""
+        logger.info(
+            "Applying squash migration (version %s) to `%s`",
+            SQUASH_MIGRATION_VERSION,
+            target_db,
+        )
+        with open(squash_path, encoding="utf-8") as f:
+            migration_sql = f.read()
+
+        self._update_migration_status(
+            target_db, SQUASH_MIGRATION_VERSION, is_start=True
+        )
+        migration_sub_commands = migration_sql.split(";")
+        for command in migration_sub_commands:
+            self._execute_migration_command(target_db, command)
+        self._update_migration_status(
+            target_db, SQUASH_MIGRATION_VERSION, is_start=False
+        )
+
+        logger.info(
+            "Squash migration applied to `%s` (version %s)",
+            target_db,
+            SQUASH_MIGRATION_VERSION,
+        )
+        return SQUASH_MIGRATION_VERSION
+
     @abstractmethod
     def _execute_migration_command(self, target_db: str, command: str) -> None:
         """Execute a single migration command (to be implemented by subclasses)."""
@@ -253,9 +301,29 @@ class BaseClickHouseTraceServerMigrator(ABC):
                 f"migration version {status['partially_applied_version']}. "
                 f"Please fix the database manually and try again."
             )
+
+        current_version = status["curr_version"]
+
+        # For fresh databases, use the squash migration if available. The squash
+        # brings the schema to SQUASH_MIGRATION_VERSION in a single pass.
+        if (
+            current_version == 0
+            and self.use_squash_migration
+            and (target_version is None or target_version >= SQUASH_MIGRATION_VERSION)
+        ):
+            squash_path = self._get_squash_migration_path()
+            if squash_path is not None:
+                self._ensure_database(target_db)
+                current_version = self._apply_squash_migration(target_db, squash_path)
+                logger.info(
+                    "Applied squash migration to `%s`, now at version %s",
+                    target_db,
+                    current_version,
+                )
+
         migration_map = self._get_migrations()
         migrations_to_apply = self._determine_migrations_to_apply(
-            status["curr_version"], migration_map, target_version
+            current_version, migration_map, target_version
         )
         if len(migrations_to_apply) == 0:
             logger.info("No migrations to apply to `%s`", target_db)
@@ -264,7 +332,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
             )
             return
         logger.info("Migrations to apply: %s", migrations_to_apply)
-        if status["curr_version"] == 0:
+        if current_version == 0:
             self._ensure_database(target_db)
         applied_target_version = target_version
         for migration_target_version, migration_file in migrations_to_apply:
@@ -322,6 +390,8 @@ class BaseClickHouseTraceServerMigrator(ABC):
         migration_map: dict[int, dict[str, str | None]] = {}
         max_version = 0
         for file in migration_files:
+            if not file.endswith(".sql"):
+                continue  # Skip non-SQL files (e.g., README.md)
             if not file.endswith(".up.sql") and not file.endswith(".down.sql"):
                 raise MigrationError(f"Invalid migration file: {file}")
             file_name_parts = file.split("_", 1)

--- a/weave/trace_server/migrations/README.md
+++ b/weave/trace_server/migrations/README.md
@@ -1,0 +1,36 @@
+# Weave Trace Server Migrations
+
+## Squash Migration
+
+The file `weave/trace_server/squash_migration.sql` contains a squashed version of
+all migrations. When the migrator detects a fresh (empty) database, it applies the
+squash file instead of running every individual migration sequentially. This makes
+fresh installations significantly faster.
+
+### Adding a new migration
+
+When you add a new migration file (e.g., `029_my_change.up.sql`):
+
+1. Create your `.up.sql` and `.down.sql` files as usual.
+2. **Update `squash_migration.sql`** to reflect the final schema state including
+   your change. The squash file should produce an identical schema to running all
+   migrations sequentially from scratch.
+3. **Update `SQUASH_MIGRATION_VERSION`** in `clickhouse_trace_server_migrator.py`
+   to match the new max migration number.
+4. Run the test `test_squash_migration_matches_sequential` to verify the squash
+   stays in sync:
+   ```
+   nox --no-install -e "tests-3.12(shard='trace_server')" -- \
+     tests/trace_server_migrator/test_migrator_functional.py::test_squash_migration_matches_sequential
+   ```
+
+### Rules
+
+- The squash file must produce **exactly** the same tables, columns, engines,
+  indexes, and views as running all individual migrations on a fresh database.
+- The squash file should NOT include data-seeding statements (e.g., cost data
+  from migration 006). Data seeding is handled by the post-migration hook.
+- The squash file should NOT include `MATERIALIZE INDEX` or `MATERIALIZE COLUMN`
+  commands, since the tables are brand new and have no existing data to reindex.
+- The squash file should NOT include intermediate/temporary tables from migration
+  upgrade procedures (e.g., `calls_complete_old` from the v1-to-v2 migration).

--- a/weave/trace_server/squash_migration.sql
+++ b/weave/trace_server/squash_migration.sql
@@ -1,0 +1,696 @@
+-- ============================================================================
+-- Squash migration: final schema state after all migrations through version 028
+--
+-- This file is used for fresh database installations as a performance
+-- optimization. Instead of running all individual migrations sequentially,
+-- we apply this single file to create the complete schema in one pass.
+--
+-- IMPORTANT: When adding a new migration (029+), you MUST also update this
+-- file to reflect the new schema state. See migrations/README.md for details.
+-- A CI test enforces that this file stays in sync with the sequential
+-- migrations.
+-- ============================================================================
+
+-- ============================================================================
+-- call_parts: Raw call data (start + end rows per logical call)
+-- ============================================================================
+CREATE TABLE call_parts (
+    id String,
+    project_id String,
+    parent_id String NULL,
+    trace_id String NULL,
+    op_name String NULL,
+    started_at Nullable(DateTime64(6)),
+    attributes_dump String NULL,
+    inputs_dump String NULL,
+    input_refs Array(String),
+    ended_at Nullable(DateTime64(6)),
+    output_dump String NULL,
+    summary_dump String NULL,
+    exception String NULL,
+    output_refs Array(String),
+    wb_user_id Nullable(String),
+    wb_run_id Nullable(String),
+    created_at DateTime64(3) DEFAULT now64(3),
+    deleted_at Nullable(DateTime64(3)) DEFAULT NULL,
+    display_name Nullable(String) DEFAULT NULL,
+    wb_run_step Nullable(UInt64) DEFAULT NULL,
+    thread_id Nullable(String) DEFAULT NULL,
+    turn_id Nullable(String) DEFAULT NULL,
+    wb_run_step_end Nullable(UInt64) DEFAULT NULL,
+    otel_dump Nullable(String)
+) ENGINE = MergeTree
+ORDER BY (project_id, id);
+
+-- ============================================================================
+-- calls_merged: Aggregated view of call_parts (start + end merged)
+-- ============================================================================
+CREATE TABLE calls_merged (
+    project_id String,
+    id String,
+    trace_id SimpleAggregateFunction(any, Nullable(String)),
+    parent_id SimpleAggregateFunction(any, Nullable(String)),
+    op_name SimpleAggregateFunction(any, Nullable(String)),
+    started_at SimpleAggregateFunction(any, Nullable(DateTime64(6))),
+    attributes_dump SimpleAggregateFunction(any, Nullable(String)),
+    inputs_dump SimpleAggregateFunction(any, Nullable(String)),
+    input_refs SimpleAggregateFunction(array_concat_agg, Array(String)),
+    ended_at SimpleAggregateFunction(any, Nullable(DateTime64(6))),
+    output_dump SimpleAggregateFunction(any, Nullable(String)),
+    summary_dump SimpleAggregateFunction(any, Nullable(String)),
+    exception SimpleAggregateFunction(any, Nullable(String)),
+    output_refs SimpleAggregateFunction(array_concat_agg, Array(String)),
+    wb_user_id SimpleAggregateFunction(any, Nullable(String)),
+    wb_run_id SimpleAggregateFunction(any, Nullable(String)),
+    deleted_at SimpleAggregateFunction(any, Nullable(DateTime64(3))),
+    display_name AggregateFunction(argMax, Nullable(String), DateTime64(3)),
+    sortable_datetime Datetime(6) DEFAULT coalesce(started_at, ended_at, NOW()),
+    wb_run_step SimpleAggregateFunction(any, Nullable(UInt64)),
+    thread_id SimpleAggregateFunction(any, Nullable(String)),
+    turn_id SimpleAggregateFunction(any, Nullable(String)),
+    wb_run_step_end SimpleAggregateFunction(any, Nullable(UInt64)),
+    otel_dump SimpleAggregateFunction(any, Nullable(String)),
+    INDEX idx_sortable_datetime (sortable_datetime) TYPE minmax GRANULARITY 1,
+    INDEX idx_wb_run_id (wb_run_id) TYPE set(100) GRANULARITY 1
+) ENGINE = AggregatingMergeTree
+ORDER BY (project_id, id);
+
+CREATE MATERIALIZED VIEW calls_merged_view TO calls_merged AS
+SELECT project_id,
+    id,
+    anySimpleState(wb_run_id) as wb_run_id,
+    anySimpleState(wb_run_step) as wb_run_step,
+    anySimpleState(wb_run_step_end) as wb_run_step_end,
+    anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+    anySimpleState(trace_id) as trace_id,
+    anySimpleState(parent_id) as parent_id,
+    anySimpleState(thread_id) as thread_id,
+    anySimpleState(turn_id) as turn_id,
+    anySimpleState(op_name) as op_name,
+    anySimpleState(started_at) as started_at,
+    anySimpleState(attributes_dump) as attributes_dump,
+    anySimpleState(inputs_dump) as inputs_dump,
+    array_concat_aggSimpleState(input_refs) as input_refs,
+    anySimpleState(ended_at) as ended_at,
+    anySimpleState(output_dump) as output_dump,
+    anySimpleState(summary_dump) as summary_dump,
+    anySimpleState(exception) as exception,
+    array_concat_aggSimpleState(output_refs) as output_refs,
+    anySimpleState(deleted_at) as deleted_at,
+    argMaxState(display_name, call_parts.created_at) as display_name,
+    anySimpleState(coalesce(call_parts.started_at, call_parts.ended_at, call_parts.created_at)) as sortable_datetime,
+    anySimpleState(otel_dump) as otel_dump
+FROM call_parts
+GROUP BY project_id,
+    id;
+
+-- ============================================================================
+-- object_versions
+-- ============================================================================
+CREATE TABLE object_versions (
+    project_id String,
+    object_id String,
+    kind Enum('op', 'object'),
+    base_object_class String NULL,
+    refs Array(String),
+    val_dump String,
+    digest String,
+    created_at DateTime64(3) DEFAULT now64(3),
+    deleted_at Nullable(DateTime64(3)) DEFAULT NULL,
+    wb_user_id Nullable(String) DEFAULT NULL,
+    leaf_object_class Nullable(String) DEFAULT NULL
+) ENGINE = ReplacingMergeTree()
+ORDER BY (project_id, kind, object_id, digest);
+
+CREATE VIEW object_versions_deduped AS
+SELECT project_id,
+    object_id,
+    created_at,
+    deleted_at,
+    kind,
+    base_object_class,
+    refs,
+    val_dump,
+    digest,
+    if (kind = 'op', 1, 0) AS is_op,
+    row_number() OVER (
+        PARTITION BY project_id,
+        kind,
+        object_id
+        ORDER BY created_at ASC
+    ) AS _version_index_plus_1,
+    _version_index_plus_1 - 1 AS version_index,
+    count(*) OVER (PARTITION BY project_id, kind, object_id) as version_count,
+    if(_version_index_plus_1 = version_count, 1, 0) AS is_latest
+FROM (
+        SELECT *,
+            row_number() OVER (
+                PARTITION BY project_id,
+                kind,
+                object_id,
+                digest
+                ORDER BY created_at ASC
+            ) AS rn
+        FROM object_versions
+    )
+WHERE rn = 1 WINDOW w AS (
+        PARTITION BY project_id,
+        kind,
+        object_id
+        ORDER BY created_at ASC
+    )
+ORDER BY project_id,
+    kind,
+    object_id,
+    created_at;
+
+-- ============================================================================
+-- table_rows
+-- ============================================================================
+CREATE TABLE table_rows (
+    project_id String,
+    digest String,
+    refs Array(String),
+    val_dump String,
+    created_at DateTime64(3) DEFAULT now64(3)
+) ENGINE = ReplacingMergeTree()
+ORDER BY (project_id, digest);
+
+CREATE VIEW table_rows_deduped AS
+SELECT project_id, digest, val_dump
+FROM (
+        SELECT *,
+            row_number() OVER (PARTITION BY project_id, digest) AS rn
+        FROM table_rows
+    )
+WHERE rn = 1
+ORDER BY project_id,
+    digest;
+
+-- ============================================================================
+-- tables
+-- ============================================================================
+CREATE TABLE tables (
+    project_id String,
+    digest String,
+    row_digests Array(String),
+    created_at DateTime64(3) DEFAULT now64(3)
+) ENGINE = ReplacingMergeTree()
+ORDER BY (project_id, digest);
+
+CREATE VIEW tables_deduped AS
+SELECT *
+FROM (
+        SELECT *,
+            row_number() OVER (PARTITION BY project_id, digest) AS rn
+        FROM tables
+    )
+WHERE rn = 1
+ORDER BY project_id,
+    digest;
+
+-- ============================================================================
+-- files
+-- NOTE: The view must be created BEFORE adding the extra columns so that its
+-- SELECT * captures only the original column list (matching the sequential
+-- migration behavior where 011 added columns after the view existed).
+-- ============================================================================
+CREATE TABLE files (
+    project_id String,
+    digest String,
+    chunk_index UInt32,
+    n_chunks UInt32,
+    name String,
+    val_bytes String,
+    created_at DateTime64(3) DEFAULT now64(3)
+) ENGINE = ReplacingMergeTree()
+ORDER BY (project_id, digest, chunk_index);
+
+CREATE VIEW files_deduped AS
+SELECT *
+FROM (
+        SELECT *,
+            row_number() OVER (PARTITION BY project_id, digest, chunk_index) AS rn
+        FROM files
+    )
+WHERE rn = 1
+ORDER BY project_id,
+    digest,
+    chunk_index;
+
+ALTER TABLE files ADD COLUMN bytes_stored Nullable(UInt32);
+ALTER TABLE files ADD COLUMN file_storage_uri Nullable(String);
+
+-- ============================================================================
+-- feedback
+-- ============================================================================
+CREATE TABLE feedback (
+    id String,
+    project_id String,
+    weave_ref String,
+    wb_user_id String,
+    creator String NULL,
+    created_at DateTime64(3) DEFAULT now64(3),
+    feedback_type String,
+    payload_dump String,
+    annotation_ref Nullable(String) DEFAULT NULL,
+    runnable_ref Nullable(String) DEFAULT NULL,
+    call_ref Nullable(String) DEFAULT NULL,
+    trigger_ref Nullable(String) DEFAULT NULL,
+    queue_id Nullable(String) DEFAULT NULL
+) ENGINE = ReplacingMergeTree()
+ORDER BY (project_id, weave_ref, wb_user_id, id);
+
+-- ============================================================================
+-- llm_token_prices
+-- ============================================================================
+CREATE TABLE llm_token_prices (
+    id String,
+    pricing_level String,
+    pricing_level_id String,
+    provider_id String,
+    llm_id String,
+    effective_date DateTime64(3) DEFAULT now64(3),
+    prompt_token_cost Float,
+    prompt_token_cost_unit String,
+    completion_token_cost Float,
+    completion_token_cost_unit String,
+    created_by String,
+    created_at DateTime64(3) DEFAULT now64(3),
+    cache_read_input_token_cost Float DEFAULT 0,
+    cache_creation_input_token_cost Float DEFAULT 0
+) ENGINE = MergeTree()
+ORDER BY (pricing_level, pricing_level_id, provider_id, llm_id, effective_date);
+
+-- ============================================================================
+-- Stats: files_stats
+-- ============================================================================
+CREATE TABLE files_stats (
+    project_id String,
+    digest String,
+    chunk_index UInt32,
+    n_chunks SimpleAggregateFunction(any, UInt32),
+    name SimpleAggregateFunction(any, String),
+    size_bytes SimpleAggregateFunction(any, UInt64),
+    created_at SimpleAggregateFunction(min, DateTime64(3)),
+    updated_at SimpleAggregateFunction(max, DateTime64(3)),
+    file_storage_uri Nullable(String)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (project_id, digest, chunk_index);
+
+CREATE MATERIALIZED VIEW files_stats_view
+TO files_stats AS
+SELECT
+    files.project_id,
+    files.digest,
+    files.chunk_index,
+    anySimpleState(files.n_chunks) as n_chunks,
+    anySimpleState(files.name) as name,
+    anySimpleState(IF(files.bytes_stored IS NOT NULL, files.bytes_stored, length(files.val_bytes))) AS size_bytes,
+    anySimpleState(files.file_storage_uri) AS file_storage_uri,
+    minSimpleState(files.created_at) AS created_at,
+    maxSimpleState(files.created_at) AS updated_at
+FROM files
+GROUP BY
+    files.project_id,
+    files.digest,
+    files.chunk_index;
+
+-- ============================================================================
+-- Stats: table_rows_stats
+-- ============================================================================
+CREATE TABLE table_rows_stats (
+    project_id String,
+    digest String,
+    size_bytes SimpleAggregateFunction(any, UInt64),
+    created_at SimpleAggregateFunction(min, DateTime64(3)),
+    updated_at SimpleAggregateFunction(max, DateTime64(3))
+) ENGINE = AggregatingMergeTree()
+ORDER BY (project_id, digest);
+
+CREATE MATERIALIZED VIEW table_rows_stats_view
+TO table_rows_stats AS
+SELECT
+    table_rows.project_id,
+    table_rows.digest,
+    anySimpleState(length(table_rows.val_dump)) AS size_bytes,
+    minSimpleState(table_rows.created_at) AS created_at,
+    maxSimpleState(table_rows.created_at) AS updated_at
+FROM table_rows
+GROUP BY
+    table_rows.project_id,
+    table_rows.digest;
+
+-- ============================================================================
+-- Stats: object_versions_stats
+-- ============================================================================
+CREATE TABLE object_versions_stats (
+    project_id String,
+    kind Enum('op', 'object'),
+    object_id String,
+    digest String,
+    base_object_class SimpleAggregateFunction(any, Nullable(String)),
+    size_bytes SimpleAggregateFunction(any, UInt64),
+    created_at SimpleAggregateFunction(min, DateTime64(3)),
+    updated_at SimpleAggregateFunction(max, DateTime64(3)),
+    wb_user_id Nullable(String) DEFAULT NULL,
+    leaf_object_class SimpleAggregateFunction(any, Nullable(String))
+) ENGINE = AggregatingMergeTree()
+ORDER BY (project_id, kind, object_id, digest);
+
+CREATE MATERIALIZED VIEW object_versions_stats_view
+TO object_versions_stats AS
+SELECT
+    object_versions.project_id,
+    object_versions.kind,
+    object_versions.object_id,
+    object_versions.digest,
+    anySimpleState(object_versions.base_object_class) AS base_object_class,
+    anySimpleState(object_versions.leaf_object_class) AS leaf_object_class,
+    anySimpleState(object_versions.wb_user_id) AS wb_user_id,
+    anySimpleState(length(object_versions.val_dump)) AS size_bytes,
+    minSimpleState(object_versions.created_at) AS created_at,
+    maxSimpleState(object_versions.created_at) AS updated_at
+FROM object_versions
+GROUP BY
+    object_versions.project_id,
+    object_versions.kind,
+    object_versions.object_id,
+    object_versions.digest;
+
+-- ============================================================================
+-- Stats: feedback_stats
+-- ============================================================================
+CREATE TABLE feedback_stats (
+    project_id String,
+    weave_ref String,
+    wb_user_id String,
+    id String,
+    creator SimpleAggregateFunction(any, Nullable(String)),
+    created_at SimpleAggregateFunction(min, DateTime64(3)),
+    updated_at SimpleAggregateFunction(max, DateTime64(3)),
+    feedback_type SimpleAggregateFunction(any, String),
+    payload_size_bytes SimpleAggregateFunction(any, UInt64)
+) ENGINE = AggregatingMergeTree()
+ORDER BY (project_id, weave_ref, wb_user_id, id);
+
+CREATE MATERIALIZED VIEW feedback_stats_view
+TO feedback_stats AS
+SELECT
+    feedback.project_id,
+    feedback.weave_ref,
+    feedback.wb_user_id,
+    feedback.id,
+    anySimpleState(feedback.creator) as creator,
+    minSimpleState(feedback.created_at) as created_at,
+    maxSimpleState(feedback.created_at) as updated_at,
+    argMaxState(feedback.feedback_type, feedback.created_at) as feedback_type,
+    anySimpleState(length(feedback.payload_dump)) as payload_size_bytes
+FROM feedback
+GROUP BY
+    feedback.project_id,
+    feedback.weave_ref,
+    feedback.wb_user_id,
+    feedback.id;
+
+-- ============================================================================
+-- Stats: calls_merged_stats
+-- ============================================================================
+CREATE TABLE calls_merged_stats (
+    project_id String,
+    id String,
+    trace_id SimpleAggregateFunction(any, Nullable(String)),
+    parent_id SimpleAggregateFunction(any, Nullable(String)),
+    op_name SimpleAggregateFunction(any, Nullable(String)),
+    started_at SimpleAggregateFunction(any, Nullable(DateTime64(3))),
+    attributes_size_bytes SimpleAggregateFunction(any, Nullable(UInt64)),
+    inputs_size_bytes SimpleAggregateFunction(any, Nullable(UInt64)),
+    ended_at SimpleAggregateFunction(any, Nullable(DateTime64(3))),
+    output_size_bytes SimpleAggregateFunction(any, Nullable(UInt64)),
+    summary_size_bytes SimpleAggregateFunction(any, Nullable(UInt64)),
+    exception_size_bytes SimpleAggregateFunction(any, Nullable(UInt64)),
+    wb_user_id SimpleAggregateFunction(any, Nullable(String)),
+    wb_run_id SimpleAggregateFunction(any, Nullable(String)),
+    updated_at SimpleAggregateFunction(max, DateTime64(3)),
+    deleted_at SimpleAggregateFunction(any, Nullable(DateTime64(3))),
+    display_name AggregateFunction(argMax, Nullable(String), DateTime64(3)),
+    wb_run_step SimpleAggregateFunction(any, Nullable(UInt64)),
+    thread_id SimpleAggregateFunction(any, Nullable(String)),
+    turn_id SimpleAggregateFunction(any, Nullable(String)),
+    wb_run_step_end SimpleAggregateFunction(any, Nullable(UInt64)),
+    otel_dump_size_bytes SimpleAggregateFunction(any, Nullable(UInt64))
+) ENGINE = AggregatingMergeTree()
+ORDER BY (project_id, id);
+
+CREATE MATERIALIZED VIEW calls_merged_stats_view
+TO calls_merged_stats AS
+SELECT
+    call_parts.project_id,
+    call_parts.id,
+    anySimpleState(call_parts.trace_id) as trace_id,
+    anySimpleState(call_parts.parent_id) as parent_id,
+    anySimpleState(call_parts.thread_id) as thread_id,
+    anySimpleState(call_parts.turn_id) as turn_id,
+    anySimpleState(call_parts.op_name) as op_name,
+    anySimpleState(call_parts.started_at) as started_at,
+    anySimpleState(length(call_parts.attributes_dump)) as attributes_size_bytes,
+    anySimpleState(length(call_parts.inputs_dump)) as inputs_size_bytes,
+    anySimpleState(call_parts.ended_at) as ended_at,
+    anySimpleState(length(call_parts.output_dump)) as output_size_bytes,
+    anySimpleState(length(call_parts.summary_dump)) as summary_size_bytes,
+    anySimpleState(length(call_parts.exception)) as exception_size_bytes,
+    anySimpleState(call_parts.wb_user_id) as wb_user_id,
+    anySimpleState(call_parts.wb_run_id) as wb_run_id,
+    anySimpleState(call_parts.wb_run_step) as wb_run_step,
+    anySimpleState(call_parts.wb_run_step_end) as wb_run_step_end,
+    anySimpleState(call_parts.deleted_at) as deleted_at,
+    maxSimpleState(call_parts.created_at) as updated_at,
+    argMaxState(call_parts.display_name, call_parts.created_at) as display_name,
+    anySimpleState(length(call_parts.otel_dump)) as otel_dump_size_bytes
+FROM call_parts
+GROUP BY
+    call_parts.project_id,
+    call_parts.id;
+
+-- ============================================================================
+-- calls_complete (v2 schema with bloom filter index)
+-- ============================================================================
+CREATE TABLE calls_complete (
+    id              String,
+    project_id      String,
+    created_at      DateTime64(3) DEFAULT now64(3),
+    trace_id        String,
+    op_name         String,
+    started_at      DateTime64(6),
+    ended_at        DateTime64(6) DEFAULT toDateTime64(0, 6),
+    updated_at      DateTime64(3) DEFAULT toDateTime64(0, 3),
+    deleted_at      DateTime64(3) DEFAULT toDateTime64(0, 3),
+    parent_id       String DEFAULT '',
+    display_name    String DEFAULT '',
+    exception       String DEFAULT '',
+    otel_dump       String DEFAULT '',
+    wb_user_id      String DEFAULT '',
+    wb_run_id       String DEFAULT '',
+    thread_id       String DEFAULT '',
+    turn_id         String DEFAULT '',
+    inputs_dump     String,
+    input_refs      Array(String),
+    output_dump     String,
+    summary_dump    String,
+    output_refs     Array(String),
+    attributes_dump String,
+    wb_run_step     UInt64 DEFAULT 0,
+    wb_run_step_end UInt64 DEFAULT 0,
+    ttl_at          DateTime DEFAULT '2100-01-01 00:00:00',
+    source          Enum8('direct' = 1, 'dual' = 2, 'migration' = 3) DEFAULT 'direct',
+    INDEX idx_parent_id parent_id TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_trace_id trace_id TYPE bloom_filter GRANULARITY 1,
+    INDEX idx_inputs_dump inputs_dump TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1,
+    INDEX idx_output_dump output_dump TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1,
+    INDEX idx_summary_dump summary_dump TYPE tokenbf_v1(32768, 3, 0) GRANULARITY 1,
+    INDEX idx_wb_run_id wb_run_id TYPE set(100) GRANULARITY 4,
+    INDEX idx_thread_id thread_id TYPE set(100) GRANULARITY 4,
+    INDEX idx_op_name op_name TYPE ngrambf_v1(8, 10000, 3, 0) GRANULARITY 1,
+    INDEX idx_ended_at ended_at TYPE minmax GRANULARITY 1,
+    INDEX idx_id id TYPE minmax GRANULARITY 1,
+    INDEX idx_id_bloom id TYPE bloom_filter(0.01) GRANULARITY 1
+) ENGINE = ReplacingMergeTree(created_at)
+PARTITION BY toYYYYMM(started_at)
+ORDER BY (project_id, started_at, id)
+TTL ttl_at DELETE
+SETTINGS
+    min_bytes_for_wide_part=0,
+    enable_block_number_column=1,
+    enable_block_offset_column=1;
+
+CREATE TABLE calls_complete_stats (
+    project_id String,
+    id String,
+    trace_id SimpleAggregateFunction(any, String),
+    parent_id SimpleAggregateFunction(any, String),
+    op_name SimpleAggregateFunction(any, String),
+    started_at SimpleAggregateFunction(any, DateTime64(6)),
+    ended_at SimpleAggregateFunction(any, DateTime64(6)),
+    attributes_size_bytes SimpleAggregateFunction(any, UInt64),
+    inputs_size_bytes SimpleAggregateFunction(any, UInt64),
+    output_size_bytes SimpleAggregateFunction(any, UInt64),
+    summary_size_bytes SimpleAggregateFunction(any, UInt64),
+    otel_size_bytes SimpleAggregateFunction(any, UInt64),
+    exception_size_bytes SimpleAggregateFunction(any, UInt64),
+    wb_user_id SimpleAggregateFunction(any, String),
+    wb_run_id SimpleAggregateFunction(any, String),
+    wb_run_step SimpleAggregateFunction(any, UInt64),
+    wb_run_step_end SimpleAggregateFunction(any, UInt64),
+    thread_id SimpleAggregateFunction(any, String),
+    turn_id SimpleAggregateFunction(any, String),
+    created_at SimpleAggregateFunction(min, DateTime64(3)),
+    updated_at SimpleAggregateFunction(max, DateTime64(3)),
+    display_name AggregateFunction(argMax, String, DateTime64(3))
+) ENGINE = AggregatingMergeTree()
+ORDER BY (project_id, id);
+
+CREATE MATERIALIZED VIEW calls_complete_stats_view
+TO calls_complete_stats AS
+SELECT
+    calls_complete.project_id,
+    calls_complete.id,
+    anySimpleState(calls_complete.trace_id) as trace_id,
+    anySimpleState(calls_complete.parent_id) as parent_id,
+    anySimpleState(calls_complete.op_name) as op_name,
+    anySimpleState(calls_complete.started_at) as started_at,
+    anySimpleState(calls_complete.ended_at) as ended_at,
+    anySimpleState(length(calls_complete.attributes_dump)) as attributes_size_bytes,
+    anySimpleState(length(calls_complete.inputs_dump)) as inputs_size_bytes,
+    anySimpleState(length(calls_complete.output_dump)) as output_size_bytes,
+    anySimpleState(length(calls_complete.summary_dump)) as summary_size_bytes,
+    anySimpleState(length(calls_complete.exception)) as exception_size_bytes,
+    anySimpleState(length(calls_complete.otel_dump)) as otel_size_bytes,
+    anySimpleState(calls_complete.wb_user_id) as wb_user_id,
+    anySimpleState(calls_complete.wb_run_id) as wb_run_id,
+    anySimpleState(calls_complete.wb_run_step) as wb_run_step,
+    anySimpleState(calls_complete.wb_run_step_end) as wb_run_step_end,
+    anySimpleState(calls_complete.thread_id) as thread_id,
+    anySimpleState(calls_complete.turn_id) as turn_id,
+    minSimpleState(calls_complete.created_at) as created_at,
+    maxSimpleState(calls_complete.updated_at) as updated_at,
+    argMaxState(calls_complete.display_name, calls_complete.created_at) as display_name
+FROM calls_complete
+GROUP BY
+    calls_complete.project_id,
+    calls_complete.id;
+
+-- ============================================================================
+-- Annotation system
+-- ============================================================================
+CREATE TABLE annotation_queues (
+    id String,
+    project_id String,
+    name String,
+    description String,
+    scorer_refs Array(String),
+    created_at DateTime64(3) DEFAULT now64(3),
+    created_by String,
+    updated_at DateTime64(3) DEFAULT now64(3),
+    deleted_at Nullable(DateTime64(3)),
+    INDEX idx_created_by created_by TYPE minmax GRANULARITY 1
+) ENGINE = MergeTree()
+ORDER BY (project_id, id)
+SETTINGS
+    enable_block_number_column = 1,
+    enable_block_offset_column = 1;
+
+CREATE TABLE annotation_queue_items (
+    id String,
+    project_id String,
+    queue_id String,
+    call_id String,
+    call_started_at DateTime64(3),
+    call_ended_at Nullable(DateTime64(3)),
+    call_op_name String,
+    call_trace_id String,
+    display_fields Array(String),
+    added_by Nullable(String),
+    created_at DateTime64(3) DEFAULT now64(3),
+    created_by String,
+    updated_at DateTime64(3) DEFAULT now64(3),
+    deleted_at Nullable(DateTime64(3))
+) ENGINE = MergeTree()
+ORDER BY (project_id, queue_id, id)
+SETTINGS
+    enable_block_number_column = 1,
+    enable_block_offset_column = 1;
+
+CREATE TABLE annotator_queue_items_progress (
+    id String,
+    project_id String,
+    queue_item_id String,
+    queue_id String,
+    annotator_id String,
+    annotation_state Enum8(
+        'unstarted' = 0,
+        'in_progress' = 1,
+        'completed' = 2,
+        'skipped' = 3
+    ) DEFAULT 'unstarted',
+    created_at DateTime64(3) DEFAULT now64(3),
+    updated_at DateTime64(3) DEFAULT now64(3),
+    deleted_at Nullable(DateTime64(3))
+) ENGINE = MergeTree()
+ORDER BY (project_id, queue_id, id)
+SETTINGS
+    enable_block_number_column = 1,
+    enable_block_offset_column = 1;
+
+-- ============================================================================
+-- Tags and aliases
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS tags (
+    project_id String,
+    object_id String,
+    digest String,
+    tag String,
+    wb_user_id String DEFAULT '',
+    created_at DateTime64(3) DEFAULT now64(3),
+    deleted_at DateTime64(3) DEFAULT toDateTime64(0, 3)
+) ENGINE = ReplacingMergeTree(created_at)
+ORDER BY (project_id, object_id, digest, tag)
+SETTINGS
+    min_bytes_for_wide_part=0,
+    enable_block_number_column=1,
+    enable_block_offset_column=1;
+
+CREATE TABLE IF NOT EXISTS aliases (
+    project_id String,
+    object_id String,
+    alias String,
+    digest String,
+    wb_user_id String DEFAULT '',
+    created_at DateTime64(3) DEFAULT now64(3),
+    deleted_at DateTime64(3) DEFAULT toDateTime64(0, 3)
+) ENGINE = ReplacingMergeTree(created_at)
+ORDER BY (project_id, object_id, alias)
+SETTINGS
+    min_bytes_for_wide_part=0,
+    enable_block_number_column=1,
+    enable_block_offset_column=1;
+
+-- ============================================================================
+-- object_version_first_seen
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS object_version_first_seen (
+    project_id String,
+    object_id String,
+    digest String,
+    first_created_at SimpleAggregateFunction(min, DateTime64(3))
+) ENGINE = AggregatingMergeTree()
+ORDER BY (project_id, object_id, digest);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS object_version_first_seen_view
+TO object_version_first_seen AS
+SELECT
+    project_id,
+    object_id,
+    digest,
+    minSimpleState(created_at) AS first_created_at
+FROM object_versions
+GROUP BY project_id, object_id, digest;


### PR DESCRIPTION
## Summary

Fresh ClickHouse installs currently run all 28 individual migrations sequentially. This adds a squash migration path: when the migrator detects an empty database, it applies a single `squash_migration.sql` file that creates the complete schema in one pass, then records version 28 in `db_management`. Any future migrations (029+) apply normally on top.

- `squash_migration.sql` — the full schema after all 28 migrations, as CREATE TABLE/VIEW statements
- Migrator gains `SQUASH_MIGRATION_VERSION` constant and `use_squash_migration` toggle
- `migrations/README.md` — tells devs/LLMs to update the squash file when adding new migrations
- `_get_migrations()` now skips non-SQL files so the README doesn't blow up the parser

## Tests

- `test_squash_migration_version_matches_migration_count` — fails if someone adds migration 029 without bumping the constant
- `test_squash_migration_matches_sequential` — creates two fresh DBs (squash vs sequential), compares `SHOW CREATE TABLE` for every table/view
- `test_squash_migration_sets_correct_version` — verifies `db_management` records the right version after squash