### PR TITLE
chore(weave): ttl_settings parent span for redis visibility

### DIFF
--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -47,6 +47,7 @@ _project_ttl_cache: TTLCache[str, int] = TTLCache(
 _project_ttl_cache_lock = threading.Lock()
 
 
+@ddtrace.tracer.wrap(name="ttl_settings.get_project_retention_days")
 def get_project_retention_days(
     project_id: str,
     ch_client: CHClient,


### PR DESCRIPTION
## Summary
- #6783 dropped the `@ddtrace.tracer.wrap` on `get_project_retention_days` as redundant, but it was the parent span tying the L2 Redis GET/SET calls (auto-captured by ddtrace's redis integration) back to a `ttl_settings` origin.
- Without it, redis spans float under whatever request/insert span happens to be on the stack, and the `set_current_span_dd_tags` calls inside the function (`ttl.cache_hit=L1/L2/clickhouse`, `ttl.retention_days`) get attached to that unrelated span.
- Restores the one-line wrap. With it back: L1 hits produce a tiny tagged span, L2 hits show a `redis.command GET` child, full misses show GET + `ttl_settings.query_clickhouse` + SET children.

## Testing
non-functional change, dd tracing only.