### PR TITLE
fix(weave): fall back to sync insert when CH rejects async_insert setting

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1022,6 +1022,75 @@ def test_insert_retries_empty_query_error():
         assert mock_ch_client.insert.call_count == 2  # Retried once
 
 
+@pytest.mark.disable_logging_error_check
+def test_insert_falls_back_to_sync_when_async_setting_rejected():
+    """Async insert against a server that rejects `async_insert` settings as
+    unknown/readonly should disable async, retry sync, and stay sync going forward.
+
+    Regression for the production traceback where `clickhouse-connect` raised
+    `ProgrammingError: Setting async_insert is unknown or readonly` and the
+    insert never recovered, dropping the entire batch.
+    """
+    mock_ch_client = MagicMock()
+    mock_ch_client.command.return_value = None
+    mock_summary_1, mock_summary_2 = MagicMock(), MagicMock()
+    # First call: async settings rejected. Second: sync retry succeeds.
+    # Third: a follow-up insert should also be sync (no further rejections).
+    mock_ch_client.insert.side_effect = [
+        ProgrammingError("Setting async_insert is unknown or readonly"),
+        mock_summary_1,
+        mock_summary_2,
+    ]
+
+    with patch.object(
+        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host", use_async_insert=True)
+
+        result = server._insert("t", data=[[1]], column_names=["a"])
+        assert result is mock_summary_1
+        assert mock_ch_client.insert.call_count == 2
+
+        # Async should have been disabled on the server after the rejection.
+        assert server._use_async_insert is False
+
+        # The retry after the rejection must not re-send the async settings,
+        # otherwise we'd hit the same ProgrammingError forever.
+        retry_settings = mock_ch_client.insert.call_args_list[1].kwargs.get("settings")
+        assert not retry_settings or "async_insert" not in retry_settings
+
+        # Subsequent inserts go straight to sync, no async settings sent.
+        result = server._insert("t", data=[[2]], column_names=["a"])
+        assert result is mock_summary_2
+        assert mock_ch_client.insert.call_count == 3
+        followup_settings = mock_ch_client.insert.call_args_list[2].kwargs.get(
+            "settings"
+        )
+        assert not followup_settings or "async_insert" not in followup_settings
+
+
+@pytest.mark.disable_logging_error_check
+def test_insert_does_not_swallow_unrelated_programming_errors():
+    """Only the async-settings rejection triggers the sync fallback. Other
+    ProgrammingErrors (e.g. table not found) must surface immediately.
+    """
+    mock_ch_client = MagicMock()
+    mock_ch_client.command.return_value = None
+    mock_ch_client.insert.side_effect = ProgrammingError("Table x does not exist")
+
+    with patch.object(
+        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host", use_async_insert=True)
+
+        with pytest.raises(ProgrammingError, match="Table x does not exist"):
+            server._insert("t", data=[[1]], column_names=["a"])
+
+        # No retry, async stays enabled. This isn't an async-setting issue.
+        assert mock_ch_client.insert.call_count == 1
+        assert server._use_async_insert is True
+
+
 def test_ensure_obj_version_exists_retries_eventual_consistency():
     """Object-version existence checks should tolerate transient read-after-write misses."""
     server = chts.ClickHouseTraceServer(host="test_host")

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -14,7 +14,7 @@ from typing import Any
 
 import ddtrace
 import sqlparse
-from clickhouse_connect.driver.exceptions import DatabaseError
+from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
 
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import trace_server_interface as tsi
@@ -206,6 +206,19 @@ def convert_to_insert_too_large(e: Exception) -> Exception:
             "the limit. If logging images, save them as `Image.PIL`."
         )
     return e
+
+
+def is_unknown_or_readonly_setting_error(e: Exception) -> bool:
+    """Detect clickhouse-connect's pre-flight setting validation rejection.
+
+    clickhouse-connect validates settings against `system.settings` before
+    issuing a request. If a setting is missing from the server's settings
+    table or marked readonly, it raises `ProgrammingError("Setting <name> is
+    unknown or readonly")` from client.py. This indicates a server/proxy that
+    does not accept the setting (e.g. async_insert against an older or
+    restricted CH cluster), not a problem with the data being inserted.
+    """
+    return isinstance(e, ProgrammingError) and "is unknown or readonly" in str(e)
 
 
 def should_retry_empty_query(e: Exception, table: str, attempt: int) -> bool:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -18,7 +18,7 @@ import clickhouse_connect
 import ddtrace
 from cachetools import TTLCache
 from clickhouse_connect.driver.client import Client as CHClient
-from clickhouse_connect.driver.exceptions import DatabaseError
+from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
 from clickhouse_connect.driver.httputil import get_pool_manager
 from clickhouse_connect.driver.query import QueryResult
 from clickhouse_connect.driver.summary import QuerySummary
@@ -122,6 +122,7 @@ from weave.trace_server.clickhouse.utilities import (
     ensure_datetimes_have_tz,
     ensure_datetimes_have_tz_strict,
     find_call_descendants,
+    is_unknown_or_readonly_setting_error,
     log_and_raise_insert_error,
     maybe_enqueue_minimal_call_end,
     num_bytes,
@@ -6898,6 +6899,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             }
         )
 
+        caller_settings = settings
         async_insert = self._use_async_insert and not do_sync_insert
         if async_insert:
             settings = ch_settings.update_settings_for_async_insert(settings)
@@ -6918,6 +6920,23 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             except ValueError as e:
                 converted = convert_to_insert_too_large(e)
                 log_and_raise_insert_error(converted, table, data)
+
+            # Async-insert settings rejected by the server (unknown or readonly):
+            # disable async_insert for this client and retry the insert without
+            # the async settings. Without this, every insert after a server that
+            # doesn't expose async_insert as a writable setting (older CH, some
+            # CH proxies, restricted clusters) fails permanently.
+            except ProgrammingError as e:
+                if async_insert and is_unknown_or_readonly_setting_error(e):
+                    logger.warning(
+                        "clickhouse_async_insert_unsupported_disabling",
+                        extra={"table": table, "error_str": str(e)},
+                    )
+                    self._use_async_insert = False
+                    async_insert = False
+                    settings = caller_settings
+                    continue
+                log_and_raise_insert_error(e, table, data)
 
             # Empty query error: RETRY (generator was consumed during HTTP retry)
             # We should retry with a fresh generator


### PR DESCRIPTION
## Summary
- `clickhouse-connect` rejects unknown/readonly settings client-side with `ProgrammingError("Setting <name> is unknown or readonly")` before the request is sent. When `use_async_insert=True` runs against a CH server/proxy that does not expose `async_insert` as a writable setting, every batched insert fails permanently and the call batch is dropped (`_flush_calls -> _insert_call_batch -> _insert("call_parts")`).
- Catch that specific error in `_insert`, disable `_use_async_insert` on the server instance, strip the async-only settings, and retry the insert with the caller-supplied settings. Other `ProgrammingError`s still surface immediately.
- Adds regression tests for both the fallback path and the unrelated-error pass-through.

Production traceback that motivated this:

```
File ".../clickhouse_connect/driver/client.py", line 145, in _validate_setting
    raise ProgrammingError(f'Setting {key} is unknown or readonly') from None
clickhouse_connect.driver.exceptions.ProgrammingError: Setting async_insert is unknown or readonly
```

Slack: https://weightsandbiases.slack.com/archives/C0880TX4U5V/p1777591106569559
Jira: [WB-33891](https://coreweave.atlassian.net/browse/WB-33891)

## Impact

Querying our Datadog logs for the rejection text in the last 30 days:

| Window | Errors | Hosts |
|---|---|---|
| 30d (4/1 to 4/30) | **116** | GKE `wandb-production` / `jungle` / `forest` |
| 4/16 (10-min burst) | 82 | one pod (`de954fc8-6srh`) |
| 4/17 to 4/18 | ~12 | three pods |
| 4/28 to 4/30 | 22 | three pods |

The pattern is **per-pod, not per-cluster**: a single pod gets stuck and bleeds the entire `call_parts` batch on every flush until restart, while sibling pods on the same deployment work fine. CH backend is `wsmkvdlncf.us-central1.gcp.clickhouse.cloud:8443` — **CH Cloud**, not self-hosted.

A sibling `clickhouse_insert_error` from the same window shows `data_len=32` for `call_parts`. Each `call_parts` row is one call (not start+end split), so order-of-magnitude **~3,000 to 4,000 calls dropped on the floor**.

## Why this "trivial" setting gets rejected

It is not the server rejecting it. `clickhouse-connect` validates settings **client-side** before the request leaves the pod (`client.py:145`):

```python
if setting_def is None or setting_def.readonly:
    ...
    raise ProgrammingError(f'Setting {key} is unknown or readonly')
```

The validation reads `system.settings` **exactly once** during `_init_common_settings` at client construction and caches the snapshot for the lifetime of the `CHClient`:

```python
server_settings = self.query(f'SELECT name, value, {readonly} as readonly FROM system.settings LIMIT 10000')
self.server_settings = {row['name']: SettingDef(**row) for row in ...}
```

Combine three things and you get this bug:

1. **CH Cloud transiently reports settings as readonly** during certain states (instance spin-up, replica routing, role/quota policy updates).
2. **A pod that connects during one of those windows** caches `async_insert: readonly=1`. The actual server is fine; the cached snapshot is wrong.
3. **The client never refreshes** `server_settings`, so the pod is poisoned for its entire lifetime. Every async insert hits client-side validation and dies before the wire.

Datadog confirms that pattern: 82 failures on one pod in 10 min (poisoned), siblings clean, then a new pod gets poisoned a week later.

This PR fixes the symptom — fall back to sync, mark the client as async-disabled, drop the doomed setting. Spans land instead of dying. Pod recycle is the eventual recovery path.

## Test plan
- [x] `uv run --group test python -m pytest tests/trace_server/test_clickhouse_trace_server_batched.py` (32 passed)
- [x] `uvx ruff check` on touched files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WB-33891]: https://coreweave.atlassian.net/browse/WB-33891?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ