### PR TITLE
fix(weave): silence Windows tempdir cleanup warnings in MemTraceFilesArtifact

### DIFF
--- a/weave/trace/serialization/mem_artifact.py
+++ b/weave/trace/serialization/mem_artifact.py
@@ -111,7 +111,14 @@ class MemTraceFilesArtifact:
         if path not in self.path_contents:
             raise FileNotFoundError(path)
 
-        self.temp_read_dir = tempfile.TemporaryDirectory()
+        # Reuse a single tempdir per artifact so repeat `path()` calls don't
+        # orphan a prior TemporaryDirectory whose finalizer fires via GC.
+        # `ignore_cleanup_errors` (Python 3.10+) swallows Windows
+        # PermissionError when a consumer still holds the file open
+        # (e.g. PIL.Image.open, wave.open, VideoFileClip), which otherwise
+        # surfaces as PytestUnraisableExceptionWarning during finalization.
+        if self.temp_read_dir is None:
+            self.temp_read_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         write_path = _safe_join(self.temp_read_dir.name, filename or path)
         os.makedirs(os.path.dirname(write_path), exist_ok=True)
         with open(write_path, "wb") as f:
@@ -126,7 +133,7 @@ class MemTraceFilesArtifact:
 
     @contextlib.contextmanager
     def writeable_file_path(self, path: str) -> Generator[str]:
-        with tempfile.TemporaryDirectory() as tmpdir:
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmpdir:
             full_path = _safe_join(tmpdir, path)
             os.makedirs(os.path.dirname(full_path), exist_ok=True)
             yield full_path


### PR DESCRIPTION
## Summary

- Windows CI was emitting ~30 `PytestUnraisableExceptionWarning` per job from `test_serialization_correctness[image/audio/video/content: *]`.
- Root cause: `MemTraceFilesArtifact.path()` creates a new `TemporaryDirectory` on every call and overwrites `self.temp_read_dir`. When a loader (`PIL.Image.open`, `wave.open`, `VideoFileClip`) still holds the file open, the orphaned tempdir's `weakref.finalize` cleanup fails with `WinError 32` on Windows. Example run: https://github.com/wandb/weave/actions/runs/24806312311/job/72601194849
- Fix: reuse a single tempdir per artifact, and pass `ignore_cleanup_errors=True` (Python 3.10+) so residual races on Windows are swallowed silently.

## Why `ignore_cleanup_errors=True` is safe

`ignore_cleanup_errors` (Python 3.10+, added exactly for this Windows case) only catches `OSError` inside `rmtree` during tempdir teardown. It does **not** change any other behavior:

- **No leaked secrets / data loss.** The tempdir only contains media payloads already persisted server-side and still held in `self.path_contents`. Nothing here is sensitive.
- **No extra disk leakage.** Without the flag, the cleanup still fails on Windows when a handle is open — it just re-raises into `sys.unraisablehook`. The file is undeleted either way; the flag only silences the warning.
- **No-op on POSIX.** Linux/macOS allow unlinking open files, so rmtree never raises there and the flag never fires.
- **Doesn't mask application errors.** Exceptions from the test body, `open()`, or the media loaders still propagate normally — this only affects `TemporaryDirectory.__exit__` / finalizer cleanup.
- **OS sweeps `%TEMP%` anyway** on reboot / via Storage Sense, so a stray file per test run is a disk-hygiene non-issue.

## Before / after

Same shard (`Windows Trace nox tests (3, 10, trace)`), same test file:

| | master | this PR |
|---|---|---|
| `WinError 32` (file in use) | ~60 | 0 |
| `WinError 267` (invalid directory) | ~30 | 0 |
| `PytestUnraisableExceptionWarning` | ~30 | 0 |
| Tests | passing | 830 passed, 106 skipped |

## Testing

- [x] Windows Trace nox (3, 10, trace) on this branch has zero `PytestUnraisableExceptionWarning` / `WinError 32` / `WinError 267` lines.
- [x] Local `tests/trace/data_serialization/test_serialization_correctness.py` still passes.