### PR TITLE
chore(weave): fix flaky call link capture test

### DIFF
--- a/tests/trace/test_call_behaviours.py
+++ b/tests/trace/test_call_behaviours.py
@@ -1,7 +1,11 @@
 import pytest
 
 import weave
-from tests.trace.util import capture_output, flushing_callback
+from tests.trace.util import (
+    capture_output,
+    flush_and_wait_for_output,
+    flushing_callback,
+)
 from weave.trace.constants import TRACE_CALL_EMOJI
 from weave.trace.display.term import configure_logger
 
@@ -19,9 +23,9 @@ async def afunc():
 
 
 def test_call_prints_link(client):
-    callbacks = [flushing_callback(client)]
-    with capture_output(callbacks) as captured:
+    with capture_output([]) as captured:
         func()
+        assert flush_and_wait_for_output(client, captured, TRACE_CALL_EMOJI)
 
     assert captured.getvalue().count(TRACE_CALL_EMOJI) == 1
 
@@ -37,9 +41,9 @@ def test_call_doesnt_print_link_if_failed(client_with_throwing_server):
 
 @pytest.mark.asyncio
 async def test_async_call_prints_link(client):
-    callbacks = [flushing_callback(client)]
-    with capture_output(callbacks) as captured:
+    with capture_output([]) as captured:
         await afunc()
+        assert flush_and_wait_for_output(client, captured, TRACE_CALL_EMOJI)
 
     assert captured.getvalue().count(TRACE_CALL_EMOJI) == 1
 
@@ -67,9 +71,9 @@ def test_nested_calls_print_single_link(client):
     def outer(a, b):
         return middle(a, b)
 
-    callbacks = [flushing_callback(client)]
-    with capture_output(callbacks) as captured:
+    with capture_output([]) as captured:
         outer(1, 2)
+        assert flush_and_wait_for_output(client, captured, TRACE_CALL_EMOJI)
 
     # Check that all 3 calls landed
     calls = list(client.get_calls())

--- a/tests/trace/test_call_behaviours.py
+++ b/tests/trace/test_call_behaviours.py
@@ -4,7 +4,7 @@ import weave
 from tests.trace.util import (
     capture_output,
     flush_and_wait_for_output,
-    flushing_callback,
+    flush_output,
 )
 from weave.trace.constants import TRACE_CALL_EMOJI
 from weave.trace.display.term import configure_logger
@@ -23,7 +23,7 @@ async def afunc():
 
 
 def test_call_prints_link(client):
-    with capture_output([]) as captured:
+    with capture_output() as captured:
         func()
         assert flush_and_wait_for_output(client, captured, TRACE_CALL_EMOJI)
 
@@ -32,16 +32,16 @@ def test_call_prints_link(client):
 
 @pytest.mark.disable_logging_error_check
 def test_call_doesnt_print_link_if_failed(client_with_throwing_server):
-    callbacks = [flushing_callback(client_with_throwing_server)]
-    with capture_output(callbacks) as captured:
+    with capture_output() as captured:
         func()
+        flush_output(client_with_throwing_server)
 
     assert captured.getvalue().count(TRACE_CALL_EMOJI) == 0
 
 
 @pytest.mark.asyncio
 async def test_async_call_prints_link(client):
-    with capture_output([]) as captured:
+    with capture_output() as captured:
         await afunc()
         assert flush_and_wait_for_output(client, captured, TRACE_CALL_EMOJI)
 
@@ -51,9 +51,9 @@ async def test_async_call_prints_link(client):
 @pytest.mark.disable_logging_error_check
 @pytest.mark.asyncio
 async def test_async_call_doesnt_print_link_if_failed(client_with_throwing_server):
-    callbacks = [flushing_callback(client_with_throwing_server)]
-    with capture_output(callbacks) as captured:
+    with capture_output() as captured:
         await afunc()
+        flush_output(client_with_throwing_server)
 
     assert captured.getvalue().count(TRACE_CALL_EMOJI) == 0
 
@@ -71,7 +71,7 @@ def test_nested_calls_print_single_link(client):
     def outer(a, b):
         return middle(a, b)
 
-    with capture_output([]) as captured:
+    with capture_output() as captured:
         outer(1, 2)
         assert flush_and_wait_for_output(client, captured, TRACE_CALL_EMOJI)
 

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -11,7 +11,7 @@ import weave
 from tests.trace.util import (
     capture_output,
     flush_and_wait_for_output,
-    flushing_callback,
+    flush_output,
 )
 from weave.trace.constants import TRACE_CALL_EMOJI, TRACE_OBJECT_EMOJI
 from weave.trace.display.term import configure_logger
@@ -130,13 +130,13 @@ def test_publish_when_disabled_ignores_tags_aliases(client, monkeypatch):
 
 def test_print_call_link_setting(client_creator):
     with client_creator(settings=UserSettings(print_call_link=False)) as client:
-        callbacks = [flushing_callback(client)]
-        with capture_output(callbacks) as captured:
+        with capture_output() as captured:
             func()
+            flush_output(client)
     assert TRACE_CALL_EMOJI not in captured.getvalue()
 
     with client_creator(settings=UserSettings(print_call_link=True)) as client:
-        with capture_output([]) as captured:
+        with capture_output() as captured:
             func()
             assert flush_and_wait_for_output(client, captured, TRACE_CALL_EMOJI)
     assert TRACE_CALL_EMOJI in captured.getvalue()
@@ -144,14 +144,14 @@ def test_print_call_link_setting(client_creator):
 
 def test_print_call_link_env(client):
     os.environ["WEAVE_PRINT_CALL_LINK"] = "false"
-    callbacks = [flushing_callback(client)]
-    with capture_output(callbacks) as captured:
+    with capture_output() as captured:
         func()
+        flush_output(client)
 
     assert TRACE_CALL_EMOJI not in captured.getvalue()
 
     os.environ["WEAVE_PRINT_CALL_LINK"] = "true"
-    with capture_output([]) as captured:
+    with capture_output() as captured:
         func()
         assert flush_and_wait_for_output(client, captured, TRACE_CALL_EMOJI)
 
@@ -412,8 +412,7 @@ def test_log_level_setting(client_creator):
 
     # Test with ERROR level - should NOT see publish messages
     with client_creator(settings=UserSettings(log_level="ERROR")) as client:
-        callbacks = [flushing_callback(client)]
-        with capture_output(callbacks) as captured:
+        with capture_output() as captured:
             weave.publish(test_func, name="test_func_error")
     output = captured.getvalue()
     assert TRACE_OBJECT_EMOJI not in output
@@ -421,8 +420,7 @@ def test_log_level_setting(client_creator):
 
     # Test with INFO level - should see publish messages
     with client_creator(settings=UserSettings(log_level="INFO")) as client:
-        callbacks = [flushing_callback(client)]
-        with capture_output(callbacks) as captured:
+        with capture_output() as captured:
             weave.publish(test_func, name="test_func_info")
     output = captured.getvalue()
     assert TRACE_OBJECT_EMOJI in output
@@ -439,8 +437,7 @@ def test_log_level_env(client_creator):
     # Test with ERROR level - should NOT see publish messages
     os.environ["WEAVE_LOG_LEVEL"] = "ERROR"
     with client_creator() as client:
-        callbacks = [flushing_callback(client)]
-        with capture_output(callbacks) as captured:
+        with capture_output() as captured:
             weave.publish(test_func, name="test_func_error_env")
     output = captured.getvalue()
     assert TRACE_OBJECT_EMOJI not in output
@@ -449,8 +446,7 @@ def test_log_level_env(client_creator):
     # Test with INFO level - should see publish messages
     os.environ["WEAVE_LOG_LEVEL"] = "INFO"
     with client_creator() as client:
-        callbacks = [flushing_callback(client)]
-        with capture_output(callbacks) as captured:
+        with capture_output() as captured:
             weave.publish(test_func, name="test_func_info_env")
     output = captured.getvalue()
     assert TRACE_OBJECT_EMOJI in output

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -8,11 +8,18 @@ import pytest
 import tenacity
 
 import weave
-from tests.trace.util import capture_output, flushing_callback
+from tests.trace.util import (
+    capture_output,
+    flush_and_wait_for_output,
+    flushing_callback,
+)
 from weave.trace.constants import TRACE_CALL_EMOJI, TRACE_OBJECT_EMOJI
+from weave.trace.display.term import configure_logger
 from weave.trace.settings import UserSettings, parse_and_apply_settings
 from weave.trace.weave_client import get_parallelism_settings
 from weave.utils.retry import with_retry
+
+configure_logger()
 
 
 @weave.op
@@ -129,9 +136,9 @@ def test_print_call_link_setting(client_creator):
     assert TRACE_CALL_EMOJI not in captured.getvalue()
 
     with client_creator(settings=UserSettings(print_call_link=True)) as client:
-        callbacks = [flushing_callback(client)]
-        with capture_output(callbacks) as captured:
+        with capture_output([]) as captured:
             func()
+            assert flush_and_wait_for_output(client, captured, TRACE_CALL_EMOJI)
     assert TRACE_CALL_EMOJI in captured.getvalue()
 
 
@@ -144,9 +151,9 @@ def test_print_call_link_env(client):
     assert TRACE_CALL_EMOJI not in captured.getvalue()
 
     os.environ["WEAVE_PRINT_CALL_LINK"] = "true"
-    callbacks = [flushing_callback(client)]
-    with capture_output(callbacks) as captured:
+    with capture_output([]) as captured:
         func()
+        assert flush_and_wait_for_output(client, captured, TRACE_CALL_EMOJI)
 
     assert TRACE_CALL_EMOJI in captured.getvalue()
 

--- a/tests/trace/util.py
+++ b/tests/trace/util.py
@@ -5,7 +5,6 @@ import io
 import logging
 import re
 import time
-from collections.abc import Callable
 from contextlib import contextmanager
 
 from tests.trace.server_utils import find_server_layer
@@ -108,7 +107,7 @@ def get_info_loglines(
 
 
 @contextmanager
-def capture_output(callbacks: list[Callable[[], None]]):
+def capture_output():
     captured_logs = io.StringIO()
 
     # Store original stdout and logging handlers
@@ -127,17 +126,12 @@ def capture_output(callbacks: list[Callable[[], None]]):
     except DummyTestException:
         pass
     finally:
-        for callback in callbacks:
-            callback()
         root_logger.handlers = old_handlers
 
 
-def flushing_callback(client):
-    def _callback():
-        client.future_executor.flush()
-        time.sleep(0.01)  # Ensure on_finish_callback has time to fire post-flush
-
-    return _callback
+def flush_output(client):
+    client.future_executor.flush()
+    time.sleep(0.01)  # Ensure on_finish_callback has time to fire post-flush
 
 
 def flush_and_wait_for_output(

--- a/tests/trace/util.py
+++ b/tests/trace/util.py
@@ -138,3 +138,22 @@ def flushing_callback(client):
         time.sleep(0.01)  # Ensure on_finish_callback has time to fire post-flush
 
     return _callback
+
+
+def flush_and_wait_for_output(
+    client,
+    captured_logs: io.StringIO,
+    expected_text: str,
+    *,
+    expected_count: int = 1,
+    timeout: float = 1.0,
+) -> bool:
+    """Flush queued work and wait for output emitted by Future callbacks."""
+    deadline = time.monotonic() + timeout
+    while True:
+        client.future_executor.flush()
+        if captured_logs.getvalue().count(expected_text) >= expected_count:
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.01)


### PR DESCRIPTION
## Summary

The call link test was racing future callback logging against teardown of the test's temporary root logger handler. The CI failure shows the donut link did print, but pytest captured it after the test's StringIO capture had already missed it.

Original failure (https://github.com/wandb/weave/actions/runs/25004069199/job/73221851118):
```
FAILED tests/trace/test_call_behaviours.py::test_call_prints_link - AssertionError: assert 0 == 1
```

## Testing

Test-only change.
