### PR TITLE
chore(weave_ts): npm trusted publishing

### DIFF
--- a/.github/workflows/publish_ts_sdk_npm.yaml
+++ b/.github/workflows/publish_ts_sdk_npm.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - uses: pnpm/action-setup@v4
@@ -73,7 +73,4 @@ jobs:
 
       - name: Publish to npm
         working-directory: sdks/node
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          npm publish --access public --tag "${{ inputs.npm_tag }}"
+        run: npm publish --access public --provenance --tag "${{ inputs.npm_tag }}"


### PR DESCRIPTION
## Description

This enables NPM trusted publishing from a Github action run.


## Informational
Prior steps needed on NPM side:

- Go to https://www.npmjs.com/package/weave/access (Settings → "Trusted Publisher")
- Click Add trusted publisher → GitHub Actions
- Fill in: 
    Organization or user: wandb
    Repository: the GitHub repo that hosts this workflow : "wandb/weave"
    Workflow filename: publish_ts_sdk_npm.yaml (just the basename, not the path)
    Environment name: release (matches environment.name in the workflow)

## Testing

The first successful run: https://github.com/wandb/weave/actions/runs/25024892465/job/73293692364
