### PR TITLE
chore(weave): retry transient empty table pages

### DIFF
--- a/tests/trace/test_table_query.py
+++ b/tests/trace/test_table_query.py
@@ -1,4 +1,6 @@
+import logging
 import random
+import time
 from collections.abc import Iterator
 
 import pytest
@@ -11,6 +13,24 @@ from weave.trace.refs import TableRef
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
+
+TABLE_QUERY_VISIBILITY_MAX_ATTEMPTS = 3
+TABLE_QUERY_VISIBILITY_RETRY_DELAY_SECONDS = 0.25
+
+
+def wait_for_table_query_rows(
+    client: WeaveClient, digest: str, expected_count: int
+) -> None:
+    if expected_count == 0 or client_is_sqlite(client):
+        return
+
+    req = tsi.TableQueryReq(project_id=client.project_id, digest=digest)
+    for attempt in range(TABLE_QUERY_VISIBILITY_MAX_ATTEMPTS):
+        res = client.server.table_query(req)
+        if len(res.rows) == expected_count:
+            return
+        if attempt < TABLE_QUERY_VISIBILITY_MAX_ATTEMPTS - 1:
+            time.sleep(TABLE_QUERY_VISIBILITY_RETRY_DELAY_SECONDS)
 
 
 def generate_table_data(client: WeaveClient, n_rows: int, n_cols: int):
@@ -43,6 +63,7 @@ def generate_table_data(client: WeaveClient, n_rows: int, n_cols: int):
     )
     digest = res.digest
     row_digests = res.row_digests
+    wait_for_table_query_rows(client, digest, len(data))
 
     return digest, row_digests, data
 
@@ -59,8 +80,10 @@ class _FakeTableQueryServer:
 
 def test_weave_table_retries_empty_page_when_table_is_known_non_empty(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     monkeypatch.setattr(vals, "REMOTE_ITER_EMPTY_PAGE_RETRY_DELAY_SECONDS", 0)
+    caplog.set_level(logging.WARNING, logger=vals.logger.name)
 
     empty_response = tsi.TableQueryRes(rows=[])
     row_response = tsi.TableQueryRes(
@@ -104,6 +127,25 @@ def test_weave_table_retries_empty_page_when_table_is_known_non_empty(
     assert [request.offset for request in server.requests] == [0, 0]
     assert rows[0]["value"] == 1
 
+    # Empty filters are still unfiltered, so known non-empty metadata can retry.
+    server = _FakeTableQueryServer([empty_response, row_response])
+    table = vals.WeaveTable(
+        server=server,
+        table_ref=TableRef(
+            entity="entity",
+            project="project",
+            _digest="table-digest",
+            _row_digests=["row-1"],
+        ),
+        filter=tsi.TableRowFilter(row_digests=None),
+    )
+
+    rows = list(table.rows)
+
+    assert len(server.requests) == 2
+    assert [request.offset for request in server.requests] == [0, 0]
+    assert rows[0]["value"] == 1
+
     # Repeated empty pages stop at the retry cap and preserve the empty result.
     server = _FakeTableQueryServer([empty_response])
     table = vals.WeaveTable(
@@ -118,8 +160,9 @@ def test_weave_table_retries_empty_page_when_table_is_known_non_empty(
 
     assert list(table.rows) == []
     assert len(server.requests) == vals.REMOTE_ITER_EMPTY_PAGE_MAX_ATTEMPTS
+    assert "known non-empty table after retries" in caplog.text
 
-    # True empty tables, unknown row digests, and filtered-empty queries do not retry.
+    # True empty tables, unknown row digests, and active filtered queries do not retry.
     no_retry_cases = [
         (
             TableRef(
@@ -439,6 +482,7 @@ def generate_duplication_simple_table_data(
     )
     digest = res.digest
     row_digests = res.row_digests
+    wait_for_table_query_rows(client, digest, len(data))
 
     return {"digest": digest, "row_digests": row_digests, "data": data}
 

--- a/tests/trace/test_table_query.py
+++ b/tests/trace/test_table_query.py
@@ -6,6 +6,8 @@ import pytest
 from tests.trace.util import (
     client_is_sqlite,
 )
+from weave.trace import vals
+from weave.trace.refs import TableRef
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
@@ -43,6 +45,120 @@ def generate_table_data(client: WeaveClient, n_rows: int, n_cols: int):
     row_digests = res.row_digests
 
     return digest, row_digests, data
+
+
+class _FakeTableQueryServer:
+    def __init__(self, responses: list[tsi.TableQueryRes]) -> None:
+        self.responses = responses
+        self.requests: list[tsi.TableQueryReq] = []
+
+    def table_query(self, req: tsi.TableQueryReq) -> tsi.TableQueryRes:
+        self.requests.append(req)
+        return self.responses[min(len(self.requests) - 1, len(self.responses) - 1)]
+
+
+def test_weave_table_retries_empty_page_when_table_is_known_non_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(vals, "REMOTE_ITER_EMPTY_PAGE_RETRY_DELAY_SECONDS", 0)
+
+    empty_response = tsi.TableQueryRes(rows=[])
+    row_response = tsi.TableQueryRes(
+        rows=[tsi.TableRowSchema(digest="row-1", val={"value": 1}, original_index=0)]
+    )
+
+    # Known non-empty table: an empty first page is inconsistent, so retry.
+    server = _FakeTableQueryServer([empty_response, row_response])
+    table = vals.WeaveTable(
+        server=server,
+        table_ref=TableRef(
+            entity="entity",
+            project="project",
+            _digest="table-digest",
+            _row_digests=["row-1"],
+        ),
+    )
+
+    rows = list(table.rows)
+
+    assert len(server.requests) == 2
+    assert [request.offset for request in server.requests] == [0, 0]
+    assert rows[0]["value"] == 1
+
+    # A known length from a prior stats call also proves an empty page is inconsistent.
+    server = _FakeTableQueryServer([empty_response, row_response])
+    table = vals.WeaveTable(
+        server=server,
+        table_ref=TableRef(
+            entity="entity",
+            project="project",
+            _digest="table-digest",
+            _row_digests=None,
+        ),
+    )
+    table._known_length = 1
+
+    rows = list(table.rows)
+
+    assert len(server.requests) == 2
+    assert [request.offset for request in server.requests] == [0, 0]
+    assert rows[0]["value"] == 1
+
+    # Repeated empty pages stop at the retry cap and preserve the empty result.
+    server = _FakeTableQueryServer([empty_response])
+    table = vals.WeaveTable(
+        server=server,
+        table_ref=TableRef(
+            entity="entity",
+            project="project",
+            _digest="table-digest",
+            _row_digests=["row-1"],
+        ),
+    )
+
+    assert list(table.rows) == []
+    assert len(server.requests) == vals.REMOTE_ITER_EMPTY_PAGE_MAX_ATTEMPTS
+
+    # True empty tables, unknown row digests, and filtered-empty queries do not retry.
+    no_retry_cases = [
+        (
+            TableRef(
+                entity="entity",
+                project="project",
+                _digest="empty-table-digest",
+                _row_digests=[],
+            ),
+            None,
+        ),
+        (
+            TableRef(
+                entity="entity",
+                project="project",
+                _digest="unknown-table-digest",
+                _row_digests=None,
+            ),
+            None,
+        ),
+        (
+            TableRef(
+                entity="entity",
+                project="project",
+                _digest="filtered-table-digest",
+                _row_digests=["row-1"],
+            ),
+            tsi.TableRowFilter(row_digests=["missing-row"]),
+        ),
+    ]
+    for table_ref, table_filter in no_retry_cases:
+        server = _FakeTableQueryServer([empty_response])
+        table = vals.WeaveTable(
+            server=server,
+            table_ref=table_ref,
+            filter=table_filter,
+        )
+
+        assert list(table.rows) == []
+        assert len(server.requests) == 1
 
 
 def test_table_query(client: WeaveClient):

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -2,6 +2,7 @@ import dataclasses
 import inspect
 import logging
 import operator
+import time
 from collections.abc import Callable, Generator, Iterator, Sequence
 from copy import deepcopy
 from typing import Any, Literal, Optional, SupportsIndex, cast
@@ -29,6 +30,7 @@ from weave.trace_server.errors import ObjectDeletedError
 from weave.trace_server.trace_server_interface import (
     ObjReadReq,
     TableQueryReq,
+    TableQueryRes,
     TableQueryStatsReq,
     TableRowFilter,
     TraceServerInterface,
@@ -39,6 +41,8 @@ from weave.utils.project_id import to_project_id
 logger = logging.getLogger(__name__)
 
 REMOTE_ITER_PAGE_SIZE = 100
+REMOTE_ITER_EMPTY_PAGE_MAX_ATTEMPTS = 3
+REMOTE_ITER_EMPTY_PAGE_RETRY_DELAY_SECONDS = 0.25
 
 
 class InternalError(Exception): ...
@@ -480,6 +484,66 @@ class WeaveTable(Traceable):  # noqa: PLW1641
             res = make_trace_obj(res, new_ref, self.server, self.root)
             yield res
 
+    def _known_remote_row_count(self) -> int | None:
+        if self._known_length is not None:
+            return self._known_length
+
+        if self.table_ref is None:
+            return None
+
+        row_digests = self.table_ref._row_digests
+        if isinstance(row_digests, list):
+            return len(row_digests)
+
+        return None
+
+    def _should_retry_empty_page(
+        self, response: TableQueryRes, offset: int
+    ) -> bool:
+        if response.rows:
+            return False
+        if self.filter is not None and self.filter.row_digests is not None:
+            return False
+
+        known_row_count = self._known_remote_row_count()
+        if known_row_count is None:
+            return False
+
+        return offset < known_row_count
+
+    def _remote_query_page(self, page_index: int, page_size: int) -> TableQueryRes:
+        if self.table_ref is None:
+            raise ValueError("Cannot query remote page of table without table ref")
+
+        offset = page_index * page_size
+        max_attempts = max(1, REMOTE_ITER_EMPTY_PAGE_MAX_ATTEMPTS)
+
+        for attempt in range(max_attempts):
+            response = self.server.table_query(
+                TableQueryReq(
+                    project_id=self.table_ref.project_id,
+                    digest=self.table_ref.digest,
+                    offset=offset,
+                    limit=page_size,
+                    filter=self.filter,
+                )
+            )
+
+            if not self._should_retry_empty_page(response, offset):
+                return response
+
+            if attempt == max_attempts - 1:
+                return response
+
+            logger.debug(
+                "Retrying empty table page for non-empty table ref %s",
+                self.table_ref.uri,
+            )
+            if REMOTE_ITER_EMPTY_PAGE_RETRY_DELAY_SECONDS > 0:
+                time.sleep(REMOTE_ITER_EMPTY_PAGE_RETRY_DELAY_SECONDS)
+
+        raise InternalError("unreachable")
+
     def _remote_iter(self) -> Generator[dict, None, None]:
         if self.table_ref is None:
             return
@@ -491,15 +555,7 @@ class WeaveTable(Traceable):  # noqa: PLW1641
         page_index = 0
         page_size = REMOTE_ITER_PAGE_SIZE
         while True:
-            response = self.server.table_query(
-                TableQueryReq(
-                    project_id=self.table_ref.project_id,
-                    digest=self.table_ref.digest,
-                    offset=page_index * page_size,
-                    limit=page_size,
-                    filter=self.filter,
-                )
-            )
+            response = self._remote_query_page(page_index, page_size)
 
             # When paginating through large datasets, we need special handling for prefetched rows
             # on the first page. This is because prefetched_rows contains ALL rows, while each

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -485,6 +485,7 @@ class WeaveTable(Traceable):  # noqa: PLW1641
             yield res
 
     def _known_unfiltered_remote_row_count(self) -> int | None:
+        """Return independent proof of unfiltered table size, if already known."""
         if self._known_length is not None:
             return self._known_length
 
@@ -498,11 +499,20 @@ class WeaveTable(Traceable):  # noqa: PLW1641
         return None
 
     def _has_active_filter(self) -> bool:
+        # Empty TableRowFilter() is used as the unfiltered default. Only populated
+        # fields actually narrow the rows, and base table size does not prove that
+        # an active filter should match anything.
         return (
             self.filter is not None and self.filter.model_dump(exclude_none=True) != {}
         )
 
     def _should_retry_empty_page(self, response: TableQueryRes, offset: int) -> bool:
+        """Retry when an empty page contradicts known unfiltered table metadata.
+
+        This is a narrow client-side guard for ClickHouse read-after-write
+        visibility. A genuinely empty table, unknown table size, or filtered query
+        can all validly return an empty page and should not be retried here.
+        """
         if response.rows:
             return False
         if self._has_active_filter():
@@ -536,6 +546,8 @@ class WeaveTable(Traceable):  # noqa: PLW1641
                 return response
 
             if attempt == max_attempts - 1:
+                # Keep the historical behavior of returning the server result, but
+                # make the consistency failure visible for debugging.
                 logger.warning(
                     "Table query returned an empty page for a known non-empty "
                     "table after retries: digest=%s offset=%s "

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -484,7 +484,7 @@ class WeaveTable(Traceable):  # noqa: PLW1641
             res = make_trace_obj(res, new_ref, self.server, self.root)
             yield res
 
-    def _known_remote_row_count(self) -> int | None:
+    def _known_unfiltered_remote_row_count(self) -> int | None:
         if self._known_length is not None:
             return self._known_length
 
@@ -497,15 +497,18 @@ class WeaveTable(Traceable):  # noqa: PLW1641
 
         return None
 
-    def _should_retry_empty_page(
-        self, response: TableQueryRes, offset: int
-    ) -> bool:
+    def _has_active_filter(self) -> bool:
+        return (
+            self.filter is not None and self.filter.model_dump(exclude_none=True) != {}
+        )
+
+    def _should_retry_empty_page(self, response: TableQueryRes, offset: int) -> bool:
         if response.rows:
             return False
-        if self.filter is not None and self.filter.row_digests is not None:
+        if self._has_active_filter():
             return False
 
-        known_row_count = self._known_remote_row_count()
+        known_row_count = self._known_unfiltered_remote_row_count()
         if known_row_count is None:
             return False
 
@@ -533,6 +536,16 @@ class WeaveTable(Traceable):  # noqa: PLW1641
                 return response
 
             if attempt == max_attempts - 1:
+                logger.warning(
+                    "Table query returned an empty page for a known non-empty "
+                    "table after retries: digest=%s offset=%s "
+                    "known_row_count=%s attempts=%s filter=%s",
+                    self.table_ref.digest,
+                    offset,
+                    self._known_unfiltered_remote_row_count(),
+                    max_attempts,
+                    self.filter,
+                )
                 return response
 
             logger.debug(


### PR DESCRIPTION
## Summary

Retries an empty table query page only when the client already knows the unfiltered table should contain rows, either from row digests or a known length. This covers the evaluation flake where a successful empty table page made a non-empty evaluation summarize to `{}` while preserving valid empty-table, unknown-metadata, and active filtered queries.

Also adds a test-side visibility wait after `table_create` for direct `client.server.table_query` tests, which bypass the `WeaveTable` retry path but showed the same ClickHouse read-after-write shape on master.

Original evaluation failure (https://github.com/wandb/weave/actions/runs/25023574403/job/73289572907):
```
tests/trace/test_evaluate.py::test_evaluation_from_weaveobject_missing_evaluation_name returned {} instead of output/score/model_latency summary
```

Related master failure (https://github.com/wandb/weave/actions/runs/25027039134/job/73300346597):
```
tests/trace/test_table_query.py::test_table_query_sort_by_column returned [] after table_create
```

## Testing

- `uvx ruff format weave/trace/vals.py tests/trace/test_table_query.py`
- `uvx ruff check weave/trace/vals.py tests/trace/test_table_query.py`
- `git diff --check`
- `uv run --group test python -m pytest tests/trace/test_table_query.py::test_weave_table_retries_empty_page_when_table_is_known_non_empty -q`
- `uv run --group test python -m pytest tests/trace/test_table_query.py::test_table_query_sort_by_column -q --trace-server=sqlite`
- `uv run --group test python -m pytest tests/trace/test_table_query.py::test_table_query_sort_by_column -q --trace-server=clickhouse`
- `uv run --group test python -m pytest tests/trace/test_evaluate.py::test_evaluation_from_weaveobject_missing_evaluation_name -q --trace-server=sqlite`
- `uv run --group test python -m pytest tests/trace/test_evaluate.py::test_evaluation_from_weaveobject_missing_evaluation_name -q --trace-server=clickhouse`
