### PR TITLE
feat(weave): add agent_turn/agent_conversation/agent_span ref kinds

### DIFF
--- a/tests/shared/test_refs_internal.py
+++ b/tests/shared/test_refs_internal.py
@@ -161,3 +161,29 @@ def test_internal_agent_ref_rejects_slash():
         refs_internal.InternalAgentTurnRef(project_id="project", trace_id="bad/value")
     with pytest.raises(refs_internal.InvalidInternalRef):
         refs_internal.InternalAgentSpanRef(project_id="project", span_id="bad/value")
+
+
+@pytest.mark.parametrize("kind", ["agent_turn", "agent_conversation", "agent_span"])
+def test_agent_ref_rejects_extra_path_segments(kind):
+    uri = f"weave:///entity/project/{kind}/user/42"
+    with pytest.raises(ValueError, match="exactly one path segment"):
+        refs.Ref.parse_uri(uri)
+
+    internal_uri = f"{refs_internal.WEAVE_INTERNAL_SCHEME}:///project/{kind}/user/42"
+    with pytest.raises(
+        refs_internal.InvalidInternalRef, match="exactly one path segment"
+    ):
+        refs_internal.parse_internal_uri(internal_uri)
+
+
+@pytest.mark.parametrize("kind", ["agent_turn", "agent_conversation", "agent_span"])
+def test_agent_ref_rejects_missing_id(kind):
+    uri = f"weave:///entity/project/{kind}"
+    with pytest.raises(ValueError, match="exactly one path segment"):
+        refs.Ref.parse_uri(uri)
+
+    internal_uri = f"{refs_internal.WEAVE_INTERNAL_SCHEME}:///project/{kind}"
+    with pytest.raises(
+        refs_internal.InvalidInternalRef, match="exactly one path segment"
+    ):
+        refs_internal.parse_internal_uri(internal_uri)

--- a/tests/shared/test_refs_internal.py
+++ b/tests/shared/test_refs_internal.py
@@ -84,3 +84,80 @@ def test_ref_parsing_internal_sanitized():
 
     parsed = refs_internal.parse_internal_uri(ref_str)
     assert parsed == ref_start
+
+
+def test_agent_turn_ref_roundtrip():
+    ref_start = refs.AgentTurnRef(
+        entity="entity",
+        project="project",
+        trace_id="0123456789abcdef0123456789abcdef",
+    )
+    assert (
+        ref_start.uri
+        == "weave:///entity/project/agent_turn/0123456789abcdef0123456789abcdef"
+    )
+    assert refs.Ref.parse_uri(ref_start.uri) == ref_start
+
+
+def test_agent_span_ref_roundtrip():
+    ref_start = refs.AgentSpanRef(
+        entity="entity",
+        project="project",
+        span_id="0123456789abcdef",
+    )
+    assert ref_start.uri == "weave:///entity/project/agent_span/0123456789abcdef"
+    assert refs.Ref.parse_uri(ref_start.uri) == ref_start
+
+
+def test_agent_conversation_ref_roundtrip():
+    ref_start = refs.AgentConversationRef(
+        entity="entity",
+        project="project",
+        conversation_id=string_with_every_char(),
+    )
+    parsed = refs.Ref.parse_uri(ref_start.uri)
+    assert parsed == ref_start
+
+
+def test_internal_agent_turn_ref_roundtrip():
+    ref_start = refs_internal.InternalAgentTurnRef(
+        project_id="project",
+        trace_id="0123456789abcdef0123456789abcdef",
+    )
+    assert (
+        ref_start.uri
+        == f"{refs_internal.WEAVE_INTERNAL_SCHEME}:///project/agent_turn/0123456789abcdef0123456789abcdef"
+    )
+    assert refs_internal.parse_internal_uri(ref_start.uri) == ref_start
+
+
+def test_internal_agent_span_ref_roundtrip():
+    ref_start = refs_internal.InternalAgentSpanRef(
+        project_id="project",
+        span_id="0123456789abcdef",
+    )
+    assert (
+        ref_start.uri
+        == f"{refs_internal.WEAVE_INTERNAL_SCHEME}:///project/agent_span/0123456789abcdef"
+    )
+    assert refs_internal.parse_internal_uri(ref_start.uri) == ref_start
+
+
+def test_internal_agent_conversation_ref_roundtrip():
+    raw_cid = "user/42:session ?name=hi"
+    ref_start = refs_internal.InternalAgentConversationRef(
+        project_id="project",
+        conversation_id=raw_cid,
+    )
+    assert (
+        ref_start.uri
+        == f"{refs_internal.WEAVE_INTERNAL_SCHEME}:///project/agent_conversation/{quote(raw_cid)}"
+    )
+    assert refs_internal.parse_internal_uri(ref_start.uri) == ref_start
+
+
+def test_internal_agent_ref_rejects_slash():
+    with pytest.raises(refs_internal.InvalidInternalRef):
+        refs_internal.InternalAgentTurnRef(project_id="project", trace_id="bad/value")
+    with pytest.raises(refs_internal.InvalidInternalRef):
+        refs_internal.InternalAgentSpanRef(project_id="project", span_id="bad/value")

--- a/tests/trace/test_ref_conversion.py
+++ b/tests/trace/test_ref_conversion.py
@@ -13,6 +13,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from weave.shared.refs_internal import (
+    InternalAgentConversationRef,
+    InternalAgentSpanRef,
+    InternalAgentTurnRef,
     InternalCallRef,
     InternalObjectRef,
     InternalOpRef,
@@ -107,6 +110,58 @@ def test_same_project_with_index_extra() -> None:
     )
 
 
+def test_same_project_agent_turn_ref() -> None:
+    result = convert_same_project_ref(
+        "weave:///entity/proj/agent_turn/0123456789abcdef0123456789abcdef",
+        ext_project_id="entity/proj",
+        internal_project_id="int-id-1",
+    )
+    assert isinstance(result, InternalAgentTurnRef)
+    assert result.trace_id == "0123456789abcdef0123456789abcdef"
+    assert (
+        result.uri
+        == "weave-trace-internal:///int-id-1/agent_turn/0123456789abcdef0123456789abcdef"
+    )
+
+
+def test_same_project_agent_span_ref() -> None:
+    result = convert_same_project_ref(
+        "weave:///entity/proj/agent_span/0123456789abcdef",
+        ext_project_id="entity/proj",
+        internal_project_id="int-id-1",
+    )
+    assert isinstance(result, InternalAgentSpanRef)
+    assert result.span_id == "0123456789abcdef"
+    assert result.uri == "weave-trace-internal:///int-id-1/agent_span/0123456789abcdef"
+
+
+def test_same_project_agent_conversation_ref_simple() -> None:
+    result = convert_same_project_ref(
+        "weave:///entity/proj/agent_conversation/sess-abc-123",
+        ext_project_id="entity/proj",
+        internal_project_id="int-id-1",
+    )
+    assert isinstance(result, InternalAgentConversationRef)
+    assert result.conversation_id == "sess-abc-123"
+    assert (
+        result.uri == "weave-trace-internal:///int-id-1/agent_conversation/sess-abc-123"
+    )
+
+
+def test_same_project_agent_conversation_ref_encoded() -> None:
+    result = convert_same_project_ref(
+        "weave:///entity/proj/agent_conversation/user%2F42%3Asession",
+        ext_project_id="entity/proj",
+        internal_project_id="int-id-1",
+    )
+    assert isinstance(result, InternalAgentConversationRef)
+    assert result.conversation_id == "user/42:session"
+    assert (
+        result.uri
+        == "weave-trace-internal:///int-id-1/agent_conversation/user%2F42%3Asession"
+    )
+
+
 # ---------------------------------------------------------------------------
 # convert_same_project_ref -- error cases
 # ---------------------------------------------------------------------------
@@ -173,6 +228,25 @@ def test_cross_project_resolves_via_resolver() -> None:
     )
     assert isinstance(result, InternalObjectRef)
     assert result.uri == "weave-trace-internal:///other-int-id/object/thing:xyz"
+    resolver.resolve_external_to_internal_project_id.assert_called_once_with(
+        "other_entity/other_proj"
+    )
+
+
+def test_cross_project_resolves_agent_turn_ref() -> None:
+    resolver = MagicMock()
+    resolver.resolve_external_to_internal_project_id.return_value = "other-int-id"
+
+    result = convert_cross_project_ref(
+        "weave:///other_entity/other_proj/agent_turn/0123456789abcdef0123456789abcdef",
+        ext_project_id="entity/proj",
+        resolver=resolver,
+    )
+    assert isinstance(result, InternalAgentTurnRef)
+    assert (
+        result.uri
+        == "weave-trace-internal:///other-int-id/agent_turn/0123456789abcdef0123456789abcdef"
+    )
     resolver.resolve_external_to_internal_project_id.assert_called_once_with(
         "other_entity/other_proj"
     )

--- a/weave/shared/refs_internal.py
+++ b/weave/shared/refs_internal.py
@@ -200,8 +200,60 @@ class InternalArtifactRef:
         return u
 
 
+@dataclass(frozen=True)
+class InternalAgentTurnRef:
+    project_id: str
+    trace_id: str
+
+    def __post_init__(self) -> None:
+        validate_no_slashes(self.project_id, "project_id")
+        validate_no_slashes(self.trace_id, "trace_id")
+
+    @CallableProperty
+    def uri(self) -> str:
+        return (
+            f"{WEAVE_INTERNAL_SCHEME}:///{self.project_id}/agent_turn/{self.trace_id}"
+        )
+
+
+@dataclass(frozen=True)
+class InternalAgentConversationRef:
+    project_id: str
+    conversation_id: str
+
+    def __post_init__(self) -> None:
+        validate_no_slashes(self.project_id, "project_id")
+
+    @CallableProperty
+    def uri(self) -> str:
+        return (
+            f"{WEAVE_INTERNAL_SCHEME}:///{self.project_id}/agent_conversation/"
+            f"{extra_value_quoter(self.conversation_id)}"
+        )
+
+
+@dataclass(frozen=True)
+class InternalAgentSpanRef:
+    project_id: str
+    span_id: str
+
+    def __post_init__(self) -> None:
+        validate_no_slashes(self.project_id, "project_id")
+        validate_no_slashes(self.span_id, "span_id")
+
+    @CallableProperty
+    def uri(self) -> str:
+        return f"{WEAVE_INTERNAL_SCHEME}:///{self.project_id}/agent_span/{self.span_id}"
+
+
 InternalRef = (
-    InternalObjectRef | InternalTableRef | InternalCallRef | InternalArtifactRef
+    InternalObjectRef
+    | InternalTableRef
+    | InternalCallRef
+    | InternalArtifactRef
+    | InternalAgentTurnRef
+    | InternalAgentConversationRef
+    | InternalAgentSpanRef
 )
 
 
@@ -253,6 +305,15 @@ def parse_internal_uri(
     elif kind == "artifact":
         id_ = remaining[0]
         return InternalArtifactRef(project_id=project_id, id=id_)
+    elif kind == "agent_turn":
+        return InternalAgentTurnRef(project_id=project_id, trace_id=remaining[0])
+    elif kind == "agent_conversation":
+        return InternalAgentConversationRef(
+            project_id=project_id,
+            conversation_id=urllib.parse.unquote(remaining[0]),
+        )
+    elif kind == "agent_span":
+        return InternalAgentSpanRef(project_id=project_id, span_id=remaining[0])
     else:
         raise InvalidInternalRef(f"Unknown ref kind: {kind}")
 

--- a/weave/shared/refs_internal.py
+++ b/weave/shared/refs_internal.py
@@ -305,14 +305,20 @@ def parse_internal_uri(
     elif kind == "artifact":
         id_ = remaining[0]
         return InternalArtifactRef(project_id=project_id, id=id_)
-    elif kind == "agent_turn":
-        return InternalAgentTurnRef(project_id=project_id, trace_id=remaining[0])
-    elif kind == "agent_conversation":
-        return InternalAgentConversationRef(
-            project_id=project_id,
-            conversation_id=urllib.parse.unquote(remaining[0]),
-        )
-    elif kind == "agent_span":
+    elif kind in {"agent_turn", "agent_conversation", "agent_span"}:
+        if len(remaining) != 1:
+            raise InvalidInternalRef(
+                f"Invalid URI: {uri}. {kind} ref must have exactly one path "
+                f"segment after the kind; got {len(remaining)}. "
+                f"IDs containing '/' must be URL-encoded."
+            )
+        if kind == "agent_turn":
+            return InternalAgentTurnRef(project_id=project_id, trace_id=remaining[0])
+        if kind == "agent_conversation":
+            return InternalAgentConversationRef(
+                project_id=project_id,
+                conversation_id=urllib.parse.unquote(remaining[0]),
+            )
         return InternalAgentSpanRef(project_id=project_id, span_id=remaining[0])
     else:
         raise InvalidInternalRef(f"Unknown ref kind: {kind}")

--- a/weave/trace/ref_conversion.py
+++ b/weave/trace/ref_conversion.py
@@ -12,13 +12,25 @@ from __future__ import annotations
 from typing import Protocol, overload
 
 from weave.shared.refs_internal import (
+    InternalAgentConversationRef,
+    InternalAgentSpanRef,
+    InternalAgentTurnRef,
     InternalCallRef,
     InternalObjectRef,
     InternalOpRef,
     InternalRef,
     InternalTableRef,
 )
-from weave.trace.refs import CallRef, ObjectRef, OpRef, Ref, TableRef
+from weave.trace.refs import (
+    AgentConversationRef,
+    AgentSpanRef,
+    AgentTurnRef,
+    CallRef,
+    ObjectRef,
+    OpRef,
+    Ref,
+    TableRef,
+)
 
 
 class ExternalToInternalProjectIdResolver(Protocol):
@@ -49,10 +61,30 @@ def ext_ref_to_internal(ref: OpRef, internal_project_id: str) -> InternalOpRef: 
 def ext_ref_to_internal(
     ref: ObjectRef, internal_project_id: str
 ) -> InternalObjectRef: ...
+@overload
+def ext_ref_to_internal(
+    ref: AgentTurnRef, internal_project_id: str
+) -> InternalAgentTurnRef: ...
+@overload
+def ext_ref_to_internal(
+    ref: AgentConversationRef, internal_project_id: str
+) -> InternalAgentConversationRef: ...
+@overload
+def ext_ref_to_internal(
+    ref: AgentSpanRef, internal_project_id: str
+) -> InternalAgentSpanRef: ...
 
 
 def ext_ref_to_internal(
-    ref: ObjectRef | OpRef | TableRef | CallRef,
+    ref: (
+        ObjectRef
+        | OpRef
+        | TableRef
+        | CallRef
+        | AgentTurnRef
+        | AgentConversationRef
+        | AgentSpanRef
+    ),
     internal_project_id: str,
 ) -> InternalRef:
     """Convert a parsed external Ref to the corresponding Internal*Ref.
@@ -85,6 +117,21 @@ def ext_ref_to_internal(
             name=ref.name,
             version=ref.digest,
             extra=list(ref.extra),
+        )
+    if isinstance(ref, AgentTurnRef):
+        return InternalAgentTurnRef(
+            project_id=internal_project_id,
+            trace_id=ref.trace_id,
+        )
+    if isinstance(ref, AgentConversationRef):
+        return InternalAgentConversationRef(
+            project_id=internal_project_id,
+            conversation_id=ref.conversation_id,
+        )
+    if isinstance(ref, AgentSpanRef):
+        return InternalAgentSpanRef(
+            project_id=internal_project_id,
+            span_id=ref.span_id,
         )
     raise TypeError(f"Unsupported ref type: {type(ref)}")
 

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -51,15 +51,23 @@ class Ref:
         remaining = tuple(parts[3:])
         if kind == "table":
             return TableRef(entity=entity, project=project, _digest=remaining[0])
-        if kind == "agent_turn":
-            return AgentTurnRef(entity=entity, project=project, trace_id=remaining[0])
-        if kind == "agent_conversation":
-            return AgentConversationRef(
-                entity=entity,
-                project=project,
-                conversation_id=urllib.parse.unquote(remaining[0]),
-            )
-        if kind == "agent_span":
+        if kind in {"agent_turn", "agent_conversation", "agent_span"}:
+            if len(remaining) != 1:
+                raise ValueError(
+                    f"Invalid URI: {uri}. {kind} ref must have exactly one path "
+                    f"segment after the kind; got {len(remaining)}. "
+                    f"IDs containing '/' must be URL-encoded."
+                )
+            if kind == "agent_turn":
+                return AgentTurnRef(
+                    entity=entity, project=project, trace_id=remaining[0]
+                )
+            if kind == "agent_conversation":
+                return AgentConversationRef(
+                    entity=entity,
+                    project=project,
+                    conversation_id=urllib.parse.unquote(remaining[0]),
+                )
             return AgentSpanRef(entity=entity, project=project, span_id=remaining[0])
         extra = tuple(urllib.parse.unquote(r) for r in remaining[1:])
         if kind == "call":

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -51,6 +51,16 @@ class Ref:
         remaining = tuple(parts[3:])
         if kind == "table":
             return TableRef(entity=entity, project=project, _digest=remaining[0])
+        if kind == "agent_turn":
+            return AgentTurnRef(entity=entity, project=project, trace_id=remaining[0])
+        if kind == "agent_conversation":
+            return AgentConversationRef(
+                entity=entity,
+                project=project,
+                conversation_id=urllib.parse.unquote(remaining[0]),
+            )
+        if kind == "agent_span":
+            return AgentSpanRef(entity=entity, project=project, span_id=remaining[0])
         extra = tuple(urllib.parse.unquote(r) for r in remaining[1:])
         if kind == "call":
             return CallRef(
@@ -330,6 +340,58 @@ class CallRef(RefWithExtra):
 
 
 @dataclass(frozen=True)
+class AgentTurnRef(Ref):
+    entity: str
+    project: str
+    trace_id: str
+
+    @CallableProperty
+    def uri(self) -> str:
+        return f"weave:///{self.entity}/{self.project}/agent_turn/{self.trace_id}"
+
+    @staticmethod
+    def parse_uri(uri: str) -> AgentTurnRef:
+        if not isinstance(parsed := Ref.parse_uri(uri), AgentTurnRef):
+            raise TypeError(f"URI is not for an AgentTurn: {uri}")
+        return parsed
+
+
+@dataclass(frozen=True)
+class AgentConversationRef(Ref):
+    entity: str
+    project: str
+    conversation_id: str
+
+    @CallableProperty
+    def uri(self) -> str:
+        encoded = refs_internal.extra_value_quoter(self.conversation_id)
+        return f"weave:///{self.entity}/{self.project}/agent_conversation/{encoded}"
+
+    @staticmethod
+    def parse_uri(uri: str) -> AgentConversationRef:
+        if not isinstance(parsed := Ref.parse_uri(uri), AgentConversationRef):
+            raise TypeError(f"URI is not for an AgentConversation: {uri}")
+        return parsed
+
+
+@dataclass(frozen=True)
+class AgentSpanRef(Ref):
+    entity: str
+    project: str
+    span_id: str
+
+    @CallableProperty
+    def uri(self) -> str:
+        return f"weave:///{self.entity}/{self.project}/agent_span/{self.span_id}"
+
+    @staticmethod
+    def parse_uri(uri: str) -> AgentSpanRef:
+        if not isinstance(parsed := Ref.parse_uri(uri), AgentSpanRef):
+            raise TypeError(f"URI is not for an AgentSpan: {uri}")
+        return parsed
+
+
+@dataclass(frozen=True)
 class DeletedRef(Ref):
     ref: Ref
     deleted_at: datetime
@@ -343,7 +405,15 @@ class DeletedRef(Ref):
         return self.ref.uri
 
 
-AnyRef = ObjectRef | TableRef | CallRef | OpRef
+AnyRef = (
+    ObjectRef
+    | TableRef
+    | CallRef
+    | OpRef
+    | AgentTurnRef
+    | AgentConversationRef
+    | AgentSpanRef
+)
 
 
 def parse_name_version(name_version: str) -> tuple[str, str]:


### PR DESCRIPTION
## Description

- Fixes [WB-33571](https://coreweave.atlassian.net/browse/WB-33571)

First of three stacked PRs for Phase 1 of human feedback on agent turns.

Adds three new ref kinds (external + internal): \`agent_turn/{trace_id}\`, \`agent_conversation/{conversation_id}\`, \`agent_span/{span_id}\`. No consumers yet — just the grammar. \`conversation_id\` is URL-encoded since it's app-chosen.

Stack: this → #6685 → #6686

## Testing

- unit tests

[WB-33571]: https://coreweave.atlassian.net/browse/WB-33571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ