### PR TITLE
perf(weave): defer output _save_nested_objects in client

### DIFF
--- a/tests/trace/conftest.py
+++ b/tests/trace/conftest.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import base64
 import os
 import threading
+from contextlib import contextmanager
 from dataclasses import dataclass, field
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -14,6 +16,8 @@ from google.auth.credentials import AnonymousCredentials
 
 from tests.trace.test_utils import FailingSaveType, failing_load, failing_save
 from weave.trace.serialization import serializer
+from weave.trace.weave_client import WeaveClient
+from weave.trace_server import trace_server_interface as tsi
 
 # Pinned to the project id of the standard `client` fixture (shawn/test-project).
 TEST_BUCKET = "test-bucket"
@@ -165,3 +169,47 @@ def gcs():
 
     with mock.patch("google.cloud.storage.Client", return_value=mock_storage_client):
         yield mock_storage_client
+
+
+class BlockingTraceServer(tsi.TraceServerInterface):
+    """Server proxy that holds a lock; while paused, all proxied calls block."""
+
+    def __init__(self, inner: tsi.TraceServerInterface):
+        self._inner = inner
+        self._lock = threading.Lock()
+
+    def pause(self) -> None:
+        self._lock.acquire()
+
+    def resume(self) -> None:
+        self._lock.release()
+
+    def __getattribute__(self, item: str) -> Any:
+        if item in {"_inner", "_lock", "pause", "resume"}:
+            return super().__getattribute__(item)
+        inner = super().__getattribute__("_inner")
+        if item in {"attribute_access_log", "remote_request_bytes_limit"}:
+            return getattr(inner, item)
+
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            with self._lock:
+                return getattr(inner, item)(*args, **kwargs)
+
+        return wrapper
+
+
+@contextmanager
+def paused(client: WeaveClient):
+    """Pause the client's server proxy, yield, then resume and flush."""
+    original = client.server
+    client.set_autoflush(False)
+    blocker = BlockingTraceServer(original)
+    client.server = blocker
+    blocker.pause()
+    try:
+        yield client
+    finally:
+        blocker.resume()
+        client.server = original
+        client._flush()
+        client.set_autoflush(True)

--- a/tests/trace/test_save_nested_defer.py
+++ b/tests/trace/test_save_nested_defer.py
@@ -9,6 +9,8 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
+import logging
 import threading
 import time
 from concurrent.futures import Future
@@ -220,7 +222,6 @@ async def test_concurrent_finishes_drain(client: WeaveClient) -> None:
     Object whose digest is pending while the server is paused; releasing the
     pause must let every pending finalize_send fire and `_flush()` return.
     """
-    import asyncio
 
     class Item(weave.Object):  # type: ignore[name-defined]
         i: int = 0
@@ -235,24 +236,55 @@ async def test_concurrent_finishes_drain(client: WeaveClient) -> None:
     assert results == [k * 2 for k in range(20)]
 
 
-def test_call_end_error_is_logged_once(client: WeaveClient) -> None:
-    """Errors in the deferred Phase 2 (server.call_end) propagate via
-    `end_complete_future` and surface to the user the same way master does.
+class _CallEndRaisingServer:
+    """Server proxy that raises `RuntimeError` from `call_end`.
 
-    Regression guard: in earlier drafts we set `log_exception=False` on the
-    barrier future, which silently swallowed call_end errors. The fix is to
-    log on `end_complete_future`; this test fails if that flips back.
+    Plain class (no `TraceServerInterface` subclass) so `__getattr__`
+    forwards every other method to the inner server — subclassing the
+    interface would resolve abstract methods via MRO and never reach
+    `__getattr__`.
+    """
+
+    def __init__(self, inner: tsi.TraceServerInterface) -> None:
+        self._inner = inner
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._inner, item)
+
+    def call_end(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("simulated call_end failure")
+
+
+@pytest.mark.disable_logging_error_check
+def test_call_end_error_is_logged(
+    client: WeaveClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Errors raised by `server.call_end` in the deferred Phase 2 must surface
+    as a "Task failed" log line via `_track_future`'s logger.
+
+    Regression guard: an earlier draft tracked the barrier future with
+    `log_exception=False`, which silently swallowed `call_end` errors. If
+    that flips back, the assertion below fails.
     """
 
     @weave.op
     def f(x: int) -> int:
         return x + 1
 
-    f(1)
-    f(2)
-    client._flush()
-    # Smoke: just asserting flush returns. The failure mode was a hang/silence,
-    # not a wrong return value.
+    original = client.server
+    client.server = _CallEndRaisingServer(original)
+    try:
+        with caplog.at_level(logging.ERROR):
+            f(1)
+            client._flush()
+    finally:
+        client.server = original
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "Task failed" in m and "simulated call_end failure" in m for m in messages
+    ), f"Expected 'Task failed' log with our error; got: {messages}"
 
 
 def test_finish_call_returns_before_send(client: WeaveClient) -> None:

--- a/tests/trace/test_save_nested_defer.py
+++ b/tests/trace/test_save_nested_defer.py
@@ -1,0 +1,289 @@
+"""Tests for the deferred-output structural fix.
+
+Covers:
+1. `_collect_pending_digests` — pre-walk that finds unresolved digest futures.
+2. The `then(...)`-chained `_save_object_basic` path (no worker block on digest).
+3. The deferred `send_end_call` (Phase 1 + Phase 2) doesn't deadlock under
+   high concurrency or paused-server scenarios.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import Future
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+import weave
+from weave.trace.object_record import ObjectRecord
+from weave.trace.refs import ObjectRef, OpRef, TableRef
+from weave.trace.weave_client import WeaveClient, _collect_pending_digests
+from weave.trace_server import trace_server_interface as tsi
+
+
+def _make_pending_future() -> Future[str]:
+    f: Future[str] = Future()
+    return f
+
+
+def _make_resolved_future(value: str) -> Future[str]:
+    f: Future[str] = Future()
+    f.set_result(value)
+    return f
+
+
+# ---------------------------------------------------------------------------
+# _collect_pending_digests: unit tests over arbitrary value shapes.
+# These don't touch the client; they verify the pre-walk that gates `to_json`
+# from blocking inside a worker thread.
+# ---------------------------------------------------------------------------
+
+
+class TestCollectPendingDigests:
+    def test_primitives_return_empty(self) -> None:
+        assert _collect_pending_digests(None) == []
+        assert _collect_pending_digests("hello") == []
+        assert _collect_pending_digests(42) == []
+        assert _collect_pending_digests(3.14) == []
+        assert _collect_pending_digests(True) == []
+
+    def test_containers_of_primitives_return_empty(self) -> None:
+        assert _collect_pending_digests([]) == []
+        assert _collect_pending_digests([1, 2, "a"]) == []
+        assert _collect_pending_digests((1, 2)) == []
+        assert _collect_pending_digests({}) == []
+        assert _collect_pending_digests({"a": 1, "b": [2, 3]}) == []
+        assert _collect_pending_digests({"nested": {"deep": {"value": 1}}}) == []
+
+    def test_object_ref_with_resolved_digest_returns_empty(self) -> None:
+        ref = ObjectRef(
+            entity="e", project="p", name="obj", _digest="resolved-digest"
+        )
+        assert _collect_pending_digests(ref) == []
+
+    def test_object_ref_with_pending_digest_is_collected(self) -> None:
+        pending = _make_pending_future()
+        ref = ObjectRef(entity="e", project="p", name="obj", _digest=pending)
+        assert _collect_pending_digests(ref) == [pending]
+
+    def test_object_ref_with_resolved_future_treated_as_pending_caller_handles(
+        self,
+    ) -> None:
+        # Done futures are skipped — the caller will read `.result()` without
+        # blocking, so we don't need the `then(...)` gate.
+        f = _make_resolved_future("done")
+        ref = ObjectRef(entity="e", project="p", name="obj", _digest=f)
+        assert _collect_pending_digests(ref) == []
+
+    def test_table_ref_collects_both_digest_and_row_digests(self) -> None:
+        digest = _make_pending_future()
+        row_digests: Future[list[str]] = Future()
+        ref = TableRef(
+            entity="e", project="p", _digest=digest, _row_digests=row_digests
+        )
+        result = _collect_pending_digests(ref)
+        assert digest in result
+        assert row_digests in result
+        assert len(result) == 2
+
+    def test_op_ref_collected(self) -> None:
+        pending = _make_pending_future()
+        ref = OpRef(entity="e", project="p", name="my_op", _digest=pending)
+        assert _collect_pending_digests(ref) == [pending]
+
+    def test_dict_with_nested_pending_ref(self) -> None:
+        pending = _make_pending_future()
+        ref = ObjectRef(entity="e", project="p", name="obj", _digest=pending)
+        val = {"a": 1, "obj": ref, "nested": {"more": [ref]}}
+        # Cycle protection: ref appears twice but is collected once.
+        result = _collect_pending_digests(val)
+        assert result == [pending]
+
+    def test_list_and_tuple_walk(self) -> None:
+        p1 = _make_pending_future()
+        p2 = _make_pending_future()
+        r1 = ObjectRef(entity="e", project="p", name="o1", _digest=p1)
+        r2 = ObjectRef(entity="e", project="p", name="o2", _digest=p2)
+        result = _collect_pending_digests([r1, (r2, 42)])
+        assert set(result) == {p1, p2}
+
+    def test_object_record_walked_via_dunder_dict(self) -> None:
+        pending = _make_pending_future()
+        ref = ObjectRef(entity="e", project="p", name="child", _digest=pending)
+        # Build an ObjectRecord whose __dict__ contains a ref.
+        rec = ObjectRecord({"_class_name": "Parent", "child_ref": ref, "n": 7})
+        assert _collect_pending_digests(rec) == [pending]
+
+    def test_cycle_is_handled(self) -> None:
+        # Build a self-referential structure. Walk must not infinite loop.
+        pending = _make_pending_future()
+        ref = ObjectRef(entity="e", project="p", name="obj", _digest=pending)
+        cycle: dict[str, Any] = {"ref": ref}
+        cycle["self"] = cycle
+        result = _collect_pending_digests(cycle)
+        assert result == [pending]
+
+    def test_does_not_recurse_into_resolved_ref_extras(self) -> None:
+        # A Ref is a leaf; its `_extra` etc. shouldn't trigger nested walks.
+        ref = ObjectRef(
+            entity="e",
+            project="p",
+            name="obj",
+            _digest="d",
+            _extra=("attr", "foo"),
+        )
+        assert _collect_pending_digests(ref) == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: under paused-server (the deadlock fixture from
+# test_evaluation_performance), a basic op chain must complete cleanly at
+# default executor parallelism. Master without the structural fix deadlocks
+# here when the deferred `_save_nested_objects` is present.
+# ---------------------------------------------------------------------------
+
+
+class _BlockingTraceServer(tsi.TraceServerInterface):
+    """Server proxy that holds a lock; while paused, all proxied calls block."""
+
+    def __init__(self, inner: tsi.TraceServerInterface):
+        self._inner = inner
+        self._lock = threading.Lock()
+
+    def pause(self) -> None:
+        self._lock.acquire()
+
+    def resume(self) -> None:
+        self._lock.release()
+
+    def __getattribute__(self, item: str) -> Any:
+        if item in {"_inner", "_lock", "pause", "resume"}:
+            return super().__getattribute__(item)
+        inner = super().__getattribute__("_inner")
+        if item in {"attribute_access_log", "remote_request_bytes_limit"}:
+            return getattr(inner, item)
+
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            with self._lock:
+                return getattr(inner, item)(*args, **kwargs)
+
+        return wrapper
+
+
+@contextmanager
+def _paused(client: WeaveClient):
+    original = client.server
+    client.set_autoflush(False)
+    blocker = _BlockingTraceServer(original)
+    client.server = blocker
+    blocker.pause()
+    try:
+        yield client
+    finally:
+        blocker.resume()
+        client.server = original
+        client._flush()
+        client.set_autoflush(True)
+
+
+def test_paused_server_does_not_deadlock_on_finish(client: WeaveClient) -> None:
+    """A traced op finishes while server is paused; flush drains cleanly.
+
+    Reproduces the failure mode that motivated the structural fix: with the
+    naive deferred `_save_nested_objects`, multiple concurrent `send_end_call`
+    workers all end up blocking inside `to_json -> digest.result()`, exhausting
+    the worker pool and deadlocking the post-resume flush. Here the chain is
+    short (one op), but `_save_object_basic` for the input pydantic model
+    builds the same digest-future dependency that the gate must release.
+    """
+
+    class Model(weave.Object):  # type: ignore[name-defined]
+        x: int = 0
+
+    @weave.op
+    def step(m: Model) -> dict:
+        return {"x": m.x}
+
+    m = Model(x=1)
+    with _paused(client) as c:
+        out = step(m)
+    assert out == {"x": 1}
+    # The flush in `_paused.__exit__` must drain. If we got here, no deadlock.
+
+
+@pytest.mark.asyncio
+async def test_concurrent_finishes_drain(client: WeaveClient) -> None:
+    """Many concurrent op finishes drain via the then-chain without deadlock.
+
+    Stresses the `then(pending, finalize)` path: each op's input is a pydantic
+    Object whose digest is pending while the server is paused; releasing the
+    pause must let every pending finalize_send fire and `_flush()` return.
+    """
+    import asyncio
+
+    class Item(weave.Object):  # type: ignore[name-defined]
+        i: int = 0
+
+    @weave.op
+    async def do(item: Item) -> int:
+        return item.i * 2
+
+    items = [Item(i=k) for k in range(20)]
+    with _paused(client):
+        results = await asyncio.gather(*(do(item) for item in items))
+    assert results == [k * 2 for k in range(20)]
+
+
+def test_call_end_error_is_logged_once(client: WeaveClient) -> None:
+    """Errors in the deferred Phase 2 (server.call_end) propagate via
+    `end_complete_future` and surface to the user the same way master does.
+
+    Regression guard: in earlier drafts we set `log_exception=False` on the
+    barrier future, which silently swallowed call_end errors. The fix is to
+    log on `end_complete_future`; this test fails if that flips back.
+    """
+
+    @weave.op
+    def f(x: int) -> int:
+        return x + 1
+
+    f(1)
+    f(2)
+    client._flush()
+    # Smoke: just asserting flush returns. The failure mode was a hang/silence,
+    # not a wrong return value.
+
+
+def test_finish_call_returns_before_send(client: WeaveClient) -> None:
+    """`finish_call` should not block on the deferred work.
+
+    Verifies the perf goal: `_save_nested_objects` and `to_json` no longer
+    run on the calling thread. We measure by holding the server lock and
+    timing `finish_call`'s own return.
+    """
+
+    @weave.op
+    def f(x: int) -> int:
+        return x + 1
+
+    blocker = _BlockingTraceServer(client.server)
+    client.server = blocker
+    client.set_autoflush(False)
+    blocker.pause()
+    try:
+        t0 = time.perf_counter()
+        f(1)  # full op: create_call + body + finish_call
+        elapsed = time.perf_counter() - t0
+        # Generous bound: the calling thread does sync work for create_call's
+        # `_save_nested_objects(inputs)` plus the body, but finish_call should
+        # have deferred everything else. 500ms is a sanity ceiling, not a perf
+        # goal — anything under "obviously waiting on the server" is enough.
+        assert elapsed < 0.5, f"finish_call appears to block: {elapsed:.3f}s"
+    finally:
+        blocker.resume()
+        client.server = blocker._inner
+        client._flush()
+        client.set_autoflush(True)

--- a/tests/trace/test_save_nested_defer.py
+++ b/tests/trace/test_save_nested_defer.py
@@ -14,12 +14,12 @@ import logging
 import threading
 import time
 from concurrent.futures import Future
-from contextlib import contextmanager
 from typing import Any
 
 import pytest
 
 import weave
+from tests.trace.conftest import BlockingTraceServer, paused
 from weave.trace.object_record import ObjectRecord
 from weave.trace.refs import ObjectRef, OpRef, TableRef
 from weave.trace.weave_client import (
@@ -150,49 +150,6 @@ class TestCollectPendingDigests:
 # ---------------------------------------------------------------------------
 
 
-class _BlockingTraceServer(tsi.TraceServerInterface):
-    """Server proxy that holds a lock; while paused, all proxied calls block."""
-
-    def __init__(self, inner: tsi.TraceServerInterface):
-        self._inner = inner
-        self._lock = threading.Lock()
-
-    def pause(self) -> None:
-        self._lock.acquire()
-
-    def resume(self) -> None:
-        self._lock.release()
-
-    def __getattribute__(self, item: str) -> Any:
-        if item in {"_inner", "_lock", "pause", "resume"}:
-            return super().__getattribute__(item)
-        inner = super().__getattribute__("_inner")
-        if item in {"attribute_access_log", "remote_request_bytes_limit"}:
-            return getattr(inner, item)
-
-        def wrapper(*args: Any, **kwargs: Any) -> Any:
-            with self._lock:
-                return getattr(inner, item)(*args, **kwargs)
-
-        return wrapper
-
-
-@contextmanager
-def _paused(client: WeaveClient):
-    original = client.server
-    client.set_autoflush(False)
-    blocker = _BlockingTraceServer(original)
-    client.server = blocker
-    blocker.pause()
-    try:
-        yield client
-    finally:
-        blocker.resume()
-        client.server = original
-        client._flush()
-        client.set_autoflush(True)
-
-
 def test_paused_server_does_not_deadlock_on_finish(client: WeaveClient) -> None:
     """A traced op finishes while server is paused; flush drains cleanly.
 
@@ -212,10 +169,10 @@ def test_paused_server_does_not_deadlock_on_finish(client: WeaveClient) -> None:
         return {"x": m.x}
 
     m = Model(x=1)
-    with _paused(client) as c:
+    with paused(client) as c:
         out = step(m)
     assert out == {"x": 1}
-    # The flush in `_paused.__exit__` must drain. If we got here, no deadlock.
+    # The flush in `paused.__exit__` must drain. If we got here, no deadlock.
 
 
 @pytest.mark.asyncio
@@ -235,7 +192,7 @@ async def test_concurrent_finishes_drain(client: WeaveClient) -> None:
         return item.i * 2
 
     items = [Item(i=k) for k in range(20)]
-    with _paused(client):
+    with paused(client):
         results = await asyncio.gather(*(do(item) for item in items))
     assert results == [k * 2 for k in range(20)]
 
@@ -303,7 +260,7 @@ def test_finish_call_returns_before_send(client: WeaveClient) -> None:
     def f(x: int) -> int:
         return x + 1
 
-    blocker = _BlockingTraceServer(client.server)
+    blocker = BlockingTraceServer(client.server)
     client.server = blocker
     client.set_autoflush(False)
     blocker.pause()

--- a/tests/trace/test_save_nested_defer.py
+++ b/tests/trace/test_save_nested_defer.py
@@ -22,7 +22,11 @@ import pytest
 import weave
 from weave.trace.object_record import ObjectRecord
 from weave.trace.refs import ObjectRef, OpRef, TableRef
-from weave.trace.weave_client import WeaveClient, _collect_pending_digests
+from weave.trace.weave_client import (
+    WeaveClient,
+    _collect_pending_digests,
+    _snapshot_mutable_containers,
+)
 from weave.trace_server import trace_server_interface as tsi
 
 
@@ -398,6 +402,71 @@ def test_output_mutation_after_finish_is_not_recorded(client: WeaveClient) -> No
     assert len(capturing.captured) == 1
     recorded_output = capturing.captured[0].end.output
     assert recorded_output == {"result": [1]}, (
-        "Deferred walk captured a post-finish_call mutation: "
-        f"{recorded_output!r}"
+        f"Deferred walk captured a post-finish_call mutation: {recorded_output!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# _snapshot_mutable_containers: type preservation. Subclasses of dict/list/
+# set/tuple must be returned by identity — rebuilding them as the bare type
+# would strip subclass information the serializer needs (namedtuple field
+# names, dict-subclass dataclass types like HuggingFace ChatCompletionOutput).
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshotPreservesSubclassTypes:
+    def test_plain_containers_are_rebuilt(self) -> None:
+        # Plain dict/list/set/tuple at the top level get fresh copies so
+        # post-finish mutations can't reach the deferred walk.
+        d = {"k": [1, 2]}
+        snap = _snapshot_mutable_containers(d)
+        assert snap == d
+        assert snap is not d
+        assert snap["k"] is not d["k"]
+
+    def test_namedtuple_preserved(self) -> None:
+        from typing import NamedTuple
+
+        class Point(NamedTuple):
+            x: int
+            y: int
+
+        snap = _snapshot_mutable_containers(Point(1, 2))
+        assert type(snap) is Point
+        assert snap._asdict() == {"x": 1, "y": 2}
+
+    def test_dict_subclass_preserved(self) -> None:
+        from collections import Counter, OrderedDict
+
+        c = Counter({"a": 1, "b": 2})
+        snap_c = _snapshot_mutable_containers(c)
+        assert type(snap_c) is Counter
+        assert snap_c is c
+
+        od = OrderedDict([("a", 1), ("b", 2)])
+        snap_od = _snapshot_mutable_containers(od)
+        assert type(snap_od) is OrderedDict
+        assert snap_od is od
+
+    def test_list_subclass_preserved(self) -> None:
+        class MyList(list):
+            pass
+
+        ml = MyList([1, 2, 3])
+        snap = _snapshot_mutable_containers(ml)
+        assert type(snap) is MyList
+        assert snap is ml
+
+    def test_namedtuple_nested_in_list_preserved(self) -> None:
+        # Mirrors test_namedtuple_support: list containing a namedtuple
+        # should round-trip with the named fields intact.
+        from typing import NamedTuple
+
+        class Point(NamedTuple):
+            x: int
+            y: int
+
+        snap = _snapshot_mutable_containers([Point(1, 2), 3])
+        assert isinstance(snap, list)
+        assert type(snap[0]) is Point
+        assert snap[0]._asdict() == {"x": 1, "y": 2}

--- a/tests/trace/test_save_nested_defer.py
+++ b/tests/trace/test_save_nested_defer.py
@@ -248,6 +248,78 @@ def test_call_end_error_is_logged(
     ), f"Expected 'Task failed' log with our error; got: {messages}"
 
 
+class _ObjCreateRaisingServer:
+    """Server proxy that raises `RuntimeError` from `obj_create`.
+
+    Same forwarding pattern as `_CallEndRaisingServer`: plain class so
+    `__getattr__` reaches the inner server for every other method.
+    """
+
+    def __init__(self, inner: tsi.TraceServerInterface) -> None:
+        self._inner = inner
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._inner, item)
+
+    def obj_create(self, *args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("simulated obj_create failure")
+
+
+@pytest.mark.disable_logging_error_check
+def test_obj_create_error_does_not_hang_flush(
+    client: WeaveClient,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An `obj_create` failure inside the deferred output-save path must not
+    hang `_flush()` and must surface as a logged error.
+
+    The deferred `schedule_send` walks the output, calls `_save_object_basic`
+    on any nested `weave.Object` (which schedules `obj_create` on the
+    executor), then gates `finalize_send` on the resulting digest futures via
+    `then(pending, ...)`. If a pending digest future fails, `finalize_send`
+    is never invoked. The barrier future (`end_complete_future`) must still
+    resolve (with the underlying exception) so that `flush` returns and the
+    error reaches `_track_future`'s logger.
+    """
+
+    class Out(weave.Object):  # type: ignore[name-defined]
+        x: int = 0
+
+    @weave.op
+    def f() -> Out:
+        return Out(x=1)
+
+    original = client.server
+    client.server = _ObjCreateRaisingServer(original)
+
+    flush_done = threading.Event()
+    flush_error: dict[str, BaseException] = {}
+
+    def do_flush() -> None:
+        try:
+            client._flush()
+        except BaseException as e:
+            flush_error["err"] = e
+        finally:
+            flush_done.set()
+
+    try:
+        with caplog.at_level(logging.ERROR):
+            f()
+            flush_thread = threading.Thread(target=do_flush, daemon=True)
+            flush_thread.start()
+            assert flush_done.wait(timeout=10.0), (
+                "_flush hung after obj_create failure (deferred barrier never resolved)"
+            )
+    finally:
+        client.server = original
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any(
+        "Task failed" in m and "simulated obj_create failure" in m for m in messages
+    ), f"Expected 'Task failed' log with obj_create error; got: {messages}"
+
+
 def test_finish_call_returns_before_send(client: WeaveClient) -> None:
     """`finish_call` should not block on the deferred work.
 

--- a/tests/trace/test_save_nested_defer.py
+++ b/tests/trace/test_save_nested_defer.py
@@ -310,10 +310,94 @@ def test_finish_call_returns_before_send(client: WeaveClient) -> None:
         # Generous bound: the calling thread does sync work for create_call's
         # `_save_nested_objects(inputs)` plus the body, but finish_call should
         # have deferred everything else. 500ms is a sanity ceiling, not a perf
-        # goal — anything under "obviously waiting on the server" is enough.
+        # goal -- anything under "obviously waiting on the server" is enough.
         assert elapsed < 0.5, f"finish_call appears to block: {elapsed:.3f}s"
     finally:
         blocker.resume()
         client.server = blocker._inner
         client._flush()
         client.set_autoflush(True)
+
+
+class _CapturingTraceServer:
+    """Server proxy that captures `call_end` requests for inspection.
+
+    Plain class (not a `TraceServerInterface` subclass) so `__getattr__`
+    forwards every other method to the inner server, matching the pattern
+    used by `_CallEndRaisingServer`.
+    """
+
+    def __init__(self, inner: tsi.TraceServerInterface) -> None:
+        self._inner = inner
+        self.captured: list[tsi.CallEndReq] = []
+
+    def __getattr__(self, item: str) -> Any:
+        return getattr(self._inner, item)
+
+    def call_end(self, req: tsi.CallEndReq) -> Any:
+        self.captured.append(req)
+        return self._inner.call_end(req)
+
+
+def test_output_mutation_after_finish_is_not_recorded(client: WeaveClient) -> None:
+    """Mutating a returned mutable output after `finish_call` must not change
+    what the server records (regression for PR #6740 review concern).
+
+    Output-side `_save_nested_objects` / `map_to_refs` / `to_json` are
+    deferred to a worker, and the deferred walk reads `postprocessed_output`
+    by reference. A caller that mutates the value between `finish_call`
+    returning and the worker running would see their post-call mutation
+    recorded as if it happened during the op:
+
+        @weave.op
+        def func(): return {"result": [1]}
+
+        res = func()
+        res["result"].append(2)   # should NOT change the recorded output
+
+    To remove the timing race we gate `client._save_nested_objects` on the
+    output-side call (call #2 -- call #1 is `create_call` for inputs, sync
+    on the main thread). The mutation lands before the gate releases, so we
+    deterministically observe what the deferred walk captures. Autoflush is
+    disabled so the test-client's per-method `_flush` does not block on the
+    gated worker.
+    """
+
+    @weave.op
+    def func() -> dict:
+        return {"result": [1]}
+
+    # Capture call_end at the server boundary -- avoids depending on the
+    # test fixture's caching/recorder stack to round-trip the value.
+    capturing = _CapturingTraceServer(client.server)
+    client.server = capturing
+
+    gate = threading.Event()
+    save_calls = {"n": 0}
+    original_save = client._save_nested_objects
+
+    def patched_save(obj: Any, name: str | None = None) -> Any:
+        save_calls["n"] += 1
+        if save_calls["n"] >= 2:  # output path inside `schedule_send`
+            gate.wait()
+        return original_save(obj, name=name)
+
+    client._save_nested_objects = patched_save  # type: ignore[method-assign]
+    client.set_autoflush(False)
+    try:
+        res = func()
+        assert res == {"result": [1]}
+        res["result"].append(2)
+        gate.set()
+        client._flush()
+    finally:
+        client.set_autoflush(True)
+        client._save_nested_objects = original_save  # type: ignore[method-assign]
+        client.server = capturing._inner
+
+    assert len(capturing.captured) == 1
+    recorded_output = capturing.captured[0].end.output
+    assert recorded_output == {"result": [1]}, (
+        "Deferred walk captured a post-finish_call mutation: "
+        f"{recorded_output!r}"
+    )

--- a/tests/trace/test_save_nested_defer.py
+++ b/tests/trace/test_save_nested_defer.py
@@ -470,3 +470,57 @@ class TestSnapshotPreservesSubclassTypes:
         assert isinstance(snap, list)
         assert type(snap[0]) is Point
         assert snap[0]._asdict() == {"x": 1, "y": 2}
+
+
+class TestSnapshotSharedReferences:
+    """Aliased mutable containers must be snapshotted, not deduped to the original.
+
+    `_snapshot_mutable_containers` uses an `id(obj) in _seen` check for cycle
+    protection. The same check also collapses non-cyclic shared references:
+    the first occurrence of an aliased list/dict gets a fresh copy, but the
+    second occurrence returns the ORIGINAL by identity. A caller mutating the
+    returned value after `finish_call` then leaks into the deferred walk for
+    every alias past the first — exactly the failure mode the snapshot is
+    supposed to close.
+    """
+
+    def test_shared_list_aliased_in_dict_is_fully_snapshotted(self) -> None:
+        shared = [1, 2]
+        out = {"a": shared, "b": shared}
+        snap = _snapshot_mutable_containers(out)
+
+        # Caller mutates the value they got back from `finish_call`.
+        shared.append(99)
+
+        # Both aliases in the snapshot must reflect the pre-mutation value.
+        # Today: `snap["a"]` is a fresh copy and stays `[1, 2]`, but
+        # `snap["b"]` is the original (dedup'd via `_seen`) and is now
+        # `[1, 2, 99]`.
+        assert snap["a"] == [1, 2]
+        assert snap["b"] == [1, 2], (
+            "Aliased reference returned the original instead of a snapshot: "
+            f"snap['b']={snap['b']!r}. The deferred walk would record a "
+            "post-finish_call mutation under the second alias."
+        )
+
+    def test_shared_list_aliased_in_tuple_is_fully_snapshotted(self) -> None:
+        shared = [1, 2]
+        snap = _snapshot_mutable_containers((shared, shared))
+
+        shared.append(99)
+
+        assert snap[0] == [1, 2]
+        assert snap[1] == [1, 2], (
+            f"Aliased reference inside tuple leaked the mutation: snap[1]={snap[1]!r}"
+        )
+
+    def test_shared_dict_aliased_in_list_is_fully_snapshotted(self) -> None:
+        shared = {"x": 1}
+        snap = _snapshot_mutable_containers([shared, shared])
+
+        shared["x"] = 99
+
+        assert snap[0] == {"x": 1}
+        assert snap[1] == {"x": 1}, (
+            f"Aliased dict inside list leaked the mutation: snap[1]={snap[1]!r}"
+        )

--- a/tests/trace/test_save_nested_defer.py
+++ b/tests/trace/test_save_nested_defer.py
@@ -524,3 +524,21 @@ class TestSnapshotSharedReferences:
         assert snap[1] == {"x": 1}, (
             f"Aliased dict inside list leaked the mutation: snap[1]={snap[1]!r}"
         )
+
+    def test_cycle_terminates_and_is_independent_of_original(self) -> None:
+        # Snapshot must terminate on a cyclic structure AND the cycle in the
+        # snapshot must not refer back to the original (otherwise post-snapshot
+        # mutations of the original would leak into the cycle).
+        a: list = [1]
+        a.append(a)
+
+        snap = _snapshot_mutable_containers(a)
+
+        a.append("post-snapshot")
+        assert snap[0] == 1
+        assert snap[1] is snap, (
+            "snapshot cycle should close on itself, not the original"
+        )
+        assert "post-snapshot" not in snap, (
+            f"snapshot reflects post-snapshot mutation of the original: {snap!r}"
+        )

--- a/tests/trace/test_save_nested_defer.py
+++ b/tests/trace/test_save_nested_defer.py
@@ -21,11 +21,11 @@ import pytest
 import weave
 from tests.trace.conftest import BlockingTraceServer, paused
 from weave.trace.object_record import ObjectRecord
+from weave.trace.output_snapshot import snapshot_mutable_containers
 from weave.trace.refs import ObjectRef, OpRef, TableRef
 from weave.trace.weave_client import (
     WeaveClient,
     _collect_pending_digests,
-    _snapshot_mutable_containers,
 )
 from weave.trace_server import trace_server_interface as tsi
 
@@ -436,7 +436,7 @@ def test_output_mutation_after_finish_is_not_recorded(client: WeaveClient) -> No
 
 
 # ---------------------------------------------------------------------------
-# _snapshot_mutable_containers: type preservation. Subclasses of dict/list/
+# snapshot_mutable_containers: type preservation. Subclasses of dict/list/
 # set/tuple must be returned by identity — rebuilding them as the bare type
 # would strip subclass information the serializer needs (namedtuple field
 # names, dict-subclass dataclass types like HuggingFace ChatCompletionOutput).
@@ -448,7 +448,7 @@ class TestSnapshotPreservesSubclassTypes:
         # Plain dict/list/set/tuple at the top level get fresh copies so
         # post-finish mutations can't reach the deferred walk.
         d = {"k": [1, 2]}
-        snap = _snapshot_mutable_containers(d)
+        snap = snapshot_mutable_containers(d)
         assert snap == d
         assert snap is not d
         assert snap["k"] is not d["k"]
@@ -460,7 +460,7 @@ class TestSnapshotPreservesSubclassTypes:
             x: int
             y: int
 
-        snap = _snapshot_mutable_containers(Point(1, 2))
+        snap = snapshot_mutable_containers(Point(1, 2))
         assert type(snap) is Point
         assert snap._asdict() == {"x": 1, "y": 2}
 
@@ -468,12 +468,12 @@ class TestSnapshotPreservesSubclassTypes:
         from collections import Counter, OrderedDict
 
         c = Counter({"a": 1, "b": 2})
-        snap_c = _snapshot_mutable_containers(c)
+        snap_c = snapshot_mutable_containers(c)
         assert type(snap_c) is Counter
         assert snap_c is c
 
         od = OrderedDict([("a", 1), ("b", 2)])
-        snap_od = _snapshot_mutable_containers(od)
+        snap_od = snapshot_mutable_containers(od)
         assert type(snap_od) is OrderedDict
         assert snap_od is od
 
@@ -482,7 +482,7 @@ class TestSnapshotPreservesSubclassTypes:
             pass
 
         ml = MyList([1, 2, 3])
-        snap = _snapshot_mutable_containers(ml)
+        snap = snapshot_mutable_containers(ml)
         assert type(snap) is MyList
         assert snap is ml
 
@@ -495,7 +495,7 @@ class TestSnapshotPreservesSubclassTypes:
             x: int
             y: int
 
-        snap = _snapshot_mutable_containers([Point(1, 2), 3])
+        snap = snapshot_mutable_containers([Point(1, 2), 3])
         assert isinstance(snap, list)
         assert type(snap[0]) is Point
         assert snap[0]._asdict() == {"x": 1, "y": 2}
@@ -504,7 +504,7 @@ class TestSnapshotPreservesSubclassTypes:
 class TestSnapshotSharedReferences:
     """Aliased mutable containers must be snapshotted, not deduped to the original.
 
-    `_snapshot_mutable_containers` uses an `id(obj) in _seen` check for cycle
+    `snapshot_mutable_containers` uses an `id(obj) in _seen` check for cycle
     protection. The same check also collapses non-cyclic shared references:
     the first occurrence of an aliased list/dict gets a fresh copy, but the
     second occurrence returns the ORIGINAL by identity. A caller mutating the
@@ -516,7 +516,7 @@ class TestSnapshotSharedReferences:
     def test_shared_list_aliased_in_dict_is_fully_snapshotted(self) -> None:
         shared = [1, 2]
         out = {"a": shared, "b": shared}
-        snap = _snapshot_mutable_containers(out)
+        snap = snapshot_mutable_containers(out)
 
         # Caller mutates the value they got back from `finish_call`.
         shared.append(99)
@@ -534,7 +534,7 @@ class TestSnapshotSharedReferences:
 
     def test_shared_list_aliased_in_tuple_is_fully_snapshotted(self) -> None:
         shared = [1, 2]
-        snap = _snapshot_mutable_containers((shared, shared))
+        snap = snapshot_mutable_containers((shared, shared))
 
         shared.append(99)
 
@@ -545,7 +545,7 @@ class TestSnapshotSharedReferences:
 
     def test_shared_dict_aliased_in_list_is_fully_snapshotted(self) -> None:
         shared = {"x": 1}
-        snap = _snapshot_mutable_containers([shared, shared])
+        snap = snapshot_mutable_containers([shared, shared])
 
         shared["x"] = 99
 
@@ -561,7 +561,7 @@ class TestSnapshotSharedReferences:
         a: list = [1]
         a.append(a)
 
-        snap = _snapshot_mutable_containers(a)
+        snap = snapshot_mutable_containers(a)
 
         a.append("post-snapshot")
         assert snap[0] == 1

--- a/tests/trace/test_save_nested_defer.py
+++ b/tests/trace/test_save_nested_defer.py
@@ -59,9 +59,7 @@ class TestCollectPendingDigests:
         assert _collect_pending_digests({"nested": {"deep": {"value": 1}}}) == []
 
     def test_object_ref_with_resolved_digest_returns_empty(self) -> None:
-        ref = ObjectRef(
-            entity="e", project="p", name="obj", _digest="resolved-digest"
-        )
+        ref = ObjectRef(entity="e", project="p", name="obj", _digest="resolved-digest")
         assert _collect_pending_digests(ref) == []
 
     def test_object_ref_with_pending_digest_is_collected(self) -> None:

--- a/weave/trace/output_snapshot.py
+++ b/weave/trace/output_snapshot.py
@@ -1,0 +1,76 @@
+"""Snapshot mutable container structure so deferred work can't see post-call mutations.
+
+The deferred `finish_call` path walks the call output on a worker thread
+*after* the user's code has resumed. If the user mutates the output dict/list
+in place, that mutation would otherwise reach into the deferred walk and
+corrupt what gets saved. `snapshot_mutable_containers` rebuilds the spine of
+plain `dict`/`list`/`set`/`tuple` containers up front so the walk is isolated.
+
+Subclasses (`namedtuple`, `Counter`, `OrderedDict`, dict-subclass dataclasses)
+and SDK leaf types (`Ref`, pydantic models, `ObjectRecord`, weave Objects) are
+returned by identity. Rebuilding them as the bare type would strip information
+the serializer needs; returning them by identity also preserves the contract
+that `_save_nested_objects` mutates an Object to attach a ref the caller can
+observe through their original handle.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def snapshot_mutable_containers(obj: Any, _memo: dict[int, Any] | None = None) -> Any:
+    """Return a copy of `obj` with plain `dict`/`list`/`set`/`tuple` containers
+    rebuilt at every level, so a caller mutating the original after
+    `finish_call` returns cannot reach into the deferred output walk.
+
+    Only EXACT `dict`/`list`/`set`/`tuple` are rebuilt. Subclasses
+    (`namedtuple`, `Counter`, `OrderedDict`, dict-subclass dataclasses like
+    `huggingface_hub.ChatCompletionOutput`) carry type information the
+    serializer needs and are returned by identity. Rebuilding as the bare
+    type would strip the subclass and silently change saved output shape
+    (namedtuple field names lost, typed dict becomes plain dict, etc.).
+
+    Frozensets, primitives, and SDK leaf types (Ref, pydantic BaseModel,
+    ObjectRecord, weave Object/Table) are also returned by identity: they
+    are either immutable or carry behavior we want preserved
+    (e.g. `_save_nested_objects` mutating an Object to attach a ref).
+
+    `_memo` maps `id(original) -> snapshot` so that aliased containers
+    (the same list/dict appearing under multiple keys) get a single shared
+    NEW copy across all aliases, and so that cycles terminate by returning
+    the already-built snapshot on the second visit. Each mutable container
+    is pre-registered in the memo BEFORE its children are walked, which is
+    what makes cycles safe.
+    """
+    if _memo is None:
+        _memo = {}
+    cached = _memo.get(id(obj))
+    if cached is not None:
+        return cached
+    t = type(obj)
+    if t is dict:
+        snap_d: dict = {}
+        _memo[id(obj)] = snap_d
+        for k, v in obj.items():
+            snap_d[k] = snapshot_mutable_containers(v, _memo)
+        return snap_d
+    if t is list:
+        snap_l: list = []
+        _memo[id(obj)] = snap_l
+        for v in obj:
+            snap_l.append(snapshot_mutable_containers(v, _memo))
+        return snap_l
+    if t is set:
+        snap_s: set = set()
+        _memo[id(obj)] = snap_s
+        for v in obj:
+            snap_s.add(snapshot_mutable_containers(v, _memo))
+        return snap_s
+    if t is tuple:
+        # Tuples are immutable, so a tuple can't be part of a cycle without
+        # going through a mutable container first. We don't pre-register
+        # the tuple result, but the memo still gives aliased mutables inside
+        # the tuple a single shared snapshot.
+        return tuple(snapshot_mutable_containers(v, _memo) for v in obj)
+    return obj

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1293,8 +1293,6 @@ class WeaveClient:
         if self.postprocess_output:
             postprocessed_output = self.postprocess_output(postprocessed_output)
 
-        # Set sync so user code reading `call.output` after `finish_call` sees
-        # the postprocessed value; refs are attached later in `send_end_call`.
         call.output = postprocessed_output
 
         # Summary handling
@@ -1369,9 +1367,7 @@ class WeaveClient:
         # Runs after any output-side digest futures resolve (see Phase 1).
         # Errors are routed to `end_complete_future` so the on_end_complete
         # callback fires once exactly when the whole pipeline finishes.
-        # Tracked in the executor's active set so `_flush()` waits for it,
-        # and `log_exception=True` so a server.call_end failure logs the
-        # same "Task failed" line master does (matches resilience tests).
+        # Tracked in the executor's active set so `_flush()` waits for it.
         end_complete_future: Future[None] = self.future_executor._track_future(
             Future(), log_exception=True
         )
@@ -1417,12 +1413,10 @@ class WeaveClient:
             except Exception as e:
                 end_complete_future.set_exception(e)
 
-        # Snapshot mutable containers so a caller mutating the returned
-        # value after `finish_call` returns can't reach into the deferred
-        # walk (PR #6740 review item). Leaf types (Refs, weave Objects,
-        # pydantic models) are preserved by identity so async ref
-        # attachment via `_save_nested_objects` still surfaces to the
-        # caller's alias.
+        # Snapshot containers so a post-finish_call mutation can't reach the
+        # deferred walk. Leaf types (Refs, weave Objects, pydantic models)
+        # stay by identity so async ref attachment surfaces to the caller's
+        # alias.
         output_for_defer = _snapshot_mutable_containers(postprocessed_output)
 
         # Phase 1: in a worker, save any new nested Objects/Tables/Ops in the

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -338,29 +338,37 @@ def map_to_refs(obj: Any) -> Any:
 
 
 def _snapshot_mutable_containers(obj: Any, _seen: set[int] | None = None) -> Any:
-    """Return a copy of `obj` with mutable Python containers (dict/list/set)
+    """Return a copy of `obj` with plain `dict`/`list`/`set`/`tuple` containers
     rebuilt at every level, so a caller mutating the original after
     `finish_call` returns cannot reach into the deferred output walk.
 
-    Tuples, frozensets, primitives, and SDK leaf types (Ref, pydantic
-    BaseModel, ObjectRecord, weave Object/Table) are returned by identity:
-    they are either immutable or carry behavior we want preserved
+    Only EXACT `dict`/`list`/`set`/`tuple` are rebuilt. Subclasses
+    (`namedtuple`, `Counter`, `OrderedDict`, dict-subclass dataclasses like
+    `huggingface_hub.ChatCompletionOutput`) carry type information the
+    serializer needs and are returned by identity — rebuilding as the bare
+    type would strip the subclass and silently change saved output shape
+    (namedtuple field names lost, typed dict becomes plain dict, etc.).
+
+    Frozensets, primitives, and SDK leaf types (Ref, pydantic BaseModel,
+    ObjectRecord, weave Object/Table) are also returned by identity: they
+    are either immutable or carry behavior we want preserved
     (e.g. `_save_nested_objects` mutating an Object to attach a ref).
     """
     if _seen is None:
         _seen = set()
     if id(obj) in _seen:
         return obj
-    if isinstance(obj, dict):
+    t = type(obj)
+    if t is dict:
         _seen.add(id(obj))
         return {k: _snapshot_mutable_containers(v, _seen) for k, v in obj.items()}
-    if isinstance(obj, list):
+    if t is list:
         _seen.add(id(obj))
         return [_snapshot_mutable_containers(v, _seen) for v in obj]
-    if isinstance(obj, set):
+    if t is set:
         _seen.add(id(obj))
         return {_snapshot_mutable_containers(v, _seen) for v in obj}
-    if isinstance(obj, tuple):
+    if t is tuple:
         return tuple(_snapshot_mutable_containers(v, _seen) for v in obj)
     return obj
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -2531,14 +2531,17 @@ class WeaveClient:
             # `_collect_pending_digests` for context.
             rows_list = list(table.rows)
             pending = _collect_pending_digests(rows_list)
-            send = lambda: self._send_table_create(rows_list)  # noqa: E731
+
+            def send_simple_table() -> TableCreateRes:
+                return self._send_table_create(rows_list)
+
             res_future: Future[TableCreateRes]
             if pending:
                 res_future = self.future_executor.then(
-                    pending, lambda _resolved: send()
+                    pending, lambda _resolved: send_simple_table()
                 )
             else:
-                res_future = self.future_executor.defer(send)
+                res_future = self.future_executor.defer(send_simple_table)
         elif chunking_config.use_parallel_chunks:
             # Need to chunk up, use parallelism
             res_future = self._create_table_with_parallel_chunks(table)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -2645,9 +2645,13 @@ class WeaveClient:
             task = make_chunk_task(raw_chunk)
             pending = _collect_pending_digests(raw_chunk)
             if pending:
-                chunk_future = self.future_executor.then(
-                    pending, lambda _resolved, t=task: t()
-                )
+
+                def chunk_after_pending(
+                    _resolved: list[Any], t: Callable[[], TableCreateRes] = task
+                ) -> TableCreateRes:
+                    return t()
+
+                chunk_future = self.future_executor.then(pending, chunk_after_pending)
             else:
                 chunk_future = self.future_executor.defer(task)
             chunk_futures.append(chunk_future)

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -64,6 +64,7 @@ from weave.trace.op import (
 )
 from weave.trace.op import op as op_deco
 from weave.trace.op_protocol import Op
+from weave.trace.output_snapshot import snapshot_mutable_containers
 from weave.trace.project_id_resolver import ProjectIdResolver
 from weave.trace.ref_util import (
     clear_refs_on_failure,
@@ -334,63 +335,6 @@ def map_to_refs(obj: Any) -> Any:
     elif isinstance(obj, WeaveObject):
         return map_to_refs(obj._val)
 
-    return obj
-
-
-def _snapshot_mutable_containers(obj: Any, _memo: dict[int, Any] | None = None) -> Any:
-    """Return a copy of `obj` with plain `dict`/`list`/`set`/`tuple` containers
-    rebuilt at every level, so a caller mutating the original after
-    `finish_call` returns cannot reach into the deferred output walk.
-
-    Only EXACT `dict`/`list`/`set`/`tuple` are rebuilt. Subclasses
-    (`namedtuple`, `Counter`, `OrderedDict`, dict-subclass dataclasses like
-    `huggingface_hub.ChatCompletionOutput`) carry type information the
-    serializer needs and are returned by identity. Rebuilding as the bare
-    type would strip the subclass and silently change saved output shape
-    (namedtuple field names lost, typed dict becomes plain dict, etc.).
-
-    Frozensets, primitives, and SDK leaf types (Ref, pydantic BaseModel,
-    ObjectRecord, weave Object/Table) are also returned by identity: they
-    are either immutable or carry behavior we want preserved
-    (e.g. `_save_nested_objects` mutating an Object to attach a ref).
-
-    `_memo` maps `id(original) -> snapshot` so that aliased containers
-    (the same list/dict appearing under multiple keys) get a single shared
-    NEW copy across all aliases, and so that cycles terminate by returning
-    the already-built snapshot on the second visit. Each mutable container
-    is pre-registered in the memo BEFORE its children are walked, which is
-    what makes cycles safe.
-    """
-    if _memo is None:
-        _memo = {}
-    cached = _memo.get(id(obj))
-    if cached is not None:
-        return cached
-    t = type(obj)
-    if t is dict:
-        snap_d: dict = {}
-        _memo[id(obj)] = snap_d
-        for k, v in obj.items():
-            snap_d[k] = _snapshot_mutable_containers(v, _memo)
-        return snap_d
-    if t is list:
-        snap_l: list = []
-        _memo[id(obj)] = snap_l
-        for v in obj:
-            snap_l.append(_snapshot_mutable_containers(v, _memo))
-        return snap_l
-    if t is set:
-        snap_s: set = set()
-        _memo[id(obj)] = snap_s
-        for v in obj:
-            snap_s.add(_snapshot_mutable_containers(v, _memo))
-        return snap_s
-    if t is tuple:
-        # Tuples are immutable, so a tuple can't be part of a cycle without
-        # going through a mutable container first. We don't pre-register
-        # the tuple result, but the memo still gives aliased mutables inside
-        # the tuple a single shared snapshot.
-        return tuple(_snapshot_mutable_containers(v, _memo) for v in obj)
     return obj
 
 
@@ -1417,7 +1361,7 @@ class WeaveClient:
         # deferred walk. Leaf types (Refs, weave Objects, pydantic models)
         # stay by identity so async ref attachment surfaces to the caller's
         # alias.
-        output_for_defer = _snapshot_mutable_containers(postprocessed_output)
+        output_for_defer = snapshot_mutable_containers(postprocessed_output)
 
         # Phase 1: in a worker, save any new nested Objects/Tables/Ops in the
         # output and rebuild `output_as_refs`. Then schedule Phase 2 either

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -11,7 +11,7 @@ import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
 
 import pydantic
 from httpx import HTTPStatusError as HTTPError
@@ -385,6 +385,27 @@ def _collect_pending_digests(val: Any) -> list[Future]:
 
     walk(val)
     return pending
+
+
+_R = TypeVar("_R")
+
+
+def _defer_after_pending_digests(
+    future_executor: FutureExecutor,
+    val: Any,
+    fn: Callable[[], _R],
+) -> Future[_R]:
+    """Schedule `fn` so it runs after any unresolved nested digest futures in
+    `val` resolve. If none are pending, defer normally.
+
+    Pre-gating via `then(...)` returns the worker thread to the pool while
+    waiting; chaining to `defer(...)` would leave the worker blocked inside
+    `to_json -> digest.result()` and risk thread pool starvation under load.
+    """
+    pending = _collect_pending_digests(val)
+    if pending:
+        return future_executor.then(pending, lambda _resolved: fn())
+    return future_executor.defer(fn)
 
 
 RESERVED_SUMMARY_USAGE_KEY = "usage"
@@ -1340,7 +1361,7 @@ class WeaveClient:
                 else:
                     self.server.call_end(call_end_req)
                 end_complete_future.set_result(None)
-            except BaseException as e:
+            except Exception as e:
                 end_complete_future.set_exception(e)
 
         # Phase 1: in a worker, save any new nested Objects/Tables/Ops in the
@@ -1362,7 +1383,7 @@ class WeaveClient:
                     )
                 else:
                     finalize_send(output_as_refs)
-            except BaseException as e:
+            except Exception as e:
                 end_complete_future.set_exception(e)
 
         # For calls_complete path (non-eager CallBatchProcessor), print the call link
@@ -2421,18 +2442,9 @@ class WeaveClient:
                 req.obj.expected_digest = None
                 return self.server.obj_create(req)
 
-        # Pre-walk val for nested unresolved digest futures. If any are still
-        # pending, chain `send_obj_create` after them via `then(...)` so the
-        # worker that ends up running it doesn't block on `digest.result()`
-        # inside `to_json`. See `_collect_pending_digests` for context.
-        pending = _collect_pending_digests(val)
-        res_future: Future[ObjCreateRes]
-        if pending:
-            res_future = self.future_executor.then(
-                pending, lambda _resolved: send_obj_create()
-            )
-        else:
-            res_future = self.future_executor.defer(send_obj_create)
+        res_future = _defer_after_pending_digests(
+            self.future_executor, val, send_obj_create
+        )
         digest_future: Future[str] = self.future_executor.then(
             [res_future], lambda res: res[0].digest
         )
@@ -2524,24 +2536,12 @@ class WeaveClient:
 
         chunking_config = self._should_use_chunking(table)
         if not chunking_config.use_chunking:
-            # Simple case: defer the entire serialization and upload.
-            # `_send_table_create` calls `to_json(rows)` which will block on
-            # any unresolved nested ref digests. Pre-gate via `then(...)` so
-            # the worker doesn't block on `result()`. See
-            # `_collect_pending_digests` for context.
             rows_list = list(table.rows)
-            pending = _collect_pending_digests(rows_list)
-
-            def send_simple_table() -> TableCreateRes:
-                return self._send_table_create(rows_list)
-
-            res_future: Future[TableCreateRes]
-            if pending:
-                res_future = self.future_executor.then(
-                    pending, lambda _resolved: send_simple_table()
-                )
-            else:
-                res_future = self.future_executor.defer(send_simple_table)
+            res_future = _defer_after_pending_digests(
+                self.future_executor,
+                rows_list,
+                lambda: self._send_table_create(rows_list),
+            )
         elif chunking_config.use_parallel_chunks:
             # Need to chunk up, use parallelism
             res_future = self._create_table_with_parallel_chunks(table)
@@ -2629,10 +2629,6 @@ class WeaveClient:
         chunk_manager = TableChunkManager()
         raw_chunks: list[list[Any]] = chunk_manager.create_chunks(table.rows)
 
-        # Create chunks in parallel using future_executor - defer serialization.
-        # Pre-walk each chunk for unresolved nested digests; if any are
-        # pending, chain via `then(...)` so the chunk worker doesn't block on
-        # `digest.result()` from inside `to_json`.
         chunk_futures = []
         for raw_chunk in raw_chunks:
 
@@ -2642,18 +2638,9 @@ class WeaveClient:
 
                 return chunk_task
 
-            task = make_chunk_task(raw_chunk)
-            pending = _collect_pending_digests(raw_chunk)
-            if pending:
-
-                def chunk_after_pending(
-                    _resolved: list[Any], t: Callable[[], TableCreateRes] = task
-                ) -> TableCreateRes:
-                    return t()
-
-                chunk_future = self.future_executor.then(pending, chunk_after_pending)
-            else:
-                chunk_future = self.future_executor.defer(task)
+            chunk_future = _defer_after_pending_digests(
+                self.future_executor, raw_chunk, make_chunk_task(raw_chunk)
+            )
             chunk_futures.append(chunk_future)
 
         # Chain the operations using future_executor.then
@@ -2700,21 +2687,15 @@ class WeaveClient:
         if not raw_chunks:
             return self.future_executor.defer(lambda: self._send_table_create([]))
 
-        # Create first chunk as the base table - defer serialization.
-        # Pre-gate on unresolved nested digests; see `_collect_pending_digests`.
         first_raw_chunk = raw_chunks[0]
 
         def create_first_chunk() -> TableCreateRes:
             serialized_rows = to_json(first_raw_chunk, self.project_id, self)
             return self._send_table_create(serialized_rows)
 
-        first_pending = _collect_pending_digests(first_raw_chunk)
-        if first_pending:
-            base_future = self.future_executor.then(
-                first_pending, lambda _resolved: create_first_chunk()
-            )
-        else:
-            base_future = self.future_executor.defer(create_first_chunk)
+        base_future = _defer_after_pending_digests(
+            self.future_executor, first_raw_chunk, create_first_chunk
+        )
 
         # Chain the incremental updates sequentially
         def process_remaining_chunks(

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -337,6 +337,56 @@ def map_to_refs(obj: Any) -> Any:
     return obj
 
 
+def _collect_pending_digests(val: Any) -> list[Future]:
+    """Walk `val` and return any unresolved digest/row-digest futures held by
+    nested refs.
+
+    Used by `_save_object_basic` and `_save_table` to pre-gate `to_json` (and
+    the subsequent server call) on child digest resolution. Without this gate,
+    a worker calls `to_json(parent_with_refs)`, which calls `child_ref.uri ->
+    child_ref.digest -> digest_future.result()` and blocks the worker thread.
+    Under high concurrency several workers can land in this state simultaneously,
+    each waiting for an `obj_create` that is queued behind them — classic thread
+    pool starvation.
+
+    Chaining `future_executor.then(pending, send_obj_create)` instead of
+    `future_executor.defer(send_obj_create)` registers a done-callback on the
+    digest futures and returns the worker thread to the pool. The continuation
+    runs once digests are resolved, by which point `to_json` is non-blocking.
+    """
+    pending: list[Future] = []
+    seen: set[int] = set()
+
+    def walk(obj: Any) -> None:
+        oid = id(obj)
+        if oid in seen:
+            return
+        seen.add(oid)
+
+        if isinstance(obj, Ref):
+            digest = obj.__dict__.get("_digest")
+            if isinstance(digest, Future) and not digest.done():
+                pending.append(digest)
+            if isinstance(obj, TableRef):
+                row_digests = obj.__dict__.get("_row_digests")
+                if isinstance(row_digests, Future) and not row_digests.done():
+                    pending.append(row_digests)
+            return
+
+        if isinstance(obj, ObjectRecord):
+            for v in obj.__dict__.values():
+                walk(v)
+        elif isinstance(obj, dict):
+            for v in obj.values():
+                walk(v)
+        elif isinstance(obj, (list, tuple)):
+            for v in obj:
+                walk(v)
+
+    walk(val)
+    return pending
+
+
 RESERVED_SUMMARY_USAGE_KEY = "usage"
 RESERVED_SUMMARY_STATUS_COUNTS_KEY = "status_counts"
 
@@ -1165,8 +1215,12 @@ class WeaveClient:
         if self.postprocess_output:
             postprocessed_output = self.postprocess_output(postprocessed_output)
 
-        self._save_nested_objects(postprocessed_output)
-        output_as_refs = map_to_refs(postprocessed_output)
+        # `_save_nested_objects` and `map_to_refs` walk the output tree once
+        # each — for ops with nested weave Objects/Tables this dominates the
+        # per-op CPU on the calling thread (the asyncio loop in async
+        # workloads). They are deferred into `send_end_call` below. `call.output`
+        # is set sync so user code reading it immediately after `finish_call`
+        # still observes the postprocessed value (refs may not be attached yet).
         call.output = postprocessed_output
 
         # Summary handling
@@ -1237,41 +1291,79 @@ class WeaveClient:
         if op is not None and op._on_finish_handler:
             op._on_finish_handler(call, original_output, exception)
 
-        def send_end_call() -> None:
-            maybe_redacted_output_as_refs = output_as_refs
-            if should_redact_pii():
-                from weave.utils.pii_redaction import redact_pii
+        # Phase 2: serialize `output_as_refs`, build the request, and send.
+        # Runs after any output-side digest futures resolve (see Phase 1).
+        # Errors are routed to `end_complete_future` so the on_end_complete
+        # callback fires once exactly when the whole pipeline finishes.
+        # Tracked in the executor's active set so `_flush()` waits for it,
+        # and `log_exception=True` so a server.call_end failure logs the
+        # same "Task failed" line master does (matches resilience tests).
+        end_complete_future: Future[None] = self.future_executor._track_future(
+            Future(), log_exception=True
+        )
 
-                maybe_redacted_output_as_refs = redact_pii(output_as_refs)
+        def finalize_send(output_as_refs: Any) -> None:
+            try:
+                maybe_redacted_output_as_refs = output_as_refs
+                if should_redact_pii():
+                    from weave.utils.pii_redaction import redact_pii
 
-            output_json = to_json(
-                maybe_redacted_output_as_refs, project_id, self, use_dictify=False
-            )
+                    maybe_redacted_output_as_refs = redact_pii(output_as_refs)
 
-            # Capture wb_run_step_end at call end time
-            wb_run_context_end = self._get_current_wb_run_context()
-            current_wb_run_step_end = (
-                wb_run_context_end.step if wb_run_context_end else None
-            )
-
-            call_end_req = CallEndReq(
-                end=EndedCallSchemaForInsertWithStartedAt(
-                    project_id=project_id,
-                    id=call.id,
-                    trace_id=call.trace_id,
-                    started_at=call.started_at,
-                    ended_at=ended_at,
-                    output=output_json,
-                    summary=merged_summary,
-                    exception=exception_str,
-                    wb_run_step_end=current_wb_run_step_end,
+                output_json = to_json(
+                    maybe_redacted_output_as_refs,
+                    project_id,
+                    self,
+                    use_dictify=False,
                 )
-            )
-            # WAL path: persist to disk; the sender replays to the server.
-            if self._wal is not None:
-                self._wal.write("call_end", call_end_req)
-            else:
-                self.server.call_end(call_end_req)
+
+                wb_run_context_end = self._get_current_wb_run_context()
+                current_wb_run_step_end = (
+                    wb_run_context_end.step if wb_run_context_end else None
+                )
+
+                call_end_req = CallEndReq(
+                    end=EndedCallSchemaForInsertWithStartedAt(
+                        project_id=project_id,
+                        id=call.id,
+                        trace_id=call.trace_id,
+                        started_at=call.started_at,
+                        ended_at=ended_at,
+                        output=output_json,
+                        summary=merged_summary,
+                        exception=exception_str,
+                        wb_run_step_end=current_wb_run_step_end,
+                    )
+                )
+                if self._wal is not None:
+                    self._wal.write("call_end", call_end_req)
+                else:
+                    self.server.call_end(call_end_req)
+                end_complete_future.set_result(None)
+            except BaseException as e:
+                end_complete_future.set_exception(e)
+
+        # Phase 1: in a worker, save any new nested Objects/Tables/Ops in the
+        # output and rebuild `output_as_refs`. Then schedule Phase 2 either
+        # inline (if no pending digests) or via `then(pending, ...)` so the
+        # worker doesn't block on `digest.result()` from inside `to_json`.
+        # `_collect_pending_digests` finds refs whose digest_future was
+        # registered by an EARLIER `_save_object_basic` (e.g., from
+        # `create_call._save_nested_objects` for inputs) and may still be
+        # queued behind us in the executor.
+        def schedule_send() -> None:
+            try:
+                self._save_nested_objects(postprocessed_output)
+                output_as_refs = map_to_refs(postprocessed_output)
+                pending = _collect_pending_digests(output_as_refs)
+                if pending:
+                    self.future_executor.then(
+                        pending, lambda _resolved: finalize_send(output_as_refs)
+                    )
+                else:
+                    finalize_send(output_as_refs)
+            except BaseException as e:
+                end_complete_future.set_exception(e)
 
         # For calls_complete path (non-eager CallBatchProcessor), print the call link
         # after finish_call, when the complete call is queued to the batch processor.
@@ -1293,8 +1385,8 @@ class WeaveClient:
             except Exception:
                 pass
 
-        fut = self.future_executor.defer(send_end_call)
-        fut.add_done_callback(on_end_complete)
+        self.future_executor.defer(schedule_send)
+        end_complete_future.add_done_callback(on_end_complete)
 
         # If a turn call is finishing, reset turn context for next sibling
         if call.turn_id == call.id and call.thread_id:
@@ -2329,7 +2421,18 @@ class WeaveClient:
                 req.obj.expected_digest = None
                 return self.server.obj_create(req)
 
-        res_future: Future[ObjCreateRes] = self.future_executor.defer(send_obj_create)
+        # Pre-walk val for nested unresolved digest futures. If any are still
+        # pending, chain `send_obj_create` after them via `then(...)` so the
+        # worker that ends up running it doesn't block on `digest.result()`
+        # inside `to_json`. See `_collect_pending_digests` for context.
+        pending = _collect_pending_digests(val)
+        res_future: Future[ObjCreateRes]
+        if pending:
+            res_future = self.future_executor.then(
+                pending, lambda _resolved: send_obj_create()
+            )
+        else:
+            res_future = self.future_executor.defer(send_obj_create)
         digest_future: Future[str] = self.future_executor.then(
             [res_future], lambda res: res[0].digest
         )
@@ -2421,10 +2524,21 @@ class WeaveClient:
 
         chunking_config = self._should_use_chunking(table)
         if not chunking_config.use_chunking:
-            # Simple case: defer the entire serialization and upload
-            res_future: Future[TableCreateRes] = self.future_executor.defer(
-                lambda: self._send_table_create(list(table.rows))
-            )
+            # Simple case: defer the entire serialization and upload.
+            # `_send_table_create` calls `to_json(rows)` which will block on
+            # any unresolved nested ref digests. Pre-gate via `then(...)` so
+            # the worker doesn't block on `result()`. See
+            # `_collect_pending_digests` for context.
+            rows_list = list(table.rows)
+            pending = _collect_pending_digests(rows_list)
+            send = lambda: self._send_table_create(rows_list)  # noqa: E731
+            res_future: Future[TableCreateRes]
+            if pending:
+                res_future = self.future_executor.then(
+                    pending, lambda _resolved: send()
+                )
+            else:
+                res_future = self.future_executor.defer(send)
         elif chunking_config.use_parallel_chunks:
             # Need to chunk up, use parallelism
             res_future = self._create_table_with_parallel_chunks(table)
@@ -2512,7 +2626,10 @@ class WeaveClient:
         chunk_manager = TableChunkManager()
         raw_chunks: list[list[Any]] = chunk_manager.create_chunks(table.rows)
 
-        # Create chunks in parallel using future_executor - defer serialization
+        # Create chunks in parallel using future_executor - defer serialization.
+        # Pre-walk each chunk for unresolved nested digests; if any are
+        # pending, chain via `then(...)` so the chunk worker doesn't block on
+        # `digest.result()` from inside `to_json`.
         chunk_futures = []
         for raw_chunk in raw_chunks:
 
@@ -2522,7 +2639,14 @@ class WeaveClient:
 
                 return chunk_task
 
-            chunk_future = self.future_executor.defer(make_chunk_task(raw_chunk))
+            task = make_chunk_task(raw_chunk)
+            pending = _collect_pending_digests(raw_chunk)
+            if pending:
+                chunk_future = self.future_executor.then(
+                    pending, lambda _resolved, t=task: t()
+                )
+            else:
+                chunk_future = self.future_executor.defer(task)
             chunk_futures.append(chunk_future)
 
         # Chain the operations using future_executor.then
@@ -2569,14 +2693,21 @@ class WeaveClient:
         if not raw_chunks:
             return self.future_executor.defer(lambda: self._send_table_create([]))
 
-        # Create first chunk as the base table - defer serialization
+        # Create first chunk as the base table - defer serialization.
+        # Pre-gate on unresolved nested digests; see `_collect_pending_digests`.
         first_raw_chunk = raw_chunks[0]
 
         def create_first_chunk() -> TableCreateRes:
             serialized_rows = to_json(first_raw_chunk, self.project_id, self)
             return self._send_table_create(serialized_rows)
 
-        base_future = self.future_executor.defer(create_first_chunk)
+        first_pending = _collect_pending_digests(first_raw_chunk)
+        if first_pending:
+            base_future = self.future_executor.then(
+                first_pending, lambda _resolved: create_first_chunk()
+            )
+        else:
+            base_future = self.future_executor.defer(create_first_chunk)
 
         # Chain the incremental updates sequentially
         def process_remaining_chunks(

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -337,6 +337,34 @@ def map_to_refs(obj: Any) -> Any:
     return obj
 
 
+def _snapshot_mutable_containers(obj: Any, _seen: set[int] | None = None) -> Any:
+    """Return a copy of `obj` with mutable Python containers (dict/list/set)
+    rebuilt at every level, so a caller mutating the original after
+    `finish_call` returns cannot reach into the deferred output walk.
+
+    Tuples, frozensets, primitives, and SDK leaf types (Ref, pydantic
+    BaseModel, ObjectRecord, weave Object/Table) are returned by identity:
+    they are either immutable or carry behavior we want preserved
+    (e.g. `_save_nested_objects` mutating an Object to attach a ref).
+    """
+    if _seen is None:
+        _seen = set()
+    if id(obj) in _seen:
+        return obj
+    if isinstance(obj, dict):
+        _seen.add(id(obj))
+        return {k: _snapshot_mutable_containers(v, _seen) for k, v in obj.items()}
+    if isinstance(obj, list):
+        _seen.add(id(obj))
+        return [_snapshot_mutable_containers(v, _seen) for v in obj]
+    if isinstance(obj, set):
+        _seen.add(id(obj))
+        return {_snapshot_mutable_containers(v, _seen) for v in obj}
+    if isinstance(obj, tuple):
+        return tuple(_snapshot_mutable_containers(v, _seen) for v in obj)
+    return obj
+
+
 def _collect_pending_digests(val: Any) -> list[Future]:
     """Walk `val` and return any unresolved digest/row-digest futures held by
     nested refs.
@@ -1364,6 +1392,14 @@ class WeaveClient:
             except Exception as e:
                 end_complete_future.set_exception(e)
 
+        # Snapshot mutable containers so a caller mutating the returned
+        # value after `finish_call` returns can't reach into the deferred
+        # walk (PR #6740 review item). Leaf types (Refs, weave Objects,
+        # pydantic models) are preserved by identity so async ref
+        # attachment via `_save_nested_objects` still surfaces to the
+        # caller's alias.
+        output_for_defer = _snapshot_mutable_containers(postprocessed_output)
+
         # Phase 1: in a worker, save any new nested Objects/Tables/Ops in the
         # output and rebuild `output_as_refs`. Then schedule Phase 2 either
         # inline (if no pending digests) or via `then(pending, ...)` so the
@@ -1374,8 +1410,8 @@ class WeaveClient:
         # queued behind us in the executor.
         def schedule_send() -> None:
             try:
-                self._save_nested_objects(postprocessed_output)
-                output_as_refs = map_to_refs(postprocessed_output)
+                self._save_nested_objects(output_for_defer)
+                output_as_refs = map_to_refs(output_for_defer)
                 pending = _collect_pending_digests(output_as_refs)
                 if pending:
                     self.future_executor.then(

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1293,12 +1293,8 @@ class WeaveClient:
         if self.postprocess_output:
             postprocessed_output = self.postprocess_output(postprocessed_output)
 
-        # `_save_nested_objects` and `map_to_refs` walk the output tree once
-        # each — for ops with nested weave Objects/Tables this dominates the
-        # per-op CPU on the calling thread (the asyncio loop in async
-        # workloads). They are deferred into `send_end_call` below. `call.output`
-        # is set sync so user code reading it immediately after `finish_call`
-        # still observes the postprocessed value (refs may not be attached yet).
+        # Set sync so user code reading `call.output` after `finish_call` sees
+        # the postprocessed value; refs are attached later in `send_end_call`.
         call.output = postprocessed_output
 
         # Summary handling

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -337,7 +337,7 @@ def map_to_refs(obj: Any) -> Any:
     return obj
 
 
-def _snapshot_mutable_containers(obj: Any, _seen: set[int] | None = None) -> Any:
+def _snapshot_mutable_containers(obj: Any, _memo: dict[int, Any] | None = None) -> Any:
     """Return a copy of `obj` with plain `dict`/`list`/`set`/`tuple` containers
     rebuilt at every level, so a caller mutating the original after
     `finish_call` returns cannot reach into the deferred output walk.
@@ -345,7 +345,7 @@ def _snapshot_mutable_containers(obj: Any, _seen: set[int] | None = None) -> Any
     Only EXACT `dict`/`list`/`set`/`tuple` are rebuilt. Subclasses
     (`namedtuple`, `Counter`, `OrderedDict`, dict-subclass dataclasses like
     `huggingface_hub.ChatCompletionOutput`) carry type information the
-    serializer needs and are returned by identity — rebuilding as the bare
+    serializer needs and are returned by identity. Rebuilding as the bare
     type would strip the subclass and silently change saved output shape
     (namedtuple field names lost, typed dict becomes plain dict, etc.).
 
@@ -353,23 +353,44 @@ def _snapshot_mutable_containers(obj: Any, _seen: set[int] | None = None) -> Any
     ObjectRecord, weave Object/Table) are also returned by identity: they
     are either immutable or carry behavior we want preserved
     (e.g. `_save_nested_objects` mutating an Object to attach a ref).
+
+    `_memo` maps `id(original) -> snapshot` so that aliased containers
+    (the same list/dict appearing under multiple keys) get a single shared
+    NEW copy across all aliases, and so that cycles terminate by returning
+    the already-built snapshot on the second visit. Each mutable container
+    is pre-registered in the memo BEFORE its children are walked, which is
+    what makes cycles safe.
     """
-    if _seen is None:
-        _seen = set()
-    if id(obj) in _seen:
-        return obj
+    if _memo is None:
+        _memo = {}
+    cached = _memo.get(id(obj))
+    if cached is not None:
+        return cached
     t = type(obj)
     if t is dict:
-        _seen.add(id(obj))
-        return {k: _snapshot_mutable_containers(v, _seen) for k, v in obj.items()}
+        snap_d: dict = {}
+        _memo[id(obj)] = snap_d
+        for k, v in obj.items():
+            snap_d[k] = _snapshot_mutable_containers(v, _memo)
+        return snap_d
     if t is list:
-        _seen.add(id(obj))
-        return [_snapshot_mutable_containers(v, _seen) for v in obj]
+        snap_l: list = []
+        _memo[id(obj)] = snap_l
+        for v in obj:
+            snap_l.append(_snapshot_mutable_containers(v, _memo))
+        return snap_l
     if t is set:
-        _seen.add(id(obj))
-        return {_snapshot_mutable_containers(v, _seen) for v in obj}
+        snap_s: set = set()
+        _memo[id(obj)] = snap_s
+        for v in obj:
+            snap_s.add(_snapshot_mutable_containers(v, _memo))
+        return snap_s
     if t is tuple:
-        return tuple(_snapshot_mutable_containers(v, _seen) for v in obj)
+        # Tuples are immutable, so a tuple can't be part of a cycle without
+        # going through a mutable container first. We don't pre-register
+        # the tuple result, but the memo still gives aliased mutables inside
+        # the tuple a single shared snapshot.
+        return tuple(_snapshot_mutable_containers(v, _memo) for v in obj)
     return obj
 
 


### PR DESCRIPTION
## TL;DR

Cuts per-op calling-thread CPU ~5× in async tracing (p50 stall 176ms → 38ms in heavy-GIL bench) by deferring output-side `_save_nested_objects` + `map_to_refs` + `to_json` from `finish_call` into the worker pool. A structural fix to `_save_object_basic` / `_save_table` keeps a naive defer from deadlocking on thread-pool starvation.

Builds on #6738 (the conservative subset). Linked: [WB-33844].

## How the work moves off the calling thread

```
master:
   ┌─ calling thread ──────────────────────────┐    ┌─ worker ──────────┐
   │ finish_call:                              │    │ send_end_call:    │
   │   _save_nested_objects(output)   <-- walk │    │   redact          │
   │   map_to_refs(output)            <-- walk │    │   to_json         │
   │   defer(send_end_call)  ──────────────────┼──► │   server.call_end │
   │   return                                  │    └───────────────────┘
   └───────────────────────────────────────────┘

this PR:
   ┌─ calling thread ──────────┐    ┌─ worker: schedule_send ─────────────┐
   │ finish_call:              │    │   _save_nested_objects(output)      │
   │   defer(schedule_send) ───┼──► │   map_to_refs(output)               │
   │   return                  │    │   pending = collect_pending_digests │
   └───────────────────────────┘    │   if pending:                       │
                                    │     then(pending, finalize_send) ───┼─► continuation
                                    │     # worker returns to pool        │   runs after
                                    │   else:                             │   digests resolve
                                    │     finalize_send(...)              │
                                    └─────────────────────────────────────┘
                                          │
                                          ▼ finalize_send: redact + to_json + server.call_end
```

## What changes

1. **Output walks deferred** in `finish_call`. `_save_nested_objects`, `map_to_refs`, redact, and `to_json` move into the worker pool. `call.output` is still set sync, so user code reading it after `finish_call` returns is unchanged.
2. **Save sites gate on pending digests.** `_save_object_basic`, `_save_table`, and the chunked-table paths now go through one `_defer_after_pending_digests` helper that pre-walks the value and uses `then(pending, send)` instead of `defer(send)`. The worker registering the callback returns to the pool instead of blocking inside `to_json -> digest.result()`.
3. **`send_end_call` split** into Phase 1 (`schedule_send` — walks + collect_pending) and Phase 2 (`finalize_send` — redact + `to_json` + `call_end`). A barrier `end_complete_future` is tracked in the executor so `_flush()` waits for the whole pipeline; `log_exception=True` keeps the same "Task failed" log line existing resilience tests assert on.
4. **Output snapshot before defer** ([review fix](#output-mutation-race-review-fix-from-andrewtruong)). `_snapshot_mutable_containers` rebuilds `dict`/`list`/`set`/`tuple` on the calling thread so a caller mutating the returned value can't reach into the deferred walk.

## Calling-thread contract (unchanged)

- User `postprocess_output` and `_on_finish_handler` still raise on the calling thread.
- `call.output` is set to the postprocessed value before `finish_call` returns.
- `call.summary` is computed and set before `finish_call` returns.
- Production worker-pool defaults unchanged.

## Risks

- **Refs attach asynchronously after `finish_call` returns.** Today (master) refs attach before `finish_call` returns. User code that synchronously inspects `output.ref` immediately after `finish_call` may briefly see no ref attached. Behavior change; not expected to affect any current pattern but called out.
- **Larger surface than #6738.** Touches `_save_object_basic`, `_save_table`, both chunked-table paths, and `finish_call`.
- **`_track_future` is private.** Used deliberately to register the barrier future; will need an update if the futures module evolves.

## Output mutation race (review fix from @andrewtruong)

Andrew flagged that with the output walks deferred, a caller mutating the returned value after `finish_call` returns has the mutation recorded:

```py
@weave.op
def func(): return {"result": [1]}

res = func()
res["result"].append(2)   # without the fix, this leaks into the recorded output
```

Fix: `_snapshot_mutable_containers` rebuilds `dict`/`list`/`set`/`tuple` at every level on the calling thread before queuing `schedule_send`. Leaf types (Refs, weave Objects, pydantic models) are returned by identity so async ref attachment via `_save_nested_objects` still flows through to the caller's alias.

Regression test: `test_output_mutation_after_finish_is_not_recorded` gates the worker at the start of `schedule_send` so the mutation deterministically lands first, then asserts the recorded `call_end` request carries the pre-mutation value. Fails on the unfixed branch with `{"result": [1, 2]}`, passes with the snapshot.

### Cost (sqlite micro-bench, calling-thread p50, n=200, no GIL pressure)

| Payload                       | Without fix | With snapshot | Delta    |
|-------------------------------|------------:|--------------:|---------:|
| completions=200               |     0.20ms  |       0.56ms  |  +0.36ms |
| completions=1000              |     0.35ms  |       2.18ms  |  +1.83ms |
| flat dict width=10000         |     1.68ms  |       4.06ms  |  +2.38ms |
| huge 1MB string leaf          |     0.16ms  |       0.17ms  |     ~0   |

Linear in container element count. Leaf strings/bytes/numerics are O(1) because they are returned by identity. Bench script: `~/Desktop/local_testing/weavetest/qa-scripts/local_bench_payloads.py`.

Compared the `copy.deepcopy` alternative on the same payloads: ~15-30% slower at every size AND breaks weave Object ref attachment for the caller's original alias (deepcopy clones the Object, ref attaches to the clone, original never gets one). Snapshot wins on both axes.

### Residual scope

Snapshot catches container mutation (Andrew's exact example). Does NOT catch:
- pydantic / dataclass field mutation: `res.x = 5`
- in-place leaf mutation: `numpy_arr += 1`
- weave Object field mutation between `finish_call` and the deferred save

The deferred `_save_nested_objects` still sees post-mutation state for those. Full master-style correctness would require moving `_save_nested_objects + map_to_refs` back to sync.

## Bench

Heavy GIL pressure (1460 ops/step, 30 steps). Median per-step is the stable comparison; avg is dominated by occasional GC stalls under heavy GIL.

| Branch                            | Median step | p50 stall | Max stall |
|-----------------------------------|------------:|----------:|----------:|
| Master                            |       ~1.0s |     176ms |    1319ms |
| Internal-only (#6738)             |       ~1.0s |     170ms |     649ms |
| **This PR**                       |   **~0.4s** |  **38ms** |     ~3s\* |

\* Max under heavy GIL is dominated by occasional consecutive bad steps (a 9.54s outlier appears once in the 30-step run, then the system recovers). Median/p50 are the meaningful numbers — calling-thread time per op is cut roughly 5×.

The 38ms p50 above is from before the snapshot fix. Need to re-run the heavy-GIL bench with the snapshot on top; the local micro-bench above suggests +0.5-2ms per op on typical payloads, so the regression should be small but should be confirmed before merge.

## Tests

`tests/trace/test_save_nested_defer.py` (17 tests):
- 12 unit tests for `_collect_pending_digests` covering primitives, nested containers, ObjectRef/OpRef/TableRef (resolved + pending), TableRef with both digest *and* row_digests pending, ObjectRecord, cycles, and resolved-future short-circuit.
- 4 integration tests against a paused-server fixture: single-op finish doesn't deadlock; 20 concurrent async finishes drain via the then-chain; a real `call_end` failure surfaces as `"Task failed"` via `_track_future` (regression guard for `log_exception=True`); `finish_call` returns before the deferred work runs.
- 1 regression test for the output-mutation race (`test_output_mutation_after_finish_is_not_recorded`): captures `call_end` via a server proxy, gates the worker at the start of `schedule_send`, mutates the returned dict between `finish_call` returning and the gate releasing, asserts the recorded output is the pre-mutation value.

Existing suites green:
- Local: `trace` shard (839 passed), `trace_calls_complete_only` shard (839 passed).
- Local: `test_evaluation_performance` 5× consecutive at default parallelism (the deadlock fixture; would hang without the structural gate).
- Local: `test_tracing_resilience` (29/29).

## Test plan

- [x] `trace` and `trace_calls_complete_only` shards green
- [x] Deadlock fixture (`test_evaluation_performance`) green at default parallelism, 5× consecutive
- [x] Bench under heavy GIL, 30 steps. p50 stall 38ms vs master 176ms.
- [x] Regression test for output mutation race (Andrew's review)
- [ ] Re-run heavy-GIL bench with the snapshot fix to confirm overhead is small
- [ ] CI sweep across trace, trace_calls_complete_only, integrations, Windows
- [ ] Hand to MRE author David Corbitt for prod repro

## Related

- #6738 — internal-only fixes. Safe to ship without this. Modest p50 win (~3%) but halves max stall (1319ms → 649ms).
- Bench tool and history: `~/Desktop/local_testing/weavetest/qa-scripts/bench_async_overhead.py` + `bench_history.jsonl`.

<details>
<summary><b>Deep dive: why naive defer deadlocks (and how the gate fixes it)</b></summary>

**Part 1 alone** — just deferring the output walks, no gate — is a one-line change but reproduces a real deadlock against `test_evaluation_performance::paused_client`:

`_save_object_basic`'s `send_obj_create` calls `to_json(parent_with_refs)`, which synchronously waits on each nested ref's `digest_future.result()`. Under high concurrency every main-pool worker can land in `to_json` at once, each blocked on a child whose `obj_create` is queued *behind* it in the same executor — classic thread-pool starvation. Master happens to escape by ~1 worker of timing headroom; the deferral consumes it.

**Part 2** — this PR — restructures the dispatch so workers don't synchronously block on digest futures. At every save site that calls `to_json(value_with_refs)`, we pre-walk `value` for unresolved digest futures via `_collect_pending_digests`. If any are pending, we register the save via `future_executor.then(pending, send)` instead of `defer(send)`. The worker that wanted to schedule the save attaches a callback and returns to the pool; the continuation runs once digests resolve, by which point `to_json` is non-blocking. No worker holds a slot waiting for another worker.

`_collect_pending_digests` walks any value (primitives, dicts, lists, tuples, `ObjectRecord`, Refs) and collects unresolved digest / row-digest futures. Cycle-safe via `seen` set, skips done futures, treats Refs as leaves (does not recurse into their fields).

</details>

[WB-33844]: https://coreweave.atlassian.net/browse/WB-33844
