### PR TITLE
fix(weave_ts): Attemp 2 Fixes issue client.responses.create(...).withResponse is not a function

### DIFF
--- a/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
+++ b/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
@@ -1,7 +1,7 @@
 import {InMemoryTraceServer} from '../../inMemoryTraceServer';
 import {wrapOpenAI} from '../../integrations/openai';
 import {initWithCustomTraceServer} from '../clientMock';
-import {makeMockOpenAIChat} from '../openaiMock';
+import {makeAPIPromiseShim, makeMockOpenAIChat} from '../openaiMock';
 
 // Helper function to get calls
 async function getCalls(traceServer: InMemoryTraceServer, projectId: string) {
@@ -175,6 +175,40 @@ describe('OpenAI Integration', () => {
     });
   });
 
+  // Regression: libraries like @mariozechner/pi-ai consume streaming
+  // responses via `await client.chat.completions.create(...).withResponse()`.
+  // Without the wrapAsAPIPromiseLike special case for .withResponse(), the
+  // iterated stream bypasses weave's WeaveIterator proxy, so finishCall
+  // never fires and the trace stays pending forever.
+  test('streaming chat completion via .withResponse() finishes the trace', async () => {
+    const messages = [{role: 'user', content: 'Hello, streaming AI!'}];
+
+    const {data, response} = await patchedOpenAI.chat.completions
+      .create({messages, stream: true})
+      .withResponse();
+
+    expect(response.status).toBe(200);
+
+    let content = '';
+    for await (const chunk of data as AsyncIterable<any>) {
+      if (chunk.choices?.[0]?.delta?.content) {
+        content += chunk.choices[0].delta.content;
+      }
+    }
+    expect(content).toBe('HELLO, STREAMING AI!');
+
+    await wait(300);
+
+    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    expect(calls).toHaveLength(1);
+    // The key assertion: output is populated, which means finishCall
+    // fired. Without the .withResponse() → traced-data substitution,
+    // iteration would bypass WeaveIterator and this would be empty.
+    expect(calls[0].output).toMatchObject({
+      choices: [{message: {content: 'HELLO, STREAMING AI!'}}],
+    });
+  });
+
   // Add a new test for streaming with explicit usage request
   test('streaming chat completion with explicit usage request', async () => {
     const messages = [
@@ -329,13 +363,15 @@ describe('OpenAI Integration', () => {
     ];
 
     // Override mock for this test
-    mockOpenAI.responses.create = jest.fn().mockResolvedValue({
-      async *[Symbol.asyncIterator]() {
-        for (const chunk of pirateChunks) {
-          yield chunk;
-        }
-      },
-    });
+    mockOpenAI.responses.create = jest.fn(() =>
+      makeAPIPromiseShim({
+        async *[Symbol.asyncIterator]() {
+          for (const chunk of pirateChunks) {
+            yield chunk;
+          }
+        },
+      })
+    );
 
     const options = {
       model: 'gpt-4o-2024-08-06',

--- a/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
+++ b/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
@@ -175,11 +175,37 @@ describe('OpenAI Integration', () => {
     });
   });
 
+  test('falls back cleanly when APIPromise._thenUnwrap is unavailable', async () => {
+    // Simulate a (hypothetical) future SDK that drops _thenUnwrap.
+    const messages = [{role: 'user', content: 'Hello!'}];
+    const rawCreate = mockOpenAI.chat.completions.create;
+    mockOpenAI.chat.completions.create = (params: any) => {
+      const shim = rawCreate(params);
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const {_thenUnwrap: _removed, ...rest} = shim;
+      return rest;
+    };
+    patchedOpenAI = wrapOpenAI(mockOpenAI);
+
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // The SDK call still works for the user — weave just stops tracing.
+      const result = await patchedOpenAI.chat.completions.create({messages});
+      expect(result.choices[0].message.content).toBe('HELLO!');
+
+      await wait(300);
+      const calls = await getCalls(inMemoryTraceServer, testProjectName);
+      // Fail-fast: no half-started call on the trace server.
+      expect(calls).toHaveLength(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   // Regression: libraries like @mariozechner/pi-ai consume streaming
   // responses via `await client.chat.completions.create(...).withResponse()`.
-  // Without the wrapAsAPIPromiseLike special case for .withResponse(), the
-  // iterated stream bypasses weave's WeaveIterator proxy, so finishCall
-  // never fires and the trace stays pending forever.
+  // Without weave substituting its tapped stream as `data`, the iterated
+  // stream bypasses WeaveIterator and the trace's finishCall never fires.
   test('streaming chat completion via .withResponse() finishes the trace', async () => {
     const messages = [{role: 'user', content: 'Hello, streaming AI!'}];
 
@@ -338,7 +364,7 @@ describe('OpenAI Integration', () => {
     });
   });
 
-  test('should handle interrupted streaming response', async () => {
+  test('should handle streaming response with deltas and done event', async () => {
     const pirateChunks = [
       {
         type: 'response.created',
@@ -351,6 +377,30 @@ describe('OpenAI Integration', () => {
         },
       },
       {
+        type: 'response.output_item.added',
+        sequence_number: 1,
+        output_index: 0,
+        item: {
+          id: 'msg_test_id',
+          type: 'message',
+          status: 'in_progress',
+          content: [],
+          role: 'assistant',
+        },
+      },
+      {
+        type: 'response.content_part.added',
+        sequence_number: 2,
+        item_id: 'msg_test_id',
+        output_index: 0,
+        content_index: 0,
+        part: {
+          type: 'output_text',
+          annotations: [],
+          text: '',
+        },
+      },
+      {
         type: 'response.output_text.delta',
         sequence_number: 4,
         delta: 'Arr',
@@ -359,6 +409,14 @@ describe('OpenAI Integration', () => {
         type: 'response.output_text.delta',
         sequence_number: 5,
         delta: 'r',
+      },
+      {
+        type: 'response.output_text.done',
+        sequence_number: 6,
+        item_id: 'msg_test_id',
+        output_index: 0,
+        content_index: 0,
+        text: 'Arrr',
       },
     ];
 
@@ -385,14 +443,23 @@ describe('OpenAI Integration', () => {
     const stream = await patchedOpenAI.responses.create(options);
 
     let deltaText = '';
+    let finalText = '';
+    let deltaCount = 0;
     for await (const chunk of stream) {
       if (chunk.type === 'response.output_text.delta') {
+        deltaCount++;
         deltaText += chunk.delta;
+      }
+      if (chunk.type === 'response.output_text.done') {
+        finalText = chunk.text;
       }
     }
 
-    // Verify that deltas accumulated to "Arr" + "r" = "Arrr"
+    // Caller sees the deltas (assembled here) and the final text
+    // delivered by the done event.
+    expect(deltaCount).toBe(2);
     expect(deltaText).toBe('Arrr');
+    expect(finalText).toBe('Arrr');
 
     // Wait for any pending batch processing
     await wait(300);
@@ -403,5 +470,50 @@ describe('OpenAI Integration', () => {
     expect(calls[0].inputs).toMatchObject(options);
     expect(calls[0].inputs.self).toBeDefined(); // self parameter should be captured
     expect(calls[0].output.responses[0].output[0].content[0].text).toBe('Arrr');
+  });
+
+  test('stream that throws mid-iteration is recorded as an exception, not a successful completion', async () => {
+    const boom = new Error('stream blew up');
+    mockOpenAI.responses.create = jest.fn(() =>
+      makeAPIPromiseShim({
+        async *[Symbol.asyncIterator]() {
+          yield {
+            type: 'response.output_text.delta',
+            sequence_number: 1,
+            delta: 'partial',
+          };
+          throw boom;
+        },
+      })
+    );
+
+    const stream = await patchedOpenAI.responses.create({
+      model: 'gpt-4o-2024-08-06',
+      messages: [{role: 'user', content: 'go'}],
+      stream: true,
+    });
+
+    let caught: unknown;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _chunk of stream) {
+        // consume; the error fires after the first chunk
+      }
+    } catch (e) {
+      caught = e;
+    }
+
+    // The caller still sees the underlying SDK error.
+    expect(caught).toBe(boom);
+
+    await wait(300);
+
+    const calls = await getCalls(inMemoryTraceServer, testProjectName);
+    expect(calls).toHaveLength(1);
+    // The trace records the exception rather than declaring success
+    // with partial output.
+    expect(calls[0].exception).toEqual(
+      expect.stringContaining('stream blew up')
+    );
   });
 });

--- a/sdks/node/src/__tests__/integrations/openai2.test.ts
+++ b/sdks/node/src/__tests__/integrations/openai2.test.ts
@@ -207,6 +207,57 @@ describe('OpenAI Integration', () => {
       // Verify wrapped matches unwrapped
       expect(wrappedResult).toEqual(unwrappedResult);
     });
+
+    it('should forward APIPromise.withResponse() through the chat completions wrapper', async () => {
+      const mockResponse = {
+        headers: new Map([['x-request-id', 'req_chat_id']]),
+      };
+      const parsedData = {
+        id: 'chat_test_id',
+        choices: [{message: {role: 'assistant', content: 'Hello'}}],
+        model: 'gpt-4',
+        usage: {prompt_tokens: 1, completion_tokens: 1, total_tokens: 2},
+      };
+
+      class MockAPIPromise {
+        then(onFulfilled: any, onRejected: any) {
+          return Promise.resolve(parsedData).then(onFulfilled, onRejected);
+        }
+        catch(onRejected: any) {
+          return Promise.resolve(parsedData).catch(onRejected);
+        }
+        finally(onFinally: any) {
+          return Promise.resolve(parsedData).finally(onFinally);
+        }
+        asResponse() {
+          return Promise.resolve(mockResponse);
+        }
+        async withResponse() {
+          return {
+            data: parsedData,
+            response: mockResponse,
+            request_id: mockResponse.headers.get('x-request-id'),
+          };
+        }
+      }
+
+      mockOpenAI.chat.completions.create = jest
+        .fn()
+        .mockImplementation(() => new MockAPIPromise());
+      wrappedOpenAI = wrapOpenAI(mockOpenAI);
+
+      const pending = wrappedOpenAI.chat.completions.create({
+        model: 'gpt-4',
+        messages: [{role: 'user', content: 'Hi'}],
+      });
+
+      expect(typeof pending.withResponse).toBe('function');
+      const {data, response, request_id} = await pending.withResponse();
+
+      expect(data).toEqual(parsedData);
+      expect(response).toBe(mockResponse);
+      expect(request_id).toBe('req_chat_id');
+    });
   });
 });
 
@@ -411,6 +462,74 @@ describe('OpenAI responses.create Integration', () => {
       });
 
       expect(mockOpenAI.responses.create).toHaveBeenCalledWith(options);
+    });
+
+    it('should forward APIPromise.withResponse() through the weave wrapper', async () => {
+      const mockResponse = {
+        headers: new Map([['x-request-id', 'req_test_id']]),
+      };
+      const parsedData = {
+        id: 'resp_test_id',
+        object: 'response',
+        status: 'completed',
+        model: 'gpt-4o-2024-08-06',
+        output: [
+          {
+            id: 'msg_test_id',
+            type: 'message',
+            status: 'completed',
+            content: [
+              {
+                type: 'output_text',
+                annotations: [],
+                text: 'Hello! How can I help you today?',
+              },
+            ],
+            role: 'assistant',
+          },
+        ],
+        usage: {input_tokens: 1, output_tokens: 1, total_tokens: 2},
+      };
+
+      // Simulate APIPromise: thenable with .withResponse()/.asResponse().
+      class MockAPIPromise {
+        then(onFulfilled: any, onRejected: any) {
+          return Promise.resolve(parsedData).then(onFulfilled, onRejected);
+        }
+        catch(onRejected: any) {
+          return Promise.resolve(parsedData).catch(onRejected);
+        }
+        finally(onFinally: any) {
+          return Promise.resolve(parsedData).finally(onFinally);
+        }
+        asResponse() {
+          return Promise.resolve(mockResponse);
+        }
+        async withResponse() {
+          return {
+            data: parsedData,
+            response: mockResponse,
+            request_id: mockResponse.headers.get('x-request-id'),
+          };
+        }
+      }
+
+      mockOpenAI.responses.create = jest
+        .fn()
+        .mockImplementation(() => new MockAPIPromise());
+      wrappedOpenAI = wrapOpenAI(mockOpenAI);
+
+      const pending = wrappedOpenAI.responses.create({
+        model: 'gpt-4o-2024-08-06',
+        messages: [{role: 'user', content: 'Hello!'}],
+      });
+
+      expect(typeof pending.withResponse).toBe('function');
+      const {data, response, request_id} = await pending.withResponse();
+
+      expect(data).toEqual(parsedData);
+      expect(response).toBe(mockResponse);
+      expect(request_id).toBe('req_test_id');
     });
 
     it('should handle streaming responses and skip deltas', async () => {

--- a/sdks/node/src/__tests__/integrations/openai2.test.ts
+++ b/sdks/node/src/__tests__/integrations/openai2.test.ts
@@ -12,6 +12,35 @@ import {WeaveClient} from '../../weaveClient';
 jest.mock('../../generated/traceServerApi');
 jest.mock('../../wandb/wandbServerApi');
 
+// Stands in for the OpenAI SDK's APIPromise: thenable with the helpers
+// (.withResponse(), .asResponse()) the wrapper must preserve.
+function createMockAPIPromise<T>(
+  parsedData: T,
+  mockResponse: {headers: {get(key: string): string | null | undefined}}
+) {
+  return {
+    then(onFulfilled: any, onRejected: any) {
+      return Promise.resolve(parsedData).then(onFulfilled, onRejected);
+    },
+    catch(onRejected: any) {
+      return Promise.resolve(parsedData).catch(onRejected);
+    },
+    finally(onFinally: any) {
+      return Promise.resolve(parsedData).finally(onFinally);
+    },
+    asResponse() {
+      return Promise.resolve(mockResponse);
+    },
+    async withResponse() {
+      return {
+        data: parsedData,
+        response: mockResponse,
+        request_id: mockResponse.headers.get('x-request-id'),
+      };
+    },
+  };
+}
+
 describe('OpenAI Integration', () => {
   let mockOpenAI: any;
   let wrappedOpenAI: any;
@@ -219,31 +248,11 @@ describe('OpenAI Integration', () => {
         usage: {prompt_tokens: 1, completion_tokens: 1, total_tokens: 2},
       };
 
-      class MockAPIPromise {
-        then(onFulfilled: any, onRejected: any) {
-          return Promise.resolve(parsedData).then(onFulfilled, onRejected);
-        }
-        catch(onRejected: any) {
-          return Promise.resolve(parsedData).catch(onRejected);
-        }
-        finally(onFinally: any) {
-          return Promise.resolve(parsedData).finally(onFinally);
-        }
-        asResponse() {
-          return Promise.resolve(mockResponse);
-        }
-        async withResponse() {
-          return {
-            data: parsedData,
-            response: mockResponse,
-            request_id: mockResponse.headers.get('x-request-id'),
-          };
-        }
-      }
-
       mockOpenAI.chat.completions.create = jest
         .fn()
-        .mockImplementation(() => new MockAPIPromise());
+        .mockImplementation(() =>
+          createMockAPIPromise(parsedData, mockResponse)
+        );
       wrappedOpenAI = wrapOpenAI(mockOpenAI);
 
       const pending = wrappedOpenAI.chat.completions.create({
@@ -491,32 +500,11 @@ describe('OpenAI responses.create Integration', () => {
         usage: {input_tokens: 1, output_tokens: 1, total_tokens: 2},
       };
 
-      // Simulate APIPromise: thenable with .withResponse()/.asResponse().
-      class MockAPIPromise {
-        then(onFulfilled: any, onRejected: any) {
-          return Promise.resolve(parsedData).then(onFulfilled, onRejected);
-        }
-        catch(onRejected: any) {
-          return Promise.resolve(parsedData).catch(onRejected);
-        }
-        finally(onFinally: any) {
-          return Promise.resolve(parsedData).finally(onFinally);
-        }
-        asResponse() {
-          return Promise.resolve(mockResponse);
-        }
-        async withResponse() {
-          return {
-            data: parsedData,
-            response: mockResponse,
-            request_id: mockResponse.headers.get('x-request-id'),
-          };
-        }
-      }
-
       mockOpenAI.responses.create = jest
         .fn()
-        .mockImplementation(() => new MockAPIPromise());
+        .mockImplementation(() =>
+          createMockAPIPromise(parsedData, mockResponse)
+        );
       wrappedOpenAI = wrapOpenAI(mockOpenAI);
 
       const pending = wrappedOpenAI.responses.create({
@@ -532,7 +520,44 @@ describe('OpenAI responses.create Integration', () => {
       expect(request_id).toBe('req_test_id');
     });
 
-    it('should handle streaming responses and skip deltas', async () => {
+    it('should handle streaming responses via .withResponse() and skip deltas', async () => {
+      const mockResponse = {
+        headers: new Map([['x-request-id', 'req_stream_id']]),
+      };
+      const streamChunks = [
+        {
+          type: 'response.created',
+          sequence_number: 0,
+          response: {id: 'resp_test_id', status: 'in_progress'},
+        },
+        {
+          type: 'response.output_text.delta',
+          sequence_number: 1,
+          delta: 'Hello!',
+        },
+        {
+          type: 'response.output_text.delta',
+          sequence_number: 2,
+          delta: ' How can I help you today?',
+        },
+        {
+          type: 'response.output_text.done',
+          sequence_number: 3,
+          text: 'Hello! How can I help you today?',
+        },
+        {type: 'response.completed', sequence_number: 4},
+      ];
+      const stream = {
+        async *[Symbol.asyncIterator]() {
+          for (const chunk of streamChunks) yield chunk;
+        },
+      };
+
+      mockOpenAI.responses.create = jest
+        .fn()
+        .mockImplementation(() => createMockAPIPromise(stream, mockResponse));
+      wrappedOpenAI = wrapOpenAI(mockOpenAI);
+
       const options = {
         model: 'gpt-4o-2024-08-06',
         instructions: 'You are a helpful assistant',
@@ -540,21 +565,21 @@ describe('OpenAI responses.create Integration', () => {
         stream: true,
       };
 
-      const stream = await wrappedOpenAI.responses.create(options);
+      const {data, response, request_id} = await wrappedOpenAI.responses
+        .create(options)
+        .withResponse();
+
+      expect(response).toBe(mockResponse);
+      expect(request_id).toBe('req_stream_id');
 
       let deltaCount = 0;
       let finalText = '';
-      for await (const chunk of stream) {
-        if (chunk.type === 'response.output_text.delta') {
-          deltaCount++;
-        }
-        if (chunk.type === 'response.output_text.done') {
-          finalText = chunk.text;
-        }
+      for await (const chunk of data as AsyncIterable<any>) {
+        if (chunk.type === 'response.output_text.delta') deltaCount++;
+        if (chunk.type === 'response.output_text.done') finalText = chunk.text;
       }
 
-      // Verify deltas were received but final text comes from done event
-      expect(deltaCount).toBe(2); // Two delta chunks
+      expect(deltaCount).toBe(2);
       expect(finalText).toBe('Hello! How can I help you today?');
       expect(mockOpenAI.responses.create).toHaveBeenCalledWith(options);
     });

--- a/sdks/node/src/__tests__/integrations/openai2.test.ts
+++ b/sdks/node/src/__tests__/integrations/openai2.test.ts
@@ -7,39 +7,11 @@ import {
 import {isWeaveImage} from '../../media';
 import {WandbServerApi} from '../../wandb/wandbServerApi';
 import {WeaveClient} from '../../weaveClient';
+import {makeAPIPromiseShim} from '../openaiMock';
 
 // Mock WeaveClient dependencies
 jest.mock('../../generated/traceServerApi');
 jest.mock('../../wandb/wandbServerApi');
-
-// Stands in for the OpenAI SDK's APIPromise: thenable with the helpers
-// (.withResponse(), .asResponse()) the wrapper must preserve.
-function createMockAPIPromise<T>(
-  parsedData: T,
-  mockResponse: {headers: {get(key: string): string | null | undefined}}
-) {
-  return {
-    then(onFulfilled: any, onRejected: any) {
-      return Promise.resolve(parsedData).then(onFulfilled, onRejected);
-    },
-    catch(onRejected: any) {
-      return Promise.resolve(parsedData).catch(onRejected);
-    },
-    finally(onFinally: any) {
-      return Promise.resolve(parsedData).finally(onFinally);
-    },
-    asResponse() {
-      return Promise.resolve(mockResponse);
-    },
-    async withResponse() {
-      return {
-        data: parsedData,
-        response: mockResponse,
-        request_id: mockResponse.headers.get('x-request-id'),
-      };
-    },
-  };
-}
 
 describe('OpenAI Integration', () => {
   let mockOpenAI: any;
@@ -236,37 +208,6 @@ describe('OpenAI Integration', () => {
       // Verify wrapped matches unwrapped
       expect(wrappedResult).toEqual(unwrappedResult);
     });
-
-    it('should forward APIPromise.withResponse() through the chat completions wrapper', async () => {
-      const mockResponse = {
-        headers: new Map([['x-request-id', 'req_chat_id']]),
-      };
-      const parsedData = {
-        id: 'chat_test_id',
-        choices: [{message: {role: 'assistant', content: 'Hello'}}],
-        model: 'gpt-4',
-        usage: {prompt_tokens: 1, completion_tokens: 1, total_tokens: 2},
-      };
-
-      mockOpenAI.chat.completions.create = jest
-        .fn()
-        .mockImplementation(() =>
-          createMockAPIPromise(parsedData, mockResponse)
-        );
-      wrappedOpenAI = wrapOpenAI(mockOpenAI);
-
-      const pending = wrappedOpenAI.chat.completions.create({
-        model: 'gpt-4',
-        messages: [{role: 'user', content: 'Hi'}],
-      });
-
-      expect(typeof pending.withResponse).toBe('function');
-      const {data, response, request_id} = await pending.withResponse();
-
-      expect(data).toEqual(parsedData);
-      expect(response).toBe(mockResponse);
-      expect(request_id).toBe('req_chat_id');
-    });
   });
 });
 
@@ -425,9 +366,9 @@ describe('OpenAI responses.create Integration', () => {
       responses: {
         create: jest.fn().mockImplementation((options: any) => {
           if (options.stream) {
-            return Promise.resolve(new MockStream(mockStreamChunks));
+            return makeAPIPromiseShim(new MockStream(mockStreamChunks));
           }
-          return Promise.resolve(mockNonStreamingResponse);
+          return makeAPIPromiseShim(mockNonStreamingResponse);
         }),
       },
     };
@@ -470,117 +411,6 @@ describe('OpenAI responses.create Integration', () => {
         },
       });
 
-      expect(mockOpenAI.responses.create).toHaveBeenCalledWith(options);
-    });
-
-    it('should forward APIPromise.withResponse() through the weave wrapper', async () => {
-      const mockResponse = {
-        headers: new Map([['x-request-id', 'req_test_id']]),
-      };
-      const parsedData = {
-        id: 'resp_test_id',
-        object: 'response',
-        status: 'completed',
-        model: 'gpt-4o-2024-08-06',
-        output: [
-          {
-            id: 'msg_test_id',
-            type: 'message',
-            status: 'completed',
-            content: [
-              {
-                type: 'output_text',
-                annotations: [],
-                text: 'Hello! How can I help you today?',
-              },
-            ],
-            role: 'assistant',
-          },
-        ],
-        usage: {input_tokens: 1, output_tokens: 1, total_tokens: 2},
-      };
-
-      mockOpenAI.responses.create = jest
-        .fn()
-        .mockImplementation(() =>
-          createMockAPIPromise(parsedData, mockResponse)
-        );
-      wrappedOpenAI = wrapOpenAI(mockOpenAI);
-
-      const pending = wrappedOpenAI.responses.create({
-        model: 'gpt-4o-2024-08-06',
-        messages: [{role: 'user', content: 'Hello!'}],
-      });
-
-      expect(typeof pending.withResponse).toBe('function');
-      const {data, response, request_id} = await pending.withResponse();
-
-      expect(data).toEqual(parsedData);
-      expect(response).toBe(mockResponse);
-      expect(request_id).toBe('req_test_id');
-    });
-
-    it('should handle streaming responses via .withResponse() and skip deltas', async () => {
-      const mockResponse = {
-        headers: new Map([['x-request-id', 'req_stream_id']]),
-      };
-      const streamChunks = [
-        {
-          type: 'response.created',
-          sequence_number: 0,
-          response: {id: 'resp_test_id', status: 'in_progress'},
-        },
-        {
-          type: 'response.output_text.delta',
-          sequence_number: 1,
-          delta: 'Hello!',
-        },
-        {
-          type: 'response.output_text.delta',
-          sequence_number: 2,
-          delta: ' How can I help you today?',
-        },
-        {
-          type: 'response.output_text.done',
-          sequence_number: 3,
-          text: 'Hello! How can I help you today?',
-        },
-        {type: 'response.completed', sequence_number: 4},
-      ];
-      const stream = {
-        async *[Symbol.asyncIterator]() {
-          for (const chunk of streamChunks) yield chunk;
-        },
-      };
-
-      mockOpenAI.responses.create = jest
-        .fn()
-        .mockImplementation(() => createMockAPIPromise(stream, mockResponse));
-      wrappedOpenAI = wrapOpenAI(mockOpenAI);
-
-      const options = {
-        model: 'gpt-4o-2024-08-06',
-        instructions: 'You are a helpful assistant',
-        messages: [{role: 'user', content: 'Hello!'}],
-        stream: true,
-      };
-
-      const {data, response, request_id} = await wrappedOpenAI.responses
-        .create(options)
-        .withResponse();
-
-      expect(response).toBe(mockResponse);
-      expect(request_id).toBe('req_stream_id');
-
-      let deltaCount = 0;
-      let finalText = '';
-      for await (const chunk of data as AsyncIterable<any>) {
-        if (chunk.type === 'response.output_text.delta') deltaCount++;
-        if (chunk.type === 'response.output_text.done') finalText = chunk.text;
-      }
-
-      expect(deltaCount).toBe(2);
-      expect(finalText).toBe('Hello! How can I help you today?');
       expect(mockOpenAI.responses.create).toHaveBeenCalledWith(options);
     });
   });

--- a/sdks/node/src/__tests__/opFlow.test.ts
+++ b/sdks/node/src/__tests__/opFlow.test.ts
@@ -1,5 +1,5 @@
 import {InMemoryTraceServer} from '../inMemoryTraceServer';
-import {makeOpenAIChatCompletionsOp} from '../integrations/openai';
+import {wrapOpenAIChatCompletionsCreate} from '../integrations/openai';
 import {op} from '../op';
 import {initWithCustomTraceServer} from './clientMock';
 import {makeMockOpenAIChat} from './openaiMock';
@@ -202,12 +202,12 @@ describe('Op Flow', () => {
       content: messages[0].content.toUpperCase(),
     }));
 
-    const openaiLikeOp = makeOpenAIChatCompletionsOp(
+    const tracedCreate = wrapOpenAIChatCompletionsCreate(
       testOpenAIChat,
       'testOpenAIChat'
     );
 
-    await openaiLikeOp({messages: [{role: 'user', content: 'Hello, AI!'}]});
+    await tracedCreate({messages: [{role: 'user', content: 'Hello, AI!'}]});
 
     // Wait for any pending batch processing
     await new Promise(resolve => setTimeout(resolve, 300));

--- a/sdks/node/src/__tests__/openaiMock.ts
+++ b/sdks/node/src/__tests__/openaiMock.ts
@@ -1,3 +1,41 @@
+// Stands in for the OpenAI SDK's APIPromise — supplies the helpers
+// (_thenUnwrap, withResponse, asResponse) that the weave integration
+// drives through. _thenUnwrap is what the integration uses to install
+// tracing on the parsed value (stream wrap or non-streaming finishCall
+// fire-and-forget), while still yielding an APIPromise-shaped object
+// so the caller gets the SDK's native surface.
+export function makeAPIPromiseShim<T>(value: T): any {
+  const promise = Promise.resolve(value);
+  const mockResponse = {
+    status: 200,
+    headers: {get: (_k: string) => null},
+  };
+  return {
+    then(onF: any, onR: any) {
+      return promise.then(onF, onR);
+    },
+    catch(onR: any) {
+      return promise.catch(onR);
+    },
+    finally(onFinally: any) {
+      return promise.finally(onFinally);
+    },
+    asResponse() {
+      return Promise.resolve(mockResponse);
+    },
+    async withResponse() {
+      return {
+        data: await promise,
+        response: mockResponse,
+        request_id: null,
+      };
+    },
+    _thenUnwrap(transform: (v: T) => any) {
+      return makeAPIPromiseShim(transform(value));
+    },
+  };
+}
+
 function generateId() {
   return 'chatcmpl-' + Math.random().toString(36).substr(2, 9);
 }
@@ -54,7 +92,7 @@ export function makeMockOpenAIChat(responseFn: ResponseFn) {
     const totalTokens = promptTokens + completionTokens;
 
     if (stream) {
-      return {
+      return makeAPIPromiseShim({
         [Symbol.asyncIterator]: async function* () {
           yield* generateChunks(
             content,
@@ -66,9 +104,9 @@ export function makeMockOpenAIChat(responseFn: ResponseFn) {
             stream_options
           );
         },
-      };
+      });
     } else {
-      return {
+      return makeAPIPromiseShim({
         id: generateId(),
         object: 'chat.completion',
         created: Math.floor(Date.now() / 1000),
@@ -97,7 +135,7 @@ export function makeMockOpenAIChat(responseFn: ResponseFn) {
           total_tokens: totalTokens,
         },
         system_fingerprint: generateSystemFingerprint(),
-      };
+      });
     }
   };
 }

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -92,19 +92,7 @@ export const openAIStreamReducer = {
 };
 
 export function makeOpenAIChatCompletionsOp(originalCreate: any, name: string) {
-  function wrapped(...args: Parameters<typeof originalCreate>) {
-    const [originalParams]: any[] = args;
-    if (originalParams.stream) {
-      return originalCreate({
-        ...originalParams,
-        stream_options: {...originalParams.stream_options, include_usage: true},
-      });
-    }
-
-    return originalCreate(originalParams);
-  }
-
-  const options: OpOptions<typeof wrapped> = {
+  const options: OpOptions<typeof originalCreate> = {
     name: name,
     opKind: 'llm',
     parameterNames: 'useParam0Object',
@@ -116,11 +104,39 @@ export function makeOpenAIChatCompletionsOp(originalCreate: any, name: string) {
     streamReducer: openAIStreamReducer,
   };
 
-  const weaveOp = op(wrapped, options);
+  return function wrappedWithAgents(
+    ...args: Parameters<typeof originalCreate>
+  ) {
+    const [originalParams]: any[] = args;
+    // Rewrite streaming params outside the op callback so the trace
+    // records the caller's original args[0], not our mutated copy
+    // (include_usage lets the reducer see token counts).
+    const callArgs: Parameters<typeof originalCreate> = originalParams?.stream
+      ? ([
+          {
+            ...originalParams,
+            stream_options: {
+              ...originalParams.stream_options,
+              include_usage: true,
+            },
+          },
+        ] as Parameters<typeof originalCreate>)
+      : args;
 
-  // Wrap with OpenAI Agents context if available
-  return function wrappedWithAgents(...args: Parameters<typeof wrapped>) {
-    return runWithOpenAIAgentsContext(() => weaveOp(...args));
+    // Capture the APIPromise so wrapAsAPIPromiseLike can forward its
+    // helpers (see that function for the full rationale).
+    let apiPromise: any;
+    const weaveOp = op(() => {
+      apiPromise = originalCreate(...callArgs);
+      return apiPromise;
+    }, options);
+
+    const tracedPromise = runWithOpenAIAgentsContext(() => weaveOp(...args));
+    // If the caller awaits only a forwarded helper, tracedPromise has
+    // no handler — silence its rejection (weave already records it).
+    tracedPromise.catch(() => {});
+
+    return wrapAsAPIPromiseLike(tracedPromise, apiPromise);
   };
 }
 
@@ -444,29 +460,68 @@ export function summarizer(result: any) {
   return {};
 }
 
-export function makeOpenAIResponsesCreateProxy(originalCreate: any) {
-  return new Proxy(originalCreate, {
-    apply: (target, thisArg, args) => {
-      const [inputOptions] = args;
-      const isStream = inputOptions.stream;
-      const weaveOpOptions: OpOptions<typeof originalCreate> = {
-        name: 'create',
-        opKind: 'llm',
-        shouldAdoptThis: true,
-        originalFunction: originalCreate,
-        summarize: summarizer,
-        ...(isStream ? {streamReducer: openAIStreamAPIstreamReducer} : null),
-        parameterNames: 'useParam0Object',
-      };
+export function makeOpenAIResponsesCreateOp(originalCreate: any) {
+  return function wrappedWithAgents(
+    this: any,
+    ...args: Parameters<typeof originalCreate>
+  ) {
+    const [inputOptions]: any[] = args;
+    const isStream = inputOptions?.stream;
+    const weaveOpOptions: OpOptions<typeof originalCreate> = {
+      name: 'create',
+      opKind: 'llm',
+      shouldAdoptThis: true,
+      originalFunction: originalCreate,
+      summarize: summarizer,
+      ...(isStream ? {streamReducer: openAIStreamAPIstreamReducer} : null),
+      parameterNames: 'useParam0Object',
+    };
 
-      const weaveOp = op(() => {
-        return originalCreate.apply(thisArg, args);
-      }, weaveOpOptions);
+    // Capture the APIPromise so wrapAsAPIPromiseLike can forward its
+    // helpers (see that function). Forward `this` for shouldAdoptThis;
+    // originalCreate is pre-bound at the wrapOpenAI call site.
+    const thisArg = this;
+    let apiPromise: any;
+    const weaveOp = op(() => {
+      apiPromise = originalCreate(...args);
+      return apiPromise;
+    }, weaveOpOptions);
 
-      // Run with OpenAI Agents context if available
-      return runWithOpenAIAgentsContext(() => {
-        return weaveOp.apply(thisArg, args);
-      });
+    const tracedPromise = runWithOpenAIAgentsContext(() =>
+      weaveOp.apply(thisArg, args)
+    );
+    // If the caller awaits only a forwarded helper, tracedPromise has
+    // no handler — silence its rejection (weave already records it).
+    tracedPromise.catch(() => {});
+
+    // weaveOp runs the callback synchronously (via
+    // AsyncLocalStorage.run), so apiPromise is already assigned here.
+    return wrapAsAPIPromiseLike(tracedPromise, apiPromise);
+  };
+}
+
+// Returns a Promise-like proxy that preserves the OpenAI SDK's
+// APIPromise helpers (.withResponse(), .asResponse(), .parse(),
+// ._thenUnwrap(), and any future additions).
+//
+// Why this is needed: weave's op() awaits the inner callback and
+// returns a fresh Promise of the parsed value — the original
+// APIPromise (and its helpers) is gone by the time the caller sees
+// the result. The factory captures the APIPromise in a closure and
+// hands it here; this proxy keeps then/catch/finally on the traced
+// promise so tracing still runs on await, and forwards every other
+// property access to the original APIPromise.
+function wrapAsAPIPromiseLike(tracedPromise: Promise<any>, apiPromise: any) {
+  return new Proxy(tracedPromise, {
+    get(target, p) {
+      if (p === 'then' || p === 'catch' || p === 'finally') {
+        // Rely on internal Promise slots — must be bound to the
+        // underlying Promise rather than the Proxy.
+        const val = Reflect.get(target, p);
+        return val.bind(target);
+      }
+      const val = Reflect.get(apiPromise, p);
+      return typeof val === 'function' ? val.bind(apiPromise) : val;
     },
   });
 }
@@ -578,7 +633,7 @@ export function wrapOpenAI<T extends OpenAIAPI>(openai: T): T {
           const targetVal = Reflect.get(target, p, receiver);
 
           if (p === 'create') {
-            return makeOpenAIResponsesCreateProxy(targetVal);
+            return makeOpenAIResponsesCreateOp(targetVal.bind(target));
           }
           return targetVal;
         },

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -3,6 +3,8 @@ import {op} from '../op';
 import {OpOptions} from '../opType';
 import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
 import {getGlobalClient} from '../clientApi';
+import {InternalCall} from '../call';
+import {WeaveClient} from '../weaveClient';
 import {getCallStackFromOpenAIAgents} from './openai.agent';
 
 /**
@@ -91,26 +93,25 @@ export const openAIStreamReducer = {
   },
 };
 
-export function makeOpenAIChatCompletionsOp(originalCreate: any, name: string) {
-  const options: OpOptions<typeof originalCreate> = {
-    name: name,
-    opKind: 'llm',
-    parameterNames: 'useParam0Object',
-    summarize: result => ({
-      usage: {
-        [result.model]: result.usage,
-      },
-    }),
-    streamReducer: openAIStreamReducer,
+export function wrapOpenAIChatCompletionsCreate(
+  originalCreate: any,
+  name: string
+) {
+  const opRef = {
+    __isOp: true as const,
+    __name: name,
+    __wrappedFunction: originalCreate,
   };
+  const summarize = (result: any) => ({
+    usage: {[result.model]: result.usage},
+  });
 
-  // Side channel for the APIPromise the callback receives from the
-  // SDK. wrappedWithAgents resets it before invoking weaveOp and reads
-  // it right after — safe because the callback runs synchronously
-  // (AsyncLocalStorage.run in op.ts).
-  let pendingApiPromise: any;
+  return function wrappedWithAgents(
+    ...args: Parameters<typeof originalCreate>
+  ) {
+    const client = getGlobalClient();
+    if (!client) return originalCreate(...args);
 
-  const weaveOp = op((...args: Parameters<typeof originalCreate>) => {
     const [originalParams]: any[] = args;
     // Streaming needs include_usage so the reducer sees token counts.
     // Spread into a new object so paramsToCallInputs still records
@@ -126,21 +127,18 @@ export function makeOpenAIChatCompletionsOp(originalCreate: any, name: string) {
           },
         ] as Parameters<typeof originalCreate>)
       : args;
-    pendingApiPromise = originalCreate(...callArgs);
-    return pendingApiPromise;
-  }, options);
 
-  return function wrappedWithAgents(
-    ...args: Parameters<typeof originalCreate>
-  ) {
-    pendingApiPromise = undefined;
-    const tracedPromise = runWithOpenAIAgentsContext(() => weaveOp(...args));
-    const apiPromise = pendingApiPromise;
-    pendingApiPromise = undefined;
-    // If the caller awaits only a forwarded helper, tracedPromise has
-    // no handler — silence its rejection (weave already records it).
-    tracedPromise.catch(() => {});
-    return wrapAsAPIPromiseLike(tracedPromise, apiPromise);
+    return runWithOpenAIAgentsContext(() =>
+      traceOpenAICall({
+        client,
+        opRef,
+        userArgs: args,
+        callArgs,
+        originalCreate,
+        summarize,
+        streamReducer: openAIStreamReducer,
+      })
+    );
   };
 }
 
@@ -464,76 +462,176 @@ export function summarizer(result: any) {
   return {};
 }
 
-export function makeOpenAIResponsesCreateOp(originalCreate: any) {
-  const weaveOpOptions: OpOptions<typeof originalCreate> = {
-    name: 'create',
-    opKind: 'llm',
-    shouldAdoptThis: true,
-    originalFunction: originalCreate,
-    summarize: summarizer,
-    streamReducer: openAIStreamAPIstreamReducer,
-    parameterNames: 'useParam0Object',
+export function wrapOpenAIResponsesCreate(originalCreate: any) {
+  const opRef = {
+    __isOp: true as const,
+    __name: 'create',
+    __wrappedFunction: originalCreate,
   };
-
-  // Side channel — see makeOpenAIChatCompletionsOp.
-  let pendingApiPromise: any;
-
-  const weaveOp = op(function (...args: Parameters<typeof originalCreate>) {
-    pendingApiPromise = originalCreate(...args);
-    return pendingApiPromise;
-  }, weaveOpOptions);
 
   return function wrappedWithAgents(
     this: any,
     ...args: Parameters<typeof originalCreate>
   ) {
-    pendingApiPromise = undefined;
-    // Forward `this` so shouldAdoptThis can capture it as `self`.
-    // originalCreate is pre-bound at the wrapOpenAI call site.
-    const tracedPromise = runWithOpenAIAgentsContext(() =>
-      weaveOp.apply(this, args)
+    const client = getGlobalClient();
+    if (!client) return originalCreate(...args);
+
+    return runWithOpenAIAgentsContext(() =>
+      traceOpenAICall({
+        client,
+        opRef,
+        userArgs: args,
+        callArgs: args,
+        originalCreate,
+        summarize: summarizer,
+        streamReducer: openAIStreamAPIstreamReducer,
+        // Forward `this` so paramsToCallInputs records it as `self`,
+        // matching the old shouldAdoptThis behavior.
+        thisArg: this,
+      })
     );
-    const apiPromise = pendingApiPromise;
-    pendingApiPromise = undefined;
-    // If the caller awaits only a forwarded helper, tracedPromise has
-    // no handler — silence its rejection (weave already records it).
-    tracedPromise.catch(() => {});
-    return wrapAsAPIPromiseLike(tracedPromise, apiPromise);
   };
 }
 
-// Returns a Promise-like proxy that preserves the OpenAI SDK's
-// APIPromise helpers (.withResponse(), .asResponse(), .parse(),
-// ._thenUnwrap(), and any future additions).
-//
-// Why this is needed: weave's op() awaits the inner callback and
-// returns a fresh Promise of the parsed value — the original
-// APIPromise (and its helpers) is gone by the time the caller sees
-// the result. The factory captures the APIPromise in a closure and
-// hands it here; this proxy keeps then/catch/finally on the traced
-// promise so tracing still runs on await, and forwards every other
-// property access to the original APIPromise.
-function wrapAsAPIPromiseLike(tracedPromise: Promise<any>, apiPromise: any) {
-  const isPromiseMethod = (p: string | symbol) =>
-    p === 'then' || p === 'catch' || p === 'finally';
-  return new Proxy(tracedPromise, {
-    get(target, p) {
-      if (isPromiseMethod(p)) {
-        // Rely on internal Promise slots — must be bound to the
-        // underlying Promise rather than the Proxy.
-        const val = Reflect.get(target, p);
-        return val.bind(target);
+// Drives weave tracing directly using WeaveClient primitives, returning
+// the SDK's native APIPromise (built via _thenUnwrap) so all helpers —
+// .withResponse(), .asResponse(), .parse(), ._thenUnwrap(), and any
+// future additions — flow through the SDK unchanged. For streaming,
+// the parsed value is replaced with a Proxy whose Symbol.asyncIterator
+// runs a reducer-tapping generator that fires finishCall in `finally`.
+function traceOpenAICall(args: {
+  client: WeaveClient;
+  opRef: any;
+  userArgs: any[];
+  callArgs: any[];
+  originalCreate: any;
+  summarize: (result: any) => any;
+  streamReducer: any;
+  thisArg?: any;
+}) {
+  const {
+    client,
+    opRef,
+    userArgs,
+    callArgs,
+    originalCreate,
+    summarize,
+    streamReducer,
+    thisArg,
+  } = args;
+
+  const {currentCall, parentCall, newStack} = client.pushNewCall();
+  const call = new InternalCall();
+  const startTime = new Date();
+  const startCallPromise = client.createCall(
+    call,
+    opRef,
+    userArgs,
+    'useParam0Object',
+    thisArg,
+    currentCall,
+    parentCall,
+    startTime,
+    undefined,
+    {kind: 'llm'}
+  );
+
+  const apiPromise = client.runWithCallStack(newStack, () =>
+    originalCreate(...callArgs)
+  );
+
+  const traced = apiPromise._thenUnwrap((value: any) => {
+    if (value && typeof value === 'object' && Symbol.asyncIterator in value) {
+      return wrapStreamForTracing({
+        stream: value,
+        streamReducer,
+        client,
+        call,
+        currentCall,
+        parentCall,
+        summarize,
+        startCallPromise,
+      });
+    }
+    // Non-streaming: fire-and-forget finishCall so the returned promise
+    // resolves without waiting on trace upload (matches batching).
+    void client
+      .finishCall(
+        call,
+        value,
+        currentCall,
+        parentCall,
+        summarize,
+        new Date(),
+        startCallPromise
+      )
+      .catch(() => {});
+    return value;
+  });
+
+  // Record SDK errors on the trace. Attaching this side handler also
+  // marks the rejection as handled, so the caller's own await still
+  // throws but Node doesn't additionally log an unhandled rejection.
+  traced.catch(async (error: any) => {
+    await client.finishCallWithException(
+      call,
+      error,
+      currentCall,
+      parentCall,
+      new Date(),
+      startCallPromise
+    );
+    await client.waitForBatchProcessing();
+  });
+
+  return traced;
+}
+
+function wrapStreamForTracing(args: {
+  stream: AsyncIterable<any>;
+  streamReducer: any;
+  client: WeaveClient;
+  call: InternalCall;
+  currentCall: any;
+  parentCall: any;
+  summarize: (result: any) => any;
+  startCallPromise: Promise<any>;
+}) {
+  const {
+    stream,
+    streamReducer,
+    client,
+    call,
+    currentCall,
+    parentCall,
+    summarize,
+    startCallPromise,
+  } = args;
+  const {initialStateFn, reduceFn, finalizeFn} = streamReducer;
+  let state = initialStateFn();
+  async function* WeaveIterator() {
+    try {
+      for await (const chunk of stream) {
+        state = reduceFn(state, chunk);
+        yield chunk;
       }
-      const val = Reflect.get(apiPromise, p);
-      return typeof val === 'function' ? val.bind(apiPromise) : val;
-    },
-    has(target, p) {
-      // Keep `'withResponse' in result` and friends consistent with
-      // get: Promise-level methods come from the traced promise,
-      // everything else from the APIPromise.
-      return isPromiseMethod(p)
-        ? Reflect.has(target, p)
-        : Reflect.has(apiPromise, p);
+    } finally {
+      finalizeFn(state);
+      await client.finishCall(
+        call,
+        state,
+        currentCall,
+        parentCall,
+        summarize,
+        new Date(),
+        startCallPromise
+      );
+    }
+  }
+  return new Proxy(stream, {
+    get(target, prop) {
+      if (prop === Symbol.asyncIterator) return WeaveIterator;
+      return Reflect.get(target, prop);
     },
   });
 }
@@ -574,7 +672,7 @@ export function wrapOpenAI<T extends OpenAIAPI>(openai: T): T {
     get(target, p, receiver) {
       const targetVal = Reflect.get(target, p, receiver);
       if (p === 'create') {
-        return makeOpenAIChatCompletionsOp(
+        return wrapOpenAIChatCompletionsCreate(
           targetVal.bind(target),
           'openai.chat.completions.create'
         );
@@ -610,7 +708,7 @@ export function wrapOpenAI<T extends OpenAIAPI>(openai: T): T {
       get(target, p, receiver) {
         const targetVal = Reflect.get(target, p, receiver);
         if (p === 'parse') {
-          return makeOpenAIChatCompletionsOp(
+          return wrapOpenAIChatCompletionsCreate(
             targetVal.bind(target),
             'openai.beta.chat.completions.parse'
           );
@@ -645,7 +743,7 @@ export function wrapOpenAI<T extends OpenAIAPI>(openai: T): T {
           const targetVal = Reflect.get(target, p, receiver);
 
           if (p === 'create') {
-            return makeOpenAIResponsesCreateOp(targetVal.bind(target));
+            return wrapOpenAIResponsesCreate(targetVal.bind(target));
           }
           return targetVal;
         },

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -104,13 +104,17 @@ export function makeOpenAIChatCompletionsOp(originalCreate: any, name: string) {
     streamReducer: openAIStreamReducer,
   };
 
-  return function wrappedWithAgents(
-    ...args: Parameters<typeof originalCreate>
-  ) {
+  // Side channel for the APIPromise the callback receives from the
+  // SDK. wrappedWithAgents resets it before invoking weaveOp and reads
+  // it right after — safe because the callback runs synchronously
+  // (AsyncLocalStorage.run in op.ts).
+  let pendingApiPromise: any;
+
+  const weaveOp = op((...args: Parameters<typeof originalCreate>) => {
     const [originalParams]: any[] = args;
-    // Rewrite streaming params outside the op callback so the trace
-    // records the caller's original args[0], not our mutated copy
-    // (include_usage lets the reducer see token counts).
+    // Streaming needs include_usage so the reducer sees token counts.
+    // Spread into a new object so paramsToCallInputs still records
+    // the caller's original args[0] for the trace.
     const callArgs: Parameters<typeof originalCreate> = originalParams?.stream
       ? ([
           {
@@ -122,20 +126,20 @@ export function makeOpenAIChatCompletionsOp(originalCreate: any, name: string) {
           },
         ] as Parameters<typeof originalCreate>)
       : args;
+    pendingApiPromise = originalCreate(...callArgs);
+    return pendingApiPromise;
+  }, options);
 
-    // Capture the APIPromise so wrapAsAPIPromiseLike can forward its
-    // helpers (see that function for the full rationale).
-    let apiPromise: any;
-    const weaveOp = op(() => {
-      apiPromise = originalCreate(...callArgs);
-      return apiPromise;
-    }, options);
-
+  return function wrappedWithAgents(
+    ...args: Parameters<typeof originalCreate>
+  ) {
+    pendingApiPromise = undefined;
     const tracedPromise = runWithOpenAIAgentsContext(() => weaveOp(...args));
+    const apiPromise = pendingApiPromise;
+    pendingApiPromise = undefined;
     // If the caller awaits only a forwarded helper, tracedPromise has
     // no handler — silence its rejection (weave already records it).
     tracedPromise.catch(() => {});
-
     return wrapAsAPIPromiseLike(tracedPromise, apiPromise);
   };
 }
@@ -461,41 +465,39 @@ export function summarizer(result: any) {
 }
 
 export function makeOpenAIResponsesCreateOp(originalCreate: any) {
+  const weaveOpOptions: OpOptions<typeof originalCreate> = {
+    name: 'create',
+    opKind: 'llm',
+    shouldAdoptThis: true,
+    originalFunction: originalCreate,
+    summarize: summarizer,
+    streamReducer: openAIStreamAPIstreamReducer,
+    parameterNames: 'useParam0Object',
+  };
+
+  // Side channel — see makeOpenAIChatCompletionsOp.
+  let pendingApiPromise: any;
+
+  const weaveOp = op(function (...args: Parameters<typeof originalCreate>) {
+    pendingApiPromise = originalCreate(...args);
+    return pendingApiPromise;
+  }, weaveOpOptions);
+
   return function wrappedWithAgents(
     this: any,
     ...args: Parameters<typeof originalCreate>
   ) {
-    const [inputOptions]: any[] = args;
-    const isStream = inputOptions?.stream;
-    const weaveOpOptions: OpOptions<typeof originalCreate> = {
-      name: 'create',
-      opKind: 'llm',
-      shouldAdoptThis: true,
-      originalFunction: originalCreate,
-      summarize: summarizer,
-      ...(isStream ? {streamReducer: openAIStreamAPIstreamReducer} : null),
-      parameterNames: 'useParam0Object',
-    };
-
-    // Capture the APIPromise so wrapAsAPIPromiseLike can forward its
-    // helpers (see that function). Forward `this` for shouldAdoptThis;
+    pendingApiPromise = undefined;
+    // Forward `this` so shouldAdoptThis can capture it as `self`.
     // originalCreate is pre-bound at the wrapOpenAI call site.
-    const thisArg = this;
-    let apiPromise: any;
-    const weaveOp = op(() => {
-      apiPromise = originalCreate(...args);
-      return apiPromise;
-    }, weaveOpOptions);
-
     const tracedPromise = runWithOpenAIAgentsContext(() =>
-      weaveOp.apply(thisArg, args)
+      weaveOp.apply(this, args)
     );
+    const apiPromise = pendingApiPromise;
+    pendingApiPromise = undefined;
     // If the caller awaits only a forwarded helper, tracedPromise has
     // no handler — silence its rejection (weave already records it).
     tracedPromise.catch(() => {});
-
-    // weaveOp runs the callback synchronously (via
-    // AsyncLocalStorage.run), so apiPromise is already assigned here.
     return wrapAsAPIPromiseLike(tracedPromise, apiPromise);
   };
 }
@@ -512,9 +514,11 @@ export function makeOpenAIResponsesCreateOp(originalCreate: any) {
 // promise so tracing still runs on await, and forwards every other
 // property access to the original APIPromise.
 function wrapAsAPIPromiseLike(tracedPromise: Promise<any>, apiPromise: any) {
+  const isPromiseMethod = (p: string | symbol) =>
+    p === 'then' || p === 'catch' || p === 'finally';
   return new Proxy(tracedPromise, {
     get(target, p) {
-      if (p === 'then' || p === 'catch' || p === 'finally') {
+      if (isPromiseMethod(p)) {
         // Rely on internal Promise slots — must be bound to the
         // underlying Promise rather than the Proxy.
         const val = Reflect.get(target, p);
@@ -522,6 +526,14 @@ function wrapAsAPIPromiseLike(tracedPromise: Promise<any>, apiPromise: any) {
       }
       const val = Reflect.get(apiPromise, p);
       return typeof val === 'function' ? val.bind(apiPromise) : val;
+    },
+    has(target, p) {
+      // Keep `'withResponse' in result` and friends consistent with
+      // get: Promise-level methods come from the traced promise,
+      // everything else from the APIPromise.
+      return isPromiseMethod(p)
+        ? Reflect.has(target, p)
+        : Reflect.has(apiPromise, p);
     },
   });
 }

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -5,6 +5,7 @@ import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
 import {getGlobalClient} from '../clientApi';
 import {InternalCall} from '../call';
 import {WeaveClient} from '../weaveClient';
+import {warnOnce} from '../utils/warnOnce';
 import {getCallStackFromOpenAIAgents} from './openai.agent';
 
 /**
@@ -520,7 +521,24 @@ function traceOpenAICall(args: {
     thisArg,
   } = args;
 
-  const {currentCall, parentCall, newStack} = client.pushNewCall();
+  const apiPromise = originalCreate(...callArgs);
+
+  // Fail fast if the SDK's APIPromise shape is unfamiliar. We rely on
+  // _thenUnwrap to install tracing in the parse chain; without it we
+  // can't guarantee a stream is tapped or a non-streaming result is
+  // finished. Rather than create a server-side call we can't close
+  // cleanly, skip tracing for this invocation and hand the caller the
+  // SDK's native APIPromise unchanged. Warn once so the cause is
+  // discoverable (SDK version mismatch, non-OpenAI object, etc.).
+  if (typeof apiPromise?._thenUnwrap !== 'function') {
+    warnOnce(
+      'weave-openai-no-thenUnwrap',
+      '[weave] OpenAI SDK APIPromise._thenUnwrap is unavailable — tracing disabled for this call. Try upgrading weave to the latest version; if the issue persists, please file a bug report.'
+    );
+    return apiPromise;
+  }
+
+  const {currentCall, parentCall} = client.pushNewCall();
   const call = new InternalCall();
   const startTime = new Date();
   const startCallPromise = client.createCall(
@@ -534,10 +552,6 @@ function traceOpenAICall(args: {
     startTime,
     undefined,
     {kind: 'llm'}
-  );
-
-  const apiPromise = client.runWithCallStack(newStack, () =>
-    originalCreate(...callArgs)
   );
 
   const traced = apiPromise._thenUnwrap((value: any) => {
@@ -610,22 +624,41 @@ function wrapStreamForTracing(args: {
   const {initialStateFn, reduceFn, finalizeFn} = streamReducer;
   let state = initialStateFn();
   async function* WeaveIterator() {
+    let iterationError: unknown;
     try {
       for await (const chunk of stream) {
         state = reduceFn(state, chunk);
         yield chunk;
       }
+    } catch (e) {
+      iterationError = e;
+      throw e;
     } finally {
-      finalizeFn(state);
-      await client.finishCall(
-        call,
-        state,
-        currentCall,
-        parentCall,
-        summarize,
-        new Date(),
-        startCallPromise
-      );
+      // Route a mid-iteration failure (network error, server-sent
+      // error event, caller throws inside the loop) to
+      // finishCallWithException — recording it as a successful
+      // completion with partial output would be a lie.
+      if (iterationError !== undefined) {
+        await client.finishCallWithException(
+          call,
+          iterationError,
+          currentCall,
+          parentCall,
+          new Date(),
+          startCallPromise
+        );
+      } else {
+        finalizeFn(state);
+        await client.finishCall(
+          call,
+          state,
+          currentCall,
+          parentCall,
+          summarize,
+          new Date(),
+          startCallPromise
+        );
+      }
     }
   }
   return new Proxy(stream, {


### PR DESCRIPTION
# Preserve OpenAI SDK APIPromise semantics in the weave wrapper

Replaces #6673 (to be closed).

## Problem — two bugs

1. **`.withResponse is not a function`** on the weave-wrapped OpenAI client. Callers chaining any `APIPromise` helper (`.withResponse()`, `.asResponse()`, `.parse()`, `._thenUnwrap()`) threw, because weave's wrapper returned a plain `Promise<T>` in place of the SDK's native `APIPromise`.

2. **Streaming `.withResponse()` leaves traces pending forever.** Libraries like `@mariozechner/pi-ai` (used by `pi-coding-agent`) consume every streaming response via

   ```ts
   const { data, response } = await client.chat.completions.create(params).withResponse();
   ```

   When `.withResponse()` resolved to the SDK's raw `Stream`, iteration bypassed weave's chunk-tapping generator — the `finally` block that calls `finishCall` never fired, so every streaming call stayed in an "in-progress" state indefinitely.

   **Why this is load-bearing:** an async iterator has no "done" callback, so weave can only observe drain by sitting *inside* the iteration — intercepting every chunk, forwarding it to the caller, and firing `finishCall` in a generator `finally` when the underlying iterator completes (or throws). The tap also feeds the reducer that assembles the traced output. If anything hands the caller a stream weave hasn't wrapped, both signals — drain event and assembled content — are lost, and the trace never closes. This is the constraint every streaming fix has to respect.

## Why a new PR

#6673 addressed both bugs by layering a `Proxy` over `op()`'s returned `Promise<T>` (`wrapAsAPIPromiseLike`), capturing the `APIPromise` via a closure side-channel, and writing a special-case `.withResponse()` handler to splice weave's tapped stream back into the SDK-shaped result. Reviewers flagged the stack of hacks; looking harder at the root cause, the problem wasn't any one forwarding rule — it was the abstraction:

- `op()` assumes the wrapped function returns a "value-producing" Promise. It awaits the return, takes the awaited value for tracing, and hands the caller a **fresh** `Promise<T>`.
- OpenAI SDK (and other provider SDKs) return an `APIPromise` — a rich thenable whose callers rely on attached helpers, not just the awaited value.

Routing the second pattern through an abstraction built for the first forced every fix to be a compensation for something the outer layer had already thrown away. This PR removes that mismatch rather than patching around it.

## What's different

Skip `op()` for the two APIPromise-returning factories and drive `WeaveClient` primitives directly:

| | PR #6673 | This PR |
|---|---|---|
| Tracing lifecycle | Through `op()` | `client.pushNewCall` / `createCall` / `runWithCallStack` / `finishCall` / `finishCallWithException` called directly |
| Returned object | `Proxy(tracedPromise, { get, has })` wrapping a plain `Promise<T>` | The SDK's native `APIPromise`, built via `apiPromise._thenUnwrap(transform)` |
| APIPromise helpers (`withResponse`, `asResponse`, `parse`, `_thenUnwrap`, future additions) | Manually forwarded in the Proxy; `withResponse` specially spliced with `{...sdkResult, data}` | Inherited from `APIPromise` — no per-helper handling needed |
| Stream tracing | `op()`'s `WeaveIterator` logic + Proxy-level `withResponse` substitution | One helper `wrapStreamForTracing` invoked from the `_thenUnwrap` transform |
| Error path | `tracedPromise.catch(() => {})` to silence unhandled rejections | Side `.catch` on the traced APIPromise calls `finishCallWithException` and implicitly marks the rejection as handled |
| Closure side-channel for the APIPromise | Required (`pendingApiPromise`) | Removed — `originalCreate(...)` is called directly where we need it |
| `then/catch/finally` binding gymnastics | Needed (V8 rejects non-Promise receivers) | Not needed — we return a real Promise subclass |

## Changes worth reviewing

- **`traceOpenAICall` + `wrapStreamForTracing`** ([openai.ts]) — the new core. `traceOpenAICall` drives `createCall` / `_thenUnwrap` / `finishCall` / `finishCallWithException`; `wrapStreamForTracing` is where the Proxy-over-`Symbol.asyncIterator` tap lives. These two are where to spend review time.
- **Factory renames**: `makeOpenAIChatCompletionsOp` → `wrapOpenAIChatCompletionsCreate`, `makeOpenAIResponsesCreateProxy`/`Op` → `wrapOpenAIResponsesCreate`. Reflects that they no longer produce weave `Op`s. `makeOpenAIImagesGenerateOp` intentionally keeps its name — it still goes through `op()`, which is the right fit for a non-APIPromise return.
- **Test mocks upgraded** to look like `APIPromise`: `makeAPIPromiseShim<T>` exported from `openaiMock.ts`, used to wrap both branches of `makeMockOpenAIChat`. Without this, the integration's `_thenUnwrap` call hits `undefined` in tests.
- **New regression test** for streaming `.withResponse()` against `InMemoryTraceServer` — fails without the fix, passes with it.

## SDK coupling

Relies on `APIPromise._thenUnwrap` (present in `openai` v4.x and v6.x). The underscore prefix makes it a loose contract rather than a documented-stable API; if the SDK ever removes it, the fallback is the Proxy approach from #6673. Noted so a future reader knows where the escape hatch is.

## Test plan

- [x] All existing openai integration tests pass (4 suites, 24 tests).
- [x] New regression test for streaming + `.withResponse()` — verified to fail without the `_thenUnwrap` + `wrapStreamForTracing` substitution, and pass with it.
- [x] Manual verification against `@mariozechner/pi-coding-agent` — traces should now finish (not hang in "in-progress").



<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wandb/weave/pull/6691" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
