### PR TITLE
chore(weave): default ClickHouseTraceServer.from_env use_async_insert to True

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -448,7 +448,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._thread_local.calls_complete_batch = value
 
     @classmethod
-    def from_env(cls, use_async_insert: bool = False, **kwargs: Any) -> Self:
+    def from_env(cls, use_async_insert: bool | None = None, **kwargs: Any) -> Self:
+        # Default to the env-driven value so any consumer (workers, scripts, the
+        # trace-server) opts into async inserts via configuration alone. Pass
+        # `False` explicitly to force sync inserts.
+        if use_async_insert is None:
+            use_async_insert = wf_env.wf_clickhouse_use_async_insert()
         return cls(
             host=wf_env.wf_clickhouse_host(),
             port=wf_env.wf_clickhouse_port(),

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -448,12 +448,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self._thread_local.calls_complete_batch = value
 
     @classmethod
-    def from_env(cls, use_async_insert: bool | None = None, **kwargs: Any) -> Self:
-        # Default to the env-driven value so any consumer (workers, scripts, the
-        # trace-server) opts into async inserts via configuration alone. Pass
-        # `False` explicitly to force sync inserts.
-        if use_async_insert is None:
-            use_async_insert = wf_env.wf_clickhouse_use_async_insert()
+    def from_env(cls, use_async_insert: bool = True, **kwargs: Any) -> Self:
         return cls(
             host=wf_env.wf_clickhouse_host(),
             port=wf_env.wf_clickhouse_port(),

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -336,20 +336,6 @@ def wf_clickhouse_disable_lightweight_update() -> bool:
     )
 
 
-def wf_clickhouse_use_async_insert() -> bool:
-    """Whether `ClickHouseTraceServer.from_env` should opt into async inserts.
-
-    Reads the `WEAVE_TRACE_CLICKHOUSE_USE_ASYNC_INSERT` env var (named after the
-    weave-trace service, where it originated) so worker pods that already mount
-    the `weave-trace-shared` configmap pick it up automatically. Defaults to
-    True, matching the trace-server's behavior.
-    """
-    return (
-        os.environ.get("WEAVE_TRACE_CLICKHOUSE_USE_ASYNC_INSERT", "true").lower()
-        == "true"
-    )
-
-
 def wf_clickhouse_async_insert_busy_timeout_max_ms() -> int:
     """The maximum async insert busy timeout in milliseconds for ClickHouse.
 

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -336,6 +336,20 @@ def wf_clickhouse_disable_lightweight_update() -> bool:
     )
 
 
+def wf_clickhouse_use_async_insert() -> bool:
+    """Whether `ClickHouseTraceServer.from_env` should opt into async inserts.
+
+    Reads the `WEAVE_TRACE_CLICKHOUSE_USE_ASYNC_INSERT` env var (named after the
+    weave-trace service, where it originated) so worker pods that already mount
+    the `weave-trace-shared` configmap pick it up automatically. Defaults to
+    True, matching the trace-server's behavior.
+    """
+    return (
+        os.environ.get("WEAVE_TRACE_CLICKHOUSE_USE_ASYNC_INSERT", "true").lower()
+        == "true"
+    )
+
+
 def wf_clickhouse_async_insert_busy_timeout_max_ms() -> int:
     """The maximum async insert busy timeout in milliseconds for ClickHouse.
 


### PR DESCRIPTION
## Summary

`ClickHouseTraceServer.from_env` defaulted `use_async_insert` to `False`, so worker pods (scoring-worker, call-scoring-worker, evaluate-model-worker, alert-worker) that call `from_env()` without the kwarg got sync inserts. Flip the default to `True` to match the trace-server. Callers can still pass `use_async_insert=False` to force sync.

## Stack

Branched off the head of #6763. Will rebase to master once #6763 lands.

## Testing

ruff clean. validation surface is async-insert behavior on the worker pods after deploy, via `system.asynchronous_inserts` on the cluster.