### PR TITLE
chore(weave): fix flaky test_wal_client_writes WAL sender drain error

### DIFF
--- a/tests/trace/test_wal_client_writes.py
+++ b/tests/trace/test_wal_client_writes.py
@@ -63,6 +63,16 @@ def _redirect_wal_to(client: weave.WeaveClient, wal_dir: str) -> None:
     wal._writer = JSONLWALWriter(dir_mgr)
 
 
+# The initial WAL points at the shared ~/.weave/wal/<entity>/<project>/
+# directory, so starting a sender there races with parallel xdist workers
+# and has triggered Windows file-handle errors.  Both fixtures redirect
+# to an isolated tmp_path, so no sender needs to run against the default.
+# A fresh UserSettings is built per fixture call because UserSettings.apply()
+# resets the instance to defaults on reuse.
+def _initial_wal_settings() -> UserSettings:
+    return UserSettings(enable_wal=True, disable_wal_sender=True)
+
+
 @pytest.fixture
 def wal_client(client_creator, tmp_path):
     """Create a client with WAL enabled but sender stopped (write-only).
@@ -70,7 +80,7 @@ def wal_client(client_creator, tmp_path):
     Redirects the WAL to ``tmp_path`` for test isolation.
     """
     wal_dir = str(tmp_path / "wal")
-    with client_creator(settings=UserSettings(enable_wal=True)) as client:
+    with client_creator(settings=_initial_wal_settings()) as client:
         _redirect_wal_to(client, wal_dir)
         yield client
 
@@ -82,9 +92,9 @@ def wal_client_with_sender(client_creator, tmp_path):
     Redirects the WAL to ``tmp_path`` for test isolation.
     """
     wal_dir = str(tmp_path / "wal")
-    with client_creator(settings=UserSettings(enable_wal=True)) as client:
+    with client_creator(settings=_initial_wal_settings()) as client:
         _redirect_wal_to(client, wal_dir)
-        # Re-create sender pointing at the isolated directory.
+        # Create sender pointing at the isolated directory.
         client._wal._sender = create_sender(wal_dir, client.server)
         client._wal._sender.start()
         yield client


### PR DESCRIPTION
## Summary

Fixtures pass `disable_wal_sender=True` so `WeaveClient` doesn't spin up a sender at the shared `~/.weave/wal/<entity>/<project>/` dir during init. That shared dir gets raced by parallel xdist workers and trips a windows file-handle error.

no coverage lost — the initial sender at the default dir was created, then immediately stopped by `_redirect_wal_to` → `wal.close()` before the test body ran. nothing ever asserted against it. the `wal_client_with_sender` tests exercise the sender that the fixture explicitly creates at `tmp_path` after the redirect, which still happens.

Original failure ([run](https://github.com/wandb/weave/actions/runs/24734642986/job/72358114410?pr=6663)):
```
WAL sender drain/cleanup error for C:\Users\runneradmin\.weave\wal\shawn\test-project\01776789878317391600_d1ee5fec39d64b0986de1de1a24c538c.jsonl
```

Test-only change. 24/24 pass locally on sqlite.