### PR TITLE
fix(weave): route redis writes through sentinel

### DIFF
--- a/tests/trace_server/test_redis_client.py
+++ b/tests/trace_server/test_redis_client.py
@@ -1,0 +1,69 @@
+"""Tests for get_redis_client URL handling (direct vs sentinel)."""
+
+from unittest.mock import MagicMock, patch
+
+from weave.trace_server import redis_client
+
+
+def _reset_cache() -> None:
+    redis_client.get_redis_client.cache_clear()
+
+
+def test_returns_none_when_url_unset(monkeypatch):
+    _reset_cache()
+    monkeypatch.delenv("WEAVE_REDIS_URL", raising=False)
+    assert redis_client.get_redis_client() is None
+
+
+@patch.object(redis_client.redis, "from_url")
+def test_direct_client_when_no_master_param(mock_from_url, monkeypatch):
+    _reset_cache()
+    monkeypatch.setenv("WEAVE_REDIS_URL", "redis://redis.example:6379")
+    mock_from_url.return_value = MagicMock(name="direct-client")
+
+    client = redis_client.get_redis_client()
+
+    mock_from_url.assert_called_once_with(
+        "redis://redis.example:6379",
+        decode_responses=True,
+        socket_connect_timeout=redis_client.REDIS_CONNECT_TIMEOUT_SECS,
+        socket_timeout=redis_client.REDIS_SOCKET_TIMEOUT_SECS,
+    )
+    assert client is mock_from_url.return_value
+
+
+@patch.object(redis_client, "Sentinel")
+def test_sentinel_client_when_master_param_set(mock_sentinel_cls, monkeypatch):
+    _reset_cache()
+    monkeypatch.setenv(
+        "WEAVE_REDIS_URL",
+        "redis://redis.example:26379?master=gorilla",
+    )
+    sentinel_instance = mock_sentinel_cls.return_value
+    master_client = sentinel_instance.master_for.return_value
+
+    client = redis_client.get_redis_client()
+
+    mock_sentinel_cls.assert_called_once_with(
+        [("redis.example", 26379)],
+        socket_connect_timeout=redis_client.REDIS_CONNECT_TIMEOUT_SECS,
+        socket_timeout=redis_client.REDIS_SOCKET_TIMEOUT_SECS,
+    )
+    sentinel_instance.master_for.assert_called_once_with(
+        "gorilla",
+        decode_responses=True,
+        socket_connect_timeout=redis_client.REDIS_CONNECT_TIMEOUT_SECS,
+        socket_timeout=redis_client.REDIS_SOCKET_TIMEOUT_SECS,
+    )
+    assert client is master_client
+
+
+@patch.object(redis_client, "Sentinel")
+def test_sentinel_defaults_port_when_omitted(mock_sentinel_cls, monkeypatch):
+    _reset_cache()
+    monkeypatch.setenv("WEAVE_REDIS_URL", "redis://redis.example?master=gorilla")
+
+    redis_client.get_redis_client()
+
+    sentinel_call = mock_sentinel_cls.call_args
+    assert sentinel_call.args[0] == [("redis.example", 26379)]

--- a/tests/trace_server/test_redis_client.py
+++ b/tests/trace_server/test_redis_client.py
@@ -13,10 +13,10 @@ def test_no_url_returns_none(monkeypatch):
 
 def test_client_resolution_from_url(monkeypatch):
     """Direct URL -> redis.from_url; ?master= URL -> Sentinel.master_for (port defaults to 26379)."""
-    timeouts = dict(
-        socket_connect_timeout=redis_client.REDIS_CONNECT_TIMEOUT_SECS,
-        socket_timeout=redis_client.REDIS_SOCKET_TIMEOUT_SECS,
-    )
+    timeouts = {
+        "socket_connect_timeout": redis_client.REDIS_CONNECT_TIMEOUT_SECS,
+        "socket_timeout": redis_client.REDIS_SOCKET_TIMEOUT_SECS,
+    }
 
     # Direct URL path.
     with patch.object(redis_client.redis, "from_url") as mock_from_url:
@@ -35,9 +35,7 @@ def test_client_resolution_from_url(monkeypatch):
             "WEAVE_REDIS_URL", "redis://redis.example:26379?master=gorilla"
         )
         client = redis_client.get_redis_client()
-        mock_sentinel.assert_called_once_with(
-            [("redis.example", 26379)], **timeouts
-        )
+        mock_sentinel.assert_called_once_with([("redis.example", 26379)], **timeouts)
         mock_sentinel.return_value.master_for.assert_called_once_with(
             "gorilla", decode_responses=True, **timeouts
         )

--- a/tests/trace_server/test_redis_client.py
+++ b/tests/trace_server/test_redis_client.py
@@ -2,7 +2,16 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from weave.trace_server import redis_client
+
+
+@pytest.fixture(autouse=True)
+def clear_cached_redis_client():
+    redis_client.get_redis_client.cache_clear()
+    yield
+    redis_client.get_redis_client.cache_clear()
 
 
 def test_no_url_returns_none(monkeypatch):

--- a/tests/trace_server/test_redis_client.py
+++ b/tests/trace_server/test_redis_client.py
@@ -1,69 +1,51 @@
 """Tests for get_redis_client URL handling (direct vs sentinel)."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from weave.trace_server import redis_client
 
 
-def _reset_cache() -> None:
+def test_no_url_returns_none(monkeypatch):
     redis_client.get_redis_client.cache_clear()
-
-
-def test_returns_none_when_url_unset(monkeypatch):
-    _reset_cache()
     monkeypatch.delenv("WEAVE_REDIS_URL", raising=False)
     assert redis_client.get_redis_client() is None
 
 
-@patch.object(redis_client.redis, "from_url")
-def test_direct_client_when_no_master_param(mock_from_url, monkeypatch):
-    _reset_cache()
-    monkeypatch.setenv("WEAVE_REDIS_URL", "redis://redis.example:6379")
-    mock_from_url.return_value = MagicMock(name="direct-client")
-
-    client = redis_client.get_redis_client()
-
-    mock_from_url.assert_called_once_with(
-        "redis://redis.example:6379",
-        decode_responses=True,
+def test_client_resolution_from_url(monkeypatch):
+    """Direct URL -> redis.from_url; ?master= URL -> Sentinel.master_for (port defaults to 26379)."""
+    timeouts = dict(
         socket_connect_timeout=redis_client.REDIS_CONNECT_TIMEOUT_SECS,
         socket_timeout=redis_client.REDIS_SOCKET_TIMEOUT_SECS,
     )
-    assert client is mock_from_url.return_value
 
+    # Direct URL path.
+    with patch.object(redis_client.redis, "from_url") as mock_from_url:
+        redis_client.get_redis_client.cache_clear()
+        monkeypatch.setenv("WEAVE_REDIS_URL", "redis://redis.example:6379")
+        client = redis_client.get_redis_client()
+        mock_from_url.assert_called_once_with(
+            "redis://redis.example:6379", decode_responses=True, **timeouts
+        )
+        assert client is mock_from_url.return_value
 
-@patch.object(redis_client, "Sentinel")
-def test_sentinel_client_when_master_param_set(mock_sentinel_cls, monkeypatch):
-    _reset_cache()
-    monkeypatch.setenv(
-        "WEAVE_REDIS_URL",
-        "redis://redis.example:26379?master=gorilla",
-    )
-    sentinel_instance = mock_sentinel_cls.return_value
-    master_client = sentinel_instance.master_for.return_value
+    # Sentinel URL path with explicit port.
+    with patch.object(redis_client, "Sentinel") as mock_sentinel:
+        redis_client.get_redis_client.cache_clear()
+        monkeypatch.setenv(
+            "WEAVE_REDIS_URL", "redis://redis.example:26379?master=gorilla"
+        )
+        client = redis_client.get_redis_client()
+        mock_sentinel.assert_called_once_with(
+            [("redis.example", 26379)], **timeouts
+        )
+        mock_sentinel.return_value.master_for.assert_called_once_with(
+            "gorilla", decode_responses=True, **timeouts
+        )
+        assert client is mock_sentinel.return_value.master_for.return_value
 
-    client = redis_client.get_redis_client()
-
-    mock_sentinel_cls.assert_called_once_with(
-        [("redis.example", 26379)],
-        socket_connect_timeout=redis_client.REDIS_CONNECT_TIMEOUT_SECS,
-        socket_timeout=redis_client.REDIS_SOCKET_TIMEOUT_SECS,
-    )
-    sentinel_instance.master_for.assert_called_once_with(
-        "gorilla",
-        decode_responses=True,
-        socket_connect_timeout=redis_client.REDIS_CONNECT_TIMEOUT_SECS,
-        socket_timeout=redis_client.REDIS_SOCKET_TIMEOUT_SECS,
-    )
-    assert client is master_client
-
-
-@patch.object(redis_client, "Sentinel")
-def test_sentinel_defaults_port_when_omitted(mock_sentinel_cls, monkeypatch):
-    _reset_cache()
-    monkeypatch.setenv("WEAVE_REDIS_URL", "redis://redis.example?master=gorilla")
-
-    redis_client.get_redis_client()
-
-    sentinel_call = mock_sentinel_cls.call_args
-    assert sentinel_call.args[0] == [("redis.example", 26379)]
+    # Sentinel URL with no port defaults to 26379.
+    with patch.object(redis_client, "Sentinel") as mock_sentinel:
+        redis_client.get_redis_client.cache_clear()
+        monkeypatch.setenv("WEAVE_REDIS_URL", "redis://redis.example?master=gorilla")
+        redis_client.get_redis_client()
+        assert mock_sentinel.call_args.args[0] == [("redis.example", 26379)]

--- a/weave/trace_server/redis_client.py
+++ b/weave/trace_server/redis_client.py
@@ -1,8 +1,10 @@
 """Redis client for weave trace server."""
 
 import functools
+from urllib.parse import parse_qs, urlparse
 
 import redis
+from redis.sentinel import Sentinel
 
 from weave.trace_server.environment import redis_url
 
@@ -19,15 +21,35 @@ REDIS_SOCKET_TIMEOUT_SECS = 1
 def get_redis_client() -> redis.Redis | None:
     """Get the Redis client.
 
-    Returns None if Redis is not configured (REDIS_URL not set).
-    The redis-py library handles connection pooling and thread safety internally.
+    Returns None if Redis is not configured (WEAVE_REDIS_URL not set).
+
+    If the URL includes `?master=<name>`, the client is resolved via Redis
+    Sentinel at the URL's host:port so writes always route to the current
+    master. This mirrors the `?master=` convention used by
+    `services/connectors/redis.go`.
     """
     url = redis_url()
-    if url:
+    if not url:
+        return None
+
+    parsed = urlparse(url)
+    master = parse_qs(parsed.query).get("master", [None])[0]
+    if not master:
         return redis.from_url(
             url,
             decode_responses=True,
             socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
             socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
         )
-    return None
+
+    sentinel = Sentinel(
+        [(parsed.hostname, parsed.port or 26379)],
+        socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
+        socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
+    )
+    return sentinel.master_for(
+        master,
+        decode_responses=True,
+        socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
+        socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
+    )

--- a/weave/trace_server/redis_client.py
+++ b/weave/trace_server/redis_client.py
@@ -42,6 +42,9 @@ def get_redis_client() -> redis.Redis | None:
             socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
         )
 
+    if not parsed.hostname:
+        raise ValueError(f"WEAVE_REDIS_URL is missing a hostname: {url!r}")
+
     sentinel = Sentinel(
         [(parsed.hostname, parsed.port or 26379)],
         socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,


### PR DESCRIPTION
## Summary

- When `WEAVE_REDIS_URL` includes `?master=<name>`, build the client via `redis.sentinel.Sentinel` and resolve the master before each command so writes always reach the primary.
- Matches the `?master=` URL convention already used by `services/connectors/redis.go` (Go).
- Direct (non-sentinel) URLs unchanged.

## Context

Prod redis is deployed via the bitnami chart in sentinel mode with 3 replicas. The top-level `redis` Service round-robins across master + replicas, so without Sentinel-aware routing a connection can land on a replica and every `SET` fails with `ReadOnlyError: You can't write against a read only replica`. The L2 TTL cache was quietly eating these errors (try/except + `logger.exception`), so requests still returned 200 but the cache never warmed.

Datadog: `service:redis env:prod @error.type:redis.exceptions.ReadOnlyError` showed ~650 errors in ~30 min before this fix.

## Testing

- [x] `tests/trace_server/test_redis_client.py` covers direct URL, sentinel URL, port default
- [x] Existing `tests/trace_server/test_ttl_settings.py` passes unchanged

<img width="566" height="146" alt="image" src="https://github.com/user-attachments/assets/780922d6-fc1b-44c9-b48d-744d77048489" />