### PR TITLE
refactor(weave): consolidate agent read endpoints into one spans query with group_by

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -6,21 +6,19 @@ formatted SQL + param dict against an expected value, matching the style of
 ``test_annotation_queues_query_builder.py`` etc.
 """
 
+import pytest
 import sqlparse
 
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
-    AgentConversationsQueryFilters,
-    AgentConversationsQueryReq,
     AgentCustomAttrFilter,
+    AgentGroupByRef,
     AgentSearchReq,
     AgentSortBy,
     AgentSpansQueryFilters,
     AgentSpansQueryReq,
-    AgentSpansTraceReq,
     AgentsQueryFilters,
     AgentsQueryReq,
-    AgentTracesQueryReq,
     AgentVersionsQueryReq,
 )
 from weave.trace_server.orm import ParamBuilder
@@ -34,14 +32,11 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_agents_count_query,
     make_agents_list_query,
     make_conversation_chat_spans_query,
-    make_conversations_count_query,
-    make_conversations_list_query,
     make_message_search_query,
     make_spans_count_query,
     make_spans_list_query,
-    make_spans_trace_query,
-    make_traces_count_query,
-    make_traces_list_query,
+    make_trace_detail_spans_query,
+    resolve_group_by,
 )
 
 
@@ -60,7 +55,7 @@ def assert_sql(
 
 
 # ============================================================================
-# make_spans_count_query
+# make_spans_count_query (ungrouped)
 # ============================================================================
 
 
@@ -111,7 +106,7 @@ class TestMakeSpansCountQuery:
 
 
 # ============================================================================
-# make_spans_list_query
+# make_spans_list_query (ungrouped)
 # ============================================================================
 
 
@@ -159,16 +154,255 @@ class TestMakeSpansListQuery:
 
 
 # ============================================================================
-# make_spans_trace_query
+# make_spans_count_query (grouped)
 # ============================================================================
 
 
-class TestMakeSpansTraceQuery:
+#: The fixed aggregate tail emitted by the grouped list query, as it would
+#: appear after ``SELECT <group_cols>,``. Used to keep test expected SQL
+#: readable without duplicating the bundle across every test.
+_GROUPED_AGG_TAIL = """count() AS span_count,
+               uniqExact(s.trace_id) AS trace_count,
+               uniqExact(s.conversation_id) AS conversation_count,
+               sum(s.input_tokens) AS total_input_tokens,
+               sum(s.output_tokens) AS total_output_tokens,
+               sum(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)) AS total_duration_ms,
+               countIf(s.status_code = 'ERROR') AS error_count,
+               groupUniqArray(s.agent_name) AS agent_names,
+               groupUniqArray(s.agent_version) AS agent_versions,
+               groupUniqArray(s.provider_name) AS provider_names,
+               groupUniqArray(s.request_model) AS request_models,
+               min(s.started_at) AS first_seen,
+               max(s.started_at) AS last_seen"""
+
+
+class TestMakeGroupedSpansCountQuery:
+    def test_group_by_column(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_spans_count_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="trace_id")],
+            ),
+        )
+
+        expected = """
+            SELECT count() FROM (
+                SELECT s.trace_id FROM spans s
+                WHERE s.project_id = {genai_0:String}
+                GROUP BY s.trace_id
+            )
+        """
+        assert_sql(expected, {"genai_0": "p1"}, query, pb.get_params())
+
+    def test_group_by_custom_attr(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_spans_count_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="custom_attrs", key="env")],
+            ),
+        )
+
+        expected = """
+            SELECT count() FROM (
+                SELECT s.custom_attrs[{genai_1:String}] FROM spans s
+                WHERE s.project_id = {genai_0:String}
+                GROUP BY s.custom_attrs[{genai_1:String}]
+            )
+        """
+        expected_params = {"genai_0": "p1", "genai_1": "env"}
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+
+# ============================================================================
+# make_spans_list_query (grouped)
+# ============================================================================
+
+
+class TestMakeGroupedSpansListQuery:
+    def test_group_by_trace_id(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="trace_id")],
+            ),
+        )
+
+        expected = f"""
+            SELECT s.trace_id AS trace_id,
+                   {_GROUPED_AGG_TAIL}
+            FROM spans s
+            WHERE s.project_id = {{genai_0:String}}
+            GROUP BY trace_id
+            ORDER BY last_seen DESC
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_group_by_conversation_id_with_time(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[
+                    AgentGroupByRef(source="column", key="conversation_id"),
+                ],
+                start="2026-01-01",
+                end="2026-02-01",
+            ),
+        )
+
+        expected = f"""
+            SELECT s.conversation_id AS conversation_id,
+                   {_GROUPED_AGG_TAIL}
+            FROM spans s
+            WHERE s.project_id = {{genai_0:String}}
+              AND s.started_at >= parseDateTimeBestEffort({{genai_1:String}})
+              AND s.started_at < parseDateTimeBestEffort({{genai_2:String}})
+            GROUP BY conversation_id
+            ORDER BY last_seen DESC
+            LIMIT {{genai_3:UInt64}} OFFSET {{genai_4:UInt64}}
+        """
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": "2026-01-01",
+            "genai_2": "2026-02-01",
+            "genai_3": 100,
+            "genai_4": 0,
+        }
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_group_by_custom_attr(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[
+                    AgentGroupByRef(source="custom_attrs", key="env"),
+                ],
+            ),
+        )
+
+        expected = f"""
+            SELECT s.custom_attrs[{{genai_3:String}}] AS env,
+                   {_GROUPED_AGG_TAIL}
+            FROM spans s
+            WHERE s.project_id = {{genai_0:String}}
+            GROUP BY env
+            ORDER BY last_seen DESC
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": 100,
+            "genai_2": 0,
+            "genai_3": "env",
+        }
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_group_by_multi_column_and_sort_by_alias(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[
+                    AgentGroupByRef(source="column", key="agent_name"),
+                    AgentGroupByRef(source="column", key="request_model"),
+                ],
+                sort_by=[AgentSortBy(field="agent_name", direction="asc")],
+            ),
+        )
+
+        expected = f"""
+            SELECT s.agent_name AS agent_name,
+                   s.request_model AS request_model,
+                   {_GROUPED_AGG_TAIL}
+            FROM spans s
+            WHERE s.project_id = {{genai_0:String}}
+            GROUP BY agent_name, request_model
+            ORDER BY agent_name asc
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+
+# ============================================================================
+# resolve_group_by validation
+# ============================================================================
+
+
+class TestResolveGroupBy:
+    def test_rejects_non_allowlisted_column(self) -> None:
+        pb = ParamBuilder("genai")
+        with pytest.raises(ValueError, match="not in the allowlist"):
+            resolve_group_by(
+                pb, [AgentGroupByRef(source="column", key="raw_span_dump")]
+            )
+
+    def test_rejects_duplicate_alias(self) -> None:
+        pb = ParamBuilder("genai")
+        with pytest.raises(ValueError, match="duplicate group_by alias"):
+            resolve_group_by(
+                pb,
+                [
+                    AgentGroupByRef(source="column", key="agent_name"),
+                    AgentGroupByRef(source="column", key="agent_name"),
+                ],
+            )
+
+    def test_rejects_invalid_alias(self) -> None:
+        pb = ParamBuilder("genai")
+        with pytest.raises(ValueError, match="must match"):
+            resolve_group_by(
+                pb,
+                [
+                    AgentGroupByRef(
+                        source="custom_attrs", key="has spaces", alias="bad alias"
+                    )
+                ],
+            )
+
+    def test_defaults_alias_to_key_when_valid(self) -> None:
+        pb = ParamBuilder("genai")
+        out = resolve_group_by(
+            pb, [AgentGroupByRef(source="custom_attrs", key="env")]
+        )
+        assert out == [("s.custom_attrs[{genai_0:String}]", "env")]
+
+    def test_custom_alias_used_when_key_non_identifier(self) -> None:
+        pb = ParamBuilder("genai")
+        out = resolve_group_by(
+            pb,
+            [
+                AgentGroupByRef(
+                    source="custom_attrs",
+                    key="has spaces",
+                    alias="spaced_attr",
+                )
+            ],
+        )
+        assert out == [("s.custom_attrs[{genai_0:String}]", "spaced_attr")]
+
+
+# ============================================================================
+# make_trace_detail_spans_query (internal helper — chat view only)
+# ============================================================================
+
+
+class TestMakeTraceDetailSpansQuery:
     def test_basic(self) -> None:
         pb = ParamBuilder("genai")
-        query = make_spans_trace_query(
-            pb, AgentSpansTraceReq(project_id="p1", trace_id="t1")
-        )
+        query = make_trace_detail_spans_query(pb, "p1", "t1")
 
         expected = f"""
             SELECT {CHAT_VIEW_COLS} FROM spans s
@@ -182,94 +416,6 @@ class TestMakeSpansTraceQuery:
             query,
             pb.get_params(),
         )
-
-
-# ============================================================================
-# make_traces_count_query
-# ============================================================================
-
-
-class TestMakeTracesCountQuery:
-    def test_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_traces_count_query(pb, AgentTracesQueryReq(project_id="p1"))
-
-        expected = """
-            SELECT count() FROM (
-                SELECT trace_id FROM spans
-                WHERE project_id = {genai_0:String}
-                GROUP BY trace_id
-            )
-        """
-        assert_sql(expected, {"genai_0": "p1"}, query, pb.get_params())
-
-    def test_with_filters(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_traces_count_query(
-            pb,
-            AgentTracesQueryReq(
-                project_id="p1",
-                conversation_id="conv-1",
-                agent_name="bot",
-                agent_version="v2",
-                start="2026-01-01",
-                end="2026-02-01",
-            ),
-        )
-
-        expected = """
-            SELECT count() FROM (
-                SELECT trace_id FROM spans
-                WHERE project_id = {genai_0:String}
-                  AND conversation_id = {genai_1:String}
-                  AND agent_name = {genai_2:String}
-                  AND agent_version = {genai_3:String}
-                  AND started_at >= parseDateTimeBestEffort({genai_4:String})
-                  AND started_at < parseDateTimeBestEffort({genai_5:String})
-                GROUP BY trace_id
-            )
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": "conv-1",
-            "genai_2": "bot",
-            "genai_3": "v2",
-            "genai_4": "2026-01-01",
-            "genai_5": "2026-02-01",
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-
-# ============================================================================
-# make_traces_list_query
-# ============================================================================
-
-
-class TestMakeTracesListQuery:
-    def test_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_traces_list_query(pb, AgentTracesQueryReq(project_id="p1"))
-
-        expected = """
-            SELECT trace_id,
-                   count() AS span_count,
-                   sum(input_tokens) AS total_input_tokens,
-                   sum(output_tokens) AS total_output_tokens,
-                   countIf(status_code = 'ERROR') AS error_count,
-                   max(conversation_id) AS conversation_id,
-                   groupUniqArray(agent_name) AS agent_names,
-                   groupUniqArray(agent_version) AS agent_versions,
-                   groupUniqArray(request_model) AS request_models,
-                   min(started_at) AS first_seen,
-                   max(started_at) AS last_seen
-            FROM spans
-            WHERE project_id = {genai_0:String}
-            GROUP BY trace_id
-            ORDER BY last_seen DESC, trace_id
-            LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
-        """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
-        assert_sql(expected, expected_params, query, pb.get_params())
 
 
 # ============================================================================
@@ -403,103 +549,6 @@ class TestMakeAgentVersionsQueries:
         expected_params = {
             "genai_0": "p1",
             "genai_1": "a1",
-            "genai_2": 100,
-            "genai_3": 0,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-
-# ============================================================================
-# make_conversations_{count,list}_query
-# ============================================================================
-
-
-class TestMakeConversationsQueries:
-    def test_count_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_conversations_count_query(
-            pb, AgentConversationsQueryReq(project_id="p1")
-        )
-
-        expected = """
-            SELECT count() FROM (
-                SELECT conversation_id FROM spans
-                WHERE project_id = {genai_0:String}
-                  AND conversation_id != ''
-                GROUP BY conversation_id
-            )
-        """
-        assert_sql(expected, {"genai_0": "p1"}, query, pb.get_params())
-
-    def test_list_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_conversations_list_query(
-            pb, AgentConversationsQueryReq(project_id="p1")
-        )
-
-        expected = """
-            SELECT conversation_id,
-                   max(conversation_name) AS conversation_name,
-                   countIf(operation_name = 'invoke_agent') AS turn_count,
-                   count() AS span_count,
-                   sum(input_tokens) AS total_input_tokens,
-                   sum(output_tokens) AS total_output_tokens,
-                   sum(toUnixTimestamp64Milli(ended_at) - toUnixTimestamp64Milli(started_at)) AS total_duration_ms,
-                   countIf(status_code = 'ERROR') AS error_count,
-                   groupUniqArray(agent_name) AS agent_names,
-                   groupUniqArray(agent_version) AS agent_versions,
-                   groupUniqArray(provider_name) AS provider_names,
-                   groupUniqArray(request_model) AS request_models,
-                   min(started_at) AS first_seen,
-                   max(started_at) AS last_seen
-            FROM spans
-            WHERE project_id = {genai_0:String}
-              AND conversation_id != ''
-            GROUP BY conversation_id
-            ORDER BY last_seen DESC, conversation_id
-            LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
-        """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_list_sort_by_array_alias(self) -> None:
-        """Sorting by ``agent_name`` must emit ``arrayElement(agent_names, 1)``."""
-        pb = ParamBuilder("genai")
-        query = make_conversations_list_query(
-            pb,
-            AgentConversationsQueryReq(
-                project_id="p1",
-                filters=AgentConversationsQueryFilters(agent_name="bot"),
-                sort_by=[AgentSortBy(field="agent_name", direction="asc")],
-            ),
-        )
-
-        expected = """
-            SELECT conversation_id,
-                   max(conversation_name) AS conversation_name,
-                   countIf(operation_name = 'invoke_agent') AS turn_count,
-                   count() AS span_count,
-                   sum(input_tokens) AS total_input_tokens,
-                   sum(output_tokens) AS total_output_tokens,
-                   sum(toUnixTimestamp64Milli(ended_at) - toUnixTimestamp64Milli(started_at)) AS total_duration_ms,
-                   countIf(status_code = 'ERROR') AS error_count,
-                   groupUniqArray(agent_name) AS agent_names,
-                   groupUniqArray(agent_version) AS agent_versions,
-                   groupUniqArray(provider_name) AS provider_names,
-                   groupUniqArray(request_model) AS request_models,
-                   min(started_at) AS first_seen,
-                   max(started_at) AS last_seen
-            FROM spans
-            WHERE project_id = {genai_0:String}
-              AND conversation_id != ''
-              AND agent_name = {genai_1:String}
-            GROUP BY conversation_id
-            ORDER BY arrayElement(agent_names, 1) asc
-            LIMIT {genai_2:UInt64} OFFSET {genai_3:UInt64}
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": "bot",
             "genai_2": 100,
             "genai_3": 0,
         }

--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -162,6 +162,7 @@ class TestMakeSpansListQuery:
 #: appear after ``SELECT <group_cols>,``. Used to keep test expected SQL
 #: readable without duplicating the bundle across every test.
 _GROUPED_AGG_TAIL = """count() AS span_count,
+               countIf(s.operation_name = 'invoke_agent') AS turn_count,
                uniqExact(s.trace_id) AS trace_count,
                uniqExact(s.conversation_id) AS conversation_count,
                sum(s.input_tokens) AS total_input_tokens,
@@ -172,6 +173,7 @@ _GROUPED_AGG_TAIL = """count() AS span_count,
                groupUniqArray(s.agent_version) AS agent_versions,
                groupUniqArray(s.provider_name) AS provider_names,
                groupUniqArray(s.request_model) AS request_models,
+               groupUniqArray(s.conversation_name) AS conversation_names,
                min(s.started_at) AS first_seen,
                max(s.started_at) AS last_seen"""
 

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -235,10 +235,14 @@ def test_group_by_conversation_id(ch_server):
     assert conv_b in by_conv
 
     assert by_conv[conv_a].span_count == 2
+    assert by_conv[conv_a].turn_count == 1  # one invoke_agent span
     assert "agent-x" in by_conv[conv_a].agent_names
+    assert "Alpha Chat" in by_conv[conv_a].conversation_names
 
     assert by_conv[conv_b].span_count == 1
+    assert by_conv[conv_b].turn_count == 1
     assert "agent-y" in by_conv[conv_b].agent_names
+    assert "Beta Chat" in by_conv[conv_b].conversation_names
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -20,12 +20,11 @@ from weave.trace_server.agents.schema import (
     NormalizedMessage,
 )
 from weave.trace_server.agents.types import (
-    AgentConversationsQueryReq,
+    AgentGroupByRef,
     AgentSearchReq,
     AgentSpansQueryFilters,
     AgentSpansQueryReq,
     AgentsQueryReq,
-    AgentTracesQueryReq,
 )
 
 
@@ -79,12 +78,12 @@ def _insert_search_rows(ch_client, spans: list[AgentSpanCHInsertable]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 1: Span insert and query
+# Test: ungrouped spans query
 # ---------------------------------------------------------------------------
 
 
 def test_spans_insert_and_query(ch_server):
-    """Insert spans and query with filters."""
+    """Insert spans and query with filters (ungrouped mode)."""
     project_id = _make_project_id("spans")
     now = datetime.datetime.now(tz=datetime.timezone.utc)
 
@@ -107,6 +106,7 @@ def test_spans_insert_and_query(ch_server):
     res = ch_server.agent_spans_query(AgentSpansQueryReq(project_id=project_id))
     assert res.total_count == 3
     assert len(res.spans) == 3
+    assert res.groups == []
 
     # Filter by agent_name
     res_filtered = ch_server.agent_spans_query(
@@ -120,12 +120,12 @@ def test_spans_insert_and_query(ch_server):
 
 
 # ---------------------------------------------------------------------------
-# Test 2: Traces GROUP BY
+# Test: group by trace_id (replaces old traces_query)
 # ---------------------------------------------------------------------------
 
 
-def test_traces_group_by(ch_server):
-    """Traces query groups spans by trace_id with correct aggregation."""
+def test_group_by_trace_id(ch_server):
+    """Grouping spans by trace_id returns per-trace aggregates."""
     project_id = _make_project_id("traces")
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     trace_a = uuid.uuid4().hex
@@ -161,10 +161,16 @@ def test_traces_group_by(ch_server):
     ]
     _insert_spans(ch_server.ch_client, spans)
 
-    res = ch_server.agent_traces_query(AgentTracesQueryReq(project_id=project_id))
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            group_by=[AgentGroupByRef(source="column", key="trace_id")],
+        )
+    )
     assert res.total_count == 2
+    assert res.spans == []
 
-    by_trace = {t.trace_id: t for t in res.traces}
+    by_trace = {g.group_keys["trace_id"]: g for g in res.groups}
     assert by_trace[trace_a].span_count == 2
     assert by_trace[trace_a].total_input_tokens == 300
     assert by_trace[trace_a].total_output_tokens == 50
@@ -175,7 +181,118 @@ def test_traces_group_by(ch_server):
 
 
 # ---------------------------------------------------------------------------
-# Test 3: Agents MV aggregation
+# Test: group by conversation_id (replaces old conversations_query)
+# ---------------------------------------------------------------------------
+
+
+def test_group_by_conversation_id(ch_server):
+    """Grouping spans by conversation_id returns per-conversation aggregates."""
+    project_id = _make_project_id("convs")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    conv_a = f"conv-{uuid.uuid4().hex[:8]}"
+    conv_b = f"conv-{uuid.uuid4().hex[:8]}"
+
+    spans = [
+        _make_span(
+            project_id,
+            conversation_id=conv_a,
+            conversation_name="Alpha Chat",
+            operation_name="invoke_agent",
+            agent_name="agent-x",
+            started_at=now,
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv_a,
+            conversation_name="Alpha Chat",
+            operation_name="chat",
+            agent_name="agent-x",
+            started_at=now + datetime.timedelta(seconds=1),
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv_b,
+            conversation_name="Beta Chat",
+            operation_name="invoke_agent",
+            agent_name="agent-y",
+            started_at=now + datetime.timedelta(seconds=2),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            filters=AgentSpansQueryFilters(),
+            group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+        )
+    )
+    # Only inserted rows have our conversation_ids, but project may include
+    # a row with the default empty conversation_id from other tests; guard
+    # by filtering to the conversation_ids we actually created.
+    by_conv = {g.group_keys["conversation_id"]: g for g in res.groups}
+    assert conv_a in by_conv
+    assert conv_b in by_conv
+
+    assert by_conv[conv_a].span_count == 2
+    assert "agent-x" in by_conv[conv_a].agent_names
+
+    assert by_conv[conv_b].span_count == 1
+    assert "agent-y" in by_conv[conv_b].agent_names
+
+
+# ---------------------------------------------------------------------------
+# Test: group by a custom_attrs map key (the new capability)
+# ---------------------------------------------------------------------------
+
+
+def test_group_by_custom_attrs(ch_server):
+    """Grouping on a custom_attrs key buckets spans by the user-supplied label."""
+    project_id = _make_project_id("cattr")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    spans = [
+        _make_span(
+            project_id,
+            agent_name="a1",
+            custom_attrs={"env": "prod"},
+            input_tokens=100,
+            started_at=now,
+        ),
+        _make_span(
+            project_id,
+            agent_name="a1",
+            custom_attrs={"env": "prod"},
+            input_tokens=200,
+            started_at=now + datetime.timedelta(seconds=1),
+        ),
+        _make_span(
+            project_id,
+            agent_name="a1",
+            custom_attrs={"env": "staging"},
+            input_tokens=50,
+            started_at=now + datetime.timedelta(seconds=2),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            group_by=[
+                AgentGroupByRef(source="custom_attrs", key="env"),
+            ],
+        )
+    )
+    by_env = {g.group_keys["env"]: g for g in res.groups}
+    assert by_env["prod"].span_count == 2
+    assert by_env["prod"].total_input_tokens == 300
+    assert by_env["staging"].span_count == 1
+    assert by_env["staging"].total_input_tokens == 50
+
+
+# ---------------------------------------------------------------------------
+# Test: Agents MV aggregation
 # ---------------------------------------------------------------------------
 
 
@@ -226,64 +343,7 @@ def test_agents_mv_aggregation(ch_server):
 
 
 # ---------------------------------------------------------------------------
-# Test 4: Conversations query
-# ---------------------------------------------------------------------------
-
-
-def test_conversations_query(ch_server):
-    """Conversations are grouped from spans by conversation_id."""
-    project_id = _make_project_id("convs")
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-    conv_a = f"conv-{uuid.uuid4().hex[:8]}"
-    conv_b = f"conv-{uuid.uuid4().hex[:8]}"
-
-    spans = [
-        # Conversation A: 2 spans, 1 invoke_agent
-        _make_span(
-            project_id,
-            conversation_id=conv_a,
-            conversation_name="Alpha Chat",
-            operation_name="invoke_agent",
-            agent_name="agent-x",
-            started_at=now,
-        ),
-        _make_span(
-            project_id,
-            conversation_id=conv_a,
-            conversation_name="Alpha Chat",
-            operation_name="chat",
-            agent_name="agent-x",
-            started_at=now + datetime.timedelta(seconds=1),
-        ),
-        # Conversation B: 1 span
-        _make_span(
-            project_id,
-            conversation_id=conv_b,
-            conversation_name="Beta Chat",
-            operation_name="invoke_agent",
-            agent_name="agent-y",
-            started_at=now + datetime.timedelta(seconds=2),
-        ),
-    ]
-    _insert_spans(ch_server.ch_client, spans)
-
-    res = ch_server.agent_conversations_query(
-        AgentConversationsQueryReq(project_id=project_id)
-    )
-    assert res.total_count == 2
-
-    by_conv = {c.conversation_id: c for c in res.conversations}
-    assert by_conv[conv_a].turn_count == 1
-    assert by_conv[conv_a].span_count == 2
-    assert "agent-x" in by_conv[conv_a].agent_names
-
-    assert by_conv[conv_b].turn_count == 1
-    assert by_conv[conv_b].span_count == 1
-    assert "agent-y" in by_conv[conv_b].agent_names
-
-
-# ---------------------------------------------------------------------------
-# Test 5: Message search
+# Test: Message search
 # ---------------------------------------------------------------------------
 
 

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -92,6 +92,7 @@ def _hydrate_group_row(
     return AgentSpanGroupRow(
         group_keys=group_keys,
         span_count=safe_int(row.get("span_count")),
+        turn_count=safe_int(row.get("turn_count")),
         trace_count=safe_int(row.get("trace_count")),
         conversation_count=safe_int(row.get("conversation_count")),
         total_input_tokens=safe_int(row.get("total_input_tokens")),
@@ -102,6 +103,7 @@ def _hydrate_group_row(
         agent_versions=unpack_string_array(row.get("agent_versions")),
         provider_names=unpack_string_array(row.get("provider_names")),
         request_models=unpack_string_array(row.get("request_models")),
+        conversation_names=unpack_string_array(row.get("conversation_names")),
         first_seen=row.get("first_seen"),
         last_seen=row.get("last_seen"),
     )

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -27,26 +27,19 @@ from weave.trace_server.agents.schema import (
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
     AgentConversationChatRes,
-    AgentConversationSchema,
-    AgentConversationsQueryReq,
-    AgentConversationsQueryRes,
     AgentSchema,
     AgentSearchConversationResult,
     AgentSearchMatchedMessage,
     AgentSearchReq,
     AgentSearchRes,
+    AgentSpanGroupRow,
     AgentSpanSchema,
     AgentSpansQueryReq,
     AgentSpansQueryRes,
-    AgentSpansTraceReq,
-    AgentSpansTraceRes,
     AgentsQueryReq,
     AgentsQueryRes,
     AgentTraceChatReq,
     AgentTraceChatRes,
-    AgentTraceSchema,
-    AgentTracesQueryReq,
-    AgentTracesQueryRes,
     AgentVersionSchema,
     AgentVersionsQueryReq,
     AgentVersionsQueryRes,
@@ -63,14 +56,10 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_agents_count_query,
     make_agents_list_query,
     make_conversation_chat_spans_query,
-    make_conversations_count_query,
-    make_conversations_list_query,
     make_message_search_query,
     make_spans_count_query,
     make_spans_list_query,
-    make_spans_trace_query,
-    make_traces_count_query,
-    make_traces_list_query,
+    make_trace_detail_spans_query,
     safe_int,
     safe_str,
 )
@@ -95,6 +84,29 @@ def _first_cell_int(result: Any) -> int:
     return safe_int(result.result_rows[0][0]) if result.result_rows else 0
 
 
+def _hydrate_group_row(
+    row: dict[str, Any], group_aliases: list[str]
+) -> AgentSpanGroupRow:
+    """Split a result row into (group_keys, aggregates) and build the response row."""
+    group_keys = {alias: row.get(alias) for alias in group_aliases}
+    return AgentSpanGroupRow(
+        group_keys=group_keys,
+        span_count=safe_int(row.get("span_count")),
+        trace_count=safe_int(row.get("trace_count")),
+        conversation_count=safe_int(row.get("conversation_count")),
+        total_input_tokens=safe_int(row.get("total_input_tokens")),
+        total_output_tokens=safe_int(row.get("total_output_tokens")),
+        total_duration_ms=safe_int(row.get("total_duration_ms")),
+        error_count=safe_int(row.get("error_count")),
+        agent_names=unpack_string_array(row.get("agent_names")),
+        agent_versions=unpack_string_array(row.get("agent_versions")),
+        provider_names=unpack_string_array(row.get("provider_names")),
+        request_models=unpack_string_array(row.get("request_models")),
+        first_seen=row.get("first_seen"),
+        last_seen=row.get("last_seen"),
+    )
+
+
 class AgentQueryHandler:
     """Read-side query operations for the agent observability system.
 
@@ -107,11 +119,17 @@ class AgentQueryHandler:
         self._query = query_fn
 
     # ------------------------------------------------------------------
-    # Spans queries
+    # Spans query (ungrouped + grouped)
     # ------------------------------------------------------------------
 
     def spans_query(self, req: AgentSpansQueryReq) -> AgentSpansQueryRes:
-        """Query spans with filters, sort, and pagination."""
+        """Query spans with filters, sort, and pagination.
+
+        If ``req.group_by`` is empty, returns raw span rows in ``spans``.
+        Otherwise, groups by the supplied refs and returns aggregate rows
+        in ``groups`` (with the same fixed aggregate bundle regardless of
+        which columns / custom_attrs are grouped on).
+        """
         pb = ParamBuilder("genai")
         count_sql = make_spans_count_query(pb, req)
         list_sql = make_spans_list_query(pb, req)
@@ -120,57 +138,19 @@ class AgentQueryHandler:
         total = _first_cell_int(self._query(count_sql, params))
         result = self._query(list_sql, params)
 
-        spans = [
-            AgentSpanSchema(**normalize_span_row(r)) for r in _rows_as_dicts(result)
-        ]
-        return AgentSpansQueryRes(spans=spans, total_count=total)
+        if not req.group_by:
+            spans = [
+                AgentSpanSchema(**normalize_span_row(r))
+                for r in _rows_as_dicts(result)
+            ]
+            return AgentSpansQueryRes(spans=spans, total_count=total)
 
-    def spans_trace(self, req: AgentSpansTraceReq) -> AgentSpansTraceRes:
-        """Get all spans for a trace."""
-        pb = ParamBuilder("genai")
-        sql = make_spans_trace_query(pb, req)
-        result = self._query(sql, pb.get_params())
-        spans = [
-            AgentSpanSchema.model_construct(**normalize_span_row(r))
-            for r in _rows_as_dicts(result)
-        ]
-        return AgentSpansTraceRes(spans=spans)
+        aliases = [ref.alias or ref.key for ref in req.group_by]
+        groups = [_hydrate_group_row(r, aliases) for r in _rows_as_dicts(result)]
+        return AgentSpansQueryRes(groups=groups, total_count=total)
 
     # ------------------------------------------------------------------
-    # Traces queries (GROUP BY trace_id on spans)
-    # ------------------------------------------------------------------
-
-    def traces_query(self, req: AgentTracesQueryReq) -> AgentTracesQueryRes:
-        """Query traces by aggregating spans with time bounds."""
-        pb = ParamBuilder("genai")
-        count_sql = make_traces_count_query(pb, req)
-        list_sql = make_traces_list_query(pb, req)
-        params = pb.get_params()
-
-        total = _first_cell_int(self._query(count_sql, params))
-        result = self._query(list_sql, params)
-
-        traces = [
-            AgentTraceSchema(
-                project_id=req.project_id,
-                trace_id=safe_str(r.get("trace_id")),
-                span_count=safe_int(r.get("span_count")),
-                total_input_tokens=safe_int(r.get("total_input_tokens")),
-                total_output_tokens=safe_int(r.get("total_output_tokens")),
-                error_count=safe_int(r.get("error_count")),
-                conversation_id=safe_str(r.get("conversation_id")),
-                agent_names=unpack_string_array(r.get("agent_names")),
-                agent_versions=unpack_string_array(r.get("agent_versions")),
-                request_models=unpack_string_array(r.get("request_models")),
-                first_seen=r.get("first_seen"),
-                last_seen=r.get("last_seen"),
-            )
-            for r in _rows_as_dicts(result)
-        ]
-        return AgentTracesQueryRes(traces=traces, total_count=total)
-
-    # ------------------------------------------------------------------
-    # Agents AMT queries
+    # AMT-backed agents queries
     # ------------------------------------------------------------------
 
     def agents_query(self, req: AgentsQueryReq) -> AgentsQueryRes:
@@ -198,10 +178,6 @@ class AgentQueryHandler:
         ]
         total = _first_cell_int(self._query(count_sql, params))
         return AgentsQueryRes(agents=agents, total_count=total)
-
-    # ------------------------------------------------------------------
-    # Agent versions AMT queries
-    # ------------------------------------------------------------------
 
     def agent_versions_query(
         self, req: AgentVersionsQueryReq
@@ -231,44 +207,6 @@ class AgentQueryHandler:
         ]
         total = _first_cell_int(self._query(count_sql, params))
         return AgentVersionsQueryRes(versions=versions, total_count=total)
-
-    # ------------------------------------------------------------------
-    # Conversations queries (GROUP BY conversation_id on spans)
-    # ------------------------------------------------------------------
-
-    def conversations_query(
-        self, req: AgentConversationsQueryReq
-    ) -> AgentConversationsQueryRes:
-        """Query conversations by aggregating spans with time bounds."""
-        pb = ParamBuilder("genai")
-        count_sql = make_conversations_count_query(pb, req)
-        list_sql = make_conversations_list_query(pb, req)
-        params = pb.get_params()
-
-        total = _first_cell_int(self._query(count_sql, params))
-        result = self._query(list_sql, params)
-
-        convs = [
-            AgentConversationSchema(
-                project_id=req.project_id,
-                conversation_id=safe_str(r.get("conversation_id")),
-                conversation_name=safe_str(r.get("conversation_name")),
-                turn_count=safe_int(r.get("turn_count")),
-                span_count=safe_int(r.get("span_count")),
-                total_input_tokens=safe_int(r.get("total_input_tokens")),
-                total_output_tokens=safe_int(r.get("total_output_tokens")),
-                total_duration_ms=safe_int(r.get("total_duration_ms")),
-                error_count=safe_int(r.get("error_count")),
-                agent_names=unpack_string_array(r.get("agent_names")),
-                agent_versions=unpack_string_array(r.get("agent_versions")),
-                provider_names=unpack_string_array(r.get("provider_names")),
-                request_models=unpack_string_array(r.get("request_models")),
-                first_seen=r.get("first_seen"),
-                last_seen=r.get("last_seen"),
-            )
-            for r in _rows_as_dicts(result)
-        ]
-        return AgentConversationsQueryRes(conversations=convs, total_count=total)
 
     # ------------------------------------------------------------------
     # Message search
@@ -306,6 +244,26 @@ class AgentQueryHandler:
 
         results = sorted(convs.values(), key=lambda c: c.last_activity, reverse=True)
         return AgentSearchRes(results=results, total_conversations=len(results))
+
+    # ------------------------------------------------------------------
+    # Internal: spans-for-one-trace with chat projection
+    # ------------------------------------------------------------------
+
+    def _trace_detail_spans(
+        self, project_id: str, trace_id: str
+    ) -> list[AgentSpanSchema]:
+        """Fetch all spans for a trace using the chat-view projection.
+
+        Used by the chat view handler to build ``AgentTraceChatRes``; not a
+        public query endpoint.
+        """
+        pb = ParamBuilder("genai")
+        sql = make_trace_detail_spans_query(pb, project_id, trace_id)
+        result = self._query(sql, pb.get_params())
+        return [
+            AgentSpanSchema.model_construct(**normalize_span_row(r))
+            for r in _rows_as_dicts(result)
+        ]
 
 
 # ---------------------------------------------------------------------------
@@ -394,13 +352,8 @@ class AgentWriteHandler:
     def traces_chat(self, req: AgentTraceChatReq) -> AgentTraceChatRes:
         """Build chat trajectory for a single trace."""
         reader = AgentQueryHandler(self._query)
-        spans_res = reader.spans_trace(
-            AgentSpansTraceReq(
-                project_id=req.project_id,
-                trace_id=req.trace_id,
-            )
-        )
-        return build_trace_chat(spans_res.spans, req.trace_id)
+        spans = reader._trace_detail_spans(req.project_id, req.trace_id)
+        return build_trace_chat(spans, req.trace_id)
 
     def conversation_chat(
         self, req: AgentConversationChatReq

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -95,11 +95,58 @@ class AgentSpansQueryFilters(BaseModel):
     custom_filters: list[AgentCustomAttrFilter] = Field(default_factory=list)
 
 
+class AgentGroupByRef(BaseModel):
+    """Reference to a column or map-key that spans should be grouped by.
+
+    ``source="column"`` targets a named span column (allowlisted server-side).
+    The other sources target keys inside the ``custom_attrs*`` Map columns,
+    which accept arbitrary user-defined keys.
+    """
+
+    source: Literal[
+        "column",
+        "custom_attrs",
+        "custom_attrs_int",
+        "custom_attrs_float",
+    ] = "column"
+    key: str
+    alias: str | None = None  # output key in AgentSpanGroupRow.group_keys (defaults to `key`)
+
+
+class AgentSpanGroupRow(BaseModel):
+    """A single row in a grouped spans query response.
+
+    ``group_keys`` maps each group_by ref's alias to its value for this row.
+    The remaining fields are a fixed aggregate bundle computed per group.
+    """
+
+    group_keys: dict[str, str | int | float | None] = Field(default_factory=dict)
+    span_count: int = 0
+    trace_count: int = 0
+    conversation_count: int = 0
+    total_input_tokens: int = 0
+    total_output_tokens: int = 0
+    total_duration_ms: int = 0
+    error_count: int = 0
+    agent_names: list[str] = Field(default_factory=list)
+    agent_versions: list[str] = Field(default_factory=list)
+    provider_names: list[str] = Field(default_factory=list)
+    request_models: list[str] = Field(default_factory=list)
+    first_seen: datetime.datetime | None = None
+    last_seen: datetime.datetime | None = None
+
+
 class AgentSpansQueryReq(BaseModel):
-    """Request to list agent spans for a project."""
+    """Request to query agent spans for a project.
+
+    When ``group_by`` is empty (or omitted), returns raw span rows in the
+    response's ``spans`` field. When ``group_by`` is non-empty, returns
+    aggregate group rows in the response's ``groups`` field.
+    """
 
     project_id: str
     filters: AgentSpansQueryFilters | None = None
+    group_by: list[AgentGroupByRef] | None = None
     sort_by: list[AgentSortBy] | None = None
     limit: int = 100
     offset: int = 0
@@ -108,23 +155,15 @@ class AgentSpansQueryReq(BaseModel):
 
 
 class AgentSpansQueryRes(BaseModel):
-    """Response containing a list of agent spans."""
+    """Response from a spans query.
 
-    spans: list[AgentSpanSchema]
+    Exactly one of ``spans`` or ``groups`` will be populated, based on
+    whether the request specified ``group_by``.
+    """
+
+    spans: list[AgentSpanSchema] = Field(default_factory=list)
+    groups: list[AgentSpanGroupRow] = Field(default_factory=list)
     total_count: int = 0
-
-
-class AgentSpansTraceReq(BaseModel):
-    """Request to get all agent spans for a specific trace."""
-
-    project_id: str
-    trace_id: str
-
-
-class AgentSpansTraceRes(BaseModel):
-    """Response containing all spans for a trace, ordered by start time."""
-
-    spans: list[AgentSpanSchema]
 
 
 # ---------------------------------------------------------------------------
@@ -249,59 +288,6 @@ class AgentTraceChatRes(BaseModel):
     messages: list[AgentChatMessage] = Field(default_factory=list)
 
 
-class AgentConversationSchema(BaseModel):
-    """Metadata for a single multi-turn conversation, keyed by conversation_id."""
-
-    conversation_id: str
-    conversation_name: str = ""
-    project_id: str
-    turn_count: int = 0
-    span_count: int = 0
-    total_input_tokens: int = 0
-    total_output_tokens: int = 0
-    total_duration_ms: int = 0
-    error_count: int = 0
-    agent_names: list[str] = Field(default_factory=list)
-    agent_versions: list[str] = Field(default_factory=list)
-    provider_names: list[str] = Field(default_factory=list)
-    request_models: list[str] = Field(default_factory=list)
-    first_seen: datetime.datetime | None = None
-    last_seen: datetime.datetime | None = None
-
-
-class AgentConversationsQueryFilters(BaseModel):
-    """Filters for querying conversations (GROUP BY on spans)."""
-
-    conversation_id: str | None = None
-    agent_name: str | None = None
-    agent_version: str | None = None
-    provider_name: str | None = None
-    has_errors: bool | None = None
-    min_turns: int | None = None
-    max_turns: int | None = None
-    started_after: datetime.datetime | None = None
-    started_before: datetime.datetime | None = None
-
-
-class AgentConversationsQueryReq(BaseModel):
-    """Request to list conversations for a project, ordered by most recent."""
-
-    project_id: str
-    filters: AgentConversationsQueryFilters | None = None
-    sort_by: list[AgentSortBy] | None = None
-    limit: int = 100
-    offset: int = 0
-    start: str | None = None
-    end: str | None = None
-
-
-class AgentConversationsQueryRes(BaseModel):
-    """Response containing a list of conversations."""
-
-    conversations: list[AgentConversationSchema]
-    total_count: int = 0
-
-
 class AgentConversationChatReq(BaseModel):
     """Request to get the multi-turn chat view for a conversation."""
 
@@ -366,7 +352,7 @@ class AgentsQueryRes(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Custom attribute filters (used by spans, conversations queries)
+# Custom attribute filters (used by spans queries)
 # ---------------------------------------------------------------------------
 
 
@@ -376,49 +362,6 @@ class AgentCustomAttrFilter(BaseModel):
     attr_key: str
     operator: str = "eq"
     value: str | int | float = ""
-
-
-# ---------------------------------------------------------------------------
-# Agent traces (GROUP BY trace_id on spans)
-# ---------------------------------------------------------------------------
-
-
-class AgentTraceSchema(BaseModel):
-    """Aggregated per-trace stats from GROUP BY trace_id on spans."""
-
-    project_id: str = ""
-    trace_id: str = ""
-    span_count: int = 0
-    total_input_tokens: int = 0
-    total_output_tokens: int = 0
-    error_count: int = 0
-    conversation_id: str = ""
-    agent_names: list[str] = Field(default_factory=list)
-    agent_versions: list[str] = Field(default_factory=list)
-    request_models: list[str] = Field(default_factory=list)
-    first_seen: datetime.datetime | None = None
-    last_seen: datetime.datetime | None = None
-
-
-class AgentTracesQueryReq(BaseModel):
-    """Request to list traces for a project."""
-
-    project_id: str
-    conversation_id: str | None = None
-    agent_name: str | None = None
-    agent_version: str | None = None
-    start: str | None = None
-    end: str | None = None
-    sort_by: list[AgentSortBy] | None = None
-    limit: int = 100
-    offset: int = 0
-
-
-class AgentTracesQueryRes(BaseModel):
-    """Response containing traces list."""
-
-    traces: list[AgentTraceSchema]
-    total_count: int = 0
 
 
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -122,6 +122,7 @@ class AgentSpanGroupRow(BaseModel):
 
     group_keys: dict[str, str | int | float | None] = Field(default_factory=dict)
     span_count: int = 0
+    turn_count: int = 0  # countIf(operation_name = 'invoke_agent')
     trace_count: int = 0
     conversation_count: int = 0
     total_input_tokens: int = 0
@@ -132,6 +133,7 @@ class AgentSpanGroupRow(BaseModel):
     agent_versions: list[str] = Field(default_factory=list)
     provider_names: list[str] = Field(default_factory=list)
     request_models: list[str] = Field(default_factory=list)
+    conversation_names: list[str] = Field(default_factory=list)
     first_seen: datetime.datetime | None = None
     last_seen: datetime.datetime | None = None
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -61,20 +61,14 @@ from weave.trace_server.agents.clickhouse import AgentQueryHandler, AgentWriteHa
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
     AgentConversationChatRes,
-    AgentConversationsQueryReq,
-    AgentConversationsQueryRes,
     AgentSearchReq,
     AgentSearchRes,
     AgentSpansQueryReq,
     AgentSpansQueryRes,
-    AgentSpansTraceReq,
-    AgentSpansTraceRes,
     AgentsQueryReq,
     AgentsQueryRes,
     AgentTraceChatReq,
     AgentTraceChatRes,
-    AgentTracesQueryReq,
-    AgentTracesQueryRes,
     AgentVersionsQueryReq,
     AgentVersionsQueryRes,
     GenAIOTelExportReq,
@@ -6423,22 +6417,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def agent_spans_query(self, req: AgentSpansQueryReq) -> AgentSpansQueryRes:
         return AgentQueryHandler(self._query).spans_query(req)
 
-    def agent_spans_trace(self, req: AgentSpansTraceReq) -> AgentSpansTraceRes:
-        return AgentQueryHandler(self._query).spans_trace(req)
-
-    def agent_traces_query(self, req: AgentTracesQueryReq) -> AgentTracesQueryRes:
-        return AgentQueryHandler(self._query).traces_query(req)
-
     def agent_agents_query(self, req: AgentsQueryReq) -> AgentsQueryRes:
         return AgentQueryHandler(self._query).agents_query(req)
 
     def agent_versions_query(self, req: AgentVersionsQueryReq) -> AgentVersionsQueryRes:
         return AgentQueryHandler(self._query).agent_versions_query(req)
-
-    def agent_conversations_query(
-        self, req: AgentConversationsQueryReq
-    ) -> AgentConversationsQueryRes:
-        return AgentQueryHandler(self._query).conversations_query(req)
 
     def agent_search(self, req: AgentSearchReq) -> AgentSearchRes:
         return AgentQueryHandler(self._query).search(req)

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -73,6 +73,7 @@ SPAN_GROUP_BY_COLS: frozenset[str] = SPAN_FILTERABLE_COLS | frozenset(
 SPAN_GROUP_AGGREGATE_COLS: frozenset[str] = frozenset(
     {
         "span_count",
+        "turn_count",
         "trace_count",
         "conversation_count",
         "total_input_tokens",
@@ -406,7 +407,11 @@ def _search_where(pb: ParamBuilder, req: AgentSearchReq) -> str:
 
 
 #: Aggregate SELECT list shared between grouped list queries.
+#: The bundle is intentionally fixed — callers do not pick aggregates. Fields
+#: that map to specific UI pivots (turn_count, conversation_names) are included
+#: alongside cross-cutting totals so all group_by shapes return the same schema.
 _GROUPED_SPAN_AGGREGATES: str = """count() AS span_count,
+               countIf(s.operation_name = 'invoke_agent') AS turn_count,
                uniqExact(s.trace_id) AS trace_count,
                uniqExact(s.conversation_id) AS conversation_count,
                sum(s.input_tokens) AS total_input_tokens,
@@ -417,6 +422,7 @@ _GROUPED_SPAN_AGGREGATES: str = """count() AS span_count,
                groupUniqArray(s.agent_version) AS agent_versions,
                groupUniqArray(s.provider_name) AS provider_names,
                groupUniqArray(s.request_model) AS request_models,
+               groupUniqArray(s.conversation_name) AS conversation_names,
                min(s.started_at) AS first_seen,
                max(s.started_at) AS last_seen"""
 

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -6,11 +6,12 @@ tables is constructed here via ``make_*_query`` functions. Consumers build a
 returned SQL through the server's ``_query`` method.
 
 Keeping the SQL in this module makes it unit-testable without a live ClickHouse:
-see ``tests/trace_server/test_genai_query_sql.py``.
+see ``tests/trace_server/query_builder/test_agent_query_builder.py``.
 """
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from weave.trace_server.agents.constants import (
@@ -22,14 +23,12 @@ from weave.trace_server.agents.constants import (
 from weave.trace_server.agents.schema import AgentSpanCHInsertable
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
-    AgentConversationsQueryReq,
     AgentCustomAttrFilter,
+    AgentGroupByRef,
     AgentSearchReq,
     AgentSortBy,
     AgentSpansQueryReq,
-    AgentSpansTraceReq,
     AgentsQueryReq,
-    AgentTracesQueryReq,
     AgentVersionsQueryReq,
 )
 from weave.trace_server.orm import ParamBuilder
@@ -59,7 +58,33 @@ SPAN_FILTERABLE_COLS: frozenset[str] = frozenset(
     }
 )
 
-#: Columns on spans that can be sorted
+#: Columns on spans that can be grouped by (superset of filterable).
+#: Kept separate so aggregation-only dimensions like agent_id can be added
+#: without widening the filter surface.
+SPAN_GROUP_BY_COLS: frozenset[str] = SPAN_FILTERABLE_COLS | frozenset(
+    {
+        "agent_id",
+        "tool_call_id",
+        "wb_user_id",
+    }
+)
+
+#: Aggregate aliases produced by a grouped spans list query.
+SPAN_GROUP_AGGREGATE_COLS: frozenset[str] = frozenset(
+    {
+        "span_count",
+        "trace_count",
+        "conversation_count",
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_duration_ms",
+        "error_count",
+        "first_seen",
+        "last_seen",
+    }
+)
+
+#: Columns on spans that can be sorted in ungrouped mode
 SPAN_SORTABLE_COLS: frozenset[str] = SPAN_FILTERABLE_COLS | frozenset(
     {
         "started_at",
@@ -68,16 +93,6 @@ SPAN_SORTABLE_COLS: frozenset[str] = SPAN_FILTERABLE_COLS | frozenset(
         "output_tokens",
         "total_tokens",
         "reasoning_tokens",
-    }
-)
-
-TRACE_SORTABLE_COLS: frozenset[str] = frozenset(
-    {
-        "last_seen",
-        "first_seen",
-        "span_count",
-        "total_input_tokens",
-        "error_count",
     }
 )
 
@@ -92,33 +107,6 @@ AGENT_SORTABLE_COLS: frozenset[str] = frozenset(
     }
 )
 
-# Conversations are aggregated with GROUP BY conversation_id, so scalar columns
-# like provider_name become arrays in the SELECT and must be sorted via arrayElement.
-CONVERSATION_SORT_EXPRS: dict[str, str] = {
-    "provider_name": "arrayElement(provider_names, 1)",
-    "provider_names": "arrayElement(provider_names, 1)",
-    "agent_name": "arrayElement(agent_names, 1)",
-    "agent_names": "arrayElement(agent_names, 1)",
-    "request_model": "arrayElement(request_models, 1)",
-    "request_models": "arrayElement(request_models, 1)",
-}
-
-CONVERSATION_SORTABLE_COLS: frozenset[str] = frozenset(
-    {
-        "last_seen",
-        "first_seen",
-        "turn_count",
-        "span_count",
-        "total_input_tokens",
-        "total_output_tokens",
-        "total_duration_ms",
-        "error_count",
-        "conversation_name",
-        "conversation_id",
-        *CONVERSATION_SORT_EXPRS.keys(),
-    }
-)
-
 #: Allowed operators for custom attribute filters
 _ATTR_OPS: dict[str, str] = {
     "eq": "=",
@@ -128,6 +116,14 @@ _ATTR_OPS: dict[str, str] = {
     "gte": ">=",
     "lte": "<=",
 }
+
+#: Valid SQL identifier (used to validate group_by aliases)
+_IDENT_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+#: Sources that read from a Map(...) column on spans, keyed by user-supplied key
+_CUSTOM_ATTR_SOURCES: frozenset[str] = frozenset(
+    {"custom_attrs", "custom_attrs_int", "custom_attrs_float"}
+)
 
 # ---------------------------------------------------------------------------
 # Column projections
@@ -302,6 +298,52 @@ def _pagination_slots(
 
 
 # ---------------------------------------------------------------------------
+# Group-by resolution
+# ---------------------------------------------------------------------------
+
+
+def resolve_group_by(
+    pb: ParamBuilder,
+    refs: list[AgentGroupByRef],
+    *,
+    table_alias: str = "s",
+) -> list[tuple[str, str]]:
+    """Resolve group_by refs to [(sql_expr, alias), ...].
+
+    Validates that:
+      - column refs target an allowlisted span column (``SPAN_GROUP_BY_COLS``)
+      - custom_attrs refs target one of the three Map columns
+      - the resulting alias is a valid SQL identifier
+      - aliases are unique within the request
+    """
+    seen: set[str] = set()
+    out: list[tuple[str, str]] = []
+    for ref in refs:
+        alias = ref.alias or ref.key
+        if not _IDENT_RE.match(alias):
+            raise ValueError(
+                f"group_by alias must match [a-zA-Z_][a-zA-Z0-9_]*, got {alias!r}"
+            )
+        if alias in seen:
+            raise ValueError(f"duplicate group_by alias: {alias!r}")
+        seen.add(alias)
+
+        if ref.source == "column":
+            if ref.key not in SPAN_GROUP_BY_COLS:
+                raise ValueError(
+                    f"group_by column {ref.key!r} is not in the allowlist"
+                )
+            sql_expr = f"{table_alias}.{ref.key}"
+        elif ref.source in _CUSTOM_ATTR_SOURCES:
+            key_slot = pb.add(str(ref.key), param_type="String")
+            sql_expr = f"{table_alias}.{ref.source}[{key_slot}]"
+        else:
+            raise ValueError(f"unknown group_by source: {ref.source!r}")
+        out.append((sql_expr, alias))
+    return out
+
+
+# ---------------------------------------------------------------------------
 # WHERE builders (private — shared between count + list variants)
 # ---------------------------------------------------------------------------
 
@@ -314,26 +356,6 @@ def _spans_where(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
         add_custom_attr_filters(
             conditions, pb, getattr(req.filters, "custom_filters", None)
         )
-    return " AND ".join(conditions)
-
-
-def _traces_where(pb: ParamBuilder, req: AgentTracesQueryReq) -> str:
-    conditions = [f"project_id = {pb.add(req.project_id, param_type='String')}"]
-    if req.conversation_id:
-        conditions.append(
-            f"conversation_id = {pb.add(req.conversation_id, param_type='String')}"
-        )
-    if req.agent_name:
-        conditions.append(
-            f"agent_name = {pb.add(req.agent_name, param_type='String')}"
-        )
-    if req.agent_version:
-        conditions.append(
-            f"agent_version = {pb.add(req.agent_version, param_type='String')}"
-        )
-    add_time_filters(
-        conditions, pb, start=req.start, end=req.end, column="started_at"
-    )
     return " AND ".join(conditions)
 
 
@@ -350,43 +372,6 @@ def _agent_versions_where(pb: ParamBuilder, req: AgentVersionsQueryReq) -> str:
     pid = pb.add(req.project_id, param_type="String")
     aname = pb.add(req.agent_name, param_type="String")
     return f"project_id = {pid} AND agent_name = {aname}"
-
-
-def _conversations_where(pb: ParamBuilder, req: AgentConversationsQueryReq) -> str:
-    conditions = [
-        f"project_id = {pb.add(req.project_id, param_type='String')}",
-        "conversation_id != ''",
-    ]
-    add_time_filters(
-        conditions, pb, start=req.start, end=req.end, column="started_at"
-    )
-    if req.filters:
-        f = req.filters
-        if f.conversation_id:
-            conditions.append(
-                f"conversation_id = {pb.add(f.conversation_id, param_type='String')}"
-            )
-        if f.agent_name:
-            conditions.append(
-                f"agent_name = {pb.add(f.agent_name, param_type='String')}"
-            )
-        if f.agent_version:
-            conditions.append(
-                f"agent_version = {pb.add(f.agent_version, param_type='String')}"
-            )
-        if f.provider_name:
-            conditions.append(
-                f"provider_name = {pb.add(f.provider_name, param_type='String')}"
-            )
-        if f.started_after:
-            conditions.append(
-                f"started_at >= parseDateTimeBestEffort({pb.add(str(f.started_after), param_type='String')})"
-            )
-        if f.started_before:
-            conditions.append(
-                f"started_at < parseDateTimeBestEffort({pb.add(str(f.started_before), param_type='String')})"
-            )
-    return " AND ".join(conditions)
 
 
 def _search_where(pb: ParamBuilder, req: AgentSearchReq) -> str:
@@ -416,31 +401,87 @@ def _search_where(pb: ParamBuilder, req: AgentSearchReq) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Public make_*_query functions
+# Spans queries (ungrouped + grouped share the same entry points)
 # ---------------------------------------------------------------------------
 
 
+#: Aggregate SELECT list shared between grouped list queries.
+_GROUPED_SPAN_AGGREGATES: str = """count() AS span_count,
+               uniqExact(s.trace_id) AS trace_count,
+               uniqExact(s.conversation_id) AS conversation_count,
+               sum(s.input_tokens) AS total_input_tokens,
+               sum(s.output_tokens) AS total_output_tokens,
+               sum(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)) AS total_duration_ms,
+               countIf(s.status_code = 'ERROR') AS error_count,
+               groupUniqArray(s.agent_name) AS agent_names,
+               groupUniqArray(s.agent_version) AS agent_versions,
+               groupUniqArray(s.provider_name) AS provider_names,
+               groupUniqArray(s.request_model) AS request_models,
+               min(s.started_at) AS first_seen,
+               max(s.started_at) AS last_seen"""
+
+
 def make_spans_count_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
+    """Count spans matching the request, or count of distinct groups if grouped."""
     where = _spans_where(pb, req)
-    return f"SELECT count() FROM spans s WHERE {where}"
+    if not req.group_by:
+        return f"SELECT count() FROM spans s WHERE {where}"
+    resolved = resolve_group_by(pb, req.group_by)
+    group_exprs = ", ".join(expr for expr, _ in resolved)
+    return (
+        f"SELECT count() FROM ("
+        f"SELECT {group_exprs} FROM spans s WHERE {where} GROUP BY {group_exprs}"
+        f")"
+    )
 
 
 def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
+    """List spans (ungrouped) or aggregate groups (grouped)."""
     where = _spans_where(pb, req)
-    order_by = build_order_by(req.sort_by, SPAN_SORTABLE_COLS, "started_at DESC")
     limit_slot, offset_slot, _ = _pagination_slots(pb, req.limit, req.offset)
+
+    if not req.group_by:
+        order_by = build_order_by(
+            req.sort_by, SPAN_SORTABLE_COLS, "started_at DESC"
+        )
+        return f"""
+            SELECT {SPANS_LIST_COLS}
+            FROM spans s
+            WHERE {where}
+            ORDER BY {order_by}
+            LIMIT {limit_slot} OFFSET {offset_slot}
+        """
+
+    resolved = resolve_group_by(pb, req.group_by)
+    aliases = [a for _, a in resolved]
+    select_group_cols = ", ".join(f"{expr} AS {alias}" for expr, alias in resolved)
+    group_by_clause = ", ".join(aliases)
+
+    sortable = SPAN_GROUP_AGGREGATE_COLS | frozenset(aliases)
+    order_by = build_order_by(req.sort_by, sortable, "last_seen DESC")
+
     return f"""
-        SELECT {SPANS_LIST_COLS}
+        SELECT {select_group_cols},
+               {_GROUPED_SPAN_AGGREGATES}
         FROM spans s
         WHERE {where}
+        GROUP BY {group_by_clause}
         ORDER BY {order_by}
         LIMIT {limit_slot} OFFSET {offset_slot}
     """
 
 
-def make_spans_trace_query(pb: ParamBuilder, req: AgentSpansTraceReq) -> str:
-    pid = pb.add(req.project_id, param_type="String")
-    tid = pb.add(req.trace_id, param_type="String")
+def make_trace_detail_spans_query(
+    pb: ParamBuilder, project_id: str, trace_id: str
+) -> str:
+    """Fetch all spans for a single trace with chat-view projection.
+
+    Internal helper for the chat view; not exposed as a public endpoint.
+    Use ``make_spans_list_query`` with a ``trace_id`` filter for general
+    span listings.
+    """
+    pid = pb.add(project_id, param_type="String")
+    tid = pb.add(trace_id, param_type="String")
     return f"""
         SELECT {CHAT_VIEW_COLS} FROM spans s
         WHERE s.project_id = {pid}
@@ -449,37 +490,9 @@ def make_spans_trace_query(pb: ParamBuilder, req: AgentSpansTraceReq) -> str:
     """
 
 
-def make_traces_count_query(pb: ParamBuilder, req: AgentTracesQueryReq) -> str:
-    where = _traces_where(pb, req)
-    return f"""SELECT count() FROM (
-        SELECT trace_id FROM spans WHERE {where} GROUP BY trace_id
-    )"""
-
-
-def make_traces_list_query(pb: ParamBuilder, req: AgentTracesQueryReq) -> str:
-    where = _traces_where(pb, req)
-    order_by = build_order_by(
-        req.sort_by, TRACE_SORTABLE_COLS, "last_seen DESC, trace_id"
-    )
-    limit_slot, offset_slot, _ = _pagination_slots(pb, req.limit, req.offset)
-    return f"""
-        SELECT trace_id,
-               count() AS span_count,
-               sum(input_tokens) AS total_input_tokens,
-               sum(output_tokens) AS total_output_tokens,
-               countIf(status_code = 'ERROR') AS error_count,
-               max(conversation_id) AS conversation_id,
-               groupUniqArray(agent_name) AS agent_names,
-               groupUniqArray(agent_version) AS agent_versions,
-               groupUniqArray(request_model) AS request_models,
-               min(started_at) AS first_seen,
-               max(started_at) AS last_seen
-        FROM spans
-        WHERE {where}
-        GROUP BY trace_id
-        ORDER BY {order_by}
-        LIMIT {limit_slot} OFFSET {offset_slot}
-    """
+# ---------------------------------------------------------------------------
+# AMT-backed queries (agents, agent_versions)
+# ---------------------------------------------------------------------------
 
 
 def make_agents_count_query(pb: ParamBuilder, req: AgentsQueryReq) -> str:
@@ -547,47 +560,9 @@ def make_agent_versions_list_query(
     """
 
 
-def make_conversations_count_query(
-    pb: ParamBuilder, req: AgentConversationsQueryReq
-) -> str:
-    where = _conversations_where(pb, req)
-    return f"""SELECT count() FROM (
-        SELECT conversation_id FROM spans WHERE {where} GROUP BY conversation_id
-    )"""
-
-
-def make_conversations_list_query(
-    pb: ParamBuilder, req: AgentConversationsQueryReq
-) -> str:
-    where = _conversations_where(pb, req)
-    order_by = build_order_by(
-        req.sort_by,
-        CONVERSATION_SORTABLE_COLS,
-        "last_seen DESC, conversation_id",
-        column_exprs=CONVERSATION_SORT_EXPRS,
-    )
-    limit_slot, offset_slot, _ = _pagination_slots(pb, req.limit, req.offset)
-    return f"""
-        SELECT conversation_id,
-               max(conversation_name) AS conversation_name,
-               countIf(operation_name = 'invoke_agent') AS turn_count,
-               count() AS span_count,
-               sum(input_tokens) AS total_input_tokens,
-               sum(output_tokens) AS total_output_tokens,
-               sum(toUnixTimestamp64Milli(ended_at) - toUnixTimestamp64Milli(started_at)) AS total_duration_ms,
-               countIf(status_code = 'ERROR') AS error_count,
-               groupUniqArray(agent_name) AS agent_names,
-               groupUniqArray(agent_version) AS agent_versions,
-               groupUniqArray(provider_name) AS provider_names,
-               groupUniqArray(request_model) AS request_models,
-               min(started_at) AS first_seen,
-               max(started_at) AS last_seen
-        FROM spans
-        WHERE {where}
-        GROUP BY conversation_id
-        ORDER BY {order_by}
-        LIMIT {limit_slot} OFFSET {offset_slot}
-    """
+# ---------------------------------------------------------------------------
+# Message search + chat spans
+# ---------------------------------------------------------------------------
 
 
 def make_message_search_query(pb: ParamBuilder, req: AgentSearchReq) -> str:


### PR DESCRIPTION
## Summary

Stacked on top of #6567. Collapses four agent read endpoints into a single flexible ``agent_spans_query``:

- `spans_query` — ungrouped list (unchanged behavior when `group_by` is empty)
- `spans_trace` — now just `spans_query` with a `trace_id` filter
- `traces_query` — now `group_by=[{source:"column", key:"trace_id"}]`
- `conversations_query` — now `group_by=[{source:"column", key:"conversation_id"}]`

`group_by` refs can also target arbitrary keys in any of the three `custom_attrs*` Map columns, so the UI can pivot on user-defined attributes without a new endpoint per attribute.

## Design notes

- **AMT endpoints stay separate.** `agent_agents_query` / `agent_versions_query` read pre-aggregated materialized views. Folding them in would silently route hot paths through raw span scans when the group_by shape didn't happen to match an AMT.
- **Fixed aggregate bundle.** Grouped responses always return the same fields (`span_count`, `trace_count`, `conversation_count`, token/duration sums, error_count, `groupUniqArray` of agent/provider/model, first/last seen). Callers don't pick aggregates — they filter the ones they want client-side.
- **Allowlisted column group_by.** Column refs are validated against `SPAN_GROUP_BY_COLS`; custom_attrs keys are always allowed (they're user-scoped). Aliases must be valid SQL identifiers and unique within the request.
- **No back-compat aliases.** The three removed endpoints are deleted outright since the base PR (#6567) hasn't merged yet and there are no external callers.
- **`make_spans_trace_query` demoted** to a private helper (`make_trace_detail_spans_query`) used only by the chat view — that path still needs `CHAT_VIEW_COLS` with message bodies, which the public list endpoint intentionally excludes.

## Test plan

- [x] SQL unit tests (`tests/trace_server/query_builder/test_agent_query_builder.py`) — 30 passing, including new grouped-span cases and `resolve_group_by` validation tests
- [x] ClickHouse integration tests (`tests/trace_server/test_genai_agent_queries.py`) — 6 passing against live ClickHouse, including a new `test_group_by_custom_attrs` case
- [x] `ruff check` clean across all modified files

## Follow-ups (not in this PR)

- A companion `distinct_attr_keys(project_id, time_range)` endpoint so the UI can populate a group_by picker without scanning the whole table.
- Cardinality guard on custom_attr group_by (mandatory time bound + stricter LIMIT).

🤖 Generated with [Claude Code](https://claude.com/claude-code)