### PR TITLE
chore(weave): add 1s3r and 2s2r migrator CI jobs with path filters

### DIFF
--- a/.github/workflows/check-which-tests-to-run.yaml
+++ b/.github/workflows/check-which-tests-to-run.yaml
@@ -9,10 +9,24 @@ on:
         value: ${{ jobs.check.outputs.trace_server_tests }}
       weave_ts_sdk_tests:
         value: ${{ jobs.check.outputs.weave_ts_sdk_tests }}
+      # Narrower outputs used to gate the multi-node ClickHouse migrator
+      # jobs (1s3r, 2s2r). Both are strict subsets of trace_server_tests.
+      trace_server_migrator_tests:
+        value: ${{ jobs.check.outputs.trace_server_migrator_tests }}
+      trace_server_distributed_tests:
+        value: ${{ jobs.check.outputs.trace_server_distributed_tests }}
 
 env:
   TRACE_SERVER_PATHS: "weave/trace_server/"
   WEAVE_TS_SDK_PATHS: "sdks/node/"
+  # Paths that warrant running migrator tests against multi-replica
+  # topology (1s3r, 2s2r). Derived from the last 22 replication/migration
+  # fix PRs from the weave team.
+  TRACE_SERVER_MIGRATOR_PATHS: "weave/trace_server/migrations/ weave/trace_server/clickhouse_trace_server_migrator.py weave/trace_server/clickhouse_schema.py weave/trace_server/database_engine.py weave/trace_server/environment.py weave/trace_server/clickhouse_trace_server_settings.py tests/trace_server_migrator/ tests/trace_server/conftest_lib/ pyproject.toml uv.lock noxfile.py"
+  # Additional paths that warrant running 2s2r (distributed+replicated).
+  # Migrator paths also trigger 2s2r — this filter only adds the
+  # distributed-query surface that wouldn't otherwise trigger.
+  TRACE_SERVER_DISTRIBUTED_PATHS: "weave/trace_server/calls_query_builder/ weave/trace_server/clickhouse/ weave/trace_server/clickhouse_trace_server_batched.py"
   # Everything else is implicitly trace SDK
 
 jobs:
@@ -21,6 +35,8 @@ jobs:
     outputs:
       trace_server_tests: ${{ steps.trace_server.outputs.run_tests }}
       weave_ts_sdk_tests: ${{ steps.weave_ts_sdk.outputs.run_tests }}
+      trace_server_migrator_tests: ${{ steps.trace_server_migrator.outputs.run_tests }}
+      trace_server_distributed_tests: ${{ steps.trace_server_distributed.outputs.run_tests }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -69,6 +85,26 @@ jobs:
         name: Weave TS SDK Checks
         run: |
           for path in ${{ env.WEAVE_TS_SDK_PATHS }}; do
+            if echo "$changed_files" | grep -q "$path"; then
+              echo "run_tests=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+          echo "run_tests=false" >> $GITHUB_OUTPUT
+      - id: trace_server_migrator
+        name: Trace Server Migrator Checks
+        run: |
+          for path in ${{ env.TRACE_SERVER_MIGRATOR_PATHS }}; do
+            if echo "$changed_files" | grep -q "$path"; then
+              echo "run_tests=true" >> $GITHUB_OUTPUT
+              exit 0
+            fi
+          done
+          echo "run_tests=false" >> $GITHUB_OUTPUT
+      - id: trace_server_distributed
+        name: Trace Server Distributed Checks
+        run: |
+          for path in ${{ env.TRACE_SERVER_DISTRIBUTED_PATHS }}; do
             if echo "$changed_files" | grep -q "$path"; then
               echo "run_tests=true" >> $GITHUB_OUTPUT
               exit 0

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -275,7 +275,6 @@ jobs:
         env:
           CI: 1
           WF_CLICKHOUSE_KEEPER_PORT: 8130
-          WF_CLICKHOUSE_TOPOLOGY: 1s1r
           DD_TRACE_ENABLED: false
         run: |
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server_migrator')"
@@ -327,14 +326,11 @@ jobs:
           CI: 1
           # Existing fixture reads WF_CLICKHOUSE_KEEPER_PORT and connects
           # to localhost at that port — we map the 1s3r entrypoint to 8130.
-          WF_CLICKHOUSE_KEEPER_PORT: 8130
-          # Topology marker read by tests/trace_server_migrator/conftest.py
-          # hook that skips @pytest.mark.topology-gated tests. Other
-          # WF_CLICKHOUSE_* vars are intentionally NOT set here: the
+          # Other WF_CLICKHOUSE_* vars are intentionally NOT set: the
           # existing migrator tests pass replicated/distributed flags
           # explicitly to the migrator factory, so env vars would be
-          # misleading (unread) documentation.
-          WF_CLICKHOUSE_TOPOLOGY: 1s3r
+          # unread documentation.
+          WF_CLICKHOUSE_KEEPER_PORT: 8130
           DD_TRACE_ENABLED: false
         run: |
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server_migrator')"
@@ -397,10 +393,8 @@ jobs:
         env:
           CI: 1
           # 2s2r entrypoint is on host port 8131 (1s3r uses 8130).
+          # See 1s3r job for why only KEEPER_PORT is set.
           WF_CLICKHOUSE_KEEPER_PORT: 8131
-          # See 1s3r job for why only TOPOLOGY is set; other
-          # WF_CLICKHOUSE_* vars would be unread today.
-          WF_CLICKHOUSE_TOPOLOGY: 2s2r
           DD_TRACE_ENABLED: false
         run: |
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server_migrator')"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -235,8 +235,8 @@ jobs:
           name: trace-tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}-${{ matrix.nox-shard }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
-  trace-server-migrator-tests:
-    name: Trace server migrator tests
+  trace-server-migrator-1s1r:
+    name: Trace server migrator tests (1s1r)
     timeout-minutes: 10
     runs-on: ubuntu-latest
     strategy:
@@ -275,6 +275,7 @@ jobs:
         env:
           CI: 1
           WF_CLICKHOUSE_KEEPER_PORT: 8130
+          WF_CLICKHOUSE_TOPOLOGY: 1s1r
           DD_TRACE_ENABLED: false
         run: |
           nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server_migrator')"
@@ -282,8 +283,146 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: ./coverage.xml
-          flags: trace-server-migrator
-          name: trace-server-migrator-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+          flags: trace-server-migrator-1s1r
+          name: trace-server-migrator-1s1r-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  trace-server-migrator-1s3r:
+    name: Trace server migrator tests (1s3r)
+    needs:
+      - check-which-tests-to-run
+    if: needs.check-which-tests-to-run.outputs.trace_server_migrator_tests == 'true' || github.ref == 'refs/heads/master'
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version-major: ["3"]
+        python-version-minor: ["12"]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Start 1s3r ClickHouse cluster
+        working-directory: tests/trace_server/conftest_lib/topologies
+        run: |
+          docker compose -f 1s3r.yaml up -d --wait
+          # Extra belt-and-suspenders health probe from host perspective.
+          for i in $(seq 1 60); do
+            wget -q -O- 'http://localhost:8130/ping' && break || sleep 2
+          done
+          # Show cluster membership so failures are diagnosable from log.
+          docker compose -f 1s3r.yaml exec -T ch-s1-r1 \
+            clickhouse-client -q "SELECT host_name, shard_num, replica_num, errors_count FROM system.clusters WHERE cluster='weave_cluster' FORMAT PrettyCompact"
+      - name: Set up Python ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox uv
+      - name: Run migrator functional tests
+        env:
+          CI: 1
+          # Existing fixture reads WF_CLICKHOUSE_KEEPER_PORT and connects
+          # to localhost at that port — we map the 1s3r entrypoint to 8130.
+          WF_CLICKHOUSE_KEEPER_PORT: 8130
+          # Topology marker read by tests/trace_server_migrator/conftest.py
+          # hook that skips @pytest.mark.topology-gated tests. Other
+          # WF_CLICKHOUSE_* vars are intentionally NOT set here: the
+          # existing migrator tests pass replicated/distributed flags
+          # explicitly to the migrator factory, so env vars would be
+          # misleading (unread) documentation.
+          WF_CLICKHOUSE_TOPOLOGY: 1s3r
+          DD_TRACE_ENABLED: false
+        run: |
+          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server_migrator')"
+      - name: Capture ClickHouse logs on failure
+        if: failure()
+        working-directory: tests/trace_server/conftest_lib/topologies
+        run: |
+          docker compose -f 1s3r.yaml logs --no-color --tail=1000 > ch-logs-1s3r.txt || true
+      - name: Upload ClickHouse logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ch-logs-1s3r-${{ github.run_id }}-${{ github.run_attempt }}
+          path: tests/trace_server/conftest_lib/topologies/ch-logs-1s3r.txt
+          retention-days: 7
+          if-no-files-found: ignore
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          flags: trace-server-migrator-1s3r
+          name: trace-server-migrator-1s3r-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+  trace-server-migrator-2s2r:
+    name: Trace server migrator tests (2s2r)
+    needs:
+      - check-which-tests-to-run
+    if: needs.check-which-tests-to-run.outputs.trace_server_migrator_tests == 'true' || needs.check-which-tests-to-run.outputs.trace_server_distributed_tests == 'true' || github.ref == 'refs/heads/master'
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version-major: ["3"]
+        python-version-minor: ["12"]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Start 2s2r ClickHouse cluster
+        working-directory: tests/trace_server/conftest_lib/topologies
+        run: |
+          docker compose -f 2s2r.yaml up -d --wait
+          # Extra belt-and-suspenders health probe. 2s2r entrypoint is on 8131.
+          for i in $(seq 1 60); do
+            wget -q -O- 'http://localhost:8131/ping' && break || sleep 2
+          done
+          docker compose -f 2s2r.yaml exec -T ch-s1-r1 \
+            clickhouse-client -q "SELECT host_name, shard_num, replica_num, errors_count FROM system.clusters WHERE cluster='weave_cluster' FORMAT PrettyCompact"
+      - name: Set up Python ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox uv
+      - name: Run migrator functional tests
+        env:
+          CI: 1
+          # 2s2r entrypoint is on host port 8131 (1s3r uses 8130).
+          WF_CLICKHOUSE_KEEPER_PORT: 8131
+          # See 1s3r job for why only TOPOLOGY is set; other
+          # WF_CLICKHOUSE_* vars would be unread today.
+          WF_CLICKHOUSE_TOPOLOGY: 2s2r
+          DD_TRACE_ENABLED: false
+        run: |
+          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='trace_server_migrator')"
+      - name: Capture ClickHouse logs on failure
+        if: failure()
+        working-directory: tests/trace_server/conftest_lib/topologies
+        run: |
+          docker compose -f 2s2r.yaml logs --no-color --tail=1000 > ch-logs-2s2r.txt || true
+      - name: Upload ClickHouse logs artifact
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ch-logs-2s2r-${{ github.run_id }}-${{ github.run_attempt }}
+          path: tests/trace_server/conftest_lib/topologies/ch-logs-2s2r.txt
+          retention-days: 7
+          if-no-files-found: ignore
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          flags: trace-server-migrator-2s2r
+          name: trace-server-migrator-2s2r-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -293,7 +432,9 @@ jobs:
     needs:
       - trace-tests
       - trace_no_server
-      - trace-server-migrator-tests
+      - trace-server-migrator-1s1r
+      - trace-server-migrator-1s3r
+      - trace-server-migrator-2s2r
 
     runs-on: ubuntu-latest
 
@@ -302,6 +443,11 @@ jobs:
         uses: re-actors/alls-green@release/v1
         with:
           jobs: ${{ toJSON(needs) }}
+          # The 1s3r and 2s2r jobs are path-filtered and will be "skipped"
+          # on PRs that don't touch migrator or distributed surfaces.
+          # alls-green treats skipped as failing by default; whitelist
+          # them here so a skipped-because-gated job doesn't wedge merge.
+          allowed-skips: trace-server-migrator-1s3r,trace-server-migrator-2s2r
 
   # ==== Windows Jobs ====
   windows_trace_no_server:

--- a/tests/trace_server/conftest_lib/keeper_1s3r.xml
+++ b/tests/trace_server/conftest_lib/keeper_1s3r.xml
@@ -1,0 +1,67 @@
+<clickhouse>
+    <!--
+      Cluster config for 1-shard, 3-replica topology.
+
+      Keeper runs embedded inside ch-s1-r1. The other replicas connect to
+      ch-s1-r1:9181 for coordination. Matches upstream's existing
+      embedded-keeper pattern, extended from 1 node to 3.
+
+      Per-node <macros> (shard/replica) live in separate files mounted at
+      /etc/clickhouse-server/config.d/macros.xml on each container — see
+      topologies/macros_s1_r{1,2,3}.xml.
+    -->
+
+    <!-- Embedded Keeper. Only ch-s1-r1 actually runs the keeper_server;
+         ch-s1-r2 and ch-s1-r3 ignore this block but still need the
+         <zookeeper> entry below to find the leader. -->
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>warning</raft_logs_level>
+        </coordination_settings>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>ch-s1-r1</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+
+    <!-- All three replicas point at ch-s1-r1 as the keeper coordinator. -->
+    <zookeeper>
+        <node>
+            <host>ch-s1-r1</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+
+    <!-- Cluster definition consumed by ON CLUSTER DDL and Distributed-engine
+         table routing. Three replicas, one shard. internal_replication=true
+         means writes to ReplicatedMergeTree tables deduplicate via Keeper
+         rather than being sent to every replica by the Distributed engine. -->
+    <remote_servers>
+        <weave_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>ch-s1-r1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>ch-s1-r2</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>ch-s1-r3</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </weave_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/trace_server/conftest_lib/keeper_2s2r.xml
+++ b/tests/trace_server/conftest_lib/keeper_2s2r.xml
@@ -1,0 +1,76 @@
+<clickhouse>
+    <!--
+      Cluster config for 2-shard × 2-replica topology.
+
+      Keeper runs embedded inside ch-s1-r1 (same pattern as 1s3r).
+      All four CH nodes point at ch-s1-r1:9181 for coordination.
+
+      Per-node <macros> (shard/replica) live in separate files mounted at
+      /etc/clickhouse-server/config.d/macros.xml on each container — see
+      topologies/macros_s{1,2}_r{1,2}.xml.
+
+      Design decision: 1 Keeper, not 3. See topologies/2s2r.yaml header
+      comment for rationale.
+    -->
+
+    <!-- Embedded Keeper. Only ch-s1-r1 runs the keeper_server;
+         the other replicas ignore this block but still need the
+         <zookeeper> entry below to find the leader. -->
+    <keeper_server>
+        <tcp_port>9181</tcp_port>
+        <server_id>1</server_id>
+        <log_storage_path>/var/lib/clickhouse/coordination/log</log_storage_path>
+        <snapshot_storage_path>/var/lib/clickhouse/coordination/snapshots</snapshot_storage_path>
+        <coordination_settings>
+            <operation_timeout_ms>10000</operation_timeout_ms>
+            <session_timeout_ms>30000</session_timeout_ms>
+            <raft_logs_level>warning</raft_logs_level>
+        </coordination_settings>
+        <raft_configuration>
+            <server>
+                <id>1</id>
+                <hostname>ch-s1-r1</hostname>
+                <port>9234</port>
+            </server>
+        </raft_configuration>
+    </keeper_server>
+
+    <!-- All four CH nodes point at ch-s1-r1 as the keeper coordinator. -->
+    <zookeeper>
+        <node>
+            <host>ch-s1-r1</host>
+            <port>9181</port>
+        </node>
+    </zookeeper>
+
+    <!-- Cluster definition: 2 shards, 2 replicas per shard.
+         internal_replication=true means writes to ReplicatedMergeTree
+         tables deduplicate via Keeper rather than being sent to every
+         replica by the Distributed engine. -->
+    <remote_servers>
+        <weave_cluster>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>ch-s1-r1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>ch-s1-r2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+            <shard>
+                <internal_replication>true</internal_replication>
+                <replica>
+                    <host>ch-s2-r1</host>
+                    <port>9000</port>
+                </replica>
+                <replica>
+                    <host>ch-s2-r2</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </weave_cluster>
+    </remote_servers>
+</clickhouse>

--- a/tests/trace_server/conftest_lib/topologies/1s3r.yaml
+++ b/tests/trace_server/conftest_lib/topologies/1s3r.yaml
@@ -1,0 +1,92 @@
+# 1 shard × 3 replicas topology for pre-merge migrator CI.
+#
+# Keeper is embedded in ch-s1-r1 (same pattern as the existing 1s1r setup,
+# just with two additional replicas joining the same Keeper instance).
+# Only ch-s1-r1 exposes the HTTP port to the host — all tests drive the
+# cluster via that entrypoint. The other replicas are reachable
+# container-to-container via the compose network.
+#
+# Design decision: 1 Keeper, not 3.
+#   Keeper replica count and CH replica count are independent. 3 CH
+#   replicas exercise data replication, ON CLUSTER DDL propagation, and
+#   ReplicatedMergeTree path templating — which is where every
+#   replication-related production bug in our history has lived. 3
+#   Keepers would additionally exercise Raft quorum / leader-election
+#   behavior, which is NOT in our incident history. The cost of 3
+#   Keepers (extra memory, Raft flake risk) isn't justified for the
+#   bugs we're trying to catch. Revisit only if an incident proves
+#   Keeper HA is part of our bug surface.
+#
+# Resource limits target the GH Actions ubuntu-latest runner (7 GB RAM,
+# 2 vCPU). Each CH node caps at 1.5 GB; total committed memory across
+# 3 CH nodes is 4.5 GB, leaving ~2.5 GB headroom for the test runner
+# and OS. Do not raise without verifying CI runner capacity.
+#
+# Usage (local):
+#   docker compose -f 1s3r.yaml up -d --wait
+#   docker compose -f 1s3r.yaml exec -T ch-s1-r1 \
+#     clickhouse-client -q "SELECT host_name, errors_count FROM system.clusters WHERE cluster='weave_cluster'"
+#   docker compose -f 1s3r.yaml down -v
+
+x-ch-node: &ch-node
+  image: clickhouse/clickhouse-server:25.11.2.24
+  environment:
+    CLICKHOUSE_DB: default
+    CLICKHOUSE_USER: default
+    CLICKHOUSE_PASSWORD: ""
+    CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+  ulimits:
+    nofile:
+      soft: 262144
+      hard: 262144
+  deploy:
+    resources:
+      limits:
+        memory: 1536M
+  healthcheck:
+    test: ["CMD-SHELL", "wget -q -O- http://localhost:8123/ping || exit 1"]
+    interval: 3s
+    timeout: 2s
+    retries: 20
+    start_period: 10s
+
+services:
+  ch-s1-r1:
+    <<: *ch-node
+    container_name: weave-ci-ch-s1-r1
+    hostname: ch-s1-r1
+    ports:
+      # Host-side port 8130 matches the default expected by
+      # tests/trace_server_migrator/conftest.py::_DEFAULT_PORT,
+      # so the existing fixture works without WF_CLICKHOUSE_KEEPER_PORT overrides.
+      - "8130:8123"     # HTTP interface (host entrypoint)
+      - "9000:9000"     # native TCP
+    volumes:
+      - ../keeper_1s3r.xml:/etc/clickhouse-server/config.d/cluster.xml:ro
+      - ./macros_s1_r1.xml:/etc/clickhouse-server/config.d/macros.xml:ro
+
+  ch-s1-r2:
+    <<: *ch-node
+    container_name: weave-ci-ch-s1-r2
+    hostname: ch-s1-r2
+    volumes:
+      - ../keeper_1s3r.xml:/etc/clickhouse-server/config.d/cluster.xml:ro
+      - ./macros_s1_r2.xml:/etc/clickhouse-server/config.d/macros.xml:ro
+    depends_on:
+      ch-s1-r1:
+        condition: service_healthy
+
+  ch-s1-r3:
+    <<: *ch-node
+    container_name: weave-ci-ch-s1-r3
+    hostname: ch-s1-r3
+    volumes:
+      - ../keeper_1s3r.xml:/etc/clickhouse-server/config.d/cluster.xml:ro
+      - ./macros_s1_r3.xml:/etc/clickhouse-server/config.d/macros.xml:ro
+    depends_on:
+      ch-s1-r1:
+        condition: service_healthy
+
+networks:
+  default:
+    name: weave-ci-1s3r

--- a/tests/trace_server/conftest_lib/topologies/2s2r.yaml
+++ b/tests/trace_server/conftest_lib/topologies/2s2r.yaml
@@ -1,0 +1,116 @@
+# 2 shards × 2 replicas topology for pre-merge migrator CI.
+#
+# Four CH nodes arranged as:
+#   shard1: ch-s1-r1 (entrypoint + keeper), ch-s1-r2
+#   shard2: ch-s2-r1, ch-s2-r2
+#
+# Keeper is embedded in ch-s1-r1 (same pattern as 1s3r). All four CH
+# nodes join the same Keeper instance. Only ch-s1-r1 exposes the HTTP
+# port to the host — tests drive the cluster via that entrypoint, and
+# distributed-engine tables route queries across both shards via the
+# compose network.
+#
+# Design decision: 2s2r instead of 2s3r.
+#   Prod runs 2 shards × 3 replicas. 2 replicas per shard is sufficient
+#   to exercise every bug class in our incident history (ReplicatedMergeTree
+#   path templating, ON CLUSTER DDL propagation, distributed-table _local
+#   suffix logic, sharding-key regressions). The 3rd replica per shard
+#   only exercises quorum edge cases, which have not been in our incident
+#   surface. Dropping to 2 replicas saves ~25% memory/CPU on a GH Actions
+#   runner, where capacity is the actual limiting factor.
+#
+# Design decision: 1 Keeper, not 3.
+#   Keeper replica count and CH replica count are independent. The
+#   production bugs we're catching live in the CH protocol surface
+#   (replication, DDL, distributed routing), not in Keeper quorum
+#   behavior. Revisit only if an incident proves Keeper HA is in our
+#   bug surface.
+#
+# Resource limits target the GH Actions ubuntu-latest runner (7 GB RAM,
+# 2 vCPU). Each CH node caps at 1.5 GB; total committed memory across
+# 4 CH nodes is 6 GB — tighter than 1s3r's 4.5 GB, but observed actual
+# usage is ~800 MB per node (~3.2 GB total) so real headroom is
+# comfortable. If CI OOMs, first lever is lowering per-node cap to 1 GB.
+#
+# Host port 8131 is used (1s3r uses 8130) to avoid collision when both
+# topologies are up simultaneously for local dev. CI runs them in
+# separate jobs on separate runners, so the port choice there is
+# cosmetic.
+#
+# Usage (local):
+#   docker compose -f 2s2r.yaml up -d --wait
+#   docker compose -f 2s2r.yaml exec -T ch-s1-r1 \
+#     clickhouse-client -q "SELECT host_name, shard_num, replica_num, errors_count FROM system.clusters WHERE cluster='weave_cluster'"
+#   docker compose -f 2s2r.yaml down -v
+
+x-ch-node: &ch-node
+  image: clickhouse/clickhouse-server:25.11.2.24
+  environment:
+    CLICKHOUSE_DB: default
+    CLICKHOUSE_USER: default
+    CLICKHOUSE_PASSWORD: ""
+    CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+  ulimits:
+    nofile:
+      soft: 262144
+      hard: 262144
+  deploy:
+    resources:
+      limits:
+        memory: 1536M
+  healthcheck:
+    test: ["CMD-SHELL", "wget -q -O- http://localhost:8123/ping || exit 1"]
+    interval: 3s
+    timeout: 2s
+    retries: 20
+    start_period: 10s
+
+services:
+  ch-s1-r1:
+    <<: *ch-node
+    container_name: weave-ci-ch-2s2r-s1-r1
+    hostname: ch-s1-r1
+    ports:
+      # Host port 8131 → container 8123. 1s3r uses 8130.
+      - "8131:8123"
+      - "9001:9000"
+    volumes:
+      - ../keeper_2s2r.xml:/etc/clickhouse-server/config.d/cluster.xml:ro
+      - ./macros_s1_r1.xml:/etc/clickhouse-server/config.d/macros.xml:ro
+
+  ch-s1-r2:
+    <<: *ch-node
+    container_name: weave-ci-ch-2s2r-s1-r2
+    hostname: ch-s1-r2
+    volumes:
+      - ../keeper_2s2r.xml:/etc/clickhouse-server/config.d/cluster.xml:ro
+      - ./macros_s1_r2.xml:/etc/clickhouse-server/config.d/macros.xml:ro
+    depends_on:
+      ch-s1-r1:
+        condition: service_healthy
+
+  ch-s2-r1:
+    <<: *ch-node
+    container_name: weave-ci-ch-2s2r-s2-r1
+    hostname: ch-s2-r1
+    volumes:
+      - ../keeper_2s2r.xml:/etc/clickhouse-server/config.d/cluster.xml:ro
+      - ./macros_s2_r1.xml:/etc/clickhouse-server/config.d/macros.xml:ro
+    depends_on:
+      ch-s1-r1:
+        condition: service_healthy
+
+  ch-s2-r2:
+    <<: *ch-node
+    container_name: weave-ci-ch-2s2r-s2-r2
+    hostname: ch-s2-r2
+    volumes:
+      - ../keeper_2s2r.xml:/etc/clickhouse-server/config.d/cluster.xml:ro
+      - ./macros_s2_r2.xml:/etc/clickhouse-server/config.d/macros.xml:ro
+    depends_on:
+      ch-s1-r1:
+        condition: service_healthy
+
+networks:
+  default:
+    name: weave-ci-2s2r

--- a/tests/trace_server/conftest_lib/topologies/macros_s1_r1.xml
+++ b/tests/trace_server/conftest_lib/topologies/macros_s1_r1.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <macros>
+        <shard>shard1</shard>
+        <replica>replica1</replica>
+        <cluster>weave_cluster</cluster>
+    </macros>
+</clickhouse>

--- a/tests/trace_server/conftest_lib/topologies/macros_s1_r2.xml
+++ b/tests/trace_server/conftest_lib/topologies/macros_s1_r2.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <macros>
+        <shard>shard1</shard>
+        <replica>replica2</replica>
+        <cluster>weave_cluster</cluster>
+    </macros>
+</clickhouse>

--- a/tests/trace_server/conftest_lib/topologies/macros_s1_r3.xml
+++ b/tests/trace_server/conftest_lib/topologies/macros_s1_r3.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <macros>
+        <shard>shard1</shard>
+        <replica>replica3</replica>
+        <cluster>weave_cluster</cluster>
+    </macros>
+</clickhouse>

--- a/tests/trace_server/conftest_lib/topologies/macros_s2_r1.xml
+++ b/tests/trace_server/conftest_lib/topologies/macros_s2_r1.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <macros>
+        <shard>shard2</shard>
+        <replica>replica1</replica>
+        <cluster>weave_cluster</cluster>
+    </macros>
+</clickhouse>

--- a/tests/trace_server/conftest_lib/topologies/macros_s2_r2.xml
+++ b/tests/trace_server/conftest_lib/topologies/macros_s2_r2.xml
@@ -1,0 +1,7 @@
+<clickhouse>
+    <macros>
+        <shard>shard2</shard>
+        <replica>replica2</replica>
+        <cluster>weave_cluster</cluster>
+    </macros>
+</clickhouse>


### PR DESCRIPTION
  ## What

  Adds two new pre-merge CI jobs that run the existing migrator functional suite against multi-replica ClickHouse topologies:

  - **`trace-server-migrator-1s3r`** — 1 shard × 3 replicas, embedded Keeper in `ch-s1-r1`.
  - **`trace-server-migrator-2s2r`** — 2 shards × 2 replicas, embedded Keeper in `ch-s1-r1`, distributed tables available for tests that opt in.

  The existing `trace-server-migrator-tests` job is renamed to `trace-server-migrator-1s1r` for clarity. Behavior is unchanged — still runs on every push.

  Both new jobs are path-filtered: they run only when a PR touches `weave/trace_server/migrations/`, `tests/trace_server_migrator/`, or `tests/trace_server/conftest_lib/`. They also run on every push to
  `master`, matching the broader pattern in this workflow.

  The `trace-tests-matrix-check` aggregator whitelists the two new jobs via `alls-green`'s `allowed-skips` so path-gated skips don't wedge merge on unrelated PRs.

  ## Why

  Prod runs ClickHouse Cloud at 2 shards × 3 replicas. CI today tests only at 1 shard × 1 replica. Between those two points, every replication-specific and distributed-specific code path has no pre-merge coverage anywhere in the pipeline.

  That gap is not theoretical. In the last ~14 months, 22+ fix PRs from @gtarpenning have addressed bugs invisible to 1s1r CI:

  - #6574  — `_local` suffix missing in ON CLUSTER mutations (needs 2s+)
  - #6503  — replica sync failure during migration (needs 1s3r+)
  - #6597  — replicated engines in replicated DBs (needs 1s3r+)
  - #6413  — distributed sharded DB engine misconfig (needs 2s+)
  - #6082  — distributed calls sharding key (needs 2s+)
  - #6335 , #6039 , #5968 , #5969 , #5864 , #5885  — similar classes

  Every one of these shipped to production and was caught post-merge.

  ## Design notes

  **Why 2s2r and not 2s3r (prod-exact).** GH Actions `ubuntu-latest` runners have ~7 GB RAM. The 3rd replica per shard only exercises Keeper quorum behavior, which has never been in our incident history. Dropping to 2
  replicas saves ~25% runner memory without losing any bug classes.
  Revisit if quorum ever becomes an incident surface.

  **Why 1 Keeper and not 3.** Keeper replica count and CH replica count are independent. The bug classes above all live in the CH protocol surface (replication, DDL, distributed routing), not in Keeper Raft behavior.
  A single Keeper catches everything we care about at a fraction of the complexity. Same revisit criterion.

  **Why path-filter to just `migrations/` and test dirs.** Per review feedback: the existing migrator functional suite only exercises end-to-end application of migration SQL. Gating on the migrator engine, schema, or environment files would over-trigger without adding coverage the tests actually validate.

  ## Local verification

  Both topologies were stood up via docker-compose locally (OrbStack on macOS) and verified end-to-end before push:

  - 1s3r: 4-node cluster (3 CH + embedded Keeper), all 3 replicas visible in
    `system.clusters` with zero errors, `ON CLUSTER` DDL propagates,
    `ReplicatedMergeTree` inserts replicate correctly. All 8 upstream
    migrator functional tests pass in 63s.
  - 2s2r: 4-node cluster, sharded + replicated, `Distributed` engine routes
    writes across both shards and reads fan out correctly. All 8 tests pass in 76s.
  - Memory footprint on both: ~2.7 GB peak across all nodes, well under
    the runner budget.

  ## Risk / rollout

  - New jobs are **not** wired into branch protection as individual required checks. They only appear via the aggregator (`trace-tests-matrix-check`).
  - Plan to run on master for ~1 week before proposing branch-protection changes that actually gate merge.
  - If CI flakes, the first lever is the `ubuntu-latest-8-cores` runner upgrade. Second lever is moving 2s2r to a nightly job. Neither is proposed in this PR.

  ## Follow-ups (out of scope)

  - **Regression tests encoding specific past bug classes** (Griffin's `_local` suffix fix, replica-sync-during-migration, distributed sharding key). Without these, the matrix validates syntax + end-to-end flow but does not assert topology-specific correctness. High priority.
  - **Nightly all-shards run** across a broader topology matrix, per reviewer suggestion. Catches indirect bugs from non-migrator PRs that path filters intentionally skip.
  - **Branch protection update** to require `trace-tests-matrix-check` (deferred until jobs are stable for a week).
