### PR TITLE
fix(weave): sanitize file paths in MemTraceFilesArtifact

### DIFF
--- a/tests/trace/test_mem_artifact.py
+++ b/tests/trace/test_mem_artifact.py
@@ -1,0 +1,40 @@
+import pytest
+
+from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact
+
+
+def test_mem_artifact_path_sanitization():
+    art = MemTraceFilesArtifact(
+        path_contents={
+            "audio.wav": b"RIFF",
+            "subdir/file.txt": b"nested",
+            "/etc/passwd": b"abs",
+            "../../etc/shadow": b"traversal",
+        }
+    )
+
+    # Valid relative paths work, including nested
+    assert art.path("audio.wav").endswith("audio.wav")
+    result = art.path("subdir/file.txt")
+    assert result.endswith("subdir/file.txt")
+
+    # Absolute paths and traversals are rejected in both path() and filename override
+    with pytest.raises(ValueError, match="absolute path"):
+        art.path("/etc/passwd")
+    with pytest.raises(ValueError, match="escapes base directory"):
+        art.path("../../etc/shadow")
+    with pytest.raises(ValueError, match="absolute path"):
+        art.path("audio.wav", filename="/tmp/evil.pth")
+
+    # writeable_file_path: valid works, absolute and traversal rejected
+    with art.writeable_file_path("output.wav") as fp:
+        with open(fp, "wb") as f:
+            f.write(b"data")
+    assert art.path_contents["output.wav"] == b"data"
+
+    with pytest.raises(ValueError, match="absolute path"):
+        with art.writeable_file_path("/etc/evil"):
+            pass
+    with pytest.raises(ValueError, match="escapes base directory"):
+        with art.writeable_file_path("../../etc/evil"):
+            pass

--- a/tests/trace/test_mem_artifact.py
+++ b/tests/trace/test_mem_artifact.py
@@ -20,13 +20,15 @@ def test_mem_artifact_path_sanitization():
     result = art.path("subdir/file.txt")
     assert result.endswith(os.path.join("subdir", "file.txt"))
 
-    # Absolute paths and traversals are rejected in both path() and filename override
-    with pytest.raises(ValueError, match="absolute path|escapes base directory"):
+    # Absolute paths rejected
+    with pytest.raises(ValueError, match="absolute path"):
         art.path("/etc/passwd")
-    with pytest.raises(ValueError, match="absolute path|escapes base directory"):
-        art.path("../../etc/shadow")
-    with pytest.raises(ValueError, match="absolute path|escapes base directory"):
+    with pytest.raises(ValueError, match="absolute path"):
         art.path("audio.wav", filename="/tmp/evil.pth")
+
+    # Traversals rejected
+    with pytest.raises(ValueError, match="escapes base directory"):
+        art.path("../../etc/shadow")
 
     # writeable_file_path: valid works, absolute and traversal rejected
     with art.writeable_file_path("output.wav") as fp:
@@ -34,9 +36,9 @@ def test_mem_artifact_path_sanitization():
             f.write(b"data")
     assert art.path_contents["output.wav"] == b"data"
 
-    with pytest.raises(ValueError, match="absolute path|escapes base directory"):
+    with pytest.raises(ValueError, match="absolute path"):
         with art.writeable_file_path("/etc/evil"):
             pass
-    with pytest.raises(ValueError, match="absolute path|escapes base directory"):
+    with pytest.raises(ValueError, match="escapes base directory"):
         with art.writeable_file_path("../../etc/evil"):
             pass

--- a/tests/trace/test_mem_artifact.py
+++ b/tests/trace/test_mem_artifact.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact
@@ -16,7 +18,7 @@ def test_mem_artifact_path_sanitization():
     # Valid relative paths work, including nested
     assert art.path("audio.wav").endswith("audio.wav")
     result = art.path("subdir/file.txt")
-    assert result.endswith("subdir/file.txt")
+    assert result.endswith(os.path.join("subdir", "file.txt"))
 
     # Absolute paths and traversals are rejected in both path() and filename override
     with pytest.raises(ValueError, match="absolute path"):

--- a/tests/trace/test_mem_artifact.py
+++ b/tests/trace/test_mem_artifact.py
@@ -21,11 +21,11 @@ def test_mem_artifact_path_sanitization():
     assert result.endswith(os.path.join("subdir", "file.txt"))
 
     # Absolute paths and traversals are rejected in both path() and filename override
-    with pytest.raises(ValueError, match="absolute path"):
+    with pytest.raises(ValueError, match="absolute path|escapes base directory"):
         art.path("/etc/passwd")
-    with pytest.raises(ValueError, match="escapes base directory"):
+    with pytest.raises(ValueError, match="absolute path|escapes base directory"):
         art.path("../../etc/shadow")
-    with pytest.raises(ValueError, match="absolute path"):
+    with pytest.raises(ValueError, match="absolute path|escapes base directory"):
         art.path("audio.wav", filename="/tmp/evil.pth")
 
     # writeable_file_path: valid works, absolute and traversal rejected
@@ -34,9 +34,9 @@ def test_mem_artifact_path_sanitization():
             f.write(b"data")
     assert art.path_contents["output.wav"] == b"data"
 
-    with pytest.raises(ValueError, match="absolute path"):
+    with pytest.raises(ValueError, match="absolute path|escapes base directory"):
         with art.writeable_file_path("/etc/evil"):
             pass
-    with pytest.raises(ValueError, match="escapes base directory"):
+    with pytest.raises(ValueError, match="absolute path|escapes base directory"):
         with art.writeable_file_path("../../etc/evil"):
             pass

--- a/weave/trace/serialization/mem_artifact.py
+++ b/weave/trace/serialization/mem_artifact.py
@@ -16,6 +16,32 @@ from weave.trace.serialization import (
 # to use this interface.
 
 
+def _safe_join(base: str, untrusted_path: str) -> str:
+    """Join base and untrusted_path, ensuring the result stays within base.
+
+    Rejects absolute paths, '..' components, and any path that would resolve
+    outside of base after symlink resolution.
+    """
+    if os.path.isabs(untrusted_path):
+        raise ValueError(
+            f"Path must be relative, got absolute path: {untrusted_path!r}"
+        )
+
+    # Normalize to collapse '..' and '.' but don't resolve symlinks yet
+    normed = os.path.normpath(untrusted_path)
+    if normed.startswith("..") or normed.startswith(os.sep):
+        raise ValueError(f"Path escapes base directory: {untrusted_path!r}")
+
+    joined = os.path.join(base, normed)
+    # realpath resolves symlinks; the result must still be under base
+    resolved = os.path.realpath(joined)
+    real_base = os.path.realpath(base)
+    if not resolved.startswith(real_base + os.sep) and resolved != real_base:
+        raise ValueError(f"Path escapes base directory: {untrusted_path!r}")
+
+    return joined
+
+
 class MemTraceFilesArtifact:
     temp_read_dir: tempfile.TemporaryDirectory | None
     path_contents: dict[str, bytes]
@@ -82,7 +108,8 @@ class MemTraceFilesArtifact:
             raise FileNotFoundError(path)
 
         self.temp_read_dir = tempfile.TemporaryDirectory()
-        write_path = os.path.join(self.temp_read_dir.name, filename or path)
+        write_path = _safe_join(self.temp_read_dir.name, filename or path)
+        os.makedirs(os.path.dirname(write_path), exist_ok=True)
         with open(write_path, "wb") as f:
             f.write(self.path_contents[path])
             f.flush()
@@ -96,7 +123,7 @@ class MemTraceFilesArtifact:
     @contextlib.contextmanager
     def writeable_file_path(self, path: str) -> Generator[str]:
         with tempfile.TemporaryDirectory() as tmpdir:
-            full_path = os.path.join(tmpdir, path)
+            full_path = _safe_join(tmpdir, path)
             os.makedirs(os.path.dirname(full_path), exist_ok=True)
             yield full_path
             with open(full_path, "rb") as fp:

--- a/weave/trace/serialization/mem_artifact.py
+++ b/weave/trace/serialization/mem_artifact.py
@@ -29,7 +29,11 @@ def _safe_join(base: str, untrusted_path: str) -> str:
 
     # Normalize to collapse '..' and '.' but don't resolve symlinks yet
     normed = os.path.normpath(untrusted_path)
-    if normed.startswith("..") or normed.startswith(os.sep):
+    if normed.startswith(os.sep):
+        raise ValueError(
+            f"Path must be relative, got absolute path: {untrusted_path!r}"
+        )
+    if normed.startswith(".."):
         raise ValueError(f"Path escapes base directory: {untrusted_path!r}")
 
     joined = os.path.join(base, normed)


### PR DESCRIPTION
## Summary

- Add `_safe_join()` helper that rejects absolute paths, `..` traversal, and symlink escapes
- Apply to `MemTraceFilesArtifact.path()` and `writeable_file_path()` to ensure all file writes stay within the intended temp directory
- Add tests covering valid relative paths, absolute path rejection, traversal rejection, and filename override

https://coreweave.atlassian.net/browse/VULNMGMT-1008
https://coreweave.atlassian.net/browse/WB-32491