### PR TITLE
fix(weave): make imperative EvaluationLogger root call eager

### DIFF
--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -42,6 +42,11 @@ def test_basic_evaluation(
 ):
     ev = EvaluationLogger()
 
+    # The imperative root `Evaluation.evaluate` op must mirror the declarative
+    # path and ship its start eagerly so the eval is visible in the UI before
+    # any predictions or `log_summary()` arrive.
+    assert ev._pseudo_evaluation.evaluate.eager_call_start is True
+
     outputs = []
     score1_results = []
     score2_results = []

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -720,7 +720,11 @@ class EvaluationLogger:
         self._context_predict_method = MethodType(predict, self.model)
 
         # --- Setup the evaluation object ---
-        @op(name="Evaluation.evaluate", enable_code_capture=False)
+        @op(
+            name="Evaluation.evaluate",
+            enable_code_capture=False,
+            eager_call_start=True,
+        )
         def evaluate(self: Evaluation, model: Model) -> None: ...
 
         @op(name="Evaluation.predict_and_score", enable_code_capture=False)


### PR DESCRIPTION
[WB-33830](https://coreweave.atlassian.net/browse/WB-33830)

The imperative `EvaluationLogger` defines its own `Evaluation.evaluate` op without `eager_call_start=True`, while the declarative `Evaluation.evaluate` (`weave/evaluation/eval.py:295`) sets it. Under `CallBatchProcessor` (auto-opted-in for the `wandb` entity via #6644), non-eager starts are paired with their end and only flushed in 1s windows — so the imperative eval root is invisible in the UI until `ev.log_summary()` runs.

Adds `eager_call_start=True` to the imperative root op so it ships its start immediately, matching declarative behavior.

Test: extends `tests/flow/test_evaluation_imperative.py::test_basic_evaluation` to assert the flag.

[WB-33830]: https://coreweave.atlassian.net/browse/WB-33830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ