### PR TITLE
fix(weave): treat partial obj value-row miss as not-found

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -969,6 +969,60 @@ def test_ensure_obj_version_exists_retries_eventual_consistency():
         assert mock_query.call_count == chts.OBJ_READ_RETRY_ATTEMPTS
 
 
+def test_select_objs_query_partial_value_miss_returns_empty():
+    """If metadata rows exist but their value rows haven't replicated yet,
+    return empty so obj_read raises NotFoundError and the retry wrapper kicks
+    in. Without this, the missing val_dump would silently default to "{}" and
+    the caller would decode a corrupted empty object.
+    """
+    server = chts.ClickHouseTraceServer(host="test_host")
+
+    metadata_row = (
+        "test_project",  # project_id
+        "obj-id-1",  # object_id
+        datetime(2024, 1, 1, tzinfo=timezone.utc),  # created_at
+        [],  # refs
+        "object",  # kind
+        None,  # base_object_class
+        None,  # leaf_object_class
+        "digest-abc",  # digest
+        0,  # version_index
+        1,  # is_latest
+        None,  # deleted_at
+        None,  # wb_user_id
+        1,  # version_count
+        0,  # is_op
+    )
+
+    builder = chts.ObjectMetadataQueryBuilder("test_project")
+    builder.add_digests_conditions("digest-abc")
+    builder.add_object_ids_condition(["obj-id-1"])
+
+    # Metadata SELECT finds the row; value SELECT returns nothing.
+    with patch.object(
+        chts.ClickHouseTraceServer,
+        "_query_stream",
+        side_effect=[iter([metadata_row]), iter([])],
+    ):
+        result = server._select_objs_query(builder, metadata_only=False)
+
+    assert result == []
+
+    # Sanity: when the value row is present, we get a populated result.
+    with patch.object(
+        chts.ClickHouseTraceServer,
+        "_query_stream",
+        side_effect=[
+            iter([metadata_row]),
+            iter([("obj-id-1", "digest-abc", '{"x": 1}')]),
+        ],
+    ):
+        result = server._select_objs_query(builder, metadata_only=False)
+
+    assert len(result) == 1
+    assert result[0].val_dump == '{"x": 1}'
+
+
 def test_file_content_read_retries_eventual_consistency():
     """File reads should tolerate transient read-after-write misses."""
     server = chts.ClickHouseTraceServer(host="test_host")

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6629,9 +6629,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # All-or-nothing: if any metadata row is missing its value row (e.g. due
         # to ClickHouse replication lag), return empty so callers raise
         # NotFoundError and retry, instead of silently filling with "{}".
-        if any(
-            (obj.object_id, obj.digest) not in object_values for obj in metadata_result
-        ):
+        all_value_rows_found = all(
+            (obj.object_id, obj.digest) in object_values for obj in metadata_result
+        )
+        if not all_value_rows_found:
             return []
         for obj in metadata_result:
             obj.val_dump = object_values[obj.object_id, obj.digest]

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6626,9 +6626,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             (object_id, digest, val_dump) = row
             object_values[object_id, digest] = val_dump
 
-        # update the val_dump for each object
+        # All-or-nothing: if any metadata row is missing its value row (e.g. due
+        # to ClickHouse replication lag), return empty so callers raise
+        # NotFoundError and retry, instead of silently filling with "{}".
+        if any(
+            (obj.object_id, obj.digest) not in object_values for obj in metadata_result
+        ):
+            return []
         for obj in metadata_result:
-            obj.val_dump = object_values.get((obj.object_id, obj.digest), "{}")
+            obj.val_dump = object_values[obj.object_id, obj.digest]
         return metadata_result
 
     def _run_migrations(self) -> None:


### PR DESCRIPTION
## Summary

`_select_objs_query` runs two SELECTs: one for object metadata, one for value rows. If the metadata row is visible but the value row hasn't replicated yet, the old code silently filled `val_dump` with `"{}"` — `obj_read` returned success and the client decoded a corrupted empty object.

Now: if any metadata row is missing its value row, return `[]`. `obj_read` raises `NotFoundError` and the existing `retry_on_not_found` wrapper reruns the read once replication catches up.

## Test plan
- [x] Added `test_select_objs_query_partial_value_miss_returns_empty` covering the partial-miss and happy-path cases
- [x] Full `test_clickhouse_trace_server_batched.py` suite passes (28/28)