### PR TITLE
feat(weave): fold feedback into agent chat-view responses via include_feedback

### DIFF
--- a/tests/trace_server/helpers.py
+++ b/tests/trace_server/helpers.py
@@ -1,3 +1,5 @@
+"""Shared helpers for trace_server tests."""
+
 import base64
 import uuid
 

--- a/tests/trace_server/project_id_util.py
+++ b/tests/trace_server/project_id_util.py
@@ -1,0 +1,8 @@
+import base64
+import uuid
+
+
+def make_project_id(prefix: str) -> str:
+    """Generate a unique base64-encoded project id for a test."""
+    raw = f"test/{prefix}_{uuid.uuid4().hex[:8]}"
+    return base64.b64encode(raw.encode()).decode()

--- a/tests/trace_server/test_agent_chat_view_feedback.py
+++ b/tests/trace_server/test_agent_chat_view_feedback.py
@@ -1,0 +1,193 @@
+"""Integration tests for include_feedback fold-in on agent chat endpoints.
+
+Requires ClickHouse backend (auto-skips on SQLite via ch_server fixture).
+"""
+
+import base64
+import datetime
+import uuid
+
+from weave.shared import refs_internal as ri
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents.helpers import genai_span_to_row
+from weave.trace_server.agents.schema import (
+    ALL_SPAN_INSERT_COLUMNS,
+    AgentSpanCHInsertable,
+)
+from weave.trace_server.agents.types import (
+    AgentConversationChatReq,
+    AgentTraceChatReq,
+)
+
+
+def _make_project_id(prefix: str) -> str:
+    raw = f"test/{prefix}_{uuid.uuid4().hex[:8]}"
+    return base64.b64encode(raw.encode()).decode()
+
+
+def _make_span(
+    project_id: str,
+    trace_id: str,
+    span_id: str,
+    **overrides: object,
+) -> AgentSpanCHInsertable:
+    defaults = {
+        "project_id": project_id,
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "span_name": "test-span",
+        "started_at": datetime.datetime.now(tz=datetime.timezone.utc),
+        "ended_at": datetime.datetime.now(tz=datetime.timezone.utc),
+        "status_code": "OK",
+        "operation_name": "invoke_agent",
+        "agent_name": "test-agent",
+        "provider_name": "openai",
+        "request_model": "gpt-4o",
+    }
+    defaults.update(overrides)
+    return AgentSpanCHInsertable(**defaults)
+
+
+def _insert_spans(ch_client, spans: list[AgentSpanCHInsertable]) -> None:
+    rows = [genai_span_to_row(s) for s in spans]
+    ch_client.insert("spans", data=rows, column_names=ALL_SPAN_INSERT_COLUMNS)
+
+
+def _create_reaction(ch_server, project_id: str, weave_ref: str, emoji: str) -> None:
+    ch_server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type="reaction",
+            payload={"emoji": emoji},
+            wb_user_id="test-user",
+        )
+    )
+
+
+def test_agent_traces_chat_folds_turn_and_step_feedback(ch_server):
+    project_id = _make_project_id("feedback")
+    trace_id = uuid.uuid4().hex
+    root_span_id = uuid.uuid4().hex[:16]
+    child_span_id = uuid.uuid4().hex[:16]
+
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                project_id, trace_id, root_span_id, operation_name="invoke_agent"
+            ),
+            _make_span(
+                project_id,
+                trace_id,
+                child_span_id,
+                parent_span_id=root_span_id,
+                operation_name="execute_tool",
+                tool_name="get_weather",
+            ),
+        ],
+    )
+
+    turn_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_id).uri
+    step_ref = ri.InternalAgentSpanRef(project_id=project_id, span_id=child_span_id).uri
+    _create_reaction(ch_server, project_id, turn_ref, "👍")
+    _create_reaction(ch_server, project_id, step_ref, "🔥")
+
+    res = ch_server.agent_traces_chat(
+        AgentTraceChatReq(
+            project_id=project_id, trace_id=trace_id, include_feedback=True
+        )
+    )
+
+    assert res.turn_feedback is not None
+    assert len(res.turn_feedback) == 1
+    assert res.turn_feedback[0]["payload"] == {"emoji": "👍"}
+
+    step_msgs = [m for m in res.messages if m.span_id == child_span_id and m.feedback]
+    assert len(step_msgs) == 1
+    assert step_msgs[0].feedback is not None
+    assert step_msgs[0].feedback[0]["payload"] == {"emoji": "🔥"}
+
+
+def test_agent_traces_chat_include_feedback_false_leaves_feedback_fields_none(
+    ch_server,
+):
+    project_id = _make_project_id("feedback_off")
+    trace_id = uuid.uuid4().hex
+    root_span_id = uuid.uuid4().hex[:16]
+
+    _insert_spans(
+        ch_server.ch_client,
+        [_make_span(project_id, trace_id, root_span_id, operation_name="invoke_agent")],
+    )
+
+    turn_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_id).uri
+    _create_reaction(ch_server, project_id, turn_ref, "👍")
+
+    res = ch_server.agent_traces_chat(
+        AgentTraceChatReq(project_id=project_id, trace_id=trace_id)
+    )
+
+    assert res.turn_feedback is None
+    for m in res.messages:
+        assert m.feedback is None
+
+
+def test_agent_conversation_chat_folds_conversation_turn_and_step_feedback(ch_server):
+    project_id = _make_project_id("conv_feedback")
+    conv_id = f"conv-{uuid.uuid4().hex[:8]}"
+    trace_id = uuid.uuid4().hex
+    root_span_id = uuid.uuid4().hex[:16]
+    child_span_id = uuid.uuid4().hex[:16]
+
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                project_id,
+                trace_id,
+                root_span_id,
+                operation_name="invoke_agent",
+                conversation_id=conv_id,
+            ),
+            _make_span(
+                project_id,
+                trace_id,
+                child_span_id,
+                parent_span_id=root_span_id,
+                operation_name="execute_tool",
+                tool_name="get_weather",
+                conversation_id=conv_id,
+            ),
+        ],
+    )
+
+    conv_ref = ri.InternalAgentConversationRef(
+        project_id=project_id, conversation_id=conv_id
+    ).uri
+    turn_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_id).uri
+    step_ref = ri.InternalAgentSpanRef(project_id=project_id, span_id=child_span_id).uri
+    _create_reaction(ch_server, project_id, conv_ref, "💬")
+    _create_reaction(ch_server, project_id, turn_ref, "👍")
+    _create_reaction(ch_server, project_id, step_ref, "🔥")
+
+    res = ch_server.agent_conversation_chat(
+        AgentConversationChatReq(
+            project_id=project_id, conversation_id=conv_id, include_feedback=True
+        )
+    )
+
+    assert res.conversation_feedback is not None
+    assert len(res.conversation_feedback) == 1
+    assert res.conversation_feedback[0]["payload"] == {"emoji": "💬"}
+
+    assert len(res.turns) == 1
+    turn = res.turns[0]
+    assert turn.turn_feedback is not None
+    assert len(turn.turn_feedback) == 1
+    assert turn.turn_feedback[0]["payload"] == {"emoji": "👍"}
+
+    step_msgs = [m for m in turn.messages if m.span_id == child_span_id and m.feedback]
+    assert len(step_msgs) == 1
+    assert step_msgs[0].feedback is not None
+    assert step_msgs[0].feedback[0]["payload"] == {"emoji": "🔥"}

--- a/tests/trace_server/test_agent_chat_view_feedback.py
+++ b/tests/trace_server/test_agent_chat_view_feedback.py
@@ -3,10 +3,10 @@
 Requires ClickHouse backend (auto-skips on SQLite via ch_server fixture).
 """
 
-import base64
 import datetime
 import uuid
 
+from tests.trace_server.project_id_util import make_project_id as _make_project_id
 from weave.shared import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.helpers import genai_span_to_row
@@ -18,11 +18,6 @@ from weave.trace_server.agents.types import (
     AgentConversationChatReq,
     AgentTraceChatReq,
 )
-
-
-def _make_project_id(prefix: str) -> str:
-    raw = f"test/{prefix}_{uuid.uuid4().hex[:8]}"
-    return base64.b64encode(raw.encode()).decode()
 
 
 def _make_span(

--- a/tests/trace_server/test_agent_chat_view_feedback.py
+++ b/tests/trace_server/test_agent_chat_view_feedback.py
@@ -6,7 +6,7 @@ Requires ClickHouse backend (auto-skips on SQLite via ch_server fixture).
 import datetime
 import uuid
 
-from tests.trace_server.project_id_util import make_project_id as _make_project_id
+from tests.trace_server.helpers import make_project_id as _make_project_id
 from weave.shared import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.helpers import genai_span_to_row
@@ -94,9 +94,9 @@ def test_agent_traces_chat_folds_turn_and_step_feedback(ch_server):
         )
     )
 
-    assert res.turn_feedback is not None
-    assert len(res.turn_feedback) == 1
-    assert res.turn_feedback[0]["payload"] == {"emoji": "👍"}
+    assert res.feedback is not None
+    assert len(res.feedback) == 1
+    assert res.feedback[0]["payload"] == {"emoji": "👍"}
 
     step_msgs = [m for m in res.messages if m.span_id == child_span_id and m.feedback]
     assert len(step_msgs) == 1
@@ -123,7 +123,7 @@ def test_agent_traces_chat_include_feedback_false_leaves_feedback_fields_none(
         AgentTraceChatReq(project_id=project_id, trace_id=trace_id)
     )
 
-    assert res.turn_feedback is None
+    assert res.feedback is None
     for m in res.messages:
         assert m.feedback is None
 
@@ -172,15 +172,15 @@ def test_agent_conversation_chat_folds_conversation_turn_and_step_feedback(ch_se
         )
     )
 
-    assert res.conversation_feedback is not None
-    assert len(res.conversation_feedback) == 1
-    assert res.conversation_feedback[0]["payload"] == {"emoji": "💬"}
+    assert res.feedback is not None
+    assert len(res.feedback) == 1
+    assert res.feedback[0]["payload"] == {"emoji": "💬"}
 
     assert len(res.turns) == 1
     turn = res.turns[0]
-    assert turn.turn_feedback is not None
-    assert len(turn.turn_feedback) == 1
-    assert turn.turn_feedback[0]["payload"] == {"emoji": "👍"}
+    assert turn.feedback is not None
+    assert len(turn.feedback) == 1
+    assert turn.feedback[0]["payload"] == {"emoji": "👍"}
 
     step_msgs = [m for m in turn.messages if m.span_id == child_span_id and m.feedback]
     assert len(step_msgs) == 1

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -11,6 +11,7 @@ import clickhouse_connect
 import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
 
+from tests.trace_server.project_id_util import make_project_id as _make_project_id
 from weave.trace_server import clickhouse_trace_server_batched as chts
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER
@@ -1362,11 +1363,6 @@ def test_file_batch_clears_on_insert_failure():
 
 
 # ── version_index ordering with MV-backed _first_created_at ─────────
-
-
-def _make_project_id(prefix: str) -> str:
-    raw = f"test/{prefix}_{uuid.uuid4().hex[:8]}"
-    return base64.b64encode(raw.encode()).decode()
 
 
 def _obj_create(server, project_id, obj_id, val):

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1411,7 +1411,7 @@ def test_version_index_stable_on_republish(ch_server):
 
 def test_delete_preserves_version_index_gaps(ch_server):
     """Deleting a version should leave a gap, not shift indices."""
-    project_id = _make_project_id("vidx")
+    project_id = make_project_id("vidx")
     obj_id = "vidx_gap"
 
     digests = []

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -11,7 +11,7 @@ import clickhouse_connect
 import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
 
-from tests.trace_server.project_id_util import make_project_id as _make_project_id
+from tests.trace_server.test_project_version import make_project_id
 from weave.trace_server import clickhouse_trace_server_batched as chts
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER
@@ -1389,7 +1389,7 @@ def test_version_index_stable_on_republish(ch_server):
     to its original creation time, so re-inserting digest A doesn't push
     it to the end of the version ordering.
     """
-    project_id = _make_project_id("vidx")
+    project_id = make_project_id("vidx")
     obj_id = "vidx_obj"
 
     r0 = _obj_create(ch_server, project_id, obj_id, {"v": "A"})

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -7,7 +7,7 @@ Migration 030 creates the genai tables automatically.
 import datetime
 import uuid
 
-from tests.trace_server.project_id_util import make_project_id as _make_project_id
+from tests.trace_server.helpers import make_project_id as _make_project_id
 from weave.trace_server.agents.helpers import genai_span_to_row
 from weave.trace_server.agents.schema import (
     ALL_SPAN_INSERT_COLUMNS,

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -4,10 +4,10 @@ Requires ClickHouse backend (auto-skips on SQLite via ch_server fixture).
 Migration 030 creates the genai tables automatically.
 """
 
-import base64
 import datetime
 import uuid
 
+from tests.trace_server.project_id_util import make_project_id as _make_project_id
 from weave.trace_server.agents.helpers import genai_span_to_row
 from weave.trace_server.agents.schema import (
     ALL_SPAN_INSERT_COLUMNS,
@@ -25,11 +25,6 @@ from weave.trace_server.agents.types import (
     AgentsQueryReq,
 )
 from weave.trace_server.interface.query import Query
-
-
-def _make_project_id(prefix: str) -> str:
-    raw = f"test/{prefix}_{uuid.uuid4().hex[:8]}"
-    return base64.b64encode(raw.encode()).decode()
 
 
 def _make_span(project_id: str, **overrides: object) -> AgentSpanCHInsertable:

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -73,6 +73,15 @@ from weave.trace_server.query_builder.agent_query_builder import (
 from weave.trace_server.query_builder.agent_stats_query_builder import (
     build_agent_span_stats_query,
 )
+from weave.trace_server.trace_server_common import (
+    AgentFeedbackByTarget,
+    group_agent_feedback_by_target,
+    make_agent_feedback_query_req,
+)
+from weave.trace_server.trace_server_interface import (
+    FeedbackQueryReq,
+    FeedbackQueryRes,
+)
 
 if TYPE_CHECKING:
     from clickhouse_connect.driver.client import Client as CHClient
@@ -84,6 +93,10 @@ logger = logging.getLogger(__name__)
 QueryParams: TypeAlias = dict[str, Any]
 ClickHouseRow: TypeAlias = dict[str, Any]
 QueryFn = Callable[[str, QueryParams], "QueryResult"]
+
+#: Signature of the server's `feedback_query` method.
+FeedbackQueryFn = Callable[[FeedbackQueryReq], FeedbackQueryRes]
+
 PaginatedReqT = TypeVar(
     "PaginatedReqT",
     AgentSpansQueryReq,
@@ -100,10 +113,13 @@ class AgentQueryHandler:
 
     Takes a `query_fn` (typically the server's `_query` method) so queries
     participate in the same logging / ddtrace / error-handling wrapper as the
-    rest of the trace server.
+    rest of the trace server. Also takes a `feedback_query_fn` (the server's
+    `feedback_query` method), invoked only when ``include_feedback=True`` to
+    fold agent-target feedback into the chat response.
     """
 
     _query: QueryFn
+    _feedback_query: FeedbackQueryFn
 
     # ------------------------------------------------------------------
     # Spans query (ungrouped + grouped)
@@ -238,7 +254,18 @@ class AgentQueryHandler:
     def traces_chat(self, req: AgentTraceChatReq) -> AgentTraceChatRes:
         """Build chat trajectory for a single trace."""
         spans = self.trace_detail_spans(req.project_id, req.trace_id)
-        return build_trace_chat(spans, req.trace_id)
+        res = build_trace_chat(spans, req.trace_id)
+
+        if req.include_feedback:
+            span_ids = [m.span_id for m in res.messages if m.span_id]
+            groups = self._fetch_agent_feedback(
+                project_id=req.project_id,
+                trace_ids=[req.trace_id],
+                span_ids=span_ids,
+            )
+            _fold_feedback_into_trace_chat(res, groups)
+
+        return res
 
     def conversation_chat(
         self, req: AgentConversationChatReq
@@ -251,7 +278,7 @@ class AgentQueryHandler:
         )
 
         if not rows:
-            return AgentConversationChatRes(
+            res = AgentConversationChatRes(
                 conversation_id=req.conversation_id,
                 turns=[],
                 total_turns=total_turns,
@@ -259,6 +286,15 @@ class AgentQueryHandler:
                 limit=req.limit,
                 offset=req.offset,
             )
+            if req.include_feedback:
+                groups = self._fetch_agent_feedback(
+                    project_id=req.project_id,
+                    conversation_ids=[req.conversation_id],
+                )
+                res.conversation_feedback = groups.by_conversation_id.get(
+                    req.conversation_id, []
+                )
+            return res
 
         # Group spans by trace_id, preserving insertion order. Weave treats
         # one trace_id as one conversation turn as a product convention based
@@ -275,7 +311,7 @@ class AgentQueryHandler:
             if trace_spans
         ]
 
-        return AgentConversationChatRes(
+        res = AgentConversationChatRes(
             conversation_id=req.conversation_id,
             turns=turns,
             total_turns=total_turns,
@@ -283,6 +319,39 @@ class AgentQueryHandler:
             limit=req.limit,
             offset=req.offset,
         )
+
+        if req.include_feedback:
+            span_ids = [m.span_id for turn in turns for m in turn.messages if m.span_id]
+            groups = self._fetch_agent_feedback(
+                project_id=req.project_id,
+                conversation_ids=[req.conversation_id],
+                trace_ids=[t.trace_id for t in turns],
+                span_ids=span_ids,
+            )
+            res.conversation_feedback = groups.by_conversation_id.get(
+                req.conversation_id, []
+            )
+            for turn in res.turns:
+                _fold_feedback_into_trace_chat(turn, groups)
+
+        return res
+
+    def _fetch_agent_feedback(
+        self,
+        project_id: str,
+        trace_ids: list[str] | None = None,
+        conversation_ids: list[str] | None = None,
+        span_ids: list[str] | None = None,
+    ) -> AgentFeedbackByTarget:
+        """Run one feedback query for a batch of agent targets."""
+        req = make_agent_feedback_query_req(
+            project_id=project_id,
+            trace_ids=trace_ids,
+            conversation_ids=conversation_ids,
+            span_ids=span_ids,
+        )
+        feedback = self._feedback_query(req)
+        return group_agent_feedback_by_target(feedback)
 
     # ------------------------------------------------------------------
     # Query plumbing
@@ -448,6 +517,17 @@ def _rows_to_dicts(
 ) -> list[dict[str, AgentSpanStatsCell]]:
     """Zip explicit column names with rows returned by a stats query."""
     return [dict(zip(columns, row, strict=True)) for row in rows]
+
+
+def _fold_feedback_into_trace_chat(
+    trace_chat: AgentTraceChatRes,
+    groups: AgentFeedbackByTarget,
+) -> None:
+    """Fold turn-level and step-level feedback into a trace chat response."""
+    trace_chat.turn_feedback = groups.by_trace_id.get(trace_chat.trace_id, [])
+    for message in trace_chat.messages:
+        if message.span_id and message.span_id in groups.by_span_id:
+            message.feedback = groups.by_span_id[message.span_id]
 
 
 def _first_cell_int(result: QueryResult) -> int:

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -13,6 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast
 
+from weave.shared import refs_internal as ri
 from weave.trace_server.agents.chat_view import build_trace_chat
 from weave.trace_server.agents.constants import (
     MAX_INGEST_ERRORS_REPORTED,
@@ -291,9 +292,7 @@ class AgentQueryHandler:
                     project_id=req.project_id,
                     conversation_ids=[req.conversation_id],
                 )
-                res.conversation_feedback = groups.by_conversation_id.get(
-                    req.conversation_id, []
-                )
+                res.feedback = groups.by_conversation_id.get(req.conversation_id, [])
             return res
 
         # Group spans by trace_id, preserving insertion order. Weave treats
@@ -328,9 +327,7 @@ class AgentQueryHandler:
                 trace_ids=[t.trace_id for t in turns],
                 span_ids=span_ids,
             )
-            res.conversation_feedback = groups.by_conversation_id.get(
-                req.conversation_id, []
-            )
+            res.feedback = groups.by_conversation_id.get(req.conversation_id, [])
             for turn in res.turns:
                 _fold_feedback_into_trace_chat(turn, groups)
 
@@ -344,12 +341,13 @@ class AgentQueryHandler:
         span_ids: list[str] | None = None,
     ) -> AgentFeedbackByTarget:
         """Run one feedback query for a batch of agent targets."""
-        req = make_agent_feedback_query_req(
+        refs = _build_agent_target_refs(
             project_id=project_id,
             trace_ids=trace_ids,
             conversation_ids=conversation_ids,
             span_ids=span_ids,
         )
+        req = make_agent_feedback_query_req(project_id=project_id, refs=refs)
         feedback = self._feedback_query(req)
         return group_agent_feedback_by_target(feedback)
 
@@ -519,12 +517,35 @@ def _rows_to_dicts(
     return [dict(zip(columns, row, strict=True)) for row in rows]
 
 
+def _build_agent_target_refs(
+    project_id: str,
+    trace_ids: list[str] | None = None,
+    conversation_ids: list[str] | None = None,
+    span_ids: list[str] | None = None,
+) -> list[str]:
+    """Build the union of agent_turn / agent_conversation / agent_span refs."""
+    refs: list[str] = []
+    for trace_id in trace_ids or []:
+        refs.append(
+            ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_id).uri
+        )
+    for conversation_id in conversation_ids or []:
+        refs.append(
+            ri.InternalAgentConversationRef(
+                project_id=project_id, conversation_id=conversation_id
+            ).uri
+        )
+    for span_id in span_ids or []:
+        refs.append(ri.InternalAgentSpanRef(project_id=project_id, span_id=span_id).uri)
+    return refs
+
+
 def _fold_feedback_into_trace_chat(
     trace_chat: AgentTraceChatRes,
     groups: AgentFeedbackByTarget,
 ) -> None:
     """Fold turn-level and step-level feedback into a trace chat response."""
-    trace_chat.turn_feedback = groups.by_trace_id.get(trace_chat.trace_id, [])
+    trace_chat.feedback = groups.by_trace_id.get(trace_chat.trace_id, [])
     for message in trace_chat.messages:
         if message.span_id and message.span_id in groups.by_span_id:
             message.feedback = groups.by_span_id[message.span_id]

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -30,9 +30,13 @@ from weave.trace_server.agents.schema import (
 from weave.trace_server.interface.query import Query
 
 if TYPE_CHECKING:
-    from weave.trace_server.trace_server_interface import ProcessedResourceSpans
+    from weave.trace_server.trace_server_interface import (
+        FeedbackDict,
+        ProcessedResourceSpans,
+    )
 else:
     ProcessedResourceSpans = Any
+    FeedbackDict = dict
 
 SearchMessageRole = Literal[
     "",
@@ -539,7 +543,7 @@ class AgentChatMessage(BaseModel):
             )
         return self
 
-    feedback: list[dict[str, Any]] | None = None
+    feedback: list[FeedbackDict] | None = None
 
 
 class AgentTraceChatReq(BaseModel):
@@ -566,7 +570,7 @@ class AgentTraceChatRes(BaseModel):
         ),
     )
     messages: list[AgentChatMessage] = Field(default_factory=list)
-    turn_feedback: list[dict[str, Any]] | None = None
+    feedback: list[FeedbackDict] | None = None
 
 
 class AgentConversationChatReq(BaseModel):
@@ -607,7 +611,7 @@ class AgentConversationChatRes(BaseModel):
     has_more: bool = False
     limit: int = MAX_CONVERSATION_CHAT_TURNS
     offset: int = 0
-    conversation_feedback: list[dict[str, Any]] | None = None
+    feedback: list[FeedbackDict] | None = None
 
 
 class AgentSchema(BaseModel):

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -539,12 +539,15 @@ class AgentChatMessage(BaseModel):
             )
         return self
 
+    feedback: list[dict[str, Any]] | None = None
+
 
 class AgentTraceChatReq(BaseModel):
     """Request to get the structured chat / trajectory view for a trace."""
 
     project_id: str
     trace_id: str
+    include_feedback: bool = False
 
 
 class AgentTraceChatRes(BaseModel):
@@ -563,6 +566,7 @@ class AgentTraceChatRes(BaseModel):
         ),
     )
     messages: list[AgentChatMessage] = Field(default_factory=list)
+    turn_feedback: list[dict[str, Any]] | None = None
 
 
 class AgentConversationChatReq(BaseModel):
@@ -584,6 +588,7 @@ class AgentConversationChatReq(BaseModel):
             "chronological order within the selected page."
         ),
     )
+    include_feedback: bool = False
 
 
 class AgentConversationChatRes(BaseModel):
@@ -602,6 +607,7 @@ class AgentConversationChatRes(BaseModel):
     has_more: bool = False
     limit: int = MAX_CONVERSATION_CHAT_TURNS
     offset: int = 0
+    conversation_feedback: list[dict[str, Any]] | None = None
 
 
 class AgentSchema(BaseModel):

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -30,13 +30,9 @@ from weave.trace_server.agents.schema import (
 from weave.trace_server.interface.query import Query
 
 if TYPE_CHECKING:
-    from weave.trace_server.trace_server_interface import (
-        FeedbackDict,
-        ProcessedResourceSpans,
-    )
+    from weave.trace_server.trace_server_interface import ProcessedResourceSpans
 else:
     ProcessedResourceSpans = Any
-    FeedbackDict = dict
 
 SearchMessageRole = Literal[
     "",
@@ -543,7 +539,7 @@ class AgentChatMessage(BaseModel):
             )
         return self
 
-    feedback: list[FeedbackDict] | None = None
+    feedback: list[dict[str, Any]] | None = None
 
 
 class AgentTraceChatReq(BaseModel):
@@ -570,7 +566,7 @@ class AgentTraceChatRes(BaseModel):
         ),
     )
     messages: list[AgentChatMessage] = Field(default_factory=list)
-    feedback: list[FeedbackDict] | None = None
+    feedback: list[dict[str, Any]] | None = None
 
 
 class AgentConversationChatReq(BaseModel):
@@ -611,7 +607,7 @@ class AgentConversationChatRes(BaseModel):
     has_more: bool = False
     limit: int = MAX_CONVERSATION_CHAT_TURNS
     offset: int = 0
-    feedback: list[FeedbackDict] | None = None
+    feedback: list[dict[str, Any]] | None = None
 
 
 class AgentSchema(BaseModel):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6597,27 +6597,31 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     # observability API is considered stable.
 
     def agent_spans_query(self, req: AgentSpansQueryReq) -> AgentSpansQueryRes:
-        return AgentQueryHandler(self._query).spans_query(req)
+        return AgentQueryHandler(self._query, self.feedback_query).spans_query(req)
 
     def agent_spans_stats(self, req: AgentSpanStatsReq) -> AgentSpanStatsRes:
         return AgentQueryHandler(self._query).spans_stats(req)
 
     def agent_agents_query(self, req: AgentsQueryReq) -> AgentsQueryRes:
-        return AgentQueryHandler(self._query).agents_query(req)
+        return AgentQueryHandler(self._query, self.feedback_query).agents_query(req)
 
     def agent_versions_query(self, req: AgentVersionsQueryReq) -> AgentVersionsQueryRes:
-        return AgentQueryHandler(self._query).agent_versions_query(req)
+        return AgentQueryHandler(self._query, self.feedback_query).agent_versions_query(
+            req
+        )
 
     def agent_search(self, req: AgentSearchReq) -> AgentSearchRes:
-        return AgentQueryHandler(self._query).search_messages(req)
+        return AgentQueryHandler(self._query, self.feedback_query).search_messages(req)
 
     def agent_traces_chat(self, req: AgentTraceChatReq) -> AgentTraceChatRes:
-        return AgentQueryHandler(self._query).traces_chat(req)
+        return AgentQueryHandler(self._query, self.feedback_query).traces_chat(req)
 
     def agent_conversation_chat(
         self, req: AgentConversationChatReq
     ) -> AgentConversationChatRes:
-        return AgentQueryHandler(self._query).conversation_chat(req)
+        return AgentQueryHandler(self._query, self.feedback_query).conversation_chat(
+            req
+        )
 
     def genai_otel_export(self, req: GenAIOTelExportReq) -> GenAIOTelExportRes:
         res, span_rows = AgentWriteHandler(self.ch_client).insert_otel_spans(req)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6600,7 +6600,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return AgentQueryHandler(self._query, self.feedback_query).spans_query(req)
 
     def agent_spans_stats(self, req: AgentSpanStatsReq) -> AgentSpanStatsRes:
-        return AgentQueryHandler(self._query).spans_stats(req)
+        return AgentQueryHandler(self._query, self.feedback_query).spans_stats(req)
 
     def agent_agents_query(self, req: AgentsQueryReq) -> AgentsQueryRes:
         return AgentQueryHandler(self._query, self.feedback_query).agents_query(req)


### PR DESCRIPTION
## Description

- Fixes [WB-33571](https://coreweave.atlassian.net/browse/WB-33571)

Third of three stacked PRs for Phase 1 of human feedback on agent turns.

Adds \`include_feedback: bool\` to \`agent_traces_chat\` and \`agent_conversation_chat\`. When true, the handler adds feedback into the response: turn feedback onto the turn, step feedback onto each message by span_id, conversation feedback onto the conversation.

Stack: #6684 → #6685 → this

## Testing

- unit tests

[WB-33571]: https://coreweave.atlassian.net/browse/WB-33571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ