### PR TITLE
chore(weave): Dont call server_info_res twice, speeding up init

### DIFF
--- a/tests/trace/test_weave_init_availability.py
+++ b/tests/trace/test_weave_init_availability.py
@@ -7,23 +7,24 @@ from weave.trace import weave_init
 from weave.trace_server_bindings import remote_http_trace_server
 
 
-def test_weave_is_available_json_decode_error():
-    """Test that _weave_is_available returns False server is not available."""
+def test_get_server_info_json_decode_error():
+    """Test that _get_server_info returns None when server info cannot be decoded."""
     mock_server = MagicMock(spec=remote_http_trace_server.RemoteHTTPTraceServer)
     mock_server.server_info.side_effect = json.JSONDecodeError("test error", "doc", 0)
 
-    result = weave_init._weave_is_available(mock_server)
+    result = weave_init._get_server_info(mock_server)
 
-    assert result is False
+    assert result is None
     mock_server.server_info.assert_called_once()
 
 
-def test_weave_is_available_success():
-    """Test that _weave_is_available returns True when server is available."""
+def test_get_server_info_success():
+    """Test that _get_server_info returns server info when server is available."""
     mock_server = MagicMock(spec=remote_http_trace_server.RemoteHTTPTraceServer)
-    mock_server.server_info.return_value = {"version": "1.0.0"}
+    server_info = {"version": "1.0.0"}
+    mock_server.server_info.return_value = server_info
 
-    result = weave_init._weave_is_available(mock_server)
+    result = weave_init._get_server_info(mock_server)
 
-    assert result is True
+    assert result == server_info
     mock_server.server_info.assert_called_once()

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import os
-from json import JSONDecodeError
 from typing import TYPE_CHECKING, Any
 
 from weave.compat import wandb
@@ -33,6 +32,7 @@ from weave.wandb_interface.context import get_wandb_api_context
 
 if TYPE_CHECKING:
     from weave.trace.op import PostprocessInputsFunc, PostprocessOutputFunc
+    from weave.trace_server.service_interface import ServerInfoRes
 
 logger = logging.getLogger(__name__)
 
@@ -93,17 +93,15 @@ Args:
 """
 
 
-def _weave_is_available(server: TraceServerClientInterface) -> bool:
+def _get_server_info(server: TraceServerClientInterface) -> ServerInfoRes | None:
+    """Fetch server_info or return None if the server is unavailable."""
     try:
-        server.server_info()
-    except JSONDecodeError:
-        return False
+        return server.server_info()
     except Exception:
         logger.warning(
             "Unexpected error when checking if Weave is available on the server.  Please contact support."
         )
-        return False
-    return True
+        return None
 
 
 def init_weave(
@@ -145,7 +143,8 @@ def init_weave(
         check_wandb_run_matches(wandb_run_id, entity_name, project_name)
 
     remote_server = init_weave_get_server(api_key, entity=entity_name)
-    if not _weave_is_available(remote_server):
+    server_info = _get_server_info(remote_server)
+    if server_info is None:
         raise RuntimeError(
             "Weave is not available on the server.  Please contact support."
         )
@@ -182,17 +181,8 @@ def init_weave(
 
         track_pii_redaction_enabled(username or "unknown", entity_name, project_name)
 
-    try:
-        server_info = remote_server.server_info()
-        min_required_version = server_info.min_required_weave_python_version
-        trace_server_version = server_info.trace_server_version
-    # TODO: Tighten this exception to only catch the specific exception
-    # that is thrown by the server_info call.
-    except Exception:
-        # Set to a minimum version that will always pass the check
-        # In the future, we may want to throw here.
-        min_required_version = "0.0.0"
-        trace_server_version = None
+    min_required_version = server_info.min_required_weave_python_version
+    trace_server_version = server_info.trace_server_version
     trace_server_url = env.weave_trace_server_url()
     if not init_message.check_min_weave_version(min_required_version, trace_server_url):
         return init_weave_disabled()


### PR DESCRIPTION
Calling it twice is unnecessary.  This saves about ~150ms of init time