### PR TITLE
fix(weave): reject CustomWeaveType payloads in evaluate model worker

### DIFF
--- a/tests/trace_server/workers/test_evaluate_model_worker.py
+++ b/tests/trace_server/workers/test_evaluate_model_worker.py
@@ -1,0 +1,78 @@
+import pytest
+
+from weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker import (
+    UnsafePayloadError,
+    _assert_safe_payload,
+)
+
+
+def test_assert_safe_payload():
+    # Safe payloads pass
+    _assert_safe_payload({"name": "test", "value": 42})
+    _assert_safe_payload({"nested": {"list": [1, "two", {"three": 3}]}})
+    _assert_safe_payload("just a string ref")
+    _assert_safe_payload(None)
+    _assert_safe_payload([1, 2, 3])
+    _assert_safe_payload({"_type": "ObjectRecord", "name": "test"})
+
+    # ALL CustomWeaveType payloads rejected — Op, unknown, and safe subtypes alike
+    with pytest.raises(UnsafePayloadError):
+        _assert_safe_payload(
+            {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "Op"},
+                "files": {"obj.py": "abc123"},
+            }
+        )
+
+    with pytest.raises(UnsafePayloadError):
+        _assert_safe_payload(
+            {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "PIL.Image.Image"},
+                "files": {"image.png": "abc123"},
+            }
+        )
+
+    with pytest.raises(UnsafePayloadError):
+        _assert_safe_payload(
+            {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "TotallyMadeUpType"},
+                "load_op": "weave:///entity/project/object/evil:abc123",
+            }
+        )
+
+    # Nested in a list
+    with pytest.raises(UnsafePayloadError):
+        _assert_safe_payload(
+            {
+                "scorers": [
+                    {
+                        "_type": "CustomWeaveType",
+                        "weave_type": {"type": "Op"},
+                    }
+                ],
+            }
+        )
+
+    # Deeply nested in dicts
+    with pytest.raises(UnsafePayloadError):
+        _assert_safe_payload(
+            {
+                "a": {
+                    "b": {
+                        "c": {
+                            "_type": "CustomWeaveType",
+                            "weave_type": {"type": "Op"},
+                        }
+                    }
+                },
+            }
+        )
+
+    # Missing/malformed weave_type still rejected
+    with pytest.raises(UnsafePayloadError):
+        _assert_safe_payload({"_type": "CustomWeaveType"})
+    with pytest.raises(UnsafePayloadError):
+        _assert_safe_payload({"_type": "CustomWeaveType", "weave_type": "not a dict"})

--- a/tests/trace_server/workers/test_evaluate_model_worker.py
+++ b/tests/trace_server/workers/test_evaluate_model_worker.py
@@ -1,23 +1,23 @@
 import pytest
 
-from weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker import (
+from weave.trace_server.validation import (
     UnsafePayloadError,
-    _assert_safe_payload,
+    assert_safe_payload,
 )
 
 
 def test_assert_safe_payload():
     # Safe payloads pass
-    _assert_safe_payload({"name": "test", "value": 42})
-    _assert_safe_payload({"nested": {"list": [1, "two", {"three": 3}]}})
-    _assert_safe_payload("just a string ref")
-    _assert_safe_payload(None)
-    _assert_safe_payload([1, 2, 3])
-    _assert_safe_payload({"_type": "ObjectRecord", "name": "test"})
+    assert_safe_payload({"name": "test", "value": 42})
+    assert_safe_payload({"nested": {"list": [1, "two", {"three": 3}]}})
+    assert_safe_payload("just a string ref")
+    assert_safe_payload(None)
+    assert_safe_payload([1, 2, 3])
+    assert_safe_payload({"_type": "ObjectRecord", "name": "test"})
 
     # ALL CustomWeaveType payloads rejected — Op, unknown, and safe subtypes alike
     with pytest.raises(UnsafePayloadError):
-        _assert_safe_payload(
+        assert_safe_payload(
             {
                 "_type": "CustomWeaveType",
                 "weave_type": {"type": "Op"},
@@ -26,7 +26,7 @@ def test_assert_safe_payload():
         )
 
     with pytest.raises(UnsafePayloadError):
-        _assert_safe_payload(
+        assert_safe_payload(
             {
                 "_type": "CustomWeaveType",
                 "weave_type": {"type": "PIL.Image.Image"},
@@ -35,7 +35,7 @@ def test_assert_safe_payload():
         )
 
     with pytest.raises(UnsafePayloadError):
-        _assert_safe_payload(
+        assert_safe_payload(
             {
                 "_type": "CustomWeaveType",
                 "weave_type": {"type": "TotallyMadeUpType"},
@@ -45,7 +45,7 @@ def test_assert_safe_payload():
 
     # Nested in a list
     with pytest.raises(UnsafePayloadError):
-        _assert_safe_payload(
+        assert_safe_payload(
             {
                 "scorers": [
                     {
@@ -58,7 +58,7 @@ def test_assert_safe_payload():
 
     # Deeply nested in dicts
     with pytest.raises(UnsafePayloadError):
-        _assert_safe_payload(
+        assert_safe_payload(
             {
                 "a": {
                     "b": {
@@ -73,6 +73,6 @@ def test_assert_safe_payload():
 
     # Missing/malformed weave_type still rejected
     with pytest.raises(UnsafePayloadError):
-        _assert_safe_payload({"_type": "CustomWeaveType"})
+        assert_safe_payload({"_type": "CustomWeaveType"})
     with pytest.raises(UnsafePayloadError):
-        _assert_safe_payload({"_type": "CustomWeaveType", "weave_type": "not a dict"})
+        assert_safe_payload({"_type": "CustomWeaveType", "weave_type": "not a dict"})

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -199,3 +199,44 @@ def validate_alias_name(name: str) -> None:
         )
     if name in _RESERVED_ALIAS_NAMES:
         raise ValueError(f"alias name '{name}' is reserved")
+
+
+# --- Server-side deserialization safety ---
+
+
+class UnsafePayloadError(ValueError):
+    """Raised when a payload contains types that are not safe for server-side deserialization."""
+
+
+def assert_safe_payload(value: Any, path: str = "root") -> None:
+    """Recursively walk a raw serialized payload and reject CustomWeaveType nodes.
+
+    CustomWeaveType payloads can trigger code execution during deserialization
+    (e.g. Op types call __import__ on user-uploaded Python files, and unknown
+    types fall back to a load_op path that does the same). None of these should
+    be deserialized in a server-side worker process.
+
+    https://coreweave.atlassian.net/browse/VULNMGMT-1007
+    """
+    if isinstance(value, list):
+        for idx, item in enumerate(value):
+            assert_safe_payload(item, f"{path}[{idx}]")
+        return
+
+    if not isinstance(value, dict):
+        return
+
+    if value.get("_type") == "CustomWeaveType":
+        weave_type = value.get("weave_type")
+        custom_type = (
+            weave_type.get("type", "unknown")
+            if isinstance(weave_type, dict)
+            else "unknown"
+        )
+        raise UnsafePayloadError(
+            f"Server-side deserialization does not allow CustomWeaveType payloads "
+            f"({custom_type} at {path})"
+        )
+
+    for key, item in value.items():
+        assert_safe_payload(item, f"{path}.{key}")

--- a/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
+++ b/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
@@ -1,6 +1,5 @@
 import asyncio
 from abc import ABC, abstractmethod
-from typing import Any
 
 import ddtrace
 from pydantic import BaseModel, ConfigDict
@@ -15,12 +14,9 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.interface.builtin_object_classes.llm_structured_model import (
     LLMStructuredCompletionModel,
 )
+from weave.trace_server.validation import assert_safe_payload
 
 EVALUATE_MODEL_WORKER_MARKER = {"_weave_eval_meta": {"evaluate_model_worker": True}}
-
-
-class UnsafePayloadError(TypeError):
-    """Raised when a ref resolves to a payload that is not safe for server-side deserialization."""
 
 
 class EvaluateModelArgs(BaseModel):
@@ -39,43 +35,6 @@ class EvaluateModelDispatcher(ABC):
         pass
 
 
-def _assert_safe_payload(value: Any, path: str = "root") -> None:
-    """Recursively walk a raw serialized payload and reject CustomWeaveType nodes.
-
-    CustomWeaveType payloads can trigger code execution during deserialization
-    (e.g. Op types call __import__ on user-uploaded Python files, and unknown
-    types fall back to a load_op path that does the same). None of these should
-    be deserialized in a server-side worker process.
-
-    https://coreweave.atlassian.net/browse/VULNMGMT-1007
-    """
-    if isinstance(value, str):
-        return
-
-    if isinstance(value, list):
-        for idx, item in enumerate(value):
-            _assert_safe_payload(item, f"{path}[{idx}]")
-        return
-
-    if not isinstance(value, dict):
-        return
-
-    if value.get("_type") == "CustomWeaveType":
-        weave_type = value.get("weave_type")
-        custom_type = (
-            weave_type.get("type", "unknown")
-            if isinstance(weave_type, dict)
-            else "unknown"
-        )
-        raise UnsafePayloadError(
-            f"Evaluate model worker does not allow CustomWeaveType payloads "
-            f"({custom_type} at {path})"
-        )
-
-    for key, item in value.items():
-        _assert_safe_payload(item, f"{path}.{key}")
-
-
 def _assert_safe_ref(client: WeaveClient, ref_uri: str, label: str) -> None:
     """Read the raw object for a ref and reject it if it contains unsafe CustomWeaveType payloads."""
     ref = Ref.parse_uri(ref_uri)
@@ -90,7 +49,7 @@ def _assert_safe_ref(client: WeaveClient, ref_uri: str, label: str) -> None:
             digest=ref.digest,
         )
     )
-    _assert_safe_payload(read_res.obj.val, label)
+    assert_safe_payload(read_res.obj.val, label)
 
 
 def evaluate_model(args: EvaluateModelArgs) -> None:

--- a/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
+++ b/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
@@ -35,23 +35,6 @@ class EvaluateModelDispatcher(ABC):
         pass
 
 
-def _assert_safe_ref(client: WeaveClient, ref_uri: str, label: str) -> None:
-    """Read the raw object for a ref and reject it if it contains unsafe CustomWeaveType payloads."""
-    ref = Ref.parse_uri(ref_uri)
-    if not isinstance(ref, ObjectRef):
-        raise TypeError(f"Expected an object ref for {label}, got: {ref_uri}")
-
-    project_id = f"{ref.entity}/{ref.project}"
-    read_res = client.server.obj_read(
-        tsi.ObjReadReq(
-            project_id=project_id,
-            object_id=ref.name,
-            digest=ref.digest,
-        )
-    )
-    assert_safe_payload(read_res.obj.val, label)
-
-
 def evaluate_model(args: EvaluateModelArgs) -> None:
     _evaluate_model(args)
 
@@ -120,3 +103,20 @@ def _run_evaluation(
                 loaded_model, __weave={"call_id": evaluation_call_id}
             )
         )
+
+
+def _assert_safe_ref(client: WeaveClient, ref_uri: str, label: str) -> None:
+    """Read the raw object for a ref and reject it if it contains unsafe CustomWeaveType payloads."""
+    ref = Ref.parse_uri(ref_uri)
+    if not isinstance(ref, ObjectRef):
+        raise TypeError(f"Expected an object ref for {label}, got: {ref_uri}")
+
+    project_id = f"{ref.entity}/{ref.project}"
+    read_res = client.server.obj_read(
+        tsi.ObjReadReq(
+            project_id=project_id,
+            object_id=ref.name,
+            digest=ref.digest,
+        )
+    )
+    assert_safe_payload(read_res.obj.val, label)

--- a/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
+++ b/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
@@ -1,5 +1,6 @@
 import asyncio
 from abc import ABC, abstractmethod
+from typing import Any
 
 import ddtrace
 from pydantic import BaseModel, ConfigDict
@@ -8,13 +9,18 @@ import weave
 from weave.evaluation.eval import Evaluation
 from weave.scorers.llm_as_a_judge_scorer import LLMAsAJudgeScorer
 from weave.trace.context.weave_client_context import require_weave_client
-from weave.trace.refs import Ref
+from weave.trace.refs import ObjectRef, Ref
 from weave.trace.weave_client import WeaveClient
+from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.interface.builtin_object_classes.llm_structured_model import (
     LLMStructuredCompletionModel,
 )
 
 EVALUATE_MODEL_WORKER_MARKER = {"_weave_eval_meta": {"evaluate_model_worker": True}}
+
+
+class UnsafePayloadError(TypeError):
+    """Raised when a ref resolves to a payload that is not safe for server-side deserialization."""
 
 
 class EvaluateModelArgs(BaseModel):
@@ -33,6 +39,60 @@ class EvaluateModelDispatcher(ABC):
         pass
 
 
+def _assert_safe_payload(value: Any, path: str = "root") -> None:
+    """Recursively walk a raw serialized payload and reject CustomWeaveType nodes.
+
+    CustomWeaveType payloads can trigger code execution during deserialization
+    (e.g. Op types call __import__ on user-uploaded Python files, and unknown
+    types fall back to a load_op path that does the same). None of these should
+    be deserialized in a server-side worker process.
+
+    https://coreweave.atlassian.net/browse/VULNMGMT-1007
+    """
+    if isinstance(value, str):
+        return
+
+    if isinstance(value, list):
+        for idx, item in enumerate(value):
+            _assert_safe_payload(item, f"{path}[{idx}]")
+        return
+
+    if not isinstance(value, dict):
+        return
+
+    if value.get("_type") == "CustomWeaveType":
+        weave_type = value.get("weave_type")
+        custom_type = (
+            weave_type.get("type", "unknown")
+            if isinstance(weave_type, dict)
+            else "unknown"
+        )
+        raise UnsafePayloadError(
+            f"Evaluate model worker does not allow CustomWeaveType payloads "
+            f"({custom_type} at {path})"
+        )
+
+    for key, item in value.items():
+        _assert_safe_payload(item, f"{path}.{key}")
+
+
+def _assert_safe_ref(client: WeaveClient, ref_uri: str, label: str) -> None:
+    """Read the raw object for a ref and reject it if it contains unsafe CustomWeaveType payloads."""
+    ref = Ref.parse_uri(ref_uri)
+    if not isinstance(ref, ObjectRef):
+        raise TypeError(f"Expected an object ref for {label}, got: {ref_uri}")
+
+    project_id = f"{ref.entity}/{ref.project}"
+    read_res = client.server.obj_read(
+        tsi.ObjReadReq(
+            project_id=project_id,
+            object_id=ref.name,
+            digest=ref.digest,
+        )
+    )
+    _assert_safe_payload(read_res.obj.val, label)
+
+
 def evaluate_model(args: EvaluateModelArgs) -> None:
     _evaluate_model(args)
 
@@ -40,6 +100,11 @@ def evaluate_model(args: EvaluateModelArgs) -> None:
 @ddtrace.tracer.wrap(name="evaluate_model_worker.evaluate_model")
 def _evaluate_model(args: EvaluateModelArgs) -> None:
     client = require_weave_client()
+
+    # Validate raw payloads before deserialization.
+    # https://coreweave.atlassian.net/browse/VULNMGMT-1007
+    _assert_safe_ref(client, args.evaluation_ref, "evaluation_ref")
+    _assert_safe_ref(client, args.model_ref, "model_ref")
 
     loaded_evaluation = _get_valid_evaluation(client, args.evaluation_ref)
 


### PR DESCRIPTION
## Summary

- Add `_assert_safe_payload` pre-deserialization check to the evaluate model worker that recursively rejects any `CustomWeaveType` nodes in raw object payloads before `client.get()` is called
- Validates both `evaluation_ref` and `model_ref` payloads via `obj_read` before deserialization
- Matches the shape of the existing scoring worker's `_assert_safe_scorer_payload`

https://coreweave.atlassian.net/browse/VULNMGMT-1007

## Overhead

Adds 2 extra `obj_read` calls (one per ref) plus a shallow recursive walk of the raw JSON vals. Refs inside the payload are strings and skipped immediately — we don't resolve them. Negligible compared to running the evaluation itself.

## Note on load_op fallback

The `_decode_custom_obj` fallback in `custom_objs.py` allows any `CustomWeaveType` with a `load_op` field to load via a stored op URI. This is intentional — it's the mechanism for user-registered custom types to survive across sessions. Server-side protection is handled here at the worker boundary.

## Surface area

This blocks ALL `CustomWeaveType` deserialization in the evaluate model worker. If evaluations or models contain `CustomWeaveType` values (e.g. images, audio, custom serialized objects), those will now be rejected at the worker boundary.