### PR TITLE
chore(weave): Better slack notifications for nightly CI

### DIFF
--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+max_attempts="${MAX_ATTEMPTS:-3}"
+for attempt in $(seq 1 "$max_attempts"); do
+  echo "::group::Attempt $attempt of $max_attempts"
+  if "$@"; then
+    echo "::endgroup::"
+    echo "Succeeded on attempt $attempt"
+    exit 0
+  fi
+  echo "::endgroup::"
+  echo "Attempt $attempt failed"
+done
+echo "All $max_attempts attempts failed"
+exit 1

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -17,6 +17,8 @@ jobs:
     name: Nightly Tests
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    env:
+      MAX_ATTEMPTS: 3
     strategy:
       matrix:
         python-version-major: ["3"]
@@ -148,7 +150,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DD_TRACE_ENABLED: false
         run: |
-          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.shard }}')" -- \
+          .github/scripts/retry.sh nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.shard }}')" -- \
             -m "trace_server" \
             --trace-server=sqlite
       - name: Run nox (Clickhouse Trace Server)
@@ -163,7 +165,7 @@ jobs:
           DD_TRACE_ENABLED: false
           OPENAI_API_KEY: sk-1234567890abcdef1234567890abcdef
         run: |
-          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.shard }}')" -- \
+          .github/scripts/retry.sh nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.shard }}')" -- \
             -m "trace_server and not skip_clickhouse_client"
       - name: Run nox (No marker filters for integration-only shards)
         if: steps.filter_shards.outputs.skip != 'true' && steps.check_trace_markers.outputs.needs_markers == 'false'
@@ -182,7 +184,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           DD_TRACE_ENABLED: false
         run: |
-          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.shard }}')"
+          .github/scripts/retry.sh nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.shard }}')"
 
   slack-notification:
     name: Slack Notification


### PR DESCRIPTION
Instead of sending a failure note if there is flake, only send a failure not if all retries fail