### PR TITLE
fix(weave): handle newer OpenAI Agents span types

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -129,6 +129,11 @@ def tests(session: nox.Session, shard: str):
 
     session.run(*sync_args)
 
+    if shard == "openai_agents":
+        # Keep the public extra broad for runtime compatibility, but exercise the
+        # newer SDK span classes in CI.
+        session.run("uv", "pip", "install", "--upgrade", "openai-agents>=0.14.7")
+
     env = {
         k: session.env.get(k) or os.getenv(k)
         for k in [

--- a/tests/integrations/openai_agents/openai_agents_test.py
+++ b/tests/integrations/openai_agents/openai_agents_test.py
@@ -526,7 +526,7 @@ def test_newer_agent_task_and_turn_fields_prevent_unknown_blocks(
         ),
     ],
 )
-def test_usage_to_metrics_branches(usage, expected) -> None:
+def test_usage_to_metrics_branches(client: WeaveClient, usage, expected) -> None:
     assert _usage_to_metrics(usage) == expected
 
 
@@ -539,7 +539,9 @@ def test_usage_to_metrics_branches(usage, expected) -> None:
         (None, None, "Turn"),
     ],
 )
-def test_call_name_for_turn_span_branches(turn, agent_name, expected) -> None:
+def test_call_name_for_turn_span_branches(
+    client: WeaveClient, turn, agent_name, expected
+) -> None:
     span_data = Mock(spec=TurnSpanData)
     span_data.name = None
     span_data.turn = turn
@@ -552,7 +554,9 @@ def test_call_name_for_turn_span_branches(turn, agent_name, expected) -> None:
     assert _call_name(span) == expected
 
 
-def test_task_and_turn_log_data_handle_missing_optional_fields() -> None:
+def test_task_and_turn_log_data_handle_missing_optional_fields(
+    client: WeaveClient,
+) -> None:
     """Task/turn spans with missing optional fields produce empty metrics and
     only the metadata they actually carry. Exercises the False branches of the
     isinstance/getattr guards in _task_log_data and _turn_log_data.
@@ -584,7 +588,7 @@ def test_task_and_turn_log_data_handle_missing_optional_fields() -> None:
     assert _call_name(turn_span) == "Turn"
 
 
-def test_generation_log_data_uses_usage_metrics() -> None:
+def test_generation_log_data_uses_usage_metrics(client: WeaveClient) -> None:
     """_generation_log_data delegates token-metric assembly to _usage_to_metrics."""
     span_data = GenerationSpanData(
         input=[{"role": "user", "content": "hi"}],

--- a/tests/integrations/openai_agents/openai_agents_test.py
+++ b/tests/integrations/openai_agents/openai_agents_test.py
@@ -3,9 +3,17 @@ from unittest.mock import Mock
 import agents
 import pytest
 from agents import Agent, GuardrailFunctionOutput, InputGuardrail, Runner
-from agents.tracing import AgentSpanData, ResponseSpanData, Span, Trace
+from agents.tracing import (
+    AgentSpanData,
+    ResponseSpanData,
+    Span,
+    TaskSpanData,
+    Trace,
+    TurnSpanData,
+)
 from pydantic import BaseModel
 
+from weave.integrations.integration_utilities import op_name_from_ref
 from weave.integrations.openai_agents.openai_agents import WeaveTracingProcessor
 from weave.trace.weave_client import WeaveClient
 
@@ -31,7 +39,7 @@ def test_openai_agents_quickstart(client: WeaveClient, setup_tests) -> None:
     result = Runner.run_sync(agent, "Write a haiku about recursion in programming.")
     calls = client.get_calls()
 
-    assert len(calls) == 2
+    assert len(calls) == 4
 
     trace_root = calls[0]
     assert trace_root.inputs["name"] == "Agent workflow"
@@ -39,7 +47,21 @@ def test_openai_agents_quickstart(client: WeaveClient, setup_tests) -> None:
     assert trace_root.output["metrics"] == {}
     assert trace_root.output["metadata"] == {}
 
-    agent_call = calls[1]
+    task_call = calls[1]
+    assert op_name_from_ref(task_call.op_name) == "openai_agent_task"
+    assert task_call.parent_id == trace_root.id
+    assert task_call.inputs["name"] == "Agent workflow"
+    assert task_call.output["output"] is None
+    assert task_call.output["metrics"] == {
+        "tokens": 60,
+        "prompt_tokens": 43,
+        "completion_tokens": 17,
+    }
+    assert task_call.output["metadata"] == {"name": "Agent workflow"}
+    assert task_call.output["error"] is None
+
+    agent_call = calls[2]
+    assert agent_call.parent_id == task_call.id
     assert agent_call.inputs["name"] == "Assistant"
     assert agent_call.output["output"] is None
     assert agent_call.output["metrics"] == {}
@@ -49,6 +71,22 @@ def test_openai_agents_quickstart(client: WeaveClient, setup_tests) -> None:
         "output_type": "str",
     }
     assert agent_call.output["error"] is None
+
+    turn_call = calls[3]
+    assert op_name_from_ref(turn_call.op_name) == "openai_agent_turn"
+    assert turn_call.parent_id == agent_call.id
+    assert turn_call.inputs["name"] == "Assistant turn 1"
+    assert turn_call.output["output"] is None
+    assert turn_call.output["metrics"] == {
+        "tokens": 60,
+        "prompt_tokens": 43,
+        "completion_tokens": 17,
+    }
+    assert turn_call.output["metadata"] == {
+        "turn": 1,
+        "agent_name": "Assistant",
+    }
+    assert turn_call.output["error"] is None
 
 
 @pytest.mark.skip(
@@ -385,3 +423,73 @@ def test_response_spans_are_skipped(client: WeaveClient) -> None:
     processor.on_trace_end(trace)
     assert "trace_1" not in processor._trace_calls
     assert "trace_1" not in processor._trace_data
+
+
+def test_newer_agent_task_and_turn_fields_prevent_unknown_blocks(
+    client: WeaveClient,
+) -> None:
+    """Task/turn span fields are required to avoid Unknown blocks in newer SDKs."""
+    processor = WeaveTracingProcessor()
+
+    trace = Mock(spec=Trace)
+    trace.trace_id = "trace_real"
+    trace.name = "test_trace_real"
+    processor.on_trace_start(trace)
+
+    task_span = Mock(spec=Span)
+    task_span.trace_id = trace.trace_id
+    task_span.span_id = "task_span_real"
+    task_span.parent_id = None
+    task_span.span_data = TaskSpanData(
+        name="Runner task",
+        usage={"input_tokens": 0, "output_tokens": 5, "total_tokens": 5},
+        metadata={"session_id": "session-1"},
+    )
+    task_span.error = None
+    processor.on_span_start(task_span)
+
+    turn_span = Mock(spec=Span)
+    turn_span.trace_id = trace.trace_id
+    turn_span.span_id = "turn_span_real"
+    turn_span.parent_id = task_span.span_id
+    turn_span.span_data = TurnSpanData(
+        turn=2,
+        agent_name="Assistant",
+        usage={"input_tokens": 7, "output_tokens": 11},
+        metadata={"callback": "session_input"},
+    )
+    turn_span.error = None
+    processor.on_span_start(turn_span)
+
+    processor.on_span_end(turn_span)
+    processor.on_span_end(task_span)
+    processor.on_trace_end(trace)
+
+    trace_call, task_call, turn_call = client.get_calls()
+
+    assert op_name_from_ref(task_call.op_name) == "openai_agent_task"
+    assert task_call.parent_id == trace_call.id
+    assert task_call.inputs["name"] == "Runner task"
+    assert task_call.output["metrics"] == {
+        "tokens": 5,
+        "prompt_tokens": 0,
+        "completion_tokens": 5,
+    }
+    assert task_call.output["metadata"] == {
+        "name": "Runner task",
+        "session_id": "session-1",
+    }
+
+    assert op_name_from_ref(turn_call.op_name) == "openai_agent_turn"
+    assert turn_call.parent_id == task_call.id
+    assert turn_call.inputs["name"] == "Assistant turn 2"
+    assert turn_call.output["metrics"] == {
+        "tokens": 18,
+        "prompt_tokens": 7,
+        "completion_tokens": 11,
+    }
+    assert turn_call.output["metadata"] == {
+        "turn": 2,
+        "agent_name": "Assistant",
+        "callback": "session_input",
+    }

--- a/tests/integrations/openai_agents/openai_agents_test.py
+++ b/tests/integrations/openai_agents/openai_agents_test.py
@@ -5,6 +5,7 @@ import pytest
 from agents import Agent, GuardrailFunctionOutput, InputGuardrail, Runner
 from agents.tracing import (
     AgentSpanData,
+    GenerationSpanData,
     ResponseSpanData,
     Span,
     TaskSpanData,
@@ -14,7 +15,14 @@ from agents.tracing import (
 from pydantic import BaseModel
 
 from weave.integrations.integration_utilities import op_name_from_ref
-from weave.integrations.openai_agents.openai_agents import WeaveTracingProcessor
+from weave.integrations.openai_agents import openai_agents as oa_module
+from weave.integrations.openai_agents.openai_agents import (
+    WeaveTracingProcessor,
+    _call_name,
+    _is_task_span_data,
+    _is_turn_span_data,
+    _usage_to_metrics,
+)
 from weave.trace.weave_client import WeaveClient
 
 
@@ -492,4 +500,150 @@ def test_newer_agent_task_and_turn_fields_prevent_unknown_blocks(
         "turn": 2,
         "agent_name": "Assistant",
         "callback": "session_input",
+    }
+
+
+@pytest.mark.parametrize(
+    ("usage", "expected"),
+    [
+        (None, {}),
+        ({}, {}),
+        (
+            {"input_tokens": 3, "output_tokens": 4, "total_tokens": 7},
+            {"tokens": 7, "prompt_tokens": 3, "completion_tokens": 4},
+        ),
+        (
+            {"input_tokens": 3, "output_tokens": 4},
+            {"tokens": 7, "prompt_tokens": 3, "completion_tokens": 4},
+        ),
+        (
+            {"input_tokens": 3},
+            {"tokens": 3, "prompt_tokens": 3, "completion_tokens": None},
+        ),
+        (
+            {"output_tokens": 4},
+            {"tokens": 4, "prompt_tokens": None, "completion_tokens": 4},
+        ),
+    ],
+)
+def test_usage_to_metrics_branches(usage, expected) -> None:
+    assert _usage_to_metrics(usage) == expected
+
+
+@pytest.mark.parametrize(
+    ("turn", "agent_name", "expected"),
+    [
+        (1, "Assistant", "Assistant turn 1"),
+        (2, None, "Turn 2"),
+        (None, "Helper", "Helper turn"),
+        (None, None, "Turn"),
+    ],
+)
+def test_call_name_for_turn_span_branches(turn, agent_name, expected) -> None:
+    span_data = Mock(spec=TurnSpanData)
+    span_data.name = None
+    span_data.turn = turn
+    span_data.agent_name = agent_name
+    span_data.__class__ = TurnSpanData
+
+    span = Mock(spec=Span)
+    span.span_data = span_data
+
+    assert _call_name(span) == expected
+
+
+def test_task_and_turn_log_data_handle_missing_optional_fields() -> None:
+    """Task/turn spans with missing optional fields produce empty metrics and
+    only the metadata they actually carry. Exercises the False branches of the
+    isinstance/getattr guards in _task_log_data and _turn_log_data.
+    """
+    processor = WeaveTracingProcessor()
+
+    task_span_data = TaskSpanData(name="placeholder")
+    task_span_data.name = None
+    task_span_data.metadata = "not-a-dict"
+    task_span_data.usage = None
+    task_span = Mock(spec=Span)
+    task_span.span_data = task_span_data
+
+    task_log = processor._task_log_data(task_span)
+    assert task_log["metadata"] == {}
+    assert task_log["metrics"] == {}
+
+    turn_span_data = TurnSpanData(turn=1, agent_name="placeholder")
+    turn_span_data.turn = None
+    turn_span_data.agent_name = None
+    turn_span_data.metadata = None
+    turn_span_data.usage = None
+    turn_span = Mock(spec=Span)
+    turn_span.span_data = turn_span_data
+
+    turn_log = processor._turn_log_data(turn_span)
+    assert turn_log["metadata"] == {}
+    assert turn_log["metrics"] == {}
+    assert _call_name(turn_span) == "Turn"
+
+
+def test_generation_log_data_uses_usage_metrics() -> None:
+    """_generation_log_data delegates token-metric assembly to _usage_to_metrics."""
+    span_data = GenerationSpanData(
+        input=[{"role": "user", "content": "hi"}],
+        output=[{"role": "assistant", "content": "hello"}],
+        model="gpt-4o",
+        model_config={"temperature": 0.0},
+        usage={"input_tokens": 5, "output_tokens": 7},
+    )
+    span = Mock(spec=Span)
+    span.span_data = span_data
+
+    result = WeaveTracingProcessor()._generation_log_data(span)
+    assert result["inputs"] == {"input": [{"role": "user", "content": "hi"}]}
+    assert result["outputs"] == {"output": [{"role": "assistant", "content": "hello"}]}
+    assert result["metadata"] == {
+        "model": "gpt-4o",
+        "model_config": {"temperature": 0.0},
+    }
+    assert result["metrics"] == {
+        "tokens": 12,
+        "prompt_tokens": 5,
+        "completion_tokens": 7,
+    }
+
+
+def test_optional_span_classes_absent_falls_back_to_unknown(
+    client: WeaveClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When TaskSpanData/TurnSpanData failed to import (older SDK), the
+    isinstance helpers must short-circuit to False and _log_data must fall
+    through to the Unknown branch instead of erroring on isinstance(None).
+    """
+    monkeypatch.setattr(oa_module, "TaskSpanData", None)
+    monkeypatch.setattr(oa_module, "TurnSpanData", None)
+
+    sentinel = object()
+    assert _is_task_span_data(sentinel) is False
+    assert _is_turn_span_data(sentinel) is False
+
+    class UnknownSpanData:
+        type = "unknown"
+        name = None
+
+    span = Mock(spec=Span)
+    span.trace_id = "trace_legacy"
+    span.span_id = "span_legacy"
+    span.parent_id = None
+    span_data = UnknownSpanData()
+    span.span_data = span_data
+    span.error = None
+
+    assert _call_name(span) == "Unknown"
+
+    processor = WeaveTracingProcessor()
+    log_data = processor._log_data(span)
+    assert log_data == {
+        "inputs": {},
+        "outputs": {},
+        "metadata": {},
+        "metrics": {},
+        "error": None,
     }

--- a/weave/integrations/openai_agents/openai_agents.py
+++ b/weave/integrations/openai_agents/openai_agents.py
@@ -25,6 +25,12 @@ from agents.tracing import (
     TranscriptionSpanData,
 )
 
+try:
+    from agents.tracing import TaskSpanData, TurnSpanData
+except ImportError:
+    TaskSpanData = None
+    TurnSpanData = None
+
 from weave.integrations.patcher import NoOpPatcher, Patcher
 from weave.trace.autopatch import IntegrationSettings
 from weave.trace.call import Call
@@ -39,10 +45,28 @@ def _call_type(span: Span) -> str:
     return span.span_data.type or "task"
 
 
+def _is_task_span_data(span_data: object) -> bool:
+    return TaskSpanData is not None and isinstance(span_data, TaskSpanData)
+
+
+def _is_turn_span_data(span_data: object) -> bool:
+    return TurnSpanData is not None and isinstance(span_data, TurnSpanData)
+
+
 def _call_name(span: Span) -> str:
     """Determine the name for a given OpenAI Agent span."""
     if name := getattr(span.span_data, "name", None):
         return name
+    elif _is_turn_span_data(span.span_data):
+        turn = getattr(span.span_data, "turn", None)
+        agent_name = getattr(span.span_data, "agent_name", None)
+        if turn is not None and agent_name:
+            return f"{agent_name} turn {turn}"
+        if turn is not None:
+            return f"Turn {turn}"
+        if agent_name:
+            return f"{agent_name} turn"
+        return "Turn"
     elif isinstance(span.span_data, ResponseSpanData):
         return "Response"
     elif isinstance(span.span_data, HandoffSpanData):
@@ -59,6 +83,23 @@ def _call_name(span: Span) -> str:
         return getattr(span.span_data, "server", None) or "MCP List Tools"
     else:
         return "Unknown"
+
+
+def _usage_to_metrics(usage: dict[str, Any] | None) -> dict[str, Any]:
+    if not usage:
+        return {}
+
+    input_tokens = usage.get("input_tokens")
+    output_tokens = usage.get("output_tokens")
+    total_tokens = usage.get("total_tokens")
+    if total_tokens is None and (input_tokens is not None or output_tokens is not None):
+        total_tokens = (input_tokens or 0) + (output_tokens or 0)
+
+    return {
+        "tokens": total_tokens,
+        "prompt_tokens": input_tokens,
+        "completion_tokens": output_tokens,
+    }
 
 
 class WeaveDataDict(TypedDict):
@@ -148,6 +189,45 @@ class WeaveTracingProcessor(TracingProcessor):  # pyright: ignore[reportGeneralT
             error=None,
         )
 
+    def _task_log_data(self, span: Span) -> WeaveDataDict:
+        """Extract log data from an OpenAI Agents task span."""
+        metadata = {}
+        if isinstance(
+            extra_metadata := getattr(span.span_data, "metadata", None), dict
+        ):
+            metadata.update(extra_metadata)
+        if name := getattr(span.span_data, "name", None):
+            metadata["name"] = name
+
+        return WeaveDataDict(
+            inputs={},
+            outputs={},
+            metadata=metadata,
+            metrics=_usage_to_metrics(getattr(span.span_data, "usage", None)),
+            error=None,
+        )
+
+    def _turn_log_data(self, span: Span) -> WeaveDataDict:
+        """Extract log data from an OpenAI Agents turn span."""
+        metadata = {}
+        turn = getattr(span.span_data, "turn", None)
+        if turn is not None:
+            metadata["turn"] = turn
+        if agent_name := getattr(span.span_data, "agent_name", None):
+            metadata["agent_name"] = agent_name
+        if isinstance(
+            extra_metadata := getattr(span.span_data, "metadata", None), dict
+        ):
+            metadata.update(extra_metadata)
+
+        return WeaveDataDict(
+            inputs={},
+            outputs={},
+            metadata=metadata,
+            metrics=_usage_to_metrics(getattr(span.span_data, "usage", None)),
+            error=None,
+        )
+
     def _response_log_data(self, span: Span[ResponseSpanData]) -> WeaveDataDict:
         """Extract log data from a response span."""
         inputs = {}
@@ -228,7 +308,6 @@ class WeaveTracingProcessor(TracingProcessor):  # pyright: ignore[reportGeneralT
         inputs: dict[str, Any] = {}
         outputs: dict[str, Any] = {}
         metadata: dict[str, Any] = {}
-        metrics: dict[str, Any] = {}
 
         if span.span_data.input is not None:
             inputs["input"] = span.span_data.input
@@ -238,22 +317,12 @@ class WeaveTracingProcessor(TracingProcessor):  # pyright: ignore[reportGeneralT
             metadata["model"] = span.span_data.model
         if span.span_data.model_config is not None:
             metadata["model_config"] = span.span_data.model_config
-        if span.span_data.usage is not None:
-            usage = span.span_data.usage
-            metrics = {
-                "tokens": usage.get("total_tokens")
-                or (
-                    (usage.get("input_tokens") or 0) + (usage.get("output_tokens") or 0)
-                ),
-                "prompt_tokens": usage.get("input_tokens"),
-                "completion_tokens": usage.get("output_tokens"),
-            }
 
         return WeaveDataDict(
             inputs=inputs,
             outputs=outputs,
             metadata=metadata,
-            metrics=metrics,
+            metrics=_usage_to_metrics(span.span_data.usage),
             error=None,
         )
 
@@ -378,6 +447,10 @@ class WeaveTracingProcessor(TracingProcessor):  # pyright: ignore[reportGeneralT
         """Extract the appropriate log data based on the span type."""
         if isinstance(span.span_data, AgentSpanData):
             return self._agent_log_data(span)
+        elif _is_task_span_data(span.span_data):
+            return self._task_log_data(span)
+        elif _is_turn_span_data(span.span_data):
+            return self._turn_log_data(span)
         elif isinstance(span.span_data, ResponseSpanData):
             return self._response_log_data(span)
         elif isinstance(span.span_data, FunctionSpanData):

--- a/weave/integrations/openai_agents/openai_agents.py
+++ b/weave/integrations/openai_agents/openai_agents.py
@@ -27,7 +27,7 @@ from agents.tracing import (
 
 try:
     from agents.tracing import TaskSpanData, TurnSpanData
-except ImportError:
+except ImportError:  # pragma: no cover - older openai-agents SDKs lack these
     TaskSpanData = None
     TurnSpanData = None
 


### PR DESCRIPTION
## Summary
Weave is out of sync with newer `openai-agents` tracing spans. Newer SDKs emit real `TaskSpanData` and `TurnSpanData` objects; the current processor only recognizes the older span classes, so these newer spans fall through to generic handling. That is why deployed traces can show turn work as `Unknown` and lose the task/turn metadata and usage fields.

This PR keeps runtime compatibility broad while covering the updated shape:

- optionally imports `TaskSpanData` / `TurnSpanData` from the user's installed SDK
- routes with `isinstance` when those classes exist, with a `span_data.type` fallback for older SDKs
- records task/turn display names, metadata, and usage metrics
- keeps the public `openai-agents>=0.0.4` extra unchanged
- bumps only the `openai_agents` nox shard to `openai-agents>=0.14.7` so CI exercises the real newer classes

SDK shape reference:
https://openai.github.io/openai-agents-python/ref/tracing/span_data/

### Testing
- adds regression tests

The regression test now uses real `TaskSpanData` / `TurnSpanData` from the upgraded nox shard and also monkeypatches the optional imports to `None` to prove the older-SDK fallback path still works.

Local older-version import check:

```text
openai-agents==0.2.0
TaskSpanData=None
TurnSpanData=None
```

### Reported by @zapulam