### PR TITLE
feat(weave): materialize call status for ClickHouse filters

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -6680,9 +6680,8 @@ def test_calls_query_ordering_with_costs_comprehensive(client, no_autoflush):
     assert calls[2].id == call4.id
 
     # Test Case 5: summary.weave.status ordering with costs
-    # Regression test: summary.weave.status internally references summary_dump
-    # which is NOT in the GROUP BY in the cost query. The ORDER BY must use
-    # the alias, not re-expand the expression referencing summary_dump.
+    # Regression test: summary.weave.status is computed before the final cost
+    # GROUP BY. The ORDER BY must use the alias, not re-expand the expression.
     sort_by = [{"field": "summary.weave.status", "direction": "asc"}]
     calls = list(
         client.get_calls(

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -873,7 +873,7 @@ def test_query_with_summary_weave_status_sort() -> None:
             any(calls_merged.exception) AS exception,
             any(calls_merged.ended_at) AS ended_at
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_5:String}
+        PREWHERE calls_merged.project_id = {pb_1:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((
@@ -886,25 +886,11 @@ def test_query_with_summary_weave_status_sort() -> None:
                ))
             ))
         )
-        ORDER BY CASE
-            WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-            WHEN IFNULL(
-                toInt64OrNull(
-                    coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')
-                ),
-                0
-            ) > 0 THEN {pb_4:String}
-            WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
-            ELSE {pb_3:String}
-            END ASC
+        ORDER BY ifNull(any(calls_merged.status), {pb_0:String}) ASC
         """,
         {
-            "pb_0": '$."status_counts"."error"',
-            "pb_1": "error",
-            "pb_2": "running",
-            "pb_3": "success",
-            "pb_4": "descendant_error",
-            "pb_5": "project",
+            "pb_0": "running",
+            "pb_1": "project",
         },
     )
 
@@ -935,30 +921,17 @@ def test_query_with_summary_weave_status_sort_and_filter() -> None:
             any(calls_merged.exception) AS exception,
             any(calls_merged.ended_at) AS ended_at
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_5:String}
+        PREWHERE calls_merged.project_id = {pb_2:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (((CASE
-                WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-                WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
-                WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
-                ELSE {pb_3:String}
-            END = {pb_3:String}))
+        HAVING (((ifNull(any(calls_merged.status), {pb_0:String}) = {pb_1:String}))
         AND ((any(calls_merged.deleted_at) IS NULL))
         AND ((NOT ((any(calls_merged.started_at) IS NULL)))))
-        ORDER BY CASE
-            WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-            WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
-            WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
-            ELSE {pb_3:String}
-        END DESC
+        ORDER BY ifNull(any(calls_merged.status), {pb_0:String}) DESC
         """,
         {
-            "pb_0": '$."status_counts"."error"',
-            "pb_1": "error",
-            "pb_2": "running",
-            "pb_3": "success",
-            "pb_4": "descendant_error",
-            "pb_5": "project",
+            "pb_0": "running",
+            "pb_1": "success",
+            "pb_2": "project",
         },
     )
 
@@ -1719,18 +1692,13 @@ def test_summary_weave_field_select_backtick_quoting(
                             regexpExtract(toString(any({expected_table}.op_name)), '/([^/:]*):', 1)
                     ELSE any({expected_table}.op_name)
                 END AS `summary.weave.trace_name`,
-                CASE
-                    WHEN any({expected_table}.exception) IS NOT NULL THEN {{pb_1:String}}
-                    WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any({expected_table}.summary_dump), {{pb_0:String}}), 'null'), '')), 0) > 0 THEN {{pb_4:String}}
-                    WHEN any({expected_table}.ended_at) IS NULL THEN {{pb_2:String}}
-                    ELSE {{pb_3:String}}
-                END AS `summary.weave.status`,
+                ifNull(any({expected_table}.status), {{pb_0:String}}) AS `summary.weave.status`,
                 CASE
                     WHEN any({expected_table}.ended_at) IS NULL THEN NULL
                     ELSE (toUnixTimestamp64Milli(any({expected_table}.ended_at)) - toUnixTimestamp64Milli(any({expected_table}.started_at)))
                 END AS `summary.weave.latency_ms`
             FROM {expected_table}
-            PREWHERE {expected_table}.project_id = {{pb_5:String}}
+            PREWHERE {expected_table}.project_id = {{pb_1:String}}
             GROUP BY ({expected_table}.project_id, {expected_table}.id)
             HAVING (
                 ((any({expected_table}.deleted_at) IS NULL))
@@ -1739,12 +1707,8 @@ def test_summary_weave_field_select_backtick_quoting(
             )
             """,
             {
-                "pb_0": '$."status_counts"."error"',
-                "pb_1": "error",
-                "pb_2": "running",
-                "pb_3": "success",
-                "pb_4": "descendant_error",
-                "pb_5": "project",
+                "pb_0": "running",
+                "pb_1": "project",
             },
         )
     else:
@@ -1759,33 +1723,21 @@ def test_summary_weave_field_select_backtick_quoting(
                             regexpExtract(toString({expected_table}.op_name), '/([^/:]*):', 1)
                     ELSE {expected_table}.op_name
                 END AS `summary.weave.trace_name`,
+                {expected_table}.status AS `summary.weave.status`,
                 CASE
-                    WHEN {expected_table}.exception != {{pb_6:String}} THEN {{pb_2:String}}
-                    WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE({expected_table}.summary_dump, {{pb_1:String}}), 'null'), '')), 0) > 0 THEN {{pb_5:String}}
-                    WHEN {expected_table}.ended_at = {{pb_7:DateTime64(6)}} THEN {{pb_3:String}}
-                    ELSE {{pb_4:String}}
-                END AS `summary.weave.status`,
-                CASE
-                    WHEN {expected_table}.ended_at = {{pb_8:DateTime64(6)}} THEN NULL
+                    WHEN {expected_table}.ended_at = {{pb_1:DateTime64(6)}} THEN NULL
                     ELSE (toUnixTimestamp64Milli({expected_table}.ended_at) - toUnixTimestamp64Milli({expected_table}.started_at))
                 END AS `summary.weave.latency_ms`
             FROM {expected_table}
-            PREWHERE {expected_table}.project_id = {{pb_10:String}}
+            PREWHERE {expected_table}.project_id = {{pb_3:String}}
             WHERE 1
-              AND ({expected_table}.deleted_at = {{pb_9:DateTime64(3)}})
+              AND ({expected_table}.deleted_at = {{pb_2:DateTime64(3)}})
             """,
             {
                 "pb_0": "",
-                "pb_1": '$."status_counts"."error"',
-                "pb_2": "error",
-                "pb_3": "running",
-                "pb_4": "success",
-                "pb_5": "descendant_error",
-                "pb_6": "",
-                "pb_7": SENTINEL_EPOCH,
-                "pb_8": SENTINEL_EPOCH,
-                "pb_9": SENTINEL_EPOCH,
-                "pb_10": "project",
+                "pb_1": SENTINEL_EPOCH,
+                "pb_2": SENTINEL_EPOCH,
+                "pb_3": "project",
             },
         )
 
@@ -1885,6 +1837,7 @@ def test_build_calls_complete_update_end_query() -> None:
         exception_param="exception",
         output_dump_param="output_dump",
         summary_dump_param="summary_dump",
+        status_param="status",
         output_refs_param="output_refs",
         wb_run_step_end_param="wb_run_step_end",
     )
@@ -1896,6 +1849,7 @@ def test_build_calls_complete_update_end_query() -> None:
             exception = {exception:String},
             output_dump = {output_dump:String},
             summary_dump = {summary_dump:String},
+            status = {status:String},
             output_refs = {output_refs:Array(String)},
             wb_run_step_end = {wb_run_step_end:UInt64},
             updated_at = now64(3)
@@ -3290,7 +3244,7 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
             calls_complete.exception AS exception,
             calls_complete.ended_at AS ended_at
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_12:String}
+        PREWHERE calls_complete.project_id = {pb_5:String}
         WHERE ((calls_complete.op_name IN {pb_3:Array(String)})
                 OR (calls_complete.op_name IS NULL))
             AND (calls_complete.trace_id = {pb_4:String}
@@ -3299,17 +3253,7 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
             ((coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_0:String}), 'null'), '') > {pb_1:Int64}))
             AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)}))
         )
-        ORDER BY CASE
-            WHEN calls_complete.exception != {pb_10:String} THEN {pb_6:String}
-            WHEN IFNULL(
-                toInt64OrNull(
-                    coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_5:String}), 'null'), '')
-                ),
-                0
-            ) > 0 THEN {pb_9:String}
-            WHEN calls_complete.ended_at = {pb_11:DateTime64(6)} THEN {pb_7:String}
-            ELSE {pb_8:String}
-            END ASC
+        ORDER BY calls_complete.status ASC
         LIMIT 100
         """,
         {
@@ -3318,14 +3262,7 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
             "pb_2": SENTINEL_EPOCH,
             "pb_3": ["my_op"],
             "pb_4": "trace_abc",
-            "pb_5": '$."status_counts"."error"',
-            "pb_6": "error",
-            "pb_7": "running",
-            "pb_8": "success",
-            "pb_9": "descendant_error",
-            "pb_10": "",
-            "pb_11": SENTINEL_EPOCH,
-            "pb_12": "project",
+            "pb_5": "project",
         },
     )
 
@@ -3520,36 +3457,19 @@ def test_query_with_summary_weave_status_filter_calls_complete() -> None:
         """
         SELECT
             calls_complete.id AS id
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_10:String}
+        FROM calls_complete PREWHERE calls_complete.project_id = {pb_3:String}
         WHERE 1
           AND (
-            (((CASE
-                WHEN calls_complete.exception != {pb_5:String} THEN {pb_1:String}
-                WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
-                WHEN calls_complete.ended_at = {pb_6:DateTime64(6)} THEN {pb_2:String}
-                ELSE {pb_3:String}
-            END = {pb_3:String})
+            (((calls_complete.status = {pb_0:String})
             OR
-            (CASE
-                WHEN calls_complete.exception != {pb_7:String} THEN {pb_1:String}
-                WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
-                WHEN calls_complete.ended_at = {pb_8:DateTime64(6)} THEN {pb_2:String}
-                ELSE {pb_3:String}
-            END = {pb_1:String})))
-       AND ((calls_complete.deleted_at = {pb_9:DateTime64(3)})))
+            (calls_complete.status = {pb_1:String})))
+       AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
         """,
         {
-            "pb_0": '$."status_counts"."error"',
+            "pb_0": "success",
             "pb_1": "error",
-            "pb_2": "running",
-            "pb_3": "success",
-            "pb_4": "descendant_error",
-            "pb_5": "",
-            "pb_6": SENTINEL_EPOCH,
-            "pb_7": "",
-            "pb_8": SENTINEL_EPOCH,
-            "pb_9": SENTINEL_EPOCH,
-            "pb_10": "project",
+            "pb_2": SENTINEL_EPOCH,
+            "pb_3": "project",
         },
     )
 
@@ -4206,8 +4126,8 @@ def test_hardcoded_filters_calls_complete() -> None:
     )
 
 
-def test_status_sort_calls_complete_uses_sentinels() -> None:
-    """Verify status computation sort uses sentinel checks on calls_complete."""
+def test_status_sort_calls_complete_uses_materialized_status() -> None:
+    """Verify status sort uses the persisted calls_complete.status column."""
     cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
     cq.add_field("id")
     cq.add_order("summary.weave.status", "asc")
@@ -4215,26 +4135,14 @@ def test_status_sort_calls_complete_uses_sentinels() -> None:
         cq,
         """
         SELECT calls_complete.id AS id
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_8:String}
+        FROM calls_complete PREWHERE calls_complete.project_id = {pb_1:String}
         WHERE 1
           AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
-        ORDER BY CASE
-                     WHEN calls_complete.exception != {pb_6:String} THEN {pb_2:String}
-                     WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_1:String}), 'null'), '')), 0) > 0 THEN {pb_5:String}
-                     WHEN calls_complete.ended_at = {pb_7:DateTime64(6)} THEN {pb_3:String}
-                     ELSE {pb_4:String}
-                 END ASC
+        ORDER BY calls_complete.status ASC
         """,
         {
             "pb_0": SENTINEL_EPOCH,
-            "pb_1": '$."status_counts"."error"',
-            "pb_2": "error",
-            "pb_3": "running",
-            "pb_4": "success",
-            "pb_5": "descendant_error",
-            "pb_6": "",
-            "pb_7": SENTINEL_EPOCH,
-            "pb_8": "project",
+            "pb_1": "project",
         },
     )
 

--- a/tests/trace_server/query_builder/test_costs_query.py
+++ b/tests/trace_server/query_builder/test_costs_query.py
@@ -185,39 +185,24 @@ def test_query_with_costs_and_attributes_order() -> None:
         cq,
         """WITH filtered_calls AS
   (SELECT calls_merged.id AS id
-   FROM calls_merged PREWHERE calls_merged.project_id = {pb_5:String}
+   FROM calls_merged PREWHERE calls_merged.project_id = {pb_1:String}
    GROUP BY (calls_merged.project_id,
              calls_merged.id)
    HAVING (((any(calls_merged.deleted_at) IS NULL))
            AND ((NOT ((any(calls_merged.started_at) IS NULL)))))
    ORDER BY (NOT (JSONType(any(calls_merged.attributes_dump)) = 'Null'
-                  OR JSONType(any(calls_merged.attributes_dump)) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, CASE
-                                                                                                                                                                                                                                                                                            WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-                                                                                                                                                                                                                                                                                            WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
-                                                                                                                                                                                                                                                                                            WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
-                                                                                                                                                                                                                                                                                            ELSE {pb_3:String}
-                                                                                                                                                                                                                                                                                        END ASC),
+                  OR JSONType(any(calls_merged.attributes_dump)) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, ifNull(any(calls_merged.status), {pb_0:String}) ASC),
      all_calls AS
   (SELECT calls_merged.id AS id,
           any(calls_merged.started_at) AS started_at,
           any(calls_merged.attributes_dump) AS attributes_dump,
-          CASE
-              WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-              WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
-              WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
-              ELSE {pb_3:String}
-          END AS `summary.weave.status`
-   FROM calls_merged PREWHERE calls_merged.project_id = {pb_5:String}
+          ifNull(any(calls_merged.status), {pb_0:String}) AS `summary.weave.status`
+   FROM calls_merged PREWHERE calls_merged.project_id = {pb_1:String}
    WHERE (calls_merged.id IN filtered_calls)
    GROUP BY (calls_merged.project_id,
              calls_merged.id)
    ORDER BY (NOT (JSONType(any(calls_merged.attributes_dump)) = 'Null'
-                  OR JSONType(any(calls_merged.attributes_dump)) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, CASE
-                                                                                                                                                                                                                                                                                            WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-                                                                                                                                                                                                                                                                                            WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')), 0) > 0 THEN {pb_4:String}
-                                                                                                                                                                                                                                                                                            WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
-                                                                                                                                                                                                                                                                                            ELSE {pb_3:String}
-                                                                                                                                                                                                                                                                                        END ASC),
+                  OR JSONType(any(calls_merged.attributes_dump)) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), '$'), 'null'), '')) ASC, ifNull(any(calls_merged.status), {pb_0:String}) ASC),
      llm_usage AS
   (-- From the all_calls we get the usage data for LLMs
  SELECT *,
@@ -265,9 +250,9 @@ def test_query_with_costs_and_attributes_order() -> None:
                                          END, llm_token_prices.effective_date DESC) AS rank
    FROM llm_usage
    LEFT JOIN llm_token_prices ON ((llm_usage.llm_id = llm_token_prices.llm_id)
-                                  AND ((llm_token_prices.pricing_level_id = {pb_6:String})
-                                       OR (llm_token_prices.pricing_level_id = {pb_7:String})
-                                       OR (llm_token_prices.pricing_level_id = {pb_8:String})))) -- Final Select, which just selects the correct fields, and adds a costs object
+	                                  AND ((llm_token_prices.pricing_level_id = {pb_2:String})
+	                                       OR (llm_token_prices.pricing_level_id = {pb_3:String})
+	                                       OR (llm_token_prices.pricing_level_id = {pb_4:String})))) -- Final Select, which just selects the correct fields, and adds a costs object
 
 SELECT id,
        started_at,
@@ -285,7 +270,7 @@ SELECT id,
                                         '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
                                         '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
 FROM ranked_prices
-WHERE (rank = {pb_9:UInt64})
+WHERE (rank = {pb_5:UInt64})
 GROUP BY id,
          started_at,
          attributes_dump,
@@ -293,16 +278,12 @@ GROUP BY id,
 ORDER BY (NOT (JSONType(ranked_prices.attributes_dump) = 'Null'
                OR JSONType(ranked_prices.attributes_dump) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(ranked_prices.attributes_dump, '$'), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(ranked_prices.attributes_dump, '$'), 'null'), '')) ASC, `summary.weave.status` ASC""",
         {
-            "pb_0": '$."status_counts"."error"',
-            "pb_1": "error",
-            "pb_2": "running",
-            "pb_3": "success",
-            "pb_4": "descendant_error",
-            "pb_5": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
-            "pb_6": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
-            "pb_7": "default",
-            "pb_8": "",
-            "pb_9": 1,
+            "pb_0": "running",
+            "pb_1": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
+            "pb_2": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
+            "pb_3": "default",
+            "pb_4": "",
+            "pb_5": 1,
         },
     )
 

--- a/tests/trace_server/query_builder/test_on_cluster_query_builder.py
+++ b/tests/trace_server/query_builder/test_on_cluster_query_builder.py
@@ -56,6 +56,7 @@ def test_on_cluster_mutations_never_inject_local_suffix() -> None:
         exception_param="x",
         output_dump_param="o",
         summary_dump_param="sm",
+        status_param="st",
         output_refs_param="or",
         wb_run_step_end_param="w",
         cluster_name=CLUSTER,

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -14,7 +14,12 @@ from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
 from weave.trace_server import clickhouse_trace_server_batched as chts
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER
-from weave.trace_server.clickhouse.schema_converters import ch_call_to_row
+from weave.trace_server.clickhouse.schema_converters import (
+    ch_call_to_row,
+    complete_call_to_ch_insertable,
+    end_call_for_insert_to_ch_insertable,
+    start_call_insertable_to_complete_start,
+)
 from weave.trace_server.clickhouse_schema import (
     ALL_CALL_INSERT_COLUMNS,
     CallCompleteCHInsertable,
@@ -240,6 +245,63 @@ def test_ch_call_to_row_sentinelizes_expire_at_for_v1_insert_paths():
     explicit_expire = datetime(2025, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
     start_with_ttl = start.model_copy(update={"expire_at": explicit_expire})
     assert ch_call_to_row(start_with_ttl)[expire_at_idx] == explicit_expire
+
+
+def test_clickhouse_insertables_materialize_call_status():
+    started_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    ended_at = datetime(2024, 1, 1, 0, 0, 1, tzinfo=timezone.utc)
+    project_id = base64.b64encode(b"test_project").decode("ascii")
+
+    # Running: a calls_complete start row is readable before its end update.
+    start = CallStartCHInsertable(
+        project_id=project_id,
+        id="0193f7a5-1234-7000-8000-000000000010",
+        trace_id="0193f7a5-1234-7000-8000-000000000011",
+        op_name="test_op",
+        started_at=started_at,
+        attributes_dump="{}",
+        inputs_dump="{}",
+    )
+    running = start_call_insertable_to_complete_start(start)
+    assert running.status == tsi.TraceStatus.RUNNING.value
+
+    # Terminal states: success, direct error, and descendant error.
+    success_end = end_call_for_insert_to_ch_insertable(
+        tsi.EndedCallSchemaForInsert(
+            project_id=project_id,
+            id="0193f7a5-1234-7000-8000-000000000012",
+            ended_at=ended_at,
+            summary={},
+        ),
+        retention_days=0,
+    )
+    error_end = end_call_for_insert_to_ch_insertable(
+        tsi.EndedCallSchemaForInsert(
+            project_id=project_id,
+            id="0193f7a5-1234-7000-8000-000000000013",
+            ended_at=ended_at,
+            exception="boom",
+            summary={},
+        ),
+        retention_days=0,
+    )
+    descendant_error = complete_call_to_ch_insertable(
+        tsi.CompletedCallSchemaForInsert(
+            project_id=project_id,
+            id="0193f7a5-1234-7000-8000-000000000014",
+            trace_id="0193f7a5-1234-7000-8000-000000000015",
+            op_name="test_op",
+            started_at=started_at,
+            ended_at=ended_at,
+            attributes={},
+            inputs={},
+            summary={"status_counts": {tsi.TraceStatus.ERROR: 1}},
+        ),
+        retention_days=0,
+    )
+    assert success_end.status == tsi.TraceStatus.SUCCESS.value
+    assert error_end.status == tsi.TraceStatus.ERROR.value
+    assert descendant_error.status == tsi.TraceStatus.DESCENDANT_ERROR.value
 
 
 def test_clickhouse_distributed_mode_properties():

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1871,40 +1871,12 @@ def _handle_status_summary_field(
     use_agg_fn: bool = True,
     read_table: "ReadTable" = ReadTable.CALLS_MERGED,
 ) -> str:
-    # Status logic:
-    # - If exception is not null -> ERROR
-    # - Else if ended_at is null -> RUNNING
-    # - Else -> SUCCESS
-    exception_field = get_field_by_name("exception")
-    ended_at_field = get_field_by_name("ended_at")
-    status_counts_field = get_field_by_name("summary.status_counts.error")
-
-    exception_sql = _field_as_sql_maybe_agg(
-        exception_field, pb, table_alias, use_agg_fn
-    )
-    ended_to_sql = _field_as_sql_maybe_agg(ended_at_field, pb, table_alias, use_agg_fn)
-    status_counts_sql = _field_as_sql_maybe_agg(
-        status_counts_field, pb, table_alias, use_agg_fn, cast="int"
-    )
-
-    error_param = pb.add_param(tsi.TraceStatus.ERROR.value)
-    running_param = pb.add_param(tsi.TraceStatus.RUNNING.value)
-    success_param = pb.add_param(tsi.TraceStatus.SUCCESS.value)
-    descendant_error_param = pb.add_param(tsi.TraceStatus.DESCENDANT_ERROR.value)
-
-    exception_check = exception_field.null_check_sql(
-        pb, table_alias, read_table, use_agg_fn=use_agg_fn, negate=True
-    )
-    ended_at_null = ended_at_field.null_check_sql(
-        pb, table_alias, read_table, use_agg_fn=use_agg_fn
-    )
-
-    return f"""CASE
-        WHEN {exception_check} THEN {param_slot(error_param, "String")}
-        WHEN IFNULL({status_counts_sql}, 0) > 0 THEN {param_slot(descendant_error_param, "String")}
-        WHEN {ended_at_null} THEN {param_slot(running_param, "String")}
-        ELSE {param_slot(success_param, "String")}
-    END"""
+    status_field = CallsMergedAggField(field="status", agg_fn="any")
+    status_sql = status_field.as_sql(pb, table_alias, use_agg_fn=use_agg_fn)
+    if read_table == ReadTable.CALLS_MERGED:
+        running_param = pb.add_param(tsi.TraceStatus.RUNNING.value)
+        return f"ifNull({status_sql}, {param_slot(running_param, 'String')})"
+    return status_sql
 
 
 # Handler function for latency_ms summary field
@@ -2963,6 +2935,7 @@ def build_calls_complete_update_end_query(
     exception_param: str,
     output_dump_param: str,
     summary_dump_param: str,
+    status_param: str,
     output_refs_param: str,
     wb_run_step_end_param: str,
     started_at_param: str | None = None,
@@ -2978,6 +2951,7 @@ def build_calls_complete_update_end_query(
         exception_param (str): Param slot key for exception.
         output_dump_param (str): Param slot key for output_dump.
         summary_dump_param (str): Param slot key for summary_dump.
+        status_param (str): Param slot key for precomputed summary.weave.status.
         output_refs_param (str): Param slot key for output_refs.
         wb_run_step_end_param (str): Param slot key for wb_run_step_end.
         started_at_param (str | None): Optional param slot key for started_at
@@ -3021,6 +2995,7 @@ def build_calls_complete_update_end_query(
             exception = {{{exception_param}:String}},
             output_dump = {{{output_dump_param}:String}},
             summary_dump = {{{summary_dump_param}:String}},
+            status = {{{status_param}:String}},
             output_refs = {{{output_refs_param}:Array(String)}},
             wb_run_step_end = {{{wb_run_step_end_param}:UInt64}},
             updated_at = now64(3)

--- a/weave/trace_server/clickhouse/schema_converters.py
+++ b/weave/trace_server/clickhouse/schema_converters.py
@@ -28,7 +28,10 @@ from weave.trace_server.clickhouse_schema import (
     SelectableCHObjSchema,
 )
 from weave.trace_server.ids import generate_id
-from weave.trace_server.trace_server_common import make_derived_summary_fields
+from weave.trace_server.trace_server_common import (
+    derive_call_summary_status,
+    make_derived_summary_fields,
+)
 from weave.trace_server.ttl_settings import compute_expire_at
 
 # ---------------------------------------------------------------------------
@@ -192,6 +195,7 @@ def start_call_insertable_to_complete_start(
         wb_run_step=ch_start.wb_run_step,
         wb_run_step_end=None,
         expire_at=ch_start.expire_at,
+        status=tsi.TraceStatus.RUNNING.value,
     )
 
 
@@ -203,17 +207,21 @@ def end_call_for_insert_to_ch_insertable(
     # wrong trace id (one that does not match the parent_id)!
     output = end_call.output
     output_refs = extract_refs_from_values(output)
+    summary = dict(end_call.summary)
 
     return CallEndCHInsertable(
         project_id=end_call.project_id,
         id=end_call.id,
         exception=end_call.exception,
         ended_at=end_call.ended_at,
-        summary_dump=dict_value_to_dump(dict(end_call.summary)),
+        summary_dump=dict_value_to_dump(summary),
         output_dump=any_value_to_dump(output),
         output_refs=output_refs,
         wb_run_step_end=end_call.wb_run_step_end,
         expire_at=compute_expire_at(retention_days, end_call.ended_at),
+        status=derive_call_summary_status(
+            summary, end_call.ended_at, end_call.exception
+        ).value,
     )
 
 
@@ -242,6 +250,7 @@ def start_end_calls_to_ch_complete_insertable(
 
     output = end_call.output
     output_refs = extract_refs_from_values(output)
+    summary = dict(end_call.summary)
 
     otel_dump_str = None
     if start_call.otel_dump is not None:
@@ -263,7 +272,7 @@ def start_end_calls_to_ch_complete_insertable(
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         output_dump=any_value_to_dump(output),
-        summary_dump=dict_value_to_dump(dict(end_call.summary)),
+        summary_dump=dict_value_to_dump(summary),
         otel_dump=otel_dump_str,
         output_refs=output_refs,
         wb_user_id=start_call.wb_user_id,
@@ -271,6 +280,9 @@ def start_end_calls_to_ch_complete_insertable(
         wb_run_step=start_call.wb_run_step,
         wb_run_step_end=end_call.wb_run_step_end,
         expire_at=compute_expire_at(retention_days, start_call.started_at),
+        status=derive_call_summary_status(
+            summary, end_call.ended_at, end_call.exception
+        ).value,
     )
 
 
@@ -301,6 +313,7 @@ def complete_call_to_ch_insertable(
 
     output = complete_call.output
     output_refs = extract_refs_from_values(output)
+    summary = dict(complete_call.summary)
 
     otel_dump_str = None
     if complete_call.otel_dump is not None:
@@ -322,7 +335,7 @@ def complete_call_to_ch_insertable(
         inputs_dump=dict_value_to_dump(inputs),
         input_refs=input_refs,
         output_dump=any_value_to_dump(output),
-        summary_dump=dict_value_to_dump(dict(complete_call.summary)),
+        summary_dump=dict_value_to_dump(summary),
         otel_dump=otel_dump_str,
         output_refs=output_refs,
         wb_user_id=complete_call.wb_user_id,
@@ -330,6 +343,9 @@ def complete_call_to_ch_insertable(
         wb_run_step=complete_call.wb_run_step,
         wb_run_step_end=complete_call.wb_run_step_end,
         expire_at=compute_expire_at(retention_days, complete_call.started_at),
+        status=derive_call_summary_status(
+            summary, complete_call.ended_at, complete_call.exception
+        ).value,
     )
 
 

--- a/weave/trace_server/clickhouse_schema.py
+++ b/weave/trace_server/clickhouse_schema.py
@@ -17,6 +17,7 @@ class CallBaseCHInsertable(BaseModel):
     id: str
     input_refs: list[str] = Field(default_factory=list)
     output_refs: list[str] = Field(default_factory=list)
+    status: str | None = None
     expire_at: datetime.datetime | None = None
 
     _project_id_v = field_validator("project_id")(validation.project_id_validator)
@@ -128,6 +129,7 @@ class CallCompleteCHInsertable(
     otel_dump: str | None = None
     wb_run_step_end: int | None = None
     source: str = "direct"
+    status: str = "running"
 
     _wb_run_step_end_v = field_validator("wb_run_step_end")(
         validation.wb_run_step_validator

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -283,6 +283,7 @@ from weave.trace_server.trace_server_common import (
     MAX_FILTER_LENGTH,
     DynamicBatchProcessor,
     LRUCache,
+    derive_call_summary_status,
     determine_call_status,
     get_nested_key,
     hydrate_calls_with_feedback,
@@ -1035,7 +1036,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         output = end_call.output
         output_refs = extract_refs_from_values(output)
         output_dump = any_value_to_dump(output)
-        summary_dump = dict_value_to_dump(dict(end_call.summary))
+        summary = dict(end_call.summary)
+        summary_dump = dict_value_to_dump(summary)
+        status = derive_call_summary_status(
+            summary, end_call.ended_at, end_call.exception
+        ).value
 
         # Convert datetimes to microseconds since epoch for DateTime64(6) parameters.
         # clickhouse-connect truncates datetime objects to seconds when passing as params,
@@ -1052,6 +1057,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         output_dump_param = pb.add_param(output_dump)
         summary_dump_param = pb.add_param(summary_dump)
+        status_param = pb.add_param(status)
         output_refs_param = pb.add_param(output_refs)
         wb_run_step_end_param = pb.add_param(
             ch_sentinel_values.to_ch_value("wb_run_step_end", end_call.wb_run_step_end)
@@ -1071,6 +1077,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             exception_param=exception_param,
             output_dump_param=output_dump_param,
             summary_dump_param=summary_dump_param,
+            status_param=status_param,
             output_refs_param=output_refs_param,
             wb_run_step_end_param=wb_run_step_end_param,
             started_at_param=started_at_param,

--- a/weave/trace_server/migrations/031_add_call_status_column.down.sql
+++ b/weave/trace_server/migrations/031_add_call_status_column.down.sql
@@ -1,0 +1,33 @@
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleState(wb_run_step) as wb_run_step,
+        anySimpleState(wb_run_step_end) as wb_run_step_end,
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(thread_id) as thread_id,
+        anySimpleState(turn_id) as turn_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        anySimpleState(deleted_at) as deleted_at,
+        argMaxState(display_name, call_parts.created_at) as display_name,
+        anySimpleState(coalesce(call_parts.started_at, call_parts.ended_at, call_parts.created_at)) as sortable_datetime,
+        anySimpleState(otel_dump) as otel_dump,
+        minSimpleState(expire_at) as expire_at
+    FROM call_parts
+    GROUP BY project_id,
+        id;
+
+ALTER TABLE calls_merged DROP COLUMN IF EXISTS status;
+ALTER TABLE call_parts DROP COLUMN IF EXISTS status;
+ALTER TABLE calls_complete DROP COLUMN IF EXISTS status;

--- a/weave/trace_server/migrations/031_add_call_status_column.up.sql
+++ b/weave/trace_server/migrations/031_add_call_status_column.up.sql
@@ -1,0 +1,66 @@
+-- Migration 031: Persist summary.weave.status for call filtering/sorting.
+--
+-- This moves the status derivation out of hot read queries. The legacy
+-- call_parts/calls_merged path stores terminal status only. NULL means the call
+-- has not ended yet and is read as "running".
+
+ALTER TABLE call_parts
+    ADD COLUMN IF NOT EXISTS status Nullable(String) DEFAULT multiIf(
+        isNotNull(exception), 'error',
+        ifNull(toInt64OrNull(coalesce(nullIf(JSON_VALUE(summary_dump, '$."status_counts"."error"'), 'null'), '')), 0) > 0, 'descendant_error',
+        isNotNull(ended_at), 'success',
+        CAST(NULL, 'Nullable(String)')
+    );
+
+ALTER TABLE call_parts MATERIALIZE COLUMN status SETTINGS mutations_sync = 1;
+
+ALTER TABLE calls_merged
+    ADD COLUMN IF NOT EXISTS status SimpleAggregateFunction(any, Nullable(String)) DEFAULT multiIf(
+        isNotNull(exception), 'error',
+        ifNull(toInt64OrNull(coalesce(nullIf(JSON_VALUE(summary_dump, '$."status_counts"."error"'), 'null'), '')), 0) > 0, 'descendant_error',
+        isNotNull(ended_at), 'success',
+        CAST(NULL, 'Nullable(String)')
+    );
+
+ALTER TABLE calls_merged_view MODIFY QUERY
+    SELECT project_id,
+        id,
+        anySimpleState(wb_run_id) as wb_run_id,
+        anySimpleState(wb_run_step) as wb_run_step,
+        anySimpleState(wb_run_step_end) as wb_run_step_end,
+        anySimpleStateIf(wb_user_id, isNotNull(call_parts.started_at)) as wb_user_id,
+        anySimpleState(trace_id) as trace_id,
+        anySimpleState(parent_id) as parent_id,
+        anySimpleState(thread_id) as thread_id,
+        anySimpleState(turn_id) as turn_id,
+        anySimpleState(op_name) as op_name,
+        anySimpleState(started_at) as started_at,
+        anySimpleState(attributes_dump) as attributes_dump,
+        anySimpleState(inputs_dump) as inputs_dump,
+        array_concat_aggSimpleState(input_refs) as input_refs,
+        anySimpleState(ended_at) as ended_at,
+        anySimpleState(output_dump) as output_dump,
+        anySimpleState(summary_dump) as summary_dump,
+        anySimpleState(exception) as exception,
+        array_concat_aggSimpleState(output_refs) as output_refs,
+        anySimpleState(deleted_at) as deleted_at,
+        argMaxState(display_name, call_parts.created_at) as display_name,
+        anySimpleState(coalesce(call_parts.started_at, call_parts.ended_at, call_parts.created_at)) as sortable_datetime,
+        anySimpleState(otel_dump) as otel_dump,
+        minSimpleState(expire_at) as expire_at,
+        anySimpleState(status) as status
+    FROM call_parts
+    GROUP BY project_id,
+        id;
+
+ALTER TABLE calls_merged MATERIALIZE COLUMN status SETTINGS mutations_sync = 1;
+
+ALTER TABLE calls_complete
+    ADD COLUMN IF NOT EXISTS status String DEFAULT multiIf(
+        exception != '', 'error',
+        ifNull(toInt64OrNull(coalesce(nullIf(JSON_VALUE(summary_dump, '$."status_counts"."error"'), 'null'), '')), 0) > 0, 'descendant_error',
+        ended_at = toDateTime64(0, 6), 'running',
+        'success'
+    );
+
+ALTER TABLE calls_complete MATERIALIZE COLUMN status SETTINGS mutations_sync = 1;

--- a/weave/trace_server/token_costs.py
+++ b/weave/trace_server/token_costs.py
@@ -648,11 +648,9 @@ def get_cost_final_select(
         order_parts = []
         for of in order_fields:
             if isinstance(of.field, CallsMergedSummaryField):
-                # Summary fields (e.g. summary.weave.status) internally
-                # reference summary_dump which is NOT in the GROUP BY (it's
-                # rebuilt with cost data).  Since the summary field is already
-                # computed as an alias in SELECT/GROUP BY, reference the alias
-                # directly instead of re-expanding the expression.
+                # Summary fields are already computed as aliases in SELECT/GROUP BY.
+                # Reuse that alias here instead of re-expanding the field expression
+                # after summary_dump has been rebuilt with cost data.
                 order_parts.append(f"{safe_alias(of.field.field)} {of.direction}")
             else:
                 # Feedback fields need use_agg_fn=True because they come from a

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -87,14 +87,7 @@ def make_derived_summary_fields(
     """
     weave_summary = summary.pop("weave", {})
 
-    status = tsi.TraceStatus.SUCCESS
-    if exception:
-        status = tsi.TraceStatus.ERROR
-    elif ended_at is None:
-        status = tsi.TraceStatus.RUNNING
-    elif summary.get("status_counts", {}).get(tsi.TraceStatus.ERROR, 0) > 0:
-        status = tsi.TraceStatus.DESCENDANT_ERROR
-    weave_summary["status"] = status
+    weave_summary["status"] = derive_call_summary_status(summary, ended_at, exception)
 
     if ended_at and started_at:
         days = (ended_at - started_at).days
@@ -115,6 +108,21 @@ def make_derived_summary_fields(
 
     summary["weave"] = weave_summary
     return cast(tsi.SummaryMap, summary)
+
+
+def derive_call_summary_status(
+    summary: dict[str, Any],
+    ended_at: datetime.datetime | None,
+    exception: str | None,
+) -> tsi.TraceStatus:
+    """Return the public summary.weave.status value for stored call state."""
+    if exception:
+        return tsi.TraceStatus.ERROR
+    if ended_at is None:
+        return tsi.TraceStatus.RUNNING
+    if summary.get("status_counts", {}).get(tsi.TraceStatus.ERROR, 0) > 0:
+        return tsi.TraceStatus.DESCENDANT_ERROR
+    return tsi.TraceStatus.SUCCESS
 
 
 def empty_str_to_none(val: str | None) -> str | None:


### PR DESCRIPTION
## Summary
- materialize call status in ClickHouse call_parts, calls_merged, and calls_complete
- route status filters/sorts/selects through the materialized status column instead of summary_dump JSON parsing
- derive status on ClickHouse insert/update paths and add migration/backfill coverage

## Testing
- uv run --group test python -m pytest tests/trace_server/query_builder/test_calls_query_builder.py -q
- uv run --group test python -m pytest tests/trace_server/query_builder/test_costs_query.py tests/trace_server/query_builder/test_on_cluster_query_builder.py tests/trace_server/test_clickhouse_trace_server_batched.py -q
- uv run --group test python -m pytest tests/trace_server/test_clickhouse_trace_server_migrator.py -q
- uv run --group test python -m pytest tests/trace_server_migrator/test_migrator_functional.py::test_all_production_migrations_replicated -q
- uv run --group test python -m pytest tests/trace_server_migrator/test_migrator_functional.py::test_all_production_migrations_distributed -q
- uvx ruff check tests/trace/test_client_trace.py tests/trace_server/query_builder/test_calls_query_builder.py tests/trace_server/query_builder/test_costs_query.py tests/trace_server/query_builder/test_on_cluster_query_builder.py tests/trace_server/test_clickhouse_trace_server_batched.py weave/trace_server/calls_query_builder/calls_query_builder.py weave/trace_server/clickhouse/schema_converters.py weave/trace_server/clickhouse_schema.py weave/trace_server/clickhouse_trace_server_batched.py weave/trace_server/token_costs.py weave/trace_server/trace_server_common.py
- git diff --check origin/master...HEAD

## Notes
- No breaking API changes expected.
- Latency and other summary fields are still feasible follow-ups, but this PR keeps the schema change focused on status.