### PR TITLE
fix(weave): make CH migration splitter comment aware

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -6,6 +6,7 @@ import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError
 
 from weave.trace_server import clickhouse_trace_server_migrator as trace_server_migrator
+from weave.trace_server.clickhouse.utilities import split_migration_sql
 from weave.trace_server.clickhouse_trace_server_migrator import (
     _MAX_RETRIES,
     BaseClickHouseTraceServerMigrator,
@@ -15,7 +16,6 @@ from weave.trace_server.clickhouse_trace_server_migrator import (
     ReplicatedClickHouseTraceServerMigrator,
     SQLPatterns,
     _is_transient_ch_error,
-    split_migration_sql,
 )
 
 DEFAULT_MIGRATION_DIR = os.path.abspath(

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -1334,39 +1334,65 @@ def test_is_transient_ch_error():
     assert not _is_transient_ch_error(DatabaseError(""))
 
 
-@pytest.mark.parametrize(
-    ("sql", "expected"),
-    [
-        # Line comment containing a `;` must not split the surrounding statement.
-        (
-            "-- attributes_dump is preserved; typed maps are a duplicated index.\n"
-            "ALTER TABLE calls ADD COLUMN foo String",
-            ["ALTER TABLE calls ADD COLUMN foo String"],
-        ),
-        # Single-quoted string containing `;` must stay in one statement.
-        (
-            "ALTER TABLE t ADD COLUMN c String DEFAULT 'a;b'",
-            ["ALTER TABLE t ADD COLUMN c String DEFAULT 'a;b'"],
-        ),
-        # Doubled single quote is an escaped quote inside a literal.
-        (
-            "ALTER TABLE t ADD COLUMN c String DEFAULT 'it''s; fine'",
-            ["ALTER TABLE t ADD COLUMN c String DEFAULT 'it''s; fine'"],
-        ),
-        # Trailing whitespace/newlines after the final `;` must not produce an empty statement.
-        ("SELECT 1;\n\n   \n", ["SELECT 1"]),
-        # A pure-comment file returns an empty list.
-        ("-- just a comment;\n-- another; one\n", []),
-        # Block comments are stripped but don't split statements.
-        ("/* note; with ; inside */ SELECT 1; SELECT 2", ["SELECT 1", "SELECT 2"]),
-    ],
-)
-def test_split_migration_sql_edge_cases(sql: str, expected: list[str]) -> None:
-    assert split_migration_sql(sql) == expected
+def test_split_migration_sql() -> None:
+    """One dense case exercising every rule the splitter cares about.
 
+    Rules verified (one assertion cluster per rule):
+    - ``;`` inside ``--`` line comments does not split a statement;
+    - ``;`` inside ``/* ... */`` block comments does not split a statement,
+      and block comments spanning lines are handled;
+    - ``;`` inside a single-quoted string stays in the statement, including
+      SQL-style ``''`` escaped quotes;
+    - trailing whitespace/newlines after the final ``;`` do not emit an
+      empty statement;
+    - a file containing only comments (line or block) yields no statements;
+    - a file with N non-empty statements yields exactly N entries, each
+      with no trailing ``;`` and no leaked comment markers;
+    - a mixed end-to-end migration (comments + block comments + string
+      literals with semicolons + blank lines) round-trips to the exact
+      statement bodies we expect.
+    """
+    # 1. Line comment with a `;` inside it does not split the statement.
+    assert split_migration_sql(
+        "-- attributes_dump is preserved; typed maps are a duplicated index.\n"
+        "ALTER TABLE calls ADD COLUMN foo String"
+    ) == ["ALTER TABLE calls ADD COLUMN foo String"]
 
-def test_split_migration_sql_combined() -> None:
-    """Dense end-to-end case: comments + string literals + blank lines + multiple stmts."""
+    # 2. String literal with a `;` stays in one statement; doubled-quote
+    #    escapes are preserved (no spurious termination of the string).
+    assert split_migration_sql("ALTER TABLE t ADD COLUMN c String DEFAULT 'a;b'") == [
+        "ALTER TABLE t ADD COLUMN c String DEFAULT 'a;b'"
+    ]
+    assert split_migration_sql(
+        "ALTER TABLE t ADD COLUMN c String DEFAULT 'it''s; fine'"
+    ) == ["ALTER TABLE t ADD COLUMN c String DEFAULT 'it''s; fine'"]
+
+    # 3. Trailing whitespace after the final `;` produces no empty statement.
+    assert split_migration_sql("SELECT 1;\n\n   \n") == ["SELECT 1"]
+
+    # 4. Comment-only files (line or block) yield zero statements.
+    assert split_migration_sql("-- just a comment;\n-- another; one\n") == []
+    assert split_migration_sql("/* header;\n only; */\n") == []
+
+    # 5. Block comments — even those spanning lines with `;` inside — do not
+    #    split the surrounding statements, and the count matches exactly.
+    assert split_migration_sql("/* note; with ; inside */ SELECT 1; SELECT 2") == [
+        "SELECT 1",
+        "SELECT 2",
+    ]
+    assert (
+        len(
+            split_migration_sql(
+                "CREATE TABLE a (id UInt64) ENGINE=Memory;"
+                " INSERT INTO a VALUES (1);"
+                " DROP TABLE a;"
+            )
+        )
+        == 3
+    )
+
+    # 6. End-to-end migration: comments, block comments, string literals with
+    #    semicolons, and blank lines all compose without corrupting bodies.
     sql = """
     -- migration: widen config; also tweak defaults
     ALTER TABLE runs
@@ -1383,23 +1409,13 @@ def test_split_migration_sql_combined() -> None:
     CREATE INDEX idx_runs_config ON runs (config) TYPE minmax;
     """
     statements = split_migration_sql(sql)
-    assert len(statements) == 3
-    assert statements[0] == (
-        "ALTER TABLE runs\n        ADD COLUMN config String DEFAULT 'k=v;other=1'"
-    )
-    assert statements[1] == (
-        "ALTER TABLE runs\n        ADD COLUMN note String DEFAULT 'it''s; ok'"
-    )
-    assert statements[2] == "CREATE INDEX idx_runs_config ON runs (config) TYPE minmax"
-    # No statement should leak a trailing `;` or contain comment text.
+    assert statements == [
+        "ALTER TABLE runs\n        ADD COLUMN config String DEFAULT 'k=v;other=1'",
+        "ALTER TABLE runs\n        ADD COLUMN note String DEFAULT 'it''s; ok'",
+        "CREATE INDEX idx_runs_config ON runs (config) TYPE minmax",
+    ]
     for s in statements:
         assert not s.endswith(";")
         assert "--" not in s
         assert "/*" not in s
-
-
-def test_split_migration_sql_multiple_statement_count() -> None:
-    """Baseline: three simple statements produce three entries."""
-    sql = "CREATE TABLE a (id UInt64) ENGINE=Memory; INSERT INTO a VALUES (1); DROP TABLE a;"
-    assert len(split_migration_sql(sql)) == 3
     assert not _is_transient_ch_error(ConnectionError("not a db error"))

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -1333,6 +1333,7 @@ def test_is_transient_ch_error():
     assert not _is_transient_ch_error(DatabaseError("Code: 62. DB::Exception: ..."))
     assert not _is_transient_ch_error(DatabaseError("some other error"))
     assert not _is_transient_ch_error(DatabaseError(""))
+    assert not _is_transient_ch_error(ConnectionError("not a db error"))
 
 
 def test_split_migration_sql() -> None:

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -3,6 +3,7 @@ import types
 from unittest.mock import Mock, call, patch
 
 import pytest
+import sqlparse
 from clickhouse_connect.driver.exceptions import DatabaseError
 
 from weave.trace_server import clickhouse_trace_server_migrator as trace_server_migrator
@@ -1418,4 +1419,54 @@ def test_split_migration_sql() -> None:
         assert not s.endswith(";")
         assert "--" not in s
         assert "/*" not in s
-    assert not _is_transient_ch_error(ConnectionError("not a db error"))
+
+
+def test_split_migration_sql_equivalent_on_all_shipped_migrations() -> None:
+    """Every shipped migration file produces the same statement sequence
+    under the new splitter as under the old naive ``split(";")``.
+
+    This is the drop-in-replacement guarantee: for migrations that existed
+    before the splitter change, ClickHouse must receive exactly the same
+    stream of statements, modulo comment stripping (which CH was already
+    ignoring server-side). If the two splitters diverge for any existing
+    migration, that migration either (a) depended on the old bug (``;``
+    inside a comment/string that was landing as garbage in CH), or (b)
+    uncovers a sqlparse quirk we did not anticipate — both worth failing
+    the test over.
+
+    Both outputs are normalized by stripping comments and collapsing
+    internal whitespace, then comparing as lists of normalized statements.
+    Comments are a no-op to ClickHouse's parser, and whitespace inside a
+    statement body never affects execution, so this normalization is the
+    right semantic identity to compare on.
+    """
+
+    # Old splitter, pre-change behavior: naive split on every ``;``, strip
+    # each chunk, drop empties (matches ``_execute_migration_command``'s
+    # ``if len(command) == 0: return`` guard).
+    def old_split(sql: str) -> list[str]:
+        return [chunk.strip() for chunk in sql.split(";") if chunk.strip()]
+
+    def normalize(stmt: str) -> str:
+        # Strip comments (CH ignores them anyway) and collapse whitespace to
+        # a canonical single-space form, so layout differences don't mask a
+        # true-positive semantic match.
+        no_comments = sqlparse.format(stmt, strip_comments=True)
+        return " ".join(no_comments.split())
+
+    migration_files = sorted(
+        f for f in os.listdir(DEFAULT_MIGRATION_DIR) if f.endswith(".up.sql")
+    )
+    assert migration_files, "no .up.sql migrations discovered — wrong path?"
+
+    for name in migration_files:
+        with open(os.path.join(DEFAULT_MIGRATION_DIR, name), encoding="utf-8") as f:
+            sql = f.read()
+        old_norm = [normalize(s) for s in old_split(sql)]
+        old_norm = [s for s in old_norm if s]  # drop comment-only chunks
+        new_norm = [normalize(s) for s in split_migration_sql(sql)]
+        assert old_norm == new_norm, (
+            f"splitter divergence in {name}:\n"
+            f"  old ({len(old_norm)}): {old_norm}\n"
+            f"  new ({len(new_norm)}): {new_norm}"
+        )

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -15,6 +15,7 @@ from weave.trace_server.clickhouse_trace_server_migrator import (
     ReplicatedClickHouseTraceServerMigrator,
     SQLPatterns,
     _is_transient_ch_error,
+    split_migration_sql,
 )
 
 DEFAULT_MIGRATION_DIR = os.path.abspath(
@@ -1331,4 +1332,74 @@ def test_is_transient_ch_error():
     assert not _is_transient_ch_error(DatabaseError("Code: 62. DB::Exception: ..."))
     assert not _is_transient_ch_error(DatabaseError("some other error"))
     assert not _is_transient_ch_error(DatabaseError(""))
+
+
+@pytest.mark.parametrize(
+    ("sql", "expected"),
+    [
+        # Line comment containing a `;` must not split the surrounding statement.
+        (
+            "-- attributes_dump is preserved; typed maps are a duplicated index.\n"
+            "ALTER TABLE calls ADD COLUMN foo String",
+            ["ALTER TABLE calls ADD COLUMN foo String"],
+        ),
+        # Single-quoted string containing `;` must stay in one statement.
+        (
+            "ALTER TABLE t ADD COLUMN c String DEFAULT 'a;b'",
+            ["ALTER TABLE t ADD COLUMN c String DEFAULT 'a;b'"],
+        ),
+        # Doubled single quote is an escaped quote inside a literal.
+        (
+            "ALTER TABLE t ADD COLUMN c String DEFAULT 'it''s; fine'",
+            ["ALTER TABLE t ADD COLUMN c String DEFAULT 'it''s; fine'"],
+        ),
+        # Trailing whitespace/newlines after the final `;` must not produce an empty statement.
+        ("SELECT 1;\n\n   \n", ["SELECT 1"]),
+        # A pure-comment file returns an empty list.
+        ("-- just a comment;\n-- another; one\n", []),
+        # Block comments are stripped but don't split statements.
+        ("/* note; with ; inside */ SELECT 1; SELECT 2", ["SELECT 1", "SELECT 2"]),
+    ],
+)
+def test_split_migration_sql_edge_cases(sql: str, expected: list[str]) -> None:
+    assert split_migration_sql(sql) == expected
+
+
+def test_split_migration_sql_combined() -> None:
+    """Dense end-to-end case: comments + string literals + blank lines + multiple stmts."""
+    sql = """
+    -- migration: widen config; also tweak defaults
+    ALTER TABLE runs
+        ADD COLUMN config String DEFAULT 'k=v;other=1';
+
+    /* block comment
+       spanning lines; with semicolons */
+
+    -- another; line comment
+    ALTER TABLE runs
+        ADD COLUMN note String DEFAULT 'it''s; ok';
+
+
+    CREATE INDEX idx_runs_config ON runs (config) TYPE minmax;
+    """
+    statements = split_migration_sql(sql)
+    assert len(statements) == 3
+    assert statements[0] == (
+        "ALTER TABLE runs\n        ADD COLUMN config String DEFAULT 'k=v;other=1'"
+    )
+    assert statements[1] == (
+        "ALTER TABLE runs\n        ADD COLUMN note String DEFAULT 'it''s; ok'"
+    )
+    assert statements[2] == "CREATE INDEX idx_runs_config ON runs (config) TYPE minmax"
+    # No statement should leak a trailing `;` or contain comment text.
+    for s in statements:
+        assert not s.endswith(";")
+        assert "--" not in s
+        assert "/*" not in s
+
+
+def test_split_migration_sql_multiple_statement_count() -> None:
+    """Baseline: three simple statements produce three entries."""
+    sql = "CREATE TABLE a (id UInt64) ENGINE=Memory; INSERT INTO a VALUES (1); DROP TABLE a;"
+    assert len(split_migration_sql(sql)) == 3
     assert not _is_transient_ch_error(ConnectionError("not a db error"))

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from typing import Any
 
 import ddtrace
+import sqlparse
 from clickhouse_connect.driver.exceptions import DatabaseError
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
@@ -70,6 +71,31 @@ def nullable_any_dump_to_any(
     val: str | None,
 ) -> Any | None:
     return any_dump_to_any(val) if val else None
+
+
+# ---------------------------------------------------------------------------
+# Migration SQL helpers
+# ---------------------------------------------------------------------------
+
+
+def split_migration_sql(sql: str) -> list[str]:
+    """Split a ClickHouse migration SQL script into individual statements.
+
+    A naive ``sql.split(";")`` breaks on ``;`` inside ``--`` line comments,
+    ``/* ... */`` block comments, or single-quoted string literals — the
+    migrator then sends a mid-comment fragment to ClickHouse and gets
+    ``DB::Exception: Empty query. (SYNTAX_ERROR)``.
+
+    Delegates to ``sqlparse`` (already a project dependency) for
+    string/comment-aware splitting, then strips comments and empty
+    statements from the result.
+    """
+    statements: list[str] = []
+    for raw in sqlparse.split(sql, strip_semicolon=True):
+        stripped = sqlparse.format(raw, strip_comments=True).strip()
+        if stripped:
+            statements.append(stripped)
+    return statements
 
 
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -93,6 +93,7 @@ from tenacity import (
 )
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
+from weave.trace_server.clickhouse.utilities import split_migration_sql
 from weave.trace_server.costs.insert_costs import insert_costs, should_insert_costs
 from weave.trace_server.database_engine import (
     ENGINE_DISCOVERY_MAX_WAIT_SECONDS,
@@ -122,98 +123,6 @@ def _is_transient_ch_error(exc: BaseException) -> bool:
     if match is None:
         return False
     return int(match.group(1)) in _TRANSIENT_CH_ERROR_CODES
-
-
-def split_migration_sql(sql: str) -> list[str]:
-    """Split a ClickHouse migration SQL script into individual statements.
-
-    A naive `sql.split(";")` breaks when `;` appears inside a `-- line comment`
-    (e.g. ``-- attributes_dump is preserved; typed maps are a dup index.``) or
-    inside a single-quoted string literal (e.g. ``DEFAULT 'a;b'``). ClickHouse
-    then receives a mid-comment fragment and raises ``DB::Exception: Empty query.
-    (SYNTAX_ERROR)``.
-
-    This tokenizer walks the SQL character-by-character tracking two pieces of
-    state: whether we are currently inside a single-quoted string literal, and
-    whether we are currently inside a ``--`` line comment or ``/* ... */`` block
-    comment. Only top-level, non-string, non-comment ``;`` characters act as
-    statement terminators. Single quotes are escaped via doubling (``''``),
-    matching ClickHouse's SQL dialect.
-
-    Empty statements (after stripping whitespace) are dropped from the result.
-    """
-    statements: list[str] = []
-    buf: list[str] = []
-    i = 0
-    n = len(sql)
-    in_string = False
-    in_line_comment = False
-    in_block_comment = False
-
-    while i < n:
-        ch = sql[i]
-        nxt = sql[i + 1] if i + 1 < n else ""
-
-        if in_line_comment:
-            # Line comments end at newline; consume the newline into the buffer
-            # so whitespace/line structure is preserved for readability.
-            if ch == "\n":
-                in_line_comment = False
-                buf.append(ch)
-            i += 1
-            continue
-
-        if in_block_comment:
-            if ch == "*" and nxt == "/":
-                in_block_comment = False
-                i += 2
-                continue
-            i += 1
-            continue
-
-        if in_string:
-            buf.append(ch)
-            if ch == "'":
-                # Doubled single-quote is an escaped quote, not a terminator.
-                if nxt == "'":
-                    buf.append(nxt)
-                    i += 2
-                    continue
-                in_string = False
-            i += 1
-            continue
-
-        # Not in string / not in comment — check for comment starts.
-        if ch == "-" and nxt == "-":
-            in_line_comment = True
-            i += 2
-            continue
-        if ch == "/" and nxt == "*":
-            in_block_comment = True
-            i += 2
-            continue
-
-        if ch == "'":
-            in_string = True
-            buf.append(ch)
-            i += 1
-            continue
-
-        if ch == ";":
-            statement = "".join(buf).strip()
-            if statement:
-                statements.append(statement)
-            buf = []
-            i += 1
-            continue
-
-        buf.append(ch)
-        i += 1
-
-    tail = "".join(buf).strip()
-    if tail:
-        statements.append(tail)
-    return statements
 
 
 # These settings are only used when `replicated` mode is enabled for

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -124,6 +124,98 @@ def _is_transient_ch_error(exc: BaseException) -> bool:
     return int(match.group(1)) in _TRANSIENT_CH_ERROR_CODES
 
 
+def split_migration_sql(sql: str) -> list[str]:
+    """Split a ClickHouse migration SQL script into individual statements.
+
+    A naive `sql.split(";")` breaks when `;` appears inside a `-- line comment`
+    (e.g. ``-- attributes_dump is preserved; typed maps are a dup index.``) or
+    inside a single-quoted string literal (e.g. ``DEFAULT 'a;b'``). ClickHouse
+    then receives a mid-comment fragment and raises ``DB::Exception: Empty query.
+    (SYNTAX_ERROR)``.
+
+    This tokenizer walks the SQL character-by-character tracking two pieces of
+    state: whether we are currently inside a single-quoted string literal, and
+    whether we are currently inside a ``--`` line comment or ``/* ... */`` block
+    comment. Only top-level, non-string, non-comment ``;`` characters act as
+    statement terminators. Single quotes are escaped via doubling (``''``),
+    matching ClickHouse's SQL dialect.
+
+    Empty statements (after stripping whitespace) are dropped from the result.
+    """
+    statements: list[str] = []
+    buf: list[str] = []
+    i = 0
+    n = len(sql)
+    in_string = False
+    in_line_comment = False
+    in_block_comment = False
+
+    while i < n:
+        ch = sql[i]
+        nxt = sql[i + 1] if i + 1 < n else ""
+
+        if in_line_comment:
+            # Line comments end at newline; consume the newline into the buffer
+            # so whitespace/line structure is preserved for readability.
+            if ch == "\n":
+                in_line_comment = False
+                buf.append(ch)
+            i += 1
+            continue
+
+        if in_block_comment:
+            if ch == "*" and nxt == "/":
+                in_block_comment = False
+                i += 2
+                continue
+            i += 1
+            continue
+
+        if in_string:
+            buf.append(ch)
+            if ch == "'":
+                # Doubled single-quote is an escaped quote, not a terminator.
+                if nxt == "'":
+                    buf.append(nxt)
+                    i += 2
+                    continue
+                in_string = False
+            i += 1
+            continue
+
+        # Not in string / not in comment — check for comment starts.
+        if ch == "-" and nxt == "-":
+            in_line_comment = True
+            i += 2
+            continue
+        if ch == "/" and nxt == "*":
+            in_block_comment = True
+            i += 2
+            continue
+
+        if ch == "'":
+            in_string = True
+            buf.append(ch)
+            i += 1
+            continue
+
+        if ch == ";":
+            statement = "".join(buf).strip()
+            if statement:
+                statements.append(statement)
+            buf = []
+            i += 1
+            continue
+
+        buf.append(ch)
+        i += 1
+
+    tail = "".join(buf).strip()
+    if tail:
+        statements.append(tail)
+    return statements
+
+
 # These settings are only used when `replicated` mode is enabled for
 # self managed clickhouse instances.
 DEFAULT_REPLICATED_PATH = "/clickhouse/tables/{db}"
@@ -427,9 +519,11 @@ class BaseClickHouseTraceServerMigrator(ABC):
         # Mark migration as partially applied
         self._update_migration_status(target_db, target_version, is_start=True)
 
-        # Execute each command in the migration
-        migration_sub_commands = migration_sql.split(";")
-        for command in migration_sub_commands:
+        # Execute each command in the migration. Use a comment- and
+        # string-literal-aware tokenizer instead of a naive ``split(";")`` so
+        # that ``;`` inside ``-- line comments`` or ``'quoted strings'`` does
+        # not fragment statements mid-way and produce empty/invalid SQL.
+        for command in split_migration_sql(migration_sql):
             self._execute_migration_command(target_db, command)
 
         # Mark migration as fully applied


### PR DESCRIPTION
## Summary

`ClickHouseTraceServerMigrator._apply_migration` split migration SQL on a naive `";"`. Any `;` inside a `-- line comment` or a single-quoted string literal fragmented the statement mid-way, producing `DB::Exception: Empty query. (SYNTAX_ERROR)` (e.g. a comment `-- attributes_dump is preserved; typed maps are a dup index.`).

Replace with `split_migration_sql` in `weave/trace_server/clickhouse/utilities.py`: a six-line wrapper that delegates to `sqlparse` (already a prod dependency) for string- and comment-aware splitting, then strips comments and empty statements via `sqlparse.format(strip_comments=True)`. No bespoke parser, no state machine. The migrator imports it.

### Testing
- unit tests
- direct comparison between pre and post formatted migrations