### PR TITLE
perf(weave): hoist write-target resolution once per call_batch

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -422,6 +422,37 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def _calls_complete_batch(self, value: list[list[Any]]) -> None:
         self._thread_local.calls_complete_batch = value
 
+    def _resolve_v1_write_target(self, project_id: str) -> WriteTarget:
+        """Resolve v1 write target, memoizing per-batch when inside `call_batch()`.
+
+        The global LRU in TableRoutingResolver does not cache EMPTY projects
+        (on purpose: residence could change between requests), so within a
+        single batch on a fresh project every item would otherwise re-query
+        ClickHouse. Residence cannot change inside a single request, so a
+        per-batch dict is safe.
+        """
+        cache = getattr(self._thread_local, "batch_resolved_targets", None)
+        if cache is not None and project_id in cache:
+            return cache[project_id]
+        target = self.table_routing_resolver.resolve_v1_write_target(
+            project_id, self.ch_client
+        )
+        if cache is not None:
+            cache[project_id] = target
+        return target
+
+    def _resolve_v2_write_target(self, project_id: str) -> WriteTarget:
+        """Resolve v2 write target, memoizing per-batch (see `_resolve_v1_write_target`)."""
+        cache = getattr(self._thread_local, "batch_resolved_targets", None)
+        if cache is not None and project_id in cache:
+            return cache[project_id]
+        target = self.table_routing_resolver.resolve_v2_write_target(
+            project_id, self.ch_client
+        )
+        if cache is not None:
+            cache[project_id] = target
+        return target
+
     @classmethod
     def from_env(cls, use_async_insert: bool = False, **kwargs: Any) -> Self:
         return cls(
@@ -743,6 +774,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         """Batch call operations and flush them all at the end."""
         # Not thread safe - do not use across threads
         self._flush_immediately = False
+        self._thread_local.batch_resolved_targets = {}
         try:
             yield
             self._flush_immediately = True
@@ -752,6 +784,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._call_batch = []
             self._calls_complete_batch = []
             self._flush_immediately = True
+            self._thread_local.batch_resolved_targets = None
 
     def _flush_all_batches_in_order(self) -> None:
         """Flush all batches in order of dependency.
@@ -810,10 +843,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ch_call = start_call_for_insert_to_ch_insertable(req.start, retention_days)
 
         # Check write target - v1 call_start cannot write to calls_complete
-        write_target = self.table_routing_resolver.resolve_v1_write_target(
-            ch_call.project_id,
-            self.ch_client,
-        )
+        write_target = self._resolve_v1_write_target(ch_call.project_id)
         if write_target == WriteTarget.CALLS_COMPLETE:
             raise CallsCompleteModeRequired(ch_call.project_id)
 
@@ -840,10 +870,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ch_call = end_call_for_insert_to_ch_insertable(req.end, retention_days)
 
         # Check write target - v1 call_end cannot write to calls_complete
-        write_target = self.table_routing_resolver.resolve_v1_write_target(
-            ch_call.project_id,
-            self.ch_client,
-        )
+        write_target = self._resolve_v1_write_target(ch_call.project_id)
         if write_target == WriteTarget.CALLS_COMPLETE:
             raise CallsCompleteModeRequired(ch_call.project_id)
 
@@ -892,13 +919,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     complete_call, self
                 )
 
-                # Determine write target based on project, this should be the same for all
-                # calls in the batch, subsequent calls just hit the in-memory cache. This
-                # is here for technical correctness, in case we relax project_id target
-                # constraints intra-batch
-                write_target = self.table_routing_resolver.resolve_v2_write_target(
-                    processed_complete_call.project_id,
-                    self.ch_client,
+                # Determine write target based on project. Memoized per-batch
+                # in `_resolve_v2_write_target`, so subsequent same-project
+                # items in this batch don't re-query ClickHouse.
+                write_target = self._resolve_v2_write_target(
+                    processed_complete_call.project_id
                 )
 
                 retention_days = get_project_retention_days(


### PR DESCRIPTION
## Summary

`POST /call/upsert_batch` was running `resolve_v1_write_target` independently for every item in the batch (~10 `call_start` + ~10 `call_end` for a typical batch), each firing its own ClickHouse query via `get_project_data_residence`. The global LRU cache in `TableRoutingResolver` intentionally skips caching `EMPTY` residence (a fresh project) so those hot projects re-query on every single item.

In the trace that surfaced this (linked below), that was ~20 serial 13-19ms CH round-trips stacked onto the request's critical path.

## Fix

Memoize per-batch in a dict stored on `self._thread_local.batch_resolved_targets`, consistent with the other batch state in `call_batch()`. Initialized to `{}` on enter, cleared to `None` on exit. `_resolve_v1_write_target` / `_resolve_v2_write_target` helpers read through the cache when it exists and fall through to the resolver when it doesn't (single-call paths are unchanged).

One dict keyed by `project_id` is enough: no existing `call_batch()` site mixes v1 and v2 (`call_start_batch` is v1-only, `calls_complete` is v2-only, `calls_delete` uses neither), and residence can't change within a single request.

Also deletes the `calls_complete` comment that acknowledged the redundant per-item call as "technical correctness" -> it was masking the actual regression.

## Evidence

Trace that triggered the investigation (project residence was `EMPTY`, every item re-queried):
https://us5.datadoghq.com/apm/trace/69ebb83b00000000da3e789d40732e8b

20 child `call_start` / `call_end` spans, each with its own `table_routing.resolve_v1_write_target` -> `clickhouse_project_version.get_project_data_residence` -> `clickhouse_connect.execute`.

## Test plan

- [x] `tests/trace_server/test_clickhouse_batching.py`, `test_ttl_insert_paths.py`, `test_project_version.py`, `test_clickhouse_trace_server_batched.py`, `test_calls_complete.py` all pass locally (84 tests) -> existing coverage exercises `call_start_batch` and `calls_complete` through both resolver helpers.
- [x] `ruff check` + `ruff format --check` clean.
- [ ] GH Actions green.
- [ ] Once merged, bump submodule pointer in `wandb/core`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)