### PR TITLE
chore(weave): fix flaky feedback linking test

### DIFF
--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -1,5 +1,6 @@
 import dataclasses
 import random
+import time
 from typing import Any
 
 import pydantic
@@ -322,6 +323,21 @@ def with_empty_feedback(obj: Any) -> Any:
         new_dict["weave"] = {**new_dict["weave"], "feedback": []}
         return new_dict
     return obj
+
+
+def calls_query_with_feedback(
+    client, req: tsi.CallsQueryReq, timeout_seconds: float = 2
+) -> tsi.CallsQueryRes:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        calls = client.server.calls_query(req)
+        if any(
+            call.summary.get("weave", {}).get("feedback") for call in calls.calls
+        ):
+            return calls
+        if time.monotonic() >= deadline:
+            return calls
+        time.sleep(0.05)
 
 
 @pytest.mark.asyncio
@@ -1005,7 +1021,9 @@ async def test_feedback_is_correctly_linked(client):
         scorers=[score],
     )
     res = await eval.evaluate(predict)
-    calls = client.server.calls_query(
+    client.flush()
+    calls = calls_query_with_feedback(
+        client,
         tsi.CallsQueryReq(
             project_id=client.project_id,
             include_feedback=True,
@@ -1047,7 +1065,9 @@ async def test_feedback_is_correctly_linked_with_scorer_subclass(client):
         scorers=[scorer],
     )
     res = await eval.evaluate(predict)
-    calls = client.server.calls_query(
+    client.flush()
+    calls = calls_query_with_feedback(
+        client,
         tsi.CallsQueryReq(
             project_id=client.project_id,
             include_feedback=True,


### PR DESCRIPTION
## Summary

Stabilizes the evaluation feedback-linking tests by flushing pending feedback work and polling the `include_feedback` query until the expected hydrated feedback is visible. This avoids a blind sleep and avoids masking the failure with a rerun marker.

Original failure ([GitHub Actions job](https://github.com/wandb/weave/actions/runs/25004773143/job/73224390027?pr=6702)):
```text
FAILED tests/trace/test_evaluations.py::test_feedback_is_correctly_linked - assert []
```

## Testing

Test-only change.
- `uvx ruff check tests/trace/test_evaluations.py`
- `unset NO_COLOR FORCE_COLOR && nox --no-install -e "tests-3.10(shard='trace_calls_complete_only')" -- -n0 tests/trace/test_evaluations.py::test_feedback_is_correctly_linked tests/trace/test_evaluations.py::test_feedback_is_correctly_linked_with_scorer_subclass --trace-server=sqlite`
- `unset NO_COLOR FORCE_COLOR && nox --no-install -e "tests-3.10(shard='trace_calls_complete_only')" -- -n0 tests/trace/test_evaluations.py::test_feedback_is_correctly_linked tests/trace/test_evaluations.py::test_feedback_is_correctly_linked_with_scorer_subclass --trace-server=clickhouse --clickhouse-process=true`
