### PR TITLE
chore(weave): Add EvaluationLoggerV2

### DIFF
--- a/tests/flow/test_bench_eval_v2.py
+++ b/tests/flow/test_bench_eval_v2.py
@@ -1,0 +1,151 @@
+"""Benchmark: EvaluationLoggerV2 vs V1 under simulated remote-backend RTT.
+
+Each server round-trip is given a ``time.sleep(0.02)`` shim to emulate a
+50 ms RTT backend. V2 now parallelizes its V2-endpoint round-trips
+(`prediction_create`, `score_create`, `prediction_finish`) through a
+ThreadPoolExecutor, so user code should not block on the network and the
+total wall-clock should stay close to V1 even though V2 issues more
+distinct round-trips per prediction.
+
+Run with::
+
+    pytest tests/flow/test_bench_eval_v2.py -v -s
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from weave.evaluation.eval_imperative import EvaluationLogger as EvaluationLoggerV1
+from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
+
+RTT_SECONDS = 0.02
+NUM_PREDICTIONS = 20
+NUM_SCORERS = 3
+
+
+def _install_rtt_shim(
+    server: Any, methods: tuple[str, ...], delay: float = RTT_SECONDS
+) -> list[tuple[str, Any]]:
+    """Wrap each ``server.<method>`` to sleep ``delay`` before dispatching.
+
+    Returns the original callables so the caller can restore them after
+    the benchmark — isolating the shim to a single benchmark region.
+    """
+    originals: list[tuple[str, Any]] = []
+    for name in methods:
+        original = getattr(server, name)
+        originals.append((name, original))
+
+        def _make_wrapper(orig: Any) -> Any:
+            def _wrapper(*args: Any, **kwargs: Any) -> Any:
+                time.sleep(delay)
+                return orig(*args, **kwargs)
+
+            return _wrapper
+
+        setattr(server, name, _make_wrapper(original))
+    return originals
+
+
+def _restore(server: Any, originals: list[tuple[str, Any]]) -> None:
+    for name, orig in originals:
+        setattr(server, name, orig)
+
+
+def _run_v2(client) -> tuple[float, float]:
+    """Drive V2 and return (user_code_elapsed, total_elapsed) in seconds."""
+    originals = _install_rtt_shim(
+        client.server,
+        ("prediction_create", "score_create", "prediction_finish"),
+    )
+    try:
+        start = time.perf_counter()
+        ev = EvaluationLoggerV2(
+            name="bench_v2",
+            model="bench_model_v2",
+            dataset=[{"i": i} for i in range(NUM_PREDICTIONS)],
+        )
+        for i in range(NUM_PREDICTIONS):
+            pred = ev.log_prediction(inputs={"i": i}, output=f"out-{i}")
+            for s in range(NUM_SCORERS):
+                pred.log_score(f"scorer_{s}", 0.5 + s * 0.1)
+            pred.finish()
+        user_code_elapsed = time.perf_counter() - start
+
+        ev.log_summary({"ok": True})
+        total_elapsed = time.perf_counter() - start
+    finally:
+        _restore(client.server, originals)
+    return user_code_elapsed, total_elapsed
+
+
+def _run_v1(client) -> tuple[float, float]:
+    """Drive V1 and return (user_code_elapsed, total_elapsed) in seconds.
+
+    V1 flushes through ``call_start``/``call_end`` — its rough per-server
+    analogue of V2's prediction/score endpoints. We shim both so the RTT
+    cost model is comparable.
+    """
+    originals = _install_rtt_shim(
+        client.server,
+        ("call_start", "call_end"),
+    )
+    try:
+        start = time.perf_counter()
+        ev = EvaluationLoggerV1(
+            name="bench_v1",
+            model="bench_model_v1",
+            dataset=[{"i": i} for i in range(NUM_PREDICTIONS)],
+        )
+        for i in range(NUM_PREDICTIONS):
+            pred = ev.log_prediction(inputs={"i": i}, output=f"out-{i}")
+            for s in range(NUM_SCORERS):
+                pred.log_score(f"scorer_{s}", 0.5 + s * 0.1)
+            pred.finish()
+        user_code_elapsed = time.perf_counter() - start
+
+        ev.log_summary({"ok": True})
+        total_elapsed = time.perf_counter() - start
+    finally:
+        _restore(client.server, originals)
+    return user_code_elapsed, total_elapsed
+
+
+def test_bench_v2_is_not_slower_than_v1(client):
+    """V2 must not be meaningfully slower than V1 under simulated RTT.
+
+    Asserts:
+      * V2 user-code < 500 ms (user code never blocks on the network).
+      * V2 total     < 4 s   (parallel HTTP drains quickly).
+      * V2 total     < V1 total * 1.2 (V2 on par with V1).
+    """
+    # Warm-up: the first eval pays a one-time module/integration init cost
+    # (imports, patching) that would bias whichever logger runs first.
+    _run_v2(client)
+    _run_v1(client)
+
+    v1_user, v1_total = _run_v1(client)
+    v2_user, v2_total = _run_v2(client)
+
+    print("\n=== EvaluationLogger benchmark (20 predictions x 3 scorers) ===")
+    print(f"RTT shim:              {RTT_SECONDS * 1000:.0f} ms per call")
+    print(f"V1 user-code elapsed:  {v1_user * 1000:8.1f} ms")
+    print(f"V1 total elapsed:      {v1_total * 1000:8.1f} ms")
+    print(f"V2 user-code elapsed:  {v2_user * 1000:8.1f} ms")
+    print(f"V2 total elapsed:      {v2_total * 1000:8.1f} ms")
+    ratio = v2_total / v1_total if v1_total > 0 else float("inf")
+    print(f"V2/V1 total ratio:     {ratio:.2f}x")
+
+    assert v2_user < 0.5, (
+        f"V2 user-code should not block on network; got {v2_user * 1000:.1f} ms"
+    )
+    assert v2_total < 4.0, (
+        f"V2 total should drain in parallel; got {v2_total * 1000:.1f} ms"
+    )
+    assert v2_total < v1_total * 1.2, (
+        "V2 must not be meaningfully slower than V1: "
+        f"V2={v2_total * 1000:.1f} ms, V1={v1_total * 1000:.1f} ms, "
+        f"ratio={ratio:.2f}x"
+    )

--- a/tests/flow/test_evaluation_imperative_contract.py
+++ b/tests/flow/test_evaluation_imperative_contract.py
@@ -1,0 +1,218 @@
+"""Contract tests parametrized across EvaluationLogger (V1) and EvaluationLoggerV2.
+
+These tests cover observable, user-facing behavior that both implementations
+must support identically. They intentionally avoid peeking at implementation
+details (specific op names, call-tree shapes, internal trace structure) so
+the same test body can run against V1 and V2.
+
+Anything that checks V1-specific trace structure (op names like
+"Evaluation.evaluate", specific parent_id relationships, V1 summary shape)
+belongs in ``test_evaluation_imperative.py``. Anything that checks V2-only
+behavior (prediction_list, evaluation_run status, deferred output update)
+belongs in ``test_evaluation_imperative_v2.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from weave.evaluation.eval_imperative import EvaluationLogger
+from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
+
+
+@pytest.fixture(params=[EvaluationLogger, EvaluationLoggerV2], ids=["v1", "v2"])
+def logger_cls(request):
+    return request.param
+
+
+def test_log_example_roundtrip(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    ev.log_example(
+        inputs={"q": "x"},
+        output="y",
+        scores={"correct": 1.0, "fluent": 0.8},
+    )
+    ev.log_summary()
+
+    pred = ev._accumulated_predictions[0]
+    assert pred._captured_scores == {"correct": 1.0, "fluent": 0.8}
+    assert pred._has_finished
+
+
+def test_log_example_multiple_examples(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "a"}, {"q": "b"}])
+    ev.log_example(inputs={"q": "a"}, output="A", scores={"s": 1.0})
+    ev.log_example(inputs={"q": "b"}, output="B", scores={"s": 0.5})
+    ev.log_summary()
+
+    assert len(ev._accumulated_predictions) == 2
+    assert ev._accumulated_predictions[0]._captured_scores == {"s": 1.0}
+    assert ev._accumulated_predictions[1]._captured_scores == {"s": 0.5}
+
+
+def test_log_example_after_finalization_raises(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    ev.log_example(inputs={"q": "x"}, output="y", scores={"s": 1.0})
+    ev.log_summary()
+    with pytest.raises(ValueError, match="finalized"):
+        ev.log_example(inputs={"q": "z"}, output="w", scores={"s": 0.0})
+
+
+def test_none_as_valid_score_value(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    pred.log_score("maybe_scorer", None)
+    pred.finish()
+    ev.log_summary()
+    assert pred._captured_scores == {"maybe_scorer": None}
+
+
+def test_passing_dict_scorer_without_name_raises(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    with pytest.raises(ValueError, match="name"):
+        pred.log_score({"not_name": "x"}, 1.0)
+
+
+def test_log_prediction_context_manager_sets_output(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    with ev.log_prediction(inputs={"q": "x"}) as pred:
+        pred.output = "dynamic_output"
+        pred.log_score("s", 0.9)
+    ev.log_summary()
+
+    assert pred._has_finished
+    assert pred._captured_scores == {"s": 0.9}
+
+
+def test_log_score_context_manager_submits_value(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    with pred.log_score("reasoning") as score_ctx:
+        score_ctx.value = 0.75
+    pred.finish()
+    ev.log_summary()
+
+    assert pred._captured_scores == {"reasoning": 0.75}
+
+
+def test_log_score_context_manager_without_value_raises(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    with pytest.raises(ValueError, match="Score value was not set"):
+        with pred.log_score("reasoning"):
+            pass
+    pred.finish()
+    ev.log_summary()
+
+
+def test_predefined_scorer_warning_on_ad_hoc_use(client, logger_cls, caplog):
+    ev = logger_cls(
+        model="m",
+        dataset=[{"q": "x"}],
+        scorers=["expected_scorer"],
+    )
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    with caplog.at_level("WARNING"):
+        pred.log_score("unexpected_scorer", 0.5)
+    pred.finish()
+    ev.log_summary()
+
+    # Both V1 and V2 log a WARNING when a scorer outside the predefined list
+    # is used.
+    assert any(
+        "unexpected_scorer" in r.message and "predefined" in r.message
+        for r in caplog.records
+    )
+
+
+def test_custom_eval_attributes_accepted(client, logger_cls):
+    # Accepting `eval_attributes=` without raising is part of the contract.
+    # V1 stores them on the evaluate call's attributes; V2 stores them via
+    # EvaluationCreateReq.eval_attributes. The observable contract here is
+    # simply that construction + a full flow succeed.
+    ev = logger_cls(
+        model="m",
+        dataset=[{"q": "x"}],
+        eval_attributes={"environment": "test", "custom_attribute": "hello"},
+    )
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    pred.log_score("s", 1.0)
+    pred.finish()
+    ev.log_summary()
+    assert ev.attributes.get("custom_attribute") == "hello"
+
+
+def test_scorers_accept_string_dict_and_instance(client, logger_cls):
+    from weave.flow.scorer import Scorer
+
+    class MyScorer(Scorer):
+        name: str = "my_scorer"
+
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    pred.log_score("string_scorer", 1.0)
+    pred.log_score({"name": "dict_scorer"}, 0.5)
+    pred.log_score(MyScorer(), 0.25)
+    pred.finish()
+    ev.log_summary()
+
+    assert set(pred._captured_scores.keys()) == {
+        "string_scorer",
+        "dict_scorer",
+        "my_scorer",
+    }
+
+
+def test_log_summary_no_auto_summarize(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    pred.log_score("s", 1.0)
+    pred.finish()
+    ev.log_summary(summary={"user_key": 42}, auto_summarize=False)
+
+    # Contract: the evaluation is finalized and doesn't raise.
+    assert ev._is_finalized
+
+
+def test_weave_disabled_captures_scores_without_failing(
+    client, logger_cls, monkeypatch
+):
+    monkeypatch.setenv("WEAVE_DISABLED", "true")
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    pred.log_score("s", 0.5)
+    pred.finish()
+    ev.log_summary()
+
+    # Contract: the logger tolerates disabled tracing, keeps user-visible
+    # state internally, and does not raise.
+    assert pred._captured_scores == {"s": 0.5}
+
+
+def test_fail_finalizes_without_raising(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    ev.log_prediction(inputs={"q": "x"}, output="y")
+    ev.fail(RuntimeError("synthetic failure"))
+    assert ev._is_finalized
+
+
+def test_finish_without_predictions_is_idempotent(client, logger_cls):
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    ev.finish()
+    ev.finish()  # Second finish should no-op, not raise.
+    assert ev._is_finalized
+
+
+def test_async_alog_score(client, logger_cls):
+    import asyncio
+
+    async def run() -> None:
+        ev = logger_cls(model="m", dataset=[{"q": "x"}])
+        pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+        await pred.alog_score("async_s", 0.33)
+        pred.finish()
+        ev.log_summary()
+        assert pred._captured_scores == {"async_s": 0.33}
+
+    asyncio.run(run())

--- a/tests/flow/test_evaluation_imperative_contract.py
+++ b/tests/flow/test_evaluation_imperative_contract.py
@@ -14,10 +14,13 @@ belongs in ``test_evaluation_imperative_v2.py``.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from weave.evaluation.eval_imperative import EvaluationLogger
 from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
+from weave.flow.scorer import Scorer
 
 
 @pytest.fixture(params=[EvaluationLogger, EvaluationLoggerV2], ids=["v1", "v2"])
@@ -144,8 +147,6 @@ def test_custom_eval_attributes_accepted(client, logger_cls):
 
 
 def test_scorers_accept_string_dict_and_instance(client, logger_cls):
-    from weave.flow.scorer import Scorer
-
     class MyScorer(Scorer):
         name: str = "my_scorer"
 
@@ -205,8 +206,6 @@ def test_finish_without_predictions_is_idempotent(client, logger_cls):
 
 
 def test_async_alog_score(client, logger_cls):
-    import asyncio
-
     async def run() -> None:
         ev = logger_cls(model="m", dataset=[{"q": "x"}])
         pred = ev.log_prediction(inputs={"q": "x"}, output="y")

--- a/tests/flow/test_evaluation_imperative_contract.py
+++ b/tests/flow/test_evaluation_imperative_contract.py
@@ -5,6 +5,9 @@ must support identically. They intentionally avoid peeking at implementation
 details (specific op names, call-tree shapes, internal trace structure) so
 the same test body can run against V1 and V2.
 
+Each test simulates a realistic user flow and bundles related assertions
+rather than testing one behavior at a time.
+
 Anything that checks V1-specific trace structure (op names like
 "Evaluation.evaluate", specific parent_id relationships, V1 summary shape)
 belongs in ``test_evaluation_imperative.py``. Anything that checks V2-only
@@ -28,190 +31,149 @@ def logger_cls(request):
     return request.param
 
 
-def test_log_example_roundtrip(client, logger_cls):
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    ev.log_example(
-        inputs={"q": "x"},
-        output="y",
-        scores={"correct": 1.0, "fluent": 0.8},
+def test_full_evaluation_flow_with_log_example(client, logger_cls):
+    """End-to-end eval: multiple predictions via log_example, mixed scorer
+    forms (string / dict / Scorer subclass), ``None`` score, eval attributes,
+    auto-summarize.
+    """
+
+    class MyScorer(Scorer):
+        name: str = "my_scorer"
+
+    ev = logger_cls(
+        model="m",
+        dataset=[{"q": "a"}, {"q": "b"}],
+        eval_attributes={"environment": "test", "custom_attribute": "hello"},
     )
-    ev.log_summary()
 
-    pred = ev._accumulated_predictions[0]
-    assert pred._captured_scores == {"correct": 1.0, "fluent": 0.8}
-    assert pred._has_finished
+    # Two log_example calls covering the all-in-one convenience path, mixed
+    # scorer types, and a None score ("N/A" in practice).
+    ev.log_example(
+        inputs={"q": "a"},
+        output="A",
+        scores={"string_scorer": 1.0, "maybe_scorer": None},
+    )
+    ev.log_example(
+        inputs={"q": "b"},
+        output="B",
+        scores={"string_scorer": 0.5, "maybe_scorer": 0.8},
+    )
 
-
-def test_log_example_multiple_examples(client, logger_cls):
-    ev = logger_cls(model="m", dataset=[{"q": "a"}, {"q": "b"}])
-    ev.log_example(inputs={"q": "a"}, output="A", scores={"s": 1.0})
-    ev.log_example(inputs={"q": "b"}, output="B", scores={"s": 0.5})
-    ev.log_summary()
-
-    assert len(ev._accumulated_predictions) == 2
-    assert ev._accumulated_predictions[0]._captured_scores == {"s": 1.0}
-    assert ev._accumulated_predictions[1]._captured_scores == {"s": 0.5}
-
-
-def test_log_example_after_finalization_raises(client, logger_cls):
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    ev.log_example(inputs={"q": "x"}, output="y", scores={"s": 1.0})
-    ev.log_summary()
-    with pytest.raises(ValueError, match="finalized"):
-        ev.log_example(inputs={"q": "z"}, output="w", scores={"s": 0.0})
-
-
-def test_none_as_valid_score_value(client, logger_cls):
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
-    pred.log_score("maybe_scorer", None)
+    # One prediction constructed imperatively that exercises dict- and
+    # class-based scorer inputs, plus the default auto_summarize=True path.
+    pred = ev.log_prediction(inputs={"q": "c"}, output="C")
+    pred.log_score({"name": "dict_scorer"}, 0.5)
+    pred.log_score(MyScorer(), 0.25)
     pred.finish()
-    ev.log_summary()
-    assert pred._captured_scores == {"maybe_scorer": None}
+
+    ev.log_summary(summary={"user_key": 42})
+
+    assert ev._is_finalized
+    assert ev.attributes.get("custom_attribute") == "hello"
+
+    assert len(ev._accumulated_predictions) == 3
+    p1, p2, p3 = ev._accumulated_predictions
+    assert p1._captured_scores == {"string_scorer": 1.0, "maybe_scorer": None}
+    assert p2._captured_scores == {"string_scorer": 0.5, "maybe_scorer": 0.8}
+    assert p3._captured_scores == {"dict_scorer": 0.5, "my_scorer": 0.25}
+    assert all(p._has_finished for p in ev._accumulated_predictions)
 
 
-def test_passing_dict_scorer_without_name_raises(client, logger_cls):
+def test_streaming_prediction_with_context_managers(client, logger_cls):
+    """Dynamic user flow: output assigned inside the prediction context,
+    scores both direct and deferred (``with pred.log_score(...) as s:``),
+    plus an async score.
+    """
     ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
-    with pytest.raises(ValueError, match="name"):
-        pred.log_score({"not_name": "x"}, 1.0)
 
-
-def test_log_prediction_context_manager_sets_output(client, logger_cls):
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
     with ev.log_prediction(inputs={"q": "x"}) as pred:
         pred.output = "dynamic_output"
-        pred.log_score("s", 0.9)
+        pred.log_score("direct", 0.9)
+        with pred.log_score("deferred") as score_ctx:
+            score_ctx.value = 0.75
+        # Mix in an explicitly None score to lock that in end-to-end.
+        pred.log_score("na", None)
+
+    # An async score on a fresh prediction — log_prediction's context manager
+    # is the "happy" finalize path; this exercises `alog_score` separately.
+    async def _async_score() -> None:
+        p = ev.log_prediction(inputs={"q": "y"}, output="Y")
+        await p.alog_score("async_s", 0.33)
+        p.finish()
+
+    asyncio.run(_async_score())
     ev.log_summary()
 
-    assert pred._has_finished
-    assert pred._captured_scores == {"s": 0.9}
+    first, second = ev._accumulated_predictions
+    assert first._has_finished
+    assert first._captured_scores == {
+        "direct": 0.9,
+        "deferred": 0.75,
+        "na": None,
+    }
+    assert second._captured_scores == {"async_s": 0.33}
+    assert ev._is_finalized
 
 
-def test_log_score_context_manager_submits_value(client, logger_cls):
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
-    with pred.log_score("reasoning") as score_ctx:
-        score_ctx.value = 0.75
-    pred.finish()
-    ev.log_summary()
-
-    assert pred._captured_scores == {"reasoning": 0.75}
-
-
-def test_log_score_context_manager_without_value_raises(client, logger_cls):
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
-    with pytest.raises(ValueError, match="Score value was not set"):
-        with pred.log_score("reasoning"):
-            pass
-    pred.finish()
-    ev.log_summary()
-
-
-def test_predefined_scorer_warning_on_ad_hoc_use(client, logger_cls, caplog):
+def test_validation_and_error_paths(client, logger_cls, caplog):
+    """Error-path contract: dict-scorer-missing-name raises, unset deferred
+    score value raises, log_example-after-finalization raises, and using an
+    ad-hoc scorer outside the predefined list logs a warning.
+    """
     ev = logger_cls(
         model="m",
         dataset=[{"q": "x"}],
         scorers=["expected_scorer"],
     )
     pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+
+    with pytest.raises(ValueError, match="name"):
+        pred.log_score({"not_name": "x"}, 1.0)
+
+    with pytest.raises(ValueError, match="Score value was not set"):
+        with pred.log_score("expected_scorer"):
+            pass  # user forgot to assign score_ctx.value
+
     with caplog.at_level("WARNING"):
         pred.log_score("unexpected_scorer", 0.5)
-    pred.finish()
-    ev.log_summary()
-
-    # Both V1 and V2 log a WARNING when a scorer outside the predefined list
-    # is used.
     assert any(
         "unexpected_scorer" in r.message and "predefined" in r.message
         for r in caplog.records
     )
 
-
-def test_custom_eval_attributes_accepted(client, logger_cls):
-    # Accepting `eval_attributes=` without raising is part of the contract.
-    # V1 stores them on the evaluate call's attributes; V2 stores them via
-    # EvaluationCreateReq.eval_attributes. The observable contract here is
-    # simply that construction + a full flow succeed.
-    ev = logger_cls(
-        model="m",
-        dataset=[{"q": "x"}],
-        eval_attributes={"environment": "test", "custom_attribute": "hello"},
-    )
-    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
-    pred.log_score("s", 1.0)
-    pred.finish()
-    ev.log_summary()
-    assert ev.attributes.get("custom_attribute") == "hello"
-
-
-def test_scorers_accept_string_dict_and_instance(client, logger_cls):
-    class MyScorer(Scorer):
-        name: str = "my_scorer"
-
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
-    pred.log_score("string_scorer", 1.0)
-    pred.log_score({"name": "dict_scorer"}, 0.5)
-    pred.log_score(MyScorer(), 0.25)
     pred.finish()
     ev.log_summary()
 
-    assert set(pred._captured_scores.keys()) == {
-        "string_scorer",
-        "dict_scorer",
-        "my_scorer",
-    }
+    with pytest.raises(ValueError, match="finalized"):
+        ev.log_example(inputs={"q": "z"}, output="w", scores={"s": 0.0})
 
 
-def test_log_summary_no_auto_summarize(client, logger_cls):
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
-    pred.log_score("s", 1.0)
-    pred.finish()
-    ev.log_summary(summary={"user_key": 42}, auto_summarize=False)
-
-    # Contract: the evaluation is finalized and doesn't raise.
-    assert ev._is_finalized
-
-
-def test_weave_disabled_captures_scores_without_failing(
+def test_logger_survives_disabled_failure_and_double_finish(
     client, logger_cls, monkeypatch
 ):
+    """Robustness contract: the logger is a no-op but still captures scores
+    locally when ``WEAVE_DISABLED=true``; ``fail(exception)`` finalizes; and
+    a second ``finish()`` is a silent no-op (not an error).
+    """
+    # Disabled-mode logger: scores still captured client-side, no raise.
     monkeypatch.setenv("WEAVE_DISABLED", "true")
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    disabled = logger_cls(model="m", dataset=[{"q": "x"}])
+    pred = disabled.log_prediction(inputs={"q": "x"}, output="y")
     pred.log_score("s", 0.5)
     pred.finish()
-    ev.log_summary()
-
-    # Contract: the logger tolerates disabled tracing, keeps user-visible
-    # state internally, and does not raise.
+    disabled.log_summary(summary={"k": 1}, auto_summarize=False)
     assert pred._captured_scores == {"s": 0.5}
+    assert disabled._is_finalized
+    monkeypatch.delenv("WEAVE_DISABLED")
 
+    # fail(exception) finalizes the run without raising.
+    failed = logger_cls(model="m", dataset=[{"q": "x"}])
+    failed.log_prediction(inputs={"q": "x"}, output="y")
+    failed.fail(RuntimeError("synthetic failure"))
+    assert failed._is_finalized
 
-def test_fail_finalizes_without_raising(client, logger_cls):
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    ev.log_prediction(inputs={"q": "x"}, output="y")
-    ev.fail(RuntimeError("synthetic failure"))
-    assert ev._is_finalized
-
-
-def test_finish_without_predictions_is_idempotent(client, logger_cls):
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    ev.finish()
-    ev.finish()  # Second finish should no-op, not raise.
-    assert ev._is_finalized
-
-
-def test_async_alog_score(client, logger_cls):
-    async def run() -> None:
-        ev = logger_cls(model="m", dataset=[{"q": "x"}])
-        pred = ev.log_prediction(inputs={"q": "x"}, output="y")
-        await pred.alog_score("async_s", 0.33)
-        pred.finish()
-        ev.log_summary()
-        assert pred._captured_scores == {"async_s": 0.33}
-
-    asyncio.run(run())
+    # Calling finish() twice is safe: the second call is a no-op.
+    idempotent = logger_cls(model="m", dataset=[{"q": "x"}])
+    idempotent.finish()
+    idempotent.finish()
+    assert idempotent._is_finalized

--- a/tests/flow/test_evaluation_imperative_contract.py
+++ b/tests/flow/test_evaluation_imperative_contract.py
@@ -16,10 +16,6 @@ from __future__ import annotations
 
 import pytest
 
-from weave.evaluation._imperative_shared import (
-    EvaluationLoggerProtocol,
-    ScoreLoggerProtocol,
-)
 from weave.evaluation.eval_imperative import EvaluationLogger
 from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
 
@@ -27,44 +23,6 @@ from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
 @pytest.fixture(params=[EvaluationLogger, EvaluationLoggerV2], ids=["v1", "v2"])
 def logger_cls(request):
     return request.param
-
-
-def test_logger_and_score_logger_match_protocol_at_runtime(client, logger_cls):
-    # Both V1 and V2 should expose the shared `EvaluationLoggerProtocol` and
-    # `ScoreLoggerProtocol` public APIs. This is a loose structural check —
-    # mypy catches mismatches at type-check time, this catches them at
-    # runtime as a safety net against drift.
-    ev = logger_cls(model="m", dataset=[{"q": "x"}])
-    for member in EvaluationLoggerProtocol.__annotations__.keys() | {
-        "log_prediction",
-        "log_example",
-        "log_summary",
-        "set_view",
-        "finish",
-        "fail",
-        "ui_url",
-        "attributes",
-    }:
-        assert hasattr(ev, member), f"{logger_cls.__name__} is missing {member}"
-
-    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
-    for member in {"output", "log_score", "alog_score", "finish"}:
-        assert hasattr(pred, member), (
-            f"{pred.__class__.__name__} is missing {member}"
-        )
-    pred.finish()
-    ev.log_summary()
-
-    # Sanity: the Protocols are importable as public names and annotations
-    # referencing them don't explode.
-    def _takes_logger(lg: EvaluationLoggerProtocol) -> None:
-        _ = lg.ui_url
-
-    def _takes_score_logger(sl: ScoreLoggerProtocol) -> None:
-        _ = sl.output
-
-    _takes_logger(ev)
-    _takes_score_logger(pred)
 
 
 def test_log_example_roundtrip(client, logger_cls):

--- a/tests/flow/test_evaluation_imperative_contract.py
+++ b/tests/flow/test_evaluation_imperative_contract.py
@@ -16,6 +16,10 @@ from __future__ import annotations
 
 import pytest
 
+from weave.evaluation._imperative_shared import (
+    EvaluationLoggerProtocol,
+    ScoreLoggerProtocol,
+)
 from weave.evaluation.eval_imperative import EvaluationLogger
 from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
 
@@ -23,6 +27,44 @@ from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
 @pytest.fixture(params=[EvaluationLogger, EvaluationLoggerV2], ids=["v1", "v2"])
 def logger_cls(request):
     return request.param
+
+
+def test_logger_and_score_logger_match_protocol_at_runtime(client, logger_cls):
+    # Both V1 and V2 should expose the shared `EvaluationLoggerProtocol` and
+    # `ScoreLoggerProtocol` public APIs. This is a loose structural check —
+    # mypy catches mismatches at type-check time, this catches them at
+    # runtime as a safety net against drift.
+    ev = logger_cls(model="m", dataset=[{"q": "x"}])
+    for member in EvaluationLoggerProtocol.__annotations__.keys() | {
+        "log_prediction",
+        "log_example",
+        "log_summary",
+        "set_view",
+        "finish",
+        "fail",
+        "ui_url",
+        "attributes",
+    }:
+        assert hasattr(ev, member), f"{logger_cls.__name__} is missing {member}"
+
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    for member in {"output", "log_score", "alog_score", "finish"}:
+        assert hasattr(pred, member), (
+            f"{pred.__class__.__name__} is missing {member}"
+        )
+    pred.finish()
+    ev.log_summary()
+
+    # Sanity: the Protocols are importable as public names and annotations
+    # referencing them don't explode.
+    def _takes_logger(lg: EvaluationLoggerProtocol) -> None:
+        _ = lg.ui_url
+
+    def _takes_score_logger(sl: ScoreLoggerProtocol) -> None:
+        _ = sl.output
+
+    _takes_logger(ev)
+    _takes_score_logger(pred)
 
 
 def test_log_example_roundtrip(client, logger_cls):

--- a/tests/flow/test_evaluation_imperative_v2.py
+++ b/tests/flow/test_evaluation_imperative_v2.py
@@ -11,6 +11,8 @@ import asyncio
 
 import pytest
 
+import weave
+from weave.evaluation.eval_imperative import EvaluationLogger as EvaluationLoggerV1
 from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
 from weave.trace_server import trace_server_interface as tsi
 
@@ -220,6 +222,33 @@ def test_log_score_context_manager_without_value_raises(client):
             pass
     pred.finish()
     ev.log_summary()
+
+
+def test_factory_defaults_to_v1(client):
+    # `weave.EvaluationLogger` is the factory; without opting in, it must
+    # keep returning V1 so existing users don't see a behavior change.
+    ev = weave.EvaluationLogger(model="m", dataset=[{"q": "x"}])
+    assert isinstance(ev, EvaluationLoggerV1)
+    ev.finish()
+
+
+def test_factory_dispatches_to_v2_via_env(client, monkeypatch):
+    monkeypatch.setenv("WEAVE_USE_EVALUATION_LOGGER_V2", "true")
+    ev = weave.EvaluationLogger(model="m", dataset=[{"q": "x"}])
+    assert isinstance(ev, EvaluationLoggerV2)
+    ev.finish()
+
+
+def test_factory_dispatches_to_v2_via_settings(client):
+    from weave.trace.settings import UserSettings, parse_and_apply_settings
+
+    parse_and_apply_settings(UserSettings(use_evaluation_logger_v2=True))
+    try:
+        ev = weave.EvaluationLogger(model="m", dataset=[{"q": "x"}])
+        assert isinstance(ev, EvaluationLoggerV2)
+        ev.finish()
+    finally:
+        parse_and_apply_settings(UserSettings())
 
 
 def test_ui_url_format(client):

--- a/tests/flow/test_evaluation_imperative_v2.py
+++ b/tests/flow/test_evaluation_imperative_v2.py
@@ -7,6 +7,8 @@ behavior is exercised in ``test_evaluation_imperative_contract.py``.
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
@@ -220,6 +222,28 @@ def test_log_score_context_manager_without_value_raises(client):
     ev.log_summary()
 
 
+def test_ui_url_format(client):
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+    assert ev.ui_url is None  # not initialized yet (lazy init)
+
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    pred.log_score("s", 1.0)  # forces lazy init + evaluation_run_id allocation
+    url = ev.ui_url
+    assert url is not None
+    # Format: <host>/<entity>/<project>/r/call/<evaluation_run_id>
+    assert url.endswith(f"/r/call/{ev._evaluation_run_id}")
+    assert f"/{ev._entity}/{ev._project}/" in url
+    pred.finish()
+    ev.log_summary()
+
+
+def test_ui_url_none_when_disabled(monkeypatch):
+    monkeypatch.setenv("WEAVE_DISABLED", "true")
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+    assert ev.ui_url is None
+    ev.finish()
+
+
 def test_set_view_not_implemented():
     ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
     with pytest.raises(NotImplementedError, match="set_view"):
@@ -282,8 +306,6 @@ def test_weave_disabled_captures_scores_without_server_calls(monkeypatch):
 
 
 def test_alog_score_async(client):
-    import asyncio
-
     async def run() -> None:
         ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
         pred = ev.log_prediction(inputs={"q": "x"}, output="y")

--- a/tests/flow/test_evaluation_imperative_v2.py
+++ b/tests/flow/test_evaluation_imperative_v2.py
@@ -1,0 +1,297 @@
+"""Tests for EvaluationLoggerV2 that assert on the V2 server object model.
+
+These tests are V2-specific: they inspect the V2 endpoints (evaluation_run_read,
+prediction_read, score_read) rather than V1's call graph. Cross-logger contract
+behavior is exercised in ``test_evaluation_imperative_contract.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
+from weave.trace_server import trace_server_interface as tsi
+
+
+def _predictions_for_run(client, run_id: str) -> list[tsi.PredictionReadRes]:
+    return list(
+        client.server.prediction_list(
+            tsi.PredictionListReq(
+                project_id=client.project_id,
+                evaluation_run_id=run_id,
+            )
+        )
+    )
+
+
+def _scores_for_run(client, run_id: str) -> list[tsi.ScoreReadRes]:
+    return list(
+        client.server.score_list(
+            tsi.ScoreListReq(
+                project_id=client.project_id,
+                evaluation_run_id=run_id,
+            )
+        )
+    )
+
+
+def test_basic_v2_flow_round_trips_through_server(client):
+    ev = EvaluationLoggerV2(
+        name="basic_v2",
+        model="my_model",
+        dataset=[{"q": "hi"}],
+        scorers=["correctness"],
+    )
+    pred = ev.log_prediction(inputs={"q": "hi"}, output="there")
+    pred.log_score("correctness", 0.9)
+    pred.finish()
+    ev.log_summary({"avg": 0.9})
+
+    assert ev._evaluation_run_id is not None
+
+    run_id = ev._evaluation_run_id
+    run = client.server.evaluation_run_read(
+        tsi.EvaluationRunReadReq(
+            project_id=client.project_id,
+            evaluation_run_id=run_id,
+        )
+    )
+    assert run.status != "error"
+    assert run.summary is not None
+    assert run.summary.get("output") == {"avg": 0.9}
+
+    predictions = _predictions_for_run(client, run_id)
+    assert len(predictions) == 1
+    assert predictions[0].inputs == {"q": "hi"}
+    assert predictions[0].output == "there"
+
+    scores = _scores_for_run(client, run_id)
+    assert len(scores) == 1
+    assert scores[0].value == 0.9
+
+
+def test_lazy_init_no_predictions_still_produces_run(client):
+    ev = EvaluationLoggerV2(model="lazy_model", dataset=[{"x": 1}])
+    ev.log_summary()
+
+    assert ev._evaluation_run_id is not None
+    run = client.server.evaluation_run_read(
+        tsi.EvaluationRunReadReq(
+            project_id=client.project_id,
+            evaluation_run_id=ev._evaluation_run_id,
+        )
+    )
+    assert run.status != "error"
+
+
+def test_deferred_output_is_updated_on_finish(client):
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "hi"}])
+    pred = ev.log_prediction(inputs={"q": "hi"})
+    pred.output = "first"
+    pred.log_score("s", 1.0)  # triggers prediction_create with output="first"
+    pred.output = "final"
+    pred.finish()
+    ev.log_summary()
+
+    predictions = _predictions_for_run(client, ev._evaluation_run_id)
+    assert len(predictions) == 1
+    assert predictions[0].output == "final"
+
+
+def test_finish_with_explicit_output_overrides_buffer(client):
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "hi"}])
+    pred = ev.log_prediction(inputs={"q": "hi"}, output="initial")
+    pred.log_score("s", 1.0)
+    pred.finish(output="from-finish")
+    ev.log_summary()
+
+    predictions = _predictions_for_run(client, ev._evaluation_run_id)
+    assert predictions[0].output == "from-finish"
+
+
+def test_fail_marks_run_as_error(client):
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "hi"}])
+    ev.log_prediction(inputs={"q": "hi"}, output="x")
+    ev.fail(RuntimeError("boom"))
+
+    run = client.server.evaluation_run_read(
+        tsi.EvaluationRunReadReq(
+            project_id=client.project_id,
+            evaluation_run_id=ev._evaluation_run_id,
+        )
+    )
+    # Server uses "error" or "failed" depending on backend naming — both
+    # indicate a failed run.
+    assert run.status in {"error", "failed"}
+
+
+def test_score_value_types_round_trip(client):
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    pred.log_score("as_float", 0.42)
+    pred.log_score("as_bool", True)
+    pred.log_score("as_dict", {"value": 1.0, "reason": "ok"})
+    pred.log_score("as_none", None)
+    pred.finish()
+    ev.log_summary()
+
+    scores = _scores_for_run(client, ev._evaluation_run_id)
+    by_name = {}
+    for s in scores:
+        # Scorer ref looks like weave:///entity/project/object/NAME:DIGEST.
+        scorer_name = s.scorer.rsplit("/", 1)[-1].split(":")[0]
+        by_name[scorer_name] = s.value
+    assert by_name == {
+        "as_float": 0.42,
+        "as_bool": True,
+        "as_dict": {"value": 1.0, "reason": "ok"},
+        "as_none": None,
+    }
+
+
+def test_ad_hoc_scorer_materializes_on_server(client):
+    ev = EvaluationLoggerV2(
+        model="m",
+        dataset=[{"q": "x"}],
+        scorers=["predeclared"],
+    )
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    pred.log_score("ad_hoc_scorer", 1.0)  # not in `scorers=[...]`
+    pred.finish()
+    ev.log_summary()
+
+    scorers = list(
+        client.server.scorer_list(tsi.ScorerListReq(project_id=client.project_id))
+    )
+    names = {s.name for s in scorers}
+    assert "predeclared" in names
+    assert "ad_hoc_scorer" in names
+
+
+def test_context_manager_finishes_on_exit(client):
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+    with ev.log_prediction(inputs={"q": "x"}) as pred:
+        pred.output = "y"
+        pred.log_score("s", 1.0)
+    ev.log_summary()
+
+    predictions = _predictions_for_run(client, ev._evaluation_run_id)
+    assert len(predictions) == 1
+    assert predictions[0].output == "y"
+
+
+def test_context_manager_propagates_exceptions(client):
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+
+    def _body() -> None:
+        with ev.log_prediction(inputs={"q": "x"}) as pred:
+            pred.output = "y"
+            raise RuntimeError("inside")
+
+    with pytest.raises(RuntimeError, match="inside"):
+        _body()
+
+    # Even with the exception, the prediction should have been finalized on exit.
+    ev.log_summary()
+    predictions = _predictions_for_run(client, ev._evaluation_run_id)
+    assert len(predictions) == 1
+
+
+def test_log_score_context_manager_submits_on_exit(client):
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    with pred.log_score("quality") as score_ctx:
+        score_ctx.value = 0.7
+    pred.finish()
+    ev.log_summary()
+
+    scores = _scores_for_run(client, ev._evaluation_run_id)
+    assert len(scores) == 1
+    assert scores[0].value == 0.7
+
+
+def test_log_score_context_manager_without_value_raises(client):
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    with pytest.raises(ValueError, match="Score value was not set"):
+        with pred.log_score("quality"):
+            pass
+    pred.finish()
+    ev.log_summary()
+
+
+def test_set_view_not_implemented():
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+    with pytest.raises(NotImplementedError, match="set_view"):
+        ev.set_view("report", "# hi", extension="md")
+    ev.finish()
+
+
+def test_log_example_after_finalization_raises(client):
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+    ev.log_example(inputs={"q": "x"}, output="y", scores={"s": 1.0})
+    ev.log_summary()
+    with pytest.raises(ValueError, match="finalized"):
+        ev.log_example(inputs={"q": "z"}, output="w", scores={"s": 0.0})
+
+
+def test_bare_string_model_scorer_dataset_round_trip(client):
+    ev = EvaluationLoggerV2(
+        model="string-named-model",
+        dataset="string-named-dataset",
+        scorers=["string-named-scorer"],
+    )
+    pred = ev.log_prediction(inputs={"x": 1}, output=2)
+    # `_cast_to_cls(Scorer)` sanitizes scorer names; pass the same string form
+    # and rely on the shared coercion so the log_score path resolves the same
+    # ref that was created up front.
+    pred.log_score("string-named-scorer", 1.0)
+    pred.finish()
+    ev.log_summary()
+
+    # Model, dataset, and scorer should all be readable by name.
+    models = list(
+        client.server.model_list(tsi.ModelListReq(project_id=client.project_id))
+    )
+    assert any(m.name == "stringnamedmodel" for m in models)
+
+    datasets = list(
+        client.server.dataset_list(tsi.DatasetListReq(project_id=client.project_id))
+    )
+    assert any(d.name == "string-named-dataset" for d in datasets)
+
+    scorers = list(
+        client.server.scorer_list(tsi.ScorerListReq(project_id=client.project_id))
+    )
+    # Scorers go through `_cast_to_cls(Scorer)` which sanitizes the name the
+    # same way V1 does (strip non-word characters).
+    assert any(s.name == "stringnamedscorer" for s in scorers)
+
+
+def test_weave_disabled_captures_scores_without_server_calls(monkeypatch):
+    monkeypatch.setenv("WEAVE_DISABLED", "true")
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+    pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+    pred.log_score("s", 0.5)
+    pred.finish()
+    ev.log_summary()
+
+    assert ev._disabled is True
+    assert ev._evaluation_run_id is None
+    assert pred._captured_scores == {"s": 0.5}
+
+
+def test_alog_score_async(client):
+    import asyncio
+
+    async def run() -> None:
+        ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+        pred = ev.log_prediction(inputs={"q": "x"}, output="y")
+        await pred.alog_score("async_scorer", 0.75)
+        pred.finish()
+        ev.log_summary()
+        scores = _scores_for_run(client, ev._evaluation_run_id)
+        assert len(scores) == 1
+        assert scores[0].value == 0.75
+
+    asyncio.run(run())

--- a/tests/flow/test_evaluation_imperative_v2.py
+++ b/tests/flow/test_evaluation_imperative_v2.py
@@ -251,6 +251,66 @@ def test_factory_dispatches_to_v2_via_settings(client):
         parse_and_apply_settings(UserSettings())
 
 
+def test_log_calls_are_non_blocking(client, monkeypatch):
+    """User-facing log_prediction/log_score/finish enqueue work on the
+    background executor and return before the server round-trips complete.
+    """
+    import time
+
+    from weave.evaluation import eval_imperative_v2
+
+    real_server_module = eval_imperative_v2.tsi
+
+    class _SlowServer:
+        """Wrap the real server and inject a delay into each V2 write so
+        we can prove the wall-clock cost is paid in the background, not in
+        the user's call.
+        """
+
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __getattr__(self, name):
+            attr = getattr(self._inner, name)
+            if name in {
+                "prediction_create",
+                "prediction_finish",
+                "score_create",
+            }:
+
+                def slow(*args, **kwargs):
+                    time.sleep(0.05)
+                    return attr(*args, **kwargs)
+
+                return slow
+            return attr
+
+    ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
+    # Swap in the slow shim after construction so `_ensure_initialized`
+    # (the one-time sync setup) stays fast; only per-prediction writes pay
+    # the 50ms tax.
+    ev._ensure_initialized()
+    assert ev._server is not None
+    ev._server = _SlowServer(ev._server)  # type: ignore[assignment]
+
+    # Six scores × 50ms would be ~300ms if each call blocked the user.
+    t0 = time.perf_counter()
+    for i in range(3):
+        pred = ev.log_prediction(inputs={"i": i}, output=i)
+        pred.log_score("s1", 1.0)
+        pred.log_score("s2", 0.5)
+        pred.finish()
+    user_code_elapsed = time.perf_counter() - t0
+
+    assert user_code_elapsed < 0.15, (
+        f"log_* calls should enqueue in the background; "
+        f"user-visible elapsed was {user_code_elapsed:.3f}s"
+    )
+
+    ev.log_summary()
+    assert real_server_module is not None  # keep import alive
+
+
 def test_ui_url_format(client):
     ev = EvaluationLoggerV2(model="m", dataset=[{"q": "x"}])
     assert ev.ui_url is None  # not initialized yet (lazy init)

--- a/tests/trace/test_trace_server_v2_api.py
+++ b/tests/trace/test_trace_server_v2_api.py
@@ -1223,6 +1223,16 @@ class ReadPredictionModel(weave.Model):
         )
         pred_res = client.server.prediction_create(pred_req)
 
+        # Finish the prediction — `prediction_create` no longer writes the
+        # output on its own. The final output is owned by `prediction_finish`.
+        client.server.prediction_finish(
+            tsi.PredictionFinishReq(
+                project_id=project_id,
+                prediction_id=pred_res.prediction_id,
+                output="4",
+            )
+        )
+
         # Read the prediction
         read_req = tsi.PredictionReadReq(
             project_id=project_id,
@@ -1316,6 +1326,15 @@ class ListPredictionModel(weave.Model):
                 output=f"result_{i}",
             )
             pred_res = client.server.prediction_create(pred_req)
+            # `prediction_create` no longer writes the output; the final output
+            # is owned by `prediction_finish` (single-write contract).
+            client.server.prediction_finish(
+                tsi.PredictionFinishReq(
+                    project_id=project_id,
+                    prediction_id=pred_res.prediction_id,
+                    output=f"result_{i}",
+                )
+            )
             pred_ids.append(pred_res.prediction_id)
 
         # List predictions
@@ -1433,10 +1452,12 @@ class PredEvalRunModel(weave.Model):
 
         assert read_res.evaluation_run_id == run_res.evaluation_run_id
 
-        # Finish the prediction (which should end the predict_and_score call with model_latency)
+        # Finish the prediction (which should end the predict_and_score call with model_latency).
+        # `prediction_create` no longer writes the output, so we pass it here.
         finish_req = tsi.PredictionFinishReq(
             project_id=project_id,
             prediction_id=pred_res.prediction_id,
+            output="result",
         )
         finish_res = client.server.prediction_finish(finish_req)
         assert finish_res.success is True

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -51,6 +51,10 @@ from weave.agent.agent import Agent as Agent
 from weave.agent.agent import AgentState as AgentState
 from weave.dataset.dataset import Dataset
 from weave.evaluation.eval import Evaluation
+from weave.evaluation._imperative_shared import (
+    EvaluationLoggerProtocol,
+    ScoreLoggerProtocol,
+)
 from weave.evaluation.eval_imperative import EvaluationLogger
 from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
 from weave.flow.annotation_spec import AnnotationSpec
@@ -82,6 +86,7 @@ __all__ = [
     "EasyPrompt",
     "Evaluation",
     "EvaluationLogger",
+    "EvaluationLoggerProtocol",
     "EvaluationLoggerV2",
     "File",
     "Markdown",
@@ -93,6 +98,7 @@ __all__ = [
     "Prompt",
     "SavedView",
     "Scorer",
+    "ScoreLoggerProtocol",
     "StringPrompt",
     "Table",
     "ThreadContext",

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -55,8 +55,9 @@ from weave.evaluation._imperative_shared import (
     ScoreLoggerProtocol,
 )
 from weave.evaluation.eval import Evaluation
-from weave.evaluation.eval_imperative import EvaluationLogger
+from weave.evaluation.eval_imperative import EvaluationLogger as EvaluationLoggerV1
 from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
+from weave.evaluation.eval_logger import EvaluationLogger
 from weave.flow.annotation_spec import AnnotationSpec
 from weave.flow.model import Model
 from weave.flow.monitor import ClassifierMonitor, Monitor
@@ -87,6 +88,7 @@ __all__ = [
     "Evaluation",
     "EvaluationLogger",
     "EvaluationLoggerProtocol",
+    "EvaluationLoggerV1",
     "EvaluationLoggerV2",
     "File",
     "Markdown",

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -50,11 +50,11 @@ wandb_init_hook()
 from weave.agent.agent import Agent as Agent
 from weave.agent.agent import AgentState as AgentState
 from weave.dataset.dataset import Dataset
-from weave.evaluation.eval import Evaluation
 from weave.evaluation._imperative_shared import (
     EvaluationLoggerProtocol,
     ScoreLoggerProtocol,
 )
+from weave.evaluation.eval import Evaluation
 from weave.evaluation.eval_imperative import EvaluationLogger
 from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
 from weave.flow.annotation_spec import AnnotationSpec
@@ -97,8 +97,8 @@ __all__ = [
     "ObjectRef",
     "Prompt",
     "SavedView",
-    "Scorer",
     "ScoreLoggerProtocol",
+    "Scorer",
     "StringPrompt",
     "Table",
     "ThreadContext",

--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -52,6 +52,7 @@ from weave.agent.agent import AgentState as AgentState
 from weave.dataset.dataset import Dataset
 from weave.evaluation.eval import Evaluation
 from weave.evaluation.eval_imperative import EvaluationLogger
+from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
 from weave.flow.annotation_spec import AnnotationSpec
 from weave.flow.model import Model
 from weave.flow.monitor import ClassifierMonitor, Monitor
@@ -81,6 +82,7 @@ __all__ = [
     "EasyPrompt",
     "Evaluation",
     "EvaluationLogger",
+    "EvaluationLoggerV2",
     "File",
     "Markdown",
     "MessagesPrompt",

--- a/weave/evaluation/_imperative_shared.py
+++ b/weave/evaluation/_imperative_shared.py
@@ -6,9 +6,12 @@ import json
 import keyword
 import logging
 import re
+import types
 from collections.abc import Callable
 from threading import Lock
-from typing import Any, TypeVar, cast
+from typing import Any, Protocol, TypeVar, cast, overload
+
+from typing_extensions import Self
 
 from weave.dataset.dataset import Dataset
 from weave.flow.scorer import Scorer
@@ -28,6 +31,100 @@ VALID_CLASS_NAME_REGEX = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
 
 IMPERATIVE_EVAL_MARKER = {"_weave_eval_meta": {"imperative": True}}
 IMPERATIVE_SCORE_MARKER = {"_weave_eval_meta": {"imperative": True, "score": True}}
+
+
+class ScoreLoggerProtocol(Protocol):
+    """Public interface of per-prediction score loggers.
+
+    Both V1 (`weave.evaluation.eval_imperative.ScoreLogger`) and V2
+    (`weave.evaluation.eval_imperative_v2.ScoreLoggerV2`) conform to this
+    Protocol. Users typing code against this Protocol (rather than either
+    concrete class) will work unchanged across both implementations.
+    """
+
+    output: Any
+
+    @overload
+    def log_score(
+        self,
+        scorer: Scorer | dict | str,
+        score: ScoreType | None,
+    ) -> None: ...
+
+    @overload
+    def log_score(self, scorer: Scorer | dict | str) -> Any: ...
+
+    def log_score(
+        self,
+        scorer: Scorer | dict | str,
+        score: Any = ...,
+    ) -> Any: ...
+
+    async def alog_score(
+        self,
+        scorer: Scorer | dict | str,
+        score: ScoreType | None,
+    ) -> None: ...
+
+    def finish(self, output: Any | None = None) -> None: ...
+
+    def __enter__(self) -> Self: ...
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None: ...
+
+
+class EvaluationLoggerProtocol(Protocol):
+    """Public interface of imperative evaluation loggers.
+
+    Both V1 (`weave.EvaluationLogger`) and V2 (`weave.EvaluationLoggerV2`)
+    conform to this Protocol. Code that programs against the Protocol
+    rather than a concrete class is portable across implementations.
+    """
+
+    @property
+    def ui_url(self) -> str | None: ...
+
+    @property
+    def attributes(self) -> dict[str, Any]: ...
+
+    def log_prediction(
+        self,
+        inputs: dict[str, Any],
+        output: Any = None,
+    ) -> ScoreLoggerProtocol: ...
+
+    def log_example(
+        self,
+        inputs: dict[str, Any],
+        output: Any,
+        scores: dict[str, ScoreType | None],
+    ) -> None: ...
+
+    def log_summary(
+        self,
+        summary: dict | None = None,
+        auto_summarize: bool = True,
+    ) -> None: ...
+
+    def set_view(
+        self,
+        name: str,
+        content: Any,
+        *,
+        extension: str | None = None,
+        mimetype: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        encoding: str = "utf-8",
+    ) -> None: ...
+
+    def finish(self, exception: BaseException | None = None) -> None: ...
+
+    def fail(self, exception: BaseException) -> None: ...
 
 
 # Accepts any logger duck-typed with `_is_finalized: bool` and `.finish()`.

--- a/weave/evaluation/_imperative_shared.py
+++ b/weave/evaluation/_imperative_shared.py
@@ -127,9 +127,10 @@ class EvaluationLoggerProtocol(Protocol):
     def fail(self, exception: BaseException) -> None: ...
 
 
-# Accepts any logger duck-typed with `_is_finalized: bool` and `.finish()`.
-# V1 (EvaluationLogger) and V2 (EvaluationLoggerV2) both satisfy this.
-_active_evaluation_loggers: list[Any] = []
+# Registry of unfinalized loggers for atexit cleanup. V1's EvaluationLogger
+# and V2's EvaluationLoggerV2 both satisfy the public protocol; `finish()`
+# is idempotent on both, so the cleanup path can simply invoke it.
+_active_evaluation_loggers: list[EvaluationLoggerProtocol] = []
 
 
 def _cleanup_all_evaluations() -> None:
@@ -137,10 +138,9 @@ def _cleanup_all_evaluations() -> None:
         _cleanup_evaluation(eval_logger)
 
 
-def _cleanup_evaluation(eval_logger: Any) -> None:
+def _cleanup_evaluation(eval_logger: EvaluationLoggerProtocol) -> None:
     try:
-        if not eval_logger._is_finalized:
-            eval_logger.finish()
+        eval_logger.finish()
     except Exception:
         logger.exception("Error during cleanup of evaluation logger")
 

--- a/weave/evaluation/_imperative_shared.py
+++ b/weave/evaluation/_imperative_shared.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import atexit
+import datetime
+import json
+import keyword
+import logging
+import re
+from collections.abc import Callable
+from threading import Lock
+from typing import Any, TypeVar, cast
+
+from weave.dataset.dataset import Dataset
+from weave.flow.scorer import Scorer
+from weave.flow.util import make_memorable_name
+from weave.object.obj import Object
+from weave.trace.table import Table
+
+DEFAULT_SCORER_CACHE_SIZE = 1000
+
+T = TypeVar("T")
+ID = str
+ScoreType = float | bool | dict
+
+logger = logging.getLogger(__name__)
+
+VALID_CLASS_NAME_REGEX = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+IMPERATIVE_EVAL_MARKER = {"_weave_eval_meta": {"imperative": True}}
+IMPERATIVE_SCORE_MARKER = {"_weave_eval_meta": {"imperative": True, "score": True}}
+
+
+# Accepts any logger duck-typed with `_is_finalized: bool` and `.finish()`.
+# V1 (EvaluationLogger) and V2 (EvaluationLoggerV2) both satisfy this.
+_active_evaluation_loggers: list[Any] = []
+
+
+def _cleanup_all_evaluations() -> None:
+    for eval_logger in _active_evaluation_loggers:
+        _cleanup_evaluation(eval_logger)
+
+
+def _cleanup_evaluation(eval_logger: Any) -> None:
+    try:
+        if not eval_logger._is_finalized:
+            eval_logger.finish()
+    except Exception:
+        logger.exception("Error during cleanup of evaluation logger")
+
+
+atexit.register(_cleanup_all_evaluations)
+
+
+def _sanitize_class_name(name: str) -> str:
+    """Return a valid Python class name based on a string."""
+    class_name = re.sub(r"\W", "", name)
+    if class_name == "":
+        return "GeneratedClass"
+
+    first_char = class_name[0]
+    if not first_char.isalpha() and first_char != "_":
+        class_name = "C" + class_name
+
+    if keyword.iskeyword(class_name):
+        class_name += "Class"
+
+    return class_name
+
+
+def _validate_class_name(name: str, base_class_name: str = "Class") -> str:
+    if not name:
+        raise ValueError(f"{base_class_name} name cannot be empty")
+
+    if not VALID_CLASS_NAME_REGEX.match(name):
+        raise ValueError(
+            f"Invalid `{base_class_name}` name: '{name}'. `{base_class_name}` names must start with a letter or underscore "
+            "and contain only alphanumeric characters and underscores."
+        )
+
+    if keyword.iskeyword(name):
+        raise ValueError(
+            f"`{base_class_name}` name '{name}' cannot be a Python keyword"
+        )
+
+    return name
+
+
+def _cast_to_cls(type_: type[T]) -> Callable[[str | dict | T], T]:
+    def _convert_to_cls_inner(value: str | dict | T) -> T:
+        if isinstance(value, str):
+            cls_name = _sanitize_class_name(value)
+            cls_name = _validate_class_name(cls_name, type_.__name__)
+
+            pydantic_config_dict = {
+                "__annotations__": {"name": str},
+                "name": cls_name,
+            }
+
+            cls = type(cls_name, (type_,), pydantic_config_dict)
+            return cast(T, cls())
+
+        elif isinstance(value, dict):
+            attributes = value
+
+            if "name" not in attributes:
+                raise ValueError("Your dict must contain a `name` key.")
+
+            pydantic_config_dict = {
+                "__annotations__": dict.fromkeys(attributes, Any),
+                **attributes,
+            }
+            cls = type(attributes["name"], (type_,), pydantic_config_dict)
+            return cast(T, cls())
+
+        elif isinstance(value, type_):
+            instance = value
+            if isinstance(instance, Object) and not instance.name:
+                instance.name = instance.__class__.__name__
+            return instance
+
+        raise TypeError("Unsupported type for casting")
+
+    return _convert_to_cls_inner
+
+
+def _cast_to_imperative_dataset(value: Dataset | list[dict] | str) -> Dataset:
+    if isinstance(value, str):
+        return Dataset(name=value, rows=Table([{"dataset_id": value}]))
+    elif isinstance(value, list):
+        return Dataset(rows=Table(value))
+    elif isinstance(value, Dataset):
+        return value
+    else:
+        raise TypeError("Unsupported type for casting")
+
+
+def _default_dataset_name() -> str:
+    date = datetime.datetime.now().strftime("%Y-%m-%d")
+    unique_name = make_memorable_name()
+    return f"{date}-{unique_name}-dataset"
+
+
+class ScorerCache:
+    _cached_scorers: dict[str, Scorer]
+    _cached_scorers_lock: Any
+    _max_size: int
+
+    def __init__(self, max_size: int = DEFAULT_SCORER_CACHE_SIZE) -> None:
+        self._cached_scorers = {}
+        self._cached_scorers_lock = Lock()
+        self._max_size = max_size
+
+    def get_scorer(
+        self, scorer_id: str, default_factory: Callable[[], Scorer]
+    ) -> Scorer:
+        with self._cached_scorers_lock:
+            if scorer_id not in self._cached_scorers:
+                if len(self._cached_scorers) >= self._max_size:
+                    self._cached_scorers.popitem()
+                self._cached_scorers[scorer_id] = default_factory()
+        return self._cached_scorers[scorer_id]
+
+
+global_scorer_cache = ScorerCache()
+
+
+def scorer_to_cache_key(scorer: Scorer | dict | str) -> str:
+    return json.dumps(scorer)

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import json
 import logging
 import types
 from collections.abc import Iterator
@@ -24,6 +23,7 @@ from weave.evaluation._imperative_shared import (
     _cleanup_evaluation,
     _default_dataset_name,
     global_scorer_cache,
+    scorer_to_cache_key,
 )
 from weave.evaluation.eval import Evaluation, default_evaluation_display_name
 from weave.flow.model import MissingInferenceMethodError, Model
@@ -256,9 +256,9 @@ class ScoreLogger:
     def _prepare_scorer(self, scorer: Scorer | dict | str) -> Scorer:
         """Prepare and validate a scorer."""
         if not isinstance(scorer, Scorer):
-            scorer_id = json.dumps(scorer)
             scorer = global_scorer_cache.get_scorer(
-                scorer_id, lambda: _cast_to_cls(Scorer)(scorer)
+                scorer_to_cache_key(scorer),
+                lambda: _cast_to_cls(Scorer)(scorer),
             )
         scorer = cast(Scorer, scorer)
 

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -67,7 +67,7 @@ def _set_current_output(output: Any) -> Iterator[None]:
 
 
 @contextmanager
-def _set_current_score(score: ScoreType) -> Iterator[None]:
+def _set_current_score(score: ScoreType | None) -> Iterator[None]:
     token = current_score.set(score)
     try:
         yield
@@ -210,7 +210,7 @@ class ScoreLogger:
         self.predict_call = predict_call
         self.predefined_scorers = predefined_scorers
 
-        self._captured_scores: dict[str, ScoreType] = {}
+        self._captured_scores: dict[str, ScoreType | None] = {}
         self._has_finished: bool = False
         self._predict_output: Any = None
         self._call_stack_context: (
@@ -319,7 +319,7 @@ class ScoreLogger:
     def log_score(
         self,
         scorer: Scorer | dict | str,
-        score: ScoreType,
+        score: ScoreType | None,
     ) -> None: ...
 
     @overload
@@ -332,7 +332,7 @@ class ScoreLogger:
     def log_score(
         self,
         scorer: Scorer | dict | str,
-        score: ScoreType | _NotSetType = NOT_SET,
+        score: ScoreType | _NotSetType | None = NOT_SET,
     ) -> _LogScoreContext | None:
         """Log a score synchronously or return a context manager for deferred scoring.
 
@@ -356,9 +356,9 @@ class ScoreLogger:
             score_call, prepared_scorer = self._create_score_call(scorer)
             return _LogScoreContext(self, prepared_scorer, score_call)
 
-        # Type narrowing: score is now guaranteed to be ScoreType
+        # Type narrowing: score is now guaranteed to be ScoreType | None
         assert not isinstance(score, _NotSetType), "score should not be NOT_SET here"
-        score_value: ScoreType = score
+        score_value: ScoreType | None = score
 
         # Otherwise, log the score immediately
         # When in an active asyncio test environment (like pytest.mark.asyncio),
@@ -403,7 +403,7 @@ class ScoreLogger:
     async def alog_score(
         self,
         scorer: Scorer | dict | str,
-        score: ScoreType,
+        score: ScoreType | None,
     ) -> None:
         if self._has_finished:
             raise ValueError("Cannot log score after finish has been called")
@@ -731,7 +731,10 @@ class EvaluationLogger:
         return pred
 
     def log_example(
-        self, inputs: dict[str, Any], output: Any, scores: dict[str, ScoreType]
+        self,
+        inputs: dict[str, Any],
+        output: Any,
+        scores: dict[str, ScoreType | None],
     ) -> None:
         """Log a complete example with inputs, output, and scores.
 

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -1,30 +1,34 @@
 from __future__ import annotations
 
 import asyncio
-import atexit
 import contextlib
-import datetime
 import json
-import keyword
 import logging
-import re
 import types
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
-from threading import Lock
 from types import MethodType
-from typing import TYPE_CHECKING, Any, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Any, cast, overload
 
 from typing_extensions import Self
 
 from weave.dataset.dataset import Dataset
+from weave.evaluation._imperative_shared import (
+    IMPERATIVE_EVAL_MARKER,
+    IMPERATIVE_SCORE_MARKER,
+    ScoreType,
+    _active_evaluation_loggers,
+    _cast_to_cls,
+    _cast_to_imperative_dataset,
+    _cleanup_evaluation,
+    _default_dataset_name,
+    global_scorer_cache,
+)
 from weave.evaluation.eval import Evaluation, default_evaluation_display_name
 from weave.flow.model import MissingInferenceMethodError, Model
 from weave.flow.scorer import Scorer
 from weave.flow.scorer import auto_summarize as auto_summarize_fn
-from weave.flow.util import make_memorable_name
-from weave.object.obj import Object
 from weave.trace.api import attributes
 from weave.trace.call import Call
 from weave.trace.context import call_context
@@ -39,36 +43,7 @@ from weave.utils.sentinel import NOT_SET, _NotSetType
 if TYPE_CHECKING:
     from weave.trace.call import Call
 
-DEFAULT_SCORER_CACHE_SIZE = 1000
-
-T = TypeVar("T")
-ID = str
-ScoreType = float | bool | dict
-
 logger = logging.getLogger(__name__)
-
-# Class names should start with a letter or underscore and contain only alphanumeric characters and underscores
-VALID_CLASS_NAME_REGEX = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
-
-# Registry to track active EvaluationLogger instances
-_active_evaluation_loggers: list[EvaluationLogger] = []
-
-
-# Register cleanup handler for program exit
-def _cleanup_all_evaluations() -> None:
-    for eval_logger in _active_evaluation_loggers:
-        _cleanup_evaluation(eval_logger)
-
-
-def _cleanup_evaluation(eval_logger: EvaluationLogger) -> None:
-    try:
-        if not eval_logger._is_finalized:
-            eval_logger.finish()
-    except Exception:
-        logger.exception("Error during cleanup of EvaluationLogger")
-
-
-atexit.register(_cleanup_all_evaluations)
 
 # Context variable to store the current output safely between threads.  This also
 # ensures that only 1 version of the predict method is saved because the code
@@ -79,9 +54,6 @@ current_summary: ContextVar[dict | None] = ContextVar("current_summary", default
 current_predict_call: ContextVar[Call | None] = ContextVar(
     "current_predict_call", default=None
 )
-
-IMPERATIVE_EVAL_MARKER = {"_weave_eval_meta": {"imperative": True}}
-IMPERATIVE_SCORE_MARKER = {"_weave_eval_meta": {"imperative": True, "score": True}}
 
 
 @contextmanager
@@ -110,128 +82,6 @@ def _set_current_summary(summary: dict) -> Iterator[None]:
         yield
     finally:
         current_summary.reset(token)
-
-
-def _sanitize_class_name(name: str) -> str:
-    """Return a valid Python class name based on a string."""
-    # Remove characters that are not alphanumeric or underscore
-    class_name = re.sub(r"\W", "", name)
-    if class_name == "":
-        return "GeneratedClass"
-
-    # Ensure it starts with a letter or underscore (prepend "C" if not)
-    first_char = class_name[0]
-    if not first_char.isalpha() and first_char != "_":
-        class_name = "C" + class_name
-
-    # Avoid Python keywords
-    if keyword.iskeyword(class_name):
-        class_name += "Class"
-
-    return class_name
-
-
-def _cast_to_cls(type_: type[T]) -> Callable[[str | dict | T], T]:
-    def _convert_to_cls_inner(value: str | dict | T) -> T:
-        if isinstance(value, str):
-            # Dynamically create the class if the user only provides a name
-            cls_name = _sanitize_class_name(value)
-
-            # Sanitization should have ensured a valid class name, but double check for safety
-            cls_name = _validate_class_name(cls_name, type_.__name__)
-
-            pydantic_config_dict = {
-                "__annotations__": {"name": str},
-                "name": cls_name,
-            }
-
-            cls = type(cls_name, (type_,), pydantic_config_dict)
-            return cast(T, cls())
-
-        elif isinstance(value, dict):
-            attributes = value
-
-            if "name" not in attributes:
-                raise ValueError("Your dict must contain a `name` key.")
-
-            pydantic_config_dict = {
-                "__annotations__": dict.fromkeys(attributes, Any),
-                **attributes,
-            }
-            cls = type(attributes["name"], (type_,), pydantic_config_dict)
-            return cast(T, cls())
-
-        elif isinstance(value, type_):
-            instance = value
-            if isinstance(instance, Object) and not instance.name:
-                instance.name = instance.__class__.__name__
-            return instance
-
-        raise TypeError("Unsupported type for casting")
-
-    return _convert_to_cls_inner
-
-
-def _cast_to_imperative_dataset(value: Dataset | list[dict] | str) -> Dataset:
-    if isinstance(value, str):
-        return Dataset(name=value, rows=Table([{"dataset_id": value}]))
-    elif isinstance(value, list):
-        return Dataset(rows=Table(value))
-    elif isinstance(value, Dataset):
-        return value
-    else:
-        raise TypeError("Unsupported type for casting")
-
-
-def _default_dataset_name() -> str:
-    date = datetime.datetime.now().strftime("%Y-%m-%d")
-    unique_name = make_memorable_name()
-    return f"{date}-{unique_name}-dataset"
-
-
-def _validate_class_name(name: str, base_class_name: str = "Class") -> str:
-    """Validate the class name to be a valid Python class name."""
-    # Check if name is not empty
-    if not name:
-        raise ValueError(f"{base_class_name} name cannot be empty")
-
-    if not VALID_CLASS_NAME_REGEX.match(name):
-        raise ValueError(
-            f"Invalid `{base_class_name}` name: '{name}'. `{base_class_name}` names must start with a letter or underscore "
-            "and contain only alphanumeric characters and underscores."
-        )
-
-    # Check if name is not a Python keyword
-    if keyword.iskeyword(name):
-        raise ValueError(
-            f"`{base_class_name}` name '{name}' cannot be a Python keyword"
-        )
-
-    return name
-
-
-class ScorerCache:
-    _cached_scorers: dict[str, Scorer]
-    _cached_scorers_lock: Any
-    _max_size: int
-
-    def __init__(self, max_size: int = DEFAULT_SCORER_CACHE_SIZE) -> None:
-        self._cached_scorers = {}
-        self._cached_scorers_lock = Lock()
-        self._max_size = max_size
-
-    def get_scorer(
-        self, scorer_id: str, default_factory: Callable[[], Scorer]
-    ) -> Scorer:
-        with self._cached_scorers_lock:
-            if scorer_id not in self._cached_scorers:
-                if len(self._cached_scorers) >= self._max_size:
-                    self._cached_scorers.popitem()
-                self._cached_scorers[scorer_id] = default_factory()
-        return self._cached_scorers[scorer_id]
-
-
-global_scorer_cache = ScorerCache()
 
 
 class _LogScoreContext:

--- a/weave/evaluation/eval_imperative_v2.py
+++ b/weave/evaluation/eval_imperative_v2.py
@@ -171,7 +171,6 @@ class ScoreLoggerV2:
         self._eval_logger = eval_logger
         self._inputs = inputs
         self._output_buffer: Any = output
-        self._output_sent: Any = NOT_SET  # what we sent to prediction_create
         self._prediction_id: str | None = None
         self._has_finished: bool = False
         self._captured_scores: dict[str, ScoreType | None] = {}
@@ -207,7 +206,6 @@ class ScoreLoggerV2:
             )
         )
         self._prediction_id = res.prediction_id
-        self._output_sent = self._output_buffer
 
     @overload
     def log_score(
@@ -289,19 +287,17 @@ class ScoreLoggerV2:
         self._ensure_prediction_created()
         assert self._eval_logger._server is not None
 
-        # If the buffered output changed between prediction_create and now
-        # (the V1 `pred.output = ...` + `finish()` flow), pass the new value
-        # so the backend updates the call before closing. Otherwise pass None
-        # and let the backend preserve what it already has.
-        finish_output = (
-            self._output_buffer if self._output_buffer != self._output_sent else None
-        )
-
+        # `prediction_create` no longer writes the output to the backend (it
+        # only emits `call_start`). `prediction_finish` is now the sole owner
+        # of the output write via `call_end`, so we always send the current
+        # buffered output here — not a diff against what `prediction_create`
+        # saw. If the caller never assigned an output, `self._output_buffer`
+        # will be whatever was passed to `log_prediction` (possibly None).
         self._eval_logger._server.prediction_finish(
             tsi.PredictionFinishReq(
                 project_id=self._eval_logger._project_id,
                 prediction_id=cast(str, self._prediction_id),
-                output=finish_output,
+                output=self._output_buffer,
                 wb_user_id=None,
             )
         )

--- a/weave/evaluation/eval_imperative_v2.py
+++ b/weave/evaluation/eval_imperative_v2.py
@@ -32,11 +32,15 @@ from weave.evaluation._imperative_shared import (
     _default_dataset_name,
     _sanitize_class_name,
     global_scorer_cache,
+    scorer_to_cache_key,
 )
 from weave.flow.model import Model
 from weave.flow.scorer import Scorer
 from weave.flow.scorer import auto_summarize as auto_summarize_fn
-from weave.trace.context.weave_client_context import require_weave_client
+from weave.trace.context.weave_client_context import (
+    WeaveInitError,
+    require_weave_client,
+)
 from weave.trace.op import is_tracing_setting_disabled
 from weave.trace.refs import ObjectRef
 from weave.trace_server import trace_server_interface as tsi
@@ -363,14 +367,15 @@ class EvaluationLoggerV2:
         self._project: str = ""
         try:
             wc = require_weave_client()
+        except WeaveInitError:
+            self._disabled = True
+        else:
             if is_tracing_setting_disabled():
                 self._disabled = True
             else:
                 self._server = wc.server
                 self._project_id = wc.project_id
                 self._entity, self._project = from_project_id(wc.project_id)
-        except Exception:
-            self._disabled = True
 
         # Server-side references populated on lazy init.
         self._dataset_ref: str | None = None
@@ -509,11 +514,9 @@ class EvaluationLoggerV2:
         if isinstance(scorer, Scorer):
             prepared: Scorer = scorer
         else:
-            import json
-
-            cache_key = json.dumps(scorer)
             prepared = global_scorer_cache.get_scorer(
-                cache_key, lambda: _cast_to_cls(Scorer)(scorer)
+                scorer_to_cache_key(scorer),
+                lambda: _cast_to_cls(Scorer)(scorer),
             )
 
         if self.scorers:
@@ -692,15 +695,7 @@ class EvaluationLoggerV2:
                 )
 
     def _unregister(self) -> None:
-        if self in _active_evaluation_loggers:
-            try:
-                _active_evaluation_loggers.remove(self)
-            except ValueError:
-                pass
-
-    def __del__(self) -> None:
         try:
-            if not self._is_finalized:
-                self.finish()
-        except Exception:
+            _active_evaluation_loggers.remove(self)
+        except ValueError:
             pass

--- a/weave/evaluation/eval_imperative_v2.py
+++ b/weave/evaluation/eval_imperative_v2.py
@@ -1,0 +1,696 @@
+"""Server-side imperative evaluation logger.
+
+EvaluationLoggerV2 mirrors the public API of EvaluationLogger (V1) but is
+implemented on top of the trace server's V2 evaluation endpoints
+(`evaluation_create`, `evaluation_run_create/finish`, `prediction_create/
+finish`, `score_create`, `scorer_create`, `model_create`, `dataset_create`)
+instead of faking a weave.Evaluation call graph.
+
+V1 predates those endpoints and drives a "pseudo" Evaluation: it injects
+placeholder `predict`, `predict_and_score`, and `summarize` ops onto runtime
+objects, smuggles outputs/scores/summaries between method boundaries through
+ContextVars, and manually pokes the call stack. V2 speaks the server APIs
+directly — no ContextVars, no method injection, no call-stack manipulation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import types
+from typing import TYPE_CHECKING, Any, cast, overload
+
+from typing_extensions import Self
+
+from weave.dataset.dataset import Dataset
+from weave.evaluation._imperative_shared import (
+    ScoreType,
+    _active_evaluation_loggers,
+    _cast_to_cls,
+    _cast_to_imperative_dataset,
+    _default_dataset_name,
+    _sanitize_class_name,
+    global_scorer_cache,
+)
+from weave.flow.model import Model
+from weave.flow.scorer import Scorer
+from weave.flow.scorer import auto_summarize as auto_summarize_fn
+from weave.trace.context.weave_client_context import require_weave_client
+from weave.trace.op import is_tracing_setting_disabled
+from weave.trace_server import trace_server_interface as tsi
+from weave.utils.project_id import from_project_id
+from weave.utils.sentinel import NOT_SET, _NotSetType
+
+if TYPE_CHECKING:
+    from weave.trace_server.trace_server_interface import TraceServerInterface
+
+logger = logging.getLogger(__name__)
+
+
+def _synthesize_model_source(model: Model) -> str:
+    """Placeholder source for models supplied as just a name or dict.
+
+    V1 accepts models as bare strings or dicts, synthesizing a pydantic
+    subclass at runtime. The V2 `model_create` endpoint requires source code,
+    so when the user passes a non-real Model we emit a minimal valid class
+    definition. The server stores it but never executes it.
+    """
+    name = _sanitize_class_name(model.name or model.__class__.__name__)
+    return f"import weave\n\n\nclass {name}(weave.Model):\n    pass\n"
+
+
+def _synthesize_scorer_source(scorer: Scorer) -> str:
+    """Placeholder source for scorers supplied as just a name or dict."""
+    return (
+        "def score(*, output, inputs):\n"
+        "    # Placeholder source emitted by EvaluationLoggerV2.\n"
+        "    return None\n"
+    )
+
+
+def _build_object_ref(entity: str, project: str, object_id: str, digest: str) -> str:
+    return f"weave:///{entity}/{project}/object/{object_id}:{digest}"
+
+
+def _resolve_dataset_spec(
+    value: Dataset | list[dict] | str | None,
+) -> tuple[str, list[dict]]:
+    """Normalize a V1-style dataset input into (name, rows) for V2."""
+    if value is None:
+        name = _default_dataset_name()
+        return name, [{"dataset_id": name}]
+    if isinstance(value, str):
+        return value, [{"dataset_id": value}]
+    if isinstance(value, list):
+        return _default_dataset_name(), value
+    ds = _cast_to_imperative_dataset(value)
+    rows = list(ds.rows)
+    name = ds.name if getattr(ds, "name", None) else _default_dataset_name()
+    return name, rows
+
+
+class _LogScoreContextV2:
+    """Context manager for deferred scoring in V2 (matches V1 semantics).
+
+    Usage:
+        with pred.log_score("quality") as score:
+            result = compute(...)
+            score.value = result
+    """
+
+    def __init__(
+        self,
+        score_logger: ScoreLoggerV2,
+        scorer: Scorer,
+    ) -> None:
+        self._score_logger = score_logger
+        self._scorer = scorer
+        # Use NOT_SET so `score.value = None` is distinguishable from
+        # "value was never set". V1 conflates the two; V2 keeps None valid.
+        self._value: ScoreType | _NotSetType | None = NOT_SET
+
+    @property
+    def value(self) -> ScoreType | None:
+        if isinstance(self._value, _NotSetType):
+            return None
+        return self._value
+
+    @value.setter
+    def value(self, val: ScoreType | None) -> None:
+        self._value = val
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        if exc_type is not None:
+            return
+        if isinstance(self._value, _NotSetType):
+            # Not a type error — it's a state error about the caller not
+            # having assigned `score_ctx.value` before the block ended. V1
+            # raises ValueError here and the V1 contract test expects it.
+            raise ValueError(  # noqa: TRY004
+                f"Score value was not set for scorer '{self._scorer.name}'. "
+                "Please set score_ctx.value within the context manager."
+            )
+        self._score_logger._submit_score(self._scorer, cast("ScoreType | None", self._value))
+
+
+class ScoreLoggerV2:
+    """V2 counterpart of V1's ScoreLogger.
+
+    Returned by `EvaluationLoggerV2.log_prediction`. Supports the same two
+    usage patterns as V1: direct and context-manager.
+    """
+
+    def __init__(
+        self,
+        eval_logger: EvaluationLoggerV2,
+        inputs: dict[str, Any],
+        output: Any,
+    ) -> None:
+        self._eval_logger = eval_logger
+        self._inputs = inputs
+        self._output_buffer: Any = output
+        self._output_sent: Any = NOT_SET  # what we sent to prediction_create
+        self._prediction_id: str | None = None
+        self._has_finished: bool = False
+        self._captured_scores: dict[str, ScoreType | None] = {}
+
+    @property
+    def output(self) -> Any:
+        return self._output_buffer
+
+    @output.setter
+    def output(self, value: Any) -> None:
+        self._output_buffer = value
+
+    # V1 exposes predefined_scorers for warning purposes; V2 mirrors it
+    # through the eval_logger.
+    @property
+    def predefined_scorers(self) -> list[str] | None:
+        return self._eval_logger.scorers
+
+    def _ensure_prediction_created(self) -> None:
+        if self._prediction_id is not None or self._eval_logger._disabled:
+            return
+        self._eval_logger._ensure_initialized()
+        res = self._eval_logger._server.prediction_create(
+            tsi.PredictionCreateReq(
+                project_id=self._eval_logger._project_id,
+                model=self._eval_logger._model_ref,
+                inputs=self._inputs,
+                output=self._output_buffer,
+                evaluation_run_id=self._eval_logger._evaluation_run_id,
+            )
+        )
+        self._prediction_id = res.prediction_id
+        self._output_sent = self._output_buffer
+
+    @overload
+    def log_score(
+        self,
+        scorer: Scorer | dict | str,
+        score: ScoreType | None,
+    ) -> None: ...
+
+    @overload
+    def log_score(
+        self,
+        scorer: Scorer | dict | str,
+        score: _NotSetType = NOT_SET,
+    ) -> _LogScoreContextV2: ...
+
+    def log_score(
+        self,
+        scorer: Scorer | dict | str,
+        score: ScoreType | _NotSetType | None = NOT_SET,
+    ) -> _LogScoreContextV2 | None:
+        if self._has_finished:
+            raise ValueError("Cannot log score after finish has been called")
+
+        prepared = self._eval_logger._prepare_scorer(scorer)
+
+        if isinstance(score, _NotSetType):
+            return _LogScoreContextV2(self, prepared)
+
+        self._submit_score(prepared, score)
+        return None
+
+    async def alog_score(
+        self,
+        scorer: Scorer | dict | str,
+        score: ScoreType | None,
+    ) -> None:
+        # The V2 server interface is synchronous. V1's alog_score existed
+        # because V1 piggybacked on `apply_scorer` which had an async path.
+        # Here we just dispatch to a thread so callers in async frameworks
+        # don't block their loop during network I/O.
+        await asyncio.to_thread(self.log_score, scorer, score)
+
+    def _submit_score(self, scorer: Scorer, score: ScoreType | None) -> None:
+        scorer_name = cast(str, scorer.name)
+
+        # Capture for auto-summarize regardless of server availability.
+        self._captured_scores[scorer_name] = score
+
+        if self._eval_logger._disabled:
+            return
+
+        self._ensure_prediction_created()
+        scorer_ref = self._eval_logger._get_or_create_scorer_ref(scorer)
+
+        self._eval_logger._server.score_create(
+            tsi.ScoreCreateReq(
+                project_id=self._eval_logger._project_id,
+                prediction_id=cast(str, self._prediction_id),
+                scorer=scorer_ref,
+                value=score,
+                evaluation_run_id=self._eval_logger._evaluation_run_id,
+            )
+        )
+
+    def finish(self, output: Any | None = None) -> None:
+        if self._has_finished:
+            logger.warning("(NO-OP): Already called finish, returning.")
+            return
+
+        if output is not None:
+            self._output_buffer = output
+
+        if self._eval_logger._disabled:
+            self._has_finished = True
+            return
+
+        self._ensure_prediction_created()
+
+        # If the buffered output changed between prediction_create and now
+        # (the V1 `pred.output = ...` + `finish()` flow), pass the new value
+        # so the backend updates the call before closing. Otherwise pass None
+        # and let the backend preserve what it already has.
+        finish_output = (
+            self._output_buffer
+            if self._output_buffer != self._output_sent
+            else None
+        )
+
+        self._eval_logger._server.prediction_finish(
+            tsi.PredictionFinishReq(
+                project_id=self._eval_logger._project_id,
+                prediction_id=cast(str, self._prediction_id),
+                output=finish_output,
+            )
+        )
+        self._has_finished = True
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> None:
+        if not self._has_finished:
+            self.finish()
+
+
+class EvaluationLoggerV2:
+    """Imperative evaluation logger backed by V2 server APIs.
+
+    This class matches the public API of `EvaluationLogger` (V1) but builds
+    on top of the first-class V2 endpoints instead of a pseudo-Evaluation.
+    Drop-in replacement for callers that don't depend on V1's exact call
+    tree shape.
+
+    ```python
+    ev = weave.EvaluationLoggerV2()
+    pred = ev.log_prediction(inputs={"q": "..."}, output="...")
+    pred.log_score("correctness", 0.9)
+    pred.finish()
+    ev.log_summary({"avg_score": 0.9})
+    ```
+    """
+
+    def __init__(
+        self,
+        name: str | None = None,
+        model: Model | dict | str | None = None,
+        dataset: Dataset | list[dict] | str | None = None,
+        eval_attributes: dict[str, Any] | None = None,
+        scorers: list[str] | None = None,
+    ) -> None:
+        self.name = name
+        self.scorers = scorers
+        self.eval_attributes = eval_attributes if eval_attributes is not None else {}
+
+        if model is None:
+            model = Model()
+        self.model: Model = _cast_to_cls(Model)(model)
+
+        # Normalize the dataset to (name, rows). V1 wraps into Dataset+Table
+        # internally; V2 sends rows to the server directly.
+        self._dataset_name, self._dataset_rows = _resolve_dataset_spec(dataset)
+
+        # Lifecycle state.
+        self._is_finalized: bool = False
+        self._initialized: bool = False
+        self._accumulated_predictions: list[ScoreLoggerV2] = []
+
+        # Disabled-mode detection. V1 returns an object that still captures
+        # scores locally when WEAVE_DISABLED=true or no client exists; V2
+        # mirrors that by skipping all server calls in this mode.
+        self._disabled: bool = False
+        self._server: TraceServerInterface | None = None
+        self._project_id: str = ""
+        self._entity: str = ""
+        self._project: str = ""
+        try:
+            wc = require_weave_client()
+            if is_tracing_setting_disabled():
+                self._disabled = True
+            else:
+                self._server = wc.server
+                self._project_id = wc.project_id
+                self._entity, self._project = from_project_id(wc.project_id)
+        except Exception:
+            self._disabled = True
+
+        # Server-side references populated on lazy init.
+        self._dataset_ref: str | None = None
+        self._model_ref: str | None = None
+        self._evaluation_ref: str | None = None
+        self._evaluation_run_id: str | None = None
+        self._scorer_refs_by_name: dict[str, str] = {}
+
+        _active_evaluation_loggers.append(self)
+
+    @property
+    def ui_url(self) -> str | None:
+        """URL to the evaluation run in the Weave UI.
+
+        V2 evaluation runs double as calls on the server (their IDs are valid
+        call IDs), so the standard `/r/call/{id}` URL resolves.
+        """
+        if self._disabled or self._evaluation_run_id is None:
+            return None
+        if self._server is None:
+            return None
+        try:
+            wc = require_weave_client()
+        except Exception:
+            return None
+        base = getattr(wc, "_server_info", None)
+        host = getattr(base, "ui_base_url", None) if base else None
+        if not host:
+            host = "https://wandb.ai"
+        return f"{host}/{self._entity}/{self._project}/r/call/{self._evaluation_run_id}"
+
+    @property
+    def attributes(self) -> dict[str, Any]:
+        """Eval-level attributes. Matches V1's shape for user-visible keys."""
+        return dict(self.eval_attributes)
+
+    # ------------------------------------------------------------------
+    # Lazy server initialization
+    # ------------------------------------------------------------------
+
+    def _ensure_initialized(self) -> None:
+        if self._initialized or self._disabled:
+            return
+        assert self._server is not None
+
+        # 1. Dataset
+        dataset_res = self._server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=self._project_id,
+                name=self._dataset_name,
+                description=None,
+                rows=self._dataset_rows,
+            )
+        )
+        self._dataset_ref = _build_object_ref(
+            self._entity, self._project, dataset_res.object_id, dataset_res.digest
+        )
+
+        # 2. Pre-declared scorers
+        scorer_refs: list[str] = []
+        if self.scorers:
+            for scorer_name in self.scorers:
+                scorer_obj = _cast_to_cls(Scorer)(scorer_name)
+                ref = self._create_scorer_on_server(scorer_obj)
+                self._scorer_refs_by_name[cast(str, scorer_obj.name)] = ref
+                scorer_refs.append(ref)
+
+        # 3. Model
+        model_source = _synthesize_model_source(self.model)
+        model_attrs = {
+            k: v
+            for k, v in self.model.model_dump().items()
+            if k not in {"name", "description"}
+        }
+        model_res = self._server.model_create(
+            tsi.ModelCreateReq(
+                project_id=self._project_id,
+                name=cast(str, self.model.name)
+                or self.model.__class__.__name__,
+                description=None,
+                source_code=model_source,
+                attributes=model_attrs or None,
+            )
+        )
+        self._model_ref = _build_object_ref(
+            self._entity, self._project, model_res.object_id, model_res.digest
+        )
+
+        # 4. Evaluation
+        eval_res = self._server.evaluation_create(
+            tsi.EvaluationCreateReq(
+                project_id=self._project_id,
+                name=self.name or self._dataset_name,
+                description=None,
+                dataset=self._dataset_ref,
+                scorers=scorer_refs or None,
+                trials=1,
+                evaluation_name=self.name,
+                eval_attributes=self.eval_attributes or None,
+            )
+        )
+        self._evaluation_ref = eval_res.evaluation_ref
+
+        # 5. Evaluation Run
+        run_res = self._server.evaluation_run_create(
+            tsi.EvaluationRunCreateReq(
+                project_id=self._project_id,
+                evaluation=self._evaluation_ref,
+                model=self._model_ref,
+            )
+        )
+        self._evaluation_run_id = run_res.evaluation_run_id
+
+        self._initialized = True
+
+    def _create_scorer_on_server(self, scorer: Scorer) -> str:
+        assert self._server is not None
+        res = self._server.scorer_create(
+            tsi.ScorerCreateReq(
+                project_id=self._project_id,
+                name=cast(str, scorer.name),
+                description=None,
+                op_source_code=_synthesize_scorer_source(scorer),
+            )
+        )
+        return _build_object_ref(
+            self._entity, self._project, res.object_id, res.digest
+        )
+
+    # ------------------------------------------------------------------
+    # Scorer coercion + ref resolution
+    # ------------------------------------------------------------------
+
+    def _prepare_scorer(self, scorer: Scorer | dict | str) -> Scorer:
+        """V1-compatible scorer coercion with predefined-list warning."""
+        if isinstance(scorer, Scorer):
+            prepared: Scorer = scorer
+        else:
+            import json
+
+            cache_key = json.dumps(scorer)
+            prepared = global_scorer_cache.get_scorer(
+                cache_key, lambda: _cast_to_cls(Scorer)(scorer)
+            )
+
+        if self.scorers:
+            scorer_name = cast(str, prepared.name)
+            if scorer_name not in self.scorers:
+                logger.warning(
+                    "Scorer '%s' is not in the predefined scorers list. "
+                    "Expected one of: %s",
+                    scorer_name,
+                    sorted(self.scorers),
+                )
+
+        return prepared
+
+    def _get_or_create_scorer_ref(self, scorer: Scorer) -> str:
+        """Look up (or lazily create) a scorer ref by name."""
+        name = cast(str, scorer.name)
+        if name in self._scorer_refs_by_name:
+            return self._scorer_refs_by_name[name]
+        ref = self._create_scorer_on_server(scorer)
+        self._scorer_refs_by_name[name] = ref
+        return ref
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def log_prediction(
+        self, inputs: dict[str, Any], output: Any = None
+    ) -> ScoreLoggerV2:
+        """Log a single prediction. Returns a ScoreLoggerV2."""
+        if self._is_finalized:
+            raise ValueError(
+                "Cannot log prediction after evaluation has been finalized."
+            )
+        pred = ScoreLoggerV2(eval_logger=self, inputs=inputs, output=output)
+        self._accumulated_predictions.append(pred)
+        return pred
+
+    def log_example(
+        self,
+        inputs: dict[str, Any],
+        output: Any,
+        scores: dict[str, ScoreType | None],
+    ) -> None:
+        """Convenience: log_prediction + log_score(s) + finish, all at once."""
+        if self._is_finalized:
+            raise ValueError(
+                "Cannot log example after evaluation has been finalized. "
+                "Call log_example before calling finish() or log_summary()."
+            )
+        pred = self.log_prediction(inputs=inputs, output=output)
+        for scorer_name, score_value in scores.items():
+            pred.log_score(scorer_name, score_value)
+        pred.finish()
+
+    def log_summary(
+        self,
+        summary: dict | None = None,
+        auto_summarize: bool = True,
+    ) -> None:
+        """Compute and attach the evaluation run's summary, then finalize."""
+        if self._is_finalized:
+            logger.warning("(NO-OP): Evaluation already finalized, cannot log summary.")
+            return
+
+        if summary is None:
+            summary = {}
+
+        if auto_summarize:
+            data_to_summarize = [
+                pred._captured_scores for pred in self._accumulated_predictions
+            ]
+            summary_data = auto_summarize_fn(data_to_summarize) or {}
+        else:
+            summary_data = {}
+
+        final_summary: dict[str, Any] = {}
+        if summary_data:
+            final_summary.update(summary_data)
+        final_summary["output"] = summary
+
+        self._cleanup_predictions()
+
+        if not self._disabled:
+            self._ensure_initialized()
+            assert self._server is not None
+            try:
+                self._server.evaluation_run_finish(
+                    tsi.EvaluationRunFinishReq(
+                        project_id=self._project_id,
+                        evaluation_run_id=cast(str, self._evaluation_run_id),
+                        summary=final_summary,
+                    )
+                )
+            except Exception:
+                logger.exception("Error finishing evaluation run during summary.")
+
+        self._is_finalized = True
+        self._unregister()
+
+    def set_view(
+        self,
+        name: str,
+        content: Any,
+        *,
+        extension: str | None = None,
+        mimetype: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        encoding: str = "utf-8",
+    ) -> None:
+        # TODO(EvaluationLoggerV2): set_view() is not yet supported by the V2
+        # server APIs. V1 stores views under `summary.weave.views.<name>` on
+        # the evaluation's Call, but V2 does not expose a mutation endpoint
+        # for evaluation-run summaries post-creation. Cleanly supporting
+        # set_view requires either:
+        #   (a) a new endpoint (e.g. EvaluationRunViewCreateReq) that mirrors
+        #       `set_call_view` semantics for evaluation_run IDs, or
+        #   (b) deferring view registration until log_summary/finish and
+        #       folding the views into the summary dict on the way out.
+        # We leave the stub raising for now so callers fail loudly rather
+        # than silently dropping content.
+        raise NotImplementedError(
+            "EvaluationLoggerV2.set_view() is not yet supported. "
+            "Use EvaluationLogger (V1) if you need set_view, or see the "
+            "TODO in eval_imperative_v2.py for the design options."
+        )
+
+    def finish(self, exception: BaseException | None = None) -> None:
+        """Finalize without computing a summary."""
+        if self._is_finalized:
+            return
+
+        self._cleanup_predictions()
+
+        # Only emit evaluation_run_finish if tracing is active AND we have a
+        # run to finish. `exception is not None` forces a lazy-init so the
+        # failure is recorded even if the user never called log_prediction.
+        if not self._disabled and (self._initialized or exception is not None):
+            self._ensure_initialized()
+            assert self._server is not None
+            try:
+                self._server.evaluation_run_finish(
+                    tsi.EvaluationRunFinishReq(
+                        project_id=self._project_id,
+                        evaluation_run_id=cast(str, self._evaluation_run_id),
+                        summary=None,
+                        exception=str(exception) if exception else None,
+                    )
+                )
+            except Exception:
+                logger.exception(
+                    "Error finishing evaluation run during finish()."
+                )
+
+        self._is_finalized = True
+        self._unregister()
+
+    def fail(self, exception: BaseException) -> None:
+        """Finalize the evaluation as failed."""
+        self.finish(exception=exception)
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _cleanup_predictions(self) -> None:
+        for pred in self._accumulated_predictions:
+            if pred._has_finished:
+                continue
+            try:
+                pred.finish()
+            except Exception:
+                logger.exception(
+                    "Error finishing prediction during evaluation cleanup."
+                )
+
+    def _unregister(self) -> None:
+        if self in _active_evaluation_loggers:
+            try:
+                _active_evaluation_loggers.remove(self)
+            except ValueError:
+                pass
+
+    def __del__(self) -> None:
+        try:
+            if not self._is_finalized:
+                self.finish()
+        except Exception:
+            pass

--- a/weave/evaluation/eval_imperative_v2.py
+++ b/weave/evaluation/eval_imperative_v2.py
@@ -25,13 +25,14 @@ from typing import Any, cast, overload
 
 from typing_extensions import Self
 
-# Number of concurrent in-flight V2 server calls per logger. One worker
-# matches V1's `AsyncBatchProcessor` model: user code never blocks on the
-# network, but writes serialize through a single background thread. This
-# is also what in-process SQLite requires (it errors on concurrent writes
-# with "database is locked"). Users on a remote HTTP backend who want more
-# parallelism can bump this via the `max_workers` constructor arg.
-_DEFAULT_MAX_WORKERS = 1
+# Number of concurrent in-flight V2 server calls per logger. Tuned for
+# remote HTTP backends where latency dominates — a 100-prediction eval at
+# 50 ms RTT is bottlenecked by serial round-trips, so we parallelize them.
+# SQLite now tolerates concurrent writes thanks to `PRAGMA busy_timeout`
+# + WAL journaling configured in `get_conn_cursor`, so this default is
+# safe for in-process SQLite too. Users can override via the
+# `max_workers` constructor arg.
+_DEFAULT_MAX_WORKERS = 32
 
 from weave.dataset.dataset import Dataset
 from weave.evaluation._imperative_shared import (
@@ -538,51 +539,39 @@ class EvaluationLoggerV2:
             return
         assert self._server is not None
 
-        # 1. Dataset
-        dataset_res = self._server.dataset_create(
-            tsi.DatasetCreateReq(
-                project_id=self._project_id,
-                name=self._dataset_spec.name,
-                description=None,
-                rows=self._dataset_spec.rows,
-                wb_user_id=None,
-            )
-        )
-        self._dataset_ref = _object_ref_uri(
-            self._entity, self._project, dataset_res.object_id, dataset_res.digest
-        )
+        # Walk the init DAG:
+        #   phase 1 (parallel): dataset_create, scorer_create × N, model_create
+        #   phase 2            : evaluation_create (needs dataset + scorers)
+        #   phase 3            : evaluation_run_create (needs evaluation + model)
+        # Phase 1 items are independent of each other; firing them on the
+        # executor drops init wall-time from ~7 RTTs to ~3 (for a typical
+        # 3-scorer eval). Evaluation + run stay sequential because they
+        # depend on phase-1 outputs.
+        executor = self._get_executor()
 
-        # 2. Pre-declared scorers
-        scorer_refs: list[str] = []
+        dataset_future = executor.submit(self._do_dataset_create)
+        model_future = executor.submit(self._do_model_create)
+        scorer_futures: list[tuple[Scorer, Future[str]]] = []
         if self.scorers:
             for scorer_name in self.scorers:
                 scorer_obj = _cast_to_cls(Scorer)(scorer_name)
-                ref = self._create_scorer_on_server(scorer_obj)
-                self._scorer_refs_by_name[cast(str, scorer_obj.name)] = ref
-                scorer_refs.append(ref)
+                scorer_futures.append(
+                    (
+                        scorer_obj,
+                        executor.submit(self._create_scorer_on_server, scorer_obj),
+                    )
+                )
 
-        # 3. Model
-        model_source = _synthesize_model_source(self.model)
-        model_attrs = {
-            k: v
-            for k, v in self.model.model_dump().items()
-            if k not in {"name", "description"}
-        }
-        model_res = self._server.model_create(
-            tsi.ModelCreateReq(
-                project_id=self._project_id,
-                name=cast(str, self.model.name) or self.model.__class__.__name__,
-                description=None,
-                source_code=model_source,
-                attributes=model_attrs or None,
-                wb_user_id=None,
-            )
-        )
-        self._model_ref = _object_ref_uri(
-            self._entity, self._project, model_res.object_id, model_res.digest
-        )
+        # Join phase 1.
+        self._dataset_ref = dataset_future.result()
+        self._model_ref = model_future.result()
+        scorer_refs: list[str] = []
+        for scorer_obj, fut in scorer_futures:
+            ref = fut.result()
+            self._scorer_refs_by_name[cast(str, scorer_obj.name)] = ref
+            scorer_refs.append(ref)
 
-        # 4. Evaluation
+        # Phase 2: evaluation_create.
         eval_res = self._server.evaluation_create(
             tsi.EvaluationCreateReq(
                 project_id=self._project_id,
@@ -598,7 +587,7 @@ class EvaluationLoggerV2:
         )
         self._evaluation_ref = eval_res.evaluation_ref
 
-        # 5. Evaluation Run
+        # Phase 3: evaluation_run_create.
         run_res = self._server.evaluation_run_create(
             tsi.EvaluationRunCreateReq(
                 project_id=self._project_id,
@@ -610,6 +599,41 @@ class EvaluationLoggerV2:
         self._evaluation_run_id = run_res.evaluation_run_id
 
         self._initialized = True
+
+    def _do_dataset_create(self) -> str:
+        """Phase-1 helper: create the Dataset on the server, return its URI."""
+        assert self._server is not None
+        res = self._server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=self._project_id,
+                name=self._dataset_spec.name,
+                description=None,
+                rows=self._dataset_spec.rows,
+                wb_user_id=None,
+            )
+        )
+        return _object_ref_uri(self._entity, self._project, res.object_id, res.digest)
+
+    def _do_model_create(self) -> str:
+        """Phase-1 helper: create the Model on the server, return its URI."""
+        assert self._server is not None
+        source = _synthesize_model_source(self.model)
+        attrs = {
+            k: v
+            for k, v in self.model.model_dump().items()
+            if k not in {"name", "description"}
+        }
+        res = self._server.model_create(
+            tsi.ModelCreateReq(
+                project_id=self._project_id,
+                name=cast(str, self.model.name) or self.model.__class__.__name__,
+                description=None,
+                source_code=source,
+                attributes=attrs or None,
+                wb_user_id=None,
+            )
+        )
+        return _object_ref_uri(self._entity, self._project, res.object_id, res.digest)
 
     def _create_scorer_on_server(self, scorer: Scorer) -> str:
         assert self._server is not None

--- a/weave/evaluation/eval_imperative_v2.py
+++ b/weave/evaluation/eval_imperative_v2.py
@@ -17,11 +17,21 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import threading
 import types
+from concurrent.futures import Future, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from typing import Any, cast, overload
 
 from typing_extensions import Self
+
+# Number of concurrent in-flight V2 server calls per logger. One worker
+# matches V1's `AsyncBatchProcessor` model: user code never blocks on the
+# network, but writes serialize through a single background thread. This
+# is also what in-process SQLite requires (it errors on concurrent writes
+# with "database is locked"). Users on a remote HTTP backend who want more
+# parallelism can bump this via the `max_workers` constructor arg.
+_DEFAULT_MAX_WORKERS = 1
 
 from weave.dataset.dataset import Dataset
 from weave.evaluation._imperative_shared import (
@@ -174,6 +184,15 @@ class ScoreLoggerV2:
         self._prediction_id: str | None = None
         self._has_finished: bool = False
         self._captured_scores: dict[str, ScoreType | None] = {}
+        # Future that resolves to `prediction_id` once `prediction_create`
+        # returns. Set lazily the first time a score or finish is submitted.
+        # Score and finish tasks chain off this so they never call the server
+        # until the prediction exists, while still unblocking the caller.
+        self._prediction_future: Future[str] | None = None
+        # Futures for every score/finish task owned by this prediction; we
+        # wait on these in `finish` to order `prediction_finish` after all
+        # its scores, and at eval-level drain time.
+        self._pending_futures: list[Future[Any]] = []
 
     @property
     def output(self) -> Any:
@@ -189,23 +208,46 @@ class ScoreLoggerV2:
     def predefined_scorers(self) -> list[str] | None:
         return self._eval_logger.scorers
 
-    def _ensure_prediction_created(self) -> None:
-        if self._prediction_id is not None or self._eval_logger._disabled:
-            return
+    def _ensure_prediction_future(self) -> Future[str]:
+        """Submit ``prediction_create`` in the background (if not started).
+
+        Returns a Future that will resolve to the new prediction_id. Safe to
+        call from user code; does not block.
+        """
+        if self._prediction_future is not None:
+            return self._prediction_future
+
+        # One-time server init (dataset / scorers / model / evaluation /
+        # evaluation_run) is kept synchronous: it runs a handful of serial
+        # round-trips once per logger and it populates state that every
+        # background task depends on (model_ref, evaluation_run_id, ...).
         self._eval_logger._ensure_initialized()
-        assert self._eval_logger._server is not None  # _ensure_initialized populates it
+        assert self._eval_logger._server is not None
         assert self._eval_logger._model_ref is not None
-        res = self._eval_logger._server.prediction_create(
-            tsi.PredictionCreateReq(
-                project_id=self._eval_logger._project_id,
-                model=self._eval_logger._model_ref,
-                inputs=self._inputs,
-                output=self._output_buffer,
-                evaluation_run_id=self._eval_logger._evaluation_run_id,
-                wb_user_id=None,
+
+        project_id = self._eval_logger._project_id
+        model_ref = self._eval_logger._model_ref
+        inputs = self._inputs
+        output = self._output_buffer
+        evaluation_run_id = self._eval_logger._evaluation_run_id
+        server = self._eval_logger._server
+
+        def _create() -> str:
+            res = server.prediction_create(
+                tsi.PredictionCreateReq(
+                    project_id=project_id,
+                    model=model_ref,
+                    inputs=inputs,
+                    output=output,
+                    evaluation_run_id=evaluation_run_id,
+                    wb_user_id=None,
+                )
             )
-        )
-        self._prediction_id = res.prediction_id
+            self._prediction_id = res.prediction_id
+            return res.prediction_id
+
+        self._prediction_future = self._eval_logger._submit(_create)
+        return self._prediction_future
 
     @overload
     def log_score(
@@ -257,20 +299,28 @@ class ScoreLoggerV2:
         if self._eval_logger._disabled:
             return
 
-        self._ensure_prediction_created()
-        scorer_ref = self._eval_logger._get_or_create_scorer_ref(scorer)
-        assert self._eval_logger._server is not None
+        prediction_future = self._ensure_prediction_future()
+        server = self._eval_logger._server
+        assert server is not None
+        project_id = self._eval_logger._project_id
+        evaluation_run_id = self._eval_logger._evaluation_run_id
 
-        self._eval_logger._server.score_create(
-            tsi.ScoreCreateReq(
-                project_id=self._eval_logger._project_id,
-                prediction_id=cast(str, self._prediction_id),
-                scorer=scorer_ref,
-                value=score,
-                evaluation_run_id=self._eval_logger._evaluation_run_id,
-                wb_user_id=None,
+        def _create_score() -> None:
+            prediction_id = prediction_future.result()
+            scorer_ref = self._eval_logger._get_or_create_scorer_ref(scorer)
+            server.score_create(
+                tsi.ScoreCreateReq(
+                    project_id=project_id,
+                    prediction_id=prediction_id,
+                    scorer=scorer_ref,
+                    value=score,
+                    evaluation_run_id=evaluation_run_id,
+                    wb_user_id=None,
+                )
             )
-        )
+
+        fut = self._eval_logger._submit(_create_score)
+        self._pending_futures.append(fut)
 
     def finish(self, output: Any | None = None) -> None:
         if self._has_finished:
@@ -284,23 +334,37 @@ class ScoreLoggerV2:
             self._has_finished = True
             return
 
-        self._ensure_prediction_created()
-        assert self._eval_logger._server is not None
+        prediction_future = self._ensure_prediction_future()
+        # Snapshot scores + pending score futures now so that later user
+        # mutations to `self._output_buffer` or `self._pending_futures` do
+        # not affect what we send.
+        scores_pending = list(self._pending_futures)
+        output_to_send = self._output_buffer
+        server = self._eval_logger._server
+        assert server is not None
+        project_id = self._eval_logger._project_id
 
-        # `prediction_create` no longer writes the output to the backend (it
-        # only emits `call_start`). `prediction_finish` is now the sole owner
-        # of the output write via `call_end`, so we always send the current
-        # buffered output here — not a diff against what `prediction_create`
-        # saw. If the caller never assigned an output, `self._output_buffer`
-        # will be whatever was passed to `log_prediction` (possibly None).
-        self._eval_logger._server.prediction_finish(
-            tsi.PredictionFinishReq(
-                project_id=self._eval_logger._project_id,
-                prediction_id=cast(str, self._prediction_id),
-                output=self._output_buffer,
-                wb_user_id=None,
+        def _finish_prediction() -> None:
+            prediction_id = prediction_future.result()
+            # Make sure every score for this prediction has landed before we
+            # close out the parent `predict_and_score` call (whose output
+            # payload includes `scores_dict`, computed from score-child
+            # queries at finish time).
+            if scores_pending:
+                wait(scores_pending)
+            # `prediction_create` only emits `call_start` in the restructure;
+            # `prediction_finish` owns the `call_end` with the final output.
+            server.prediction_finish(
+                tsi.PredictionFinishReq(
+                    project_id=project_id,
+                    prediction_id=prediction_id,
+                    output=output_to_send,
+                    wb_user_id=None,
+                )
             )
-        )
+
+        fut = self._eval_logger._submit(_finish_prediction)
+        self._pending_futures.append(fut)
         self._has_finished = True
 
     def __enter__(self) -> Self:
@@ -340,10 +404,13 @@ class EvaluationLoggerV2:
         dataset: Dataset | list[dict] | str | None = None,
         eval_attributes: dict[str, Any] | None = None,
         scorers: list[str] | None = None,
+        *,
+        max_workers: int = _DEFAULT_MAX_WORKERS,
     ) -> None:
         self.name = name
         self.scorers = scorers
         self.eval_attributes = eval_attributes if eval_attributes is not None else {}
+        self._max_workers = max_workers
 
         if model is None:
             model = Model()
@@ -391,7 +458,50 @@ class EvaluationLoggerV2:
         self._evaluation_run_id: str | None = None
         self._scorer_refs_by_name: dict[str, str] = {}
 
+        # Background submission machinery. User-facing ``log_prediction`` /
+        # ``log_score`` / ``finish`` calls enqueue work here and return
+        # instantly; real server round-trips happen on the executor threads.
+        # The executor is lazy so constructing a logger without using it
+        # (e.g. in a disabled-mode or validation path) doesn't spin threads.
+        self._executor: ThreadPoolExecutor | None = None
+        # Protects `_scorer_refs_by_name` during concurrent
+        # `_get_or_create_scorer_ref` calls across worker threads.
+        self._scorer_lock = threading.Lock()
+        # Every submitted future, for draining at log_summary/finish time.
+        self._pending_futures: list[Future[Any]] = []
+
         _active_evaluation_loggers.append(self)
+
+    def _get_executor(self) -> ThreadPoolExecutor:
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(
+                max_workers=self._max_workers,
+                thread_name_prefix="eval-logger-v2",
+            )
+        return self._executor
+
+    def _submit(self, fn: Any) -> Future[Any]:
+        """Submit a no-arg callable to the background executor."""
+        executor = self._get_executor()
+        fut = executor.submit(fn)
+        self._pending_futures.append(fut)
+        return fut
+
+    def _drain_pending(self) -> None:
+        """Wait for every in-flight background task to finish.
+
+        Background failures are logged (matching V1's batch-processor
+        behavior) but not re-raised — we want ``finish`` / ``log_summary``
+        to succeed even if a transient server error dropped a score.
+        """
+        if not self._pending_futures:
+            return
+        wait(self._pending_futures)
+        for fut in self._pending_futures:
+            exc = fut.exception()
+            if exc is not None:
+                logger.exception("Background V2 server call failed", exc_info=exc)
+        self._pending_futures.clear()
 
     @property
     def ui_url(self) -> str | None:
@@ -541,13 +651,21 @@ class EvaluationLoggerV2:
         return prepared
 
     def _get_or_create_scorer_ref(self, scorer: Scorer) -> str:
-        """Look up (or lazily create) a scorer ref by name."""
+        """Look up (or lazily create) a scorer ref by name.
+
+        Called from background worker threads during score submission, so
+        we guard the cache with a lock and double-check after paying the
+        server round-trip to avoid two threads creating the same scorer.
+        """
         name = cast(str, scorer.name)
-        if name in self._scorer_refs_by_name:
-            return self._scorer_refs_by_name[name]
+        with self._scorer_lock:
+            existing = self._scorer_refs_by_name.get(name)
+        if existing is not None:
+            return existing
         ref = self._create_scorer_on_server(scorer)
-        self._scorer_refs_by_name[name] = ref
-        return ref
+        with self._scorer_lock:
+            # Another thread may have raced us; its ref is just as valid.
+            return self._scorer_refs_by_name.setdefault(name, ref)
 
     # ------------------------------------------------------------------
     # Public API
@@ -609,6 +727,10 @@ class EvaluationLoggerV2:
         final_summary["output"] = summary
 
         self._cleanup_predictions()
+        # Wait for all in-flight prediction/score/finish tasks before we
+        # close the run — summary aggregation on the server expects every
+        # score and prediction_finish to have landed.
+        self._drain_pending()
 
         if not self._disabled:
             self._ensure_initialized()
@@ -662,6 +784,9 @@ class EvaluationLoggerV2:
             return
 
         self._cleanup_predictions()
+        # Wait for any in-flight background work to settle before we close
+        # the run (or shut down the executor below).
+        self._drain_pending()
 
         # Only emit evaluation_run_finish if tracing is active AND we have a
         # run to finish. `exception is not None` forces a lazy-init so the
@@ -705,6 +830,12 @@ class EvaluationLoggerV2:
                 )
 
     def _unregister(self) -> None:
+        # Shut the executor down after the run is closed so any lingering
+        # scheduled work runs to completion. Done here (not in `finish`)
+        # because both `finish` and `log_summary` funnel into `_unregister`.
+        if self._executor is not None:
+            self._executor.shutdown(wait=True)
+            self._executor = None
         try:
             _active_evaluation_loggers.remove(self)
         except ValueError:

--- a/weave/evaluation/eval_imperative_v2.py
+++ b/weave/evaluation/eval_imperative_v2.py
@@ -97,7 +97,7 @@ def _resolve_dataset_spec(
         return _DatasetSpec(name=_default_dataset_name(), rows=value)
     ds = _cast_to_imperative_dataset(value)
     rows = list(ds.rows)
-    name = ds.name if getattr(ds, "name", None) else _default_dataset_name()
+    name = ds.name or _default_dataset_name()
     return _DatasetSpec(name=name, rows=rows)
 
 
@@ -194,6 +194,8 @@ class ScoreLoggerV2:
         if self._prediction_id is not None or self._eval_logger._disabled:
             return
         self._eval_logger._ensure_initialized()
+        assert self._eval_logger._server is not None  # _ensure_initialized populates it
+        assert self._eval_logger._model_ref is not None
         res = self._eval_logger._server.prediction_create(
             tsi.PredictionCreateReq(
                 project_id=self._eval_logger._project_id,
@@ -201,6 +203,7 @@ class ScoreLoggerV2:
                 inputs=self._inputs,
                 output=self._output_buffer,
                 evaluation_run_id=self._eval_logger._evaluation_run_id,
+                wb_user_id=None,
             )
         )
         self._prediction_id = res.prediction_id
@@ -258,6 +261,7 @@ class ScoreLoggerV2:
 
         self._ensure_prediction_created()
         scorer_ref = self._eval_logger._get_or_create_scorer_ref(scorer)
+        assert self._eval_logger._server is not None
 
         self._eval_logger._server.score_create(
             tsi.ScoreCreateReq(
@@ -266,6 +270,7 @@ class ScoreLoggerV2:
                 scorer=scorer_ref,
                 value=score,
                 evaluation_run_id=self._eval_logger._evaluation_run_id,
+                wb_user_id=None,
             )
         )
 
@@ -282,6 +287,7 @@ class ScoreLoggerV2:
             return
 
         self._ensure_prediction_created()
+        assert self._eval_logger._server is not None
 
         # If the buffered output changed between prediction_create and now
         # (the V1 `pred.output = ...` + `finish()` flow), pass the new value
@@ -296,6 +302,7 @@ class ScoreLoggerV2:
                 project_id=self._eval_logger._project_id,
                 prediction_id=cast(str, self._prediction_id),
                 output=finish_output,
+                wb_user_id=None,
             )
         )
         self._has_finished = True
@@ -359,7 +366,11 @@ class EvaluationLoggerV2:
         # scores locally when WEAVE_DISABLED=true or no client exists; V2
         # mirrors that by skipping all server calls in this mode.
         self._disabled: bool = False
-        self._server: tsi.TraceServerInterface | None = None
+        # Use `FullTraceServerInterface` so mypy sees the V2 endpoints
+        # (dataset_create, evaluation_run_create, etc.) that live on
+        # `ObjectInterface` — those methods aren't on `TraceServerInterface`
+        # but are present at runtime on every concrete backend.
+        self._server: tsi.FullTraceServerInterface | None = None
         self._project_id: str = ""
         self._entity: str = ""
         self._project: str = ""
@@ -371,7 +382,9 @@ class EvaluationLoggerV2:
             if is_tracing_setting_disabled():
                 self._disabled = True
             else:
-                self._server = wc.server
+                # All concrete backends satisfy FullTraceServerInterface; the
+                # cast lets us call V2 endpoints that live on ObjectInterface.
+                self._server = cast("tsi.FullTraceServerInterface", wc.server)
                 self._project_id = wc.project_id
                 self._entity, self._project = from_project_id(wc.project_id)
 
@@ -426,6 +439,7 @@ class EvaluationLoggerV2:
                 name=self._dataset_spec.name,
                 description=None,
                 rows=self._dataset_spec.rows,
+                wb_user_id=None,
             )
         )
         self._dataset_ref = _object_ref_uri(
@@ -455,6 +469,7 @@ class EvaluationLoggerV2:
                 description=None,
                 source_code=model_source,
                 attributes=model_attrs or None,
+                wb_user_id=None,
             )
         )
         self._model_ref = _object_ref_uri(
@@ -472,6 +487,7 @@ class EvaluationLoggerV2:
                 trials=1,
                 evaluation_name=self.name,
                 eval_attributes=self.eval_attributes or None,
+                wb_user_id=None,
             )
         )
         self._evaluation_ref = eval_res.evaluation_ref
@@ -482,6 +498,7 @@ class EvaluationLoggerV2:
                 project_id=self._project_id,
                 evaluation=self._evaluation_ref,
                 model=self._model_ref,
+                wb_user_id=None,
             )
         )
         self._evaluation_run_id = run_res.evaluation_run_id
@@ -496,6 +513,7 @@ class EvaluationLoggerV2:
                 name=cast(str, scorer.name),
                 description=None,
                 op_source_code=_synthesize_scorer_source(scorer),
+                wb_user_id=None,
             )
         )
         return _object_ref_uri(self._entity, self._project, res.object_id, res.digest)
@@ -605,6 +623,8 @@ class EvaluationLoggerV2:
                         project_id=self._project_id,
                         evaluation_run_id=cast(str, self._evaluation_run_id),
                         summary=final_summary,
+                        exception=None,
+                        wb_user_id=None,
                     )
                 )
             except Exception:
@@ -660,6 +680,7 @@ class EvaluationLoggerV2:
                         evaluation_run_id=cast(str, self._evaluation_run_id),
                         summary=None,
                         exception=str(exception) if exception else None,
+                        wb_user_id=None,
                     )
                 )
             except Exception:

--- a/weave/evaluation/eval_imperative_v2.py
+++ b/weave/evaluation/eval_imperative_v2.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import types
-from typing import TYPE_CHECKING, Any, cast, overload
+from dataclasses import dataclass
+from typing import Any, cast, overload
 
 from typing_extensions import Self
 
@@ -37,12 +38,10 @@ from weave.flow.scorer import Scorer
 from weave.flow.scorer import auto_summarize as auto_summarize_fn
 from weave.trace.context.weave_client_context import require_weave_client
 from weave.trace.op import is_tracing_setting_disabled
+from weave.trace.refs import ObjectRef
 from weave.trace_server import trace_server_interface as tsi
 from weave.utils.project_id import from_project_id
 from weave.utils.sentinel import NOT_SET, _NotSetType
-
-if TYPE_CHECKING:
-    from weave.trace_server.trace_server_interface import TraceServerInterface
 
 logger = logging.getLogger(__name__)
 
@@ -68,25 +67,36 @@ def _synthesize_scorer_source(scorer: Scorer) -> str:
     )
 
 
-def _build_object_ref(entity: str, project: str, object_id: str, digest: str) -> str:
-    return f"weave:///{entity}/{project}/object/{object_id}:{digest}"
+def _object_ref_uri(entity: str, project: str, object_id: str, digest: str) -> str:
+    """Build a canonical `weave:///...` object ref URI via `ObjectRef`."""
+    return ObjectRef(
+        entity=entity, project=project, name=object_id, _digest=digest
+    ).uri
+
+
+@dataclass(frozen=True)
+class _DatasetSpec:
+    """Normalized dataset input: name + raw rows for the V2 dataset_create API."""
+
+    name: str
+    rows: list[dict]
 
 
 def _resolve_dataset_spec(
     value: Dataset | list[dict] | str | None,
-) -> tuple[str, list[dict]]:
-    """Normalize a V1-style dataset input into (name, rows) for V2."""
+) -> _DatasetSpec:
+    """Normalize a V1-style dataset input for V2."""
     if value is None:
         name = _default_dataset_name()
-        return name, [{"dataset_id": name}]
+        return _DatasetSpec(name=name, rows=[{"dataset_id": name}])
     if isinstance(value, str):
-        return value, [{"dataset_id": value}]
+        return _DatasetSpec(name=value, rows=[{"dataset_id": value}])
     if isinstance(value, list):
-        return _default_dataset_name(), value
+        return _DatasetSpec(name=_default_dataset_name(), rows=value)
     ds = _cast_to_imperative_dataset(value)
     rows = list(ds.rows)
     name = ds.name if getattr(ds, "name", None) else _default_dataset_name()
-    return name, rows
+    return _DatasetSpec(name=name, rows=rows)
 
 
 class _LogScoreContextV2:
@@ -336,7 +346,7 @@ class EvaluationLoggerV2:
 
         # Normalize the dataset to (name, rows). V1 wraps into Dataset+Table
         # internally; V2 sends rows to the server directly.
-        self._dataset_name, self._dataset_rows = _resolve_dataset_spec(dataset)
+        self._dataset_spec = _resolve_dataset_spec(dataset)
 
         # Lifecycle state.
         self._is_finalized: bool = False
@@ -347,7 +357,7 @@ class EvaluationLoggerV2:
         # scores locally when WEAVE_DISABLED=true or no client exists; V2
         # mirrors that by skipping all server calls in this mode.
         self._disabled: bool = False
-        self._server: TraceServerInterface | None = None
+        self._server: tsi.TraceServerInterface | None = None
         self._project_id: str = ""
         self._entity: str = ""
         self._project: str = ""
@@ -410,12 +420,12 @@ class EvaluationLoggerV2:
         dataset_res = self._server.dataset_create(
             tsi.DatasetCreateReq(
                 project_id=self._project_id,
-                name=self._dataset_name,
+                name=self._dataset_spec.name,
                 description=None,
-                rows=self._dataset_rows,
+                rows=self._dataset_spec.rows,
             )
         )
-        self._dataset_ref = _build_object_ref(
+        self._dataset_ref = _object_ref_uri(
             self._entity, self._project, dataset_res.object_id, dataset_res.digest
         )
 
@@ -445,7 +455,7 @@ class EvaluationLoggerV2:
                 attributes=model_attrs or None,
             )
         )
-        self._model_ref = _build_object_ref(
+        self._model_ref = _object_ref_uri(
             self._entity, self._project, model_res.object_id, model_res.digest
         )
 
@@ -453,7 +463,7 @@ class EvaluationLoggerV2:
         eval_res = self._server.evaluation_create(
             tsi.EvaluationCreateReq(
                 project_id=self._project_id,
-                name=self.name or self._dataset_name,
+                name=self.name or self._dataset_spec.name,
                 description=None,
                 dataset=self._dataset_ref,
                 scorers=scorer_refs or None,
@@ -486,7 +496,7 @@ class EvaluationLoggerV2:
                 op_source_code=_synthesize_scorer_source(scorer),
             )
         )
-        return _build_object_ref(
+        return _object_ref_uri(
             self._entity, self._project, res.object_id, res.digest
         )
 

--- a/weave/evaluation/eval_imperative_v2.py
+++ b/weave/evaluation/eval_imperative_v2.py
@@ -73,9 +73,7 @@ def _synthesize_scorer_source(scorer: Scorer) -> str:
 
 def _object_ref_uri(entity: str, project: str, object_id: str, digest: str) -> str:
     """Build a canonical `weave:///...` object ref URI via `ObjectRef`."""
-    return ObjectRef(
-        entity=entity, project=project, name=object_id, _digest=digest
-    ).uri
+    return ObjectRef(entity=entity, project=project, name=object_id, _digest=digest).uri
 
 
 @dataclass(frozen=True)
@@ -152,7 +150,9 @@ class _LogScoreContextV2:
                 f"Score value was not set for scorer '{self._scorer.name}'. "
                 "Please set score_ctx.value within the context manager."
             )
-        self._score_logger._submit_score(self._scorer, cast("ScoreType | None", self._value))
+        self._score_logger._submit_score(
+            self._scorer, cast("ScoreType | None", self._value)
+        )
 
 
 class ScoreLoggerV2:
@@ -288,9 +288,7 @@ class ScoreLoggerV2:
         # so the backend updates the call before closing. Otherwise pass None
         # and let the backend preserve what it already has.
         finish_output = (
-            self._output_buffer
-            if self._output_buffer != self._output_sent
-            else None
+            self._output_buffer if self._output_buffer != self._output_sent else None
         )
 
         self._eval_logger._server.prediction_finish(
@@ -453,8 +451,7 @@ class EvaluationLoggerV2:
         model_res = self._server.model_create(
             tsi.ModelCreateReq(
                 project_id=self._project_id,
-                name=cast(str, self.model.name)
-                or self.model.__class__.__name__,
+                name=cast(str, self.model.name) or self.model.__class__.__name__,
                 description=None,
                 source_code=model_source,
                 attributes=model_attrs or None,
@@ -501,9 +498,7 @@ class EvaluationLoggerV2:
                 op_source_code=_synthesize_scorer_source(scorer),
             )
         )
-        return _object_ref_uri(
-            self._entity, self._project, res.object_id, res.digest
-        )
+        return _object_ref_uri(self._entity, self._project, res.object_id, res.digest)
 
     # ------------------------------------------------------------------
     # Scorer coercion + ref resolution
@@ -668,9 +663,7 @@ class EvaluationLoggerV2:
                     )
                 )
             except Exception:
-                logger.exception(
-                    "Error finishing evaluation run during finish()."
-                )
+                logger.exception("Error finishing evaluation run during finish().")
 
         self._is_finalized = True
         self._unregister()

--- a/weave/evaluation/eval_logger.py
+++ b/weave/evaluation/eval_logger.py
@@ -1,0 +1,34 @@
+"""Factory that returns an imperative evaluation logger (V1 or V2).
+
+Public callers should use `weave.EvaluationLogger(...)`, which dispatches
+through this factory. By default it returns the V1 `EvaluationLogger` so
+existing users see no behavior change. Setting `use_evaluation_logger_v2`
+(via `weave.init(settings={"use_evaluation_logger_v2": True})` or the
+`WEAVE_USE_EVALUATION_LOGGER_V2` env var) switches the factory to the V2
+implementation. V2 will become the default in a future release.
+
+The concrete classes `EvaluationLogger` (V1) and `EvaluationLoggerV2` are
+still importable directly from their modules for callers that want to pin
+to a specific implementation.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from weave.evaluation._imperative_shared import EvaluationLoggerProtocol
+from weave.evaluation.eval_imperative import EvaluationLogger as EvaluationLoggerV1
+from weave.evaluation.eval_imperative_v2 import EvaluationLoggerV2
+from weave.trace.settings import should_use_evaluation_logger_v2
+
+
+def EvaluationLogger(*args: Any, **kwargs: Any) -> EvaluationLoggerProtocol:  # noqa: N802
+    """Construct an imperative evaluation logger.
+
+    Returns `EvaluationLoggerV2` when `use_evaluation_logger_v2` is set
+    (via the settings object or `WEAVE_USE_EVALUATION_LOGGER_V2=true`);
+    otherwise returns the V1 `EvaluationLogger`.
+    """
+    if should_use_evaluation_logger_v2():
+        return EvaluationLoggerV2(*args, **kwargs)
+    return EvaluationLoggerV1(*args, **kwargs)

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -80,6 +80,15 @@ class UserSettings(BaseModel):
     patch functions like `weave.integrations.patch_openai()` to enable tracing for integrations.
     Can be overridden with the environment variable `WEAVE_IMPLICITLY_PATCH_INTEGRATIONS`"""
 
+    use_evaluation_logger_v2: bool = False
+    """Toggles use of EvaluationLoggerV2 (the server-side-native imperative logger).
+
+    If True, `weave.EvaluationLogger(...)` returns `EvaluationLoggerV2`, which
+    is built on the V2 evaluation endpoints (evaluation_run, prediction, score)
+    instead of V1's pseudo-Evaluation call graph. Defaults to False while V2
+    rolls out; will become the default in a future release.
+    Can be overridden with the environment variable `WEAVE_USE_EVALUATION_LOGGER_V2`"""
+
     redact_pii: bool = False
     """Toggles PII redaction using Microsoft Presidio.
 
@@ -386,6 +395,11 @@ def should_use_parallel_table_upload() -> bool:
 def should_implicitly_patch_integrations() -> bool:
     """Returns whether implicit patching of integrations is enabled."""
     return _should("implicitly_patch_integrations")
+
+
+def should_use_evaluation_logger_v2() -> bool:
+    """Returns whether the imperative logger factory should dispatch to V2."""
+    return _should("use_evaluation_logger_v2")
 
 
 def http_timeout() -> float:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1030,78 +1030,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             settings=ch_settings.CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
         )
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._update_call_output")
-    def _update_call_output(
-        self,
-        project_id: str,
-        call_id: str,
-        output: Any,
-    ) -> None:
-        """Overwrite a call's output in both `call_parts` and `calls_merged`.
-
-        Used when a late mutation (e.g. `prediction_finish(output=...)`) needs
-        to replace an output that was already written via `call_end`. The
-        `calls_merged` table uses `SimpleAggregateFunction(any, ...)` for
-        `output_dump`, so inserting another `call_end` row does not reliably
-        override the earlier value — `any` picks whichever value was merged
-        first. This issues a synchronous `ALTER TABLE ... UPDATE` on both the
-        raw source table (`call_parts`) and the aggregate (`calls_merged`) so
-        subsequent reads return the new output regardless of part-merge timing.
-        """
-        output_dump = any_value_to_dump(output)
-        output_refs = extract_refs_from_values(output)
-
-        cluster_suffix = (
-            f" ON CLUSTER {self.clickhouse_cluster_name}"
-            if self.clickhouse_cluster_name
-            else ""
-        )
-        local_suffix = (
-            ch_settings.LOCAL_TABLE_SUFFIX if self.use_distributed_mode else ""
-        )
-
-        # mutations_sync=1 makes the ALTER UPDATE wait for mutation to apply
-        # on the current node, which is what the tests rely on. Mutations on
-        # AggregatingMergeTree columns rewrite part files; they are heavier
-        # than lightweight updates but are the only correct way to override
-        # an `any()` aggregation after the fact.
-        settings: dict[str, int | str] = {"mutations_sync": 1}
-
-        pb_parts = ParamBuilder()
-        project_id_param_parts = pb_parts.add_param(project_id)
-        id_param_parts = pb_parts.add_param(call_id)
-        output_dump_param_parts = pb_parts.add_param(output_dump)
-        output_refs_param_parts = pb_parts.add_param(output_refs)
-        call_parts_query = f"""
-            ALTER TABLE call_parts{local_suffix}{cluster_suffix}
-            UPDATE
-                output_dump = {{{output_dump_param_parts}:String}},
-                output_refs = {{{output_refs_param_parts}:Array(String)}}
-            WHERE project_id = {{{project_id_param_parts}:String}}
-              AND id = {{{id_param_parts}:String}}
-              AND ended_at IS NOT NULL
-        """
-        self._command(
-            call_parts_query, parameters=pb_parts.get_params(), settings=settings
-        )
-
-        pb_merged = ParamBuilder()
-        project_id_param_merged = pb_merged.add_param(project_id)
-        id_param_merged = pb_merged.add_param(call_id)
-        output_dump_param_merged = pb_merged.add_param(output_dump)
-        output_refs_param_merged = pb_merged.add_param(output_refs)
-        calls_merged_query = f"""
-            ALTER TABLE calls_merged{local_suffix}{cluster_suffix}
-            UPDATE
-                output_dump = {{{output_dump_param_merged}:String}},
-                output_refs = {{{output_refs_param_merged}:Array(String)}}
-            WHERE project_id = {{{project_id_param_merged}:String}}
-              AND id = {{{id_param_merged}:String}}
-        """
-        self._command(
-            calls_merged_query, parameters=pb_merged.get_params(), settings=settings
-        )
-
     def call_read(self, req: tsi.CallReadReq) -> tsi.CallReadRes:
         res = self.calls_query_stream(
             tsi.CallsQueryReq(
@@ -4599,18 +4527,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         self.call_start(call_start_req)
 
-        # End the call immediately with the output
-        call_end_req = tsi.CallEndReq(
-            end=tsi.EndedCallSchemaForInsert(
-                project_id=req.project_id,
-                id=prediction_id,
-                ended_at=datetime.datetime.now(datetime.timezone.utc),
-                output=req.output,
-                summary={},
-            )
-        )
-        self.call_end(call_end_req)
-
+        # NOTE: We intentionally do NOT emit `call_end` here. The prediction
+        # remains "in progress" until `prediction_finish` owns the `call_end`
+        # with the final output. Writing `output_dump` exactly once per
+        # prediction avoids the need for `ALTER TABLE ... UPDATE` mutations
+        # on ClickHouse's `calls_merged` aggregate (which uses
+        # `SimpleAggregateFunction(any, ...)` for `output_dump` and cannot be
+        # reliably overwritten by a later `call_end` row).
         return tsi.PredictionCreateRes(prediction_id=prediction_id)
 
     def prediction_read(self, req: tsi.PredictionReadReq) -> tsi.PredictionReadRes:
@@ -4786,66 +4709,20 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         prediction_res = self.call_read(prediction_read_req)
 
-        # If the caller supplied a new `output` on finish (e.g. EvaluationLogger
-        # V2's deferred `pred.output = ...` flow), use it; otherwise preserve
-        # the output that was set at prediction_create time.
-        existing_output = (
-            prediction_res.call.output if prediction_res.call is not None else None
-        )
-        finish_output = req.output if req.output is not None else existing_output
-
-        # Finish the prediction call
+        # `prediction_create` no longer emits a `call_end`, so this is the
+        # one and only place `output_dump` gets written for this prediction.
+        # Use `req.output` directly (may be None, which is allowed).
+        prediction_ended_at = datetime.datetime.now(datetime.timezone.utc)
         call_end_req = tsi.CallEndReq(
             end=tsi.EndedCallSchemaForInsert(
                 project_id=req.project_id,
                 id=req.prediction_id,
-                ended_at=datetime.datetime.now(datetime.timezone.utc),
-                output=finish_output,
+                ended_at=prediction_ended_at,
+                output=req.output,
                 summary={},
             )
         )
         self.call_end(call_end_req)
-
-        # If a new `output` was supplied on finish, overwrite the aggregated
-        # output for this call. `prediction_create` already emitted a
-        # `call_end` row with the create-time output, and `calls_merged` uses
-        # `SimpleAggregateFunction(any, ...)` for `output_dump` — so a second
-        # `call_end` row alone cannot win against the first one. We issue an
-        # `ALTER TABLE ... UPDATE` mutation on both `call_parts` (source) and
-        # `calls_merged` (aggregate) so reads return the latest output
-        # regardless of merge timing.
-        # Handle a late output change (EvaluationLogger V2's deferred
-        # `pred.output = ...` flow) on ClickHouse.
-        #
-        # Context: `prediction_create` already emits a call_end row with its
-        # create-time output, and `calls_merged` uses
-        # `SimpleAggregateFunction(any, ...)` for `output_dump`. `any`
-        # non-deterministically keeps one value per key during merge, so a
-        # second call_end with a new output does NOT reliably overwrite the
-        # earlier one. The only way to force the new value without a schema
-        # migration is `ALTER TABLE ... UPDATE`, which rewrites affected
-        # part files — expensive per row.
-        #
-        # We mitigate the cost by:
-        #   (a) only calling this when the new output actually differs from
-        #       what's already stored (diff check below), and
-        #   (b) the V2 logger's common flow (output provided upfront OR
-        #       assigned before any log_score) never triggers this because
-        #       create-time output already matches the final output.
-        # In practice the mutation only fires when a caller mutates
-        # `pred.output` AFTER logging a score, or overrides via
-        # `pred.finish(output=...)`. For high-frequency eval workloads that
-        # rely on that pattern, the right long-term fix is to change
-        # `prediction_create` to emit only `call_start` and let
-        # `prediction_finish` own the `call_end`, so `output_dump` is
-        # written exactly once per prediction. That restructuring is a
-        # larger change than this PR's scope.
-        if req.output is not None and req.output != existing_output:
-            self._update_call_output(
-                project_id=req.project_id,
-                call_id=req.prediction_id,
-                output=req.output,
-            )
 
         # If this prediction has a parent (predict_and_score call), finish that too
         prediction_call = prediction_res.call
@@ -4918,24 +4795,26 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
             scores_dict[scorer_name] = score_call.output
 
-        # Calculate model latency from the prediction call's timestamps
+        # Calculate model latency from the prediction call's timestamps.
+        # `prediction_call` was read BEFORE we emitted `call_end`, so its
+        # `ended_at` is None — use the `prediction_ended_at` we just wrote.
         model_latency = None
-        if prediction_call.started_at and prediction_call.ended_at:
+        if prediction_call.started_at:
             latency_seconds = (
-                prediction_call.ended_at - prediction_call.started_at
+                prediction_ended_at - prediction_call.started_at
             ).total_seconds()
             model_latency = {"mean": latency_seconds}
 
-        # Finish the predict_and_score parent call with proper output. Use the
-        # finish-time output (potentially overridden via `req.output`) rather
-        # than the one captured at prediction_create time.
+        # Finish the predict_and_score parent call with proper output. Use
+        # `req.output` directly — it is the authoritative final output for
+        # this prediction.
         parent_end_req = tsi.CallEndReq(
             end=tsi.EndedCallSchemaForInsert(
                 project_id=req.project_id,
                 id=parent_id,
                 ended_at=datetime.datetime.now(datetime.timezone.utc),
                 output={
-                    "output": finish_output,
+                    "output": req.output,
                     "scores": scores_dict,
                     "model_latency": model_latency,
                 },

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1081,7 +1081,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
               AND id = {{{id_param_parts}:String}}
               AND ended_at IS NOT NULL
         """
-        self._command(call_parts_query, parameters=pb_parts.get_params(), settings=settings)
+        self._command(
+            call_parts_query, parameters=pb_parts.get_params(), settings=settings
+        )
 
         pb_merged = ParamBuilder()
         project_id_param_merged = pb_merged.add_param(project_id)
@@ -1096,7 +1098,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             WHERE project_id = {{{project_id_param_merged}:String}}
               AND id = {{{id_param_merged}:String}}
         """
-        self._command(calls_merged_query, parameters=pb_merged.get_params(), settings=settings)
+        self._command(
+            calls_merged_query, parameters=pb_merged.get_params(), settings=settings
+        )
 
     def call_read(self, req: tsi.CallReadReq) -> tsi.CallReadRes:
         res = self.calls_query_stream(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1030,6 +1030,74 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             settings=ch_settings.CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
         )
 
+    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._update_call_output")
+    def _update_call_output(
+        self,
+        project_id: str,
+        call_id: str,
+        output: Any,
+    ) -> None:
+        """Overwrite a call's output in both `call_parts` and `calls_merged`.
+
+        Used when a late mutation (e.g. `prediction_finish(output=...)`) needs
+        to replace an output that was already written via `call_end`. The
+        `calls_merged` table uses `SimpleAggregateFunction(any, ...)` for
+        `output_dump`, so inserting another `call_end` row does not reliably
+        override the earlier value — `any` picks whichever value was merged
+        first. This issues a synchronous `ALTER TABLE ... UPDATE` on both the
+        raw source table (`call_parts`) and the aggregate (`calls_merged`) so
+        subsequent reads return the new output regardless of part-merge timing.
+        """
+        output_dump = any_value_to_dump(output)
+        output_refs = extract_refs_from_values(output)
+
+        cluster_suffix = (
+            f" ON CLUSTER {self.clickhouse_cluster_name}"
+            if self.clickhouse_cluster_name
+            else ""
+        )
+        local_suffix = (
+            ch_settings.LOCAL_TABLE_SUFFIX if self.use_distributed_mode else ""
+        )
+
+        # mutations_sync=1 makes the ALTER UPDATE wait for mutation to apply
+        # on the current node, which is what the tests rely on. Mutations on
+        # AggregatingMergeTree columns rewrite part files; they are heavier
+        # than lightweight updates but are the only correct way to override
+        # an `any()` aggregation after the fact.
+        settings: dict[str, int | str] = {"mutations_sync": 1}
+
+        pb_parts = ParamBuilder()
+        project_id_param_parts = pb_parts.add_param(project_id)
+        id_param_parts = pb_parts.add_param(call_id)
+        output_dump_param_parts = pb_parts.add_param(output_dump)
+        output_refs_param_parts = pb_parts.add_param(output_refs)
+        call_parts_query = f"""
+            ALTER TABLE call_parts{local_suffix}{cluster_suffix}
+            UPDATE
+                output_dump = {{{output_dump_param_parts}:String}},
+                output_refs = {{{output_refs_param_parts}:Array(String)}}
+            WHERE project_id = {{{project_id_param_parts}:String}}
+              AND id = {{{id_param_parts}:String}}
+              AND ended_at IS NOT NULL
+        """
+        self._command(call_parts_query, parameters=pb_parts.get_params(), settings=settings)
+
+        pb_merged = ParamBuilder()
+        project_id_param_merged = pb_merged.add_param(project_id)
+        id_param_merged = pb_merged.add_param(call_id)
+        output_dump_param_merged = pb_merged.add_param(output_dump)
+        output_refs_param_merged = pb_merged.add_param(output_refs)
+        calls_merged_query = f"""
+            ALTER TABLE calls_merged{local_suffix}{cluster_suffix}
+            UPDATE
+                output_dump = {{{output_dump_param_merged}:String}},
+                output_refs = {{{output_refs_param_merged}:Array(String)}}
+            WHERE project_id = {{{project_id_param_merged}:String}}
+              AND id = {{{id_param_merged}:String}}
+        """
+        self._command(calls_merged_query, parameters=pb_merged.get_params(), settings=settings)
+
     def call_read(self, req: tsi.CallReadReq) -> tsi.CallReadRes:
         res = self.calls_query_stream(
             tsi.CallsQueryReq(
@@ -4733,6 +4801,21 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             )
         )
         self.call_end(call_end_req)
+
+        # If a new `output` was supplied on finish, overwrite the aggregated
+        # output for this call. `prediction_create` already emitted a
+        # `call_end` row with the create-time output, and `calls_merged` uses
+        # `SimpleAggregateFunction(any, ...)` for `output_dump` — so a second
+        # `call_end` row alone cannot win against the first one. We issue an
+        # `ALTER TABLE ... UPDATE` mutation on both `call_parts` (source) and
+        # `calls_merged` (aggregate) so reads return the latest output
+        # regardless of merge timing.
+        if req.output is not None:
+            self._update_call_output(
+                project_id=req.project_id,
+                call_id=req.prediction_id,
+                output=req.output,
+            )
 
         # If this prediction has a parent (predict_and_score call), finish that too
         prediction_call = prediction_res.call

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -4814,10 +4814,32 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # `ALTER TABLE ... UPDATE` mutation on both `call_parts` (source) and
         # `calls_merged` (aggregate) so reads return the latest output
         # regardless of merge timing.
-        # Skip the mutation when the new output matches what's already stored.
-        # `ALTER TABLE ... UPDATE` rewrites part files and is expensive
-        # (~20k blocking mutations for a 10k-prediction eval if every
-        # finish touches output); the diff check keeps the fast path cheap.
+        # Handle a late output change (EvaluationLogger V2's deferred
+        # `pred.output = ...` flow) on ClickHouse.
+        #
+        # Context: `prediction_create` already emits a call_end row with its
+        # create-time output, and `calls_merged` uses
+        # `SimpleAggregateFunction(any, ...)` for `output_dump`. `any`
+        # non-deterministically keeps one value per key during merge, so a
+        # second call_end with a new output does NOT reliably overwrite the
+        # earlier one. The only way to force the new value without a schema
+        # migration is `ALTER TABLE ... UPDATE`, which rewrites affected
+        # part files — expensive per row.
+        #
+        # We mitigate the cost by:
+        #   (a) only calling this when the new output actually differs from
+        #       what's already stored (diff check below), and
+        #   (b) the V2 logger's common flow (output provided upfront OR
+        #       assigned before any log_score) never triggers this because
+        #       create-time output already matches the final output.
+        # In practice the mutation only fires when a caller mutates
+        # `pred.output` AFTER logging a score, or overrides via
+        # `pred.finish(output=...)`. For high-frequency eval workloads that
+        # rely on that pattern, the right long-term fix is to change
+        # `prediction_create` to emit only `call_start` and let
+        # `prediction_finish` own the `call_end`, so `output_dump` is
+        # written exactly once per prediction. That restructuring is a
+        # larger change than this PR's scope.
         if req.output is not None and req.output != existing_output:
             self._update_call_output(
                 project_id=req.project_id,

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -4373,7 +4373,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         self.call_end(summarize_end_req)
 
-        # End the evaluation run call
+        # End the evaluation run call. If the caller indicated the run failed
+        # (via the optional `exception` field), pass that through to the
+        # underlying call so the evaluation run's status becomes "error".
         call_end_req = tsi.CallEndReq(
             end=tsi.EndedCallSchemaForInsert(
                 project_id=req.project_id,
@@ -4381,6 +4383,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 ended_at=datetime.datetime.now(datetime.timezone.utc),
                 output=eval_output,
                 summary=summary,
+                exception=req.exception,
             )
         )
         self.call_end(call_end_req)
@@ -4711,13 +4714,21 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         prediction_res = self.call_read(prediction_read_req)
 
+        # If the caller supplied a new `output` on finish (e.g. EvaluationLogger
+        # V2's deferred `pred.output = ...` flow), use it; otherwise preserve
+        # the output that was set at prediction_create time.
+        existing_output = (
+            prediction_res.call.output if prediction_res.call is not None else None
+        )
+        finish_output = req.output if req.output is not None else existing_output
+
         # Finish the prediction call
         call_end_req = tsi.CallEndReq(
             end=tsi.EndedCallSchemaForInsert(
                 project_id=req.project_id,
                 id=req.prediction_id,
                 ended_at=datetime.datetime.now(datetime.timezone.utc),
-                output=None,
+                output=finish_output,
                 summary={},
             )
         )
@@ -4802,14 +4813,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             ).total_seconds()
             model_latency = {"mean": latency_seconds}
 
-        # Finish the predict_and_score parent call with proper output
+        # Finish the predict_and_score parent call with proper output. Use the
+        # finish-time output (potentially overridden via `req.output`) rather
+        # than the one captured at prediction_create time.
         parent_end_req = tsi.CallEndReq(
             end=tsi.EndedCallSchemaForInsert(
                 project_id=req.project_id,
                 id=parent_id,
                 ended_at=datetime.datetime.now(datetime.timezone.utc),
                 output={
-                    "output": prediction_call.output,
+                    "output": finish_output,
                     "scores": scores_dict,
                     "model_latency": model_latency,
                 },
@@ -4987,7 +5000,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # Extract score value from output
         # The output is stored directly as the numeric value
-        value = call.output if call.output is not None else 0.0
+        # The score value is stored directly as the call's output. None is a
+        # valid score per V1 contract (see `ScoreValue` union), so preserve
+        # it rather than coercing to 0.0.
+        value = call.output
 
         # Get evaluation_run_id from attributes (preferred), fallback to parent traversal for backwards compatibility
         evaluation_run_id = attributes.get(constants.SCORE_EVALUATION_RUN_ID_ATTR_KEY)
@@ -5066,7 +5082,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # Yield scores
         for call in self.calls_query_stream(calls_query_req):
             attributes = call.attributes.get(constants.WEAVE_ATTRIBUTES_NAMESPACE, {})
-            value = call.output if call.output is not None else 0.0
+            # The score value is stored directly as the call's output. None is
+            # a valid score per V1 contract (see `ScoreValue` union), so
+            # preserve it rather than coercing to 0.0.
+            value = call.output
 
             # Get evaluation_run_id from attributes (preferred), fallback to parent traversal for backwards compatibility
             evaluation_run_id = attributes.get(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -4810,7 +4810,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # `ALTER TABLE ... UPDATE` mutation on both `call_parts` (source) and
         # `calls_merged` (aggregate) so reads return the latest output
         # regardless of merge timing.
-        if req.output is not None:
+        # Skip the mutation when the new output matches what's already stored.
+        # `ALTER TABLE ... UPDATE` rewrites part files and is expensive
+        # (~20k blocking mutations for a 10k-prediction eval if every
+        # finish touches output); the diff check keeps the fast path cheap.
+        if req.output is not None and req.output != existing_output:
             self._update_call_output(
                 project_id=req.project_id,
                 call_id=req.prediction_id,

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -6,6 +6,7 @@ import logging
 import re
 import sqlite3
 import threading
+import time
 from collections.abc import Iterator
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -128,6 +129,62 @@ def _apply_aggregations(
             bucket[f"p{int(p)}_{metric}"] = sorted_vals[idx]
 
 
+# Ceiling for our Python-level retry on SQLITE_LOCKED / SQLITE_BUSY errors
+# that `PRAGMA busy_timeout` doesn't cover (notably SQLITE_LOCKED on
+# shared-cache databases — which is what the test fixture uses).
+_LOCK_RETRY_TIMEOUT_S = 5.0
+_LOCK_RETRY_BACKOFF_INITIAL_S = 0.001
+_LOCK_RETRY_BACKOFF_CAP_S = 0.05
+
+
+class _RetryingCursor:
+    """Thin wrapper around ``sqlite3.Cursor`` that retries on lock errors.
+
+    SQLite's ``PRAGMA busy_timeout`` waits out SQLITE_BUSY but does NOT
+    retry on SQLITE_LOCKED, which is the error you get on a shared-cache
+    connection when another connection holds a write lock. Without the
+    retry, bumping the V2 logger from 1 to N worker threads surfaces
+    ``sqlite3.OperationalError: database table is locked`` on both
+    readers and writers. Retrying transparently here preserves the
+    single-threaded contract for all callers of ``cursor.execute``.
+    """
+
+    __slots__ = ("_cursor",)
+
+    def __init__(self, cursor: sqlite3.Cursor) -> None:
+        self._cursor = cursor
+
+    def _run_with_retry(self, op: Any, *args: Any, **kwargs: Any) -> Any:
+        deadline = time.monotonic() + _LOCK_RETRY_TIMEOUT_S
+        backoff = _LOCK_RETRY_BACKOFF_INITIAL_S
+        while True:
+            try:
+                return op(*args, **kwargs)
+            except sqlite3.OperationalError as e:
+                msg = str(e).lower()
+                if "locked" not in msg and "busy" not in msg:
+                    raise
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(backoff)
+                backoff = min(backoff * 2, _LOCK_RETRY_BACKOFF_CAP_S)
+
+    def execute(self, *args: Any, **kwargs: Any) -> Any:
+        return self._run_with_retry(self._cursor.execute, *args, **kwargs)
+
+    def executemany(self, *args: Any, **kwargs: Any) -> Any:
+        return self._run_with_retry(self._cursor.executemany, *args, **kwargs)
+
+    def executescript(self, *args: Any, **kwargs: Any) -> Any:
+        return self._run_with_retry(self._cursor.executescript, *args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._cursor, name)
+
+    def __iter__(self) -> Any:
+        return iter(self._cursor)
+
+
 @dataclass(frozen=True)
 class ConnCursor:
     conn: sqlite3.Connection
@@ -161,10 +218,31 @@ def get_conn_cursor(db_path: str) -> tuple[sqlite3.Connection, sqlite3.Cursor]:
         # Use uri=True for URIs like "file::memory:?cache=shared"
         # This is required on Windows to properly handle URI paths
         is_uri = db_path.startswith("file:")
-        conn = sqlite3.connect(db_path, uri=is_uri)
+        # `check_same_thread=False` lets a connection created on one thread
+        # be used from worker threads — required now that client-side
+        # parallelism (e.g. `EvaluationLoggerV2`) dispatches writes from a
+        # ThreadPoolExecutor. We pair it with `busy_timeout` and WAL to keep
+        # concurrent writers from racing on the DB lock.
+        conn = sqlite3.connect(db_path, uri=is_uri, check_same_thread=False)
         # Create an array reverse function.
         conn.create_function("reverse", 1, lambda x: x[::-1])
-        cursor = conn.cursor()
+        raw_cursor = conn.cursor()
+        # Wait up to 5s for a held lock instead of immediately raising
+        # "database is locked". Combined with WAL, this is enough to absorb
+        # bursts from a small (~32) worker pool on a real file path.
+        raw_cursor.execute("PRAGMA busy_timeout = 5000;")
+        # WAL journaling allows readers and a writer to coexist, and
+        # tolerates far more concurrency than the default rollback journal.
+        # It can fail on exotic paths (e.g. some :memory: URIs, where it
+        # silently degrades to `memory`); fall back to the default
+        # journal_mode silently in that case.
+        try:
+            raw_cursor.execute("PRAGMA journal_mode = WAL;")
+        except sqlite3.DatabaseError:
+            pass
+        # Wrap in our retrying cursor so shared-cache SQLITE_LOCKED errors
+        # (which `busy_timeout` doesn't retry) get transparently retried.
+        cursor = cast("sqlite3.Cursor", _RetryingCursor(raw_cursor))
         conn_cursor = ConnCursor(conn, cursor)
         conn_map[db_path] = conn_cursor
     return conn_cursor.conn, conn_cursor.cursor

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -4110,18 +4110,10 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         )
         self.call_start(call_start_req)
 
-        # End the call immediately with the output
-        call_end_req = tsi.CallEndReq(
-            end=tsi.EndedCallSchemaForInsert(
-                project_id=req.project_id,
-                id=prediction_id,
-                ended_at=datetime.datetime.now(datetime.timezone.utc),
-                output=req.output,
-                summary={},
-            )
-        )
-        self.call_end(call_end_req)
-
+        # NOTE: We intentionally do NOT emit `call_end` here. The prediction
+        # remains "in progress" until `prediction_finish` owns the `call_end`
+        # with the final output. This mirrors the ClickHouse backend and
+        # keeps the contract consistent.
         return tsi.PredictionCreateRes(prediction_id=prediction_id)
 
     def prediction_read(self, req: tsi.PredictionReadReq) -> tsi.PredictionReadRes:
@@ -4298,21 +4290,16 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         )
         prediction_res = self.call_read(prediction_read_req)
 
-        # If the caller supplied a new `output` on finish (e.g. EvaluationLogger
-        # V2's deferred `pred.output = ...` flow), use it; otherwise preserve
-        # the output that was set at prediction_create time.
-        existing_output = (
-            prediction_res.call.output if prediction_res.call is not None else None
-        )
-        finish_output = req.output if req.output is not None else existing_output
-
-        # Finish the prediction call
+        # `prediction_create` no longer emits a `call_end`, so this is the
+        # one and only place the prediction's output gets written.
+        # Use `req.output` directly (may be None, which is allowed).
+        prediction_ended_at = datetime.datetime.now(datetime.timezone.utc)
         call_end_req = tsi.CallEndReq(
             end=tsi.EndedCallSchemaForInsert(
                 project_id=req.project_id,
                 id=req.prediction_id,
-                ended_at=datetime.datetime.now(datetime.timezone.utc),
-                output=finish_output,
+                ended_at=prediction_ended_at,
+                output=req.output,
                 summary={},
             )
         )
@@ -4387,24 +4374,25 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
 
             scores_dict[scorer_name] = score_call.output
 
-        # Calculate model latency from the prediction call's timestamps
+        # Calculate model latency from the prediction call's timestamps.
+        # `prediction_call` was read BEFORE we emitted `call_end`, so its
+        # `ended_at` is None — use the `prediction_ended_at` we just wrote.
         model_latency = None
-        if prediction_call.started_at and prediction_call.ended_at:
+        if prediction_call.started_at:
             latency_seconds = (
-                prediction_call.ended_at - prediction_call.started_at
+                prediction_ended_at - prediction_call.started_at
             ).total_seconds()
             model_latency = {"mean": latency_seconds}
 
-        # Finish the predict_and_score parent call with proper output. Use the
-        # finish-time output (potentially overridden via `req.output`) rather
-        # than the one captured at prediction_create time.
+        # Finish the predict_and_score parent call with proper output. Use
+        # `req.output` directly — it is the authoritative final output.
         parent_end_req = tsi.CallEndReq(
             end=tsi.EndedCallSchemaForInsert(
                 project_id=req.project_id,
                 id=parent_id,
                 ended_at=datetime.datetime.now(datetime.timezone.utc),
                 output={
-                    "output": finish_output,
+                    "output": req.output,
                     "scores": scores_dict,
                     "model_latency": model_latency,
                 },

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -3956,7 +3956,9 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         )
         self.call_end(summarize_end_req)
 
-        # End the evaluation run call
+        # End the evaluation run call. If the caller indicated the run failed
+        # (via the optional `exception` field), pass that through to the
+        # underlying call so the evaluation run's status becomes "error".
         call_end_req = tsi.CallEndReq(
             end=tsi.EndedCallSchemaForInsert(
                 project_id=req.project_id,
@@ -3964,6 +3966,7 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                 ended_at=datetime.datetime.now(datetime.timezone.utc),
                 output=eval_output,
                 summary=summary,
+                exception=req.exception,
             )
         )
         self.call_end(call_end_req)
@@ -4295,13 +4298,21 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         )
         prediction_res = self.call_read(prediction_read_req)
 
+        # If the caller supplied a new `output` on finish (e.g. EvaluationLogger
+        # V2's deferred `pred.output = ...` flow), use it; otherwise preserve
+        # the output that was set at prediction_create time.
+        existing_output = (
+            prediction_res.call.output if prediction_res.call is not None else None
+        )
+        finish_output = req.output if req.output is not None else existing_output
+
         # Finish the prediction call
         call_end_req = tsi.CallEndReq(
             end=tsi.EndedCallSchemaForInsert(
                 project_id=req.project_id,
                 id=req.prediction_id,
                 ended_at=datetime.datetime.now(datetime.timezone.utc),
-                output=None,
+                output=finish_output,
                 summary={},
             )
         )
@@ -4384,14 +4395,16 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
             ).total_seconds()
             model_latency = {"mean": latency_seconds}
 
-        # Finish the predict_and_score parent call with proper output
+        # Finish the predict_and_score parent call with proper output. Use the
+        # finish-time output (potentially overridden via `req.output`) rather
+        # than the one captured at prediction_create time.
         parent_end_req = tsi.CallEndReq(
             end=tsi.EndedCallSchemaForInsert(
                 project_id=req.project_id,
                 id=parent_id,
                 ended_at=datetime.datetime.now(datetime.timezone.utc),
                 output={
-                    "output": prediction_call.output,
+                    "output": finish_output,
                     "scores": scores_dict,
                     "model_latency": model_latency,
                 },
@@ -4566,9 +4579,10 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         call = call_res.call
         attributes = call.attributes.get(constants.WEAVE_ATTRIBUTES_NAMESPACE, {})
 
-        # Extract score value from output
-        # The output is stored directly as the numeric value
-        value = call.output if call.output is not None else 0.0
+        # The score value is stored directly as the call's output. None is a
+        # valid score per V1 contract (see `ScoreValue` union), so preserve
+        # it rather than coercing to 0.0.
+        value = call.output
 
         # Get evaluation_run_id from attributes (preferred), fallback to parent traversal for backwards compatibility
         evaluation_run_id = attributes.get(constants.SCORE_EVALUATION_RUN_ID_ATTR_KEY)
@@ -4649,8 +4663,10 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         for call in self.calls_query_stream(calls_query_req):
             attributes = call.attributes.get(constants.WEAVE_ATTRIBUTES_NAMESPACE, {})
 
-            # Extract score value from output (output is the value directly now)
-            value = call.output if call.output is not None else 0.0
+            # The score value is stored directly as the call's output. None is
+            # a valid score per V1 contract (see `ScoreValue` union), so
+            # preserve it rather than coercing to 0.0.
+            value = call.output
 
             # Get evaluation_run_id from attributes (preferred), fallback to parent traversal for backwards compatibility
             evaluation_run_id = attributes.get(

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -2478,6 +2478,18 @@ class EvaluationRunFinishBody(BaseModel):
     summary: dict[str, Any] | None = Field(
         None, description="Optional summary dictionary for the evaluation run"
     )
+    # The EvaluationLogger V1 `fail(exception)` method needs to be able to mark
+    # an evaluation run as errored when the caller encountered a failure. The V2
+    # server tracks evaluation runs as calls with a `status` field that can be
+    # "error", so we accept an optional exception string here and wire it into
+    # the underlying call's exception + status on finish.
+    exception: str | None = Field(
+        None,
+        description=(
+            "If provided, the evaluation run is marked as failed with this "
+            "exception message. The run's status becomes 'error'."
+        ),
+    )
 
 
 class EvaluationRunFinishReq(EvaluationRunFinishBody):
@@ -2582,6 +2594,19 @@ class PredictionFinishReq(BaseModel):
         ..., description="The `entity/project` where this prediction is saved"
     )
     prediction_id: str = Field(..., description="The prediction ID to finish")
+    # EvaluationLogger V1 lets callers set `pred.output` after the prediction
+    # is created and still honors it at finish time. Prediction creation in V2
+    # happens lazily on the first score, so the output at finish can differ
+    # from what was sent at create. This optional field updates the prediction
+    # call's output before closing when provided.
+    output: Any | None = Field(
+        None,
+        description=(
+            "If provided, the prediction call's output is updated to this "
+            "value before the call is closed. Used by EvaluationLogger V2 to "
+            "honor late output mutations."
+        ),
+    )
     wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)
 
 
@@ -2589,6 +2614,14 @@ class PredictionFinishRes(BaseModel):
     success: bool = Field(
         ..., description="Whether the prediction was finished successfully"
     )
+
+
+# Matches the V1 EvaluationLogger `ScoreType` union (`float | bool | dict`)
+# plus `None` (which is a valid score value per V1 contract tests — e.g. used
+# to record an "N/A" result). Dict scores carry structured metrics such as
+# `{"value": 0.9, "reason": "..."}`. Kept as an explicit union rather than
+# `Any` so the API documents what callers may send.
+ScoreValue = float | bool | dict | None
 
 
 class ScoreCreateBody(BaseModel):
@@ -2599,7 +2632,7 @@ class ScoreCreateBody(BaseModel):
 
     prediction_id: str = Field(..., description="The prediction ID")
     scorer: str = Field(..., description="The scorer reference (weave:// URI)")
-    value: float = Field(..., description="The value of the score")
+    value: ScoreValue = Field(..., description="The value of the score")
     evaluation_run_id: str | None = Field(
         None,
         description="Optional evaluation run ID to link this score as a child call",
@@ -2633,7 +2666,9 @@ class ScoreReadReq(BaseModel):
 class ScoreReadRes(BaseModel):
     score_id: str = Field(..., description="The score ID")
     scorer: str = Field(..., description="The scorer reference (weave:// URI)")
-    value: float = Field(..., description="The value of the score")
+    # Same justification as `ScoreCreateBody.value`: V1 supports
+    # `float | bool | dict | None`, so the read side must also surface them.
+    value: ScoreValue = Field(..., description="The value of the score")
     evaluation_run_id: str | None = Field(
         None, description="Evaluation run ID if this score is linked to one"
     )


### PR DESCRIPTION
This PR adds a variant of `EvaluationLogger` that uses the server-side APIs instead of our client-side hack.