### PR TITLE
fix(weave): retry ClickHouse file reads

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -969,6 +969,36 @@ def test_ensure_obj_version_exists_retries_eventual_consistency():
         assert mock_query.call_count == chts.OBJ_READ_RETRY_ATTEMPTS
 
 
+def test_file_content_read_retries_eventual_consistency():
+    """File reads should tolerate transient read-after-write misses."""
+    server = chts.ClickHouseTraceServer(host="test_host")
+    req = tsi.FileContentReadReq(project_id="test_project", digest="digest-1")
+
+    # Transient miss: the first lookup doesn't see the chunks yet, but the retry does.
+    with patch.object(server, "_file_content_read_once") as mock_read_once:
+        mock_read_once.side_effect = [
+            NotFoundError("File with digest digest-1 not found"),
+            tsi.FileContentReadRes(content=b"saved code"),
+        ]
+
+        assert server.file_content_read(req).content == b"saved code"
+        assert mock_read_once.call_count == 2
+
+    # Real miss: after exhausting retries, the original NotFoundError still surfaces.
+    with patch.object(
+        server,
+        "_file_content_read_once",
+        side_effect=NotFoundError("File with digest digest-1 not found"),
+    ) as mock_read_once:
+        with pytest.raises(
+            NotFoundError,
+            match="File with digest digest-1 not found",
+        ):
+            server.file_content_read(req)
+
+        assert mock_read_once.call_count == 2
+
+
 @pytest.mark.disable_logging_error_check
 @pytest.mark.parametrize(
     ("error", "expected_calls"),

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5356,7 +5356,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     ) -> tsi.FileContentReadRes:
         """Read file content with retry for ClickHouse eventual consistency."""
         return self._read_with_retry(
-            lambda: self.file_content_read(req), max_attempts=max_attempts
+            lambda: self._file_content_read_once(req), max_attempts=max_attempts
         )
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._parsed_refs_read_batch")
@@ -5766,6 +5766,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return True
 
     def file_content_read(self, req: tsi.FileContentReadReq) -> tsi.FileContentReadRes:
+        return self._file_content_read_with_retry(req)
+
+    def _file_content_read_once(
+        self, req: tsi.FileContentReadReq
+    ) -> tsi.FileContentReadRes:
         pb = ParamBuilder()
         query = make_file_content_read_query(
             project_id=req.project_id,


### PR DESCRIPTION
## Summary

Retry ClickHouse file content reads on transient NotFoundError using the existing read-after-write retry helper. This covers cases where object metadata is visible before referenced file chunks, including test_object_op_versioning.

We can be pretty sure that file version should exist when looking them up by a hash, retry using the existing object/file retry semantics.

Original failure:
```
FAILED tests/trace/test_op_versioning.py::test_object_op_versioning - weave.trace_server.errors.NotFoundError: File with digest l6haNh4BKO2xYHVbeoMttOfXsY2ixQHKNwv957lTOWI not found
```

## Testing

- add unit test