### PR TITLE
chore(weave_ts): Add trusted publishing for Weave TS

### DIFF
--- a/.github/workflows/publish_ts_sdk_npm.yaml
+++ b/.github/workflows/publish_ts_sdk_npm.yaml
@@ -73,4 +73,5 @@ jobs:
 
       - name: Publish to npm
         working-directory: sdks/node
+        # npm trusted publishing authenticates this step through GitHub OIDC.
         run: npm publish --access public --provenance --tag "${{ inputs.npm_tag }}"

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -35,7 +35,8 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/wandb/weave/tree/master/sdks/node"
+    "url": "git+https://github.com/wandb/weave.git",
+    "directory": "sdks/node"
   },
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
Support tagging and publishing from GHA