### PR TITLE
chore(weave): replace GitHub Actions PAT auth

### DIFF
--- a/.github/workflows/bump_ts_sdk_version.yaml
+++ b/.github/workflows/bump_ts_sdk_version.yaml
@@ -33,9 +33,19 @@ jobs:
       contents: write
       id-token: write
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.WANDBOT_3000_APP_ID }}
+          private-key: ${{ secrets.WANDBOT_3000_PRIVATE_KEY }}
+          owner: wandb
+          repositories: weave
+          permission-contents: write
+
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.WANDBMACHINE_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -21,9 +21,19 @@ jobs:
       contents: "write"
       id-token: "write"
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.WANDBOT_3000_APP_ID }}
+          private-key: ${{ secrets.WANDBOT_3000_PRIVATE_KEY }}
+          owner: wandb
+          repositories: weave
+          permission-contents: write
+
       - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.WANDBMACHINE_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
       - id: setup_git
         run: |

--- a/.github/workflows/notify-wandb-core-branch-deleted.yaml
+++ b/.github/workflows/notify-wandb-core-branch-deleted.yaml
@@ -14,6 +14,16 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
+            -   name: Create GitHub App token
+                id: app-token
+                uses: actions/create-github-app-token@v3
+                with:
+                    app-id: ${{ vars.WANDBOT_3000_APP_ID }}
+                    private-key: ${{ secrets.WANDBOT_3000_PRIVATE_KEY }}
+                    owner: wandb
+                    repositories: core
+                    permission-contents: write
+
             -   name: capture payload
                 run: |
                     cat >> "${GITHUB_STEP_SUMMARY}" <<- '__summary'
@@ -29,7 +39,7 @@ jobs:
             -   name: Send repository dispatch to wandb/core
                 uses: peter-evans/repository-dispatch@v3
                 with:
-                    token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
+                    token: ${{ steps.app-token.outputs.token }}
                     repository: wandb/core
                     event-type: weave-branch-deleted
                     client-payload: |-

--- a/.github/workflows/notify-wandb-core.yaml
+++ b/.github/workflows/notify-wandb-core.yaml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  contents: read
   packages: write
 
 jobs:
@@ -22,10 +23,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.WANDBOT_3000_APP_ID }}
+          private-key: ${{ secrets.WANDBOT_3000_PRIVATE_KEY }}
+          owner: wandb
+          repositories: core
+          permission-contents: write
+
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.WANDB_CORE_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           repository: wandb/core
           event-type: weave-package-updated
           client-payload: |-

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -5,6 +5,9 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize]
 
+permissions:
+  pull-requests: read
+
 jobs:
   cc:
     name: Validate PR title
@@ -13,7 +16,7 @@ jobs:
       # https://github.com/amannn/action-semantic-pull-request/releases
       - uses: amannn/action-semantic-pull-request@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.PR_TITLE_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           # Allowed types: See CONTRIBUTING.md
           types: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,12 +49,13 @@ jobs:
     steps:
       - name: Create GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.WANDBOT_3000_APP_ID }}
           private-key: ${{ secrets.WANDBOT_3000_PRIVATE_KEY }}
           owner: wandb
           repositories: core
+          permission-contents: write
 
       - name: Repository dispatch
         uses: peter-evans/repository-dispatch@v2

--- a/.github/workflows/wandb-core-updated.yaml
+++ b/.github/workflows/wandb-core-updated.yaml
@@ -6,6 +6,9 @@ on:
       - core-updated
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update-frontend:
     runs-on: ubuntu-latest
@@ -15,6 +18,15 @@ jobs:
         with:
           ref: master
           fetch-depth: 1
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ vars.WANDBOT_3000_APP_ID }}
+          private-key: ${{ secrets.WANDBOT_3000_PRIVATE_KEY }}
+          owner: wandb
+          repositories: core
+          permission-contents: read
       - name: Checkout wandb/core
         uses: actions/checkout@v6
         with:
@@ -23,6 +35,6 @@ jobs:
           fetch-depth: 1
           repository: wandb/core
           ref: refs/heads/master
-          token: ${{ secrets.WANDB_CORE_PAT }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Placeholder
         run: git status

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,12 @@ npm run test
 3. Update documentation if needed
 4. Check for any breaking changes
 
+### GitHub Actions Authentication
+
+- Prefer native `${{ secrets.GITHUB_TOKEN }}` for repository-local workflow operations that only need the current repo.
+- Use `actions/create-github-app-token@v3` with `vars.WANDBOT_3000_APP_ID` and `secrets.WANDBOT_3000_PRIVATE_KEY` for cross-repository access or bot pushes that must behave like app-authenticated writes.
+- Do not introduce new GitHub PAT secrets in workflows unless there is no viable `GITHUB_TOKEN` or GitHub App alternative.
+
 ## Common Development Patterns
 
 ### Code Organization


### PR DESCRIPTION
## Summary
- Replace PAT-backed GitHub workflow auth with GITHUB_TOKEN or WANDBOT_3000 app tokens
- Scope app tokens to weave/core repositories with explicit contents permissions
- Document the workflow auth convention in AGENTS.md

## Testing
- rg -n "WANDBMACHINE_GITHUB_TOKEN|WANDB_CORE_PAT|WANDB_CORE_ACCESS_TOKEN|PR_TITLE_GITHUB_TOKEN" .github AGENTS.md
- ruby -e 'require "yaml"; ARGV.each {|f| YAML.load_file(f); puts "#{f}: ok" }' changed workflow files
- actionlint -ignore 'label "ubuntu-8core" is unknown' changed workflow files
- git diff --check

## Notes
- Full actionlint still reports unrelated pre-existing issues in untouched workflows.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/wandb/weave/pull/6761" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->