### PR TITLE
chore(weave): fix flaky test_sync_eval_parallelism

### DIFF
--- a/tests/trace/test_evaluate.py
+++ b/tests/trace/test_evaluate.py
@@ -327,7 +327,7 @@ async def test_sync_eval_parallelism(client):
         {"a": 10},
     ]
 
-    # 10 rows, should complete in <5 seconds. if sync, 10+
+    # 10 rows, should complete in <8 seconds. if sync, 10+
 
     now = time.time()
 
@@ -338,7 +338,7 @@ async def test_sync_eval_parallelism(client):
         "score": {"mean": 1.0},
         "model_latency": {"mean": pytest.approx(1, abs=LATENCY_TOL)},
     }
-    assert time.time() - now < (15 if sys.platform == "win32" else 5)
+    assert time.time() - now < (15 if sys.platform == "win32" else 8)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Relax the parallelism timing assertion from 5s to 8s. The test runs 10 items sleeping 1s each in parallel (~1-2s expected), but CI can exceed 5s under load. 8s still catches serial execution (10+s).

Original failure ([CI job](https://github.com/wandb/weave/actions/runs/24370626713/job/71173228176)):
```
assert (1776120270.3072548 - 1776120265.185984) < 5
```

## Testing

Test-only change.