### PR TITLE
chore(weave): reduce Python 3.13 deprecation warnings

### DIFF
--- a/weave/trace/object_record.py
+++ b/weave/trace/object_record.py
@@ -11,6 +11,15 @@ from pydantic import BaseModel
 from weave.shared.pydantic_util import pydantic_asdict_one_level
 from weave.trace.op import is_op
 
+_PYDANTIC_DEPRECATED_MEMBER_NAMES = frozenset(
+    {
+        "__fields__",
+        "__fields_set__",
+        "model_computed_fields",
+        "model_fields",
+    }
+)
+
 
 class ObjectRecord:  # noqa: PLW1641
     _class_name: str
@@ -105,6 +114,10 @@ def getmembers(
     results = []
     processed = set()
     names = dir(object)
+    if isinstance(object, BaseModel):
+        names = [
+            name for name in names if name not in _PYDANTIC_DEPRECATED_MEMBER_NAMES
+        ]
     # :dd any DynamicClassAttributes to the list of names if object is a class;
     # this may result in duplicate entries if, for example, a virtual
     # attribute with the same name as a DynamicClassAttribute exists

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -271,7 +271,7 @@ class UserSettings(BaseModel):
     _is_first_apply: bool = PrivateAttr(True)
 
     def _reset(self) -> None:
-        for name, field in self.model_fields.items():
+        for name, field in type(self).model_fields.items():
             setattr(self, name, field.default)
 
     def apply(self) -> None:
@@ -280,7 +280,7 @@ class UserSettings(BaseModel):
         else:
             self._reset()
 
-        for name in self.model_fields:
+        for name in type(self).model_fields:
             context_var = _context_vars[name]
             context_var.set(getattr(self, name))
 

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -271,7 +271,7 @@ class UserSettings(BaseModel):
     _is_first_apply: bool = PrivateAttr(True)
 
     def _reset(self) -> None:
-        for name, field in type(self).model_fields.items():
+        for name, field in UserSettings.model_fields.items():
             setattr(self, name, field.default)
 
     def apply(self) -> None:
@@ -280,7 +280,7 @@ class UserSettings(BaseModel):
         else:
             self._reset()
 
-        for name in type(self).model_fields:
+        for name in UserSettings.model_fields:
             context_var = _context_vars[name]
             context_var.set(getattr(self, name))
 

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -161,7 +161,7 @@ def pydantic_getattribute(self: BaseModel, name: str) -> Any:
     if name.startswith("__") and name.endswith("__"):
         return attribute
 
-    if name not in object.__getattribute__(self, "model_fields"):  # noqa: PLC2801
+    if name not in type(self).model_fields:
         return attribute
     if name == "ref":
         try:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1778,7 +1778,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._insert(
             "object_versions",
             data=[list(ch_obj.model_dump().values())],
-            column_names=list(ch_obj.model_fields.keys()),
+            column_names=list(type(ch_obj).model_fields.keys()),
         )
 
         return tsi.ObjCreateRes(
@@ -1990,7 +1990,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 )
 
         data = [list(obj.model_dump().values()) for obj in delete_insertables]
-        column_names = list(delete_insertables[0].model_fields.keys())
+        column_names = list(type(delete_insertables[0]).model_fields.keys())
 
         self._insert("object_versions", data=data, column_names=column_names)
         num_deleted = len(delete_insertables)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1778,7 +1778,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._insert(
             "object_versions",
             data=[list(ch_obj.model_dump().values())],
-            column_names=list(type(ch_obj).model_fields.keys()),
+            column_names=ALL_OBJ_INSERT_COLUMNS,
         )
 
         return tsi.ObjCreateRes(
@@ -1990,7 +1990,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 )
 
         data = [list(obj.model_dump().values()) for obj in delete_insertables]
-        column_names = list(type(delete_insertables[0]).model_fields.keys())
+        column_names = list(ObjDeleteCHInsertable.model_fields.keys())
 
         self._insert("object_versions", data=data, column_names=column_names)
         num_deleted = len(delete_insertables)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -321,8 +321,9 @@ class ObjSchemaForInsert(BaseModel):
 
     def model_post_init(self, context: Any, /) -> None:
         # If set_base_object_class is provided, use it to set builtin_object_class for backwards compatibility
-        if self.set_base_object_class is not None and self.builtin_object_class is None:
-            self.builtin_object_class = self.set_base_object_class
+        set_base_object_class = self.__dict__.get("set_base_object_class")
+        if set_base_object_class is not None and self.builtin_object_class is None:
+            self.builtin_object_class = set_base_object_class
 
 
 class TableSchemaForInsert(BaseModel):


### PR DESCRIPTION
## Summary
- replace repo-owned Pydantic patterns that now warn on Python 3.13 / Pydantic 2.11+
- keep behavior the same while switching instance-level `model_fields` access to class-level access
- stop introspecting deprecated Pydantic compatibility attributes in `ObjectRecord`

## Why
`weave-trace-tests` started emitting a large warnings summary in CI. A subset of that noise was coming from `weave-public` code that still used older Pydantic APIs. These changes are the mechanical fixes on our side before deciding what to do about the remaining third-party warnings.

## Notes
- this branch contains the 5 remaining cleanup hunks that were still needed on current `master`
- instance reads like `self.model_fields` / `obj.model_fields` are switched to `type(self).model_fields` / `type(obj).model_fields`
- `ObjSchemaForInsert.model_post_init` now reads the deprecated compatibility field from `__dict__` so we preserve backward compatibility without triggering the deprecation
- `ObjectRecord.getmembers()` now skips deprecated Pydantic compatibility members when the target is a `BaseModel`


<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wandb/weave/pull/6624" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
