### PR TITLE
fix(weave): surface ObjectDeletedError consistently from remote server

### DIFF
--- a/tests/trace_server_bindings/test_http_behavior_remote.py
+++ b/tests/trace_server_bindings/test_http_behavior_remote.py
@@ -24,11 +24,9 @@ from tests.trace_server_bindings.conftest import (
 )
 from weave.trace.display.term import configure_logger
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.errors import ErrorCode
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
-from weave.trace_server_bindings.http_utils import (
-    ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED,
-)
 from weave.trace_server_bindings.models import (
     CompleteBatchItem,
     EndBatchItem,
@@ -44,7 +42,7 @@ def make_calls_complete_required_response() -> httpx.Response:
     return httpx.Response(
         400,
         json={
-            "error_code": ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED,
+            "error_code": ErrorCode.CALLS_COMPLETE_MODE_REQUIRED,
             "message": "Project requires calls_complete mode",
         },
         request=httpx.Request("POST", "http://example.com/call/upsert_batch"),

--- a/tests/trace_server_bindings/test_http_utils.py
+++ b/tests/trace_server_bindings/test_http_utils.py
@@ -113,67 +113,75 @@ def test_retry_on_not_found_behavior(monkeypatch):
     assert calls["deleted_local"] == 1
 
 
-def test_object_deleted_404_raises_typed_error():
-    """A 404 with `error_code=OBJECT_DELETED` (or legacy deleted_at-only body)
-    surfaces as ObjectDeletedError. Other 404s, or 404s with a different
-    error_code, fall through to HTTPStatusError.
+DELETED_AT_ISO = "2024-01-01T00:00:00+00:00"
+PARSED_DELETED_AT = datetime.datetime.fromisoformat(DELETED_AT_ISO)
+
+
+@pytest.mark.parametrize(
+    ("body", "expected_exc", "expected_deleted_at"),
+    [
+        # New-style: explicit error_code, well-formed deleted_at.
+        (
+            {
+                "error_code": "OBJECT_DELETED",
+                "reason": "obj was deleted",
+                "deleted_at": DELETED_AT_ISO,
+            },
+            ObjectDeletedError,
+            PARSED_DELETED_AT,
+        ),
+        # error_code=OBJECT_DELETED with malformed deleted_at still raises
+        # ObjectDeletedError: error_code is the authoritative discriminator;
+        # deleted_at is a secondary field that must not downgrade the signal.
+        (
+            {
+                "error_code": "OBJECT_DELETED",
+                "reason": "deleted",
+                "deleted_at": "not-a-date",
+            },
+            ObjectDeletedError,
+            None,
+        ),
+        # Legacy server: no error_code, deleted_at present -> delete.
+        (
+            {"reason": "obj was deleted", "deleted_at": DELETED_AT_ISO},
+            ObjectDeletedError,
+            PARSED_DELETED_AT,
+        ),
+        # Legacy server with malformed deleted_at: fall through conservatively
+        # (only evidence was the timestamp, and it's unparseable).
+        (
+            {"reason": "deleted", "deleted_at": "not-a-date"},
+            httpx.HTTPStatusError,
+            None,
+        ),
+        # Plain 404: no signal.
+        ({"reason": "Obj foo:bar not found"}, httpx.HTTPStatusError, None),
+        # Unrelated error_code that happens to include deleted_at must not
+        # trip a false ObjectDeletedError.
+        (
+            {
+                "error_code": "SOMETHING_ELSE",
+                "reason": "other",
+                "deleted_at": DELETED_AT_ISO,
+            },
+            httpx.HTTPStatusError,
+            None,
+        ),
+    ],
+)
+def test_object_deleted_404_raises_typed_error(
+    body: dict, expected_exc: type, expected_deleted_at: datetime.datetime | None
+):
+    """A 404 with `error_code=OBJECT_DELETED` is authoritatively surfaced as
+    ObjectDeletedError even when the `deleted_at` secondary field is
+    malformed. Legacy servers that only emit `deleted_at` still work. Other
+    404s fall through to HTTPStatusError.
     """
-    deleted_at_iso = "2024-01-01T00:00:00+00:00"
-    parsed_deleted_at = datetime.datetime.fromisoformat(deleted_at_iso)
-
-    # New-style response: explicit error_code.
-    new_response = httpx.Response(
-        404,
-        json={
-            "error_code": "OBJECT_DELETED",
-            "reason": "obj was deleted",
-            "deleted_at": deleted_at_iso,
-        },
-        request=httpx.Request("POST", "http://example.com"),
+    response = httpx.Response(
+        404, json=body, request=httpx.Request("POST", "http://example.com")
     )
-    with pytest.raises(ObjectDeletedError) as exc_info:
-        handle_response_error(new_response, "/obj/read")
-    assert exc_info.value.deleted_at == parsed_deleted_at
-
-    # Legacy response: deleted_at but no error_code (pre-error_code server).
-    legacy_response = httpx.Response(
-        404,
-        json={"reason": "obj was deleted", "deleted_at": deleted_at_iso},
-        request=httpx.Request("POST", "http://example.com"),
-    )
-    with pytest.raises(ObjectDeletedError) as exc_info:
-        handle_response_error(legacy_response, "/obj/read")
-    assert exc_info.value.deleted_at == parsed_deleted_at
-
-    # Plain 404 falls through.
-    plain_404 = httpx.Response(
-        404,
-        json={"reason": "Obj foo:bar not found"},
-        request=httpx.Request("POST", "http://example.com"),
-    )
-    with pytest.raises(httpx.HTTPStatusError):
-        handle_response_error(plain_404, "/obj/read")
-
-    # Different error_code with an unrelated deleted_at-ish field: don't
-    # match, so an unrelated 404 that happens to include `deleted_at` can't
-    # trigger a false ObjectDeletedError.
-    wrong_code = httpx.Response(
-        404,
-        json={
-            "error_code": "SOMETHING_ELSE",
-            "reason": "other",
-            "deleted_at": deleted_at_iso,
-        },
-        request=httpx.Request("POST", "http://example.com"),
-    )
-    with pytest.raises(httpx.HTTPStatusError):
-        handle_response_error(wrong_code, "/obj/read")
-
-    # Malformed deleted_at: fall through conservatively.
-    malformed_deleted_at = httpx.Response(
-        404,
-        json={"reason": "deleted", "deleted_at": "not-a-date"},
-        request=httpx.Request("POST", "http://example.com"),
-    )
-    with pytest.raises(httpx.HTTPStatusError):
-        handle_response_error(malformed_deleted_at, "/obj/read")
+    with pytest.raises(expected_exc) as exc_info:
+        handle_response_error(response, "/obj/read")
+    if expected_exc is ObjectDeletedError:
+        assert exc_info.value.deleted_at == expected_deleted_at

--- a/tests/trace_server_bindings/test_http_utils.py
+++ b/tests/trace_server_bindings/test_http_utils.py
@@ -114,22 +114,38 @@ def test_retry_on_not_found_behavior(monkeypatch):
 
 
 def test_object_deleted_404_raises_typed_error():
-    """A 404 with `deleted_at` in the body surfaces as ObjectDeletedError.
-
-    Other 404s fall through to HTTPStatusError so retry layers can distinguish.
-    A malformed `deleted_at` also falls through (conservative).
+    """A 404 with `error_code=OBJECT_DELETED` (or legacy deleted_at-only body)
+    surfaces as ObjectDeletedError. Other 404s, or 404s with a different
+    error_code, fall through to HTTPStatusError.
     """
     deleted_at_iso = "2024-01-01T00:00:00+00:00"
-    deleted_response = httpx.Response(
+    parsed_deleted_at = datetime.datetime.fromisoformat(deleted_at_iso)
+
+    # New-style response: explicit error_code.
+    new_response = httpx.Response(
+        404,
+        json={
+            "error_code": "OBJECT_DELETED",
+            "reason": "obj was deleted",
+            "deleted_at": deleted_at_iso,
+        },
+        request=httpx.Request("POST", "http://example.com"),
+    )
+    with pytest.raises(ObjectDeletedError) as exc_info:
+        handle_response_error(new_response, "/obj/read")
+    assert exc_info.value.deleted_at == parsed_deleted_at
+
+    # Legacy response: deleted_at but no error_code (pre-error_code server).
+    legacy_response = httpx.Response(
         404,
         json={"reason": "obj was deleted", "deleted_at": deleted_at_iso},
         request=httpx.Request("POST", "http://example.com"),
     )
-
     with pytest.raises(ObjectDeletedError) as exc_info:
-        handle_response_error(deleted_response, "/obj/read")
-    assert exc_info.value.deleted_at == datetime.datetime.fromisoformat(deleted_at_iso)
+        handle_response_error(legacy_response, "/obj/read")
+    assert exc_info.value.deleted_at == parsed_deleted_at
 
+    # Plain 404 falls through.
     plain_404 = httpx.Response(
         404,
         json={"reason": "Obj foo:bar not found"},
@@ -138,6 +154,22 @@ def test_object_deleted_404_raises_typed_error():
     with pytest.raises(httpx.HTTPStatusError):
         handle_response_error(plain_404, "/obj/read")
 
+    # Different error_code with an unrelated deleted_at-ish field: don't
+    # match, so an unrelated 404 that happens to include `deleted_at` can't
+    # trigger a false ObjectDeletedError.
+    wrong_code = httpx.Response(
+        404,
+        json={
+            "error_code": "SOMETHING_ELSE",
+            "reason": "other",
+            "deleted_at": deleted_at_iso,
+        },
+        request=httpx.Request("POST", "http://example.com"),
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        handle_response_error(wrong_code, "/obj/read")
+
+    # Malformed deleted_at: fall through conservatively.
     malformed_deleted_at = httpx.Response(
         404,
         json={"reason": "deleted", "deleted_at": "not-a-date"},

--- a/tests/trace_server_bindings/test_http_utils.py
+++ b/tests/trace_server_bindings/test_http_utils.py
@@ -89,7 +89,13 @@ def test_retry_on_not_found_behavior(monkeypatch):
     @retry_on_not_found
     def deleted_http():
         calls["deleted_http"] += 1
-        raise _make_404({"reason": "deleted", "deleted_at": "2024-01-01T00:00:00Z"})
+        raise _make_404(
+            {
+                "error_code": "OBJECT_DELETED",
+                "reason": "deleted",
+                "deleted_at": "2024-01-01T00:00:00Z",
+            }
+        )
 
     @retry_on_not_found
     def deleted_local():

--- a/tests/trace_server_bindings/test_http_utils.py
+++ b/tests/trace_server_bindings/test_http_utils.py
@@ -111,3 +111,37 @@ def test_retry_on_not_found_behavior(monkeypatch):
     with pytest.raises(ObjectDeletedError):
         deleted_local()
     assert calls["deleted_local"] == 1
+
+
+def test_object_deleted_404_raises_typed_error():
+    """A 404 with `deleted_at` in the body surfaces as ObjectDeletedError.
+
+    Other 404s fall through to HTTPStatusError so retry layers can distinguish.
+    A malformed `deleted_at` also falls through (conservative).
+    """
+    deleted_at_iso = "2024-01-01T00:00:00+00:00"
+    deleted_response = httpx.Response(
+        404,
+        json={"reason": "obj was deleted", "deleted_at": deleted_at_iso},
+        request=httpx.Request("POST", "http://example.com"),
+    )
+
+    with pytest.raises(ObjectDeletedError) as exc_info:
+        handle_response_error(deleted_response, "/obj/read")
+    assert exc_info.value.deleted_at == datetime.datetime.fromisoformat(deleted_at_iso)
+
+    plain_404 = httpx.Response(
+        404,
+        json={"reason": "Obj foo:bar not found"},
+        request=httpx.Request("POST", "http://example.com"),
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        handle_response_error(plain_404, "/obj/read")
+
+    malformed_deleted_at = httpx.Response(
+        404,
+        json={"reason": "deleted", "deleted_at": "not-a-date"},
+        request=httpx.Request("POST", "http://example.com"),
+    )
+    with pytest.raises(httpx.HTTPStatusError):
+        handle_response_error(malformed_deleted_at, "/obj/read")

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -332,7 +332,10 @@ class CallRef(RefWithExtra):
 @dataclass(frozen=True)
 class DeletedRef(Ref):
     ref: Ref
-    deleted_at: datetime
+    # Optional to mirror `ObjectDeletedError.deleted_at`: the remote HTTP path
+    # can surface an authoritative delete (`error_code=OBJECT_DELETED`) even
+    # when the server's `deleted_at` field fails to parse.
+    deleted_at: datetime | None
     error: ObjectDeletedError
 
     def __repr__(self) -> str:

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -22,6 +22,7 @@ class ErrorCode:
     """
 
     CALLS_COMPLETE_MODE_REQUIRED = "CALLS_COMPLETE_MODE_REQUIRED"
+    OBJECT_DELETED = "OBJECT_DELETED"
 
 
 # =============================================================================
@@ -136,14 +137,23 @@ class MissingLLMApiKeyError(Error):
 
 
 class ObjectDeletedError(Error):
-    """Raised when an object has been deleted."""
+    """Raised when an object has been deleted.
+
+    `deleted_at` is optional so client-side code can still surface an
+    authoritative delete when the server emitted the `OBJECT_DELETED` error
+    code but the `deleted_at` field failed to parse (server bug or
+    unexpected format). Server-side raise sites always pass a real
+    datetime.
+    """
 
     # Surfaced in the HTTP body via `_format_error_to_json_with_extra` so
     # clients can distinguish an authoritative delete from a generic 404
     # without sniffing message fields.
-    error_code = "OBJECT_DELETED"
+    error_code: str = ErrorCode.OBJECT_DELETED
 
-    def __init__(self, message: str, deleted_at: datetime.datetime):
+    def __init__(
+        self, message: str, deleted_at: datetime.datetime | None = None
+    ):
         self.deleted_at = deleted_at
         super().__init__(message)
 
@@ -449,8 +459,8 @@ def _format_missing_llm_api_key(exc: Exception) -> dict[str, Any]:
 
 def _format_object_deleted_error(exc: Exception) -> dict[str, Any]:
     """Format ObjectDeletedError with deleted_at timestamp."""
-    extra = {}
-    if isinstance(exc, ObjectDeletedError):
+    extra: dict[str, Any] = {}
+    if isinstance(exc, ObjectDeletedError) and exc.deleted_at is not None:
         extra["deleted_at"] = exc.deleted_at.isoformat()
     return _format_error_to_json_with_extra(exc, extra)
 

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -138,6 +138,11 @@ class MissingLLMApiKeyError(Error):
 class ObjectDeletedError(Error):
     """Raised when an object has been deleted."""
 
+    # Surfaced in the HTTP body via `_format_error_to_json_with_extra` so
+    # clients can distinguish an authoritative delete from a generic 404
+    # without sniffing message fields.
+    error_code = "OBJECT_DELETED"
+
     def __init__(self, message: str, deleted_at: datetime.datetime):
         self.deleted_at = deleted_at
         super().__init__(message)

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -151,9 +151,7 @@ class ObjectDeletedError(Error):
     # without sniffing message fields.
     error_code: str = ErrorCode.OBJECT_DELETED
 
-    def __init__(
-        self, message: str, deleted_at: datetime.datetime | None = None
-    ):
+    def __init__(self, message: str, deleted_at: datetime.datetime | None = None):
         self.deleted_at = deleted_at
         super().__init__(message)
 

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -285,11 +285,16 @@ def handle_response_error(response: httpx.Response, url: str) -> None:
         message = extracted_message or default_message or "Calls complete mode required"
         raise CallsCompleteModeRequired(message)
 
-    # Authoritative delete: the server formats `ObjectDeletedError` as a 404
-    # with `deleted_at` in the JSON body. Surface it as the typed exception so
-    # SDK callers see the same error class regardless of local vs remote
-    # server, and so retry layers can tell it apart from a replica-lag 404.
-    if response.status_code == 404:
+    # Authoritative delete: surface the typed exception so SDK callers see
+    # the same error class regardless of local vs remote server, and so
+    # retry layers can tell it apart from a replica-lag 404. `error_code` is
+    # the official discriminator going forward (matches how
+    # CallsCompleteModeRequired is identified); `error_code is None` covers
+    # pre-error_code servers that only set `deleted_at`.
+    if response.status_code == 404 and error_code in {
+        ERROR_CODE_OBJECT_DELETED,
+        None,
+    }:
         deleted_at = _parse_deleted_at(error_data)
         if deleted_at is not None:
             raise ObjectDeletedError(
@@ -425,6 +430,9 @@ def retry_on_not_found(func: Callable[P, R]) -> Callable[P, R]:
 # Error code from server when project requires calls_complete mode
 # This matches the ErrorCode.CALLS_COMPLETE_MODE_REQUIRED from weave.trace_server.errors
 ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED = "CALLS_COMPLETE_MODE_REQUIRED"
+
+# Matches `ObjectDeletedError.error_code` on the server.
+ERROR_CODE_OBJECT_DELETED = "OBJECT_DELETED"
 
 
 class CallsCompleteModeRequired(Exception):

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -9,7 +9,7 @@ import tenacity
 from typing_extensions import ParamSpec
 
 from weave.trace_server import trace_server_interface as tsi
-from weave.trace_server.errors import NotFoundError, ObjectDeletedError
+from weave.trace_server.errors import ErrorCode, NotFoundError, ObjectDeletedError
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.utils.retry import _is_retryable_exception, with_retry
 
@@ -263,44 +263,54 @@ def handle_response_error(response: httpx.Response, url: str) -> None:
         default_message = str(e)
 
     # Try to extract custom error message from JSON response
-    extracted_message = None
-    error_code = None
-    error_data: Any = None
+    extracted_message: str | None = None
+    error_code: str | None = None
+    error_data: dict[str, Any] | None = None
     try:
-        error_data = response.json()
-        if isinstance(error_data, dict):
-            error_code = error_data.get("error_code")
-            # Common error message fields
-            extracted_message = (
-                error_data.get("message")
-                or error_data.get("error")
-                or error_data.get("detail")
-                or error_data.get("reason")
-            )
+        parsed = response.json()
     except (json.JSONDecodeError, ValueError):
-        pass
+        parsed = None
+    if isinstance(parsed, dict):
+        error_data = parsed
+        raw_code = error_data.get("error_code")
+        error_code = raw_code if isinstance(raw_code, str) else None
+        # Common error message fields
+        extracted_message = (
+            error_data.get("message")
+            or error_data.get("error")
+            or error_data.get("detail")
+            or error_data.get("reason")
+        )
 
     # Handle calls_complete mode requirement for automatic SDK upgrade
-    if error_code == ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED:
+    if error_code == ErrorCode.CALLS_COMPLETE_MODE_REQUIRED:
         message = extracted_message or default_message or "Calls complete mode required"
         raise CallsCompleteModeRequired(message)
 
     # Authoritative delete: surface the typed exception so SDK callers see
     # the same error class regardless of local vs remote server, and so
-    # retry layers can tell it apart from a replica-lag 404. `error_code` is
-    # the official discriminator going forward (matches how
-    # CallsCompleteModeRequired is identified); `error_code is None` covers
-    # pre-error_code servers that only set `deleted_at`.
-    if response.status_code == 404 and error_code in {
-        ERROR_CODE_OBJECT_DELETED,
-        None,
-    }:
-        deleted_at = _parse_deleted_at(error_data)
-        if deleted_at is not None:
+    # retry layers can tell it apart from a replica-lag 404.
+    if response.status_code == 404:
+        if error_code == ErrorCode.OBJECT_DELETED:
+            # Server told us authoritatively this is a delete. Trust it even
+            # if `deleted_at` fails to parse (server bug); the discriminator
+            # is the error_code, not the timestamp.
             raise ObjectDeletedError(
                 extracted_message or default_message or "Object deleted",
-                deleted_at=deleted_at,
+                deleted_at=(
+                    _parse_deleted_at(error_data) if error_data else None
+                ),
             )
+        # TODO(#6658 follow-up): remove the legacy `deleted_at`-only branch
+        # once all server instances emit `error_code=OBJECT_DELETED` (i.e.
+        # after this PR has been deployed to all managed weave servers).
+        if error_code is None and error_data is not None:
+            deleted_at = _parse_deleted_at(error_data)
+            if deleted_at is not None:
+                raise ObjectDeletedError(
+                    extracted_message or default_message or "Object deleted",
+                    deleted_at=deleted_at,
+                )
 
     # Combine messages
     if default_message and extracted_message:
@@ -369,15 +379,13 @@ def _is_413_error(e: Exception) -> bool:
     )
 
 
-def _parse_deleted_at(body: Any) -> datetime.datetime | None:
+def _parse_deleted_at(body: dict[str, Any]) -> datetime.datetime | None:
     """Return a parsed `deleted_at` from an error response body, or None.
 
     The server emits an ISO-8601 string via `_format_object_deleted_error`.
     Anything that doesn't parse is treated as absent so callers fall back to
     the generic HTTPStatusError path.
     """
-    if not isinstance(body, dict):
-        return None
     raw = body.get("deleted_at")
     if not isinstance(raw, str):
         return None
@@ -410,7 +418,12 @@ def _is_retryable_not_found(exc: BaseException) -> bool:
         body = exc.response.json()
     except (json.JSONDecodeError, ValueError):
         return False
-    return _parse_deleted_at(body) is None
+    if not isinstance(body, dict):
+        return False
+    # Presence check, not a parse: a malformed `deleted_at` still means the
+    # server is signaling a delete, and we shouldn't retry. The strict parse
+    # lives in `_parse_deleted_at` for extracting the timestamp.
+    return body.get("deleted_at") is None
 
 
 def retry_on_not_found(func: Callable[P, R]) -> Callable[P, R]:
@@ -425,14 +438,6 @@ def retry_on_not_found(func: Callable[P, R]) -> Callable[P, R]:
         retry_if=_is_retryable_not_found,
         wait=tenacity.wait_fixed(NOT_FOUND_RETRY_WAIT_SECONDS),
     )(func)
-
-
-# Error code from server when project requires calls_complete mode
-# This matches the ErrorCode.CALLS_COMPLETE_MODE_REQUIRED from weave.trace_server.errors
-ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED = "CALLS_COMPLETE_MODE_REQUIRED"
-
-# Matches `ObjectDeletedError.error_code` on the server.
-ERROR_CODE_OBJECT_DELETED = "OBJECT_DELETED"
 
 
 class CallsCompleteModeRequired(Exception):
@@ -464,5 +469,5 @@ def is_calls_complete_mode_error(error: Exception) -> bool:
     else:
         return (
             isinstance(error_data, dict)
-            and error_data.get("error_code") == ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED
+            and error_data.get("error_code") == ErrorCode.CALLS_COMPLETE_MODE_REQUIRED
         )

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -30,6 +30,13 @@ ROW_COUNT_CHUNKING_THRESHOLD = 1000
 # when the object is genuinely missing.
 NOT_FOUND_RETRY_WAIT_SECONDS = 0.25
 
+# Fallback messages when the server response has neither a default httpx
+# status line nor an extracted `reason`/`message`/`error`/`detail` field. In
+# practice the server always sends one of those, so these are belt-and-
+# suspenders for the typed-exception paths.
+DEFAULT_OBJECT_DELETED_MESSAGE = "Object deleted"
+DEFAULT_CALLS_COMPLETE_REQUIRED_MESSAGE = "Calls complete mode required"
+
 # Type variable for batch items
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -284,7 +291,11 @@ def handle_response_error(response: httpx.Response, url: str) -> None:
 
     # Handle calls_complete mode requirement for automatic SDK upgrade
     if error_code == ErrorCode.CALLS_COMPLETE_MODE_REQUIRED:
-        message = extracted_message or default_message or "Calls complete mode required"
+        message = (
+            extracted_message
+            or default_message
+            or DEFAULT_CALLS_COMPLETE_REQUIRED_MESSAGE
+        )
         raise CallsCompleteModeRequired(message)
 
     # Authoritative delete: surface the typed exception so SDK callers see
@@ -296,7 +307,7 @@ def handle_response_error(response: httpx.Response, url: str) -> None:
             # if `deleted_at` fails to parse (server bug); the discriminator
             # is the error_code, not the timestamp.
             raise ObjectDeletedError(
-                extracted_message or default_message or "Object deleted",
+                extracted_message or default_message or DEFAULT_OBJECT_DELETED_MESSAGE,
                 deleted_at=(
                     None if error_data is None else _parse_deleted_at(error_data)
                 ),
@@ -308,7 +319,9 @@ def handle_response_error(response: httpx.Response, url: str) -> None:
             deleted_at = _parse_deleted_at(error_data)
             if deleted_at is not None:
                 raise ObjectDeletedError(
-                    extracted_message or default_message or "Object deleted",
+                    extracted_message
+                    or default_message
+                    or DEFAULT_OBJECT_DELETED_MESSAGE,
                     deleted_at=deleted_at,
                 )
 
@@ -379,6 +392,23 @@ def _is_413_error(e: Exception) -> bool:
     )
 
 
+def _extract_error_code(response: httpx.Response) -> str | None:
+    """Return the server-emitted `error_code` string from a response, or None.
+
+    Returns None if the body isn't JSON, isn't a dict, lacks `error_code`,
+    or the value isn't a string. Use this as the single reader for the
+    error_code discriminator so the enum comparison lives in one place.
+    """
+    try:
+        body = response.json()
+    except (json.JSONDecodeError, ValueError, AttributeError):
+        return None
+    if not isinstance(body, dict):
+        return None
+    code = body.get("error_code")
+    return code if isinstance(code, str) else None
+
+
 def _parse_deleted_at(body: dict[str, Any]) -> datetime.datetime | None:
     """Return a parsed `deleted_at` from an error response body, or None.
 
@@ -418,13 +448,7 @@ def _is_retryable_not_found(exc: BaseException) -> bool:
         return False
     if exc.response.status_code != 404:
         return False
-    try:
-        body = exc.response.json()
-    except (json.JSONDecodeError, ValueError):
-        return False
-    if not isinstance(body, dict):
-        return False
-    return body.get("error_code") != ErrorCode.OBJECT_DELETED
+    return _extract_error_code(exc.response) != ErrorCode.OBJECT_DELETED
 
 
 def retry_on_not_found(func: Callable[P, R]) -> Callable[P, R]:
@@ -462,13 +486,4 @@ def is_calls_complete_mode_error(error: Exception) -> bool:
     response = getattr(error, "response", None)
     if response is None:
         return False
-
-    try:
-        error_data = response.json()
-    except (json.JSONDecodeError, ValueError, AttributeError):
-        return False
-    else:
-        return (
-            isinstance(error_data, dict)
-            and error_data.get("error_code") == ErrorCode.CALLS_COMPLETE_MODE_REQUIRED
-        )
+    return _extract_error_code(response) == ErrorCode.CALLS_COMPLETE_MODE_REQUIRED

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 from collections.abc import Callable
@@ -264,6 +265,7 @@ def handle_response_error(response: httpx.Response, url: str) -> None:
     # Try to extract custom error message from JSON response
     extracted_message = None
     error_code = None
+    error_data: Any = None
     try:
         error_data = response.json()
         if isinstance(error_data, dict):
@@ -282,6 +284,18 @@ def handle_response_error(response: httpx.Response, url: str) -> None:
     if error_code == ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED:
         message = extracted_message or default_message or "Calls complete mode required"
         raise CallsCompleteModeRequired(message)
+
+    # Authoritative delete: the server formats `ObjectDeletedError` as a 404
+    # with `deleted_at` in the JSON body. Surface it as the typed exception so
+    # SDK callers see the same error class regardless of local vs remote
+    # server, and so retry layers can tell it apart from a replica-lag 404.
+    if response.status_code == 404:
+        deleted_at = _parse_deleted_at(error_data)
+        if deleted_at is not None:
+            raise ObjectDeletedError(
+                extracted_message or default_message or "Object deleted",
+                deleted_at=deleted_at,
+            )
 
     # Combine messages
     if default_message and extracted_message:
@@ -350,6 +364,24 @@ def _is_413_error(e: Exception) -> bool:
     )
 
 
+def _parse_deleted_at(body: Any) -> datetime.datetime | None:
+    """Return a parsed `deleted_at` from an error response body, or None.
+
+    The server emits an ISO-8601 string via `_format_object_deleted_error`.
+    Anything that doesn't parse is treated as absent so callers fall back to
+    the generic HTTPStatusError path.
+    """
+    if not isinstance(body, dict):
+        return None
+    raw = body.get("deleted_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        return datetime.datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+
+
 def _is_retryable_not_found(exc: BaseException) -> bool:
     """True only for 404-like misses worth retrying.
 
@@ -373,9 +405,7 @@ def _is_retryable_not_found(exc: BaseException) -> bool:
         body = exc.response.json()
     except (json.JSONDecodeError, ValueError):
         return False
-    if not isinstance(body, dict):
-        return False
-    return body.get("deleted_at") is None
+    return _parse_deleted_at(body) is None
 
 
 def retry_on_not_found(func: Callable[P, R]) -> Callable[P, R]:

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -298,7 +298,7 @@ def handle_response_error(response: httpx.Response, url: str) -> None:
             raise ObjectDeletedError(
                 extracted_message or default_message or "Object deleted",
                 deleted_at=(
-                    _parse_deleted_at(error_data) if error_data else None
+                    None if error_data is None else _parse_deleted_at(error_data)
                 ),
             )
         # TODO(#6658 follow-up): remove the legacy `deleted_at`-only branch

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -398,10 +398,10 @@ def _parse_deleted_at(body: dict[str, Any]) -> datetime.datetime | None:
 def _is_retryable_not_found(exc: BaseException) -> bool:
     """True only for 404-like misses worth retrying.
 
-    Skips authoritative deletes (local `ObjectDeletedError` or HTTP response
-    body with `deleted_at`). Covers both local server domain exceptions
-    (`NotFoundError`) and remote HTTP 404s; anything else (including a 404
-    with a non-JSON body) is out of scope for this retry layer.
+    Skips authoritative deletes (local `ObjectDeletedError` or remote 404
+    with `error_code=OBJECT_DELETED`). Covers both local server domain
+    exceptions (`NotFoundError`) and remote HTTP 404s; anything else
+    (including a 404 with a non-JSON body) is out of scope for this layer.
     """
     # Authoritative delete -- never retry.
     if isinstance(exc, ObjectDeletedError):
@@ -409,7 +409,11 @@ def _is_retryable_not_found(exc: BaseException) -> bool:
     # Local server raised a plain not-found -- retry.
     if isinstance(exc, NotFoundError):
         return True
-    # Remote HTTP 404 -- retry unless the body indicates a delete.
+    # Remote HTTP 404 -- retry unless the body identifies an authoritative
+    # delete via `error_code`. A pre-error_code server's delete (legacy
+    # `deleted_at`-only body) will be retried once before the final failure;
+    # that's an acceptable cost for keeping `error_code` as the single
+    # discriminator.
     if not isinstance(exc, httpx.HTTPStatusError) or exc.response is None:
         return False
     if exc.response.status_code != 404:
@@ -420,10 +424,7 @@ def _is_retryable_not_found(exc: BaseException) -> bool:
         return False
     if not isinstance(body, dict):
         return False
-    # Presence check, not a parse: a malformed `deleted_at` still means the
-    # server is signaling a delete, and we shouldn't retry. The strict parse
-    # lives in `_parse_deleted_at` for extracting the timestamp.
-    return body.get("deleted_at") is None
+    return body.get("error_code") != ErrorCode.OBJECT_DELETED
 
 
 def retry_on_not_found(func: Callable[P, R]) -> Callable[P, R]:

--- a/weave/utils/retry.py
+++ b/weave/utils/retry.py
@@ -101,11 +101,13 @@ def _is_retryable_exception(e: BaseException) -> bool:
     if isinstance(e, ValidationError):
         return False
 
-    # Don't retry CallsCompleteModeRequired - should trigger immediate mode switch
-    # Lazy import to avoid circular dependency (http_utils imports from this module)
+    # Don't retry ObjectDeletedError or CallsCompleteModeRequired: the server
+    # response is authoritative. Lazy import avoids circular dependency
+    # (http_utils imports from this module).
+    from weave.trace_server.errors import ObjectDeletedError
     from weave.trace_server_bindings.http_utils import CallsCompleteModeRequired
 
-    if isinstance(e, CallsCompleteModeRequired):
+    if isinstance(e, (ObjectDeletedError, CallsCompleteModeRequired)):
         return False
 
     # Don't retry on HTTP 4xx (except 429)


### PR DESCRIPTION
## Summary

Follow-up to #6653. When an object is deleted, the local trace server raises a typed `ObjectDeletedError` with a `deleted_at` timestamp; the remote HTTP binding raises a generic `httpx.HTTPStatusError` with the same information buried in the response body. Downstream code that wants to distinguish "deleted" from "not found" (e.g. `vals.py::make_trace_obj` producing `DeletedRef`) only works against the local server.

This PR normalizes the surface.

- **Server**: `ObjectDeletedError.error_code = "OBJECT_DELETED"`. The existing `_format_error_to_json_with_extra` path already forwards `error_code` onto the response body whenever the exception class exposes one, so this is a one-line addition.
- **Client**: `handle_response_error` now translates a 404 with `error_code == "OBJECT_DELETED"` into a typed `ObjectDeletedError` (same pattern as `CALLS_COMPLETE_MODE_REQUIRED`). `error_code is None` is accepted as a backcompat fallback for pre-error_code servers that only set `deleted_at`.
- **Retry**: `_is_retryable_exception` treats `ObjectDeletedError` as non-retryable so `_post_request_executor`'s `@with_retry` does not re-fire on an authoritative delete.
- `WeaveClient.get()` needs no change: `ObjectDeletedError` isn't `HTTPError`, so the existing `except HTTPError` block passes it through. Downstream `vals.py::make_trace_obj` already catches it and produces a `DeletedRef` -> works on remote now too.

## Deploy sequencing

SDK paired with old server (no `error_code`): falls back to legacy `deleted_at`-only detection. Works.
Old SDK paired with new server: server sends both `error_code` and `deleted_at`; old SDK only sniffs `deleted_at`. Works.

## Test plan

- [x] `test_object_deleted_404_raises_typed_error` covers: new-style (`error_code=OBJECT_DELETED`), legacy (no `error_code`), mismatched `error_code`, malformed `deleted_at`, plain 404.
- [x] 18/18 existing tests in `test_http_utils`, `test_http_behavior_remote`, `test_retry` still green.
- [x] Smoke: `test_simple_op`, `test_basic_dataset_lifecycle` pass.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)