### PR TITLE
test(weave): speed trace tests by disabling autoflush

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,19 +283,6 @@ class TestOnlyFlushingWeaveClient(weave_client.WeaveClient):
     def set_autoflush(self, value: bool):
         self._autoflush = value
 
-    @contextlib.contextmanager
-    def no_autoflush(self):
-        """Disable per-method autoflush during bulk operations, drain on exit."""
-        self.set_autoflush(False)
-        try:
-            yield
-        finally:
-            for _ in range(10):
-                self.flush()
-                if not self._has_pending_jobs():
-                    break
-            self.set_autoflush(True)
-
     def __getattribute__(self, name):
         self_super = super()
         attr = self_super.__getattribute__(name)
@@ -412,6 +399,18 @@ def client(zero_stack, request, trace_server, caching_client_isolation):
             client.server.close()
         except Exception:
             pass
+
+
+@pytest.fixture
+def no_autoflush(client):
+    """Disable per-method autoflush for speed; call client.flush() before reads."""
+    client.set_autoflush(False)
+    yield
+    for _ in range(10):
+        client.flush()
+        if not client._has_pending_jobs():
+            break
+    client.set_autoflush(True)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -283,6 +283,19 @@ class TestOnlyFlushingWeaveClient(weave_client.WeaveClient):
     def set_autoflush(self, value: bool):
         self._autoflush = value
 
+    @contextlib.contextmanager
+    def no_autoflush(self):
+        """Disable per-method autoflush during bulk operations, drain on exit."""
+        self.set_autoflush(False)
+        try:
+            yield
+        finally:
+            for _ in range(10):
+                self.flush()
+                if not self._has_pending_jobs():
+                    break
+            self.set_autoflush(True)
+
     def __getattribute__(self, name):
         self_super = super()
         attr = self_super.__getattribute__(name)

--- a/tests/trace/test_client_filter_calls_by_refs.py
+++ b/tests/trace/test_client_filter_calls_by_refs.py
@@ -1,5 +1,3 @@
-from contextlib import contextmanager
-
 import pytest
 
 import weave
@@ -8,26 +6,12 @@ from weave import Evaluation
 from weave.trace_server.common_interface import SortBy
 
 
-@contextmanager
-def no_autoflush(client):
-    """Disable per-method autoflush during bulk call creation, flush once on exit."""
-    client.set_autoflush(False)
-    try:
-        yield
-    finally:
-        for _ in range(10):
-            client.flush()
-            if not client._has_pending_jobs():
-                break
-        client.set_autoflush(True)
-
-
 def test_filter_calls_by_ref_properties(client):
     """Test filtering calls by values within objects stored as refs in inputs/outputs."""
     if client_is_sqlite(client):
         pytest.skip("Not implemented in SQLite")
 
-    with no_autoflush(client):
+    with client.no_autoflush():
         nested1 = {"nested key with spaces": {"one": "1"}}
         nested_ref = weave.publish(nested1, "nested")
         nested2 = {"nested key with spaces": {"one": "2"}}
@@ -372,7 +356,7 @@ async def test_filter_calls_by_ref_properties_with_table_rows_simple(client):
     async def model_predict(input) -> str:
         return eval(input)
 
-    with no_autoflush(client):
+    with client.no_autoflush():
         object_ref1 = weave.publish({"a": 1, "b": 2}, "object")
         object_ref2 = weave.publish({"a": 3, "b": 4}, "object")
         object_ref3 = weave.publish({"a": 5, "b": 6}, "object")

--- a/tests/trace/test_client_filter_calls_by_refs.py
+++ b/tests/trace/test_client_filter_calls_by_refs.py
@@ -6,59 +6,60 @@ from weave import Evaluation
 from weave.trace_server.common_interface import SortBy
 
 
-def test_filter_calls_by_ref_properties(client):
+def test_filter_calls_by_ref_properties(client, no_autoflush):
     """Test filtering calls by values within objects stored as refs in inputs/outputs."""
     if client_is_sqlite(client):
         pytest.skip("Not implemented in SQLite")
 
-    with client.no_autoflush():
-        nested1 = {"nested key with spaces": {"one": "1"}}
-        nested_ref = weave.publish(nested1, "nested")
-        nested2 = {"nested key with spaces": {"one": "2"}}
-        nested2_ref = weave.publish(nested2, "nested")
+    nested1 = {"nested key with spaces": {"one": "1"}}
+    nested_ref = weave.publish(nested1, "nested")
+    nested2 = {"nested key with spaces": {"one": "2"}}
+    nested2_ref = weave.publish(nested2, "nested")
 
-        # Create configuration objects to be referenced
-        config1 = {
-            "temperature": 0.5,
-            "model": "gpt-4",
-            "max_tokens": 100,
-            "nested": nested_ref,
+    # Create configuration objects to be referenced
+    config1 = {
+        "temperature": 0.5,
+        "model": "gpt-4",
+        "max_tokens": 100,
+        "nested": nested_ref,
+    }
+    config1_ref = weave.publish(config1, "config1")
+
+    config2 = {
+        "temperature": 0.8,
+        "model": "gpt-3.5",
+        "max_tokens": 200,
+        "nested": nested2_ref,
+    }
+    config2_ref = weave.publish(config2, "config2")
+
+    # Create nested objects with references
+    worker_info1 = {"id": 1, "status": "active", "config": config1_ref}
+    worker1_ref = weave.publish(worker_info1, "worker1")
+
+    worker_info2 = {"id": 2, "status": "inactive", "config": config2_ref}
+    worker2_ref = weave.publish(worker_info2, "worker2")
+
+    # Create a more complex nested structure
+    project_data = {
+        "name": "test_project",
+        "version": "v1.0",
+        "settings": {"debug": True, "workers": [worker1_ref, worker2_ref]},
+    }
+    project_ref = weave.publish(project_data, "project")
+
+    @weave.op
+    def process_with_config(worker_config, project_info):
+        return {
+            "processed_worker": worker_config,
+            "project_context": project_info,
         }
-        config1_ref = weave.publish(config1, "config1")
 
-        config2 = {
-            "temperature": 0.8,
-            "model": "gpt-3.5",
-            "max_tokens": 200,
-            "nested": nested2_ref,
-        }
-        config2_ref = weave.publish(config2, "config2")
+    # Create calls that use these referenced objects
+    process_with_config(worker1_ref, project_ref)
+    process_with_config(worker2_ref, project_ref)
 
-        # Create nested objects with references
-        worker_info1 = {"id": 1, "status": "active", "config": config1_ref}
-        worker1_ref = weave.publish(worker_info1, "worker1")
-
-        worker_info2 = {"id": 2, "status": "inactive", "config": config2_ref}
-        worker2_ref = weave.publish(worker_info2, "worker2")
-
-        # Create a more complex nested structure
-        project_data = {
-            "name": "test_project",
-            "version": "v1.0",
-            "settings": {"debug": True, "workers": [worker1_ref, worker2_ref]},
-        }
-        project_ref = weave.publish(project_data, "project")
-
-        @weave.op
-        def process_with_config(worker_config, project_info):
-            return {
-                "processed_worker": worker_config,
-                "project_context": project_info,
-            }
-
-        # Create calls that use these referenced objects
-        process_with_config(worker1_ref, project_ref)
-        process_with_config(worker2_ref, project_ref)
+    client.flush()
 
     # Test filtering by simple ref value in inputs
     calls = list(
@@ -346,7 +347,9 @@ def test_filter_calls_by_ref_properties(client):
 
 
 @pytest.mark.asyncio
-async def test_filter_calls_by_ref_properties_with_table_rows_simple(client):
+async def test_filter_calls_by_ref_properties_with_table_rows_simple(
+    client, no_autoflush
+):
     """Test filtering calls by values within objects stored as refs in inputs/outputs."""
     if client_is_sqlite(client):
         pytest.skip("Not implemented in SQLite")
@@ -356,31 +359,31 @@ async def test_filter_calls_by_ref_properties_with_table_rows_simple(client):
     async def model_predict(input) -> str:
         return eval(input)
 
-    with client.no_autoflush():
-        object_ref1 = weave.publish({"a": 1, "b": 2}, "object")
-        object_ref2 = weave.publish({"a": 3, "b": 4}, "object")
-        object_ref3 = weave.publish({"a": 5, "b": 6}, "object")
-        object_ref4 = weave.publish({"a": 7, "b": 8}, "object")
-        object_ref5 = weave.publish({"a": 9, "b": 10}, "object")
+    object_ref1 = weave.publish({"a": 1, "b": 2}, "object")
+    object_ref2 = weave.publish({"a": 3, "b": 4}, "object")
+    object_ref3 = weave.publish({"a": 5, "b": 6}, "object")
+    object_ref4 = weave.publish({"a": 7, "b": 8}, "object")
+    object_ref5 = weave.publish({"a": 9, "b": 10}, "object")
 
-        dataset_rows = [
-            {"input": "1+2", "target": 3, "object": object_ref1},
-            {"input": "2**4", "target": 15, "object": object_ref2},
-            {"input": "3**3", "target": 27, "object": object_ref3},
-            {"input": "4**2", "target": 16, "object": object_ref4},
-            {"input": "5**1", "target": 5, "object": object_ref5},
-        ]
+    dataset_rows = [
+        {"input": "1+2", "target": 3, "object": object_ref1},
+        {"input": "2**4", "target": 15, "object": object_ref2},
+        {"input": "3**3", "target": 27, "object": object_ref3},
+        {"input": "4**2", "target": 16, "object": object_ref4},
+        {"input": "5**1", "target": 5, "object": object_ref5},
+    ]
 
-        @weave.op
-        async def score(target, model_output, object):
-            return target == model_output
+    @weave.op
+    async def score(target, model_output, object):
+        return target == model_output
 
-        evaluation = Evaluation(
-            name="my-eval",
-            dataset=dataset_rows,
-            scorers=[score],
-        )
-        await evaluation.evaluate(model_predict)
+    evaluation = Evaluation(
+        name="my-eval",
+        dataset=dataset_rows,
+        scorers=[score],
+    )
+    await evaluation.evaluate(model_predict)
+    client.flush()
 
     calls = list(
         client.get_calls(

--- a/tests/trace/test_client_filter_calls_by_refs.py
+++ b/tests/trace/test_client_filter_calls_by_refs.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import pytest
 
 import weave
@@ -6,60 +8,73 @@ from weave import Evaluation
 from weave.trace_server.common_interface import SortBy
 
 
+@contextmanager
+def no_autoflush(client):
+    """Disable per-method autoflush during bulk call creation, flush once on exit."""
+    client.set_autoflush(False)
+    try:
+        yield
+    finally:
+        for _ in range(10):
+            client.flush()
+            if not client._has_pending_jobs():
+                break
+        client.set_autoflush(True)
+
+
 def test_filter_calls_by_ref_properties(client):
     """Test filtering calls by values within objects stored as refs in inputs/outputs."""
     if client_is_sqlite(client):
         pytest.skip("Not implemented in SQLite")
 
-    nested1 = {"nested key with spaces": {"one": "1"}}
-    nested_ref = weave.publish(nested1, "nested")
-    nested2 = {"nested key with spaces": {"one": "2"}}
-    nested2_ref = weave.publish(nested2, "nested")
+    with no_autoflush(client):
+        nested1 = {"nested key with spaces": {"one": "1"}}
+        nested_ref = weave.publish(nested1, "nested")
+        nested2 = {"nested key with spaces": {"one": "2"}}
+        nested2_ref = weave.publish(nested2, "nested")
 
-    # Create configuration objects to be referenced
-    config1 = {
-        "temperature": 0.5,
-        "model": "gpt-4",
-        "max_tokens": 100,
-        "nested": nested_ref,
-    }
-    config1_ref = weave.publish(config1, "config1")
-
-    config2 = {
-        "temperature": 0.8,
-        "model": "gpt-3.5",
-        "max_tokens": 200,
-        "nested": nested2_ref,
-    }
-    config2_ref = weave.publish(config2, "config2")
-
-    # Create nested objects with references
-    worker_info1 = {"id": 1, "status": "active", "config": config1_ref}
-    worker1_ref = weave.publish(worker_info1, "worker1")
-
-    worker_info2 = {"id": 2, "status": "inactive", "config": config2_ref}
-    worker2_ref = weave.publish(worker_info2, "worker2")
-
-    # Create a more complex nested structure
-    project_data = {
-        "name": "test_project",
-        "version": "v1.0",
-        "settings": {"debug": True, "workers": [worker1_ref, worker2_ref]},
-    }
-    project_ref = weave.publish(project_data, "project")
-
-    @weave.op
-    def process_with_config(worker_config, project_info):
-        return {
-            "processed_worker": worker_config,
-            "project_context": project_info,
+        # Create configuration objects to be referenced
+        config1 = {
+            "temperature": 0.5,
+            "model": "gpt-4",
+            "max_tokens": 100,
+            "nested": nested_ref,
         }
+        config1_ref = weave.publish(config1, "config1")
 
-    # Create calls that use these referenced objects
-    process_with_config(worker1_ref, project_ref)
-    process_with_config(worker2_ref, project_ref)
+        config2 = {
+            "temperature": 0.8,
+            "model": "gpt-3.5",
+            "max_tokens": 200,
+            "nested": nested2_ref,
+        }
+        config2_ref = weave.publish(config2, "config2")
 
-    client.flush()
+        # Create nested objects with references
+        worker_info1 = {"id": 1, "status": "active", "config": config1_ref}
+        worker1_ref = weave.publish(worker_info1, "worker1")
+
+        worker_info2 = {"id": 2, "status": "inactive", "config": config2_ref}
+        worker2_ref = weave.publish(worker_info2, "worker2")
+
+        # Create a more complex nested structure
+        project_data = {
+            "name": "test_project",
+            "version": "v1.0",
+            "settings": {"debug": True, "workers": [worker1_ref, worker2_ref]},
+        }
+        project_ref = weave.publish(project_data, "project")
+
+        @weave.op
+        def process_with_config(worker_config, project_info):
+            return {
+                "processed_worker": worker_config,
+                "project_context": project_info,
+            }
+
+        # Create calls that use these referenced objects
+        process_with_config(worker1_ref, project_ref)
+        process_with_config(worker2_ref, project_ref)
 
     # Test filtering by simple ref value in inputs
     calls = list(
@@ -357,30 +372,31 @@ async def test_filter_calls_by_ref_properties_with_table_rows_simple(client):
     async def model_predict(input) -> str:
         return eval(input)
 
-    object_ref1 = weave.publish({"a": 1, "b": 2}, "object")
-    object_ref2 = weave.publish({"a": 3, "b": 4}, "object")
-    object_ref3 = weave.publish({"a": 5, "b": 6}, "object")
-    object_ref4 = weave.publish({"a": 7, "b": 8}, "object")
-    object_ref5 = weave.publish({"a": 9, "b": 10}, "object")
+    with no_autoflush(client):
+        object_ref1 = weave.publish({"a": 1, "b": 2}, "object")
+        object_ref2 = weave.publish({"a": 3, "b": 4}, "object")
+        object_ref3 = weave.publish({"a": 5, "b": 6}, "object")
+        object_ref4 = weave.publish({"a": 7, "b": 8}, "object")
+        object_ref5 = weave.publish({"a": 9, "b": 10}, "object")
 
-    dataset_rows = [
-        {"input": "1+2", "target": 3, "object": object_ref1},
-        {"input": "2**4", "target": 15, "object": object_ref2},
-        {"input": "3**3", "target": 27, "object": object_ref3},
-        {"input": "4**2", "target": 16, "object": object_ref4},
-        {"input": "5**1", "target": 5, "object": object_ref5},
-    ]
+        dataset_rows = [
+            {"input": "1+2", "target": 3, "object": object_ref1},
+            {"input": "2**4", "target": 15, "object": object_ref2},
+            {"input": "3**3", "target": 27, "object": object_ref3},
+            {"input": "4**2", "target": 16, "object": object_ref4},
+            {"input": "5**1", "target": 5, "object": object_ref5},
+        ]
 
-    @weave.op
-    async def score(target, model_output, object):
-        return target == model_output
+        @weave.op
+        async def score(target, model_output, object):
+            return target == model_output
 
-    evaluation = Evaluation(
-        name="my-eval",
-        dataset=dataset_rows,
-        scorers=[score],
-    )
-    await evaluation.evaluate(model_predict)
+        evaluation = Evaluation(
+            name="my-eval",
+            dataset=dataset_rows,
+            scorers=[score],
+        )
+        await evaluation.evaluate(model_predict)
 
     calls = list(
         client.get_calls(

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -948,9 +948,11 @@ def test_trace_call_query_filter_wb_run_ids(client, no_autoflush):
 
 def test_trace_call_query_filter_wb_user_ids(client, trace_server, no_autoflush):
     call_spec_1 = simple_line_call_bootstrap()
+    client.flush()
 
     trace_server.set_user_id("second_user")
     call_spec_2 = simple_line_call_bootstrap()
+    client.flush()
 
     trace_server.set_user_id("third_user")
     call_spec_3 = simple_line_call_bootstrap()

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1,3 +1,4 @@
+import contextlib
 import dataclasses
 import datetime
 import json
@@ -92,24 +93,6 @@ def get_client_trace_server(
 
 def get_client_project_id(client: weave_client.WeaveClient) -> str:
     return client.project_id
-
-
-@contextmanager
-def no_autoflush(client):
-    """Disable per-method autoflush during bulk call creation, flush once on exit.
-
-    Chained futures (from FutureExecutor.then) create work that isn't captured
-    by a single flush snapshot, so we loop until everything drains.
-    """
-    client.set_autoflush(False)
-    try:
-        yield
-    finally:
-        for _ in range(10):
-            client.flush()
-            if not client._has_pending_jobs():
-                break
-        client.set_autoflush(True)
 
 
 ## End hacky interface compatibility helpers
@@ -324,7 +307,13 @@ class OpCallSpec(BaseModel):
     part_sequence: list[tuple[str, str]]
 
 
-def simple_line_call_bootstrap() -> OpCallSpec:
+def simple_line_call_bootstrap(client=None) -> OpCallSpec:
+    """Bootstrap a set of ops and calls for testing query/filter behavior.
+
+    Args:
+        client: When provided, disables autoflush during bulk call creation
+                for significantly faster execution.
+    """
     part_sequence = []
 
     def track_sequence(name: str):
@@ -381,40 +370,42 @@ def simple_line_call_bootstrap() -> OpCallSpec:
     result["liner"] = OpCallSummary(op=liner)
     root_calls = 0
 
-    # Call each op a distinct number of time (allows for easier assertions later)
-    num_calls = 1
-    for i in range(num_calls):
-        adder_v0(Number(value=i))
-    result["adder_v0"].num_calls += num_calls
-    root_calls += num_calls
+    cm = client.no_autoflush() if client else contextlib.nullcontext()
+    with cm:
+        # Call each op a distinct number of times (allows for easier assertions later)
+        num_calls = 1
+        for i in range(num_calls):
+            adder_v0(Number(value=i))
+        result["adder_v0"].num_calls += num_calls
+        root_calls += num_calls
 
-    num_calls = 2
-    for i in range(num_calls):
-        adder(Number(value=i), i)
-    result["adder"].num_calls += num_calls
-    root_calls += num_calls
+        num_calls = 2
+        for i in range(num_calls):
+            adder(Number(value=i), i)
+        result["adder"].num_calls += num_calls
+        root_calls += num_calls
 
-    num_calls = 3
-    for i in range(num_calls):
-        subtractor(Number(value=i), i)
-    result["subtractor"].num_calls += num_calls
-    root_calls += num_calls
+        num_calls = 3
+        for i in range(num_calls):
+            subtractor(Number(value=i), i)
+        result["subtractor"].num_calls += num_calls
+        root_calls += num_calls
 
-    num_calls = 4
-    for i in range(num_calls):
-        multiplier(Number(value=i), i)
-    result["multiplier"].num_calls += num_calls
-    root_calls += num_calls
+        num_calls = 4
+        for i in range(num_calls):
+            multiplier(Number(value=i), i)
+        result["multiplier"].num_calls += num_calls
+        root_calls += num_calls
 
-    num_calls = 5
-    run_calls = 0
-    for i in range(num_calls):
-        liner(Number(value=i), i, i)
-    result["liner"].num_calls += num_calls
-    result["adder"].num_calls += num_calls
-    result["multiplier"].num_calls += num_calls
-    run_calls += num_calls * 3
-    root_calls += num_calls
+        num_calls = 5
+        run_calls = 0
+        for i in range(num_calls):
+            liner(Number(value=i), i, i)
+        result["liner"].num_calls += num_calls
+        result["adder"].num_calls += num_calls
+        result["multiplier"].num_calls += num_calls
+        run_calls += num_calls * 3
+        root_calls += num_calls
 
     total_calls = sum(op_call.num_calls for op_call in result.values())
 
@@ -432,8 +423,7 @@ def ref_str(op):
 
 
 def test_trace_call_query_filter_op_version_refs(client):
-    with no_autoflush(client):
-        call_spec = simple_line_call_bootstrap()
+    call_spec = simple_line_call_bootstrap(client)
     call_summaries = call_spec.call_summaries
 
     # This is just a string representation of the ref
@@ -898,8 +888,7 @@ def test_trace_call_query_filter_call_ids(client):
 
 
 def test_trace_call_query_filter_trace_roots_only(client):
-    with no_autoflush(client):
-        call_spec = simple_line_call_bootstrap()
+    call_spec = simple_line_call_bootstrap(client)
 
     for trace_roots_only, exp_count in [
         # Test the None case
@@ -925,7 +914,7 @@ def test_trace_call_query_filter_wb_run_ids(client):
     from weave.trace import weave_client
     from weave.trace.wandb_run_context import WandbRunContext
 
-    with no_autoflush(client):
+    with client.no_autoflush():
         with mock.patch.object(
             weave_client,
             "get_global_wb_run_context",
@@ -965,14 +954,11 @@ def test_trace_call_query_filter_wb_run_ids(client):
 
 
 def test_trace_call_query_filter_wb_user_ids(client, trace_server):
-    with no_autoflush(client):
-        call_spec_1 = simple_line_call_bootstrap()
+    call_spec_1 = simple_line_call_bootstrap(client)
     trace_server.set_user_id("second_user")
-    with no_autoflush(client):
-        call_spec_2 = simple_line_call_bootstrap()
+    call_spec_2 = simple_line_call_bootstrap(client)
     trace_server.set_user_id("third_user")
-    with no_autoflush(client):
-        call_spec_3 = simple_line_call_bootstrap()
+    call_spec_3 = simple_line_call_bootstrap(client)
 
     for wb_user_ids, exp_count in [
         (
@@ -1001,8 +987,7 @@ def test_trace_call_query_filter_wb_user_ids(client, trace_server):
 
 
 def test_trace_call_query_limit(client):
-    with no_autoflush(client):
-        call_spec = simple_line_call_bootstrap()
+    call_spec = simple_line_call_bootstrap(client)
 
     for limit, exp_count in [
         # Test the None case
@@ -1023,8 +1008,7 @@ def test_trace_call_query_limit(client):
 
 
 def test_trace_call_query_offset(client):
-    with no_autoflush(client):
-        call_spec = simple_line_call_bootstrap()
+    call_spec = simple_line_call_bootstrap(client)
 
     for offset, exp_count in [
         # Test the None case
@@ -1066,7 +1050,7 @@ def test_trace_call_query_timings(client):
             return even_later
 
     with (
-        no_autoflush(client),
+        client.no_autoflush(),
         mock.patch("weave.trace.weave_client.datetime.datetime") as mock_datetime_class,
     ):
         # Mock only the .now() method, keep everything else as-is
@@ -6585,7 +6569,7 @@ def test_calls_query_ordering_with_costs_comprehensive(client):
     def my_op(x: int) -> int:
         return x
 
-    with no_autoflush(client):
+    with client.no_autoflush():
         # Calls with multiple sortable attributes
         call1 = client.create_call(
             my_op, {"x": 1}, attributes={"category": "A", "priority": 2}

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -94,6 +94,24 @@ def get_client_project_id(client: weave_client.WeaveClient) -> str:
     return client.project_id
 
 
+@contextmanager
+def no_autoflush(client):
+    """Disable per-method autoflush during bulk call creation, flush once on exit.
+
+    Chained futures (from FutureExecutor.then) create work that isn't captured
+    by a single flush snapshot, so we loop until everything drains.
+    """
+    client.set_autoflush(False)
+    try:
+        yield
+    finally:
+        for _ in range(10):
+            client.flush()
+            if not client._has_pending_jobs():
+                break
+        client.set_autoflush(True)
+
+
 ## End hacky interface compatibility helpers
 
 
@@ -414,7 +432,8 @@ def ref_str(op):
 
 
 def test_trace_call_query_filter_op_version_refs(client):
-    call_spec = simple_line_call_bootstrap()
+    with no_autoflush(client):
+        call_spec = simple_line_call_bootstrap()
     call_summaries = call_spec.call_summaries
 
     # This is just a string representation of the ref
@@ -879,7 +898,8 @@ def test_trace_call_query_filter_call_ids(client):
 
 
 def test_trace_call_query_filter_trace_roots_only(client):
-    call_spec = simple_line_call_bootstrap()
+    with no_autoflush(client):
+        call_spec = simple_line_call_bootstrap()
 
     for trace_roots_only, exp_count in [
         # Test the None case
@@ -905,19 +925,20 @@ def test_trace_call_query_filter_wb_run_ids(client):
     from weave.trace import weave_client
     from weave.trace.wandb_run_context import WandbRunContext
 
-    with mock.patch.object(
-        weave_client,
-        "get_global_wb_run_context",
-        return_value=WandbRunContext(run_id="test-run-1", step=0),
-    ):
-        call_spec_1 = simple_line_call_bootstrap()
-    with mock.patch.object(
-        weave_client,
-        "get_global_wb_run_context",
-        return_value=WandbRunContext(run_id="test-run-2", step=0),
-    ):
-        call_spec_2 = simple_line_call_bootstrap()
-    call_spec_3 = simple_line_call_bootstrap()
+    with no_autoflush(client):
+        with mock.patch.object(
+            weave_client,
+            "get_global_wb_run_context",
+            return_value=WandbRunContext(run_id="test-run-1", step=0),
+        ):
+            call_spec_1 = simple_line_call_bootstrap()
+        with mock.patch.object(
+            weave_client,
+            "get_global_wb_run_context",
+            return_value=WandbRunContext(run_id="test-run-2", step=0),
+        ):
+            call_spec_2 = simple_line_call_bootstrap()
+        call_spec_3 = simple_line_call_bootstrap()
 
     total_calls = (
         call_spec_1.total_calls + call_spec_2.total_calls + call_spec_3.total_calls
@@ -944,13 +965,14 @@ def test_trace_call_query_filter_wb_run_ids(client):
 
 
 def test_trace_call_query_filter_wb_user_ids(client, trace_server):
-    call_spec_1 = simple_line_call_bootstrap()
-
+    with no_autoflush(client):
+        call_spec_1 = simple_line_call_bootstrap()
     trace_server.set_user_id("second_user")
-    call_spec_2 = simple_line_call_bootstrap()
-
+    with no_autoflush(client):
+        call_spec_2 = simple_line_call_bootstrap()
     trace_server.set_user_id("third_user")
-    call_spec_3 = simple_line_call_bootstrap()
+    with no_autoflush(client):
+        call_spec_3 = simple_line_call_bootstrap()
 
     for wb_user_ids, exp_count in [
         (
@@ -979,7 +1001,8 @@ def test_trace_call_query_filter_wb_user_ids(client, trace_server):
 
 
 def test_trace_call_query_limit(client):
-    call_spec = simple_line_call_bootstrap()
+    with no_autoflush(client):
+        call_spec = simple_line_call_bootstrap()
 
     for limit, exp_count in [
         # Test the None case
@@ -1000,7 +1023,8 @@ def test_trace_call_query_limit(client):
 
 
 def test_trace_call_query_offset(client):
-    call_spec = simple_line_call_bootstrap()
+    with no_autoflush(client):
+        call_spec = simple_line_call_bootstrap()
 
     for offset, exp_count in [
         # Test the None case
@@ -1041,9 +1065,10 @@ def test_trace_call_query_timings(client):
         else:  # call 99 gets 'even_later'
             return even_later
 
-    with mock.patch(
-        "weave.trace.weave_client.datetime.datetime"
-    ) as mock_datetime_class:
+    with (
+        no_autoflush(client),
+        mock.patch("weave.trace.weave_client.datetime.datetime") as mock_datetime_class,
+    ):
         # Mock only the .now() method, keep everything else as-is
         mock_datetime_class.now = mock.Mock(side_effect=mock_now)
         # Preserve other datetime functionality
@@ -6560,45 +6585,46 @@ def test_calls_query_ordering_with_costs_comprehensive(client):
     def my_op(x: int) -> int:
         return x
 
-    # Calls with multiple sortable attributes
-    call1 = client.create_call(
-        my_op, {"x": 1}, attributes={"category": "A", "priority": 2}
-    )
-    client.finish_call(call1, 1)
-    time.sleep(0.01)
+    with no_autoflush(client):
+        # Calls with multiple sortable attributes
+        call1 = client.create_call(
+            my_op, {"x": 1}, attributes={"category": "A", "priority": 2}
+        )
+        client.finish_call(call1, 1)
+        time.sleep(0.01)
 
-    call2 = client.create_call(
-        my_op, {"x": 2}, attributes={"category": "A", "priority": 1}
-    )
-    client.finish_call(call2, 2)
-    time.sleep(0.01)
+        call2 = client.create_call(
+            my_op, {"x": 2}, attributes={"category": "A", "priority": 1}
+        )
+        client.finish_call(call2, 2)
+        time.sleep(0.01)
 
-    call3 = client.create_call(
-        my_op, {"x": 3}, attributes={"category": "B", "priority": 1}
-    )
-    client.finish_call(call3, 3)
-    time.sleep(0.01)
+        call3 = client.create_call(
+            my_op, {"x": 3}, attributes={"category": "B", "priority": 1}
+        )
+        client.finish_call(call3, 3)
+        time.sleep(0.01)
 
-    # Calls with deeply nested attributes
-    call4 = client.create_call(
-        my_op,
-        {"x": 4},
-        attributes={"metadata": {"config": {"model": {"temperature": 0.1}}}},
-    )
-    client.finish_call(call4, 4)
-    time.sleep(0.01)
+        # Calls with deeply nested attributes
+        call4 = client.create_call(
+            my_op,
+            {"x": 4},
+            attributes={"metadata": {"config": {"model": {"temperature": 0.1}}}},
+        )
+        client.finish_call(call4, 4)
+        time.sleep(0.01)
 
-    call5 = client.create_call(
-        my_op,
-        {"x": 5},
-        attributes={"metadata": {"config": {"model": {"temperature": 0.9}}}},
-    )
-    client.finish_call(call5, 5)
-    time.sleep(0.01)
+        call5 = client.create_call(
+            my_op,
+            {"x": 5},
+            attributes={"metadata": {"config": {"model": {"temperature": 0.9}}}},
+        )
+        client.finish_call(call5, 5)
+        time.sleep(0.01)
 
-    # Call with missing/NULL attributes
-    call6 = client.create_call(my_op, {"x": 6}, attributes={})
-    client.finish_call(call6, 6)
+        # Call with missing/NULL attributes
+        call6 = client.create_call(my_op, {"x": 6}, attributes={})
+        client.finish_call(call6, 6)
 
     # Test Case 1: Multiple order fields with costs
     sort_by = [

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1,4 +1,3 @@
-import contextlib
 import dataclasses
 import datetime
 import json
@@ -307,13 +306,7 @@ class OpCallSpec(BaseModel):
     part_sequence: list[tuple[str, str]]
 
 
-def simple_line_call_bootstrap(client=None) -> OpCallSpec:
-    """Bootstrap a set of ops and calls for testing query/filter behavior.
-
-    Args:
-        client: When provided, disables autoflush during bulk call creation
-                for significantly faster execution.
-    """
+def simple_line_call_bootstrap() -> OpCallSpec:
     part_sequence = []
 
     def track_sequence(name: str):
@@ -370,42 +363,40 @@ def simple_line_call_bootstrap(client=None) -> OpCallSpec:
     result["liner"] = OpCallSummary(op=liner)
     root_calls = 0
 
-    cm = client.no_autoflush() if client else contextlib.nullcontext()
-    with cm:
-        # Call each op a distinct number of times (allows for easier assertions later)
-        num_calls = 1
-        for i in range(num_calls):
-            adder_v0(Number(value=i))
-        result["adder_v0"].num_calls += num_calls
-        root_calls += num_calls
+    # Call each op a distinct number of time (allows for easier assertions later)
+    num_calls = 1
+    for i in range(num_calls):
+        adder_v0(Number(value=i))
+    result["adder_v0"].num_calls += num_calls
+    root_calls += num_calls
 
-        num_calls = 2
-        for i in range(num_calls):
-            adder(Number(value=i), i)
-        result["adder"].num_calls += num_calls
-        root_calls += num_calls
+    num_calls = 2
+    for i in range(num_calls):
+        adder(Number(value=i), i)
+    result["adder"].num_calls += num_calls
+    root_calls += num_calls
 
-        num_calls = 3
-        for i in range(num_calls):
-            subtractor(Number(value=i), i)
-        result["subtractor"].num_calls += num_calls
-        root_calls += num_calls
+    num_calls = 3
+    for i in range(num_calls):
+        subtractor(Number(value=i), i)
+    result["subtractor"].num_calls += num_calls
+    root_calls += num_calls
 
-        num_calls = 4
-        for i in range(num_calls):
-            multiplier(Number(value=i), i)
-        result["multiplier"].num_calls += num_calls
-        root_calls += num_calls
+    num_calls = 4
+    for i in range(num_calls):
+        multiplier(Number(value=i), i)
+    result["multiplier"].num_calls += num_calls
+    root_calls += num_calls
 
-        num_calls = 5
-        run_calls = 0
-        for i in range(num_calls):
-            liner(Number(value=i), i, i)
-        result["liner"].num_calls += num_calls
-        result["adder"].num_calls += num_calls
-        result["multiplier"].num_calls += num_calls
-        run_calls += num_calls * 3
-        root_calls += num_calls
+    num_calls = 5
+    run_calls = 0
+    for i in range(num_calls):
+        liner(Number(value=i), i, i)
+    result["liner"].num_calls += num_calls
+    result["adder"].num_calls += num_calls
+    result["multiplier"].num_calls += num_calls
+    run_calls += num_calls * 3
+    root_calls += num_calls
 
     total_calls = sum(op_call.num_calls for op_call in result.values())
 
@@ -422,8 +413,9 @@ def ref_str(op):
     return weave_client.get_ref(op).uri
 
 
-def test_trace_call_query_filter_op_version_refs(client):
-    call_spec = simple_line_call_bootstrap(client)
+def test_trace_call_query_filter_op_version_refs(client, no_autoflush):
+    call_spec = simple_line_call_bootstrap()
+    client.flush()
     call_summaries = call_spec.call_summaries
 
     # This is just a string representation of the ref
@@ -887,8 +879,9 @@ def test_trace_call_query_filter_call_ids(client):
         assert len(inner_res.calls) == exp_count
 
 
-def test_trace_call_query_filter_trace_roots_only(client):
-    call_spec = simple_line_call_bootstrap(client)
+def test_trace_call_query_filter_trace_roots_only(client, no_autoflush):
+    call_spec = simple_line_call_bootstrap()
+    client.flush()
 
     for trace_roots_only, exp_count in [
         # Test the None case
@@ -908,26 +901,26 @@ def test_trace_call_query_filter_trace_roots_only(client):
         assert len(inner_res.calls) == exp_count
 
 
-def test_trace_call_query_filter_wb_run_ids(client):
+def test_trace_call_query_filter_wb_run_ids(client, no_autoflush):
     full_wb_run_id_1 = f"{client.entity}/{client.project}/test-run-1"
     full_wb_run_id_2 = f"{client.entity}/{client.project}/test-run-2"
     from weave.trace import weave_client
     from weave.trace.wandb_run_context import WandbRunContext
 
-    with client.no_autoflush():
-        with mock.patch.object(
-            weave_client,
-            "get_global_wb_run_context",
-            return_value=WandbRunContext(run_id="test-run-1", step=0),
-        ):
-            call_spec_1 = simple_line_call_bootstrap()
-        with mock.patch.object(
-            weave_client,
-            "get_global_wb_run_context",
-            return_value=WandbRunContext(run_id="test-run-2", step=0),
-        ):
-            call_spec_2 = simple_line_call_bootstrap()
-        call_spec_3 = simple_line_call_bootstrap()
+    with mock.patch.object(
+        weave_client,
+        "get_global_wb_run_context",
+        return_value=WandbRunContext(run_id="test-run-1", step=0),
+    ):
+        call_spec_1 = simple_line_call_bootstrap()
+    with mock.patch.object(
+        weave_client,
+        "get_global_wb_run_context",
+        return_value=WandbRunContext(run_id="test-run-2", step=0),
+    ):
+        call_spec_2 = simple_line_call_bootstrap()
+    call_spec_3 = simple_line_call_bootstrap()
+    client.flush()
 
     total_calls = (
         call_spec_1.total_calls + call_spec_2.total_calls + call_spec_3.total_calls
@@ -953,12 +946,15 @@ def test_trace_call_query_filter_wb_run_ids(client):
         assert len(inner_res.calls) == exp_count
 
 
-def test_trace_call_query_filter_wb_user_ids(client, trace_server):
-    call_spec_1 = simple_line_call_bootstrap(client)
+def test_trace_call_query_filter_wb_user_ids(client, trace_server, no_autoflush):
+    call_spec_1 = simple_line_call_bootstrap()
+
     trace_server.set_user_id("second_user")
-    call_spec_2 = simple_line_call_bootstrap(client)
+    call_spec_2 = simple_line_call_bootstrap()
+
     trace_server.set_user_id("third_user")
-    call_spec_3 = simple_line_call_bootstrap(client)
+    call_spec_3 = simple_line_call_bootstrap()
+    client.flush()
 
     for wb_user_ids, exp_count in [
         (
@@ -986,8 +982,9 @@ def test_trace_call_query_filter_wb_user_ids(client, trace_server):
         assert len(inner_res.calls) == exp_count
 
 
-def test_trace_call_query_limit(client):
-    call_spec = simple_line_call_bootstrap(client)
+def test_trace_call_query_limit(client, no_autoflush):
+    call_spec = simple_line_call_bootstrap()
+    client.flush()
 
     for limit, exp_count in [
         # Test the None case
@@ -1007,8 +1004,9 @@ def test_trace_call_query_limit(client):
         assert len(inner_res.calls) == exp_count
 
 
-def test_trace_call_query_offset(client):
-    call_spec = simple_line_call_bootstrap(client)
+def test_trace_call_query_offset(client, no_autoflush):
+    call_spec = simple_line_call_bootstrap()
+    client.flush()
 
     for offset, exp_count in [
         # Test the None case
@@ -1028,7 +1026,7 @@ def test_trace_call_query_offset(client):
         assert len(inner_res.calls) == exp_count
 
 
-def test_trace_call_query_timings(client):
+def test_trace_call_query_timings(client, no_autoflush):
     now = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     later = now + datetime.timedelta(seconds=1)
     even_later = later + datetime.timedelta(seconds=1)
@@ -1049,10 +1047,9 @@ def test_trace_call_query_timings(client):
         else:  # call 99 gets 'even_later'
             return even_later
 
-    with (
-        client.no_autoflush(),
-        mock.patch("weave.trace.weave_client.datetime.datetime") as mock_datetime_class,
-    ):
+    with mock.patch(
+        "weave.trace.weave_client.datetime.datetime"
+    ) as mock_datetime_class:
         # Mock only the .now() method, keep everything else as-is
         mock_datetime_class.now = mock.Mock(side_effect=mock_now)
         # Preserve other datetime functionality
@@ -1061,6 +1058,7 @@ def test_trace_call_query_timings(client):
         for i in range(num_calls):
             call_index = i
             client.create_call("y", {"a": i})
+    client.flush()
 
     def query_server():
         result = get_client_trace_server(client).calls_query_stream(
@@ -6564,51 +6562,51 @@ def test_calls_query_sort_by_trace_name_with_costs(client):
     assert calls[1].id == call_a.id
 
 
-def test_calls_query_ordering_with_costs_comprehensive(client):
+def test_calls_query_ordering_with_costs_comprehensive(client, no_autoflush):
     @weave.op
     def my_op(x: int) -> int:
         return x
 
-    with client.no_autoflush():
-        # Calls with multiple sortable attributes
-        call1 = client.create_call(
-            my_op, {"x": 1}, attributes={"category": "A", "priority": 2}
-        )
-        client.finish_call(call1, 1)
-        time.sleep(0.01)
+    # Calls with multiple sortable attributes
+    call1 = client.create_call(
+        my_op, {"x": 1}, attributes={"category": "A", "priority": 2}
+    )
+    client.finish_call(call1, 1)
+    time.sleep(0.01)
 
-        call2 = client.create_call(
-            my_op, {"x": 2}, attributes={"category": "A", "priority": 1}
-        )
-        client.finish_call(call2, 2)
-        time.sleep(0.01)
+    call2 = client.create_call(
+        my_op, {"x": 2}, attributes={"category": "A", "priority": 1}
+    )
+    client.finish_call(call2, 2)
+    time.sleep(0.01)
 
-        call3 = client.create_call(
-            my_op, {"x": 3}, attributes={"category": "B", "priority": 1}
-        )
-        client.finish_call(call3, 3)
-        time.sleep(0.01)
+    call3 = client.create_call(
+        my_op, {"x": 3}, attributes={"category": "B", "priority": 1}
+    )
+    client.finish_call(call3, 3)
+    time.sleep(0.01)
 
-        # Calls with deeply nested attributes
-        call4 = client.create_call(
-            my_op,
-            {"x": 4},
-            attributes={"metadata": {"config": {"model": {"temperature": 0.1}}}},
-        )
-        client.finish_call(call4, 4)
-        time.sleep(0.01)
+    # Calls with deeply nested attributes
+    call4 = client.create_call(
+        my_op,
+        {"x": 4},
+        attributes={"metadata": {"config": {"model": {"temperature": 0.1}}}},
+    )
+    client.finish_call(call4, 4)
+    time.sleep(0.01)
 
-        call5 = client.create_call(
-            my_op,
-            {"x": 5},
-            attributes={"metadata": {"config": {"model": {"temperature": 0.9}}}},
-        )
-        client.finish_call(call5, 5)
-        time.sleep(0.01)
+    call5 = client.create_call(
+        my_op,
+        {"x": 5},
+        attributes={"metadata": {"config": {"model": {"temperature": 0.9}}}},
+    )
+    client.finish_call(call5, 5)
+    time.sleep(0.01)
 
-        # Call with missing/NULL attributes
-        call6 = client.create_call(my_op, {"x": 6}, attributes={})
-        client.finish_call(call6, 6)
+    # Call with missing/NULL attributes
+    call6 = client.create_call(my_op, {"x": 6}, attributes={})
+    client.finish_call(call6, 6)
+    client.flush()
 
     # Test Case 1: Multiple order fields with costs
     sort_by = [

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -371,10 +371,16 @@ async def populate_feedback(client: WeaveClient) -> None:
         ][x]
 
     ids = []
+    client.set_autoflush(False)
     for x in range(4):
         _, c = my_model.call(x)
         ids.append(c.id)
         await c.apply_scorer(my_scorer)
+    for _ in range(10):
+        client.flush()
+        if not client._has_pending_jobs():
+            break
+    client.set_autoflush(True)
 
     assert len(list(my_scorer.calls())) == 4
     assert len(list(my_model.calls())) == 4

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -371,16 +371,11 @@ async def populate_feedback(client: WeaveClient) -> None:
         ][x]
 
     ids = []
-    client.set_autoflush(False)
-    for x in range(4):
-        _, c = my_model.call(x)
-        ids.append(c.id)
-        await c.apply_scorer(my_scorer)
-    for _ in range(10):
-        client.flush()
-        if not client._has_pending_jobs():
-            break
-    client.set_autoflush(True)
+    with client.no_autoflush():
+        for x in range(4):
+            _, c = my_model.call(x)
+            ids.append(c.id)
+            await c.apply_scorer(my_scorer)
 
     assert len(list(my_scorer.calls())) == 4
     assert len(list(my_model.calls())) == 4

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -371,11 +371,11 @@ async def populate_feedback(client: WeaveClient) -> None:
         ][x]
 
     ids = []
-    with client.no_autoflush():
-        for x in range(4):
-            _, c = my_model.call(x)
-            ids.append(c.id)
-            await c.apply_scorer(my_scorer)
+    for x in range(4):
+        _, c = my_model.call(x)
+        ids.append(c.id)
+        await c.apply_scorer(my_scorer)
+    client.flush()
 
     assert len(list(my_scorer.calls())) == 4
     assert len(list(my_model.calls())) == 4
@@ -384,7 +384,7 @@ async def populate_feedback(client: WeaveClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_sort_by_feedback(client: WeaveClient) -> None:
+async def test_sort_by_feedback(client: WeaveClient, no_autoflush) -> None:
     """Test sorting by feedback."""
     ids, my_scorer, my_model = await populate_feedback(client)
 
@@ -445,7 +445,7 @@ async def test_sort_by_feedback(client: WeaveClient) -> None:
 
 
 @pytest.mark.asyncio
-async def test_filter_by_feedback(client: WeaveClient) -> None:
+async def test_filter_by_feedback(client: WeaveClient, no_autoflush) -> None:
     """Test filtering by feedback."""
     ids, my_scorer, my_model = await populate_feedback(client)
     for field, value, eq_ids, gt_ids in [
@@ -549,7 +549,7 @@ class MatchAnyDatetime:  # noqa: PLW1641
 
 
 @pytest.mark.asyncio
-async def test_filter_and_sort_by_feedback(client: WeaveClient) -> None:
+async def test_filter_and_sort_by_feedback(client: WeaveClient, no_autoflush) -> None:
     """Test filtering and sorting by feedback."""
     ids, my_scorer, my_model = await populate_feedback(client)
     calls = client.server.calls_query_stream(


### PR DESCRIPTION
## Summary
- Adds `no_autoflush` pytest fixture to disable per-method autoflush during bulk call creation in tests
- Tests that create many calls via `simple_line_call_bootstrap()` or direct loops were paying flush cost per-method-call
- Opting into the fixture defers flushing until teardown; tests call `client.flush()` manually before reads mid-body

Key speedups (sqlite backend):
- `test_trace_call_query_timings`: 14.84s → 0.09s
- `test_trace_call_query_filter_wb_run_ids`: 14.80s → 1.49s
- `test_trace_call_query_filter_wb_user_ids`: 14.54s → 1.55s
- `test_calls_query_ordering_with_costs_comprehensive`: 11.67s → 0.07s
- `test_sort_by_feedback`: 7.37s → 0.04s