### PR TITLE
feat(weave): add typed attribute maps for fast filtering

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -20,6 +20,7 @@ from weave.trace_server import clickhouse_trace_server_batched
 from weave.trace_server import clickhouse_trace_server_migrator as wf_migrator
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.project_version import project_version
+from weave.trace_server.project_version.types import CallsStorageServerMode
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
 from weave.trace_server.sqlite_trace_server import SqliteTraceServer
 
@@ -376,6 +377,23 @@ def ch_server(trace_server):
     if not isinstance(server, ClickHouseTraceServer):
         pytest.skip("ClickHouse-only test")
     return server
+
+
+@pytest.fixture
+def clickhouse_trace_server(trace_server: object) -> ClickHouseTraceServer:
+    """Extract ClickHouseTraceServer and pin routing to AUTO for calls_complete tests.
+
+    Variant of ``ch_server`` that also sets the table routing resolver to
+    AUTO so tests exercising the calls_complete path get the same residence
+    dispatch shape production uses. Tests needing a different mode (e.g.
+    FORCE_LEGACY for raw call_parts inserts) can override the mode after
+    receiving the fixture.
+    """
+    internal_server = trace_server._internal_trace_server  # type: ignore[attr-defined]
+    if isinstance(internal_server, SqliteTraceServer):
+        pytest.skip("ClickHouse-only test")
+    internal_server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
+    return internal_server  # type: ignore[no-any-return]
 
 
 @pytest.fixture

--- a/tests/trace_server/query_builder/test_attributes_map_dispatch.py
+++ b/tests/trace_server/query_builder/test_attributes_map_dispatch.py
@@ -5,12 +5,13 @@ cast, the query builder emits a hybrid
 ``if(mapContains(map, key), map[key], clickhouse_cast(JSON_VALUE(...)))``
 expression: the typed Map column wins on rows where migration 030 populated
 it at ingest, and the old JSON_VALUE path takes over on legacy rows whose
-maps are still empty. This file exercises the dispatch SQL shape end-to-end
-on both read tables plus the fall-through cases (missing cast, ``exists``
-cast, empty extra_path).
-"""
+maps are still empty. This file asserts the full SQL shape end-to-end on
+both read tables plus the fall-through cases (no cast, ``exists`` cast).
 
-import pytest
+Each test is intentionally un-parametrized and pins the complete query
+shape — the SQL layer is load-bearing enough that a shared template or
+fuzzy match would miss regressions at the punctuation level.
+"""
 
 from tests.trace_server.query_builder.utils import assert_sql
 from weave.trace_server.calls_query_builder.calls_query_builder import CallsQuery
@@ -20,35 +21,18 @@ from weave.trace_server.clickhouse.utilities import (
     extract_typed_attrs,
 )
 from weave.trace_server.interface import query as tsi_query
-from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.project_version.types import ReadTable
 
 # ---------------------------------------------------------------------------
-# Query-builder dispatch
+# calls_merged dispatch (one test per supported cast)
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize(
-    ("cast", "expected_column", "expected_param_type", "fallback_cast", "literal"),
-    [
-        ("int", "attributes_map_int", "Int64", "toInt64OrNull", 1),
-        ("double", "attributes_map_float", "Float64", "toFloat64OrNull", 1.5),
-        ("bool", "attributes_map_bool", "Bool", "toUInt8OrNull", True),
-        ("string", "attributes_map_str", "String", "toString", "prod"),
-    ],
-)
-def test_typed_map_dispatch_on_calls_merged(
-    cast: str,
-    expected_column: str,
-    expected_param_type: str,
-    fallback_cast: str,
-    literal: object,
-) -> None:
-    """Each supported cast emits an if(mapContains, map-read, cast(JSON_VALUE)) gate.
+def test_typed_map_dispatch_on_calls_merged_int() -> None:
+    """``$convert(attributes.env, int)`` on calls_merged.
 
-    The fast branch reads the agg-wrapped typed column, and the else branch is
-    the existing JSON_VALUE-over-attributes_dump path preserved for legacy rows
-    whose maps haven't been backfilled.
+    Fast branch: ``any(attributes_map_int)[key]``.
+    Fallback: ``toInt64OrNull(coalesce(nullIf(JSON_VALUE(...), 'null'), ''))``.
     """
     cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
     cq.add_field("id")
@@ -59,10 +43,10 @@ def test_typed_map_dispatch_on_calls_merged(
                     {
                         "$convert": {
                             "input": {"$getField": "attributes.env"},
-                            "to": cast,
+                            "to": "int",
                         }
                     },
-                    {"$literal": literal},
+                    {"$literal": 1},
                 ]
             }
         )
@@ -70,22 +54,163 @@ def test_typed_map_dispatch_on_calls_merged(
 
     assert_sql(
         cq,
-        f"""
+        """
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {{pb_3:String}}
+        PREWHERE calls_merged.project_id = {pb_3:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
-            ((if(mapContains(any(calls_merged.{expected_column}), {{pb_0:String}}),
-                 any(calls_merged.{expected_column})[{{pb_0:String}}],
-                 {fallback_cast}(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {{pb_1:String}}), 'null'), '')))
-             = {{pb_2:{expected_param_type}}}))
+            ((if(mapContains(any(calls_merged.attributes_map_int), {pb_0:String}),
+                 any(calls_merged.attributes_map_int)[{pb_0:String}],
+                 toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')))
+             = {pb_2:Int64}))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.started_at) IS NULL))))
         )
         """,
-        {"pb_0": "env", "pb_1": '$."env"', "pb_2": literal, "pb_3": "p"},
+        {"pb_0": "env", "pb_1": '$."env"', "pb_2": 1, "pb_3": "p"},
     )
+
+
+def test_typed_map_dispatch_on_calls_merged_double() -> None:
+    """``$convert(attributes.env, double)`` on calls_merged.
+
+    Fast branch: ``any(attributes_map_float)[key]``.
+    Fallback: ``toFloat64OrNull(coalesce(nullIf(JSON_VALUE(...), 'null'), ''))``.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.env"},
+                            "to": "double",
+                        }
+                    },
+                    {"$literal": 1.5},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((if(mapContains(any(calls_merged.attributes_map_float), {pb_0:String}),
+                 any(calls_merged.attributes_map_float)[{pb_0:String}],
+                 toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')))
+             = {pb_2:Float64}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "env", "pb_1": '$."env"', "pb_2": 1.5, "pb_3": "p"},
+    )
+
+
+def test_typed_map_dispatch_on_calls_merged_bool() -> None:
+    """``$convert(attributes.env, bool)`` on calls_merged.
+
+    Fast branch: ``any(attributes_map_bool)[key]``.
+    Fallback: ``(JSON_VALUE(...) = 'true')`` — bool is special-cased because
+    ``JSON_VALUE`` emits the literal string ``"true"``/``"false"`` for JSON
+    booleans and the generic ``toUInt8OrNull`` cast returns NULL on those
+    strings, which would silently drop legacy bool rows. Comparing the raw
+    JSON_VALUE to ``'true'`` yields a Bool directly.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.env"},
+                            "to": "bool",
+                        }
+                    },
+                    {"$literal": True},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((if(mapContains(any(calls_merged.attributes_map_bool), {pb_0:String}),
+                 any(calls_merged.attributes_map_bool)[{pb_0:String}],
+                 (JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}) = 'true'))
+             = {pb_2:Bool}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "env", "pb_1": '$."env"', "pb_2": True, "pb_3": "p"},
+    )
+
+
+def test_typed_map_dispatch_on_calls_merged_string() -> None:
+    """``$convert(attributes.env, string)`` on calls_merged.
+
+    Fast branch: ``any(attributes_map_str)[key]``.
+    Fallback: ``toString(coalesce(nullIf(JSON_VALUE(...), 'null'), ''))``.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.env"},
+                            "to": "string",
+                        }
+                    },
+                    {"$literal": "prod"},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((if(mapContains(any(calls_merged.attributes_map_str), {pb_0:String}),
+                 any(calls_merged.attributes_map_str)[{pb_0:String}],
+                 toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')))
+             = {pb_2:String}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "env", "pb_1": '$."env"', "pb_2": "prod", "pb_3": "p"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# calls_complete dispatch + nested attribute paths
+# ---------------------------------------------------------------------------
 
 
 def test_typed_map_dispatch_on_calls_complete() -> None:
@@ -160,6 +285,7 @@ def test_nested_attribute_path_joins_with_dot() -> None:
             }
         )
     )
+
     assert_sql(
         cq,
         """
@@ -180,47 +306,85 @@ def test_nested_attribute_path_joins_with_dot() -> None:
     )
 
 
-@pytest.mark.parametrize(
-    "condition",
-    [
-        # No $convert at all -> falls through to JSON_VALUE.
-        {
-            "$eq": [
-                {"$getField": "attributes.env"},
-                {"$literal": "prod"},
-            ]
-        },
-        # $convert with "exists" -> no typed map for existence checks, falls through.
-        {
-            "$eq": [
-                {
-                    "$convert": {
-                        "input": {"$getField": "attributes.env"},
-                        "to": "exists",
-                    }
-                },
-                {"$literal": True},
-            ]
-        },
-    ],
-)
-def test_fallback_to_json_value_when_no_typed_cast(condition: dict) -> None:
-    """Filters without a typed cast keep using the JSON_VALUE path.
+# ---------------------------------------------------------------------------
+# Fall-through (no typed cast → JSON_VALUE path only, no map read)
+# ---------------------------------------------------------------------------
 
-    This preserves read-path compatibility for clients that haven't adopted
-    typed dispatch — they keep working against the existing attributes_dump
-    column without needing a migration or filter rewrite.
+
+def test_fallback_no_convert_uses_json_value_only() -> None:
+    """A plain ``$getField`` on attributes.* — no ``$convert`` — stays on the
+    JSON_VALUE path with no map read. This preserves read-path compatibility
+    for clients that never adopted typed dispatch, and the LIKE prefilter on
+    attributes_dump is the existing optimization for equality-on-string.
     """
     cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
     cq.add_field("id")
-    cq.add_condition(tsi_query.EqOperation.model_validate(condition))
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {"$getField": "attributes.env"},
+                    {"$literal": "prod"},
+                ]
+            }
+        )
+    )
 
-    sql = cq.as_sql(ParamBuilder("pb"))
-    assert "attributes_map_" not in sql
-    # Either the plain JSON_VALUE path (no cast / non-exists casts) or the
-    # JSONType existence-check path (cast=exists) must be present.
-    assert "JSON_VALUE(any(calls_merged.attributes_dump)" in sql or (
-        "JSONType(any(calls_merged.attributes_dump)" in sql
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        WHERE ((calls_merged.attributes_dump LIKE {pb_2:String} OR calls_merged.attributes_dump IS NULL))
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": '$."env"', "pb_1": "prod", "pb_2": '%"prod"%', "pb_3": "p"},
+    )
+
+
+def test_fallback_convert_exists_uses_json_value_only() -> None:
+    """``$convert(..., "exists")`` has no typed Map analogue, so it stays on
+    the JSON_VALUE existence-check path (``... IS NOT NULL``) and does not
+    touch any ``attributes_map_*`` column.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.env"},
+                            "to": "exists",
+                        }
+                    },
+                    {"$literal": True},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_2:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            (((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_0:String}), 'null'), '') IS NOT NULL) = {pb_1:Bool}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": '$."env"', "pb_1": True, "pb_2": "p"},
     )
 
 

--- a/tests/trace_server/query_builder/test_attributes_map_dispatch.py
+++ b/tests/trace_server/query_builder/test_attributes_map_dispatch.py
@@ -1,0 +1,255 @@
+"""Tests for the typed attributes-map fast-filter dispatch.
+
+When a caller filters on ``attributes.<path>`` with an explicit ``$convert``
+cast, the query builder should route through the typed Map column populated
+at ingest instead of falling through to ``JSON_VALUE(attributes_dump, ...)``.
+This file exercises that routing end-to-end on both read tables plus the
+fallback paths (missing cast, ``exists`` cast, empty extra_path).
+"""
+
+import pytest
+
+from tests.trace_server.query_builder.utils import assert_sql
+from weave.trace_server.calls_query_builder.calls_query_builder import CallsQuery
+from weave.trace_server.ch_sentinel_values import SENTINEL_DATETIME
+from weave.trace_server.clickhouse.utilities import (
+    MAX_TYPED_ATTR_ENTRIES_PER_MAP,
+    extract_typed_attrs,
+)
+from weave.trace_server.interface import query as tsi_query
+from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.project_version.types import ReadTable
+
+# ---------------------------------------------------------------------------
+# Query-builder dispatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("cast", "expected_column", "expected_param_type", "literal"),
+    [
+        ("int", "attributes_map_int", "Int64", 1),
+        ("double", "attributes_map_float", "Float64", 1.5),
+        ("bool", "attributes_map_bool", "Bool", True),
+        ("string", "attributes_map_str", "String", "prod"),
+    ],
+)
+def test_typed_map_dispatch_on_calls_merged(
+    cast: str, expected_column: str, expected_param_type: str, literal: object
+) -> None:
+    """Each supported cast routes to its typed Map column with agg-wrapped access."""
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.env"},
+                            "to": cast,
+                        }
+                    },
+                    {"$literal": literal},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        f"""
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {{pb_2:String}}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((any(calls_merged.{expected_column})[{{pb_0:String}}] = {{pb_1:{expected_param_type}}}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "env", "pb_1": literal, "pb_2": "p"},
+    )
+
+
+def test_typed_map_dispatch_on_calls_complete() -> None:
+    """calls_complete uses the unwrapped typed column (no any() aggregation)."""
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_COMPLETE)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.GtOperation.model_validate(
+            {
+                "$gt": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.retries"},
+                            "to": "int",
+                        }
+                    },
+                    {"$literal": 3},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_complete.id AS id
+        FROM calls_complete
+        PREWHERE calls_complete.project_id = {pb_3:String}
+        WHERE 1
+          AND (((calls_complete.attributes_map_int[{pb_0:String}] > {pb_1:Int64}))
+               AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
+        """,
+        {
+            "pb_0": "retries",
+            "pb_1": 3,
+            "pb_2": SENTINEL_DATETIME,
+            "pb_3": "p",
+        },
+    )
+
+
+def test_nested_attribute_path_joins_with_dot() -> None:
+    """``attributes.a.b.c`` uses ``a.b.c`` as the typed-map key.
+
+    The extractor flattens nested dicts with dot-joined keys, so the read
+    path must use the same joiner to hit the stored key.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.a.b.c"},
+                            "to": "int",
+                        }
+                    },
+                    {"$literal": 5},
+                ]
+            }
+        )
+    )
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_2:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((any(calls_merged.attributes_map_int)[{pb_0:String}] = {pb_1:Int64}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "a.b.c", "pb_1": 5, "pb_2": "p"},
+    )
+
+
+@pytest.mark.parametrize(
+    "condition",
+    [
+        # No $convert at all -> falls through to JSON_VALUE.
+        {
+            "$eq": [
+                {"$getField": "attributes.env"},
+                {"$literal": "prod"},
+            ]
+        },
+        # $convert with "exists" -> no typed map for existence checks, falls through.
+        {
+            "$eq": [
+                {
+                    "$convert": {
+                        "input": {"$getField": "attributes.env"},
+                        "to": "exists",
+                    }
+                },
+                {"$literal": True},
+            ]
+        },
+    ],
+)
+def test_fallback_to_json_value_when_no_typed_cast(condition: dict) -> None:
+    """Filters without a typed cast keep using the JSON_VALUE path.
+
+    This preserves read-path compatibility for clients that haven't adopted
+    typed dispatch — they keep working against the existing attributes_dump
+    column without needing a migration or filter rewrite.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(tsi_query.EqOperation.model_validate(condition))
+
+    sql = cq.as_sql(ParamBuilder("pb"))
+    assert "attributes_map_" not in sql
+    # Either the plain JSON_VALUE path (no cast / non-exists casts) or the
+    # JSONType existence-check path (cast=exists) must be present.
+    assert "JSON_VALUE(any(calls_merged.attributes_dump)" in sql or (
+        "JSONType(any(calls_merged.attributes_dump)" in sql
+    )
+
+
+# ---------------------------------------------------------------------------
+# Extractor (ingest-side)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_typed_attrs_dispatch_and_edge_cases() -> None:
+    """One dense assertion block covering type dispatch, flattening, drops, and cap.
+
+    - bool branch must precede int branch (Python bool is a subclass of int);
+    - dicts flatten to dot-joined keys so read-side ``attributes.a.b`` matches;
+    - None values are dropped (not written as empty strings);
+    - non-finite floats (NaN/+inf/-inf) are dropped;
+    - non-scalars (list/tuple/etc.) land in the string map as JSON;
+    - each map independently caps at MAX_TYPED_ATTR_ENTRIES_PER_MAP.
+    """
+    cap = MAX_TYPED_ATTR_ENTRIES_PER_MAP
+    attrs: dict = {
+        "s": "hello",
+        "i": 42,
+        "f": 3.14,
+        "b": True,
+        "b2": False,
+        "none": None,
+        "nan": float("nan"),
+        "pinf": float("inf"),
+        "ninf": float("-inf"),
+        "nested": {"a": 1, "b": {"c": "deep"}},
+        "list": [1, 2, 3],
+    }
+    for i in range(cap + 5):
+        attrs[f"str_{i:05d}"] = f"v{i}"
+
+    s, i, f, b = extract_typed_attrs(attrs)
+
+    assert b == {"b": True, "b2": False}
+    assert i == {"i": 42, "nested.a": 1}
+    assert f == {"f": 3.14}
+    assert s["s"] == "hello"
+    assert s["nested.b.c"] == "deep"
+    assert s["list"] == "[1, 2, 3]"
+    assert "none" not in s
+    assert "none" not in i
+    assert "none" not in f
+    assert "none" not in b
+    assert "nan" not in f
+    assert "pinf" not in f
+    assert "ninf" not in f
+    assert len(s) == cap
+    assert len(b) == 2
+    assert len(i) == 2
+    assert len(f) == 1
+
+
+def test_extract_typed_attrs_non_dict_input() -> None:
+    """Non-dict input returns four empty maps rather than raising."""
+    assert extract_typed_attrs(None) == ({}, {}, {}, {})  # type: ignore[arg-type]
+    assert extract_typed_attrs("not a dict") == ({}, {}, {}, {})  # type: ignore[arg-type]

--- a/tests/trace_server/query_builder/test_attributes_map_dispatch.py
+++ b/tests/trace_server/query_builder/test_attributes_map_dispatch.py
@@ -1,10 +1,13 @@
 """Tests for the typed attributes-map fast-filter dispatch.
 
 When a caller filters on ``attributes.<path>`` with an explicit ``$convert``
-cast, the query builder should route through the typed Map column populated
-at ingest instead of falling through to ``JSON_VALUE(attributes_dump, ...)``.
-This file exercises that routing end-to-end on both read tables plus the
-fallback paths (missing cast, ``exists`` cast, empty extra_path).
+cast, the query builder emits a hybrid
+``if(mapContains(map, key), map[key], clickhouse_cast(JSON_VALUE(...)))``
+expression: the typed Map column wins on rows where migration 030 populated
+it at ingest, and the old JSON_VALUE path takes over on legacy rows whose
+maps are still empty. This file exercises the dispatch SQL shape end-to-end
+on both read tables plus the fall-through cases (missing cast, ``exists``
+cast, empty extra_path).
 """
 
 import pytest
@@ -26,18 +29,27 @@ from weave.trace_server.project_version.types import ReadTable
 
 
 @pytest.mark.parametrize(
-    ("cast", "expected_column", "expected_param_type", "literal"),
+    ("cast", "expected_column", "expected_param_type", "fallback_cast", "literal"),
     [
-        ("int", "attributes_map_int", "Int64", 1),
-        ("double", "attributes_map_float", "Float64", 1.5),
-        ("bool", "attributes_map_bool", "Bool", True),
-        ("string", "attributes_map_str", "String", "prod"),
+        ("int", "attributes_map_int", "Int64", "toInt64OrNull", 1),
+        ("double", "attributes_map_float", "Float64", "toFloat64OrNull", 1.5),
+        ("bool", "attributes_map_bool", "Bool", "toUInt8OrNull", True),
+        ("string", "attributes_map_str", "String", "toString", "prod"),
     ],
 )
 def test_typed_map_dispatch_on_calls_merged(
-    cast: str, expected_column: str, expected_param_type: str, literal: object
+    cast: str,
+    expected_column: str,
+    expected_param_type: str,
+    fallback_cast: str,
+    literal: object,
 ) -> None:
-    """Each supported cast routes to its typed Map column with agg-wrapped access."""
+    """Each supported cast emits an if(mapContains, map-read, cast(JSON_VALUE)) gate.
+
+    The fast branch reads the agg-wrapped typed column, and the else branch is
+    the existing JSON_VALUE-over-attributes_dump path preserved for legacy rows
+    whose maps haven't been backfilled.
+    """
     cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
     cq.add_field("id")
     cq.add_condition(
@@ -61,20 +73,28 @@ def test_typed_map_dispatch_on_calls_merged(
         f"""
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {{pb_2:String}}
+        PREWHERE calls_merged.project_id = {{pb_3:String}}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
-            ((any(calls_merged.{expected_column})[{{pb_0:String}}] = {{pb_1:{expected_param_type}}}))
+            ((if(mapContains(any(calls_merged.{expected_column}), {{pb_0:String}}),
+                 any(calls_merged.{expected_column})[{{pb_0:String}}],
+                 {fallback_cast}(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {{pb_1:String}}), 'null'), '')))
+             = {{pb_2:{expected_param_type}}}))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.started_at) IS NULL))))
         )
         """,
-        {"pb_0": "env", "pb_1": literal, "pb_2": "p"},
+        {"pb_0": "env", "pb_1": '$."env"', "pb_2": literal, "pb_3": "p"},
     )
 
 
 def test_typed_map_dispatch_on_calls_complete() -> None:
-    """calls_complete uses the unwrapped typed column (no any() aggregation)."""
+    """calls_complete uses the unwrapped typed column (no any() aggregation).
+
+    The mapContains gate still emits around each lookup so a not-yet-backfilled
+    row in calls_complete (e.g. migrated from call_parts before 030) reads the
+    attributes_dump fallback rather than the Map default.
+    """
     cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_COMPLETE)
     cq.add_field("id")
     cq.add_condition(
@@ -98,16 +118,20 @@ def test_typed_map_dispatch_on_calls_complete() -> None:
         """
         SELECT calls_complete.id AS id
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_3:String}
+        PREWHERE calls_complete.project_id = {pb_4:String}
         WHERE 1
-          AND (((calls_complete.attributes_map_int[{pb_0:String}] > {pb_1:Int64}))
-               AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
+          AND (((if(mapContains(calls_complete.attributes_map_int, {pb_0:String}),
+                    calls_complete.attributes_map_int[{pb_0:String}],
+                    toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.attributes_dump, {pb_1:String}), 'null'), '')))
+                 > {pb_2:Int64}))
+               AND ((calls_complete.deleted_at = {pb_3:DateTime64(3)})))
         """,
         {
             "pb_0": "retries",
-            "pb_1": 3,
-            "pb_2": SENTINEL_DATETIME,
-            "pb_3": "p",
+            "pb_1": '$."retries"',
+            "pb_2": 3,
+            "pb_3": SENTINEL_DATETIME,
+            "pb_4": "p",
         },
     )
 
@@ -115,8 +139,9 @@ def test_typed_map_dispatch_on_calls_complete() -> None:
 def test_nested_attribute_path_joins_with_dot() -> None:
     """``attributes.a.b.c`` uses ``a.b.c`` as the typed-map key.
 
-    The extractor flattens nested dicts with dot-joined keys, so the read
-    path must use the same joiner to hit the stored key.
+    The extractor flattens nested dicts with dot-joined keys, so the Map
+    read-side uses the same joiner to hit the stored key. The JSON_VALUE
+    fallback keeps its own JSONPath (``$."a"."b"."c"``) for legacy rows.
     """
     cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
     cq.add_field("id")
@@ -140,15 +165,18 @@ def test_nested_attribute_path_joins_with_dot() -> None:
         """
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
+        PREWHERE calls_merged.project_id = {pb_3:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
-            ((any(calls_merged.attributes_map_int)[{pb_0:String}] = {pb_1:Int64}))
+            ((if(mapContains(any(calls_merged.attributes_map_int), {pb_0:String}),
+                 any(calls_merged.attributes_map_int)[{pb_0:String}],
+                 toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')))
+             = {pb_2:Int64}))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.started_at) IS NULL))))
         )
         """,
-        {"pb_0": "a.b.c", "pb_1": 5, "pb_2": "p"},
+        {"pb_0": "a.b.c", "pb_1": '$."a"."b"."c"', "pb_2": 5, "pb_3": "p"},
     )
 
 

--- a/tests/trace_server/query_builder/test_attributes_map_dispatch.py
+++ b/tests/trace_server/query_builder/test_attributes_map_dispatch.py
@@ -16,10 +16,7 @@ fuzzy match would miss regressions at the punctuation level.
 from tests.trace_server.query_builder.utils import assert_sql
 from weave.trace_server.calls_query_builder.calls_query_builder import CallsQuery
 from weave.trace_server.ch_sentinel_values import SENTINEL_DATETIME
-from weave.trace_server.clickhouse.utilities import (
-    MAX_TYPED_ATTR_ENTRIES_PER_MAP,
-    extract_typed_attrs,
-)
+from weave.trace_server.clickhouse.utilities import extract_typed_attrs
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.project_version.types import ReadTable
 
@@ -394,16 +391,17 @@ def test_fallback_convert_exists_uses_json_value_only() -> None:
 
 
 def test_extract_typed_attrs_dispatch_and_edge_cases() -> None:
-    """One dense assertion block covering type dispatch, flattening, drops, and cap.
+    """One dense assertion block covering type dispatch, flattening, and drops.
 
     - bool branch must precede int branch (Python bool is a subclass of int);
     - dicts flatten to dot-joined keys so read-side ``attributes.a.b`` matches;
     - None values are dropped (not written as empty strings);
     - non-finite floats (NaN/+inf/-inf) are dropped;
     - non-scalars (list/tuple/etc.) land in the string map as JSON;
-    - each map independently caps at MAX_TYPED_ATTR_ENTRIES_PER_MAP.
+    - no entry cap: oversized rows are handled downstream by
+      ``_strip_large_values``, not by truncating the extractor output.
     """
-    cap = MAX_TYPED_ATTR_ENTRIES_PER_MAP
+    big_batch = 250  # well above the removed 100-entry cap.
     attrs: dict = {
         "s": "hello",
         "i": 42,
@@ -417,7 +415,7 @@ def test_extract_typed_attrs_dispatch_and_edge_cases() -> None:
         "nested": {"a": 1, "b": {"c": "deep"}},
         "list": [1, 2, 3],
     }
-    for i in range(cap + 5):
+    for i in range(big_batch):
         attrs[f"str_{i:05d}"] = f"v{i}"
 
     s, i, f, b = extract_typed_attrs(attrs)
@@ -435,7 +433,8 @@ def test_extract_typed_attrs_dispatch_and_edge_cases() -> None:
     assert "nan" not in f
     assert "pinf" not in f
     assert "ninf" not in f
-    assert len(s) == cap
+    # All big_batch str_NNNNN entries survive + s/nested.b.c/list = big_batch + 3.
+    assert len(s) == big_batch + 3
     assert len(b) == 2
     assert len(i) == 2
     assert len(f) == 1

--- a/tests/trace_server/query_builder/test_attributes_map_dispatch.py
+++ b/tests/trace_server/query_builder/test_attributes_map_dispatch.py
@@ -470,7 +470,11 @@ def test_extract_typed_attrs_dispatch_and_edge_cases() -> None:
     for i in range(big_batch):
         attrs[f"str_{i:05d}"] = f"v{i}"
 
-    s, i, f, b = extract_typed_attrs(attrs)
+    maps = extract_typed_attrs(attrs)
+    s = maps["attributes_map_str"]
+    i = maps["attributes_map_int"]
+    f = maps["attributes_map_float"]
+    b = maps["attributes_map_bool"]
 
     assert b == {"b": True, "b2": False}
     assert i == {"i": 42, "nested.a": 1}
@@ -493,9 +497,15 @@ def test_extract_typed_attrs_dispatch_and_edge_cases() -> None:
 
 
 def test_extract_typed_attrs_non_dict_input() -> None:
-    """Non-dict input returns four empty maps rather than raising."""
-    assert extract_typed_attrs(None) == ({}, {}, {}, {})  # type: ignore[arg-type]
-    assert extract_typed_attrs("not a dict") == ({}, {}, {}, {})  # type: ignore[arg-type]
+    """Non-dict input returns empty maps rather than raising."""
+    empty = {
+        "attributes_map_str": {},
+        "attributes_map_int": {},
+        "attributes_map_float": {},
+        "attributes_map_bool": {},
+    }
+    assert extract_typed_attrs(None) == empty  # type: ignore[arg-type]
+    assert extract_typed_attrs("not a dict") == empty  # type: ignore[arg-type]
 
 
 def test_extract_typed_attrs_dot_key_collision_is_documented() -> None:
@@ -511,12 +521,14 @@ def test_extract_typed_attrs_dot_key_collision_is_documented() -> None:
 
     This test pins the current behavior so it doesn't drift silently.
     """
-    _, int_map, _, _ = extract_typed_attrs({"a": {"b": 1}, "a.b": 2})
+    int_map = extract_typed_attrs({"a": {"b": 1}, "a.b": 2})["attributes_map_int"]
     assert int_map == {"a.b": 2}, (
         "Literal-dot key must overwrite the nested flattening (insertion order)."
     )
 
-    _, int_map_reverse, _, _ = extract_typed_attrs({"a.b": 2, "a": {"b": 1}})
+    int_map_reverse = extract_typed_attrs({"a.b": 2, "a": {"b": 1}})[
+        "attributes_map_int"
+    ]
     assert int_map_reverse == {"a.b": 1}, (
         "Nested flattening must overwrite the literal-dot key when inserted later."
     )

--- a/tests/trace_server/query_builder/test_attributes_map_dispatch.py
+++ b/tests/trace_server/query_builder/test_attributes_map_dispatch.py
@@ -308,11 +308,16 @@ def test_nested_attribute_path_joins_with_dot() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_fallback_no_convert_uses_json_value_only() -> None:
-    """A plain ``$getField`` on attributes.* — no ``$convert`` — stays on the
-    JSON_VALUE path with no map read. This preserves read-path compatibility
-    for clients that never adopted typed dispatch, and the LIKE prefilter on
-    attributes_dump is the existing optimization for equality-on-string.
+def test_implicit_string_literal_eq_uses_fast_path() -> None:
+    """``attributes.env = 'prod'`` (no ``$convert``) hits the typed Map.
+
+    The fast path infers the string type from the ``$literal`` peer so
+    callers don't have to wrap in ``$convert(..., "string")`` to get the
+    typed-map read. Emits the same ``if(mapContains(...), map[key],
+    JSON_VALUE fallback)`` hybrid as the ``$convert`` path, pinned to
+    ``attributes_map_str``. The ``attributes_dump LIKE`` prefilter added by
+    the optimization pass is independent of the HAVING shape and still
+    fires alongside the fast path.
     """
     cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
     cq.add_field("id")
@@ -332,16 +337,63 @@ def test_fallback_no_convert_uses_json_value_only() -> None:
         """
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_3:String}
-        WHERE ((calls_merged.attributes_dump LIKE {pb_2:String} OR calls_merged.attributes_dump IS NULL))
+        PREWHERE calls_merged.project_id = {pb_4:String}
+        WHERE ((calls_merged.attributes_dump LIKE {pb_3:String} OR calls_merged.attributes_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
-            ((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+            ((if(mapContains(any(calls_merged.attributes_map_str), {pb_0:String}),
+                 any(calls_merged.attributes_map_str)[{pb_0:String}],
+                 coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), ''))
+             = {pb_2:String}))
             AND ((any(calls_merged.deleted_at) IS NULL))
             AND ((NOT ((any(calls_merged.started_at) IS NULL))))
         )
         """,
-        {"pb_0": '$."env"', "pb_1": "prod", "pb_2": '%"prod"%', "pb_3": "p"},
+        {
+            "pb_0": "env",
+            "pb_1": '$."env"',
+            "pb_2": "prod",
+            "pb_3": '%"prod"%',
+            "pb_4": "p",
+        },
+    )
+
+
+def test_implicit_non_string_literal_eq_stays_on_json_value() -> None:
+    """``attributes.retries = 3`` (no ``$convert``, non-string peer) stays on
+    the JSON_VALUE path — the implicit fast path only fires for string
+    literals because JSON_VALUE returns a string and the Map columns for
+    non-string types would require a cast on both branches to match. Users
+    who want the int/float/bool fast path must wrap in ``$convert``.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {"$getField": "attributes.retries"},
+                    {"$literal": 3},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        WHERE ((calls_merged.attributes_dump LIKE {pb_2:String} OR calls_merged.attributes_dump IS NULL))
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_0:String}), 'null'), '') = {pb_1:Int64}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": '$."retries"', "pb_1": 3, "pb_2": "%3%", "pb_3": "p"},
     )
 
 
@@ -444,3 +496,27 @@ def test_extract_typed_attrs_non_dict_input() -> None:
     """Non-dict input returns four empty maps rather than raising."""
     assert extract_typed_attrs(None) == ({}, {}, {}, {})  # type: ignore[arg-type]
     assert extract_typed_attrs("not a dict") == ({}, {}, {}, {})  # type: ignore[arg-type]
+
+
+def test_extract_typed_attrs_dot_key_collision_is_documented() -> None:
+    """``{"a": {"b": 1}}`` and ``{"a.b": 2}`` both flatten to key ``"a.b"``.
+
+    The second write wins in the typed Map because Python dicts are
+    insertion-ordered and ``extract_typed_attrs`` iterates once per leaf.
+    The JSON_VALUE fallback can still distinguish them (``$."a"."b"`` vs
+    ``$."a.b"``) — so a row with a literal-dot key would read different
+    values from the fast and fallback branches. We accept this divergence
+    because nested dicts are the common shape and literal-dot keys
+    already break the JSONPath-based filter convention.
+
+    This test pins the current behavior so it doesn't drift silently.
+    """
+    _, int_map, _, _ = extract_typed_attrs({"a": {"b": 1}, "a.b": 2})
+    assert int_map == {"a.b": 2}, (
+        "Literal-dot key must overwrite the nested flattening (insertion order)."
+    )
+
+    _, int_map_reverse, _, _ = extract_typed_attrs({"a.b": 2, "a": {"b": 1}})
+    assert int_map_reverse == {"a.b": 1}, (
+        "Nested flattening must overwrite the literal-dot key when inserted later."
+    )

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -1488,20 +1488,23 @@ def test_calls_query_with_combined_like_optimizations_and_op_filter() -> None:
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_12:String}
-            WHERE ((calls_merged.op_name IN {pb_7:Array(String)})
+            PREWHERE calls_merged.project_id = {pb_13:String}
+            WHERE ((calls_merged.op_name IN {pb_8:Array(String)})
                     OR (calls_merged.op_name IS NULL))
-                AND ((calls_merged.attributes_dump LIKE {pb_8:String} OR calls_merged.attributes_dump IS NULL)
-                    AND (lower(calls_merged.inputs_dump) LIKE {pb_9:String} OR calls_merged.inputs_dump IS NULL)
-                    AND ((calls_merged.attributes_dump LIKE {pb_10:String} OR calls_merged.attributes_dump LIKE {pb_11:String})
+                AND ((calls_merged.attributes_dump LIKE {pb_9:String} OR calls_merged.attributes_dump IS NULL)
+                    AND (lower(calls_merged.inputs_dump) LIKE {pb_10:String} OR calls_merged.inputs_dump IS NULL)
+                    AND ((calls_merged.attributes_dump LIKE {pb_11:String} OR calls_merged.attributes_dump LIKE {pb_12:String})
                         OR calls_merged.attributes_dump IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
-                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+                ((if(mapContains(any(calls_merged.attributes_map_str), {pb_0:String}),
+                     any(calls_merged.attributes_map_str)[{pb_0:String}],
+                     coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), ''))
+                 = {pb_2:String}))
                 AND
-                (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_2:String}), 'null'), ''), {pb_3:String}) > 0)
+                (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_3:String}), 'null'), ''), {pb_4:String}) > 0)
                 AND
-                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_4:String}), 'null'), '') IN ({pb_5:String},{pb_6:String})))
+                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_5:String}), 'null'), '') IN ({pb_6:String},{pb_7:String})))
                 AND ((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.started_at) IS NULL))))
             )
@@ -1511,24 +1514,25 @@ def test_calls_query_with_combined_like_optimizations_and_op_filter() -> None:
             any(calls_merged.attributes_dump) AS attributes_dump,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_12:String}
+        PREWHERE calls_merged.project_id = {pb_13:String}
         WHERE (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         """,
         {
-            "pb_0": '$."model"',
-            "pb_1": "gpt-4",
-            "pb_2": '$."prompt"',
-            "pb_3": "weather",
-            "pb_4": '$."temperature"',
-            "pb_5": "0.7",
-            "pb_6": "0.8",
-            "pb_7": ["llm/openai", "llm/anthropic"],
-            "pb_8": '%"gpt-4"%',
-            "pb_9": '%"%weather%"%',
-            "pb_10": '%"0.7"%',
-            "pb_11": '%"0.8"%',
-            "pb_12": "project",
+            "pb_0": "model",
+            "pb_1": '$."model"',
+            "pb_2": "gpt-4",
+            "pb_3": '$."prompt"',
+            "pb_4": "weather",
+            "pb_5": '$."temperature"',
+            "pb_6": "0.7",
+            "pb_7": "0.8",
+            "pb_8": ["llm/openai", "llm/anthropic"],
+            "pb_9": '%"gpt-4"%',
+            "pb_10": '%"%weather%"%',
+            "pb_11": '%"0.7"%',
+            "pb_12": '%"0.8"%',
+            "pb_13": "project",
         },
     )
 

--- a/tests/trace_server/test_attributes_map_fast_filter.py
+++ b/tests/trace_server/test_attributes_map_fast_filter.py
@@ -202,26 +202,47 @@ def _populate_two_by_two(
     )
 
 
-def test_fast_filter_mixed_backfill_string_cast(
+@pytest.mark.parametrize(
+    ("attr_key", "matching_value", "other_value", "cast_to"),
+    [
+        # The hybrid ``if(mapContains(...))`` wins on the populated row and
+        # falls back to ``toString(coalesce(nullIf(JSON_VALUE, 'null'), ''))``
+        # on the legacy row whose typed maps are empty.
+        ("env", "prod", "staging", "string"),
+        ("retries", 5, 2, "int"),
+        ("score", 0.9, 0.1, "double"),
+        # bool is the case that would have failed before we special-cased it:
+        # the bool fallback compares the raw JSON_VALUE to ``'true'`` rather
+        # than going through the generic ``toUInt8OrNull`` cast (which returns
+        # NULL on the JSON bool strings ``"true"``/``"false"`` and would drop
+        # legacy rows with ``enabled: true`` in the dump).
+        ("enabled", True, False, "bool"),
+    ],
+    ids=["string", "int", "double", "bool"],
+)
+def test_fast_filter_mixed_backfill_convert(
     trace_server: object,
     ch_server_force_legacy: ClickHouseTraceServer,
+    attr_key: str,
+    matching_value: object,
+    other_value: object,
+    cast_to: str,
 ) -> None:
-    """``$convert(attributes.env, string)`` returns populated *and* legacy matches.
+    """``$convert(attributes.<key>, <cast>)`` returns populated *and* legacy matches.
 
-    The hybrid ``if(mapContains(...))`` wins on the populated row and falls
-    back to ``toString(coalesce(nullIf(JSON_VALUE, 'null'), ''))`` on the
-    legacy row whose typed maps are empty. Both ``env=prod`` rows come back;
-    the ``env=staging`` rows don't.
+    Both the typed-map row and the JSON_VALUE-only legacy row come back; the
+    "other" rows don't. Pinned per-cast so a regression in any one type's
+    fallback (especially bool) surfaces independently.
     """
-    external_project_id = f"{TEST_ENTITY}/string_{uuid.uuid4().hex[:8]}"
+    external_project_id = f"{TEST_ENTITY}/{cast_to}_{uuid.uuid4().hex[:8]}"
     internal_project_id = b64(external_project_id)
     reset_project_residence_cache()
     populated_match, legacy_match, *_ = _populate_two_by_two(
         ch_server_force_legacy.ch_client,
         internal_project_id,
-        attr_key="env",
-        matching_value="prod",
-        other_value="staging",
+        attr_key=attr_key,
+        matching_value=matching_value,
+        other_value=other_value,
         now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
     )
 
@@ -232,123 +253,11 @@ def test_fast_filter_mixed_backfill_string_cast(
             "$eq": [
                 {
                     "$convert": {
-                        "input": {"$getField": "attributes.env"},
-                        "to": "string",
+                        "input": {"$getField": f"attributes.{attr_key}"},
+                        "to": cast_to,
                     }
                 },
-                {"$literal": "prod"},
-            ]
-        },
-    )
-    assert matching_ids == {populated_match, legacy_match}
-
-
-def test_fast_filter_mixed_backfill_int_cast(
-    trace_server: object,
-    ch_server_force_legacy: ClickHouseTraceServer,
-) -> None:
-    """``$convert(attributes.retries, int)`` returns populated *and* legacy matches."""
-    external_project_id = f"{TEST_ENTITY}/int_{uuid.uuid4().hex[:8]}"
-    internal_project_id = b64(external_project_id)
-    reset_project_residence_cache()
-    populated_match, legacy_match, *_ = _populate_two_by_two(
-        ch_server_force_legacy.ch_client,
-        internal_project_id,
-        attr_key="retries",
-        matching_value=5,
-        other_value=2,
-        now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
-    )
-
-    matching_ids = _query_ids(
-        trace_server,
-        external_project_id,
-        {
-            "$eq": [
-                {
-                    "$convert": {
-                        "input": {"$getField": "attributes.retries"},
-                        "to": "int",
-                    }
-                },
-                {"$literal": 5},
-            ]
-        },
-    )
-    assert matching_ids == {populated_match, legacy_match}
-
-
-def test_fast_filter_mixed_backfill_double_cast(
-    trace_server: object,
-    ch_server_force_legacy: ClickHouseTraceServer,
-) -> None:
-    """``$convert(attributes.score, double)`` returns populated *and* legacy matches."""
-    external_project_id = f"{TEST_ENTITY}/double_{uuid.uuid4().hex[:8]}"
-    internal_project_id = b64(external_project_id)
-    reset_project_residence_cache()
-    populated_match, legacy_match, *_ = _populate_two_by_two(
-        ch_server_force_legacy.ch_client,
-        internal_project_id,
-        attr_key="score",
-        matching_value=0.9,
-        other_value=0.1,
-        now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
-    )
-
-    matching_ids = _query_ids(
-        trace_server,
-        external_project_id,
-        {
-            "$eq": [
-                {
-                    "$convert": {
-                        "input": {"$getField": "attributes.score"},
-                        "to": "double",
-                    }
-                },
-                {"$literal": 0.9},
-            ]
-        },
-    )
-    assert matching_ids == {populated_match, legacy_match}
-
-
-def test_fast_filter_mixed_backfill_bool_cast(
-    trace_server: object,
-    ch_server_force_legacy: ClickHouseTraceServer,
-) -> None:
-    """``$convert(attributes.enabled, bool)`` returns populated *and* legacy matches.
-
-    The bool fallback compares the raw JSON_VALUE to the literal string
-    ``'true'`` (rather than the generic ``toUInt8OrNull`` cast that returns
-    NULL on JSON bool strings). This is the test that would have failed
-    before we special-cased bool — legacy rows with ``enabled: true`` in
-    the dump would have been dropped.
-    """
-    external_project_id = f"{TEST_ENTITY}/bool_{uuid.uuid4().hex[:8]}"
-    internal_project_id = b64(external_project_id)
-    reset_project_residence_cache()
-    populated_match, legacy_match, *_ = _populate_two_by_two(
-        ch_server_force_legacy.ch_client,
-        internal_project_id,
-        attr_key="enabled",
-        matching_value=True,
-        other_value=False,
-        now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
-    )
-
-    matching_ids = _query_ids(
-        trace_server,
-        external_project_id,
-        {
-            "$eq": [
-                {
-                    "$convert": {
-                        "input": {"$getField": "attributes.enabled"},
-                        "to": "bool",
-                    }
-                },
-                {"$literal": True},
+                {"$literal": matching_value},
             ]
         },
     )

--- a/tests/trace_server/test_attributes_map_fast_filter.py
+++ b/tests/trace_server/test_attributes_map_fast_filter.py
@@ -34,24 +34,26 @@ from weave.trace_server.project_version.project_version import (
     reset_project_residence_cache,
 )
 from weave.trace_server.project_version.types import CallsStorageServerMode
-from weave.trace_server.sqlite_trace_server import SqliteTraceServer
 
 TEST_ENTITY = "attrs_fast_filter_entity"
 
 
 @pytest.fixture
-def clickhouse_trace_server(trace_server: object) -> ClickHouseTraceServer:
-    """Return the internal CH server; skip on SQLite.
+def ch_server_force_legacy(
+    clickhouse_trace_server: ClickHouseTraceServer,
+) -> ClickHouseTraceServer:
+    """Reuse the global ``clickhouse_trace_server`` fixture but pin FORCE_LEGACY.
 
-    Force FORCE_LEGACY routing so reads hit calls_merged — this test inserts
-    directly into call_parts, not calls_complete, so we want the merged view.
+    This test inserts directly into ``call_parts`` (bypassing the v2 write
+    path) so reads must go through ``calls_merged``. The shared fixture
+    defaults to AUTO, which would route reads to ``calls_complete`` and
+    miss the raw-inserted rows.
     """
-    internal = trace_server._internal_trace_server  # type: ignore[attr-defined]
-    if isinstance(internal, SqliteTraceServer):
-        pytest.skip("ClickHouse-only test")
-    internal.table_routing_resolver._mode = CallsStorageServerMode.FORCE_LEGACY
+    clickhouse_trace_server.table_routing_resolver._mode = (
+        CallsStorageServerMode.FORCE_LEGACY
+    )
     reset_project_residence_cache()
-    return internal
+    return clickhouse_trace_server
 
 
 # Columns populated on a call_parts start row. Kept as a list so ch_client.insert
@@ -142,81 +144,85 @@ def _query_ids(trace_server: object, project_id: str, filter_query: dict) -> set
     return {c.id for c in calls}
 
 
-@pytest.mark.parametrize(
-    ("cast", "attr_key", "filter_literal", "matching_value", "other_value"),
-    [
-        ("string", "env", "prod", "prod", "staging"),
-        ("int", "retries", 5, 5, 2),
-        ("double", "score", 0.9, 0.9, 0.1),
-        # bool is intentionally excluded: the JSON_VALUE fallback cast is
-        # ``toUInt8OrNull``, which returns NULL for the string ``"true"``
-        # that JSON_VALUE emits for a JSON bool. That preexisting fallback
-        # limitation means legacy bool rows can't be recovered via the dump,
-        # independent of this hybrid path.
-    ],
-)
-def test_fast_filter_mixed_backfill_returns_correct_rows(
-    trace_server: object,
-    clickhouse_trace_server: ClickHouseTraceServer,
-    cast: str,
+def _populate_two_by_two(
+    ch_client: object,
+    internal_project_id: str,
     attr_key: str,
-    filter_literal: object,
     matching_value: object,
     other_value: object,
-) -> None:
-    """``$convert`` filter must return both populated and legacy rows that match.
+    now: datetime.datetime,
+) -> tuple[str, str, str, str]:
+    """Insert the four-row fixture: populated+match, legacy+match, populated+other, legacy+other.
 
-    Four rows per type go into one project: two match the filter (populated
-    + legacy), two don't (populated + legacy with a different value). The
-    hybrid ``if(mapContains(...))`` path is the only thing that can return
-    the legacy-matching row — a pure Map read would miss it because the
-    map is empty and the CH default for the value type is used instead.
+    Returns the call ids in that order so tests can assert membership. All
+    rows share a project; the assertion is that only the two "match" rows
+    come back regardless of backfill state.
     """
-    external_project_id = f"{TEST_ENTITY}/{cast}_{uuid.uuid4().hex[:8]}"
-    internal_project_id = b64(external_project_id)
-    reset_project_residence_cache()
-
-    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
     call_populated_match = str(uuid.uuid4())
     call_legacy_match = str(uuid.uuid4())
     call_populated_other = str(uuid.uuid4())
     call_legacy_other = str(uuid.uuid4())
-
-    # Populated row that matches the filter.
     _insert_start_row(
-        clickhouse_trace_server.ch_client,
+        ch_client,
         internal_project_id,
         call_populated_match,
         now,
         {attr_key: matching_value},
         populate_typed_maps=True,
     )
-    # Legacy row that matches the filter (typed maps empty, dump has the key).
     _insert_start_row(
-        clickhouse_trace_server.ch_client,
+        ch_client,
         internal_project_id,
         call_legacy_match,
         now + datetime.timedelta(seconds=1),
         {attr_key: matching_value},
         populate_typed_maps=False,
     )
-    # Populated row that doesn't match.
     _insert_start_row(
-        clickhouse_trace_server.ch_client,
+        ch_client,
         internal_project_id,
         call_populated_other,
         now + datetime.timedelta(seconds=2),
         {attr_key: other_value},
         populate_typed_maps=True,
     )
-    # Legacy row that doesn't match.
     _insert_start_row(
-        clickhouse_trace_server.ch_client,
+        ch_client,
         internal_project_id,
         call_legacy_other,
         now + datetime.timedelta(seconds=3),
         {attr_key: other_value},
         populate_typed_maps=False,
+    )
+    return (
+        call_populated_match,
+        call_legacy_match,
+        call_populated_other,
+        call_legacy_other,
+    )
+
+
+def test_fast_filter_mixed_backfill_string_cast(
+    trace_server: object,
+    ch_server_force_legacy: ClickHouseTraceServer,
+) -> None:
+    """``$convert(attributes.env, string)`` returns populated *and* legacy matches.
+
+    The hybrid ``if(mapContains(...))`` wins on the populated row and falls
+    back to ``toString(coalesce(nullIf(JSON_VALUE, 'null'), ''))`` on the
+    legacy row whose typed maps are empty. Both ``env=prod`` rows come back;
+    the ``env=staging`` rows don't.
+    """
+    external_project_id = f"{TEST_ENTITY}/string_{uuid.uuid4().hex[:8]}"
+    internal_project_id = b64(external_project_id)
+    reset_project_residence_cache()
+    populated_match, legacy_match, *_ = _populate_two_by_two(
+        ch_server_force_legacy.ch_client,
+        internal_project_id,
+        attr_key="env",
+        matching_value="prod",
+        other_value="staging",
+        now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
     )
 
     matching_ids = _query_ids(
@@ -226,24 +232,132 @@ def test_fast_filter_mixed_backfill_returns_correct_rows(
             "$eq": [
                 {
                     "$convert": {
-                        "input": {"$getField": f"attributes.{attr_key}"},
-                        "to": cast,
+                        "input": {"$getField": "attributes.env"},
+                        "to": "string",
                     }
                 },
-                {"$literal": filter_literal},
+                {"$literal": "prod"},
             ]
         },
     )
+    assert matching_ids == {populated_match, legacy_match}
 
-    assert matching_ids == {call_populated_match, call_legacy_match}, (
-        f"cast={cast}: expected both populated and legacy matching rows; "
-        f"got {matching_ids}"
+
+def test_fast_filter_mixed_backfill_int_cast(
+    trace_server: object,
+    ch_server_force_legacy: ClickHouseTraceServer,
+) -> None:
+    """``$convert(attributes.retries, int)`` returns populated *and* legacy matches."""
+    external_project_id = f"{TEST_ENTITY}/int_{uuid.uuid4().hex[:8]}"
+    internal_project_id = b64(external_project_id)
+    reset_project_residence_cache()
+    populated_match, legacy_match, *_ = _populate_two_by_two(
+        ch_server_force_legacy.ch_client,
+        internal_project_id,
+        attr_key="retries",
+        matching_value=5,
+        other_value=2,
+        now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
     )
+
+    matching_ids = _query_ids(
+        trace_server,
+        external_project_id,
+        {
+            "$eq": [
+                {
+                    "$convert": {
+                        "input": {"$getField": "attributes.retries"},
+                        "to": "int",
+                    }
+                },
+                {"$literal": 5},
+            ]
+        },
+    )
+    assert matching_ids == {populated_match, legacy_match}
+
+
+def test_fast_filter_mixed_backfill_double_cast(
+    trace_server: object,
+    ch_server_force_legacy: ClickHouseTraceServer,
+) -> None:
+    """``$convert(attributes.score, double)`` returns populated *and* legacy matches."""
+    external_project_id = f"{TEST_ENTITY}/double_{uuid.uuid4().hex[:8]}"
+    internal_project_id = b64(external_project_id)
+    reset_project_residence_cache()
+    populated_match, legacy_match, *_ = _populate_two_by_two(
+        ch_server_force_legacy.ch_client,
+        internal_project_id,
+        attr_key="score",
+        matching_value=0.9,
+        other_value=0.1,
+        now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
+    )
+
+    matching_ids = _query_ids(
+        trace_server,
+        external_project_id,
+        {
+            "$eq": [
+                {
+                    "$convert": {
+                        "input": {"$getField": "attributes.score"},
+                        "to": "double",
+                    }
+                },
+                {"$literal": 0.9},
+            ]
+        },
+    )
+    assert matching_ids == {populated_match, legacy_match}
+
+
+def test_fast_filter_mixed_backfill_bool_cast(
+    trace_server: object,
+    ch_server_force_legacy: ClickHouseTraceServer,
+) -> None:
+    """``$convert(attributes.enabled, bool)`` returns populated *and* legacy matches.
+
+    The bool fallback compares the raw JSON_VALUE to the literal string
+    ``'true'`` (rather than the generic ``toUInt8OrNull`` cast that returns
+    NULL on JSON bool strings). This is the test that would have failed
+    before we special-cased bool — legacy rows with ``enabled: true`` in
+    the dump would have been dropped.
+    """
+    external_project_id = f"{TEST_ENTITY}/bool_{uuid.uuid4().hex[:8]}"
+    internal_project_id = b64(external_project_id)
+    reset_project_residence_cache()
+    populated_match, legacy_match, *_ = _populate_two_by_two(
+        ch_server_force_legacy.ch_client,
+        internal_project_id,
+        attr_key="enabled",
+        matching_value=True,
+        other_value=False,
+        now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
+    )
+
+    matching_ids = _query_ids(
+        trace_server,
+        external_project_id,
+        {
+            "$eq": [
+                {
+                    "$convert": {
+                        "input": {"$getField": "attributes.enabled"},
+                        "to": "bool",
+                    }
+                },
+                {"$literal": True},
+            ]
+        },
+    )
+    assert matching_ids == {populated_match, legacy_match}
 
 
 def test_fast_filter_missing_int_key_does_not_match_map_default(
     trace_server: object,
-    clickhouse_trace_server: ClickHouseTraceServer,
+    ch_server_force_legacy: ClickHouseTraceServer,
 ) -> None:
     """Without the mapContains gate, ``attributes.missing = 0`` would match every
     populated row — ClickHouse returns ``0`` for a missing Int64 Map key. The
@@ -266,7 +380,7 @@ def test_fast_filter_missing_int_key_does_not_match_map_default(
     # cannot leak into the comparison.
     call_populated_missing_key = str(uuid.uuid4())
     _insert_start_row(
-        clickhouse_trace_server.ch_client,
+        ch_server_force_legacy.ch_client,
         internal_project_id,
         call_populated_missing_key,
         now,
@@ -277,7 +391,7 @@ def test_fast_filter_missing_int_key_does_not_match_map_default(
     # not match, because the JSON path for a missing key is NULL.
     call_legacy_missing_key = str(uuid.uuid4())
     _insert_start_row(
-        clickhouse_trace_server.ch_client,
+        ch_server_force_legacy.ch_client,
         internal_project_id,
         call_legacy_missing_key,
         now + datetime.timedelta(seconds=1),
@@ -288,7 +402,7 @@ def test_fast_filter_missing_int_key_does_not_match_map_default(
     # This one *should* match, proving the filter itself is wired up.
     call_populated_zero = str(uuid.uuid4())
     _insert_start_row(
-        clickhouse_trace_server.ch_client,
+        ch_server_force_legacy.ch_client,
         internal_project_id,
         call_populated_zero,
         now + datetime.timedelta(seconds=2),

--- a/tests/trace_server/test_attributes_map_fast_filter.py
+++ b/tests/trace_server/test_attributes_map_fast_filter.py
@@ -355,6 +355,43 @@ def test_fast_filter_mixed_backfill_bool_cast(
     assert matching_ids == {populated_match, legacy_match}
 
 
+def test_fast_filter_mixed_backfill_implicit_string_no_convert(
+    trace_server: object,
+    ch_server_force_legacy: ClickHouseTraceServer,
+) -> None:
+    """``attributes.env = 'prod'`` (no ``$convert``) matches populated + legacy.
+
+    Covers the implicit-string fast path: when the peer is a string
+    ``$literal``, the query builder routes through ``attributes_map_str``
+    without requiring the caller to wrap in ``$convert(..., "string")``.
+    The row-level ``mapContains`` guard still gates the fast read so the
+    legacy row falls back to the JSON_VALUE branch and matches.
+    """
+    external_project_id = f"{TEST_ENTITY}/implicit_string_{uuid.uuid4().hex[:8]}"
+    internal_project_id = b64(external_project_id)
+    reset_project_residence_cache()
+    populated_match, legacy_match, *_ = _populate_two_by_two(
+        ch_server_force_legacy.ch_client,
+        internal_project_id,
+        attr_key="env",
+        matching_value="prod",
+        other_value="staging",
+        now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
+    )
+
+    matching_ids = _query_ids(
+        trace_server,
+        external_project_id,
+        {
+            "$eq": [
+                {"$getField": "attributes.env"},
+                {"$literal": "prod"},
+            ]
+        },
+    )
+    assert matching_ids == {populated_match, legacy_match}
+
+
 def test_fast_filter_missing_int_key_does_not_match_map_default(
     trace_server: object,
     ch_server_force_legacy: ClickHouseTraceServer,

--- a/tests/trace_server/test_attributes_map_fast_filter.py
+++ b/tests/trace_server/test_attributes_map_fast_filter.py
@@ -1,0 +1,317 @@
+"""End-to-end test for the attributes_map_* fast-filter path on ClickHouse.
+
+Migration 030 adds typed ``attributes_map_*`` columns that ``extract_typed_attrs``
+populates at ingest. Legacy rows inserted before the migration ran (or before
+a backfill job reaches them) have empty maps, so a naive ``map[key]`` lookup
+would return the CH value-type default and silently miss legitimate matches.
+
+The query builder emits ``if(mapContains(map, key), map[key], JSON_VALUE(...))``
+per row; this test pins that contract end-to-end by raw-inserting three rows
+into ``call_parts`` with different ingest states and asserting the
+``calls_query_stream`` results:
+
+  - populated   : typed maps set at ingest (post-migration)
+  - legacy      : attributes_dump only, typed maps empty (pre-migration)
+  - negative    : attributes_dump mismatch (must not match, regardless of maps)
+
+Mixed inserts in the same project cover the partial-backfill scenario the
+reviewer flagged on #6678.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import uuid
+
+import pytest
+
+from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.clickhouse_schema import EXPIRE_AT_NEVER
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.project_version.project_version import (
+    reset_project_residence_cache,
+)
+from weave.trace_server.project_version.types import CallsStorageServerMode
+from weave.trace_server.sqlite_trace_server import SqliteTraceServer
+
+TEST_ENTITY = "attrs_fast_filter_entity"
+
+
+@pytest.fixture
+def clickhouse_trace_server(trace_server: object) -> ClickHouseTraceServer:
+    """Return the internal CH server; skip on SQLite.
+
+    Force FORCE_LEGACY routing so reads hit calls_merged — this test inserts
+    directly into call_parts, not calls_complete, so we want the merged view.
+    """
+    internal = trace_server._internal_trace_server  # type: ignore[attr-defined]
+    if isinstance(internal, SqliteTraceServer):
+        pytest.skip("ClickHouse-only test")
+    internal.table_routing_resolver._mode = CallsStorageServerMode.FORCE_LEGACY
+    reset_project_residence_cache()
+    return internal
+
+
+# Columns populated on a call_parts start row. Kept as a list so ch_client.insert
+# can enforce positional order with the value rows below.
+_START_COLUMNS = [
+    "project_id",
+    "id",
+    "trace_id",
+    "parent_id",
+    "op_name",
+    "started_at",
+    "attributes_dump",
+    "attributes_map_str",
+    "attributes_map_int",
+    "attributes_map_float",
+    "attributes_map_bool",
+    "inputs_dump",
+    "input_refs",
+    "output_refs",
+    "expire_at",
+]
+
+
+def _insert_start_row(
+    ch_client: object,
+    project_id: str,
+    call_id: str,
+    started_at: datetime.datetime,
+    attributes: dict[str, object],
+    *,
+    populate_typed_maps: bool,
+) -> None:
+    """Raw-insert one call_parts start row with optional typed-map population.
+
+    ``populate_typed_maps=False`` simulates a legacy pre-migration row: the
+    attributes dict is written to ``attributes_dump`` only and the four typed
+    maps remain empty ``{}``. ``populate_typed_maps=True`` mirrors what
+    ``extract_typed_attrs`` would do at ingest for rows the feature sees.
+    """
+    attrs_str: dict[str, str] = {}
+    attrs_int: dict[str, int] = {}
+    attrs_float: dict[str, float] = {}
+    attrs_bool: dict[str, bool] = {}
+    if populate_typed_maps:
+        for k, v in attributes.items():
+            # Match extract_typed_attrs dispatch: bool before int (bool ⊂ int).
+            if isinstance(v, bool):
+                attrs_bool[k] = v
+            elif isinstance(v, int):
+                attrs_int[k] = v
+            elif isinstance(v, float):
+                attrs_float[k] = v
+            elif isinstance(v, str):
+                attrs_str[k] = v
+
+    ch_client.insert(  # type: ignore[attr-defined]
+        "call_parts",
+        [
+            [
+                project_id,
+                call_id,
+                str(uuid.uuid4()),
+                "",
+                "test_op",
+                started_at,
+                json.dumps(attributes),
+                attrs_str,
+                attrs_int,
+                attrs_float,
+                attrs_bool,
+                "{}",
+                [],
+                [],
+                EXPIRE_AT_NEVER,
+            ]
+        ],
+        column_names=_START_COLUMNS,
+    )
+
+
+def _query_ids(trace_server: object, project_id: str, filter_query: dict) -> set[str]:
+    """Return the set of call ids returned by a filtered calls_query_stream."""
+    calls = list(
+        trace_server.calls_query_stream(  # type: ignore[attr-defined]
+            tsi.CallsQueryReq(project_id=project_id, query={"$expr": filter_query})
+        )
+    )
+    return {c.id for c in calls}
+
+
+@pytest.mark.parametrize(
+    ("cast", "attr_key", "filter_literal", "matching_value", "other_value"),
+    [
+        ("string", "env", "prod", "prod", "staging"),
+        ("int", "retries", 5, 5, 2),
+        ("double", "score", 0.9, 0.9, 0.1),
+        # bool is intentionally excluded: the JSON_VALUE fallback cast is
+        # ``toUInt8OrNull``, which returns NULL for the string ``"true"``
+        # that JSON_VALUE emits for a JSON bool. That preexisting fallback
+        # limitation means legacy bool rows can't be recovered via the dump,
+        # independent of this hybrid path.
+    ],
+)
+def test_fast_filter_mixed_backfill_returns_correct_rows(
+    trace_server: object,
+    clickhouse_trace_server: ClickHouseTraceServer,
+    cast: str,
+    attr_key: str,
+    filter_literal: object,
+    matching_value: object,
+    other_value: object,
+) -> None:
+    """``$convert`` filter must return both populated and legacy rows that match.
+
+    Four rows per type go into one project: two match the filter (populated
+    + legacy), two don't (populated + legacy with a different value). The
+    hybrid ``if(mapContains(...))`` path is the only thing that can return
+    the legacy-matching row — a pure Map read would miss it because the
+    map is empty and the CH default for the value type is used instead.
+    """
+    external_project_id = f"{TEST_ENTITY}/{cast}_{uuid.uuid4().hex[:8]}"
+    internal_project_id = b64(external_project_id)
+    reset_project_residence_cache()
+
+    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+    call_populated_match = str(uuid.uuid4())
+    call_legacy_match = str(uuid.uuid4())
+    call_populated_other = str(uuid.uuid4())
+    call_legacy_other = str(uuid.uuid4())
+
+    # Populated row that matches the filter.
+    _insert_start_row(
+        clickhouse_trace_server.ch_client,
+        internal_project_id,
+        call_populated_match,
+        now,
+        {attr_key: matching_value},
+        populate_typed_maps=True,
+    )
+    # Legacy row that matches the filter (typed maps empty, dump has the key).
+    _insert_start_row(
+        clickhouse_trace_server.ch_client,
+        internal_project_id,
+        call_legacy_match,
+        now + datetime.timedelta(seconds=1),
+        {attr_key: matching_value},
+        populate_typed_maps=False,
+    )
+    # Populated row that doesn't match.
+    _insert_start_row(
+        clickhouse_trace_server.ch_client,
+        internal_project_id,
+        call_populated_other,
+        now + datetime.timedelta(seconds=2),
+        {attr_key: other_value},
+        populate_typed_maps=True,
+    )
+    # Legacy row that doesn't match.
+    _insert_start_row(
+        clickhouse_trace_server.ch_client,
+        internal_project_id,
+        call_legacy_other,
+        now + datetime.timedelta(seconds=3),
+        {attr_key: other_value},
+        populate_typed_maps=False,
+    )
+
+    matching_ids = _query_ids(
+        trace_server,
+        external_project_id,
+        {
+            "$eq": [
+                {
+                    "$convert": {
+                        "input": {"$getField": f"attributes.{attr_key}"},
+                        "to": cast,
+                    }
+                },
+                {"$literal": filter_literal},
+            ]
+        },
+    )
+
+    assert matching_ids == {call_populated_match, call_legacy_match}, (
+        f"cast={cast}: expected both populated and legacy matching rows; "
+        f"got {matching_ids}"
+    )
+
+
+def test_fast_filter_missing_int_key_does_not_match_map_default(
+    trace_server: object,
+    clickhouse_trace_server: ClickHouseTraceServer,
+) -> None:
+    """Without the mapContains gate, ``attributes.missing = 0`` would match every
+    populated row — ClickHouse returns ``0`` for a missing Int64 Map key. The
+    ``if(mapContains(...))`` wrapper ensures we instead fall through to the
+    JSON_VALUE path, which yields NULL for a missing JSON key and does not
+    compare equal to ``0``.
+
+    This is the concrete failure mode the reviewer warned about on #6678:
+    a partially-backfilled table (or a row whose particular attribute never
+    existed) silently looking like it holds the zero value. The filter must
+    not match either populated-but-missing or legacy rows.
+    """
+    external_project_id = f"{TEST_ENTITY}/missing_int_{uuid.uuid4().hex[:8]}"
+    internal_project_id = b64(external_project_id)
+    reset_project_residence_cache()
+    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+
+    # Populated row: attribute exists, but *not* the one we'll filter on.
+    # mapContains('missing_key') must be false, so the Int64 Map default (0)
+    # cannot leak into the comparison.
+    call_populated_missing_key = str(uuid.uuid4())
+    _insert_start_row(
+        clickhouse_trace_server.ch_client,
+        internal_project_id,
+        call_populated_missing_key,
+        now,
+        {"unrelated": 42},
+        populate_typed_maps=True,
+    )
+    # Legacy row with nothing in the typed maps either — fallback must also
+    # not match, because the JSON path for a missing key is NULL.
+    call_legacy_missing_key = str(uuid.uuid4())
+    _insert_start_row(
+        clickhouse_trace_server.ch_client,
+        internal_project_id,
+        call_legacy_missing_key,
+        now + datetime.timedelta(seconds=1),
+        {"unrelated": 42},
+        populate_typed_maps=False,
+    )
+    # Control: a populated row that actually has the attribute set to 0.
+    # This one *should* match, proving the filter itself is wired up.
+    call_populated_zero = str(uuid.uuid4())
+    _insert_start_row(
+        clickhouse_trace_server.ch_client,
+        internal_project_id,
+        call_populated_zero,
+        now + datetime.timedelta(seconds=2),
+        {"counter": 0},
+        populate_typed_maps=True,
+    )
+
+    matching_ids = _query_ids(
+        trace_server,
+        external_project_id,
+        {
+            "$eq": [
+                {
+                    "$convert": {
+                        "input": {"$getField": "attributes.counter"},
+                        "to": "int",
+                    }
+                },
+                {"$literal": 0},
+            ]
+        },
+    )
+    assert matching_ids == {call_populated_zero}, (
+        "Only the populated row whose 'counter' is actually 0 should match; "
+        f"the missing-key rows must not leak the Map default. got {matching_ids}"
+    )

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -17,32 +17,10 @@ from weave.trace_server.project_version.project_version import (
     reset_project_residence_cache,
 )
 from weave.trace_server.project_version.types import (
-    CallsStorageServerMode,
     ProjectDataResidence,
     ReadTable,
     WriteTarget,
 )
-from weave.trace_server.sqlite_trace_server import SqliteTraceServer
-
-
-@pytest.fixture
-def clickhouse_trace_server(trace_server):
-    """Return internal ClickHouse server and enforce AUTO routing mode.
-
-    Args:
-        trace_server: External trace server fixture.
-
-    Returns:
-        ClickHouseTraceServer: The internal ClickHouse trace server.
-
-    Examples:
-        >>> internal = clickhouse_trace_server
-    """
-    internal_server = trace_server._internal_trace_server
-    if isinstance(internal_server, SqliteTraceServer):
-        pytest.skip("ClickHouse-only test")
-    internal_server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
-    return internal_server
 
 
 def _count_project_rows(ch_client, table: str, project_id: str) -> int:

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -93,6 +93,11 @@ ATTRIBUTES_MAP_COLUMN_BY_CAST: dict[str, str] = {
     "string": "attributes_map_str",
 }
 
+# Field-name prefix that identifies an attributes path in the query DSL.
+# Stripping it gives the dot-joined key used to read the typed Map column
+# (which mirrors extract_typed_attrs at write time).
+ATTRIBUTES_FIELD_PREFIX = "attributes."
+
 
 class FilterConditionsResult(NamedTuple):
     """Result from building filter conditions.
@@ -2090,37 +2095,83 @@ def _attributes_dump_json_path(field_name: str, pb: ParamBuilder) -> str:
 
     Mirrors the JSONPath shape that ``CallsMergedDynamicField.as_sql`` uses so
     the fallback branch of the typed-map hybrid reads the same JSON location
-    the non-hybrid JSON_VALUE path would. Centralized here to keep the bool
-    fallback (which uses raw JSON_VALUE compared to the string ``'true'``) in
-    sync with the int/double/string fallback (which wraps the same JSON_VALUE
-    in ``clickhouse_cast``).
+    the non-hybrid JSON_VALUE path would.
     """
-    parts = field_name[len("attributes.") :].split(".")
+    parts = field_name.removeprefix(ATTRIBUTES_FIELD_PREFIX).split(".")
     json_path = "$" + "".join(f'."{p}"' for p in parts)
     return param_slot(pb.add_param(json_path), "String")
 
 
 def _attributes_map_fallback_sql(
-    cast: tsi_query.CastTo, json_path_slot: str, attributes_dump_sql: str
+    cast: "tsi_query.CastTo | None",
+    json_path_slot: str,
+    attributes_dump_sql: str,
 ) -> str:
-    """Typed-map fallback SQL for a single ``$convert`` cast.
+    """JSON_VALUE fallback expression for the typed-map hybrid.
 
-    Reads from ``attributes_dump`` via JSON_VALUE and returns a value of the
-    same ClickHouse type as the Map column, so the surrounding ``if(...)`` can
-    hand either branch to the outer comparison without a second cast.
+    Returns a value whose CH type matches the typed Map column on the fast
+    branch, so the surrounding ``if(...)`` hands either branch to the outer
+    comparison without a second cast.
 
-    ``bool`` is special-cased: JSON_VALUE on a JSON bool emits the literal
-    string ``"true"`` or ``"false"``, and ``toUInt8OrNull("true")`` is NULL —
-    the generic ``clickhouse_cast`` fallback would drop legacy bool rows on
-    the floor. We compare the raw JSON_VALUE against ``'true'`` instead, which
-    yields a Bool directly. int/double/string reuse ``clickhouse_cast`` because
-    the generic numeric/string casts already handle the JSON_VALUE string output.
+    - ``cast=None`` (implicit-string path): plain ``coalesce/nullIf`` over
+      ``JSON_VALUE``. Both branches are already ``String``, so no cast.
+    - ``cast="bool"``: ``JSON_VALUE`` on a JSON bool emits the literal string
+      ``"true"``/``"false"``, and ``toUInt8OrNull("true")`` is NULL — the
+      generic ``clickhouse_cast`` would drop legacy bool rows on the floor.
+      We compare the raw JSON_VALUE against ``'true'`` to yield ``Bool``.
+    - other casts: reuse ``clickhouse_cast`` since the numeric/string casts
+      already handle the JSON_VALUE string output.
     """
     json_value_expr = f"JSON_VALUE({attributes_dump_sql}, {json_path_slot})"
     if cast == "bool":
         return f"({json_value_expr} = 'true')"
     coalesced = f"coalesce(nullIf({json_value_expr}, 'null'), '')"
+    if cast is None:
+        return coalesced
     return clickhouse_cast(coalesced, cast)
+
+
+def _emit_typed_map_hybrid(
+    field_name: str,
+    column: str,
+    fallback_cast: "tsi_query.CastTo | None",
+    pb: ParamBuilder,
+    table_alias: str,
+    use_agg_fn: bool,
+    raw_fields_used: dict[str, "CallsMergedField"],
+) -> str | None:
+    """Build ``if(mapContains(map, key), map[key], JSON_VALUE fallback)`` for
+    one ``attributes.<path>`` read.
+
+    Because migration 030 only populates the typed maps for rows inserted
+    after it runs, a pure ``map[key]`` read is unsafe on mixed-backfill
+    tables: CH returns the value-type default (``0``/``0.0``/``false``/``''``)
+    for a missing key, which silently produces wrong filter results on
+    legacy rows whose attributes live only in ``attributes_dump``. The
+    per-row ``mapContains`` gate means no cutoff timestamp, no backfill
+    completion gate, and mixed tables Just Work — the fast read fires when
+    it's safe, and the old path stays correct when it isn't.
+
+    Returns None when the path has no key (e.g. bare ``attributes.``).
+    """
+    key = field_name.removeprefix(ATTRIBUTES_FIELD_PREFIX)
+    if not key:
+        return None
+    structured_field = get_field_by_name(field_name)
+    raw_fields_used[structured_field.field] = structured_field
+
+    key_slot = param_slot(pb.add_param(key), "String")
+    column_sql = f"{table_alias}.{column}"
+    attributes_dump_sql = f"{table_alias}.attributes_dump"
+    if use_agg_fn:
+        column_sql = f"any({column_sql})"
+        attributes_dump_sql = f"any({attributes_dump_sql})"
+
+    fast_expr = f"{column_sql}[{key_slot}]"
+    fallback_expr = _attributes_map_fallback_sql(
+        fallback_cast, _attributes_dump_json_path(field_name, pb), attributes_dump_sql
+    )
+    return f"if(mapContains({column_sql}, {key_slot}), {fast_expr}, {fallback_expr})"
 
 
 def _maybe_attributes_map_str_field_sql(
@@ -2137,11 +2188,11 @@ def _maybe_attributes_map_str_field_sql(
     Fires when ``operand`` is ``$getField(attributes.<path>)`` and ``peer`` is
     a string literal, covering the common ``attributes.model = 'gpt-4'``
     query shape that would otherwise require a ``$convert(..., "string")``
-    wrap to hit the typed map. Returns the same ``if(mapContains(...), fast,
-    JSON_VALUE fallback)`` hybrid as the ``$convert`` path, pinned to
-    ``attributes_map_str`` with a plain ``coalesce/nullIf`` fallback (no
-    cast wrapping — the Map value and the fallback both evaluate to
-    ``String``).
+    wrap to hit the typed map. Routes through ``_emit_typed_map_hybrid`` with
+    ``fallback_cast=None`` so the fallback is a plain ``coalesce/nullIf``
+    (the explicit ``$convert(..., "string")`` path adds a ``toString`` wrap
+    via ``clickhouse_cast`` for DSL consistency; the implicit path skips
+    that since both Map and JSON_VALUE branches are already ``String``).
 
     Returns None when the operand/peer shape doesn't match so callers fall
     back to ``process_operand`` and preserve existing behavior (including
@@ -2154,27 +2205,17 @@ def _maybe_attributes_map_str_field_sql(
     if not isinstance(peer.literal_, str):
         return None
     field_name = operand.get_field_
-    if not field_name.startswith("attributes."):
+    if not field_name.startswith(ATTRIBUTES_FIELD_PREFIX):
         return None
-    key = field_name[len("attributes.") :]
-    if not key:
-        return None
-
-    structured_field = get_field_by_name(field_name)
-    raw_fields_used[structured_field.field] = structured_field
-
-    key_slot = param_slot(pb.add_param(key), "String")
-    column_sql = f"{table_alias}.attributes_map_str"
-    attributes_dump_sql = f"{table_alias}.attributes_dump"
-    if use_agg_fn:
-        column_sql = f"any({column_sql})"
-        attributes_dump_sql = f"any({attributes_dump_sql})"
-
-    fast_expr = f"{column_sql}[{key_slot}]"
-    json_path_slot = _attributes_dump_json_path(field_name, pb)
-    json_value_expr = f"JSON_VALUE({attributes_dump_sql}, {json_path_slot})"
-    fallback_expr = f"coalesce(nullIf({json_value_expr}, 'null'), '')"
-    return f"if(mapContains({column_sql}, {key_slot}), {fast_expr}, {fallback_expr})"
+    return _emit_typed_map_hybrid(
+        field_name,
+        "attributes_map_str",
+        None,
+        pb,
+        table_alias,
+        use_agg_fn,
+        raw_fields_used,
+    )
 
 
 def _maybe_attributes_map_filter_sql(
@@ -2184,7 +2225,7 @@ def _maybe_attributes_map_filter_sql(
     use_agg_fn: bool,
     raw_fields_used: dict[str, "CallsMergedField"],
 ) -> str | None:
-    """Return hybrid fast/fallback SQL for ``$convert`` over ``attributes.<path>``.
+    """Hybrid fast/fallback SQL for ``$convert`` over ``attributes.<path>``.
 
     Only fires when:
     - the converted operand is a plain ``$getField`` on ``attributes.*``,
@@ -2194,47 +2235,26 @@ def _maybe_attributes_map_filter_sql(
 
     The Map key is the dot-joined path after ``attributes.`` to mirror the
     flattening done by ``extract_typed_attrs`` at write time.
-
-    Because migration 030 only populates the typed maps for rows inserted
-    after it runs, a pure ``map[key]`` read is unsafe on mixed-backfill
-    tables: CH returns the value-type default (``0``/``0.0``/``false``/``''``)
-    for a missing key, which silently produces wrong filter results on
-    legacy rows whose attributes live only in ``attributes_dump``. We emit
-    ``if(mapContains(map, key), map[key], <type-aware JSON_VALUE fallback>)``
-    so each row picks the typed read when the map was populated for that row
-    and falls back to the JSON_VALUE path otherwise. Per-row means no
-    cutoff timestamp, no backfill-completion gate, and mixed tables Just
-    Work — the fast read is the fast path when it's safe, and the old
-    path stays correct when it isn't.
     """
     inner = operand.convert_.input
     if not isinstance(inner, tsi_query.GetFieldOperator):
         return None
     field_name = inner.get_field_
-    if not field_name.startswith("attributes."):
+    if not field_name.startswith(ATTRIBUTES_FIELD_PREFIX):
         return None
     cast = operand.convert_.to
     column = ATTRIBUTES_MAP_COLUMN_BY_CAST.get(cast)
     if column is None:
         return None
-    key = field_name[len("attributes.") :]
-    if not key:
-        return None
-    structured_field = get_field_by_name(field_name)
-    raw_fields_used[structured_field.field] = structured_field
-
-    key_slot = param_slot(pb.add_param(key), "String")
-    column_sql = f"{table_alias}.{column}"
-    attributes_dump_sql = f"{table_alias}.attributes_dump"
-    if use_agg_fn:
-        column_sql = f"any({column_sql})"
-        attributes_dump_sql = f"any({attributes_dump_sql})"
-
-    fast_expr = f"{column_sql}[{key_slot}]"
-    fallback_expr = _attributes_map_fallback_sql(
-        cast, _attributes_dump_json_path(field_name, pb), attributes_dump_sql
+    return _emit_typed_map_hybrid(
+        field_name,
+        column,
+        cast,
+        pb,
+        table_alias,
+        use_agg_fn,
+        raw_fields_used,
     )
-    return f"if(mapContains({column_sql}, {key_slot}), {fast_expr}, {fallback_expr})"
 
 
 def process_query_to_conditions(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -2092,7 +2092,7 @@ def _maybe_attributes_map_filter_sql(
     use_agg_fn: bool,
     raw_fields_used: dict[str, "CallsMergedField"],
 ) -> str | None:
-    """Return typed-Map column SQL for ``$convert`` over ``attributes.<path>``.
+    """Return hybrid fast/fallback SQL for ``$convert`` over ``attributes.<path>``.
 
     Only fires when:
     - the converted operand is a plain ``$getField`` on ``attributes.*``,
@@ -2101,10 +2101,19 @@ def _maybe_attributes_map_filter_sql(
       falls through to the JSON_VALUE path).
 
     The Map key is the dot-joined path after ``attributes.`` to mirror the
-    flattening done by ``extract_typed_attrs`` at write time. Returns None for
-    anything outside that narrow pattern so the caller can fall back to the
-    JSON_VALUE implementation — this keeps ORDER BY and non-filter call sites
-    on the compatible path without special-casing context through the API.
+    flattening done by ``extract_typed_attrs`` at write time.
+
+    Because migration 030 only populates the typed maps for rows inserted
+    after it runs, a pure ``map[key]`` read is unsafe on mixed-backfill
+    tables: CH returns the value-type default (``0``/``0.0``/``false``/``''``)
+    for a missing key, which silently produces wrong filter results on
+    legacy rows whose attributes live only in ``attributes_dump``. We emit
+    ``if(mapContains(map, key), map[key], clickhouse_cast(JSON_VALUE(...)))``
+    so each row picks the typed read when the map was populated for that row
+    and falls back to the JSON_VALUE path otherwise. Per-row means no
+    cutoff timestamp, no backfill-completion gate, and mixed tables Just
+    Work — the fast read is the fast path when it's safe, and the old
+    path stays correct when it isn't.
     """
     inner = operand.convert_.input
     if not isinstance(inner, tsi_query.GetFieldOperator):
@@ -2124,7 +2133,12 @@ def _maybe_attributes_map_filter_sql(
     column_sql = f"{table_alias}.{column}"
     if use_agg_fn:
         column_sql = f"any({column_sql})"
-    return f"{column_sql}[{key_slot}]"
+    fast_expr = f"{column_sql}[{key_slot}]"
+    fallback_expr = clickhouse_cast(
+        structured_field.as_sql(pb, table_alias, use_agg_fn=use_agg_fn),
+        operand.convert_.to,
+    )
+    return f"if(mapContains({column_sql}, {key_slot}), {fast_expr}, {fallback_expr})"
 
 
 def process_query_to_conditions(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -2123,6 +2123,60 @@ def _attributes_map_fallback_sql(
     return clickhouse_cast(coalesced, cast)
 
 
+def _maybe_attributes_map_str_field_sql(
+    operand: "tsi_query.Operand",
+    peer: "tsi_query.Operand",
+    pb: ParamBuilder,
+    table_alias: str,
+    use_agg_fn: bool,
+    raw_fields_used: dict[str, "CallsMergedField"],
+) -> str | None:
+    """Implicit-string fast path for ``attributes.<path>`` compared against a
+    string ``$literal`` (no ``$convert`` wrapping).
+
+    Fires when ``operand`` is ``$getField(attributes.<path>)`` and ``peer`` is
+    a string literal, covering the common ``attributes.model = 'gpt-4'``
+    query shape that would otherwise require a ``$convert(..., "string")``
+    wrap to hit the typed map. Returns the same ``if(mapContains(...), fast,
+    JSON_VALUE fallback)`` hybrid as the ``$convert`` path, pinned to
+    ``attributes_map_str`` with a plain ``coalesce/nullIf`` fallback (no
+    cast wrapping — the Map value and the fallback both evaluate to
+    ``String``).
+
+    Returns None when the operand/peer shape doesn't match so callers fall
+    back to ``process_operand`` and preserve existing behavior (including
+    the ``IS NULL`` peer path and the ``$convert(..., "exists")`` case).
+    """
+    if not isinstance(operand, tsi_query.GetFieldOperator):
+        return None
+    if not isinstance(peer, tsi_query.LiteralOperation):
+        return None
+    if not isinstance(peer.literal_, str):
+        return None
+    field_name = operand.get_field_
+    if not field_name.startswith("attributes."):
+        return None
+    key = field_name[len("attributes.") :]
+    if not key:
+        return None
+
+    structured_field = get_field_by_name(field_name)
+    raw_fields_used[structured_field.field] = structured_field
+
+    key_slot = param_slot(pb.add_param(key), "String")
+    column_sql = f"{table_alias}.attributes_map_str"
+    attributes_dump_sql = f"{table_alias}.attributes_dump"
+    if use_agg_fn:
+        column_sql = f"any({column_sql})"
+        attributes_dump_sql = f"any({attributes_dump_sql})"
+
+    fast_expr = f"{column_sql}[{key_slot}]"
+    json_path_slot = _attributes_dump_json_path(field_name, pb)
+    json_value_expr = f"JSON_VALUE({attributes_dump_sql}, {json_path_slot})"
+    fallback_expr = f"coalesce(nullIf({json_value_expr}, 'null'), '')"
+    return f"if(mapContains({column_sql}, {key_slot}), {fast_expr}, {fallback_expr})"
+
+
 def _maybe_attributes_map_filter_sql(
     operand: tsi_query.ConvertOperation,
     pb: ParamBuilder,
@@ -2231,7 +2285,22 @@ def process_query_to_conditions(
                     rhs_part = process_operand(ops[1])
                     cond = f"has({array_expr}, {rhs_part})"
             else:
-                lhs_part = process_operand(ops[0])
+                # Implicit-string fast path: route $getField(attributes.x) vs
+                # a string literal through the typed Map column instead of
+                # JSON_VALUE, without requiring the caller to wrap the field
+                # in $convert(..., "string"). Falls through to the plain
+                # JSON_VALUE path for any other operand/peer shape (nested
+                # ops, typed-literal peers, attributes.* with no key, etc.),
+                # and is skipped entirely for the IS NULL peer case below.
+                lhs_fast = _maybe_attributes_map_str_field_sql(
+                    ops[0],
+                    ops[1],
+                    param_builder,
+                    table_alias,
+                    use_agg_fn,
+                    raw_fields_used,
+                )
+                lhs_part = lhs_fast if lhs_fast is not None else process_operand(ops[0])
                 if (
                     isinstance(ops[1], tsi_query.LiteralOperation)
                     and ops[1].literal_ is None

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -82,6 +82,17 @@ logger = logging.getLogger(__name__)
 CTE_FILTERED_CALLS = "filtered_calls"
 CTE_ALL_CALLS = "all_calls"
 
+# Maps a DSL cast-to type onto the typed Map column that stores attribute
+# values of that type. Used by CallsMergedDynamicField to route attribute
+# filters through the typed Map columns instead of JSON_VALUE over
+# attributes_dump when the caller declares the field's type via $convert.
+ATTRIBUTES_MAP_COLUMN_BY_CAST: dict[str, str] = {
+    "int": "attributes_map_int",
+    "double": "attributes_map_float",
+    "bool": "attributes_map_bool",
+    "string": "attributes_map_str",
+}
+
 
 class FilterConditionsResult(NamedTuple):
     """Result from building filter conditions.
@@ -2074,6 +2085,48 @@ def _get_multi_value_feedback_field(
     return None
 
 
+def _maybe_attributes_map_filter_sql(
+    operand: tsi_query.ConvertOperation,
+    pb: ParamBuilder,
+    table_alias: str,
+    use_agg_fn: bool,
+    raw_fields_used: dict[str, "CallsMergedField"],
+) -> str | None:
+    """Return typed-Map column SQL for ``$convert`` over ``attributes.<path>``.
+
+    Only fires when:
+    - the converted operand is a plain ``$getField`` on ``attributes.*``,
+    - the target cast maps to one of the typed Map columns populated at ingest
+      (``int``/``double``/``bool``/``string`` — ``exists`` has no typed Map and
+      falls through to the JSON_VALUE path).
+
+    The Map key is the dot-joined path after ``attributes.`` to mirror the
+    flattening done by ``extract_typed_attrs`` at write time. Returns None for
+    anything outside that narrow pattern so the caller can fall back to the
+    JSON_VALUE implementation — this keeps ORDER BY and non-filter call sites
+    on the compatible path without special-casing context through the API.
+    """
+    inner = operand.convert_.input
+    if not isinstance(inner, tsi_query.GetFieldOperator):
+        return None
+    field_name = inner.get_field_
+    if not field_name.startswith("attributes."):
+        return None
+    column = ATTRIBUTES_MAP_COLUMN_BY_CAST.get(operand.convert_.to)
+    if column is None:
+        return None
+    key = field_name[len("attributes.") :]
+    if not key:
+        return None
+    structured_field = get_field_by_name(field_name)
+    raw_fields_used[structured_field.field] = structured_field
+    key_slot = param_slot(pb.add_param(key), "String")
+    column_sql = f"{table_alias}.{column}"
+    if use_agg_fn:
+        column_sql = f"any({column_sql})"
+    return f"{column_sql}[{key_slot}]"
+
+
 def process_query_to_conditions(
     query: tsi.Query,
     param_builder: ParamBuilder,
@@ -2233,6 +2286,11 @@ def process_query_to_conditions(
             raw_fields_used[structured_field.field] = structured_field
             return field
         elif isinstance(operand, tsi_query.ConvertOperation):
+            fast_sql = _maybe_attributes_map_filter_sql(
+                operand, param_builder, table_alias, use_agg_fn, raw_fields_used
+            )
+            if fast_sql is not None:
+                return fast_sql
             field = process_operand(operand.convert_.input)
             return clickhouse_cast(field, operand.convert_.to)
         elif isinstance(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -2085,6 +2085,44 @@ def _get_multi_value_feedback_field(
     return None
 
 
+def _attributes_dump_json_path(field_name: str, pb: ParamBuilder) -> str:
+    """Return the ``$."a"."b"..."`` JSONPath param slot for an ``attributes.<path>`` key.
+
+    Mirrors the JSONPath shape that ``CallsMergedDynamicField.as_sql`` uses so
+    the fallback branch of the typed-map hybrid reads the same JSON location
+    the non-hybrid JSON_VALUE path would. Centralized here to keep the bool
+    fallback (which uses raw JSON_VALUE compared to the string ``'true'``) in
+    sync with the int/double/string fallback (which wraps the same JSON_VALUE
+    in ``clickhouse_cast``).
+    """
+    parts = field_name[len("attributes.") :].split(".")
+    json_path = "$" + "".join(f'."{p}"' for p in parts)
+    return param_slot(pb.add_param(json_path), "String")
+
+
+def _attributes_map_fallback_sql(
+    cast: tsi_query.CastTo, json_path_slot: str, attributes_dump_sql: str
+) -> str:
+    """Typed-map fallback SQL for a single ``$convert`` cast.
+
+    Reads from ``attributes_dump`` via JSON_VALUE and returns a value of the
+    same ClickHouse type as the Map column, so the surrounding ``if(...)`` can
+    hand either branch to the outer comparison without a second cast.
+
+    ``bool`` is special-cased: JSON_VALUE on a JSON bool emits the literal
+    string ``"true"`` or ``"false"``, and ``toUInt8OrNull("true")`` is NULL —
+    the generic ``clickhouse_cast`` fallback would drop legacy bool rows on
+    the floor. We compare the raw JSON_VALUE against ``'true'`` instead, which
+    yields a Bool directly. int/double/string reuse ``clickhouse_cast`` because
+    the generic numeric/string casts already handle the JSON_VALUE string output.
+    """
+    json_value_expr = f"JSON_VALUE({attributes_dump_sql}, {json_path_slot})"
+    if cast == "bool":
+        return f"({json_value_expr} = 'true')"
+    coalesced = f"coalesce(nullIf({json_value_expr}, 'null'), '')"
+    return clickhouse_cast(coalesced, cast)
+
+
 def _maybe_attributes_map_filter_sql(
     operand: tsi_query.ConvertOperation,
     pb: ParamBuilder,
@@ -2108,7 +2146,7 @@ def _maybe_attributes_map_filter_sql(
     tables: CH returns the value-type default (``0``/``0.0``/``false``/``''``)
     for a missing key, which silently produces wrong filter results on
     legacy rows whose attributes live only in ``attributes_dump``. We emit
-    ``if(mapContains(map, key), map[key], clickhouse_cast(JSON_VALUE(...)))``
+    ``if(mapContains(map, key), map[key], <type-aware JSON_VALUE fallback>)``
     so each row picks the typed read when the map was populated for that row
     and falls back to the JSON_VALUE path otherwise. Per-row means no
     cutoff timestamp, no backfill-completion gate, and mixed tables Just
@@ -2121,7 +2159,8 @@ def _maybe_attributes_map_filter_sql(
     field_name = inner.get_field_
     if not field_name.startswith("attributes."):
         return None
-    column = ATTRIBUTES_MAP_COLUMN_BY_CAST.get(operand.convert_.to)
+    cast = operand.convert_.to
+    column = ATTRIBUTES_MAP_COLUMN_BY_CAST.get(cast)
     if column is None:
         return None
     key = field_name[len("attributes.") :]
@@ -2129,14 +2168,17 @@ def _maybe_attributes_map_filter_sql(
         return None
     structured_field = get_field_by_name(field_name)
     raw_fields_used[structured_field.field] = structured_field
+
     key_slot = param_slot(pb.add_param(key), "String")
     column_sql = f"{table_alias}.{column}"
+    attributes_dump_sql = f"{table_alias}.attributes_dump"
     if use_agg_fn:
         column_sql = f"any({column_sql})"
+        attributes_dump_sql = f"any({attributes_dump_sql})"
+
     fast_expr = f"{column_sql}[{key_slot}]"
-    fallback_expr = clickhouse_cast(
-        structured_field.as_sql(pb, table_alias, use_agg_fn=use_agg_fn),
-        operand.convert_.to,
+    fallback_expr = _attributes_map_fallback_sql(
+        cast, _attributes_dump_json_path(field_name, pb), attributes_dump_sql
     )
     return f"if(mapContains({column_sql}, {key_slot}), {fast_expr}, {fallback_expr})"
 

--- a/weave/trace_server/clickhouse/schema_converters.py
+++ b/weave/trace_server/clickhouse/schema_converters.py
@@ -101,7 +101,7 @@ def ch_call_dict_to_call_schema_dict(ch_call_dict: dict) -> dict:
 # call_parts columns for the typed attribute Maps. End/delete/update
 # insertables don't populate them, so ch_call_to_row must substitute an
 # empty dict — ClickHouse rejects None for non-Nullable Map columns.
-EMPTY_ATTRIBUTES_MAP_COLUMNS = frozenset(
+ATTRIBUTES_MAP_COLUMNS = frozenset(
     {
         "attributes_map_str",
         "attributes_map_int",
@@ -117,7 +117,7 @@ def ch_call_to_row(ch_call: CallCHInsertable) -> list[Any]:
     row: list[Any] = []
     for col in ALL_CALL_INSERT_COLUMNS:
         val = call_dict.get(col)
-        if val is None and col in EMPTY_ATTRIBUTES_MAP_COLUMNS:
+        if val is None and col in ATTRIBUTES_MAP_COLUMNS:
             val = {}
         row.append(val)
     return row

--- a/weave/trace_server/clickhouse/schema_converters.py
+++ b/weave/trace_server/clickhouse/schema_converters.py
@@ -139,10 +139,6 @@ def start_call_for_insert_to_ch_insertable(
     if start_call.otel_dump is not None:
         otel_dump_str = dict_value_to_dump(start_call.otel_dump)
 
-    attrs_str, attrs_int, attrs_float, attrs_bool = extract_typed_attrs(
-        start_call.attributes
-    )
-
     return CallStartCHInsertable(
         project_id=start_call.project_id,
         id=call_id,
@@ -153,10 +149,7 @@ def start_call_for_insert_to_ch_insertable(
         op_name=start_call.op_name,
         started_at=start_call.started_at,
         attributes_dump=dict_value_to_dump(start_call.attributes),
-        attributes_map_str=attrs_str,
-        attributes_map_int=attrs_int,
-        attributes_map_float=attrs_float,
-        attributes_map_bool=attrs_bool,
+        **extract_typed_attrs(start_call.attributes),
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         otel_dump=otel_dump_str,
@@ -262,10 +255,6 @@ def start_end_calls_to_ch_complete_insertable(
     if start_call.otel_dump is not None:
         otel_dump_str = dict_value_to_dump(start_call.otel_dump)
 
-    attrs_str, attrs_int, attrs_float, attrs_bool = extract_typed_attrs(
-        start_call.attributes
-    )
-
     return CallCompleteCHInsertable(
         project_id=start_call.project_id,
         id=call_id,
@@ -279,10 +268,7 @@ def start_end_calls_to_ch_complete_insertable(
         ended_at=end_call.ended_at,
         exception=end_call.exception,
         attributes_dump=dict_value_to_dump(start_call.attributes),
-        attributes_map_str=attrs_str,
-        attributes_map_int=attrs_int,
-        attributes_map_float=attrs_float,
-        attributes_map_bool=attrs_bool,
+        **extract_typed_attrs(start_call.attributes),
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         output_dump=any_value_to_dump(output),
@@ -329,10 +315,6 @@ def complete_call_to_ch_insertable(
     if complete_call.otel_dump is not None:
         otel_dump_str = dict_value_to_dump(complete_call.otel_dump)
 
-    attrs_str, attrs_int, attrs_float, attrs_bool = extract_typed_attrs(
-        complete_call.attributes
-    )
-
     return CallCompleteCHInsertable(
         project_id=complete_call.project_id,
         id=complete_call.id,
@@ -346,10 +328,7 @@ def complete_call_to_ch_insertable(
         ended_at=complete_call.ended_at,
         exception=complete_call.exception,
         attributes_dump=dict_value_to_dump(complete_call.attributes),
-        attributes_map_str=attrs_str,
-        attributes_map_int=attrs_int,
-        attributes_map_float=attrs_float,
-        attributes_map_bool=attrs_bool,
+        **extract_typed_attrs(complete_call.attributes),
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         output_dump=any_value_to_dump(output),

--- a/weave/trace_server/clickhouse/schema_converters.py
+++ b/weave/trace_server/clickhouse/schema_converters.py
@@ -16,6 +16,7 @@ from weave.trace_server.clickhouse.utilities import (
     dict_dump_to_dict,
     dict_value_to_dump,
     ensure_datetimes_have_tz,
+    extract_typed_attrs,
     nullable_any_dump_to_any,
 )
 from weave.trace_server.clickhouse_schema import (
@@ -97,10 +98,29 @@ def ch_call_dict_to_call_schema_dict(ch_call_dict: dict) -> dict:
     }
 
 
+# call_parts columns for the typed attribute Maps. End/delete/update
+# insertables don't populate them, so ch_call_to_row must substitute an
+# empty dict — ClickHouse rejects None for non-Nullable Map columns.
+EMPTY_ATTRIBUTES_MAP_COLUMNS = frozenset(
+    {
+        "attributes_map_str",
+        "attributes_map_int",
+        "attributes_map_float",
+        "attributes_map_bool",
+    }
+)
+
+
 def ch_call_to_row(ch_call: CallCHInsertable) -> list[Any]:
     """Convert a CH insertable call to a row for batch insertion with the correct defaults."""
     call_dict = ch_call.model_dump()
-    return [call_dict.get(col) for col in ALL_CALL_INSERT_COLUMNS]
+    row: list[Any] = []
+    for col in ALL_CALL_INSERT_COLUMNS:
+        val = call_dict.get(col)
+        if val is None and col in EMPTY_ATTRIBUTES_MAP_COLUMNS:
+            val = {}
+        row.append(val)
+    return row
 
 
 def start_call_for_insert_to_ch_insertable(
@@ -119,6 +139,10 @@ def start_call_for_insert_to_ch_insertable(
     if start_call.otel_dump is not None:
         otel_dump_str = dict_value_to_dump(start_call.otel_dump)
 
+    attrs_str, attrs_int, attrs_float, attrs_bool = extract_typed_attrs(
+        start_call.attributes
+    )
+
     return CallStartCHInsertable(
         project_id=start_call.project_id,
         id=call_id,
@@ -129,6 +153,10 @@ def start_call_for_insert_to_ch_insertable(
         op_name=start_call.op_name,
         started_at=start_call.started_at,
         attributes_dump=dict_value_to_dump(start_call.attributes),
+        attributes_map_str=attrs_str,
+        attributes_map_int=attrs_int,
+        attributes_map_float=attrs_float,
+        attributes_map_bool=attrs_bool,
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         otel_dump=otel_dump_str,
@@ -164,6 +192,10 @@ def start_call_insertable_to_complete_start(
         ended_at=None,
         exception=None,
         attributes_dump=ch_start.attributes_dump,
+        attributes_map_str=ch_start.attributes_map_str,
+        attributes_map_int=ch_start.attributes_map_int,
+        attributes_map_float=ch_start.attributes_map_float,
+        attributes_map_bool=ch_start.attributes_map_bool,
         inputs_dump=ch_start.inputs_dump,
         input_refs=ch_start.input_refs,
         output_dump=any_value_to_dump(None),
@@ -230,6 +262,10 @@ def start_end_calls_to_ch_complete_insertable(
     if start_call.otel_dump is not None:
         otel_dump_str = dict_value_to_dump(start_call.otel_dump)
 
+    attrs_str, attrs_int, attrs_float, attrs_bool = extract_typed_attrs(
+        start_call.attributes
+    )
+
     return CallCompleteCHInsertable(
         project_id=start_call.project_id,
         id=call_id,
@@ -243,6 +279,10 @@ def start_end_calls_to_ch_complete_insertable(
         ended_at=end_call.ended_at,
         exception=end_call.exception,
         attributes_dump=dict_value_to_dump(start_call.attributes),
+        attributes_map_str=attrs_str,
+        attributes_map_int=attrs_int,
+        attributes_map_float=attrs_float,
+        attributes_map_bool=attrs_bool,
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         output_dump=any_value_to_dump(output),
@@ -289,6 +329,10 @@ def complete_call_to_ch_insertable(
     if complete_call.otel_dump is not None:
         otel_dump_str = dict_value_to_dump(complete_call.otel_dump)
 
+    attrs_str, attrs_int, attrs_float, attrs_bool = extract_typed_attrs(
+        complete_call.attributes
+    )
+
     return CallCompleteCHInsertable(
         project_id=complete_call.project_id,
         id=complete_call.id,
@@ -302,6 +346,10 @@ def complete_call_to_ch_insertable(
         ended_at=complete_call.ended_at,
         exception=complete_call.exception,
         attributes_dump=dict_value_to_dump(complete_call.attributes),
+        attributes_map_str=attrs_str,
+        attributes_map_int=attrs_int,
+        attributes_map_float=attrs_float,
+        attributes_map_bool=attrs_bool,
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         output_dump=any_value_to_dump(output),

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -110,6 +110,14 @@ def _flatten_attrs(attrs: dict[str, Any], prefix: str = "") -> list[tuple[str, A
     Matches the dot-path convention already used by read-side filters
     (`attributes.nested.leaf`), so a caller filtering on "attributes.foo.bar"
     hits the same key the extractor writes.
+
+    Collision caveat: ``{"a": {"b": 1}}`` and ``{"a.b": 1}`` both flatten to
+    key ``"a.b"``; the second write wins in the typed map. The ``JSON_VALUE``
+    fallback can still distinguish them (``$."a"."b"`` vs ``$."a.b"``), so a
+    row with a literal-dot key can legitimately read different values from
+    the fast and fallback branches. We accept this divergence because nested
+    dicts are the common shape; literal-dot keys are pathological and already
+    break the existing JSONPath-based filter convention.
     """
     result: list[tuple[str, Any]] = []
     for key, val in attrs.items():

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -25,11 +25,6 @@ from weave.trace_server.kafka import KafkaProducer
 
 logger = logging.getLogger(__name__)
 
-# Per-map cap for the typed attribute maps populated by extract_typed_attrs.
-# Applied independently to each of the four maps, so a single call can
-# contribute up to 4 * MAX_TYPED_ATTR_ENTRIES_PER_MAP entries across all maps.
-MAX_TYPED_ATTR_ENTRIES_PER_MAP = 100
-
 
 # ---------------------------------------------------------------------------
 # JSON serialization helpers
@@ -131,10 +126,14 @@ def extract_typed_attrs(
 ) -> tuple[dict[str, str], dict[str, int], dict[str, float], dict[str, bool]]:
     """Route a Python attributes dict into four typed maps for fast filtering.
 
-    Each map is independently capped at MAX_TYPED_ATTR_ENTRIES_PER_MAP entries;
-    once a map is full, additional values of that type are dropped. Non-finite
-    floats (NaN, +/-Inf) are dropped because they break JSON/CH round-trips.
-    Non-scalar leaf values (lists, etc.) are JSON-encoded into the string map.
+    No per-map entry cap: ``attributes_dump`` already admits arbitrarily large
+    payloads, the typed maps mirror it, and ``_strip_large_values`` clears the
+    maps together with the dump when a row exceeds the insert byte limit. A
+    dedicated cap would only hide truncation from callers.
+
+    Non-finite floats (NaN, +/-Inf) are dropped because they break
+    JSON/CH round-trips. Non-scalar leaf values (lists, etc.) are
+    JSON-encoded into the string map.
 
     The ``bool`` branch must come before the ``int`` branch: Python's ``bool``
     is a subclass of ``int``, so ``isinstance(True, int)`` is True, and an
@@ -154,20 +153,16 @@ def extract_typed_attrs(
         if val is None:
             continue
         if isinstance(val, bool):
-            if len(bool_map) < MAX_TYPED_ATTR_ENTRIES_PER_MAP:
-                bool_map[key] = val
+            bool_map[key] = val
         elif isinstance(val, int):
-            if len(int_map) < MAX_TYPED_ATTR_ENTRIES_PER_MAP:
-                int_map[key] = val
+            int_map[key] = val
         elif isinstance(val, float):
             if not math.isfinite(val):
                 continue
-            if len(float_map) < MAX_TYPED_ATTR_ENTRIES_PER_MAP:
-                float_map[key] = val
+            float_map[key] = val
         elif isinstance(val, str):
-            if len(str_map) < MAX_TYPED_ATTR_ENTRIES_PER_MAP:
-                str_map[key] = val
-        elif len(str_map) < MAX_TYPED_ATTR_ENTRIES_PER_MAP:
+            str_map[key] = val
+        else:
             str_map[key] = json.dumps(val)
 
     return str_map, int_map, float_map, bool_map

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -11,7 +11,7 @@ import logging
 import math
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, TypedDict
 
 import ddtrace
 import sqlparse
@@ -129,9 +129,21 @@ def _flatten_attrs(attrs: dict[str, Any], prefix: str = "") -> list[tuple[str, A
     return result
 
 
-def extract_typed_attrs(
-    attrs: dict[str, Any],
-) -> tuple[dict[str, str], dict[str, int], dict[str, float], dict[str, bool]]:
+class TypedAttrMaps(TypedDict):
+    """Typed attribute maps keyed by their CH column name.
+
+    Keys match the ``CallStartCHInsertable`` / ``CallCompleteCHInsertable``
+    fields so call sites can ``**spread`` the result straight into the
+    insertable constructor.
+    """
+
+    attributes_map_str: dict[str, str]
+    attributes_map_int: dict[str, int]
+    attributes_map_float: dict[str, float]
+    attributes_map_bool: dict[str, bool]
+
+
+def extract_typed_attrs(attrs: dict[str, Any]) -> TypedAttrMaps:
     """Route a Python attributes dict into four typed maps for fast filtering.
 
     No per-map entry cap: ``attributes_dump`` already admits arbitrarily large
@@ -146,34 +158,33 @@ def extract_typed_attrs(
     The ``bool`` branch must come before the ``int`` branch: Python's ``bool``
     is a subclass of ``int``, so ``isinstance(True, int)`` is True, and an
     int-first dispatch would land True/False in the int map.
-
-    Returns (str_map, int_map, float_map, bool_map) in insert-column order.
     """
+    result: TypedAttrMaps = {
+        "attributes_map_str": {},
+        "attributes_map_int": {},
+        "attributes_map_float": {},
+        "attributes_map_bool": {},
+    }
     if not isinstance(attrs, dict):
-        return {}, {}, {}, {}
-
-    str_map: dict[str, str] = {}
-    int_map: dict[str, int] = {}
-    float_map: dict[str, float] = {}
-    bool_map: dict[str, bool] = {}
+        return result
 
     for key, val in _flatten_attrs(attrs):
         if val is None:
             continue
         if isinstance(val, bool):
-            bool_map[key] = val
+            result["attributes_map_bool"][key] = val
         elif isinstance(val, int):
-            int_map[key] = val
+            result["attributes_map_int"][key] = val
         elif isinstance(val, float):
             if not math.isfinite(val):
                 continue
-            float_map[key] = val
+            result["attributes_map_float"][key] = val
         elif isinstance(val, str):
-            str_map[key] = val
+            result["attributes_map_str"][key] = val
         else:
-            str_map[key] = json.dumps(val)
+            result["attributes_map_str"][key] = json.dumps(val)
 
-    return str_map, int_map, float_map, bool_map
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -8,6 +8,7 @@ import datetime
 import hashlib
 import json
 import logging
+import math
 from collections import defaultdict
 from collections.abc import Sequence
 from typing import Any
@@ -23,6 +24,11 @@ from weave.trace_server.errors import InsertTooLarge
 from weave.trace_server.kafka import KafkaProducer
 
 logger = logging.getLogger(__name__)
+
+# Per-map cap for the typed attribute maps populated by extract_typed_attrs.
+# Applied independently to each of the four maps, so a single call can
+# contribute up to 4 * MAX_TYPED_ATTR_ENTRIES_PER_MAP entries across all maps.
+MAX_TYPED_ATTR_ENTRIES_PER_MAP = 100
 
 
 # ---------------------------------------------------------------------------
@@ -96,6 +102,75 @@ def split_migration_sql(sql: str) -> list[str]:
         if stripped:
             statements.append(stripped)
     return statements
+
+
+# ---------------------------------------------------------------------------
+# Typed attribute map extraction (fast-filter path)
+# ---------------------------------------------------------------------------
+
+
+def _flatten_attrs(attrs: dict[str, Any], prefix: str = "") -> list[tuple[str, Any]]:
+    """Flatten a nested dict into dot-joined (key, leaf-value) pairs.
+
+    Matches the dot-path convention already used by read-side filters
+    (`attributes.nested.leaf`), so a caller filtering on "attributes.foo.bar"
+    hits the same key the extractor writes.
+    """
+    result: list[tuple[str, Any]] = []
+    for key, val in attrs.items():
+        full_key = key if not prefix else f"{prefix}.{key}"
+        if isinstance(val, dict):
+            result.extend(_flatten_attrs(val, full_key))
+        else:
+            result.append((full_key, val))
+    return result
+
+
+def extract_typed_attrs(
+    attrs: dict[str, Any],
+) -> tuple[dict[str, str], dict[str, int], dict[str, float], dict[str, bool]]:
+    """Route a Python attributes dict into four typed maps for fast filtering.
+
+    Each map is independently capped at MAX_TYPED_ATTR_ENTRIES_PER_MAP entries;
+    once a map is full, additional values of that type are dropped. Non-finite
+    floats (NaN, +/-Inf) are dropped because they break JSON/CH round-trips.
+    Non-scalar leaf values (lists, etc.) are JSON-encoded into the string map.
+
+    The ``bool`` branch must come before the ``int`` branch: Python's ``bool``
+    is a subclass of ``int``, so ``isinstance(True, int)`` is True, and an
+    int-first dispatch would land True/False in the int map.
+
+    Returns (str_map, int_map, float_map, bool_map) in insert-column order.
+    """
+    if not isinstance(attrs, dict):
+        return {}, {}, {}, {}
+
+    str_map: dict[str, str] = {}
+    int_map: dict[str, int] = {}
+    float_map: dict[str, float] = {}
+    bool_map: dict[str, bool] = {}
+
+    for key, val in _flatten_attrs(attrs):
+        if val is None:
+            continue
+        if isinstance(val, bool):
+            if len(bool_map) < MAX_TYPED_ATTR_ENTRIES_PER_MAP:
+                bool_map[key] = val
+        elif isinstance(val, int):
+            if len(int_map) < MAX_TYPED_ATTR_ENTRIES_PER_MAP:
+                int_map[key] = val
+        elif isinstance(val, float):
+            if not math.isfinite(val):
+                continue
+            if len(float_map) < MAX_TYPED_ATTR_ENTRIES_PER_MAP:
+                float_map[key] = val
+        elif isinstance(val, str):
+            if len(str_map) < MAX_TYPED_ATTR_ENTRIES_PER_MAP:
+                str_map[key] = val
+        elif len(str_map) < MAX_TYPED_ATTR_ENTRIES_PER_MAP:
+            str_map[key] = json.dumps(val)
+
+    return str_map, int_map, float_map, bool_map
 
 
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/clickhouse_schema.py
+++ b/weave/trace_server/clickhouse_schema.py
@@ -67,6 +67,10 @@ class CallStartCHInsertable(
 
     started_at: datetime.datetime
     attributes_dump: str
+    attributes_map_str: dict[str, str] = Field(default_factory=dict)
+    attributes_map_int: dict[str, int] = Field(default_factory=dict)
+    attributes_map_float: dict[str, float] = Field(default_factory=dict)
+    attributes_map_bool: dict[str, bool] = Field(default_factory=dict)
     inputs_dump: str
     otel_dump: str | None = None
     expire_at: datetime.datetime = EXPIRE_AT_NEVER
@@ -128,6 +132,10 @@ class CallCompleteCHInsertable(
     ended_at: datetime.datetime | None = None
     exception: str | None = None
     attributes_dump: str
+    attributes_map_str: dict[str, str] = Field(default_factory=dict)
+    attributes_map_int: dict[str, int] = Field(default_factory=dict)
+    attributes_map_float: dict[str, float] = Field(default_factory=dict)
+    attributes_map_bool: dict[str, bool] = Field(default_factory=dict)
     inputs_dump: str
     output_dump: str
     summary_dump: str

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6199,15 +6199,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             if exception:
                 end.exception = exception
             end_call = end_call_for_insert_to_ch_insertable(end, retention_days)
-            calls: list[CallStartCHInsertable | CallEndCHInsertable] = [
-                start_call,
-                end_call,
-            ]
-            batch_data = []
-            for call in calls:
-                call_dict = call.model_dump()
-                values = [call_dict.get(col) for col in ALL_CALL_INSERT_COLUMNS]
-                batch_data.append(values)
+            batch_data = [ch_call_to_row(start_call), ch_call_to_row(end_call)]
 
             self._insert_call_batch(batch_data)
 
@@ -6455,15 +6447,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             end.exception = res.response["error"]
 
         end_call = end_call_for_insert_to_ch_insertable(end, retention_days)
-        calls: list[CallStartCHInsertable | CallEndCHInsertable] = [
-            start_call,
-            end_call,
-        ]
-        batch_data = []
-        for call in calls:
-            call_dict = call.model_dump()
-            values = [call_dict.get(col) for col in ALL_CALL_INSERT_COLUMNS]
-            batch_data.append(values)
+        batch_data = [ch_call_to_row(start_call), ch_call_to_row(end_call)]
 
         try:
             self._insert_call_batch(batch_data)
@@ -6845,11 +6829,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._insert_call")
     def _insert_call(self, ch_call: CallCHInsertable) -> None:
-        parameters = ch_call.model_dump()
-        row = []
-        for key in ALL_CALL_INSERT_COLUMNS:
-            row.append(parameters.get(key, None))
-        self._call_batch.append(row)
+        self._call_batch.append(ch_call_to_row(ch_call))
         if self._flush_immediately:
             self._flush_calls()
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -83,6 +83,7 @@ from weave.trace_server.calls_query_builder.usage_query_builder import (
     build_usage_query,
 )
 from weave.trace_server.clickhouse.schema_converters import (
+    ATTRIBUTES_MAP_COLUMNS,
     ch_call_dict_to_call_schema_dict,
     ch_call_to_row,
     ch_complete_call_to_row,
@@ -6943,8 +6944,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def _strip_large_values(self, batch: list[list[Any]]) -> list[list[Any]]:
         """Iterate through the batch and replace large JSON values with placeholders.
 
-        Only considers JSON dump columns and ensures their combined size stays under
-        the limit by selectively replacing the largest values.
+        Considers each ``*_dump`` JSON column individually, plus the four
+        ``attributes_map_*`` columns as a group bound to ``attributes_dump``.
+        The typed maps mirror the attributes dict at ingest and must be cleared
+        alongside the dump — otherwise stripping ``attributes_dump`` alone
+        leaves the row oversized by the sum of the map bytes.
         """
         stripped_count = 0
         final_batch = []
@@ -6953,13 +6957,26 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             ALL_CALL_INSERT_COLUMNS.index(f"{col}_dump")
             for col in ALL_CALL_JSON_COLUMNS
         ]
+        attributes_dump_idx = ALL_CALL_INSERT_COLUMNS.index("attributes_dump")
+        attributes_map_indices = [
+            ALL_CALL_INSERT_COLUMNS.index(col) for col in ATTRIBUTES_MAP_COLUMNS
+        ]
         entity_too_large_payload_byte_size = num_bytes(
             ch_settings.ENTITY_TOO_LARGE_PAYLOAD
         )
 
         for item in batch:
-            # Calculate only JSON dump bytes
-            json_idx_size_pairs = [(i, num_bytes(item[i])) for i in json_column_indices]
+            # Count attributes_dump + typed map bytes as one slot so stripping
+            # attributes hits the full byte cost in a single pass.
+            attributes_map_bytes = sum(
+                num_bytes(item[i]) for i in attributes_map_indices
+            )
+            json_idx_size_pairs = []
+            for col_idx in json_column_indices:
+                size = num_bytes(item[col_idx])
+                if col_idx == attributes_dump_idx:
+                    size += attributes_map_bytes
+                json_idx_size_pairs.append((col_idx, size))
             total_json_bytes = sum(size for _, size in json_idx_size_pairs)
 
             # If over limit, try to optimize by selectively stripping largest JSON values
@@ -6980,6 +6997,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 stripped_item[col_idx] = ch_settings.ENTITY_TOO_LARGE_PAYLOAD
                 total_json_bytes -= size - entity_too_large_payload_byte_size
                 stripped_count += 1
+                # Clear typed attribute maps together with attributes_dump; the
+                # maps are derived from the dump and would otherwise keep the
+                # row oversized after the dump placeholder is in place.
+                if col_idx == attributes_dump_idx:
+                    for map_idx in attributes_map_indices:
+                        stripped_item[map_idx] = {}
 
             final_batch.append(stripped_item)
 

--- a/weave/trace_server/migrations/030_add_attributes_map.down.sql
+++ b/weave/trace_server/migrations/030_add_attributes_map.down.sql
@@ -1,0 +1,53 @@
+-- Rollback Migration 030: Remove typed attribute maps.
+
+-- Step 1: Revert calls_merged_view to the 029 shape (without typed maps).
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleState(wb_run_step) as wb_run_step,
+        anySimpleState(wb_run_step_end) as wb_run_step_end,
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(thread_id) as thread_id,
+        anySimpleState(turn_id) as turn_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        anySimpleState(deleted_at) as deleted_at,
+        argMaxState(display_name, call_parts.created_at) as display_name,
+        anySimpleState(coalesce(call_parts.started_at, call_parts.ended_at, call_parts.created_at)) as sortable_datetime,
+        anySimpleState(otel_dump) as otel_dump,
+        minSimpleState(expire_at) as expire_at
+    FROM call_parts
+    GROUP BY project_id,
+        id;
+
+-- Step 2: Drop typed map columns from calls_merged.
+ALTER TABLE calls_merged
+    DROP COLUMN IF EXISTS attributes_map_str,
+    DROP COLUMN IF EXISTS attributes_map_int,
+    DROP COLUMN IF EXISTS attributes_map_float,
+    DROP COLUMN IF EXISTS attributes_map_bool;
+
+-- Step 3: Drop typed map columns from call_parts.
+ALTER TABLE call_parts
+    DROP COLUMN IF EXISTS attributes_map_str,
+    DROP COLUMN IF EXISTS attributes_map_int,
+    DROP COLUMN IF EXISTS attributes_map_float,
+    DROP COLUMN IF EXISTS attributes_map_bool;
+
+-- Step 4: Drop typed map columns from calls_complete.
+ALTER TABLE calls_complete
+    DROP COLUMN IF EXISTS attributes_map_str,
+    DROP COLUMN IF EXISTS attributes_map_int,
+    DROP COLUMN IF EXISTS attributes_map_float,
+    DROP COLUMN IF EXISTS attributes_map_bool;

--- a/weave/trace_server/migrations/030_add_attributes_map.up.sql
+++ b/weave/trace_server/migrations/030_add_attributes_map.up.sql
@@ -6,7 +6,7 @@
 -- Read-path filters with a known type (via $convert) hit the typed map
 -- directly instead of JSON_VALUE over attributes_dump.
 --
--- attributes_dump is preserved; typed maps are a duplicated read-path index.
+-- attributes_dump is preserved — typed maps are a duplicated read-path index.
 -- Existing rows get empty maps by default and continue to work via the
 -- JSON_VALUE fallback.
 

--- a/weave/trace_server/migrations/030_add_attributes_map.up.sql
+++ b/weave/trace_server/migrations/030_add_attributes_map.up.sql
@@ -1,0 +1,72 @@
+-- Migration 030: Add typed attribute maps for fast filtering.
+--
+-- Adds four Map columns alongside attributes_dump on call_parts, calls_merged,
+-- and calls_complete. The typed maps are populated at ingest from the Python
+-- attributes dict by dispatching each value to the map matching its type.
+-- Read-path filters with a known type (via $convert) hit the typed map
+-- directly instead of JSON_VALUE over attributes_dump.
+--
+-- attributes_dump is preserved; typed maps are a duplicated read-path index.
+-- Existing rows get empty maps by default and continue to work via the
+-- JSON_VALUE fallback.
+
+-- Step 1: Add typed maps to call_parts. Map columns default to empty map in
+-- ClickHouse, so no explicit DEFAULT clause is needed.
+ALTER TABLE call_parts
+    ADD COLUMN attributes_map_str   Map(String, String),
+    ADD COLUMN attributes_map_int   Map(String, Int64),
+    ADD COLUMN attributes_map_float Map(String, Float64),
+    ADD COLUMN attributes_map_bool  Map(String, Bool);
+
+-- Step 2: Add typed maps to calls_merged as SimpleAggregateFunction(any, ...)
+-- to match the existing AMT aggregation pattern.
+ALTER TABLE calls_merged
+    ADD COLUMN attributes_map_str   SimpleAggregateFunction(any, Map(String, String)),
+    ADD COLUMN attributes_map_int   SimpleAggregateFunction(any, Map(String, Int64)),
+    ADD COLUMN attributes_map_float SimpleAggregateFunction(any, Map(String, Float64)),
+    ADD COLUMN attributes_map_bool  SimpleAggregateFunction(any, Map(String, Bool));
+
+-- Step 3: Propagate typed maps through calls_merged_view.
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleState(wb_run_step) as wb_run_step,
+        anySimpleState(wb_run_step_end) as wb_run_step_end,
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(thread_id) as thread_id,
+        anySimpleState(turn_id) as turn_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        -- Maps default to map() on non-start rows. Gate on isNotNull(started_at)
+        -- so the empty default from an end/delete/update row can't win over
+        -- the start row's populated maps under SimpleAggregateFunction(any).
+        anySimpleStateIf(attributes_map_str, isNotNull(call_parts.started_at)) as attributes_map_str,
+        anySimpleStateIf(attributes_map_int, isNotNull(call_parts.started_at)) as attributes_map_int,
+        anySimpleStateIf(attributes_map_float, isNotNull(call_parts.started_at)) as attributes_map_float,
+        anySimpleStateIf(attributes_map_bool, isNotNull(call_parts.started_at)) as attributes_map_bool,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        anySimpleState(deleted_at) as deleted_at,
+        argMaxState(display_name, call_parts.created_at) as display_name,
+        anySimpleState(coalesce(call_parts.started_at, call_parts.ended_at, call_parts.created_at)) as sortable_datetime,
+        anySimpleState(otel_dump) as otel_dump,
+        minSimpleState(expire_at) as expire_at
+    FROM call_parts
+    GROUP BY project_id,
+        id;
+
+-- Step 4: Add typed maps to calls_complete.
+ALTER TABLE calls_complete
+    ADD COLUMN attributes_map_str   Map(String, String),
+    ADD COLUMN attributes_map_int   Map(String, Int64),
+    ADD COLUMN attributes_map_float Map(String, Float64),
+    ADD COLUMN attributes_map_bool  Map(String, Bool);


### PR DESCRIPTION
## Summary

Adds four typed Map columns to `call_parts`, `calls_merged`, and `calls_complete` alongside `attributes_dump`. At ingest, each attribute value is routed into `attributes_map_str` / `_int` / `_float` / `_bool` by Python type. Filters wrapped in `$convert` hit the typed column directly instead of `JSON_VALUE(attributes_dump, ...)`.

- ORDER BY and unconverted filters keep the JSON_VALUE path — no behavior change for those.
- Modeled on the `custom_attrs*` pattern in #6567.

## Back-compat

Rows inserted before migration 030 (or before backfill completes) have empty typed maps. The query builder emits a row-level `if(mapContains(...), ...)` guard so the fast path fires only when the map was populated for that row; legacy rows fall back to the existing JSON_VALUE path. Mixed-backfill tables stay correct without a cutoff timestamp or table-wide flag.

Minimal example — `$convert(attributes.retries, int) == 3` on `calls_complete`:

```sql
if(attributes_map_int != NULL,  -- fix me (can break out to top)
   attributes_map_int['retries'],
   toInt64OrNull(coalesce(nullIf(JSON_VALUE(attributes_dump, '$."retries"'), 'null'), '')))
= 3
```

## Test plan

- [x] 10 new unit tests in `test_attributes_map_dispatch.py` (dispatch per cast, nested paths, fallback, extractor edge cases)
- [x] 366 existing `query_builder/` tests pass
- [x] `clickhouse_trace_server_migrator` tests pass


Local benchmarking:

