### PR TITLE
fix(weave): retry ClickHouse object reads

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -10,11 +10,12 @@ from unittest.mock import MagicMock, Mock, patch
 import clickhouse_connect
 import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
+from tenacity import wait_none
 
 from weave.trace_server import clickhouse_trace_server_batched as chts
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.clickhouse_schema import ALL_CALL_INSERT_COLUMNS
-from weave.trace_server.errors import NotFoundError
+from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
 
 
@@ -967,6 +968,135 @@ def test_ensure_obj_version_exists_retries_eventual_consistency():
             server._ensure_obj_version_exists("test_project", "test_object", "digest-1")
 
         assert mock_query.call_count == chts.OBJ_READ_RETRY_ATTEMPTS
+
+
+def test_obj_read_retries_eventual_consistency():
+    """Object reads should tolerate transient read-after-write misses."""
+    server = chts.ClickHouseTraceServer(host="test_host")
+    req = tsi.ObjReadReq(
+        project_id="test_project",
+        object_id="test_object",
+        digest="digest-1",
+    )
+    obj = tsi.ObjSchema(
+        project_id="test_project",
+        object_id="test_object",
+        digest="digest-1",
+        base_object_class=None,
+        val={"ok": True},
+        created_at=datetime.now(),
+        version_index=1,
+        is_latest=1,
+        kind="object",
+        deleted_at=None,
+    )
+    diagnostics = {
+        "candidate_rows": 0,
+        "exact_rows": 0,
+        "project_object_rows": 0,
+        "project_digest_rows": 0,
+        "object_digest_rows": 0,
+        "exact_deleted_rows": 0,
+        "example_project_for_object_digest": None,
+        "example_object_for_project_digest": None,
+        "example_digest_for_project_object": None,
+    }
+
+    # Transient miss: the first lookup doesn't see the object yet, but the retry does.
+    with (
+        patch.object(chts, "wait_exponential", return_value=wait_none()),
+        patch.object(
+            server, "_obj_read_miss_diagnostics", return_value=diagnostics
+        ) as mock_diagnostics,
+        patch.object(server, "_obj_read_once") as mock_read_once,
+    ):
+        mock_read_once.side_effect = [
+            NotFoundError("Obj test_object:digest-1 not found"),
+            tsi.ObjReadRes(obj=obj),
+        ]
+
+        assert server.obj_read(req).obj.val == {"ok": True}
+        assert mock_read_once.call_count == 2
+        assert mock_diagnostics.call_count == 1
+
+    # Real miss: after exhausting retries, the original NotFoundError still surfaces.
+    with (
+        patch.object(chts, "wait_exponential", return_value=wait_none()),
+        patch.object(
+            server, "_obj_read_miss_diagnostics", return_value=diagnostics
+        ) as mock_diagnostics,
+        patch.object(
+            server,
+            "_obj_read_once",
+            side_effect=NotFoundError("Obj test_object:digest-1 not found"),
+        ) as mock_read_once,
+    ):
+        with pytest.raises(
+            NotFoundError,
+            match="Obj test_object:digest-1 not found",
+        ):
+            server.obj_read(req)
+
+        assert mock_read_once.call_count == chts.OBJ_READ_RETRY_ATTEMPTS
+        assert mock_diagnostics.call_count == chts.OBJ_READ_RETRY_ATTEMPTS
+
+    # Authoritative deletes are not eventual-consistency misses and should not retry.
+    with (
+        patch.object(chts, "wait_exponential", return_value=wait_none()),
+        patch.object(server, "_obj_read_miss_diagnostics") as mock_diagnostics,
+        patch.object(
+            server,
+            "_obj_read_once",
+            side_effect=ObjectDeletedError(
+                "test_object:v1 was deleted",
+                deleted_at=datetime.now(timezone.utc),
+            ),
+        ) as mock_read_once,
+    ):
+        with pytest.raises(ObjectDeletedError):
+            server.obj_read(req)
+
+        assert mock_read_once.call_count == 1
+        assert mock_diagnostics.call_count == 0
+
+    # Diagnostics distinguish stale reads from project/object/digest mismatches.
+    with patch.object(
+        server,
+        "_query",
+        return_value=MagicMock(
+            result_rows=[
+                (
+                    3,
+                    0,
+                    2,
+                    0,
+                    1,
+                    0,
+                    "other_project",
+                    "",
+                    "other_digest",
+                )
+            ]
+        ),
+    ) as mock_query:
+        assert server._obj_read_miss_diagnostics(req) == {
+            "candidate_rows": 3,
+            "exact_rows": 0,
+            "project_object_rows": 2,
+            "project_digest_rows": 0,
+            "object_digest_rows": 1,
+            "exact_deleted_rows": 0,
+            "example_project_for_object_digest": "other_project",
+            "example_object_for_project_digest": None,
+            "example_digest_for_project_object": "other_digest",
+        }
+        query, params = mock_query.call_args.args
+        assert "object_versions" in query
+        assert params == {
+            "project_id": "test_project",
+            "object_id": "test_object",
+            "digest": "digest-1",
+        }
 
 
 def test_file_content_read_retries_eventual_consistency():

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1865,6 +1865,114 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return obj_results
 
     def obj_read(self, req: tsi.ObjReadReq) -> tsi.ObjReadRes:
+        return self._obj_read_with_retry(req, max_attempts=OBJ_READ_RETRY_ATTEMPTS)
+
+    def _obj_read_miss_diagnostics(self, req: tsi.ObjReadReq) -> dict[str, Any]:
+        """Return counts that distinguish stale reads from malformed refs."""
+        pb = ParamBuilder()
+        project_id = pb.add(req.project_id, "project_id", "String")
+        object_id = pb.add(req.object_id, "object_id", "String")
+        digest = pb.add(req.digest, "digest", "String")
+        query = f"""
+            SELECT
+                count() AS candidate_rows,
+                countIf(
+                    project_id = {project_id}
+                    AND object_id = {object_id}
+                    AND digest = {digest}
+                ) AS exact_rows,
+                countIf(
+                    project_id = {project_id}
+                    AND object_id = {object_id}
+                ) AS project_object_rows,
+                countIf(
+                    project_id = {project_id}
+                    AND digest = {digest}
+                ) AS project_digest_rows,
+                countIf(
+                    object_id = {object_id}
+                    AND digest = {digest}
+                ) AS object_digest_rows,
+                countIf(
+                    project_id = {project_id}
+                    AND object_id = {object_id}
+                    AND digest = {digest}
+                    AND deleted_at IS NOT NULL
+                ) AS exact_deleted_rows,
+                anyIf(project_id, object_id = {object_id} AND digest = {digest})
+                    AS example_project_for_object_digest,
+                anyIf(object_id, project_id = {project_id} AND digest = {digest})
+                    AS example_object_for_project_digest,
+                anyIf(digest, project_id = {project_id} AND object_id = {object_id})
+                    AS example_digest_for_project_object
+            FROM object_versions
+            WHERE
+                (project_id = {project_id} AND object_id = {object_id})
+                OR (project_id = {project_id} AND digest = {digest})
+                OR (object_id = {object_id} AND digest = {digest})
+        """
+        result = self._query(query, pb.get_params())
+        row = result.result_rows[0]
+        return {
+            "candidate_rows": row[0],
+            "exact_rows": row[1],
+            "project_object_rows": row[2],
+            "project_digest_rows": row[3],
+            "object_digest_rows": row[4],
+            "exact_deleted_rows": row[5],
+            "example_project_for_object_digest": row[6] or None,
+            "example_object_for_project_digest": row[7] or None,
+            "example_digest_for_project_object": row[8] or None,
+        }
+
+    def _log_obj_read_miss(
+        self,
+        req: tsi.ObjReadReq,
+        *,
+        attempt: int,
+        max_attempts: int,
+        elapsed_ms: float,
+        error: NotFoundError,
+    ) -> None:
+        try:
+            diagnostics = self._obj_read_miss_diagnostics(req)
+        except Exception as diagnostics_error:
+            diagnostics = {"diagnostics_error": str(diagnostics_error)}
+
+        will_retry = attempt < max_attempts
+        logger.info(
+            "clickhouse_obj_read_not_found "
+            "attempt=%s/%s will_retry=%s project_id=%s object_id=%s digest=%s "
+            "elapsed_ms=%s database=%s async_insert=%s flush_immediately=%s "
+            "diagnostics=%s",
+            attempt,
+            max_attempts,
+            will_retry,
+            req.project_id,
+            req.object_id,
+            req.digest,
+            elapsed_ms,
+            self._database,
+            self._use_async_insert,
+            self._flush_immediately,
+            diagnostics,
+            extra={
+                "attempt": attempt,
+                "max_attempts": max_attempts,
+                "will_retry": will_retry,
+                "project_id": req.project_id,
+                "object_id": req.object_id,
+                "digest": req.digest,
+                "elapsed_ms": elapsed_ms,
+                "database": self._database,
+                "async_insert": self._use_async_insert,
+                "flush_immediately": self._flush_immediately,
+                "diagnostics": diagnostics,
+                "error_str": str(error),
+            },
+        )
+
+    def _obj_read_once(self, req: tsi.ObjReadReq) -> tsi.ObjReadRes:
         # Check if digest is an alias name (not a hash, not version-like, not "latest")
         digest = req.digest
         resolved_digest = self._maybe_resolve_alias(
@@ -5341,11 +5449,29 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._obj_read_with_retry")
     def _obj_read_with_retry(
-        self, req: tsi.ObjReadReq, max_attempts: int = 2
+        self, req: tsi.ObjReadReq, max_attempts: int = OBJ_READ_RETRY_ATTEMPTS
     ) -> tsi.ObjReadRes:
         """Read an object with retry for ClickHouse eventual consistency."""
+        start = time.monotonic()
+        attempt = 0
+
+        def read_once() -> tsi.ObjReadRes:
+            nonlocal attempt
+            attempt += 1
+            try:
+                return self._obj_read_once(req)
+            except NotFoundError as e:
+                self._log_obj_read_miss(
+                    req,
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    elapsed_ms=round((time.monotonic() - start) * 1000, 1),
+                    error=e,
+                )
+                raise
+
         return self._read_with_retry(
-            lambda: self.obj_read(req), max_attempts=max_attempts
+            read_once, max_attempts=max_attempts
         )
 
     @ddtrace.tracer.wrap(


### PR DESCRIPTION
## Summary

Routes public ClickHouse `obj_read` through the existing NotFound retry helper, matching the recent `file_content_read` behavior. This covers read-after-write visibility races like `weave.publish(...); ref.get()` without adding sleeps or marking individual mutation tests flaky.

Also adds diagnostic logging on every ClickHouse object-read NotFound attempt. The log message includes attempt count, elapsed time, database/write settings, and near-match counts in `object_versions` so the next occurrence can distinguish stale visibility from malformed project/object/digest refs.

Original failure ([GitHub Actions job](https://github.com/wandb/weave/actions/runs/25020779169/job/73280454045?pr=6705)):
```
FAILED tests/trace/test_weave_client_mutations.py::test_table_cant_set_bad_data - weave.trace_server.errors.NotFoundError: Obj Table:acv6SFFywYc9feb1YwBbU03IZ9kJ1IdVlgBPelY4d6Q not found
```

## Testing

- `uvx ruff check weave/trace_server/clickhouse_trace_server_batched.py tests/trace_server/test_clickhouse_trace_server_batched.py`
- `uv run --group test python -m pytest tests/trace_server/test_clickhouse_trace_server_batched.py::test_obj_read_retries_eventual_consistency tests/trace_server/test_clickhouse_trace_server_batched.py::test_file_content_read_retries_eventual_consistency -q`
- `uv run --group test python -m pytest tests/trace/test_weave_client_mutations.py::test_table_cant_set_bad_data --trace-server=sqlite -q`
- `uv run --group test python -m pytest tests/trace/test_weave_client_mutations.py::test_table_cant_set_bad_data --trace-server=clickhouse -q`
- `uv run --group test python -m pytest tests/trace/test_weave_client_mutations.py --trace-server=clickhouse -q`