### PR TITLE
chore(weave): 0.80.x server release patch 2

### DIFF
--- a/tests/trace/test_mem_artifact.py
+++ b/tests/trace/test_mem_artifact.py
@@ -1,0 +1,44 @@
+import os
+
+import pytest
+
+from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact
+
+
+def test_mem_artifact_path_sanitization():
+    art = MemTraceFilesArtifact(
+        path_contents={
+            "audio.wav": b"RIFF",
+            "subdir/file.txt": b"nested",
+            "/etc/passwd": b"abs",
+            "../../etc/shadow": b"traversal",
+        }
+    )
+
+    # Valid relative paths work, including nested
+    assert art.path("audio.wav").endswith("audio.wav")
+    result = art.path("subdir/file.txt")
+    assert result.endswith(os.path.join("subdir", "file.txt"))
+
+    # Absolute paths rejected
+    with pytest.raises(ValueError, match="absolute path"):
+        art.path("/etc/passwd")
+    with pytest.raises(ValueError, match="absolute path"):
+        art.path("audio.wav", filename="/tmp/evil.pth")
+
+    # Traversals rejected
+    with pytest.raises(ValueError, match="escapes base directory"):
+        art.path("../../etc/shadow")
+
+    # writeable_file_path: valid works, absolute and traversal rejected
+    with art.writeable_file_path("output.wav") as fp:
+        with open(fp, "wb") as f:
+            f.write(b"data")
+    assert art.path_contents["output.wav"] == b"data"
+
+    with pytest.raises(ValueError, match="absolute path"):
+        with art.writeable_file_path("/etc/evil"):
+            pass
+    with pytest.raises(ValueError, match="escapes base directory"):
+        with art.writeable_file_path("../../etc/evil"):
+            pass

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -25,7 +25,7 @@ DEFAULT_MIGRATION_DIR = os.path.abspath(
 def _make_ch_client(database_engine: str = "Atomic") -> Mock:
     """Create a mock CH client that returns *database_engine* for system.databases queries.
 
-    Only ``system.databases`` queries are stubbed; all other ``query()`` calls
+    Only `system.databases` queries are stubbed; all other `query()` calls
     fall through to the default Mock behaviour so they don't silently return
     engine data for unrelated code paths.
     """
@@ -305,8 +305,13 @@ def test_create_db_sql(mock_costs):
     with pytest.raises(MigrationError, match="Invalid database name"):
         cloud_migrator._create_db_sql("test;db")
 
-    # Test replicated mode — should use ENGINE = Replicated(...) so DDL is
-    # auto-replicated via ZooKeeper without needing ON CLUSTER per-statement.
+    # Test replicated mode — uses ENGINE = Atomic + ON CLUSTER. Atomic does
+    # not self-replicate DDL, so ON CLUSTER is the sole fan-out mechanism and
+    # reaches every replica. Tables inside are rewritten to
+    # ReplicatedMergeTree by _format_replicated_sql so data still replicates
+    # via ZooKeeper. This avoids the ON CLUSTER + ENGINE = Replicated
+    # collision (deadlock on CH 25.10, silent plain-MergeTree on CH 25.3,
+    # split-brain when ON CLUSTER is stripped from a Replicated CREATE DATABASE).
     replicated_migrator = ReplicatedClickHouseTraceServerMigrator(
         _make_ch_client(),
         replicated_cluster="test_cluster",
@@ -314,8 +319,7 @@ def test_create_db_sql(mock_costs):
     )
     sql = replicated_migrator._create_db_sql("test_db")
     assert sql.strip() == (
-        "CREATE DATABASE IF NOT EXISTS test_db ON CLUSTER test_cluster"
-        " ENGINE = Replicated('/clickhouse/tables/test_db', '{shard}', '{replica}')"
+        "CREATE DATABASE IF NOT EXISTS test_db ON CLUSTER test_cluster ENGINE = Atomic"
     )
 
     # Test invalid cluster name
@@ -325,6 +329,26 @@ def test_create_db_sql(mock_costs):
             replicated_cluster="test;cluster",
             migration_dir=DEFAULT_MIGRATION_DIR,
         )
+
+    # Test distributed mode — uses ENGINE = Atomic + ON CLUSTER for both the
+    # management DB and data DBs. Atomic doesn't self-replicate DDL, so
+    # ON CLUSTER is the sole fan-out mechanism (no collision like Replicated
+    # + ON CLUSTER) and it reaches every shard in the cluster, which is
+    # required for multi-shard deployments.
+    distributed_migrator = DistributedClickHouseTraceServerMigrator(
+        _make_ch_client(),
+        replicated_cluster="test_cluster",
+        migration_dir=DEFAULT_MIGRATION_DIR,
+    )
+    mgmt_sql = distributed_migrator._create_db_sql(distributed_migrator.management_db)
+    assert mgmt_sql.strip() == (
+        f"CREATE DATABASE IF NOT EXISTS {distributed_migrator.management_db}"
+        " ON CLUSTER test_cluster ENGINE = Atomic"
+    )
+    data_sql = distributed_migrator._create_db_sql("test_db")
+    assert data_sql.strip() == (
+        "CREATE DATABASE IF NOT EXISTS test_db ON CLUSTER test_cluster ENGINE = Atomic"
+    )
 
 
 def test_engine_discovery_init_behavior():
@@ -410,10 +434,12 @@ def test_replicated_engine_discovery_wait_and_timeout(mock_sleep):
 
     assert migrator._replicated_db_engine_cache[migrator.management_db] is True
     assert mock_sleep.call_count == 2
-    # Management table DDL should use ReplicatedMergeTree without ON CLUSTER.
+    # Management table DDL for a Replicated DB: ReplicatedMergeTree (no ON CLUSTER).
+    # The Replicated DB engine auto-replicates DDL via Keeper and rejects
+    # ON CLUSTER on CH 25.8+, so the shape of this statement is fully pinned
+    # by test_replicated_management_table_follows_database_engine.
     create_table_sql = ch_client.command.call_args_list[1][0][0]
     assert "ENGINE = ReplicatedMergeTree()" in create_table_sql
-    assert "ON CLUSTER" not in create_table_sql
 
     # Times out: engine never becomes visible, error includes the SQL context
     timeout_client = Mock()
@@ -773,8 +799,6 @@ def test_non_replicated_preserves_table_names(migrator):
     assert migrator.ch_client.command.call_count == 1
     call_sql = migrator.ch_client.command.call_args_list[0][0][0]
     assert call_sql == "CREATE TABLE test (id Int32) ENGINE = MergeTree"
-    assert "test_local" not in call_sql
-    assert "Distributed" not in call_sql
 
 
 @pytest.mark.parametrize(
@@ -1176,22 +1200,21 @@ def test_ddl_adapts_to_database_engine(replicated_migrator, distributed_migrator
     )
     replicated_migrator.ch_client.command.reset_mock()
 
-    # Distributed migrator also skips ON CLUSTER for Replicated DBs, while
-    # still creating ReplicatedMergeTree local tables plus a distributed table.
+    # Distributed migrator on a legacy Replicated DB: the local table keeps
+    # its MergeTree rewrite but skips ON CLUSTER (the Replicated DB engine
+    # handles fan-out); the distributed overlay also skips ON CLUSTER.
     distributed_migrator._replicated_db_engine_cache["test_db"] = True
     distributed_migrator._execute_migration_command("test_db", create_sql)
     local_sql, dist_sql = [
         call.args[0] for call in distributed_migrator.ch_client.command.call_args_list
     ]
-    assert "ON CLUSTER" not in local_sql
     assert (
         local_sql
         == "CREATE TABLE test_local (id Int32) ENGINE = ReplicatedMergeTree() ORDER BY id"
     )
-    assert "ON CLUSTER" not in dist_sql
-    assert (
+    assert " ".join(dist_sql.split()) == (
+        "CREATE TABLE IF NOT EXISTS test AS test_local "
         "ENGINE = Distributed(test_cluster, currentDatabase(), test_local, rand())"
-        in dist_sql
     )
 
 

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from weave.trace_server import clickhouse_trace_server_batched as chts
 from weave.trace_server import trace_server_interface as tsi
@@ -12,6 +13,7 @@ from weave.trace_server.errors import (
     MissingLLMApiKeyError,
     NotFoundError,
 )
+from weave.trace_server.interface.builtin_object_classes.provider import Provider
 from weave.trace_server.llm_completion import get_custom_provider_info
 from weave.trace_server.project_version.types import WriteTarget
 from weave.trace_server.secret_fetcher_context import (
@@ -1675,6 +1677,83 @@ def test_streaming_completions_error_routes_correctly(
 
         assert mock_insert_complete.called == expect_complete_called
         assert mock_update_end.called == expect_update_end_called
+
+
+def _make_provider(base_url: str, extra_headers: dict | None = None):
+    return Provider(
+        name="test",
+        base_url=base_url,
+        api_key_name="MY_KEY",
+        extra_headers=extra_headers or {},
+    )
+
+
+def test_provider_base_url_validation():
+    """Verify that Provider.base_url only accepts well-formed, public HTTP(S) URLs."""
+    # Valid URLs accepted
+    p = _make_provider("https://api.openai.com/v1")
+    assert p.base_url == "https://api.openai.com/v1"
+    p = _make_provider("http://my-ollama-server.example.com:11434")
+    assert p.base_url == "http://my-ollama-server.example.com:11434"
+
+    # Non-http schemes rejected
+    with pytest.raises(ValidationError):
+        _make_provider("ftp://bad.example.com")
+    with pytest.raises(ValidationError):
+        _make_provider("file:///etc/passwd")
+
+    # Query strings, bare '?', and fragments rejected
+    with pytest.raises(ValidationError):
+        _make_provider("https://api.example.com/v1?foo=bar")
+    with pytest.raises(ValidationError):
+        _make_provider("https://api.example.com/v1#section")
+    with pytest.raises(ValidationError):
+        _make_provider("http://10.0.0.1/path?")
+
+    # Blocked hostnames rejected
+    for hostname in (
+        "metadata.google.internal",
+        "metadata.google.internal.",
+        "foo.metadata.google.internal",
+        "169.254.169.254",
+    ):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{hostname}/v1")
+
+    # Non-globally-routable IPs rejected
+    for addr in ("10.0.0.1", "172.16.0.1", "192.168.1.1", "127.0.0.1"):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{addr}/v1")
+
+    # Alternative IP encodings rejected
+    for alt_ip in ("0xa9fea9fe", "2852039166", "0x7f000001", "0"):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{alt_ip}/v1")
+
+    # IPv6 non-global addresses rejected
+    with pytest.raises(ValidationError):
+        _make_provider("http://[::1]/v1")
+    with pytest.raises(ValidationError):
+        _make_provider("http://[::ffff:169.254.169.254]/v1")
+
+    # Blocked extra_headers rejected
+    for blocked in ("Metadata-Flavor", "METADATA-FLAVOR", "X-aws-ec2-metadata-token"):
+        with pytest.raises(ValidationError):
+            _make_provider("https://api.example.com", extra_headers={blocked: "val"})
+
+    # Allowed headers accepted
+    p = _make_provider(
+        "https://api.example.com",
+        extra_headers={"X-Custom-Header": "value", "Authorization": "Bearer tok"},
+    )
+    assert "X-Custom-Header" in p.extra_headers
+
+    # Validation also runs on assignment, not just init
+    p = _make_provider("https://api.example.com")
+    with pytest.raises(ValidationError):
+        p.base_url = "http://169.254.169.254/v1"
+    with pytest.raises(ValidationError):
+        p.extra_headers = {"Metadata-Flavor": "Google"}
 
 
 if __name__ == "__main__":

--- a/tests/trace_server/workers/test_evaluate_model_worker.py
+++ b/tests/trace_server/workers/test_evaluate_model_worker.py
@@ -1,0 +1,78 @@
+import pytest
+
+from weave.trace_server.validation import (
+    UnsafePayloadError,
+    assert_safe_payload,
+)
+
+
+def test_assert_safe_payload():
+    # Safe payloads pass
+    assert_safe_payload({"name": "test", "value": 42})
+    assert_safe_payload({"nested": {"list": [1, "two", {"three": 3}]}})
+    assert_safe_payload("just a string ref")
+    assert_safe_payload(None)
+    assert_safe_payload([1, 2, 3])
+    assert_safe_payload({"_type": "ObjectRecord", "name": "test"})
+
+    # ALL CustomWeaveType payloads rejected — Op, unknown, and safe subtypes alike
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload(
+            {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "Op"},
+                "files": {"obj.py": "abc123"},
+            }
+        )
+
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload(
+            {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "PIL.Image.Image"},
+                "files": {"image.png": "abc123"},
+            }
+        )
+
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload(
+            {
+                "_type": "CustomWeaveType",
+                "weave_type": {"type": "TotallyMadeUpType"},
+                "load_op": "weave:///entity/project/object/evil:abc123",
+            }
+        )
+
+    # Nested in a list
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload(
+            {
+                "scorers": [
+                    {
+                        "_type": "CustomWeaveType",
+                        "weave_type": {"type": "Op"},
+                    }
+                ],
+            }
+        )
+
+    # Deeply nested in dicts
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload(
+            {
+                "a": {
+                    "b": {
+                        "c": {
+                            "_type": "CustomWeaveType",
+                            "weave_type": {"type": "Op"},
+                        }
+                    }
+                },
+            }
+        )
+
+    # Missing/malformed weave_type still rejected
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload({"_type": "CustomWeaveType"})
+    with pytest.raises(UnsafePayloadError):
+        assert_safe_payload({"_type": "CustomWeaveType", "weave_type": "not a dict"})

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -65,6 +65,60 @@ def _table_exists(ch_client, db_name: str, table_name: str) -> bool:
     return result.result_rows[0][0] > 0
 
 
+def _cluster_replica_count(ch_client) -> int:
+    """Return the number of replicas in the test cluster."""
+    result = ch_client.query(
+        f"SELECT count() FROM system.clusters WHERE cluster = '{_CLUSTER}'"
+    )
+    return int(result.result_rows[0][0])
+
+
+def _db_engines_across_cluster(ch_client, db_name: str) -> dict[str, str]:
+    """{host: engine} for db_name across every replica in the cluster.
+
+    Uses clusterAllReplicas so this works through a single HTTP entrypoint
+    on multi-replica topologies (1s3r / 2s2r) where only one CH node
+    exposes a host port. On a single-node local fallback, returns a
+    one-entry dict.
+
+    A DB missing from a replica shows up as that host being absent from
+    the returned dict — which is exactly the silent-misconfig failure
+    mode from the pre-#6659 ON CLUSTER + ENGINE = Replicated bug on
+    CH <= 25.3 (peer replicas never got the DB; migrator saw success
+    because pod 0 had it).
+    """
+    result = ch_client.query(
+        f"SELECT hostName(), engine FROM clusterAllReplicas('{_CLUSTER}', system.databases) "
+        f"WHERE name = '{db_name}'"
+    )
+    return {row[0]: row[1] for row in result.result_rows}
+
+
+def _assert_db_on_every_replica(
+    ch_client, db_name: str, expected_engine: str | None = None
+) -> None:
+    """Fail if the DB is missing from any replica or has an inconsistent engine.
+
+    Pass expected_engine to pin the engine; leave it None to only check
+    that every replica reports the same engine.
+    """
+    engines = _db_engines_across_cluster(ch_client, db_name)
+    expected_count = _cluster_replica_count(ch_client)
+    assert len(engines) == expected_count, (
+        f"{db_name} missing from {expected_count - len(engines)} replica(s). "
+        f"Got: {engines}"
+    )
+    distinct = set(engines.values())
+    assert len(distinct) == 1, (
+        f"{db_name} engine inconsistent across replicas: {engines}"
+    )
+    if expected_engine is not None:
+        (actual,) = distinct
+        assert actual == expected_engine, (
+            f"{db_name} engine = {actual!r}, expected {expected_engine!r}"
+        )
+
+
 def test_cloud_creates_db_and_tables(ch_client):
     mgmt_db = _unique_name("db_mgmt_cloud")
     target_db = _unique_name("test_cloud")
@@ -214,6 +268,12 @@ def test_all_production_migrations_replicated(ch_client):
     migrator.apply_migrations(target_db)
 
     assert _get_db_engine(ch_client, target_db) == "Replicated"
+    # On multi-replica topologies (1s3r / 2s2r in CI), the DB must exist on
+    # every replica with a consistent engine. A silent-misconfig bug like
+    # the pre-#6659 ON CLUSTER + ENGINE = Replicated collision would leave
+    # the DB on only the migrator's entrypoint pod — this assertion is the
+    # observable signal for that class of failure.
+    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Replicated")
 
 
 def test_all_production_migrations_distributed(ch_client):
@@ -237,6 +297,11 @@ def test_all_production_migrations_distributed(ch_client):
 
     assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
     assert _get_db_engine(ch_client, target_db) == "Replicated"
+    # Distributed mode uses ON CLUSTER to fan DBs to every shard/replica.
+    # If the fan-out is broken (e.g. the pre-#6659 ON CLUSTER + Replicated
+    # collision), peer replicas never receive the CREATE DATABASE.
+    _assert_db_on_every_replica(ch_client, mgmt_db, expected_engine="Atomic")
+    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Replicated")
 
 
 def test_all_production_down_migrations_replicated(ch_client):

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -82,10 +82,10 @@ def _db_engines_across_cluster(ch_client, db_name: str) -> dict[str, str]:
     one-entry dict.
 
     A DB missing from a replica shows up as that host being absent from
-    the returned dict — which is exactly the silent-misconfig failure
-    mode from the pre-#6659 ON CLUSTER + ENGINE = Replicated bug on
-    CH <= 25.3 (peer replicas never got the DB; migrator saw success
-    because pod 0 had it).
+    the returned dict. That is the silent-misconfig failure mode of the
+    `ON CLUSTER + ENGINE = Replicated` combination on CH <= 25.3: peer
+    replicas never got the DB, and the migrator saw success because the
+    entrypoint pod had it.
     """
     result = ch_client.query(
         f"SELECT hostName(), engine FROM clusterAllReplicas('{_CLUSTER}', system.databases) "
@@ -144,7 +144,14 @@ def test_cloud_creates_db_and_tables(ch_client):
     )
 
 
-def test_replicated_creates_replicated_db_and_tables(ch_client):
+def test_replicated_creates_atomic_dbs_and_replicated_tables(ch_client):
+    """New replicated-mode deployment: DBs are Atomic + ON CLUSTER, tables
+    inside are ReplicatedMergeTree.
+
+    Atomic databases don't race the Replicated DB engine against the
+    distributed-DDL queue, and ON CLUSTER fans CREATE DATABASE out to
+    every replica, so every replica ends up with the DB (no split-brain).
+    """
     mgmt_db = _unique_name("db_mgmt_repl")
     target_db = _unique_name("test_repl")
     ch_client.track_db(mgmt_db)
@@ -162,8 +169,8 @@ def test_replicated_creates_replicated_db_and_tables(ch_client):
     )
     migrator.apply_migrations(target_db)
 
-    assert _get_db_engine(ch_client, mgmt_db) == "Replicated"
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
     assert _get_table_engine_full(ch_client, mgmt_db, "migrations").startswith(
         "ReplicatedMergeTree"
     )
@@ -172,8 +179,14 @@ def test_replicated_creates_replicated_db_and_tables(ch_client):
     )
 
 
-def test_distributed_fresh_creates_atomic_management_db(ch_client):
-    """New deployment: management DB is Atomic with explicit shared ReplicatedMergeTree."""
+def test_distributed_fresh_creates_atomic_dbs(ch_client):
+    """New deployment: both management DB and data DB are Atomic + ON CLUSTER.
+
+    Atomic + ON CLUSTER is the only shape that fans out across every shard
+    without racing the Replicated DB engine's own DDL propagation. Tables
+    inside Atomic DBs get explicit ReplicatedMergeTree with per-shard ZK
+    paths so data still replicates within each shard.
+    """
     mgmt_db = _unique_name("db_mgmt_dist")
     target_db = _unique_name("test_dist")
     ch_client.track_db(mgmt_db)
@@ -197,7 +210,7 @@ def test_distributed_fresh_creates_atomic_management_db(ch_client):
     assert mgmt_engine.startswith("ReplicatedMergeTree")
     assert "/shared/" in mgmt_engine
 
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
     assert _table_exists(ch_client, target_db, "test_tbl_local")
     assert _get_table_engine_full(ch_client, target_db, "test_tbl_local").startswith(
         "ReplicatedMergeTree"
@@ -233,12 +246,23 @@ def test_distributed_legacy_replicated_management_db(ch_client):
 
     assert _get_db_engine(ch_client, mgmt_db) == "Replicated"
 
+    # Legacy Replicated management DB: the migrator sends plain
+    # `ENGINE = MergeTree()` and lets the DB engine handle replication.
+    # On single-node CI the DB engine does NOT auto-convert to
+    # ReplicatedMergeTree (single host, no peers to replicate to), so the
+    # engine_full column reports plain MergeTree. The important property
+    # here is the absence of the Atomic branch's shared ZK path
+    # (`/clickhouse/tables/shared/...`) - this assertion pins both the
+    # engine and the full ORDER BY / SETTINGS tail so any drift surfaces.
     mgmt_engine = _get_table_engine_full(ch_client, mgmt_db, "migrations")
-    assert "/shared/" not in mgmt_engine
+    assert mgmt_engine == "MergeTree ORDER BY db_name SETTINGS index_granularity = 8192"
 
     migrator.apply_migrations(target_db)
 
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    # target_db is freshly created by the migrator, which now uses Atomic +
+    # ON CLUSTER for every DB in distributed mode. The legacy Replicated
+    # management DB keeps its engine via IF NOT EXISTS.
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
     assert _table_exists(ch_client, target_db, "test_tbl_local")
     assert _get_table_engine_full(ch_client, target_db, "test_tbl_local").startswith(
         "ReplicatedMergeTree"
@@ -267,13 +291,16 @@ def test_all_production_migrations_replicated(ch_client):
     )
     migrator.apply_migrations(target_db)
 
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
     # On multi-replica topologies (1s3r / 2s2r in CI), the DB must exist on
-    # every replica with a consistent engine. A silent-misconfig bug like
-    # the pre-#6659 ON CLUSTER + ENGINE = Replicated collision would leave
-    # the DB on only the migrator's entrypoint pod — this assertion is the
-    # observable signal for that class of failure.
-    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Replicated")
+    # every replica with a consistent engine. Historical failure modes this
+    # assertion guards against:
+    #   * `ON CLUSTER` combined with `ENGINE = Replicated` (silent plain
+    #     MergeTree on CH <= 25.3, deadlock on CH >= 25.10).
+    #   * `ENGINE = Replicated` with `ON CLUSTER` stripped (split-brain:
+    #     only the migrator's entrypoint pod gets the DB, sibling replicas
+    #     never join the ZK path).
+    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")
 
 
 def test_all_production_migrations_distributed(ch_client):
@@ -296,12 +323,12 @@ def test_all_production_migrations_distributed(ch_client):
     migrator.apply_migrations(target_db)
 
     assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
     # Distributed mode uses ON CLUSTER to fan DBs to every shard/replica.
-    # If the fan-out is broken (e.g. the pre-#6659 ON CLUSTER + Replicated
+    # If the fan-out is broken (e.g. the `ON CLUSTER + ENGINE = Replicated`
     # collision), peer replicas never receive the CREATE DATABASE.
     _assert_db_on_every_replica(ch_client, mgmt_db, expected_engine="Atomic")
-    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Replicated")
+    _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")
 
 
 def test_all_production_down_migrations_replicated(ch_client):
@@ -324,7 +351,7 @@ def test_all_production_down_migrations_replicated(ch_client):
 
     # Migrate up to latest
     migrator.apply_migrations(target_db)
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
 
     # ALTER TABLE UPDATE mutations are async; wait for them to settle
     _sync_mutations(ch_client, mgmt_db, "migrations")
@@ -354,7 +381,7 @@ def test_all_production_down_migrations_distributed(ch_client):
     # Migrate up to latest
     migrator.apply_migrations(target_db)
     assert _get_db_engine(ch_client, mgmt_db) == "Atomic"
-    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_db_engine(ch_client, target_db) == "Atomic"
 
     # ALTER TABLE UPDATE mutations are async; wait for them to settle
     _sync_mutations(ch_client, mgmt_db, "migrations")

--- a/weave/trace/serialization/mem_artifact.py
+++ b/weave/trace/serialization/mem_artifact.py
@@ -16,6 +16,36 @@ from weave.trace.serialization import (
 # to use this interface.
 
 
+def _safe_join(base: str, untrusted_path: str) -> str:
+    """Join base and untrusted_path, ensuring the result stays within base.
+
+    Rejects absolute paths, '..' components, and any path that would resolve
+    outside of base after symlink resolution.
+    """
+    if os.path.isabs(untrusted_path):
+        raise ValueError(
+            f"Path must be relative, got absolute path: {untrusted_path!r}"
+        )
+
+    # Normalize to collapse '..' and '.' but don't resolve symlinks yet
+    normed = os.path.normpath(untrusted_path)
+    if normed.startswith(os.sep):
+        raise ValueError(
+            f"Path must be relative, got absolute path: {untrusted_path!r}"
+        )
+    if normed.startswith(".."):
+        raise ValueError(f"Path escapes base directory: {untrusted_path!r}")
+
+    joined = os.path.join(base, normed)
+    # realpath resolves symlinks; the result must still be under base
+    resolved = os.path.realpath(joined)
+    real_base = os.path.realpath(base)
+    if not resolved.startswith(real_base + os.sep) and resolved != real_base:
+        raise ValueError(f"Path escapes base directory: {untrusted_path!r}")
+
+    return joined
+
+
 class MemTraceFilesArtifact:
     temp_read_dir: tempfile.TemporaryDirectory | None
     path_contents: dict[str, bytes]
@@ -82,7 +112,8 @@ class MemTraceFilesArtifact:
             raise FileNotFoundError(path)
 
         self.temp_read_dir = tempfile.TemporaryDirectory()
-        write_path = os.path.join(self.temp_read_dir.name, filename or path)
+        write_path = _safe_join(self.temp_read_dir.name, filename or path)
+        os.makedirs(os.path.dirname(write_path), exist_ok=True)
         with open(write_path, "wb") as f:
             f.write(self.path_contents[path])
             f.flush()
@@ -96,7 +127,7 @@ class MemTraceFilesArtifact:
     @contextlib.contextmanager
     def writeable_file_path(self, path: str) -> Generator[str]:
         with tempfile.TemporaryDirectory() as tmpdir:
-            full_path = os.path.join(tmpdir, path)
+            full_path = _safe_join(tmpdir, path)
             os.makedirs(os.path.dirname(full_path), exist_ok=True)
             yield full_path
             with open(full_path, "rb") as fp:

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -8,10 +8,13 @@
 
 ## Replicated Mode (replicated=True, use_distributed=False)
 - Multi-node ClickHouse cluster with automatic replication
-- Tables have 'Replicated' prepended to MergeTree engine with ZooKeeper coordination
-- DDL statements include `ON CLUSTER {cluster_name}` UNLESS the target database uses the
-  ClickHouse Replicated database engine (ENGINE = Replicated(...)), which auto-replicates
-  DDL and rejects ON CLUSTER with error 80 (INCORRECT_QUERY)
+- Databases are `ENGINE = Atomic` and created `ON CLUSTER` so the DDL fans out
+  to every replica. Tables are rewritten to `Replicated*MergeTree` and also
+  emitted `ON CLUSTER`. Data replicates via ZooKeeper.
+- Legacy deployments with `ENGINE = Replicated` data DBs keep working: engine
+  discovery caches the real engine and DDL paths skip `ON CLUSTER` for those,
+  since `ON CLUSTER` against a Replicated DB is rejected with error 80 on
+  CH 25.8+.
 
 ## Distributed Mode (replicated=True, use_distributed=True)
 - Extends replicated mode with sharding and distributed query capabilities
@@ -198,7 +201,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
         "ON CLUSTER is not allowed for Replicated database."
 
         The base class always returns False. The replicated subclass overrides
-        this to read from ``_replicated_db_engine_cache``.
+        this to read from `_replicated_db_engine_cache`.
         """
         return False
 
@@ -206,7 +209,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
         """Create a database if it does not exist.
 
         Subclasses that need engine introspection override this to also
-        populate ``_replicated_db_engine_cache``.
+        populate `_replicated_db_engine_cache`.
         """
         db_sql = self._create_db_sql(db_name)
         self._run_ddl_with_retry(db_sql)
@@ -503,8 +506,18 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
     """Migrator for replicated ClickHouse deployments.
 
     In replicated mode:
-    - Tables use ReplicatedMergeTree engines with ZooKeeper coordination
-    - All DDL statements include `ON CLUSTER {cluster_name}`
+    - Databases use `ENGINE = Atomic` and are created with `ON CLUSTER` so
+      the DDL fans out to every replica.
+    - Tables inside are rewritten to `ReplicatedMergeTree` and also emitted
+      `ON CLUSTER`. Data replicates via ZooKeeper using the server-side
+      `default_replica_path` / `default_replica_name` macros.
+    - `WF_CLICKHOUSE_REPLICATED=true` means "ReplicatedMergeTree tables",
+      NOT "Replicated database engine". The Replicated DB engine has a
+      bootstrap hole against `ON CLUSTER` on CH 25.8+ and is not used
+      for new deployments.
+    - Legacy deployments with `ENGINE = Replicated` data databases keep
+      working via the engine-discovery cache; see
+      `_prepare_ddl_for_database`.
     """
 
     replicated_path: str
@@ -558,10 +571,10 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
     def _ensure_database(self, db_name: str) -> None:
         """Create the database and discover its engine for the DDL cache.
 
-        After ``CREATE DATABASE IF NOT EXISTS``, the engine may not be
-        immediately visible in ``system.databases`` (metadata propagation lag
+        After `CREATE DATABASE IF NOT EXISTS`, the engine may not be
+        immediately visible in `system.databases` (metadata propagation lag
         on replicated clusters).  We poll with back-off so that all later DDL
-        knows whether to emit ``ON CLUSTER`` / ``ReplicatedMergeTree``.
+        knows whether to emit `ON CLUSTER` / `ReplicatedMergeTree`.
         """
         db_sql = self._create_db_sql(db_name)
         self._run_ddl_with_retry(db_sql)
@@ -579,56 +592,53 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
     def _create_db_sql(self, db_name: str) -> str:
         """Generate SQL to create a database in replicated mode.
 
-        Uses ENGINE = Replicated(...) so that DDL within the database is
-        automatically replicated via ZooKeeper, without needing ON CLUSTER
-        on every subsequent CREATE TABLE / ALTER TABLE statement.
+        Uses `ENGINE = Atomic + ON CLUSTER`. Atomic does not self-replicate
+        DDL, so `ON CLUSTER` is the sole fan-out mechanism and reaches
+        every replica in the cluster. Tables inside are rewritten to
+        `ReplicatedMergeTree` by `_format_replicated_sql` so data
+        still replicates via ZooKeeper.
 
-        If the database already exists (IF NOT EXISTS), this is a no-op
-        regardless of the existing engine. Databases created by older weave
-        versions already use Replicated; databases created by the intermediate
-        code (19052e896c..HEAD~) may be Atomic. Both are handled: the
-        auto-detection in _add_on_cluster_clause skips ON CLUSTER for
-        Replicated databases and keeps it for Atomic ones.
+        This avoids the `ON CLUSTER + ENGINE = Replicated` collision that
+        silently created plain `MergeTree` tables on CH <= 25.3 and
+        deadlocked `CREATE DATABASE` on CH >= 25.10. The `Replicated`
+        database engine is also a bootstrap trap: it does not auto-join
+        sibling hosts at the database level, each host has to issue its
+        own `CREATE DATABASE` with the shared ZooKeeper path, and the
+        only official way to do that is `ON CLUSTER` which 25.8+ rejects.
+
+        Legacy deployments that already have `ENGINE = Replicated` data
+        DBs stay on that engine (`IF NOT EXISTS` is a no-op). Engine
+        discovery caches the real engine, and the DDL path in
+        `_prepare_ddl_for_database` branches on that cache, so both
+        shapes continue to work.
         """
         if not self._is_safe_identifier(db_name):
             raise MigrationError(f"Invalid database name: {db_name}")
 
-        replicated_path = self.replicated_path.replace("{db}", db_name)
-        if not all(
-            self._is_safe_identifier(part)
-            for part in replicated_path.split("/")
-            if part
-        ):
-            raise MigrationError(f"Invalid replicated path: {replicated_path}")
-
         return (
             f"CREATE DATABASE IF NOT EXISTS {db_name}"
             f" ON CLUSTER {self.replicated_cluster}"
-            f" ENGINE = Replicated('{replicated_path}', '{{shard}}', '{{replica}}')"
+            f" ENGINE = Atomic"
         )
 
     def _prepare_ddl_for_database(self, sql_query: str, target_db: str) -> str:
         """Adapt DDL for the target database's engine type.
 
-        Engine handling matrix:
-        - replicated-only DB: Replicated*MergeTree() with no ON CLUSTER
-        - distributed + Atomic DB: explicit ZK args plus ON CLUSTER
-        - distributed + Replicated DB: Replicated*MergeTree() with no explicit
-          ZK args and no ON CLUSTER
+        Two shapes, picked by the engine-discovery cache:
 
-        * **Replicated engine** — DDL is auto-replicated by the database, so
-          ``ON CLUSTER`` must be omitted to avoid ClickHouse error 80
-          (INCORRECT_QUERY). We still rewrite MergeTree-family engines to
-          ``Replicated*MergeTree`` so table data replicates across replicas.
-        * **Atomic engine** — the database does not auto-replicate, so we must
-          explicitly rewrite ``MergeTree`` → ``ReplicatedMergeTree`` and add
-          ``ON CLUSTER`` to every DDL statement.
+        * **Atomic database (default for new deployments).** Rewrite
+          `MergeTree` to `Replicated*MergeTree` so data replicates via
+          ZooKeeper, and add `ON CLUSTER` so the DDL fans out to every
+          replica.
+        * **Replicated database (legacy deployments only).** The Replicated
+          DB engine auto-replicates DDL and rejects `ON CLUSTER` with
+          error 80 on CH 25.8+. Rewrite to `Replicated*MergeTree` but
+          omit `ON CLUSTER`; the engine handles the fan-out itself
+          within the shard.
 
-        In the distributed migrator, ``db_management`` is intentionally Atomic
-        so the migrations table can use an explicit ``ReplicatedMergeTree``
-        with a shared ZooKeeper path across all shards.  A Replicated-engine
-        database would auto-assign per-shard ZK paths, causing each shard to
-        track migration state independently instead of sharing it.
+        New deployments always get the Atomic shape. The Replicated-DB shape
+        exists only as a compatibility path for clusters installed by earlier
+        weave versions that explicitly created `ENGINE = Replicated(...)`.
         """
         sql_query = self._format_replicated_sql(sql_query)
         if self._uses_replicated_db_engine(target_db):
@@ -797,19 +807,33 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
     def _create_db_sql(self, db_name: str) -> str:
         """Generate SQL to create a database in distributed mode.
 
-        The management database uses ENGINE = Atomic (not Replicated) so that the
-        migrations table can use explicit ReplicatedMergeTree with a shared ZK path
-        across all shards. Data databases still use ENGINE = Replicated.
+        All databases (management and data) use ENGINE = Atomic + ON CLUSTER.
+
+        The Replicated DB engine only auto-syncs within a single replication
+        group (same `{shard}` value), so it cannot fan a CREATE DATABASE
+        out across shards on its own. ON CLUSTER fans across every shard and
+        replica in the cluster, and Atomic — unlike Replicated — does not
+        also try to replicate DDL itself, so there is no collision between
+        the two mechanisms (the bug that deadlocks CH 25.10 with Replicated
+        + ON CLUSTER).
+
+        Tables inside Atomic databases are rewritten to explicit
+        ReplicatedMergeTree engines with per-shard ZK paths by
+        `_format_replicated_sql_distributed`, so data still replicates
+        correctly within each shard.
+
+        Legacy deployments that already have ENGINE = Replicated data
+        databases stay Replicated (IF NOT EXISTS is a no-op). Engine
+        discovery caches the real engine; the DDL path branches on that
+        cache, so both shapes continue to work.
         """
-        if db_name == self.management_db:
-            if not self._is_safe_identifier(db_name):
-                raise MigrationError(f"Invalid database name: {db_name}")
-            return (
-                f"CREATE DATABASE IF NOT EXISTS {db_name}"
-                f" ON CLUSTER {self.replicated_cluster}"
-                f" ENGINE = Atomic"
-            )
-        return super()._create_db_sql(db_name)
+        if not self._is_safe_identifier(db_name):
+            raise MigrationError(f"Invalid database name: {db_name}")
+        return (
+            f"CREATE DATABASE IF NOT EXISTS {db_name}"
+            f" ON CLUSTER {self.replicated_cluster}"
+            f" ENGINE = Atomic"
+        )
 
     def _create_management_table_sql(self) -> str:
         """Generate SQL to create the management table in distributed mode.

--- a/weave/trace_server/interface/builtin_object_classes/provider.py
+++ b/weave/trace_server/interface/builtin_object_classes/provider.py
@@ -1,8 +1,79 @@
+import ipaddress
+import re
+import socket
 from enum import Enum
+from urllib.parse import urlparse
 
-from pydantic import Field
+from pydantic import ConfigDict, Field, field_validator
 
 from weave.trace_server.interface.builtin_object_classes import base_object_def
+
+# Headers that must not appear in user-supplied extra_headers.
+# https://coreweave.atlassian.net/browse/VULNMGMT-770
+BLOCKED_HEADER_RE = re.compile(
+    r"^(?:metadata-flavor"
+    r"|x-aws-ec2-metadata-token(?:-ttl-seconds)?"
+    r")$",
+    re.IGNORECASE,
+)
+
+# Hostnames that must not appear in user-supplied base_url values.
+# https://coreweave.atlassian.net/browse/VULNMGMT-770
+BLOCKED_HOSTNAME_RE = re.compile(
+    r"(?:^|\.)"
+    r"(?:metadata\.google\.internal"
+    r"|metadata\.goog"
+    r"|metadata\.internal"
+    r"|metadata\.azure\.com"
+    r")\.?$",
+    re.IGNORECASE,
+)
+
+
+INVALID_BASE_URL_MSG = "base_url is not a valid provider URL"
+
+
+def _validate_provider_base_url(url: str) -> str:
+    """Validate that a provider base_url is a well-formed, publicly-routable HTTP(S) URL.
+
+    See https://coreweave.atlassian.net/browse/VULNMGMT-770
+    """
+    try:
+        parsed = urlparse(url)
+    except Exception as exc:
+        raise ValueError(INVALID_BASE_URL_MSG) from exc
+
+    if parsed.scheme not in {"http", "https"}:
+        raise ValueError(INVALID_BASE_URL_MSG)
+
+    # urlparse silently strips a bare trailing '?', so check the raw string too.
+    if "?" in url or parsed.fragment:
+        raise ValueError(INVALID_BASE_URL_MSG)
+
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        raise ValueError(INVALID_BASE_URL_MSG)
+
+    if BLOCKED_HOSTNAME_RE.search(host):
+        raise ValueError(INVALID_BASE_URL_MSG)
+
+    # Reject non-globally-routable IP addresses.  socket.inet_aton handles
+    # alternative IPv4 encodings that ipaddress.ip_address does not.
+    addr = None
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        # Not a strict IP literal — try inet_aton for alternative IPv4 forms.
+        try:
+            packed = socket.inet_aton(host)
+            addr = ipaddress.ip_address(packed)
+        except OSError:
+            pass  # Not any form of IP — hostname checks above are sufficient.
+
+    if addr is not None and not addr.is_global:
+        raise ValueError(INVALID_BASE_URL_MSG)
+
+    return url
 
 
 class ProviderReturnType(str, Enum):
@@ -10,10 +81,25 @@ class ProviderReturnType(str, Enum):
 
 
 class Provider(base_object_def.BaseObject):
+    model_config = ConfigDict(validate_assignment=True)
+
     base_url: str
     api_key_name: str
     extra_headers: dict[str, str] = Field(default_factory=dict)
     return_type: ProviderReturnType = Field(default=ProviderReturnType.OPENAI)
+
+    @field_validator("base_url")
+    @classmethod
+    def validate_base_url(cls, v: str) -> str:
+        return _validate_provider_base_url(v)
+
+    @field_validator("extra_headers")
+    @classmethod
+    def validate_extra_headers(cls, v: dict[str, str]) -> dict[str, str]:
+        for key in v:
+            if BLOCKED_HEADER_RE.match(key):
+                raise ValueError("extra_headers contains a disallowed header")
+        return v
 
 
 class ProviderModel(base_object_def.BaseObject):

--- a/weave/trace_server/validation.py
+++ b/weave/trace_server/validation.py
@@ -199,3 +199,44 @@ def validate_alias_name(name: str) -> None:
         )
     if name in _RESERVED_ALIAS_NAMES:
         raise ValueError(f"alias name '{name}' is reserved")
+
+
+# --- Server-side deserialization safety ---
+
+
+class UnsafePayloadError(ValueError):
+    """Raised when a payload contains types that are not safe for server-side deserialization."""
+
+
+def assert_safe_payload(value: Any, path: str = "root") -> None:
+    """Recursively walk a raw serialized payload and reject CustomWeaveType nodes.
+
+    CustomWeaveType payloads can trigger code execution during deserialization
+    (e.g. Op types call __import__ on user-uploaded Python files, and unknown
+    types fall back to a load_op path that does the same). None of these should
+    be deserialized in a server-side worker process.
+
+    https://coreweave.atlassian.net/browse/VULNMGMT-1007
+    """
+    if isinstance(value, list):
+        for idx, item in enumerate(value):
+            assert_safe_payload(item, f"{path}[{idx}]")
+        return
+
+    if not isinstance(value, dict):
+        return
+
+    if value.get("_type") == "CustomWeaveType":
+        weave_type = value.get("weave_type")
+        custom_type = (
+            weave_type.get("type", "unknown")
+            if isinstance(weave_type, dict)
+            else "unknown"
+        )
+        raise UnsafePayloadError(
+            f"Server-side deserialization does not allow CustomWeaveType payloads "
+            f"({custom_type} at {path})"
+        )
+
+    for key, item in value.items():
+        assert_safe_payload(item, f"{path}.{key}")

--- a/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
+++ b/weave/trace_server/workers/evaluate_model_worker/evaluate_model_worker.py
@@ -8,11 +8,13 @@ import weave
 from weave.evaluation.eval import Evaluation
 from weave.scorers.llm_as_a_judge_scorer import LLMAsAJudgeScorer
 from weave.trace.context.weave_client_context import require_weave_client
-from weave.trace.refs import Ref
+from weave.trace.refs import ObjectRef, Ref
 from weave.trace.weave_client import WeaveClient
+from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.interface.builtin_object_classes.llm_structured_model import (
     LLMStructuredCompletionModel,
 )
+from weave.trace_server.validation import assert_safe_payload
 
 EVALUATE_MODEL_WORKER_MARKER = {"_weave_eval_meta": {"evaluate_model_worker": True}}
 
@@ -40,6 +42,11 @@ def evaluate_model(args: EvaluateModelArgs) -> None:
 @ddtrace.tracer.wrap(name="evaluate_model_worker.evaluate_model")
 def _evaluate_model(args: EvaluateModelArgs) -> None:
     client = require_weave_client()
+
+    # Validate raw payloads before deserialization.
+    # https://coreweave.atlassian.net/browse/VULNMGMT-1007
+    _assert_safe_ref(client, args.evaluation_ref, "evaluation_ref")
+    _assert_safe_ref(client, args.model_ref, "model_ref")
 
     loaded_evaluation = _get_valid_evaluation(client, args.evaluation_ref)
 
@@ -96,3 +103,20 @@ def _run_evaluation(
                 loaded_model, __weave={"call_id": evaluation_call_id}
             )
         )
+
+
+def _assert_safe_ref(client: WeaveClient, ref_uri: str, label: str) -> None:
+    """Read the raw object for a ref and reject it if it contains unsafe CustomWeaveType payloads."""
+    ref = Ref.parse_uri(ref_uri)
+    if not isinstance(ref, ObjectRef):
+        raise TypeError(f"Expected an object ref for {label}, got: {ref_uri}")
+
+    project_id = f"{ref.entity}/{ref.project}"
+    read_res = client.server.obj_read(
+        tsi.ObjReadReq(
+            project_id=project_id,
+            object_id=ref.name,
+            digest=ref.digest,
+        )
+    )
+    assert_safe_payload(read_res.obj.val, label)


### PR DESCRIPTION
## Summary
Cherry-picks accompanying core `server-release-0.80.x` patch 2. Not intended to merge to master — fixes already on master.

Cherry-picked from:
- #6657 — test(weave): assert migrator CREATE DATABASE reaches every replica
- #6659 — fix(weave): rip Replicated-DB-engine out of migrator, use Atomic + ReplicatedMergeTree + ON CLUSTER

Branched off submodule SHA `b3e6448a0a` (pinned on core `server-release-0.80.x`).

## Test plan
- [x] CI green