### PR TITLE
feat(weave): auto opt in calls_complete on wandb-entity projects

### DIFF
--- a/tests/trace_server_bindings/test_http_behavior_remote.py
+++ b/tests/trace_server_bindings/test_http_behavior_remote.py
@@ -23,6 +23,7 @@ from tests.trace_server_bindings.conftest import (
     generate_start,
 )
 from weave.trace.display.term import configure_logger
+from weave.trace.settings import should_use_calls_complete
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
@@ -135,6 +136,14 @@ def test_calls_complete_batch_endpoint_and_payload(mock_post, monkeypatch):
     payload = json.loads(sent_data.decode("utf-8"))
     expected = tsi.CallsUpsertCompleteReq(batch=[complete]).model_dump(mode="json")
     assert payload == expected
+
+
+def test_calls_complete_entity_allowlist(monkeypatch):
+    """Allowlisted entities opt into calls_complete even with env var unset."""
+    monkeypatch.delenv("WEAVE_USE_CALLS_COMPLETE", raising=False)
+    assert should_use_calls_complete("wandb") is True
+    assert should_use_calls_complete("acme") is False
+    assert should_use_calls_complete(None) is False
 
 
 @patch("weave.utils.http_requests.post")

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -20,6 +20,12 @@ from pydantic import BaseModel, ConfigDict, PrivateAttr
 DEFAULT_RETRY_MAX_INTERVAL_SECONDS = 60 * 5  # 5 minutes
 SETTINGS_PREFIX = "WEAVE_"
 
+# Entities that auto-opt-in to the calls_complete write path, independent of
+# the WEAVE_USE_CALLS_COMPLETE env var. This lets us dogfood calls_complete on
+# wandb-internal projects first so any regressions land on us, not customers.
+# Expand the allowlist (or flip the env default) once we have confidence.
+CALLS_COMPLETE_ENTITY_ALLOWLIST: frozenset[str] = frozenset({"wandb"})
+
 # Attention Devs:
 # To add new settings:
 # 1. Add a new field to `UserSettings`
@@ -225,7 +231,10 @@ class UserSettings(BaseModel):
     If False (default), uses the legacy call_start/call_end endpoints which
     send start and end events separately.
 
-    Can be overridden with the environment variable `WEAVE_USE_CALLS_COMPLETE`
+    Can be overridden with the environment variable `WEAVE_USE_CALLS_COMPLETE`.
+
+    Note: entities in `CALLS_COMPLETE_ENTITY_ALLOWLIST` auto-opt-in regardless
+    of this setting (see `should_use_calls_complete`).
     """
 
     enable_client_side_digests: bool = False
@@ -401,9 +410,15 @@ def should_use_stainless_server() -> bool:
     return _should("use_stainless_server")
 
 
-def should_use_calls_complete() -> bool:
-    """Returns whether the calls_complete write path should be used."""
-    return _should("use_calls_complete")
+def should_use_calls_complete(entity: str | None = None) -> bool:
+    """Returns whether the calls_complete write path should be used.
+
+    True if the `use_calls_complete` setting/env var is enabled, OR if
+    `entity` is in `CALLS_COMPLETE_ENTITY_ALLOWLIST` (dogfood gate).
+    """
+    if _should("use_calls_complete"):
+        return True
+    return entity is not None and entity in CALLS_COMPLETE_ENTITY_ALLOWLIST
 
 
 def should_enable_client_side_digests() -> bool:

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -144,7 +144,7 @@ def init_weave(
         wandb_run_id = f"{entity_name}/{project_name}/{wb_run_context.run_id}"
         check_wandb_run_matches(wandb_run_id, entity_name, project_name)
 
-    remote_server = init_weave_get_server(api_key)
+    remote_server = init_weave_get_server(api_key, entity=entity_name)
     if not _weave_is_available(remote_server):
         raise RuntimeError(
             "Weave is not available on the server.  Please contact support."
@@ -255,6 +255,8 @@ def init_weave_disabled(
 def init_weave_get_server(
     api_key: str | None = None,
     should_batch: bool = True,
+    *,
+    entity: str | None = None,
 ) -> TraceServerClientInterface:
     res: TraceServerClientInterface
     if should_use_stainless_server():
@@ -264,7 +266,9 @@ def init_weave_get_server(
 
         res = StainlessRemoteHTTPTraceServer.from_env(should_batch)
     else:
-        res = RemoteHTTPTraceServer.from_env(should_batch)
+        # `entity` enables the wandb/* dogfood gate for the calls_complete
+        # write path; StainlessRemoteHTTPTraceServer does not use it.
+        res = RemoteHTTPTraceServer.from_env(should_batch, entity=entity)
     if api_key is not None:
         res.set_auth(("api", api_key))
     return res

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -63,12 +63,12 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         remote_request_bytes_limit: int = REMOTE_REQUEST_BYTES_LIMIT,
         auth: tuple[str, str] | None = None,
         extra_headers: dict[str, str] | None = None,
+        entity: str | None = None,
     ):
         super().__init__()
         self.trace_server_url = trace_server_url
         self.should_batch = should_batch
-        # Opt-in to new calls_complete write path via env var
-        self.use_calls_complete = should_use_calls_complete() and should_batch
+        self.use_calls_complete = should_use_calls_complete(entity) and should_batch
         self.call_processor: AsyncBatchProcessor | CallBatchProcessor | None = None
         self.feedback_processor: AsyncBatchProcessor | None = None
         if self.should_batch:
@@ -104,8 +104,8 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         )
 
     @classmethod
-    def from_env(cls, should_batch: bool = False) -> Self:
-        return cls(weave_trace_server_url(), should_batch)
+    def from_env(cls, should_batch: bool = False, entity: str | None = None) -> Self:
+        return cls(weave_trace_server_url(), should_batch, entity=entity)
 
     def set_auth(self, auth: tuple[str, str]) -> None:
         self._auth = auth


### PR DESCRIPTION
https://coreweave.atlassian.net/browse/WB-33669

Pivots from "flip `WEAVE_USE_CALLS_COMPLETE` default to true" to an entity-based dogfood gate. Entities in `CALLS_COMPLETE_ENTITY_ALLOWLIST` (currently `{"wandb"}`) auto-opt-in to the calls_complete write path regardless of the env var; everyone else stays on the legacy default.

validate calls_complete on wandb/* traffic first. Flipping the env default remains a follow-up once we have more evidence that its fully functional.

Entity is threaded from `weave.init()` → `init_weave_get_server` → `RemoteHTTPTraceServer`. `StainlessRemoteHTTPTraceServer` does not use this path and is unaffected.