### PR TITLE
fix(weave): discover target db engine during migrations

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -47,6 +47,26 @@ def _make_ch_client(database_engine: str = "Atomic") -> Mock:
     return ch_client
 
 
+def _make_ch_client_with_database_engines(database_engines: dict[str, str]) -> Mock:
+    """Create a mock CH client with per-database system.databases responses."""
+    ch_client = Mock()
+    ch_client.database = "test_db"
+
+    def _query_side_effect(sql, *args, **kwargs):
+        if "system.databases" in sql:
+            db_name = kwargs.get("parameters", {}).get("db_name")
+            engine_result = Mock()
+            if db_name in database_engines:
+                engine_result.result_rows = [(database_engines[db_name],)]
+            else:
+                engine_result.result_rows = []
+            return engine_result
+        return Mock()
+
+    ch_client.query.side_effect = _query_side_effect
+    return ch_client
+
+
 @pytest.fixture
 def mock_migration_lock():
     """Bypass the distributed migration lock for tests that call apply_migrations."""
@@ -177,6 +197,97 @@ def test_apply_migrations_with_target_version(
     assert migrator.ch_client.command.call_count == 2
     migrator.ch_client.command.assert_has_calls(
         [call("CREATE TABLE test1 (id Int32)"), call("CREATE TABLE test2 (id Int32)")]
+    )
+
+
+def test_apply_migrations_discovers_existing_target_database_engine(
+    mock_migration_lock, mock_costs, tmp_path
+):
+    migration_dir = tmp_path / "migrations"
+    migration_dir.mkdir()
+    migration_file = migration_dir / "026_object_version_first_seen.up.sql"
+    migration_file.write_text(
+        """
+        -- Customer regression: comments before CREATE TABLE must not hide the DDL.
+        CREATE TABLE IF NOT EXISTS object_version_first_seen (
+            project_id String,
+            object_id String,
+            digest String,
+            first_created_at SimpleAggregateFunction(min, DateTime64(3))
+        ) ENGINE = AggregatingMergeTree()
+        ORDER BY (project_id, object_id, digest);
+        """
+    )
+
+    def run_upgrade_case(
+        *,
+        target_db: str,
+        target_engine: str,
+        expect_on_cluster: bool,
+        use_distributed: bool = False,
+    ) -> None:
+        ch_client = _make_ch_client_with_database_engines(
+            {"db_management": "Atomic", target_db: target_engine}
+        )
+        migrator = trace_server_migrator.get_clickhouse_trace_server_migrator(
+            ch_client,
+            replicated=True,
+            use_distributed=use_distributed,
+            replicated_cluster="test_cluster",
+            migration_dir=str(migration_dir),
+            post_migration_hook=None,
+        )
+        migrator._get_migration_status = Mock(
+            return_value={"curr_version": 25, "partially_applied_version": None}
+        )
+        migrator._get_migrations = Mock()
+        migrator._determine_migrations_to_apply = Mock(
+            return_value=[(26, migration_file.name)]
+        )
+        migrator._update_migration_status = Mock()
+        ch_client.command.reset_mock()
+
+        migrator.apply_migrations(target_db, target_version=26)
+
+        executed_sql = [call.args[0] for call in ch_client.command.call_args_list]
+        create_sql = executed_sql[0]
+        assert "CREATE TABLE" in create_sql
+        assert "object_version_first_seen" in create_sql
+        assert "ENGINE = ReplicatedAggregatingMergeTree()" in create_sql
+        assert ("ON CLUSTER test_cluster" in create_sql) is expect_on_cluster
+        assert migrator._replicated_db_engine_cache[target_db] is (
+            target_engine == "Replicated"
+        )
+
+        if use_distributed:
+            distributed_sql = executed_sql[1]
+            assert "CREATE TABLE IF NOT EXISTS object_version_first_seen" in (
+                distributed_sql
+            )
+            assert "ENGINE = Distributed" in distributed_sql
+            assert ("ON CLUSTER test_cluster" in distributed_sql) is expect_on_cluster
+
+    # Existing legacy Replicated DBs reject ON CLUSTER during upgrades.
+    run_upgrade_case(
+        target_db="legacy_replicated_db",
+        target_engine="Replicated",
+        expect_on_cluster=False,
+    )
+
+    # Existing Atomic DBs still need ON CLUSTER fan-out.
+    run_upgrade_case(
+        target_db="atomic_db",
+        target_engine="Atomic",
+        expect_on_cluster=True,
+    )
+
+    # Distributed mode inherits the same discovery path before splitting DDL
+    # into local and distributed table statements.
+    run_upgrade_case(
+        target_db="legacy_replicated_distributed_db",
+        target_engine="Replicated",
+        expect_on_cluster=False,
+        use_distributed=True,
     )
 
 
@@ -1260,6 +1371,77 @@ def test_ddl_adapts_to_database_engine(replicated_migrator, distributed_migrator
     )
 
 
+def test_replicated_database_engine_suppresses_on_cluster_for_ddl_families(
+    replicated_migrator, distributed_migrator
+):
+    """Legacy Replicated DBs must not get ON CLUSTER from any DDL branch."""
+    replicated_commands = [
+        "CREATE TABLE test (id Int32) ENGINE = MergeTree() ORDER BY id",
+        "ALTER TABLE test ADD COLUMN x Int32",
+        "ALTER TABLE test MODIFY TTL toDateTime(expire_at) DELETE",
+        "DROP TABLE IF EXISTS test",
+        "DROP VIEW IF EXISTS test_view",
+        "CREATE VIEW test_view AS SELECT * FROM test",
+        "CREATE MATERIALIZED VIEW test_mv TO test AS SELECT * FROM test",
+        "RENAME TABLE old_name TO new_name",
+    ]
+    distributed_commands = [
+        "CREATE TABLE test (id Int32) ENGINE = MergeTree() ORDER BY id",
+        "ALTER TABLE test ADD COLUMN x Int32",
+        "ALTER TABLE test ADD INDEX idx_id id TYPE bloom_filter(0.01) GRANULARITY 1",
+        "ALTER TABLE test MODIFY TTL toDateTime(expire_at) DELETE",
+        "ALTER TABLE calls_merged_view MODIFY QUERY SELECT project_id, id FROM call_parts GROUP BY project_id, id",
+        "DROP TABLE IF EXISTS test",
+        "DROP VIEW IF EXISTS test_view",
+        "CREATE VIEW test_view AS SELECT * FROM test",
+        "CREATE MATERIALIZED VIEW test_mv TO test AS SELECT * FROM test",
+        "RENAME TABLE old_name TO new_name",
+    ]
+
+    for migrator, commands in [
+        (replicated_migrator, replicated_commands),
+        (distributed_migrator, distributed_commands),
+    ]:
+        migrator._replicated_db_engine_cache["test_db"] = True
+        for command in commands:
+            migrator.ch_client.command.reset_mock()
+
+            migrator._execute_migration_command("test_db", command)
+
+            emitted_sql = [
+                call.args[0] for call in migrator.ch_client.command.call_args_list
+            ]
+            assert emitted_sql, command
+            assert all("ON CLUSTER" not in sql for sql in emitted_sql), (
+                command,
+                emitted_sql,
+            )
+            assert migrator.ch_client.database == "original_db"
+
+
+def test_execute_migration_command_restores_database_on_error(
+    replicated_migrator, distributed_migrator
+):
+    """DDL errors should not leave the shared ClickHouse client on target_db."""
+    for migrator, command in [
+        (
+            replicated_migrator,
+            "CREATE TABLE test (id Int32) ENGINE = MergeTree() ORDER BY id",
+        ),
+        (distributed_migrator, "ALTER TABLE test ADD COLUMN x Int32"),
+    ]:
+        migrator.ch_client.command.reset_mock()
+        migrator.ch_client.command.side_effect = DatabaseError(
+            "Code: 80. DB::Exception: boom"
+        )
+
+        with pytest.raises(DatabaseError, match="boom"):
+            migrator._execute_migration_command("test_db", command)
+
+        assert migrator.ch_client.database == "original_db"
+        migrator.ch_client.command.side_effect = None
+
+
 def test_index_operations_only_on_local_tables_distributed(distributed_migrator):
     """Test that ADD/DROP INDEX operations are only applied to local tables in distributed mode."""
     test_cases = [
@@ -1460,6 +1642,22 @@ def test_split_migration_sql() -> None:
         assert not s.endswith(";")
         assert "--" not in s
         assert "/*" not in s
+
+
+def test_shipped_migrations_do_not_embed_on_cluster() -> None:
+    """The migrator owns ON CLUSTER insertion so Replicated DBs can suppress it."""
+    offenders: list[str] = []
+    for file_name in sorted(os.listdir(DEFAULT_MIGRATION_DIR)):
+        if not file_name.endswith((".up.sql", ".down.sql")):
+            continue
+        file_path = os.path.join(DEFAULT_MIGRATION_DIR, file_name)
+        with open(file_path, encoding="utf-8") as f:
+            for statement in split_migration_sql(f.read()):
+                if SQLPatterns.ON_CLUSTER.search(statement):
+                    offenders.append(file_name)
+                    break
+
+    assert offenders == []
 
 
 def test_split_migration_sql_equivalent_on_all_shipped_migrations() -> None:

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -7,6 +7,8 @@ import os
 import time
 import uuid
 
+import pytest
+
 from weave.trace_server.clickhouse_trace_server_migrator import (
     get_clickhouse_trace_server_migrator,
 )
@@ -43,6 +45,24 @@ def _get_table_engine_full(ch_client, db_name: str, table_name: str) -> str:
     )
     assert len(result.result_rows) == 1, f"Table {db_name}.{table_name} not found"
     return result.result_rows[0][0]
+
+
+def _get_migration_version(ch_client, mgmt_db: str, target_db: str) -> int:
+    result = ch_client.query(
+        f"SELECT curr_version FROM {mgmt_db}.migrations WHERE db_name = '{target_db}'"
+    )
+    assert len(result.result_rows) == 1, f"Migration status for {target_db} not found"
+    return int(result.result_rows[0][0])
+
+
+def _get_latest_migration_version(migration_dir: str) -> int:
+    versions = [
+        int(file.split("_", 1)[0])
+        for file in os.listdir(migration_dir)
+        if file.endswith(".up.sql")
+    ]
+    assert versions, f"No up migrations found in {migration_dir}"
+    return max(versions)
 
 
 def _sync_mutations(ch_client, db_name: str, table_name: str) -> None:
@@ -269,6 +289,151 @@ def test_distributed_legacy_replicated_management_db(ch_client):
     )
     assert _get_table_engine_full(ch_client, target_db, "test_tbl").startswith(
         "Distributed"
+    )
+
+
+def test_replicated_existing_replicated_target_db_upgrade(ch_client, tmp_path):
+    """Upgrade path: existing Replicated data DBs must not receive ON CLUSTER DDL."""
+    mgmt_db = _unique_name("db_mgmt_upgrade")
+    target_db = _unique_name("test_upgrade")
+    ch_client.track_db(mgmt_db)
+    ch_client.track_db(target_db)
+
+    replicated_path = _REPLICATED_PATH.replace("{db}", target_db)
+    ch_client.command(
+        f"CREATE DATABASE {target_db} ON CLUSTER {_CLUSTER}"
+        f" ENGINE = Replicated('{replicated_path}', '{{shard}}', '{{replica}}')"
+    )
+
+    migration_dir = tmp_path / "migrations"
+    migration_dir.mkdir()
+    (migration_dir / "001_init.up.sql").write_text(
+        "CREATE TABLE already_applied (id String) ENGINE = MergeTree ORDER BY id;"
+    )
+    (migration_dir / "001_init.down.sql").write_text(
+        "DROP TABLE IF EXISTS already_applied;"
+    )
+    (migration_dir / "002_upgrade.up.sql").write_text(
+        """
+        -- Mirrors the 026 object_version_first_seen shape that failed for customers.
+        CREATE TABLE IF NOT EXISTS object_version_first_seen (
+            project_id String,
+            object_id String,
+            digest String,
+            first_created_at SimpleAggregateFunction(min, DateTime64(3))
+        ) ENGINE = AggregatingMergeTree()
+        ORDER BY (project_id, object_id, digest);
+        """
+    )
+    (migration_dir / "002_upgrade.down.sql").write_text(
+        "DROP TABLE IF EXISTS object_version_first_seen;"
+    )
+
+    migrator = get_clickhouse_trace_server_migrator(
+        ch_client,
+        replicated=True,
+        use_distributed=False,
+        replicated_cluster=_CLUSTER,
+        replicated_path=_REPLICATED_PATH,
+        management_db=mgmt_db,
+        migration_dir=str(migration_dir),
+        post_migration_hook=None,
+    )
+    ch_client.insert(
+        f"{mgmt_db}.migrations",
+        data=[[target_db, 1, None]],
+        column_names=["db_name", "curr_version", "partially_applied_version"],
+    )
+
+    migrator.apply_migrations(target_db, target_version=2)
+
+    assert _get_db_engine(ch_client, target_db) == "Replicated"
+    assert _get_table_engine_full(
+        ch_client, target_db, "object_version_first_seen"
+    ).startswith("ReplicatedAggregatingMergeTree")
+
+
+@pytest.mark.parametrize(
+    ("case_name", "use_distributed", "precreate_replicated_db", "expected_engine"),
+    [
+        pytest.param("repl_atomic", False, False, "Atomic", id="replicated-atomic-db"),
+        pytest.param(
+            "repl_replicated",
+            False,
+            True,
+            "Replicated",
+            id="replicated-legacy-replicated-db",
+        ),
+        pytest.param("dist_atomic", True, False, "Atomic", id="distributed-atomic-db"),
+        pytest.param(
+            "dist_replicated",
+            True,
+            True,
+            "Replicated",
+            id="distributed-legacy-replicated-db",
+        ),
+    ],
+)
+def test_recent_production_upgrade_path(
+    ch_client,
+    case_name: str,
+    use_distributed: bool,
+    precreate_replicated_db: bool,
+    expected_engine: str,
+):
+    """Customer-style upgrades from an existing DB run the latest migration batch."""
+    latest_version = _get_latest_migration_version(_PROD_MIGRATION_DIR)
+    seed_version = latest_version - 5
+    assert seed_version > 0
+
+    def make_migrator(*, mgmt_db: str, use_distributed: bool):
+        return get_clickhouse_trace_server_migrator(
+            ch_client,
+            replicated=True,
+            use_distributed=use_distributed,
+            replicated_cluster=_CLUSTER,
+            replicated_path=_REPLICATED_PATH,
+            management_db=mgmt_db,
+            migration_dir=_PROD_MIGRATION_DIR,
+            post_migration_hook=None,
+        )
+
+    mgmt_db = _unique_name(f"db_mgmt_recent_{case_name}")
+    target_db = _unique_name(f"prod_recent_{case_name}")
+    ch_client.track_db(mgmt_db)
+    ch_client.track_db(target_db)
+
+    if precreate_replicated_db:
+        replicated_path = _REPLICATED_PATH.replace("{db}", target_db)
+        ch_client.command(
+            f"CREATE DATABASE {target_db} ON CLUSTER {_CLUSTER}"
+            f" ENGINE = Replicated('{replicated_path}', '{{shard}}', '{{replica}}')"
+        )
+
+    # Seed a real old schema using production migrations, not hand-written DDL.
+    seed_migrator = make_migrator(mgmt_db=mgmt_db, use_distributed=use_distributed)
+    seed_migrator.apply_migrations(target_db, target_version=seed_version)
+    _sync_mutations(ch_client, mgmt_db, "migrations")
+    assert _get_migration_version(ch_client, mgmt_db, target_db) == seed_version
+    assert _get_db_engine(ch_client, target_db) == expected_engine
+
+    # A new init container starts with an empty engine cache, then upgrades.
+    upgrade_migrator = make_migrator(mgmt_db=mgmt_db, use_distributed=use_distributed)
+    upgrade_migrator.apply_migrations(target_db)
+    _sync_mutations(ch_client, mgmt_db, "migrations")
+
+    assert _get_migration_version(ch_client, mgmt_db, target_db) == latest_version
+    assert _get_db_engine(ch_client, target_db) == expected_engine
+    assert _table_exists(ch_client, target_db, "object_version_first_seen")
+
+    if use_distributed:
+        assert _table_exists(ch_client, target_db, "object_version_first_seen_local")
+        engine_table = "object_version_first_seen_local"
+    else:
+        engine_table = "object_version_first_seen"
+
+    assert _get_table_engine_full(ch_client, target_db, engine_table).startswith(
+        "ReplicatedAggregatingMergeTree"
     )
 
 

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -232,6 +232,13 @@ class BaseClickHouseTraceServerMigrator(ABC):
         db_sql = self._create_db_sql(db_name)
         self._run_ddl_with_retry(db_sql)
 
+    def _prepare_target_database_for_migrations(
+        self, target_db: str, current_version: int
+    ) -> None:
+        """Prepare the target database before applying migration statements."""
+        if current_version == 0:
+            self._ensure_database(target_db)
+
     @staticmethod
     def _resolve_migration_dir(migration_dir: str) -> str:
         if not os.path.isabs(migration_dir):
@@ -295,8 +302,7 @@ class BaseClickHouseTraceServerMigrator(ABC):
             )
             return
         logger.info("Migrations to apply: %s", migrations_to_apply)
-        if status["curr_version"] == 0:
-            self._ensure_database(target_db)
+        self._prepare_target_database_for_migrations(target_db, status["curr_version"])
         applied_target_version = target_version
         for migration_target_version, migration_file in migrations_to_apply:
             self._apply_migration(target_db, migration_target_version, migration_file)
@@ -617,12 +623,31 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
         """
         db_sql = self._create_db_sql(db_name)
         self._run_ddl_with_retry(db_sql)
+        self._discover_database_engine(db_name, context=db_sql)
+
+    def _prepare_target_database_for_migrations(
+        self, target_db: str, current_version: int
+    ) -> None:
+        """Ensure target DB engine is known before emitting migration DDL.
+
+        Fresh installs still create the DB first. Upgrades against existing
+        databases must also discover the engine: legacy `ENGINE = Replicated`
+        databases reject `ON CLUSTER`, and `_uses_replicated_db_engine`
+        defaults missing cache entries to False.
+        """
+        if current_version == 0:
+            self._ensure_database(target_db)
+        else:
+            self._discover_database_engine(target_db, context=None)
+
+    def _discover_database_engine(self, db_name: str, context: str | None) -> None:
+        """Populate the database-engine cache for DDL formatting decisions."""
         try:
             engine = wait_for_database_engine(
                 self.ch_client,
                 db_name,
                 max_wait_seconds=ENGINE_DISCOVERY_MAX_WAIT_SECONDS,
-                context=db_sql,
+                context=context,
             )
         except EngineDiscoveryError as exc:
             raise MigrationError(str(exc)) from exc
@@ -708,10 +733,11 @@ class ReplicatedClickHouseTraceServerMigrator(BaseClickHouseTraceServerMigrator)
         curr_db = self.ch_client.database
         self.ch_client.database = target_db
 
-        formatted_command = self._prepare_ddl_for_database(command, target_db)
-        self._run_ddl_with_retry(formatted_command)
-
-        self.ch_client.database = curr_db
+        try:
+            formatted_command = self._prepare_ddl_for_database(command, target_db)
+            self._run_ddl_with_retry(formatted_command)
+        finally:
+            self.ch_client.database = curr_db
 
     def _format_replicated_sql(self, sql_query: str) -> str:
         """Format SQL query to use replicated engines."""
@@ -931,68 +957,65 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
 
         curr_db = self.ch_client.database
         self.ch_client.database = target_db
-        command_for_match = SQLPatterns.LINE_COMMENT.sub("", command)
+        try:
+            command_for_match = SQLPatterns.LINE_COMMENT.sub("", command)
 
-        # Skip MATERIALIZE commands (not supported by distributed tables)
-        if SQLPatterns.MATERIALIZE.search(command_for_match):
-            logger.warning(
-                "Skipping MATERIALIZE command (not supported in distributed mode): %s",
-                command,
-            )
-            self.ch_client.database = curr_db
-            return
-
-        # Skip INSERT commands (backfill not supported in distributed mode)
-        if SQLPatterns.INSERT_STMT.search(command_for_match):
-            logger.warning(
-                "Skipping INSERT command (not supported in distributed mode): %s...",
-                command[:_COMMAND_PREVIEW_LENGTH],
-            )
-            self.ch_client.database = curr_db
-            return
-
-        # Handle RENAME TABLE (local rename + drop/recreate distributed table)
-        if SQLPatterns.RENAME_TABLE_STMT.search(command_for_match):
-            self._execute_distributed_rename(command)
-            self.ch_client.database = curr_db
-            return
-
-        # Handle CREATE/DROP VIEW (no local/distributed split, just add ON CLUSTER)
-        if SQLPatterns.CREATE_VIEW_STMT.search(
-            command_for_match
-        ) or SQLPatterns.DROP_VIEW_STMT.search(command_for_match):
-            # When the DB uses ENGINE = Replicated, it auto-converts MergeTree
-            # and handles DDL replication — skip explicit engine conversion and ON CLUSTER.
-            if self._uses_replicated_db_engine(target_db):
-                formatted_command = command
-            else:
-                formatted_command = self._format_replicated_sql(command)
-                formatted_command = self._add_on_cluster_clause(
-                    formatted_command, target_db=target_db
+            # Skip MATERIALIZE commands (not supported by distributed tables)
+            if SQLPatterns.MATERIALIZE.search(command_for_match):
+                logger.warning(
+                    "Skipping MATERIALIZE command (not supported in distributed mode): %s",
+                    command,
                 )
-            self._run_ddl_with_retry(formatted_command)
+                return
+
+            # Skip INSERT commands (backfill not supported in distributed mode)
+            if SQLPatterns.INSERT_STMT.search(command_for_match):
+                logger.warning(
+                    "Skipping INSERT command (not supported in distributed mode): %s...",
+                    command[:_COMMAND_PREVIEW_LENGTH],
+                )
+                return
+
+            # Handle RENAME TABLE (local rename + drop/recreate distributed table)
+            if SQLPatterns.RENAME_TABLE_STMT.search(command_for_match):
+                self._execute_distributed_rename(command)
+                return
+
+            # Handle CREATE/DROP VIEW (no local/distributed split, just add ON CLUSTER)
+            if SQLPatterns.CREATE_VIEW_STMT.search(
+                command_for_match
+            ) or SQLPatterns.DROP_VIEW_STMT.search(command_for_match):
+                # When the DB uses ENGINE = Replicated, it auto-converts MergeTree
+                # and handles DDL replication — skip explicit engine conversion and ON CLUSTER.
+                if self._uses_replicated_db_engine(target_db):
+                    formatted_command = command
+                else:
+                    formatted_command = self._format_replicated_sql(command)
+                    formatted_command = self._add_on_cluster_clause(
+                        formatted_command, target_db=target_db
+                    )
+                self._run_ddl_with_retry(formatted_command)
+                return
+
+            # Engine handling matrix for distributed local tables:
+            # - distributed + Atomic DB: explicit ZK args plus ON CLUSTER
+            # - distributed + Replicated DB: Replicated*MergeTree() with no
+            #   explicit ZK args and no ON CLUSTER
+            if self._uses_replicated_db_engine(target_db):
+                formatted_command = self._format_replicated_sql(command)
+            else:
+                formatted_command = self._format_replicated_sql_distributed(
+                    command, target_db
+                )
+
+            # Handle ALTER TABLE
+            if SQLPatterns.ALTER_TABLE_STMT.search(command_for_match):
+                self._execute_distributed_alter(formatted_command)
+            else:
+                # Handle CREATE TABLE and other DDL
+                self._execute_distributed_ddl(formatted_command)
+        finally:
             self.ch_client.database = curr_db
-            return
-
-        # Engine handling matrix for distributed local tables:
-        # - distributed + Atomic DB: explicit ZK args plus ON CLUSTER
-        # - distributed + Replicated DB: Replicated*MergeTree() with no
-        #   explicit ZK args and no ON CLUSTER
-        if self._uses_replicated_db_engine(target_db):
-            formatted_command = self._format_replicated_sql(command)
-        else:
-            formatted_command = self._format_replicated_sql_distributed(
-                command, target_db
-            )
-
-        # Handle ALTER TABLE
-        if SQLPatterns.ALTER_TABLE_STMT.search(command_for_match):
-            self._execute_distributed_alter(formatted_command)
-        else:
-            # Handle CREATE TABLE and other DDL
-            self._execute_distributed_ddl(formatted_command)
-
-        self.ch_client.database = curr_db
 
     def _format_replicated_sql_distributed(self, sql_query: str, target_db: str) -> str:
         """Format SQL query to use replicated engines with explicit paths for distributed mode."""


### PR DESCRIPTION
## Summary
- discover the target database engine before applying migrations to an existing replicated-mode database
- keep legacy `ENGINE = Replicated` databases off the `ON CLUSTER` DDL path during upgrades
- preserve `ON CLUSTER` for Atomic databases, including distributed mode, so fresh/newer deployments still fan DDL out correctly
- add targeted unit coverage plus functional upgrade coverage for real production migrations

## Testing
- adds regression test
- adds coverage for migrating existing databases from intermediate states (specifically the current migration count - 5 as a heuristic for customers that have fallen behind), not just fresh, with parameterized replicated/distributed/engine-replicated/engine-atomic

Without the change, these tests failed:
- `test_apply_migrations_discovers_existing_target_database_engine`
   - Failed because generated SQL still had ON CLUSTER test_cluster for a legacy ENGINE = Replicated DB.
- `test_replicated_existing_replicated_target_db_upgrade`
   - Failed against real ClickHouse with code 80: ON CLUSTER is not allowed for Replicated database.
- `test_recent_production_upgrade_path[replicated-legacy-replicated-db]`
   - Failed with the same code 80 during the real latest - 5 -> current production migration upgrade.
- `test_recent_production_upgrade_path[distributed-legacy-replicated-db]`
   - Also failed with code 80, so the distributed legacy path is covered too.