### PR TITLE
fix(weave): disable session_id on clickhouse clients

### DIFF
--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -304,7 +304,7 @@ def test_calls_complete_routing_by_residence(
     )
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server._mint_client,
+        clickhouse_trace_server.ch_client,
     )
     if read_table == ReadTable.CALLS_MERGED:
         expected_call_ids = {call.id, *merged_call_ids}
@@ -399,7 +399,7 @@ def test_calls_complete_routing_both_residence_state(
     # Verify resolver detects BOTH residence
     resolver = clickhouse_trace_server.table_routing_resolver
     residence = resolver._get_residence(
-        internal_project_id, clickhouse_trace_server._mint_client
+        internal_project_id, clickhouse_trace_server.ch_client
     )
     assert residence == ProjectDataResidence.BOTH, (
         f"Expected BOTH residence, got {residence}"
@@ -409,7 +409,7 @@ def test_calls_complete_routing_both_residence_state(
     # PART 3: Verify read routing in BOTH state
     # =========================================================================
     read_table = resolver.resolve_read_table(
-        internal_project_id, clickhouse_trace_server._mint_client
+        internal_project_id, clickhouse_trace_server.ch_client
     )
     assert read_table == ReadTable.CALLS_COMPLETE, (
         "BOTH residence should route reads to calls_complete"
@@ -428,7 +428,7 @@ def test_calls_complete_routing_both_residence_state(
     # =========================================================================
     # V2 writes should go to calls_complete
     v2_write_target = resolver.resolve_v2_write_target(
-        internal_project_id, clickhouse_trace_server._mint_client
+        internal_project_id, clickhouse_trace_server.ch_client
     )
     assert v2_write_target == WriteTarget.CALLS_COMPLETE, (
         "BOTH residence should route V2 writes to calls_complete"
@@ -515,7 +515,7 @@ def test_calls_complete_routing_both_residence_state(
     # V1 write target should be COMPLETE (signaling error should be raised)
     # because BOTH state has calls_complete data
     v1_write_target = resolver.resolve_v1_write_target(
-        internal_project_id, clickhouse_trace_server._mint_client
+        internal_project_id, clickhouse_trace_server.ch_client
     )
     assert v1_write_target == WriteTarget.CALLS_COMPLETE, (
         "V1 write target should be CALLS_COMPLETE for BOTH state to trigger error"
@@ -760,7 +760,7 @@ def test_call_start_end_v2_writes_calls_complete_for_empty_project(
     # Verify read-side returns the call with correct data
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server._mint_client,
+        clickhouse_trace_server.ch_client,
     )
     expected_call_ids = {call_id}
     calls = _fetch_calls_stream(trace_server, project_id)
@@ -998,7 +998,7 @@ def test_calls_query_routing_by_residence(
 
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server._mint_client,
+        clickhouse_trace_server.ch_client,
     )
     if seed_complete:
         assert read_table == ReadTable.CALLS_COMPLETE
@@ -1139,7 +1139,7 @@ def test_calls_complete_query_with_status_filter(trace_server, clickhouse_trace_
     # Verify we're reading from calls_complete
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server._mint_client,
+        clickhouse_trace_server.ch_client,
     )
     assert read_table == ReadTable.CALLS_COMPLETE
 
@@ -1432,7 +1432,7 @@ def test_project_stats_with_calls_complete(trace_server, clickhouse_trace_server
     # Verify we're reading from calls_complete
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server._mint_client,
+        clickhouse_trace_server.ch_client,
     )
     assert read_table == ReadTable.CALLS_COMPLETE
 
@@ -1518,10 +1518,10 @@ def test_project_stats_uses_correct_stats_table_based_on_residence(
 
     # Verify project residences
     read_table1 = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
-        internal_project1_id, clickhouse_trace_server._mint_client
+        internal_project1_id, clickhouse_trace_server.ch_client
     )
     read_table2 = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
-        internal_project2_id, clickhouse_trace_server._mint_client
+        internal_project2_id, clickhouse_trace_server.ch_client
     )
 
     assert read_table1 == ReadTable.CALLS_MERGED
@@ -1635,7 +1635,7 @@ def test_call_stats_with_calls_complete(trace_server, clickhouse_trace_server):
     # Verify we're reading from calls_complete
     read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project_id,
-        clickhouse_trace_server._mint_client,
+        clickhouse_trace_server.ch_client,
     )
     assert read_table == ReadTable.CALLS_COMPLETE
 
@@ -1836,7 +1836,7 @@ def test_feedback_filter_does_not_duplicate_calls_complete(
     # verify we are reading from calls_complete
     resolver = clickhouse_trace_server.table_routing_resolver
     read_table = resolver.resolve_read_table(
-        internal_project_id, clickhouse_trace_server._mint_client
+        internal_project_id, clickhouse_trace_server.ch_client
     )
     assert read_table == ReadTable.CALLS_COMPLETE
 

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1,6 +1,7 @@
 import base64
 import datetime as dt
 import json
+import threading
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -8,7 +9,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import clickhouse_connect
 import pytest
-from clickhouse_connect.driver.exceptions import DatabaseError
+from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
 
 from weave.trace_server import clickhouse_trace_server_batched as chts
 from weave.trace_server import trace_server_interface as tsi
@@ -1248,8 +1249,9 @@ def test_delete_preserves_version_index_gaps(ch_server):
 def test_concurrent_queries_on_one_client_vs_session_autogeneration(
     ch_server, autogenerate_session_id: bool
 ) -> None:
-    """With session_id enabled, overlapping queries on one client raise
-    SESSION_IS_LOCKED (code 373); with it disabled, they succeed.
+    """Session-id guard: clickhouse-connect rejects overlapping queries on one
+    client with ProgrammingError when a session_id is present; with it
+    disabled, overlapping queries succeed. See fix PR #6655.
     """
     client = clickhouse_connect.get_client(
         host=ch_server._host,
@@ -1260,9 +1262,14 @@ def test_concurrent_queries_on_one_client_vs_session_autogeneration(
         autogenerate_session_id=autogenerate_session_id,
     )
     n_workers = 8
+    # Barrier makes all workers fire their query in the same instant; without
+    # it the 8 queries can serialize on a cold container and the True branch
+    # never produces an overlap.
+    barrier = threading.Barrier(n_workers)
 
     def run_slow_query() -> None:
-        client.query("SELECT sleep(0.2)")
+        barrier.wait()
+        client.query("SELECT sleep(1.0)")
 
     try:
         errors: list[Exception] = []
@@ -1277,8 +1284,11 @@ def test_concurrent_queries_on_one_client_vs_session_autogeneration(
         client.close()
 
     if autogenerate_session_id:
-        assert errors, "expected overlapping queries to be rejected"
-        joined = " | ".join(str(e) for e in errors).lower()
-        assert "session" in joined or "373" in joined, joined
+        # Exactly one query wins the session mutex; the remaining n-1 are
+        # rejected client-side by clickhouse-connect.
+        assert len(errors) == n_workers - 1, errors
+        for e in errors:
+            assert isinstance(e, ProgrammingError), (type(e), e)
+            assert "concurrent queries within the same session" in str(e), e
     else:
         assert not errors, errors

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -6,6 +6,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, Mock, patch
 
+import clickhouse_connect
 import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError
 
@@ -1243,61 +1244,41 @@ def test_delete_preserves_version_index_gaps(ch_server):
     assert by_digest[digests[2]].version_index == 2
 
 
-# Regression guards for SESSION_IS_LOCKED (ClickHouse error code 373).
-# weave-trace does not use server-side ClickHouse sessions; if _mint_client
-# ever starts auto-generating a session_id again, two concurrent requests
-# that share a thread-local client will race and ClickHouse will reject one
-# of them with code 373.
-
-
-def test_mint_client_disables_session_autogeneration() -> None:
-    """_mint_client must pass autogenerate_session_id=False to clickhouse_connect."""
-    captured_kwargs: dict[str, object] = {}
-
-    def fake_get_client(**kwargs: object) -> MagicMock:
-        captured_kwargs.update(kwargs)
-        return MagicMock()
-
-    with (
-        patch.object(chts.ClickHouseTraceServer, "_ensure_database", return_value=None),
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.clickhouse_connect.get_client",
-            side_effect=fake_get_client,
-        ),
-    ):
-        server = chts.ClickHouseTraceServer(host="test_host")
-        server._mint_client()
-
-    assert captured_kwargs.get("autogenerate_session_id") is False
-
-
-def test_concurrent_queries_on_shared_client_do_not_raise_session_locked(
-    ch_server,
+@pytest.mark.parametrize("autogenerate_session_id", [True, False])
+def test_concurrent_queries_on_one_client_vs_session_autogeneration(
+    ch_server, autogenerate_session_id: bool
 ) -> None:
-    """Interface-level regression: concurrent queries on one shared ClickHouse
-    client must not raise a session-locking error.
-
-    Reproduces the production failure mode: many workers hitting the same
-    thread-local ch_client. With autogenerate_session_id=True (the old
-    clickhouse-connect default), overlapping requests with the same UUID
-    session_id are rejected either server-side (SESSION_IS_LOCKED, code 373)
-    or client-side ("concurrent queries within the same session"). With
-    autogenerate_session_id=False there is no session_id and overlapping
-    requests succeed.
+    """With session_id enabled, overlapping queries on one client raise
+    SESSION_IS_LOCKED (code 373); with it disabled, they succeed.
     """
-    shared_client = ch_server.ch_client
-    n_workers = 16
+    client = clickhouse_connect.get_client(
+        host=ch_server._host,
+        port=ch_server._port,
+        user=ch_server._user,
+        password=ch_server._password,
+        secure=ch_server._port == chts.CLICKHOUSE_SECURE_PORT,
+        autogenerate_session_id=autogenerate_session_id,
+    )
+    n_workers = 8
 
     def run_slow_query() -> None:
-        shared_client.query("SELECT sleep(0.05)")
+        client.query("SELECT sleep(0.2)")
 
-    errors: list[BaseException] = []
-    with ThreadPoolExecutor(max_workers=n_workers) as pool:
-        futures = [pool.submit(run_slow_query) for _ in range(n_workers)]
-        for future in as_completed(futures):
-            try:
-                future.result()
-            except BaseException as e:
-                errors.append(e)
+    try:
+        errors: list[Exception] = []
+        with ThreadPoolExecutor(max_workers=n_workers) as pool:
+            futures = [pool.submit(run_slow_query) for _ in range(n_workers)]
+            for future in as_completed(futures):
+                try:
+                    future.result()
+                except Exception as e:
+                    errors.append(e)
+    finally:
+        client.close()
 
-    assert not errors, f"Concurrent queries raised: {errors}"
+    if autogenerate_session_id:
+        assert errors, "expected overlapping queries to be rejected"
+        joined = " | ".join(str(e) for e in errors).lower()
+        assert "session" in joined or "373" in joined, joined
+    else:
+        assert not errors, errors

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1240,3 +1240,31 @@ def test_delete_preserves_version_index_gaps(ch_server):
     by_digest = {o.digest: o for o in non_deleted}
     assert by_digest[digests[0]].version_index == 0
     assert by_digest[digests[2]].version_index == 2
+
+
+# Regression guard for SESSION_IS_LOCKED (ClickHouse error code 373).
+# weave-trace does not use server-side ClickHouse sessions; if _mint_client
+# ever starts auto-generating a session_id again, two concurrent requests
+# that share a thread-local client will race and ClickHouse will reject one
+# of them with code 373.
+
+
+def test_mint_client_disables_session_autogeneration():
+    """_mint_client must pass autogenerate_session_id=False to clickhouse_connect."""
+    captured_kwargs: dict = {}
+
+    def fake_get_client(**kwargs):
+        captured_kwargs.update(kwargs)
+        return MagicMock()
+
+    with (
+        patch.object(chts.ClickHouseTraceServer, "_ensure_database", return_value=None),
+        patch(
+            "weave.trace_server.clickhouse_trace_server_batched.clickhouse_connect.get_client",
+            side_effect=fake_get_client,
+        ),
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host")
+        server._mint_client()
+
+    assert captured_kwargs.get("autogenerate_session_id") is False

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -2,6 +2,7 @@ import base64
 import datetime as dt
 import json
 import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, Mock, patch
 
@@ -1242,18 +1243,18 @@ def test_delete_preserves_version_index_gaps(ch_server):
     assert by_digest[digests[2]].version_index == 2
 
 
-# Regression guard for SESSION_IS_LOCKED (ClickHouse error code 373).
+# Regression guards for SESSION_IS_LOCKED (ClickHouse error code 373).
 # weave-trace does not use server-side ClickHouse sessions; if _mint_client
 # ever starts auto-generating a session_id again, two concurrent requests
 # that share a thread-local client will race and ClickHouse will reject one
 # of them with code 373.
 
 
-def test_mint_client_disables_session_autogeneration():
+def test_mint_client_disables_session_autogeneration() -> None:
     """_mint_client must pass autogenerate_session_id=False to clickhouse_connect."""
-    captured_kwargs: dict = {}
+    captured_kwargs: dict[str, object] = {}
 
-    def fake_get_client(**kwargs):
+    def fake_get_client(**kwargs: object) -> MagicMock:
         captured_kwargs.update(kwargs)
         return MagicMock()
 
@@ -1268,3 +1269,35 @@ def test_mint_client_disables_session_autogeneration():
         server._mint_client()
 
     assert captured_kwargs.get("autogenerate_session_id") is False
+
+
+def test_concurrent_queries_on_shared_client_do_not_raise_session_locked(
+    ch_server,
+) -> None:
+    """Interface-level regression: concurrent queries on one shared ClickHouse
+    client must not raise a session-locking error.
+
+    Reproduces the production failure mode: many workers hitting the same
+    thread-local ch_client. With autogenerate_session_id=True (the old
+    clickhouse-connect default), overlapping requests with the same UUID
+    session_id are rejected either server-side (SESSION_IS_LOCKED, code 373)
+    or client-side ("concurrent queries within the same session"). With
+    autogenerate_session_id=False there is no session_id and overlapping
+    requests succeed.
+    """
+    shared_client = ch_server.ch_client
+    n_workers = 16
+
+    def run_slow_query() -> None:
+        shared_client.query("SELECT sleep(0.05)")
+
+    errors: list[BaseException] = []
+    with ThreadPoolExecutor(max_workers=n_workers) as pool:
+        futures = [pool.submit(run_slow_query) for _ in range(n_workers)]
+        for future in as_completed(futures):
+            try:
+                future.result()
+            except BaseException as e:
+                errors.append(e)
+
+    assert not errors, f"Concurrent queries raised: {errors}"

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -289,6 +289,7 @@ class TestLLMCompletionStreaming(unittest.TestCase):
         self.server = chts.ClickHouseTraceServer(host="test_host")
         mock_ch_client = MagicMock()
         mock_ch_client.query.return_value = MagicMock(result_rows=[[0, 0]])
+        # ch_client is lazy; pre-populating _thread_local.ch_client bypasses _mint_client.
         self.server._thread_local.ch_client = mock_ch_client
         self.mock_secret_fetcher = MagicMock()
         self.mock_secret_fetcher.fetch.return_value = {
@@ -1313,6 +1314,7 @@ def completions_mock_server():
     server = chts.ClickHouseTraceServer(host="test_host")
     mock_ch_client = MagicMock()
     mock_ch_client.query.return_value = MagicMock(result_rows=[[0, 0]])
+    # ch_client is lazy; pre-populating _thread_local.ch_client bypasses _mint_client.
     server._thread_local.ch_client = mock_ch_client
     return server
 

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -286,13 +286,9 @@ class TestLLMCompletionStreaming(unittest.TestCase):
 
     def setUp(self):
         """Set up test fixtures before each test."""
+        self.server = chts.ClickHouseTraceServer(host="test_host")
         mock_ch_client = MagicMock()
         mock_ch_client.query.return_value = MagicMock(result_rows=[[0, 0]])
-        self._mint_patcher = patch.object(
-            chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
-        )
-        self._mint_patcher.start()
-        self.server = chts.ClickHouseTraceServer(host="test_host")
         self.server._thread_local.ch_client = mock_ch_client
         self.mock_secret_fetcher = MagicMock()
         self.mock_secret_fetcher.fetch.return_value = {
@@ -305,7 +301,6 @@ class TestLLMCompletionStreaming(unittest.TestCase):
         self.token = _secret_fetcher_context.set(self.mock_secret_fetcher)
 
     def tearDown(self):
-        self._mint_patcher.stop()
         _secret_fetcher_context.reset(self.token)
 
     def test_basic_streaming_completion(self):
@@ -1315,14 +1310,11 @@ class TestResolveAndApplyPrompt(unittest.TestCase):
 @pytest.fixture
 def completions_mock_server():
     """Create a mock ClickHouseTraceServer for completions tests."""
+    server = chts.ClickHouseTraceServer(host="test_host")
     mock_ch_client = MagicMock()
     mock_ch_client.query.return_value = MagicMock(result_rows=[[0, 0]])
-    with patch.object(
-        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
-    ):
-        server = chts.ClickHouseTraceServer(host="test_host")
-        server._thread_local.ch_client = mock_ch_client
-        yield server
+    server._thread_local.ch_client = mock_ch_client
+    return server
 
 
 @pytest.fixture

--- a/tests/trace_server/test_project_version.py
+++ b/tests/trace_server/test_project_version.py
@@ -33,30 +33,16 @@ def insert_call(ch_client, table: str, project_id: str):
 
 @contextmanager
 def count_queries(ch_client):
-    """Count CH queries made through the given client.
-
-    Returns a (get_count, mint_client) tuple. mint_client is a factory that
-    returns the counted client (with close() suppressed so the resolver
-    doesn't tear it down).
-    """
     call_count = 0
     original_query = ch_client.query
-    original_close = ch_client.close
 
     def counting_query(*args, **kwargs):
         nonlocal call_count
         call_count += 1
         return original_query(*args, **kwargs)
 
-    with (
-        patch.object(ch_client, "query", side_effect=counting_query),
-        patch.object(ch_client, "close"),
-    ):
-
-        def _mint() -> type(ch_client):
-            return ch_client
-
-        yield lambda: call_count, _mint
+    with patch.object(ch_client, "query", side_effect=counting_query):
+        yield lambda: call_count
 
 
 @pytest.mark.parametrize(
@@ -129,15 +115,15 @@ def test_version_resolution_by_table_contents(
         insert_call(ch_server.ch_client, table, project_id)
 
     assert (
-        resolver.resolve_read_table(project_id, ch_server._mint_client)
+        resolver.resolve_read_table(project_id, ch_server.ch_client)
         == expected_read_table
     )
     assert (
-        resolver.resolve_v1_write_target(project_id, ch_server._mint_client)
+        resolver.resolve_v1_write_target(project_id, ch_server.ch_client)
         == expected_v1_write_target
     )
     assert (
-        resolver.resolve_v2_write_target(project_id, ch_server._mint_client)
+        resolver.resolve_v2_write_target(project_id, ch_server.ch_client)
         == expected_v2_write_target
     )
 
@@ -167,22 +153,22 @@ def test_caching_behavior(client, trace_server):
     cached_proj = make_project_id("cached_project")
     insert_call(ch_server.ch_client, "calls_complete", cached_proj)
 
-    with count_queries(ch_server.ch_client) as (get_count, mint):
-        table1 = resolver.resolve_read_table(cached_proj, mint)
+    with count_queries(ch_server.ch_client) as get_count:
+        table1 = resolver.resolve_read_table(cached_proj, ch_server.ch_client)
         assert table1 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
-        table2 = resolver.resolve_read_table(cached_proj, mint)
+        table2 = resolver.resolve_read_table(cached_proj, ch_server.ch_client)
         assert table2 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
     empty_proj = make_project_id("empty_not_cached")
-    with count_queries(ch_server.ch_client) as (get_count, mint):
-        table1 = resolver.resolve_read_table(empty_proj, mint)
+    with count_queries(ch_server.ch_client) as get_count:
+        table1 = resolver.resolve_read_table(empty_proj, ch_server.ch_client)
         assert table1 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
-        table2 = resolver.resolve_read_table(empty_proj, mint)
+        table2 = resolver.resolve_read_table(empty_proj, ch_server.ch_client)
         assert table2 == ReadTable.CALLS_COMPLETE
         assert get_count() == 2
 
@@ -198,20 +184,20 @@ def test_mode_off_and_force_legacy(client, trace_server):
     insert_call(ch_server.ch_client, "calls_complete", project_id)
 
     resolver._mode = CallsStorageServerMode.OFF
-    with count_queries(ch_server.ch_client) as (get_count, mint):
-        table = resolver.resolve_read_table(project_id, mint)
+    with count_queries(ch_server.ch_client) as get_count:
+        table = resolver.resolve_read_table(project_id, ch_server.ch_client)
         assert table == ReadTable.CALLS_MERGED
         assert get_count() == 0
 
     resolver._mode = CallsStorageServerMode.FORCE_LEGACY
     # FORCE_LEGACY performs the query but returns MERGED
-    with count_queries(ch_server.ch_client) as (get_count, mint):
-        table = resolver.resolve_read_table(project_id, mint)
+    with count_queries(ch_server.ch_client) as get_count:
+        table = resolver.resolve_read_table(project_id, ch_server.ch_client)
         assert table == ReadTable.CALLS_MERGED
         assert get_count() == 1
 
     resolver._mode = CallsStorageServerMode.AUTO
-    table = resolver.resolve_read_table(project_id, ch_server._mint_client)
+    table = resolver.resolve_read_table(project_id, ch_server.ch_client)
     assert table == ReadTable.CALLS_COMPLETE
 
 
@@ -246,18 +232,18 @@ def test_resolver_as_trace_server_member(client, trace_server):
     project_id = make_project_id("trace_server_member")
     insert_call(ch_server.ch_client, "calls_complete", project_id)
 
-    with count_queries(ch_server.ch_client) as (get_count, mint):
+    with count_queries(ch_server.ch_client) as get_count:
         resolver1._mode = CallsStorageServerMode.AUTO
-        table = resolver1.resolve_read_table(project_id, mint)
+        table = resolver1.resolve_read_table(project_id, ch_server.ch_client)
         assert table == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
         # Subsequent requests hit the cache
-        table2 = resolver1.resolve_read_table(project_id, mint)
+        table2 = resolver1.resolve_read_table(project_id, ch_server.ch_client)
         assert table2 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 
-        table3 = resolver2.resolve_read_table(project_id, mint)
+        table3 = resolver2.resolve_read_table(project_id, ch_server.ch_client)
         assert table3 == ReadTable.CALLS_COMPLETE
         assert get_count() == 1
 

--- a/tests/trace_server_migrator/conftest.py
+++ b/tests/trace_server_migrator/conftest.py
@@ -96,7 +96,9 @@ def ch_keeper_server():
 def ch_client(ch_keeper_server):
     """Create a clickhouse_connect client and track databases for cleanup."""
     host, port = ch_keeper_server
-    client = clickhouse_connect.get_client(host=host, port=port)
+    client = clickhouse_connect.get_client(
+        host=host, port=port, autogenerate_session_id=False
+    )
     tracked_dbs: list[str] = []
 
     # Attach a tracking helper directly on the client instance

--- a/tests/trace_server_migrator/conftest.py
+++ b/tests/trace_server_migrator/conftest.py
@@ -96,6 +96,7 @@ def ch_keeper_server():
 def ch_client(ch_keeper_server):
     """Create a clickhouse_connect client and track databases for cleanup."""
     host, port = ch_keeper_server
+    # Mirror production _mint_client kwargs (cosmetic; migrator is single-threaded).
     client = clickhouse_connect.get_client(
         host=host, port=port, autogenerate_session_id=False
     )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -667,7 +667,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     self._op_ref_cache[req.project_id, op_name] = op_ref_uri
 
         write_target = self.table_routing_resolver.resolve_v2_write_target(
-            req.project_id, self._mint_client
+            req.project_id,
+            self.ch_client,
         )
 
         # Build event callbacks (same for both write targets)
@@ -796,7 +797,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Check write target - v1 call_start cannot write to calls_complete
         write_target = self.table_routing_resolver.resolve_v1_write_target(
-            ch_call.project_id, self._mint_client
+            ch_call.project_id,
+            self.ch_client,
         )
         if write_target == WriteTarget.CALLS_COMPLETE:
             raise CallsCompleteModeRequired(ch_call.project_id)
@@ -824,7 +826,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Check write target - v1 call_end cannot write to calls_complete
         write_target = self.table_routing_resolver.resolve_v1_write_target(
-            ch_call.project_id, self._mint_client
+            ch_call.project_id,
+            self.ch_client,
         )
         if write_target == WriteTarget.CALLS_COMPLETE:
             raise CallsCompleteModeRequired(ch_call.project_id)
@@ -879,7 +882,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 # is here for technical correctness, in case we relax project_id target
                 # constraints intra-batch
                 write_target = self.table_routing_resolver.resolve_v2_write_target(
-                    processed_complete_call.project_id, self._mint_client
+                    processed_complete_call.project_id,
+                    self.ch_client,
                 )
 
                 ch_call = complete_call_to_ch_insertable(processed_complete_call)
@@ -907,7 +911,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ch_start = start_call_for_insert_to_ch_insertable(start_req.start)
 
         write_target = self.table_routing_resolver.resolve_v2_write_target(
-            ch_start.project_id, self._mint_client
+            ch_start.project_id,
+            self.ch_client,
         )
         if write_target == WriteTarget.CALLS_COMPLETE:
             ch_complete_start = start_call_insertable_to_complete_start(ch_start)
@@ -933,7 +938,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         req = process_call_req_to_content(req, self)
 
         write_target = self.table_routing_resolver.resolve_v2_write_target(
-            req.end.project_id, self._mint_client
+            req.end.project_id,
+            self.ch_client,
         )
 
         # If writing to calls_complete, perform lightweight UPDATE
@@ -1055,7 +1061,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         aggregate statistics that are not directly queryable from the calls themselves.
         """
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self._mint_client
+            req.project_id, self.ch_client
         )
         pb = ParamBuilder()
         query, columns = build_calls_stats_query(req, pb, read_table)
@@ -1197,7 +1203,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Resolve which table to read from based on project data residence
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self._mint_client
+            req.project_id, self.ch_client
         )
 
         token_metrics, requested_cost_metrics = split_usage_metrics(req.usage_metrics)
@@ -1368,7 +1374,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def calls_query_stream(self, req: tsi.CallsQueryReq) -> Iterator[tsi.CallSchema]:
         """Returns a stream of calls that match the given query."""
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self._mint_client
+            req.project_id, self.ch_client
         )
         settings = None
         cq = CallsQuery(
@@ -1509,8 +1515,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             return
 
         feedback_query_req = make_feedback_query_req(project_id, calls)
-        with self.with_new_client():
-            feedback = self.feedback_query(feedback_query_req)
+        feedback = self.feedback_query(feedback_query_req)
         hydrate_calls_with_feedback(calls, feedback)
 
     def _get_refs_to_resolve(
@@ -1559,31 +1564,30 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             if not refs_to_resolve:
                 continue
 
-            with self.with_new_client():
-                # Filter out non-unique refs
-                unique_ref_map = {}
-                for ref in refs_to_resolve.values():
-                    if ref.uri not in unique_ref_map:
-                        unique_ref_map[ref.uri] = ref
+            # Filter out non-unique refs
+            unique_ref_map = {}
+            for ref in refs_to_resolve.values():
+                if ref.uri not in unique_ref_map:
+                    unique_ref_map[ref.uri] = ref
 
-                # Fetch values only for the unique refs
-                vals = self._refs_read_batch_within_project(
-                    project_id, list(unique_ref_map.values()), ref_cache
-                )
+            # Fetch values only for the unique refs
+            vals = self._refs_read_batch_within_project(
+                project_id, list(unique_ref_map.values()), ref_cache
+            )
 
-                # update the ref map with the fetched values
-                ref_val_map = {}
-                for ref, val in zip(unique_ref_map.values(), vals, strict=False):
-                    ref_val_map[ref.uri] = val
+            # update the ref map with the fetched values
+            ref_val_map = {}
+            for ref, val in zip(unique_ref_map.values(), vals, strict=False):
+                ref_val_map[ref.uri] = val
 
-                # Replace the refs with values and add ref key
-                for (i, col), ref in refs_to_resolve.items():
-                    # Look up the value using the ref's URI
-                    val = ref_val_map.get(ref.uri)
-                    if val is not None:
-                        if isinstance(val, dict) and "_ref" not in val:
-                            val["_ref"] = ref.uri
-                        set_nested_key(calls[i], col, val)
+            # Replace the refs with values and add ref key
+            for (i, col), ref in refs_to_resolve.items():
+                # Look up the value using the ref's URI
+                val = ref_val_map.get(ref.uri)
+                if val is not None:
+                    if isinstance(val, dict) and "_ref" not in val:
+                        val["_ref"] = ref.uri
+                    set_nested_key(calls[i], col, val)
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.calls_delete")
     def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
@@ -1632,7 +1636,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
         write_target = self.table_routing_resolver.resolve_v1_write_target(
-            req.project_id, self._mint_client
+            req.project_id,
+            self.ch_client,
         )
         if write_target == WriteTarget.CALLS_COMPLETE:
             self._delete_calls_complete(req.project_id, all_descendants)
@@ -1688,7 +1693,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._ensure_valid_update_field(req)
 
         write_target = self.table_routing_resolver.resolve_v1_write_target(
-            req.project_id, self._mint_client
+            req.project_id,
+            self.ch_client,
         )
         if write_target == WriteTarget.CALLS_COMPLETE:
             self._update_calls_complete(req.project_id, req.call_id, req.display_name)
@@ -2547,7 +2553,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Resolve which table to read from based on project data residence
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self._mint_client
+            req.project_id, self.ch_client
         )
 
         pb = ParamBuilder()
@@ -2574,7 +2580,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     ) -> Iterator[tsi.ThreadSchema]:
         """Stream threads with aggregated statistics sorted by last activity."""
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self._mint_client
+            req.project_id, self.ch_client
         )
         pb = ParamBuilder()
 
@@ -2917,7 +2923,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Step 0: Determine which table to query based on project data residence
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self._mint_client
+            req.project_id, self.ch_client
         )
 
         # Step 1: Check for existing calls (duplicate prevention)
@@ -5124,7 +5130,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     ) -> tsi.EvalResultsQueryRes:
         """Sort/filter/paginate eval results with a single ClickHouse query."""
         read_table = self.table_routing_resolver.resolve_read_table(
-            req.project_id, self._mint_client
+            req.project_id, self.ch_client
         )
 
         # when summary is requested, fetch all rows
@@ -6096,7 +6102,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             return tsi.CompletionsCreateRes(response=res.response)
 
         write_target = self.table_routing_resolver.resolve_v2_write_target(
-            req.project_id, self._mint_client
+            req.project_id,
+            self.ch_client,
         )
 
         req.inputs.messages = initial_messages
@@ -6240,7 +6247,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         write_target: WriteTarget | None = None
         if req.track_llm_call:
             write_target = self.table_routing_resolver.resolve_v2_write_target(
-                req.project_id, self._mint_client
+                req.project_id,
+                self.ch_client,
             )
             # Prepare inputs for tracking: use original messages (with template syntax)
             # and include prompt and template_vars
@@ -6491,7 +6499,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._database_ensured = True
 
     def _mint_client(self) -> CHClient:
-        """Create a new ClickHouse client using the shared pool manager."""
+        """Create a new ClickHouse client using the shared pool manager.
+
+        We disable server-side ClickHouse sessions (no temp tables, no
+        per-session settings, no transactions are used here). If left
+        enabled, clickhouse-connect auto-generates a UUID session_id per
+        client; two concurrent requests sharing a thread-local client
+        then race on that session_id and ClickHouse returns
+        SESSION_IS_LOCKED (error code 373).
+        """
         client = clickhouse_connect.get_client(
             host=self._host,
             port=self._port,
@@ -6499,30 +6515,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             password=self._password,
             secure=self._port == CLICKHOUSE_SECURE_PORT,
             pool_mgr=_CH_POOL_MANAGER,
+            autogenerate_session_id=False,
         )
         self._ensure_database(client)
         client.database = self._database
         return client
-
-    @contextmanager
-    def with_new_client(self) -> Iterator[None]:
-        """Context manager to use a new client for operations.
-        Each call gets a fresh client with its own clickhouse session ID.
-
-        Usage:
-        ```
-        with self.with_new_client():
-            self.feedback_query(req)
-        ```
-        """
-        client = self._mint_client()
-        original_client = self.ch_client
-        self._thread_local.ch_client = client
-        try:
-            yield
-        finally:
-            self._thread_local.ch_client = original_client
-            client.close()
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._insert_call_batch")
     def _insert_call_batch(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6481,8 +6481,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def ch_client(self) -> CHClient:
         """Returns a thread-local clickhouse client.
 
-        Each thread gets its own client instance to avoid session conflicts,
-        but all clients share the same underlying connection pool via _CH_POOL_MANAGER.
+        Each thread gets its own client instance; all clients share the
+        same underlying connection pool via _CH_POOL_MANAGER.
         """
         if not hasattr(self._thread_local, "ch_client"):
             self._thread_local.ch_client = self._mint_client()
@@ -6501,12 +6501,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def _mint_client(self) -> CHClient:
         """Create a new ClickHouse client using the shared pool manager.
 
-        We disable server-side ClickHouse sessions (no temp tables, no
-        per-session settings, no transactions are used here). If left
-        enabled, clickhouse-connect auto-generates a UUID session_id per
-        client; two concurrent requests sharing a thread-local client
-        then race on that session_id and ClickHouse returns
-        SESSION_IS_LOCKED (error code 373).
+        autogenerate_session_id=False: weave-trace uses no session features,
+        and the default collides on overlapping queries with SESSION_IS_LOCKED
+        (code 373).
         """
         client = clickhouse_connect.get_client(
             host=self._host,

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6503,7 +6503,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         autogenerate_session_id=False: weave-trace uses no session features,
         and the default collides on overlapping queries with SESSION_IS_LOCKED
-        (code 373).
+        (code 373). See PR #6655.
         """
         client = clickhouse_connect.get_client(
             host=self._host,

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -1,6 +1,5 @@
 import logging
 import threading
-from collections.abc import Callable
 
 import ddtrace
 from cachetools import LRUCache
@@ -16,10 +15,6 @@ from weave.trace_server.project_version.types import (
     ReadTable,
     WriteTarget,
 )
-
-# Factory callable that creates a fresh CH client. The consumer
-# (e.g. _get_residence) is responsible for closing the returned client.
-MintClient = Callable[[], CHClient]
 
 logger = logging.getLogger(__name__)
 
@@ -53,21 +48,14 @@ class TableRoutingResolver:
         self._mode = CallsStorageServerMode.from_env()
 
     def _get_residence(
-        self, project_id: str, mint_client: MintClient
+        self, project_id: str, ch_client: CHClient
     ) -> ProjectDataResidence:
         with _project_residence_cache_lock:
             cached = _project_residence_cache.get(project_id)
         if cached is not None:
             return cached
 
-        # Mint a fresh client so the residence query runs on its own CH
-        # session, preventing SESSION_IS_LOCKED when the caller subsequently
-        # performs inserts on the main thread-local session.
-        client = mint_client()
-        try:
-            residence = get_project_data_residence(project_id, client)
-        finally:
-            client.close()
+        residence = get_project_data_residence(project_id, ch_client)
 
         # Log warning if we detect dual residency - data should only ever be in
         # calls_merged OR calls_complete, not both. This is handled gracefully but
@@ -89,12 +77,12 @@ class TableRoutingResolver:
         return residence
 
     @ddtrace.tracer.wrap(name="table_routing.resolve_read_table")
-    def resolve_read_table(self, project_id: str, mint_client: MintClient) -> ReadTable:
+    def resolve_read_table(self, project_id: str, ch_client: CHClient) -> ReadTable:
         """Resolve which table to read from for a given project."""
         if self._mode == CallsStorageServerMode.OFF:
             return ReadTable.CALLS_MERGED
 
-        residence = self._get_residence(project_id, mint_client)
+        residence = self._get_residence(project_id, ch_client)
         set_current_span_dd_tags(
             {
                 "project_version.residence": residence.value,
@@ -121,7 +109,7 @@ class TableRoutingResolver:
     def resolve_v1_write_target(
         self,
         project_id: str,
-        mint_client: MintClient,
+        ch_client: CHClient,
     ) -> WriteTarget:
         """Resolve write target for V1 (legacy) API calls.
 
@@ -131,7 +119,7 @@ class TableRoutingResolver:
 
         Args:
             project_id: The internal project ID.
-            mint_client: Factory that creates a fresh CH client with its own session.
+            ch_client: ClickHouse client instance.
 
         Returns:
             WriteTarget indicating which table to write to.
@@ -139,7 +127,7 @@ class TableRoutingResolver:
         if self._mode == CallsStorageServerMode.OFF:
             return WriteTarget.CALLS_MERGED
 
-        residence = self._get_residence(project_id, mint_client)
+        residence = self._get_residence(project_id, ch_client)
         set_current_span_dd_tags(
             {
                 "project_version.residence": residence.value,
@@ -166,7 +154,7 @@ class TableRoutingResolver:
     def resolve_v2_write_target(
         self,
         project_id: str,
-        mint_client: MintClient,
+        ch_client: CHClient,
     ) -> WriteTarget:
         """Resolve write target for V2 API calls.
 
@@ -174,7 +162,7 @@ class TableRoutingResolver:
 
         Args:
             project_id: The internal project ID.
-            mint_client: Factory that creates a fresh CH client with its own session.
+            ch_client: ClickHouse client instance.
 
         Returns:
             WriteTarget indicating which table to write to.
@@ -182,7 +170,7 @@ class TableRoutingResolver:
         if self._mode == CallsStorageServerMode.OFF:
             return WriteTarget.CALLS_MERGED
 
-        residence = self._get_residence(project_id, mint_client)
+        residence = self._get_residence(project_id, ch_client)
         set_current_span_dd_tags(
             {
                 "project_version.residence": residence.value,


### PR DESCRIPTION
## Summary

Pass `autogenerate_session_id=False` to `clickhouse_connect.get_client(...)` in `_mint_client`. Without a `session_id` in request params, ClickHouse never creates a server-side session, so concurrent requests sharing a thread-local client cannot race on one. Also supersedes PR #6573 / PR #6625 (the `_mint_client` factory workaround) and removes the now-dead `with_new_client()` context manager.

## Why

`weave-trace` does not use any stateful ClickHouse session features — no temp tables, no per-session settings, no transactions. But `clickhouse-connect` auto-generates a UUID `session_id` per client. When any two queries on the same thread-local `ch_client` overlap, ClickHouse rejects one with code 373 `SESSION_IS_LOCKED`.

PR #6573 tried to paper over this by minting a fresh client for the write-target resolver path only. That covers ~11 of the ~30 `self.ch_client.query(...)` sites. The remaining hot-path sites (`/call/start`, `/call/end`, `/call/upsert_batch`, `/calls/stream_query`, inserts) still share the thread-local session, so the error persisted after shipping.

## Evidence

Full investigation with DD queries, daily counts, and deploy correlation:
https://www.notion.so/348e2f5c7ef381d49459e4ddaebe6dad

**SESSION_IS_LOCKED (code 373) daily counts, pre/post PR #6573:**

| Date | Errors | Notes |
| --- | ---: | --- |
| 2026-04-09 | 31 | pre-fix |
| 2026-04-10 | 122 | pre-fix peak |
| 2026-04-15 | 89 | PR #6573 merged 22:25Z |
| 2026-04-16 | 55 | #6573 live in prod 20:16Z |
| 2026-04-17 | **167** | **new peak, full day with #6573 live** |
| 2026-04-18 | 22 | |
| 2026-04-19 | 5 | |
| 2026-04-20 | 1 | |

30-day total: 524 SESSION_IS_LOCKED spans on `weave-trace`.

## What changed (net vs master)

- `weave/trace_server/clickhouse_trace_server_batched.py`: pass `autogenerate_session_id=False` to `get_client`; revert PR #6573 resolver-factory threading; delete `with_new_client()` and inline its two callers.
- `tests/trace_server_migrator/conftest.py`: same kwarg on the test harness's CH client.
- `tests/trace_server/test_clickhouse_trace_server_batched.py`: add `test_mint_client_disables_session_autogeneration` as a regression guard.

## Audit

- [x] `clickhouse_connect.get_client(` grep across repo -> only two call sites, both updated.
- [x] `session_id` grep in trace-server code -> nothing leaking into `settings={...}` on queries/inserts.

## Testing

- additional unit tests
- existing coverage
- manual qa

<img width="1259" height="441" alt="image" src="https://github.com/user-attachments/assets/d3ad8dc7-f00a-41b7-8f2e-a60b6188f653" />