### PR TITLE
fix(weave): WB-34041 honor WANDB_ERROR_REPORTING in trace_sentry

### DIFF
--- a/tests/trace/test_sentry_disable.py
+++ b/tests/trace/test_sentry_disable.py
@@ -1,0 +1,73 @@
+"""Tests that `weave.telemetry.trace_sentry.Sentry` honors `WANDB_ERROR_REPORTING`.
+
+The wandb SDK's own Sentry wrapper (`wandb/analytics/sentry.py`) reads
+`WANDB_ERROR_REPORTING` to let customers in security-sensitive environments
+disable outbound error reporting. The Weave SDK's parallel wrapper must
+behave the same way so that a single env var disables both.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from weave.telemetry import trace_sentry
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["false", "False", "FALSE", "0", "no", "No", "off", "OFF", "f", "n"],
+)
+def test_disabled_when_wandb_error_reporting_falsy(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Falsy spellings of `WANDB_ERROR_REPORTING` disable Sentry."""
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", value)
+    sentry = trace_sentry.Sentry()
+    assert sentry._disabled is True
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["true", "True", "TRUE", "1", "yes", "on", "anything-else", ""],
+)
+def test_enabled_unless_wandb_error_reporting_is_falsy(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Anything other than a recognized falsy value leaves Sentry enabled.
+
+    `_disabled` still reflects `SENTRY_AVAILABLE` so this passes whether or
+    not the optional `sentry-sdk` dependency is installed in the env.
+    """
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", value)
+    sentry = trace_sentry.Sentry()
+    assert sentry._disabled == (not trace_sentry.SENTRY_AVAILABLE)
+
+
+def test_enabled_when_wandb_error_reporting_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unset `WANDB_ERROR_REPORTING` defaults to enabled (no opt-out)."""
+    monkeypatch.delenv("WANDB_ERROR_REPORTING", raising=False)
+    sentry = trace_sentry.Sentry()
+    assert sentry._disabled == (not trace_sentry.SENTRY_AVAILABLE)
+
+
+def test_setup_is_a_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When disabled, `setup()` does not create a Sentry client and `scope` stays None.
+
+    This is the load-bearing assertion for WB-34041: no Sentry client means no
+    transport thread, which means no outbound traffic to the hardcoded DSN.
+    """
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", "false")
+    sentry = trace_sentry.Sentry()
+    sentry.setup()
+    assert sentry.scope is None
+
+
+def test_value_is_stripped_and_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitespace and casing in the env value should not change the outcome."""
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", "  False  ")
+    sentry = trace_sentry.Sentry()
+    assert sentry._disabled is True

--- a/tests/trace/test_sentry_disable.py
+++ b/tests/trace/test_sentry_disable.py
@@ -4,6 +4,10 @@ The wandb SDK's own Sentry wrapper (`wandb/analytics/sentry.py`) reads
 `WANDB_ERROR_REPORTING` to let customers in security-sensitive environments
 disable outbound error reporting. The Weave SDK's parallel wrapper must
 behave the same way so that a single env var disables both.
+
+Truthy / falsy semantics match the canonical `_str2bool_truthy` helper in
+`weave/trace/settings.py` (i.e. only `yes`, `true`, `1`, `on` keep reporting
+enabled; everything else, including unrecognized values, disables it).
 """
 
 from __future__ import annotations
@@ -15,12 +19,12 @@ from weave.telemetry import trace_sentry
 
 @pytest.mark.parametrize(
     "value",
-    ["false", "False", "FALSE", "0", "no", "No", "off", "OFF", "f", "n"],
+    ["false", "False", "FALSE", "0", "no", "off", "anything-else", ""],
 )
-def test_disabled_when_wandb_error_reporting_falsy(
+def test_disabled_when_wandb_error_reporting_is_not_truthy(
     monkeypatch: pytest.MonkeyPatch, value: str
 ) -> None:
-    """Falsy spellings of `WANDB_ERROR_REPORTING` disable Sentry."""
+    """Anything that is not a recognized truthy value disables Sentry."""
     monkeypatch.setenv("WANDB_ERROR_REPORTING", value)
     sentry = trace_sentry.Sentry()
     assert sentry._disabled is True
@@ -28,15 +32,15 @@ def test_disabled_when_wandb_error_reporting_falsy(
 
 @pytest.mark.parametrize(
     "value",
-    ["true", "True", "TRUE", "1", "yes", "on", "anything-else", ""],
+    ["true", "True", "TRUE", "1", "yes", "Yes", "on", "ON"],
 )
-def test_enabled_unless_wandb_error_reporting_is_falsy(
+def test_enabled_when_wandb_error_reporting_is_truthy(
     monkeypatch: pytest.MonkeyPatch, value: str
 ) -> None:
-    """Anything other than a recognized falsy value leaves Sentry enabled.
+    """Recognized truthy values leave Sentry enabled (modulo `SENTRY_AVAILABLE`).
 
-    `_disabled` still reflects `SENTRY_AVAILABLE` so this passes whether or
-    not the optional `sentry-sdk` dependency is installed in the env.
+    `_disabled` still reflects whether the optional `sentry-sdk` dependency is
+    installed in the env, so this passes whether or not Sentry is importable.
     """
     monkeypatch.setenv("WANDB_ERROR_REPORTING", value)
     sentry = trace_sentry.Sentry()
@@ -62,12 +66,3 @@ def test_setup_is_a_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     sentry = trace_sentry.Sentry()
     sentry.setup()
     assert sentry.scope is None
-
-
-def test_value_is_stripped_and_case_insensitive(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Whitespace and casing in the env value should not change the outcome."""
-    monkeypatch.setenv("WANDB_ERROR_REPORTING", "  False  ")
-    sentry = trace_sentry.Sentry()
-    assert sentry._disabled is True

--- a/weave/telemetry/trace_sentry.py
+++ b/weave/telemetry/trace_sentry.py
@@ -18,6 +18,8 @@ import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
+from weave.trace.settings import _str2bool_truthy
+
 try:
     import sentry_sdk  # type: ignore
     import sentry_sdk.utils  # type: ignore
@@ -40,11 +42,6 @@ SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
 
 logger = logging.getLogger(__name__)
 
-# Values of `WANDB_ERROR_REPORTING` that opt the user out of error reporting.
-# Mirrors the falsy spellings accepted by `wandb.env.error_reporting_enabled`
-# (which routes through `distutils.util.strtobool`).
-_ERROR_REPORTING_FALSY = frozenset({"false", "0", "no", "off", "f", "n"})
-
 
 def _error_reporting_enabled() -> bool:
     """Whether outbound error reporting to Sentry is enabled.
@@ -53,8 +50,7 @@ def _error_reporting_enabled() -> bool:
     that customers who already disable error reporting for the `wandb` SDK get
     the same behavior here. Default is enabled when the variable is unset.
     """
-    val = os.environ.get("WANDB_ERROR_REPORTING", "").strip().lower()
-    return val not in _ERROR_REPORTING_FALSY
+    return _str2bool_truthy(os.environ.get("WANDB_ERROR_REPORTING", "true"))
 
 
 def _safe_noop(func: Callable) -> Callable:

--- a/weave/telemetry/trace_sentry.py
+++ b/weave/telemetry/trace_sentry.py
@@ -40,6 +40,22 @@ SessionStatus = Literal["ok", "exited", "crashed", "abnormal"]
 
 logger = logging.getLogger(__name__)
 
+# Values of `WANDB_ERROR_REPORTING` that opt the user out of error reporting.
+# Mirrors the falsy spellings accepted by `wandb.env.error_reporting_enabled`
+# (which routes through `distutils.util.strtobool`).
+_ERROR_REPORTING_FALSY = frozenset({"false", "0", "no", "off", "f", "n"})
+
+
+def _error_reporting_enabled() -> bool:
+    """Whether outbound error reporting to Sentry is enabled.
+
+    Honors the wandb-canonical `WANDB_ERROR_REPORTING` environment variable so
+    that customers who already disable error reporting for the `wandb` SDK get
+    the same behavior here. Default is enabled when the variable is unset.
+    """
+    val = os.environ.get("WANDB_ERROR_REPORTING", "").strip().lower()
+    return val not in _ERROR_REPORTING_FALSY
+
 
 def _safe_noop(func: Callable) -> Callable:
     """Decorator to ensure that Sentry methods do nothing if disabled and don't raise."""
@@ -69,8 +85,9 @@ class Sentry:
 
         self.scope: Scope | None = None
 
-        # Disable if sentry is not available
-        self._disabled = not SENTRY_AVAILABLE
+        # Disable if sentry is not available, or if the user opted out via
+        # `WANDB_ERROR_REPORTING=false` (matches `wandb/analytics/sentry.py`).
+        self._disabled = (not SENTRY_AVAILABLE) or (not _error_reporting_enabled())
 
         # ensure we always end the Sentry session
         atexit.register(self.end_session)


### PR DESCRIPTION
## JIRA Issue(s)

[WB-34041 — Add env var to disable Weave SDK Sentry error reporting](https://coreweave.atlassian.net/browse/WB-34041)

## Description

Operators running customer-managed instances of W&B sometimes need to prevent any outbound traffic to third-party services from their environment, including the Weave SDK's Sentry error reporting. Today the Weave SDK exposes no way to do that — `WANDB_ERROR_REPORTING=false` (the standard W&B env var [documented for the `wandb` SDK](https://docs.wandb.ai/models/track/environment-variables)) is silently ignored by Weave's own Sentry wrapper, and the only working workaround is to `pip uninstall sentry-sdk`, which is undone on every `pip install --upgrade weave` because `sentry-sdk` is a hard dependency.

This PR fixes that mismatch. After this change, setting `WANDB_ERROR_REPORTING=false` disables the Weave SDK's Sentry the same way it already disables the `wandb` SDK's Sentry — one environment variable, both packages, consistent behavior. The default (env var unset) is unchanged.

## Why this approach

The `wandb` SDK's parallel Sentry wrapper at [`wandb/analytics/sentry.py:69`](https://github.com/wandb/wandb/blob/main/wandb/analytics/sentry.py) already gates itself on `WANDB_ERROR_REPORTING` via `bool(_env.error_reporting_enabled())`. The Weave SDK has a near-identical `Sentry` class in `weave/telemetry/trace_sentry.py` but never wired the same check in. Mirroring the wandb-side helper is the smallest change that lines the two wrappers up, and the truthy-vs-falsy parsing here goes through the existing `_str2bool_truthy` helper in `weave/trace/settings.py` — the same helper every other Weave env-var toggle already uses — rather than reimplementing the magic strings inline.

Two alternatives were considered and rejected. Adding a Weave-only `WEAVE_DISABLE_SENTRY` env var (auto-derived from a `disable_sentry` field on `UserSettings`) was rejected because the contract everyone expects to work — and that the `wandb` SDK already honors — is `WANDB_ERROR_REPORTING`; doubling the API surface would not give operators any new capability, and a programmatic toggle through `weave.init(settings={...})` can still be added later, strictly additively. Moving `sentry-sdk` to an optional dependency, attempted in [#5230](https://github.com/wandb/weave/pull/5230) and tracked in [#5228](https://github.com/wandb/weave/issues/5228), is a strictly larger change with broader review surface; the env-var fix here lands the user-facing behavior in a few lines and does not preclude that follow-up.

## Why it is safe

All `sentry_sdk` imports in the Weave SDK are localized to a single file (`weave/telemetry/trace_sentry.py`) — verified by searching the repository for `import sentry_sdk` and `from sentry_sdk`, with no other entry points. Every Weave call site reaches Sentry through `global_trace_sentry` and the existing `@_safe_noop` decorator, which already returns early when `self._disabled` is `True`, so flipping `_disabled` at construction time short-circuits the entire Sentry path.

In particular, `Sentry.setup()` is `@_safe_noop`-decorated, so when disabled it never reaches the line that constructs a `sentry_sdk.Client(dsn=...)`. No client means no transport thread, which means no outbound connection to the hardcoded DSN — that is the load-bearing property for the security-sensitive use case, and it is asserted directly in `test_setup_is_a_noop_when_disabled`.

## Testing

A new test file `tests/trace/test_sentry_disable.py` covers the behavior with 18 parameterized cases. It asserts that any non-truthy spelling of `WANDB_ERROR_REPORTING` (`false`, `0`, `no`, `off`, the empty string, an unrecognized value) sets `_disabled` to `True`; that recognized truthy spellings (`true`, `1`, `yes`, `on`, case-insensitive) leave `_disabled` reflecting only `SENTRY_AVAILABLE`; that an unset env var defaults to enabled; and that `setup()` does not create a Sentry scope when disabled — the load-bearing assertion that no scope means no client and no outbound traffic. The test suite's `tests/conftest.py` has long set `WANDB_ERROR_REPORTING=false` globally for tests but had no effect because the variable was never read; after this change, that line becomes meaningful and the entire suite stops emitting any Sentry events at runtime as a free side-effect.

Verified locally: the new file (18 passed), the two `trace_server_bindings` files that patch `weave.telemetry.trace_sentry.logger` (20 passed), the full `tests/durability/` directory which imports `log_warning` / `log_error` from `trace_sentry` (93 passed), and a sqlite-backed sample of `tests/trace/` (`test_dataset.py`, `test_anonymous_ops.py`, `test_call_behaviours.py` — 17 passed, 1 skipped). `uvx ruff check` is clean on both changed files.

## Backward compatibility

Default behavior (env var unset) is unchanged. No new public API, no new env var name, no signature changes, no removed code paths. Users who never set `WANDB_ERROR_REPORTING` see exactly the same Sentry behavior as before.