### PR TITLE
fix(weave): restore replicated table engines in replicated DBs

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -362,14 +362,14 @@ def test_replicated_management_table_follows_database_engine(replicated_migrator
     def _normalize(sql: str) -> str:
         return " ".join(sql.split())
 
-    # Replicated DB: plain MergeTree, no ON CLUSTER (auto-replicated)
+    # Replicated DB: explicit ReplicatedMergeTree, no ON CLUSTER
     replicated_migrator._replicated_db_engine_cache[
         replicated_migrator.management_db
     ] = True
     assert _normalize(replicated_migrator._create_management_table_sql()) == _normalize(
         """CREATE TABLE IF NOT EXISTS db_management.migrations
            ( db_name String, curr_version UInt64, partially_applied_version UInt64 NULL, )
-           ENGINE = MergeTree() ORDER BY (db_name)"""
+           ENGINE = ReplicatedMergeTree() ORDER BY (db_name)"""
     )
 
     # Atomic DB: explicit ReplicatedMergeTree + ON CLUSTER
@@ -410,10 +410,9 @@ def test_replicated_engine_discovery_wait_and_timeout(mock_sleep):
 
     assert migrator._replicated_db_engine_cache[migrator.management_db] is True
     assert mock_sleep.call_count == 2
-    # Management table DDL should use plain MergeTree (Replicated DB auto-converts)
+    # Management table DDL should use ReplicatedMergeTree without ON CLUSTER.
     create_table_sql = ch_client.command.call_args_list[1][0][0]
-    assert "ENGINE = MergeTree()" in create_table_sql
-    assert "ReplicatedMergeTree" not in create_table_sql
+    assert "ENGINE = ReplicatedMergeTree()" in create_table_sql
     assert "ON CLUSTER" not in create_table_sql
 
     # Times out: engine never becomes visible, error includes the SQL context
@@ -1156,13 +1155,16 @@ def test_drop_table_replicated(replicated_migrator):
 
 
 def test_ddl_adapts_to_database_engine(replicated_migrator, distributed_migrator):
-    """DDL is passed through on Replicated engines, gets ON CLUSTER + ReplicatedMergeTree on Atomic."""
+    """Replicated DBs still get replicated engines, but never ON CLUSTER."""
     create_sql = "CREATE TABLE test (id Int32) ENGINE = MergeTree() ORDER BY id"
 
-    # Replicated engine: SQL passed through as-is (DB auto-converts and auto-replicates)
+    # Replicated engine: rewrite to ReplicatedMergeTree, but omit ON CLUSTER.
     replicated_migrator._replicated_db_engine_cache["test_db"] = True
     replicated_migrator._execute_migration_command("test_db", create_sql)
-    assert replicated_migrator.ch_client.command.call_args_list[0][0][0] == create_sql
+    assert (
+        replicated_migrator.ch_client.command.call_args_list[0][0][0]
+        == "CREATE TABLE test (id Int32) ENGINE = ReplicatedMergeTree() ORDER BY id"
+    )
     replicated_migrator.ch_client.command.reset_mock()
 
     # Atomic engine: explicit ON CLUSTER + ReplicatedMergeTree
@@ -1172,14 +1174,25 @@ def test_ddl_adapts_to_database_engine(replicated_migrator, distributed_migrator
         replicated_migrator.ch_client.command.call_args_list[0][0][0]
         == "CREATE TABLE test ON CLUSTER test_cluster (id Int32) ENGINE = ReplicatedMergeTree() ORDER BY id"
     )
+    replicated_migrator.ch_client.command.reset_mock()
 
-    # Distributed migrator also skips ON CLUSTER for Replicated engine
+    # Distributed migrator also skips ON CLUSTER for Replicated DBs, while
+    # still creating ReplicatedMergeTree local tables plus a distributed table.
     distributed_migrator._replicated_db_engine_cache["test_db"] = True
-    distributed_migrator._execute_migration_command(
-        "test_db", "DROP TABLE IF EXISTS my_table"
+    distributed_migrator._execute_migration_command("test_db", create_sql)
+    local_sql, dist_sql = [
+        call.args[0] for call in distributed_migrator.ch_client.command.call_args_list
+    ]
+    assert "ON CLUSTER" not in local_sql
+    assert (
+        local_sql
+        == "CREATE TABLE test_local (id Int32) ENGINE = ReplicatedMergeTree() ORDER BY id"
     )
-    for c in distributed_migrator.ch_client.command.call_args_list:
-        assert "ON CLUSTER" not in c[0][0]
+    assert "ON CLUSTER" not in dist_sql
+    assert (
+        "ENGINE = Distributed(test_cluster, currentDatabase(), test_local, rand())"
+        in dist_sql
+    )
 
 
 def test_index_operations_only_on_local_tables_distributed(distributed_migrator):

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -110,8 +110,12 @@ def test_replicated_creates_replicated_db_and_tables(ch_client):
 
     assert _get_db_engine(ch_client, mgmt_db) == "Replicated"
     assert _get_db_engine(ch_client, target_db) == "Replicated"
-    assert _table_exists(ch_client, mgmt_db, "migrations")
-    assert _table_exists(ch_client, target_db, "test_tbl")
+    assert _get_table_engine_full(ch_client, mgmt_db, "migrations").startswith(
+        "ReplicatedMergeTree"
+    )
+    assert _get_table_engine_full(ch_client, target_db, "test_tbl").startswith(
+        "ReplicatedMergeTree"
+    )
 
 
 def test_distributed_fresh_creates_atomic_management_db(ch_client):
@@ -141,6 +145,9 @@ def test_distributed_fresh_creates_atomic_management_db(ch_client):
 
     assert _get_db_engine(ch_client, target_db) == "Replicated"
     assert _table_exists(ch_client, target_db, "test_tbl_local")
+    assert _get_table_engine_full(ch_client, target_db, "test_tbl_local").startswith(
+        "ReplicatedMergeTree"
+    )
     assert _get_table_engine_full(ch_client, target_db, "test_tbl").startswith(
         "Distributed"
     )
@@ -179,6 +186,9 @@ def test_distributed_legacy_replicated_management_db(ch_client):
 
     assert _get_db_engine(ch_client, target_db) == "Replicated"
     assert _table_exists(ch_client, target_db, "test_tbl_local")
+    assert _get_table_engine_full(ch_client, target_db, "test_tbl_local").startswith(
+        "ReplicatedMergeTree"
+    )
     assert _get_table_engine_full(ch_client, target_db, "test_tbl").startswith(
         "Distributed"
     )

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -610,10 +610,16 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
     def _prepare_ddl_for_database(self, sql_query: str, target_db: str) -> str:
         """Adapt DDL for the target database's engine type.
 
-        * **Replicated engine** — the database auto-converts ``MergeTree`` to
-          ``ReplicatedMergeTree`` and auto-replicates DDL, so we pass the SQL
-          through unchanged.  Emitting ``ON CLUSTER`` would cause ClickHouse
-          error 80 (INCORRECT_QUERY).
+        Engine handling matrix:
+        - replicated-only DB: Replicated*MergeTree() with no ON CLUSTER
+        - distributed + Atomic DB: explicit ZK args plus ON CLUSTER
+        - distributed + Replicated DB: Replicated*MergeTree() with no explicit
+          ZK args and no ON CLUSTER
+
+        * **Replicated engine** — DDL is auto-replicated by the database, so
+          ``ON CLUSTER`` must be omitted to avoid ClickHouse error 80
+          (INCORRECT_QUERY). We still rewrite MergeTree-family engines to
+          ``Replicated*MergeTree`` so table data replicates across replicas.
         * **Atomic engine** — the database does not auto-replicate, so we must
           explicitly rewrite ``MergeTree`` → ``ReplicatedMergeTree`` and add
           ``ON CLUSTER`` to every DDL statement.
@@ -624,10 +630,9 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
         database would auto-assign per-shard ZK paths, causing each shard to
         track migration state independently instead of sharing it.
         """
+        sql_query = self._format_replicated_sql(sql_query)
         if self._uses_replicated_db_engine(target_db):
             return sql_query
-
-        sql_query = self._format_replicated_sql(sql_query)
         return self._add_on_cluster_clause(sql_query, target_db=target_db)
 
     def _create_management_table_sql(self) -> str:
@@ -883,10 +888,12 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
             self.ch_client.database = curr_db
             return
 
-        # When the DB uses ENGINE = Replicated, skip explicit ReplicatedMergeTree
-        # conversion — the DB engine auto-converts MergeTree tables.
+        # Engine handling matrix for distributed local tables:
+        # - distributed + Atomic DB: explicit ZK args plus ON CLUSTER
+        # - distributed + Replicated DB: Replicated*MergeTree() with no
+        #   explicit ZK args and no ON CLUSTER
         if self._uses_replicated_db_engine(target_db):
-            formatted_command = command
+            formatted_command = self._format_replicated_sql(command)
         else:
             formatted_command = self._format_replicated_sql_distributed(
                 command, target_db


### PR DESCRIPTION
## Summary
This fixes a replicated ClickHouse migration regression where fresh `ENGINE = Replicated(...)` databases were creating plain `MergeTree`-family tables instead of `Replicated*MergeTree` tables.

## Actual cause
The regression came from a bad assumption introduced in `f654147b91` ([chore(weave): actually test the replicated ch tests in CI](https://github.com/wandb/weave/pull/6419)). We taught the migrator to skip `ON CLUSTER` for `Replicated` databases to avoid ClickHouse error 80, which was correct. But we also started skipping the table-engine rewrite entirely under the assumption that a `Replicated` database would auto-convert `MergeTree` tables into replicated table engines for us.

That assumption is false for the clusters we run against. The result was:
- fresh replicated-only DBs created plain `MergeTree` / `ReplacingMergeTree` / `AggregatingMergeTree` tables
- each replica stored independent local data! Not replicated!

## Fix
The migrator now treats engine conversion and `ON CLUSTER` as separate concerns.

Engine handling matrix:
- replicated-only DB: `Replicated*MergeTree()` with no `ON CLUSTER`
- distributed + Atomic DB: explicit ZooKeeper args plus `ON CLUSTER`
- distributed + Replicated DB: `Replicated*MergeTree()` with no explicit ZooKeeper args and no `ON CLUSTER`

This preserves the original reason for the March fix:
- we still do not emit `ON CLUSTER` inside `ENGINE = Replicated` databases
- we still avoid explicit ZooKeeper args in distributed local tables when ClickHouse forbids them in `Replicated` databases

## Why this is durable
This change makes the logic explicit instead of relying on implicit ClickHouse behavior:
- the replicated-only and distributed codepaths now encode the engine-handling matrix directly
- the migrator comments explain the expected behavior at the decision points
- tests now assert actual table engines, not just database engine / table existence

## Preventing regressions
The main failure before was that our tests proved DDL executed, but not that the resulting storage engines were actually replicated.

This change tightens that by:
- updating unit tests to assert the exact DDL emitted for replicated vs distributed cases
- updating functional tests to check `system.tables.engine_full` for replicated tables in replicated mode and replicated local tables in distributed mode

That means future changes that accidentally turn replicated tables back into plain `MergeTree` tables should fail in CI instead of only showing up on a fresh multi-replica cluster.
