### PR TITLE
chore(weave): Retrofit `.js` extensions on relative imports

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -56,7 +56,8 @@
         },
         "moduleNameMapper": {
           "^weave$": "<rootDir>/src/index.ts",
-          "^weave/(.+)$": "<rootDir>/src/$1"
+          "^weave/(.+)$": "<rootDir>/src/$1",
+          "^(\\.{1,2}/.*)\\.js$": "$1"
         }
       },
       {
@@ -74,7 +75,8 @@
         },
         "moduleNameMapper": {
           "^weave$": "<rootDir>/src/index.ts",
-          "^weave/(.+)$": "<rootDir>/src/$1"
+          "^weave/(.+)$": "<rootDir>/src/$1",
+          "^(\\.{1,2}/.*)\\.js$": "$1"
         }
       },
       {
@@ -97,7 +99,8 @@
         },
         "moduleNameMapper": {
           "^weave$": "<rootDir>/src/index.ts",
-          "^weave/(.*)$": "<rootDir>/src/$1"
+          "^weave/(.*)$": "<rootDir>/src/$1",
+          "^(\\.{1,2}/.*)\\.js$": "$1"
         }
       }
     ],

--- a/sdks/node/src/__tests__/attributes.test.ts
+++ b/sdks/node/src/__tests__/attributes.test.ts
@@ -1,8 +1,8 @@
 import {withAttributes, op} from 'weave';
 
-import {initWithCustomTraceServer} from './clientMock';
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
-import {Settings} from '../settings';
+import {initWithCustomTraceServer} from './clientMock.js';
+import {InMemoryTraceServer} from '../inMemoryTraceServer.js';
+import {Settings} from '../settings.js';
 
 describe('attributes context', () => {
   const projectId = 'test-project';

--- a/sdks/node/src/__tests__/clientApi.test.ts
+++ b/sdks/node/src/__tests__/clientApi.test.ts
@@ -1,8 +1,8 @@
-import {init, requireGlobalClient, login} from '../clientApi';
-import {getWandbConfigs} from '../wandb/settings';
-import {WandbServerApi} from '../wandb/wandbServerApi';
-import {Api as TraceServerApi} from '../generated/traceServerApi';
-import {Netrc} from '../utils/netrc';
+import {init, requireGlobalClient, login} from '../clientApi.js';
+import {getWandbConfigs} from '../wandb/settings.js';
+import {WandbServerApi} from '../wandb/wandbServerApi.js';
+import {Api as TraceServerApi} from '../generated/traceServerApi.js';
+import {Netrc} from '../utils/netrc.js';
 
 jest.mock('../wandb/wandbServerApi');
 jest.mock('../wandb/settings');

--- a/sdks/node/src/__tests__/clientMock.ts
+++ b/sdks/node/src/__tests__/clientMock.ts
@@ -1,9 +1,9 @@
-import {setGlobalClient} from '../clientApi';
-import {Api as TraceServerApi} from '../generated/traceServerApi';
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
-import {Settings} from '../settings';
-import {WandbServerApi} from '../wandb/wandbServerApi';
-import {WeaveClient} from '../weaveClient';
+import {setGlobalClient} from '../clientApi.js';
+import {Api as TraceServerApi} from '../generated/traceServerApi.js';
+import {InMemoryTraceServer} from '../inMemoryTraceServer.js';
+import {Settings} from '../settings.js';
+import {WandbServerApi} from '../wandb/wandbServerApi.js';
+import {WeaveClient} from '../weaveClient.js';
 
 export function initWithCustomTraceServer(
   projectName: string,

--- a/sdks/node/src/__tests__/dataset.test.ts
+++ b/sdks/node/src/__tests__/dataset.test.ts
@@ -2,11 +2,11 @@
  * Tests for Dataset and Table lazy loading
  */
 
-import {Dataset} from '../dataset';
-import {ObjectRef} from '../weaveObject';
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
-import {initWithCustomTraceServer} from './clientMock';
-import {requireGlobalClient} from '../clientApi';
+import {Dataset} from '../dataset.js';
+import {ObjectRef} from '../weaveObject.js';
+import {InMemoryTraceServer} from '../inMemoryTraceServer.js';
+import {initWithCustomTraceServer} from './clientMock.js';
+import {requireGlobalClient} from '../clientApi.js';
 
 describe('Dataset', () => {
   let traceServer: InMemoryTraceServer;

--- a/sdks/node/src/__tests__/digest.test.ts
+++ b/sdks/node/src/__tests__/digest.test.ts
@@ -1,4 +1,4 @@
-import {stringifyPythonDumps} from '../digest';
+import {stringifyPythonDumps} from '../digest.js';
 
 describe('stringifyPythonDumps', () => {
   test('Basic types', async () => {

--- a/sdks/node/src/__tests__/evaluation.test.ts
+++ b/sdks/node/src/__tests__/evaluation.test.ts
@@ -1,7 +1,7 @@
-import {Dataset} from '../dataset';
-import {Evaluation} from '../evaluation';
-import {ColumnMapping} from '../fn';
-import {op} from '../op';
+import {Dataset} from '../dataset.js';
+import {Evaluation} from '../evaluation.js';
+import {ColumnMapping} from '../fn.js';
+import {op} from '../op.js';
 
 const createMockDataset = () =>
   new Dataset({

--- a/sdks/node/src/__tests__/evaluationLogger.test.ts
+++ b/sdks/node/src/__tests__/evaluationLogger.test.ts
@@ -2,10 +2,10 @@
  * Unit tests for EvaluationLogger (Imperative Evaluation)
  */
 
-import {EvaluationLogger} from '../evaluationLogger';
-import {WeaveObject} from '../weaveObject';
-import {initWithCustomTraceServer} from './clientMock';
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
+import {EvaluationLogger} from '../evaluationLogger.js';
+import {WeaveObject} from '../weaveObject.js';
+import {initWithCustomTraceServer} from './clientMock.js';
+import {InMemoryTraceServer} from '../inMemoryTraceServer.js';
 
 // Helper function to get calls from trace server
 async function getCalls(traceServer: InMemoryTraceServer, projectId: string) {

--- a/sdks/node/src/__tests__/integrations/anthropic.test.ts
+++ b/sdks/node/src/__tests__/integrations/anthropic.test.ts
@@ -1,6 +1,6 @@
-import {InMemoryTraceServer} from '../../inMemoryTraceServer';
-import {commonPatchAnthropic} from '../../integrations/anthropic';
-import {initWithCustomTraceServer} from '../clientMock';
+import {InMemoryTraceServer} from '../../inMemoryTraceServer.js';
+import {commonPatchAnthropic} from '../../integrations/anthropic.js';
+import {initWithCustomTraceServer} from '../clientMock.js';
 
 // Helper function to get calls
 async function getCalls(traceServer: InMemoryTraceServer, projectId: string) {

--- a/sdks/node/src/__tests__/integrations/googleGenAI.test.ts
+++ b/sdks/node/src/__tests__/integrations/googleGenAI.test.ts
@@ -1,6 +1,6 @@
-import {InMemoryTraceServer} from '../../inMemoryTraceServer';
-import {commonPatchGoogleGenAI} from '../../integrations/googleGenAI';
-import {initWithCustomTraceServer} from '../clientMock';
+import {InMemoryTraceServer} from '../../inMemoryTraceServer.js';
+import {commonPatchGoogleGenAI} from '../../integrations/googleGenAI.js';
+import {initWithCustomTraceServer} from '../clientMock.js';
 
 function createMockGoogleGenAI() {
   const mockGenerateContent = jest

--- a/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
+++ b/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
@@ -1,7 +1,7 @@
-import {InMemoryTraceServer} from '../../inMemoryTraceServer';
-import {wrapOpenAI} from '../../integrations/openai';
-import {initWithCustomTraceServer} from '../clientMock';
-import {makeAPIPromiseShim, makeMockOpenAIChat} from '../openaiMock';
+import {InMemoryTraceServer} from '../../inMemoryTraceServer.js';
+import {wrapOpenAI} from '../../integrations/openai.js';
+import {initWithCustomTraceServer} from '../clientMock.js';
+import {makeAPIPromiseShim, makeMockOpenAIChat} from '../openaiMock.js';
 
 // Helper function to get calls
 async function getCalls(traceServer: InMemoryTraceServer, projectId: string) {

--- a/sdks/node/src/__tests__/integrations/openai2.test.ts
+++ b/sdks/node/src/__tests__/integrations/openai2.test.ts
@@ -1,13 +1,13 @@
-import {Api as TraceServerApi} from '../../generated/traceServerApi';
+import {Api as TraceServerApi} from '../../generated/traceServerApi.js';
 import {
   makeOpenAIImagesGenerateOp,
   openAIStreamReducer,
   wrapOpenAI,
-} from '../../integrations/openai';
-import {isWeaveImage} from '../../media';
-import {WandbServerApi} from '../../wandb/wandbServerApi';
-import {WeaveClient} from '../../weaveClient';
-import {makeAPIPromiseShim} from '../openaiMock';
+} from '../../integrations/openai.js';
+import {isWeaveImage} from '../../media.js';
+import {WandbServerApi} from '../../wandb/wandbServerApi.js';
+import {WeaveClient} from '../../weaveClient.js';
+import {makeAPIPromiseShim} from '../openaiMock.js';
 
 // Mock WeaveClient dependencies
 jest.mock('../../generated/traceServerApi');

--- a/sdks/node/src/__tests__/integrations/openaiAgent.realtime.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.realtime.test.ts
@@ -1,7 +1,7 @@
 import {EventEmitter} from 'events';
-import {WeaveRealtimeTracingAdapter} from '../../integrations/openai.realtime.agent';
-import {InMemoryTraceServer} from '../../inMemoryTraceServer';
-import {initWithCustomTraceServer} from '../clientMock';
+import {WeaveRealtimeTracingAdapter} from '../../integrations/openai.realtime.agent.js';
+import {InMemoryTraceServer} from '../../inMemoryTraceServer.js';
+import {initWithCustomTraceServer} from '../clientMock.js';
 
 function makeMockSession() {
   const session = new EventEmitter() as any;

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -1,6 +1,6 @@
-import {InMemoryTraceServer} from '../../inMemoryTraceServer';
-import {createOpenAIAgentsTracingProcessor} from '../../integrations/openai.agent';
-import {initWithCustomTraceServer} from '../clientMock';
+import {InMemoryTraceServer} from '../../inMemoryTraceServer.js';
+import {createOpenAIAgentsTracingProcessor} from '../../integrations/openai.agent.js';
+import {initWithCustomTraceServer} from '../clientMock.js';
 
 describe('OpenAI Agents Integration', () => {
   let inMemoryTraceServer: InMemoryTraceServer;

--- a/sdks/node/src/__tests__/integrations/openaiMock.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiMock.test.ts
@@ -1,4 +1,4 @@
-import {makeMockOpenAIChat} from '../openaiMock';
+import {makeMockOpenAIChat} from '../openaiMock.js';
 
 describe('OpenAI Mock', () => {
   const mockResponse = (messages: any[]) => ({

--- a/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
@@ -5,11 +5,11 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 
-import {PiCodingAgentOtelAdapter} from '../../integrations/piCodingAgent';
+import {PiCodingAgentOtelAdapter} from '../../integrations/piCodingAgent.js';
 import type {
   PiExtensionApi,
   PiExtensionContext,
-} from '../../integrations/piCodingAgent.types';
+} from '../../integrations/piCodingAgent.types.js';
 
 // ---------------------------------------------------------------------------
 // Test helpers

--- a/sdks/node/src/__tests__/linkAssetToRegistry.test.ts
+++ b/sdks/node/src/__tests__/linkAssetToRegistry.test.ts
@@ -1,10 +1,10 @@
-import {ContentType} from '../generated/traceServerApi';
-import type {Api as TraceServerApi} from '../generated/traceServerApi';
+import {ContentType} from '../generated/traceServerApi.js';
+import type {Api as TraceServerApi} from '../generated/traceServerApi.js';
 import {
   LINK_TO_REGISTRY_PATH,
   linkAssetToRegistry,
-} from '../traceServerBindings/linkAssetToRegistry';
-import type {LinkAssetToRegistryReq} from '../traceServerBindings/linkAssetToRegistry';
+} from '../traceServerBindings/linkAssetToRegistry.js';
+import type {LinkAssetToRegistryReq} from '../traceServerBindings/linkAssetToRegistry.js';
 
 function makeReq(
   overrides: Partial<LinkAssetToRegistryReq> = {}

--- a/sdks/node/src/__tests__/live/dataset.test.ts
+++ b/sdks/node/src/__tests__/live/dataset.test.ts
@@ -1,5 +1,5 @@
-import {init, login} from '../../clientApi';
-import {Dataset} from '../../dataset';
+import {init, login} from '../../clientApi.js';
+import {Dataset} from '../../dataset.js';
 
 describe.skip('Dataset', () => {
   beforeEach(async () => {

--- a/sdks/node/src/__tests__/live/fn.test.ts
+++ b/sdks/node/src/__tests__/live/fn.test.ts
@@ -1,7 +1,7 @@
-import {init, login} from '../../clientApi';
-import {CallableObject} from '../../fn';
-import {op} from '../../op';
-import {WeaveObjectParameters} from '../../weaveObject';
+import {init, login} from '../../clientApi.js';
+import {CallableObject} from '../../fn.js';
+import {op} from '../../op.js';
+import {WeaveObjectParameters} from '../../weaveObject.js';
 
 interface ParametrizedFunctionOptions extends WeaveObjectParameters {
   magicNumber?: number;

--- a/sdks/node/src/__tests__/live/prompt.test.ts
+++ b/sdks/node/src/__tests__/live/prompt.test.ts
@@ -1,7 +1,7 @@
-import {MessagesPrompt, StringPrompt} from '../../prompt';
-import {init} from '../../clientApi';
+import {MessagesPrompt, StringPrompt} from '../../prompt.js';
+import {init} from '../../clientApi.js';
 import {WandbServerApi} from 'weave/wandb/wandbServerApi';
-import {Api as TraceServerApi} from '../../generated/traceServerApi';
+import {Api as TraceServerApi} from '../../generated/traceServerApi.js';
 
 jest.mock('../../wandb/wandbServerApi');
 

--- a/sdks/node/src/__tests__/live/publish.test.ts
+++ b/sdks/node/src/__tests__/live/publish.test.ts
@@ -1,5 +1,5 @@
-import {init, login} from '../../clientApi';
-import {Dataset, op, weaveAudio, weaveImage} from '../../index';
+import {init, login} from '../../clientApi.js';
+import {Dataset, op, weaveAudio, weaveImage} from '../../index.js';
 
 describe.skip('Publishing Various Data Types', () => {
   beforeEach(async () => {

--- a/sdks/node/src/__tests__/live/table.test.ts
+++ b/sdks/node/src/__tests__/live/table.test.ts
@@ -1,5 +1,5 @@
-import {init, login} from '../../clientApi';
-import {Table} from '../../table';
+import {init, login} from '../../clientApi.js';
+import {Table} from '../../table.js';
 
 describe.skip('Table', () => {
   beforeEach(async () => {

--- a/sdks/node/src/__tests__/live/weaveObject.test.ts
+++ b/sdks/node/src/__tests__/live/weaveObject.test.ts
@@ -1,6 +1,6 @@
-import {init, login} from '../../clientApi';
-import {op} from '../../op';
-import {WeaveObject} from '../../weaveObject';
+import {init, login} from '../../clientApi.js';
+import {op} from '../../op.js';
+import {WeaveObject} from '../../weaveObject.js';
 
 class ExampleObject extends WeaveObject {
   constructor(

--- a/sdks/node/src/__tests__/login.test.ts
+++ b/sdks/node/src/__tests__/login.test.ts
@@ -1,7 +1,7 @@
-import {login} from '../clientApi';
-import {Api as TraceServerApi} from '../generated/traceServerApi';
-import {getUrls} from '../urls';
-import {Netrc} from '../utils/netrc';
+import {login} from '../clientApi.js';
+import {Api as TraceServerApi} from '../generated/traceServerApi.js';
+import {getUrls} from '../urls.js';
+import {Netrc} from '../utils/netrc.js';
 
 // Mock dependencies
 jest.mock('../utils/netrc');

--- a/sdks/node/src/__tests__/media.test.ts
+++ b/sdks/node/src/__tests__/media.test.ts
@@ -1,4 +1,4 @@
-import {weaveAudio, weaveImage} from '../media';
+import {weaveAudio, weaveImage} from '../media.js';
 
 describe('media', () => {
   test('logging weaveImage', () => {

--- a/sdks/node/src/__tests__/opFlow.test.ts
+++ b/sdks/node/src/__tests__/opFlow.test.ts
@@ -1,8 +1,8 @@
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
-import {wrapOpenAIChatCompletionsCreate} from '../integrations/openai';
-import {op} from '../op';
-import {initWithCustomTraceServer} from './clientMock';
-import {makeMockOpenAIChat} from './openaiMock';
+import {InMemoryTraceServer} from '../inMemoryTraceServer.js';
+import {wrapOpenAIChatCompletionsCreate} from '../integrations/openai.js';
+import {op} from '../op.js';
+import {initWithCustomTraceServer} from './clientMock.js';
+import {makeMockOpenAIChat} from './openaiMock.js';
 
 // Helper function to get calls
 async function getCalls(

--- a/sdks/node/src/__tests__/util/concurrentLimit.test.ts
+++ b/sdks/node/src/__tests__/util/concurrentLimit.test.ts
@@ -1,4 +1,4 @@
-import {ConcurrencyLimiter} from '../../utils/concurrencyLimit';
+import {ConcurrencyLimiter} from '../../utils/concurrencyLimit.js';
 
 describe('concurrency limiting', () => {
   test('it works', async () => {

--- a/sdks/node/src/__tests__/util/netrc.test.ts
+++ b/sdks/node/src/__tests__/util/netrc.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import {Netrc} from '../../utils/netrc';
+import {Netrc} from '../../utils/netrc.js';
 
 jest.mock('fs');
 jest.mock('os');

--- a/sdks/node/src/__tests__/util/retry.test.ts
+++ b/sdks/node/src/__tests__/util/retry.test.ts
@@ -1,4 +1,4 @@
-import {createFetchWithRetry} from '../../utils/retry';
+import {createFetchWithRetry} from '../../utils/retry.js';
 
 describe('retry', () => {
   let originalFetch: typeof global.fetch;

--- a/sdks/node/src/__tests__/util/topologicalSort.test.ts
+++ b/sdks/node/src/__tests__/util/topologicalSort.test.ts
@@ -1,4 +1,4 @@
-import {topologicalSortChildrenFirst} from '../../utils/topologicalSort';
+import {topologicalSortChildrenFirst} from '../../utils/topologicalSort.js';
 
 // Helper: assert that every parent appears after all its children in the result.
 function assertChildrenBeforeParents(

--- a/sdks/node/src/__tests__/wandb/settings.test.ts
+++ b/sdks/node/src/__tests__/wandb/settings.test.ts
@@ -1,5 +1,5 @@
-import {Netrc} from '../../utils/netrc';
-import {getApiKey, getWandbConfigs} from '../../wandb/settings';
+import {Netrc} from '../../utils/netrc.js';
+import {getApiKey, getWandbConfigs} from '../../wandb/settings.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';

--- a/sdks/node/src/__tests__/wandb/wandbServerApi.test.ts
+++ b/sdks/node/src/__tests__/wandb/wandbServerApi.test.ts
@@ -1,4 +1,4 @@
-import {WandbServerApi} from '../../wandb/wandbServerApi';
+import {WandbServerApi} from '../../wandb/wandbServerApi.js';
 
 const originalFetch = global.fetch;
 const api = new WandbServerApi('https://api.wandb.ai', 'abcdef123456');

--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -1,10 +1,10 @@
 import {ReadableStream} from 'stream/web';
-import {Api as TraceServerApi} from '../generated/traceServerApi';
-import {StringPrompt} from '../prompt';
-import * as registryLinkBindings from '../traceServerBindings/linkAssetToRegistry';
-import {WandbServerApi} from '../wandb/wandbServerApi';
-import {WeaveClient} from '../weaveClient';
-import {ObjectRef} from '../weaveObject';
+import {Api as TraceServerApi} from '../generated/traceServerApi.js';
+import {StringPrompt} from '../prompt.js';
+import * as registryLinkBindings from '../traceServerBindings/linkAssetToRegistry.js';
+import {WandbServerApi} from '../wandb/wandbServerApi.js';
+import {WeaveClient} from '../weaveClient.js';
+import {ObjectRef} from '../weaveObject.js';
 
 // Mock the TraceServerApi and WandbServerApi
 jest.mock('../generated/traceServerApi');

--- a/sdks/node/src/call.ts
+++ b/sdks/node/src/call.ts
@@ -1,5 +1,5 @@
-import {getGlobalClient} from './clientApi';
-import {CallSchema} from './generated/traceServerApi';
+import {getGlobalClient} from './clientApi.js';
+import {CallSchema} from './generated/traceServerApi.js';
 
 const MAX_DISPLAY_NAME_LENGTH = 1000;
 

--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -1,13 +1,13 @@
-import {Api as TraceServerApi} from './generated/traceServerApi';
-import {makeSettings, SettingsInit} from './settings';
-import {defaultHost, getUrls, setGlobalDomain} from './urls';
-import {ConcurrencyLimiter} from './utils/concurrencyLimit';
-import {Netrc} from './utils/netrc';
-import {createFetchWithRetry} from './utils/retry';
-import {getWandbConfigs} from './wandb/settings';
-import {WandbServerApi} from './wandb/wandbServerApi';
-import {CallStackEntry, WeaveClient} from './weaveClient';
-import {globalSingleton} from './utils/globalSingleton';
+import {Api as TraceServerApi} from './generated/traceServerApi.js';
+import {makeSettings, SettingsInit} from './settings.js';
+import {defaultHost, getUrls, setGlobalDomain} from './urls.js';
+import {ConcurrencyLimiter} from './utils/concurrencyLimit.js';
+import {Netrc} from './utils/netrc.js';
+import {createFetchWithRetry} from './utils/retry.js';
+import {getWandbConfigs} from './wandb/settings.js';
+import {WandbServerApi} from './wandb/wandbServerApi.js';
+import {CallStackEntry, WeaveClient} from './weaveClient.js';
+import {globalSingleton} from './utils/globalSingleton.js';
 
 // Held behind a globalThis-backed container so that a dual-package-hazard load
 // (same module loaded as both CJS and ESM) resolves to a single shared client

--- a/sdks/node/src/dataset.ts
+++ b/sdks/node/src/dataset.ts
@@ -1,6 +1,6 @@
-import {requireGlobalClient} from './clientApi';
-import {Table} from './table';
-import {ObjectRef, WeaveObject, WeaveObjectParameters} from './weaveObject';
+import {requireGlobalClient} from './clientApi.js';
+import {Table} from './table.js';
+import {ObjectRef, WeaveObject, WeaveObjectParameters} from './weaveObject.js';
 
 interface DatasetParameters<R extends DatasetRow>
   extends WeaveObjectParameters {

--- a/sdks/node/src/esm/instrument.ts
+++ b/sdks/node/src/esm/instrument.ts
@@ -18,14 +18,14 @@ import {
   symESMInstrumentations,
   ESMInstrumentation,
   symESMCache,
-} from '../integrations/instrumentations';
-import {requirePackageJson} from '../utils/npmModuleUtils';
+} from '../integrations/instrumentations.js';
+import {requirePackageJson} from '../utils/npmModuleUtils.js';
 import semifies from 'semifies';
 
 // Side-effect import — populates the instrumentation registry that
 // `instrumentations.ts` exposes on `globalThis`. Must evaluate before the
 // loader hook below starts consulting that registry for matching modules.
-import '../integrations/hooks';
+import '../integrations/hooks.js';
 
 const {registerOptions, waitForAllMessagesAcknowledged} =
   createAddHookMessageChannel();

--- a/sdks/node/src/evaluation.ts
+++ b/sdks/node/src/evaluation.ts
@@ -1,10 +1,10 @@
 import cliProgress from 'cli-progress';
-import {Dataset, DatasetRow} from './dataset';
-import {ColumnMapping, mapArgs} from './fn';
-import {isMedia} from './media';
-import {op} from './op';
-import {Op, getOpName} from './opType';
-import {WeaveObject, WeaveObjectParameters} from './weaveObject';
+import {Dataset, DatasetRow} from './dataset.js';
+import {ColumnMapping, mapArgs} from './fn.js';
+import {isMedia} from './media.js';
+import {op} from './op.js';
+import {Op, getOpName} from './opType.js';
+import {WeaveObject, WeaveObjectParameters} from './weaveObject.js';
 
 const PROGRESS_BAR = false;
 

--- a/sdks/node/src/evaluationLogger.ts
+++ b/sdks/node/src/evaluationLogger.ts
@@ -16,13 +16,13 @@
  * await ev.logSummary();
  */
 
-import {WeaveObject, WeaveObjectParameters} from './weaveObject';
-import {Dataset, DatasetRow} from './dataset';
-import {op} from './op';
-import {requireGlobalClient} from './clientApi';
-import {InternalCall} from './call';
-import {CallStackEntry, WeaveClient} from './weaveClient';
-import {Op, OpRef, ParameterNamesOption} from './opType';
+import {WeaveObject, WeaveObjectParameters} from './weaveObject.js';
+import {Dataset, DatasetRow} from './dataset.js';
+import {op} from './op.js';
+import {requireGlobalClient} from './clientApi.js';
+import {InternalCall} from './call.js';
+import {CallStackEntry, WeaveClient} from './weaveClient.js';
+import {Op, OpRef, ParameterNamesOption} from './opType.js';
 import {uuidv7} from 'uuidv7';
 
 // ============================================================================

--- a/sdks/node/src/fn.ts
+++ b/sdks/node/src/fn.ts
@@ -1,4 +1,4 @@
-import {WeaveObject} from './weaveObject';
+import {WeaveObject} from './weaveObject.js';
 
 export type ColumnMapping<I, O> = {
   [K in keyof O]: keyof I;

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -4,17 +4,17 @@ export {
   withAttributes,
   requireCurrentCallStackEntry,
   requireCurrentChildSummary,
-} from './clientApi';
-export {Dataset} from './dataset';
-export {Evaluation} from './evaluation';
-export {EvaluationLogger, ScoreLogger} from './evaluationLogger';
+} from './clientApi.js';
+export {Dataset} from './dataset.js';
+export {Evaluation} from './evaluation.js';
+export {EvaluationLogger, ScoreLogger} from './evaluationLogger.js';
 export {
   CallSchema,
   CallsFilter,
   Query,
   SortBy,
-} from './generated/traceServerApi';
-export {GetCallsOptions} from './weaveClient';
+} from './generated/traceServerApi.js';
+export {GetCallsOptions} from './weaveClient.js';
 export {
   wrapOpenAI,
   wrapGoogleGenAI,
@@ -22,11 +22,11 @@ export {
   instrumentOpenAIAgents,
   patchRealtimeSession,
   createOtelExtension,
-} from './integrations';
-export {weaveAudio, weaveImage, WeaveAudio, WeaveImage} from './media';
-export {op} from './op';
-export * from './types';
-export {WeaveObject, ObjectRef} from './weaveObject';
-export {MessagesPrompt, StringPrompt} from './prompt';
-import './utils/commonJSLoader';
-import './integrations/hooks';
+} from './integrations/index.js';
+export {weaveAudio, weaveImage, WeaveAudio, WeaveImage} from './media.js';
+export {op} from './op.js';
+export * from './types.js';
+export {WeaveObject, ObjectRef} from './weaveObject.js';
+export {MessagesPrompt, StringPrompt} from './prompt.js';
+import './utils/commonJSLoader.js';
+import './integrations/hooks.js';

--- a/sdks/node/src/integrations/anthropic.ts
+++ b/sdks/node/src/integrations/anthropic.ts
@@ -1,6 +1,9 @@
-import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
-import {op} from '../op';
-import {OpOptions, StreamReducer} from '../opType';
+import {
+  addCJSInstrumentation,
+  addESMInstrumentation,
+} from './instrumentations.js';
+import {op} from '../op.js';
+import {OpOptions, StreamReducer} from '../opType.js';
 
 type Message = {
   id: string;

--- a/sdks/node/src/integrations/googleGenAI.ts
+++ b/sdks/node/src/integrations/googleGenAI.ts
@@ -1,6 +1,9 @@
-import {op} from '../op';
-import {OpOptions, StreamReducer} from '../opType';
-import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
+import {op} from '../op.js';
+import {OpOptions, StreamReducer} from '../opType.js';
+import {
+  addCJSInstrumentation,
+  addESMInstrumentation,
+} from './instrumentations.js';
 
 const weaveGeminiModelHint = Symbol.for('_weave_gemini_model_hint');
 const weaveGeminiModelsWrapped = Symbol.for('_weave_gemini_models_wrapped');

--- a/sdks/node/src/integrations/hooks.ts
+++ b/sdks/node/src/integrations/hooks.ts
@@ -1,8 +1,8 @@
-import {instrumentOpenAI} from '../integrations/openai';
-import {instrumentAnthropic} from './anthropic';
-import {instrumentGoogleGenAI} from './googleGenAI';
-import {instrumentOpenAIAgent} from './openai.agent';
-import {instrumentOpenAIRealtimeAgent} from './openai.realtime.agent';
+import {instrumentOpenAI} from '../integrations/openai.js';
+import {instrumentAnthropic} from './anthropic.js';
+import {instrumentGoogleGenAI} from './googleGenAI.js';
+import {instrumentOpenAIAgent} from './openai.agent.js';
+import {instrumentOpenAIRealtimeAgent} from './openai.realtime.agent.js';
 instrumentOpenAI();
 instrumentAnthropic();
 instrumentGoogleGenAI();

--- a/sdks/node/src/integrations/index.ts
+++ b/sdks/node/src/integrations/index.ts
@@ -1,9 +1,12 @@
-export {wrapOpenAI} from './openai';
-export {wrapGoogleGenAI} from './googleGenAI';
+export {wrapOpenAI} from './openai.js';
+export {wrapGoogleGenAI} from './googleGenAI.js';
 export {
   createOpenAIAgentsTracingProcessor,
   instrumentOpenAIAgents,
-} from './openai.agent';
-export {patchRealtimeSession} from './openai.realtime.agent';
-export {createOtelExtension, PiCodingAgentOtelAdapter} from './piCodingAgent';
-export type {OtelExtensionOptions} from './piCodingAgent';
+} from './openai.agent.js';
+export {patchRealtimeSession} from './openai.realtime.agent.js';
+export {
+  createOtelExtension,
+  PiCodingAgentOtelAdapter,
+} from './piCodingAgent.js';
+export type {OtelExtensionOptions} from './piCodingAgent.js';

--- a/sdks/node/src/integrations/openai.agent.ts
+++ b/sdks/node/src/integrations/openai.agent.ts
@@ -14,12 +14,15 @@
  * ```
  */
 
-import {getGlobalClient} from '../clientApi';
-import {CallStack} from '../weaveClient';
-import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
+import {getGlobalClient} from '../clientApi.js';
+import {CallStack} from '../weaveClient.js';
+import {
+  addCJSInstrumentation,
+  addESMInstrumentation,
+} from './instrumentations.js';
 import {uuidv7} from 'uuidv7';
-import {topologicalSortChildrenFirst} from '../utils/topologicalSort';
-import {globalSingleton} from '../utils/globalSingleton';
+import {topologicalSortChildrenFirst} from '../utils/topologicalSort.js';
+import {globalSingleton} from '../utils/globalSingleton.js';
 import type {
   Span,
   Trace,
@@ -30,7 +33,7 @@ import type {
   HandoffSpanData,
   GuardrailSpanData,
   CustomSpanData,
-} from './openai.agent.types';
+} from './openai.agent.types.js';
 
 // ============================================================================
 // Helper Functions

--- a/sdks/node/src/integrations/openai.realtime.agent.ts
+++ b/sdks/node/src/integrations/openai.realtime.agent.ts
@@ -28,11 +28,14 @@
  * ```
  */
 
-import {getGlobalClient} from '../clientApi';
+import {getGlobalClient} from '../clientApi.js';
 import {uuidv7} from 'uuidv7';
-import type {RealtimeSessionLike} from './openai.realtime.agent.types';
-import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
-import {globalSingleton} from '../utils/globalSingleton';
+import type {RealtimeSessionLike} from './openai.realtime.agent.types.js';
+import {
+  addCJSInstrumentation,
+  addESMInstrumentation,
+} from './instrumentations.js';
+import {globalSingleton} from '../utils/globalSingleton.js';
 
 // ============================================================================
 // Helpers

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -1,12 +1,15 @@
-import {weaveImage} from '../media';
-import {op} from '../op';
-import {OpOptions} from '../opType';
-import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
-import {getGlobalClient} from '../clientApi';
-import {InternalCall} from '../call';
-import {WeaveClient} from '../weaveClient';
-import {warnOnce} from '../utils/warnOnce';
-import {getCallStackFromOpenAIAgents} from './openai.agent';
+import {weaveImage} from '../media.js';
+import {op} from '../op.js';
+import {OpOptions} from '../opType.js';
+import {
+  addCJSInstrumentation,
+  addESMInstrumentation,
+} from './instrumentations.js';
+import {getGlobalClient} from '../clientApi.js';
+import {InternalCall} from '../call.js';
+import {WeaveClient} from '../weaveClient.js';
+import {warnOnce} from '../utils/warnOnce.js';
+import {getCallStackFromOpenAIAgents} from './openai.agent.js';
 
 /**
  * Wraps a function to run with OpenAI Agents call stack if available.
@@ -183,7 +186,7 @@ export function makeOpenAIImagesGenerateOp(originalGenerate: any) {
   };
 }
 
-import {StreamReducer} from '../opType';
+import {StreamReducer} from '../opType.js';
 
 export type Response = {
   id: string;

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -38,10 +38,10 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 
-import {getGlobalClient} from '../clientApi';
-import {getWandbConfigs} from '../wandb/settings';
+import {getGlobalClient} from '../clientApi.js';
+import {getWandbConfigs} from '../wandb/settings.js';
 
-import {GEN_AI_ATTR, GEN_AI_EVENT, OTEL_ATTR} from './common/genai';
+import {GEN_AI_ATTR, GEN_AI_EVENT, OTEL_ATTR} from './common/genai.js';
 
 import type {
   PiAgentMessage,
@@ -51,7 +51,7 @@ import type {
   PiExtensionDefinition,
   PiExtensionEvent,
   PiModel,
-} from './piCodingAgent.types';
+} from './piCodingAgent.types.js';
 
 // ---------------------------------------------------------------------------
 // Options
@@ -606,4 +606,4 @@ export type {
   PiExtensionDefinition,
   PiExtensionContext,
   PiModel,
-} from './piCodingAgent.types';
+} from './piCodingAgent.types.js';

--- a/sdks/node/src/op.ts
+++ b/sdks/node/src/op.ts
@@ -1,9 +1,9 @@
-import {Call, InternalCall} from './call';
-import {getGlobalClient} from './clientApi';
-import {TRACE_CALL_EMOJI} from './constants';
-import {Op, OpOptions, OpRef, CallMethod} from './opType';
-import {getGlobalDomain} from './urls';
-import {warnOnce} from './utils/warnOnce';
+import {Call, InternalCall} from './call.js';
+import {getGlobalClient} from './clientApi.js';
+import {TRACE_CALL_EMOJI} from './constants.js';
+import {Op, OpOptions, OpRef, CallMethod} from './opType.js';
+import {getGlobalDomain} from './urls.js';
+import {warnOnce} from './utils/warnOnce.js';
 
 export interface MethodDecoratorContext {
   kind: 'method';

--- a/sdks/node/src/opType.ts
+++ b/sdks/node/src/opType.ts
@@ -1,6 +1,6 @@
-import {Call} from './call';
-import {getGlobalDomain} from './urls';
-import {WeaveObject} from './weaveObject';
+import {Call} from './call.js';
+import {getGlobalDomain} from './urls.js';
+import {WeaveObject} from './weaveObject.js';
 
 export type ParameterNamesOption = 'useParam0Object' | string[] | undefined;
 

--- a/sdks/node/src/prompt.ts
+++ b/sdks/node/src/prompt.ts
@@ -1,5 +1,5 @@
-import {WeaveClient} from './weaveClient';
-import {ObjectRef, WeaveObject, WeaveObjectParameters} from './weaveObject';
+import {WeaveClient} from './weaveClient.js';
+import {ObjectRef, WeaveObject, WeaveObjectParameters} from './weaveObject.js';
 
 export class Prompt extends WeaveObject {
   constructor(parameters: WeaveObjectParameters) {

--- a/sdks/node/src/summary.ts
+++ b/sdks/node/src/summary.ts
@@ -1,4 +1,4 @@
-import {CallStackEntry} from './weaveClient';
+import {CallStackEntry} from './weaveClient.js';
 
 /**
  * Represents a summary object with string keys and any type of values.

--- a/sdks/node/src/table.ts
+++ b/sdks/node/src/table.ts
@@ -1,4 +1,4 @@
-import {parseTableRefUri} from './uriParser';
+import {parseTableRefUri} from './uriParser.js';
 
 export class TableRef {
   constructor(
@@ -73,7 +73,7 @@ export class Table<R extends TableRow = TableRow> {
 
     const tableRef = await this.__savedRef;
 
-    const {requireGlobalClient} = await import('./clientApi');
+    const {requireGlobalClient} = await import('./clientApi.js');
     const client = requireGlobalClient();
 
     // Fetch table data from server

--- a/sdks/node/src/traceServerBindings/linkAssetToRegistry.ts
+++ b/sdks/node/src/traceServerBindings/linkAssetToRegistry.ts
@@ -1,5 +1,5 @@
-import {ContentType} from '../generated/traceServerApi';
-import type {Api as TraceServerApi} from '../generated/traceServerApi';
+import {ContentType} from '../generated/traceServerApi.js';
+import type {Api as TraceServerApi} from '../generated/traceServerApi.js';
 
 export const LINK_TO_REGISTRY_PATH = '/link_to_registry';
 

--- a/sdks/node/src/types.ts
+++ b/sdks/node/src/types.ts
@@ -1,2 +1,2 @@
-export {Op, OpDecorator} from './opType';
-export {WeaveClient} from './weaveClient';
+export {Op, OpDecorator} from './opType.js';
+export {WeaveClient} from './weaveClient.js';

--- a/sdks/node/src/urls.ts
+++ b/sdks/node/src/urls.ts
@@ -1,4 +1,4 @@
-import {globalSingleton} from './utils/globalSingleton';
+import {globalSingleton} from './utils/globalSingleton.js';
 
 export const defaultHost = 'api.wandb.ai';
 export const defaultDomain = 'wandb.ai';

--- a/sdks/node/src/utils/commonJSLoader.ts
+++ b/sdks/node/src/utils/commonJSLoader.ts
@@ -5,8 +5,8 @@ import semifies from 'semifies';
 import instrumentations, {
   CacheEntry,
   CJSInstrumentation,
-} from '../integrations/instrumentations';
-import {requirePackageJson} from './npmModuleUtils';
+} from '../integrations/instrumentations.js';
+import {requirePackageJson} from './npmModuleUtils.js';
 
 const parse: (filePath: string) => {
   name: string;

--- a/sdks/node/src/utils/userAgent.ts
+++ b/sdks/node/src/utils/userAgent.ts
@@ -1,4 +1,4 @@
-import {packageVersion} from './packageVersion';
+import {packageVersion} from './packageVersion.js';
 
 export {packageVersion};
 

--- a/sdks/node/src/utils/warnOnce.ts
+++ b/sdks/node/src/utils/warnOnce.ts
@@ -1,4 +1,4 @@
-import {globalSingleton} from './globalSingleton';
+import {globalSingleton} from './globalSingleton.js';
 
 // Deduped across CJS/ESM module copies so a dual-loaded SDK does not emit the
 // same warning twice.

--- a/sdks/node/src/wandb/settings.ts
+++ b/sdks/node/src/wandb/settings.ts
@@ -1,5 +1,5 @@
-import {defaultHost, getUrls} from '../urls';
-import {Netrc} from '../utils/netrc';
+import {defaultHost, getUrls} from '../urls.js';
+import {Netrc} from '../utils/netrc.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';

--- a/sdks/node/src/wandb/wandbServerApi.ts
+++ b/sdks/node/src/wandb/wandbServerApi.ts
@@ -1,4 +1,4 @@
-import {userAgent} from '../utils/userAgent';
+import {userAgent} from '../utils/userAgent.js';
 
 const VIEWER_DEFAULT_ENTITY_QUERY = `
 query DefaultEntity {

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -2,8 +2,8 @@ import {AsyncLocalStorage} from 'async_hooks';
 import * as fs from 'fs';
 import {uuidv7} from 'uuidv7';
 
-import {MAX_OBJECT_NAME_LENGTH} from './constants';
-import {computeDigest} from './digest';
+import {MAX_OBJECT_NAME_LENGTH} from './constants.js';
+import {computeDigest} from './digest.js';
 import {
   CallSchema,
   CallsQueryReq,
@@ -13,7 +13,7 @@ import {
   SortBy,
   StartedCallSchemaForInsert,
   Api as TraceServerApi,
-} from './generated/traceServerApi';
+} from './generated/traceServerApi.js';
 import {
   AudioType,
   DEFAULT_AUDIO_TYPE,
@@ -21,7 +21,7 @@ import {
   ImageType,
   isWeaveAudio,
   isWeaveImage,
-} from './media';
+} from './media.js';
 import {
   Op,
   OpRef,
@@ -29,20 +29,20 @@ import {
   getOpName,
   getOpWrappedFunction,
   isOp,
-} from './opType';
-import {Settings} from './settings';
-import {Table, TableRef, TableRowRef} from './table';
-import {linkAssetToRegistry} from './traceServerBindings/linkAssetToRegistry';
+} from './opType.js';
+import {Settings} from './settings.js';
+import {Table, TableRef, TableRowRef} from './table.js';
+import {linkAssetToRegistry} from './traceServerBindings/linkAssetToRegistry.js';
 import type {
   LinkAssetToRegistryReq,
   LinkAssetToRegistryRes,
-} from './traceServerBindings/linkAssetToRegistry';
-import {packageVersion} from './utils/userAgent';
-import {WandbServerApi} from './wandb/wandbServerApi';
-import {ObjectRef, WeaveObject, getClassChain} from './weaveObject';
-import {Call, CallState, InternalCall} from './call';
-import {CallRef} from './refs';
-import type {Prompt} from './prompt';
+} from './traceServerBindings/linkAssetToRegistry.js';
+import {packageVersion} from './utils/userAgent.js';
+import {WandbServerApi} from './wandb/wandbServerApi.js';
+import {ObjectRef, WeaveObject, getClassChain} from './weaveObject.js';
+import {Call, CallState, InternalCall} from './call.js';
+import {CallRef} from './refs.js';
+import type {Prompt} from './prompt.js';
 
 const WEAVE_ERRORS_LOG_FNAME = 'weaveErrors.log';
 const DEFAULT_GET_CALLS_LIMIT = 1000;
@@ -440,7 +440,7 @@ export class WeaveClient {
     const t = val?._type;
 
     if (t == 'StringPrompt') {
-      const {StringPrompt} = await import('./prompt');
+      const {StringPrompt} = await import('./prompt.js');
 
       const {content, description, name} = val;
 
@@ -456,7 +456,7 @@ export class WeaveClient {
     }
 
     if (t == 'MessagesPrompt') {
-      const {MessagesPrompt} = await import('./prompt');
+      const {MessagesPrompt} = await import('./prompt.js');
 
       const {description, messages, name} = val;
 
@@ -473,7 +473,7 @@ export class WeaveClient {
 
     if (t == 'Dataset') {
       // Avoid circular dependency
-      const {Dataset} = await import('./dataset');
+      const {Dataset} = await import('./dataset.js');
 
       const {description, rows, name} = val;
 

--- a/sdks/node/src/weaveObject.ts
+++ b/sdks/node/src/weaveObject.ts
@@ -1,7 +1,7 @@
-import {requireGlobalClient} from './clientApi';
-import {isOp} from './op';
-import {getGlobalDomain} from './urls';
-import {parseWeaveUri} from './uriParser';
+import {requireGlobalClient} from './clientApi.js';
+import {isOp} from './op.js';
+import {getGlobalDomain} from './urls.js';
+import {parseWeaveUri} from './uriParser.js';
 
 export interface Callable {}
 


### PR DESCRIPTION
# Weave Node SDK — dual-build PR 2: retrofit `.js` extensions on relative imports

Mechanical change. Every relative import in `src/**/*.ts` now ends in `.js`. No logic changes, no build-tool changes, no published-output changes. Background and full plan: [Tech-Report-Should-the-Weave-Node-SDK-ship-a-dual-CJS-ESM-build](https://www.notion.so/wandbai/Tech-Report-Should-the-Weave-Node-SDK-ship-a-dual-CJS-ESM-build-348e2f5c7ef380149c80fdeb5a546f3c?source=copy_link) (§5 "Output shape", §7 PR 2).

## Why

PR 3 (next) emits **file-per-module** ESM (`bundle: false`) — the shape `openai`, `@openai/agents`, `@anthropic-ai/sdk` all ship. That requires explicit file extensions on every relative import in the emitted `.mjs` files; without them Node's ESM resolver throws `ERR_MODULE_NOT_FOUND`. This PR is the precondition.

The current CJS build is unaffected — TypeScript's resolver maps `'./foo.js'` back to `'./foo.ts'` at typecheck time under both `node` and `nodenext` resolution.

## What changed

- **228 imports rewritten** across 50 files (18 SDK source + 32 tests) via a one-shot codemod.

- **One manual fix:** [`src/index.ts`](sdks/node/src/index.ts) had `from './integrations'` (directory import); the codemod naively added `.js` → corrected to `./integrations/index.js`.

- **Jest config:** added `"^(\\.{1,2}/.*)\\.js$": "$1"` to `moduleNameMapper` in all three jest projects. Strips the `.js` suffix at jest's resolve time so its source-level resolver finds the underlying `.ts` files. Without this, every test would fail with `Cannot find module`. This simply because Jest loads source file (ts), not built files(js), so we have to retrofit for the Jest use case here

## What's not in this PR

- No `tsup`, no `package.json` exports changes — that's PR 3.
- No ESLint rule preventing future extensionless imports. ESLint isn't configured in this SDK; setting it up is its own work, deferred.

## Test plan

- [x] `pnpm run build` — clean.
- [x] `WANDB_API_KEY=dummy pnpm run test` — **183 passed, 7 skipped**. Same counts as `master`.
