### PR TITLE
fix(weave): retry_on_not_found on remaining obj_read call sites

### DIFF
--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1326,7 +1326,7 @@ class WeaveClient:
             has no tags.
         """
         obj_ref = self._resolve_obj_ref(obj_ref)
-        res = self.server.obj_read(
+        res = retry_on_not_found(self.server.obj_read)(
             ObjReadReq(
                 project_id=self.project_id,
                 object_id=obj_ref.name,
@@ -1351,7 +1351,7 @@ class WeaveClient:
             Returns empty lists if the object version has no tags or aliases.
         """
         obj_ref = self._resolve_obj_ref(obj_ref)
-        res = self.server.obj_read(
+        res = retry_on_not_found(self.server.obj_read)(
             ObjReadReq(
                 project_id=self.project_id,
                 object_id=obj_ref.name,
@@ -1417,7 +1417,7 @@ class WeaveClient:
             if the object version is the latest.
         """
         obj_ref = self._resolve_obj_ref(obj_ref)
-        res = self.server.obj_read(
+        res = retry_on_not_found(self.server.obj_read)(
             ObjReadReq(
                 project_id=self.project_id,
                 object_id=obj_ref.name,


### PR DESCRIPTION
## Summary

Scope miss from #6653: `client.get()` was wrapped with `retry_on_not_found` to ride out write-then-read replica-lag 404s, but three other `obj_read` paths on `WeaveClient` were left unprotected. They hit the exact same `publish(obj); client.get_tags(ref)` race and flake identically.

Applied the wrapper to:
- `get_tags` (L1329)
- `get_tags_and_aliases` (L1354)
- `get_aliases` (L1420)

## Observed flake

`tests/trace/test_obj_tags_aliases.py::test_sdk_tag_lifecycle` — https://github.com/wandb/weave/actions/runs/24732591427/job/72350815445?pr=6663. Stack points directly at `weave_client.py:1329` (`get_tags`), confirming the un-retried path.

## Not covered

`test_content_in_dataset` and `test_published_dataset_laziness` also flake with `NotFoundError` but both already go through `client.get()` (retry-wrapped). Retry logs show all 3 attempts fire and fail — the row is genuinely invisible on `obj_read` for >3s after a sync `obj_create` returned. That's a separate issue (not retry coverage) and needs its own investigation.