### PR TITLE
fix(weave): add provider hostname and header sanitization

### DIFF
--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -1748,6 +1748,13 @@ def test_provider_base_url_validation():
     )
     assert "X-Custom-Header" in p.extra_headers
 
+    # Validation also runs on assignment, not just init
+    p = _make_provider("https://api.example.com")
+    with pytest.raises(ValidationError):
+        p.base_url = "http://169.254.169.254/v1"
+    with pytest.raises(ValidationError):
+        p.extra_headers = {"Metadata-Flavor": "Google"}
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from weave.trace_server import clickhouse_trace_server_batched as chts
 from weave.trace_server import trace_server_interface as tsi
@@ -12,6 +13,7 @@ from weave.trace_server.errors import (
     MissingLLMApiKeyError,
     NotFoundError,
 )
+from weave.trace_server.interface.builtin_object_classes.provider import Provider
 from weave.trace_server.llm_completion import get_custom_provider_info
 from weave.trace_server.project_version.types import WriteTarget
 from weave.trace_server.secret_fetcher_context import (
@@ -1675,6 +1677,76 @@ def test_streaming_completions_error_routes_correctly(
 
         assert mock_insert_complete.called == expect_complete_called
         assert mock_update_end.called == expect_update_end_called
+
+
+def _make_provider(base_url: str, extra_headers: dict | None = None):
+    return Provider(
+        name="test",
+        base_url=base_url,
+        api_key_name="MY_KEY",
+        extra_headers=extra_headers or {},
+    )
+
+
+def test_provider_base_url_validation():
+    """Verify that Provider.base_url only accepts well-formed, public HTTP(S) URLs."""
+    # Valid URLs accepted
+    p = _make_provider("https://api.openai.com/v1")
+    assert p.base_url == "https://api.openai.com/v1"
+    p = _make_provider("http://my-ollama-server.example.com:11434")
+    assert p.base_url == "http://my-ollama-server.example.com:11434"
+
+    # Non-http schemes rejected
+    with pytest.raises(ValidationError):
+        _make_provider("ftp://bad.example.com")
+    with pytest.raises(ValidationError):
+        _make_provider("file:///etc/passwd")
+
+    # Query strings, bare '?', and fragments rejected
+    with pytest.raises(ValidationError):
+        _make_provider("https://api.example.com/v1?foo=bar")
+    with pytest.raises(ValidationError):
+        _make_provider("https://api.example.com/v1#section")
+    with pytest.raises(ValidationError):
+        _make_provider("http://10.0.0.1/path?")
+
+    # Blocked hostnames rejected
+    for hostname in (
+        "metadata.google.internal",
+        "metadata.google.internal.",
+        "foo.metadata.google.internal",
+        "169.254.169.254",
+    ):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{hostname}/v1")
+
+    # Non-globally-routable IPs rejected
+    for addr in ("10.0.0.1", "172.16.0.1", "192.168.1.1", "127.0.0.1"):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{addr}/v1")
+
+    # Alternative IP encodings rejected
+    for alt_ip in ("0xa9fea9fe", "2852039166", "0x7f000001", "0"):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{alt_ip}/v1")
+
+    # IPv6 non-global addresses rejected
+    with pytest.raises(ValidationError):
+        _make_provider("http://[::1]/v1")
+    with pytest.raises(ValidationError):
+        _make_provider("http://[::ffff:169.254.169.254]/v1")
+
+    # Blocked extra_headers rejected
+    for blocked in ("Metadata-Flavor", "METADATA-FLAVOR", "X-aws-ec2-metadata-token"):
+        with pytest.raises(ValidationError):
+            _make_provider("https://api.example.com", extra_headers={blocked: "val"})
+
+    # Allowed headers accepted
+    p = _make_provider(
+        "https://api.example.com",
+        extra_headers={"X-Custom-Header": "value", "Authorization": "Bearer tok"},
+    )
+    assert "X-Custom-Header" in p.extra_headers
 
 
 if __name__ == "__main__":

--- a/weave/trace_server/interface/builtin_object_classes/provider.py
+++ b/weave/trace_server/interface/builtin_object_classes/provider.py
@@ -4,7 +4,7 @@ import socket
 from enum import Enum
 from urllib.parse import urlparse
 
-from pydantic import Field, field_validator
+from pydantic import ConfigDict, Field, field_validator
 
 from weave.trace_server.interface.builtin_object_classes import base_object_def
 
@@ -30,6 +30,9 @@ BLOCKED_HOSTNAME_RE = re.compile(
 )
 
 
+INVALID_BASE_URL_MSG = "base_url is not a valid provider URL"
+
+
 def _validate_provider_base_url(url: str) -> str:
     """Validate that a provider base_url is a well-formed, publicly-routable HTTP(S) URL.
 
@@ -38,25 +41,21 @@ def _validate_provider_base_url(url: str) -> str:
     try:
         parsed = urlparse(url)
     except Exception as exc:
-        raise ValueError(f"Invalid URL: {url!r}") from exc
+        raise ValueError(INVALID_BASE_URL_MSG) from exc
 
     if parsed.scheme not in {"http", "https"}:
-        raise ValueError(
-            f"base_url scheme must be 'http' or 'https', got {parsed.scheme!r}"
-        )
+        raise ValueError(INVALID_BASE_URL_MSG)
 
     # urlparse silently strips a bare trailing '?', so check the raw string too.
     if "?" in url or parsed.fragment:
-        raise ValueError(
-            "base_url must not contain '?', query parameters, or URL fragments"
-        )
+        raise ValueError(INVALID_BASE_URL_MSG)
 
     host = (parsed.hostname or "").lower().rstrip(".")
     if not host:
-        raise ValueError("base_url must have a valid hostname")
+        raise ValueError(INVALID_BASE_URL_MSG)
 
     if BLOCKED_HOSTNAME_RE.search(host):
-        raise ValueError(f"base_url references a blocked hostname: {host!r}")
+        raise ValueError(INVALID_BASE_URL_MSG)
 
     # Reject non-globally-routable IP addresses.  socket.inet_aton handles
     # alternative IPv4 encodings that ipaddress.ip_address does not.
@@ -72,9 +71,7 @@ def _validate_provider_base_url(url: str) -> str:
             pass  # Not any form of IP — hostname checks above are sufficient.
 
     if addr is not None and not addr.is_global:
-        raise ValueError(
-            "base_url must not reference a non-globally-routable IP address"
-        )
+        raise ValueError(INVALID_BASE_URL_MSG)
 
     return url
 
@@ -84,6 +81,8 @@ class ProviderReturnType(str, Enum):
 
 
 class Provider(base_object_def.BaseObject):
+    model_config = ConfigDict(validate_assignment=True)
+
     base_url: str
     api_key_name: str
     extra_headers: dict[str, str] = Field(default_factory=dict)
@@ -99,7 +98,7 @@ class Provider(base_object_def.BaseObject):
     def validate_extra_headers(cls, v: dict[str, str]) -> dict[str, str]:
         for key in v:
             if BLOCKED_HEADER_RE.match(key):
-                raise ValueError(f"extra_headers contains a blocked header: {key!r}")
+                raise ValueError("extra_headers contains a disallowed header")
         return v
 
 

--- a/weave/trace_server/interface/builtin_object_classes/provider.py
+++ b/weave/trace_server/interface/builtin_object_classes/provider.py
@@ -1,8 +1,82 @@
+import ipaddress
+import re
+import socket
 from enum import Enum
+from urllib.parse import urlparse
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from weave.trace_server.interface.builtin_object_classes import base_object_def
+
+# Headers that must not appear in user-supplied extra_headers.
+# https://coreweave.atlassian.net/browse/VULNMGMT-770
+BLOCKED_HEADER_RE = re.compile(
+    r"^(?:metadata-flavor"
+    r"|x-aws-ec2-metadata-token(?:-ttl-seconds)?"
+    r")$",
+    re.IGNORECASE,
+)
+
+# Hostnames that must not appear in user-supplied base_url values.
+# https://coreweave.atlassian.net/browse/VULNMGMT-770
+BLOCKED_HOSTNAME_RE = re.compile(
+    r"(?:^|\.)"
+    r"(?:metadata\.google\.internal"
+    r"|metadata\.goog"
+    r"|metadata\.internal"
+    r"|metadata\.azure\.com"
+    r")\.?$",
+    re.IGNORECASE,
+)
+
+
+def _validate_provider_base_url(url: str) -> str:
+    """Validate that a provider base_url is a well-formed, publicly-routable HTTP(S) URL.
+
+    See https://coreweave.atlassian.net/browse/VULNMGMT-770
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception as exc:
+        raise ValueError(f"Invalid URL: {url!r}") from exc
+
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(
+            f"base_url scheme must be 'http' or 'https', got {parsed.scheme!r}"
+        )
+
+    # urlparse silently strips a bare trailing '?', so check the raw string too.
+    if "?" in url or parsed.fragment:
+        raise ValueError(
+            "base_url must not contain '?', query parameters, or URL fragments"
+        )
+
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        raise ValueError("base_url must have a valid hostname")
+
+    if BLOCKED_HOSTNAME_RE.search(host):
+        raise ValueError(f"base_url references a blocked hostname: {host!r}")
+
+    # Reject non-globally-routable IP addresses.  socket.inet_aton handles
+    # alternative IPv4 encodings that ipaddress.ip_address does not.
+    addr = None
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        # Not a strict IP literal — try inet_aton for alternative IPv4 forms.
+        try:
+            packed = socket.inet_aton(host)
+            addr = ipaddress.ip_address(packed)
+        except OSError:
+            pass  # Not any form of IP — hostname checks above are sufficient.
+
+    if addr is not None and not addr.is_global:
+        raise ValueError(
+            "base_url must not reference a non-globally-routable IP address"
+        )
+
+    return url
 
 
 class ProviderReturnType(str, Enum):
@@ -14,6 +88,19 @@ class Provider(base_object_def.BaseObject):
     api_key_name: str
     extra_headers: dict[str, str] = Field(default_factory=dict)
     return_type: ProviderReturnType = Field(default=ProviderReturnType.OPENAI)
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, v: str) -> str:
+        return _validate_provider_base_url(v)
+
+    @field_validator("extra_headers")
+    @classmethod
+    def validate_extra_headers(cls, v: dict[str, str]) -> dict[str, str]:
+        for key in v:
+            if BLOCKED_HEADER_RE.match(key):
+                raise ValueError(f"extra_headers contains a blocked header: {key!r}")
+        return v
 
 
 class ProviderModel(base_object_def.BaseObject):


### PR DESCRIPTION
## Summary

- Add validation to `Provider.base_url`: enforce HTTP(S) scheme, reject query params/fragments, block cloud metadata hostnames, reject non-globally-routable IPs (including alternative encodings)
- Add validation to `Provider.extra_headers`: reject cloud metadata service headers
- Add tests covering valid/invalid URLs, blocked hostnames, private IPs, IPv6, alternative IP encodings, and blocked headers

https://coreweave.atlassian.net/browse/VULNMGMT-770
https://coreweave.atlassian.net/browse/WB-32353