### PR TITLE
feat(weave): infer json filter casts in feedback path

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -981,10 +981,10 @@ def test_feedback_query_contains_numeric_literal(client) -> None:
 def test_feedback_query_typed_payload_filters(client: WeaveClient) -> None:
     """Regression for WB-33832: /feedback/query 500s on typed payload literals.
 
-    Without inferred field-side casts, ClickHouse refuses ``JSON_VALUE(...)``
+    Without inferred field-side casts, ClickHouse refuses `JSON_VALUE(...)`
     (String) compared against a typed param (Bool / Int64 / Float64) with
-    ``Code: 386 NO_COMMON_TYPE``. JSON_VALUE on a JSON boolean emits the
-    literal string ``'true'`` / ``'false'``, so the bool path must coerce
+    `Code: 386 NO_COMMON_TYPE`. JSON_VALUE on a JSON boolean emits the
+    literal string `'true'` / `'false'`, so the bool path must coerce
     those before any numeric fallback.
 
     Asserts on both backends so the same query shape works through sqlite

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -978,6 +978,77 @@ def test_feedback_query_contains_numeric_literal(client) -> None:
     assert res.result[0]["payload"]["dataset_id_str"] == "94"
 
 
+def test_feedback_query_typed_payload_filters(client: WeaveClient) -> None:
+    """Regression for WB-33832: /feedback/query 500s on typed payload literals.
+
+    Without inferred field-side casts, ClickHouse refuses ``JSON_VALUE(...)``
+    (String) compared against a typed param (Bool / Int64 / Float64) with
+    ``Code: 386 NO_COMMON_TYPE``. JSON_VALUE on a JSON boolean emits the
+    literal string ``'true'`` / ``'false'``, so the bool path must coerce
+    those before any numeric fallback.
+
+    Asserts on both backends so the same query shape works through sqlite
+    too (where the cast is silently dropped and sqlite's loose typing
+    handles the comparison).
+    """
+    project_id = client.project_id
+    call_ref = f"weave:///{project_id}/call/call_id_typed_payload"
+
+    client.server.feedback_create(
+        FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=call_ref,
+            feedback_type="custom.annotation",
+            payload={"is_positive": True, "score": 0.9, "rank": 1},
+        )
+    )
+    client.server.feedback_create(
+        FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=call_ref,
+            feedback_type="custom.annotation",
+            payload={"is_positive": False, "score": 0.1, "rank": 2},
+        )
+    )
+
+    def query(expr: dict) -> list[dict]:
+        return client.server.feedback_query(
+            FeedbackQueryReq(project_id=project_id, query=Query(**{"$expr": expr}))
+        ).result
+
+    # Bool literal: this is the exact shape that was 502'ing in production.
+    rows = query({"$eq": [{"$getField": "payload.is_positive"}, {"$literal": False}]})
+    assert len(rows) == 1
+    assert rows[0]["payload"]["is_positive"] is False
+
+    rows = query({"$eq": [{"$getField": "payload.is_positive"}, {"$literal": True}]})
+    assert len(rows) == 1
+    assert rows[0]["payload"]["is_positive"] is True
+
+    # Int literal: previously fell through to lexicographic string comparison.
+    rows = query({"$eq": [{"$getField": "payload.rank"}, {"$literal": 2}]})
+    assert len(rows) == 1
+    assert rows[0]["payload"]["rank"] == 2
+
+    # Float literal with $gt: same compat note as #6729.
+    rows = query({"$gt": [{"$getField": "payload.score"}, {"$literal": 0.5}]})
+    assert len(rows) == 1
+    assert rows[0]["payload"]["score"] == 0.9
+
+    # AND-wrapped bool comparison: inference is per-binary-op, but this pins
+    # that nesting doesn't regress the lookup.
+    rows = query(
+        {
+            "$and": [
+                {"$eq": [{"$getField": "payload.is_positive"}, {"$literal": False}]},
+                {"$gt": [{"$getField": "payload.rank"}, {"$literal": 1}]},
+            ]
+        }
+    )
+    assert len(rows) == 1
+    assert rows[0]["payload"] == {"is_positive": False, "score": 0.1, "rank": 2}
+
+
 def test_feedback_with_queue_id(client: WeaveClient) -> None:
     """Test feedback creation with queue_id field."""
     if client_is_sqlite(client):

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -345,6 +345,55 @@ def test_cte_chain_sort_and_multi_eval_filters() -> None:
     )
 
 
+def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
+    """Red-team for PR #6735: orm.py infers field-side casts from peer
+    literals so feedback / threads / objects don't need an explicit
+    `$convert` to compare a JSON-extracted field against a typed param. The
+    PR promises that any caller of `Select.where(...)` benefits, but
+    `_process_query_to_conditions`'s `GetFieldOperator` branch silently
+    drops the inferred cast when a `field_resolver` is provided. Eval
+    results filtering reaches `_process_query_to_conditions` exactly that
+    way, so a numeric / bool literal without `$convert` should still pick
+    up the typed cast (matching the explicit-`$convert` shape pinned by
+    `test_cte_chain_sort_and_multi_eval_filters`).
+    """
+    pb = ParamBuilder("pb")
+    filters = [
+        tsi.EvalResultsFilter(
+            evaluation_call_id="eval-1",
+            query=Query.model_validate(
+                {
+                    "$expr": {
+                        "$gte": [
+                            {"$getField": "scores.accuracy"},
+                            {"$literal": 0.5},
+                        ]
+                    }
+                }
+            ),
+        ),
+    ]
+    cte = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1"],
+        sort_by=None,
+        filters=filters,
+        require_intersection=False,
+        limit=10,
+        offset=0,
+        pb=pb,
+        read_table="calls_merged",
+    )
+    # The HAVING clause must wrap the per-eval scores aggregate in
+    # `toFloat64OrNull(...)` so the comparison against the `Float64`
+    # parameter type-checks in ClickHouse. Without the fix, the field
+    # comes through as a `String` and CH refuses the comparison with
+    # NO_COMMON_TYPE.
+    assert "toFloat64OrNull(any(CASE WHEN eval_call_id =" in cte, (
+        f"Expected inferred double cast on field side of $gte, got:\n{cte}"
+    )
+
+
 def test_full_query_calls_merged() -> None:
     """Full SQL: lean CTEs + outer SELECT hydrates from calls_merged."""
     pb = ParamBuilder("pb")

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -356,6 +356,12 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
     way, so a numeric / bool literal without `$convert` should still pick
     up the typed cast (matching the explicit-`$convert` shape pinned by
     `test_cte_chain_sort_and_multi_eval_filters`).
+
+    The HAVING clause on `ranked_digests` must wrap the per-eval scores
+    aggregate in `toFloat64OrNull(...)` so the comparison against the
+    `Float64` parameter type-checks in ClickHouse. Without the fix the
+    field comes through as `String` and CH refuses the comparison with
+    `NO_COMMON_TYPE`.
     """
     pb = ParamBuilder("pb")
     filters = [
@@ -384,13 +390,89 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
         pb=pb,
         read_table="calls_merged",
     )
-    # The HAVING clause must wrap the per-eval scores aggregate in
-    # `toFloat64OrNull(...)` so the comparison against the `Float64`
-    # parameter type-checks in ClickHouse. Without the fix, the field
-    # comes through as a `String` and CH refuses the comparison with
-    # NO_COMMON_TYPE.
-    assert "toFloat64OrNull(any(CASE WHEN eval_call_id =" in cte, (
-        f"Expected inferred double cast on field side of $gte, got:\n{cte}"
+    assert_raw_sql(
+        cte,
+        """
+            predict_and_score_calls AS (
+                SELECT calls_merged.id AS call_id,
+                    any(calls_merged.parent_id) AS eval_call_id,
+                    any(calls_merged.inputs_dump) AS inputs_dump,
+                    any(calls_merged.output_dump) AS output_dump,
+                    CASE
+                        WHEN position(JSON_VALUE(any(calls_merged.inputs_dump), '$.example'), '/attr/rows/id/') > 0
+                            THEN regexpExtract(JSON_VALUE(any(calls_merged.inputs_dump), '$.example'), '/attr/rows/id/([^/]+)$', 1)
+                        ELSE hex(SHA256(JSONExtractRaw(any(calls_merged.inputs_dump), 'example')))
+                    END AS row_digest
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_0:String}
+                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
+                    OR calls_merged.parent_id IS NULL)
+                    AND calls_merged.id NOT IN {pb_1:Array(String)}
+                    AND (position(calls_merged.op_name, {pb_2:String}) > 0
+                        OR position(calls_merged.op_name, {pb_3:String}) > 0
+                        OR calls_merged.op_name IS NULL)
+                GROUP BY (calls_merged.project_id, calls_merged.id)
+                HAVING any(calls_merged.parent_id) IN {pb_1:Array(String)}
+                    AND (position(any(calls_merged.op_name), {pb_2:String}) > 0
+                        OR position(any(calls_merged.op_name), {pb_3:String}) > 0)
+                    AND any(calls_merged.deleted_at) IS NULL
+                    AND any(calls_merged.started_at) IS NOT NULL
+            ),
+
+            predict_and_score_calls_resolved AS (
+                SELECT * FROM predict_and_score_calls
+            ),
+
+            ranked_digests AS (
+                SELECT row_digest,
+                    ROW_NUMBER() OVER(ORDER BY row_digest ASC) AS row_order
+                FROM predict_and_score_calls_resolved
+                GROUP BY row_digest
+                HAVING 1=1
+                    AND (toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_5:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_4:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_4:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_4:String}), 'null'), '')) ELSE NULL END)) >= {pb_6:Float64})
+            ),
+
+            ranked_digest_count AS (
+                SELECT count(*) AS total_rows FROM ranked_digests
+            ),
+
+            page_digests AS (
+                SELECT row_digest, row_order
+                FROM ranked_digests
+                ORDER BY row_order
+                LIMIT 10
+                OFFSET 0
+            ),
+
+            page_resolved_inputs AS (
+                SELECT digest, any(val_dump) AS val_dump
+                FROM table_rows
+                PREWHERE project_id = {pb_0:String}
+                WHERE digest IN (SELECT row_digest FROM page_digests)
+                GROUP BY digest
+            ),
+
+            page_rows AS (
+                SELECT predict_and_score_calls_resolved.call_id AS call_id,
+                    predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
+                    predict_and_score_calls_resolved.row_digest AS row_digest,
+                    page_digests.row_order AS row_order,
+                    COALESCE(page_resolved_inputs.val_dump, JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                FROM predict_and_score_calls_resolved
+                INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
+                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
+            )
+            """,
+        pb.get_params(),
+        {
+            "pb_0": "proj-1",
+            "pb_1": ["eval-1"],
+            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
+            "pb_4": '$."scores"."accuracy"',
+            "pb_5": "eval-1",
+            "pb_6": 0.5,
+        },
     )
 
 

--- a/tests/trace_server/test_orm.py
+++ b/tests/trace_server/test_orm.py
@@ -353,3 +353,242 @@ def test_split_escaped_field_path() -> None:
 
     # Edge case: leading dot (unescaped)
     assert split_escaped_field_path(".output") == ["", "output"]
+
+
+def _feedback_table() -> Table:
+    return Table(
+        "feedback",
+        [
+            Column("id", "string"),
+            Column("payload", "json", db_name="payload_dump"),
+        ],
+    )
+
+
+def _prepare_clickhouse(select):
+    return select.prepare(
+        database_type="clickhouse",
+        param_builder=ParamBuilder(prefix="pb", database_type="clickhouse"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("literal", "expected_field_sql", "expected_param_value", "expected_param_type"),
+    [
+        # Bool literals: JSON_VALUE returns 'true'/'false' strings, so
+        # multiIf must coerce both before falling back to numeric coercion.
+        (
+            False,
+            "multiIf(JSON_VALUE(payload_dump, {pb_0:String}) = 'true', 1, "
+            "JSON_VALUE(payload_dump, {pb_0:String}) = 'false', 0, "
+            "toUInt8OrNull(JSON_VALUE(payload_dump, {pb_0:String})))",
+            False,
+            "Bool",
+        ),
+        (
+            True,
+            "multiIf(JSON_VALUE(payload_dump, {pb_0:String}) = 'true', 1, "
+            "JSON_VALUE(payload_dump, {pb_0:String}) = 'false', 0, "
+            "toUInt8OrNull(JSON_VALUE(payload_dump, {pb_0:String})))",
+            True,
+            "Bool",
+        ),
+        (
+            5,
+            "toInt64OrNull(JSON_VALUE(payload_dump, {pb_0:String}))",
+            5,
+            "Int64",
+        ),
+        (
+            2.5,
+            "toFloat64OrNull(JSON_VALUE(payload_dump, {pb_0:String}))",
+            2.5,
+            "Float64",
+        ),
+    ],
+)
+def test_feedback_query_infers_cast_from_literal(
+    literal, expected_field_sql, expected_param_value, expected_param_type
+) -> None:
+    """Regression for WB-33832: /feedback/query 500s with NO_COMMON_TYPE.
+
+    JSON_VALUE returns a string and the literal is bound with its native CH
+    type, so without inference ClickHouse refuses the comparison. The peer
+    literal's type now drives the field-side cast.
+    """
+    select = (
+        _feedback_table()
+        .select()
+        .fields(["id"])
+        .where(
+            tsi.Query(
+                **{
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "payload.is_positive"},
+                            {"$literal": literal},
+                        ]
+                    }
+                }
+            )
+        )
+    )
+    prepared = _prepare_clickhouse(select)
+    assert prepared.sql == (
+        "SELECT id\n"
+        "FROM feedback\n"
+        f"WHERE ({expected_field_sql} = {{pb_1:{expected_param_type}}})"
+    )
+    assert prepared.parameters == {
+        "pb_0": '$."is_positive"',
+        "pb_1": expected_param_value,
+    }
+
+
+def test_feedback_query_string_literal_keeps_uncast_path() -> None:
+    """String literals must keep the existing toString(JSON_VALUE(...)) path.
+
+    Inferring a cast for strings would break legitimate JSON-string
+    comparisons (e.g. category fields).
+    """
+    select = (
+        _feedback_table()
+        .select()
+        .fields(["id"])
+        .where(
+            tsi.Query(
+                **{
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "payload.label"},
+                            {"$literal": "ok"},
+                        ]
+                    }
+                }
+            )
+        )
+    )
+    prepared = _prepare_clickhouse(select)
+    assert prepared.sql == (
+        "SELECT id\n"
+        "FROM feedback\n"
+        "WHERE (toString(JSON_VALUE(payload_dump, {pb_0:String})) = {pb_1:String})"
+    )
+
+
+def test_feedback_query_explicit_convert_overrides_inference() -> None:
+    """An explicit $convert wins over inference and is not double-cast."""
+    select = (
+        _feedback_table()
+        .select()
+        .fields(["id"])
+        .where(
+            tsi.Query(
+                **{
+                    "$expr": {
+                        "$eq": [
+                            {
+                                "$convert": {
+                                    "input": {"$getField": "payload.is_positive"},
+                                    "to": "bool",
+                                },
+                            },
+                            {"$literal": True},
+                        ]
+                    }
+                }
+            )
+        )
+    )
+    prepared = _prepare_clickhouse(select)
+    # ConvertOperation runs after process_operand for the field, so the cast
+    # we infer for the field side has no effect (the inner JSON_VALUE
+    # already wears toString from the default), and the outer cast wins.
+    assert prepared.sql == (
+        "SELECT id\n"
+        "FROM feedback\n"
+        "WHERE (toUInt8OrNull(toString(JSON_VALUE(payload_dump, {pb_0:String}))) = {pb_1:Bool})"
+    )
+
+
+def test_feedback_query_literal_on_lhs_casts_field_on_rhs() -> None:
+    """Inference works regardless of which side carries the literal."""
+    select = (
+        _feedback_table()
+        .select()
+        .fields(["id"])
+        .where(
+            tsi.Query(
+                **{
+                    "$expr": {
+                        "$gt": [
+                            {"$literal": 3},
+                            {"$getField": "payload.score"},
+                        ]
+                    }
+                }
+            )
+        )
+    )
+    prepared = _prepare_clickhouse(select)
+    assert prepared.sql == (
+        "SELECT id\n"
+        "FROM feedback\n"
+        "WHERE ({pb_0:Int64} > toInt64OrNull(JSON_VALUE(payload_dump, {pb_1:String})))"
+    )
+
+
+def test_feedback_query_in_homogeneous_literal_list_casts_field() -> None:
+    """$in with a homogeneous numeric list infers a single cast for the field."""
+    select = (
+        _feedback_table()
+        .select()
+        .fields(["id"])
+        .where(
+            tsi.Query(
+                **{
+                    "$expr": {
+                        "$in": [
+                            {"$getField": "payload.score"},
+                            [{"$literal": 1}, {"$literal": 2}, {"$literal": 3}],
+                        ]
+                    }
+                }
+            )
+        )
+    )
+    prepared = _prepare_clickhouse(select)
+    assert prepared.sql == (
+        "SELECT id\n"
+        "FROM feedback\n"
+        "WHERE (toInt64OrNull(JSON_VALUE(payload_dump, {pb_0:String})) "
+        "IN ({pb_1:Int64},{pb_2:Int64},{pb_3:Int64}))"
+    )
+
+
+def test_feedback_query_in_mixed_literal_list_keeps_uncast_path() -> None:
+    """A heterogeneous $in list cannot share a single cast and falls back."""
+    select = (
+        _feedback_table()
+        .select()
+        .fields(["id"])
+        .where(
+            tsi.Query(
+                **{
+                    "$expr": {
+                        "$in": [
+                            {"$getField": "payload.value"},
+                            [{"$literal": 1}, {"$literal": "two"}],
+                        ]
+                    }
+                }
+            )
+        )
+    )
+    prepared = _prepare_clickhouse(select)
+    assert prepared.sql == (
+        "SELECT id\n"
+        "FROM feedback\n"
+        "WHERE (toString(JSON_VALUE(payload_dump, {pb_0:String})) "
+        "IN ({pb_1:Int64},{pb_2:String}))"
+    )

--- a/tests/trace_server/test_orm.py
+++ b/tests/trace_server/test_orm.py
@@ -566,6 +566,70 @@ def test_feedback_query_in_homogeneous_literal_list_casts_field() -> None:
     )
 
 
+def test_feedback_query_inference_threads_through_and_or_not() -> None:
+    """Inference is per-binary-op, so each leaf inside AND/OR/NOT must
+    independently resolve its own cast. This pins that nested combinators
+    don't drop the inference (e.g. by accidentally short-circuiting in
+    process_operation before reaching the leaf).
+    """
+    select = (
+        _feedback_table()
+        .select()
+        .fields(["id"])
+        .where(
+            tsi.Query(
+                **{
+                    "$expr": {
+                        "$and": [
+                            {
+                                "$eq": [
+                                    {"$getField": "payload.is_positive"},
+                                    {"$literal": False},
+                                ]
+                            },
+                            {
+                                "$or": [
+                                    {
+                                        "$gt": [
+                                            {"$getField": "payload.score"},
+                                            {"$literal": 0.5},
+                                        ]
+                                    },
+                                    {
+                                        "$not": [
+                                            {
+                                                "$eq": [
+                                                    {"$getField": "payload.rank"},
+                                                    {"$literal": 1},
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                ]
+                            },
+                        ]
+                    }
+                }
+            )
+        )
+    )
+    prepared = _prepare_clickhouse(select)
+    bool_field = (
+        "multiIf(JSON_VALUE(payload_dump, {pb_0:String}) = 'true', 1, "
+        "JSON_VALUE(payload_dump, {pb_0:String}) = 'false', 0, "
+        "toUInt8OrNull(JSON_VALUE(payload_dump, {pb_0:String})))"
+    )
+    score_field = "toFloat64OrNull(JSON_VALUE(payload_dump, {pb_2:String}))"
+    rank_field = "toInt64OrNull(JSON_VALUE(payload_dump, {pb_4:String}))"
+    assert prepared.sql == (
+        "SELECT id\n"
+        "FROM feedback\n"
+        f"WHERE (({bool_field} = {{pb_1:Bool}}) "
+        f"AND (({score_field} > {{pb_3:Float64}}) "
+        f"OR (NOT (({rank_field} = {{pb_5:Int64}})))))"
+    )
+
+
 def test_feedback_query_in_mixed_literal_list_keeps_uncast_path() -> None:
     """A heterogeneous $in list cannot share a single cast and falls back."""
     select = (

--- a/weave/trace_server/calls_query_builder/utils.py
+++ b/weave/trace_server/calls_query_builder/utils.py
@@ -6,7 +6,11 @@ from collections.abc import Generator
 import sqlparse
 
 from weave.trace_server.interface import query as tsi_query
-from weave.trace_server.orm import ParamBuilder, clickhouse_cast, quote_json_path_parts
+from weave.trace_server.orm import (
+    ParamBuilder,
+    clickhouse_cast_json_value,
+    quote_json_path_parts,
+)
 
 
 def safe_alias(field_name: str) -> str:
@@ -175,16 +179,7 @@ def json_dump_field_as_sql(
             param_name = pb.add_param(quote_json_path_parts(extra_path))
             path_str = param_slot(param_name, "String")
         val = f"coalesce(nullIf(JSON_VALUE({root_field_sanitized}, {path_str}), 'null'), '')"
-        if cast == "bool":
-            # JSON_VALUE on a JSON bool emits the literal strings 'true'/
-            # 'false', which `toUInt8OrNull` would turn into NULL. Match those
-            # first; fall back to `toUInt8OrNull` for legacy rows that stored
-            # 1/0 (or any numeric-string) so a plain Bool comparison still
-            # works in CH.
-            return (
-                f"multiIf({val} = 'true', 1, {val} = 'false', 0, toUInt8OrNull({val}))"
-            )
-        return clickhouse_cast(val, cast)
+        return clickhouse_cast_json_value(val, cast)
     else:
         # Note: ClickHouse has limitations in distinguishing between null, non-existent, empty string, and "null".
         # This workaround helps to handle these cases.

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -530,6 +530,62 @@ def clickhouse_cast(inner_sql: str, cast: tsi_query.CastTo | None = None) -> str
         raise ValueError(f"Unknown cast: {cast}")
 
 
+def clickhouse_cast_json_value(
+    json_value_sql: str, cast: tsi_query.CastTo | None = None
+) -> str:
+    """Apply a cast to a JSON_VALUE result.
+
+    Identical to ``clickhouse_cast`` except for ``bool``: JSON_VALUE returns the
+    literal strings ``'true'`` / ``'false'`` for JSON booleans, and
+    ``toUInt8OrNull`` would map both to NULL. The multiIf handles those first
+    and falls back to numeric coercion for legacy rows storing 1/0.
+    """
+    if cast == "bool":
+        return (
+            f"multiIf({json_value_sql} = 'true', 1, "
+            f"{json_value_sql} = 'false', 0, "
+            f"toUInt8OrNull({json_value_sql}))"
+        )
+    return clickhouse_cast(json_value_sql, cast)
+
+
+def cast_for_literal_filter(
+    literal: tsi_query.LiteralOperation,
+) -> tsi_query.CastTo | None:
+    """Infer a JSON-field cast from a comparison literal type.
+
+    JSON_VALUE returns strings, so numeric and boolean literals need the field
+    side cast to match the parameter type ClickHouse receives. String, None,
+    and structured literals keep the existing uncast (string) path.
+    """
+    value = literal.literal_
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "double"
+    return None
+
+
+def shared_cast_for_literal_filters(
+    operands: Sequence[tsi_query.Operand],
+) -> tsi_query.CastTo | None:
+    """Return a shared inferred cast for a homogeneous literal list, else None."""
+    cast: tsi_query.CastTo | None = None
+    for operand in operands:
+        if not isinstance(operand, tsi_query.LiteralOperation):
+            return None
+        operand_cast = cast_for_literal_filter(operand)
+        if operand_cast is None:
+            return None
+        if cast is None:
+            cast = operand_cast
+        elif operand_cast != cast:
+            return None
+    return cast
+
+
 def split_escaped_field_path(path: str) -> list[str]:
     r"""Split a field path on dots, respecting backslash-escaped dots.
 
@@ -630,7 +686,7 @@ def _transform_external_field_to_internal_field(
             json_func = "json_extract(" if is_sqlite else "JSON_VALUE("
             field = json_func + field + ", " + json_path_param + ")"
             if not is_sqlite:
-                field = clickhouse_cast(field, cast or "string")  # type: ignore
+                field = clickhouse_cast_json_value(field, cast or "string")  # type: ignore
 
     if table_prefix:
         field = f"{table_prefix}.{field}"
@@ -677,27 +733,25 @@ def _process_query_to_conditions(
             operand_part = process_operand(operation.not_[0])
             cond = f"(NOT ({operand_part}))"
         elif isinstance(operation, tsi_query.EqOperation):
-            lhs_part = process_operand(operation.eq_[0])
-            rhs_part = process_operand(operation.eq_[1])
+            lhs_part, rhs_part = process_binary_operands(*operation.eq_)
             cond = f"({lhs_part} = {rhs_part})"
         elif isinstance(operation, tsi_query.GtOperation):
-            lhs_part = process_operand(operation.gt_[0])
-            rhs_part = process_operand(operation.gt_[1])
+            lhs_part, rhs_part = process_binary_operands(*operation.gt_)
             cond = f"({lhs_part} > {rhs_part})"
         elif isinstance(operation, tsi_query.LtOperation):
-            lhs_part = process_operand(operation.lt_[0])
-            rhs_part = process_operand(operation.lt_[1])
+            lhs_part, rhs_part = process_binary_operands(*operation.lt_)
             cond = f"({lhs_part} < {rhs_part})"
         elif isinstance(operation, tsi_query.GteOperation):
-            lhs_part = process_operand(operation.gte_[0])
-            rhs_part = process_operand(operation.gte_[1])
+            lhs_part, rhs_part = process_binary_operands(*operation.gte_)
             cond = f"({lhs_part} >= {rhs_part})"
         elif isinstance(operation, tsi_query.LteOperation):
-            lhs_part = process_operand(operation.lte_[0])
-            rhs_part = process_operand(operation.lte_[1])
+            lhs_part, rhs_part = process_binary_operands(*operation.lte_)
             cond = f"({lhs_part} <= {rhs_part})"
         elif isinstance(operation, tsi_query.InOperation):
-            lhs_part = process_operand(operation.in_[0])
+            lhs_part = process_operand(
+                operation.in_[0],
+                cast=shared_cast_for_literal_filters(operation.in_[1]),
+            )
             rhs_part = ",".join(process_operand(op) for op in operation.in_[1])
             cond = f"({lhs_part} IN ({rhs_part}))"
         elif isinstance(operation, tsi_query.ContainsOperation):
@@ -723,7 +777,29 @@ def _process_query_to_conditions(
 
         return cond
 
-    def process_operand(operand: tsi_query.Operand) -> str:
+    def process_binary_operands(
+        lhs: tsi_query.Operand, rhs: tsi_query.Operand
+    ) -> tuple[str, str]:
+        # Each side's cast is inferred from the *peer* literal: a numeric RHS
+        # tells us to cast the LHS field, and vice versa. Without this, a
+        # JSON_VALUE-extracted field comes through as a String while the
+        # literal is bound as Bool/Int64/Float64, and ClickHouse refuses
+        # the comparison (NO_COMMON_TYPE).
+        lhs_cast = (
+            cast_for_literal_filter(rhs)
+            if isinstance(rhs, tsi_query.LiteralOperation)
+            else None
+        )
+        rhs_cast = (
+            cast_for_literal_filter(lhs)
+            if isinstance(lhs, tsi_query.LiteralOperation)
+            else None
+        )
+        return process_operand(lhs, cast=lhs_cast), process_operand(rhs, cast=rhs_cast)
+
+    def process_operand(
+        operand: tsi_query.Operand, cast: tsi_query.CastTo | None = None
+    ) -> str:
         if isinstance(operand, tsi_query.LiteralOperation):
             return pb.add(
                 operand.literal_, None, python_value_to_ch_type(operand.literal_)
@@ -737,7 +813,7 @@ def _process_query_to_conditions(
                     _,
                     fields_used,
                 ) = _transform_external_field_to_internal_field(
-                    operand.get_field_, all_columns, json_columns, None, pb
+                    operand.get_field_, all_columns, json_columns, cast, pb
                 )
             raw_fields_used.update(fields_used)
             return field

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -535,9 +535,9 @@ def clickhouse_cast_json_value(
 ) -> str:
     """Apply a cast to a JSON_VALUE result.
 
-    Identical to ``clickhouse_cast`` except for ``bool``: JSON_VALUE returns the
-    literal strings ``'true'`` / ``'false'`` for JSON booleans, and
-    ``toUInt8OrNull`` would map both to NULL. The multiIf handles those first
+    Identical to `clickhouse_cast` except for `bool`: JSON_VALUE returns the
+    literal strings `'true'` / `'false'` for JSON booleans, and
+    `toUInt8OrNull` would map both to NULL. The multiIf handles those first
     and falls back to numeric coercion for legacy rows storing 1/0.
     """
     if cast == "bool":

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -549,43 +549,6 @@ def clickhouse_cast_json_value(
     return clickhouse_cast(json_value_sql, cast)
 
 
-def cast_for_literal_filter(
-    literal: tsi_query.LiteralOperation,
-) -> tsi_query.CastTo | None:
-    """Infer a JSON-field cast from a comparison literal type.
-
-    JSON_VALUE returns strings, so numeric and boolean literals need the field
-    side cast to match the parameter type ClickHouse receives. String, None,
-    and structured literals keep the existing uncast (string) path.
-    """
-    value = literal.literal_
-    if isinstance(value, bool):
-        return "bool"
-    if isinstance(value, int):
-        return "int"
-    if isinstance(value, float):
-        return "double"
-    return None
-
-
-def shared_cast_for_literal_filters(
-    operands: Sequence[tsi_query.Operand],
-) -> tsi_query.CastTo | None:
-    """Return a shared inferred cast for a homogeneous literal list, else None."""
-    cast: tsi_query.CastTo | None = None
-    for operand in operands:
-        if not isinstance(operand, tsi_query.LiteralOperation):
-            return None
-        operand_cast = cast_for_literal_filter(operand)
-        if operand_cast is None:
-            return None
-        if cast is None:
-            cast = operand_cast
-        elif operand_cast != cast:
-            return None
-    return cast
-
-
 def split_escaped_field_path(path: str) -> list[str]:
     r"""Split a field path on dots, respecting backslash-escaped dots.
 
@@ -750,7 +713,7 @@ def _process_query_to_conditions(
         elif isinstance(operation, tsi_query.InOperation):
             lhs_part = process_operand(
                 operation.in_[0],
-                cast=shared_cast_for_literal_filters(operation.in_[1]),
+                cast=tsi_query.infer_shared_literal_filter_cast(operation.in_[1]),
             )
             rhs_part = ",".join(process_operand(op) for op in operation.in_[1])
             cond = f"({lhs_part} IN ({rhs_part}))"
@@ -780,21 +743,13 @@ def _process_query_to_conditions(
     def process_binary_operands(
         lhs: tsi_query.Operand, rhs: tsi_query.Operand
     ) -> tuple[str, str]:
-        # Each side's cast is inferred from the *peer* literal: a numeric RHS
+        # Each side's cast is inferred from the peer literal: a numeric RHS
         # tells us to cast the LHS field, and vice versa. Without this, a
         # JSON_VALUE-extracted field comes through as a String while the
         # literal is bound as Bool/Int64/Float64, and ClickHouse refuses
         # the comparison (NO_COMMON_TYPE).
-        lhs_cast = (
-            cast_for_literal_filter(rhs)
-            if isinstance(rhs, tsi_query.LiteralOperation)
-            else None
-        )
-        rhs_cast = (
-            cast_for_literal_filter(lhs)
-            if isinstance(lhs, tsi_query.LiteralOperation)
-            else None
-        )
+        lhs_cast = tsi_query.infer_literal_filter_cast(rhs)
+        rhs_cast = tsi_query.infer_literal_filter_cast(lhs)
         return process_operand(lhs, cast=lhs_cast), process_operand(rhs, cast=rhs_cast)
 
     def process_operand(

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -762,6 +762,14 @@ def _process_query_to_conditions(
         elif isinstance(operand, tsi_query.GetFieldOperator):
             if field_resolver is not None:
                 field, fields_used = field_resolver(operand.get_field_, pb)
+                # The default `_transform_external_field_to_internal_field`
+                # path applies the inferred cast inside JSON extraction; the
+                # field_resolver path replaces that with caller-controlled
+                # SQL, so the cast has to be reapplied here for the typed
+                # comparison to type-check in CH. Sqlite drops the cast for
+                # the same reason it's dropped in the JSON extraction path.
+                if cast is not None and pb._database_type == "clickhouse":
+                    field = clickhouse_cast_json_value(field, cast)
             else:
                 (
                     field,


### PR DESCRIPTION
[WB-33832](https://coreweave.atlassian.net/browse/WB-33832)

## Summary

- Original problem: `POST /feedback/query` with a Python `bool` literal against a JSON feedback payload field (`feedback.[...].payload.is_positive == False`) 502'd in prod with ClickHouse `Code: 386 (NO_COMMON_TYPE)`. `JSON_VALUE` returns `String`, `python_value_to_ch_type(False)` binds the literal as `Bool`, and with no cast on either side CH refused the compare. #6729 fixed the analogous shape on `CallsQuery` but gated inference to `CallsMergedDynamicField`, so the feedback / threads / objects paths kept hitting the same failure.
- Lifts the literal-cast inference into `orm.py`'s `_process_query_to_conditions` so any caller of `Select.where(...)` (feedback, threads, objects, etc.) gets typed JSON comparisons, not just the `CallsQuery` path.
- Adds `clickhouse_cast_json_value` for the bool quirk (`JSON_VALUE` on a JSON bool returns the strings `'true'` / `'false'`; `toUInt8OrNull` would NULL them out, so wrap in `multiIf('true' -> 1, 'false' -> 0, toUInt8OrNull(...))`).
- Collapses #6729's `interface/query.py` inference helpers and the inline JSON-bool `multiIf` in `calls_query_builder.json_dump_field_as_sql` so there's one source of truth across `CallsQuery`, `sqlite_trace_server`, and `orm.py`. Net: -50 lines after the dedup commit.

[Datadog trace](https://us5.datadoghq.com/apm/trace/69f2605b000000004396a487a93635d0) for the original failure:

```
Code: 386. DB::Exception: There is no supertype for types String, Bool ...
while executing function equals on arguments
  toString(JSON_VALUE(__table1.payload_dump, '$."is_positive"'_String)) String,
  _CAST(0_Bool, 'Bool'_String) Bool
```

## Compatibility note

Same as #6729: pre-existing queries that compared a JSON-extracted field against an `int` / `float` / `bool` `$literal` *without* `$convert` previously fell through to lexicographic string compare (`'10' > '3'`); they now emit a typed cast and compare numerically. Queries with explicit `$convert` or string literals are unchanged.

## Stacking

Currently stacked on #6729. When #6729 lands, rebase drops those commits and this PR is just the orm.py expansion + dedup (3 commits, ~ +90 / -10 net).

## Testing

`tests/trace_server/test_orm.py` covers bool / int / float / string / `$convert` / literal-on-LHS / homogeneous + mixed `$in` shapes against `Table.select().where(...).prepare("clickhouse")`. `tests/trace/test_feedback.py` exercises the feedback path against sqlite. Query-builder snapshot tests (multiIf SQL) keep the inline-removal honest.

[WB-33832]: https://coreweave.atlassian.net/browse/WB-33832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ