### PR TITLE
chore(weave): fix flaky server filter by aliases

### DIFF
--- a/tests/trace/test_obj_tags_aliases.py
+++ b/tests/trace/test_obj_tags_aliases.py
@@ -785,6 +785,7 @@ def test_server_filter_by_tags(client: WeaveClient):
     assert len(res.objs) >= 1
 
 
+@pytest.mark.flaky(reruns=3)
 def test_server_filter_by_aliases(client: WeaveClient):
     """Filter by aliases: custom alias, 'latest', nonexistent, specific version only."""
     oid, digest = _publish_obj(client, "srv_falias")


### PR DESCRIPTION
## Summary

Marks `test_server_filter_by_aliases` as flaky so the known ClickHouse visibility race can rerun instead of failing the shard on a transient empty query result.

Original failure (https://github.com/wandb/weave/actions/runs/25019698704/job/73276788916):
```
FAILED tests/trace/test_obj_tags_aliases.py::test_server_filter_by_aliases - IndexError: list index out of range
```

## Testing

Test-only change.
`uvx ruff check tests/trace/test_obj_tags_aliases.py`
`uv run --group test python -m pytest tests/trace/test_obj_tags_aliases.py::test_server_filter_by_aliases -v --trace-server=sqlite`
