### PR TITLE
chore(weave): consistent ReplicatedMergeTree in distributed legacy management table

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -362,14 +362,14 @@ def test_replicated_management_table_follows_database_engine(replicated_migrator
     def _normalize(sql: str) -> str:
         return " ".join(sql.split())
 
-    # Replicated DB: plain MergeTree, no ON CLUSTER (auto-replicated)
+    # Replicated DB: explicit ReplicatedMergeTree, no ON CLUSTER
     replicated_migrator._replicated_db_engine_cache[
         replicated_migrator.management_db
     ] = True
     assert _normalize(replicated_migrator._create_management_table_sql()) == _normalize(
         """CREATE TABLE IF NOT EXISTS db_management.migrations
            ( db_name String, curr_version UInt64, partially_applied_version UInt64 NULL, )
-           ENGINE = MergeTree() ORDER BY (db_name)"""
+           ENGINE = ReplicatedMergeTree() ORDER BY (db_name)"""
     )
 
     # Atomic DB: explicit ReplicatedMergeTree + ON CLUSTER
@@ -410,10 +410,9 @@ def test_replicated_engine_discovery_wait_and_timeout(mock_sleep):
 
     assert migrator._replicated_db_engine_cache[migrator.management_db] is True
     assert mock_sleep.call_count == 2
-    # Management table DDL should use plain MergeTree (Replicated DB auto-converts)
+    # Management table DDL should use ReplicatedMergeTree without ON CLUSTER.
     create_table_sql = ch_client.command.call_args_list[1][0][0]
-    assert "ENGINE = MergeTree()" in create_table_sql
-    assert "ReplicatedMergeTree" not in create_table_sql
+    assert "ENGINE = ReplicatedMergeTree()" in create_table_sql
     assert "ON CLUSTER" not in create_table_sql
 
     # Times out: engine never becomes visible, error includes the SQL context
@@ -1156,13 +1155,16 @@ def test_drop_table_replicated(replicated_migrator):
 
 
 def test_ddl_adapts_to_database_engine(replicated_migrator, distributed_migrator):
-    """DDL is passed through on Replicated engines, gets ON CLUSTER + ReplicatedMergeTree on Atomic."""
+    """Replicated DBs still get replicated engines, but never ON CLUSTER."""
     create_sql = "CREATE TABLE test (id Int32) ENGINE = MergeTree() ORDER BY id"
 
-    # Replicated engine: SQL passed through as-is (DB auto-converts and auto-replicates)
+    # Replicated engine: rewrite to ReplicatedMergeTree, but omit ON CLUSTER.
     replicated_migrator._replicated_db_engine_cache["test_db"] = True
     replicated_migrator._execute_migration_command("test_db", create_sql)
-    assert replicated_migrator.ch_client.command.call_args_list[0][0][0] == create_sql
+    assert (
+        replicated_migrator.ch_client.command.call_args_list[0][0][0]
+        == "CREATE TABLE test (id Int32) ENGINE = ReplicatedMergeTree() ORDER BY id"
+    )
     replicated_migrator.ch_client.command.reset_mock()
 
     # Atomic engine: explicit ON CLUSTER + ReplicatedMergeTree
@@ -1172,14 +1174,25 @@ def test_ddl_adapts_to_database_engine(replicated_migrator, distributed_migrator
         replicated_migrator.ch_client.command.call_args_list[0][0][0]
         == "CREATE TABLE test ON CLUSTER test_cluster (id Int32) ENGINE = ReplicatedMergeTree() ORDER BY id"
     )
+    replicated_migrator.ch_client.command.reset_mock()
 
-    # Distributed migrator also skips ON CLUSTER for Replicated engine
+    # Distributed migrator also skips ON CLUSTER for Replicated DBs, while
+    # still creating ReplicatedMergeTree local tables plus a distributed table.
     distributed_migrator._replicated_db_engine_cache["test_db"] = True
-    distributed_migrator._execute_migration_command(
-        "test_db", "DROP TABLE IF EXISTS my_table"
+    distributed_migrator._execute_migration_command("test_db", create_sql)
+    local_sql, dist_sql = [
+        call.args[0] for call in distributed_migrator.ch_client.command.call_args_list
+    ]
+    assert "ON CLUSTER" not in local_sql
+    assert (
+        local_sql
+        == "CREATE TABLE test_local (id Int32) ENGINE = ReplicatedMergeTree() ORDER BY id"
     )
-    for c in distributed_migrator.ch_client.command.call_args_list:
-        assert "ON CLUSTER" not in c[0][0]
+    assert "ON CLUSTER" not in dist_sql
+    assert (
+        "ENGINE = Distributed(test_cluster, currentDatabase(), test_local, rand())"
+        in dist_sql
+    )
 
 
 def test_index_operations_only_on_local_tables_distributed(distributed_migrator):

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -384,6 +384,34 @@ def test_replicated_management_table_follows_database_engine(replicated_migrator
     )
 
 
+def test_distributed_management_table_uses_replicated_engine(distributed_migrator):
+    """Distributed migrator's legacy Replicated-DB management table uses ReplicatedMergeTree."""
+
+    def _normalize(sql: str) -> str:
+        return " ".join(sql.split())
+
+    # Legacy path: management DB uses Replicated engine.
+    # Must emit ReplicatedMergeTree — not plain MergeTree — so the table
+    # actually replicates across replicas.
+    distributed_migrator._replicated_db_engine_cache[
+        distributed_migrator.management_db
+    ] = True
+    sql = distributed_migrator._create_management_table_sql()
+    normalized = _normalize(sql)
+    assert "ReplicatedMergeTree()" in normalized
+    assert "ON CLUSTER" not in normalized
+
+    # Non-legacy path: management DB uses Atomic engine.
+    # Must emit explicit ReplicatedMergeTree with ZK path + ON CLUSTER.
+    distributed_migrator._replicated_db_engine_cache[
+        distributed_migrator.management_db
+    ] = False
+    sql = distributed_migrator._create_management_table_sql()
+    normalized = _normalize(sql)
+    assert "ReplicatedMergeTree(" in normalized
+    assert "ON CLUSTER" in normalized
+
+
 @patch("tenacity.nap.time.sleep")
 def test_replicated_engine_discovery_wait_and_timeout(mock_sleep):
     """Engine discovery retries until visible, then uses the result for DDL.

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -110,8 +110,12 @@ def test_replicated_creates_replicated_db_and_tables(ch_client):
 
     assert _get_db_engine(ch_client, mgmt_db) == "Replicated"
     assert _get_db_engine(ch_client, target_db) == "Replicated"
-    assert _table_exists(ch_client, mgmt_db, "migrations")
-    assert _table_exists(ch_client, target_db, "test_tbl")
+    assert _get_table_engine_full(ch_client, mgmt_db, "migrations").startswith(
+        "ReplicatedMergeTree"
+    )
+    assert _get_table_engine_full(ch_client, target_db, "test_tbl").startswith(
+        "ReplicatedMergeTree"
+    )
 
 
 def test_distributed_fresh_creates_atomic_management_db(ch_client):
@@ -141,6 +145,9 @@ def test_distributed_fresh_creates_atomic_management_db(ch_client):
 
     assert _get_db_engine(ch_client, target_db) == "Replicated"
     assert _table_exists(ch_client, target_db, "test_tbl_local")
+    assert _get_table_engine_full(ch_client, target_db, "test_tbl_local").startswith(
+        "ReplicatedMergeTree"
+    )
     assert _get_table_engine_full(ch_client, target_db, "test_tbl").startswith(
         "Distributed"
     )
@@ -179,6 +186,9 @@ def test_distributed_legacy_replicated_management_db(ch_client):
 
     assert _get_db_engine(ch_client, target_db) == "Replicated"
     assert _table_exists(ch_client, target_db, "test_tbl_local")
+    assert _get_table_engine_full(ch_client, target_db, "test_tbl_local").startswith(
+        "ReplicatedMergeTree"
+    )
     assert _get_table_engine_full(ch_client, target_db, "test_tbl").startswith(
         "Distributed"
     )

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -610,10 +610,16 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
     def _prepare_ddl_for_database(self, sql_query: str, target_db: str) -> str:
         """Adapt DDL for the target database's engine type.
 
-        * **Replicated engine** — the database auto-converts ``MergeTree`` to
-          ``ReplicatedMergeTree`` and auto-replicates DDL, so we pass the SQL
-          through unchanged.  Emitting ``ON CLUSTER`` would cause ClickHouse
-          error 80 (INCORRECT_QUERY).
+        Engine handling matrix:
+        - replicated-only DB: Replicated*MergeTree() with no ON CLUSTER
+        - distributed + Atomic DB: explicit ZK args plus ON CLUSTER
+        - distributed + Replicated DB: Replicated*MergeTree() with no explicit
+          ZK args and no ON CLUSTER
+
+        * **Replicated engine** — DDL is auto-replicated by the database, so
+          ``ON CLUSTER`` must be omitted to avoid ClickHouse error 80
+          (INCORRECT_QUERY). We still rewrite MergeTree-family engines to
+          ``Replicated*MergeTree`` so table data replicates across replicas.
         * **Atomic engine** — the database does not auto-replicate, so we must
           explicitly rewrite ``MergeTree`` → ``ReplicatedMergeTree`` and add
           ``ON CLUSTER`` to every DDL statement.
@@ -624,10 +630,9 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
         database would auto-assign per-shard ZK paths, causing each shard to
         track migration state independently instead of sharing it.
         """
+        sql_query = self._format_replicated_sql(sql_query)
         if self._uses_replicated_db_engine(target_db):
             return sql_query
-
-        sql_query = self._format_replicated_sql(sql_query)
         return self._add_on_cluster_clause(sql_query, target_db=target_db)
 
     def _create_management_table_sql(self) -> str:
@@ -883,10 +888,12 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
             self.ch_client.database = curr_db
             return
 
-        # When the DB uses ENGINE = Replicated, skip explicit ReplicatedMergeTree
-        # conversion — the DB engine auto-converts MergeTree tables.
+        # Engine handling matrix for distributed local tables:
+        # - distributed + Atomic DB: explicit ZK args plus ON CLUSTER
+        # - distributed + Replicated DB: Replicated*MergeTree() with no
+        #   explicit ZK args and no ON CLUSTER
         if self._uses_replicated_db_engine(target_db):
-            formatted_command = command
+            formatted_command = self._format_replicated_sql(command)
         else:
             formatted_command = self._format_replicated_sql_distributed(
                 command, target_db

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -814,9 +814,9 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
     def _create_management_table_sql(self) -> str:
         """Generate SQL to create the management table in distributed mode.
 
-        If the management DB uses Replicated engine, use MergeTree() (auto-converted
-        by the DB engine) and skip ON CLUSTER. Otherwise, use explicit
-        ReplicatedMergeTree with a shared ZK path so all shards share migration state.
+        If the management DB uses Replicated engine, use ReplicatedMergeTree()
+        and skip ON CLUSTER. Otherwise, use explicit ReplicatedMergeTree with a
+        shared ZK path so all shards share migration state.
         """
         if self._uses_replicated_db_engine(self.management_db):
             # Legacy path: existing deployments where db_management was created with
@@ -826,7 +826,7 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
             return f"""
                 CREATE TABLE IF NOT EXISTS {self.management_db}.migrations
                 ({_MIGRATIONS_TABLE_COLUMNS})
-                ENGINE = MergeTree()
+                ENGINE = ReplicatedMergeTree()
                 ORDER BY (db_name)
             """
         return f"""
@@ -875,8 +875,8 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
         if SQLPatterns.CREATE_VIEW_STMT.search(
             command_for_match
         ) or SQLPatterns.DROP_VIEW_STMT.search(command_for_match):
-            # When the DB uses ENGINE = Replicated, it auto-converts MergeTree
-            # and handles DDL replication — skip explicit engine conversion and ON CLUSTER.
+            # Replicated DB: DDL is auto-replicated, so skip ON CLUSTER.
+            # Views have no MergeTree engine to rewrite.
             if self._uses_replicated_db_engine(target_db):
                 formatted_command = command
             else:


### PR DESCRIPTION
Followup to #6597 — the distributed migrator's `_create_management_table_sql` legacy path still emitted plain `MergeTree()`, relying on the auto-conversion assumption that #6597 disproved. In practice this is a no-op: the legacy path only fires when `db_management` already uses `ENGINE = Replicated`, and in that case the migrations table already exists, so `CREATE TABLE IF NOT EXISTS` skips execution. The only way this could matter is if someone manually dropped the migrations table but kept the database. Fixing for consistency with the #6597 mental model, plus cleaning up stale comments.