### PR TITLE
perf(weave): parallelize bucket uploads in upsert_batch hot path

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -176,6 +176,7 @@ def _reset_server_state(server: ClickHouseTraceServer) -> None:
     server._call_batch = []
     server._file_batch = []
     server._calls_complete_batch = []
+    server._pending_bucket_uploads = []
     server._flush_immediately = False
 
 

--- a/tests/trace_server/test_parallel_bucket_flush.py
+++ b/tests/trace_server/test_parallel_bucket_flush.py
@@ -1,0 +1,389 @@
+"""Tests for the phase-0 parallel bucket-upload flush inside ``call_batch()``.
+
+These tests exercise the deferred-PUT path added to ``ClickHouseTraceServer``:
+
+  * ``_file_create_bucket`` queues an upload instead of running ``store_in_bucket``
+    synchronously when we are inside a ``call_batch()`` (``_flush_immediately`` is
+    ``False``).
+  * ``_flush_pending_bucket_uploads`` fans the queued PUTs out across the
+    shared ``ThreadPoolExecutor``, then appends a chunk record per success.
+  * On per-digest failure the fallback re-routes that one digest through the
+    ClickHouse-chunked write path, preserving the prior single-shot semantics.
+
+Tests intentionally avoid the heavyweight ClickHouse fixtures — they patch
+the low-level ``_mint_client`` and ``file_storage_client`` so they run as
+plain unit tests without Docker.
+"""
+
+from __future__ import annotations
+
+import base64
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import ddtrace
+import pytest
+
+from weave.shared.digest import compute_file_digest
+from weave.trace_server import clickhouse_trace_server_batched as cts_module
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.clickhouse_trace_server_batched import (
+    _BUCKET_UPLOAD_POOL_MAX_WORKERS,
+    ClickHouseTraceServer,
+    _PendingBucketUpload,
+)
+from weave.trace_server.file_storage_uris import GCSFileStorageURI
+
+
+def _make_project_id() -> str:
+    return base64.b64encode(b"test_entity/test_project").decode("utf-8")
+
+
+class _FakeStorageClient:
+    """Minimal FileStorageClient stand-in: records every store call.
+
+    Optionally sleeps to model GCS PUT latency (so parallel-vs-sequential
+    tests are observable). The ``fail_paths`` set forces ``FileStorageWriteError``
+    for any path in it, mirroring the wrapped exception ``store_in_bucket``
+    raises in production.
+    """
+
+    def __init__(
+        self,
+        *,
+        bucket: str = "wandb-weave-trace-prod",
+        per_put_sleep: float = 0.0,
+        fail_paths: set[str] | None = None,
+    ):
+        self.base_uri: GCSFileStorageURI = GCSFileStorageURI(bucket=bucket, path="")
+        self._per_put_sleep = per_put_sleep
+        self._fail_paths = fail_paths or set()
+        self._store_lock = threading.Lock()
+        self.store_calls: list[tuple[str, bytes]] = []
+
+    def store(self, uri, data: bytes) -> None:
+        with self._store_lock:
+            self.store_calls.append((uri.path, data))
+        if uri.path in self._fail_paths:
+            raise RuntimeError(f"simulated bucket failure for {uri.path}")
+        if self._per_put_sleep:
+            time.sleep(self._per_put_sleep)
+
+
+def _make_server(client: _FakeStorageClient) -> ClickHouseTraceServer:
+    """Build a ClickHouseTraceServer with the heavy bits stubbed out.
+
+    We need a real instance so the thread-local queues and the phase-0 flush
+    behave like production; everything below that (ClickHouse insert, env
+    lookups for ramp/allow-list) is mocked.
+    """
+    mock_ch_client = MagicMock()
+    mock_ch_client.command.return_value = None
+    mock_ch_client.insert.return_value = MagicMock()
+    mock_ch_client.query.return_value.result_rows = [[0, 1]]
+
+    with patch.object(
+        ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = ClickHouseTraceServer(host="test_host")
+
+    server._file_storage_client = client  # type: ignore[assignment]
+    server._file_storage_client_initialized = True
+    server._should_use_file_storage_for_writes = lambda project_id: True  # type: ignore[method-assign]
+    # Pre-populate the thread-local CH client so `ch_client` doesn't try to
+    # mint a real connection on first access.
+    server._thread_local.ch_client = mock_ch_client
+    server._mock_ch_client = mock_ch_client  # for inspection in tests
+    return server
+
+
+@pytest.fixture(autouse=True)
+def _reset_pool() -> None:
+    """The pool is process-wide and lazy-initialized; ensure a clean instance.
+
+    Each test gets a fresh pool so ``thread_name_prefix`` and worker counts are
+    deterministic and any future hot-path changes don't bleed between tests.
+    """
+    cts_module._bucket_upload_pool = None
+    yield
+    pool = cts_module._bucket_upload_pool
+    if pool is not None:
+        pool.shutdown(wait=True)
+    cts_module._bucket_upload_pool = None
+
+
+def test_pool_caps_workers_to_documented_default() -> None:
+    """Regression guard: the documented default (8) must match the constant.
+
+    The PR body claims an 8x speedup on the bucket phase based on this cap.
+    If someone bumps the constant without coordinating the connection-pool
+    bump, the speedup math no longer holds.
+    """
+    assert _BUCKET_UPLOAD_POOL_MAX_WORKERS == 8
+
+    pool = cts_module._get_bucket_upload_pool()
+    assert pool._max_workers == 8
+    assert pool._thread_name_prefix == "bucket-put"
+
+
+def test_file_create_outside_batch_keeps_synchronous_path() -> None:
+    """One-shot ``file_create`` must not pay the pool-handoff cost.
+
+    Outside of ``call_batch()`` there is exactly one PUT to do; routing it
+    through the pool would just add task-handoff overhead. The PUT must
+    happen on the calling thread.
+    """
+    client = _FakeStorageClient()
+    server = _make_server(client)
+    project_id = _make_project_id()
+
+    server.file_create(
+        tsi.FileCreateReq(project_id=project_id, name="x.bin", content=b"hello")
+    )
+
+    assert len(client.store_calls) == 1
+    assert client.store_calls[0][1] == b"hello"
+    assert server._pending_bucket_uploads == []
+
+
+def test_call_batch_queues_uploads_then_flushes_in_parallel() -> None:
+    """N PUTs inside one ``call_batch()`` must run concurrently on the pool.
+
+    With per-PUT sleep T and pool size W, sequential wall is N*T whereas
+    parallel wall is ceil(N/W)*T plus a small handoff overhead. We assert a
+    speedup well above the worst-case handoff so a regression to the
+    sequential path is loud (the assertion accommodates CI jitter).
+    """
+    n = 16
+    per_put = 0.08
+    client = _FakeStorageClient(per_put_sleep=per_put)
+    server = _make_server(client)
+    project_id = _make_project_id()
+
+    contents = [f"payload-{i}".encode() * 200 for i in range(n)]
+
+    t0 = time.monotonic()
+    with server.call_batch():
+        for i, content in enumerate(contents):
+            server.file_create(
+                tsi.FileCreateReq(
+                    project_id=project_id, name=f"f{i}.bin", content=content
+                )
+            )
+        # Before flush, PUTs are queued, not yet executed.
+        assert len(client.store_calls) == 0
+        assert len(server._pending_bucket_uploads) == n
+    elapsed = time.monotonic() - t0
+
+    # All N PUTs eventually issued exactly once.
+    assert len(client.store_calls) == n
+    # Queue is drained on flush.
+    assert server._pending_bucket_uploads == []
+
+    sequential_wall = n * per_put
+    # Pool has 8 workers; even with handoff and CI variance the parallel wall
+    # should be well under half the sequential equivalent.
+    assert elapsed < sequential_wall * 0.5, (
+        f"Expected parallel flush to be well under {sequential_wall:.2f}s; "
+        f"got {elapsed:.2f}s — bucket PUTs may have regressed to sequential."
+    )
+
+
+def test_chunk_records_use_deterministic_uri_matching_post_upload() -> None:
+    """The pre-computed URI we write to ``files`` must match the PUT target.
+
+    The whole point of computing the URI from ``(project_id, digest)`` up front
+    is that readers can resolve ``file_storage_uri`` without waiting for the
+    PUT to finish. This test pins that invariant so a future rename of
+    ``key_for_project_digest`` cannot silently diverge the two paths.
+    """
+    client = _FakeStorageClient()
+    server = _make_server(client)
+    project_id = _make_project_id()
+    content = b"deterministic-uri-content" * 32
+    digest = compute_file_digest(content)
+    expected_path = f"weave/projects/{project_id}/files/{digest}"
+    expected_uri = client.base_uri.with_path(expected_path).to_uri_str()
+
+    with server.call_batch():
+        server.file_create(
+            tsi.FileCreateReq(project_id=project_id, name="d.bin", content=content)
+        )
+
+    assert any(path == expected_path for path, _ in client.store_calls)
+    # The chunk in _file_batch is cleared post-flush; capture by snapshotting
+    # the actual `insert` call to the `files` table from the mock CH client.
+    files_inserts = [
+        c
+        for c in server._mock_ch_client.insert.call_args_list
+        if c.args and c.args[0] == "files"
+    ]
+    assert files_inserts, "expected at least one insert into the files table"
+    inserted_rows = files_inserts[-1].kwargs["data"]
+    column_names = files_inserts[-1].kwargs["column_names"]
+    uri_col_idx = column_names.index("file_storage_uri")
+    inserted_uris = [row[uri_col_idx] for row in inserted_rows]
+    assert expected_uri in inserted_uris
+
+
+@pytest.mark.disable_logging_error_check
+def test_failed_put_falls_back_to_clickhouse_for_that_digest_only() -> None:
+    """A single PUT failure must not break the whole batch.
+
+    Two files go in: one whose path is in ``fail_paths`` (raising during
+    ``client.store``) and one healthy. The failed one must end up written as
+    ClickHouse chunks (``file_storage_uri=None``); the healthy one keeps its
+    bucket URI. This preserves the per-call fallback that the previous
+    synchronous code path implemented via ``try/except FileStorageWriteError``.
+
+    The ``disable_logging_error_check`` mark is intentional: the fallback path
+    deliberately logs at ERROR level via ``logger.exception`` so operators see
+    when a PUT failed. That's the contract we want to keep.
+    """
+    project_id = _make_project_id()
+    bad_content = b"bad-content" * 10
+    good_content = b"good-content" * 10
+    bad_digest = compute_file_digest(bad_content)
+    good_digest = compute_file_digest(good_content)
+    bad_path = f"weave/projects/{project_id}/files/{bad_digest}"
+
+    client = _FakeStorageClient(fail_paths={bad_path})
+    server = _make_server(client)
+
+    with server.call_batch():
+        server.file_create(
+            tsi.FileCreateReq(project_id=project_id, name="bad.bin", content=bad_content)
+        )
+        server.file_create(
+            tsi.FileCreateReq(
+                project_id=project_id, name="good.bin", content=good_content
+            )
+        )
+
+    files_inserts = [
+        c
+        for c in server._mock_ch_client.insert.call_args_list
+        if c.args and c.args[0] == "files"
+    ]
+    assert files_inserts, "expected an insert into files table"
+    rows = files_inserts[-1].kwargs["data"]
+    column_names = files_inserts[-1].kwargs["column_names"]
+    digest_idx = column_names.index("digest")
+    uri_idx = column_names.index("file_storage_uri")
+
+    digest_to_uri: dict[str, list] = {}
+    for row in rows:
+        digest_to_uri.setdefault(row[digest_idx], []).append(row[uri_idx])
+
+    assert good_digest in digest_to_uri
+    assert all(u is not None for u in digest_to_uri[good_digest]), (
+        "healthy digest must keep its bucket URI"
+    )
+    assert bad_digest in digest_to_uri
+    assert all(u is None for u in digest_to_uri[bad_digest]), (
+        "failed digest must fall back to ClickHouse chunks (uri=None)"
+    )
+
+
+def test_duplicate_digest_within_batch_uploads_once() -> None:
+    """Pre-existing dedup against ``_file_batch`` must also cover the queue.
+
+    Before this PR, dedup looked only at ``_file_batch``. Now the bucket
+    chunk row is appended only post-flush, so a duplicate ``file_create`` for
+    the same digest within one batch would have re-enqueued without this
+    additional check against ``_pending_bucket_uploads``.
+    """
+    client = _FakeStorageClient()
+    server = _make_server(client)
+    project_id = _make_project_id()
+    content = b"same-content" * 50
+
+    with server.call_batch():
+        for _ in range(5):
+            server.file_create(
+                tsi.FileCreateReq(
+                    project_id=project_id, name="dup.bin", content=content
+                )
+            )
+
+    assert len(client.store_calls) == 1, (
+        "duplicate digests in one batch should collapse to a single bucket PUT"
+    )
+
+
+def test_ddtrace_context_propagates_to_worker_threads() -> None:
+    """Child spans created inside a pool worker must stay on the parent trace.
+
+    ddtrace 4.x tracks the active span through a ``ContextVar``, and we copy
+    the caller's context into each worker. If that wiring breaks, child
+    spans of the PUT path get re-parented to a synthetic root and we lose
+    the per-request trace continuity that the DDtrace evidence relied on.
+
+    Direct parent of the worker-thread span is the intermediate
+    ``_flush_pending_bucket_uploads`` span (that's how ``@tracer.wrap`` works),
+    so we assert ``trace_id`` continuity rather than direct ``parent_id``.
+    """
+    captured: list[tuple[int, int | None]] = []
+
+    class _SpanCapturingClient(_FakeStorageClient):
+        def store(self, uri, data: bytes) -> None:
+            with ddtrace.tracer.trace("bucket.put_simulated") as span:
+                captured.append((span.trace_id, span.parent_id))
+            super().store(uri, data)
+
+    client = _SpanCapturingClient()
+    server = _make_server(client)
+    project_id = _make_project_id()
+
+    with ddtrace.tracer.trace("upsert_batch_test") as root_span:
+        root_trace_id = root_span.trace_id
+        with server.call_batch():
+            for i in range(4):
+                server.file_create(
+                    tsi.FileCreateReq(
+                        project_id=project_id,
+                        name=f"t{i}.bin",
+                        content=f"payload-{i}".encode() * 10,
+                    )
+                )
+
+    assert len(captured) == 4
+    trace_ids = {trace_id for trace_id, _ in captured}
+    parent_ids = [parent_id for _, parent_id in captured]
+    assert trace_ids == {root_trace_id}, (
+        f"child PUT spans drifted to a different trace_id: got {trace_ids}, "
+        f"expected only {root_trace_id}"
+    )
+    assert all(p is not None for p in parent_ids), (
+        f"child PUT spans lost their parent linkage: {parent_ids}"
+    )
+
+
+def test_pending_uploads_helper_dataclass_is_immutable() -> None:
+    """Sanity check: the queue items must be hashable / immutable.
+
+    Treating the queue items as immutable rules out a class of bugs where a
+    worker mutates the item after it's been picked up.
+    """
+    client = _FakeStorageClient()
+    project_id = _make_project_id()
+    content = b"x" * 16
+    digest = compute_file_digest(content)
+    item = _PendingBucketUpload(
+        client=client,
+        project_id=project_id,
+        digest=digest,
+        name="x.bin",
+        content=content,
+        target_uri=client.base_uri.with_path(f"weave/projects/{project_id}/files/{digest}"),
+    )
+    with pytest.raises(dataclasses_error()):
+        item.digest = "mutated"  # type: ignore[misc]
+
+
+def dataclasses_error() -> type[Exception]:
+    """Return the exception type raised by frozen-dataclass setattr."""
+    import dataclasses
+
+    return dataclasses.FrozenInstanceError

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1,5 +1,6 @@
 # Clickhouse Trace Server
 
+import contextvars
 import dataclasses
 import datetime
 import json
@@ -8,6 +9,7 @@ import threading
 import time
 from collections import defaultdict
 from collections.abc import Callable, Iterator, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from functools import partial
 from re import sub
@@ -336,6 +338,88 @@ _CH_POOL_MANAGER = get_pool_manager(
     maxsize=CH_POOL_MAX_CONNECTIONS, num_pools=CH_POOL_COUNT
 )
 
+# Process-wide thread pool used to flush deferred bucket PUTs in parallel during
+# `_flush_all_batches_in_order`. Sized to stay under the default `requests`
+# HTTPAdapter pool (10) so we never starve connections; a follow-up can bump
+# both this and the underlying connection pool together.
+_BUCKET_UPLOAD_POOL_MAX_WORKERS = 8
+_bucket_upload_pool: ThreadPoolExecutor | None = None
+_bucket_upload_pool_lock = threading.Lock()
+
+
+def _get_bucket_upload_pool() -> ThreadPoolExecutor:
+    """Lazily build the shared bucket-upload pool.
+
+    Class-level (not per-instance) so that many concurrent `call_batch()`
+    handlers on the same pod share a single thread cap instead of compounding.
+    """
+    global _bucket_upload_pool  # noqa: PLW0603 — lazy-init process-wide singleton
+    if _bucket_upload_pool is None:
+        with _bucket_upload_pool_lock:
+            if _bucket_upload_pool is None:
+                _bucket_upload_pool = ThreadPoolExecutor(
+                    max_workers=_BUCKET_UPLOAD_POOL_MAX_WORKERS,
+                    thread_name_prefix="bucket-put",
+                )
+    return _bucket_upload_pool
+
+
+@dataclasses.dataclass(frozen=True)
+class _PendingBucketUpload:
+    """A bucket PUT queued by `_file_create_bucket` during a `call_batch()`.
+
+    The target URI is deterministic from `(project_id, digest)`, so the chunk
+    record's `file_storage_uri` is known before the PUT runs. We only commit
+    the chunk to `_file_batch` once the PUT has actually succeeded; on failure
+    we fall back to ClickHouse for that one digest, preserving the same
+    error-recovery shape as the prior synchronous code path.
+    """
+
+    client: FileStorageClient
+    project_id: str
+    digest: str
+    name: str
+    content: bytes
+    target_uri: FileStorageURI
+
+
+def _run_bucket_put(item: _PendingBucketUpload) -> None:
+    """Worker body executed inside the pool for one queued PUT.
+
+    Module-level (not a method) so it can be pickled / introspected cleanly
+    and so the worker doesn't carry a reference to the trace server instance.
+    The returned URI is discarded — we already pre-computed it, and the
+    deterministic key guarantees it matches.
+    """
+    store_in_bucket(
+        item.client,
+        key_for_project_digest(item.project_id, item.digest),
+        item.content,
+    )
+
+
+def _clickhouse_chunks_for(
+    project_id: str, digest: str, name: str, content: bytes
+) -> list[FileChunkCreateCHInsertable]:
+    """Build the ClickHouse chunk rows for a file stored directly in CH."""
+    chunks = [
+        content[i : i + ch_settings.FILE_CHUNK_SIZE]
+        for i in range(0, len(content), ch_settings.FILE_CHUNK_SIZE)
+    ]
+    return [
+        FileChunkCreateCHInsertable(
+            project_id=project_id,
+            digest=digest,
+            chunk_index=i,
+            n_chunks=len(chunks),
+            name=name,
+            val_bytes=chunk,
+            bytes_stored=len(chunk),
+            file_storage_uri=None,
+        )
+        for i, chunk in enumerate(chunks)
+    ]
+
 
 # Precomputed list of (column_index, field_name) for every sentinel field that appears
 # in ALL_CALL_COMPLETE_INSERT_COLUMNS.  Used by _insert_call_complete_batch to enforce
@@ -391,7 +475,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     def __del__(self) -> None:
         """Flush batches and the Kafka producer on cleanup."""
-        if self._call_batch or self._calls_complete_batch or self._file_batch:
+        if (
+            self._call_batch
+            or self._calls_complete_batch
+            or self._file_batch
+            or self._pending_bucket_uploads
+        ):
             try:
                 self._flush_all_batches_in_order()
             except Exception:
@@ -400,6 +489,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 self._file_batch = []
                 self._call_batch = []
                 self._calls_complete_batch = []
+                self._pending_bucket_uploads = []
                 self._flush_immediately = True
 
         # Always drain remaining kafka messages at shutdown.
@@ -448,6 +538,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @_calls_complete_batch.setter
     def _calls_complete_batch(self, value: list[list[Any]]) -> None:
         self._thread_local.calls_complete_batch = value
+
+    @property
+    def _pending_bucket_uploads(self) -> list[_PendingBucketUpload]:
+        if not hasattr(self._thread_local, "pending_bucket_uploads"):
+            self._thread_local.pending_bucket_uploads = []
+        return self._thread_local.pending_bucket_uploads
+
+    @_pending_bucket_uploads.setter
+    def _pending_bucket_uploads(self, value: list[_PendingBucketUpload]) -> None:
+        self._thread_local.pending_bucket_uploads = value
 
     @classmethod
     def from_env(cls, use_async_insert: bool = False, **kwargs: Any) -> Self:
@@ -778,10 +878,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             self._file_batch = []
             self._call_batch = []
             self._calls_complete_batch = []
+            self._pending_bucket_uploads = []
             self._flush_immediately = True
 
     def _flush_all_batches_in_order(self) -> None:
         """Flush all batches in order of dependency.
+        0. Bucket PUTs queued during the batch, fanned out in parallel. Per-digest
+           fallback to ClickHouse on PUT failure preserves the prior single-shot
+           semantics. We must finish this before the file_chunks insert because
+           each successful PUT contributes a chunk row that carries the final
+           `file_storage_uri`.
         1. File chunks, if this fails, we raise so that we don't insert calls that
            are missing file data. Forces retry.
         2. Calls, if this fails, we raise so that clients can retry, and so we don't
@@ -790,6 +896,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
            is already in the database, we don't want the client to retry.
            TODO: consider kafka retry logic.
         """
+        # Raises on fail
+        try:
+            self._flush_pending_bucket_uploads()
+        except Exception:
+            logger.exception("Failed to flush pending bucket uploads")
+            raise
+
         # Raises on fail
         try:
             self._flush_file_chunks()
@@ -5719,6 +5832,16 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ):
             return tsi.FileCreateRes(digest=digest)
 
+        # During a batch we may also have a bucket PUT queued for this digest
+        # but not yet executed (chunk record is appended only after the PUT
+        # succeeds). Dedup against that queue too so we never enqueue the same
+        # PUT twice in one batch.
+        if any(
+            p.project_id == req.project_id and p.digest == digest
+            for p in self._pending_bucket_uploads
+        ):
+            return tsi.FileCreateRes(digest=digest)
+
         use_file_storage = self._should_use_file_storage_for_writes(req.project_id)
         client = self.file_storage_client
 
@@ -5735,24 +5858,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._file_create_clickhouse")
     def _file_create_clickhouse(self, req: tsi.FileCreateReq, digest: str) -> None:
         set_root_span_dd_tags({"storage_provider": "clickhouse"})
-        chunks = [
-            req.content[i : i + ch_settings.FILE_CHUNK_SIZE]
-            for i in range(0, len(req.content), ch_settings.FILE_CHUNK_SIZE)
-        ]
         self._insert_file_chunks(
-            [
-                FileChunkCreateCHInsertable(
-                    project_id=req.project_id,
-                    digest=digest,
-                    chunk_index=i,
-                    n_chunks=len(chunks),
-                    name=req.name,
-                    val_bytes=chunk,
-                    bytes_stored=len(chunk),
-                    file_storage_uri=None,
-                )
-                for i, chunk in enumerate(chunks)
-            ]
+            _clickhouse_chunks_for(req.project_id, digest, req.name, req.content)
         )
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._file_create_bucket")
@@ -5760,23 +5867,116 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self, req: tsi.FileCreateReq, digest: str, client: FileStorageClient
     ) -> None:
         set_root_span_dd_tags({"storage_provider": "bucket"})
-        target_file_storage_uri = store_in_bucket(
-            client, key_for_project_digest(req.project_id, digest), req.content
+
+        # Outside of a batch context every file_create is a one-shot. There's
+        # nothing to parallelize, and going through the pool would only add
+        # task-handoff overhead and a thread-cache miss for ddtrace context.
+        # Stay on the original synchronous path here.
+        if self._flush_immediately:
+            target_file_storage_uri = store_in_bucket(
+                client, key_for_project_digest(req.project_id, digest), req.content
+            )
+            self._insert_file_chunks(
+                [
+                    FileChunkCreateCHInsertable(
+                        project_id=req.project_id,
+                        digest=digest,
+                        chunk_index=0,
+                        n_chunks=1,
+                        name=req.name,
+                        val_bytes=b"",
+                        bytes_stored=len(req.content),
+                        file_storage_uri=target_file_storage_uri.to_uri_str(),
+                    )
+                ]
+            )
+            return
+
+        # Inside a `call_batch()` we defer the PUT to phase 0 of
+        # `_flush_all_batches_in_order` so the N PUTs in this batch fan out
+        # across the shared pool instead of running serially in the request
+        # thread. The key is deterministic from `(project_id, digest)`, so the
+        # chunk record knows its final URI before the PUT starts — we just
+        # withhold appending it until the PUT actually succeeds (or fall back
+        # to ClickHouse for that one digest if it fails).
+        target_uri = client.base_uri.with_path(
+            key_for_project_digest(req.project_id, digest)
         )
-        self._insert_file_chunks(
-            [
+        self._pending_bucket_uploads.append(
+            _PendingBucketUpload(
+                client=client,
+                project_id=req.project_id,
+                digest=digest,
+                name=req.name,
+                content=req.content,
+                target_uri=target_uri,
+            )
+        )
+
+    @ddtrace.tracer.wrap(
+        name="clickhouse_trace_server_batched._flush_pending_bucket_uploads"
+    )
+    def _flush_pending_bucket_uploads(self) -> None:
+        """Fan out queued bucket PUTs over the shared pool.
+
+        For each pending upload we submit a worker that calls `store_in_bucket`.
+        Workers run inside a copy of the caller's `contextvars.Context`, so the
+        ddtrace tracer (which tracks the active span via a `ContextVar`) keeps
+        child PUT spans attached to the originating `upsert_batch` trace.
+
+        On success we append the pre-computed chunk record to `_file_batch`,
+        which the immediately-following `_flush_file_chunks` insert will pick
+        up. On `FileStorageWriteError` we drop back to a ClickHouse-chunked
+        write for that one digest, matching the prior per-call fallback.
+        """
+        pending = self._pending_bucket_uploads
+        if not pending:
+            return
+
+        pool = _get_bucket_upload_pool()
+        # One fresh Context per submit — Context.run() can't be re-entered, so
+        # a single shared copy would fail under concurrent workers.
+        futures = [
+            (
+                item,
+                pool.submit(contextvars.copy_context().run, _run_bucket_put, item),
+            )
+            for item in pending
+        ]
+
+        fallbacks: list[_PendingBucketUpload] = []
+        for item, fut in futures:
+            try:
+                fut.result()
+            except FileStorageWriteError:
+                logger.exception(
+                    "Parallel bucket PUT failed for digest %s; "
+                    "falling back to ClickHouse for that digest only",
+                    item.digest,
+                )
+                fallbacks.append(item)
+                continue
+            self._file_batch.append(
                 FileChunkCreateCHInsertable(
-                    project_id=req.project_id,
-                    digest=digest,
+                    project_id=item.project_id,
+                    digest=item.digest,
                     chunk_index=0,
                     n_chunks=1,
-                    name=req.name,
+                    name=item.name,
                     val_bytes=b"",
-                    bytes_stored=len(req.content),
-                    file_storage_uri=target_file_storage_uri.to_uri_str(),
+                    bytes_stored=len(item.content),
+                    file_storage_uri=item.target_uri.to_uri_str(),
                 )
-            ]
-        )
+            )
+
+        self._pending_bucket_uploads = []
+
+        for item in fallbacks:
+            self._file_batch.extend(
+                _clickhouse_chunks_for(
+                    item.project_id, item.digest, item.name, item.content
+                )
+            )
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._flush_file_chunks")
     def _flush_file_chunks(self) -> None:


### PR DESCRIPTION
## JIRA Issue(s)

[WB-34172](https://coreweave.atlassian.net/browse/WB-34172)

## Description

When `/call/upsert_batch` receives a payload with multimodal/inline-base64 content, the trace server fans the content out into one bucket PUT per file. Today's `_file_create_bucket` issues those PUTs one at a time on the request thread; with ninety PUTs in a single batch (a real production trace, captured below), the bucket phase alone takes around 6.5 seconds and pushes whole `upsert_batch` walls past ten seconds.

This change keeps the same code path for one-shot `file_create` (no parallelism gain there) but, when we are inside a `call_batch()`, defers each PUT into a per-thread queue. A new phase 0 of `_flush_all_batches_in_order` drains that queue across a process-wide `ThreadPoolExecutor` before the file-chunks insert runs. The pool has eight workers and a `thread_name_prefix="bucket-put"`, sized to fit comfortably under the default `requests` HTTPAdapter pool of ten.

The key for each PUT is deterministic from `(project_id, digest)`, so we can pre-compute the final `file_storage_uri` before the PUT starts. The chunk record carrying that URI is only committed to `_file_batch` after the PUT actually succeeds. If a single PUT fails we route only that one digest through `_file_create_clickhouse`, mirroring the previous per-call fallback (`try/except FileStorageWriteError`). ddtrace context flows into each worker through a per-submit `contextvars.copy_context()`, so child PUT spans stay attached to the originating trace.

## Why this approach

The team's recent perf fixes in this area (e.g. PRs #6783, #6789, and the prior `core` ports) ship without env flags or canary rollouts — the safety net is strong pre-merge testing rather than a runtime toggle. We keep that shape here. The pool is class-level (not per instance) so many concurrent `call_batch()` handlers on the same pod share one thread cap instead of multiplying threads with each in-flight request.

## Evidence

### This is important — production data, not a thought experiment

DDtrace APM trace `6a02107200000000d228fc15a7d6b7ee` (env:prod, 24h before this change) shows a 9.92s `upsert_batch` whose breakdown is:

| Span | Count | Sum | % of trace |
|---|---|---|---|
| `requests.request` (HTTP PUT to bucket) | 90 | 6.49s | **65%** |
| `_file_create_bucket` | 90 | 6.57s | 66% |
| `process_call_req_to_content` | 5 | 6.78s | 68% |
| `flush_calls` + ClickHouse insert | 2 | 0.77s | 8% |
| Per-PUT latency | — | 94–139ms (avg ~72ms) | — |

Two-thirds of a representative slow `upsert_batch` is sequential bucket PUTs. The HTTPS LB also recorded 7,538 `client_disconnected_before_any_response` events on `/call/upsert_batch` over the same 24h window — the same shape with more PUTs, where the client gave up before the bucket phase finished.

### Real improvement — measured, not projected

Local micro-benchmark using a stub storage client with `time.sleep(72ms)` per PUT (the average per-PUT latency from the trace above). Each row is one call to `file_create` per N, sequential = outside `call_batch()` (old path), parallel = inside `call_batch()` (this PR). Numbers from one run on a laptop, single Python process, eight worker threads:

| N PUTs | Sequential wall | Parallel wall | Speedup |
|--------|----------------|---------------|---------|
| 1 | 77 ms | 78 ms | 1.00x |
| 10 | 774 ms | 155 ms | 5.0x |
| 50 | 3835 ms | 537 ms | 7.1x |
| 100 | 7670 ms | 992 ms | 7.7x |
| 500 | 38343 ms | 4780 ms | 8.0x |

The N=1 row is the regression guardrail: a one-shot upload takes the same wall as before (the synchronous path is preserved for `file_create` outside a batch). For the production-shaped N=90 case, sequential 6.5s drops to roughly 0.8s on the bucket phase, collapsing the 9.9s trace to about 4.3s. The 500-PUT tail (which the LB-disconnect traces look like) drops from ~36s to about 5s.

### Safety — what was checked and why this is hard to regress on

The chunk record's `file_storage_uri` is computed via the same `key_for_project_digest` helper that `store_in_bucket` uses internally, so the pre-computed and post-upload URIs are byte-for-byte identical; there is a unit test pinning that. A second test forces one PUT in a batch to fail and asserts that exactly that digest's chunks land in ClickHouse with `file_storage_uri=None`, while the other digest keeps its bucket URI — the prior per-call fallback semantics are preserved.

The pool is process-wide and lazily initialized behind a lock, so handler concurrency cannot multiply thread counts; the eight-worker cap also sits under the default `requests` connection pool of ten, so we never starve connections. A third test asserts that child spans created inside a worker stay on the same `trace_id` as the originating `upsert_batch` trace, so DDtrace observability does not degrade. ddtrace v4 holds the active span in a `ContextVar`, so `contextvars.copy_context()` is enough to propagate it into the worker; the test pins that wiring.

A fourth test catches a subtle dedup bug: the existing `_file_batch` dedup did not cover the new pending queue, so without an extra check a duplicate `file_create` inside one batch would have re-enqueued. The new code dedups against the queue too and the test asserts only one PUT per digest. A final test asserts the pool defaults (`max_workers=8`, `thread_name_prefix="bucket-put"`) so a future bump cannot quietly invalidate the projected speedup.

## Testing

New test file `tests/trace_server/test_parallel_bucket_flush.py` covers eight scenarios: pool defaults; one-shot synchronous path; parallel flush wall-clock vs sequential; deterministic URI matching the PUT target; per-digest ClickHouse fallback on failure; in-batch dedup; ddtrace trace-id continuity across the worker boundary; and immutability of the queue items. All eight pass locally on SQLite. Existing trace_server tests still pass against SQLite (131 passed, 28 skipped — the skips are ClickHouse-only tests). ClickHouse-backend CI runs via `tests-3.12(shard='trace_server')` will exercise the full insert path.

## Backward compatibility

No API or schema changes. Outside a `call_batch()` the synchronous path is preserved exactly. Inside a batch, behavior is identical except for latency and the order in which PUTs hit the bucket — every successful PUT still lands the same chunk row, and every failing PUT still falls back to ClickHouse for that digest only. Rollback is one or two revert commits; no flags, no migrations.


[WB-34172]: https://coreweave.atlassian.net/browse/WB-34172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ