### PR TITLE
feat(weave): add helper for querying feedback by agent target refs

### DIFF
--- a/tests/trace_server/test_agent_feedback_helpers.py
+++ b/tests/trace_server/test_agent_feedback_helpers.py
@@ -1,0 +1,62 @@
+from weave.shared import refs_internal as ri
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.trace_server_common import (
+    group_agent_feedback_by_target,
+    make_agent_feedback_query_req,
+)
+
+
+def _extract_ref_literals(req) -> list[str]:
+    expr = req.query.model_dump(by_alias=True)["$expr"]
+    return [lit["$literal"] for lit in expr["$in"][1]]
+
+
+def test_make_agent_feedback_query_req_unions_arbitrary_ref_kinds():
+    refs = [
+        ri.InternalAgentTurnRef(
+            project_id="p", trace_id="0123456789abcdef0123456789abcdef"
+        ).uri,
+        ri.InternalAgentConversationRef(project_id="p", conversation_id="sess-1").uri,
+        ri.InternalAgentSpanRef(project_id="p", span_id="0123456789abcdef").uri,
+        ri.InternalCallRef(project_id="p", id="call-xyz").uri,
+    ]
+
+    req = make_agent_feedback_query_req(project_id="p", refs=refs)
+
+    assert req.project_id == "p"
+    assert _extract_ref_literals(req) == refs
+
+
+def test_group_agent_feedback_by_target_separates_kinds_and_skips_non_agent_refs():
+    feedback = tsi.FeedbackQueryRes(
+        result=[
+            {
+                "id": "f1",
+                "weave_ref": ri.InternalAgentTurnRef(project_id="p", trace_id="t1").uri,
+            },
+            {
+                "id": "f2",
+                "weave_ref": ri.InternalAgentTurnRef(project_id="p", trace_id="t1").uri,
+            },
+            {
+                "id": "f3",
+                "weave_ref": ri.InternalAgentConversationRef(
+                    project_id="p", conversation_id="c1"
+                ).uri,
+            },
+            {
+                "id": "f4",
+                "weave_ref": ri.InternalAgentSpanRef(project_id="p", span_id="s1").uri,
+            },
+            {
+                "id": "f5",
+                "weave_ref": ri.InternalCallRef(project_id="p", id="call-xyz").uri,
+            },
+        ]
+    )
+
+    groups = group_agent_feedback_by_target(feedback)
+
+    assert [item["id"] for item in groups.by_trace_id["t1"]] == ["f1", "f2"]
+    assert [item["id"] for item in groups.by_conversation_id["c1"]] == ["f3"]
+    assert [item["id"] for item in groups.by_span_id["s1"]] == ["f4"]

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -3,12 +3,27 @@ import datetime
 import json
 from collections import OrderedDict, defaultdict
 from collections.abc import Iterator
+from dataclasses import dataclass, field
 from typing import Any, Literal, cast
 
 from weave.shared import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
 
 CallStatus = Literal["running", "completed", "failed"]
+
+FEEDBACK_QUERY_FIELDS = [
+    "id",
+    "feedback_type",
+    "weave_ref",
+    "payload",
+    "creator",
+    "created_at",
+    "wb_user_id",
+    "runnable_ref",
+    "call_ref",
+    "trigger_ref",
+    "annotation_ref",
+]
 
 
 def make_feedback_query_req(
@@ -34,22 +49,78 @@ def make_feedback_query_req(
     )
     feedback_query_req = tsi.FeedbackQueryReq(
         project_id=project_id,
-        fields=[
-            "id",
-            "feedback_type",
-            "weave_ref",
-            "payload",
-            "creator",
-            "created_at",
-            "wb_user_id",
-            "runnable_ref",
-            "call_ref",
-            "trigger_ref",
-            "annotation_ref",
-        ],
+        fields=FEEDBACK_QUERY_FIELDS,
         query=query,
     )
     return feedback_query_req
+
+
+@dataclass(frozen=True)
+class AgentFeedbackByTarget:
+    """Feedback rows grouped by agent target kind + raw identifier.
+
+    Keys are raw trace_id / conversation_id / span_id strings (not ref URIs)
+    so callers can look up by whatever identifier they already have from the
+    spans row.
+    """
+
+    by_trace_id: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    by_conversation_id: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    by_span_id: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+
+
+def make_agent_feedback_query_req(
+    project_id: str,
+    refs: list[str],
+) -> tsi.FeedbackQueryReq:
+    """Build a FeedbackQueryReq that returns feedback for any of `refs`.
+
+    The refs are unioned (OR'd) into a single `$in` over `weave_ref` so
+    the chat-view handler can fetch feedback for a turn plus all of its
+    steps (or a conversation plus all its turns) in one round-trip.
+    """
+    query = tsi.Query(
+        **{
+            "$expr": {
+                "$in": [
+                    {"$getField": "weave_ref"},
+                    [{"$literal": ref} for ref in refs],
+                ]
+            }
+        }
+    )
+    return tsi.FeedbackQueryReq(
+        project_id=project_id,
+        fields=FEEDBACK_QUERY_FIELDS,
+        query=query,
+    )
+
+
+def group_agent_feedback_by_target(
+    feedback: tsi.FeedbackQueryRes,
+) -> AgentFeedbackByTarget:
+    """Group feedback rows by agent target kind + raw identifier."""
+    by_trace_id: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    by_conversation_id: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    by_span_id: dict[str, list[dict[str, Any]]] = defaultdict(list)
+
+    for raw in feedback.result:
+        # `FeedbackQueryRes.result` is intentionally `dict[str, Any]` because
+        # callers can request arbitrary fields; this helper always passes
+        # FEEDBACK_QUERY_FIELDS, so the rows match FeedbackDict shape.
+        ref = ri.parse_internal_uri(raw.get("weave_ref", ""))
+        if isinstance(ref, ri.InternalAgentTurnRef):
+            by_trace_id[ref.trace_id].append(raw)
+        elif isinstance(ref, ri.InternalAgentConversationRef):
+            by_conversation_id[ref.conversation_id].append(raw)
+        elif isinstance(ref, ri.InternalAgentSpanRef):
+            by_span_id[ref.span_id].append(raw)
+
+    return AgentFeedbackByTarget(
+        by_trace_id=by_trace_id,
+        by_conversation_id=by_conversation_id,
+        by_span_id=by_span_id,
+    )
 
 
 def hydrate_calls_with_feedback(


### PR DESCRIPTION
## Description

- Fixes [WB-33571](https://coreweave.atlassian.net/browse/WB-33571)

Second of three stacked PRs for Phase 1 of human feedback on agent turns.

Adds two helpers: \`make_agent_feedback_query_req\` builds one feedback query for a mix of turn/conversation/span targets; \`group_agent_feedback_by_target\` buckets the result by identifier. Tiny refactor: shared feedback field list extracted to a constant so the call and agent helpers don't duplicate it.

Stack: #6684 → this → #6686

## Testing

- unit tests

[WB-33571]: https://coreweave.atlassian.net/browse/WB-33571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ