### PR TITLE
chore(weave): drop redundant DD spans in hot paths

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6920,6 +6920,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 "clickhouse_trace_server_batched._insert.table": table,
             }
         )
+        set_root_span_dd_tags(
+            {
+                "weave_trace_server.insert.table": table,
+                "weave_trace_server.insert.row_count": len(data),
+            }
+        )
 
         async_insert = self._use_async_insert and not do_sync_insert
         if async_insert:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6668,13 +6668,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         client.database = self._database
         return client
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._insert_call_batch")
     def _insert_call_batch(
         self,
         batch: list,
         settings: dict[str, Any] | None = None,
         do_sync_insert: bool = False,
     ) -> None:
+        # Tags roll up to the parent _flush_calls span instead of creating a
+        # separate intermediate span on every call.
         set_current_span_dd_tags(
             {
                 "clickhouse_trace_server_batched._insert_call_batch.count": str(
@@ -6977,7 +6978,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 )
                 return result
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._insert_call")
     def _insert_call(self, ch_call: CallCHInsertable) -> None:
         self._call_batch.append(ch_call_to_row(ch_call))
         if self._flush_immediately:
@@ -6996,7 +6996,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         finally:
             self._call_batch = []
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._insert_call_complete")
     def _insert_call_complete(self, ch_call: CallCompleteCHInsertable) -> None:
         """Insert a complete call into the calls_complete batch.
 
@@ -7012,7 +7011,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if self._flush_immediately:
             self._flush_calls_complete()
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._insert_call_to_v1")
     def _insert_call_to_v1(self, ch_call: CallCompleteCHInsertable) -> None:
         """Insert a complete call into the v1 call_parts table.
 
@@ -7026,9 +7024,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if self._flush_immediately:
             self._flush_calls()
 
-    @ddtrace.tracer.wrap(
-        name="clickhouse_trace_server_batched._insert_call_complete_batch"
-    )
     def _insert_call_complete_batch(
         self,
         batch: list,
@@ -7042,6 +7037,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             settings: Optional ClickHouse settings.
             do_sync_insert: If True, use synchronous insert.
         """
+        # Tags roll up to the parent _flush_calls_complete span instead of
+        # creating a separate intermediate span on every call.
         set_current_span_dd_tags(
             {
                 "clickhouse_trace_server_batched._insert_call_complete_batch.count": str(

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -5,7 +5,10 @@ import ddtrace
 from cachetools import LRUCache
 from clickhouse_connect.driver.client import Client as CHClient
 
-from weave.trace_server.datadog import set_current_span_dd_tags
+from weave.trace_server.datadog import (
+    set_current_span_dd_tags,
+    set_root_span_dd_tags,
+)
 from weave.trace_server.project_version.clickhouse_project_version import (
     get_project_data_residence,
 )
@@ -60,6 +63,8 @@ class TableRoutingResolver:
         with ddtrace.tracer.trace("table_routing.fetch_residence"):
             residence = get_project_data_residence(project_id, ch_client)
 
+            set_root_span_dd_tags({"project_version.fetch_residence": residence.value})
+
             # Log warning if we detect dual residency - data should only ever be in
             # calls_merged OR calls_complete, not both. This is handled gracefully but
             # indicates an unexpected state that should be investigated.
@@ -83,6 +88,11 @@ class TableRoutingResolver:
 
     def resolve_read_table(self, project_id: str, ch_client: CHClient) -> ReadTable:
         """Resolve which table to read from for a given project."""
+        result = self._resolve_read_table(project_id, ch_client)
+        set_root_span_dd_tags({"call_project_residence": result.value})
+        return result
+
+    def _resolve_read_table(self, project_id: str, ch_client: CHClient) -> ReadTable:
         if self._mode == CallsStorageServerMode.OFF:
             return ReadTable.CALLS_MERGED
 
@@ -127,6 +137,13 @@ class TableRoutingResolver:
         Returns:
             WriteTarget indicating which table to write to.
         """
+        result = self._resolve_v1_write_target(project_id, ch_client)
+        set_root_span_dd_tags({"call_project_residence": result.value})
+        return result
+
+    def _resolve_v1_write_target(
+        self, project_id: str, ch_client: CHClient
+    ) -> WriteTarget:
         if self._mode == CallsStorageServerMode.OFF:
             return WriteTarget.CALLS_MERGED
 
@@ -169,6 +186,13 @@ class TableRoutingResolver:
         Returns:
             WriteTarget indicating which table to write to.
         """
+        result = self._resolve_v2_write_target(project_id, ch_client)
+        set_root_span_dd_tags({"call_project_residence": result.value})
+        return result
+
+    def _resolve_v2_write_target(
+        self, project_id: str, ch_client: CHClient
+    ) -> WriteTarget:
         if self._mode == CallsStorageServerMode.OFF:
             return WriteTarget.CALLS_MERGED
 

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -55,28 +55,32 @@ class TableRoutingResolver:
         if cached is not None:
             return cached
 
-        residence = get_project_data_residence(project_id, ch_client)
+        # Only span the cache-miss path. Cache-hit calls are extremely high
+        # volume and produce noisy DD spans with no useful information.
+        with ddtrace.tracer.trace("table_routing.fetch_residence"):
+            residence = get_project_data_residence(project_id, ch_client)
 
-        # Log warning if we detect dual residency - data should only ever be in
-        # calls_merged OR calls_complete, not both. This is handled gracefully but
-        # indicates an unexpected state that should be investigated.
-        if residence == ProjectDataResidence.BOTH:
-            logger.warning("Detected dual call residency for project %s. ", project_id)
-            set_current_span_dd_tags(
-                {
-                    "project_version.dual_residency": "true",
-                    "project_version.dual_residency.project_id": project_id,
-                }
-            )
+            # Log warning if we detect dual residency - data should only ever be in
+            # calls_merged OR calls_complete, not both. This is handled gracefully but
+            # indicates an unexpected state that should be investigated.
+            if residence == ProjectDataResidence.BOTH:
+                logger.warning(
+                    "Detected dual call residency for project %s. ", project_id
+                )
+                set_current_span_dd_tags(
+                    {
+                        "project_version.dual_residency": "true",
+                        "project_version.dual_residency.project_id": project_id,
+                    }
+                )
 
-        # Don't cache if project is empty, we could write to either table.
-        if residence != ProjectDataResidence.EMPTY:
-            with _project_residence_cache_lock:
-                _project_residence_cache[project_id] = residence
+            # Don't cache if project is empty, we could write to either table.
+            if residence != ProjectDataResidence.EMPTY:
+                with _project_residence_cache_lock:
+                    _project_residence_cache[project_id] = residence
 
-        return residence
+            return residence
 
-    @ddtrace.tracer.wrap(name="table_routing.resolve_read_table")
     def resolve_read_table(self, project_id: str, ch_client: CHClient) -> ReadTable:
         """Resolve which table to read from for a given project."""
         if self._mode == CallsStorageServerMode.OFF:
@@ -105,7 +109,6 @@ class TableRoutingResolver:
 
         raise ValueError(f"Invalid mode/residence: {self._mode}/{residence}")
 
-    @ddtrace.tracer.wrap(name="table_routing.resolve_v1_write_target")
     def resolve_v1_write_target(
         self,
         project_id: str,
@@ -150,7 +153,6 @@ class TableRoutingResolver:
 
         raise ValueError(f"Invalid mode/residence: {self._mode}/{residence}")
 
-    @ddtrace.tracer.wrap(name="table_routing.resolve_v2_write_target")
     def resolve_v2_write_target(
         self,
         project_id: str,

--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -47,7 +47,6 @@ _project_ttl_cache: TTLCache[str, int] = TTLCache(
 _project_ttl_cache_lock = threading.Lock()
 
 
-@ddtrace.tracer.wrap(name="ttl_settings.get_project_retention_days")
 def get_project_retention_days(
     project_id: str,
     ch_client: CHClient,
@@ -180,6 +179,7 @@ def _l2_delete(redis_client: redis.Redis, project_id: str) -> None:
         logger.exception("Redis L2 cache delete failed for project %s", project_id)
 
 
+@ddtrace.tracer.wrap(name="ttl_settings.query_clickhouse")
 def _query_clickhouse(ch_client: CHClient, project_id: str) -> int:
     """Query ClickHouse for the latest retention_days via argMax.
 


### PR DESCRIPTION
## Summary
- `table_routing`: drop the per-call `@ddtrace.tracer.wrap` from `resolve_read_table` / `resolve_v1_write_target` / `resolve_v2_write_target`. The residence lookup is cached process-wide, so most calls were emitting an empty span. The cache-miss path inside `_get_residence` is now wrapped in a `table_routing.fetch_residence` span so the actual ClickHouse work remains observable.
- `clickhouse insert path`: drop intermediate spans on `_insert_call`, `_insert_call_complete`, `_insert_call_to_v1`, `_insert_call_batch`, `_insert_call_complete_batch`. Keep `_flush_calls` / `_flush_calls_complete` (top-level) and `_insert` (the actual ch-client insert). Existing `set_current_span_dd_tags` calls now roll batch counts up to the parent flush span.
- pair with `wandb/core#<TBD>` for worker-side reductions.

## Why
On the `wandbench-small` env we were seeing massive DD span volume from `weave-trace-worker`. Two patterns dominated:
1. `table_routing.resolve_*` spans firing on every read/write even though almost all calls hit a warm process-wide residence cache.
2. The insert pipeline producing 4 spans per call (`_insert_call` -> `_flush_calls` -> `_insert_call_batch` -> `_insert`), with the 3 outer ones contributing nothing beyond duplicating the ch-insert timing.

The remaining spans (`_flush_calls`, `_flush_calls_complete`, `_insert`, `table_routing.fetch_residence`) cover the actual work; tags previously emitted on the dropped spans are attached to the parent span via `set_current_span_dd_tags`.

## Testing
manual verification post-deploy on wandbench-small: span counts for `table_routing.resolve_*` and the dropped insert wrappers drop to zero, `_flush_calls`/`_flush_calls_complete` retain their `_insert_call_batch.count` / `_insert_call_complete_batch.count` tags, and `table_routing.fetch_residence` appears on first-touch projects.
