### PR TITLE
fix(weave): drop setup_git step from bump_version workflow

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -35,10 +35,6 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
-      - id: setup_git
-        run: |
-          git config --global user.name 'Weave Build Bot'
-          git config --global user.email weave@wandb.com
       - id: install_bump
         run: pip install --upgrade bump-my-version
       - id: drop_pre_release


### PR DESCRIPTION
## Summary
- Remove the `setup_git` step that set `user.name` / `user.email` globally to `Weave Build Bot` / `weave@wandb.com`.
- The override caused commits to be attributed to the wrong identity instead of the GitHub App token's identity from the `WANDBOT_3000` app.

## Test plan
- [ ] Run the `bump-python-sdk-version` workflow via `workflow_dispatch` and verify the resulting commits + tag are attributed to the GitHub App identity rather than `Weave Build Bot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)