### PR TITLE
chore(weave): 0.79.1 hotfix: _local suffix fix

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -3346,7 +3346,9 @@ def test_build_calls_complete_delete_query() -> None:
 def test_build_calls_complete_delete_query_with_cluster() -> None:
     """Ensure the delete helper builds the expected query with cluster name.
 
-    In distributed mode, mutations target the local table with ON CLUSTER clause.
+    _format_table_name_with_cluster only adds ON CLUSTER; the caller is
+    responsible for passing the correct table name (e.g. calls_complete_local
+    in distributed mode via _get_calls_complete_table_name).
     """
     query = build_calls_complete_delete_query(
         table_name="calls_complete",
@@ -3357,7 +3359,7 @@ def test_build_calls_complete_delete_query_with_cluster() -> None:
 
     expected = sqlparse.format(
         """
-        DELETE FROM calls_complete_local ON CLUSTER my_cluster
+        DELETE FROM calls_complete ON CLUSTER my_cluster
         WHERE project_id = {project_id:String} AND id IN {call_ids:Array(String)}
         """,
         reindent=True,
@@ -3390,7 +3392,9 @@ def test_build_calls_complete_update_query() -> None:
 def test_build_calls_complete_update_query_with_cluster() -> None:
     """Ensure the update helper builds the expected query with cluster name.
 
-    In distributed mode, mutations target the local table with ON CLUSTER clause.
+    _format_table_name_with_cluster only adds ON CLUSTER; the caller is
+    responsible for passing the correct table name (e.g. calls_complete_local
+    in distributed mode via _get_calls_complete_table_name).
     """
     query = build_calls_complete_update_query(
         table_name="calls_complete",
@@ -3402,7 +3406,7 @@ def test_build_calls_complete_update_query_with_cluster() -> None:
 
     expected = sqlparse.format(
         """
-        UPDATE calls_complete_local ON CLUSTER my_cluster
+        UPDATE calls_complete ON CLUSTER my_cluster
         SET display_name = {display_name:String}
         WHERE project_id = {project_id:String} AND id = {id:String}
         """,

--- a/tests/trace_server/query_builder/test_on_cluster_query_builder.py
+++ b/tests/trace_server/query_builder/test_on_cluster_query_builder.py
@@ -1,75 +1,154 @@
-"""Tests for CallsQuery with distributed mode (ON CLUSTER clause).
+"""Tests for ON CLUSTER clause handling in query builders.
 
-These tests verify that when cluster_name is set, the ON CLUSTER clause
-is properly added to all table references in the generated SQL.
+Regression: _format_table_name_with_cluster used to bake _local into the table
+name whenever cluster_name was set. But cluster_name is set in replicated mode
+too, where _local tables don't exist. The _local suffix is now the caller's
+responsibility (via _get_calls_complete_table_name in the batched server).
 """
 
+from unittest.mock import patch
+
 import pytest
-import sqlparse
 
 from weave.trace_server.calls_query_builder.calls_query_builder import (
+    _format_table_name_with_cluster,
+    build_calls_complete_delete_query,
     build_calls_complete_update_end_query,
+    build_calls_complete_update_query,
 )
-from weave.trace_server.clickhouse_trace_server_settings import LOCAL_TABLE_SUFFIX
+from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.query_builder.annotation_queues_query_builder import (
+    make_annotator_progress_update_query,
+    make_queue_delete_query,
+    make_queue_update_query,
+)
 
-CLUSTER_NAME = "weave_cluster"
+CLUSTER = "weave_cluster"
+
+
+def test_format_table_name_with_cluster_never_appends_local() -> None:
+    """_format_table_name_with_cluster only adds ON CLUSTER, never _local."""
+    # With cluster -> ON CLUSTER appended, table name unchanged
+    assert _format_table_name_with_cluster("t", CLUSTER) == f"t ON CLUSTER {CLUSTER}"
+    # Already-local table name preserved as-is
+    assert (
+        _format_table_name_with_cluster("t_local", CLUSTER)
+        == f"t_local ON CLUSTER {CLUSTER}"
+    )
+    # No cluster -> plain table name
+    assert _format_table_name_with_cluster("t", None) == "t"
+
+
+def test_on_cluster_mutations_never_inject_local_suffix() -> None:
+    """No mutation builder should inject _local -- only the caller controls the table name.
+
+    Exercises all 6 mutation builders. calls_complete builders receive the plain
+    table name; in production the batched server passes _get_calls_complete_table_name()
+    which resolves to calls_complete_local only in distributed mode.
+    """
+    # --- calls_complete builders ---
+    update_end = build_calls_complete_update_end_query(
+        table_name="calls_complete",
+        project_id_param="p",
+        started_at_param="s",
+        id_param="i",
+        ended_at_param="e",
+        exception_param="x",
+        output_dump_param="o",
+        summary_dump_param="sm",
+        output_refs_param="or",
+        wb_run_step_end_param="w",
+        cluster_name=CLUSTER,
+    )
+    assert f"calls_complete ON CLUSTER {CLUSTER}" in update_end
+
+    delete = build_calls_complete_delete_query(
+        table_name="calls_complete",
+        project_id_param="p",
+        call_ids_param="c",
+        cluster_name=CLUSTER,
+    )
+    assert f"calls_complete ON CLUSTER {CLUSTER}" in delete
+
+    update = build_calls_complete_update_query(
+        table_name="calls_complete",
+        project_id_param="p",
+        id_param="i",
+        display_name_param="d",
+        cluster_name=CLUSTER,
+    )
+    assert f"calls_complete ON CLUSTER {CLUSTER}" in update
+
+    # --- annotation queues ---
+    pb = ParamBuilder()
+    q_delete = make_queue_delete_query(
+        project_id="proj", queue_id="q", pb=pb, cluster_name=CLUSTER
+    )
+    assert f"annotation_queues ON CLUSTER {CLUSTER}" in q_delete
+
+    pb = ParamBuilder()
+    q_update = make_queue_update_query(
+        project_id="proj", queue_id="q", pb=pb, cluster_name=CLUSTER, name="n"
+    )
+    assert f"annotation_queues ON CLUSTER {CLUSTER}" in q_update
+
+    pb = ParamBuilder()
+    progress = make_annotator_progress_update_query(
+        project_id="proj",
+        queue_item_id="qi",
+        annotator_id="a",
+        annotation_state="done",
+        pb=pb,
+        cluster_name=CLUSTER,
+    )
+    assert f"annotator_queue_items_progress ON CLUSTER {CLUSTER}" in progress
 
 
 @pytest.mark.parametrize(
-    ("table_name", "cluster_name", "expected_table_clause"),
+    ("use_distributed", "cluster_name", "expected_table", "expected_on_cluster"),
     [
-        # In distributed mode: use _local table with ON CLUSTER
-        (
-            "calls_complete",
-            CLUSTER_NAME,
-            f"calls_complete{LOCAL_TABLE_SUFFIX} ON CLUSTER {CLUSTER_NAME}",
-        ),
-        # In non-distributed mode: use regular table without ON CLUSTER
-        ("calls_complete", None, "calls_complete"),
+        # Cloud mode: no cluster, no _local
+        (False, None, "calls_complete", False),
+        # Replicated mode: cluster set, but NOT distributed -> no _local
+        (False, CLUSTER, "calls_complete", True),
+        # Distributed mode: cluster set AND distributed -> _local
+        (True, CLUSTER, "calls_complete_local", True),
     ],
-    ids=["distributed_mode", "non_distributed_mode"],
+    ids=["cloud", "replicated", "distributed"],
 )
-def test_update_query_cluster_support(
-    table_name: str, cluster_name: str | None, expected_table_clause: str
+def test_calls_complete_table_resolution_by_mode(
+    use_distributed: bool,
+    cluster_name: str | None,
+    expected_table: str,
+    expected_on_cluster: bool,
 ) -> None:
-    """Test that build_calls_complete_update_end_query handles ON CLUSTER correctly.
+    """_get_calls_complete_table_name + _format_table_name_with_cluster must produce
+    correct SQL for each deployment mode.
 
-    In distributed mode, UPDATE statements must target the local table
-    (calls_complete_local) with ON CLUSTER clause. In non-distributed mode,
-    we target the regular table without ON CLUSTER.
+    This is the integration-level test that would have caught the original bug:
+    in replicated mode (cluster_name set, distributed=False), the old code produced
+    'calls_complete_local ON CLUSTER ...' but calls_complete_local doesn't exist.
     """
-    query = build_calls_complete_update_end_query(
-        table_name=table_name,
-        project_id_param="project_id",
-        started_at_param="started_at",
-        id_param="id",
-        ended_at_param="ended_at",
-        exception_param="exception",
-        output_dump_param="output_dump",
-        summary_dump_param="summary_dump",
-        output_refs_param="output_refs",
-        wb_run_step_end_param="wb_run_step_end",
-        cluster_name=cluster_name,
-    )
+    env_vars = {
+        "WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES": str(use_distributed).lower(),
+    }
+    if cluster_name:
+        env_vars["WF_CLICKHOUSE_REPLICATED_CLUSTER"] = cluster_name
 
-    expected = f"""
-        UPDATE {expected_table_clause}
-        SET
-            ended_at = fromUnixTimestamp64Micro({{ended_at:Int64}}, 'UTC'),
-            exception = {{exception:String}},
-            output_dump = {{output_dump:String}},
-            summary_dump = {{summary_dump:String}},
-            output_refs = {{output_refs:Array(String)}},
-            wb_run_step_end = {{wb_run_step_end:UInt64}},
-            updated_at = now64(3)
-        WHERE project_id = {{project_id:String}}
-            AND started_at = fromUnixTimestamp64Micro({{started_at:Int64}}, 'UTC')
-            AND id = {{id:String}}
-    """
+    with patch.dict("os.environ", env_vars, clear=False):
+        from weave.trace_server import environment as wf_env
 
-    exp_formatted = sqlparse.format(expected, reindent=True)
-    found_formatted = sqlparse.format(query, reindent=True)
-
-    assert exp_formatted == found_formatted, (
-        f"\nExpected:\n{exp_formatted}\n\nGot:\n{found_formatted}"
-    )
+        table_name = (
+            "calls_complete_local"
+            if wf_env.wf_clickhouse_use_distributed_tables()
+            else "calls_complete"
+        )
+        result = _format_table_name_with_cluster(
+            table_name, wf_env.wf_clickhouse_replicated_cluster()
+        )
+        expected = (
+            f"{expected_table} ON CLUSTER {cluster_name}"
+            if expected_on_cluster
+            else expected_table
+        )
+        assert result == expected

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -59,7 +59,6 @@ from weave.trace_server.calls_query_builder.utils import (
     safely_format_sql,
     timestamp_to_datetime_str,
 )
-from weave.trace_server.clickhouse_trace_server_settings import LOCAL_TABLE_SUFFIX
 from weave.trace_server.common_interface import SortBy
 from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.interface import query as tsi_query
@@ -2799,14 +2798,18 @@ def _is_minimal_filter(filter: tsi.CallsFilter | None) -> bool:
     )
 
 
-def _format_table_name_with_cluster(table_name: str, cluster_name: str | None) -> str:
+def _format_table_name_with_cluster(
+    table_name: str,
+    cluster_name: str | None,
+) -> str:
     """Format a table name with ON CLUSTER clause if cluster_name is provided.
 
-    In distributed mode, mutations (UPDATE, DELETE, etc.) must target the local
-    table with the ON CLUSTER clause to execute across all cluster nodes.
+    Callers are responsible for passing the correct table name (e.g.
+    calls_complete_local in distributed mode). This function only appends the
+    ON CLUSTER clause.
     """
     if cluster_name:
-        return f"{table_name}{LOCAL_TABLE_SUFFIX} ON CLUSTER {cluster_name}"
+        return f"{table_name} ON CLUSTER {cluster_name}"
     return table_name
 
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1564,7 +1564,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         project_id_param = pb.add_param(project_id)
         call_ids_param = pb.add_param(call_ids)
         delete_query = build_calls_complete_delete_query(
-            "calls_complete",
+            self._get_calls_complete_table_name(),
             project_id_param,
             call_ids_param,
             cluster_name=self.clickhouse_cluster_name,
@@ -1619,7 +1619,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             ch_sentinel_values.to_ch_value("display_name", display_name)
         )
         update_query = build_calls_complete_update_query(
-            "calls_complete",
+            self._get_calls_complete_table_name(),
             project_id_param,
             call_id_param,
             display_name_param,


### PR DESCRIPTION
## Summary
Cherry-picks the `_local` suffix fix onto the weave SHA pinned by `wandb/core` tag `server/v0.79.1`. Accompanies a core hotfix stacked on `chance_griffin/0.79.1_base`. Not intended to merge to master: the fix is already on master.

Cherry-picked from:
- wandb/weave#6574 -> fix(weave): only append _local suffix for distributed tables in ON CLUSTER mutations

Branched off submodule SHA `fc5b897946` (pinned on core `server/v0.79.1`).

Note: one hunk conflicted in `tests/trace_server/query_builder/test_calls_query_builder.py` against an unrelated test block that landed on master after `fc5b897`. Resolution kept base, then applied the fix's real test edits surgically (docstrings + expected SQL in the two `*_with_cluster` tests).

## Test plan
- [ ] CI green