### PR TITLE
fix(weave): take inputs as explicit dict

### DIFF
--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -82,7 +82,7 @@ llm_as_a_judge_scorer_digest_for_current_non_legacy_test_on_current_python = (
     "9YxDZRgBdoy8X5WEXuqYvhwTBuTtFSxKKT7ZPf9ubRA"
 )
 llm_as_a_judge_scorer_digest_for_current_non_legacy_test_on_old_python = (
-    "9YxDZRgBdoy8X5WEXuqYvhwTBuTtFSxKKT7ZPf9ubRA"
+    "hoglXaCXaJbyUlwhJClqC0S0gYzalCBrEUP62OEC8t8"
 )
 llm_as_a_judge_scorer_digest = (
     llm_as_a_judge_scorer_digest_for_current_non_legacy_test_on_current_python

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -79,10 +79,10 @@ def evaluation_equality_check(a, b):
 # When doing this, replace "llm_as_a_judge_scorer_digest" with the current value of llm_as_a_judge_scorer_digest_for_current_non_legacy_test_on_old_python
 # Do this, rather than creating a new variable, because each new version of legacy test case will need a different value.
 llm_as_a_judge_scorer_digest_for_current_non_legacy_test_on_current_python = (
-    "hoglXaCXaJbyUlwhJClqC0S0gYzalCBrEUP62OEC8t8"
+    "9YxDZRgBdoy8X5WEXuqYvhwTBuTtFSxKKT7ZPf9ubRA"
 )
 llm_as_a_judge_scorer_digest_for_current_non_legacy_test_on_old_python = (
-    "hoglXaCXaJbyUlwhJClqC0S0gYzalCBrEUP62OEC8t8"
+    "9YxDZRgBdoy8X5WEXuqYvhwTBuTtFSxKKT7ZPf9ubRA"
 )
 llm_as_a_judge_scorer_digest = (
     llm_as_a_judge_scorer_digest_for_current_non_legacy_test_on_current_python

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -4585,3 +4585,38 @@ def test_evaluate_with_llm_completion_model_and_prompt_template_vars(client):
     assert req_with_input.inputs.messages == [
         {"role": "user", "content": "Additional context"}
     ]
+
+
+def test_prepare_completion_request_template_vars_with_reserved_names(client):
+    # Regression test: template_vars used to be **kwargs on prepare_completion_request,
+    # so a template variable named "config", "project_id", or "user_input" either
+    # collided with the explicit kwarg (TypeError) or got absorbed into the wrong
+    # parameter. With the explicit-dict signature these names must round-trip
+    # untouched into req.inputs.template_vars.
+    messages_prompt = MessagesPrompt(
+        messages=[{"role": "user", "content": "{config} {project_id} {user_input}"}]
+    )
+    prompt_ref = weave.publish(messages_prompt, name="reserved_name_prompt")
+
+    model = LLMStructuredCompletionModel(
+        llm_model_id="gpt-4o-mini",
+        default_params=LLMStructuredCompletionModelDefaultParams(
+            prompt=prompt_ref.uri,
+            response_format="text",
+        ),
+    )
+
+    colliding_vars = {
+        "config": "user-supplied-config",
+        "project_id": "user-supplied-project-id",
+        "user_input": "user-supplied-user-input",
+    }
+    req = model.prepare_completion_request(
+        project_id=client.project_id,
+        user_input=[],
+        config=None,
+        template_vars=colliding_vars,
+    )
+
+    assert req.inputs.template_vars == colliding_vars
+    assert req.project_id == client.project_id

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -4537,9 +4537,11 @@ def test_evaluate_with_llm_completion_model_and_prompt_template_vars(client):
         project_id=client.project_id,
         user_input=[],
         config=None,
-        assistant_name="MathBot",
-        topic="mathematics",
-        question="What is 2+2?",
+        template_vars={
+            "assistant_name": "MathBot",
+            "topic": "mathematics",
+            "question": "What is 2+2?",
+        },
     )
 
     # Verify the request has prompt reference and template_vars
@@ -4564,9 +4566,11 @@ def test_evaluate_with_llm_completion_model_and_prompt_template_vars(client):
         project_id=client.project_id,
         user_input=[{"role": "user", "content": "Additional context"}],
         config=None,
-        assistant_name="MathBot",
-        topic="mathematics",
-        question="What is 2+2?",
+        template_vars={
+            "assistant_name": "MathBot",
+            "topic": "mathematics",
+            "question": "What is 2+2?",
+        },
     )
 
     # Should still have prompt and template_vars

--- a/weave/trace_server/interface/builtin_object_classes/llm_structured_model.py
+++ b/weave/trace_server/interface/builtin_object_classes/llm_structured_model.py
@@ -164,7 +164,7 @@ class LLMStructuredCompletionModel(Model):
             project_id=to_project_id(current_client.entity, current_client.project),
             user_input=user_input,
             config=config,
-            **template_vars,
+            template_vars=template_vars,
         )
 
         # 5. Call the LLM API
@@ -199,8 +199,12 @@ class LLMStructuredCompletionModel(Model):
         project_id: str,
         user_input: MessageListLike,
         config: LLMStructuredModelParamsLike | None,
-        **template_vars: Any,
+        template_vars: dict[str, Any] | None = None,
     ) -> CompletionsCreateReq:
+        # template_vars is a dict (not **kwargs) so that user-defined variable names
+        # like "config" or "project_id" can't collide with this method's reserved kwargs.
+        template_vars = template_vars or {}
+
         # Ensure user_input is properly converted to a list of Message objects
         # This is needed because the @op decorator might interfere with Pydantic validation
         if not isinstance(user_input, list) or (


### PR DESCRIPTION
## Description

- This PR resolves this [issue](https://us5.datadoghq.com/apm/traces?query=%28resource_name%3Ascoring_worker.score_call%20status%3Aerror%20env%3A%28prod%20OR%20managed-install%29%20-customer-ns%3A%2Atest%2A%20-customer-ns%3A%2Aperf-int%2A%20-customer-ns%3A%2Aqa%2A%20-customer-ns%3A%2Awandbench%2A%20-customer-ns%3A%2Aaravind%2A%20-customer-ns%3A%2Afe-crew%2A%20-customer-ns%3A%2Adaniel%2A%29%20AND%20%40error.message%3A%22weave.trace_server.interface.builtin_object_classes.llm_structured_model.LLMStructuredCompletionModel.prepare_completion_request%28%29%20got%20multiple%20values%20for%20keyword%20argument%20%27config%27%22&agg_m=count&agg_m_source=base&agg_t=count&cols=service%2Cresource_name%2C%40duration%2C%40http.method%2C%40http.status_code%2C%40_span.count%2C%40_duration.by_service&fromUser=false&historicalData=true&messageDisplay=inline&sort=desc&spanType=all&storage=hot&view=spans&start=1774655385530&end=1777333785530&paused=true)

tldr;
users could input 'config' into their llm inputs and that would conflict with the functions signature.
fix is just to not use **kwargs for this and encapsulating into a dict instead.


## Testing

- Unit tests
