### PR TITLE
feat(weave): infer typed attribute filters from literals

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -20,6 +20,7 @@ from weave.trace_server import clickhouse_trace_server_batched
 from weave.trace_server import clickhouse_trace_server_migrator as wf_migrator
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.project_version import project_version
+from weave.trace_server.project_version.types import CallsStorageServerMode
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
 from weave.trace_server.sqlite_trace_server import SqliteTraceServer
 
@@ -376,6 +377,23 @@ def ch_server(trace_server):
     if not isinstance(server, ClickHouseTraceServer):
         pytest.skip("ClickHouse-only test")
     return server
+
+
+@pytest.fixture
+def clickhouse_trace_server(trace_server: object) -> ClickHouseTraceServer:
+    """Extract ClickHouseTraceServer and pin routing to AUTO for calls_complete tests.
+
+    Variant of ``ch_server`` that also sets the table routing resolver to
+    AUTO so tests exercising the calls_complete path get the same residence
+    dispatch shape production uses. Tests needing a different mode (e.g.
+    FORCE_LEGACY for raw call_parts inserts) can override the mode after
+    receiving the fixture.
+    """
+    internal_server = trace_server._internal_trace_server  # type: ignore[attr-defined]
+    if isinstance(internal_server, SqliteTraceServer):
+        pytest.skip("ClickHouse-only test")
+    internal_server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
+    return internal_server  # type: ignore[no-any-return]
 
 
 @pytest.fixture

--- a/tests/trace_server/query_builder/test_attributes_map_dispatch.py
+++ b/tests/trace_server/query_builder/test_attributes_map_dispatch.py
@@ -1,0 +1,608 @@
+"""Tests for the typed attributes-map fast-filter dispatch.
+
+When a caller filters on ``attributes.<path>`` with an explicit ``$convert``
+cast or compares it to a scalar literal with an inferable type, the query
+builder emits a hybrid
+``if(mapContains(map, key), map[key], clickhouse_cast(JSON_VALUE(...)))``
+expression: the typed Map column wins on rows where migration 031 populated
+it at ingest, and the old JSON_VALUE path takes over on legacy rows whose
+maps are still empty. This file asserts the full SQL shape end-to-end on
+both read tables plus the fall-through cases (``exists`` cast, ambiguous
+literal types).
+
+The SQL layer is load-bearing enough that these tests pin complete query
+shapes; where one test groups related subcases, each subcase still asserts the
+full emitted SQL rather than a fuzzy fragment.
+"""
+
+from tests.trace_server.query_builder.utils import assert_sql
+from weave.trace_server.calls_query_builder.calls_query_builder import CallsQuery
+from weave.trace_server.ch_sentinel_values import SENTINEL_DATETIME
+from weave.trace_server.clickhouse.utilities import extract_typed_attrs
+from weave.trace_server.interface import query as tsi_query
+from weave.trace_server.project_version.types import ReadTable
+
+# ---------------------------------------------------------------------------
+# calls_merged dispatch (one test per supported cast)
+# ---------------------------------------------------------------------------
+
+
+def test_typed_map_dispatch_on_calls_merged_int() -> None:
+    """``$convert(attributes.env, int)`` on calls_merged.
+
+    Fast branch: ``any(attributes_map_int)[key]``.
+    Fallback: ``toInt64OrNull(coalesce(nullIf(JSON_VALUE(...), 'null'), ''))``.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.env"},
+                            "to": "int",
+                        }
+                    },
+                    {"$literal": 1},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((if(mapContains(any(calls_merged.attributes_map_int), {pb_0:String}),
+                 any(calls_merged.attributes_map_int)[{pb_0:String}],
+                 toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')))
+             = {pb_2:Int64}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "env", "pb_1": '$."env"', "pb_2": 1, "pb_3": "p"},
+    )
+
+
+def test_typed_map_dispatch_on_calls_merged_double() -> None:
+    """``$convert(attributes.env, double)`` on calls_merged.
+
+    Fast branch: ``any(attributes_map_float)[key]``.
+    Fallback: ``toFloat64OrNull(coalesce(nullIf(JSON_VALUE(...), 'null'), ''))``.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.env"},
+                            "to": "double",
+                        }
+                    },
+                    {"$literal": 1.5},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((if(mapContains(any(calls_merged.attributes_map_float), {pb_0:String}),
+                 any(calls_merged.attributes_map_float)[{pb_0:String}],
+                 toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')))
+             = {pb_2:Float64}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "env", "pb_1": '$."env"', "pb_2": 1.5, "pb_3": "p"},
+    )
+
+
+def test_typed_map_dispatch_on_calls_merged_bool() -> None:
+    """``$convert(attributes.env, bool)`` on calls_merged.
+
+    Fast branch: ``any(attributes_map_bool)[key]``.
+    Fallback: ``(JSON_VALUE(...) = 'true')`` — bool is special-cased because
+    ``JSON_VALUE`` emits the literal string ``"true"``/``"false"`` for JSON
+    booleans and the generic ``toUInt8OrNull`` cast returns NULL on those
+    strings, which would silently drop legacy bool rows. Comparing the raw
+    JSON_VALUE to ``'true'`` yields a Bool directly.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.env"},
+                            "to": "bool",
+                        }
+                    },
+                    {"$literal": True},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((if(mapContains(any(calls_merged.attributes_map_bool), {pb_0:String}),
+                 any(calls_merged.attributes_map_bool)[{pb_0:String}],
+                 (JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}) = 'true'))
+             = {pb_2:Bool}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "env", "pb_1": '$."env"', "pb_2": True, "pb_3": "p"},
+    )
+
+
+def test_typed_map_dispatch_on_calls_merged_string() -> None:
+    """``$convert(attributes.env, string)`` on calls_merged.
+
+    Fast branch: ``any(attributes_map_str)[key]``.
+    Fallback: ``toString(coalesce(nullIf(JSON_VALUE(...), 'null'), ''))``.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.env"},
+                            "to": "string",
+                        }
+                    },
+                    {"$literal": "prod"},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((if(mapContains(any(calls_merged.attributes_map_str), {pb_0:String}),
+                 any(calls_merged.attributes_map_str)[{pb_0:String}],
+                 toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')))
+             = {pb_2:String}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "env", "pb_1": '$."env"', "pb_2": "prod", "pb_3": "p"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# calls_complete dispatch + nested attribute paths
+# ---------------------------------------------------------------------------
+
+
+def test_typed_map_dispatch_on_calls_complete() -> None:
+    """calls_complete uses the unwrapped typed column (no any() aggregation).
+
+    The mapContains gate still emits around each lookup so a not-yet-backfilled
+    row in calls_complete (e.g. migrated from call_parts before 031) reads the
+    attributes_dump fallback rather than the Map default.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_COMPLETE)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.GtOperation.model_validate(
+            {
+                "$gt": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.retries"},
+                            "to": "int",
+                        }
+                    },
+                    {"$literal": 3},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_complete.id AS id
+        FROM calls_complete
+        PREWHERE calls_complete.project_id = {pb_4:String}
+        WHERE 1
+          AND (((if(mapContains(calls_complete.attributes_map_int, {pb_0:String}),
+                    calls_complete.attributes_map_int[{pb_0:String}],
+                    toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.attributes_dump, {pb_1:String}), 'null'), '')))
+                 > {pb_2:Int64}))
+               AND ((calls_complete.deleted_at = {pb_3:DateTime64(3)})))
+        """,
+        {
+            "pb_0": "retries",
+            "pb_1": '$."retries"',
+            "pb_2": 3,
+            "pb_3": SENTINEL_DATETIME,
+            "pb_4": "p",
+        },
+    )
+
+
+def test_nested_attribute_path_joins_with_dot() -> None:
+    """``attributes.a.b.c`` uses ``a.b.c`` as the typed-map key.
+
+    The extractor flattens nested dicts with dot-joined keys, so the Map
+    read-side uses the same joiner to hit the stored key. The JSON_VALUE
+    fallback keeps its own JSONPath (``$."a"."b"."c"``) for legacy rows.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.a.b.c"},
+                            "to": "int",
+                        }
+                    },
+                    {"$literal": 5},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((if(mapContains(any(calls_merged.attributes_map_int), {pb_0:String}),
+                 any(calls_merged.attributes_map_int)[{pb_0:String}],
+                 toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')))
+             = {pb_2:Int64}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "a.b.c", "pb_1": '$."a"."b"."c"', "pb_2": 5, "pb_3": "p"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Literal-inferred dispatch (no $convert required)
+# ---------------------------------------------------------------------------
+
+
+def test_literal_inference_eq_uses_typed_map_on_calls_merged() -> None:
+    """Unconverted equality filters infer typed maps from scalar literals.
+
+    This is the PR comment's proposed shape: callers can send
+    ``attributes.<key> = <typed literal>`` and omit ``$convert`` as long as
+    the literal is already the type they mean to compare against. The four
+    subcases intentionally live in one test so the SQL shape is easy to
+    compare across map types.
+    """
+    cases = [
+        # string
+        (
+            "env",
+            "prod",
+            "attributes_map_str",
+            "String",
+            "coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')",
+            '%"prod"%',
+        ),
+        # int
+        (
+            "retries",
+            3,
+            "attributes_map_int",
+            "Int64",
+            "toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), ''))",
+            "%3%",
+        ),
+        # double
+        (
+            "score",
+            0.9,
+            "attributes_map_float",
+            "Float64",
+            "toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), ''))",
+            "%0.9%",
+        ),
+        # bool
+        (
+            "enabled",
+            True,
+            "attributes_map_bool",
+            "Bool",
+            "(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}) = 'true')",
+            "%true%",
+        ),
+    ]
+
+    for attr_key, literal, column, literal_type, fallback_sql, like_pattern in cases:
+        cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+        cq.add_field("id")
+        cq.add_condition(
+            tsi_query.EqOperation.model_validate(
+                {
+                    "$eq": [
+                        {"$getField": f"attributes.{attr_key}"},
+                        {"$literal": literal},
+                    ]
+                }
+            )
+        )
+
+        assert_sql(
+            cq,
+            f"""
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {{pb_4:String}}
+            WHERE ((calls_merged.attributes_dump LIKE {{pb_3:String}} OR calls_merged.attributes_dump IS NULL))
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((if(mapContains(any(calls_merged.{column}), {{pb_0:String}}),
+                     any(calls_merged.{column})[{{pb_0:String}}],
+                     {fallback_sql})
+                 = {{pb_2:{literal_type}}}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+            )
+            """,
+            {
+                "pb_0": attr_key,
+                "pb_1": f'$."{attr_key}"',
+                "pb_2": literal,
+                "pb_3": like_pattern,
+                "pb_4": "p",
+            },
+        )
+
+
+def test_literal_inference_gt_uses_typed_map_on_calls_complete() -> None:
+    """Range comparisons infer numeric typed maps on calls_complete too."""
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_COMPLETE)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.GtOperation.model_validate(
+            {
+                "$gt": [
+                    {"$getField": "attributes.retries"},
+                    {"$literal": 3},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_complete.id AS id
+        FROM calls_complete
+        PREWHERE calls_complete.project_id = {pb_4:String}
+        WHERE 1
+          AND (((if(mapContains(calls_complete.attributes_map_int, {pb_0:String}),
+                    calls_complete.attributes_map_int[{pb_0:String}],
+                    toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.attributes_dump, {pb_1:String}), 'null'), '')))
+                 > {pb_2:Int64}))
+               AND ((calls_complete.deleted_at = {pb_3:DateTime64(3)})))
+        """,
+        {
+            "pb_0": "retries",
+            "pb_1": '$."retries"',
+            "pb_2": 3,
+            "pb_3": SENTINEL_DATETIME,
+            "pb_4": "p",
+        },
+    )
+
+
+def test_literal_inference_when_field_is_rhs_preserves_operator_direction() -> None:
+    """``3 < attributes.retries`` keeps the field on the RHS of the operator."""
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.LtOperation.model_validate(
+            {
+                "$lt": [
+                    {"$literal": 3},
+                    {"$getField": "attributes.retries"},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            (({pb_2:Int64} < if(mapContains(any(calls_merged.attributes_map_int), {pb_0:String}),
+                 any(calls_merged.attributes_map_int)[{pb_0:String}],
+                 toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), '')))))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": "retries", "pb_1": '$."retries"', "pb_2": 3, "pb_3": "p"},
+    )
+
+
+def test_fallback_convert_exists_uses_json_value_only() -> None:
+    """``$convert(..., "exists")`` has no typed Map analogue, so it stays on
+    the JSON_VALUE existence-check path (``... IS NOT NULL``) and does not
+    touch any ``attributes_map_*`` column.
+    """
+    cq = CallsQuery(project_id="p", read_table=ReadTable.CALLS_MERGED)
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "attributes.env"},
+                            "to": "exists",
+                        }
+                    },
+                    {"$literal": True},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_2:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            (((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_0:String}), 'null'), '') IS NOT NULL) = {pb_1:Bool}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {"pb_0": '$."env"', "pb_1": True, "pb_2": "p"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Extractor (ingest-side)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_typed_attrs_dispatch_and_edge_cases() -> None:
+    """One dense assertion block covering type dispatch, flattening, and drops.
+
+    - bool branch must precede int branch (Python bool is a subclass of int);
+    - dicts flatten to dot-joined keys so read-side ``attributes.a.b`` matches;
+    - None values are dropped (not written as empty strings);
+    - non-finite floats (NaN/+inf/-inf) are dropped;
+    - non-scalars (list/tuple/etc.) land in the string map as JSON;
+    - no entry cap: oversized rows are handled downstream by
+      ``_strip_large_values``, not by truncating the extractor output.
+    """
+    big_batch = 250  # well above the removed 100-entry cap.
+    attrs: dict = {
+        "s": "hello",
+        "i": 42,
+        "f": 3.14,
+        "b": True,
+        "b2": False,
+        "none": None,
+        "nan": float("nan"),
+        "pinf": float("inf"),
+        "ninf": float("-inf"),
+        "nested": {"a": 1, "b": {"c": "deep"}},
+        "list": [1, 2, 3],
+    }
+    for i in range(big_batch):
+        attrs[f"str_{i:05d}"] = f"v{i}"
+
+    maps = extract_typed_attrs(attrs)
+    s = maps["attributes_map_str"]
+    i = maps["attributes_map_int"]
+    f = maps["attributes_map_float"]
+    b = maps["attributes_map_bool"]
+
+    assert b == {"b": True, "b2": False}
+    assert i == {"i": 42, "nested.a": 1}
+    assert f == {"f": 3.14}
+    assert s["s"] == "hello"
+    assert s["nested.b.c"] == "deep"
+    assert s["list"] == "[1, 2, 3]"
+    assert "none" not in s
+    assert "none" not in i
+    assert "none" not in f
+    assert "none" not in b
+    assert "nan" not in f
+    assert "pinf" not in f
+    assert "ninf" not in f
+    # All big_batch str_NNNNN entries survive + s/nested.b.c/list = big_batch + 3.
+    assert len(s) == big_batch + 3
+    assert len(b) == 2
+    assert len(i) == 2
+    assert len(f) == 1
+
+
+def test_extract_typed_attrs_non_dict_input() -> None:
+    """Non-dict input returns empty maps rather than raising."""
+    empty = {
+        "attributes_map_str": {},
+        "attributes_map_int": {},
+        "attributes_map_float": {},
+        "attributes_map_bool": {},
+    }
+    assert extract_typed_attrs(None) == empty  # type: ignore[arg-type]
+    assert extract_typed_attrs("not a dict") == empty  # type: ignore[arg-type]
+
+
+def test_extract_typed_attrs_dot_key_collision_is_documented() -> None:
+    """``{"a": {"b": 1}}`` and ``{"a.b": 2}`` both flatten to key ``"a.b"``.
+
+    The second write wins in the typed Map because Python dicts are
+    insertion-ordered and ``extract_typed_attrs`` iterates once per leaf.
+    The JSON_VALUE fallback can still distinguish them (``$."a"."b"`` vs
+    ``$."a.b"``) — so a row with a literal-dot key would read different
+    values from the fast and fallback branches. We accept this divergence
+    because nested dicts are the common shape and literal-dot keys
+    already break the JSONPath-based filter convention.
+
+    This test pins the current behavior so it doesn't drift silently.
+    """
+    int_map = extract_typed_attrs({"a": {"b": 1}, "a.b": 2})["attributes_map_int"]
+    assert int_map == {"a.b": 2}, (
+        "Literal-dot key must overwrite the nested flattening (insertion order)."
+    )
+
+    int_map_reverse = extract_typed_attrs({"a.b": 2, "a": {"b": 1}})[
+        "attributes_map_int"
+    ]
+    assert int_map_reverse == {"a.b": 1}, (
+        "Nested flattening must overwrite the literal-dot key when inserted later."
+    )

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -1488,20 +1488,26 @@ def test_calls_query_with_combined_like_optimizations_and_op_filter() -> None:
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_12:String}
-            WHERE ((calls_merged.op_name IN {pb_7:Array(String)})
+            PREWHERE calls_merged.project_id = {pb_14:String}
+            WHERE ((calls_merged.op_name IN {pb_9:Array(String)})
                     OR (calls_merged.op_name IS NULL))
-                AND ((calls_merged.attributes_dump LIKE {pb_8:String} OR calls_merged.attributes_dump IS NULL)
-                    AND (lower(calls_merged.inputs_dump) LIKE {pb_9:String} OR calls_merged.inputs_dump IS NULL)
-                    AND ((calls_merged.attributes_dump LIKE {pb_10:String} OR calls_merged.attributes_dump LIKE {pb_11:String})
+                AND ((calls_merged.attributes_dump LIKE {pb_10:String} OR calls_merged.attributes_dump IS NULL)
+                    AND (lower(calls_merged.inputs_dump) LIKE {pb_11:String} OR calls_merged.inputs_dump IS NULL)
+                    AND ((calls_merged.attributes_dump LIKE {pb_12:String} OR calls_merged.attributes_dump LIKE {pb_13:String})
                         OR calls_merged.attributes_dump IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
-                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+                ((if(mapContains(any(calls_merged.attributes_map_str), {pb_0:String}),
+                     any(calls_merged.attributes_map_str)[{pb_0:String}],
+                     coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), ''))
+                 = {pb_2:String}))
                 AND
-                (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_2:String}), 'null'), ''), {pb_3:String}) > 0)
+                (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_3:String}), 'null'), ''), {pb_4:String}) > 0)
                 AND
-                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_4:String}), 'null'), '') IN ({pb_5:String},{pb_6:String})))
+                ((if(mapContains(any(calls_merged.attributes_map_str), {pb_5:String}),
+                     any(calls_merged.attributes_map_str)[{pb_5:String}],
+                     coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_6:String}), 'null'), ''))
+                 IN ({pb_7:String},{pb_8:String})))
                 AND ((any(calls_merged.deleted_at) IS NULL))
                 AND ((NOT ((any(calls_merged.started_at) IS NULL))))
             )
@@ -1511,24 +1517,26 @@ def test_calls_query_with_combined_like_optimizations_and_op_filter() -> None:
             any(calls_merged.attributes_dump) AS attributes_dump,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_12:String}
+        PREWHERE calls_merged.project_id = {pb_14:String}
         WHERE (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         """,
         {
-            "pb_0": '$."model"',
-            "pb_1": "gpt-4",
-            "pb_2": '$."prompt"',
-            "pb_3": "weather",
-            "pb_4": '$."temperature"',
-            "pb_5": "0.7",
-            "pb_6": "0.8",
-            "pb_7": ["llm/openai", "llm/anthropic"],
-            "pb_8": '%"gpt-4"%',
-            "pb_9": '%"%weather%"%',
-            "pb_10": '%"0.7"%',
-            "pb_11": '%"0.8"%',
-            "pb_12": "project",
+            "pb_0": "model",
+            "pb_1": '$."model"',
+            "pb_2": "gpt-4",
+            "pb_3": '$."prompt"',
+            "pb_4": "weather",
+            "pb_5": "temperature",
+            "pb_6": '$."temperature"',
+            "pb_7": "0.7",
+            "pb_8": "0.8",
+            "pb_9": ["llm/openai", "llm/anthropic"],
+            "pb_10": '%"gpt-4"%',
+            "pb_11": '%"%weather%"%',
+            "pb_12": '%"0.7"%',
+            "pb_13": '%"0.8"%',
+            "pb_14": "project",
         },
     )
 

--- a/tests/trace_server/test_attributes_map_fast_filter.py
+++ b/tests/trace_server/test_attributes_map_fast_filter.py
@@ -1,0 +1,385 @@
+"""End-to-end test for the attributes_map_* fast-filter path on ClickHouse.
+
+Migration 031 adds typed ``attributes_map_*`` columns that ``extract_typed_attrs``
+populates at ingest. Legacy rows inserted before the migration ran (or before
+a backfill job reaches them) have empty maps, so a naive ``map[key]`` lookup
+would return the CH value-type default and silently miss legitimate matches.
+
+The query builder emits ``if(mapContains(map, key), map[key], JSON_VALUE(...))``
+per row; this test pins that contract end-to-end by raw-inserting three rows
+into ``call_parts`` with different ingest states and asserting the
+``calls_query_stream`` results:
+
+  - populated   : typed maps set at ingest (post-migration)
+  - legacy      : attributes_dump only, typed maps empty (pre-migration)
+  - negative    : attributes_dump mismatch (must not match, regardless of maps)
+
+Mixed inserts in the same project cover the partial-backfill scenario the
+reviewer flagged on #6678.
+"""
+
+from __future__ import annotations
+
+import datetime
+import json
+import uuid
+
+import pytest
+
+from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.clickhouse_schema import EXPIRE_AT_NEVER
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.project_version.project_version import (
+    reset_project_residence_cache,
+)
+from weave.trace_server.project_version.types import CallsStorageServerMode
+
+TEST_ENTITY = "attrs_fast_filter_entity"
+
+
+@pytest.fixture
+def ch_server_force_legacy(
+    clickhouse_trace_server: ClickHouseTraceServer,
+) -> ClickHouseTraceServer:
+    """Reuse the global ``clickhouse_trace_server`` fixture but pin FORCE_LEGACY.
+
+    This test inserts directly into ``call_parts`` (bypassing the v2 write
+    path) so reads must go through ``calls_merged``. The shared fixture
+    defaults to AUTO, which would route reads to ``calls_complete`` and
+    miss the raw-inserted rows.
+    """
+    clickhouse_trace_server.table_routing_resolver._mode = (
+        CallsStorageServerMode.FORCE_LEGACY
+    )
+    reset_project_residence_cache()
+    return clickhouse_trace_server
+
+
+# Columns populated on a call_parts start row. Kept as a list so ch_client.insert
+# can enforce positional order with the value rows below.
+_START_COLUMNS = [
+    "project_id",
+    "id",
+    "trace_id",
+    "parent_id",
+    "op_name",
+    "started_at",
+    "attributes_dump",
+    "attributes_map_str",
+    "attributes_map_int",
+    "attributes_map_float",
+    "attributes_map_bool",
+    "inputs_dump",
+    "input_refs",
+    "output_refs",
+    "expire_at",
+]
+
+
+def _insert_start_row(
+    ch_client: object,
+    project_id: str,
+    call_id: str,
+    started_at: datetime.datetime,
+    attributes: dict[str, object],
+    *,
+    populate_typed_maps: bool,
+) -> None:
+    """Raw-insert one call_parts start row with optional typed-map population.
+
+    ``populate_typed_maps=False`` simulates a legacy pre-migration row: the
+    attributes dict is written to ``attributes_dump`` only and the four typed
+    maps remain empty ``{}``. ``populate_typed_maps=True`` mirrors what
+    ``extract_typed_attrs`` would do at ingest for rows the feature sees.
+    """
+    attrs_str: dict[str, str] = {}
+    attrs_int: dict[str, int] = {}
+    attrs_float: dict[str, float] = {}
+    attrs_bool: dict[str, bool] = {}
+    if populate_typed_maps:
+        for k, v in attributes.items():
+            # Match extract_typed_attrs dispatch: bool before int (bool ⊂ int).
+            if isinstance(v, bool):
+                attrs_bool[k] = v
+            elif isinstance(v, int):
+                attrs_int[k] = v
+            elif isinstance(v, float):
+                attrs_float[k] = v
+            elif isinstance(v, str):
+                attrs_str[k] = v
+
+    ch_client.insert(  # type: ignore[attr-defined]
+        "call_parts",
+        [
+            [
+                project_id,
+                call_id,
+                str(uuid.uuid4()),
+                "",
+                "test_op",
+                started_at,
+                json.dumps(attributes),
+                attrs_str,
+                attrs_int,
+                attrs_float,
+                attrs_bool,
+                "{}",
+                [],
+                [],
+                EXPIRE_AT_NEVER,
+            ]
+        ],
+        column_names=_START_COLUMNS,
+    )
+
+
+def _query_ids(trace_server: object, project_id: str, filter_query: dict) -> set[str]:
+    """Return the set of call ids returned by a filtered calls_query_stream."""
+    calls = list(
+        trace_server.calls_query_stream(  # type: ignore[attr-defined]
+            tsi.CallsQueryReq(project_id=project_id, query={"$expr": filter_query})
+        )
+    )
+    return {c.id for c in calls}
+
+
+def _populate_two_by_two(
+    ch_client: object,
+    internal_project_id: str,
+    attr_key: str,
+    matching_value: object,
+    other_value: object,
+    now: datetime.datetime,
+) -> tuple[str, str, str, str]:
+    """Insert the four-row fixture: populated+match, legacy+match, populated+other, legacy+other.
+
+    Returns the call ids in that order so tests can assert membership. All
+    rows share a project; the assertion is that only the two "match" rows
+    come back regardless of backfill state.
+    """
+    call_populated_match = str(uuid.uuid4())
+    call_legacy_match = str(uuid.uuid4())
+    call_populated_other = str(uuid.uuid4())
+    call_legacy_other = str(uuid.uuid4())
+    _insert_start_row(
+        ch_client,
+        internal_project_id,
+        call_populated_match,
+        now,
+        {attr_key: matching_value},
+        populate_typed_maps=True,
+    )
+    _insert_start_row(
+        ch_client,
+        internal_project_id,
+        call_legacy_match,
+        now + datetime.timedelta(seconds=1),
+        {attr_key: matching_value},
+        populate_typed_maps=False,
+    )
+    _insert_start_row(
+        ch_client,
+        internal_project_id,
+        call_populated_other,
+        now + datetime.timedelta(seconds=2),
+        {attr_key: other_value},
+        populate_typed_maps=True,
+    )
+    _insert_start_row(
+        ch_client,
+        internal_project_id,
+        call_legacy_other,
+        now + datetime.timedelta(seconds=3),
+        {attr_key: other_value},
+        populate_typed_maps=False,
+    )
+    return (
+        call_populated_match,
+        call_legacy_match,
+        call_populated_other,
+        call_legacy_other,
+    )
+
+
+@pytest.mark.parametrize(
+    ("attr_key", "matching_value", "other_value", "cast_to"),
+    [
+        # The hybrid ``if(mapContains(...))`` wins on the populated row and
+        # falls back to ``toString(coalesce(nullIf(JSON_VALUE, 'null'), ''))``
+        # on the legacy row whose typed maps are empty.
+        ("env", "prod", "staging", "string"),
+        ("retries", 5, 2, "int"),
+        ("score", 0.9, 0.1, "double"),
+        # bool is the case that would have failed before we special-cased it:
+        # the bool fallback compares the raw JSON_VALUE to ``'true'`` rather
+        # than going through the generic ``toUInt8OrNull`` cast (which returns
+        # NULL on the JSON bool strings ``"true"``/``"false"`` and would drop
+        # legacy rows with ``enabled: true`` in the dump).
+        ("enabled", True, False, "bool"),
+    ],
+    ids=["string", "int", "double", "bool"],
+)
+def test_fast_filter_mixed_backfill_convert(
+    trace_server: object,
+    ch_server_force_legacy: ClickHouseTraceServer,
+    attr_key: str,
+    matching_value: object,
+    other_value: object,
+    cast_to: str,
+) -> None:
+    """``$convert(attributes.<key>, <cast>)`` returns populated *and* legacy matches.
+
+    Both the typed-map row and the JSON_VALUE-only legacy row come back; the
+    "other" rows don't. Pinned per-cast so a regression in any one type's
+    fallback (especially bool) surfaces independently.
+    """
+    external_project_id = f"{TEST_ENTITY}/{cast_to}_{uuid.uuid4().hex[:8]}"
+    internal_project_id = b64(external_project_id)
+    reset_project_residence_cache()
+    populated_match, legacy_match, *_ = _populate_two_by_two(
+        ch_server_force_legacy.ch_client,
+        internal_project_id,
+        attr_key=attr_key,
+        matching_value=matching_value,
+        other_value=other_value,
+        now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
+    )
+
+    matching_ids = _query_ids(
+        trace_server,
+        external_project_id,
+        {
+            "$eq": [
+                {
+                    "$convert": {
+                        "input": {"$getField": f"attributes.{attr_key}"},
+                        "to": cast_to,
+                    }
+                },
+                {"$literal": matching_value},
+            ]
+        },
+    )
+    assert matching_ids == {populated_match, legacy_match}
+
+
+@pytest.mark.parametrize(
+    ("attr_key", "matching_value", "other_value"),
+    [
+        ("env", "prod", "staging"),
+        ("retries", 5, 2),
+        ("score", 0.9, 0.1),
+        ("enabled", True, False),
+    ],
+    ids=["string", "int", "double", "bool"],
+)
+def test_fast_filter_mixed_backfill_literal_inference_no_convert(
+    trace_server: object,
+    ch_server_force_legacy: ClickHouseTraceServer,
+    attr_key: str,
+    matching_value: object,
+    other_value: object,
+) -> None:
+    """``attributes.<key> = <typed literal>`` matches populated + legacy rows.
+
+    This proves the review comment's proposed query shape is possible for all
+    scalar typed maps: the query builder can infer the map column from the
+    literal type, so callers do not have to wrap attributes in ``$convert``.
+    The row-level ``mapContains`` guard still gates the fast read so legacy
+    rows fall back to JSON_VALUE and match.
+    """
+    external_project_id = f"{TEST_ENTITY}/literal_infer_{attr_key}_{uuid.uuid4().hex[:8]}"
+    internal_project_id = b64(external_project_id)
+    reset_project_residence_cache()
+    populated_match, legacy_match, *_ = _populate_two_by_two(
+        ch_server_force_legacy.ch_client,
+        internal_project_id,
+        attr_key=attr_key,
+        matching_value=matching_value,
+        other_value=other_value,
+        now=datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0),
+    )
+
+    matching_ids = _query_ids(
+        trace_server,
+        external_project_id,
+        {
+            "$eq": [
+                {"$getField": f"attributes.{attr_key}"},
+                {"$literal": matching_value},
+            ]
+        },
+    )
+    assert matching_ids == {populated_match, legacy_match}
+
+
+def test_fast_filter_missing_int_key_does_not_match_map_default(
+    trace_server: object,
+    ch_server_force_legacy: ClickHouseTraceServer,
+) -> None:
+    """Without the mapContains gate, ``attributes.missing = 0`` would match every
+    populated row — ClickHouse returns ``0`` for a missing Int64 Map key. The
+    ``if(mapContains(...))`` wrapper ensures we instead fall through to the
+    JSON_VALUE path, which yields NULL for a missing JSON key and does not
+    compare equal to ``0``.
+
+    This is the concrete failure mode the reviewer warned about on #6678:
+    a partially-backfilled table (or a row whose particular attribute never
+    existed) silently looking like it holds the zero value. The filter must
+    not match either populated-but-missing or legacy rows.
+    """
+    external_project_id = f"{TEST_ENTITY}/missing_int_{uuid.uuid4().hex[:8]}"
+    internal_project_id = b64(external_project_id)
+    reset_project_residence_cache()
+    now = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0)
+
+    # Populated row: attribute exists, but *not* the one we'll filter on.
+    # mapContains('missing_key') must be false, so the Int64 Map default (0)
+    # cannot leak into the comparison.
+    call_populated_missing_key = str(uuid.uuid4())
+    _insert_start_row(
+        ch_server_force_legacy.ch_client,
+        internal_project_id,
+        call_populated_missing_key,
+        now,
+        {"unrelated": 42},
+        populate_typed_maps=True,
+    )
+    # Legacy row with nothing in the typed maps either — fallback must also
+    # not match, because the JSON path for a missing key is NULL.
+    call_legacy_missing_key = str(uuid.uuid4())
+    _insert_start_row(
+        ch_server_force_legacy.ch_client,
+        internal_project_id,
+        call_legacy_missing_key,
+        now + datetime.timedelta(seconds=1),
+        {"unrelated": 42},
+        populate_typed_maps=False,
+    )
+    # Control: a populated row that actually has the attribute set to 0.
+    # This one *should* match, proving the filter itself is wired up.
+    call_populated_zero = str(uuid.uuid4())
+    _insert_start_row(
+        ch_server_force_legacy.ch_client,
+        internal_project_id,
+        call_populated_zero,
+        now + datetime.timedelta(seconds=2),
+        {"counter": 0},
+        populate_typed_maps=True,
+    )
+
+    matching_ids = _query_ids(
+        trace_server,
+        external_project_id,
+        {
+            "$eq": [
+                {"$getField": "attributes.counter"},
+                {"$literal": 0},
+            ]
+        },
+    )
+    assert matching_ids == {call_populated_zero}, (
+        "Only the populated row whose 'counter' is actually 0 should match; "
+        f"the missing-key rows must not leak the Map default. got {matching_ids}"
+    )

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -17,32 +17,10 @@ from weave.trace_server.project_version.project_version import (
     reset_project_residence_cache,
 )
 from weave.trace_server.project_version.types import (
-    CallsStorageServerMode,
     ProjectDataResidence,
     ReadTable,
     WriteTarget,
 )
-from weave.trace_server.sqlite_trace_server import SqliteTraceServer
-
-
-@pytest.fixture
-def clickhouse_trace_server(trace_server):
-    """Return internal ClickHouse server and enforce AUTO routing mode.
-
-    Args:
-        trace_server: External trace server fixture.
-
-    Returns:
-        ClickHouseTraceServer: The internal ClickHouse trace server.
-
-    Examples:
-        >>> internal = clickhouse_trace_server
-    """
-    internal_server = trace_server._internal_trace_server
-    if isinstance(internal_server, SqliteTraceServer):
-        pytest.skip("ClickHouse-only test")
-    internal_server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
-    return internal_server
 
 
 def _count_project_rows(ch_client, table: str, project_id: str) -> int:

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -82,6 +82,22 @@ logger = logging.getLogger(__name__)
 CTE_FILTERED_CALLS = "filtered_calls"
 CTE_ALL_CALLS = "all_calls"
 
+# Maps a DSL cast-to type onto the typed Map column that stores attribute
+# values of that type. Used to route attribute filters through the typed Map
+# columns instead of JSON_VALUE over attributes_dump when the comparison type
+# is known from either $convert or the peer $literal.
+ATTRIBUTES_MAP_COLUMN_BY_CAST: dict[str, str] = {
+    "int": "attributes_map_int",
+    "double": "attributes_map_float",
+    "bool": "attributes_map_bool",
+    "string": "attributes_map_str",
+}
+
+# Field-name prefix that identifies an attributes path in the query DSL.
+# Stripping it gives the dot-joined key used to read the typed Map column
+# (which mirrors extract_typed_attrs at write time).
+ATTRIBUTES_FIELD_PREFIX = "attributes."
+
 
 class FilterConditionsResult(NamedTuple):
     """Result from building filter conditions.
@@ -2074,6 +2090,244 @@ def _get_multi_value_feedback_field(
     return None
 
 
+def _attributes_dump_json_path(field_name: str, pb: ParamBuilder) -> str:
+    """Return the ``$."a"."b"..."`` JSONPath param slot for an ``attributes.<path>`` key.
+
+    Mirrors the JSONPath shape that ``CallsMergedDynamicField.as_sql`` uses so
+    the fallback branch of the typed-map hybrid reads the same JSON location
+    the non-hybrid JSON_VALUE path would.
+    """
+    parts = field_name.removeprefix(ATTRIBUTES_FIELD_PREFIX).split(".")
+    json_path = "$" + "".join(f'."{p}"' for p in parts)
+    return param_slot(pb.add_param(json_path), "String")
+
+
+def _attributes_map_fallback_sql(
+    cast: "tsi_query.CastTo | None",
+    json_path_slot: str,
+    attributes_dump_sql: str,
+) -> str:
+    """JSON_VALUE fallback expression for the typed-map hybrid.
+
+    Returns a value whose CH type matches the typed Map column on the fast
+    branch, so the surrounding ``if(...)`` hands either branch to the outer
+    comparison without a second cast.
+
+    - ``cast=None`` (inferred string path): plain ``coalesce/nullIf`` over
+      ``JSON_VALUE``. Both branches are already ``String``, so no cast.
+    - ``cast="bool"``: ``JSON_VALUE`` on a JSON bool emits the literal string
+      ``"true"``/``"false"``, and ``toUInt8OrNull("true")`` is NULL — the
+      generic ``clickhouse_cast`` would drop legacy bool rows on the floor.
+      We compare the raw JSON_VALUE against ``'true'`` to yield ``Bool``.
+    - other casts: reuse ``clickhouse_cast`` since the numeric/string casts
+      already handle the JSON_VALUE string output.
+    """
+    json_value_expr = f"JSON_VALUE({attributes_dump_sql}, {json_path_slot})"
+    if cast == "bool":
+        return f"({json_value_expr} = 'true')"
+    coalesced = f"coalesce(nullIf({json_value_expr}, 'null'), '')"
+    if cast is None:
+        return coalesced
+    return clickhouse_cast(coalesced, cast)
+
+
+def _emit_typed_map_hybrid(
+    field_name: str,
+    column: str,
+    fallback_cast: "tsi_query.CastTo | None",
+    pb: ParamBuilder,
+    table_alias: str,
+    use_agg_fn: bool,
+    raw_fields_used: dict[str, "CallsMergedField"],
+) -> str | None:
+    """Build ``if(mapContains(map, key), map[key], JSON_VALUE fallback)`` for
+    one ``attributes.<path>`` read.
+
+    Because migration 031 only populates the typed maps for rows inserted
+    after it runs, a pure ``map[key]`` read is unsafe on mixed-backfill
+    tables: CH returns the value-type default (``0``/``0.0``/``false``/``''``)
+    for a missing key, which silently produces wrong filter results on
+    legacy rows whose attributes live only in ``attributes_dump``. The
+    per-row ``mapContains`` gate means no cutoff timestamp, no backfill
+    completion gate, and mixed tables Just Work — the fast read fires when
+    it's safe, and the old path stays correct when it isn't.
+
+    Returns None when the path has no key (e.g. bare ``attributes.``).
+    """
+    key = field_name.removeprefix(ATTRIBUTES_FIELD_PREFIX)
+    if not key:
+        return None
+    structured_field = get_field_by_name(field_name)
+    raw_fields_used[structured_field.field] = structured_field
+
+    key_slot = param_slot(pb.add_param(key), "String")
+    column_sql = f"{table_alias}.{column}"
+    attributes_dump_sql = f"{table_alias}.attributes_dump"
+    if use_agg_fn:
+        column_sql = f"any({column_sql})"
+        attributes_dump_sql = f"any({attributes_dump_sql})"
+
+    fast_expr = f"{column_sql}[{key_slot}]"
+    fallback_expr = _attributes_map_fallback_sql(
+        fallback_cast, _attributes_dump_json_path(field_name, pb), attributes_dump_sql
+    )
+    return f"if(mapContains({column_sql}, {key_slot}), {fast_expr}, {fallback_expr})"
+
+
+def _cast_for_literal_value(value: object) -> "tsi_query.CastTo | None":
+    """Infer the typed attribute map from a scalar query literal.
+
+    Bool must be checked before int because ``bool`` is an ``int`` subclass in
+    Python. ``None`` and structured literals intentionally fall through to the
+    existing JSON_VALUE path.
+    """
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "double"
+    if isinstance(value, str):
+        return "string"
+    return None
+
+
+def _all_literals_share_cast(
+    operands: Sequence["tsi_query.Operand"],
+) -> "tsi_query.CastTo | None":
+    """Return a shared cast for a list of literal operands, if unambiguous."""
+    cast: tsi_query.CastTo | None = None
+    for operand in operands:
+        if not isinstance(operand, tsi_query.LiteralOperation):
+            return None
+        operand_cast = _cast_for_literal_value(operand.literal_)
+        if operand_cast is None:
+            return None
+        if cast is None:
+            cast = operand_cast
+        elif operand_cast != cast:
+            return None
+    return cast
+
+
+def _maybe_attributes_map_literal_field_sql(
+    operand: "tsi_query.Operand",
+    peer: "tsi_query.Operand",
+    pb: ParamBuilder,
+    table_alias: str,
+    use_agg_fn: bool,
+    raw_fields_used: dict[str, "CallsMergedField"],
+) -> str | None:
+    """Fast path for ``attributes.<path>`` compared against a scalar literal.
+
+    Fires when ``operand`` is ``$getField(attributes.<path>)`` and ``peer`` is
+    a scalar literal whose Python type maps cleanly to one typed Map column.
+    This covers common query shapes such as ``attributes.model = 'gpt-4'`` and
+    ``attributes.retries > 3`` without requiring callers to wrap the field in
+    ``$convert``.
+
+    String literals route through ``attributes_map_str`` with ``fallback_cast=None``
+    so the fallback is a plain ``coalesce/nullIf``. Explicit
+    ``$convert(..., "string")`` still adds a ``toString`` wrap for DSL
+    consistency; the inferred path skips it because both Map and JSON_VALUE
+    branches are already ``String``.
+
+    Returns None when the operand/peer shape doesn't match so callers fall
+    back to ``process_operand`` and preserve existing behavior (including
+    the ``IS NULL`` peer path and the ``$convert(..., "exists")`` case).
+    """
+    if not isinstance(operand, tsi_query.GetFieldOperator):
+        return None
+    if not isinstance(peer, tsi_query.LiteralOperation):
+        return None
+    cast = _cast_for_literal_value(peer.literal_)
+    if cast is None:
+        return None
+    field_name = operand.get_field_
+    if not field_name.startswith(ATTRIBUTES_FIELD_PREFIX):
+        return None
+    column = ATTRIBUTES_MAP_COLUMN_BY_CAST[cast]
+    fallback_cast: tsi_query.CastTo | None = None if cast == "string" else cast
+    return _emit_typed_map_hybrid(
+        field_name,
+        column,
+        fallback_cast,
+        pb,
+        table_alias,
+        use_agg_fn,
+        raw_fields_used,
+    )
+
+
+def _maybe_attributes_map_in_field_sql(
+    operand: "tsi_query.Operand",
+    literal_operands: Sequence["tsi_query.Operand"],
+    pb: ParamBuilder,
+    table_alias: str,
+    use_agg_fn: bool,
+    raw_fields_used: dict[str, "CallsMergedField"],
+) -> str | None:
+    """Fast path for ``attributes.<path> IN [same-typed scalar literals...]``."""
+    if not isinstance(operand, tsi_query.GetFieldOperator):
+        return None
+    cast = _all_literals_share_cast(literal_operands)
+    if cast is None:
+        return None
+    field_name = operand.get_field_
+    if not field_name.startswith(ATTRIBUTES_FIELD_PREFIX):
+        return None
+    column = ATTRIBUTES_MAP_COLUMN_BY_CAST[cast]
+    fallback_cast: tsi_query.CastTo | None = None if cast == "string" else cast
+    return _emit_typed_map_hybrid(
+        field_name,
+        column,
+        fallback_cast,
+        pb,
+        table_alias,
+        use_agg_fn,
+        raw_fields_used,
+    )
+
+
+def _maybe_attributes_map_filter_sql(
+    operand: tsi_query.ConvertOperation,
+    pb: ParamBuilder,
+    table_alias: str,
+    use_agg_fn: bool,
+    raw_fields_used: dict[str, "CallsMergedField"],
+) -> str | None:
+    """Hybrid fast/fallback SQL for ``$convert`` over ``attributes.<path>``.
+
+    Only fires when:
+    - the converted operand is a plain ``$getField`` on ``attributes.*``,
+    - the target cast maps to one of the typed Map columns populated at ingest
+      (``int``/``double``/``bool``/``string`` — ``exists`` has no typed Map and
+      falls through to the JSON_VALUE path).
+
+    The Map key is the dot-joined path after ``attributes.`` to mirror the
+    flattening done by ``extract_typed_attrs`` at write time.
+    """
+    inner = operand.convert_.input
+    if not isinstance(inner, tsi_query.GetFieldOperator):
+        return None
+    field_name = inner.get_field_
+    if not field_name.startswith(ATTRIBUTES_FIELD_PREFIX):
+        return None
+    cast = operand.convert_.to
+    column = ATTRIBUTES_MAP_COLUMN_BY_CAST.get(cast)
+    if column is None:
+        return None
+    return _emit_typed_map_hybrid(
+        field_name,
+        column,
+        cast,
+        pb,
+        table_alias,
+        use_agg_fn,
+        raw_fields_used,
+    )
+
+
 def process_query_to_conditions(
     query: tsi.Query,
     param_builder: ParamBuilder,
@@ -2089,6 +2343,29 @@ def process_query_to_conditions(
     # This is the mongo-style query
     def process_operation(operation: tsi_query.Operation) -> str:
         cond = None
+
+        def process_binary_operands(
+            ops: Sequence["tsi_query.Operand"],
+        ) -> tuple[str, str]:
+            lhs_fast = _maybe_attributes_map_literal_field_sql(
+                ops[0],
+                ops[1],
+                param_builder,
+                table_alias,
+                use_agg_fn,
+                raw_fields_used,
+            )
+            rhs_fast = _maybe_attributes_map_literal_field_sql(
+                ops[1],
+                ops[0],
+                param_builder,
+                table_alias,
+                use_agg_fn,
+                raw_fields_used,
+            )
+            lhs_part = lhs_fast if lhs_fast is not None else process_operand(ops[0])
+            rhs_part = rhs_fast if rhs_fast is not None else process_operand(ops[1])
+            return lhs_part, rhs_part
 
         if isinstance(operation, tsi_query.AndOperation):
             if len(operation.and_) == 0:
@@ -2121,54 +2398,59 @@ def process_query_to_conditions(
                 else:
                     rhs_part = process_operand(ops[1])
                     cond = f"has({array_expr}, {rhs_part})"
-            else:
+            elif (
+                isinstance(ops[1], tsi_query.LiteralOperation)
+                and ops[1].literal_ is None
+            ):
                 lhs_part = process_operand(ops[0])
-                if (
-                    isinstance(ops[1], tsi_query.LiteralOperation)
-                    and ops[1].literal_ is None
-                ):
-                    # For calls_complete, sentinel fields use equality checks
-                    # against the sentinel value instead of IS NULL.
-                    field_name = _extract_field_name(ops[0])
-                    sentinel = (
-                        ch_sentinel_values.get_sentinel_value(field_name)
-                        if use_sentinels and field_name
-                        else None
+                # For calls_complete, sentinel fields use equality checks
+                # against the sentinel value instead of IS NULL.
+                field_name = _extract_field_name(ops[0])
+                sentinel = (
+                    ch_sentinel_values.get_sentinel_value(field_name)
+                    if use_sentinels and field_name
+                    else None
+                )
+                if sentinel is not None:
+                    assert field_name is not None
+                    sentinel_type = ch_sentinel_values.sentinel_ch_type(field_name)
+                    sentinel_slot = param_builder.add(
+                        sentinel, param_type=sentinel_type
                     )
-                    if sentinel is not None:
-                        assert field_name is not None
-                        sentinel_type = ch_sentinel_values.sentinel_ch_type(field_name)
-                        sentinel_slot = param_builder.add(
-                            sentinel, param_type=sentinel_type
-                        )
-                        cond = f"({lhs_part} = {sentinel_slot})"
-                    else:
-                        cond = f"({lhs_part} IS NULL)"
+                    cond = f"({lhs_part} = {sentinel_slot})"
                 else:
-                    rhs_part = process_operand(ops[1])
-                    cond = f"({lhs_part} = {rhs_part})"
+                    cond = f"({lhs_part} IS NULL)"
+            else:
+                lhs_part, rhs_part = process_binary_operands(ops)
+                cond = f"({lhs_part} = {rhs_part})"
         elif isinstance(operation, tsi_query.GtOperation):
             ops = _maybe_convert_datetime_operands(operation.gt_)
-            lhs_part = process_operand(ops[0])
-            rhs_part = process_operand(ops[1])
+            lhs_part, rhs_part = process_binary_operands(ops)
             cond = f"({lhs_part} > {rhs_part})"
         elif isinstance(operation, tsi_query.LtOperation):
             ops = _maybe_convert_datetime_operands(operation.lt_)
-            lhs_part = process_operand(ops[0])
-            rhs_part = process_operand(ops[1])
+            lhs_part, rhs_part = process_binary_operands(ops)
             cond = f"({lhs_part} < {rhs_part})"
         elif isinstance(operation, tsi_query.GteOperation):
             ops = _maybe_convert_datetime_operands(operation.gte_)
-            lhs_part = process_operand(ops[0])
-            rhs_part = process_operand(ops[1])
+            lhs_part, rhs_part = process_binary_operands(ops)
             cond = f"({lhs_part} >= {rhs_part})"
         elif isinstance(operation, tsi_query.LteOperation):
             ops = _maybe_convert_datetime_operands(operation.lte_)
-            lhs_part = process_operand(ops[0])
-            rhs_part = process_operand(ops[1])
+            lhs_part, rhs_part = process_binary_operands(ops)
             cond = f"({lhs_part} <= {rhs_part})"
         elif isinstance(operation, tsi_query.InOperation):
-            lhs_part = process_operand(operation.in_[0])
+            lhs_fast = _maybe_attributes_map_in_field_sql(
+                operation.in_[0],
+                operation.in_[1],
+                param_builder,
+                table_alias,
+                use_agg_fn,
+                raw_fields_used,
+            )
+            lhs_part = (
+                lhs_fast if lhs_fast is not None else process_operand(operation.in_[0])
+            )
             rhs_part = ",".join(process_operand(op) for op in operation.in_[1])
             cond = f"({lhs_part} IN ({rhs_part}))"
         elif isinstance(operation, tsi_query.ContainsOperation):
@@ -2233,6 +2515,11 @@ def process_query_to_conditions(
             raw_fields_used[structured_field.field] = structured_field
             return field
         elif isinstance(operand, tsi_query.ConvertOperation):
+            fast_sql = _maybe_attributes_map_filter_sql(
+                operand, param_builder, table_alias, use_agg_fn, raw_fields_used
+            )
+            if fast_sql is not None:
+                return fast_sql
             field = process_operand(operand.convert_.input)
             return clickhouse_cast(field, operand.convert_.to)
         elif isinstance(

--- a/weave/trace_server/clickhouse/schema_converters.py
+++ b/weave/trace_server/clickhouse/schema_converters.py
@@ -16,6 +16,7 @@ from weave.trace_server.clickhouse.utilities import (
     dict_dump_to_dict,
     dict_value_to_dump,
     ensure_datetimes_have_tz,
+    extract_typed_attrs,
     nullable_any_dump_to_any,
 )
 from weave.trace_server.clickhouse_schema import (
@@ -97,10 +98,29 @@ def ch_call_dict_to_call_schema_dict(ch_call_dict: dict) -> dict:
     }
 
 
+# call_parts columns for the typed attribute Maps. End/delete/update
+# insertables don't populate them, so ch_call_to_row must substitute an
+# empty dict — ClickHouse rejects None for non-Nullable Map columns.
+ATTRIBUTES_MAP_COLUMNS = frozenset(
+    {
+        "attributes_map_str",
+        "attributes_map_int",
+        "attributes_map_float",
+        "attributes_map_bool",
+    }
+)
+
+
 def ch_call_to_row(ch_call: CallCHInsertable) -> list[Any]:
     """Convert a CH insertable call to a row for batch insertion with the correct defaults."""
     call_dict = ch_call.model_dump()
-    return [call_dict.get(col) for col in ALL_CALL_INSERT_COLUMNS]
+    row: list[Any] = []
+    for col in ALL_CALL_INSERT_COLUMNS:
+        val = call_dict.get(col)
+        if val is None and col in ATTRIBUTES_MAP_COLUMNS:
+            val = {}
+        row.append(val)
+    return row
 
 
 def start_call_for_insert_to_ch_insertable(
@@ -129,6 +149,7 @@ def start_call_for_insert_to_ch_insertable(
         op_name=start_call.op_name,
         started_at=start_call.started_at,
         attributes_dump=dict_value_to_dump(start_call.attributes),
+        **extract_typed_attrs(start_call.attributes),
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         otel_dump=otel_dump_str,
@@ -164,6 +185,10 @@ def start_call_insertable_to_complete_start(
         ended_at=None,
         exception=None,
         attributes_dump=ch_start.attributes_dump,
+        attributes_map_str=ch_start.attributes_map_str,
+        attributes_map_int=ch_start.attributes_map_int,
+        attributes_map_float=ch_start.attributes_map_float,
+        attributes_map_bool=ch_start.attributes_map_bool,
         inputs_dump=ch_start.inputs_dump,
         input_refs=ch_start.input_refs,
         output_dump=any_value_to_dump(None),
@@ -243,6 +268,7 @@ def start_end_calls_to_ch_complete_insertable(
         ended_at=end_call.ended_at,
         exception=end_call.exception,
         attributes_dump=dict_value_to_dump(start_call.attributes),
+        **extract_typed_attrs(start_call.attributes),
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         output_dump=any_value_to_dump(output),
@@ -302,6 +328,7 @@ def complete_call_to_ch_insertable(
         ended_at=complete_call.ended_at,
         exception=complete_call.exception,
         attributes_dump=dict_value_to_dump(complete_call.attributes),
+        **extract_typed_attrs(complete_call.attributes),
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         output_dump=any_value_to_dump(output),

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -8,9 +8,10 @@ import datetime
 import hashlib
 import json
 import logging
+import math
 from collections import defaultdict
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, TypedDict
 
 import ddtrace
 import sqlparse
@@ -96,6 +97,94 @@ def split_migration_sql(sql: str) -> list[str]:
         if stripped:
             statements.append(stripped)
     return statements
+
+
+# ---------------------------------------------------------------------------
+# Typed attribute map extraction (fast-filter path)
+# ---------------------------------------------------------------------------
+
+
+def _flatten_attrs(attrs: dict[str, Any], prefix: str = "") -> list[tuple[str, Any]]:
+    """Flatten a nested dict into dot-joined (key, leaf-value) pairs.
+
+    Matches the dot-path convention already used by read-side filters
+    (`attributes.nested.leaf`), so a caller filtering on "attributes.foo.bar"
+    hits the same key the extractor writes.
+
+    Collision caveat: ``{"a": {"b": 1}}`` and ``{"a.b": 1}`` both flatten to
+    key ``"a.b"``; the second write wins in the typed map. The ``JSON_VALUE``
+    fallback can still distinguish them (``$."a"."b"`` vs ``$."a.b"``), so a
+    row with a literal-dot key can legitimately read different values from
+    the fast and fallback branches. We accept this divergence because nested
+    dicts are the common shape; literal-dot keys are pathological and already
+    break the existing JSONPath-based filter convention.
+    """
+    result: list[tuple[str, Any]] = []
+    for key, val in attrs.items():
+        full_key = key if not prefix else f"{prefix}.{key}"
+        if isinstance(val, dict):
+            result.extend(_flatten_attrs(val, full_key))
+        else:
+            result.append((full_key, val))
+    return result
+
+
+class TypedAttrMaps(TypedDict):
+    """Typed attribute maps keyed by their CH column name.
+
+    Keys match the ``CallStartCHInsertable`` / ``CallCompleteCHInsertable``
+    fields so call sites can ``**spread`` the result straight into the
+    insertable constructor.
+    """
+
+    attributes_map_str: dict[str, str]
+    attributes_map_int: dict[str, int]
+    attributes_map_float: dict[str, float]
+    attributes_map_bool: dict[str, bool]
+
+
+def extract_typed_attrs(attrs: dict[str, Any]) -> TypedAttrMaps:
+    """Route a Python attributes dict into four typed maps for fast filtering.
+
+    No per-map entry cap: ``attributes_dump`` already admits arbitrarily large
+    payloads, the typed maps mirror it, and ``_strip_large_values`` clears the
+    maps together with the dump when a row exceeds the insert byte limit. A
+    dedicated cap would only hide truncation from callers.
+
+    Non-finite floats (NaN, +/-Inf) are dropped because they break
+    JSON/CH round-trips. Non-scalar leaf values (lists, etc.) are
+    JSON-encoded into the string map.
+
+    The ``bool`` branch must come before the ``int`` branch: Python's ``bool``
+    is a subclass of ``int``, so ``isinstance(True, int)`` is True, and an
+    int-first dispatch would land True/False in the int map.
+    """
+    result: TypedAttrMaps = {
+        "attributes_map_str": {},
+        "attributes_map_int": {},
+        "attributes_map_float": {},
+        "attributes_map_bool": {},
+    }
+    if not isinstance(attrs, dict):
+        return result
+
+    for key, val in _flatten_attrs(attrs):
+        if val is None:
+            continue
+        if isinstance(val, bool):
+            result["attributes_map_bool"][key] = val
+        elif isinstance(val, int):
+            result["attributes_map_int"][key] = val
+        elif isinstance(val, float):
+            if not math.isfinite(val):
+                continue
+            result["attributes_map_float"][key] = val
+        elif isinstance(val, str):
+            result["attributes_map_str"][key] = val
+        else:
+            result["attributes_map_str"][key] = json.dumps(val)
+
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/clickhouse_schema.py
+++ b/weave/trace_server/clickhouse_schema.py
@@ -67,6 +67,10 @@ class CallStartCHInsertable(
 
     started_at: datetime.datetime
     attributes_dump: str
+    attributes_map_str: dict[str, str] = Field(default_factory=dict)
+    attributes_map_int: dict[str, int] = Field(default_factory=dict)
+    attributes_map_float: dict[str, float] = Field(default_factory=dict)
+    attributes_map_bool: dict[str, bool] = Field(default_factory=dict)
     inputs_dump: str
     otel_dump: str | None = None
     expire_at: datetime.datetime = EXPIRE_AT_NEVER
@@ -128,6 +132,10 @@ class CallCompleteCHInsertable(
     ended_at: datetime.datetime | None = None
     exception: str | None = None
     attributes_dump: str
+    attributes_map_str: dict[str, str] = Field(default_factory=dict)
+    attributes_map_int: dict[str, int] = Field(default_factory=dict)
+    attributes_map_float: dict[str, float] = Field(default_factory=dict)
+    attributes_map_bool: dict[str, bool] = Field(default_factory=dict)
     inputs_dump: str
     output_dump: str
     summary_dump: str

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -83,6 +83,7 @@ from weave.trace_server.calls_query_builder.usage_query_builder import (
     build_usage_query,
 )
 from weave.trace_server.clickhouse.schema_converters import (
+    ATTRIBUTES_MAP_COLUMNS,
     ch_call_dict_to_call_schema_dict,
     ch_call_to_row,
     ch_complete_call_to_row,
@@ -6204,15 +6205,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             if exception:
                 end.exception = exception
             end_call = end_call_for_insert_to_ch_insertable(end, retention_days)
-            calls: list[CallStartCHInsertable | CallEndCHInsertable] = [
-                start_call,
-                end_call,
-            ]
-            batch_data = []
-            for call in calls:
-                call_dict = call.model_dump()
-                values = [call_dict.get(col) for col in ALL_CALL_INSERT_COLUMNS]
-                batch_data.append(values)
+            batch_data = [ch_call_to_row(start_call), ch_call_to_row(end_call)]
 
             self._insert_call_batch(batch_data)
 
@@ -6460,15 +6453,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             end.exception = res.response["error"]
 
         end_call = end_call_for_insert_to_ch_insertable(end, retention_days)
-        calls: list[CallStartCHInsertable | CallEndCHInsertable] = [
-            start_call,
-            end_call,
-        ]
-        batch_data = []
-        for call in calls:
-            call_dict = call.model_dump()
-            values = [call_dict.get(col) for col in ALL_CALL_INSERT_COLUMNS]
-            batch_data.append(values)
+        batch_data = [ch_call_to_row(start_call), ch_call_to_row(end_call)]
 
         try:
             self._insert_call_batch(batch_data)
@@ -6857,11 +6842,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._insert_call")
     def _insert_call(self, ch_call: CallCHInsertable) -> None:
-        parameters = ch_call.model_dump()
-        row = []
-        for key in ALL_CALL_INSERT_COLUMNS:
-            row.append(parameters.get(key, None))
-        self._call_batch.append(row)
+        self._call_batch.append(ch_call_to_row(ch_call))
         if self._flush_immediately:
             self._flush_calls()
 
@@ -6975,8 +6956,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def _strip_large_values(self, batch: list[list[Any]]) -> list[list[Any]]:
         """Iterate through the batch and replace large JSON values with placeholders.
 
-        Only considers JSON dump columns and ensures their combined size stays under
-        the limit by selectively replacing the largest values.
+        Considers each ``*_dump`` JSON column individually, plus the four
+        ``attributes_map_*`` columns as a group bound to ``attributes_dump``.
+        The typed maps mirror the attributes dict at ingest and must be cleared
+        alongside the dump — otherwise stripping ``attributes_dump`` alone
+        leaves the row oversized by the sum of the map bytes.
         """
         stripped_count = 0
         final_batch = []
@@ -6985,13 +6969,26 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             ALL_CALL_INSERT_COLUMNS.index(f"{col}_dump")
             for col in ALL_CALL_JSON_COLUMNS
         ]
+        attributes_dump_idx = ALL_CALL_INSERT_COLUMNS.index("attributes_dump")
+        attributes_map_indices = [
+            ALL_CALL_INSERT_COLUMNS.index(col) for col in ATTRIBUTES_MAP_COLUMNS
+        ]
         entity_too_large_payload_byte_size = num_bytes(
             ch_settings.ENTITY_TOO_LARGE_PAYLOAD
         )
 
         for item in batch:
-            # Calculate only JSON dump bytes
-            json_idx_size_pairs = [(i, num_bytes(item[i])) for i in json_column_indices]
+            # Count attributes_dump + typed map bytes as one slot so stripping
+            # attributes hits the full byte cost in a single pass.
+            attributes_map_bytes = sum(
+                num_bytes(item[i]) for i in attributes_map_indices
+            )
+            json_idx_size_pairs = []
+            for col_idx in json_column_indices:
+                size = num_bytes(item[col_idx])
+                if col_idx == attributes_dump_idx:
+                    size += attributes_map_bytes
+                json_idx_size_pairs.append((col_idx, size))
             total_json_bytes = sum(size for _, size in json_idx_size_pairs)
 
             # If over limit, try to optimize by selectively stripping largest JSON values
@@ -7012,6 +7009,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 stripped_item[col_idx] = ch_settings.ENTITY_TOO_LARGE_PAYLOAD
                 total_json_bytes -= size - entity_too_large_payload_byte_size
                 stripped_count += 1
+                # Clear typed attribute maps together with attributes_dump; the
+                # maps are derived from the dump and would otherwise keep the
+                # row oversized after the dump placeholder is in place.
+                if col_idx == attributes_dump_idx:
+                    for map_idx in attributes_map_indices:
+                        stripped_item[map_idx] = {}
 
             final_batch.append(stripped_item)
 

--- a/weave/trace_server/migrations/031_add_attributes_map.down.sql
+++ b/weave/trace_server/migrations/031_add_attributes_map.down.sql
@@ -1,0 +1,53 @@
+-- Rollback Migration 031: Remove typed attribute maps.
+
+-- Step 1: Revert calls_merged_view to the pre-031 shape (without typed maps).
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleState(wb_run_step) as wb_run_step,
+        anySimpleState(wb_run_step_end) as wb_run_step_end,
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(thread_id) as thread_id,
+        anySimpleState(turn_id) as turn_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        anySimpleState(deleted_at) as deleted_at,
+        argMaxState(display_name, call_parts.created_at) as display_name,
+        anySimpleState(coalesce(call_parts.started_at, call_parts.ended_at, call_parts.created_at)) as sortable_datetime,
+        anySimpleState(otel_dump) as otel_dump,
+        minSimpleState(expire_at) as expire_at
+    FROM call_parts
+    GROUP BY project_id,
+        id;
+
+-- Step 2: Drop typed map columns from calls_merged.
+ALTER TABLE calls_merged
+    DROP COLUMN IF EXISTS attributes_map_str,
+    DROP COLUMN IF EXISTS attributes_map_int,
+    DROP COLUMN IF EXISTS attributes_map_float,
+    DROP COLUMN IF EXISTS attributes_map_bool;
+
+-- Step 3: Drop typed map columns from call_parts.
+ALTER TABLE call_parts
+    DROP COLUMN IF EXISTS attributes_map_str,
+    DROP COLUMN IF EXISTS attributes_map_int,
+    DROP COLUMN IF EXISTS attributes_map_float,
+    DROP COLUMN IF EXISTS attributes_map_bool;
+
+-- Step 4: Drop typed map columns from calls_complete.
+ALTER TABLE calls_complete
+    DROP COLUMN IF EXISTS attributes_map_str,
+    DROP COLUMN IF EXISTS attributes_map_int,
+    DROP COLUMN IF EXISTS attributes_map_float,
+    DROP COLUMN IF EXISTS attributes_map_bool;

--- a/weave/trace_server/migrations/031_add_attributes_map.up.sql
+++ b/weave/trace_server/migrations/031_add_attributes_map.up.sql
@@ -1,0 +1,72 @@
+-- Migration 031: Add typed attribute maps for fast filtering.
+--
+-- Adds four Map columns alongside attributes_dump on call_parts, calls_merged,
+-- and calls_complete. The typed maps are populated at ingest from the Python
+-- attributes dict by dispatching each value to the map matching its type.
+-- Read-path filters with a known type (via $convert or a typed literal)
+-- hit the typed map directly instead of JSON_VALUE over attributes_dump.
+--
+-- attributes_dump is preserved — typed maps are a duplicated read-path index.
+-- Existing rows get empty maps by default and continue to work via the
+-- JSON_VALUE fallback.
+
+-- Step 1: Add typed maps to call_parts. Map columns default to empty map in
+-- ClickHouse, so no explicit DEFAULT clause is needed.
+ALTER TABLE call_parts
+    ADD COLUMN attributes_map_str   Map(String, String),
+    ADD COLUMN attributes_map_int   Map(String, Int64),
+    ADD COLUMN attributes_map_float Map(String, Float64),
+    ADD COLUMN attributes_map_bool  Map(String, Bool);
+
+-- Step 2: Add typed maps to calls_merged as SimpleAggregateFunction(any, ...)
+-- to match the existing AMT aggregation pattern.
+ALTER TABLE calls_merged
+    ADD COLUMN attributes_map_str   SimpleAggregateFunction(any, Map(String, String)),
+    ADD COLUMN attributes_map_int   SimpleAggregateFunction(any, Map(String, Int64)),
+    ADD COLUMN attributes_map_float SimpleAggregateFunction(any, Map(String, Float64)),
+    ADD COLUMN attributes_map_bool  SimpleAggregateFunction(any, Map(String, Bool));
+
+-- Step 3: Propagate typed maps through calls_merged_view.
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleState(wb_run_step) as wb_run_step,
+        anySimpleState(wb_run_step_end) as wb_run_step_end,
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(thread_id) as thread_id,
+        anySimpleState(turn_id) as turn_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        -- Maps default to map() on non-start rows. Gate on isNotNull(started_at)
+        -- so the empty default from an end/delete/update row can't win over
+        -- the start row's populated maps under SimpleAggregateFunction(any).
+        anySimpleStateIf(attributes_map_str, isNotNull(call_parts.started_at)) as attributes_map_str,
+        anySimpleStateIf(attributes_map_int, isNotNull(call_parts.started_at)) as attributes_map_int,
+        anySimpleStateIf(attributes_map_float, isNotNull(call_parts.started_at)) as attributes_map_float,
+        anySimpleStateIf(attributes_map_bool, isNotNull(call_parts.started_at)) as attributes_map_bool,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        anySimpleState(deleted_at) as deleted_at,
+        argMaxState(display_name, call_parts.created_at) as display_name,
+        anySimpleState(coalesce(call_parts.started_at, call_parts.ended_at, call_parts.created_at)) as sortable_datetime,
+        anySimpleState(otel_dump) as otel_dump,
+        minSimpleState(expire_at) as expire_at
+    FROM call_parts
+    GROUP BY project_id,
+        id;
+
+-- Step 4: Add typed maps to calls_complete.
+ALTER TABLE calls_complete
+    ADD COLUMN attributes_map_str   Map(String, String),
+    ADD COLUMN attributes_map_int   Map(String, Int64),
+    ADD COLUMN attributes_map_float Map(String, Float64),
+    ADD COLUMN attributes_map_bool  Map(String, Bool);


### PR DESCRIPTION
## Summary

Follow-up to #6678 and the review question about whether `$convert` is necessary when the comparison literal already carries the intended type. This proves the answer is "yes, we can infer it" for scalar attribute filters.

- Adds typed `attributes_map_str` / `_int` / `_float` / `_bool` columns via migration `031_add_attributes_map`.
- Populates those maps at ingest from `attributes_dump`, using the same dot-flattened keys the query builder reads.
- Routes `attributes.<path>` filters through the typed map when the type is known from either explicit `$convert` or from a scalar `$literal` peer.
- Keeps the row-level `mapContains(..., key)` guard so legacy or partially backfilled rows fall back to `JSON_VALUE(attributes_dump, ...)` instead of leaking ClickHouse map defaults.

## Why Users Might Want This

Filter builders and hand-written queries often already know the type from the literal they are comparing against: `3` means int, `0.9` means float, `true` means bool, and `"prod"` means string. Requiring callers to wrap the field in `$convert` exposes an internal query-shaping detail and is easy to miss. When missed, numeric/bool dynamic-field comparisons either stay on the slower JSON path or can hit ClickHouse common-type errors. Literal inference lets users write the natural query shape while still getting the typed-map fast path.

## Query Shape Changes

The explicit `$convert` form still works:

```json
{
  "$expr": {
    "$eq": [
      {"$convert": {"input": {"$getField": "attributes.retries"}, "to": "int"}},
      {"$literal": 3}
    ]
  }
}
```

The new inferred form is also accepted and emits the same typed-map hybrid:

```json
{
  "$expr": {
    "$eq": [
      {"$getField": "attributes.retries"},
      {"$literal": 3}
    ]
  }
}
```

For `calls_complete`, that becomes the equivalent of:

```sql
if(
  mapContains(calls_complete.attributes_map_int, {key:String}),
  calls_complete.attributes_map_int[{key:String}],
  toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.attributes_dump, {json_path:String}), 'null'), ''))
) = {literal:Int64}
```

Literal dispatch rules:

- `str` literal -> `attributes_map_str`, JSON fallback stays string-shaped.
- `int` literal -> `attributes_map_int`, JSON fallback uses `toInt64OrNull(...)`.
- `float` literal -> `attributes_map_float`, JSON fallback uses `toFloat64OrNull(...)`.
- `bool` literal -> `attributes_map_bool`, JSON fallback uses `JSON_VALUE(...) = 'true'` because ClickHouse does not cast JSON bool strings through `toUInt8OrNull` correctly.
- `$in` uses the typed map when all list literals share one scalar type.
- `$convert(..., "exists")`, `null`, structured literals, mixed-type `$in` lists, and non-attribute fields keep the existing JSON_VALUE path.

## Test Plan

- [x] `uv run --group test python -m pytest tests/trace_server/query_builder/test_attributes_map_dispatch.py -v`
- [x] `uv run --group test python -m pytest tests/trace_server/query_builder/ -v`
- [x] `uv run --group test python -m pytest tests/trace_server/test_attributes_map_fast_filter.py -v --trace-server=clickhouse --clickhouse-process=true`
- [x] `uv run --group test python -m pytest tests/trace_server/test_clickhouse_trace_server_migrator.py -v`
- [x] `uvx ruff check weave/trace_server/calls_query_builder/calls_query_builder.py tests/trace_server/query_builder/test_attributes_map_dispatch.py tests/trace_server/query_builder/test_calls_query_builder.py tests/trace_server/test_attributes_map_fast_filter.py`
