### PR TITLE
chore(weave): 0.80.x server release patch 1

### DIFF
--- a/tests/trace/test_mem_artifact.py
+++ b/tests/trace/test_mem_artifact.py
@@ -1,0 +1,44 @@
+import os
+
+import pytest
+
+from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact
+
+
+def test_mem_artifact_path_sanitization():
+    art = MemTraceFilesArtifact(
+        path_contents={
+            "audio.wav": b"RIFF",
+            "subdir/file.txt": b"nested",
+            "/etc/passwd": b"abs",
+            "../../etc/shadow": b"traversal",
+        }
+    )
+
+    # Valid relative paths work, including nested
+    assert art.path("audio.wav").endswith("audio.wav")
+    result = art.path("subdir/file.txt")
+    assert result.endswith(os.path.join("subdir", "file.txt"))
+
+    # Absolute paths rejected
+    with pytest.raises(ValueError, match="absolute path"):
+        art.path("/etc/passwd")
+    with pytest.raises(ValueError, match="absolute path"):
+        art.path("audio.wav", filename="/tmp/evil.pth")
+
+    # Traversals rejected
+    with pytest.raises(ValueError, match="escapes base directory"):
+        art.path("../../etc/shadow")
+
+    # writeable_file_path: valid works, absolute and traversal rejected
+    with art.writeable_file_path("output.wav") as fp:
+        with open(fp, "wb") as f:
+            f.write(b"data")
+    assert art.path_contents["output.wav"] == b"data"
+
+    with pytest.raises(ValueError, match="absolute path"):
+        with art.writeable_file_path("/etc/evil"):
+            pass
+    with pytest.raises(ValueError, match="escapes base directory"):
+        with art.writeable_file_path("../../etc/evil"):
+            pass

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from weave.trace_server import clickhouse_trace_server_batched as chts
 from weave.trace_server import trace_server_interface as tsi
@@ -12,6 +13,7 @@ from weave.trace_server.errors import (
     MissingLLMApiKeyError,
     NotFoundError,
 )
+from weave.trace_server.interface.builtin_object_classes.provider import Provider
 from weave.trace_server.llm_completion import get_custom_provider_info
 from weave.trace_server.project_version.types import WriteTarget
 from weave.trace_server.secret_fetcher_context import (
@@ -1675,6 +1677,83 @@ def test_streaming_completions_error_routes_correctly(
 
         assert mock_insert_complete.called == expect_complete_called
         assert mock_update_end.called == expect_update_end_called
+
+
+def _make_provider(base_url: str, extra_headers: dict | None = None):
+    return Provider(
+        name="test",
+        base_url=base_url,
+        api_key_name="MY_KEY",
+        extra_headers=extra_headers or {},
+    )
+
+
+def test_provider_base_url_validation():
+    """Verify that Provider.base_url only accepts well-formed, public HTTP(S) URLs."""
+    # Valid URLs accepted
+    p = _make_provider("https://api.openai.com/v1")
+    assert p.base_url == "https://api.openai.com/v1"
+    p = _make_provider("http://my-ollama-server.example.com:11434")
+    assert p.base_url == "http://my-ollama-server.example.com:11434"
+
+    # Non-http schemes rejected
+    with pytest.raises(ValidationError):
+        _make_provider("ftp://bad.example.com")
+    with pytest.raises(ValidationError):
+        _make_provider("file:///etc/passwd")
+
+    # Query strings, bare '?', and fragments rejected
+    with pytest.raises(ValidationError):
+        _make_provider("https://api.example.com/v1?foo=bar")
+    with pytest.raises(ValidationError):
+        _make_provider("https://api.example.com/v1#section")
+    with pytest.raises(ValidationError):
+        _make_provider("http://10.0.0.1/path?")
+
+    # Blocked hostnames rejected
+    for hostname in (
+        "metadata.google.internal",
+        "metadata.google.internal.",
+        "foo.metadata.google.internal",
+        "169.254.169.254",
+    ):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{hostname}/v1")
+
+    # Non-globally-routable IPs rejected
+    for addr in ("10.0.0.1", "172.16.0.1", "192.168.1.1", "127.0.0.1"):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{addr}/v1")
+
+    # Alternative IP encodings rejected
+    for alt_ip in ("0xa9fea9fe", "2852039166", "0x7f000001", "0"):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{alt_ip}/v1")
+
+    # IPv6 non-global addresses rejected
+    with pytest.raises(ValidationError):
+        _make_provider("http://[::1]/v1")
+    with pytest.raises(ValidationError):
+        _make_provider("http://[::ffff:169.254.169.254]/v1")
+
+    # Blocked extra_headers rejected
+    for blocked in ("Metadata-Flavor", "METADATA-FLAVOR", "X-aws-ec2-metadata-token"):
+        with pytest.raises(ValidationError):
+            _make_provider("https://api.example.com", extra_headers={blocked: "val"})
+
+    # Allowed headers accepted
+    p = _make_provider(
+        "https://api.example.com",
+        extra_headers={"X-Custom-Header": "value", "Authorization": "Bearer tok"},
+    )
+    assert "X-Custom-Header" in p.extra_headers
+
+    # Validation also runs on assignment, not just init
+    p = _make_provider("https://api.example.com")
+    with pytest.raises(ValidationError):
+        p.base_url = "http://169.254.169.254/v1"
+    with pytest.raises(ValidationError):
+        p.extra_headers = {"Metadata-Flavor": "Google"}
 
 
 if __name__ == "__main__":

--- a/tests/trace_server/workers/test_evaluate_model_worker.py
+++ b/tests/trace_server/workers/test_evaluate_model_worker.py
@@ -1,0 +1,78 @@
+import pytest
+
+from weave.trace_server.validation import (
+    UnsafePayloadError,
+    assert_safe_payload,
+)
+
+
+def test_assert_safe_payload():
+    # Safe payloads pass
+    assert_safe_payload({"name": "test", "value": 42})
+    assert_safe_payload({"nested": {"list": [1, "two", {"three": 3}]}})
+    assert_safe_payload("just a string ref")
+    assert_safe_payload(None)
+    assert_safe_payload([1, 2, 3])
+    assert_safe_payload({"_type": "ObjectRecord", "name": "test"})
+
+    # ALL CustomWeaveType payloads rejected — Op, unknown, and safe subtypes alike
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload(
+            {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "Op"},
+                "files": {"obj.py": "abc123"},
+            }
+        )
+
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload(
+            {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "PIL.Image.Image"},
+                "files": {"image.png": "abc123"},
+            }
+        )
+
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload(
+            {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "TotallyMadeUpType"},
+                "load_op": "weave:///entity/project/object/evil:abc123",
+            }
+        )
+
+    # Nested in a list
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload(
+            {
+                "scorers": [
+                    {
+                        "_type": "CustomWeaveType",
+                        "weave_type": {"type": "Op"},
+                    }
+                ],
+            }
+        )
+
+    # Deeply nested in dicts
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload(
+            {
+                "a": {
+                    "b": {
+                        "c": {
+                            "_type": "CustomWeaveType",
+                            "weave_type": {"type": "Op"},
+                        }
+                    }
+                },
+            }
+        )
+
+    # Missing/malformed weave_type still rejected
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload({"_type": "CustomWeaveType"})
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload({"_type": "CustomWeaveType", "weave_type": "not a dict"})

--- a/weave/trace/serialization/mem_artifact.py
+++ b/weave/trace/serialization/mem_artifact.py
@@ -16,6 +16,36 @@ from weave.trace.serialization import (
 # to use this interface.
 
 
+def _safe_join(base: str, untrusted_path: str) -> str:
+    """Join base and untrusted_path, ensuring the result stays within base.
+
+    Rejects absolute paths, '..' components, and any path that would resolve
+    outside of base after symlink resolution.
+    """
+    if os.path.isabs(untrusted_path):
+        raise ValueError(
+            f"Path must be relative, got absolute path: {untrusted_path!r}"
+        )
+
+    # Normalize to collapse '..' and '.' but don't resolve symlinks yet
+    normed = os.path.normpath(untrusted_path)
+    if normed.startswith(os.sep):
+        raise ValueError(
+            f"Path must be relative, got absolute path: {untrusted_path!r}"
+        )
+    if normed.startswith(".."):
+        raise ValueError(f"Path escapes base directory: {untrusted_path!r}")
+
+    joined = os.path.join(base, normed)
+    # realpath resolves symlinks; the result must still be under base
+    resolved = os.path.realpath(joined)
+    real_base = os.path.realpath(base)
+    if not resolved.startswith(real_base + os.sep) and resolved != real_base:
+        raise ValueError(f"Path escapes base directory: {untrusted_path!r}")
+
+    return joined
+
+
 class MemTraceFilesArtifact:
     temp_read_dir: tempfile.TemporaryDirectory | None
     path_contents: dict[str, bytes]
@@ -82,7 +112,8 @@ class MemTraceFilesArtifact:
             raise FileNotFoundError(path)
 
         self.temp_read_dir = tempfile.TemporaryDirectory()
-        write_path = os.path.join(self.temp_read_dir.name, filename or path)
+        write_path = _safe_join(self.temp_read_dir.name, filename or path)
+        os.makedirs(os.path.dirname(write_path), exist_ok=True)
         with open(write_path, "wb") as f:
             f.write(self.path_contents[path])
             f.flush()
@@ -96,7 +127,7 @@ class MemTraceFilesArtifact:
     @contextlib.contextmanager
     def writeable_file_path(self, path: str) -> Generator[str]:
         with tempfile.TemporaryDirectory() as tmpdir:
-            full_path = os.path.join(tmpdir, path)
+            full_path = _safe_join(tmpdir, path)
             os.makedirs(os.path.dirname(full_path), exist_ok=True)
             yield full_path
             with open(full_path, "rb") as fp:

--- a/weave/trace_server/interface/builtin_object_classes/provider.py
+++ b/weave/trace_server/interface/builtin_object_classes/provider.py
@@ -1,8 +1,79 @@
+import ipaddress
+import re
+import socket
 from enum import Enum
+from urllib.parse import urlparse
 
-from pydantic import Field
+from pydantic import ConfigDict, Field, field_validator
 
 from weave.trace_server.interface.builtin_object_classes import base_object_def
+
+# Headers that must not appear in user-supplied extra_headers.
+# https://coreweave.atlassian.net/browse/VULNMGMT-770
+BLOCKED_HEADER_RE = re.compile(
+    r"^(?:metadata-flavor"
+    r"|x-aws-ec2-metadata-token(?:-ttl-seconds)?"
+    r")$",
+    re.IGNORECASE,
+)
+
+# Hostnames that must not appear in user-supplied base_url values.
+# https://coreweave.atlassian.net/browse/VULNMGMT-770
+BLOCKED_HOSTNAME_RE = re.compile(
+    r"(?:^|\.)"
+    r"(?:metadata\.google\.internal"
+    r"|metadata\.goog"
+    r"|metadata\.internal"
+    r"|metadata\.azure\.com"
+    r")\.?$",
+    re.IGNORECASE,
+)
+
+
+INVALID_BASE_URL_MSG = "base_url is not a valid provider URL"
+
+
+def _validate_provider_base_url(url: str) -> str:
+    """Validate that a provider base_url is a well-formed, publicly-routable HTTP(S) URL.
+
+    See https://coreweave.atlassian.net/browse/VULNMGMT-770
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception as exc:
+        raise ValueError(INVALID_BASE_URL_MSG) from exc
+
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(INVALID_BASE_URL_MSG)
+
+    # urlparse silently strips a bare trailing '?', so check the raw string too.
+    if "?" in url or parsed.fragment:
+        raise ValueError(INVALID_BASE_URL_MSG)
+
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        raise ValueError(INVALID_BASE_URL_MSG)
+
+    if BLOCKED_HOSTNAME_RE.search(host):
+        raise ValueError(INVALID_BASE_URL_MSG)
+
+    # Reject non-globally-routable IP addresses.  socket.inet_aton handles
+    # alternative IPv4 encodings that ipaddress.ip_address does not.
+    addr = None
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        # Not a strict IP literal — try inet_aton for alternative IPv4 forms.
+        try:
+            packed = socket.inet_aton(host)
+            addr = ipaddress.ip_address(packed)
+        except OSError:
+            pass  # Not any form of IP — hostname checks above are sufficient.
+
+    if addr is not None and not addr.is_global:
+        raise ValueError(INVALID_BASE_URL_MSG)
+
+    return url
 
 
 class ProviderReturnType(str, Enum):
@@ -10,10 +81,25 @@ class ProviderReturnType(str, Enum):
 
 
 class Provider(base_object_def.BaseObject):
+    model_config = ConfigDict(validate_assignment=True)
+
     base_url: str
     api_key_name: str
     extra_headers: dict[str, str] = Field(default_factory=dict)
     return_type: ProviderReturnType = Field(default=ProviderReturnType.OPENAI)
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, v: str) -> str:
+        return _validate_provider_base_url(v)
+
+    @field_validator("extra_headers")
+    @classmethod
+    def validate_extra_headers(cls, v: dict[str, str]) -> dict[str, str]:
+        for key in v:
+            if BLOCKED_HEADER_RE.match(key):
+                raise ValueError("extra_headers contains a disallowed header")
+        return v
 
 
 class ProviderModel(base_object_def.BaseObject):

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -199,3 +199,44 @@ def validate_alias_name(name: str) -> None:
         )
     if name in _RESERVED_ALIAS_NAMES:
         raise ValueError(f"alias name '{name}' is reserved")
+
+
+# --- Server-side deserialization safety ---
+
+
+class UnsafePayloadError(ValueError):
+    """Raised when a payload contains types that are not safe for server-side deserialization."""
+
+
+def assert_safe_payload(value: Any, path: str = "root") -> None:
+    """Recursively walk a raw serialized payload and reject CustomWeaveType nodes.
+
+    CustomWeaveType payloads can trigger code execution during deserialization
+    (e.g. Op types call __import__ on user-uploaded Python files, and unknown
+    types fall back to a load_op path that does the same). None of these should
+    be deserialized in a server-side worker process.
+
+    https://coreweave.atlassian.net/browse/VULNMGMT-1007
+    """
+    if isinstance(value, list):
+        for idx, item in enumerate(value):
+            assert_safe_payload(item, f"{path}[{idx}]")
+        return
+
+    if not isinstance(value, dict):
+        return
+
+    if value.get("_type") == "CustomWeaveType":
+        weave_type = value.get("weave_type")
+        custom_type = (
+            weave_type.get("type", "unknown")
+            if isinstance(weave_type, dict)
+            else "unknown"
+        )
+        raise UnsafePayloadError(
+            f"Server-side deserialization does not allow CustomWeaveType payloads "
+            f"({custom_type} at {path})"
+        )
+
+    for key, item in value.items():
+        assert_safe_payload(item, f"{path}.{key}")

--- a/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
+++ b/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
@@ -8,11 +8,13 @@ import weave
 from weave.evaluation.eval import Evaluation
 from weave.scorers.llm_as_a_judge_scorer import LLMAsAJudgeScorer
 from weave.trace.context.weave_client_context import require_weave_client
-from weave.trace.refs import Ref
+from weave.trace.refs import ObjectRef, Ref
 from weave.trace.weave_client import WeaveClient
+from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.interface.builtin_object_classes.llm_structured_model import (
     LLMStructuredCompletionModel,
 )
+from weave.trace_server.validation import assert_safe_payload
 
 EVALUATE_MODEL_WORKER_MARKER = {"_weave_eval_meta": {"evaluate_model_worker": True}}
 
@@ -40,6 +42,11 @@ def evaluate_model(args: EvaluateModelArgs) -> None:
 @ddtrace.tracer.wrap(name="evaluate_model_worker.evaluate_model")
 def _evaluate_model(args: EvaluateModelArgs) -> None:
     client = require_weave_client()
+
+    # Validate raw payloads before deserialization.
+    # https://coreweave.atlassian.net/browse/VULNMGMT-1007
+    _assert_safe_ref(client, args.evaluation_ref, "evaluation_ref")
+    _assert_safe_ref(client, args.model_ref, "model_ref")
 
     loaded_evaluation = _get_valid_evaluation(client, args.evaluation_ref)
 
@@ -96,3 +103,20 @@ def _run_evaluation(
                 loaded_model, __weave={"call_id": evaluation_call_id}
             )
         )
+
+
+def _assert_safe_ref(client: WeaveClient, ref_uri: str, label: str) -> None:
+    """Read the raw object for a ref and reject it if it contains unsafe CustomWeaveType payloads."""
+    ref = Ref.parse_uri(ref_uri)
+    if not isinstance(ref, ObjectRef):
+        raise TypeError(f"Expected an object ref for {label}, got: {ref_uri}")
+
+    project_id = f"{ref.entity}/{ref.project}"
+    read_res = client.server.obj_read(
+        tsi.ObjReadReq(
+            project_id=project_id,
+            object_id=ref.name,
+            digest=ref.digest,
+        )
+    )
+    assert_safe_payload(read_res.obj.val, label)


### PR DESCRIPTION
## Summary
Cherry-picks accompanying core `server-release-0.80.x` patch 1. Not intended to merge to master — fixes already on master.

Cherry-picked from:
- #6615 — fix(weave): add provider hostname and header sanitization
- #6618 — fix(weave): sanitize file paths in MemTraceFilesArtifact
- #6622 — fix(weave): reject CustomWeaveType payloads in evaluate model worker

Branched off submodule SHA `7e05504b` (pinned on core `server-release-0.80.x`).

## Test plan
- [ ] CI green