### PR TITLE
refactor(weave): contextvars batch state + CH pool env var

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -172,7 +172,7 @@ def _reset_server_state(server: ClickHouseTraceServer) -> None:
     # Reset file storage client so tests that mock env vars get a fresh client
     server._file_storage_client = None
     server._file_storage_client_initialized = False
-    # Reset batch queues (thread-local, for current thread)
+    # Reset batch queues (ContextVar-backed, scoped to the current task context).
     server._call_batch = []
     server._file_batch = []
     server._calls_complete_batch = []

--- a/tests/trace_server/test_clickhouse_batching.py
+++ b/tests/trace_server/test_clickhouse_batching.py
@@ -540,69 +540,66 @@ def test_obj_batch_mixed_projects_errors(trace_server, client):
         server.obj_create_batch(batch=batch)
 
 
-def test_call_batch_state_is_per_task_and_survives_to_thread():
-    """Batch state is per-asyncio-task via ContextVars.
-
-    Verifies three invariants of the ContextVar-backed batch state:
-    1. `call_batch()` resets state on entry so a parent task's prior appends
-       don't leak in (defensive init).
-    2. Two concurrent tasks each see their own batch list. With the old
-       `threading.local()` impl, both tasks ran on the same event loop
-       thread and silently shared a buffer.
-    3. State propagates correctly into `asyncio.to_thread`: appends made on
-       the executor thread are visible back in the calling coroutine.
-    """
+def test_call_batch_real_writes_are_per_task_and_survive_to_thread():
+    """Concurrent async call batches flush isolated real call_start rows."""
     mock_ch_client = MagicMock()
+    mock_ch_client.command.return_value = None
+    mock_ch_client.insert.return_value = MagicMock()
+
+    def fake_query(query: str, *args: Any, **kwargs: Any) -> MagicMock:
+        result = MagicMock()
+        if "project_ttl_settings" in query:
+            result.row_count = 0
+            return result
+        result.result_rows = [[0, 1]]  # legacy project: write to call_parts
+        return result
+
+    mock_ch_client.query.side_effect = fake_query
+
     with patch.object(
         ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
     ):
         server = ClickHouseTraceServer(host="test_host")
+        project_id = base64.b64encode(b"test_entity/contextvars_batch").decode("utf-8")
 
-    # This test only cares about batch-state isolation, not the flush path.
-    captured: dict[str, list[list[str]]] = {}
+        def make_req(label: str, suffix: str) -> tsi.CallStartReq:
+            return tsi.CallStartReq(
+                start=tsi.StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    op_name=f"{label}_{suffix}",
+                    started_at=datetime.datetime.now(datetime.timezone.utc),
+                    attributes={},
+                    inputs={},
+                )
+            )
 
-    def fake_flush(self: ClickHouseTraceServer) -> None:
-        # Snapshot the batch contents at flush time, keyed by the first column
-        # which we use as the task label below.
-        if self._call_batch:
-            captured[self._call_batch[0][0]] = list(self._call_batch)
+        async def write_three_calls(label: str) -> None:
+            with server.call_batch():
+                server.call_start(make_req(label, "a"))
+                # Old threading.local state leaked across concurrent tasks here.
+                await asyncio.sleep(0)
+                server.call_start(make_req(label, "b"))
+                # ContextVar state must also follow blocking work into executor threads.
+                await asyncio.to_thread(server.call_start, make_req(label, "c"))
 
-    async def task_appends(label: str) -> list[str]:
-        with server.call_batch():
-            server._call_batch.append([label, "a"])
-            # Yield control so the other task can run between appends.
-            await asyncio.sleep(0)
-            server._call_batch.append([label, "b"])
-            # Bounce through a worker thread and append from there. With
-            # ContextVars, the executor thread inherits the task's context
-            # and mutates the same list.
-            await asyncio.to_thread(server._call_batch.append, [label, "c"])
-            return [row[1] for row in server._call_batch]
+        async def driver() -> None:
+            await asyncio.gather(write_three_calls("X"), write_three_calls("Y"))
 
-    async def driver() -> tuple[list[str], list[str]]:
-        return await asyncio.gather(task_appends("X"), task_appends("Y"))
+        asyncio.run(driver())
 
-    with patch.object(
-        ClickHouseTraceServer,
-        "_flush_all_batches_in_order",
-        fake_flush,
-    ):
-        # Pre-pollute the outer context's batch to verify call_batch() resets on entry.
-        server._call_batch.append(["outer", "pollution"])
-        assert server._call_batch == [["outer", "pollution"]]
+    call_part_inserts = [
+        call
+        for call in mock_ch_client.insert.call_args_list
+        if call.args[0] == "call_parts"
+    ]
+    assert len(call_part_inserts) == 2
 
-        x_rows, y_rows = asyncio.run(driver())
+    op_name_batches = []
+    for insert_call in call_part_inserts:
+        op_name_idx = insert_call.kwargs["column_names"].index("op_name")
+        op_name_batches.append([row[op_name_idx] for row in insert_call.kwargs["data"]])
 
-    # Each task sees only its own appends -> ContextVar isolation works.
-    assert x_rows == ["a", "b", "c"]
-    assert y_rows == ["a", "b", "c"]
-
-    # Flush saw each task's complete batch independently.
-    assert captured["X"] == [["X", "a"], ["X", "b"], ["X", "c"]]
-    assert captured["Y"] == [["Y", "a"], ["Y", "b"], ["Y", "c"]]
-
-    # Outer context's pre-existing state is untouched by the inner tasks.
-    assert server._call_batch == [["outer", "pollution"]]
-
-    # Clear so __del__ doesn't try to flush the synthetic row at gc time.
-    server._call_batch = []
+    assert sorted(op_name_batches) == [
+        ["X_a", "X_b", "X_c"],
+        ["Y_a", "Y_b", "Y_c"],
+    ]

--- a/tests/trace_server/test_clickhouse_batching.py
+++ b/tests/trace_server/test_clickhouse_batching.py
@@ -4,6 +4,7 @@ This module verifies that multiple calls are properly batched into a single
 ClickHouse insert operation for performance optimization.
 """
 
+import asyncio
 import base64
 import datetime
 import json
@@ -537,3 +538,71 @@ def test_obj_batch_mixed_projects_errors(trace_server, client):
         match="obj_create_batch only supports updating a single project.",
     ):
         server.obj_create_batch(batch=batch)
+
+
+def test_call_batch_state_is_per_task_and_survives_to_thread():
+    """Batch state is per-asyncio-task via ContextVars.
+
+    Verifies three invariants of the ContextVar-backed batch state:
+    1. `call_batch()` resets state on entry so a parent task's prior appends
+       don't leak in (defensive init).
+    2. Two concurrent tasks each see their own batch list. With the old
+       `threading.local()` impl, both tasks ran on the same event loop
+       thread and silently shared a buffer.
+    3. State propagates correctly into `asyncio.to_thread`: appends made on
+       the executor thread are visible back in the calling coroutine.
+    """
+    mock_ch_client = MagicMock()
+    with patch.object(
+        ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = ClickHouseTraceServer(host="test_host")
+
+    # This test only cares about batch-state isolation, not the flush path.
+    captured: dict[str, list[list[str]]] = {}
+
+    def fake_flush(self: ClickHouseTraceServer) -> None:
+        # Snapshot the batch contents at flush time, keyed by the first column
+        # which we use as the task label below.
+        if self._call_batch:
+            captured[self._call_batch[0][0]] = list(self._call_batch)
+
+    async def task_appends(label: str) -> list[str]:
+        with server.call_batch():
+            server._call_batch.append([label, "a"])
+            # Yield control so the other task can run between appends.
+            await asyncio.sleep(0)
+            server._call_batch.append([label, "b"])
+            # Bounce through a worker thread and append from there. With
+            # ContextVars, the executor thread inherits the task's context
+            # and mutates the same list.
+            await asyncio.to_thread(server._call_batch.append, [label, "c"])
+            return [row[1] for row in server._call_batch]
+
+    async def driver() -> tuple[list[str], list[str]]:
+        return await asyncio.gather(task_appends("X"), task_appends("Y"))
+
+    with patch.object(
+        ClickHouseTraceServer,
+        "_flush_all_batches_in_order",
+        fake_flush,
+    ):
+        # Pre-pollute the outer context's batch to verify call_batch() resets on entry.
+        server._call_batch.append(["outer", "pollution"])
+        assert server._call_batch == [["outer", "pollution"]]
+
+        x_rows, y_rows = asyncio.run(driver())
+
+    # Each task sees only its own appends -> ContextVar isolation works.
+    assert x_rows == ["a", "b", "c"]
+    assert y_rows == ["a", "b", "c"]
+
+    # Flush saw each task's complete batch independently.
+    assert captured["X"] == [["X", "a"], ["X", "b"], ["X", "c"]]
+    assert captured["Y"] == [["Y", "a"], ["Y", "b"], ["Y", "c"]]
+
+    # Outer context's pre-existing state is untouched by the inner tasks.
+    assert server._call_batch == [["outer", "pollution"]]
+
+    # Clear so __del__ doesn't try to flush the synthetic row at gc time.
+    server._call_batch = []

--- a/tests/trace_server/test_trace_server_conftest.py
+++ b/tests/trace_server/test_trace_server_conftest.py
@@ -30,11 +30,15 @@ def test_skip_clickhouse_client(
 # _reset_server_state in conftest.py needs to reset it between tests.
 KNOWN_SERVER_ATTRS = frozenset(
     {
+        "_call_batch_var",
+        "_calls_complete_batch_var",
         "_database",
         "_database_ensured",
         "_evaluate_model_dispatcher",
+        "_file_batch_var",
         "_file_storage_client",
         "_file_storage_client_initialized",
+        "_flush_immediately_var",
         "_host",
         "_init_lock",
         "_kafka_producer",

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1,5 +1,6 @@
 # Clickhouse Trace Server
 
+import contextvars
 import dataclasses
 import datetime
 import json
@@ -306,7 +307,7 @@ logger.setLevel(logging.INFO)
 T = TypeVar("T")
 
 # ClickHouse connection pool settings
-CH_POOL_MAX_CONNECTIONS = 50
+CH_POOL_MAX_CONNECTIONS = wf_env.wf_clickhouse_pool_max_connections()
 CH_POOL_COUNT = 2
 
 # ClickHouse port defaults
@@ -359,7 +360,25 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         evaluate_model_dispatcher: EvaluateModelDispatcher | None = None,
     ):
         super().__init__()
+        # Thread-local storage for the ClickHouse client. `clickhouse-connect`
+        # Client instances are not safe to share across threads, so each OS
+        # thread gets its own (all sharing the same underlying HTTP pool).
         self._thread_local = threading.local()
+        # Per-asyncio-task batch state. ContextVars propagate into executor threads
+        # via `asyncio.to_thread`, unlike `threading.local`, so a `with self.call_batch():`
+        # block can safely span an `await`.
+        self._call_batch_var: contextvars.ContextVar[list[list[Any]] | None] = (
+            contextvars.ContextVar("ch_call_batch", default=None)
+        )
+        self._file_batch_var: contextvars.ContextVar[
+            list[FileChunkCreateCHInsertable] | None
+        ] = contextvars.ContextVar("ch_file_batch", default=None)
+        self._calls_complete_batch_var: contextvars.ContextVar[
+            list[list[Any]] | None
+        ] = contextvars.ContextVar("ch_calls_complete_batch", default=None)
+        self._flush_immediately_var: contextvars.ContextVar[bool] = (
+            contextvars.ContextVar("ch_flush_immediately", default=True)
+        )
         self._host = host
         self._port = port
         self._user = user
@@ -411,41 +430,47 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @property
     def _flush_immediately(self) -> bool:
-        return getattr(self._thread_local, "flush_immediately", True)
+        return self._flush_immediately_var.get()
 
     @_flush_immediately.setter
     def _flush_immediately(self, value: bool) -> None:
-        self._thread_local.flush_immediately = value
+        self._flush_immediately_var.set(value)
 
     @property
     def _call_batch(self) -> list[list[Any]]:
-        if not hasattr(self._thread_local, "call_batch"):
-            self._thread_local.call_batch = []
-        return self._thread_local.call_batch
+        batch = self._call_batch_var.get()
+        if batch is None:
+            batch = []
+            self._call_batch_var.set(batch)
+        return batch
 
     @_call_batch.setter
     def _call_batch(self, value: list[list[Any]]) -> None:
-        self._thread_local.call_batch = value
+        self._call_batch_var.set(value)
 
     @property
     def _file_batch(self) -> list[FileChunkCreateCHInsertable]:
-        if not hasattr(self._thread_local, "file_batch"):
-            self._thread_local.file_batch = []
-        return self._thread_local.file_batch
+        batch = self._file_batch_var.get()
+        if batch is None:
+            batch = []
+            self._file_batch_var.set(batch)
+        return batch
 
     @_file_batch.setter
     def _file_batch(self, value: list[FileChunkCreateCHInsertable]) -> None:
-        self._thread_local.file_batch = value
+        self._file_batch_var.set(value)
 
     @property
     def _calls_complete_batch(self) -> list[list[Any]]:
-        if not hasattr(self._thread_local, "calls_complete_batch"):
-            self._thread_local.calls_complete_batch = []
-        return self._thread_local.calls_complete_batch
+        batch = self._calls_complete_batch_var.get()
+        if batch is None:
+            batch = []
+            self._calls_complete_batch_var.set(batch)
+        return batch
 
     @_calls_complete_batch.setter
     def _calls_complete_batch(self, value: list[list[Any]]) -> None:
-        self._thread_local.calls_complete_batch = value
+        self._calls_complete_batch_var.set(value)
 
     @classmethod
     def from_env(cls, use_async_insert: bool = False, **kwargs: Any) -> Self:
@@ -765,8 +790,17 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @contextmanager
     def call_batch(self) -> Iterator[None]:
-        """Batch call operations and flush them all at the end."""
-        # Not thread safe - do not use across threads
+        """Batch call operations and flush them all at the end.
+
+        Batch state is per-asyncio-task via ContextVars and is safe across
+        `asyncio.to_thread` hops within a single task. Concurrent tasks each
+        observe their own independent batches.
+        """
+        # Bind fresh batches to the current context so we don't inherit a parent
+        # task's mid-flight state and so child contexts are isolated.
+        self._file_batch = []
+        self._call_batch = []
+        self._calls_complete_batch = []
         self._flush_immediately = False
         try:
             yield

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -246,6 +246,11 @@ def wf_clickhouse_use_distributed_tables() -> bool:
     )
 
 
+def wf_clickhouse_pool_max_connections() -> int:
+    """Max connections in the shared urllib3 pool used by `clickhouse-connect`."""
+    return int(os.environ.get("WF_CLICKHOUSE_POOL_MAX_CONNECTIONS", "100"))
+
+
 VALID_CALLS_SHARD_KEYS = frozenset({"trace_id", "id", "project_id"})
 
 


### PR DESCRIPTION
## Summary
- Swap `threading.local()` to per-instance `contextvars.ContextVar`s for the three call/file/calls_complete batch buffers and `_flush_immediately`. ContextVars propagate into executor threads via `asyncio.to_thread`, so a `with self.call_batch():` block can safely span an `await` without losing buffer state.
- The CH client itself stays thread-local (`clickhouse-connect` Clients aren't thread-safe to share).
- Adds `WF_CLICKHOUSE_POOL_MAX_CONNECTIONS` env var (default 100, was 50) to support higher CH concurrency once async handlers land in `core`.
- This unblocks the upcoming async migration of write-path FastAPI handlers (`/call/upsert_batch`, etc.) without silent batch corruption.

## Testing
new regression test runs two concurrent `asyncio.Task`s, each entering `call_batch()` and appending across `await` boundaries and `asyncio.to_thread`, then asserts each task's batch stays isolated and the outer context's state survives. previously the `threading.local` impl would clobber both buffers since both tasks share an event-loop thread.