### PR TITLE
fix(weave_ts): # Weave Node SDK — clean up `src/esm/instrument.ts` comment and imports

### DIFF
--- a/sdks/node/src/esm/instrument.ts
+++ b/sdks/node/src/esm/instrument.ts
@@ -1,12 +1,18 @@
-// @ts-ignore-file This file is compiled as ESM via tsconfig.instrument.json
+// Preload entry for Weave ESM host support.
+//
+// Invoked via `node --import=weave/instrument <entry>`. The file is compiled
+// as CommonJS by the main tsconfig (same as every other file under `src/`);
+// Node's `--import` flag goes through the ESM resolver but transparently
+// handles CJS targets via ESM→CJS interop, so the preload still works for
+// ESM host apps. A future PR will switch this file to true ESM output; for
+// now it stays CJS to keep the build a single tsc invocation.
+//
+// Its job is to register an `import-in-the-middle` loader hook so the host's
+// ESM graph can be patched as modules are resolved.
 
-const satisfies = require('semifies');
-const {register} = require('node:module');
-const {pathToFileURL} = require('node:url');
-
+import {register} from 'node:module';
+import {pathToFileURL} from 'node:url';
 import {Hook, createAddHookMessageChannel} from 'import-in-the-middle';
-require('../integrations/hooks');
-
 import {
   getESMInstrumentedModules,
   symESMInstrumentations,
@@ -15,6 +21,11 @@ import {
 } from '../integrations/instrumentations';
 import {requirePackageJson} from '../utils/npmModuleUtils';
 import semifies from 'semifies';
+
+// Side-effect import — populates the instrumentation registry that
+// `instrumentations.ts` exposes on `globalThis`. Must evaluate before the
+// loader hook below starts consulting that registry for matching modules.
+import '../integrations/hooks';
 
 const {registerOptions, waitForAllMessagesAcknowledged} =
   createAddHookMessageChannel();
@@ -28,7 +39,7 @@ register(
 (async () => {
   await waitForAllMessagesAcknowledged();
 
-  if (satisfies(process.versions.node, '>=14.13.1')) {
+  if (semifies(process.versions.node, '>=14.13.1')) {
     const modules = getESMInstrumentedModules();
 
     for (const module of modules) {


### PR DESCRIPTION
# Weave Node SDK — clean up `src/esm/instrument.ts` comment and imports

## Why this PR exists

[`sdks/node/src/esm/instrument.ts`](sdks/node/src/esm/instrument.ts) carries a comment that is wrong on three axes, plus a few source-quality issues that confuse readers. None of these affect runtime behaviour, but they mislead anyone trying to understand how the file works before a larger dual-build migration lands.

**The stale comment** —

```ts
// @ts-ignore-file This file is compiled as ESM via tsconfig.instrument.json
```

— is incorrect in three separate ways:

1. **There is no** **`tsconfig.instrument.json`.** Never was. Grep across the SDK returns zero references outside that comment.
2. **The file is not compiled as ESM.** The root [`tsconfig.json`](sdks/node/tsconfig.json) has `"module": "commonjs"` and `"include": ["src/**/*", …]`, so this file is compiled to CJS just like every other file in the SDK. The built output at `dist/esm/instrument.js` opens with `"use strict"; const {register} = require('node:module'); …` — textbook CJS.
3. **`// @ts-ignore-file`** **is not a real TypeScript directive.** The real directive is `// @ts-nocheck`. TypeScript silently ignores `@ts-ignore-file`, so the line never did what it claimed to do.

**The source also has two smaller quality issues** —

- `semifies` is imported twice: once via `const satisfies = require('semifies')` at the top, and again via `import semifies from 'semifies'` lower down. Two names for the same package in the same file.
- The file mixes `require()` calls and `import` statements for no apparent reason. Under `module: commonjs` they compile to the same `require()` output, but stylistically it reads like a half-finished ESM conversion.

## Why the file works today despite the misleading comment

`--import=weave/instrument` is not ESM-host-only. The flag has been available since Node 20.6 and accepts any module — Node's ESM resolver locates the target, and ESM→CJS interop handles CJS files transparently. The preload currently runs under this interop path, which is why nobody noticed the comment was wrong.

A future PR will convert this file to genuine ESM output (`.mjs`) for cleanliness and to match the pattern field-studied in §3.3 of the dual-build report (`dd-trace`'s `initialize.mjs`). That work requires a proper dual-build tool (e.g. `tsup`), which is out of scope here and is covered in PR 2 of the stack referenced above.

## What this PR does

Single-file change to [`src/esm/instrument.ts`](sdks/node/src/esm/instrument.ts):

- **Delete the misleading comment** and replace it with a truthful header explaining: file is CJS-emitted, loaded via `--import` using Node's ESM→CJS interop, conversion to true ESM deferred to a future PR.
- **Remove the duplicate** **`const satisfies = require('semifies')`** — the single `import semifies from 'semifies'` import covers both usages. The call site `if (satisfies(...))` becomes `if (semifies(...))`.
- **Convert the remaining** **`require()`** **calls to** **`import`** **statements** for consistent style. Under `module: commonjs` TypeScript emits them as `require()` either way, so the compiled output shape is unchanged.
- **Add a brief comment on the side-effect** **`import '../integrations/hooks'`** noting it must evaluate before the loader hook consults the instrumentation registry.

## What this PR deliberately does NOT do

- No `.mts` rename.
- No second `tsconfig.instrument.json`.
- No changes to [`package.json`](sdks/node/package.json) `exports` or `scripts`.
- No change to the emitted file's runtime shape (still `dist/esm/instrument.js` CJS, byte-compatible semantics).

Dual-build / true-ESM emission is the PR 2 scope in [`Tech Report — Should the Weave Node SDK ship a dual CJS/ESM build`](https://www.notion.so/wandbai/Tech-Report-Should-the-Weave-Node-SDK-ship-a-dual-CJS-ESM-build-348e2f5c7ef380149c80fdeb5a546f3c?source=copy_link) §7.

## Test plan

- [x] `pnpm run build` — clean TypeScript compile.
- [x] `WANDB_API_KEY=dummy pnpm run test` — 183 passed, 7 skipped (pre-existing live-network tests), 0 failed. Same counts as master.
- [x] `head -20 dist/esm/instrument.js` — confirm the emitted CJS shape is unchanged.
- [x] Smoke tested OpenAI agent, py-coding-agent with the `node --import=weave/instrument dist/pi-coding-agent2.js` usage in ESM mode.
- [x] Smoke tested OpenAI agent in CJS mode as well. Auto module load intercepter is working.

