### PR TITLE
fix(weave): make future executor flush wait for callbacks

### DIFF
--- a/tests/trace/concurrent/test_futures.py
+++ b/tests/trace/concurrent/test_futures.py
@@ -258,6 +258,8 @@ def test_flush_waits_for_then_callback_work() -> None:
 
     release_root.set()
     assert callback_started.wait(timeout=5)
+    # The logical then-future remains tracked while callback work is running.
+    assert executor.num_outstanding_futures == 1
 
     flush_thread = threading.Thread(
         target=lambda: (executor.flush(), flush_finished.set())

--- a/tests/trace/concurrent/test_futures.py
+++ b/tests/trace/concurrent/test_futures.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from concurrent.futures import Future
 from typing import Any
@@ -234,6 +235,45 @@ def test_empty_futures_list() -> None:
 
     future_result: Future[int] = executor.then([], process_data)
     assert future_result.result() == 0
+
+
+def test_flush_waits_for_then_callback_work() -> None:
+    executor: FutureExecutor = FutureExecutor(max_workers=1)
+    release_root = threading.Event()
+    callback_started = threading.Event()
+    release_callback = threading.Event()
+    flush_finished = threading.Event()
+
+    def root_task() -> int:
+        assert release_root.wait(timeout=5)
+        return 1
+
+    def blocking_callback(data_list: list[int]) -> int:
+        callback_started.set()
+        assert release_callback.wait(timeout=5)
+        return data_list[0] + 1
+
+    root_future: Future[int] = executor.defer(root_task)
+    result_future: Future[int] = executor.then([root_future], blocking_callback)
+
+    release_root.set()
+    assert callback_started.wait(timeout=5)
+
+    flush_thread = threading.Thread(
+        target=lambda: (executor.flush(), flush_finished.set())
+    )
+    flush_thread.start()
+
+    try:
+        time.sleep(0.05)
+        early_finished = flush_finished.is_set()
+    finally:
+        release_callback.set()
+        flush_thread.join(timeout=5)
+
+    assert not early_finished
+    assert flush_finished.is_set()
+    assert result_future.result() == 2
 
 
 def test_nested_futures_with_1_max_worker_classic_deadlock_case() -> None:

--- a/tests/trace/concurrent/test_futures.py
+++ b/tests/trace/concurrent/test_futures.py
@@ -7,6 +7,14 @@ import pytest
 
 from weave.trace.concurrent.futures import FutureExecutor
 
+# Wait budget for events/threads in flush race tests; generous so slow CI
+# runners don't false-fail, tight enough that a real hang surfaces fast.
+EVENT_TIMEOUT_S = 5
+# Window we let an incorrect flush() implementation use to (wrongly) return
+# before chained callback work completes. Long enough to observe the bug,
+# short enough to keep the suite snappy.
+RACE_WINDOW_S = 0.05
+
 
 def test_defer_simple() -> None:
     executor: FutureExecutor = FutureExecutor()
@@ -245,19 +253,19 @@ def test_flush_waits_for_then_callback_work() -> None:
     flush_finished = threading.Event()
 
     def root_task() -> int:
-        assert release_root.wait(timeout=5)
+        assert release_root.wait(timeout=EVENT_TIMEOUT_S)
         return 1
 
     def blocking_callback(data_list: list[int]) -> int:
         callback_started.set()
-        assert release_callback.wait(timeout=5)
+        assert release_callback.wait(timeout=EVENT_TIMEOUT_S)
         return data_list[0] + 1
 
     root_future: Future[int] = executor.defer(root_task)
     result_future: Future[int] = executor.then([root_future], blocking_callback)
 
     release_root.set()
-    assert callback_started.wait(timeout=5)
+    assert callback_started.wait(timeout=EVENT_TIMEOUT_S)
     # The logical then-future remains tracked while callback work is running.
     assert executor.num_outstanding_futures == 1
 
@@ -267,15 +275,110 @@ def test_flush_waits_for_then_callback_work() -> None:
     flush_thread.start()
 
     try:
-        time.sleep(0.05)
+        time.sleep(RACE_WINDOW_S)
         early_finished = flush_finished.is_set()
     finally:
         release_callback.set()
-        flush_thread.join(timeout=5)
+        flush_thread.join(timeout=EVENT_TIMEOUT_S)
 
     assert not early_finished
     assert flush_finished.is_set()
     assert result_future.result() == 2
+
+
+def test_then_callback_runs_once_under_concurrent_input_completion() -> None:
+    """Two inputs completing simultaneously must not double-submit `g`.
+
+    Both `on_done_callback` invocations can observe `all(fut.done())` as True
+    in the racy interleaving; the dedup lock is what keeps `g` running once.
+    """
+    executor: FutureExecutor = FutureExecutor(max_workers=2)
+    callback_count = 0
+    count_lock = threading.Lock()
+
+    def count_callback(data_list: list[int]) -> int:
+        nonlocal callback_count
+        with count_lock:
+            callback_count += 1
+        return sum(data_list)
+
+    f1: Future[int] = Future()
+    f2: Future[int] = Future()
+    result_future: Future[int] = executor.then([f1, f2], count_callback)
+
+    barrier = threading.Barrier(2)
+
+    def fire(f: Future[int], v: int) -> None:
+        barrier.wait(timeout=EVENT_TIMEOUT_S)
+        f.set_result(v)
+
+    threads = [
+        threading.Thread(target=fire, args=(f1, 1)),
+        threading.Thread(target=fire, args=(f2, 2)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=EVENT_TIMEOUT_S)
+
+    assert result_future.result(timeout=EVENT_TIMEOUT_S) == 3
+    assert executor.flush(timeout=EVENT_TIMEOUT_S)
+    assert callback_count == 1
+
+
+def test_flush_drains_work_added_after_snapshot() -> None:
+    """Work submitted after flush() snapshots must still be drained.
+
+    flush() snapshots `_active_futures`, waits, then re-checks. A submission
+    that lands between the snapshot and the original future completing is
+    the canonical case: a single-pass flush would return early and leave
+    real work pending.
+    """
+    executor: FutureExecutor = FutureExecutor(max_workers=2)
+    release_root = threading.Event()
+    release_chained = threading.Event()
+    chained_started = threading.Event()
+    chained_finished = threading.Event()
+    flush_finished = threading.Event()
+
+    def root_task() -> int:
+        assert release_root.wait(timeout=EVENT_TIMEOUT_S)
+        return 1
+
+    def chained_task() -> int:
+        chained_started.set()
+        assert release_chained.wait(timeout=EVENT_TIMEOUT_S)
+        chained_finished.set()
+        return 99
+
+    executor.defer(root_task)
+
+    flush_thread = threading.Thread(
+        target=lambda: (executor.flush(), flush_finished.set())
+    )
+    flush_thread.start()
+
+    # Let flush() snapshot _active_futures = {root_future} before the
+    # chained work exists.
+    time.sleep(RACE_WINDOW_S)
+    # Submit additional work *after* the snapshot. This future is tracked
+    # but invisible to flush()'s in-flight `as_completed` call.
+    executor.defer(chained_task)
+    assert chained_started.wait(timeout=EVENT_TIMEOUT_S)
+    # Release root_task so the snapshot drains; flush() must outer-loop to
+    # discover chained_task_future.
+    release_root.set()
+    # Give a single-pass flush() enough headroom to (incorrectly) return
+    # after the snapshot drains but before chained_task_future completes.
+    time.sleep(RACE_WINDOW_S)
+    early_finished = flush_finished.is_set()
+
+    release_chained.set()
+    flush_thread.join(timeout=EVENT_TIMEOUT_S)
+
+    assert not early_finished
+    assert chained_finished.is_set()
+    assert flush_finished.is_set()
 
 
 def test_nested_futures_with_1_max_worker_classic_deadlock_case() -> None:

--- a/weave/trace/concurrent/futures.py
+++ b/weave/trace/concurrent/futures.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import atexit
 import concurrent.futures
 import logging
+import time
 from collections.abc import Callable
 from concurrent.futures import Future, wait
 from contextvars import ContextVar
@@ -116,7 +117,9 @@ class FutureExecutor:
         Returns:
             Future[U]: A new Future object representing the result of applying g to the results of the futures.
         """
-        result_future: Future[U] = Future()
+        result_future: Future[U] = self._track_future(Future(), log_exception=False)
+        callback_submit_lock = Lock()
+        callback_submitted = False
 
         def callback() -> None:
             try:
@@ -139,12 +142,20 @@ class FutureExecutor:
 
             self._safe_add_done_callback(g_future, on_g_done)
 
+        def submit_callback_once() -> None:
+            nonlocal callback_submitted
+            with callback_submit_lock:
+                if callback_submitted:
+                    return
+                callback_submitted = True
+            self._safe_submit(callback)
+
         def on_done_callback(_: Future[T]) -> None:
             if all(fut.done() for fut in futures):
-                self._safe_submit(callback)
+                submit_callback_once()
 
         if not futures:
-            self._safe_submit(callback)
+            submit_callback_once()
         else:
             for f in futures:
                 self._safe_add_done_callback(f, on_done_callback)
@@ -167,28 +178,34 @@ class FutureExecutor:
             RuntimeError: If called from within a thread context.
             TimeoutError: If the timeout is reached.
         """
-        with self._active_futures_lock:
-            if not self._active_futures:
-                return True
-            futures_to_wait = list(self._active_futures)
-
         if self._in_thread_context.get():
             raise RuntimeError("Cannot flush from within a thread")
 
-        for future in concurrent.futures.as_completed(futures_to_wait, timeout=timeout):
-            try:
-                future.result()
-            except Exception as e:
-                if get_raise_on_captured_errors():
-                    raise
+        start = time.monotonic()
+        while True:
+            with self._active_futures_lock:
+                if not self._active_futures:
+                    return True
+                futures_to_wait = list(self._active_futures)
+
+            wait_timeout = _remaining_timeout(start, timeout)
+            for future in concurrent.futures.as_completed(
+                futures_to_wait, timeout=wait_timeout
+            ):
+                try:
+                    future.result()
+                except Exception:
+                    if get_raise_on_captured_errors():
+                        raise
         return True
 
-    def _future_done_callback(self, future: Future) -> None:
+    def _future_done_callback(
+        self, future: Future, *, log_exception: bool = True
+    ) -> None:
         """Callback for when a future is done to remove it from the active futures list."""
         with self._active_futures_lock:
             self._active_futures.discard(future)
-
-            if exception := future.exception():
+            if log_exception and (exception := future.exception()):
                 logger.error("Task failed: %s", _format_exception(exception))
 
     def _shutdown(self) -> None:
@@ -218,6 +235,19 @@ class FutureExecutor:
         """Add a done callback to a future."""
         future.add_done_callback(self._make_deadlock_safe(callback))
 
+    def _track_future(
+        self, future: Future[R], *, log_exception: bool = True
+    ) -> Future[R]:
+        """Track a logical executor future until it completes."""
+        with self._active_futures_lock:
+            self._active_futures.add(future)
+
+        def on_done(future: Future[R]) -> None:
+            self._future_done_callback(future, log_exception=log_exception)
+
+        future.add_done_callback(on_done)
+        return future
+
     def _safe_submit(
         self, f: Callable[P, R], *args: P.args, **kwargs: P.kwargs
     ) -> Future[R]:
@@ -238,11 +268,7 @@ class FutureExecutor:
                 raise
             return self._execute_directly(wrapped, *args, **kwargs)
 
-        with self._active_futures_lock:
-            self._active_futures.add(future)
-        future.add_done_callback(self._future_done_callback)
-
-        return future
+        return self._track_future(future)
 
     def _execute_directly(
         self, f: Callable[P, R], *args: P.args, **kwargs: P.kwargs
@@ -269,6 +295,12 @@ def _format_exception(e: BaseException) -> str:
     #     return exception_str
     # except:
     #     return exception_str
+
+
+def _remaining_timeout(start: float, timeout: float | None) -> float | None:
+    if timeout is None:
+        return None
+    return max(0, timeout - (time.monotonic() - start))
 
 
 __all__ = ["FutureExecutor"]

--- a/weave/trace/concurrent/futures.py
+++ b/weave/trace/concurrent/futures.py
@@ -118,6 +118,11 @@ class FutureExecutor:
             Future[U]: A new Future object representing the result of applying g to the results of the futures.
         """
         result_future: Future[U] = self._track_future(Future(), log_exception=False)
+        # `on_done_callback` is registered on every input future, so when more
+        # than one input completes concurrently, multiple threads can pass the
+        # `all(fut.done())` gate below and try to schedule `callback`. The lock
+        # + flag ensure `callback` (and therefore `g`) is submitted exactly
+        # once even under that race.
         callback_submit_lock = Lock()
         callback_submitted = False
 
@@ -181,6 +186,14 @@ class FutureExecutor:
         if self._in_thread_context.get():
             raise RuntimeError("Cannot flush from within a thread")
 
+        # Drain iteratively. A `then(...)` chain only schedules its inner
+        # `callback` / `g_future` once its inputs complete, so chained work
+        # can be added to `_active_futures` *after* we snapshot it. Each pass:
+        #   1. snapshot the tracked futures
+        #   2. wait for that snapshot to drain (sharing the overall timeout)
+        #   3. re-check the set; if it grew while we waited, repeat
+        # The loop returns once the set is empty, which is the point at which
+        # all logical work the caller submitted has actually finished.
         start = time.monotonic()
         while True:
             with self._active_futures_lock:


### PR DESCRIPTION
## Summary

Strict red/green TDD split-out for the `FutureExecutor.flush()` callback barrier.

`FutureExecutor.flush()` used to wait on a snapshot of active futures. With `then(...)`, a completed future can run a done callback that submits/runs chained work after that snapshot is already drained, so `flush()` can return before the chained callback work is complete.

This PR adds exactly one regression test and then fixes `flush()` by tracking logical futures, including the public future returned by `then()`.

## Red Phase

Red commit: `d9b7fdec237554d0c9eadce884a99bd912caf112` (`test(weave): expose future executor flush callback race`)

The commit adds only `tests/trace/concurrent/test_futures.py::test_flush_waits_for_then_callback_work`. It blocks inside a `then(...)` callback, calls `flush()` from another thread, and asserts that `flush()` does not return until the callback is released.

Red result on that commit:

```text
FAILED tests/trace/concurrent/test_futures.py::test_flush_waits_for_then_callback_work
E       assert not True
```

CI red result on that commit:

- Run: https://github.com/wandb/weave/actions/runs/25063213064
- Failed job: https://github.com/wandb/weave/actions/runs/25063213064/job/73423002037
- Job: `Trace non-trace server tests (3, 13, trace_no_server)`

## Green Phase

Green commit: `1d60251505c5f04cf0122f37dbd87dc9902e3a84` (`fix(weave): wait for future callbacks during flush`)

The patch:

- adds `_track_future(...)` as the single owner of `_active_futures` membership
- tracks the `then()` `result_future` directly, because that is the logical work unit callers receive and `flush()` should wait on
- guards dependency callbacks with a lock/boolean so multiple completed dependencies cannot submit the chained callback twice
- keeps failure logging inside the tracked-future completion barrier, so `flush()` cannot return before executor-owned error logs are emitted
- makes `flush()` loop until tracked logical futures are drained, recomputing timeout across the full drain