### PR TITLE
fix(weave): gate remote code execution with `dangerously_import_remote_ops`

### DIFF
--- a/tests/trace/test_custom_objs.py
+++ b/tests/trace/test_custom_objs.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
 import rich.markdown
 from PIL import Image
 
@@ -12,6 +13,7 @@ from weave.trace.serialization.custom_objs import (
     decode_custom_obj,
     encode_custom_obj,
 )
+from weave.trace.settings import UserSettings
 
 
 def test_encode_custom_obj_unknown_type(client):
@@ -50,11 +52,8 @@ def test_inline_custom_obj(client):
     assert decoded == dt_with_tz
 
 
-def test_inline_custom_obj_needs_load_op(client):
-    """Test the condition that the current version of the SDK doesn't know how to load the object.
-
-    In that case we fallback to the saved load op.
-    """
+def test_inline_custom_obj_needs_load_op_default(client):
+    """By default (dangerously_import_remote_ops=True), the load_op fallback works."""
     md = rich.markdown.Markdown("# Hello")
 
     @weave.op
@@ -74,6 +73,50 @@ def test_inline_custom_obj_needs_load_op(client):
         assert isinstance(loaded_markdown, rich.markdown.Markdown)
     finally:
         KNOWN_TYPES = original_known_types
+
+
+def test_inline_custom_obj_needs_load_op_blocked_by_setting(client):
+    """When dangerously_import_remote_ops is disabled via settings,
+    the load_op fallback raises ValueError.
+    """
+    md = rich.markdown.Markdown("# Hello")
+
+    @weave.op
+    def return_markdown(md):
+        return md
+
+    _, call = return_markdown.call(md)
+    client.flush()
+
+    global KNOWN_TYPES  # noqa: PLW0603
+    original_known_types = KNOWN_TYPES.copy()
+    KNOWN_TYPES.remove("rich.markdown.Markdown")
+    settings = UserSettings(dangerously_import_remote_ops=False)
+    settings.apply()
+    try:
+        with pytest.raises(ValueError, match="dangerously_import_remote_ops"):
+            client.get_call(call.id)
+    finally:
+        KNOWN_TYPES = original_known_types
+        UserSettings().apply()
+
+
+def test_inline_custom_obj_needs_load_op_per_call_override(client):
+    """Per-call dangerously_import_remote_ops=True overrides a False setting."""
+    md = rich.markdown.Markdown("# Hello")
+    ref = weave.publish(md, "test-markdown")
+
+    global KNOWN_TYPES  # noqa: PLW0603
+    original_known_types = KNOWN_TYPES.copy()
+    KNOWN_TYPES.remove("rich.markdown.Markdown")
+    settings = UserSettings(dangerously_import_remote_ops=False)
+    settings.apply()
+    try:
+        loaded = client.get(ref, dangerously_import_remote_ops=True)
+        assert isinstance(loaded, rich.markdown.Markdown)
+    finally:
+        KNOWN_TYPES = original_known_types
+        UserSettings().apply()
 
 
 def test_no_extra_calls_created(client):

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -399,9 +399,9 @@ def _normalize_openai_cache_tokens(usage: dict[str, Any]) -> None:
     and the Responses API nests them under input_tokens_details. This extracts
     them to the top-level canonical field `cache_read_input_tokens`.
     """
-    ptd = usage.get("prompt_tokens_details")
-    if isinstance(ptd, dict) and ptd.get("cached_tokens") is not None:
-        usage.setdefault("cache_read_input_tokens", ptd["cached_tokens"])
+    pdf = usage.get("prompt_tokens_details")
+    if isinstance(pdf, dict) and pdf.get("cached_tokens") is not None:
+        usage.setdefault("cache_read_input_tokens", pdf["cached_tokens"])
     itd = usage.get("input_tokens_details")
     if isinstance(itd, dict) and itd.get("cached_tokens") is not None:
         usage.setdefault("cache_read_input_tokens", itd["cached_tokens"])

--- a/weave/trace/serialization/custom_objs.py
+++ b/weave/trace/serialization/custom_objs.py
@@ -19,6 +19,7 @@ from weave.trace.serialization.serializer import (
     is_probably_legacy_file_load,
     is_probably_legacy_inline_load,
 )
+from weave.trace.settings import should_dangerously_import_remote_ops
 from weave.trace_server.trace_server_interface import (
     FileContentReadReq,
     TraceServerInterface,
@@ -177,12 +178,16 @@ def _load_custom_obj(
     return res
 
 
-def decode_custom_obj(encoded: EncodedCustomObjDict) -> Any:
+def decode_custom_obj(
+    encoded: EncodedCustomObjDict,
+    dangerously_import_remote_ops: bool | None = None,
+) -> Any:
     return _decode_custom_obj(
         encoded["weave_type"],
         encoded.get("files", {}),
         encoded.get("val"),
         encoded.get("load_op"),
+        dangerously_import_remote_ops=dangerously_import_remote_ops,
     )
 
 
@@ -191,9 +196,32 @@ def _decode_custom_obj(
     encoded_path_contents: Mapping[str, str | bytes],
     val: Any | None,
     load_instance_op_uri: str | None = None,
+    dangerously_import_remote_ops: bool | None = None,
 ) -> Any:
     type_ = weave_type["type"]
     found_serializer = False
+
+    deprecation_msg = (
+        "In a future version, deserializing objects that execute remote code will "
+        "require an explicit opt-in. Pass `dangerously_import_remote_ops=True` to "
+        "`client.get()` to silence this warning."
+    )
+
+    def _allow_remote_ops() -> bool:
+        if dangerously_import_remote_ops is not None:
+            return dangerously_import_remote_ops
+        return should_dangerously_import_remote_ops()
+
+    # Op deserialization imports and executes user-uploaded Python code.
+    if type_ == "Op":
+        if not _allow_remote_ops():
+            raise ValueError(
+                "Deserializing Op objects requires importing and executing remote code. "
+                "Set `WEAVE_DANGEROUSLY_IMPORT_REMOTE_OPS=true` or pass "
+                "`dangerously_import_remote_ops=True` to `client.get()` to allow this."
+            )
+        if dangerously_import_remote_ops is None:
+            logger.warning("Deserializing Op from remote code. %s", deprecation_msg)
 
     # First, try to load the object using a known serializer
     if type_ in KNOWN_TYPES:
@@ -209,14 +237,29 @@ def _decode_custom_obj(
             else:
                 return res
 
-    # Otherwise, fall back to load_instance_op
+    # Otherwise, fall back to load_instance_op which fetches and executes a remote Op.
     if not found_serializer:
         if load_instance_op_uri is None:
             raise ValueError(f"No serializer found for `{type_}`")
 
+        if not _allow_remote_ops():
+            raise ValueError(
+                f"Deserializing unknown type `{type_}` requires fetching and executing a "
+                f"remote load_op. Set `WEAVE_DANGEROUSLY_IMPORT_REMOTE_OPS=true` or pass "
+                f"`dangerously_import_remote_ops=True` to `client.get()` to allow this."
+            )
+        if dangerously_import_remote_ops is None:
+            logger.warning(
+                "Deserializing unknown type `%s` via remote load_op. %s",
+                type_,
+                deprecation_msg,
+            )
+
         obj_ref = ObjectRef.parse_uri(load_instance_op_uri)
         wc = require_weave_client()
-        load_instance_op = wc.get(obj_ref)
+        load_instance_op = wc.get(
+            obj_ref, dangerously_import_remote_ops=dangerously_import_remote_ops
+        )
         if load_instance_op is None:
             raise ValueError(
                 f"Failed to load op needed to decode object of type `{type_}`. See logs above for more information."

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -302,15 +302,20 @@ def _load_custom_obj_files(
     return loaded_files
 
 
-def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
+def from_json(
+    obj: Any,
+    project_id: str,
+    server: TraceServerInterface,
+    dangerously_import_remote_ops: bool | None = None,
+) -> Any:
     if isinstance(obj, list):
-        return [from_json(v, project_id, server) for v in obj]
+        return [from_json(v, project_id, server, dangerously_import_remote_ops) for v in obj]
     elif isinstance(obj, dict):
         if (val_type := obj.pop("_type", None)) is None:
-            return {k: from_json(v, project_id, server) for k, v in obj.items()}
+            return {k: from_json(v, project_id, server, dangerously_import_remote_ops) for k, v in obj.items()}
         elif val_type == "ObjectRecord":
             return ObjectRecord(
-                {k: from_json(v, project_id, server) for k, v in obj.items()}
+                {k: from_json(v, project_id, server, dangerously_import_remote_ops) for k, v in obj.items()}
             )
         elif val_type == "CustomWeaveType":
             encoded: custom_objs.EncodedCustomObjDict = {
@@ -326,7 +331,7 @@ def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
                     files = _load_custom_obj_files(project_id, server, file_spec)
                     encoded["files"] = files
 
-            return custom_objs.decode_custom_obj(encoded)
+            return custom_objs.decode_custom_obj(encoded, dangerously_import_remote_ops)
         elif isinstance(val_type, str) and obj.get("_class_name") == val_type:
             from weave.trace_server.interface.builtin_object_classes.builtin_object_registry import (
                 BUILTIN_OBJECT_REGISTRY,
@@ -341,7 +346,7 @@ def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
                 return cls.model_validate(obj_data)
 
         return ObjectRecord(
-            {k: from_json(v, project_id, server) for k, v in obj.items()}
+            {k: from_json(v, project_id, server, dangerously_import_remote_ops) for k, v in obj.items()}
         )
     elif isinstance(obj, str) and obj.startswith("weave://"):
         return Ref.parse_uri(obj)

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -309,13 +309,21 @@ def from_json(
     dangerously_import_remote_ops: bool | None = None,
 ) -> Any:
     if isinstance(obj, list):
-        return [from_json(v, project_id, server, dangerously_import_remote_ops) for v in obj]
+        return [
+            from_json(v, project_id, server, dangerously_import_remote_ops) for v in obj
+        ]
     elif isinstance(obj, dict):
         if (val_type := obj.pop("_type", None)) is None:
-            return {k: from_json(v, project_id, server, dangerously_import_remote_ops) for k, v in obj.items()}
+            return {
+                k: from_json(v, project_id, server, dangerously_import_remote_ops)
+                for k, v in obj.items()
+            }
         elif val_type == "ObjectRecord":
             return ObjectRecord(
-                {k: from_json(v, project_id, server, dangerously_import_remote_ops) for k, v in obj.items()}
+                {
+                    k: from_json(v, project_id, server, dangerously_import_remote_ops)
+                    for k, v in obj.items()
+                }
             )
         elif val_type == "CustomWeaveType":
             encoded: custom_objs.EncodedCustomObjDict = {
@@ -346,7 +354,10 @@ def from_json(
                 return cls.model_validate(obj_data)
 
         return ObjectRecord(
-            {k: from_json(v, project_id, server, dangerously_import_remote_ops) for k, v in obj.items()}
+            {
+                k: from_json(v, project_id, server, dangerously_import_remote_ops)
+                for k, v in obj.items()
+            }
         )
     elif isinstance(obj, str) and obj.startswith("weave://"):
         return Ref.parse_uri(obj)

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -273,8 +273,8 @@ class UserSettings(BaseModel):
 
     When True, deserializing Op objects and certain CustomWeaveType objects
     will import and execute user-uploaded Python code. Set to False to prevent
-    remote code execution during deserialization (e.g. in server-side workers).
-    Can be overridden with the environment variable `WEAVE_DANGEROUSLY_IMPORT_REMOTE_OPS`
+    remote code execution during deserialization. Can be overridden with the
+    environment variable `WEAVE_DANGEROUSLY_IMPORT_REMOTE_OPS`.
 
     In the future this will default to False to require explicit opt-in.
     """

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -267,6 +267,18 @@ class UserSettings(BaseModel):
     Can be overridden with the environment variable `WEAVE_DISABLE_WAL_SENDER`
     """
 
+    # TODO: Default to False in a future release.
+    dangerously_import_remote_ops: bool = True
+    """Allows execution of remote code during deserialization.
+
+    When True, deserializing Op objects and certain CustomWeaveType objects
+    will import and execute user-uploaded Python code. Set to False to prevent
+    remote code execution during deserialization (e.g. in server-side workers).
+    Can be overridden with the environment variable `WEAVE_DANGEROUSLY_IMPORT_REMOTE_OPS`
+
+    In the future this will default to False to require explicit opt-in.
+    """
+
     model_config = ConfigDict(extra="forbid")
     _is_first_apply: bool = PrivateAttr(True)
 
@@ -419,6 +431,11 @@ def should_enable_wal() -> bool:
 def should_disable_wal_sender() -> bool:
     """Returns whether the WAL sender thread should be disabled."""
     return _should("disable_wal_sender")
+
+
+def should_dangerously_import_remote_ops() -> bool:
+    """Returns whether remote code execution during deserialization is allowed."""
+    return _should("dangerously_import_remote_ops")
 
 
 def parse_and_apply_settings(

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -456,7 +456,16 @@ class WeaveClient:
         return self.get(ref)
 
     @trace_sentry.global_trace_sentry.watch()
-    def get(self, ref: ObjectRef, *, objectify: bool = True) -> Any:
+    def get(
+        self,
+        ref: ObjectRef,
+        *,
+        objectify: bool = True,
+        # Ops (and some CustomWeaveTypes) may store serialized python code for reuse.
+        # Deserializing these objects requires importing and executing this remote code.
+        # Set this to `True` if you trust this ref and you want to fetch executable code.
+        dangerously_import_remote_ops: bool | None = None,
+    ) -> Any:
         project_id = to_project_id(ref.entity, ref.project)
         try:
             read_res = self.server.obj_read(
@@ -509,7 +518,7 @@ class WeaveClient:
         else:
             data = read_res.obj.val
 
-        val = from_json(data, project_id, self.server)
+        val = from_json(data, project_id, self.server, dangerously_import_remote_ops)
         weave_obj = make_trace_obj(val, ref, self.server, None)
         if objectify:
             return maybe_objectify(weave_obj)


### PR DESCRIPTION
## Description

Some weave objects are python functions (e.g. ops and certain custom types). When you fetch these objects with `client.get(ref)`, they deserialize to real python that is now being executed on your device or server. That behavior is surprising, and has obvious security implications. This PR adds a new setting named `dangerously_import_remote_ops` that allows developers to configure the default behavior. You can also set `client.get(ref, dangerously_import_remote_ops=bool)` to configure this per-call.

For backwards compatibility the default is still `dangerously_import_remote_ops = True`. However we should change this in a future release so that remote code execution requires explicit opt-in.

**Open question:** we also do `get(ref)` throughout the SDK itself, how do we want to handle this? Thread through the `dangerously_import_remote_ops` arg everywhere it's used? I'll look into this after an initial review.

## Test plan

- [x] Added unit tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wandb/weave/pull/6623" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
