### PR TITLE
chore(weave): Make serialization more clear

### DIFF
--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -7,8 +7,8 @@ from weave.trace.object_record import pydantic_object_record
 from weave.trace.serialization.op_type import _replace_memory_address
 from weave.trace.serialization.serialize import (
     dictify,
-    fallback_encode,
     is_pydantic_model_class,
+    stringify,
     to_json,
 )
 
@@ -144,21 +144,14 @@ def test_dictify_to_dict() -> None:
     }
 
 
-def test_fallback_encode_dictify_fails() -> None:
+def test_stringify_returns_repr() -> None:
+    @dataclass
     class Point:
         x: int
         y: int
 
-        def __init__(self, x: int, y: int) -> None:
-            self.x = x
-            self.y = y
-
-        def to_dict(self) -> dict:
-            # Intentionally make dictify fail
-            raise ValueError("a bug in user code")
-
     pt = Point(1, 2)
-    assert fallback_encode(pt) == repr(pt)
+    assert stringify(pt) == repr(pt)
 
 
 def test_dictify_sanitizes() -> None:

--- a/tests/trace/test_serialize_encoders.py
+++ b/tests/trace/test_serialize_encoders.py
@@ -1,0 +1,511 @@
+"""Tests for the encoder ladder in ``weave.trace.serialization.serialize``.
+
+Each ``_encode_*`` helper is tested in isolation for two behaviors:
+  1. Match: returns the correctly-shaped JSON payload for an input it owns.
+  2. Miss: returns the ``_MISS`` sentinel for an input it does not own.
+
+Separately, ``to_json`` is tested end-to-end to verify the dispatch order —
+higher-priority encoders win when multiple could match — and that the terminal
+``stringify`` fallback catches anything that falls through.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, NamedTuple
+
+import pytest
+from pydantic import BaseModel
+
+from weave.flow.scorer import WeaveScorerResult
+from weave.trace.object_record import ObjectRecord
+from weave.trace.refs import ObjectRef, TableRef
+from weave.trace.serialization.serialize import (
+    _MISS,
+    _encode_container,
+    _encode_custom_obj,
+    _encode_dictify,
+    _encode_object_record,
+    _encode_primitive,
+    _encode_pydantic_schema,
+    _encode_ref,
+    _encode_try_to_dict,
+    _encode_weave_scorer_result,
+    to_json,
+)
+
+PROJECT_ID = "entity/project"
+
+
+# ---------- _encode_ref ----------
+
+
+def test_encode_ref_table_ref_returns_uri() -> None:
+    ref = TableRef(entity="e", project="p", _digest="abc123")
+    assert _encode_ref(ref, PROJECT_ID, None, False) == ref.uri
+
+
+def test_encode_ref_object_ref_returns_uri() -> None:
+    ref = ObjectRef(entity="e", project="p", name="obj", _digest="abc123")
+    assert _encode_ref(ref, PROJECT_ID, None, False) == ref.uri
+
+
+@pytest.mark.parametrize(
+    "value",
+    [1, 1.5, "s", True, False, None, [1], {"a": 1}, (1, 2), object()],
+)
+def test_encode_ref_non_ref_returns_miss(value: Any) -> None:
+    assert _encode_ref(value, PROJECT_ID, None, False) is _MISS
+
+
+# ---------- _encode_object_record ----------
+
+
+def test_encode_object_record_basic() -> None:
+    # The encoder adds "_type" at the top then copies every attribute from
+    # __dict__, which includes the raw "_class_name" as well. Both keys end
+    # up in the payload; downstream code treats "_type" as authoritative.
+    rec = ObjectRecord({"_class_name": "Foo", "x": 1, "y": "hi"})
+    result = _encode_object_record(rec, PROJECT_ID, None, False)
+    assert result == {"_type": "Foo", "_class_name": "Foo", "x": 1, "y": "hi"}
+
+
+def test_encode_object_record_recurses_into_nested_values() -> None:
+    rec = ObjectRecord(
+        {
+            "_class_name": "Foo",
+            "nested_list": [1, 2, 3],
+            "nested_dict": {"k": "v"},
+        }
+    )
+    result = _encode_object_record(rec, PROJECT_ID, None, False)
+    assert result == {
+        "_type": "Foo",
+        "_class_name": "Foo",
+        "nested_list": [1, 2, 3],
+        "nested_dict": {"k": "v"},
+    }
+
+
+def test_encode_object_record_drops_null_ref() -> None:
+    rec = ObjectRecord({"_class_name": "Foo", "ref": None, "x": 1})
+    result = _encode_object_record(rec, PROJECT_ID, None, False)
+    assert "ref" not in result
+    assert result == {"_type": "Foo", "_class_name": "Foo", "x": 1}
+
+
+def test_encode_object_record_logs_on_non_null_ref(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    rec = ObjectRecord(
+        {
+            "_class_name": "Foo",
+            "ref": "weave:///e/p/object/x:abc",
+            "x": 1,
+        }
+    )
+    with caplog.at_level(logging.ERROR):
+        result = _encode_object_record(rec, PROJECT_ID, None, False)
+    assert "Unexpected ref" in caplog.text
+    # The ref field is preserved (the current behavior is to log + keep),
+    # so downstream code doesn't silently drop data.
+    assert result["_type"] == "Foo"
+    assert result["x"] == 1
+
+
+@pytest.mark.parametrize("value", [1, "hi", None, [1], {"a": 1}, object()])
+def test_encode_object_record_non_record_returns_miss(value: Any) -> None:
+    assert _encode_object_record(value, PROJECT_ID, None, False) is _MISS
+
+
+# ---------- _encode_container ----------
+
+
+def test_encode_container_list() -> None:
+    assert _encode_container([1, 2, 3], PROJECT_ID, None, False) == [1, 2, 3]
+
+
+def test_encode_container_tuple_returns_list() -> None:
+    # Tuples are encoded as JSON arrays (lists) — JSON has no tuple concept.
+    assert _encode_container((1, 2, 3), PROJECT_ID, None, False) == [1, 2, 3]
+
+
+def test_encode_container_dict() -> None:
+    assert _encode_container({"a": 1, "b": 2}, PROJECT_ID, None, False) == {
+        "a": 1,
+        "b": 2,
+    }
+
+
+def test_encode_container_namedtuple_returns_dict() -> None:
+    class Point(NamedTuple):
+        x: int
+        y: int
+
+    assert _encode_container(Point(1, 2), PROJECT_ID, None, False) == {"x": 1, "y": 2}
+
+
+def test_encode_container_namedtuple_takes_priority_over_tuple() -> None:
+    # Namedtuples are tuples — the encoder must dispatch on namedtuple first,
+    # not fall into the (list, tuple) branch which would emit a plain list.
+    class Point(NamedTuple):
+        x: int
+        y: int
+
+    result = _encode_container(Point(1, 2), PROJECT_ID, None, False)
+    assert isinstance(result, dict)
+
+
+def test_encode_container_empty_list() -> None:
+    assert _encode_container([], PROJECT_ID, None, False) == []
+
+
+def test_encode_container_empty_dict() -> None:
+    assert _encode_container({}, PROJECT_ID, None, False) == {}
+
+
+def test_encode_container_nested_structures() -> None:
+    result = _encode_container(
+        [{"a": [1, 2]}, {"b": (3, 4)}],
+        PROJECT_ID,
+        None,
+        False,
+    )
+    assert result == [{"a": [1, 2]}, {"b": [3, 4]}]
+
+
+@pytest.mark.parametrize("value", [1, 1.5, "hi", None, True, object()])
+def test_encode_container_non_container_returns_miss(value: Any) -> None:
+    assert _encode_container(value, PROJECT_ID, None, False) is _MISS
+
+
+# ---------- _encode_pydantic_schema ----------
+
+
+def test_encode_pydantic_class_returns_schema() -> None:
+    class Foo(BaseModel):
+        x: int
+        y: str
+
+    schema = _encode_pydantic_schema(Foo, PROJECT_ID, None, False)
+    assert schema is not _MISS
+    assert schema["title"] == "Foo"
+    assert schema["type"] == "object"
+    assert "x" in schema["properties"]
+    assert "y" in schema["properties"]
+
+
+def test_encode_pydantic_instance_returns_miss() -> None:
+    # Instances must NOT match — this encoder is for the class itself.
+    class Foo(BaseModel):
+        x: int
+
+    assert _encode_pydantic_schema(Foo(x=1), PROJECT_ID, None, False) is _MISS
+
+
+def test_encode_pydantic_base_model_itself_returns_miss() -> None:
+    # BaseModel is the abstract base; encoding its schema is meaningless.
+    assert _encode_pydantic_schema(BaseModel, PROJECT_ID, None, False) is _MISS
+
+
+@pytest.mark.parametrize(
+    "value", [int, str, list, dict, type(None), 1, "hi", None, [1], {"a": 1}]
+)
+def test_encode_pydantic_non_pydantic_returns_miss(value: Any) -> None:
+    assert _encode_pydantic_schema(value, PROJECT_ID, None, False) is _MISS
+
+
+# ---------- _encode_primitive ----------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [0, 1, -1, 2**31, -(2**31), 1.5, -1.5, 0.0, True, False, None, "", "hi"],
+)
+def test_encode_primitive_identity(value: Any) -> None:
+    assert _encode_primitive(value, PROJECT_ID, None, False) == value
+
+
+def test_encode_primitive_long_string_passes_through() -> None:
+    # Strings of any length are primitives; no truncation at this layer.
+    long_str = "a" * 1000
+    assert _encode_primitive(long_str, PROJECT_ID, None, False) == long_str
+
+
+@pytest.mark.parametrize(
+    "value",
+    [[1], (1, 2), {"a": 1}, {1, 2}, object(), b"bytes"],
+)
+def test_encode_primitive_non_primitive_returns_miss(value: Any) -> None:
+    assert _encode_primitive(value, PROJECT_ID, None, False) is _MISS
+
+
+# ---------- _encode_weave_scorer_result ----------
+
+
+def test_encode_weave_scorer_result_basic() -> None:
+    result = WeaveScorerResult(passed=True, metadata={"score": 0.9})
+    encoded = _encode_weave_scorer_result(result, PROJECT_ID, None, False)
+    assert encoded == {"passed": True, "metadata": {"score": 0.9}}
+
+
+def test_encode_weave_scorer_result_recurses_into_metadata() -> None:
+    # Metadata values are recursively encoded via to_json — nested containers
+    # should flatten through the ladder.
+    result = WeaveScorerResult(
+        passed=False,
+        metadata={"list": [1, 2], "dict": {"a": 1}},
+    )
+    encoded = _encode_weave_scorer_result(result, PROJECT_ID, None, False)
+    assert encoded == {
+        "passed": False,
+        "metadata": {"list": [1, 2], "dict": {"a": 1}},
+    }
+
+
+@pytest.mark.parametrize(
+    "value",
+    [{"passed": True, "metadata": {}}, 42, "scorer", None, object()],
+)
+def test_encode_weave_scorer_result_non_scorer_returns_miss(value: Any) -> None:
+    assert _encode_weave_scorer_result(value, PROJECT_ID, None, False) is _MISS
+
+
+# ---------- _encode_custom_obj ----------
+
+
+def test_encode_custom_obj_registered_type(client: Any) -> None:
+    # datetime has a built-in registered serializer; encoding produces a
+    # CustomWeaveType payload with the inline value format.
+    dt = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    encoded = _encode_custom_obj(dt, client.project_id, client, False)
+    assert encoded is not _MISS
+    assert encoded["_type"] == "CustomWeaveType"
+    assert encoded["weave_type"]["type"] == "datetime.datetime"
+
+
+def test_encode_custom_obj_unregistered_returns_miss() -> None:
+    class Bespoke:
+        pass
+
+    # Client not needed on the miss path — no registered serializer means we
+    # never reach client-touching code.
+    assert _encode_custom_obj(Bespoke(), PROJECT_ID, None, False) is _MISS
+
+
+# ---------- _encode_dictify ----------
+
+
+def test_encode_dictify_with_flag_scans_attributes() -> None:
+    # Dataclasses generate __repr__ which trips has_custom_repr — must use
+    # a plain class so dictify actually runs.
+    class Foo:  # noqa: B903 — plain class intentional (see comment above)
+        def __init__(self, x: int, y: str) -> None:
+            self.x = x
+            self.y = y
+
+    result = _encode_dictify(Foo(1, "hi"), PROJECT_ID, None, True)
+    assert result is not _MISS
+    assert result["x"] == 1
+    assert result["y"] == "hi"
+    assert "__class__" in result
+
+
+def test_encode_dictify_without_flag_returns_miss() -> None:
+    class Foo:  # noqa: B903 — plain class intentional
+        def __init__(self, x: int) -> None:
+            self.x = x
+
+    assert _encode_dictify(Foo(1), PROJECT_ID, None, False) is _MISS
+
+
+def test_encode_dictify_dataclass_returns_miss_due_to_custom_repr() -> None:
+    # Dataclasses auto-generate __repr__, which opts them out of the dictify
+    # fallback (assumption: the repr is the intended human form).
+    @dataclass
+    class Foo:
+        x: int
+
+    assert _encode_dictify(Foo(1), PROJECT_ID, None, True) is _MISS
+
+
+def test_encode_dictify_logger_returns_miss() -> None:
+    # Loggers are in ALWAYS_STRINGIFY — recursing attributes causes problems.
+    logger = logging.getLogger("test_encoder")
+    assert _encode_dictify(logger, PROJECT_ID, None, True) is _MISS
+
+
+def test_encode_dictify_coroutine_returns_miss() -> None:
+    async def coro() -> None:
+        pass
+
+    c = coro()
+    try:
+        assert _encode_dictify(c, PROJECT_ID, None, True) is _MISS
+    finally:
+        c.close()
+
+
+def test_encode_dictify_custom_repr_returns_miss() -> None:
+    # Objects with a custom __repr__ are assumed to have a sensible string
+    # form; dictify would be redundant or lossy.
+    class Foo:
+        def __repr__(self) -> str:
+            return "CustomFoo"
+
+    assert _encode_dictify(Foo(), PROJECT_ID, None, True) is _MISS
+
+
+# ---------- _encode_try_to_dict ----------
+
+
+def test_encode_try_to_dict_with_to_dict_method() -> None:
+    class Foo:
+        def to_dict(self) -> dict:
+            return {"x": 1, "y": 2}
+
+    result = _encode_try_to_dict(Foo(), PROJECT_ID, None, False)
+    assert result == {"x": 1, "y": 2}
+
+
+def test_encode_try_to_dict_recurses_into_values() -> None:
+    class Foo:
+        def to_dict(self) -> dict:
+            return {"nested": [1, 2, 3]}
+
+    result = _encode_try_to_dict(Foo(), PROJECT_ID, None, False)
+    assert result == {"nested": [1, 2, 3]}
+
+
+def test_encode_try_to_dict_empty_dict_returns_miss() -> None:
+    # An empty dict is falsy, so the walrus assignment yields miss. This
+    # matches the pre-refactor behavior and lets stringify take over.
+    class Foo:
+        def to_dict(self) -> dict:
+            return {}
+
+    assert _encode_try_to_dict(Foo(), PROJECT_ID, None, False) is _MISS
+
+
+def test_encode_try_to_dict_no_method_returns_miss() -> None:
+    class Foo:
+        pass
+
+    assert _encode_try_to_dict(Foo(), PROJECT_ID, None, False) is _MISS
+
+
+# ---------- to_json dispatch order ----------
+
+
+def test_to_json_ref_wins_over_generic_encoding(client: Any) -> None:
+    ref = TableRef(entity="e", project="p", _digest="abc123")
+    assert to_json(ref, PROJECT_ID, client) == ref.uri
+
+
+def test_to_json_pydantic_class_emits_schema_not_stringified(
+    client: Any,
+) -> None:
+    class Foo(BaseModel):
+        x: int
+
+    result = to_json(Foo, PROJECT_ID, client)
+    assert isinstance(result, dict)
+    assert result["title"] == "Foo"
+    assert "properties" in result
+
+
+def test_to_json_primitive_passes_through() -> None:
+    # Primitives skip the custom-obj registry entirely — no client required.
+    assert to_json(42, PROJECT_ID, None) == 42
+    assert to_json(3.14, PROJECT_ID, None) == 3.14
+    assert to_json("hi", PROJECT_ID, None) == "hi"
+    assert to_json(True, PROJECT_ID, None) is True
+    assert to_json(None, PROJECT_ID, None) is None
+
+
+def test_to_json_container_recurses(client: Any) -> None:
+    assert to_json([1, [2, 3]], PROJECT_ID, client) == [1, [2, 3]]
+    assert to_json({"a": {"b": 1}}, PROJECT_ID, client) == {"a": {"b": 1}}
+    assert to_json((1, 2, 3), PROJECT_ID, client) == [1, 2, 3]
+
+
+def test_to_json_object_record_recurses_values(client: Any) -> None:
+    rec = ObjectRecord(
+        {
+            "_class_name": "Foo",
+            "nested": [1, 2, 3],
+            "obj": {"a": 1},
+        }
+    )
+    assert to_json(rec, PROJECT_ID, client) == {
+        "_type": "Foo",
+        "_class_name": "Foo",
+        "nested": [1, 2, 3],
+        "obj": {"a": 1},
+    }
+
+
+def test_to_json_weave_scorer_result_emits_plain_dict() -> None:
+    # WeaveScorerResult round-trips as a plain dict (no CustomWeaveType
+    # wrapper) — this is the wire contract the encoder preserves.
+    result = WeaveScorerResult(passed=True, metadata={"score": 1.0})
+    encoded = to_json(result, PROJECT_ID, None)
+    assert encoded == {"passed": True, "metadata": {"score": 1.0}}
+
+
+def test_to_json_custom_obj_datetime_roundtrips_via_registry(client: Any) -> None:
+    dt = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+    encoded = to_json(dt, client.project_id, client)
+    assert isinstance(encoded, dict)
+    assert encoded["_type"] == "CustomWeaveType"
+    assert encoded["weave_type"]["type"] == "datetime.datetime"
+
+
+def test_to_json_dictify_used_when_flag_set(client: Any) -> None:
+    # Plain class (no custom __repr__) — dictify should run and return a dict.
+    class Foo:  # noqa: B903 — plain class intentional
+        def __init__(self, x: int) -> None:
+            self.x = x
+
+    result = to_json(Foo(1), PROJECT_ID, client, use_dictify=True)
+    assert isinstance(result, dict)
+    assert result["x"] == 1
+
+
+def test_to_json_falls_to_stringify_without_dictify(client: Any) -> None:
+    class NoHelpers:
+        def __init__(self) -> None:
+            self.x = 1
+
+        def __repr__(self) -> str:
+            return "NoHelpers(x=1)"
+
+    inst = NoHelpers()
+    # No to_dict, no registry match, use_dictify=False → terminal stringify.
+    assert to_json(inst, PROJECT_ID, client) == "NoHelpers(x=1)"
+
+
+def test_to_json_try_to_dict_used_when_to_dict_present(client: Any) -> None:
+    class WithToDict:
+        def to_dict(self) -> dict:
+            return {"snapshot": "value"}
+
+    assert to_json(WithToDict(), PROJECT_ID, client) == {"snapshot": "value"}
+
+
+def test_to_json_deeply_nested_mixed(client: Any) -> None:
+    # Sanity check that the ladder composes under recursion — each encoder's
+    # recursive to_json calls must keep routing through the same priority.
+    payload = {
+        "primitives": [1, "s", None, True],
+        "nested_dict": {"a": {"b": [1, 2, {"c": 3}]}},
+        "scorer": WeaveScorerResult(passed=True, metadata={"n": 1}),
+    }
+    expected = {
+        "primitives": [1, "s", None, True],
+        "nested_dict": {"a": {"b": [1, 2, {"c": 3}]}},
+        "scorer": {"passed": True, "metadata": {"n": 1}},
+    }
+    assert to_json(payload, PROJECT_ID, client) == expected

--- a/tests/trace/test_serialize_encoders.py
+++ b/tests/trace/test_serialize_encoders.py
@@ -39,16 +39,27 @@ from weave.trace.serialization.serialize import (
 PROJECT_ID = "entity/project"
 
 
+class _ExampleModel(BaseModel):
+    """Concrete pydantic subclass. Only used to get an INSTANCE for miss
+    tests — the class itself needs to live at module scope so ``_ExampleModel(x=1)``
+    can appear inside a parametrize decorator (evaluated at import time).
+    """
+
+    x: int
+
+
 # ---------- _encode_ref ----------
 
 
-def test_encode_ref_table_ref_returns_uri() -> None:
-    ref = TableRef(entity="e", project="p", _digest="abc123")
-    assert _encode_ref(ref, PROJECT_ID, None, False) == ref.uri
-
-
-def test_encode_ref_object_ref_returns_uri() -> None:
-    ref = ObjectRef(entity="e", project="p", name="obj", _digest="abc123")
+@pytest.mark.parametrize(
+    "ref",
+    [
+        TableRef(entity="e", project="p", _digest="abc123"),
+        ObjectRef(entity="e", project="p", name="obj", _digest="abc123"),
+    ],
+    ids=["TableRef", "ObjectRef"],
+)
+def test_encode_ref_returns_uri(ref: Any) -> None:
     assert _encode_ref(ref, PROJECT_ID, None, False) == ref.uri
 
 
@@ -123,57 +134,31 @@ def test_encode_object_record_non_record_returns_miss(value: Any) -> None:
 # ---------- _encode_container ----------
 
 
-def test_encode_container_list() -> None:
-    assert _encode_container([1, 2, 3], PROJECT_ID, None, False) == [1, 2, 3]
-
-
-def test_encode_container_tuple_returns_list() -> None:
-    # Tuples are encoded as JSON arrays (lists) — JSON has no tuple concept.
-    assert _encode_container((1, 2, 3), PROJECT_ID, None, False) == [1, 2, 3]
-
-
-def test_encode_container_dict() -> None:
-    assert _encode_container({"a": 1, "b": 2}, PROJECT_ID, None, False) == {
-        "a": 1,
-        "b": 2,
-    }
+@pytest.mark.parametrize(
+    ("obj", "expected"),
+    [
+        ([1, 2, 3], [1, 2, 3]),
+        # Tuples encode as JSON arrays (lists) — JSON has no tuple concept.
+        ((1, 2, 3), [1, 2, 3]),
+        ({"a": 1, "b": 2}, {"a": 1, "b": 2}),
+        ([], []),
+        ({}, {}),
+        ([{"a": [1, 2]}, {"b": (3, 4)}], [{"a": [1, 2]}, {"b": [3, 4]}]),
+    ],
+    ids=["list", "tuple", "dict", "empty-list", "empty-dict", "nested"],
+)
+def test_encode_container_match(obj: Any, expected: Any) -> None:
+    assert _encode_container(obj, PROJECT_ID, None, False) == expected
 
 
 def test_encode_container_namedtuple_returns_dict() -> None:
+    # Namedtuples dispatch BEFORE the plain-tuple branch — result is a dict,
+    # not a list. This also pins the dispatch priority.
     class Point(NamedTuple):
         x: int
         y: int
 
     assert _encode_container(Point(1, 2), PROJECT_ID, None, False) == {"x": 1, "y": 2}
-
-
-def test_encode_container_namedtuple_takes_priority_over_tuple() -> None:
-    # Namedtuples are tuples — the encoder must dispatch on namedtuple first,
-    # not fall into the (list, tuple) branch which would emit a plain list.
-    class Point(NamedTuple):
-        x: int
-        y: int
-
-    result = _encode_container(Point(1, 2), PROJECT_ID, None, False)
-    assert isinstance(result, dict)
-
-
-def test_encode_container_empty_list() -> None:
-    assert _encode_container([], PROJECT_ID, None, False) == []
-
-
-def test_encode_container_empty_dict() -> None:
-    assert _encode_container({}, PROJECT_ID, None, False) == {}
-
-
-def test_encode_container_nested_structures() -> None:
-    result = _encode_container(
-        [{"a": [1, 2]}, {"b": (3, 4)}],
-        PROJECT_ID,
-        None,
-        False,
-    )
-    assert result == [{"a": [1, 2]}, {"b": [3, 4]}]
 
 
 @pytest.mark.parametrize("value", [1, 1.5, "hi", None, True, object()])
@@ -197,23 +182,27 @@ def test_encode_pydantic_class_returns_schema() -> None:
     assert "y" in schema["properties"]
 
 
-def test_encode_pydantic_instance_returns_miss() -> None:
-    # Instances must NOT match — this encoder is for the class itself.
-    class Foo(BaseModel):
-        x: int
-
-    assert _encode_pydantic_schema(Foo(x=1), PROJECT_ID, None, False) is _MISS
-
-
-def test_encode_pydantic_base_model_itself_returns_miss() -> None:
-    # BaseModel is the abstract base; encoding its schema is meaningless.
-    assert _encode_pydantic_schema(BaseModel, PROJECT_ID, None, False) is _MISS
-
-
 @pytest.mark.parametrize(
-    "value", [int, str, list, dict, type(None), 1, "hi", None, [1], {"a": 1}]
+    "value",
+    [
+        # Pydantic INSTANCES miss — only concrete subclasses (types) match.
+        _ExampleModel(x=1),
+        # BaseModel itself misses — it's the abstract base.
+        BaseModel,
+        # Non-pydantic types and values.
+        int,
+        str,
+        list,
+        dict,
+        type(None),
+        1,
+        "hi",
+        None,
+        [1],
+        {"a": 1},
+    ],
 )
-def test_encode_pydantic_non_pydantic_returns_miss(value: Any) -> None:
+def test_encode_pydantic_schema_returns_miss(value: Any) -> None:
     assert _encode_pydantic_schema(value, PROJECT_ID, None, False) is _MISS
 
 
@@ -226,12 +215,6 @@ def test_encode_pydantic_non_pydantic_returns_miss(value: Any) -> None:
 )
 def test_encode_primitive_identity(value: Any) -> None:
     assert _encode_primitive(value, PROJECT_ID, None, False) == value
-
-
-def test_encode_primitive_long_string_passes_through() -> None:
-    # Strings of any length are primitives; no truncation at this layer.
-    long_str = "a" * 1000
-    assert _encode_primitive(long_str, PROJECT_ID, None, False) == long_str
 
 
 @pytest.mark.parametrize(
@@ -361,22 +344,20 @@ def test_encode_dictify_custom_repr_returns_miss() -> None:
 # ---------- _encode_try_to_dict ----------
 
 
-def test_encode_try_to_dict_with_to_dict_method() -> None:
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"x": 1, "y": 2},
+        # Nested values recurse back through to_json.
+        {"nested": [1, 2, 3]},
+    ],
+)
+def test_encode_try_to_dict_match(payload: dict[str, Any]) -> None:
     class Foo:
         def to_dict(self) -> dict:
-            return {"x": 1, "y": 2}
+            return payload
 
-    result = _encode_try_to_dict(Foo(), PROJECT_ID, None, False)
-    assert result == {"x": 1, "y": 2}
-
-
-def test_encode_try_to_dict_recurses_into_values() -> None:
-    class Foo:
-        def to_dict(self) -> dict:
-            return {"nested": [1, 2, 3]}
-
-    result = _encode_try_to_dict(Foo(), PROJECT_ID, None, False)
-    assert result == {"nested": [1, 2, 3]}
+    assert _encode_try_to_dict(Foo(), PROJECT_ID, None, False) == payload
 
 
 def test_encode_try_to_dict_empty_dict_returns_miss() -> None:

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from types import CoroutineType
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeAlias, TypedDict
 
 from pydantic import BaseModel
 
@@ -35,8 +35,30 @@ def is_pydantic_model_class(obj: Any) -> bool:
         return False
 
 
+# A JSON-safe value — the target shape every encoder produces on match. The
+# leaf types line up with what json.dumps accepts; the recursion covers nested
+# containers. Some encoder outputs are typed ``Any`` in practice (e.g. dictify,
+# or registry-produced CustomWeaveType payloads), but they still conform
+# structurally via the ``Any``-inside-``dict``/``list`` branches.
+JsonValue: TypeAlias = (
+    bool | int | float | str | list[Any] | dict[str, Any] | None
+)
+
+
+class _MissType:
+    """Type of the ``_MISS`` sentinel — a distinct class so encoders can
+    declare "I might decline" in their return type without collapsing to
+    ``Any``. Exactly one instance exists (``_MISS``).
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:
+        return "<_MISS>"
+
+
 # Sentinel returned by an encoder when the input is not its responsibility.
-_MISS: Any = object()
+_MISS: _MissType = _MissType()
 
 
 class Encoder(Protocol):
@@ -60,12 +82,12 @@ class Encoder(Protocol):
         project_id: str,
         client: WeaveClient,
         use_dictify: bool,
-    ) -> Any: ...
+    ) -> JsonValue | _MissType: ...
 
 
 def to_json(
     obj: Any, project_id: str, client: WeaveClient, use_dictify: bool = False
-) -> Any:
+) -> JsonValue:
     """Encode an arbitrary Python value to a JSON-safe payload.
 
     Dispatch is a priority ladder. Each encoder below is asked in order;

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -40,9 +40,7 @@ def is_pydantic_model_class(obj: Any) -> bool:
 # containers. Some encoder outputs are typed ``Any`` in practice (e.g. dictify,
 # or registry-produced CustomWeaveType payloads), but they still conform
 # structurally via the ``Any``-inside-``dict``/``list`` branches.
-JsonValue: TypeAlias = (
-    bool | int | float | str | list[Any] | dict[str, Any] | None
-)
+JsonValue: TypeAlias = bool | int | float | str | list[Any] | dict[str, Any] | None
 
 
 class _MissType:
@@ -87,7 +85,7 @@ class Encoder(Protocol):
 
 def to_json(
     obj: Any, project_id: str, client: WeaveClient, use_dictify: bool = False
-) -> JsonValue:
+) -> Any:
     """Encode an arbitrary Python value to a JSON-safe payload.
 
     Dispatch is a priority ladder. Each encoder below is asked in order;
@@ -108,7 +106,7 @@ def to_json(
     """
     for encoder in _ENCODERS:
         result = encoder(obj, project_id, client, use_dictify)
-        if result is not _MISS:
+        if not isinstance(result, _MissType):
             return result
     return stringify(obj)
 

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -13,7 +13,6 @@ from weave.trace.refs import ObjectRef, Ref, TableRef
 from weave.trace.serialization import custom_objs
 from weave.trace.serialization.dictifiable import try_to_dict
 from weave.trace_server.trace_server_interface import (
-    FileContentReadReq,
     FileCreateReq,
     TraceServerInterface,
 )
@@ -36,46 +35,102 @@ def is_pydantic_model_class(obj: Any) -> bool:
         return False
 
 
+# Sentinel returned by an encoder when the input is not its responsibility.
+_MISS: Any = object()
+
+
 def to_json(
     obj: Any, project_id: str, client: WeaveClient, use_dictify: bool = False
 ) -> Any:
-    if isinstance(obj, TableRef):
+    """Encode an arbitrary Python value to a JSON-safe payload.
+
+    Dispatch is a priority ladder. Each encoder below is asked in order;
+    the first one to return a non-_MISS value wins. ``stringify`` is the
+    terminal fallback and always succeeds.
+
+    Order:
+        1. _encode_ref                 Ref (TableRef, ObjectRef) -> URI string
+        2. _encode_object_record       ObjectRecord wrapper
+        3. _encode_container           namedtuple / list / tuple / dict
+        4. _encode_pydantic_schema     pydantic class (not instance) -> schema
+        5. _encode_primitive           int / float / str / bool / None
+        6. _encode_weave_scorer_result WeaveScorerResult (special case)
+        7. _encode_custom_obj          registered type serializers
+        8. _encode_dictify             use_dictify fallback
+        9. _encode_try_to_dict         duck-typed to_dict fallback
+       10. stringify                   repr/str terminal fallback
+    """
+    for encoder in _ENCODERS:
+        result = encoder(obj, project_id, client, use_dictify)
+        if result is not _MISS:
+            return result
+    return stringify(obj)
+
+
+def _encode_ref(
+    obj: Any, project_id: str, client: WeaveClient, use_dictify: bool
+) -> Any:
+    if isinstance(obj, (TableRef, ObjectRef)):
         return obj.uri
-    elif isinstance(obj, ObjectRef):
-        return obj.uri
-    elif isinstance(obj, ObjectRecord):
-        res = {"_type": obj._class_name}
-        for k, v in obj.__dict__.items():
-            if k == "ref":
-                # Refs are pointers to remote objects and should not be part of
-                # the serialized payload. They are attached by the client after
-                # the object is saved and returned from the server. If we encounter
-                # a ref in the serialized payload, this would almost certainly be a
-                # bug. However, we would prefer not to raise and error as that would
-                # result in lost data. These refs should be removed before serialization.
-                if v is not None:
-                    logging.exception("Unexpected ref in object record: %s", obj)
-                else:
-                    logging.warning("Unexpected null ref in object record: %s", obj)
-                    continue
-            res[k] = to_json(v, project_id, client, use_dictify)
-        return res
-    elif isinstance_namedtuple(obj):
+    return _MISS
+
+
+def _encode_object_record(
+    obj: Any, project_id: str, client: WeaveClient, use_dictify: bool
+) -> Any:
+    if not isinstance(obj, ObjectRecord):
+        return _MISS
+    res: dict[str, Any] = {"_type": obj._class_name}
+    for k, v in obj.__dict__.items():
+        if k == "ref":
+            # Refs are pointers to remote objects and should not appear in a
+            # serialized payload — the client attaches them after save. A ref
+            # showing up here is almost certainly a bug, but we log rather
+            # than raise to avoid dropping user data.
+            if v is not None:
+                logging.exception("Unexpected ref in object record: %s", obj)
+            else:
+                logging.warning("Unexpected null ref in object record: %s", obj)
+                continue
+        res[k] = to_json(v, project_id, client, use_dictify)
+    return res
+
+
+def _encode_container(
+    obj: Any, project_id: str, client: WeaveClient, use_dictify: bool
+) -> Any:
+    if isinstance_namedtuple(obj):
         return {
             k: to_json(v, project_id, client, use_dictify)
             for k, v in obj._asdict().items()
         }
-    elif isinstance(obj, (list, tuple)):
+    if isinstance(obj, (list, tuple)):
         return [to_json(v, project_id, client, use_dictify) for v in obj]
-    elif isinstance(obj, dict):
+    if isinstance(obj, dict):
         return {k: to_json(v, project_id, client, use_dictify) for k, v in obj.items()}
-    elif is_pydantic_model_class(obj):
-        return obj.model_json_schema()
+    return _MISS
 
+
+def _encode_pydantic_schema(
+    obj: Any, project_id: str, client: WeaveClient, use_dictify: bool
+) -> Any:
+    if is_pydantic_model_class(obj):
+        return obj.model_json_schema()
+    return _MISS
+
+
+def _encode_primitive(
+    obj: Any, project_id: str, client: WeaveClient, use_dictify: bool
+) -> Any:
     if isinstance(obj, (int, float, str, bool)) or obj is None:
         return obj
+    return _MISS
 
-    # Add explicit handling for WeaveScorerResult models
+
+def _encode_weave_scorer_result(
+    obj: Any, project_id: str, client: WeaveClient, use_dictify: bool
+) -> Any:
+    # Phase-3 target: replace with a registered serializer in weave/flow/scorer.py.
     from weave.flow.scorer import WeaveScorerResult
 
     if isinstance(obj, WeaveScorerResult):
@@ -83,27 +138,53 @@ def to_json(
             k: to_json(v, project_id, client, use_dictify)
             for k, v in obj.model_dump().items()
         }
+    return _MISS
 
-    # This still blocks potentially on large-file i/o.
+
+def _encode_custom_obj(
+    obj: Any, project_id: str, client: WeaveClient, use_dictify: bool
+) -> Any:
+    # Can block on large-file I/O for file-backed serializers.
     encoded = custom_objs.encode_custom_obj(obj)
     if encoded is None:
-        if (
-            use_dictify
-            and not isinstance(obj, ALWAYS_STRINGIFY)
-            and not has_custom_repr(obj)
-        ):
-            return dictify(obj)
+        return _MISS
+    return _build_result_from_encoded(encoded, project_id, client)
 
-        # TODO: I would prefer to only have this once in dictify? Maybe dictify and to_json need to be merged?
-        # However, even if dictify is false, i still want to try to convert to dict
-        elif as_dict := try_to_dict(obj):
-            return {
-                k: to_json(v, project_id, client, use_dictify)
-                for k, v in as_dict.items()
-            }
-        return fallback_encode(obj)
-    result = _build_result_from_encoded(encoded, project_id, client)
-    return result
+
+def _encode_dictify(
+    obj: Any, project_id: str, client: WeaveClient, use_dictify: bool
+) -> Any:
+    if (
+        use_dictify
+        and not isinstance(obj, ALWAYS_STRINGIFY)
+        and not has_custom_repr(obj)
+    ):
+        return dictify(obj)
+    return _MISS
+
+
+def _encode_try_to_dict(
+    obj: Any, project_id: str, client: WeaveClient, use_dictify: bool
+) -> Any:
+    if as_dict := try_to_dict(obj):
+        return {
+            k: to_json(v, project_id, client, use_dictify)
+            for k, v in as_dict.items()
+        }
+    return _MISS
+
+
+_ENCODERS = [
+    _encode_ref,
+    _encode_object_record,
+    _encode_container,
+    _encode_pydantic_schema,
+    _encode_primitive,
+    _encode_weave_scorer_result,
+    _encode_custom_obj,
+    _encode_dictify,
+    _encode_try_to_dict,
+]
 
 
 class EncodedCustomObjDictWithFilesAsDigests(TypedDict, total=False):
@@ -270,36 +351,10 @@ ALWAYS_STRINGIFY = (logging.Logger, CoroutineType)
 DEFAULT_MAX_DICTIFY_DEPTH = 10
 
 
-def fallback_encode(obj: Any) -> Any:
-    rep = None
-    try:
-        rep = repr(obj)
-    except Exception:
-        try:
-            rep = str(obj)
-        except Exception:
-            rep = f"<{type(obj).__name__}: {id(obj)}>"
-    if isinstance(rep, str) and len(rep) > MAX_STR_LEN:
-        rep = rep[:MAX_STR_LEN] + "..."
-    return rep
-
-
 def isinstance_namedtuple(obj: Any) -> bool:
     return (
         isinstance(obj, tuple) and hasattr(obj, "_asdict") and hasattr(obj, "_fields")
     )
-
-
-def _load_custom_obj_files(
-    project_id: str, server: TraceServerInterface, file_digests: dict
-) -> dict[str, bytes]:
-    loaded_files: dict[str, bytes] = {}
-    for name, digest in file_digests.items():
-        file_response = server.file_content_read(
-            FileContentReadReq(project_id=project_id, digest=digest)
-        )
-        loaded_files[name] = file_response.content
-    return loaded_files
 
 
 def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
@@ -323,7 +378,9 @@ def from_json(obj: Any, project_id: str, server: TraceServerInterface) -> Any:
             if "files" in obj:
                 file_spec = obj.get("files")
                 if file_spec:
-                    files = _load_custom_obj_files(project_id, server, file_spec)
+                    files = custom_objs._load_custom_obj_files(
+                        project_id, server, file_spec
+                    )
                     encoded["files"] = files
 
             return custom_objs.decode_custom_obj(encoded)

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from types import CoroutineType
-from typing import TYPE_CHECKING, Any, Literal, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict
 
 from pydantic import BaseModel
 
@@ -37,6 +37,30 @@ def is_pydantic_model_class(obj: Any) -> bool:
 
 # Sentinel returned by an encoder when the input is not its responsibility.
 _MISS: Any = object()
+
+
+class Encoder(Protocol):
+    """A single step in the ``to_json`` priority ladder.
+
+    Called once per candidate value. The encoder either claims the value and
+    returns its JSON-safe encoded form, or declines by returning the ``_MISS``
+    sentinel — in which case ``to_json`` tries the next encoder in order.
+
+    Contract:
+        - Never mutate ``obj``.
+        - Never raise for "not my type" — return ``_MISS``. Exceptions should
+          be reserved for genuine encoding failures (bad state, I/O errors).
+        - Recurse through ``to_json`` for nested values rather than calling
+          other encoders directly, so the full ladder applies uniformly.
+    """
+
+    def __call__(
+        self,
+        obj: Any,
+        project_id: str,
+        client: WeaveClient,
+        use_dictify: bool,
+    ) -> Any: ...
 
 
 def to_json(
@@ -168,13 +192,12 @@ def _encode_try_to_dict(
 ) -> Any:
     if as_dict := try_to_dict(obj):
         return {
-            k: to_json(v, project_id, client, use_dictify)
-            for k, v in as_dict.items()
+            k: to_json(v, project_id, client, use_dictify) for k, v in as_dict.items()
         }
     return _MISS
 
 
-_ENCODERS = [
+_ENCODERS: list[Encoder] = [
     _encode_ref,
     _encode_object_record,
     _encode_container,


### PR DESCRIPTION
This PR splits out the serializers into their own functions which makes it easier to test each case and understand how payloads get serialized