### PR TITLE
chore(weave_ts): re-enable the jest test for TS SDK integration tests

### DIFF
--- a/.github/workflows/weave-node-tests.yaml
+++ b/.github/workflows/weave-node-tests.yaml
@@ -25,6 +25,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
         working-directory: sdks/node
+      # The hostApps Jest project (src/__tests__/hostApps/) spawns the
+      # Python Weave trace-server mock via `uv run python -m trace_server_mock`
+      # in its globalSetup. uv is required on PATH; uv handles the Python
+      # toolchain itself.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
       - name: Run tests
         run: pnpm test
         working-directory: sdks/node

--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -19,9 +19,9 @@
   "scripts": {
     "build": "node scripts/build.mjs",
     "prepare": "npm run build",
-    "test": "jest --silent --selectProjects legacy modern default",
-    "test:coverage": "jest --coverage --selectProjects legacy modern default",
-    "test:watch": "jest --watch --selectProjects legacy modern default",
+    "test": "jest --silent",
+    "test:coverage": "jest --coverage",
+    "test:watch": "jest --watch",
     "test:legacy": "jest --selectProjects legacy",
     "test:modern": "jest --selectProjects modern",
     "test:hostApps": "jest --selectProjects hostApps --runInBand",


### PR DESCRIPTION
## Description

Adds `uv` installation to the Node SDK CI workflow so that the `hostApps` Jest project can spawn the Python Weave trace-server mock during its `globalSetup`. Also removes the explicit `--selectProjects`flags from the default test scripts so that all Jest projects (including `hostApps`) are run by default when invoking `pnpm test`.

## Testing

The CI workflow now installs `uv` via `astral-sh/setup-uv@v7` before running tests, enabling the `hostApps` test suite to launch the Python trace-server mock as part of the test run.