### PR TITLE
chore(weave): inline CHValidationError into errors.py

### DIFF
--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -7,8 +7,6 @@ from typing import Any, Optional
 import httpx
 from gql.transport.exceptions import TransportQueryError, TransportServerError
 
-from weave.trace_server.validation_util import CHValidationError
-
 # =============================================================================
 # Error Codes - Machine-readable codes for client-side error detection
 # =============================================================================
@@ -123,6 +121,17 @@ class InvalidFieldError(Error):
 
 class NotFoundError(Error):
     """Raised when a general not found error occurs."""
+
+    pass
+
+
+class CHValidationError(Exception):
+    """Raised when a ClickHouse-bound value fails validation (IDs, refs, base64, length).
+
+    Defined here so that ``errors.py`` is self-contained and has no dependency on
+    server-side validation helpers; ``validation_util.py`` re-exports it for
+    backwards compatibility.
+    """
 
     pass
 

--- a/weave/trace_server/validation_util.py
+++ b/weave/trace_server/validation_util.py
@@ -2,15 +2,24 @@ import base64
 import uuid
 
 from weave.shared import refs_internal
+from weave.trace_server.errors import CHValidationError
+
+__all__ = [
+    "OTEL_SPAN_ID_HEX_LENGTH",
+    "OTEL_TRACE_ID_HEX_LENGTH",
+    "CHValidationError",
+    "require_base64",
+    "require_internal_ref_uri",
+    "require_max_str_len",
+    "require_otel_span_id",
+    "require_otel_trace_id",
+    "require_uuid",
+]
 
 # OTel trace ID: 16 bytes encoded as 32 hex characters
 OTEL_TRACE_ID_HEX_LENGTH = 32
 # OTel span ID: 8 bytes encoded as 16 hex characters
 OTEL_SPAN_ID_HEX_LENGTH = 16
-
-
-class CHValidationError(Exception):
-    pass
 
 
 def require_otel_trace_id(s: str) -> str:


### PR DESCRIPTION
## Summary

- Moves `CHValidationError` from `weave/trace_server/validation_util.py` into `weave/trace_server/errors.py`
- `validation_util.py` re-exports it, so every existing import path keeps working
- `errors.py` no longer imports from `validation_util`, so it is now a self-contained public contract module (no cross-file deps inside `weave/trace_server/` except the public sibling set and `weave.shared`)

## Why

Prep work for a planned refactor that splits `weave/trace_server/` into a small frozen public contract (schemas, errors, ids, query AST, builtin object classes) and a closed server implementation. `errors.py` is part of that public contract and was the only file in the set still reaching into a would-be-closed module. Inlining the one-line class here removes that last edge so the contract can be enforced with a lint guard in a follow-up.

Zero behavior change: identical exception class (same name, same bases), `validation_util.CHValidationError is errors.CHValidationError`, and the error registry still maps it to HTTP 400.

## Test plan

- [x] `uvx ruff check` passes on both edited files
- [x] `pytest --collect-only tests/trace_server/test_clickhouse_batching.py tests/trace/test_client_trace.py` collects cleanly (139 tests)
- [x] Smoke-tested `require_otel_trace_id`, `require_otel_span_id`, `require_uuid`, `require_base64`, `require_max_str_len` each raise `CHValidationError` on bad input
- [x] Smoke-tested `handle_server_exception(CHValidationError(...))` still returns HTTP 400
- [x] `validation_util.CHValidationError is errors.CHValidationError` holds
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)