### PR TITLE
fix(weave): set obj `is_latest` based on `created_at`

### DIFF
--- a/weave/trace_server/query_builder/objects_query_builder.py
+++ b/weave/trace_server/query_builder/objects_query_builder.py
@@ -336,10 +336,10 @@ class ObjectMetadataQueryBuilder:
         #
         # object_versions_with_index: For each object, number its versions
         # 0, 1, 2, ... ordered by when each digest was first published
-        # (_first_created_at).  Also marks is_latest (1 for the most recently
-        # published non-deleted version; callers always filter with
-        # deleted_at IS NULL, so if all versions are deleted the query returns
-        # no results), and version_count.
+        # (_first_created_at).  is_latest tracks the most recent publish
+        # (by ov.created_at) so re-publishing a prior digest correctly
+        # promotes that digest back to latest; this can yield is_latest=1
+        # on a row whose version_index is not the maximum.
         query = f"""
 WITH latest_row_per_digest AS (
     SELECT
@@ -380,7 +380,7 @@ object_versions_with_index AS (
         ) AS version_count,
         row_number() OVER (
             PARTITION BY project_id, kind, object_id
-            ORDER BY (deleted_at IS NULL) DESC, _first_created_at DESC, digest DESC
+            ORDER BY (deleted_at IS NULL) DESC, created_at DESC, digest DESC
         ) AS row_num,
         if (row_num = 1, 1, 0) AS is_latest
     FROM latest_row_per_digest


### PR DESCRIPTION
## JIRA

[WB-34036](https://coreweave.atlassian.net/browse/WB-34036?atlOrigin=eyJpIjoiNWZiMDcxMmZjMTc5NGU1YmEzYWQ4YzMxMjMyZGY1OGYiLCJwIjoiaiJ9
)

## Description

When querying on the object versions table we append an `is_latest` column that is based on when each object version was "first seen". The version is based on a hash of the object, so if a change reverts back to a previously-seen version, we won't treat that as new. Currently, we also don't update `is_latest`, which is a bug:

```
Error-classifiers(active=true)  -> version 1  # new monitor (latest)
Error-classifiers(active=false) -> version 2  # updated monitor (latest)
Error-classifiers(active=true)  -> version 1  # toggled back to true (NOT latest)
```

To fix this we instead need to set `is_latest` based on `created_at` instead of `first_seen`.

## Testing

Tested locally

## Before

https://github.com/user-attachments/assets/df065b89-6c22-401c-b9b0-ea49c8742df4

## After

https://github.com/user-attachments/assets/2d6c5651-34c1-4ca0-9113-d89c83de27ac

[WB-34036]: https://coreweave.atlassian.net/browse/WB-34036?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ