### PR TITLE
chore(weave): dual CJS/ESM emission via tsc-multi

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -8,16 +8,16 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.js"
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
     },
     "./instrument": {
-      "types": "./dist/esm/instrument.d.ts",
-      "import": "./dist/esm/instrument.js"
+      "types": "./dist/esm/instrument.d.mts",
+      "import": "./dist/esm/instrument.mjs"
     }
   },
   "scripts": {
-    "build": "tsc --outDir dist",
+    "build": "node scripts/build.mjs",
     "prepare": "npm run build",
     "test": "jest --silent",
     "test:coverage": "jest --coverage",
@@ -167,6 +167,7 @@
     "swagger-typescript-api": "^13.0.22",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
+    "tsc-multi": "^1.1.0",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.19.1",
     "typedoc": "^0.28",

--- a/sdks/node/pnpm-lock.yaml
+++ b/sdks/node/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@22.14.1)(typescript@5.5.4)
+      tsc-multi:
+        specifier: ^1.1.0
+        version: 1.1.0(typescript@5.5.4)
       tsconfig-paths:
         specifier: ^4.2.0
         version: 4.2.0
@@ -518,6 +521,18 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
 
   '@opentelemetry/api-logs@0.53.0':
     resolution: {integrity: sha512-8HArjKx+RaAI8uEIgcORbZIPklyh1YLjPSBus8hjRmvLi6DeFzgOcdZ7KwPabKj8mXF8dX0hyfAyGfycz0DbFw==}
@@ -1097,11 +1112,18 @@ packages:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-safe-stringify@2.1.1:
     resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
@@ -1174,12 +1196,20 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stdin@8.0.0:
+    resolution: {integrity: sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==}
+    engines: {node: '>=10'}
+
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
   get-tsconfig@4.10.0:
     resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -1267,6 +1297,10 @@ packages:
     resolution: {integrity: sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==}
     engines: {node: '>= 0.4'}
 
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -1274,6 +1308,10 @@ packages:
   is-generator-fn@2.1.0:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
     engines: {node: '>=6'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -1547,6 +1585,10 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -1666,6 +1708,10 @@ packages:
       zod:
         optional: true
 
+  p-all@3.0.0:
+    resolution: {integrity: sha512-qUZbvbBFVXm6uJ7U/WDiO0fv6waBMbjlCm4E66oZdRR+egswICarIdHyVSZZHudH8T5SF8x/JG0q0duFzPnlBw==}
+    engines: {node: '>=10'}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -1681,6 +1727,10 @@ packages:
   p-map@3.0.0:
     resolution: {integrity: sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==}
     engines: {node: '>=8'}
+
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
+    engines: {node: '>=10'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -1756,8 +1806,15 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
 
   reftools@1.1.9:
     resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==}
@@ -1796,10 +1853,20 @@ packages:
     resolution: {integrity: sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==}
     hasBin: true
 
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   semifies@1.0.0:
     resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
@@ -1881,9 +1948,15 @@ packages:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
 
+  string-to-stream@3.0.1:
+    resolution: {integrity: sha512-Hl092MV3USJuUCC6mfl9sPzGloA3K5VwdIeJjYIkXY/8K+mUvaeEabWJgArp+xXrsWxCajeT2pc4axbVhIZJyg==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -1904,6 +1977,10 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  superstruct@1.0.4:
+    resolution: {integrity: sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ==}
+    engines: {node: '>=14.0.0'}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1981,9 +2058,19 @@ packages:
       '@swc/wasm':
         optional: true
 
+  tsc-multi@1.1.0:
+    resolution: {integrity: sha512-THE6X+sse7EZ2qMhqXvBhd2HMTvXyWwYnx+2T/ijqdp/6Rf7rUc2uPRzPdrrljZCNcYDeL0qP2P7tqm2IwayTg==}
+    engines: {node: '>=14'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=4.3.0'
+
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsx@4.19.3:
     resolution: {integrity: sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==}
@@ -2037,6 +2124,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -2611,6 +2701,18 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
 
   '@opentelemetry/api-logs@0.53.0':
     dependencies:
@@ -3212,9 +3314,21 @@ snapshots:
       jest-message-util: 29.7.0
       jest-util: 29.7.0
 
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-safe-stringify@2.1.1: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
 
   fb-watchman@2.0.2:
     dependencies:
@@ -3297,11 +3411,17 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stdin@8.0.0: {}
+
   get-stream@6.0.1: {}
 
   get-tsconfig@4.10.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob@7.2.3:
     dependencies:
@@ -3381,9 +3501,15 @@ snapshots:
     dependencies:
       hasown: 2.0.2
 
+  is-extglob@2.1.1: {}
+
   is-fullwidth-code-point@3.0.0: {}
 
   is-generator-fn@2.1.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
 
   is-number@7.0.0: {}
 
@@ -3839,6 +3965,8 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
+  merge2@1.4.1: {}
+
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
@@ -3985,6 +4113,10 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  p-all@3.0.0:
+    dependencies:
+      p-map: 4.0.0
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -3998,6 +4130,10 @@ snapshots:
       p-limit: 2.3.0
 
   p-map@3.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
+
+  p-map@4.0.0:
     dependencies:
       aggregate-error: 3.1.0
 
@@ -4075,7 +4211,15 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  queue-microtask@1.2.3: {}
+
   react-is@18.3.1: {}
+
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
 
   reftools@1.1.9: {}
 
@@ -4105,9 +4249,17 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  reusify@1.1.0: {}
+
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
 
   semifies@1.0.0: {}
 
@@ -4189,11 +4341,19 @@ snapshots:
       char-regex: 1.0.2
       strip-ansi: 6.0.1
 
+  string-to-stream@3.0.1:
+    dependencies:
+      readable-stream: 3.6.2
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
 
   strip-ansi@6.0.1:
     dependencies:
@@ -4206,6 +4366,8 @@ snapshots:
   strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  superstruct@1.0.4: {}
 
   supports-color@7.2.0:
     dependencies:
@@ -4303,11 +4465,29 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
+  tsc-multi@1.1.0(typescript@5.5.4):
+    dependencies:
+      debug: 4.3.7
+      fast-glob: 3.3.3
+      get-stdin: 8.0.0
+      p-all: 3.0.0
+      picocolors: 1.1.1
+      signal-exit: 3.0.7
+      string-to-stream: 3.0.1
+      superstruct: 1.0.4
+      tslib: 2.8.1
+      typescript: 5.5.4
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - supports-color
+
   tsconfig-paths@4.2.0:
     dependencies:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@2.8.1: {}
 
   tsx@4.19.3:
     dependencies:
@@ -4352,6 +4532,8 @@ snapshots:
       browserslist: 4.24.2
       escalade: 3.2.0
       picocolors: 1.1.1
+
+  util-deprecate@1.0.2: {}
 
   uuid@8.3.2: {}
 

--- a/sdks/node/scripts/build.mjs
+++ b/sdks/node/scripts/build.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+// Drives the dual CJS/ESM build by calling tsc-multi's public `build()`
+// function twice — once per target — with a different tsconfig per call.
+//
+// This pattern gives us per-target file selection (each tsconfig has its
+// own `exclude` list) plus tsc-multi's AST transformer that rewrites
+// relative-import specifiers to the right extension per format. Both
+// without reaching into tsc-multi internals.
+//
+// See `weave-sdk-dual-build-report.md` §5 for background; the rationale
+// for this specific layout vs. alternatives is captured in the conversation
+// log under PR 2.
+
+import {build} from 'tsc-multi';
+import {fileURLToPath} from 'node:url';
+import {dirname, resolve} from 'node:path';
+
+const cwd = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+await build({
+  cwd,
+  projects: ['tsconfig.cjs.json'],
+  targets: [{extname: '.js', module: 'commonjs', moduleResolution: 'node'}],
+});
+
+await build({
+  cwd,
+  projects: ['tsconfig.esm.json'],
+  targets: [{extname: '.mjs', module: 'esnext'}],
+});

--- a/sdks/node/src/__tests__/integrations/openaiIITM.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiIITM.test.ts
@@ -63,7 +63,7 @@ describe('ESM Module instrumentation', () => {
     fs.writeFileSync(customInstrumentationPath, customInstrumentationFile);
     const esmLoaderPath = path.resolve(
       __dirname,
-      '../../../dist/esm/instrument.js'
+      '../../../dist/esm/instrument.mjs'
     );
     const childPath = path.join(tmpDir, 'openaiRequire.forkChild.mjs');
     fs.writeFileSync(
@@ -167,7 +167,7 @@ client.chat.completions.create({messages: [{role: 'user', content: 'test'}]}).th
     fs.writeFileSync(customInstrumentationPath, customInstrumentationFile);
     const esmLoaderPath = path.resolve(
       __dirname,
-      '../../../dist/esm/instrument.js'
+      '../../../dist/esm/instrument.mjs'
     );
     const childPath = path.join(tmpDir, 'openaiRequire.forkChild.mjs');
     fs.writeFileSync(

--- a/sdks/node/src/esm/instrument.mts
+++ b/sdks/node/src/esm/instrument.mts
@@ -1,17 +1,16 @@
 // Preload entry for Weave ESM host support.
 //
-// Invoked via `node --import=weave/instrument <entry>`. The file is compiled
-// as CommonJS by the main tsconfig (same as every other file under `src/`);
-// Node's `--import` flag goes through the ESM resolver but transparently
-// handles CJS targets via ESM→CJS interop, so the preload still works for
-// ESM host apps. A future PR will switch this file to true ESM output; for
-// now it stays CJS to keep the build a single tsc invocation.
+// Invoked via `node --import=weave/instrument <entry>`. The `.mts` extension
+// marks this file as ESM-only — TypeScript always emits it as `.mjs`. The
+// CJS target's tsconfig also excludes `src/esm/**` so it is never even
+// considered by the CJS build pass. The `package.json` `"./instrument"`
+// exports map only routes the `import` condition, so consumers always get
+// the ESM build.
 //
 // Its job is to register an `import-in-the-middle` loader hook so the host's
 // ESM graph can be patched as modules are resolved.
 
 import {register} from 'node:module';
-import {pathToFileURL} from 'node:url';
 import {Hook, createAddHookMessageChannel} from 'import-in-the-middle';
 import {
   getESMInstrumentedModules,
@@ -30,11 +29,10 @@ import '../integrations/hooks';
 const {registerOptions, waitForAllMessagesAcknowledged} =
   createAddHookMessageChannel();
 
-register(
-  'import-in-the-middle/hook.mjs',
-  pathToFileURL(__filename),
-  registerOptions
-);
+// Pass `import.meta.url` as `register()`'s `parentURL` so it can resolve the
+// bare `'import-in-the-middle/hook.mjs'` specifier through `node_modules`
+// (omitting parentURL defaults to `data:/`, which can't).
+register('import-in-the-middle/hook.mjs', import.meta.url, registerOptions);
 
 (async () => {
   await waitForAllMessagesAcknowledged();

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -28,5 +28,17 @@ export {op} from './op';
 export * from './types';
 export {WeaveObject, ObjectRef} from './weaveObject';
 export {MessagesPrompt, StringPrompt} from './prompt';
-import './utils/commonJSLoader';
+// CJS-only side-effect: install the `require()` patcher so CJS hosts
+// auto-instrument supported modules. ESM hosts use the loader hook in
+// `./esm/instrument.mjs` instead, registered via `--import=weave/instrument`.
+//
+// The runtime guard pairs with the ESM tsconfig's `exclude` of
+// `src/utils/commonJSLoader.ts`: under the ESM build, no `.mjs` sibling
+// is emitted, the `require()` call here is dead code, and the typeof
+// check prevents the missing module from ever being requested.
+if (typeof require === 'function' && typeof module === 'object') {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require('./utils/commonJSLoader');
+}
+
 import './integrations/hooks';

--- a/sdks/node/tsconfig.cjs.json
+++ b/sdks/node/tsconfig.cjs.json
@@ -1,0 +1,19 @@
+// CJS-target tsconfig used by `scripts/build.mjs`. Extends the project root
+// tsconfig and pins `module: commonjs` here so the format is self-evident
+// without having to chase the `extends` chain. Also excludes the ESM-only
+// `src/esm/**` files (which use `import.meta.url`, a syntax error under
+// `module: commonjs`).
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  },
+  "exclude": [
+    "examples",
+    "dist",
+    "node_modules",
+    "src/integrations/checkOpenai.ts",
+    "src/__tests__/**/*",
+    "src/esm/**"
+  ]
+}

--- a/sdks/node/tsconfig.esm.json
+++ b/sdks/node/tsconfig.esm.json
@@ -1,0 +1,20 @@
+// ESM-target tsconfig used by `scripts/build.mjs`. Extends the project root
+// tsconfig and pins `module: esnext` here so the format is self-evident
+// without having to chase the `extends` chain. Also excludes the CJS-only
+// file: `src/utils/commonJSLoader.ts` exists to patch the `require()`
+// chain for CJS hosts and has no role under ESM (where the loader hook in
+// `src/esm/instrument.mts` plays the equivalent role).
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext"
+  },
+  "exclude": [
+    "examples",
+    "dist",
+    "node_modules",
+    "src/integrations/checkOpenai.ts",
+    "src/__tests__/**/*",
+    "src/utils/commonJSLoader.ts"
+  ]
+}

--- a/sdks/node/tsconfig.json
+++ b/sdks/node/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "composite": true,
-    "target": "es2018",
-    "module": "commonjs",
+    // ES2022 matches our minimum supported runtime(Node 18+).
+    "target": "es2022",
     "moduleResolution": "node",
     "sourceMap": true,
     "strict": true,


### PR DESCRIPTION
# Weave Node SDK — dual-build PR 2: dual CJS/ESM emission via tsc-multi

Migrates the Weave Node SDK to a true file-per-module dual CJS/ESM build. ESM consumers loading `weave` (or `--import=weave/instrument`) now get real `.mjs` output that imports other `.mjs` siblings; CJS consumers get the same shape they shipped before. Background: [`Tech Report — Should the Weave Node SDK ship a dual CJS/ESM build`](https://www.notion.so/wandbai/Tech-Report-Should-the-Weave-Node-SDK-ship-a-dual-CJS-ESM-build-348e2f5c7ef380149c80fdeb5a546f3c?source=copy_link), particularly §5 ("Output shape") and §7 PR 2.

## TL;DR

- **Build pipeline:** [`scripts/build.mjs`](sdks/node/scripts/build.mjs) calls `tsc-multi`'s public `build()` function **twice** — once per target — with a different tsconfig per call.
- **Per-target file selection:** [`tsconfig.cjs.json`](sdks/node/tsconfig.cjs.json) excludes `src/esm/**`; [`tsconfig.esm.json`](sdks/node/tsconfig.esm.json) excludes `src/utils/commonJSLoader.ts`. Each format only sees the files it should.
- **One file rename:** `src/esm/instrument.ts` → `src/esm/instrument.mts` so TypeScript emits it as `.mjs` natively. Source uses `import.meta.url` directly — no eval workaround, no `@ts-ignore`.
- **One source-side change in** **`src/index.ts`:** runtime-conditional `require('./utils/commonJSLoader')` so the ESM build never tries to import the (now-not-emitted) CJS-only file.

## Why this is non-trivial

A naive dual-emit setup would be: "run tsc twice with different `module` settings, ship both outputs." That falls over for two reasons specific to this SDK.

### The two format-specific files

The SDK has exactly two source files that legitimately have no business in the _other_ format:

- [**`src/utils/commonJSLoader.ts`**](sdks/node/src/utils/commonJSLoader.ts) **(CJS-only).** Patches Node's `Module.prototype.require` so CJS hosts auto-instrument supported packages. There is no `require` chain to patch under ESM — the equivalent role is filled by an `import-in-the-middle` loader hook (registered from [`src/esm/instrument.mts`](sdks/node/src/esm/instrument.mts)). Compiling this file as ESM produces dead, broken code: a `.mjs` that calls `require()` (ReferenceError under ESM) and would crash if loaded.
- [**`src/esm/instrument.mts`**](sdks/node/src/esm/instrument.mts) **(ESM-only).** The `--import=weave/instrument` preload entry. Calls `register()` with `import.meta.url` to install the loader hook. `import.meta` is **a syntax error** under `module: commonjs`, so the file simply cannot be compiled as CJS without contortions (eval indirection, `@ts-ignore`, or a separate file split).

Each file is _intentionally_ format-specific and trying to compile each in the other format produces nonsense at best and broken output at worst.

### `tsc-multi` doesn't expose per-target file selection

`tsc-multi` is the right core: its AST transformer rewrites relative-import specifiers per target (so `.mjs` output imports `.mjs` siblings, `.js` output imports `.js` siblings — no dual-package hazard). But its config file (`tsc-multi.json`) only supports per-target **compiler-option overrides** (`module`, `moduleResolution`, `extname`, etc.). It does not support per-target `include` / `exclude`. From its [Target schema](https://github.com/tommy351/tsc-multi/blob/main/src/config.ts):

```ts
const targetSchema = type({
  extname: optional(string()),
  transpileOnly: optional(boolean()),
});
// plus arbitrary compiler options merged into compilerOptions
```

So out of the box, every project source file is compiled under every target. The two format-specific files above can't be excluded per target through `tsc-multi.json` alone.

## Approaches we explored, and why they were not ideal

The PR is the third design we tried. The earlier attempts taught us what doesn't work; capturing them here so future readers don't re-tread.

### 1\. `tsup` with `bundle: false`

The migration plan in §5 originally recommended `tsup`. Empirically, `tsup` with `bundle: false` does **not** rewrite import-specifier extensions — `.mjs` files end up importing `.js` siblings, which Node's ESM resolver loads as the **CJS** sibling next to it. The dual build degrades into "ESM-shaped CJS." The community workaround ([`esbuild-plugin-file-path-extensions`](https://github.com/favware/esbuild-plugin-file-path-extensions)) explicitly requires `bundle: true`, which loses the file-per-module shape we committed to in §5 ("Output shape"). Long-standing tsup issue: [#953](https://github.com/egoist/tsup/issues/953).

### 2\. `tsc-multi` + dedicated `tsc` invocation for `instrument`

Run `tsc-multi` against the bulk of the source, then run plain `tsc -p tsconfig.instrument.esm.json` for `instrument.mts`, then a `move-esm-instrument.mjs` script to copy just the wanted files into `dist/`.

This worked but had real drawbacks:

- The dedicated `tsc` invocation transitively compiles every imported source file (TypeScript's design — `include` doesn't gate emission), so we needed a sandbox `outDir` and a manual cherry-pick to avoid clobbering `tsc-multi`'s output.
- Asymmetric: `instrument.mts` got special-case build infrastructure; `commonJSLoader.ts` did not. The build pipeline had to grow more carve-outs as new format-specific files arrived.
- ~55 lines of build infrastructure (extra tsconfig + move script) for a one-file problem.

### 3\. `process.argv[1]` as `parentURL`, no `import.meta.url`

If `instrument`'s source could avoid `import.meta.url`, it would compile cleanly under both `module: commonjs` and `module: esnext`, and the whole dedicated-tsc workaround disappears. We tried passing `pathToFileURL(process.argv[1])` (the user's entry script) to `register()` as `parentURL`.

This worked for typical Node invocations but is fragile for global CLIs, npx, workspace-hoisted-`node_modules` setups, and any case where the entry script lives outside the project's `node_modules` ancestry. A tracing SDK can't tolerate "doesn't auto-instrument when launched in pattern X." Rejected.

### 4\. Rename source files to `.cts` / `.mts` to encode format at the filename level

Considered for both files; rejected for `commonJSLoader.cts` because `tsc-multi`'s extension-rewriting transformer is naive about `.cts`/`.mts` siblings. It rewrites `'./commonJSLoader'` → `'./commonJSLoader.js'` (CJS target), but the actual emitted file is `commonJSLoader.cjs` (TypeScript's per-extension rule). Mismatch → runtime resolution failure. We saw the same issue earlier in this stack with `.cts` source.

We **did** rename `instrument.ts` → `instrument.mts` because nothing imports that file from source (it's only invoked as a preload), so the transformer's mismatch behavior never gets a chance to fire. The rename makes the file's ESM-only nature self-documenting at the file-tree level.

### 5\. Roll our own dual-emit driver (vendor `tsc-multi`'s transformer)

Two tsconfigs (CJS, ESM) extending a shared base, plus our own AST transformer (lifted from `tsc-multi`'s public source) plus a custom build script that drives `ts.createProgram` + `program.emit` × 2.

Architecturally clean — full per-target file selection, no dependency on `tsc-multi` internals. ~240 lines of build infrastructure to own forever, including a TypeScript custom transformer to maintain across compiler-API drift. Not worth it for two format-specific files.

## What this PR actually does — and why it's the right shape

**Use** **`tsc-multi`'s public** **`build()`** **API directly, twice, with different tsconfigs per call.**

```js
// scripts/build.mjs
import {build} from 'tsc-multi';

await build({
  cwd,
  projects: ['tsconfig.cjs.json'],
  targets: [{extname: '.js', module: 'commonjs', moduleResolution: 'node'}],
});

await build({
  cwd,
  projects: ['tsconfig.esm.json'],
  targets: [{extname: '.mjs', module: 'esnext'}],
});
```

Each `build()` call runs `tsc-multi` for **one project against one target**. The per-target tsconfig declares its own `exclude` list (the file selection that `tsc-multi.json` cannot express), and the per-target settings live where they belong (the `module` field is in each per-format tsconfig, not in the root). The AST transformer runs as part of `tsc-multi`'s normal pipeline, so import-extension rewriting Just Works.

### Why this is a great leverage of `tsc-multi`'s design

The CLI surface (`tsc-multi` + `tsc-multi.json`) was designed for the typical "one source tree, two targets, no per-target file selection" case. We have a less typical case (per-target file selection), and the CLI doesn't cover it. But the **library API** — the exported `build()` function — accepts everything we need: the project paths, the target options, the cwd. It happily runs once per call with a one-target array. Nothing about its design objects to being called multiple times.

By calling `build()` ourselves we:

1. Get full control over which tsconfig pairs with which target.
2. Inherit `tsc-multi`'s well-tested AST transformer for free, with no internal-API coupling.
3. Avoid maintaining a `tsc-multi` clone (~240 lines of compiler-API code).
4. Stay on the upgrade path: a future `tsc-multi` version that fixes bugs or adds features ships to us via a normal `pnpm update`.

This is a relatively common pattern for build tools that ship a CLI thin wrapper around a programmatic API: when the CLI's config doesn't cover your case, drop down one layer and drive the API directly.

## Source-level changes in detail

### [`src/index.ts`](sdks/node/src/index.ts) — runtime-conditional `commonJSLoader` import

```ts
// CJS-only side-effect: install the `require()` patcher so CJS hosts
// auto-instrument supported modules. ESM hosts use the loader hook in
// `./esm/instrument.mjs` instead, registered via `--import=weave/instrument`.
if (typeof require === 'function' && typeof module === 'object') {
  require('./utils/commonJSLoader');
}
```

The `commonJSLoader.ts` source file is **excluded from the ESM tsconfig**, so no `commonJSLoader.mjs` ships in `dist/`. The runtime guard prevents the `require()` from being called under ESM (where the file wouldn't exist anyway). CJS consumers are unchanged: the guard passes, and `commonJSLoader.js` patches `Module.prototype.require` like before.

### [`src/esm/instrument.mts`](sdks/node/src/esm/instrument.mts) — `.mts` rename

Renamed from `.ts` so TypeScript emits `.mjs` natively (and `.d.mts` for the declaration). Source uses `import.meta.url` directly with no contortions — works because the file is excluded from the CJS tsconfig and only ever compiled under `module: esnext`.

### [`src/__tests__/integrations/openaiIITM.test.ts`](sdks/node/src/__tests__/integrations/openaiIITM.test.ts)

Two occurrences of `dist/esm/instrument.js` updated to `dist/esm/instrument.mjs` since the runtime artifact is now `.mjs`.

## Tsconfig structure

- [`tsconfig.json`](sdks/node/tsconfig.json) — shared base. `target: es2022` (matches our Node-18-minimum commitment, drops unnecessary downleveling), `moduleResolution: node`, `strict`, `paths`, etc. **No** **`module`** **setting** — that's a per-target concern.
- [`tsconfig.cjs.json`](sdks/node/tsconfig.cjs.json) — extends base, pins `module: commonjs` explicitly, excludes `src/esm/**`. Passed to the first `build()` call with `extname: '.js'`.
- [`tsconfig.esm.json`](sdks/node/tsconfig.esm.json) — extends base, pins `module: esnext` explicitly, excludes `src/utils/commonJSLoader.ts`. Passed to the second `build()` call with `extname: '.mjs'`.

Each per-format tsconfig is self-explanatory at a glance: you don't have to chase the `extends` chain to know what format it produces.

## What the published package looks like now

```
dist/
├── index.js / index.mjs / index.d.ts          # main entry, both formats
├── clientApi.js / clientApi.mjs / clientApi.d.ts
├── …                                           # every src/ file mirrored
├── integrations/
│   ├── openai.js / openai.mjs / openai.d.ts
│   └── …
├── utils/
│   ├── commonJSLoader.js / commonJSLoader.d.ts # CJS-only — no .mjs sibling
│   └── …
└── esm/
    └── instrument.mjs / instrument.d.mts       # ESM-only — no .js sibling
```

`exports` map:

```jsonc
{
  ".": {
    "types": "./dist/index.d.ts",
    "import": "./dist/index.mjs",
    "require": "./dist/index.js"
  },
  "./instrument": {
    "types": "./dist/esm/instrument.d.mts",
    "import": "./dist/esm/instrument.mjs"
  }
}
```

`./instrument` only routes the `import` condition — CJS consumers don't use this entry; they use the `commonJSLoader` patch baked into `require('weave')`.

## Tested scenarios

- [x] `pnpm run build` — clean (`[js]: Found 0 errors. [mjs]: Found 0 errors.`).
- [x] Smoke test 1: `node -e "require('weave')"` — succeeds, exposes expected keys.
- [x] Smoke test 2: `node --input-type=module -e "import * as w from 'weave'"` — succeeds, exposes expected keys.
- [x] Smoke test 3: `node --input-type=module --import='weave/instrument' -e "console.log('OK')"` — succeeds (preload completes without errors).
- [x] `WANDB_API_KEY=dummy pnpm run test` — **185 passed, 7 skipped** (live-network tests, pre-existing skip), 0 failed. Same counts as `master` plus the 2 retest fixes.
- [x] Manual validation against several host applications (compiled with both CJS and ESM).
- [x] `dist/esm/instrument.mjs` import audit: imports from `.mjs` siblings (`./integrations/instrumentations.mjs`, etc.), not via ESM→CJS interop. True file-per-module dual build.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wandb/weave/pull/6737" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
