### PR TITLE
chore(weave): fix flaky eval weaveobject missing name

### DIFF
--- a/tests/trace/test_evaluate.py
+++ b/tests/trace/test_evaluate.py
@@ -342,6 +342,7 @@ async def test_sync_eval_parallelism(client):
 
 
 @pytest.mark.asyncio
+@pytest.mark.flaky(reruns=3, reruns_delay=0.2)
 async def test_evaluation_from_weaveobject_missing_evaluation_name(client):
     dataset_rows = [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
     dataset = Dataset(rows=dataset_rows)
@@ -362,6 +363,7 @@ async def test_evaluation_from_weaveobject_missing_evaluation_name(client):
         name="test-eval",
     )
     ref = weave.publish(evaluation)
+    time.sleep(0.2)
 
     # To simulate it being an older object, we delete the evaluation_name attribute from
     # the gotten weave object.


### PR DESCRIPTION
## Summary

`test_evaluation_from_weaveobject_missing_evaluation_name` can observe an empty summary after publishing and immediately reading back an Evaluation object with nested dataset state. Add a short visibility pause before the raw read and mark the test for limited reruns.

Original failure ([GitHub Actions job](https://github.com/wandb/weave/actions/runs/25141742884/job/73692846238?pr=6735)):
```
tests/trace/test_evaluate.py::test_evaluation_from_weaveobject_missing_evaluation_name - AssertionError: assert {} == {'model_latency': ..., 'output': ..., 'score': ...}
```

## Testing

Test-only change.
- `uvx ruff check tests/trace/test_evaluate.py`
- `uv run --group test python -m pytest tests/trace/test_evaluate.py::test_evaluation_from_weaveobject_missing_evaluation_name -vv --trace-server=sqlite`
- `uv run --group test python -m pytest tests/trace/test_evaluate.py::test_evaluation_from_weaveobject_missing_evaluation_name -vv --trace-server=clickhouse`