### PR TITLE
fix(weave): fix tz-aware/naive compare bug in agent-scoring-worker

### DIFF
--- a/tests/trace_server/test_agent_scorer_event_ingest.py
+++ b/tests/trace_server/test_agent_scorer_event_ingest.py
@@ -13,8 +13,8 @@ from weave.trace_server.agents.types import GenAIOTelExportReq
 
 def test_insert_otel_spans_returns_accepted_rows(monkeypatch):
     # Stub Span.from_proto and extract_genai_span so we don't need real OTel bytes.
-    # Datetimes must be tz-aware because from_row compares against SENTINEL_EPOCH (UTC).
-    utc = datetime.timezone.utc
+    # Datetimes are naive to match what the OTel ingest path produces (Span.end_time
+    # is built from a unix epoch via datetime.fromtimestamp without a tz).
     stub_rows = [
         AgentSpanCHInsertable(
             project_id="p",
@@ -22,8 +22,8 @@ def test_insert_otel_spans_returns_accepted_rows(monkeypatch):
             span_id="root",
             parent_span_id="",
             span_name="root",
-            started_at=datetime.datetime(2024, 1, 1, 11, 0, 0, tzinfo=utc),
-            ended_at=datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=utc),
+            started_at=datetime.datetime(2024, 1, 1, 11, 0, 0),
+            ended_at=datetime.datetime(2024, 1, 1, 12, 0, 0),
             agent_name="a",
             operation_name="invoke_agent",
         ),
@@ -33,8 +33,8 @@ def test_insert_otel_spans_returns_accepted_rows(monkeypatch):
             span_id="child",
             parent_span_id="root",
             span_name="child",
-            started_at=datetime.datetime(2024, 1, 1, 11, 5, 0, tzinfo=utc),
-            ended_at=datetime.datetime(2024, 1, 1, 11, 55, 0, tzinfo=utc),
+            started_at=datetime.datetime(2024, 1, 1, 11, 5, 0),
+            ended_at=datetime.datetime(2024, 1, 1, 11, 55, 0),
         ),
     ]
 

--- a/tests/trace_server/test_agent_scorer_events.py
+++ b/tests/trace_server/test_agent_scorer_events.py
@@ -7,8 +7,8 @@ import datetime
 from weave.trace_server.agents.kafka_events import ScoreAgentSpansEvent
 from weave.trace_server.agents.schema import AgentSpanCHInsertable
 
-_STARTED_AT = datetime.datetime(2024, 1, 1, 11, 0, 0, tzinfo=datetime.timezone.utc)
-_ENDED_AT = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+_STARTED_AT = datetime.datetime(2024, 1, 1, 11, 0, 0)
+_ENDED_AT = datetime.datetime(2024, 1, 1, 12, 0, 0)
 
 
 def test_from_row() -> None:

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Literal
 from pydantic import BaseModel
 
 from weave.trace_server.agents.schema import AgentSpanCHInsertable, StatusCodeLiteral
-from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH
+from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH as SENTINEL_EPOCH_UTC
 
 if TYPE_CHECKING:
     from weave.trace_server.kafka import KafkaProducer
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SCORE_AGENT_SPANS_TOPIC = "weave.score_agent_spans"
+
+_SENTINEL_EPOCH_NAIVE = SENTINEL_EPOCH_UTC.replace(tzinfo=None)
 
 ScoreAgentSpansEventType = Literal["turn_ended"]
 
@@ -52,7 +54,7 @@ class ScoreAgentSpansEvent(BaseModel):
         if not row.parent_span_id:
             event_type = "turn_ended"
         # Ignore in-progress spans
-        if event_type and row.ended_at > SENTINEL_EPOCH:
+        if event_type and row.ended_at > _SENTINEL_EPOCH_NAIVE:
             return ScoreAgentSpansEvent(
                 event_type=event_type,
                 status_code=row.status_code,


### PR DESCRIPTION
## Description

Bugfix: was previously comparing tz-aware with tz-naive datetimes in agents/kafka_events.py.

This code is gated behind an env var that is currently disabled in all environments, so no services were affected.
