### PR TITLE
chore(weave): Drop unnecessary client fixtures

### DIFF
--- a/tests/flow/test_weaveflow.py
+++ b/tests/flow/test_weaveflow.py
@@ -134,7 +134,7 @@ class MyModel(weave.Model):
         return x + 1
 
 
-def test_op_method_name(client):
+def test_op_method_name():
     model = MyModel(a=1)
 
     assert model.predict.name == "MyModel.predict"

--- a/tests/integrations/openai_agents/openai_agents_test.py
+++ b/tests/integrations/openai_agents/openai_agents_test.py
@@ -526,7 +526,7 @@ def test_newer_agent_task_and_turn_fields_prevent_unknown_blocks(
         ),
     ],
 )
-def test_usage_to_metrics_branches(client: WeaveClient, usage, expected) -> None:
+def test_usage_to_metrics_branches(usage, expected) -> None:
     assert _usage_to_metrics(usage) == expected
 
 
@@ -539,9 +539,7 @@ def test_usage_to_metrics_branches(client: WeaveClient, usage, expected) -> None
         (None, None, "Turn"),
     ],
 )
-def test_call_name_for_turn_span_branches(
-    client: WeaveClient, turn, agent_name, expected
-) -> None:
+def test_call_name_for_turn_span_branches(turn, agent_name, expected) -> None:
     span_data = Mock(spec=TurnSpanData)
     span_data.name = None
     span_data.turn = turn
@@ -554,9 +552,7 @@ def test_call_name_for_turn_span_branches(
     assert _call_name(span) == expected
 
 
-def test_task_and_turn_log_data_handle_missing_optional_fields(
-    client: WeaveClient,
-) -> None:
+def test_task_and_turn_log_data_handle_missing_optional_fields() -> None:
     """Task/turn spans with missing optional fields produce empty metrics and
     only the metadata they actually carry. Exercises the False branches of the
     isinstance/getattr guards in _task_log_data and _turn_log_data.
@@ -588,7 +584,7 @@ def test_task_and_turn_log_data_handle_missing_optional_fields(
     assert _call_name(turn_span) == "Turn"
 
 
-def test_generation_log_data_uses_usage_metrics(client: WeaveClient) -> None:
+def test_generation_log_data_uses_usage_metrics() -> None:
     """_generation_log_data delegates token-metric assembly to _usage_to_metrics."""
     span_data = GenerationSpanData(
         input=[{"role": "user", "content": "hi"}],
@@ -615,7 +611,7 @@ def test_generation_log_data_uses_usage_metrics(client: WeaveClient) -> None:
 
 
 def test_optional_span_classes_absent_falls_back_to_unknown(
-    client: WeaveClient, monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When TaskSpanData/TurnSpanData failed to import (older SDK), the
     isinstance helpers must short-circuit to False and _log_data must fall

--- a/tests/integrations/test_patching_resilience.py
+++ b/tests/integrations/test_patching_resilience.py
@@ -12,7 +12,7 @@ def assert_no_current_call():
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_patcher_errors(client, log_collector):
+def test_resilience_to_patcher_errors(log_collector):
     class Module:
         def method(self):
             return 0

--- a/tests/trace/test_client_server_caching.py
+++ b/tests/trace/test_client_server_caching.py
@@ -165,7 +165,7 @@ def get_cache_sizes(cache_dir: str) -> dict[str, int]:
     }
 
 
-def test_server_cache_size_limit(client):
+def test_server_cache_size_limit():
     count = 500
     limit = 50000
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -215,7 +215,7 @@ def test_server_cache_size_limit(client):
 
 
 @pytest.mark.flaky(reruns=3, reruns_delay=0.2)
-def test_server_cache_latency(client):
+def test_server_cache_latency():
     count = 500
 
     base_server = MockServer("a" * 1000)

--- a/tests/trace/test_custom_objs.py
+++ b/tests/trace/test_custom_objs.py
@@ -14,7 +14,7 @@ from weave.trace.serialization.custom_objs import (
 )
 
 
-def test_encode_custom_obj_unknown_type(client):
+def test_encode_custom_obj_unknown_type():
     """No encoding should be done for unregistered types."""
 
     class UnknownType:

--- a/tests/trace/test_deepcopy.py
+++ b/tests/trace/test_deepcopy.py
@@ -104,7 +104,7 @@ def test_deepcopy_weaveobject_e2e(client, example_class):
         BoxedTimedelta(seconds=1),
     ],
 )
-def test_deepcopy_boxed(client, boxed_val):
+def test_deepcopy_boxed(boxed_val):
     res = deepcopy(boxed_val)
     assert res == boxed_val
     assert id(res) != id(boxed_val)
@@ -123,7 +123,7 @@ def test_deepcopy_boxed_model_e2e(client):
     assert res == "hmm, You are a helpful assistant."
 
 
-def test_deepcopy_ref_with_future(client):
+def test_deepcopy_ref_with_future():
     future = Future()
     future.set_result("digest")
 

--- a/tests/trace/test_llm_as_a_judge_scorer.py
+++ b/tests/trace/test_llm_as_a_judge_scorer.py
@@ -50,7 +50,7 @@ def test_publish_and_load_scorer_with_prompt_ref(client):
     assert len(loaded_scorer.scoring_prompt.messages) == 1
 
 
-def test_score_with_string_prompt(client):
+def test_score_with_string_prompt():
     """Test score() with a simple string prompt."""
     scorer = LLMAsAJudgeScorer(
         model=LLMStructuredCompletionModel(
@@ -74,7 +74,7 @@ def test_score_with_string_prompt(client):
         assert messages == [{"role": "user", "content": "Output: hello"}]
 
 
-def test_score_with_messages_prompt(client):
+def test_score_with_messages_prompt():
     """Test score() with a MessagesPrompt and template variables."""
     prompt = MessagesPrompt(
         messages=[

--- a/tests/trace/test_llm_structured_completion_model.py
+++ b/tests/trace/test_llm_structured_completion_model.py
@@ -194,9 +194,7 @@ def test_llm_structured_completion_model_filtering(client: WeaveClient):
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
-def test_llm_structured_completion_model_predict_text_response(
-    mock_get_client, client: WeaveClient
-):
+def test_llm_structured_completion_model_predict_text_response(mock_get_client):
     """Test the predict function with mocked LLM API response for text format."""
     # Setup mock client
     mock_client = Mock()
@@ -248,9 +246,7 @@ def test_llm_structured_completion_model_predict_text_response(
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
-def test_llm_structured_completion_model_predict_json_response(
-    mock_get_client, client: WeaveClient
-):
+def test_llm_structured_completion_model_predict_json_response(mock_get_client):
     """Test the predict function with mocked LLM API response for JSON format."""
     # Setup mock client
     mock_client = Mock()
@@ -289,9 +285,7 @@ def test_llm_structured_completion_model_predict_json_response(
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
-def test_llm_structured_completion_model_predict_with_template(
-    mock_get_client, client: WeaveClient
-):
+def test_llm_structured_completion_model_predict_with_template(mock_get_client):
     """Test the predict function with message templates and template variables."""
     # Setup mock client
     mock_client = Mock()
@@ -350,9 +344,7 @@ def test_llm_structured_completion_model_predict_with_template(
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
-def test_llm_structured_completion_model_predict_with_config_override(
-    mock_get_client, client: WeaveClient
-):
+def test_llm_structured_completion_model_predict_with_config_override(mock_get_client):
     """Test the predict function with config parameter overriding defaults."""
     # Setup mock client
     mock_client = Mock()
@@ -404,9 +396,7 @@ def test_llm_structured_completion_model_predict_with_config_override(
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
-def test_llm_structured_completion_model_predict_error_handling(
-    mock_get_client, client: WeaveClient
-):
+def test_llm_structured_completion_model_predict_error_handling(mock_get_client):
     """Test the predict function error handling."""
     # Setup mock client
     mock_client = Mock()

--- a/tests/trace/test_op_versioning.py
+++ b/tests/trace/test_op_versioning.py
@@ -107,7 +107,7 @@ def test_op_versioning_lotsofstuff():
         return np.array(k).mean()
 
 
-def test_op_versioning_inline_import(client):
+def test_op_versioning_inline_import():
     pass
 
 

--- a/tests/trace/test_saved_view.py
+++ b/tests/trace/test_saved_view.py
@@ -292,7 +292,7 @@ def chat_completion_create(
     return "Hello, world!"
 
 
-def make_calls(client):
+def make_calls():
     chat_completion_create(
         custom_id="1",
         model="gpt-4o-mini",
@@ -336,7 +336,7 @@ def make_calls(client):
 
 
 def test_saved_view_column_select(client):
-    make_calls(client)
+    make_calls()
     view = weave.SavedView("traces", "My saved view")
     view.add_column("inputs.custom_id")
     calls = view.get_calls()

--- a/tests/utils/test_dict_utils.py
+++ b/tests/utils/test_dict_utils.py
@@ -1,7 +1,7 @@
 from weave.utils.dict_utils import sum_dict_leaves
 
 
-def test_sum_dict_leaves_list_of_dicts(client):
+def test_sum_dict_leaves_list_of_dicts():
     """Test that sum_dict_leaves correctly handles lists of dictionaries."""
     dicts = [
         {"a": 1, "b": "hello", "c": 2},
@@ -36,7 +36,7 @@ def test_sum_dict_leaves_list_of_dicts(client):
     assert result == {"a": 9, "c": 12}
 
 
-def test_sum_dict_leaves_mixed_types(client):
+def test_sum_dict_leaves_mixed_types():
     """Test that sum_dict_leaves correctly handles dictionaries where the same key has different types."""
     dicts = [
         {"a": 1, "b": "hello", "c": 2},
@@ -60,7 +60,7 @@ def test_sum_dict_leaves_mixed_types(client):
     }
 
 
-def test_sum_dict_leaves_deep_nested(client):
+def test_sum_dict_leaves_deep_nested():
     """Test that sum_dict_leaves correctly handles deeply nested dictionaries (2 levels) with mixed types."""
     dicts = [
         {


### PR DESCRIPTION
Don't use the client fixture if the test doesn't need it