### PR TITLE
chore(weave): partition agent scoring worker topic on trace_id

### DIFF
--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -167,7 +167,8 @@ class KafkaProducer(ConfluentKafkaProducer):
         ):
             return
 
-        publish_key = event.project_id if kafka_partition_by_project_id() else None
+        # Partition on trace_id so spans for the same turn route to the same worker.
+        publish_key = event.trace_id
         self.produce(
             topic=SCORE_AGENT_SPANS_TOPIC,
             value=event.model_dump_json(),

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -97,7 +97,9 @@ class KafkaProducer(ConfluentKafkaProducer):
         ):
             return
 
-        publish_key = call_end.project_id if kafka_partition_by_project_id() else None
+        # The scoring worker assumes that events for each project all route to the same worker instance.
+        # Before changing the partition key, ensure the scoring worker has been updated to support this.
+        publish_key = call_end.project_id
         self.produce(
             topic=CALL_ENDED_TOPIC,
             value=call_end.model_dump_json(),

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -167,8 +167,12 @@ class KafkaProducer(ConfluentKafkaProducer):
         ):
             return
 
-        # Partition on trace_id so spans for the same turn route to the same worker.
-        publish_key = event.trace_id
+        # Partition by conversation_id if available, falling back to trace_id.
+        # This ensures spans for the same conversation or turn always route to
+        # the same worker, which allows for more efficient caching/querying in
+        # the scoring worker. We intentionally do NOT partition on project_id:
+        # that would send all spans for a project to a single worker instance.
+        publish_key = event.conversation_id or event.trace_id
         self.produce(
             topic=SCORE_AGENT_SPANS_TOPIC,
             value=event.model_dump_json(),


### PR DESCRIPTION
## Description

Changes the partition key for the agent scoring worker from `project_id` to `trace_id`. See [this slack thread](https://coreweave.slack.com/archives/C03BSTEBD7F/p1777915325401149) for details and discussion. The agent scoring worker isn't deployed yet so this won't affect any live systems.