### PR TITLE
chore(weave): fix flaky dataset rows ref

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -280,6 +280,10 @@ class TestOnlyFlushingWeaveClient(weave_client.WeaveClient):
     read operation(s) are performed.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.server = TestOnlyFlushingTraceServer(self, self.server)
+
     def set_autoflush(self, value: bool):
         self._autoflush = value
 
@@ -290,14 +294,82 @@ class TestOnlyFlushingWeaveClient(weave_client.WeaveClient):
         if callable(attr) and name != "flush":
 
             def wrapper(*args, **kwargs):
-                res = attr(*args, **kwargs)
-                if self.__dict__.get("_autoflush", True):
-                    self_super._flush()
-                return res
+                try:
+                    return attr(*args, **kwargs)
+                finally:
+                    # Failed test-client methods can still enqueue background
+                    # writes before raising. Drain them so the next test's
+                    # ClickHouse reset cannot race leaked work from this test.
+                    if self.__dict__.get("_autoflush", True):
+                        self_super._flush()
 
             return wrapper
 
         return attr
+
+    def _flush_for_teardown(self) -> None:
+        """Flush without going through __getattribute__'s autoflush wrapper."""
+        super()._flush()
+
+
+def _flush_test_client_for_teardown(client: weave_client.WeaveClient) -> None:
+    if isinstance(client, TestOnlyFlushingWeaveClient):
+        TestOnlyFlushingWeaveClient._flush_for_teardown(client)
+    else:
+        client._flush()
+
+
+class TestOnlyFlushingTraceServer:
+    """Flush a test client around direct client.server method calls.
+
+    Tests often bypass WeaveClient methods and call client.server.* directly.
+    Those calls still need the same flush barrier as client methods before they
+    read state written through the client's background executors.
+    """
+
+    def __init__(
+        self,
+        client: TestOnlyFlushingWeaveClient,
+        server: tsi.TraceServerInterface,
+    ) -> None:
+        object.__setattr__(self, "_client", client)
+        object.__setattr__(self, "_server", server)
+
+    def __setattr__(self, name, value):
+        if name.startswith("_"):
+            object.__setattr__(self, name, value)
+        else:
+            setattr(self._server, name, value)
+
+    def __delattr__(self, name):
+        if name.startswith("_"):
+            object.__delattr__(self, name)
+        else:
+            delattr(self._server, name)
+
+    def __getattr__(self, name):
+        attr = getattr(self._server, name)
+        if name.startswith("_") or not callable(attr):
+            return attr
+
+        def wrapper(*args, **kwargs):
+            self._flush_client_if_safe()
+            try:
+                return attr(*args, **kwargs)
+            finally:
+                self._flush_client_if_safe()
+
+        return wrapper
+
+    def _flush_client_if_safe(self) -> None:
+        client = self._client
+        if not client.__dict__.get("_autoflush", True):
+            return
+        for executor_name in ("future_executor", "future_executor_fastlane"):
+            executor = client.__dict__.get(executor_name)
+            if executor is not None and executor._in_thread_context.get():
+                return
+        weave_client.WeaveClient._flush(client)
 
 
 def make_server_recorder(server: tsi.TraceServerInterface):  # type: ignore
@@ -393,11 +465,14 @@ def client(zero_stack, request, trace_server, caching_client_isolation):
     try:
         yield client
     finally:
-        weave_client_context.set_weave_client_global(None)
         try:
-            client.server.close()
-        except Exception:
-            pass
+            _flush_test_client_for_teardown(client)
+        finally:
+            weave_client_context.set_weave_client_global(None)
+            try:
+                client.server.close()
+            except Exception:
+                pass
 
 
 @pytest.fixture
@@ -431,17 +506,20 @@ def client_creator(zero_stack, request, trace_server, caching_client_isolation):
         try:
             yield client
         finally:
-            weave_client_context.set_weave_client_global(None)
-            weave.trace.settings.parse_and_apply_settings(
-                weave.trace.settings.UserSettings()
-            )
-            # Only close the caching layer, not the underlying trace_server.
-            # The trace_server is shared across multiple clients within this
-            # fixture and will be cleaned up by its own fixture teardown.
             try:
-                client.server._cache.close()
-            except Exception:
-                pass
+                _flush_test_client_for_teardown(client)
+            finally:
+                weave_client_context.set_weave_client_global(None)
+                weave.trace.settings.parse_and_apply_settings(
+                    weave.trace.settings.UserSettings()
+                )
+                # Only close the caching layer, not the underlying trace_server.
+                # The trace_server is shared across multiple clients within this
+                # fixture and will be cleaned up by its own fixture teardown.
+                try:
+                    client.server._cache.close()
+                except Exception:
+                    pass
 
     return client
 

--- a/tests/integrations/openai/openai_test.py
+++ b/tests/integrations/openai/openai_test.py
@@ -1,12 +1,19 @@
 import os
 from collections.abc import Generator
 
+import httpx
 import pytest
 from openai import AsyncOpenAI, OpenAI
+from openai._legacy_response import LegacyAPIResponse
+from openai._models import FinalRequestOptions
+from openai.types.chat import ChatCompletion
 
 import weave
 from weave.integrations.integration_utilities import op_name_from_ref
-from weave.integrations.openai.openai_sdk import get_openai_patcher
+from weave.integrations.openai.openai_sdk import (
+    get_openai_patcher,
+    maybe_unwrap_api_response,
+)
 from weave.trace.weave_client import WeaveClient
 
 model = "gpt-4o"
@@ -19,6 +26,50 @@ def patch_openai() -> Generator[None, None, None]:
     patcher.attempt_patch()
     yield
     patcher.undo_patch()
+
+
+def _unread_chat_completion_response() -> LegacyAPIResponse[ChatCompletion]:
+    body = (
+        b'{"id":"chatcmpl-test","object":"chat.completion","created":1,'
+        b'"model":"gpt-4o-mini","choices":[{"index":0,"message":'
+        b'{"role":"assistant","content":"hi"},"finish_reason":"stop"}]}'
+    )
+    response = httpx.Response(
+        200,
+        headers={"content-type": "application/json"},
+        stream=httpx.ByteStream(body),
+        request=httpx.Request(
+            "POST",
+            "https://api.openai.com/v1/chat/completions",
+        ),
+    )
+    return LegacyAPIResponse(
+        raw=response,
+        cast_to=ChatCompletion,
+        client=OpenAI(api_key="sk-test"),
+        stream=False,
+        stream_cls=None,
+        options=FinalRequestOptions.construct(
+            method="post",
+            url="/chat/completions",
+        ),
+        retries_taken=0,
+    )
+
+
+def test_maybe_unwrap_api_response_reads_unread_raw_response() -> None:
+    with pytest.raises(httpx.ResponseNotRead):
+        _unread_chat_completion_response().parse()
+
+    raw_response = _unread_chat_completion_response()
+    parsed_for_trace = maybe_unwrap_api_response(raw_response)
+
+    assert isinstance(parsed_for_trace, ChatCompletion)
+    assert parsed_for_trace.choices[0].message.content == "hi"
+
+    # The same raw response is returned to raw-response callers after tracing.
+    parsed_for_caller = raw_response.parse()
+    assert parsed_for_caller.choices[0].message.content == "hi"
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1041,31 +1041,14 @@ def test_trace_call_query_timings(client, no_autoflush):
 
     num_calls = 100
 
-    # Create calls with controlled timing - mock only datetime.datetime.now()
-    call_index = 0
-
-    def mock_now(*args, **kwargs):
-        nonlocal call_index
-        # Each create_call increments the index once at the start
-        # Return the appropriate time based on which call we're processing
-        if call_index <= num_calls - 3:  # calls 0-97 get 'now'
-            return now
-        elif call_index == num_calls - 2:  # call 98 gets 'later'
-            return later
+    for i in range(num_calls):
+        if i <= num_calls - 3:  # calls 0-97 get 'now'
+            started_at = now
+        elif i == num_calls - 2:  # call 98 gets 'later'
+            started_at = later
         else:  # call 99 gets 'even_later'
-            return even_later
-
-    with mock.patch(
-        "weave.trace.weave_client.datetime.datetime"
-    ) as mock_datetime_class:
-        # Mock only the .now() method, keep everything else as-is
-        mock_datetime_class.now = mock.Mock(side_effect=mock_now)
-        # Preserve other datetime functionality
-        mock_datetime_class.side_effect = datetime.datetime
-
-        for i in range(num_calls):
-            call_index = i
-            client.create_call("y", {"a": i})
+            started_at = even_later
+        client.create_call("y", {"a": i}, started_at=started_at)
     client.flush()
 
     def query_server():

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -5,6 +5,7 @@ import re
 import sys
 import time
 import uuid
+from unittest import mock
 
 import httpx
 import pydantic
@@ -14,7 +15,7 @@ from pydantic import ValidationError
 import weave
 import weave.trace.call
 import weave.trace_server.trace_server_interface as tsi
-from tests.conftest import TestOnlyFlushingWeaveClient
+from tests.conftest import TestOnlyFlushingWeaveClient, _flush_test_client_for_teardown
 from tests.trace.server_utils import find_server_layer
 from tests.trace.testutil import ObjectRefStrMatcher
 from tests.trace.util import (
@@ -2275,6 +2276,48 @@ def test_repeated_flushing(client):
     # make sure there are no pending jobs
     assert client._get_pending_jobs()["total_jobs"] == 0
     assert client._has_pending_jobs() == False
+
+
+def test_test_client_autoflushes_when_wrapped_method_raises(client, monkeypatch):
+    flush_calls = 0
+
+    def fake_flush(_self):
+        nonlocal flush_calls
+        flush_calls += 1
+
+    def fail_after_enqueue_point():
+        raise RuntimeError("intentional test failure")
+
+    monkeypatch.setattr(weave_client.WeaveClient, "_flush", fake_flush)
+    client.fail_after_enqueue_point = fail_after_enqueue_point
+
+    with pytest.raises(RuntimeError, match="intentional test failure"):
+        client.fail_after_enqueue_point()
+
+    assert flush_calls == 1
+
+    _flush_test_client_for_teardown(client)
+
+    assert flush_calls == 2
+
+
+def test_test_client_autoflushes_direct_server_calls(client, monkeypatch):
+    flush_calls = 0
+
+    def fake_flush(_self):
+        nonlocal flush_calls
+        flush_calls += 1
+
+    with monkeypatch.context() as m:
+        m.setattr(weave_client.WeaveClient, "_flush", fake_flush)
+        client.server.objs_query(tsi.ObjQueryReq(project_id=client.project_id))
+
+    assert flush_calls == 2
+
+
+def test_test_client_server_proxy_supports_patch_object(client):
+    with mock.patch.object(client.server, "refs_read_batch"):
+        pass
 
 
 def test_calls_query_filter_by_strings(client):

--- a/tests/trace/util.py
+++ b/tests/trace/util.py
@@ -111,16 +111,21 @@ def get_info_loglines(
 def capture_output(callbacks: list[Callable[[], None]]):
     captured_logs = io.StringIO()
 
-    # Store original stdout and logging handlers
-    old_handlers = logging.getLogger().handlers[:]
+    weave_logger = logging.getLogger("weave")
+    old_handlers = weave_logger.handlers[:]
+    old_level = weave_logger.level
+    old_propagate = weave_logger.propagate
 
-    # Create a new handler for capturing logs
     log_handler = logging.StreamHandler(captured_logs)
     log_handler.setFormatter(logging.Formatter("%(message)s"))
 
-    # Replace stdout and logging handlers
-    root_logger = logging.getLogger()
-    root_logger.handlers = [log_handler]
+    # Capture the logger Weave actually emits user-facing links through.
+    # Replacing only root handlers is import-order dependent because
+    # configure_logger() installs a handler directly on the "weave" logger.
+    weave_logger.handlers = [log_handler]
+    weave_logger.propagate = False
+    if weave_logger.getEffectiveLevel() > logging.INFO:
+        weave_logger.setLevel(logging.INFO)
 
     try:
         yield captured_logs
@@ -129,7 +134,9 @@ def capture_output(callbacks: list[Callable[[], None]]):
     finally:
         for callback in callbacks:
             callback()
-        root_logger.handlers = old_handlers
+        weave_logger.handlers = old_handlers
+        weave_logger.setLevel(old_level)
+        weave_logger.propagate = old_propagate
 
 
 def flushing_callback(client):

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -152,7 +152,7 @@ def _discover_truncatable_tables(ch_client, database: str) -> list[str]:
 def _truncate_all_tables(ch_client, database: str, tables: list[str]) -> None:
     """Truncate all data tables in the database for test isolation."""
     for table in tables:
-        ch_client.command(f"TRUNCATE TABLE {database}.{table}")
+        ch_client.command(f"TRUNCATE TABLE {database}.{table} SYNC")
 
 
 def _reset_server_state(server: ClickHouseTraceServer) -> None:

--- a/tests/trace_server/test_clickhouse_connect_streaming.py
+++ b/tests/trace_server/test_clickhouse_connect_streaming.py
@@ -1,0 +1,148 @@
+from collections import deque
+from typing import Any
+
+from clickhouse_connect.driver.exceptions import StreamCompleteException
+from clickhouse_connect.driver.httpclient import HttpClient
+from clickhouse_connect.driver.query import QueryContext, QueryResult
+from clickhouse_connect.driver.transform import NativeTransform
+from clickhouse_connect.driver.types import ByteSource
+
+
+class _DummyHTTPResponse:
+    def __init__(self) -> None:
+        self.headers: dict[str, str] = {}
+
+
+class _RecordingTransform:
+    def parse_response(self, byte_source: Any, context: QueryContext) -> QueryResult:
+        return QueryResult([])
+
+
+class _RecordingHttpClient:
+    database = None
+    protocol_version = None
+    compression = False
+    _send_comp_setting = False
+    form_encode_query_params = False
+    query_retries = 0
+    _rename_response_column = None
+    _transform = _RecordingTransform()
+
+    def __init__(self) -> None:
+        self.server_wait_values: list[bool] = []
+
+    def _validate_settings(self, settings: dict[str, Any]) -> dict[str, Any]:
+        return {}
+
+    def _prep_query(self, context: QueryContext) -> str | bytes:
+        return context.final_query
+
+    def _raw_request(
+        self,
+        data: str | bytes,
+        params: dict[str, str],
+        headers: dict[str, Any],
+        *,
+        stream: bool,
+        retries: int,
+        fields: dict[str, tuple] | None,
+        server_wait: bool,
+    ) -> _DummyHTTPResponse:
+        self.server_wait_values.append(server_wait)
+        return _DummyHTTPResponse()
+
+    def _check_tz_change(self, timezone: str | None) -> None:
+        return None
+
+    def _summary(self, response: _DummyHTTPResponse) -> dict[str, Any]:
+        return {}
+
+
+class _ScriptedNativeSource(ByteSource):
+    def __init__(
+        self,
+        leb128_values: list[int] | None = None,
+        strings: list[str] | None = None,
+    ) -> None:
+        self._leb128_values = deque(leb128_values or [])
+        self._strings = deque(strings or [])
+        self.last_message = b""
+        self.closed = False
+
+    def read_leb128(self) -> int:
+        if not self._leb128_values:
+            raise StreamCompleteException
+        return self._leb128_values.popleft()
+
+    def read_leb128_str(self) -> str:
+        if not self._strings:
+            raise StreamCompleteException
+        return self._strings.popleft()
+
+    def read_uint64(self) -> int:
+        raise AssertionError("unexpected uint64 read")
+
+    def read_bytes(self, sz: int) -> bytes:
+        raise AssertionError("unexpected bytes read")
+
+    def read_str_col(
+        self,
+        num_rows: int,
+        encoding: str,
+        nullable: bool = False,
+        null_obj: Any = None,
+    ) -> list[str]:
+        raise AssertionError("unexpected string column read")
+
+    def read_bytes_col(self, sz: int, num_rows: int) -> list[bytes]:
+        raise AssertionError("unexpected bytes column read")
+
+    def read_fixed_str_col(self, sz: int, num_rows: int, encoding: str) -> list[str]:
+        raise AssertionError("unexpected fixed string column read")
+
+    def read_array(self, array_type: str, num_rows: int) -> list[Any]:
+        raise AssertionError("unexpected array read")
+
+    def read_byte(self) -> int:
+        raise AssertionError("unexpected byte read")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_clickhouse_connect_streaming_controls_http_response_buffering() -> None:
+    client = _RecordingHttpClient()
+
+    # Normal query requests a server-side response boundary.
+    HttpClient._query_with_context(
+        client,
+        QueryContext(query="SELECT 1", streaming=False),
+    )
+
+    # Row streaming disables that boundary.
+    HttpClient._query_with_context(
+        client,
+        QueryContext(query="SELECT 1", streaming=True),
+    )
+
+    assert client.server_wait_values == [True, False]
+
+
+def test_clickhouse_connect_native_parser_empty_result_boundaries() -> None:
+    # EOF before the first Native block becomes an empty result with no schema.
+    eof_result = NativeTransform.parse_response(_ScriptedNativeSource())
+    assert eof_result.result_rows == []
+    assert eof_result.column_names == ()
+
+    # A valid zero-row Native block is also row-empty, but it preserves schema.
+    zero_row_result = NativeTransform.parse_response(
+        _ScriptedNativeSource(
+            leb128_values=[1, 0],
+            strings=["digest", "String"],
+        )
+    )
+    assert zero_row_result.result_rows == []
+    assert zero_row_result.column_names == ("digest",)
+    assert [column_type.name for column_type in zero_row_result.column_types] == [
+        "String"
+    ]

--- a/tests/trace_server/test_clickhouse_read_after_write_probe.py
+++ b/tests/trace_server/test_clickhouse_read_after_write_probe.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import concurrent.futures
+import datetime
 import os
+import threading
 import time
 import uuid
 from collections import Counter
+from types import SimpleNamespace
 from typing import Any
 
 import clickhouse_connect
 import pytest
+
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 
 PROBE_ENV_VAR = "WEAVE_CLICKHOUSE_READ_AFTER_WRITE_PROBE"
 
@@ -132,6 +137,59 @@ def _has_query_log_evidence(
         ):
             return True
     return False
+
+
+def test_select_obj_exact_digest_requires_value_row() -> None:
+    created_at = datetime.datetime.now(datetime.UTC)
+    metadata_row = (
+        "project",
+        "obj",
+        created_at,
+        [],
+        "object",
+        None,
+        None,
+        "digest",
+        None,
+        None,
+    )
+    first_seen_row = ("obj", "digest", created_at)
+
+    def select_with_value_rows(value_rows: list[tuple[str, str, str]]) -> list[Any]:
+        server = object.__new__(ClickHouseTraceServer)
+        server._thread_local = threading.local()
+        server._call_batch = []
+        server._calls_complete_batch = []
+        server._file_batch = []
+        server._flush_immediately = True
+        server._init_lock = threading.Lock()
+        server._kafka_producer = None
+        responses = iter(
+            [
+                SimpleNamespace(result_rows=[metadata_row]),
+                SimpleNamespace(result_rows=[first_seen_row]),
+                SimpleNamespace(result_rows=value_rows),
+            ]
+        )
+
+        def fake_query(*args: Any, **kwargs: Any) -> Any:
+            return next(responses)
+
+        server._query = fake_query
+        return server._select_obj_exact_digest(
+            "project",
+            "obj",
+            "digest",
+            metadata_only=False,
+        )
+
+    # Missing value rows are incomplete reads, not empty objects.
+    assert select_with_value_rows([]) == []
+
+    # Present value rows are attached normally.
+    objs = select_with_value_rows([("obj", "digest", '{"rows":[{"a":5,"b":6}]}')])
+    assert len(objs) == 1
+    assert objs[0].val_dump == '{"rows":[{"a":5,"b":6}]}'
 
 
 @pytest.mark.skipif(

--- a/tests/trace_server/test_clickhouse_read_after_write_probe.py
+++ b/tests/trace_server/test_clickhouse_read_after_write_probe.py
@@ -140,7 +140,7 @@ def _has_query_log_evidence(
 
 
 def test_select_obj_exact_digest_requires_value_row() -> None:
-    created_at = datetime.datetime.now(datetime.UTC)
+    created_at = datetime.datetime.now(datetime.timezone.utc)
     metadata_row = (
         "project",
         "obj",

--- a/tests/trace_server/test_clickhouse_read_after_write_probe.py
+++ b/tests/trace_server/test_clickhouse_read_after_write_probe.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import concurrent.futures
+import os
+import time
+import uuid
+from collections import Counter
+from typing import Any
+
+import clickhouse_connect
+import pytest
+
+PROBE_ENV_VAR = "WEAVE_CLICKHOUSE_READ_AFTER_WRITE_PROBE"
+
+
+def _env_int(name: str, default: int) -> int:
+    return int(os.environ.get(name, str(default)))
+
+
+def _make_client(ch_server: Any) -> Any:
+    return clickhouse_connect.get_client(
+        host=ch_server._host,
+        port=ch_server._port,
+        user=ch_server._user,
+        password=ch_server._password,
+        database=ch_server._database,
+    )
+
+
+def _read_probe_row(
+    client: Any,
+    query: str,
+    params: dict[str, str],
+    mode: str,
+) -> dict[str, Any]:
+    if mode == "stream":
+        with client.query_rows_stream(
+            query, parameters=params, use_none=True
+        ) as stream:
+            source = stream.source
+            return {
+                "rows": list(stream),
+                "columns": tuple(getattr(source, "column_names", ())),
+                "summary": dict(getattr(source, "summary", {}) or {}),
+            }
+
+    if mode == "buffered":
+        res = client.query(query, parameters=params, use_none=True)
+        return {
+            "rows": res.result_rows,
+            "columns": tuple(res.column_names),
+            "summary": dict(res.summary or {}),
+        }
+
+    raise ValueError(f"Unsupported probe mode: {mode}")
+
+
+def _query_log_rows(ch_server: Any, query_ids: list[str]) -> list[tuple[Any, ...]]:
+    if not query_ids:
+        return []
+
+    ch_server.ch_client.command("SYSTEM FLUSH LOGS")
+    query_ids_sql = ", ".join(repr(query_id) for query_id in query_ids)
+    res = ch_server.ch_client.query(f"""
+SELECT
+    query_id,
+    type,
+    query_start_time_microseconds,
+    event_time_microseconds,
+    query_duration_ms,
+    read_rows,
+    written_rows,
+    result_rows,
+    exception_code,
+    left(query, 160)
+FROM system.query_log
+WHERE query_id IN ({query_ids_sql})
+ORDER BY query_start_time_microseconds, type
+""")
+    return list(res.result_rows)
+
+
+def _event(
+    query_log_rows: list[tuple[Any, ...]],
+    query_id: str | None,
+    event_type: str,
+) -> tuple[Any, ...] | None:
+    if query_id is None:
+        return None
+    for row in query_log_rows:
+        if row[0] == query_id and row[1] == event_type:
+            return row
+    return None
+
+
+def _has_query_log_evidence(
+    samples: list[dict[str, Any]],
+    query_log_rows: list[tuple[Any, ...]],
+) -> bool:
+    for sample in samples:
+        insert_finish = _event(
+            query_log_rows,
+            sample["insert_summary"].get("query_id"),
+            "QueryFinish",
+        )
+        first_start = _event(
+            query_log_rows,
+            sample["first"]["summary"].get("query_id"),
+            "QueryStart",
+        )
+        first_finish = _event(
+            query_log_rows,
+            sample["first"]["summary"].get("query_id"),
+            "QueryFinish",
+        )
+        retry_finish = _event(
+            query_log_rows,
+            sample["retry"]["summary"].get("query_id"),
+            "QueryFinish",
+        )
+        required_events = (insert_finish, first_start, first_finish, retry_finish)
+        if any(row is None for row in required_events):
+            continue
+
+        first_select_started_after_insert = insert_finish[3] <= first_start[2]
+        first_select_missed = first_finish[7] == 0
+        retry_select_hit = retry_finish[7] == 1
+        if (
+            first_select_started_after_insert
+            and first_select_missed
+            and retry_select_hit
+        ):
+            return True
+    return False
+
+
+@pytest.mark.skipif(
+    os.environ.get(PROBE_ENV_VAR) != "1",
+    reason=f"Set {PROBE_ENV_VAR}=1 to run the ClickHouse visibility probe.",
+)
+def test_clickhouse_read_after_write_visibility_probe(ch_server: Any) -> None:
+    """Probe ClickHouse read-after-write visibility for tiny ReplacingMergeTree inserts.
+
+    This is an opt-in diagnostic, not part of the normal suite. It exists to make
+    the object-read flake falsifiable: under high concurrent single-row inserts,
+    ClickHouse 25.11 can acknowledge an INSERT and then let an immediate SELECT
+    observe the previous table snapshot. The probe prints query IDs and query_log
+    timing for any miss.
+    """
+    workers = _env_int("WEAVE_CLICKHOUSE_READ_AFTER_WRITE_WORKERS", 16)
+    iterations = _env_int("WEAVE_CLICKHOUSE_READ_AFTER_WRITE_ITERATIONS", 1000)
+    sample_limit = _env_int("WEAVE_CLICKHOUSE_READ_AFTER_WRITE_SAMPLE_LIMIT", 10)
+    mode = os.environ.get("WEAVE_CLICKHOUSE_READ_AFTER_WRITE_MODE", "buffered")
+    require_miss = (
+        os.environ.get("WEAVE_CLICKHOUSE_READ_AFTER_WRITE_REQUIRE_MISS") == "1"
+    )
+
+    table = f"read_after_write_probe_{uuid.uuid4().hex}"
+    ch_server.ch_client.command(f"""
+CREATE TABLE {table} (
+    project_id String,
+    object_id String,
+    kind Enum('op' = 1, 'object' = 2),
+    base_object_class Nullable(String),
+    refs Array(String),
+    val_dump String,
+    digest String,
+    created_at DateTime64(3) DEFAULT now64(3),
+    deleted_at Nullable(DateTime64(3)) DEFAULT NULL,
+    wb_user_id Nullable(String) DEFAULT NULL,
+    leaf_object_class Nullable(String) DEFAULT NULL
+) ENGINE = ReplacingMergeTree()
+ORDER BY (project_id, kind, object_id, digest)
+""")
+
+    query = f"""
+SELECT digest
+FROM {table}
+WHERE project_id = {{project_id:String}}
+  AND object_id = {{object_id:String}}
+  AND digest = {{digest:String}}
+"""
+    column_names = [
+        "project_id",
+        "object_id",
+        "kind",
+        "base_object_class",
+        "refs",
+        "val_dump",
+        "digest",
+    ]
+
+    def worker(worker_idx: int) -> tuple[Counter[str], list[dict[str, Any]]]:
+        client = _make_client(ch_server)
+        stats: Counter[str] = Counter()
+        samples: list[dict[str, Any]] = []
+        try:
+            for i in range(iterations):
+                digest = f"d-{worker_idx}-{i}-{uuid.uuid4().hex}"
+                object_id = f"o-{worker_idx}-{i}-{uuid.uuid4().hex}"
+                project_id = f"p-{worker_idx}"
+                insert_summary = client.insert(
+                    table,
+                    data=[
+                        [
+                            project_id,
+                            object_id,
+                            "object",
+                            None,
+                            [],
+                            '{"x":1}',
+                            digest,
+                        ]
+                    ],
+                    column_names=column_names,
+                )
+                params = {
+                    "project_id": project_id,
+                    "object_id": object_id,
+                    "digest": digest,
+                }
+                expected = [(digest,)]
+                first = _read_probe_row(client, query, params, mode)
+                if first["rows"] == expected:
+                    stats["hit"] += 1
+                    continue
+
+                retry = _read_probe_row(client, query, params, mode)
+                stats[
+                    "miss_retry_hit" if retry["rows"] == expected else "miss_retry_miss"
+                ] += 1
+                if len(samples) < sample_limit:
+                    samples.append(
+                        {
+                            "params": params,
+                            "insert_summary": dict(insert_summary.summary or {}),
+                            "first": first,
+                            "retry": retry,
+                        }
+                    )
+            return stats, samples
+        finally:
+            client.close()
+
+    start = time.monotonic()
+    stats: Counter[str] = Counter()
+    samples: list[dict[str, Any]] = []
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = [executor.submit(worker, idx) for idx in range(workers)]
+            for future in concurrent.futures.as_completed(futures):
+                worker_stats, worker_samples = future.result()
+                stats.update(worker_stats)
+                if len(samples) < sample_limit:
+                    samples.extend(worker_samples[: sample_limit - len(samples)])
+    finally:
+        ch_server.ch_client.command(f"DROP TABLE IF EXISTS {table}")
+
+    query_ids: list[str] = []
+    for sample in samples:
+        for key in ("insert_summary", "first", "retry"):
+            summary = (
+                sample[key]["summary"] if key in {"first", "retry"} else sample[key]
+            )
+            query_id = summary.get("query_id")
+            if query_id:
+                query_ids.append(query_id)
+    query_log_rows = _query_log_rows(ch_server, query_ids)
+
+    print(
+        {
+            "mode": mode,
+            "workers": workers,
+            "iterations_per_worker": iterations,
+            "elapsed_s": round(time.monotonic() - start, 3),
+            "stats": dict(stats),
+            "samples": samples,
+            "query_log_rows": query_log_rows,
+        }
+    )
+
+    if require_miss:
+        assert stats["miss_retry_hit"] + stats["miss_retry_miss"] > 0
+        assert _has_query_log_evidence(samples, query_log_rows)
+    assert stats["miss_retry_miss"] == 0

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -8,6 +8,8 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
+import httpx
+
 # Do not import this module directly, it should only be invoked
 from openai._legacy_response import LegacyAPIResponse
 from openai._response import APIResponse
@@ -47,6 +49,14 @@ _openai_patcher: MultiPatcher | None = None
 logger = logging.getLogger(__name__)
 
 
+def _parse_api_response(value: LegacyAPIResponse | APIResponse) -> Any:
+    try:
+        return value.parse()
+    except httpx.ResponseNotRead:
+        value.http_response.read()
+        return value.parse()
+
+
 def maybe_unwrap_api_response(value: Any) -> Any:
     """If the caller requests a raw response, we unwrap the APIResponse object.
     We take a very conservative approach to only unwrap the types we know about.
@@ -55,14 +65,13 @@ def maybe_unwrap_api_response(value: Any) -> Any:
 
     try:
         if isinstance(value, LegacyAPIResponse):
-            maybe_value = value.parse()
+            maybe_value = _parse_api_response(value)
 
         if isinstance(value, APIResponse):
-            maybe_value = value.parse()
+            maybe_value = _parse_api_response(value)
     except Exception:
-        # LegacyAPIResponse.parse() can fail in streaming contexts due to
-        # async race conditions (e.g. httpx.ResponseNotRead on Windows CI).
-        # Since this is best-effort unwrapping, fall back to the original response.
+        # This is best-effort unwrapping. If parsing still fails, fall back to the
+        # original response so tracing does not alter the caller-visible behavior.
         return value
 
     if isinstance(maybe_value, (ChatCompletion, ChatCompletionChunk)):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2001,8 +2001,12 @@ GROUP BY object_id, digest
             obj_id, obj_digest, val_dump = row
             object_values[obj_id, obj_digest] = val_dump
 
+        # Treat metadata-without-value as an incomplete exact read so obj_read retries.
+        if any((obj.object_id, obj.digest) not in object_values for obj in result):
+            return []
+
         for obj in result:
-            obj.val_dump = object_values.get((obj.object_id, obj.digest), "{}")
+            obj.val_dump = object_values[obj.object_id, obj.digest]
         return result
 
     def obj_read(self, req: tsi.ObjReadReq) -> tsi.ObjReadRes:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1864,6 +1864,147 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return obj_results
 
+    def _select_obj_exact_digest(
+        self,
+        project_id: str,
+        object_id: str,
+        digest: str,
+        metadata_only: bool,
+    ) -> list[SelectableCHObjSchema]:
+        """Read an exact object digest from the source table.
+
+        The general object metadata query computes version indexes for listing,
+        aliases, latest, and vN lookups. Exact digest reads do not need that
+        query to find the row; they only need the source rows for one object.
+        """
+        metadata_columns = [
+            "project_id",
+            "object_id",
+            "created_at",
+            "refs",
+            "kind",
+            "base_object_class",
+            "leaf_object_class",
+            "digest",
+            "deleted_at",
+            "wb_user_id",
+        ]
+        metadata_query = f"""
+SELECT
+    {", ".join(metadata_columns)}
+FROM object_versions
+WHERE project_id = {{project_id: String}}
+    AND object_id = {{object_id: String}}
+"""
+        metadata_query_result = self._query(
+            metadata_query,
+            {"project_id": project_id, "object_id": object_id},
+        )
+        metadata_rows = [
+            dict(zip(metadata_columns, row, strict=True))
+            for row in metadata_query_result.result_rows
+        ]
+        if not metadata_rows:
+            return []
+
+        first_seen_query = """
+SELECT object_id, digest, min(first_created_at) AS first_created_at
+FROM object_version_first_seen
+WHERE project_id = {project_id: String}
+    AND object_id = {object_id: String}
+GROUP BY object_id, digest
+"""
+        first_seen_query_result = self._query(
+            first_seen_query,
+            {"project_id": project_id, "object_id": object_id},
+        )
+        first_seen_by_digest = {
+            row[1]: row[2] for row in first_seen_query_result.result_rows
+        }
+
+        first_created_at: dict[tuple[str, str], datetime.datetime] = {}
+        latest_rows: dict[tuple[str, str], dict[str, Any]] = {}
+        for row in metadata_rows:
+            key = (row["kind"], row["digest"])
+            source_first_created_at = row["created_at"]
+            stable_first_created_at = first_seen_by_digest.get(
+                row["digest"], source_first_created_at
+            )
+            if (
+                key not in first_created_at
+                or stable_first_created_at < first_created_at[key]
+            ):
+                first_created_at[key] = stable_first_created_at
+
+            existing = latest_rows.get(key)
+            row_sort_key = (row["created_at"], row["deleted_at"] is not None)
+            if existing is None or row_sort_key > (
+                existing["created_at"],
+                existing["deleted_at"] is not None,
+            ):
+                latest_rows[key] = row
+
+        rows_by_kind: dict[str, list[dict[str, Any]]] = defaultdict(list)
+        for row in latest_rows.values():
+            rows_by_kind[row["kind"]].append(row)
+
+        result: list[SelectableCHObjSchema] = []
+        for kind_rows in rows_by_kind.values():
+            indexed_rows = sorted(
+                kind_rows,
+                key=lambda row: (
+                    first_created_at[row["kind"], row["digest"]],
+                    row["digest"],
+                ),
+            )
+            latest_key = max(
+                ((row["kind"], row["digest"]) for row in kind_rows),
+                key=lambda key: (
+                    latest_rows[key]["deleted_at"] is None,
+                    first_created_at[key],
+                    key[1],
+                ),
+            )
+            for version_index, row in enumerate(indexed_rows):
+                if row["digest"] != digest:
+                    continue
+                result.append(
+                    SelectableCHObjSchema.model_validate(
+                        {
+                            **row,
+                            "version_index": version_index,
+                            "version_count": len(indexed_rows),
+                            "is_latest": 1
+                            if (row["kind"], row["digest"]) == latest_key
+                            else 0,
+                            "is_op": 1 if row["kind"] == "op" else 0,
+                            "val_dump": "{}",
+                        }
+                    )
+                )
+
+        if not result:
+            return []
+
+        result.sort(key=lambda obj: obj.created_at)
+        if metadata_only:
+            return result
+
+        value_query, value_parameters = make_objects_val_query_and_parameters(
+            project_id=project_id,
+            object_ids=[object_id],
+            digests=[digest],
+        )
+        object_values: dict[tuple[str, str], Any] = {}
+        value_query_result = self._query(value_query, value_parameters)
+        for row in value_query_result.result_rows:
+            obj_id, obj_digest, val_dump = row
+            object_values[obj_id, obj_digest] = val_dump
+
+        for obj in result:
+            obj.val_dump = object_values.get((obj.object_id, obj.digest), "{}")
+        return result
+
     def obj_read(self, req: tsi.ObjReadReq) -> tsi.ObjReadRes:
         # Check if digest is an alias name (not a hash, not version-like, not "latest")
         digest = req.digest
@@ -1873,13 +2014,21 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if resolved_digest is not None:
             digest = resolved_digest
 
-        object_query_builder = ObjectMetadataQueryBuilder(req.project_id)
-        object_query_builder.add_digests_conditions(digest)
-        object_query_builder.add_object_ids_condition([req.object_id])
-        object_query_builder.set_include_deleted(include_deleted=True)
         metadata_only = req.metadata_only or False
-
-        objs = self._select_objs_query(object_query_builder, metadata_only)
+        is_version, _ = tsc.digest_is_version_like(digest)
+        if digest != "latest" and not is_version:
+            objs = self._select_obj_exact_digest(
+                req.project_id,
+                req.object_id,
+                digest,
+                metadata_only,
+            )
+        else:
+            object_query_builder = ObjectMetadataQueryBuilder(req.project_id)
+            object_query_builder.add_digests_conditions(digest)
+            object_query_builder.add_object_ids_condition([req.object_id])
+            object_query_builder.set_include_deleted(include_deleted=True)
+            objs = self._select_objs_query(object_query_builder, metadata_only)
         if len(objs) == 0:
             raise NotFoundError(f"Obj {req.object_id}:{req.digest} not found")
 


### PR DESCRIPTION
## Summary

Fixes the ClickHouse object publish/read flakes by tightening exact-digest object reads and hardening test isolation, with an opt-in probe that reproduces the underlying ClickHouse read-after-write visibility gap.

The root cause is not a missing client flush, a materialized-view-only delay, or a permanently lost row. Under concurrent tiny `ReplacingMergeTree` inserts, ClickHouse 25.11 can acknowledge an INSERT and then allow an immediate exact SELECT, started after that INSERT's `QueryFinish`, to observe an older table snapshot and return `result_rows=0`. A near-immediate retry sees the row. The object flakes happen because `client.save(...)->client.get(ref)` does exactly that kind of immediate exact object read.

Original failure ([job](https://github.com/wandb/weave/actions/runs/25026612700/job/73298997583)):

```text
tests/trace/test_weave_client.py::test_dataset_rows_ref - weave.trace_server.errors.NotFoundError: Obj my-dataset:vyX2wXX16o1CQtpBHC2FAosDjCLLbmXzCR5co9XvHgA not found
```

Follow-up failures that disproved incomplete fixes:

```text
https://github.com/wandb/weave/actions/runs/25035014624/job/73326217017?pr=6717
FAILED tests/trace/test_op_versioning.py::test_op_return_return_custom_class - NotFoundError: Obj some_d:cr7pRcHGXo5Dg3E7lX8U6RZh3NtcGzEYnpoJmbyPhiI not found

https://github.com/wandb/weave/actions/runs/25063536259/job/73424198984?pr=6717
FAILED tests/trace/test_weave_client.py::test_object_mismatch_project_ref_nested - NotFoundError: Obj my-object:5wPKYJDEjvfnN0GxeJobfpsFS2TKsjYr6mjKGsP0UHs not found

https://github.com/wandb/weave/actions/runs/25065201453/attempts/2
FAILED tests/trace/test_dirty_model_op_retrieval.py::test_dirty_model_op_retrieval - NotFoundError: Obj MyModel:vDzjsXGrKOdu8vsGlqQsHbsPtfWj55rQYgPGOETSzcg not found
FAILED tests/trace/test_weave_client_mutations.py::test_object_mutation_saving - NotFoundError: Obj Thing:ZpCkQNPQiHpAQJIvn0JDHuehqjpSuYYgNDmQQfBBAX8 not found

https://github.com/wandb/weave/actions/runs/25072516183/job/73456388508
FAILED tests/trace/test_weave_client_mutations.py::test_table_mutation_saving_replace_rows - exact metadata read succeeded, exact value read missed, and the object decoded as an empty table
```

## What Changed

- Exact ClickHouse object digest reads now use a primary source-table path over `object_versions`, while still returning `version_index`, `version_count`, `is_latest`, deletion state, and object value.
- Exact digest reads use `_query` instead of `_query_stream`; streaming is unnecessary for point object reads and weakens the response-completion contract.
- Exact digest reads now require the matching value row when `metadata_only=False`. Metadata-without-value is treated as an incomplete exact read, so `obj_read` raises `NotFoundError` and the existing retry re-runs the full read instead of returning `{}`.
- The existing `retry_on_not_found` now retries the smallest correct read path. The new probe shows these misses are short-lived and retry-healable; this PR does not increase the retry budget.
- `TestOnlyFlushingWeaveClient` flushes in `finally`, so failed wrapped client calls cannot leak queued writes into the next test.
- Test client teardown flushes before clearing/closing the client.
- Direct public `client.server.*` calls in tests get the same before/after flush barrier as client methods.
- ClickHouse test reset remains the discovered non-view table loop, with each reset now using `TRUNCATE TABLE ... SYNC`.
- Added clickhouse-connect boundary tests documenting that `query_rows_stream` disables clickhouse-connect's server-side wait mode, and how Native parsing represents pre-block EOF vs valid zero-row schema.
- Added an opt-in ClickHouse read-after-write probe that can be run locally/CI to reproduce the exact visibility gap and assert query-log evidence.
- Added a deterministic unit test for the metadata-hit/value-miss edge case.
- Separately fixed two non-object-path CI issues found while validating: OpenAI raw-response parsing after `httpx.ResponseNotRead`, and `capture_output()` missing Weave call-link logs when the `weave` logger owns its own handler.

## What Was Removed Or Disproven

- No flaky marks and no increased object-read retry budget.
- Removed async/sync insert setting changes. They did not prevent the object flakes.
- Removed `_select_obj_exact_digest_fallback`; exact digest reads now have one primary path, not a fallback after a failed general query.
- Removed the object visibility/reinsert loop. Rewriting write semantics on read miss was speculative.
- Restored `obj_create` and `file_create` caching.
- Removed the dedicated truncate-command unit test. The ClickHouse tests exercise reset behavior.
- No changes remain in `weave/trace/concurrent/futures.py`; FutureExecutor flush semantics are tracked separately in #6719.
- Did not use `TRUNCATE ALL TABLES FROM ...`: the migrated schema includes views, and ClickHouse rejects truncating views.
- The final root-cause probe disproves the streaming-only theory: buffered `client.query` can also observe the same first-read miss. Streaming was a contributing surface in our object read implementation, not the sole ClickHouse failure mode.

## Root Cause Evidence

The opt-in probe creates a temporary `ReplacingMergeTree` table with object-version-shaped rows, then runs concurrent single-row INSERTs followed immediately by exact point SELECTs.

Local ClickHouse 25.11.2.24 repro on head `015b7d4fef6920594cbba76d100cd6f54641962b`:

```text
WF_CLICKHOUSE_PORT=8124 WF_CLICKHOUSE_DATABASE=probe_serial WEAVE_CLICKHOUSE_READ_AFTER_WRITE_PROBE=1 WEAVE_CLICKHOUSE_READ_AFTER_WRITE_REQUIRE_MISS=1 WEAVE_CLICKHOUSE_READ_AFTER_WRITE_WORKERS=16 WEAVE_CLICKHOUSE_READ_AFTER_WRITE_ITERATIONS=1000 WEAVE_CLICKHOUSE_READ_AFTER_WRITE_SAMPLE_LIMIT=2 .nox/tests-3-11-shard-trace/bin/python -m pytest tests/trace_server/test_clickhouse_read_after_write_probe.py::test_clickhouse_read_after_write_visibility_probe -q -s --trace-server=clickhouse
```

Result:

```text
stats: {'hit': 15998, 'miss_retry_hit': 2}
1 passed in 41.05s
```

The same run asserts query-log evidence for at least one sampled miss:

```text
INSERT QueryFinish: 2026-04-28 19:28:33.709937, written_rows=1
first SELECT QueryStart: 2026-04-28 19:28:33.711686
first SELECT QueryFinish: result_rows=0
retry SELECT QueryFinish: result_rows=1
```

That is the flake in miniature: ClickHouse accepted the insert, the first exact read started afterward and missed, and the retry hit. The latest CI failure showed the same gap can occur on the value phase after metadata already hit; the fix now converts that partial read into the same retryable `NotFound` path.

## Why Calls Are Less Exposed

Calls are not read back through the object metadata path. The object failures converged on exact object digest reads through the object tables; calls use the call tables and call query builders, and common call query paths already use `_query` rather than this exact object stream path.

## Notes On CI Noise

The `EvaluationLogger` closed-stream logging error in the pasted job occurs during cleanup after the SQLite half of the trace shard and before the ClickHouse run that produced the object failure. The sqlite `ResourceWarning` messages are noisy, but they are not on the object read call stack and do not explain the ClickHouse exact-digest miss.

## Testing

- `uvx ruff check tests/conftest.py tests/integrations/openai/openai_test.py tests/trace/test_client_trace.py tests/trace/test_weave_client.py tests/trace/util.py tests/trace_server/conftest.py weave/integrations/openai/openai_sdk.py weave/trace_server/clickhouse_trace_server_batched.py`
- `uvx ruff format --check tests/conftest.py tests/integrations/openai/openai_test.py tests/trace/test_client_trace.py tests/trace/test_weave_client.py tests/trace/util.py tests/trace_server/conftest.py weave/integrations/openai/openai_sdk.py weave/trace_server/clickhouse_trace_server_batched.py`
- `python -m py_compile tests/conftest.py tests/integrations/openai/openai_test.py tests/trace/test_client_trace.py tests/trace/test_weave_client.py tests/trace/util.py tests/trace_server/conftest.py weave/integrations/openai/openai_sdk.py weave/trace_server/clickhouse_trace_server_batched.py`
- `git diff --check`
- `uvx ruff check weave/trace_server/clickhouse_trace_server_batched.py tests/trace_server/test_clickhouse_connect_streaming.py tests/trace_server/test_clickhouse_read_after_write_probe.py`
- `uvx ruff format --check weave/trace_server/clickhouse_trace_server_batched.py tests/trace_server/test_clickhouse_connect_streaming.py tests/trace_server/test_clickhouse_read_after_write_probe.py`
- `.nox/tests-3-11-shard-trace/bin/python -m pytest tests/trace_server/test_clickhouse_connect_streaming.py tests/trace_server/test_clickhouse_read_after_write_probe.py -q` -> `3 passed, 1 skipped`
- `WF_CLICKHOUSE_PORT=8124 .nox/tests-3-11-shard-trace/bin/python -m pytest tests/trace/test_weave_client_mutations.py::test_table_mutation_saving_replace_rows -q --trace-server=clickhouse` -> `1 passed`
- `WF_CLICKHOUSE_PORT=8124` same `test_table_mutation_saving_replace_rows` command, 20x loop -> `20 passed`
- `WF_CLICKHOUSE_PORT=8124 WF_CLICKHOUSE_DATABASE=target_verify .nox/tests-3-11-shard-trace/bin/python -m pytest tests/trace/test_weave_client_mutations.py::test_table_mutation_saving_replace_rows tests/trace/test_weave_client_mutations.py::test_object_mutation_saving tests/trace/test_dirty_model_op_retrieval.py::test_dirty_model_op_retrieval tests/trace/test_weave_client.py::test_object_mismatch_project_ref_nested tests/trace/test_weave_client.py::test_dataset_rows_ref tests/trace/test_op_versioning.py::test_op_return_return_custom_class -q --trace-server=clickhouse` -> `6 passed`
- Opt-in read-after-write repro command above -> `stats: {'hit': 15998, 'miss_retry_hit': 2}`, `1 passed in 41.05s`
- ClickHouse 25.11.2.24 targeted set, Python 3.11 on earlier head: `test_dirty_model_op_retrieval`, `test_object_mutation_saving`, `test_object_mismatch_project_ref_nested`, `test_dataset_rows_ref`, `test_op_return_return_custom_class` -> `5 passed`
- Same ClickHouse 25.11.2.24 targeted set, Python 3.11, 10x loop on earlier head -> `50 passed`
- Same ClickHouse 25.11.2.24 targeted set, Python 3.12 on earlier head -> `5 passed`
- Full GitHub `test` workflow on head `6dccc014729976e14c3f481e79cf0223eb5250b6`: [attempts 1-5](https://github.com/wandb/weave/actions/runs/25066692602) all passed. The previously failing Linux trace jobs passed in every attempt.
- Full GitHub `test` workflow on head `8694be7ba2fa2de9960f58ec76f556996c1e257b`: failed `test_table_mutation_saving_replace_rows`, which exposed metadata-hit/value-miss and is fixed in current head.
- Full GitHub `test` workflow on head `34f3c4bcebca0fd107c40255b560a724389275c5`: failed Python 3.10 due `datetime.UTC` in the new deterministic test; fixed in current head.
- `.nox/tests-3-10-shard-trace_server/bin/python -m pytest tests/trace_server/test_clickhouse_read_after_write_probe.py::test_select_obj_exact_digest_requires_value_row -q --trace-server=sqlite` -> `1 passed`
- Full GitHub `test` workflow on current head `015b7d4fef6920594cbba76d100cd6f54641962b`: passed at https://github.com/wandb/weave/actions/runs/25073619606.

Current head: `015b7d4fef6920594cbba76d100cd6f54641962b`.


