### PR TITLE
fix(weave): lazy httpx.Client to honor env vars set after import

### DIFF
--- a/tests/utils/test_http_requests.py
+++ b/tests/utils/test_http_requests.py
@@ -25,7 +25,7 @@ def clear_http_env(monkeypatch):
 
 
 def test_client_uses_default_httpx_transport():
-    assert isinstance(http_requests.client._transport, httpx.HTTPTransport)
+    assert isinstance(http_requests.get_client()._transport, httpx.HTTPTransport)
 
 
 def test_request_hook_logs_when_enabled(monkeypatch):

--- a/tests/utils/test_ssl_verification.py
+++ b/tests/utils/test_ssl_verification.py
@@ -39,48 +39,69 @@ class TestSslVerifyEnv:
 class TestHttpxClientSslVerify:
     """The shared httpx.Client in http_requests respects ssl_verify().
 
-    The client is now created lazily on first use, so we use ``reset_client()``
-    to drop the cached client and let the next access re-read the env var.
+    The client is built lazily on first call to ``get_client()`` and then
+    frozen — to assert behavior tied to env vars read at construction time
+    we drop the cached client first via ``_reset_client_for_tests``.
     """
 
     def test_client_verify_disabled(self, monkeypatch):
         monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "true")
-        http_requests.reset_client()
+        http_requests._reset_client_for_tests()
         try:
             # httpx bakes the verify flag into an ssl_context on the transport pool;
             # CERT_NONE means SSL certificate verification is disabled.
-            transport = http_requests.client._transport
-            assert isinstance(transport, httpx.HTTPTransport)
-            pool = transport._pool
-            assert pool._ssl_context.verify_mode.name == "CERT_NONE"
+            client = http_requests.get_client()
+            assert isinstance(client._transport, httpx.HTTPTransport)
+            assert client._transport._pool._ssl_context.verify_mode.name == "CERT_NONE"
         finally:
             monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
-            http_requests.reset_client()
+            http_requests._reset_client_for_tests()
 
     def test_client_verify_enabled_by_default(self):
         # Without WEAVE_INSECURE_DISABLE_SSL set, the client should verify certs.
-        transport = http_requests.client._transport
-        assert isinstance(transport, httpx.HTTPTransport)
-        pool = transport._pool
-        assert pool._ssl_context.verify_mode.name != "CERT_NONE"
+        client = http_requests.get_client()
+        assert isinstance(client._transport, httpx.HTTPTransport)
+        assert client._transport._pool._ssl_context.verify_mode.name != "CERT_NONE"
 
-    def test_client_is_lazy(self, monkeypatch):
-        """Setting WEAVE_INSECURE_DISABLE_SSL after import still takes effect.
+    def test_env_var_takes_effect_when_set_after_import(self, monkeypatch):
+        """Regression for WB-33539.
 
-        Regression: the client used to be created at import time, so setting
-        the env var after ``import weave`` was a no-op. With lazy init, the
-        env var is read on first access.
+        The client used to be constructed at module import time, so users
+        setting ``WEAVE_INSECURE_DISABLE_SSL`` after ``import weave`` saw no
+        effect. With lazy construction, the env var is read on first call.
         """
-        http_requests.reset_client()
+        http_requests._reset_client_for_tests()
         assert http_requests._client is None
         monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "true")
         try:
-            transport = http_requests.client._transport
-            pool = transport._pool
-            assert pool._ssl_context.verify_mode.name == "CERT_NONE"
+            client = http_requests.get_client()
+            assert client._transport._pool._ssl_context.verify_mode.name == "CERT_NONE"
         finally:
             monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
-            http_requests.reset_client()
+            http_requests._reset_client_for_tests()
+
+    def test_config_is_frozen_after_first_use(self, monkeypatch):
+        """Documents the intentional freeze-after-first-use contract.
+
+        httpx does not allow changing ``verify`` on a live client (the SSL
+        context is owned by the connection pool — encode/httpx#554), so once
+        the client is built, env-var changes are ignored. Callers that need
+        to change SSL config must set the env var before the first HTTP call.
+        """
+        http_requests._reset_client_for_tests()
+        try:
+            # First call: verify enabled.
+            first = http_requests.get_client()
+            assert first._transport._pool._ssl_context.verify_mode.name != "CERT_NONE"
+
+            # Flip the env var. The cached client should NOT change.
+            monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "true")
+            second = http_requests.get_client()
+            assert second is first
+            assert second._transport._pool._ssl_context.verify_mode.name != "CERT_NONE"
+        finally:
+            monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
+            http_requests._reset_client_for_tests()
 
 
 class TestInternalApiSslVerify:

--- a/tests/utils/test_ssl_verification.py
+++ b/tests/utils/test_ssl_verification.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import importlib
 from unittest.mock import MagicMock, patch
 
 import gql
@@ -38,18 +37,15 @@ class TestSslVerifyEnv:
 
 
 class TestHttpxClientSslVerify:
-    """The global httpx.Client in http_requests respects ssl_verify().
+    """The shared httpx.Client in http_requests respects ssl_verify().
 
-    The http_requests module creates a module-level `client = httpx.Client(verify=...)`
-    at import time, so we must reload the module after changing the env var to
-    re-create the client with the new SSL setting. After the test we reload again
-    to restore the default client for other tests.
+    The client is now created lazily on first use, so we use ``reset_client()``
+    to drop the cached client and let the next access re-read the env var.
     """
 
     def test_client_verify_disabled(self, monkeypatch):
         monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "true")
-        # Reload to re-create the module-level httpx.Client with verify=False.
-        importlib.reload(http_requests)
+        http_requests.reset_client()
         try:
             # httpx bakes the verify flag into an ssl_context on the transport pool;
             # CERT_NONE means SSL certificate verification is disabled.
@@ -58,10 +54,8 @@ class TestHttpxClientSslVerify:
             pool = transport._pool
             assert pool._ssl_context.verify_mode.name == "CERT_NONE"
         finally:
-            # Restore the module-level client to its default (verify=True) state
-            # so other tests aren't affected.
             monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
-            importlib.reload(http_requests)
+            http_requests.reset_client()
 
     def test_client_verify_enabled_by_default(self):
         # Without WEAVE_INSECURE_DISABLE_SSL set, the client should verify certs.
@@ -69,6 +63,24 @@ class TestHttpxClientSslVerify:
         assert isinstance(transport, httpx.HTTPTransport)
         pool = transport._pool
         assert pool._ssl_context.verify_mode.name != "CERT_NONE"
+
+    def test_client_is_lazy(self, monkeypatch):
+        """Setting WEAVE_INSECURE_DISABLE_SSL after import still takes effect.
+
+        Regression: the client used to be created at import time, so setting
+        the env var after ``import weave`` was a no-op. With lazy init, the
+        env var is read on first access.
+        """
+        http_requests.reset_client()
+        assert http_requests._client is None
+        monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "true")
+        try:
+            transport = http_requests.client._transport
+            pool = transport._pool
+            assert pool._ssl_context.verify_mode.name == "CERT_NONE"
+        finally:
+            monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
+            http_requests.reset_client()
 
 
 class TestInternalApiSslVerify:

--- a/weave/utils/http_requests.py
+++ b/weave/utils/http_requests.py
@@ -171,50 +171,59 @@ def _log_response(response: Response) -> None:
     pprint_response(response)
 
 
+# Shared httpx.Client lifecycle.
+#
+# The client is built lazily on first use so env-driven config such as
+# ``WEAVE_INSECURE_DISABLE_SSL`` and ``WF_HTTP_TIMEOUT`` is read at first-use
+# time, not at import time. The trade-off this design makes:
+#
+#   Config (verify=, timeout=, event_hooks) is captured when the client is
+#   built, and frozen for the life of the process.
+#
+# This matches how httpx itself wants to be used — ``verify`` is a property of
+# the connection pool and cannot be changed per-request (see encode/httpx#554).
+# It also matches the openai/anthropic SDKs, which build their httpx.Client
+# eagerly per SDK instance and do not reconfigure it. Callers who need to
+# change SSL/timeout config must set the env var *before* the first HTTP
+# call (typically before ``weave.init``).
 _client: httpx.Client | None = None
 _client_lock = threading.Lock()
 
 
-def _create_client() -> httpx.Client:
-    # Use HTTPX's default transport so env proxy handling (including NO_PROXY)
-    # works natively.
-    return httpx.Client(
-        event_hooks={"request": [_log_request], "response": [_log_response]},
-        timeout=http_timeout(),
-        limits=CLIENT_LIMITS,
-        verify=ssl_verify(),
-    )
-
-
 def get_client() -> httpx.Client:
-    """Return the shared httpx.Client, creating it on first use.
+    """Return the shared httpx.Client, building it on first use.
 
-    Lazy creation lets env-driven settings like ``WEAVE_INSECURE_DISABLE_SSL``
-    take effect even if ``import weave`` happened before the env var was set.
+    See module-level comment for the freeze-after-first-use contract.
     """
     global _client  # noqa: PLW0603
-    if _client is None:
-        with _client_lock:
-            if _client is None:
-                _client = _create_client()
-    return _client
+    with _client_lock:
+        if _client is None:
+            # Use HTTPX's default transport so env proxy handling
+            # (including NO_PROXY) works natively.
+            _client = httpx.Client(
+                event_hooks={
+                    "request": [_log_request],
+                    "response": [_log_response],
+                },
+                timeout=http_timeout(),
+                limits=CLIENT_LIMITS,
+                verify=ssl_verify(),
+            )
+        return _client
 
 
-def reset_client() -> None:
-    """Close and forget the cached client so the next call re-reads env vars."""
+def _reset_client_for_tests() -> None:
+    """Close the cached client and clear it. Test seam only.
+
+    Production code must not call this — the freeze-after-first-use contract
+    is intentional. Tests use it to simulate a fresh process when asserting
+    behavior tied to env vars read at client-construction time.
+    """
     global _client  # noqa: PLW0603
     with _client_lock:
         if _client is not None:
             _client.close()
         _client = None
-
-
-def __getattr__(name: str) -> Any:
-    # PEP 562: expose ``client`` as a lazily-initialized module attribute
-    # so existing ``http_requests.client`` access keeps working.
-    if name == "client":
-        return get_client()
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get(

--- a/weave/utils/http_requests.py
+++ b/weave/utils/http_requests.py
@@ -171,14 +171,50 @@ def _log_response(response: Response) -> None:
     pprint_response(response)
 
 
-client = httpx.Client(
+_client: httpx.Client | None = None
+_client_lock = threading.Lock()
+
+
+def _create_client() -> httpx.Client:
     # Use HTTPX's default transport so env proxy handling (including NO_PROXY)
     # works natively.
-    event_hooks={"request": [_log_request], "response": [_log_response]},
-    timeout=http_timeout(),
-    limits=CLIENT_LIMITS,
-    verify=ssl_verify(),
-)
+    return httpx.Client(
+        event_hooks={"request": [_log_request], "response": [_log_response]},
+        timeout=http_timeout(),
+        limits=CLIENT_LIMITS,
+        verify=ssl_verify(),
+    )
+
+
+def get_client() -> httpx.Client:
+    """Return the shared httpx.Client, creating it on first use.
+
+    Lazy creation lets env-driven settings like ``WEAVE_INSECURE_DISABLE_SSL``
+    take effect even if ``import weave`` happened before the env var was set.
+    """
+    global _client  # noqa: PLW0603
+    if _client is None:
+        with _client_lock:
+            if _client is None:
+                _client = _create_client()
+    return _client
+
+
+def reset_client() -> None:
+    """Close and forget the cached client so the next call re-reads env vars."""
+    global _client  # noqa: PLW0603
+    with _client_lock:
+        if _client is not None:
+            _client.close()
+        _client = None
+
+
+def __getattr__(name: str) -> Any:
+    # PEP 562: expose ``client`` as a lazily-initialized module attribute
+    # so existing ``http_requests.client`` access keeps working.
+    if name == "client":
+        return get_client()
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def get(
@@ -189,6 +225,7 @@ def get(
     **kwargs: Any,
 ) -> Response:
     """Send a GET request with optional logging."""
+    client = get_client()
     if stream:
         # Extract auth since build_request doesn't accept it
         auth = kwargs.pop("auth", None)
@@ -206,6 +243,7 @@ def post(
     **kwargs: Any,
 ) -> Response:
     """Send a POST request with optional logging."""
+    client = get_client()
     if stream:
         # Extract auth since build_request doesn't accept it
         auth = kwargs.pop("auth", None)
@@ -223,6 +261,7 @@ def put(
     **kwargs: Any,
 ) -> Response:
     """Send a PUT request with optional logging."""
+    client = get_client()
     if stream:
         # Extract auth since build_request doesn't accept it
         auth = kwargs.pop("auth", None)
@@ -239,6 +278,7 @@ def delete(
     **kwargs: Any,
 ) -> Response:
     """Send a DELETE request with optional logging."""
+    client = get_client()
     if stream:
         # Extract auth since build_request doesn't accept it
         auth = kwargs.pop("auth", None)


### PR DESCRIPTION
Fixes [WB-33539](https://wandb.atlassian.net/browse/WB-33539).

## Problem
The shared `httpx.Client` in `weave/utils/http_requests.py` was constructed at module import time, baking in `ssl_verify()` / `http_timeout()` before the caller had a chance to set env vars. Setting `WEAVE_INSECURE_DISABLE_SSL=true` *after* `import weave` was a no-op:

```python
import weave                                          # client created, verify=True
os.environ["WEAVE_INSECURE_DISABLE_SSL"] = "true"     # too late
weave.init(...)                                       # SSL fails, surfaces as
                                                      # "Weave is not available on the server"
```

## Fix
Build the `httpx.Client` lazily on first use instead of at module import time. Env-driven config is read when the client is constructed.

```python
def get_client() -> httpx.Client:
    """Return the shared httpx.Client, building it on first use."""
    global _client
    with _client_lock:
        if _client is None:
            _client = httpx.Client(
                event_hooks={"request": [_log_request], "response": [_log_response]},
                timeout=http_timeout(),
                limits=CLIENT_LIMITS,
                verify=ssl_verify(),
            )
        return _client
```

## Contract: frozen after first use
**Once the client is built, its config is immutable.** Changing `WEAVE_INSECURE_DISABLE_SSL` or `WF_HTTP_TIMEOUT` after the first HTTP call has no effect.

This is the same contract `httpx` itself enforces: SSL config is owned by the connection pool, and `httpx.Client.get/post/send` do not accept a per-request `verify=` ([encode/httpx#554](https://github.com/encode/httpx/issues/554)). It also matches the openai and anthropic Python SDKs, which build their `httpx.Client` eagerly per SDK instance and never reconfigure it.

Callers who need to change SSL/timeout config must set the env var **before** the first HTTP call (typically before `weave.init`).

Both behaviors are pinned by tests:
- `test_env_var_takes_effect_when_set_after_import` — the WB-33539 regression
- `test_config_is_frozen_after_first_use` — documents the intentional freeze

## Out of scope (follow-up tickets)
- Six other `httpx.Client` instances in the codebase ignore `ssl_verify()` entirely (`weave/chat/completions.py`, `weave/chat/inference_models.py`, `weave/utils/pypi_version_check.py`, `weave/trace_server/costs/update_costs.py`, `weave/trace_server/model_providers/{model_providers.py,catalog_augment_hf.py}`). `WEAVE_INSECURE_DISABLE_SSL=true` will fix the trace ingestion path but not these. Worth centralizing through `get_client()` in a follow-up.

## Test plan
- [x] `uvx ruff check` clean
- [x] `tests/utils/test_http_requests.py` + `tests/utils/test_ssl_verification.py` — 16/16 pass
- [x] `tests/trace_server_bindings/test_http_behavior_remote.py` — 13/13 pass
- [ ] CI green

<details>
<summary>Performance (irrelevant to correctness, included for completeness)</summary>

`import weave`, n=20 cold subprocesses each:

| Op                          | Before (eager)                                     | After (lazy)                                       | Δ                          |
|-----------------------------|----------------------------------------------------|----------------------------------------------------|----------------------------|
| `import weave` (cold)       | 1428.7 ms median (mean 1439.5, stdev 42.7)         | 1421.3 ms median (mean 1422.7, stdev 67.3)         | within noise               |
| `httpx.Client()` ctor       | 24.6 ms median                                     | 24.8 ms median                                     | unchanged (sanity check)   |

The ~25 ms `httpx.Client()` construction simply moves from import to the first HTTP request, where it's negligible next to network latency.
</details>

[WB-33539]: https://coreweave.atlassian.net/browse/WB-33539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ