### PR TITLE
chore(weave): allows the pi-coding-agent to automatically send OTEL spans to the weave endpoint

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -140,10 +140,8 @@
     "ext": "ts,json",
     "exec": "tsx examples/evaluate.ts"
   },
-  "peerDependencies": {
-    "@opentelemetry/api": "^1.9.1"
-  },
   "dependencies": {
+    "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-proto": "^0.53.0",
     "@opentelemetry/resources": "^1.26.0",
     "@opentelemetry/sdk-trace-base": "^1.26.0",

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -144,6 +144,9 @@
     "@opentelemetry/api": "^1.9.1"
   },
   "dependencies": {
+    "@opentelemetry/exporter-trace-otlp-proto": "^0.53.0",
+    "@opentelemetry/resources": "^1.26.0",
+    "@opentelemetry/sdk-trace-base": "^1.26.0",
     "cli-progress": "^3.12.0",
     "cross-spawn": "^7.0.5",
     "form-data": "^4.0.4",
@@ -155,7 +158,6 @@
     "uuidv7": "^1.0.1"
   },
   "devDependencies": {
-    "@opentelemetry/sdk-trace-base": "^1.26.0",
     "@types/cli-progress": "^3.11.6",
     "@types/ini": "^1.3.3",
     "@types/jest": "^29.5.13",

--- a/sdks/node/pnpm-lock.yaml
+++ b/sdks/node/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       '@opentelemetry/api':
         specifier: ^1.9.1
         version: 1.9.1
+      '@opentelemetry/exporter-trace-otlp-proto':
+        specifier: ^0.53.0
+        version: 0.53.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources':
+        specifier: ^1.26.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base':
+        specifier: ^1.26.0
+        version: 1.30.1(@opentelemetry/api@1.9.1)
       cli-progress:
         specifier: ^3.12.0
         version: 3.12.0
@@ -39,9 +48,6 @@ importers:
         specifier: ^1.0.1
         version: 1.0.2
     devDependencies:
-      '@opentelemetry/sdk-trace-base':
-        specifier: ^1.26.0
-        version: 1.30.1(@opentelemetry/api@1.9.1)
       '@types/cli-progress':
         specifier: ^3.11.6
         version: 3.11.6
@@ -513,12 +519,46 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@opentelemetry/api-logs@0.53.0':
+    resolution: {integrity: sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/api@1.9.1':
     resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
     engines: {node: '>=8.0.0'}
 
+  '@opentelemetry/core@1.26.0':
+    resolution: {integrity: sha512-1iKxXXE8415Cdv0yjG3G6hQnB5eVEsJce3QaawX8SjDn0mAS0ZM8fAbZZJD4ajvhC15cePvosSCut404KrIIvQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/core@1.30.1':
     resolution: {integrity: sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
+  '@opentelemetry/exporter-trace-otlp-proto@0.53.0':
+    resolution: {integrity: sha512-T/bdXslwRKj23S96qbvGtaYOdfyew3TjPEKOk5mHjkCmkVl1O9C/YMdejwSsdLdOq2YW30KjR9kVi0YMxZushQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/otlp-exporter-base@0.53.0':
+    resolution: {integrity: sha512-UCWPreGQEhD6FjBaeDuXhiMf6kkBODF0ZQzrk/tuQcaVDJ+dDQ/xhJp192H9yWnKxVpEjFrSSLnpqmX4VwX+eA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.0.0
+
+  '@opentelemetry/otlp-transformer@0.53.0':
+    resolution: {integrity: sha512-rM0sDA9HD8dluwuBxLetUmoqGJKSAbWenwD65KY9iZhUxdBHRLrIdrABfNDP7aiTjcgK8XFyTn5fhDz7N+W6DA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.3.0
+
+  '@opentelemetry/resources@1.26.0':
+    resolution: {integrity: sha512-CPNYchBE7MBecCSVy0HKpUISEeJOniWqcHaAHpmasZ3j9o6V3AyBzhRc90jdmemq0HOxDr6ylhUbDhBqqPpeNw==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -529,15 +569,67 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/sdk-logs@0.53.0':
+    resolution: {integrity: sha512-dhSisnEgIj/vJZXZV6f6KcTnyLDx/VuQ6l3ejuZpMpPlh9S1qMHiZU9NMmOkVkwwHkMy3G6mEBwdP23vUZVr4g==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.4.0 <1.10.0'
+
+  '@opentelemetry/sdk-metrics@1.26.0':
+    resolution: {integrity: sha512-0SvDXmou/JjzSDOjUmetAAvcKQW6ZrvosU0rkbDGpXvvZN+pQF6JbK/Kd4hNdK4q/22yeruqvukXEJyySTzyTQ==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.3.0 <1.10.0'
+
+  '@opentelemetry/sdk-trace-base@1.26.0':
+    resolution: {integrity: sha512-olWQldtvbK4v22ymrKLbIcBi9L2SpMO84sCPY54IVsJhP9fRsxJT194C/AVaAuJzLE30EdhhM1VmvVYR7az+cw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      '@opentelemetry/api': '>=1.0.0 <1.10.0'
+
   '@opentelemetry/sdk-trace-base@1.30.1':
     resolution: {integrity: sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==}
     engines: {node: '>=14'}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
+  '@opentelemetry/semantic-conventions@1.27.0':
+    resolution: {integrity: sha512-sAay1RrB+ONOem0OZanAR1ZI/k7yDpnOQSQmTMuGImUQb2y8EbSaCJ94FQluM74xoU03vlb2d2U90hZluL6nQg==}
+    engines: {node: '>=14'}
+
   '@opentelemetry/semantic-conventions@1.28.0':
     resolution: {integrity: sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==}
     engines: {node: '>=14'}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@shikijs/engine-oniguruma@3.4.2':
     resolution: {integrity: sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==}
@@ -1418,6 +1510,9 @@ packages:
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1649,6 +1744,10 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
 
   punycode.js@2.3.1:
     resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
@@ -2513,18 +2612,79 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  '@opentelemetry/api-logs@0.53.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+
   '@opentelemetry/api@1.9.1': {}
+
+  '@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/semantic-conventions': 1.27.0
 
   '@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.28.0
 
+  '@opentelemetry/exporter-trace-otlp-proto@0.53.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.53.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.53.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-exporter-base@0.53.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.53.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/otlp-transformer@0.53.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.53.0
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.53.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 1.26.0(@opentelemetry/api@1.9.1)
+      protobufjs: 7.5.4
+
+  '@opentelemetry/resources@1.26.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.27.0
+
   '@opentelemetry/resources@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
+
+  '@opentelemetry/sdk-logs@0.53.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/api-logs': 0.53.0
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-metrics@1.26.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.1)
+
+  '@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.1)':
+    dependencies:
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 1.26.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/semantic-conventions': 1.27.0
 
   '@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -2533,7 +2693,32 @@ snapshots:
       '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.28.0
 
+  '@opentelemetry/semantic-conventions@1.27.0': {}
+
   '@opentelemetry/semantic-conventions@1.28.0': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@shikijs/engine-oniguruma@3.4.2':
     dependencies:
@@ -3617,6 +3802,8 @@ snapshots:
 
   lodash@4.17.21: {}
 
+  long@5.3.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -3868,6 +4055,21 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 22.14.1
+      long: 5.3.2
 
   punycode.js@2.3.1: {}
 

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -21,6 +21,7 @@ export {
   createOpenAIAgentsTracingProcessor,
   instrumentOpenAIAgents,
   patchRealtimeSession,
+  createOtelExtension,
 } from './integrations';
 export {weaveAudio, weaveImage, WeaveAudio, WeaveImage} from './media';
 export {op} from './op';

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -412,7 +412,10 @@ export class PiCodingAgentOtelAdapter {
           [ATTR.PI_USAGE_COST_USD]: usage.cost.total,
         });
 
-        if (event.message.stopReason === 'error' && event.message.errorMessage) {
+        if (
+          event.message.stopReason === 'error' &&
+          event.message.errorMessage
+        ) {
           this.chatSpan.setAttribute(ATTR.ERROR_TYPE, 'llm_error');
           this.chatSpan.setStatus({
             code: SpanStatusCode.ERROR,

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -8,14 +8,17 @@
  * Usage:
  * ```typescript
  * import { init } from 'weave';
- * import { createAgentSession } from '@mariozechner/pi-coding-agent';
  * import { createOtelExtension } from 'weave';
+ * import { createAgentSession, DefaultResourceLoader } from '@mariozechner/pi-coding-agent';
  *
  * await init('my-entity/my-project');
  *
- * const session = await createAgentSession({
- *   extensions: [createOtelExtension()],
+ * const resourceLoader = new DefaultResourceLoader({
+ *   extensionFactories: [createOtelExtension()],
  * });
+ * await resourceLoader.reload();
+ *
+ * const { session } = await createAgentSession({ resourceLoader });
  * ```
  */
 
@@ -32,7 +35,7 @@ import {OTLPTraceExporter} from '@opentelemetry/exporter-trace-otlp-proto';
 import {Resource} from '@opentelemetry/resources';
 import {
   BasicTracerProvider,
-  BatchSpanProcessor,
+  SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 
 import {getGlobalClient} from '../clientApi';
@@ -152,16 +155,11 @@ export class PiCodingAgentOtelAdapter {
   private agentTotalTokens = 0;
   private agentCostUsd = 0;
 
-  // Private TracerProvider created when auto-configuring from the Weave global client.
-  // null when the user supplied their own tracer or no Weave client is initialised.
-  private readonly privateProvider: BasicTracerProvider | null;
-
   constructor(opts: OtelExtensionOptions = {}) {
     this.captureContent = opts.captureContent ?? true;
 
     if (opts.tracer) {
       this.tracer = opts.tracer;
-      this.privateProvider = null;
     } else {
       const client = getGlobalClient();
       if (client) {
@@ -177,7 +175,7 @@ export class PiCodingAgentOtelAdapter {
               'wandb.project': project,
             }),
             spanProcessors: [
-              new BatchSpanProcessor(
+              new SimpleSpanProcessor(
                 new OTLPTraceExporter({
                   url: endpoint,
                   headers: {
@@ -189,14 +187,25 @@ export class PiCodingAgentOtelAdapter {
             ],
           });
 
-          this.privateProvider = provider;
           this.tracer = provider.getTracer('pi-coding-agent-weave-ext');
+
+          // Ensure all spans are flushed before the process exits.
+          // The pi agent doesn't await async shutdown handlers, so
+          // endSessionSpan may not complete. This hook catches the
+          // event loop draining and flushes any remaining spans.
+          process.once('beforeExit', async () => {
+            this.endInvokeAgentSpan();
+            if (this.sessionSpan) {
+              this.sessionSpan.end();
+              this.sessionSpan = null;
+              this.sessionCtx = ROOT_CONTEXT;
+            }
+            await provider.shutdown().catch(() => {});
+          });
         } catch {
-          this.privateProvider = null;
           this.tracer = trace.getTracer('pi-coding-agent-weave-ext');
         }
       } else {
-        this.privateProvider = null;
         this.tracer = trace.getTracer('pi-coding-agent-weave-ext');
       }
     }
@@ -252,8 +261,8 @@ export class PiCodingAgentOtelAdapter {
     this.sessionCtx = trace.setSpan(ROOT_CONTEXT, this.sessionSpan);
   };
 
-  private onSessionShutdown = async (): Promise<void> => {
-    await this.endSessionSpan();
+  private onSessionShutdown = (): void => {
+    this.endSessionSpan();
   };
 
   private onModelSelect = (
@@ -402,6 +411,14 @@ export class PiCodingAgentOtelAdapter {
           [ATTR.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]: usage.cacheWrite,
           [ATTR.PI_USAGE_COST_USD]: usage.cost.total,
         });
+
+        if (event.message.stopReason === 'error' && event.message.errorMessage) {
+          this.chatSpan.setAttribute(ATTR.ERROR_TYPE, 'llm_error');
+          this.chatSpan.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: event.message.errorMessage,
+          });
+        }
       }
     }
     this.endChatSpan();
@@ -533,15 +550,12 @@ export class PiCodingAgentOtelAdapter {
     }
   }
 
-  private async endSessionSpan(): Promise<void> {
+  private endSessionSpan(): void {
     this.endInvokeAgentSpan();
     if (this.sessionSpan) {
       this.sessionSpan.end();
       this.sessionSpan = null;
       this.sessionCtx = ROOT_CONTEXT;
-    }
-    if (this.privateProvider) {
-      await this.privateProvider.shutdown().catch(() => {});
     }
   }
 }
@@ -560,15 +574,16 @@ export class PiCodingAgentOtelAdapter {
  *
  * @example
  * ```typescript
- * const session = await createAgentSession({
- *   extensions: [createOtelExtension()],
+ * const resourceLoader = new DefaultResourceLoader({
+ *   extensionFactories: [createOtelExtension()],
  * });
  * ```
  */
 export function createOtelExtension(
   opts: OtelExtensionOptions = {}
-): PiExtensionDefinition {
-  return new PiCodingAgentOtelAdapter(opts).asExtension();
+): (pi: PiExtensionApi) => void {
+  const {setup} = new PiCodingAgentOtelAdapter(opts).asExtension();
+  return setup;
 }
 
 // Re-export types for consumers

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -28,6 +28,15 @@ import {
   SpanStatusCode,
   trace,
 } from '@opentelemetry/api';
+import {OTLPTraceExporter} from '@opentelemetry/exporter-trace-otlp-proto';
+import {Resource} from '@opentelemetry/resources';
+import {
+  BasicTracerProvider,
+  BatchSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+
+import {getGlobalClient} from '../clientApi';
+import {getWandbConfigs} from '../wandb/settings';
 
 import {GEN_AI_ATTR, GEN_AI_EVENT, OTEL_ATTR} from './common/genai';
 
@@ -143,9 +152,54 @@ export class PiCodingAgentOtelAdapter {
   private agentTotalTokens = 0;
   private agentCostUsd = 0;
 
+  // Private TracerProvider created when auto-configuring from the Weave global client.
+  // null when the user supplied their own tracer or no Weave client is initialised.
+  private readonly privateProvider: BasicTracerProvider | null;
+
   constructor(opts: OtelExtensionOptions = {}) {
-    this.tracer = opts.tracer ?? trace.getTracer('pi-coding-agent-weave-ext');
     this.captureContent = opts.captureContent ?? true;
+
+    if (opts.tracer) {
+      this.tracer = opts.tracer;
+      this.privateProvider = null;
+    } else {
+      const client = getGlobalClient();
+      if (client) {
+        try {
+          const [entity, project] = client.projectId.split('/');
+          const {apiKey} = getWandbConfigs();
+          const endpoint = `${client.traceServerApi.baseUrl}/otel/v1/traces`;
+
+          const authHeader = `Basic ${Buffer.from(`api:${apiKey}`).toString('base64')}`;
+          const provider = new BasicTracerProvider({
+            resource: new Resource({
+              'wandb.entity': entity,
+              'wandb.project': project,
+            }),
+            spanProcessors: [
+              new BatchSpanProcessor(
+                new OTLPTraceExporter({
+                  url: endpoint,
+                  headers: {
+                    Authorization: authHeader,
+                    project_id: client.projectId,
+                  },
+                })
+              ),
+            ],
+          });
+
+          this.privateProvider = provider;
+          this.tracer = provider.getTracer('pi-coding-agent-weave-ext');
+        } catch {
+          this.privateProvider = null;
+          this.tracer = trace.getTracer('pi-coding-agent-weave-ext');
+        }
+      } else {
+        this.privateProvider = null;
+        this.tracer = trace.getTracer('pi-coding-agent-weave-ext');
+      }
+    }
   }
 
   /** Returns a pi extension definition for use with createAgentSession({ extensions: [...] }). */
@@ -198,8 +252,8 @@ export class PiCodingAgentOtelAdapter {
     this.sessionCtx = trace.setSpan(ROOT_CONTEXT, this.sessionSpan);
   };
 
-  private onSessionShutdown = (): void => {
-    this.endSessionSpan();
+  private onSessionShutdown = async (): Promise<void> => {
+    await this.endSessionSpan();
   };
 
   private onModelSelect = (
@@ -479,12 +533,15 @@ export class PiCodingAgentOtelAdapter {
     }
   }
 
-  private endSessionSpan(): void {
+  private async endSessionSpan(): Promise<void> {
     this.endInvokeAgentSpan();
     if (this.sessionSpan) {
       this.sessionSpan.end();
       this.sessionSpan = null;
       this.sessionCtx = ROOT_CONTEXT;
+    }
+    if (this.privateProvider) {
+      await this.privateProvider.shutdown().catch(() => {});
     }
   }
 }

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -200,12 +200,24 @@ export class PiCodingAgentOtelAdapter {
               this.sessionSpan = null;
               this.sessionCtx = ROOT_CONTEXT;
             }
-            await provider.shutdown().catch(() => {});
+            await provider.shutdown().catch(err => {
+              console.warn(
+                '[weave] OTEL provider shutdown failed; some spans may not have been flushed.',
+                err instanceof Error ? err.message : err
+              );
+            });
           });
-        } catch {
+        } catch (err) {
+          console.warn(
+            '[weave] OTEL auto-configure failed; spans will not be sent. Check WANDB_API_KEY.',
+            err instanceof Error ? err.message : err
+          );
           this.tracer = trace.getTracer('pi-coding-agent-weave-ext');
         }
       } else {
+        console.warn(
+          '[weave] No Weave client; spans will not be sent. Call weave.init() first or pass { tracer }.'
+        );
         this.tracer = trace.getTracer('pi-coding-agent-weave-ext');
       }
     }


### PR DESCRIPTION
## Description

This PR adds OpenTelemetry trace export capabilities to the Pi Coding Agent integration. The implementation automatically configures an OTLP trace exporter when a Weave global client is available, enabling traces to be sent to the Weave trace server automatically without needing a user sets up https://docs.wandb.ai/weave/guides/integrations/pydantic_ai#configure-otel-tracing-in-weave.

Key changes:

- Added OpenTelemetry dependencies: `@opentelemetry/exporter-trace-otlp-proto`, `@opentelemetry/resources`, and `@opentelemetry/sdk-trace-base (These are must-haves, because the client appplication does not necessarily install them into the runtime)`
- Enhanced `PiCodingAgentOtelAdapter` to auto-configure a `BasicTracerProvider` with OTLP export when no custom tracer is provided
- Configured the exporter to send traces to the Weave trace server endpoint with proper authentication headers
- Added proper cleanup by shutting down the private provider during session shutdown
- Made session shutdown asynchronous to handle the provider shutdown properly

The adapter now falls back gracefully: if a custom tracer is provided, it uses that; if a Weave client exists, it auto-configures OTLP export; otherwise, it uses the global tracer.

## Testing

TBD
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wandb/weave/pull/6613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
