### PR TITLE
chore(weave): fix trace_server_bindings tests for default calls_complete

### DIFF
--- a/tests/trace_server_bindings/test_http_behavior_remote.py
+++ b/tests/trace_server_bindings/test_http_behavior_remote.py
@@ -9,16 +9,13 @@ from __future__ import annotations
 import datetime
 import json
 import logging
-from types import MethodType
 from unittest.mock import MagicMock, patch
 
 import httpx
 import pytest
-import tenacity
 from pydantic import ValidationError
 
 from tests.trace_server_bindings.conftest import (
-    generate_call_start_end_pair,
     generate_end,
     generate_id,
     generate_start,
@@ -320,59 +317,31 @@ def test_timeout_retry_mechanism(mock_post, success_response, monkeypatch):
         success_response,
     ]
 
-    # Send a start+end pair so CallBatchProcessor produces a CompleteBatchItem
-    # and the background thread actually sends it to the server (and retries).
-    call_id = generate_id()
-    start_req, end_req = generate_call_start_end_pair(
-        id=call_id, project_id="entity/project"
+    # Use eager_call_start so the item is queued directly and sent via the
+    # v2 eager start endpoint (both paths are @with_retry-wrapped). A non-eager
+    # lone start would be held in _pending_starts and never hit the network.
+    server.call_processor.enqueue_start(
+        StartBatchItem(
+            req=tsi.CallStartReq(start=generate_start(project_id="entity/project"))
+        ),
+        eager_call_start=True,
     )
-    server.call_start(start_req)
-    server.call_end(end_req)
     server.call_processor.stop_accepting_new_work_and_flush_queue()
 
     # Verify that requests.post was called 3 times
     assert mock_post.call_count == 3
 
 
-@pytest.fixture
-def fast_retrying_server():
-    """Create a RemoteHTTPTraceServer with fast retry settings for testing."""
-    server = RemoteHTTPTraceServer("http://example.com", should_batch=True)
-    _apply_fast_retry(server)
-    yield server
-    if server.call_processor:
-        server.call_processor.stop_accepting_new_work_and_flush_queue()
-    if server.feedback_processor:
-        server.feedback_processor.stop_accepting_new_work_and_flush_queue()
-
-
-def _apply_fast_retry(server: RemoteHTTPTraceServer) -> None:
-    """Replace the retry wrappers on both legacy and calls_complete send paths."""
-    fast_retry = tenacity.retry(
-        wait=tenacity.wait_fixed(0.1),
-        stop=tenacity.stop_after_attempt(2),
-        reraise=True,
-    )
-    unwrapped_send_batch = MethodType(
-        server._send_batch_to_server.__wrapped__,  # type: ignore[attr-defined]
-        server,
-    )
-    server._send_batch_to_server = fast_retry(unwrapped_send_batch)
-    unwrapped_send_complete = MethodType(
-        server._send_calls_complete_to_server.__wrapped__,  # type: ignore[attr-defined]
-        server,
-    )
-    server._send_calls_complete_to_server = fast_retry(unwrapped_send_complete)
-
-
 @pytest.mark.disable_logging_error_check
 @patch("weave.utils.http_requests.post")
-def test_post_timeout(mock_post, success_response, fast_retrying_server, log_collector):
+def test_post_timeout(mock_post, success_response, log_collector, monkeypatch):
     """Test batch recovery after timeout exhaustion.
 
     This test verifies that we can still send new batches even if one batch
     times out and exhausts all retries.
     """
+    monkeypatch.setenv("WEAVE_RETRY_MAX_ATTEMPTS", "2")
+    monkeypatch.setenv("WEAVE_RETRY_MAX_INTERVAL", "0.1")
     configure_logger()
     # Configure mock to timeout twice to exhaust retries
     mock_post.side_effect = [
@@ -381,19 +350,21 @@ def test_post_timeout(mock_post, success_response, fast_retrying_server, log_col
     ]
 
     # Phase 1: Try but fail to process the first batch.
-    # Send a start+end pair so CallBatchProcessor produces a CompleteBatchItem
-    # that actually hits the send path (a lone start is held in _pending_starts
-    # and is dropped at flush timeout without being sent).
-    call_id = generate_id()
-    start_req, end_req = generate_call_start_end_pair(
-        id=call_id, project_id="entity/project"
+    # Use eager_call_start so the item actually reaches the send path; a non-eager
+    # lone start would be held in _pending_starts and dropped on flush timeout.
+    server = RemoteHTTPTraceServer("http://example.com", should_batch=True)
+    server.call_processor.enqueue_start(
+        StartBatchItem(
+            req=tsi.CallStartReq(start=generate_start(project_id="entity/project"))
+        ),
+        eager_call_start=True,
     )
-    fast_retrying_server.call_start(start_req)
-    fast_retrying_server.call_end(end_req)
-    fast_retrying_server.call_processor.stop_accepting_new_work_and_flush_queue()
-    logs = log_collector.get_warning_logs()
-    assert len(logs) >= 1
-    assert any("requeuing batch" in log.msg for log in logs)
+    server.call_processor.stop_accepting_new_work_and_flush_queue()
+    if server.feedback_processor:
+        server.feedback_processor.stop_accepting_new_work_and_flush_queue()
+    assert mock_post.call_count == 2  # both retry attempts were made
+    error_logs = log_collector.get_error_logs()
+    assert any("Error sending batch" in log.msg for log in error_logs)
 
     # Phase 2: Reset mock and verify we can still process a new batch
     mock_post.reset_mock()
@@ -404,7 +375,6 @@ def test_post_timeout(mock_post, success_response, fast_retrying_server, log_col
 
     # Create a new server since the old one has shutdown its batch processor
     new_server = RemoteHTTPTraceServer("http://example.com", should_batch=False)
-    _apply_fast_retry(new_server)
 
     # Should succeed with retry
     start_req = tsi.CallStartReq(start=generate_start())

--- a/tests/trace_server_bindings/test_http_behavior_remote.py
+++ b/tests/trace_server_bindings/test_http_behavior_remote.py
@@ -18,6 +18,7 @@ import tenacity
 from pydantic import ValidationError
 
 from tests.trace_server_bindings.conftest import (
+    generate_call_start_end_pair,
     generate_end,
     generate_id,
     generate_start,
@@ -304,8 +305,10 @@ def test_other_error_retry(mock_post, unbatched_server, monkeypatch):
 
 
 @patch("weave.utils.http_requests.post")
-def test_timeout_retry_mechanism(mock_post, success_response):
+def test_timeout_retry_mechanism(mock_post, success_response, monkeypatch):
     """Test that timeouts trigger the retry mechanism."""
+    monkeypatch.setenv("WEAVE_RETRY_MAX_ATTEMPTS", "3")
+    monkeypatch.setenv("WEAVE_RETRY_MAX_INTERVAL", "0.1")
     server = RemoteHTTPTraceServer("http://example.com", should_batch=True)
 
     # Mock server to raise errors twice, then succeed
@@ -317,8 +320,14 @@ def test_timeout_retry_mechanism(mock_post, success_response):
         success_response,
     ]
 
-    # Trying to send a batch should fail 2 times, then succeed
-    server.call_start(tsi.CallStartReq(start=generate_start()))
+    # Send a start+end pair so CallBatchProcessor produces a CompleteBatchItem
+    # and the background thread actually sends it to the server (and retries).
+    call_id = generate_id()
+    start_req, end_req = generate_call_start_end_pair(
+        id=call_id, project_id="entity/project"
+    )
+    server.call_start(start_req)
+    server.call_end(end_req)
     server.call_processor.stop_accepting_new_work_and_flush_queue()
 
     # Verify that requests.post was called 3 times
@@ -329,21 +338,31 @@ def test_timeout_retry_mechanism(mock_post, success_response):
 def fast_retrying_server():
     """Create a RemoteHTTPTraceServer with fast retry settings for testing."""
     server = RemoteHTTPTraceServer("http://example.com", should_batch=True)
-    fast_retry = tenacity.retry(
-        wait=tenacity.wait_fixed(0.1),
-        stop=tenacity.stop_after_attempt(2),
-        reraise=True,
-    )
-    unwrapped_send_batch_to_server = MethodType(
-        server._send_batch_to_server.__wrapped__,  # type: ignore[attr-defined]
-        server,
-    )
-    server._send_batch_to_server = fast_retry(unwrapped_send_batch_to_server)
+    _apply_fast_retry(server)
     yield server
     if server.call_processor:
         server.call_processor.stop_accepting_new_work_and_flush_queue()
     if server.feedback_processor:
         server.feedback_processor.stop_accepting_new_work_and_flush_queue()
+
+
+def _apply_fast_retry(server: RemoteHTTPTraceServer) -> None:
+    """Replace the retry wrappers on both legacy and calls_complete send paths."""
+    fast_retry = tenacity.retry(
+        wait=tenacity.wait_fixed(0.1),
+        stop=tenacity.stop_after_attempt(2),
+        reraise=True,
+    )
+    unwrapped_send_batch = MethodType(
+        server._send_batch_to_server.__wrapped__,  # type: ignore[attr-defined]
+        server,
+    )
+    server._send_batch_to_server = fast_retry(unwrapped_send_batch)
+    unwrapped_send_complete = MethodType(
+        server._send_calls_complete_to_server.__wrapped__,  # type: ignore[attr-defined]
+        server,
+    )
+    server._send_calls_complete_to_server = fast_retry(unwrapped_send_complete)
 
 
 @pytest.mark.disable_logging_error_check
@@ -361,8 +380,16 @@ def test_post_timeout(mock_post, success_response, fast_retrying_server, log_col
         httpx.TimeoutException("Connection timed out"),
     ]
 
-    # Phase 1: Try but fail to process the first batch
-    fast_retrying_server.call_start(tsi.CallStartReq(start=generate_start()))
+    # Phase 1: Try but fail to process the first batch.
+    # Send a start+end pair so CallBatchProcessor produces a CompleteBatchItem
+    # that actually hits the send path (a lone start is held in _pending_starts
+    # and is dropped at flush timeout without being sent).
+    call_id = generate_id()
+    start_req, end_req = generate_call_start_end_pair(
+        id=call_id, project_id="entity/project"
+    )
+    fast_retrying_server.call_start(start_req)
+    fast_retrying_server.call_end(end_req)
     fast_retrying_server.call_processor.stop_accepting_new_work_and_flush_queue()
     logs = log_collector.get_warning_logs()
     assert len(logs) >= 1
@@ -377,16 +404,7 @@ def test_post_timeout(mock_post, success_response, fast_retrying_server, log_col
 
     # Create a new server since the old one has shutdown its batch processor
     new_server = RemoteHTTPTraceServer("http://example.com", should_batch=False)
-    fast_retry = tenacity.retry(
-        wait=tenacity.wait_fixed(0.1),
-        stop=tenacity.stop_after_attempt(2),
-        reraise=True,
-    )
-    unwrapped_send_batch_to_server = MethodType(
-        new_server._send_batch_to_server.__wrapped__,  # type: ignore[attr-defined]
-        new_server,
-    )
-    new_server._send_batch_to_server = fast_retry(unwrapped_send_batch_to_server)
+    _apply_fast_retry(new_server)
 
     # Should succeed with retry
     start_req = tsi.CallStartReq(start=generate_start())

--- a/tests/trace_server_bindings/test_trace_server_bindings.py
+++ b/tests/trace_server_bindings/test_trace_server_bindings.py
@@ -19,6 +19,7 @@ import requests
 from tests.trace_server_bindings.conftest import (
     generate_call_start_end_pair,
     generate_end,
+    generate_id,
     generate_start,
 )
 from weave.trace_server import trace_server_interface as tsi
@@ -226,7 +227,13 @@ def test_drop_data_when_queue_is_full(server, server_class, log_collector):
     mock_queue.put_nowait.side_effect = Full
     server.call_processor.queue = mock_queue
 
-    server.call_start(tsi.CallStartReq(start=generate_start()))
+    # Send a start+end pair so CallBatchProcessor pairs them into a CompleteBatchItem
+    # and attempts to queue it (triggering put_nowait). A lone start is held in
+    # _pending_starts and never hits the queue.
+    call_id = generate_id()
+    start_req, end_req = generate_call_start_end_pair(id=call_id)
+    server.call_start(start_req)
+    server.call_end(end_req)
 
     # Verify that the put_nowait method was called (meaning we tried to enqueue the item)
     mock_queue.put_nowait.assert_called_once()

--- a/tests/trace_server_bindings/test_trace_server_bindings.py
+++ b/tests/trace_server_bindings/test_trace_server_bindings.py
@@ -19,7 +19,6 @@ import requests
 from tests.trace_server_bindings.conftest import (
     generate_call_start_end_pair,
     generate_end,
-    generate_id,
     generate_start,
 )
 from weave.trace_server import trace_server_interface as tsi
@@ -227,13 +226,13 @@ def test_drop_data_when_queue_is_full(server, server_class, log_collector):
     mock_queue.put_nowait.side_effect = Full
     server.call_processor.queue = mock_queue
 
-    # Send a start+end pair so CallBatchProcessor pairs them into a CompleteBatchItem
-    # and attempts to queue it (triggering put_nowait). A lone start is held in
-    # _pending_starts and never hits the queue.
-    call_id = generate_id()
-    start_req, end_req = generate_call_start_end_pair(id=call_id)
-    server.call_start(start_req)
-    server.call_end(end_req)
+    # Use eager_call_start so the StartBatchItem is queued directly. A non-eager
+    # lone start is held in _pending_starts until its end arrives and never hits
+    # the queue.
+    server.call_processor.enqueue_start(
+        StartBatchItem(req=tsi.CallStartReq(start=generate_start())),
+        eager_call_start=True,
+    )
 
     # Verify that the put_nowait method was called (meaning we tried to enqueue the item)
     mock_queue.put_nowait.assert_called_once()


### PR DESCRIPTION
## Summary

Deterministic test failures on #6644 once `WEAVE_USE_CALLS_COMPLETE` defaults to `True`. A lone `call_start` under `CallBatchProcessor` is held in `_pending_starts` waiting for an end, so it never reaches the queue or the send path — three tests that only issued a start failed as a result. Pair starts with ends so a `CompleteBatchItem` actually flows through the queue, and extend `fast_retrying_server` to wrap `_send_calls_complete_to_server` (the new active path).

Original failure ([GHA run](https://github.com/wandb/weave/actions/runs/24675555585/job/72158352427?pr=6644)):
```
FAILED tests/trace_server_bindings/test_http_behavior_remote.py::test_timeout_retry_mechanism - AssertionError: assert 0 == 3
FAILED tests/trace_server_bindings/test_http_behavior_remote.py::test_post_timeout - assert False
FAILED tests/trace_server_bindings/test_trace_server_bindings.py::test_drop_data_when_queue_is_full[warning-normal] - AssertionError: Expected 'put_nowait' to have been called once. Called 0 times.
```

## Testing

Test-only change. Full `tests/trace_server_bindings/` shard: 54 passed locally (3.10, sqlite).