### PR TITLE
chore(weave): fix flaky model_latency assertions in eval tests

### DIFF
--- a/tests/trace/test_evaluate.py
+++ b/tests/trace/test_evaluate.py
@@ -66,7 +66,7 @@ async def test_predict_can_receive_other_params(client):
         "output": {"mean": 18.5},
         "score": {"true_count": 0, "true_fraction": 0.0},
         "model_latency": {
-            "mean": pytest.approx(0, abs=1),
+            "mean": pytest.approx(0, abs=LATENCY_TOL),
         },
     }
 
@@ -134,7 +134,7 @@ async def test_score_as_class(client):
         "output": {"mean": 9.5},
         "MyScorer": {"true_count": 1, "true_fraction": 0.5},
         "model_latency": {
-            "mean": pytest.approx(0, abs=1),
+            "mean": pytest.approx(0, abs=LATENCY_TOL),
         },
     }
 
@@ -161,7 +161,7 @@ async def test_score_with_custom_summarize(client):
         "output": {"mean": 9.5},
         "MyScorer": {"awesome": 3},
         "model_latency": {
-            "mean": pytest.approx(0, abs=1),
+            "mean": pytest.approx(0, abs=LATENCY_TOL),
         },
     }
 

--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -66,7 +66,7 @@ async def test_predict_can_receive_other_params(client):
         "model_output": {"mean": 18.5},
         "score_oldstyle": {"true_count": 0, "true_fraction": 0.0},
         "model_latency": {
-            "mean": pytest.approx(0, abs=1),
+            "mean": pytest.approx(0, abs=LATENCY_TOL),
         },
     }
 
@@ -150,7 +150,7 @@ async def test_score_as_class(client):
         "model_output": {"mean": 9.5},
         "MyScorerOldstyle": {"true_count": 1, "true_fraction": 0.5},
         "model_latency": {
-            "mean": pytest.approx(0, abs=1),
+            "mean": pytest.approx(0, abs=LATENCY_TOL),
         },
     }
 
@@ -177,7 +177,7 @@ async def test_score_with_custom_summarize(client):
         "model_output": {"mean": 9.5},
         "MyScorerOldstyle": {"awesome": 3},
         "model_latency": {
-            "mean": pytest.approx(0, abs=1),
+            "mean": pytest.approx(0, abs=LATENCY_TOL),
         },
     }
 
@@ -204,6 +204,6 @@ async def test_multiclass_f1_score(client):
             "b": {"f1": 0, "precision": 0, "recall": 0.0},
         },
         "model_latency": {
-            "mean": pytest.approx(0, abs=1),
+            "mean": pytest.approx(0, abs=LATENCY_TOL),
         },
     }

--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -447,7 +447,7 @@ async def test_evaluation_data_topology(client):
     }
     # BUG: latency reported includes weave internal latency
     # actual_latency = (predict_call.ended_at - predict_call.started_at).total_seconds()
-    actual_latency = pytest.approx(0, abs=1)
+    actual_latency = pytest.approx(0, abs=LATENCY_TOL)
     model_1_latency = {"mean": actual_latency}
     score_int_score = 1
     score_float_score = 1.0


### PR DESCRIPTION
## Summary

Replace tight `pytest.approx(0, abs=1)` tolerances on `model_latency` assertions with the shared `LATENCY_TOL` constant (2s posix / 10s win32). On loaded CI runners, `model_latency` wraps the full async_call_op including flush overhead and can exceed 1s — observed 1.047s.

Original failure:
```
FAILED tests/trace/test_evaluations.py::test_evaluation_data_topology - AssertionError: assert {'model_laten...': True, ...} == {'model_laten...': True, ...}
```

## Testing

Test-only change.