### PR TITLE
chore(weave): validate CustomWeaveType file path keys server-side

### DIFF
--- a/tests/trace/test_custom_type_file_key_validation.py
+++ b/tests/trace/test_custom_type_file_key_validation.py
@@ -1,0 +1,51 @@
+import pytest
+
+from weave.shared.digest import compute_object_digest_result
+
+
+def test_custom_type_file_key_validation() -> None:
+    """Validate that unsafe file path keys in CustomWeaveType nodes are rejected."""
+    # Valid keys pass through and produce a digest
+    valid_val = {
+        "_type": "CustomWeaveType",
+        "weave_type": {"type": "wave.Wave_read"},
+        "files": {
+            "audio.wav": "digest_aaa",
+            "subdir/nested.bin": "digest_bbb",
+        },
+    }
+    result = compute_object_digest_result(valid_val)
+    assert result.digest
+
+    # Absolute path key is rejected
+    abs_val = {
+        "_type": "CustomWeaveType",
+        "weave_type": {"type": "wave.Wave_read"},
+        "files": {"/etc/evil.pth": "digest_bad"},
+    }
+    with pytest.raises(ValueError, match="Invalid file path"):
+        compute_object_digest_result(abs_val)
+
+    # Path traversal key is rejected
+    traversal_val = {
+        "_type": "CustomWeaveType",
+        "weave_type": {"type": "wave.Wave_read"},
+        "files": {"../../etc/shadow": "digest_bad"},
+    }
+    with pytest.raises(ValueError, match="Invalid file path"):
+        compute_object_digest_result(traversal_val)
+
+    # Deeply nested bad key (inside list inside dict) is caught
+    nested_val = {
+        "outer": {
+            "items": [
+                {
+                    "_type": "CustomWeaveType",
+                    "weave_type": {"type": "some.Type"},
+                    "files": {"../sneaky": "digest_bad"},
+                }
+            ]
+        }
+    }
+    with pytest.raises(ValueError, match="Invalid file path"):
+        compute_object_digest_result(nested_val)

--- a/weave/shared/digest.py
+++ b/weave/shared/digest.py
@@ -18,10 +18,29 @@ from __future__ import annotations
 import base64
 import hashlib
 import json
+import os
 from dataclasses import dataclass
 from typing import Any
 
 from weave.shared.object_class_util import process_incoming_object_val
+
+CUSTOM_WEAVE_TYPE = "CustomWeaveType"
+
+
+def _validate_custom_type_file_keys(val: Any) -> None:
+    """Recursively walk val and reject unsafe file path keys in CustomWeaveType nodes."""
+    if isinstance(val, dict):
+        if val.get("_type") == CUSTOM_WEAVE_TYPE:
+            for key in val.get("files", {}):
+                if os.path.isabs(key):
+                    raise ValueError(f"Invalid file path key: {key!r}")
+                if ".." in os.path.normpath(key).split(os.sep):
+                    raise ValueError(f"Invalid file path key: {key!r}")
+        for v in val.values():
+            _validate_custom_type_file_keys(v)
+    elif isinstance(val, list):
+        for item in val:
+            _validate_custom_type_file_keys(item)
 
 
 def bytes_digest(json_val: bytes) -> str:
@@ -51,6 +70,7 @@ def compute_object_digest_result(
     val: Any, builtin_object_class: str | None = None
 ) -> ObjectDigestResult:
     """Compute the object digest using server-equivalent normalization and hashing."""
+    _validate_custom_type_file_keys(val)
     processed_result = process_incoming_object_val(val, builtin_object_class)
     processed_val = processed_result["val"]
     # Keep object digests stable regardless of dictionary insertion order.


### PR DESCRIPTION
## Summary

- Add recursive validation of `files` dict keys in `CustomWeaveType` nodes during object creation
- Reject absolute paths and path traversal sequences before storing
- Add tests

https://coreweave.atlassian.net/browse/VULNMGMT-1008
https://coreweave.atlassian.net/browse/WB-32491