### PR TITLE
chore(weave): remove usage from agent classifier prompt

### DIFF
--- a/tests/trace_server/test_agent_scorer_event_producer.py
+++ b/tests/trace_server/test_agent_scorer_event_producer.py
@@ -16,7 +16,7 @@ from weave.trace_server.kafka import KafkaProducer
 def _make_event(**overrides) -> ScoreAgentSpansEvent:
     """Minimal valid ScoreAgentSpansEvent for tests; override any field."""
     base = {
-        "event_type": "turn_ended",
+        "event_type": "weave.genai.turn_ended",
         "status_code": "OK",
         "project_id": "p",
         "trace_id": "t",

--- a/tests/trace_server/test_agent_scorer_events.py
+++ b/tests/trace_server/test_agent_scorer_events.py
@@ -27,7 +27,7 @@ def test_from_row() -> None:
     )
     event = ScoreAgentSpansEvent.from_row(root_row)
     assert event == ScoreAgentSpansEvent(
-        event_type="turn_ended",
+        event_type="weave.genai.turn_ended",
         status_code="OK",
         project_id="p",
         trace_id="tr",

--- a/weave/flow/monitor.py
+++ b/weave/flow/monitor.py
@@ -14,7 +14,7 @@ DebounceAggregationField: TypeAlias = Literal["trace_id", "thread_id"]
 DebounceAggregationMethod: TypeAlias = Literal["last_message", "all_messages"]
 
 # Monitors can be configured to score agent spans by including an AgentSpanOpName in their `op_names` list.
-AgentSpanOpName: TypeAlias = Literal["weave.genai.turn"]
+AgentSpanOpName: TypeAlias = Literal["weave.genai.turn_ended"]
 AGENT_SPAN_OP_NAMES: frozenset[AgentSpanOpName] = frozenset(get_args(AgentSpanOpName))
 
 # Runtime-valid sets derived from Literals above

--- a/weave/flow/monitor.py
+++ b/weave/flow/monitor.py
@@ -161,11 +161,6 @@ _AGENT_SPAN_CLASSIFIER_PROMPT_HEADER = "\n".join(
         "  {output_messages}",
         "  </output-messages>",
         "</messages>",
-        "<usage>",
-        "  <input-tokens>{input_tokens}</input-tokens>",
-        "  <output-tokens>{output_tokens}</output-tokens>",
-        "  <reasoning-tokens>{reasoning_tokens}</reasoning-tokens>",
-        "</usage>",
         "</agent>",
         "Evaluate the trace above against each classifier below. Base your judgment strictly on the evidence in the trace.",
     ]

--- a/weave/trace_server/agents/kafka_events.py
+++ b/weave/trace_server/agents/kafka_events.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
+from weave.flow.monitor import AgentSpanOpName
 from weave.trace_server.agents.schema import AgentSpanCHInsertable, StatusCodeLiteral
 from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH as SENTINEL_EPOCH_UTC
 
@@ -19,13 +20,11 @@ SCORE_AGENT_SPANS_TOPIC = "weave.score_agent_spans"
 
 _SENTINEL_EPOCH_NAIVE = SENTINEL_EPOCH_UTC.replace(tzinfo=None)
 
-ScoreAgentSpansEventType = Literal["turn_ended"]
-
 
 class ScoreAgentSpansEvent(BaseModel):
     """Trigger event for agent scoring."""
 
-    event_type: ScoreAgentSpansEventType
+    event_type: AgentSpanOpName
     status_code: StatusCodeLiteral
     project_id: str
     trace_id: str
@@ -49,10 +48,10 @@ class ScoreAgentSpansEvent(BaseModel):
 
         Currently only "turn_ended" is supported, but the interface is designed to support multiple types.
         """
-        event_type: ScoreAgentSpansEventType | None = None
+        event_type: AgentSpanOpName | None = None
         # A span with no parent is assumed to represent the end of a turn
         if not row.parent_span_id:
-            event_type = "turn_ended"
+            event_type = "weave.genai.turn_ended"
         # Ignore in-progress spans
         if event_type and row.ended_at > _SENTINEL_EPOCH_NAIVE:
             return ScoreAgentSpansEvent(


### PR DESCRIPTION
## Description

Drop token usage from the prompt we use for agent signals.

Token usage isn't typically available on the root span for a turn, and would require fetching and aggregating over all child spans in the turn. We might want to add that in the future, but no one is yet asking for it.