### PR TITLE
fix(weave): fix feedback dedup test passing ch_client instead of _mint_client

### DIFF
--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -1836,7 +1836,7 @@ def test_feedback_filter_does_not_duplicate_calls_complete(
     # verify we are reading from calls_complete
     resolver = clickhouse_trace_server.table_routing_resolver
     read_table = resolver.resolve_read_table(
-        internal_project_id, clickhouse_trace_server.ch_client
+        internal_project_id, clickhouse_trace_server._mint_client
     )
     assert read_table == ReadTable.CALLS_COMPLETE
 


### PR DESCRIPTION
## Summary
- `test_feedback_filter_does_not_duplicate_calls_complete` was missed in #6573 when `resolve_read_table` changed from accepting a `CHClient` instance to a `MintClient` callable factory
- Passes `_mint_client` instead of `ch_client` to match the updated API