### PR TITLE
chore(weave): Add tool call auto-retry, compact events support to pi-coding-agent

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -155,6 +155,7 @@
     "uuidv7": "^1.0.1"
   },
   "devDependencies": {
+    "@opentelemetry/sdk-trace-base": "^1.26.0",
     "@types/cli-progress": "^3.11.6",
     "@types/ini": "^1.3.3",
     "@types/jest": "^29.5.13",

--- a/sdks/node/pnpm-lock.yaml
+++ b/sdks/node/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
         specifier: ^1.0.1
         version: 1.0.2
     devDependencies:
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.26.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
       '@types/cli-progress':
         specifier: ^3.11.6
         version: 3.11.6
@@ -513,6 +516,28 @@ packages:
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
+
+  '@opentelemetry/core@1.30.1':
+    resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/resources@1.30.1':
+    resolution: {integrity: sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.30.1':
+    resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/semantic-conventions@1.28.0':
+    resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
+    engines: {node: '>=14'}
 
   '@shikijs/engine-oniguruma@3.4.2':
     resolution: {integrity: sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==}
@@ -2489,6 +2514,26 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
 
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/semantic-conventions@1.28.0': {}
 
   '@shikijs/engine-oniguruma@3.4.2':
     dependencies:

--- a/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
@@ -1,0 +1,483 @@
+import {SpanKind, SpanStatusCode} from '@opentelemetry/api';
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+
+import {PiCodingAgentOtelAdapter} from '../../integrations/piCodingAgent';
+import type {
+  PiExtensionApi,
+  PiExtensionContext,
+} from '../../integrations/piCodingAgent.types';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function makeExporterAndAdapter(opts: {captureContent?: boolean} = {}): {
+  exporter: InMemorySpanExporter;
+  emit: EmitFn;
+} {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new SimpleSpanProcessor(exporter)],
+  });
+  const adapter = new PiCodingAgentOtelAdapter({
+    tracer: provider.getTracer('test'),
+    ...opts,
+  });
+
+  const handlers = new Map<string, (event: any, ctx: any) => any>();
+  const pi: PiExtensionApi = {
+    on(type, handler) {
+      handlers.set(type, handler as any);
+    },
+  };
+  adapter.asExtension().setup(pi);
+
+  const emit: EmitFn = (type, event = {}, ctx = DEFAULT_CTX) =>
+    handlers.get(type)?.({type, ...event}, ctx);
+
+  return {exporter, emit};
+}
+
+type EmitFn = (
+  type: string,
+  event?: Record<string, unknown>,
+  ctx?: PiExtensionContext
+) => void;
+
+const DEFAULT_CTX: PiExtensionContext = {
+  cwd: '/home/user/project',
+  model: {id: 'claude-3-5-sonnet-20241022', provider: 'anthropic'},
+  sessionManager: {getSessionId: () => 'test-session-id'},
+};
+
+const MOCK_USAGE = {
+  input: 100,
+  output: 50,
+  cacheRead: 10,
+  cacheWrite: 5,
+  totalTokens: 150,
+  cost: {total: 0.0015},
+};
+
+const MOCK_ASSISTANT_MSG = {
+  role: 'assistant',
+  model: 'claude-3-5-sonnet-20241022',
+  provider: 'anthropic',
+  usage: MOCK_USAGE,
+  stopReason: 'stop',
+  content: [{type: 'text', text: 'Hello!'}],
+};
+
+// Fire the standard session → invoke_agent preamble
+function startSession(emit: EmitFn, ctx = DEFAULT_CTX) {
+  emit('session_start', {reason: 'initial'}, ctx);
+}
+
+function startInvoke(emit: EmitFn, prompt = 'hello', ctx = DEFAULT_CTX) {
+  startSession(emit, ctx);
+  emit('before_agent_start', {prompt, systemPrompt: 'be helpful'}, ctx);
+}
+
+function startTurn(emit: EmitFn, ctx = DEFAULT_CTX) {
+  startInvoke(emit, 'hello', ctx);
+  emit('turn_start', {turnIndex: 0, timestamp: Date.now()}, ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('PiCodingAgentOtelAdapter', () => {
+  // ── Session span ──────────────────────────────────────────────────────────
+
+  describe('session span', () => {
+    it('starts with correct attributes', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startSession(emit);
+      emit('session_shutdown');
+
+      const span = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'pi.coding_agent.session');
+      expect(span).toBeDefined();
+      expect(span!.kind).toBe(SpanKind.INTERNAL);
+      expect(span!.attributes['gen_ai.agent.name']).toBe('pi-coding-agent');
+      expect(span!.attributes['gen_ai.conversation.id']).toBe(
+        'test-session-id'
+      );
+      expect(span!.attributes['pi.session.cwd']).toBe('/home/user/project');
+    });
+
+    it('is ended by session_shutdown', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startSession(emit);
+      expect(exporter.getFinishedSpans()).toHaveLength(0);
+      emit('session_shutdown');
+      expect(
+        exporter
+          .getFinishedSpans()
+          .find(s => s.name === 'pi.coding_agent.session')
+      ).toBeDefined();
+    });
+  });
+
+  // ── invoke_agent span ─────────────────────────────────────────────────────
+
+  describe('invoke_agent span', () => {
+    it('has correct attributes and is a child of the session span', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startInvoke(emit);
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const spans = exporter.getFinishedSpans();
+      const session = spans.find(s => s.name === 'pi.coding_agent.session')!;
+      const invoke = spans.find(
+        s => s.name === 'invoke_agent pi-coding-agent'
+      )!;
+      expect(invoke.parentSpanId).toBe(session.spanContext().spanId);
+      expect(invoke.attributes['gen_ai.provider.name']).toBe('anthropic');
+      expect(invoke.attributes['gen_ai.conversation.id']).toBe(
+        'test-session-id'
+      );
+    });
+
+    it('adds gen_ai.user.message event when captureContent is true', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startInvoke(emit, 'what time is it?');
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const invoke = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'invoke_agent pi-coding-agent')!;
+      expect(invoke.events).toHaveLength(2);
+      expect(invoke.events[0].name).toBe('gen_ai.system.message');
+
+      expect(invoke.events[1].name).toBe('gen_ai.user.message');
+      const userContent = JSON.parse(
+        invoke.events[1].attributes!['gen_ai.event.content'] as string
+      );
+      expect(userContent.content).toBe('what time is it?');
+    });
+
+    it('omits event content when captureContent is false', () => {
+      const {exporter, emit} = makeExporterAndAdapter({captureContent: false});
+      startInvoke(emit, 'what time is it?');
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const invoke = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'invoke_agent pi-coding-agent')!;
+      expect(invoke.events).toHaveLength(0);
+    });
+
+    it('aggregates usage across multiple turns', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startInvoke(emit);
+
+      // Turn 1
+      emit('turn_start', {turnIndex: 0, timestamp: Date.now()});
+      emit('turn_end', {
+        turnIndex: 0,
+        message: {
+          ...MOCK_ASSISTANT_MSG,
+          usage: {
+            input: 100,
+            output: 50,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 150,
+            cost: {total: 0.001},
+          },
+        },
+      });
+
+      // Turn 2
+      emit('turn_start', {turnIndex: 1, timestamp: Date.now()});
+      emit('turn_end', {
+        turnIndex: 1,
+        message: {
+          ...MOCK_ASSISTANT_MSG,
+          usage: {
+            input: 200,
+            output: 80,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 280,
+            cost: {total: 0.002},
+          },
+        },
+      });
+
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const invoke = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'invoke_agent pi-coding-agent')!;
+      expect(invoke.attributes['gen_ai.usage.input_tokens']).toBe(300);
+      expect(invoke.attributes['gen_ai.usage.output_tokens']).toBe(130);
+      expect(invoke.attributes['gen_ai.usage.total_tokens']).toBe(430);
+      expect(invoke.attributes['pi.usage.cost_usd']).toBeCloseTo(0.003);
+    });
+  });
+
+  // ── chat span ─────────────────────────────────────────────────────────────
+
+  describe('chat span', () => {
+    it('has correct attributes, is a child of invoke_agent, and sets response attributes on turn_end', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startTurn(emit);
+      emit('turn_end', {turnIndex: 0, message: MOCK_ASSISTANT_MSG});
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const spans = exporter.getFinishedSpans();
+      const invoke = spans.find(
+        s => s.name === 'invoke_agent pi-coding-agent'
+      )!;
+      const chat = spans.find(s => s.name.startsWith('chat '))!;
+      expect(chat.kind).toBe(SpanKind.CLIENT);
+      expect(chat.parentSpanId).toBe(invoke.spanContext().spanId);
+      expect(chat.attributes['gen_ai.operation.name']).toBe('chat');
+      expect(chat.attributes['gen_ai.provider.name']).toBe('anthropic');
+      expect(chat.attributes['gen_ai.request.model']).toBe(
+        'claude-3-5-sonnet-20241022'
+      );
+      expect(chat.attributes['gen_ai.conversation.id']).toBe('test-session-id');
+      expect(chat.attributes['gen_ai.response.model']).toBe(
+        'claude-3-5-sonnet-20241022'
+      );
+      expect(chat.attributes['gen_ai.response.finish_reasons']).toEqual([
+        'stop',
+      ]);
+      expect(chat.attributes['gen_ai.usage.input_tokens']).toBe(100);
+      expect(chat.attributes['gen_ai.usage.output_tokens']).toBe(50);
+      expect(chat.attributes['gen_ai.usage.total_tokens']).toBe(150);
+      expect(chat.attributes['gen_ai.usage.cache_read.input_tokens']).toBe(10);
+      expect(chat.attributes['gen_ai.usage.cache_creation.input_tokens']).toBe(
+        5
+      );
+    });
+
+    it('adds gen_ai.system.message event from context', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startTurn(emit);
+      emit('context', {
+        messages: [
+          {role: 'system', content: 'You are a helpful assistant.'},
+          {role: 'user', content: 'hello'},
+        ],
+      });
+      emit('turn_end', {turnIndex: 0, message: MOCK_ASSISTANT_MSG});
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const chat = exporter
+        .getFinishedSpans()
+        .find(s => s.name.startsWith('chat '))!;
+      const sysEvent = chat.events.find(
+        e => e.name === 'gen_ai.system.message'
+      );
+      expect(sysEvent).toBeDefined();
+      const content = JSON.parse(
+        sysEvent!.attributes!['gen_ai.event.content'] as string
+      );
+      expect(content[0].role).toBe('system');
+    });
+
+    it('skips gen_ai.system.message when no system messages in context', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startTurn(emit);
+      emit('context', {messages: [{role: 'user', content: 'hello'}]});
+      emit('turn_end', {turnIndex: 0, message: MOCK_ASSISTANT_MSG});
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const chat = exporter
+        .getFinishedSpans()
+        .find(s => s.name.startsWith('chat '))!;
+      expect(
+        chat.events.find(e => e.name === 'gen_ai.system.message')
+      ).toBeUndefined();
+    });
+
+    it('adds gen_ai.assistant.message event on message_end', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startTurn(emit);
+      emit('message_end', {message: MOCK_ASSISTANT_MSG});
+      emit('turn_end', {turnIndex: 0, message: MOCK_ASSISTANT_MSG});
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const chat = exporter
+        .getFinishedSpans()
+        .find(s => s.name.startsWith('chat '))!;
+      const assistantEvent = chat.events.find(
+        e => e.name === 'gen_ai.assistant.message'
+      );
+      expect(assistantEvent).toBeDefined();
+      const content = JSON.parse(
+        assistantEvent!.attributes!['gen_ai.event.content'] as string
+      );
+      expect(content.role).toBe('assistant');
+    });
+
+    it('omits event content when captureContent is false', () => {
+      const {exporter, emit} = makeExporterAndAdapter({captureContent: false});
+      startTurn(emit);
+      emit('context', {messages: [{role: 'system', content: 'sys'}]});
+      emit('message_end', {message: MOCK_ASSISTANT_MSG});
+      emit('turn_end', {turnIndex: 0, message: MOCK_ASSISTANT_MSG});
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const chat = exporter
+        .getFinishedSpans()
+        .find(s => s.name.startsWith('chat '))!;
+      for (const event of chat.events) {
+        expect(event.attributes?.['gen_ai.event.content']).toBeUndefined();
+      }
+    });
+  });
+
+  // ── tool spans ────────────────────────────────────────────────────────────
+
+  describe('tool spans', () => {
+    it('has correct attributes, is a sibling of chat, and adds tool message event', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startTurn(emit);
+      emit('tool_call', {
+        toolCallId: 'call-1',
+        toolName: 'bash',
+        input: {cmd: 'ls'},
+      });
+      emit('tool_result', {
+        toolCallId: 'call-1',
+        toolName: 'bash',
+        content: 'file.ts',
+        isError: false,
+      });
+      emit('turn_end', {turnIndex: 0, message: MOCK_ASSISTANT_MSG});
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const spans = exporter.getFinishedSpans();
+      const invoke = spans.find(
+        s => s.name === 'invoke_agent pi-coding-agent'
+      )!;
+      const tool = spans.find(s => s.name === 'execute_tool bash')!;
+      expect(tool.kind).toBe(SpanKind.INTERNAL);
+      expect(tool.parentSpanId).toBe(invoke.spanContext().spanId);
+      expect(tool.attributes['gen_ai.tool.name']).toBe('bash');
+      expect(tool.attributes['gen_ai.tool.call.id']).toBe('call-1');
+      expect(tool.attributes['gen_ai.conversation.id']).toBe('test-session-id');
+      const toolEvent = tool.events.find(e => e.name === 'gen_ai.tool.message');
+      expect(toolEvent).toBeDefined();
+      const content = JSON.parse(
+        toolEvent!.attributes!['gen_ai.event.content'] as string
+      );
+      expect(content.content).toBe('file.ts');
+    });
+
+    it('sets error attributes on tool_result with isError', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startTurn(emit);
+      emit('tool_call', {toolCallId: 'call-1', toolName: 'bash', input: {}});
+      emit('tool_result', {
+        toolCallId: 'call-1',
+        toolName: 'bash',
+        content: 'Permission denied',
+        isError: true,
+      });
+      emit('turn_end', {turnIndex: 0, message: MOCK_ASSISTANT_MSG});
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const tool = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'execute_tool bash')!;
+      expect(tool.attributes['error.type']).toBe('tool_error');
+      expect(tool.status.code).toBe(SpanStatusCode.ERROR);
+      expect(tool.status.message).toBe('Permission denied');
+    });
+
+    it('aborts open tool spans when agent_end fires', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startTurn(emit);
+      emit('tool_call', {toolCallId: 'call-1', toolName: 'bash', input: {}});
+      // tool_result never fires — agent ends with open tool
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const tool = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'execute_tool bash')!;
+      expect(tool.attributes['error.type']).toBe('aborted');
+      expect(tool.status.code).toBe(SpanStatusCode.ERROR);
+    });
+  });
+
+  // ── compaction span ───────────────────────────────────────────────────────
+
+  describe('compaction span', () => {
+    it('emits pi.coding_agent.compaction as child of session', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startSession(emit);
+      emit('session_compact', {
+        reason: 'context_limit',
+        aborted: false,
+        willRetry: false,
+      });
+      emit('session_shutdown');
+
+      const spans = exporter.getFinishedSpans();
+      const session = spans.find(s => s.name === 'pi.coding_agent.session')!;
+      const compact = spans.find(s => s.name === 'pi.coding_agent.compaction')!;
+      expect(compact).toBeDefined();
+      expect(compact.parentSpanId).toBe(session.spanContext().spanId);
+      expect(compact.attributes['pi.compaction.reason']).toBe('context_limit');
+      expect(compact.attributes['pi.compaction.aborted']).toBe(false);
+      expect(compact.attributes['pi.compaction.will_retry']).toBe(false);
+      expect(compact.attributes['gen_ai.conversation.id']).toBe(
+        'test-session-id'
+      );
+    });
+  });
+
+  // ── auto-retry events ─────────────────────────────────────────────────────
+
+  describe('auto-retry events', () => {
+    it('adds auto_retry_start and auto_retry_end events to invoke_agent span', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
+      startInvoke(emit);
+      emit('auto_retry_start', {
+        attempt: 1,
+        maxAttempts: 3,
+        errorMessage: 'rate limit',
+      });
+      emit('auto_retry_end', {success: true, attempt: 1});
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const invoke = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'invoke_agent pi-coding-agent')!;
+      const retryStart = invoke.events.find(e => e.name === 'auto_retry_start');
+      const retryEnd = invoke.events.find(e => e.name === 'auto_retry_end');
+      expect(retryStart).toBeDefined();
+      expect(retryStart!.attributes!['auto_retry.attempt']).toBe(1);
+      expect(retryStart!.attributes!['auto_retry.error_message']).toBe(
+        'rate limit'
+      );
+      expect(retryEnd).toBeDefined();
+      expect(retryEnd!.attributes!['auto_retry.success']).toBe(true);
+    });
+  });
+});

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -354,24 +354,84 @@ export class PiCodingAgentOtelAdapter {
   };
 
   private onToolCall = (
-    _event: Extract<PiExtensionEvent, {type: 'tool_call'}>
-  ): void => {};
+    event: Extract<PiExtensionEvent, {type: 'tool_call'}>
+  ): void => {
+    const span = this.tracer.startSpan(
+      `execute_tool ${event.toolName}`,
+      {
+        kind: SpanKind.INTERNAL,
+        attributes: {
+          [ATTR.GEN_AI_OPERATION_NAME]: 'execute_tool',
+          [ATTR.GEN_AI_TOOL_NAME]: event.toolName,
+          [ATTR.GEN_AI_TOOL_CALL_ID]: event.toolCallId,
+          ...(this.conversationId
+            ? {[ATTR.GEN_AI_CONVERSATION_ID]: this.conversationId}
+            : {}),
+        },
+      },
+      this.invokeAgentCtx
+    );
+    this.toolSpans.set(event.toolCallId, span);
+  };
 
   private onToolResult = (
-    _event: Extract<PiExtensionEvent, {type: 'tool_result'}>
-  ): void => {};
+    event: Extract<PiExtensionEvent, {type: 'tool_result'}>
+  ): void => {
+    const span = this.toolSpans.get(event.toolCallId);
+    if (!span) return;
+    this.toolSpans.delete(event.toolCallId);
+    if (event.isError) {
+      span.setAttribute(ATTR.ERROR_TYPE, 'tool_error');
+      span.setStatus({code: SpanStatusCode.ERROR});
+    }
+    if (this.captureContent) {
+      span.addEvent('gen_ai.tool.message', {
+        'gen_ai.event.content': JSON.stringify({role: 'tool', content: event.content}),
+      });
+    }
+    span.end();
+  };
 
   private onSessionCompact = (
-    _event: Extract<PiExtensionEvent, {type: 'session_compact'}>
-  ): void => {};
+    event: Extract<PiExtensionEvent, {type: 'session_compact'}>
+  ): void => {
+    const span = this.tracer.startSpan(
+      'pi.coding_agent.compaction',
+      {
+        kind: SpanKind.INTERNAL,
+        attributes: {
+          [ATTR.PI_COMPACTION_REASON]: event.reason,
+          [ATTR.PI_COMPACTION_ABORTED]: event.aborted,
+          [ATTR.PI_COMPACTION_WILL_RETRY]: event.willRetry,
+          ...(this.conversationId
+            ? {[ATTR.GEN_AI_CONVERSATION_ID]: this.conversationId}
+            : {}),
+        },
+      },
+      this.sessionCtx
+    );
+    span.end();
+  };
 
   private onAutoRetryStart = (
-    _event: Extract<PiExtensionEvent, {type: 'auto_retry_start'}>
-  ): void => {};
+    event: Extract<PiExtensionEvent, {type: 'auto_retry_start'}>
+  ): void => {
+    this.invokeAgentSpan?.addEvent('auto_retry_start', {
+      'auto_retry.attempt': event.attempt,
+      'auto_retry.max_attempts': event.maxAttempts,
+      'auto_retry.error_message': event.errorMessage,
+    });
+  };
 
   private onAutoRetryEnd = (
-    _event: Extract<PiExtensionEvent, {type: 'auto_retry_end'}>
-  ): void => {};
+    event: Extract<PiExtensionEvent, {type: 'auto_retry_end'}>
+  ): void => {
+    this.invokeAgentSpan?.addEvent('auto_retry_end', {
+      'auto_retry.success': event.success,
+      'auto_retry.attempt': event.attempt,
+      ...(event.finalError ? {'auto_retry.final_error': event.finalError} : {}),
+    });
+  };
 
   // ---------------------------------------------------------------------------
   // Span lifecycle helpers

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -382,11 +382,20 @@ export class PiCodingAgentOtelAdapter {
     this.toolSpans.delete(event.toolCallId);
     if (event.isError) {
       span.setAttribute(ATTR.ERROR_TYPE, 'tool_error');
-      span.setStatus({code: SpanStatusCode.ERROR});
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message:
+          typeof event.content === 'string'
+            ? event.content
+            : JSON.stringify(event.content),
+      });
     }
     if (this.captureContent) {
-      span.addEvent('gen_ai.tool.message', {
-        'gen_ai.event.content': JSON.stringify({role: 'tool', content: event.content}),
+      span.addEvent(GEN_AI_EVENT.TOOL_MESSAGE, {
+        [GEN_AI_EVENT.CONTENT_ATTR]: JSON.stringify({
+          role: 'tool',
+          content: event.content,
+        }),
       });
     }
     span.end();
@@ -417,9 +426,9 @@ export class PiCodingAgentOtelAdapter {
     event: Extract<PiExtensionEvent, {type: 'auto_retry_start'}>
   ): void => {
     this.invokeAgentSpan?.addEvent('auto_retry_start', {
-      'auto_retry.attempt': event.attempt,
-      'auto_retry.max_attempts': event.maxAttempts,
-      'auto_retry.error_message': event.errorMessage,
+      [ATTR.PI_AUTO_RETRY_ATTEMPT]: event.attempt,
+      [ATTR.PI_AUTO_RETRY_MAX_ATTEMPTS]: event.maxAttempts,
+      [ATTR.PI_AUTO_RETRY_ERROR_MESSAGE]: event.errorMessage,
     });
   };
 
@@ -427,9 +436,11 @@ export class PiCodingAgentOtelAdapter {
     event: Extract<PiExtensionEvent, {type: 'auto_retry_end'}>
   ): void => {
     this.invokeAgentSpan?.addEvent('auto_retry_end', {
-      'auto_retry.success': event.success,
-      'auto_retry.attempt': event.attempt,
-      ...(event.finalError ? {'auto_retry.final_error': event.finalError} : {}),
+      [ATTR.PI_AUTO_RETRY_SUCCESS]: event.success,
+      [ATTR.PI_AUTO_RETRY_ATTEMPT]: event.attempt,
+      ...(event.finalError
+        ? {[ATTR.PI_AUTO_RETRY_FINAL_ERROR]: event.finalError}
+        : {}),
     });
   };
 


### PR DESCRIPTION
## Description

<!--
Include reference to internal ticket "Fixes WB-NNNNN" and/or GitHub issue "Fixes #NNNN" (if applicable)
-->

Implements OpenTelemetry tracing for Pi Coding Agent tool execution and session management events. Adds span creation and tracking for tool calls with proper attributes including tool name, call ID, and conversation ID. Implements tool result handling with error status tracking and content capture. Adds session compaction tracing with reason, abort status, and retry information. Implements auto-retry event tracking with attempt counts, error messages, and success status.

## Testing

TBD