### PR TITLE
chore(weave): exclude incompatible py-version/shard combos at matrix level

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -147,6 +147,20 @@ jobs:
             # "stainless",
             "autogen_tests",
           ]
+        # Shards that don't support certain Python versions. Excluding here
+        # (vs. skipping inside noxfile) avoids spinning up a runner just to
+        # emit an empty coverage.xml that Codecov then rejects.
+        exclude:
+          - python-version-minor: "10"
+            nox-shard: "notdiamond"
+          - python-version-minor: "10"
+            nox-shard: "verifiers_test"
+          - python-version-minor: "13"
+            nox-shard: "cohere"
+          - python-version-minor: "13"
+            nox-shard: "notdiamond"
+          - python-version-minor: "13"
+            nox-shard: "verifiers_test"
       fail-fast: false
     services:
       wandbservice:
@@ -439,7 +453,7 @@ jobs:
           jobs: ${{ toJSON(needs) }}
           # The 1s3r and 2s2r jobs are path-filtered and will be "skipped"
           # on PRs that don't touch migrator or distributed surfaces.
-          # alls-green treats skipped as failing by default; whitelist
+          # This action treats skipped as failing by default; whitelist
           # them here so a skipped-because-gated job doesn't wedge merge.
           allowed-skips: trace-server-migrator-1s3r,trace-server-migrator-2s2r
 
@@ -525,6 +539,20 @@ jobs:
             # "stainless",
             "autogen_tests",
           ]
+        # Shards that don't support certain Python versions. Excluding here
+        # (vs. skipping inside noxfile) avoids spinning up a runner just to
+        # emit an empty coverage.xml that Codecov then rejects.
+        exclude:
+          - python-version-minor: "10"
+            nox-shard: "notdiamond"
+          - python-version-minor: "10"
+            nox-shard: "verifiers_test"
+          - python-version-minor: "13"
+            nox-shard: "cohere"
+          - python-version-minor: "13"
+            nox-shard: "notdiamond"
+          - python-version-minor: "13"
+            nox-shard: "verifiers_test"
       fail-fast: false
     steps:
       - name: Checkout

--- a/noxfile.py
+++ b/noxfile.py
@@ -8,17 +8,6 @@ nox.options.stop_on_first_error = True
 
 
 SUPPORTED_PYTHON_VERSIONS = ["3.10", "3.11", "3.12", "3.13"]
-INCOMPATIBLE_SHARDS = {
-    "3.10": [
-        "notdiamond",
-        "verifiers_test",
-    ],
-    "3.13": [
-        "cohere",
-        "notdiamond",
-        "verifiers_test",
-    ],
-}
 NUM_TRACE_SERVER_SHARDS = 4
 
 
@@ -120,13 +109,6 @@ SHARDS_WITHOUT_EXTRAS = {
     ],
 )
 def tests(session: nox.Session, shard: str):
-    python_version = session.python[:4]  # e.g., "3.10"
-    if shard in INCOMPATIBLE_SHARDS.get(python_version, []):
-        session.skip(
-            f"Skipping {shard=} as it is not compatible with Python {python_version}"
-        )
-        return
-
     # Only add --extra shard if the shard has a corresponding optional dependency
     # Use --active to sync to the active nox virtual environment
     # Test-related shards (ending in _test/_tests) are dependency groups, not extras


### PR DESCRIPTION
## Summary

- Moves the `INCOMPATIBLE_SHARDS` skip logic out of `noxfile.py` and into `strategy.matrix.exclude` on both the `trace-tests` (Linux) and `windows_trace_tests` (Windows) jobs.
- Deletes `INCOMPATIBLE_SHARDS` from `noxfile.py`; the matrix is now the single source of truth for "which (py-version, shard) combos run."

## Why

Today, `notdiamond × 3.10`, `notdiamond × 3.13`, `verifiers_test × 3.10`, `verifiers_test × 3.13`, and `cohere × 3.13` combinations still spin up full runners, install Python + nox, then have nox call `session.skip()` and exit 0. The next step unconditionally uploads `./coverage.xml`, which is missing or empty -> Codecov reports "Unusable report due to ... empty report, or incorrect data format."

That's the 5 upload errors visible on every coverage run (e.g. https://app.codecov.io/gh/wandb/weave/commit/cca9d0428accdca3ca664cb22630f9e7a7a7cb17).

Excluding these cells at the matrix layer:
1. Stops scheduling runners for combos that can't run -> saves Windows + Linux CI minutes.
2. Eliminates the phantom Codecov upload errors.

The in-scope typo-hook touch (`alls-green` -> "this action") was a pre-existing false positive from #6648 that blocked the commit.

## Test plan

- [ ] CI green on this PR
- [ ] `coverage.xml`-upload jobs matching the excluded cells are no longer scheduled (check the Actions matrix)
- [ ] Codecov commit summary shows 0 "upload errors"
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wandb/weave/pull/6694" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
