### PR TITLE
fix(weave): Fixes issue client.responses.create(...).withResponse is not a function

### DIFF
--- a/sdks/node/src/__tests__/integrations/openai2.test.ts
+++ b/sdks/node/src/__tests__/integrations/openai2.test.ts
@@ -207,6 +207,57 @@ describe('OpenAI Integration', () => {
       // Verify wrapped matches unwrapped
       expect(wrappedResult).toEqual(unwrappedResult);
     });
+
+    it('should forward APIPromise.withResponse() through the chat completions wrapper', async () => {
+      const mockResponse = {
+        headers: new Map([['x-request-id', 'req_chat_id']]),
+      };
+      const parsedData = {
+        id: 'chat_test_id',
+        choices: [{message: {role: 'assistant', content: 'Hello'}}],
+        model: 'gpt-4',
+        usage: {prompt_tokens: 1, completion_tokens: 1, total_tokens: 2},
+      };
+
+      class MockAPIPromise {
+        then(onFulfilled: any, onRejected: any) {
+          return Promise.resolve(parsedData).then(onFulfilled, onRejected);
+        }
+        catch(onRejected: any) {
+          return Promise.resolve(parsedData).catch(onRejected);
+        }
+        finally(onFinally: any) {
+          return Promise.resolve(parsedData).finally(onFinally);
+        }
+        asResponse() {
+          return Promise.resolve(mockResponse);
+        }
+        async withResponse() {
+          return {
+            data: parsedData,
+            response: mockResponse,
+            request_id: mockResponse.headers.get('x-request-id'),
+          };
+        }
+      }
+
+      mockOpenAI.chat.completions.create = jest
+        .fn()
+        .mockImplementation(() => new MockAPIPromise());
+      wrappedOpenAI = wrapOpenAI(mockOpenAI);
+
+      const pending = wrappedOpenAI.chat.completions.create({
+        model: 'gpt-4',
+        messages: [{role: 'user', content: 'Hi'}],
+      });
+
+      expect(typeof pending.withResponse).toBe('function');
+      const {data, response, request_id} = await pending.withResponse();
+
+      expect(data).toEqual(parsedData);
+      expect(response).toBe(mockResponse);
+      expect(request_id).toBe('req_chat_id');
+    });
   });
 });
 
@@ -411,6 +462,74 @@ describe('OpenAI responses.create Integration', () => {
       });
 
       expect(mockOpenAI.responses.create).toHaveBeenCalledWith(options);
+    });
+
+    it('should forward APIPromise.withResponse() through the weave wrapper', async () => {
+      const mockResponse = {
+        headers: new Map([['x-request-id', 'req_test_id']]),
+      };
+      const parsedData = {
+        id: 'resp_test_id',
+        object: 'response',
+        status: 'completed',
+        model: 'gpt-4o-2024-08-06',
+        output: [
+          {
+            id: 'msg_test_id',
+            type: 'message',
+            status: 'completed',
+            content: [
+              {
+                type: 'output_text',
+                annotations: [],
+                text: 'Hello! How can I help you today?',
+              },
+            ],
+            role: 'assistant',
+          },
+        ],
+        usage: {input_tokens: 1, output_tokens: 1, total_tokens: 2},
+      };
+
+      // Simulate APIPromise: thenable with .withResponse()/.asResponse().
+      class MockAPIPromise {
+        then(onFulfilled: any, onRejected: any) {
+          return Promise.resolve(parsedData).then(onFulfilled, onRejected);
+        }
+        catch(onRejected: any) {
+          return Promise.resolve(parsedData).catch(onRejected);
+        }
+        finally(onFinally: any) {
+          return Promise.resolve(parsedData).finally(onFinally);
+        }
+        asResponse() {
+          return Promise.resolve(mockResponse);
+        }
+        async withResponse() {
+          return {
+            data: parsedData,
+            response: mockResponse,
+            request_id: mockResponse.headers.get('x-request-id'),
+          };
+        }
+      }
+
+      mockOpenAI.responses.create = jest
+        .fn()
+        .mockImplementation(() => new MockAPIPromise());
+      wrappedOpenAI = wrapOpenAI(mockOpenAI);
+
+      const pending = wrappedOpenAI.responses.create({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{role: 'user', content: 'Hello!'}],
+      });
+
+      expect(typeof pending.withResponse).toBe('function');
+      const {data, response, request_id} = await pending.withResponse();
+
+      expect(data).toEqual(parsedData);
+      expect(response).toBe(mockResponse);
+      expect(request_id).toBe('req_test_id');
     });
 
     it('should handle streaming responses and skip deltas', async () => {

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -92,19 +92,7 @@ export const openAIStreamReducer = {
 };
 
 export function makeOpenAIChatCompletionsOp(originalCreate: any, name: string) {
-  function wrapped(...args: Parameters<typeof originalCreate>) {
-    const [originalParams]: any[] = args;
-    if (originalParams.stream) {
-      return originalCreate({
-        ...originalParams,
-        stream_options: {...originalParams.stream_options, include_usage: true},
-      });
-    }
-
-    return originalCreate(originalParams);
-  }
-
-  const options: OpOptions<typeof wrapped> = {
+  const options: OpOptions<typeof originalCreate> = {
     name: name,
     opKind: 'llm',
     parameterNames: 'useParam0Object',
@@ -116,11 +104,39 @@ export function makeOpenAIChatCompletionsOp(originalCreate: any, name: string) {
     streamReducer: openAIStreamReducer,
   };
 
-  const weaveOp = op(wrapped, options);
+  return function wrappedWithAgents(
+    ...args: Parameters<typeof originalCreate>
+  ) {
+    const [originalParams]: any[] = args;
+    // Rewrite streaming params outside the op callback so the trace
+    // records the caller's original args[0], not our mutated copy
+    // (include_usage lets the reducer see token counts).
+    const callArgs: Parameters<typeof originalCreate> = originalParams?.stream
+      ? ([
+          {
+            ...originalParams,
+            stream_options: {
+              ...originalParams.stream_options,
+              include_usage: true,
+            },
+          },
+        ] as Parameters<typeof originalCreate>)
+      : args;
 
-  // Wrap with OpenAI Agents context if available
-  return function wrappedWithAgents(...args: Parameters<typeof wrapped>) {
-    return runWithOpenAIAgentsContext(() => weaveOp(...args));
+    // Capture the APIPromise so wrapAsAPIPromiseLike can forward its
+    // helpers (see that function for the full rationale).
+    let apiPromise: any;
+    const weaveOp = op(() => {
+      apiPromise = originalCreate(...callArgs);
+      return apiPromise;
+    }, options);
+
+    const tracedPromise = runWithOpenAIAgentsContext(() => weaveOp(...args));
+    // If the caller awaits only a forwarded helper, tracedPromise has
+    // no handler — silence its rejection (weave already records it).
+    tracedPromise.catch(() => {});
+
+    return wrapAsAPIPromiseLike(tracedPromise, apiPromise);
   };
 }
 
@@ -444,29 +460,68 @@ export function summarizer(result: any) {
   return {};
 }
 
-export function makeOpenAIResponsesCreateProxy(originalCreate: any) {
-  return new Proxy(originalCreate, {
-    apply: (target, thisArg, args) => {
-      const [inputOptions] = args;
-      const isStream = inputOptions.stream;
-      const weaveOpOptions: OpOptions<typeof originalCreate> = {
-        name: 'create',
-        opKind: 'llm',
-        shouldAdoptThis: true,
-        originalFunction: originalCreate,
-        summarize: summarizer,
-        ...(isStream ? {streamReducer: openAIStreamAPIstreamReducer} : null),
-        parameterNames: 'useParam0Object',
-      };
+export function makeOpenAIResponsesCreateOp(originalCreate: any) {
+  return function wrappedWithAgents(
+    this: any,
+    ...args: Parameters<typeof originalCreate>
+  ) {
+    const [inputOptions]: any[] = args;
+    const isStream = inputOptions?.stream;
+    const weaveOpOptions: OpOptions<typeof originalCreate> = {
+      name: 'create',
+      opKind: 'llm',
+      shouldAdoptThis: true,
+      originalFunction: originalCreate,
+      summarize: summarizer,
+      ...(isStream ? {streamReducer: openAIStreamAPIstreamReducer} : null),
+      parameterNames: 'useParam0Object',
+    };
 
-      const weaveOp = op(() => {
-        return originalCreate.apply(thisArg, args);
-      }, weaveOpOptions);
+    // Capture the APIPromise so wrapAsAPIPromiseLike can forward its
+    // helpers (see that function). Forward `this` for shouldAdoptThis;
+    // originalCreate is pre-bound at the wrapOpenAI call site.
+    const thisArg = this;
+    let apiPromise: any;
+    const weaveOp = op(() => {
+      apiPromise = originalCreate(...args);
+      return apiPromise;
+    }, weaveOpOptions);
 
-      // Run with OpenAI Agents context if available
-      return runWithOpenAIAgentsContext(() => {
-        return weaveOp.apply(thisArg, args);
-      });
+    const tracedPromise = runWithOpenAIAgentsContext(() =>
+      weaveOp.apply(thisArg, args)
+    );
+    // If the caller awaits only a forwarded helper, tracedPromise has
+    // no handler — silence its rejection (weave already records it).
+    tracedPromise.catch(() => {});
+
+    // weaveOp runs the callback synchronously (via
+    // AsyncLocalStorage.run), so apiPromise is already assigned here.
+    return wrapAsAPIPromiseLike(tracedPromise, apiPromise);
+  };
+}
+
+// Returns a Promise-like proxy that preserves the OpenAI SDK's
+// APIPromise helpers (.withResponse(), .asResponse(), .parse(),
+// ._thenUnwrap(), and any future additions).
+//
+// Why this is needed: weave's op() awaits the inner callback and
+// returns a fresh Promise of the parsed value — the original
+// APIPromise (and its helpers) is gone by the time the caller sees
+// the result. The factory captures the APIPromise in a closure and
+// hands it here; this proxy keeps then/catch/finally on the traced
+// promise so tracing still runs on await, and forwards every other
+// property access to the original APIPromise.
+function wrapAsAPIPromiseLike(tracedPromise: Promise<any>, apiPromise: any) {
+  return new Proxy(tracedPromise, {
+    get(target, p) {
+      if (p === 'then' || p === 'catch' || p === 'finally') {
+        // Rely on internal Promise slots — must be bound to the
+        // underlying Promise rather than the Proxy.
+        const val = Reflect.get(target, p);
+        return val.bind(target);
+      }
+      const val = Reflect.get(apiPromise, p);
+      return typeof val === 'function' ? val.bind(apiPromise) : val;
     },
   });
 }
@@ -578,7 +633,7 @@ export function wrapOpenAI<T extends OpenAIAPI>(openai: T): T {
           const targetVal = Reflect.get(target, p, receiver);
 
           if (p === 'create') {
-            return makeOpenAIResponsesCreateProxy(targetVal);
+            return makeOpenAIResponsesCreateOp(targetVal.bind(target));
           }
           return targetVal;
         },


### PR DESCRIPTION
# Preserve OpenAI SDK `APIPromise` helpers through weave's wrapper

## Problem

Calling `withResponse` helpers on a weave-wrapped OpenAI client throws:

```
Exception: client.responses.create(...).withResponse is not a function
```

`weave.op()`'s async wrapper `await`s the inner callback and returns a fresh `Promise<T>` — the SDK's original `APIPromise` (and its `.withResponse()` / `.asResponse()` / `.parse()` / `._thenUnwrap()` helpers) never reaches the caller.

Affects `responses.create`, `chat.completions.create`, and `beta.chat.completions.parse`.

## Fix

- New helper `wrapAsAPIPromiseLike` — a `Proxy` that keeps `then`/`catch`/`finally` on the traced promise (so tracing still runs on `await`) and forwards every other property access to the original `APIPromise`.
- Both `makeOpenAIResponsesCreateOp` (renamed from `…Proxy`) and `makeOpenAIChatCompletionsOp` now capture the `APIPromise` from inside the op callback and hand it to `wrapAsAPIPromiseLike`.
- `makeOpenAIResponsesCreateOp` also converted from a `new Proxy(originalCreate, {apply})` form to a plain returned function matching `makeOpenAIChatCompletionsOp`; `originalCreate` is pre-bound at the `wrapOpenAI` call site. `shouldAdoptThis` is preserved so `self` still appears in traces.
- Silent `tracedPromise.catch(() => {})` on both paths: if a caller awaits only a forwarded helper, the outer traced promise has no handler — this avoids an unhandled-rejection warning in error cases (weave still records the exception inside the op).

## Test plan

- [x] Existing OpenAI integration tests still pass.
- [x] New regression tests added in `openai2.test.ts` covering `.withResponse()` on both `responses.create` and `chat.completions.create`.
- [x] Manual smoke test against a OpenAI + pi-coding-agent scenario.
