### PR TITLE
test(weave): fix flaky test_dspy_evaluate

### DIFF
--- a/tests/integrations/dspy/dspy_test.py
+++ b/tests/integrations/dspy/dspy_test.py
@@ -313,11 +313,12 @@ def test_dspy_custom_module(client: WeaveClient) -> None:
     sys.platform == "win32",
     reason="Currently not working on Windows",
 )
-@pytest.mark.flaky(reruns=3)
 def test_dspy_evaluate(client: WeaveClient) -> None:
     dspy.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=False))
     module = dspy.ChainOfThought("question -> answer: str, explanation: str")
-    evaluate = dspy.Evaluate(devset=SAMPLE_EVAL_DATASET, metric=accuracy_metric)
+    evaluate = dspy.Evaluate(
+        devset=SAMPLE_EVAL_DATASET, metric=accuracy_metric, num_threads=1
+    )
     accuracy = evaluate(module)
     assert accuracy.score > 30
 

--- a/tests/integrations/dspy/dspy_test.py
+++ b/tests/integrations/dspy/dspy_test.py
@@ -313,6 +313,7 @@ def test_dspy_custom_module(client: WeaveClient) -> None:
     sys.platform == "win32",
     reason="Currently not working on Windows",
 )
+@pytest.mark.flaky(reruns=3)
 def test_dspy_evaluate(client: WeaveClient) -> None:
     dspy.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=False))
     module = dspy.ChainOfThought("question -> answer: str, explanation: str")


### PR DESCRIPTION
## Summary

`test_dspy_evaluate` flaked with `assert 51 == 32`. Test isn't hitting the real network — VCR intercepts all OpenAI traffic. The flake is a thread race:

1. `dspy.Evaluate` defaults to `num_threads=8` (via `dspy.settings.num_threads`), so the 3 examples fire concurrently.
2. VCR's default matchers are URL-only; all 3 cassette entries share the same URL, so VCR hands them out in recorded order regardless of which thread arrived first.
3. On an unlucky interleaving, a mismatched response trips DSPy's ChatAdapter parser → DSPy re-prompts with a new body → cassette exhausted → VCR raises → LiteLLM sees it as a connection error and retries 3x (dspy.LM default `num_retries=3`) → all 4 failed attempts get traced → call count explodes.

Fix: force `num_threads=1` on this `dspy.Evaluate`. Responses are consumed in order, no race, call count stays deterministic.

Original failure ([run](https://github.com/wandb/weave/actions/runs/24589295897/job/71906401990)):
```
E       AssertionError: assert 51 == 32
```

## Testing

Test-only change.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wandb/weave/pull/6645" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
