### PR TITLE
fix(weave): include tests in trace_no_server shard and fix

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -186,7 +186,13 @@ def tests(session: nox.Session, shard: str):
             "tests/utils/",
             "tests/wandb_interface/",
         ],
-        "trace_no_server": ["tests/trace/", "tests/durability/"],
+        "trace_no_server": [
+            "tests/trace/",
+            "tests/durability/",
+            "tests/utils/",
+            "tests/compat/",
+            "tests/wandb_interface/",
+        ],
     }
 
     test_dirs = test_dirs_dict.get(shard, default_test_dirs)

--- a/tests/compat/wandb/conftest.py
+++ b/tests/compat/wandb/conftest.py
@@ -1,18 +1,24 @@
 """Shared fixtures for wandb compatibility tests."""
 
+import importlib
 import os
 from unittest.mock import Mock, patch
 
 import pytest
 
+# Import the submodule explicitly to dodge a Python 3.10/3.11 quirk: the parent
+# package's __init__.py does `from .login import login`, which makes
+# `wandb_thin.login` resolve to the function (not the submodule). On those
+# versions mock.patch's getattr-walk then trips on `login._set_setting`. Using
+# patch.object against the actual module is portable across all versions.
+_login_module = importlib.import_module("weave.compat.wandb.wandb_thin.login")
+_util_module = importlib.import_module("weave.compat.wandb.wandb_thin.util")
+
 
 @pytest.fixture
 def mock_netrc():
     """Fixture that provides a mocked Netrc instance."""
-    with patch(
-        "weave.compat.wandb.wandb_thin.login.Netrc",
-        autospec=True,
-    ) as mock_netrc_class:
+    with patch.object(_login_module, "Netrc", autospec=True) as mock_netrc_class:
         mock_netrc_instance = Mock()
         mock_netrc_class.return_value = mock_netrc_instance
         yield mock_netrc_instance
@@ -21,20 +27,14 @@ def mock_netrc():
 @pytest.fixture
 def mock_default_host():
     """Fixture that mocks _get_default_host to return api.wandb.ai."""
-    with patch(
-        "weave.compat.wandb.wandb_thin.login._get_default_host",
-        return_value="api.wandb.ai",
-    ):
+    with patch.object(_login_module, "_get_default_host", return_value="api.wandb.ai"):
         yield
 
 
 @pytest.fixture
 def mock_app_url():
     """Fixture that mocks app_url to return https://wandb.ai."""
-    with patch(
-        "weave.compat.wandb.wandb_thin.util.app_url",
-        return_value="https://wandb.ai",
-    ):
+    with patch.object(_util_module, "app_url", return_value="https://wandb.ai"):
         yield
 
 

--- a/tests/compat/wandb/test_login.py
+++ b/tests/compat/wandb/test_login.py
@@ -95,7 +95,7 @@ def test_validate_api_key_success(api_key):
 @pytest.mark.parametrize("api_key", all_invalid_keys, indirect=True)
 def test_validate_api_key_failure(api_key):
     """All invalid API keys should raise ValueError."""
-    with pytest.raises(ValueError, match="API key must be 40 characters long"):
+    with pytest.raises(ValueError, match="API key must be at least 40 characters long"):
         _validate_api_key(api_key)
 
 

--- a/tests/compat/wandb/test_login.py
+++ b/tests/compat/wandb/test_login.py
@@ -1,6 +1,7 @@
 """Tests for wandb login compatibility layer."""
 
 import configparser
+import importlib
 import os
 from dataclasses import dataclass
 from unittest.mock import patch
@@ -20,6 +21,10 @@ from weave.compat.wandb.wandb_thin.login import (
     _WandbLogin,
 )
 from weave.wandb_interface.project_creator import _ensure_project_exists
+
+# See conftest.py: we patch via the actual module object to dodge a
+# Python 3.10/3.11 mock.patch resolution quirk.
+_login_module = importlib.import_module("weave.compat.wandb.wandb_thin.login")
 
 
 @dataclass
@@ -126,10 +131,7 @@ def test_get_default_host_settings_file(tmp_path, host_and_base_url):
 def test_get_default_host_fallback():
     """If there is no env var or settings file, it should fallback to api.wandb.ai."""
     with patch.dict(os.environ, {}, clear=True):
-        with patch(
-            "weave.compat.wandb.wandb_thin.login._get_host_from_settings",
-            return_value=None,
-        ):
+        with patch.object(_login_module, "_get_host_from_settings", return_value=None):
             assert _get_default_host() == "api.wandb.ai"
 
 
@@ -179,18 +181,18 @@ def test_clear_setting(tmp_path):
 
 def test_handle_host_wandb_setting_default():
     """Test host setting handling for default values."""
-    with patch("weave.compat.wandb.wandb_thin.login._clear_setting") as mock_clear:
+    with patch.object(_login_module, "_clear_setting") as mock_clear:
         _handle_host_wandb_setting("https://api.wandb.ai")
         mock_clear.assert_called_once_with("base_url")
 
-    with patch("weave.compat.wandb.wandb_thin.login._clear_setting") as mock_clear:
+    with patch.object(_login_module, "_clear_setting") as mock_clear:
         _handle_host_wandb_setting(None)
         mock_clear.assert_called_once_with("base_url")
 
 
 def test_handle_host_wandb_setting_custom():
     """Test host setting handling for custom values."""
-    with patch("weave.compat.wandb.wandb_thin.login._set_setting") as mock_set:
+    with patch.object(_login_module, "_set_setting") as mock_set:
         _handle_host_wandb_setting("https://custom.wandb.ai/")
         mock_set.assert_called_once_with("base_url", "https://custom.wandb.ai")
 

--- a/tests/compat/wandb/test_login.py
+++ b/tests/compat/wandb/test_login.py
@@ -135,6 +135,15 @@ def test_get_default_host_fallback():
             assert _get_default_host() == "api.wandb.ai"
 
 
+def test_resolve_config_dir_falls_back_to_home(tmp_path):
+    """When WANDB_CONFIG_DIR is unset, fall back to ~/.config/wandb."""
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch.object(_login_module.Path, "home", return_value=tmp_path),
+    ):
+        assert _login_module._resolve_config_dir() == tmp_path / ".config" / "wandb"
+
+
 def test_get_host_from_settings_missing_file(tmp_path):
     """If there is no settings file, it should return None."""
     with patch.dict(os.environ, {"WANDB_CONFIG_DIR": str(tmp_path)}, clear=True):

--- a/tests/utils/test_ipython_utils.py
+++ b/tests/utils/test_ipython_utils.py
@@ -1,5 +1,4 @@
 import sys
-import types
 from typing import Any, ClassVar
 
 import pytest
@@ -13,9 +12,12 @@ def test_is_running_interactively_without_ipython(monkeypatch):
 
 
 def test_is_running_interactively_with_stub(monkeypatch):
-    module = types.ModuleType("IPython")
-    module.get_ipython = object
-    monkeypatch.setitem(sys.modules, "IPython", module)
+    sentinel = object()
+
+    def fake_get_ipython():
+        return sentinel
+
+    monkeypatch.setattr(ipy, "_lazy_get_ipython", fake_get_ipython)
     assert ipy.is_running_interactively() is True
 
 
@@ -26,11 +28,11 @@ def test_get_notebook_source_requires_interactive(monkeypatch):
 
 
 def test_get_notebook_source_reads_cells(monkeypatch):
-    module = types.ModuleType("IPython")
-
     class DummyShell:
         user_ns: ClassVar[dict[str, Any]] = {"In": ["", "a = 1", "", "b = 2"]}
 
-    module.get_ipython = DummyShell
-    monkeypatch.setitem(sys.modules, "IPython", module)
+    def fake_get_ipython():
+        return DummyShell()
+
+    monkeypatch.setattr(ipy, "_lazy_get_ipython", fake_get_ipython)
     assert ipy.get_notebook_source() == "a = 1\n\nb = 2"

--- a/tests/utils/test_netrc.py
+++ b/tests/utils/test_netrc.py
@@ -6,6 +6,7 @@ the Netrc class, helper functions, and edge cases.
 
 import netrc
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -100,9 +101,11 @@ def test_netrc_write_credentials(temp_netrc):
     # Verify file was created
     assert temp_netrc.path.exists()
 
-    # Check file permissions (should be 0o600)
-    file_stat = temp_netrc.path.stat()
-    assert file_stat.st_mode & 0o777 == 0o600
+    # Check file permissions (should be 0o600). POSIX-only — Windows ignores
+    # chmod for these mode bits.
+    if sys.platform != "win32":
+        file_stat = temp_netrc.path.stat()
+        assert file_stat.st_mode & 0o777 == 0o600
 
     # Verify content by reading it back
     written_credentials = temp_netrc.read()
@@ -358,7 +361,7 @@ def test_check_netrc_access_os_error(mock_stat, tmp_path):
 def test_get_netrc_file_path_from_env():
     """Test getting netrc file path from environment variable."""
     path = get_netrc_file_path()
-    assert path == "/custom/netrc/path"
+    assert Path(path) == Path("/custom/netrc/path")
 
 
 @patch.dict(os.environ, {"NETRC": "~/custom/netrc"})
@@ -386,7 +389,7 @@ def test_get_netrc_file_path_default_unix(mock_system):
     """Test getting default netrc file path on Unix systems."""
     with patch("pathlib.Path.home", return_value=Path("/home/user")):
         path = get_netrc_file_path()
-        assert path == "/home/user/.netrc"
+        assert Path(path) == Path("/home/user/.netrc")
 
 
 @patch.dict(os.environ, {}, clear=True)
@@ -395,4 +398,4 @@ def test_get_netrc_file_path_default_windows(mock_system):
     """Test getting default netrc file path on Windows systems."""
     with patch("pathlib.Path.home", return_value=Path("C:/Users/user")):
         path = get_netrc_file_path()
-        assert path == "C:/Users/user/_netrc"
+        assert Path(path) == Path("C:/Users/user/_netrc")

--- a/weave/compat/wandb/wandb_thin/login.py
+++ b/weave/compat/wandb/wandb_thin/login.py
@@ -52,12 +52,22 @@ def _handle_host_wandb_setting(host: str | None) -> None:
         _set_setting("base_url", host)
 
 
+def _resolve_config_dir() -> Path:
+    """Resolve WANDB_CONFIG_DIR, falling back to ~/.config/wandb only when unset.
+
+    Avoids calling Path.home() when the env var is set, since on Windows with a
+    cleared environment Path.home() raises RuntimeError and silently breaks
+    settings I/O.
+    """
+    if config_dir := os.getenv(env.CONFIG_DIR):
+        return Path(config_dir)
+    return Path.home() / ".config" / "wandb"
+
+
 def _set_setting(key: str, value: str) -> None:
     """Set a setting in the wandb settings file."""
     try:
-        default_config_dir = Path.home() / ".config" / "wandb"
-        config_dir = os.getenv(env.CONFIG_DIR, str(default_config_dir))
-        settings_path = Path(config_dir) / "settings"
+        settings_path = _resolve_config_dir() / "settings"
 
         # Ensure directory exists
         settings_path.parent.mkdir(parents=True, exist_ok=True)
@@ -80,9 +90,7 @@ def _set_setting(key: str, value: str) -> None:
 def _clear_setting(key: str) -> None:
     """Clear a setting from the wandb settings file."""
     try:
-        default_config_dir = Path.home() / ".config" / "wandb"
-        config_dir = os.getenv(env.CONFIG_DIR, str(default_config_dir))
-        settings_path = Path(config_dir) / "settings"
+        settings_path = _resolve_config_dir() / "settings"
 
         if not settings_path.exists():
             return
@@ -430,9 +438,7 @@ def _get_host_from_settings() -> str | None:
         'custom.wandb.server'
     """
     try:
-        default_config_dir = Path.home() / ".config" / "wandb"
-        config_dir = os.getenv(env.CONFIG_DIR, str(default_config_dir))
-        settings_path = Path(config_dir) / "settings"
+        settings_path = _resolve_config_dir() / "settings"
 
         if not settings_path.exists():
             return None


### PR DESCRIPTION
## TL;DR
- 156 unit tests in \`tests/utils/\`, \`tests/compat/\`, \`tests/wandb_interface/\` were silently deselected by every shard. This PR runs them in \`trace_no_server\`.
- Surfaced 1 prod bug + 4 test bugs. All fixed here.
- Linux: 156 newly running, all green. Windows: 156 newly running, 4 path tests fixed, 9 settings tests pass via prod fix.

## Root cause
- CI runs \`pytest -m trace_server\` on most shards.
- \`tests/trace_server/conftest.py\` auto-applies the marker only to tests that pull the \`client\` fixture (transitively → \`trace_server\` fixture).
- Pure-unit tests in \`utils\`/\`compat\`/\`wandb_interface\` carry no fixture, never get the marker, get filtered out → never executed.
- Discovered while debugging codecov on #6724 (which surfaced the same symptom narrowly).

## Fix
- \`noxfile.py\`: add \`tests/utils/\` \`tests/compat/\` \`tests/wandb_interface/\` to \`trace_no_server\` shard's dirs. \`-m "not trace_server"\` then picks them up.
- No conftest changes. No marker semantics changed. \`tests/durability/\` (already in the shard) unaffected.

## Bugs surfaced + fixed
**Prod (1):** \`weave/compat/wandb/wandb_thin/login.py\`
- \`_set_setting\`/\`_clear_setting\`/\`_get_host_from_settings\` called \`Path.home()\` before checking \`WANDB_CONFIG_DIR\`. On Windows with cleared env, \`Path.home()\` raises \`RuntimeError\` → caught by broad \`except\` → settings I/O silently no-ops.
- Fix: \`_resolve_config_dir()\` helper, lazy fallback. Honors env var without ever resolving home dir when set.

**Tests (4):**
- \`test_ipython_utils.py\` ×2: stubbed \`sys.modules["IPython"]\` but real import path is \`IPython.core.getipython\`. Switched to monkeypatching \`_lazy_get_ipython\` directly.
- \`test_login.py::test_validate_api_key_failure\` ×2: regex pattern \`"must be 40"\` didn't match actual \`"must be at least 40"\`.
- \`test_netrc.py\` ×4: POSIX-hardcoded assertions (path separators, \`0o600\` mode). Use \`Path()\` for normalization; skip mode check on Windows.

## Out of scope
- \`tests/scorers/\`: ~72 more orphans. Different dep group, can't share \`trace_no_server\`. Needs separate fix (auto-mark in scorers conftest, or remove from \`TRACE_SERVER_SHARDS\` in workflow).

## Verification
- Linux \`trace_no_server\`: \`utils\` 101 + \`compat\` 48 + \`wandb_interface\` 7 + \`durability\` 83 = 239 pass.
- Marker behavior preserved: \`utils\` still has 13 tests pulled into \`trace\` shard via \`client\` fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)