### PR TITLE
investigation: FLAKE_PROBE on obj_read NotFound (DO NOT MERGE)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,13 +110,12 @@ def reset_digest_settings():
 
 @pytest.fixture(autouse=True)
 def force_flake_reproduction(monkeypatch):
-    """DO NOT MERGE: force replica-lag flakes to surface by disabling the
-    retry_on_not_found safety net. Any write-then-read race that is
-    currently masked by the 3-attempt/0.25s retry window will now fail
-    on first attempt.
+    """DO NOT MERGE: zero the inter-attempt wait so the 3 retries fire
+    back-to-back (~sub-10ms total window). Any race wider than that will
+    surface as a hard failure. Not setting WEAVE_RETRY_MAX_ATTEMPTS
+    because that breaks tests that assert on retry behavior.
     """
     monkeypatch.setattr(http_utils, "NOT_FOUND_RETRY_WAIT_SECONDS", 0.0)
-    monkeypatch.setenv("WEAVE_RETRY_MAX_ATTEMPTS", "1")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ from weave.trace.context import weave_client_context
 from weave.trace.context.call_context import set_call_stack
 from weave.trace.settings import UserSettings, parse_and_apply_settings
 from weave.trace_server import trace_server_interface as tsi
-from weave.trace_server_bindings import remote_http_trace_server
+from weave.trace_server_bindings import http_utils, remote_http_trace_server
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.trace_server_bindings.caching_middleware_trace_server import (
     CachingMiddlewareTraceServer,
@@ -106,6 +106,17 @@ def reset_digest_settings():
     """Reset client-side digest settings after each test."""
     yield
     parse_and_apply_settings(UserSettings())
+
+
+@pytest.fixture(autouse=True)
+def force_flake_reproduction(monkeypatch):
+    """DO NOT MERGE: force replica-lag flakes to surface by disabling the
+    retry_on_not_found safety net. Any write-then-read race that is
+    currently masked by the 3-attempt/0.25s retry window will now fail
+    on first attempt.
+    """
+    monkeypatch.setattr(http_utils, "NOT_FOUND_RETRY_WAIT_SECONDS", 0.0)
+    monkeypatch.setenv("WEAVE_RETRY_MAX_ATTEMPTS", "1")
 
 
 @pytest.fixture(autouse=True)

--- a/tests/trace/test_dataset.py
+++ b/tests/trace/test_dataset.py
@@ -1,8 +1,48 @@
 import pytest
 
 import weave
+from tests.trace.server_utils import find_server_layer
 from tests.trace.test_evaluate import Dataset
 from weave.trace.context.tests_context import raise_on_captured_errors
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.errors import NotFoundError
+
+
+def _probe_ch_state(client, ref, tag: str) -> None:
+    """DO NOT MERGE: post-failure probe. On flake, dumps what ClickHouse
+    actually contains for the ref we couldn't find, so we can tell whether
+    the row is genuinely absent, present under a different digest, or
+    present in a different project.
+    """
+    try:
+        ch = find_server_layer(client.server, ClickHouseTraceServer)
+    except TypeError:
+        print(f"FLAKE_PROBE {tag}: backend is not ClickHouse, skipping")
+        return
+    try:
+        rows = ch.ch_client.query(
+            "SELECT "
+            "countIf(object_id = {object_id: String}) AS by_object, "
+            "countIf(object_id = {object_id: String} AND digest = {digest: String}) AS by_obj_digest, "
+            "countIf(digest = {digest: String}) AS by_digest, "
+            "count() AS total, "
+            "groupArray((project_id, object_id, digest))[1:20] AS sample "
+            "FROM object_versions",
+            parameters={"object_id": ref.name, "digest": ref.digest},
+        ).result_rows
+    except Exception as exc:
+        print(f"FLAKE_PROBE {tag}: query failed: {exc!r}")
+        return
+    if not rows:
+        print(f"FLAKE_PROBE {tag}: empty probe result")
+        return
+    by_object, by_obj_digest, by_digest, total, sample = rows[0]
+    print(
+        f"FLAKE_PROBE {tag}: ref={ref.name!r} digest={ref.digest!r} "
+        f"database={ch._database!r} total_rows={total} "
+        f"by_object={by_object} by_obj_digest={by_obj_digest} "
+        f"by_digest={by_digest} sample={sample}"
+    )
 
 
 def test_basic_dataset_lifecycle(client):
@@ -92,7 +132,12 @@ def test_published_dataset_laziness(client):
     assert _top_level_logs(log) == ["table_create", "obj_create"]
     client.server.attribute_access_log = []
 
-    dataset = ref.get()
+    try:
+        dataset = ref.get()
+    except (NotFoundError, ValueError) as exc:
+        _probe_ch_state(client, ref, "test_published_dataset_laziness.ref.get")
+        print(f"FLAKE_PROBE raised: {type(exc).__name__}: {exc}")
+        raise
     log = client.server.attribute_access_log
     assert _top_level_logs(log) == ["obj_read"]
     client.server.attribute_access_log = []

--- a/tests/trace/test_dataset.py
+++ b/tests/trace/test_dataset.py
@@ -26,7 +26,7 @@ def _probe_ch_state(client, ref, tag: str) -> None:
             "countIf(object_id = {object_id: String} AND digest = {digest: String}) AS by_obj_digest, "
             "countIf(digest = {digest: String}) AS by_digest, "
             "count() AS total, "
-            "groupArray((project_id, object_id, digest))[1:20] AS sample "
+            "arraySlice(groupArray((project_id, object_id, digest)), 1, 20) AS sample "
             "FROM object_versions",
             parameters={"object_id": ref.name, "digest": ref.digest},
         ).result_rows

--- a/tests/trace/type_handlers/Content/test_content.py
+++ b/tests/trace/type_handlers/Content/test_content.py
@@ -8,11 +8,47 @@ import pytest
 from util import generate_media
 
 import weave
+from tests.trace.server_utils import find_server_layer
 from weave import Dataset
 from weave.trace.table import Table
 from weave.trace.weave_client import WeaveClient
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.errors import NotFoundError
 from weave.type_wrappers.Content.content import Content
 from weave.utils import http_requests as _http_requests
+
+
+def _probe_ch_state(client, ref, tag: str) -> None:
+    """DO NOT MERGE: post-failure probe (see tests/trace/test_dataset.py)."""
+    try:
+        ch = find_server_layer(client.server, ClickHouseTraceServer)
+    except TypeError:
+        print(f"FLAKE_PROBE {tag}: backend is not ClickHouse, skipping")
+        return
+    try:
+        rows = ch.ch_client.query(
+            "SELECT "
+            "countIf(object_id = {object_id: String}) AS by_object, "
+            "countIf(object_id = {object_id: String} AND digest = {digest: String}) AS by_obj_digest, "
+            "countIf(digest = {digest: String}) AS by_digest, "
+            "count() AS total, "
+            "groupArray((project_id, object_id, digest))[1:20] AS sample "
+            "FROM object_versions",
+            parameters={"object_id": ref.name, "digest": ref.digest},
+        ).result_rows
+    except Exception as exc:
+        print(f"FLAKE_PROBE {tag}: query failed: {exc!r}")
+        return
+    if not rows:
+        print(f"FLAKE_PROBE {tag}: empty probe result")
+        return
+    by_object, by_obj_digest, by_digest, total, sample = rows[0]
+    print(
+        f"FLAKE_PROBE {tag}: ref={ref.name!r} digest={ref.digest!r} "
+        f"database={ch._database!r} total_rows={total} "
+        f"by_object={by_object} by_obj_digest={by_obj_digest} "
+        f"by_digest={by_digest} sample={sample}"
+    )
 
 
 class _FakeHTTPError(Exception):
@@ -409,7 +445,12 @@ class TestWeaveContent:
         ref = weave.publish(dataset, name="test_content_dataset")
 
         # Retrieve and verify
-        retrieved_dataset = ref.get()
+        try:
+            retrieved_dataset = ref.get()
+        except (NotFoundError, ValueError) as exc:
+            _probe_ch_state(client, ref, "test_content_in_dataset.ref.get")
+            print(f"FLAKE_PROBE raised: {type(exc).__name__}: {exc}")
+            raise
         assert len(retrieved_dataset.rows) == len(rows)
 
         for row in retrieved_dataset.rows:

--- a/tests/trace/type_handlers/Content/test_content.py
+++ b/tests/trace/type_handlers/Content/test_content.py
@@ -32,7 +32,7 @@ def _probe_ch_state(client, ref, tag: str) -> None:
             "countIf(object_id = {object_id: String} AND digest = {digest: String}) AS by_obj_digest, "
             "countIf(digest = {digest: String}) AS by_digest, "
             "count() AS total, "
-            "groupArray((project_id, object_id, digest))[1:20] AS sample "
+            "arraySlice(groupArray((project_id, object_id, digest)), 1, 20) AS sample "
             "FROM object_versions",
             parameters={"object_id": ref.name, "digest": ref.digest},
         ).result_rows

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1860,7 +1860,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     "countIf(project_id = {project_id: String} AND object_id = {object_id: String}) AS by_object, "
                     "countIf(project_id = {project_id: String} AND object_id = {object_id: String} AND digest = {digest: String}) AS by_digest, "
                     "countIf(object_id = {object_id: String} AND digest = {digest: String}) AS digest_any_project, "
-                    "groupArray((object_id, digest))[1:10] AS sample "
+                    "arraySlice(groupArray((object_id, digest)), 1, 10) AS sample "
                     "FROM object_versions "
                     "WHERE project_id = {project_id: String} OR digest = {digest: String}"
                 )
@@ -5475,7 +5475,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                             "countIf(project_id = {project_id: String}) AS in_project, "
                             "countIf(digest IN {digests: Array(String)}) AS digest_any_project, "
                             "countIf(project_id = {project_id: String} AND digest IN {digests: Array(String)}) AS in_project_and_digest, "
-                            "groupArray((project_id, object_id, digest))[1:20] AS sample "
+                            "arraySlice(groupArray((project_id, object_id, digest)), 1, 20) AS sample "
                             "FROM object_versions "
                             "WHERE project_id = {project_id: String} OR digest IN {digests: Array(String)}",
                             parameters={
@@ -5843,7 +5843,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     "countIf(digest = {digest: String}) AS by_digest_any_project, "
                     "countIf(project_id = {project_id: String} AND digest = {digest: String}) AS in_project_and_digest, "
                     "count() AS total, "
-                    "groupArray((project_id, digest))[1:10] AS sample "
+                    "arraySlice(groupArray((project_id, digest)), 1, 10) AS sample "
                     "FROM files",
                     parameters={
                         "project_id": req.project_id,

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1847,6 +1847,55 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         objs = self._select_objs_query(object_query_builder, metadata_only)
         if len(objs) == 0:
+            # DO NOT MERGE: diagnostic probe for flake investigation.
+            # Capture the actual object_versions state at the moment of the
+            # NotFoundError so we can tell whether the row is genuinely
+            # absent, has a different digest, or belongs to a different
+            # project_id (which would point at ref-conversion or caching
+            # issues rather than replica lag).
+            try:
+                probe_query = (
+                    "SELECT "
+                    "countIf(project_id = {project_id: String}) AS all_project, "
+                    "countIf(project_id = {project_id: String} AND object_id = {object_id: String}) AS by_object, "
+                    "countIf(project_id = {project_id: String} AND object_id = {object_id: String} AND digest = {digest: String}) AS by_digest, "
+                    "countIf(object_id = {object_id: String} AND digest = {digest: String}) AS digest_any_project, "
+                    "groupArray((object_id, digest))[1:10] AS sample "
+                    "FROM object_versions "
+                    "WHERE project_id = {project_id: String} OR digest = {digest: String}"
+                )
+                probe_rows = self.ch_client.query(
+                    probe_query,
+                    parameters={
+                        "project_id": req.project_id,
+                        "object_id": req.object_id,
+                        "digest": req.digest,
+                    },
+                ).result_rows
+                if probe_rows:
+                    (
+                        all_project,
+                        by_object,
+                        by_digest,
+                        digest_any_project,
+                        sample,
+                    ) = probe_rows[0]
+                    logger.warning(
+                        "FLAKE_PROBE obj_read NotFound: project_id=%r object_id=%r "
+                        "digest=%r database=%r all_project=%s by_object=%s "
+                        "by_digest=%s digest_any_project=%s sample=%s",
+                        req.project_id,
+                        req.object_id,
+                        req.digest,
+                        self._database,
+                        all_project,
+                        by_object,
+                        by_digest,
+                        digest_any_project,
+                        sample,
+                    )
+            except Exception as probe_exc:
+                logger.warning("FLAKE_PROBE query failed: %s", probe_exc)
             raise NotFoundError(f"Obj {req.object_id}:{req.digest} not found")
 
         obj = objs[0]

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5835,6 +5835,47 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
 
         if len(query_result.result_rows) == 0:
+            # DO NOT MERGE: diagnostic probe for flake investigation.
+            try:
+                probe_rows = self.ch_client.query(
+                    "SELECT "
+                    "countIf(project_id = {project_id: String}) AS in_project, "
+                    "countIf(digest = {digest: String}) AS by_digest_any_project, "
+                    "countIf(project_id = {project_id: String} AND digest = {digest: String}) AS in_project_and_digest, "
+                    "count() AS total, "
+                    "groupArray((project_id, digest))[1:10] AS sample "
+                    "FROM files",
+                    parameters={
+                        "project_id": req.project_id,
+                        "digest": req.digest,
+                    },
+                ).result_rows
+                if probe_rows:
+                    (
+                        in_project,
+                        by_digest_any_project,
+                        in_project_and_digest,
+                        total,
+                        sample,
+                    ) = probe_rows[0]
+                    logger.warning(
+                        "FLAKE_PROBE file_content_read NotFound: "
+                        "project_id=%r digest=%r database=%r "
+                        "files_total=%s in_project=%s by_digest_any_project=%s "
+                        "in_project_and_digest=%s sample=%s",
+                        req.project_id,
+                        req.digest,
+                        self._database,
+                        total,
+                        in_project,
+                        by_digest_any_project,
+                        in_project_and_digest,
+                        sample,
+                    )
+            except Exception as probe_exc:
+                logger.warning(
+                    "FLAKE_PROBE file_content_read query failed: %s", probe_exc
+                )
             raise NotFoundError(f"File with digest {req.digest} not found")
 
         n_chunks = query_result.result_rows[0][0]

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1759,6 +1759,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             data=[list(ch_obj.model_dump().values())],
             column_names=list(ch_obj.model_fields.keys()),
         )
+        # DO NOT MERGE: flake investigation.
+        logger.warning(
+            "FLAKE_TRACE obj_create OK: project_id=%r object_id=%r digest=%r database=%r",
+            req.obj.project_id,
+            req.obj.object_id,
+            digest,
+            self._database,
+        )
 
         return tsi.ObjCreateRes(
             digest=digest,
@@ -1831,6 +1839,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return obj_results
 
     def obj_read(self, req: tsi.ObjReadReq) -> tsi.ObjReadRes:
+        # DO NOT MERGE: flake investigation.
+        logger.warning(
+            "FLAKE_TRACE obj_read IN: project_id=%r object_id=%r digest=%r database=%r",
+            req.project_id,
+            req.object_id,
+            req.digest,
+            self._database,
+        )
         # Check if digest is an alias name (not a hash, not version-like, not "latest")
         digest = req.digest
         resolved_digest = self._maybe_resolve_alias(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1759,14 +1759,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             data=[list(ch_obj.model_dump().values())],
             column_names=list(ch_obj.model_fields.keys()),
         )
-        # DO NOT MERGE: flake investigation.
-        logger.warning(
-            "FLAKE_TRACE obj_create OK: project_id=%r object_id=%r digest=%r database=%r",
-            req.obj.project_id,
-            req.obj.object_id,
-            digest,
-            self._database,
-        )
 
         return tsi.ObjCreateRes(
             digest=digest,
@@ -1839,14 +1831,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return obj_results
 
     def obj_read(self, req: tsi.ObjReadReq) -> tsi.ObjReadRes:
-        # DO NOT MERGE: flake investigation.
-        logger.warning(
-            "FLAKE_TRACE obj_read IN: project_id=%r object_id=%r digest=%r database=%r",
-            req.project_id,
-            req.object_id,
-            req.digest,
-            self._database,
-        )
         # Check if digest is an alias name (not a hash, not version-like, not "latest")
         digest = req.digest
         resolved_digest = self._maybe_resolve_alias(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5467,6 +5467,47 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 objs = self._select_objs_query(object_query_builder)
                 found_digests = {obj.digest for obj in objs}
                 if len(ref_digests) != len(found_digests):
+                    # DO NOT MERGE: diagnostic probe for flake investigation.
+                    missing = ref_digests - found_digests
+                    try:
+                        probe_rows = self.ch_client.query(
+                            "SELECT "
+                            "countIf(project_id = {project_id: String}) AS in_project, "
+                            "countIf(digest IN {digests: Array(String)}) AS digest_any_project, "
+                            "countIf(project_id = {project_id: String} AND digest IN {digests: Array(String)}) AS in_project_and_digest, "
+                            "groupArray((project_id, object_id, digest))[1:20] AS sample "
+                            "FROM object_versions "
+                            "WHERE project_id = {project_id: String} OR digest IN {digests: Array(String)}",
+                            parameters={
+                                "project_id": project_id_scope,
+                                "digests": list(missing),
+                            },
+                        ).result_rows
+                        if probe_rows:
+                            (
+                                in_project,
+                                digest_any_project,
+                                in_project_and_digest,
+                                sample,
+                            ) = probe_rows[0]
+                            logger.warning(
+                                "FLAKE_PROBE refs_read_batch NotFound: "
+                                "project_id=%r missing_digests=%s database=%r "
+                                "in_project=%s digest_any_project=%s "
+                                "in_project_and_digest=%s sample=%s",
+                                project_id_scope,
+                                missing,
+                                self._database,
+                                in_project,
+                                digest_any_project,
+                                in_project_and_digest,
+                                sample,
+                            )
+                    except Exception as probe_exc:
+                        logger.warning(
+                            "FLAKE_PROBE refs_read_batch query failed: %s",
+                            probe_exc,
+                        )
                     raise NotFoundError(
                         f"Ref read contains {len(ref_digests)} digests, but found {len(found_digests)} objects. Diff digests: {ref_digests - found_digests}"
                     )


### PR DESCRIPTION
Throwaway investigation branch. Adds a diagnostic SELECT against `object_versions` at the moment `obj_read` is about to raise `NotFoundError`, so we can tell whether the row is genuinely missing or just being looked up wrong (project_id, digest, cross-project).

Target flakes:
- `test_content_in_dataset`
- `test_published_dataset_laziness`

Re-triggering CI until we capture a `FLAKE_PROBE` log line on a failing run. Revert once we've learned something.