### PR TITLE
chore(weave): set 1s Redis connect/socket timeouts on weave-trace client

### DIFF
--- a/weave/trace_server/redis_client.py
+++ b/weave/trace_server/redis_client.py
@@ -6,6 +6,14 @@ import redis
 
 from weave.trace_server.environment import redis_url
 
+# Redis here is an optional L2 cache in front of ClickHouse. When it's
+# unreachable we must fall through quickly; without explicit timeouts the
+# socket inherits the OS default TCP connect timeout (~2 min on Linux),
+# which stalls every cache-miss request path. redis-py's default retry
+# config is zero retries, so a single failure fails fast.
+REDIS_CONNECT_TIMEOUT_SECS = 1
+REDIS_SOCKET_TIMEOUT_SECS = 1
+
 
 @functools.lru_cache(maxsize=1)
 def get_redis_client() -> redis.Redis | None:
@@ -16,5 +24,10 @@ def get_redis_client() -> redis.Redis | None:
     """
     url = redis_url()
     if url:
-        return redis.from_url(url, decode_responses=True)
+        return redis.from_url(
+            url,
+            decode_responses=True,
+            socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
+            socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
+        )
     return None


### PR DESCRIPTION
## Summary

Deployed `ttl/04b-redis-l2-wiring` to QA and saw ~2-min TCP connect timeouts bubbling up in `ttl_settings._l2_get` because the configured Redis ClusterIP had drifted. `redis-py` inherits the OS TCP connect timeout when none is set. Pin both `socket_connect_timeout` and `socket_timeout` to 1s so the L2 path fails fast on a dead/misconfigured Redis.

Companion PR in core updates the configmap to use DNS (`redis.redis.svc.cluster.local`) so the drift won't recur: https://github.com/wandb/core/pull/42774

Targets `ttl/04b-redis-l2-wiring` since that's the branch that activates the L2 path.