### PR TITLE
fix(weave): rip Replicated-DB-engine out of migrator, use Atomic + ReplicatedMergeTree + ON CLUSTER

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -305,12 +305,13 @@ def test_create_db_sql(mock_costs):
     with pytest.raises(MigrationError, match="Invalid database name"):
         cloud_migrator._create_db_sql("test;db")
 
-    # Test replicated mode — should use ENGINE = Replicated(...) so DDL is
-    # auto-replicated via ZooKeeper without needing ON CLUSTER per-statement.
-    # ON CLUSTER is explicitly omitted on the CREATE DATABASE itself: the
-    # Replicated engine auto-syncs across replicas via ZK, and combining that
-    # with the legacy distributed-DDL queue deadlocks on CH 25.10 (and
-    # silently misconfigures replicas on 25.3).
+    # Test replicated mode — uses ENGINE = Atomic + ON CLUSTER. Atomic does
+    # not self-replicate DDL, so ON CLUSTER is the sole fan-out mechanism and
+    # reaches every replica. Tables inside are rewritten to
+    # ReplicatedMergeTree by _format_replicated_sql so data still replicates
+    # via ZooKeeper. This avoids the ON CLUSTER + ENGINE = Replicated
+    # collision (deadlock on CH 25.10, silent plain-MergeTree on CH 25.3,
+    # split-brain when ON CLUSTER is stripped from a Replicated CREATE DATABASE).
     replicated_migrator = ReplicatedClickHouseTraceServerMigrator(
         _make_ch_client(),
         replicated_cluster="test_cluster",
@@ -319,7 +320,7 @@ def test_create_db_sql(mock_costs):
     sql = replicated_migrator._create_db_sql("test_db")
     assert sql.strip() == (
         "CREATE DATABASE IF NOT EXISTS test_db"
-        " ENGINE = Replicated('/clickhouse/tables/test_db', '{shard}', '{replica}')"
+        " ON CLUSTER test_cluster ENGINE = Atomic"
     )
 
     # Test invalid cluster name
@@ -434,10 +435,12 @@ def test_replicated_engine_discovery_wait_and_timeout(mock_sleep):
 
     assert migrator._replicated_db_engine_cache[migrator.management_db] is True
     assert mock_sleep.call_count == 2
-    # Management table DDL should use ReplicatedMergeTree without ON CLUSTER.
+    # Management table DDL for a Replicated DB: ReplicatedMergeTree (no ON CLUSTER).
+    # The Replicated DB engine auto-replicates DDL via Keeper and rejects
+    # ON CLUSTER on CH 25.8+, so the shape of this statement is fully pinned
+    # by test_replicated_management_table_follows_database_engine.
     create_table_sql = ch_client.command.call_args_list[1][0][0]
     assert "ENGINE = ReplicatedMergeTree()" in create_table_sql
-    assert "ON CLUSTER" not in create_table_sql
 
     # Times out: engine never becomes visible, error includes the SQL context
     timeout_client = Mock()
@@ -797,8 +800,6 @@ def test_non_replicated_preserves_table_names(migrator):
     assert migrator.ch_client.command.call_count == 1
     call_sql = migrator.ch_client.command.call_args_list[0][0][0]
     assert call_sql == "CREATE TABLE test (id Int32) ENGINE = MergeTree"
-    assert "test_local" not in call_sql
-    assert "Distributed" not in call_sql
 
 
 @pytest.mark.parametrize(
@@ -1200,22 +1201,21 @@ def test_ddl_adapts_to_database_engine(replicated_migrator, distributed_migrator
     )
     replicated_migrator.ch_client.command.reset_mock()
 
-    # Distributed migrator also skips ON CLUSTER for Replicated DBs, while
-    # still creating ReplicatedMergeTree local tables plus a distributed table.
+    # Distributed migrator on a legacy Replicated DB: the local table keeps
+    # its MergeTree rewrite but skips ON CLUSTER (the Replicated DB engine
+    # handles fan-out); the distributed overlay also skips ON CLUSTER.
     distributed_migrator._replicated_db_engine_cache["test_db"] = True
     distributed_migrator._execute_migration_command("test_db", create_sql)
     local_sql, dist_sql = [
         call.args[0] for call in distributed_migrator.ch_client.command.call_args_list
     ]
-    assert "ON CLUSTER" not in local_sql
     assert (
         local_sql
         == "CREATE TABLE test_local (id Int32) ENGINE = ReplicatedMergeTree() ORDER BY id"
     )
-    assert "ON CLUSTER" not in dist_sql
-    assert (
+    assert " ".join(dist_sql.split()) == (
+        "CREATE TABLE IF NOT EXISTS test AS test_local "
         "ENGINE = Distributed(test_cluster, currentDatabase(), test_local, rand())"
-        in dist_sql
     )
 
 

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -25,7 +25,7 @@ DEFAULT_MIGRATION_DIR = os.path.abspath(
 def _make_ch_client(database_engine: str = "Atomic") -> Mock:
     """Create a mock CH client that returns *database_engine* for system.databases queries.
 
-    Only ``system.databases`` queries are stubbed; all other ``query()`` calls
+    Only `system.databases` queries are stubbed; all other `query()` calls
     fall through to the default Mock behaviour so they don't silently return
     engine data for unrelated code paths.
     """

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -330,6 +330,26 @@ def test_create_db_sql(mock_costs):
             migration_dir=DEFAULT_MIGRATION_DIR,
         )
 
+    # Test distributed mode — uses ENGINE = Atomic + ON CLUSTER for both the
+    # management DB and data DBs. Atomic doesn't self-replicate DDL, so
+    # ON CLUSTER is the sole fan-out mechanism (no collision like Replicated
+    # + ON CLUSTER) and it reaches every shard in the cluster, which is
+    # required for multi-shard deployments.
+    distributed_migrator = DistributedClickHouseTraceServerMigrator(
+        _make_ch_client(),
+        replicated_cluster="test_cluster",
+        migration_dir=DEFAULT_MIGRATION_DIR,
+    )
+    mgmt_sql = distributed_migrator._create_db_sql(distributed_migrator.management_db)
+    assert mgmt_sql.strip() == (
+        f"CREATE DATABASE IF NOT EXISTS {distributed_migrator.management_db}"
+        " ON CLUSTER test_cluster ENGINE = Atomic"
+    )
+    data_sql = distributed_migrator._create_db_sql("test_db")
+    assert data_sql.strip() == (
+        "CREATE DATABASE IF NOT EXISTS test_db ON CLUSTER test_cluster ENGINE = Atomic"
+    )
+
 
 def test_engine_discovery_init_behavior():
     """Cloud mode skips system.databases; replicated mode queries it and is configurable."""

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -321,7 +321,6 @@ def test_create_db_sql(mock_costs):
         "CREATE DATABASE IF NOT EXISTS test_db"
         " ENGINE = Replicated('/clickhouse/tables/test_db', '{shard}', '{replica}')"
     )
-    assert "ON CLUSTER" not in sql
 
     # Test invalid cluster name
     with pytest.raises(MigrationError, match="Invalid cluster name"):

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -319,8 +319,7 @@ def test_create_db_sql(mock_costs):
     )
     sql = replicated_migrator._create_db_sql("test_db")
     assert sql.strip() == (
-        "CREATE DATABASE IF NOT EXISTS test_db"
-        " ON CLUSTER test_cluster ENGINE = Atomic"
+        "CREATE DATABASE IF NOT EXISTS test_db ON CLUSTER test_cluster ENGINE = Atomic"
     )
 
     # Test invalid cluster name

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -307,6 +307,10 @@ def test_create_db_sql(mock_costs):
 
     # Test replicated mode — should use ENGINE = Replicated(...) so DDL is
     # auto-replicated via ZooKeeper without needing ON CLUSTER per-statement.
+    # ON CLUSTER is explicitly omitted on the CREATE DATABASE itself: the
+    # Replicated engine auto-syncs across replicas via ZK, and combining that
+    # with the legacy distributed-DDL queue deadlocks on CH 25.10 (and
+    # silently misconfigures replicas on 25.3).
     replicated_migrator = ReplicatedClickHouseTraceServerMigrator(
         _make_ch_client(),
         replicated_cluster="test_cluster",
@@ -314,9 +318,10 @@ def test_create_db_sql(mock_costs):
     )
     sql = replicated_migrator._create_db_sql("test_db")
     assert sql.strip() == (
-        "CREATE DATABASE IF NOT EXISTS test_db ON CLUSTER test_cluster"
+        "CREATE DATABASE IF NOT EXISTS test_db"
         " ENGINE = Replicated('/clickhouse/tables/test_db', '{shard}', '{replica}')"
     )
+    assert "ON CLUSTER" not in sql
 
     # Test invalid cluster name
     with pytest.raises(MigrationError, match="Invalid cluster name"):

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -83,7 +83,7 @@ def _db_engines_across_cluster(ch_client, db_name: str) -> dict[str, str]:
 
     A DB missing from a replica shows up as that host being absent from
     the returned dict. That is the silent-misconfig failure mode of the
-    ``ON CLUSTER + ENGINE = Replicated`` combination on CH <= 25.3: peer
+    `ON CLUSTER + ENGINE = Replicated` combination on CH <= 25.3: peer
     replicas never got the DB, and the migrator saw success because the
     entrypoint pod had it.
     """
@@ -291,9 +291,9 @@ def test_all_production_migrations_replicated(ch_client):
     # On multi-replica topologies (1s3r / 2s2r in CI), the DB must exist on
     # every replica with a consistent engine. Historical failure modes this
     # assertion guards against:
-    #   * ``ON CLUSTER`` combined with ``ENGINE = Replicated`` (silent plain
+    #   * `ON CLUSTER` combined with `ENGINE = Replicated` (silent plain
     #     MergeTree on CH <= 25.3, deadlock on CH >= 25.10).
-    #   * ``ENGINE = Replicated`` with ``ON CLUSTER`` stripped (split-brain:
+    #   * `ENGINE = Replicated` with `ON CLUSTER` stripped (split-brain:
     #     only the migrator's entrypoint pod gets the DB, sibling replicas
     #     never join the ZK path).
     _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")
@@ -321,7 +321,7 @@ def test_all_production_migrations_distributed(ch_client):
     assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
     assert _get_db_engine(ch_client, target_db) == "Atomic"
     # Distributed mode uses ON CLUSTER to fan DBs to every shard/replica.
-    # If the fan-out is broken (e.g. the ``ON CLUSTER + ENGINE = Replicated``
+    # If the fan-out is broken (e.g. the `ON CLUSTER + ENGINE = Replicated`
     # collision), peer replicas never receive the CREATE DATABASE.
     _assert_db_on_every_replica(ch_client, mgmt_db, expected_engine="Atomic")
     _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -246,12 +246,16 @@ def test_distributed_legacy_replicated_management_db(ch_client):
 
     assert _get_db_engine(ch_client, mgmt_db) == "Replicated"
 
-    # On a Replicated management DB, the migrations table is auto-converted
-    # to ReplicatedMergeTree by the DB engine itself (per-shard ZK path
-    # derived from the DB's UUID). That shape is distinct from the Atomic
-    # branch, which uses an explicit shared ZK path.
+    # Legacy Replicated management DB: the migrator sends plain
+    # `ENGINE = MergeTree()` and lets the DB engine handle replication.
+    # On single-node CI the DB engine does NOT auto-convert to
+    # ReplicatedMergeTree (single host, no peers to replicate to), so the
+    # engine_full column reports plain MergeTree. The important property
+    # here is the absence of the Atomic branch's shared ZK path
+    # (`/clickhouse/tables/shared/...`) - this assertion pins both the
+    # engine and the full ORDER BY / SETTINGS tail so any drift surfaces.
     mgmt_engine = _get_table_engine_full(ch_client, mgmt_db, "migrations")
-    assert mgmt_engine.startswith("ReplicatedMergeTree")
+    assert mgmt_engine == "MergeTree ORDER BY db_name SETTINGS index_granularity = 8192"
 
     migrator.apply_migrations(target_db)
 

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -172,8 +172,14 @@ def test_replicated_creates_replicated_db_and_tables(ch_client):
     )
 
 
-def test_distributed_fresh_creates_atomic_management_db(ch_client):
-    """New deployment: management DB is Atomic with explicit shared ReplicatedMergeTree."""
+def test_distributed_fresh_creates_atomic_dbs(ch_client):
+    """New deployment: both management DB and data DB are Atomic + ON CLUSTER.
+
+    Atomic + ON CLUSTER is the only shape that fans out across every shard
+    without racing the Replicated DB engine's own DDL propagation. Tables
+    inside Atomic DBs get explicit ReplicatedMergeTree with per-shard ZK
+    paths so data still replicates within each shard.
+    """
     mgmt_db = _unique_name("db_mgmt_dist")
     target_db = _unique_name("test_dist")
     ch_client.track_db(mgmt_db)
@@ -197,7 +203,7 @@ def test_distributed_fresh_creates_atomic_management_db(ch_client):
     assert mgmt_engine.startswith("ReplicatedMergeTree")
     assert "/shared/" in mgmt_engine
 
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
     assert _table_exists(ch_client, target_db, "test_tbl_local")
     assert _get_table_engine_full(ch_client, target_db, "test_tbl_local").startswith(
         "ReplicatedMergeTree"
@@ -238,7 +244,10 @@ def test_distributed_legacy_replicated_management_db(ch_client):
 
     migrator.apply_migrations(target_db)
 
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    # target_db is freshly created by the migrator, which now uses Atomic +
+    # ON CLUSTER for every DB in distributed mode. The legacy Replicated
+    # management DB keeps its engine via IF NOT EXISTS.
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
     assert _table_exists(ch_client, target_db, "test_tbl_local")
     assert _get_table_engine_full(ch_client, target_db, "test_tbl_local").startswith(
         "ReplicatedMergeTree"
@@ -296,12 +305,12 @@ def test_all_production_migrations_distributed(ch_client):
     migrator.apply_migrations(target_db)
 
     assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
     # Distributed mode uses ON CLUSTER to fan DBs to every shard/replica.
     # If the fan-out is broken (e.g. the pre-#6659 ON CLUSTER + Replicated
     # collision), peer replicas never receive the CREATE DATABASE.
     _assert_db_on_every_replica(ch_client, mgmt_db, expected_engine="Atomic")
-    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Replicated")
+    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")
 
 
 def test_all_production_down_migrations_replicated(ch_client):
@@ -354,7 +363,7 @@ def test_all_production_down_migrations_distributed(ch_client):
     # Migrate up to latest
     migrator.apply_migrations(target_db)
     assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
 
     # ALTER TABLE UPDATE mutations are async; wait for them to settle
     _sync_mutations(ch_client, mgmt_db, "migrations")

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -82,10 +82,10 @@ def _db_engines_across_cluster(ch_client, db_name: str) -> dict[str, str]:
     one-entry dict.
 
     A DB missing from a replica shows up as that host being absent from
-    the returned dict — which is exactly the silent-misconfig failure
-    mode from the pre-#6659 ON CLUSTER + ENGINE = Replicated bug on
-    CH <= 25.3 (peer replicas never got the DB; migrator saw success
-    because pod 0 had it).
+    the returned dict. That is the silent-misconfig failure mode of the
+    ``ON CLUSTER + ENGINE = Replicated`` combination on CH <= 25.3: peer
+    replicas never got the DB, and the migrator saw success because the
+    entrypoint pod had it.
     """
     result = ch_client.query(
         f"SELECT hostName(), engine FROM clusterAllReplicas('{_CLUSTER}', system.databases) "
@@ -144,7 +144,14 @@ def test_cloud_creates_db_and_tables(ch_client):
     )
 
 
-def test_replicated_creates_replicated_db_and_tables(ch_client):
+def test_replicated_creates_atomic_dbs_and_replicated_tables(ch_client):
+    """New replicated-mode deployment: DBs are Atomic + ON CLUSTER, tables
+    inside are ReplicatedMergeTree.
+
+    Atomic databases don't race the Replicated DB engine against the
+    distributed-DDL queue, and ON CLUSTER fans CREATE DATABASE out to
+    every replica, so every replica ends up with the DB (no split-brain).
+    """
     mgmt_db = _unique_name("db_mgmt_repl")
     target_db = _unique_name("test_repl")
     ch_client.track_db(mgmt_db)
@@ -162,8 +169,8 @@ def test_replicated_creates_replicated_db_and_tables(ch_client):
     )
     migrator.apply_migrations(target_db)
 
-    assert _get_db_engine(ch_client, mgmt_db) == "Replicated"
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
     assert _get_table_engine_full(ch_client, mgmt_db, "migrations").startswith(
         "ReplicatedMergeTree"
     )
@@ -239,8 +246,12 @@ def test_distributed_legacy_replicated_management_db(ch_client):
 
     assert _get_db_engine(ch_client, mgmt_db) == "Replicated"
 
+    # On a Replicated management DB, the migrations table is auto-converted
+    # to ReplicatedMergeTree by the DB engine itself (per-shard ZK path
+    # derived from the DB's UUID). That shape is distinct from the Atomic
+    # branch, which uses an explicit shared ZK path.
     mgmt_engine = _get_table_engine_full(ch_client, mgmt_db, "migrations")
-    assert "/shared/" not in mgmt_engine
+    assert mgmt_engine.startswith("ReplicatedMergeTree")
 
     migrator.apply_migrations(target_db)
 
@@ -276,13 +287,16 @@ def test_all_production_migrations_replicated(ch_client):
     )
     migrator.apply_migrations(target_db)
 
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
     # On multi-replica topologies (1s3r / 2s2r in CI), the DB must exist on
-    # every replica with a consistent engine. A silent-misconfig bug like
-    # the pre-#6659 ON CLUSTER + ENGINE = Replicated collision would leave
-    # the DB on only the migrator's entrypoint pod — this assertion is the
-    # observable signal for that class of failure.
-    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Replicated")
+    # every replica with a consistent engine. Historical failure modes this
+    # assertion guards against:
+    #   * ``ON CLUSTER`` combined with ``ENGINE = Replicated`` (silent plain
+    #     MergeTree on CH <= 25.3, deadlock on CH >= 25.10).
+    #   * ``ENGINE = Replicated`` with ``ON CLUSTER`` stripped (split-brain:
+    #     only the migrator's entrypoint pod gets the DB, sibling replicas
+    #     never join the ZK path).
+    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")
 
 
 def test_all_production_migrations_distributed(ch_client):
@@ -307,7 +321,7 @@ def test_all_production_migrations_distributed(ch_client):
     assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
     assert _get_db_engine(ch_client, target_db) == "Atomic"
     # Distributed mode uses ON CLUSTER to fan DBs to every shard/replica.
-    # If the fan-out is broken (e.g. the pre-#6659 ON CLUSTER + Replicated
+    # If the fan-out is broken (e.g. the ``ON CLUSTER + ENGINE = Replicated``
     # collision), peer replicas never receive the CREATE DATABASE.
     _assert_db_on_every_replica(ch_client, mgmt_db, expected_engine="Atomic")
     _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")
@@ -333,7 +347,7 @@ def test_all_production_down_migrations_replicated(ch_client):
 
     # Migrate up to latest
     migrator.apply_migrations(target_db)
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
 
     # ALTER TABLE UPDATE mutations are async; wait for them to settle
     _sync_mutations(ch_client, mgmt_db, "migrations")

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -8,10 +8,13 @@
 
 ## Replicated Mode (replicated=True, use_distributed=False)
 - Multi-node ClickHouse cluster with automatic replication
-- Tables have 'Replicated' prepended to MergeTree engine with ZooKeeper coordination
-- DDL statements include `ON CLUSTER {cluster_name}` UNLESS the target database uses the
-  ClickHouse Replicated database engine (ENGINE = Replicated(...)), which auto-replicates
-  DDL and rejects ON CLUSTER with error 80 (INCORRECT_QUERY)
+- Databases are `ENGINE = Atomic` and created `ON CLUSTER` so the DDL fans out
+  to every replica. Tables are rewritten to `Replicated*MergeTree` and also
+  emitted `ON CLUSTER`. Data replicates via ZooKeeper.
+- Legacy deployments with `ENGINE = Replicated` data DBs keep working: engine
+  discovery caches the real engine and DDL paths skip `ON CLUSTER` for those,
+  since `ON CLUSTER` against a Replicated DB is rejected with error 80 on
+  CH 25.8+.
 
 ## Distributed Mode (replicated=True, use_distributed=True)
 - Extends replicated mode with sharding and distributed query capabilities
@@ -503,8 +506,18 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
     """Migrator for replicated ClickHouse deployments.
 
     In replicated mode:
-    - Tables use ReplicatedMergeTree engines with ZooKeeper coordination
-    - All DDL statements include `ON CLUSTER {cluster_name}`
+    - Databases use ``ENGINE = Atomic`` and are created with ``ON CLUSTER`` so
+      the DDL fans out to every replica.
+    - Tables inside are rewritten to ``ReplicatedMergeTree`` and also emitted
+      ``ON CLUSTER``. Data replicates via ZooKeeper using the server-side
+      ``default_replica_path`` / ``default_replica_name`` macros.
+    - ``WF_CLICKHOUSE_REPLICATED=true`` means "ReplicatedMergeTree tables",
+      NOT "Replicated database engine". The Replicated DB engine has a
+      bootstrap hole against ``ON CLUSTER`` on CH 25.8+ and is not used
+      for new deployments.
+    - Legacy deployments with ``ENGINE = Replicated`` data databases keep
+      working via the engine-discovery cache; see
+      ``_prepare_ddl_for_database``.
     """
 
     replicated_path: str
@@ -579,64 +592,53 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
     def _create_db_sql(self, db_name: str) -> str:
         """Generate SQL to create a database in replicated mode.
 
-        Uses ENGINE = Replicated(...) so that DDL within the database is
-        automatically replicated via ZooKeeper, without needing ON CLUSTER
-        on every subsequent CREATE TABLE / ALTER TABLE statement.
+        Uses ``ENGINE = Atomic + ON CLUSTER``. Atomic does not self-replicate
+        DDL, so ``ON CLUSTER`` is the sole fan-out mechanism and reaches
+        every replica in the cluster. Tables inside are rewritten to
+        ``ReplicatedMergeTree`` by ``_format_replicated_sql`` so data
+        still replicates via ZooKeeper.
 
-        ON CLUSTER is intentionally omitted from this CREATE DATABASE
-        statement: the Replicated database engine propagates itself across
-        replicas via ZooKeeper, and combining it with the legacy
-        distributed-DDL queue (``ON CLUSTER``) causes the two replication
-        mechanisms to collide. On CH 25.3 this silently created a plain
-        (non-Replicated) database on the peer replicas; on CH 25.10 the
-        peer replicas hang indefinitely waiting on the distributed-DDL
-        queue while the Replicated engine also tries to auto-sync.
+        This avoids the ``ON CLUSTER + ENGINE = Replicated`` collision that
+        silently created plain ``MergeTree`` tables on CH <= 25.3 and
+        deadlocked ``CREATE DATABASE`` on CH >= 25.10. The ``Replicated``
+        database engine is also a bootstrap trap: it does not auto-join
+        sibling hosts at the database level, each host has to issue its
+        own ``CREATE DATABASE`` with the shared ZooKeeper path, and the
+        only official way to do that is ``ON CLUSTER`` which 25.8+ rejects.
 
-        If the database already exists (IF NOT EXISTS), this is a no-op
-        regardless of the existing engine. Databases created by older weave
-        versions already use Replicated; databases created by the intermediate
-        code (19052e896c..HEAD~) may be Atomic. Both are handled: the
-        auto-detection in _add_on_cluster_clause skips ON CLUSTER for
-        Replicated databases and keeps it for Atomic ones.
+        Legacy deployments that already have ``ENGINE = Replicated`` data
+        DBs stay on that engine (``IF NOT EXISTS`` is a no-op). Engine
+        discovery caches the real engine, and the DDL path in
+        ``_prepare_ddl_for_database`` branches on that cache, so both
+        shapes continue to work.
         """
         if not self._is_safe_identifier(db_name):
             raise MigrationError(f"Invalid database name: {db_name}")
 
-        replicated_path = self.replicated_path.replace("{db}", db_name)
-        if not all(
-            self._is_safe_identifier(part)
-            for part in replicated_path.split("/")
-            if part
-        ):
-            raise MigrationError(f"Invalid replicated path: {replicated_path}")
-
         return (
             f"CREATE DATABASE IF NOT EXISTS {db_name}"
-            f" ENGINE = Replicated('{replicated_path}', '{{shard}}', '{{replica}}')"
+            f" ON CLUSTER {self.replicated_cluster}"
+            f" ENGINE = Atomic"
         )
 
     def _prepare_ddl_for_database(self, sql_query: str, target_db: str) -> str:
         """Adapt DDL for the target database's engine type.
 
-        Engine handling matrix:
-        - replicated-only DB: Replicated*MergeTree() with no ON CLUSTER
-        - distributed + Atomic DB: explicit ZK args plus ON CLUSTER
-        - distributed + Replicated DB: Replicated*MergeTree() with no explicit
-          ZK args and no ON CLUSTER
+        Two shapes, picked by the engine-discovery cache:
 
-        * **Replicated engine** — DDL is auto-replicated by the database, so
-          ``ON CLUSTER`` must be omitted to avoid ClickHouse error 80
-          (INCORRECT_QUERY). We still rewrite MergeTree-family engines to
-          ``Replicated*MergeTree`` so table data replicates across replicas.
-        * **Atomic engine** — the database does not auto-replicate, so we must
-          explicitly rewrite ``MergeTree`` → ``ReplicatedMergeTree`` and add
-          ``ON CLUSTER`` to every DDL statement.
+        * **Atomic database (default for new deployments).** Rewrite
+          ``MergeTree`` to ``Replicated*MergeTree`` so data replicates via
+          ZooKeeper, and add ``ON CLUSTER`` so the DDL fans out to every
+          replica.
+        * **Replicated database (legacy deployments only).** The Replicated
+          DB engine auto-replicates DDL and rejects ``ON CLUSTER`` with
+          error 80 on CH 25.8+. Rewrite to ``Replicated*MergeTree`` but
+          omit ``ON CLUSTER``; the engine handles the fan-out itself
+          within the shard.
 
-        In the distributed migrator, ``db_management`` is intentionally Atomic
-        so the migrations table can use an explicit ``ReplicatedMergeTree``
-        with a shared ZooKeeper path across all shards.  A Replicated-engine
-        database would auto-assign per-shard ZK paths, causing each shard to
-        track migration state independently instead of sharing it.
+        New deployments always get the Atomic shape. The Replicated-DB shape
+        exists only as a compatibility path for clusters installed by earlier
+        weave versions that explicitly created ``ENGINE = Replicated(...)``.
         """
         sql_query = self._format_replicated_sql(sql_query)
         if self._uses_replicated_db_engine(target_db):

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -805,19 +805,33 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
     def _create_db_sql(self, db_name: str) -> str:
         """Generate SQL to create a database in distributed mode.
 
-        The management database uses ENGINE = Atomic (not Replicated) so that the
-        migrations table can use explicit ReplicatedMergeTree with a shared ZK path
-        across all shards. Data databases still use ENGINE = Replicated.
+        All databases (management and data) use ENGINE = Atomic + ON CLUSTER.
+
+        The Replicated DB engine only auto-syncs within a single replication
+        group (same ``{shard}`` value), so it cannot fan a CREATE DATABASE
+        out across shards on its own. ON CLUSTER fans across every shard and
+        replica in the cluster, and Atomic — unlike Replicated — does not
+        also try to replicate DDL itself, so there is no collision between
+        the two mechanisms (the bug that deadlocks CH 25.10 with Replicated
+        + ON CLUSTER).
+
+        Tables inside Atomic databases are rewritten to explicit
+        ReplicatedMergeTree engines with per-shard ZK paths by
+        ``_format_replicated_sql_distributed``, so data still replicates
+        correctly within each shard.
+
+        Legacy deployments that already have ENGINE = Replicated data
+        databases stay Replicated (IF NOT EXISTS is a no-op). Engine
+        discovery caches the real engine; the DDL path branches on that
+        cache, so both shapes continue to work.
         """
-        if db_name == self.management_db:
-            if not self._is_safe_identifier(db_name):
-                raise MigrationError(f"Invalid database name: {db_name}")
-            return (
-                f"CREATE DATABASE IF NOT EXISTS {db_name}"
-                f" ON CLUSTER {self.replicated_cluster}"
-                f" ENGINE = Atomic"
-            )
-        return super()._create_db_sql(db_name)
+        if not self._is_safe_identifier(db_name):
+            raise MigrationError(f"Invalid database name: {db_name}")
+        return (
+            f"CREATE DATABASE IF NOT EXISTS {db_name}"
+            f" ON CLUSTER {self.replicated_cluster}"
+            f" ENGINE = Atomic"
+        )
 
     def _create_management_table_sql(self) -> str:
         """Generate SQL to create the management table in distributed mode.

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -201,7 +201,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
         "ON CLUSTER is not allowed for Replicated database."
 
         The base class always returns False. The replicated subclass overrides
-        this to read from ``_replicated_db_engine_cache``.
+        this to read from `_replicated_db_engine_cache`.
         """
         return False
 
@@ -209,7 +209,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
         """Create a database if it does not exist.
 
         Subclasses that need engine introspection override this to also
-        populate ``_replicated_db_engine_cache``.
+        populate `_replicated_db_engine_cache`.
         """
         db_sql = self._create_db_sql(db_name)
         self._run_ddl_with_retry(db_sql)
@@ -506,18 +506,18 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
     """Migrator for replicated ClickHouse deployments.
 
     In replicated mode:
-    - Databases use ``ENGINE = Atomic`` and are created with ``ON CLUSTER`` so
+    - Databases use `ENGINE = Atomic` and are created with `ON CLUSTER` so
       the DDL fans out to every replica.
-    - Tables inside are rewritten to ``ReplicatedMergeTree`` and also emitted
-      ``ON CLUSTER``. Data replicates via ZooKeeper using the server-side
-      ``default_replica_path`` / ``default_replica_name`` macros.
-    - ``WF_CLICKHOUSE_REPLICATED=true`` means "ReplicatedMergeTree tables",
+    - Tables inside are rewritten to `ReplicatedMergeTree` and also emitted
+      `ON CLUSTER`. Data replicates via ZooKeeper using the server-side
+      `default_replica_path` / `default_replica_name` macros.
+    - `WF_CLICKHOUSE_REPLICATED=true` means "ReplicatedMergeTree tables",
       NOT "Replicated database engine". The Replicated DB engine has a
-      bootstrap hole against ``ON CLUSTER`` on CH 25.8+ and is not used
+      bootstrap hole against `ON CLUSTER` on CH 25.8+ and is not used
       for new deployments.
-    - Legacy deployments with ``ENGINE = Replicated`` data databases keep
+    - Legacy deployments with `ENGINE = Replicated` data databases keep
       working via the engine-discovery cache; see
-      ``_prepare_ddl_for_database``.
+      `_prepare_ddl_for_database`.
     """
 
     replicated_path: str
@@ -571,10 +571,10 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
     def _ensure_database(self, db_name: str) -> None:
         """Create the database and discover its engine for the DDL cache.
 
-        After ``CREATE DATABASE IF NOT EXISTS``, the engine may not be
-        immediately visible in ``system.databases`` (metadata propagation lag
+        After `CREATE DATABASE IF NOT EXISTS`, the engine may not be
+        immediately visible in `system.databases` (metadata propagation lag
         on replicated clusters).  We poll with back-off so that all later DDL
-        knows whether to emit ``ON CLUSTER`` / ``ReplicatedMergeTree``.
+        knows whether to emit `ON CLUSTER` / `ReplicatedMergeTree`.
         """
         db_sql = self._create_db_sql(db_name)
         self._run_ddl_with_retry(db_sql)
@@ -592,24 +592,24 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
     def _create_db_sql(self, db_name: str) -> str:
         """Generate SQL to create a database in replicated mode.
 
-        Uses ``ENGINE = Atomic + ON CLUSTER``. Atomic does not self-replicate
-        DDL, so ``ON CLUSTER`` is the sole fan-out mechanism and reaches
+        Uses `ENGINE = Atomic + ON CLUSTER`. Atomic does not self-replicate
+        DDL, so `ON CLUSTER` is the sole fan-out mechanism and reaches
         every replica in the cluster. Tables inside are rewritten to
-        ``ReplicatedMergeTree`` by ``_format_replicated_sql`` so data
+        `ReplicatedMergeTree` by `_format_replicated_sql` so data
         still replicates via ZooKeeper.
 
-        This avoids the ``ON CLUSTER + ENGINE = Replicated`` collision that
-        silently created plain ``MergeTree`` tables on CH <= 25.3 and
-        deadlocked ``CREATE DATABASE`` on CH >= 25.10. The ``Replicated``
+        This avoids the `ON CLUSTER + ENGINE = Replicated` collision that
+        silently created plain `MergeTree` tables on CH <= 25.3 and
+        deadlocked `CREATE DATABASE` on CH >= 25.10. The `Replicated`
         database engine is also a bootstrap trap: it does not auto-join
         sibling hosts at the database level, each host has to issue its
-        own ``CREATE DATABASE`` with the shared ZooKeeper path, and the
-        only official way to do that is ``ON CLUSTER`` which 25.8+ rejects.
+        own `CREATE DATABASE` with the shared ZooKeeper path, and the
+        only official way to do that is `ON CLUSTER` which 25.8+ rejects.
 
-        Legacy deployments that already have ``ENGINE = Replicated`` data
-        DBs stay on that engine (``IF NOT EXISTS`` is a no-op). Engine
+        Legacy deployments that already have `ENGINE = Replicated` data
+        DBs stay on that engine (`IF NOT EXISTS` is a no-op). Engine
         discovery caches the real engine, and the DDL path in
-        ``_prepare_ddl_for_database`` branches on that cache, so both
+        `_prepare_ddl_for_database` branches on that cache, so both
         shapes continue to work.
         """
         if not self._is_safe_identifier(db_name):
@@ -627,18 +627,18 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
         Two shapes, picked by the engine-discovery cache:
 
         * **Atomic database (default for new deployments).** Rewrite
-          ``MergeTree`` to ``Replicated*MergeTree`` so data replicates via
-          ZooKeeper, and add ``ON CLUSTER`` so the DDL fans out to every
+          `MergeTree` to `Replicated*MergeTree` so data replicates via
+          ZooKeeper, and add `ON CLUSTER` so the DDL fans out to every
           replica.
         * **Replicated database (legacy deployments only).** The Replicated
-          DB engine auto-replicates DDL and rejects ``ON CLUSTER`` with
-          error 80 on CH 25.8+. Rewrite to ``Replicated*MergeTree`` but
-          omit ``ON CLUSTER``; the engine handles the fan-out itself
+          DB engine auto-replicates DDL and rejects `ON CLUSTER` with
+          error 80 on CH 25.8+. Rewrite to `Replicated*MergeTree` but
+          omit `ON CLUSTER`; the engine handles the fan-out itself
           within the shard.
 
         New deployments always get the Atomic shape. The Replicated-DB shape
         exists only as a compatibility path for clusters installed by earlier
-        weave versions that explicitly created ``ENGINE = Replicated(...)``.
+        weave versions that explicitly created `ENGINE = Replicated(...)`.
         """
         sql_query = self._format_replicated_sql(sql_query)
         if self._uses_replicated_db_engine(target_db):
@@ -810,7 +810,7 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
         All databases (management and data) use ENGINE = Atomic + ON CLUSTER.
 
         The Replicated DB engine only auto-syncs within a single replication
-        group (same ``{shard}`` value), so it cannot fan a CREATE DATABASE
+        group (same `{shard}` value), so it cannot fan a CREATE DATABASE
         out across shards on its own. ON CLUSTER fans across every shard and
         replica in the cluster, and Atomic — unlike Replicated — does not
         also try to replicate DDL itself, so there is no collision between
@@ -819,7 +819,7 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
 
         Tables inside Atomic databases are rewritten to explicit
         ReplicatedMergeTree engines with per-shard ZK paths by
-        ``_format_replicated_sql_distributed``, so data still replicates
+        `_format_replicated_sql_distributed`, so data still replicates
         correctly within each shard.
 
         Legacy deployments that already have ENGINE = Replicated data

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -583,6 +583,15 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
         automatically replicated via ZooKeeper, without needing ON CLUSTER
         on every subsequent CREATE TABLE / ALTER TABLE statement.
 
+        ON CLUSTER is intentionally omitted from this CREATE DATABASE
+        statement: the Replicated database engine propagates itself across
+        replicas via ZooKeeper, and combining it with the legacy
+        distributed-DDL queue (``ON CLUSTER``) causes the two replication
+        mechanisms to collide. On CH 25.3 this silently created a plain
+        (non-Replicated) database on the peer replicas; on CH 25.10 the
+        peer replicas hang indefinitely waiting on the distributed-DDL
+        queue while the Replicated engine also tries to auto-sync.
+
         If the database already exists (IF NOT EXISTS), this is a no-op
         regardless of the existing engine. Databases created by older weave
         versions already use Replicated; databases created by the intermediate
@@ -603,7 +612,6 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
 
         return (
             f"CREATE DATABASE IF NOT EXISTS {db_name}"
-            f" ON CLUSTER {self.replicated_cluster}"
             f" ENGINE = Replicated('{replicated_path}', '{{shard}}', '{{replica}}')"
         )
 


### PR DESCRIPTION
## Summary

After validation on a live 1-shard x 3-replica Altinity cluster on CH 25.10.6.36, the **Replicated DB engine approach in this PR's first commit was wrong** and has been superseded. The current direction of this PR is to **rip the Replicated DB engine out of the migrator entirely** and use the same pattern Altinity themselves document: `ENGINE = Atomic` databases + `ReplicatedMergeTree` tables + `ON CLUSTER` on every DDL. This works identically on CH 25.3, 25.8, 25.10+.

This PR's first approach (commit `332bc3e3`: drop ON CLUSTER from `CREATE DATABASE` but keep `ENGINE = Replicated`) was validated in a soak cluster and produced a split-brain: only the pod the migrator talked to joined the ZK path. Pods 1 and 2 reported empty `system.databases`, ZK `/clickhouse/tables/db_management/replicas` listed only one replica. Replicated DB engine does NOT auto-discover and join sibling hosts at the database level, despite what the commit message assumed.

## Why the Replicated DB engine is a dead end for self-hosted

- Bootstrap chicken-and-egg: the Replicated DB engine only propagates DDL to replicas that have already joined the same ZK path. `CREATE DATABASE` itself is not auto-propagated, every host has to run its own `CREATE DATABASE` pointing at the shared ZK path.
- The only officially documented way to bootstrap a Replicated DB across hosts is `ON CLUSTER`.
- On CH 25.8+, `ON CLUSTER` against a Replicated DB is explicitly rejected: `Code 80: ON CLUSTER is not allowed for Replicated database` (ClickHouse PR #74942 tightened this deliberately).
- So you either deadlock (25.10+), silently create plain MergeTree (25.3), or split-brain (this PR's first commit).

## The correct shape

Use `ENGINE = Atomic` databases everywhere + `ReplicatedMergeTree` tables + `ON CLUSTER` on every DDL. This is what `db_management` already does in distributed mode. The regression in 0.79.0 introduced a separate "Replicated DB engine" branch for data DBs that shouldn't exist.

**Plain-replicated (1 shard x N replicas):**

```sql
CREATE DATABASE IF NOT EXISTS db_management  ON CLUSTER clickhouse;  -- Atomic (default)
CREATE DATABASE IF NOT EXISTS wandb_weave_00 ON CLUSTER clickhouse;

CREATE TABLE IF NOT EXISTS wandb_weave_00.calls
  ON CLUSTER clickhouse (id UUID, project_id String, ...)
  ENGINE = ReplicatedMergeTree
  ORDER BY (project_id, id);
-- No explicit ZK args needed: Altinity operator sets
-- default_replica_path = /clickhouse/tables/{database}/{table}
-- default_replica_name = {replica} at the server level.
```

No `Distributed` table needed, any replica can answer every SELECT.

**Distributed (multi-shard):**

```sql
CREATE TABLE default.calls_local ON CLUSTER clickhouse (...)
  ENGINE = ReplicatedMergeTree ORDER BY (project_id, id);

CREATE TABLE default.calls ON CLUSTER clickhouse AS default.calls_local
  ENGINE = Distributed(clickhouse, default, calls_local, sipHash64(trace_id));
```

Same Atomic + ReplicatedMergeTree spine, plus a Distributed overlay.

## What changes in the migrator

- Delete the `Replicated` DB engine branch from `_create_db_sql` for replicated mode. Make both replicated-mode and distributed-mode emit `CREATE DATABASE ... ON CLUSTER ...` with no explicit engine (defaults to Atomic).
- `_format_replicated_sql` / `_prepare_ddl_for_database` already handle rewriting `MergeTree` -> `ReplicatedMergeTree` and adding `ON CLUSTER` for Atomic DBs. Collapse the Replicated-DB-engine codepath so all replicated DDL goes through that same path.
- `WF_CLICKHOUSE_REPLICATED=true` now means "use ReplicatedMergeTree tables with ON CLUSTER", NOT "use the Replicated DB engine". Those two were conflated in the current code.
- Engine discovery cache stays, so legacy deployments that already have `ENGINE = Replicated` data DBs continue to work (`IF NOT EXISTS` is a no-op, and the DDL path branches on the discovered engine).

## Why this was so hard to pin down

Two completely different ClickHouse features are both called "Replicated":

1. `ReplicatedMergeTree` **table engine** (battle-tested since 2016, what you actually want).
2. `Replicated` **database engine** (newer, Cloud-focused, with bootstrap assumptions that don't match a migrator-pod model).

The 0.79.0 regression mixed them. PR #6597 patched one layer (stripped ON CLUSTER from table DDL). The first commit on this PR patched another layer (stripped ON CLUSTER from CREATE DATABASE). Each fix produced a new failure mode because the fundamental premise, "database engine = Replicated", is wrong for self-hosted Altinity.

## Validation (to repeat after the Atomic-only rewrite lands)

- [ ] Soak cluster on CH 25.10.6.36, 1 shard x 3 replicas, Altinity operator.
- [ ] All 3 replicas report `db_management` and `wandb_weave_00` in `system.databases` (engine = Atomic).
- [ ] All data tables have `engine` starting with `Replicated*`.
- [ ] Schema hash identical across all 3 replicas.
- [ ] `system.replicas` zero across the board (readonly, session_expired, max_delay_s, queue_size).
- [ ] Distributed DDL queue only `Finished`.
- [ ] Writes land on all replicas, no "Call not found" on reads.

## Related

- #6419 introduced the Replicated-DB-engine regression.
- #6597 shipped partial fix (table DDL only) in `0.80.0-rc.1776706055`.
- This PR was originally "drop ON CLUSTER from CREATE DATABASE" which produced split-brain in the soak cluster. Pivoting to "rip out the Replicated DB engine entirely" per validation findings.
