### PR TITLE
chore(weave): add error_code to typed exceptions

### DIFF
--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -1,9 +1,29 @@
+import datetime
+
 import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError as CHDatabaseError
 from gql.transport.exceptions import TransportServerError
 
 from weave.trace_server.errors import (
+    BadQueryParameterError,
+    DigestMismatchError,
+    ErrorCode,
+    InsertTooLarge,
+    InvalidExternalRef,
+    InvalidFieldError,
+    InvalidIdFormat,
     InvalidRequest,
+    LightweightUpdateNotAllowedError,
+    MissingLLMApiKeyError,
+    NotFoundError,
+    ObjectDeletedError,
+    ProjectNotFound,
+    QueryIllegalTypeofArgumentError,
+    QueryMemoryLimitExceededError,
+    QueryNoCommonTypeError,
+    QueryTimeoutExceededError,
+    RequestTooLarge,
+    RunNotFound,
     handle_clickhouse_query_error,
     handle_server_exception,
 )
@@ -42,3 +62,55 @@ def test_clickhouse_type_mismatch_returns_400() -> None:
 
     result = handle_server_exception(InvalidRequest(error_msg))
     assert result.status_code == 400
+    assert result.message["error_code"] == ErrorCode.INVALID_REQUEST
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected_status", "expected_code"),
+    [
+        (BadQueryParameterError("x"), 403, ErrorCode.BAD_QUERY_PARAMETER),
+        (DigestMismatchError("x"), 409, ErrorCode.DIGEST_MISMATCH),
+        (InsertTooLarge("x"), 413, ErrorCode.INSERT_TOO_LARGE),
+        (InvalidExternalRef("x"), 400, ErrorCode.INVALID_EXTERNAL_REF),
+        (InvalidFieldError("x"), 403, ErrorCode.INVALID_FIELD),
+        (InvalidIdFormat("x"), 400, ErrorCode.INVALID_ID_FORMAT),
+        (InvalidRequest("x"), 400, ErrorCode.INVALID_REQUEST),
+        (
+            LightweightUpdateNotAllowedError("x"),
+            501,
+            ErrorCode.LIGHTWEIGHT_UPDATE_NOT_ALLOWED,
+        ),
+        (
+            MissingLLMApiKeyError("x", api_key_name="OPENAI_API_KEY"),
+            400,
+            ErrorCode.MISSING_LLM_API_KEY,
+        ),
+        (NotFoundError("x"), 404, ErrorCode.NOT_FOUND),
+        (
+            ObjectDeletedError("x", deleted_at=datetime.datetime(2026, 1, 1)),
+            404,
+            ErrorCode.OBJECT_DELETED,
+        ),
+        (ProjectNotFound("x"), 404, ErrorCode.PROJECT_NOT_FOUND),
+        (
+            QueryIllegalTypeofArgumentError("x"),
+            403,
+            ErrorCode.QUERY_ILLEGAL_TYPE_OF_ARGUMENT,
+        ),
+        (
+            QueryMemoryLimitExceededError("x"),
+            502,
+            ErrorCode.QUERY_MEMORY_LIMIT_EXCEEDED,
+        ),
+        (QueryNoCommonTypeError("x"), 400, ErrorCode.QUERY_NO_COMMON_TYPE),
+        (QueryTimeoutExceededError("x"), 504, ErrorCode.QUERY_TIMEOUT_EXCEEDED),
+        (RequestTooLarge(), 413, ErrorCode.REQUEST_TOO_LARGE),
+        (RunNotFound("x"), 404, ErrorCode.RUN_NOT_FOUND),
+    ],
+)
+def test_error_code_emitted_for_typed_exception(
+    exc: Exception, expected_status: int, expected_code: str
+) -> None:
+    result = handle_server_exception(exc)
+    assert result.status_code == expected_status
+    assert result.message["error_code"] == expected_code

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -21,7 +21,25 @@ class ErrorCode:
     identify specific error conditions without parsing human-readable messages.
     """
 
+    BAD_QUERY_PARAMETER = "BAD_QUERY_PARAMETER"
     CALLS_COMPLETE_MODE_REQUIRED = "CALLS_COMPLETE_MODE_REQUIRED"
+    DIGEST_MISMATCH = "DIGEST_MISMATCH"
+    INSERT_TOO_LARGE = "INSERT_TOO_LARGE"
+    INVALID_EXTERNAL_REF = "INVALID_EXTERNAL_REF"
+    INVALID_FIELD = "INVALID_FIELD"
+    INVALID_ID_FORMAT = "INVALID_ID_FORMAT"
+    INVALID_REQUEST = "INVALID_REQUEST"
+    LIGHTWEIGHT_UPDATE_NOT_ALLOWED = "LIGHTWEIGHT_UPDATE_NOT_ALLOWED"
+    MISSING_LLM_API_KEY = "MISSING_LLM_API_KEY"
+    NOT_FOUND = "NOT_FOUND"
+    OBJECT_DELETED = "OBJECT_DELETED"
+    PROJECT_NOT_FOUND = "PROJECT_NOT_FOUND"
+    QUERY_ILLEGAL_TYPE_OF_ARGUMENT = "QUERY_ILLEGAL_TYPE_OF_ARGUMENT"
+    QUERY_MEMORY_LIMIT_EXCEEDED = "QUERY_MEMORY_LIMIT_EXCEEDED"
+    QUERY_NO_COMMON_TYPE = "QUERY_NO_COMMON_TYPE"
+    QUERY_TIMEOUT_EXCEEDED = "QUERY_TIMEOUT_EXCEEDED"
+    REQUEST_TOO_LARGE = "REQUEST_TOO_LARGE"
+    RUN_NOT_FOUND = "RUN_NOT_FOUND"
 
 
 # =============================================================================
@@ -38,13 +56,13 @@ class Error(Exception):
 class RequestTooLarge(Error):
     """Raised when a request is too large."""
 
-    pass
+    error_code: str = ErrorCode.REQUEST_TOO_LARGE
 
 
 class InvalidRequest(Error):
     """Raised when a request is invalid."""
 
-    pass
+    error_code: str = ErrorCode.INVALID_REQUEST
 
 
 class CallsCompleteModeRequired(InvalidRequest):
@@ -75,60 +93,62 @@ class CallsCompleteModeRequired(InvalidRequest):
 class QueryMemoryLimitExceededError(Error):
     """Raised when a query memory limit is exceeded."""
 
-    pass
+    error_code: str = ErrorCode.QUERY_MEMORY_LIMIT_EXCEEDED
 
 
 class QueryNoCommonTypeError(Error):
     """Raised when a query has no common type."""
 
-    pass
+    error_code: str = ErrorCode.QUERY_NO_COMMON_TYPE
 
 
 class QueryIllegalTypeofArgumentError(Error):
     """Raised when a query has an illegal type of argument."""
 
-    pass
+    error_code: str = ErrorCode.QUERY_ILLEGAL_TYPE_OF_ARGUMENT
 
 
 class BadQueryParameterError(Error):
     """Raised when a query parameter is invalid."""
 
-    pass
+    error_code: str = ErrorCode.BAD_QUERY_PARAMETER
 
 
 class QueryTimeoutExceededError(Error):
     """Raised when a query timeout is exceeded."""
 
-    pass
+    error_code: str = ErrorCode.QUERY_TIMEOUT_EXCEEDED
 
 
 class InsertTooLarge(Error):
     """Raised when a single insert is too large."""
 
-    pass
+    error_code: str = ErrorCode.INSERT_TOO_LARGE
 
 
 class LightweightUpdateNotAllowedError(Error):
     """Raised when ClickHouse lightweight updates are not enabled."""
 
-    pass
+    error_code: str = ErrorCode.LIGHTWEIGHT_UPDATE_NOT_ALLOWED
 
 
 # User error
 class InvalidFieldError(Error):
     """Raised when a field is invalid."""
 
-    pass
+    error_code: str = ErrorCode.INVALID_FIELD
 
 
 class NotFoundError(Error):
     """Raised when a general not found error occurs."""
 
-    pass
+    error_code: str = ErrorCode.NOT_FOUND
 
 
 class MissingLLMApiKeyError(Error):
     """Raised when a LLM API key is missing for completion."""
+
+    error_code: str = ErrorCode.MISSING_LLM_API_KEY
 
     def __init__(self, message: str, api_key_name: str):
         self.api_key_name = api_key_name
@@ -138,6 +158,8 @@ class MissingLLMApiKeyError(Error):
 class ObjectDeletedError(Error):
     """Raised when an object has been deleted."""
 
+    error_code: str = ErrorCode.OBJECT_DELETED
+
     def __init__(self, message: str, deleted_at: datetime.datetime):
         self.deleted_at = deleted_at
         super().__init__(message)
@@ -146,27 +168,27 @@ class ObjectDeletedError(Error):
 class InvalidExternalRef(Error):
     """Raised when an external reference is invalid."""
 
-    pass
+    error_code: str = ErrorCode.INVALID_EXTERNAL_REF
 
 
 class DigestMismatchError(Error):
     """Raised when a client-provided digest does not match the server-computed digest."""
 
-    pass
+    error_code: str = ErrorCode.DIGEST_MISMATCH
 
 
 class ProjectNotFound(Error):
     """Raised when a project is not found."""
 
-    pass
+    error_code: str = ErrorCode.PROJECT_NOT_FOUND
 
 
 class InvalidIdFormat(Exception):
-    pass
+    error_code: str = ErrorCode.INVALID_ID_FORMAT
 
 
 class RunNotFound(Exception):
-    pass
+    error_code: str = ErrorCode.RUN_NOT_FOUND
 
 
 def _format_error_to_json_with_extra(
@@ -296,7 +318,14 @@ class ErrorRegistry:
 
         # 413
         self.register(InsertTooLarge, 413)
-        self.register(RequestTooLarge, 413, lambda exc: {"reason": "Request too large"})
+        self.register(
+            RequestTooLarge,
+            413,
+            lambda exc: {
+                "reason": "Request too large",
+                "error_code": ErrorCode.REQUEST_TOO_LARGE,
+            },
+        )
 
         # 501
         self.register(LightweightUpdateNotAllowedError, 501)


### PR DESCRIPTION
## Summary

Annotate every typed exception in the `ErrorRegistry` with a stable, machine-readable `error_code` so clients (FE, SDKs) can detect specific error conditions without parsing human-readable reasons.

The base `Error.error_code` attribute and `_format_error_to_json_with_extra` helper were already in place — `CallsCompleteModeRequired` was the only class using the pattern. This PR fills it in across the rest of the registered exceptions.

### What changes
- New constants on `ErrorCode` for each exception.
- `error_code: str = ErrorCode.X` on every typed exception registered with the `ErrorRegistry` (CH query errors, `RequestTooLarge`, `InvalidRequest`, `NotFoundError`, `ProjectNotFound`, etc.).
- `RequestTooLarge`'s custom formatter is updated to include `error_code` (the others use the default formatter, which picks it up via `hasattr`).
- New parametrized test asserting each typed exception emits the right (`status_code`, `error_code`).

### Why this approach
Originally this PR added a single `QueryTooExpensiveError` and collapsed multiple CH limit errors into it. That worked but lost specificity (memory vs. timeout vs. estimated-time all became one type). Adding `error_code` to the existing classes preserves each exception's identity while still letting the client bucket them however it wants (e.g., a "query too expensive" UI panel triggered by a small set of codes on the FE side).

Companion FE change: wandb/core#43038 (and stack) reads `body.error_code` from error responses; the small set of "user-actionable query limit" codes (`QUERY_TIMEOUT_EXCEEDED`, `QUERY_MEMORY_LIMIT_EXCEEDED`) is bucketed there to render the friendly "Query cancelled" panel.

## Testing

- `tests/trace_server/test_errors.py` parametrized over all 18 typed exceptions, verifying status code and emitted `error_code`.
- Verified locally that `handle_server_exception(QueryTimeoutExceededError("..."))` produces `{"reason": "...", "error_code": "QUERY_TIMEOUT_EXCEEDED"}` with status 504, etc.