### PR TITLE
chore(weave): mark obj tests flaky

### DIFF
--- a/tests/trace/test_weave_client_mutations.py
+++ b/tests/trace/test_weave_client_mutations.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from pydantic import Field
 
@@ -185,6 +187,7 @@ def test_object_mutation_saving_nested_lists_and_dicts(client):
     assert g3.b.f == {"d": {"e": "f"}}
 
 
+@pytest.mark.flaky(reruns=3)
 def test_list_mutation_saving_nested_objects(client):
     class A(weave.Object):
         b: int
@@ -192,10 +195,12 @@ def test_list_mutation_saving_nested_objects(client):
     lst = [A(b=1), A(b=2)]
     ref = weave.publish(lst)
 
+    time.sleep(0.2)
     lst2 = ref.get()
     lst2.append(A(b=3))
     ref2 = weave.publish(lst2)
 
+    time.sleep(0.2)
     lst3 = ref2.get()
     assert len(lst3) == 3
     assert lst3[0].b == 1

--- a/tests/trace/test_weave_client_mutations.py
+++ b/tests/trace/test_weave_client_mutations.py
@@ -91,6 +91,7 @@ def test_object_mutation_saving_nested(client):
     assert d3.c.a.b == 3
 
 
+@pytest.mark.flaky(reruns=3)
 def test_list_mutation_saving_nested(client):
     lst = [1, 2, 3]
     ref = weave.publish(lst)
@@ -98,6 +99,7 @@ def test_list_mutation_saving_nested(client):
     lst2 = [4, 5, 6]
     ref2 = weave.publish(lst2)
 
+    time.sleep(0.2)
     lst3 = ref.get()
     assert lst3 == [1, 2, 3]
 
@@ -107,6 +109,7 @@ def test_list_mutation_saving_nested(client):
     lst3.append(lst4)
     ref5 = weave.publish(lst3)
 
+    time.sleep(0.2)
     lst5 = ref5.get()
     assert lst5 == [1, 2, 3, [4, 5, 6]]
 
@@ -135,6 +138,7 @@ def test_dict_mutation_saving_nested(client):
     }
 
 
+@pytest.mark.flaky(reruns=3)
 def test_object_mutation_saving_nested_lists_and_dicts(client):
     class A(weave.Object):
         b: int
@@ -162,6 +166,7 @@ def test_object_mutation_saving_nested_lists_and_dicts(client):
     )
     ref = weave.publish(g)
 
+    time.sleep(0.2)
     g2 = ref.get()
     assert g2.a.b == 1
     assert g2.b.a.b == 2
@@ -178,6 +183,7 @@ def test_object_mutation_saving_nested_lists_and_dicts(client):
     g2.b.f = {"d": {"e": "f"}}  # Replace an entire dict
     ref2 = weave.publish(g2)
 
+    time.sleep(0.2)
     g3 = ref2.get()
     assert g3.a.b == 1
     assert g3.b.a.b == 2
@@ -208,14 +214,17 @@ def test_list_mutation_saving_nested_objects(client):
     assert lst3[2].b == 3
 
 
+@pytest.mark.flaky(reruns=3)
 def test_list_mutation_saving_nested_dicts(client):
     lst = [{"a": {"b": 1}}, {"a": {"b": 2}}]
     ref = weave.publish(lst)
 
+    time.sleep(0.2)
     lst2 = ref.get()
     lst2.append({"a": {"b": 3}})
     ref2 = weave.publish(lst2)
 
+    time.sleep(0.2)
     lst3 = ref2.get()
     assert len(lst3) == 3
     assert lst3[0]["a"]["b"] == 1
@@ -223,6 +232,7 @@ def test_list_mutation_saving_nested_dicts(client):
     assert lst3[2]["a"]["b"] == 3
 
 
+@pytest.mark.flaky(reruns=3)
 def test_dict_mutation_saving_nested_objects(client):
     class A(weave.Object):
         b: int
@@ -230,24 +240,29 @@ def test_dict_mutation_saving_nested_objects(client):
     d = {"a": A(b=1), "b": A(b=2)}
     ref = weave.publish(d)
 
+    time.sleep(0.2)
     d2 = ref.get()
     d2["c"] = A(b=3)
     ref2 = weave.publish(d2)
 
+    time.sleep(0.2)
     d3 = ref2.get()
     assert d3["a"].b == 1
     assert d3["b"].b == 2
     assert d3["c"].b == 3
 
 
+@pytest.mark.flaky(reruns=3)
 def test_dict_mutation_saving_nested_lists(client):
     d = {"a": [1, 2], "b": [3, 4]}
     ref = weave.publish(d)
 
+    time.sleep(0.2)
     d2 = ref.get()
     d2["c"] = [5, 6]
     ref2 = weave.publish(d2)
 
+    time.sleep(0.2)
     d3 = ref2.get()
     assert d3["a"] == [1, 2]
     assert d3["b"] == [3, 4]


### PR DESCRIPTION
## Summary

Race between `weave.publish()` returning and the `WeaveList` becoming queryable on ClickHouse caused `NotFoundError` in CI. Mirrors the existing `time.sleep(0.2) + @pytest.mark.flaky(reruns=3)` pattern used for similar publish→get races.

Also preemptively covers 5 sibling tests in the same file that share the exact publish-nested-container → get shape and are structurally at the same risk.

Original failure ([job](https://github.com/wandb/weave/actions/runs/24582238190/job/71882800455?pr=6639)):
```
NotFoundError: Obj WeaveList:huU6RuytfnYediLjJV0lg6BgGH8ElEngI76SKuXxyXo not found
```

## Testing

Test-only change.