### PR TITLE
perf(weave): wire redis L2 cache for project residence

### DIFF
--- a/tests/trace_server/test_project_version.py
+++ b/tests/trace_server/test_project_version.py
@@ -2,13 +2,21 @@ import base64
 import os
 import uuid
 from contextlib import contextmanager
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from tests.trace.util import client_is_sqlite
+from weave.trace_server.project_version import project_version
 from weave.trace_server.project_version.clickhouse_project_version import (
     get_project_data_residence,
+)
+from weave.trace_server.project_version.project_version import (
+    REDIS_RESIDENCE_EXPIRY_SECS,
+    TableRoutingResolver,
+    _residence_cache_key,
+    invalidate_project_residence_cache,
+    reset_project_residence_cache,
 )
 from weave.trace_server.project_version.types import (
     CallsStorageServerMode,
@@ -274,3 +282,222 @@ def test_project_version_mode_from_env():
             os.environ["PROJECT_VERSION_MODE"] = original_value
         elif "PROJECT_VERSION_MODE" in os.environ:
             del os.environ["PROJECT_VERSION_MODE"]
+
+
+# ---------------------------------------------------------------------------
+# Two-layer cache (L1 + Redis L2) unit tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeRedis:
+    """Minimal dict-backed Redis mock for testing L2 cache."""
+
+    def __init__(self):
+        self._store: dict[str, tuple[str, int | None]] = {}
+
+    def get(self, key: str) -> str | None:
+        entry = self._store.get(key)
+        return entry[0] if entry else None
+
+    def set(self, key: str, value: str, ex: int | None = None) -> None:
+        self._store[key] = (value, ex)
+
+    def delete(self, key: str) -> None:
+        self._store.pop(key, None)
+
+
+@pytest.fixture
+def fresh_l1_cache():
+    """Ensure L1 is empty around each test."""
+    reset_project_residence_cache()
+    yield
+    reset_project_residence_cache()
+
+
+@pytest.fixture
+def no_redis(monkeypatch):
+    """Pin get_redis_client() to None so L2 is skipped."""
+    monkeypatch.setattr(project_version, "get_redis_client", lambda: None)
+
+
+def _patch_redis(monkeypatch, redis_obj):
+    """Pin get_redis_client() to return the given redis-like object."""
+    monkeypatch.setattr(project_version, "get_redis_client", lambda: redis_obj)
+
+
+def _make_resolver_with_residence(residences):
+    """Return (resolver, ch_client, residence_fn_mock) backed by `residences`.
+
+    `residences` is the value (or list of sequential values) that the patched
+    `get_project_data_residence` returns. A MagicMock CH client stands in for
+    a real ClickHouse client; the residence fn is what we count to detect
+    fall-through to the DB.
+    """
+    resolver = TableRoutingResolver()
+    resolver._mode = CallsStorageServerMode.AUTO
+    ch_client = MagicMock()
+    fn = MagicMock()
+    if isinstance(residences, list):
+        fn.side_effect = residences
+    else:
+        fn.return_value = residences
+    return resolver, ch_client, fn
+
+
+def test_get_residence_l1_cache_hit_skips_redis_and_ch(
+    fresh_l1_cache, monkeypatch
+):
+    """L1 hit short-circuits — neither Redis nor ClickHouse should be touched."""
+    redis_mock = MagicMock()
+    _patch_redis(monkeypatch, redis_mock)
+    resolver, ch_client, residence_fn = _make_resolver_with_residence(
+        ProjectDataResidence.MERGED_ONLY
+    )
+    monkeypatch.setattr(
+        project_version, "get_project_data_residence", residence_fn
+    )
+
+    # Cold: one CH fetch populates L1 + L2.
+    first = resolver._get_residence("p1", ch_client)
+    # Warm: pure L1 hit — Redis and CH untouched on this call.
+    redis_mock.reset_mock()
+    second = resolver._get_residence("p1", ch_client)
+
+    assert first == ProjectDataResidence.MERGED_ONLY
+    assert second == ProjectDataResidence.MERGED_ONLY
+    assert residence_fn.call_count == 1
+    redis_mock.get.assert_not_called()
+    redis_mock.set.assert_not_called()
+
+
+def test_get_residence_redis_l2_paths(fresh_l1_cache, monkeypatch):
+    """L2 read, L2 populate after CH miss, and graceful Redis-failure fallback."""
+    # 1. Pre-populated Redis → serves L2, no CH; second call promoted to L1.
+    redis = _FakeRedis()
+    _patch_redis(monkeypatch, redis)
+    resolver, ch_client, residence_fn = _make_resolver_with_residence(
+        ProjectDataResidence.COMPLETE_ONLY
+    )
+    monkeypatch.setattr(
+        project_version, "get_project_data_residence", residence_fn
+    )
+    redis.set(
+        _residence_cache_key("p_warm"),
+        ProjectDataResidence.MERGED_ONLY.value,
+        ex=REDIS_RESIDENCE_EXPIRY_SECS,
+    )
+
+    first = resolver._get_residence("p_warm", ch_client)
+    second = resolver._get_residence("p_warm", ch_client)
+    assert first == ProjectDataResidence.MERGED_ONLY
+    assert second == ProjectDataResidence.MERGED_ONLY
+    assert residence_fn.call_count == 0
+
+    # 2. Cold Redis → CH populates both L2 and L1 (with the right TTL).
+    reset_project_residence_cache()
+    cold_redis = _FakeRedis()
+    _patch_redis(monkeypatch, cold_redis)
+    resolver2, ch2, fn2 = _make_resolver_with_residence(
+        ProjectDataResidence.BOTH
+    )
+    monkeypatch.setattr(project_version, "get_project_data_residence", fn2)
+
+    result = resolver2._get_residence("p_cold", ch2)
+    assert result == ProjectDataResidence.BOTH
+    assert fn2.call_count == 1
+    key = _residence_cache_key("p_cold")
+    assert cold_redis.get(key) == ProjectDataResidence.BOTH.value
+    assert cold_redis._store[key][1] == REDIS_RESIDENCE_EXPIRY_SECS
+
+    # 3. EMPTY residence must NOT be cached at either layer.
+    reset_project_residence_cache()
+    empty_redis = _FakeRedis()
+    _patch_redis(monkeypatch, empty_redis)
+    resolver3, ch3, fn3 = _make_resolver_with_residence(
+        [ProjectDataResidence.EMPTY, ProjectDataResidence.EMPTY]
+    )
+    monkeypatch.setattr(project_version, "get_project_data_residence", fn3)
+
+    assert resolver3._get_residence("p_empty", ch3) == ProjectDataResidence.EMPTY
+    assert resolver3._get_residence("p_empty", ch3) == ProjectDataResidence.EMPTY
+    # Both calls fall through — no caching.
+    assert fn3.call_count == 2
+    assert empty_redis.get(_residence_cache_key("p_empty")) is None
+
+
+@pytest.mark.disable_logging_error_check
+def test_get_residence_broken_redis_falls_back_to_clickhouse(
+    fresh_l1_cache, monkeypatch
+):
+    """Redis read/write/decode failures degrade gracefully to ClickHouse."""
+    # Connection errors on get/set.
+    broken = MagicMock()
+    broken.get.side_effect = ConnectionError("Redis down")
+    broken.set.side_effect = ConnectionError("Redis down")
+    _patch_redis(monkeypatch, broken)
+    resolver, ch_client, residence_fn = _make_resolver_with_residence(
+        ProjectDataResidence.COMPLETE_ONLY
+    )
+    monkeypatch.setattr(
+        project_version, "get_project_data_residence", residence_fn
+    )
+
+    assert (
+        resolver._get_residence("p_broken", ch_client)
+        == ProjectDataResidence.COMPLETE_ONLY
+    )
+    assert residence_fn.call_count == 1
+
+    # Stale/unknown enum value in Redis is treated as a miss.
+    reset_project_residence_cache()
+    stale_redis = _FakeRedis()
+    stale_redis.set(_residence_cache_key("p_stale"), "future_value")
+    _patch_redis(monkeypatch, stale_redis)
+    resolver2, ch2, fn2 = _make_resolver_with_residence(
+        ProjectDataResidence.MERGED_ONLY
+    )
+    monkeypatch.setattr(project_version, "get_project_data_residence", fn2)
+
+    assert (
+        resolver2._get_residence("p_stale", ch2)
+        == ProjectDataResidence.MERGED_ONLY
+    )
+    assert fn2.call_count == 1
+
+
+@pytest.mark.disable_logging_error_check
+def test_invalidate_project_residence_cache_clears_both_layers(
+    fresh_l1_cache, monkeypatch
+):
+    """Invalidation drops L1 + L2 and forces a refetch from ClickHouse."""
+    redis = _FakeRedis()
+    _patch_redis(monkeypatch, redis)
+    resolver, ch_client, residence_fn = _make_resolver_with_residence(
+        [ProjectDataResidence.MERGED_ONLY, ProjectDataResidence.COMPLETE_ONLY]
+    )
+    monkeypatch.setattr(
+        project_version, "get_project_data_residence", residence_fn
+    )
+    key = _residence_cache_key("p_inv")
+
+    # Populate caches via a CH fetch.
+    assert (
+        resolver._get_residence("p_inv", ch_client)
+        == ProjectDataResidence.MERGED_ONLY
+    )
+    assert redis.get(key) == ProjectDataResidence.MERGED_ONLY.value
+    assert residence_fn.call_count == 1
+
+    # Invalidate clears L2 immediately and forces the next call back to CH.
+    invalidate_project_residence_cache("p_inv")
+    assert redis.get(key) is None
+
+    refreshed = resolver._get_residence("p_inv", ch_client)
+    assert refreshed == ProjectDataResidence.COMPLETE_ONLY
+    assert residence_fn.call_count == 2
+
+    # Broken Redis on delete must not raise.
+    broken = MagicMock()
+    broken.delete.side_effect = ConnectionError("Redis down")
+    _patch_redis(monkeypatch, broken)
+    invalidate_project_residence_cache("p_inv")

--- a/tests/trace_server/test_project_version.py
+++ b/tests/trace_server/test_project_version.py
@@ -295,209 +295,143 @@ class _FakeRedis:
     def __init__(self):
         self._store: dict[str, tuple[str, int | None]] = {}
 
-    def get(self, key: str) -> str | None:
+    def get(self, key):
         entry = self._store.get(key)
         return entry[0] if entry else None
 
-    def set(self, key: str, value: str, ex: int | None = None) -> None:
+    def set(self, key, value, ex=None):
         self._store[key] = (value, ex)
 
-    def delete(self, key: str) -> None:
+    def delete(self, key):
         self._store.pop(key, None)
 
 
-@pytest.fixture
-def fresh_l1_cache():
-    """Ensure L1 is empty around each test."""
-    reset_project_residence_cache()
-    yield
-    reset_project_residence_cache()
-
-
-@pytest.fixture
-def no_redis(monkeypatch):
-    """Pin get_redis_client() to None so L2 is skipped."""
-    monkeypatch.setattr(project_version, "get_redis_client", lambda: None)
-
-
-def _patch_redis(monkeypatch, redis_obj):
-    """Pin get_redis_client() to return the given redis-like object."""
+def _wire(monkeypatch, *, redis_obj, residences):
+    """Patch L2 client + CH fetch and return (resolver, ch_client, residence_fn)."""
     monkeypatch.setattr(project_version, "get_redis_client", lambda: redis_obj)
-
-
-def _make_resolver_with_residence(residences):
-    """Return (resolver, ch_client, residence_fn_mock) backed by `residences`.
-
-    `residences` is the value (or list of sequential values) that the patched
-    `get_project_data_residence` returns. A MagicMock CH client stands in for
-    a real ClickHouse client; the residence fn is what we count to detect
-    fall-through to the DB.
-    """
-    resolver = TableRoutingResolver()
-    resolver._mode = CallsStorageServerMode.AUTO
-    ch_client = MagicMock()
     fn = MagicMock()
     if isinstance(residences, list):
         fn.side_effect = residences
     else:
         fn.return_value = residences
-    return resolver, ch_client, fn
+    monkeypatch.setattr(project_version, "get_project_data_residence", fn)
+    resolver = TableRoutingResolver()
+    resolver._mode = CallsStorageServerMode.AUTO
+    return resolver, MagicMock(), fn
 
 
-def test_get_residence_l1_cache_hit_skips_redis_and_ch(
-    fresh_l1_cache, monkeypatch
-):
-    """L1 hit short-circuits — neither Redis nor ClickHouse should be touched."""
-    redis_mock = MagicMock()
-    _patch_redis(monkeypatch, redis_mock)
-    resolver, ch_client, residence_fn = _make_resolver_with_residence(
-        ProjectDataResidence.MERGED_ONLY
-    )
-    monkeypatch.setattr(
-        project_version, "get_project_data_residence", residence_fn
-    )
-
-    # Cold: one CH fetch populates L1 + L2.
-    first = resolver._get_residence("p1", ch_client)
-    # Warm: pure L1 hit — Redis and CH untouched on this call.
-    redis_mock.reset_mock()
-    second = resolver._get_residence("p1", ch_client)
-
-    assert first == ProjectDataResidence.MERGED_ONLY
-    assert second == ProjectDataResidence.MERGED_ONLY
-    assert residence_fn.call_count == 1
-    redis_mock.get.assert_not_called()
-    redis_mock.set.assert_not_called()
-
-
-def test_get_residence_redis_l2_paths(fresh_l1_cache, monkeypatch):
-    """L2 read, L2 populate after CH miss, and graceful Redis-failure fallback."""
-    # 1. Pre-populated Redis → serves L2, no CH; second call promoted to L1.
-    redis = _FakeRedis()
-    _patch_redis(monkeypatch, redis)
-    resolver, ch_client, residence_fn = _make_resolver_with_residence(
-        ProjectDataResidence.COMPLETE_ONLY
-    )
-    monkeypatch.setattr(
-        project_version, "get_project_data_residence", residence_fn
-    )
-    redis.set(
-        _residence_cache_key("p_warm"),
-        ProjectDataResidence.MERGED_ONLY.value,
-        ex=REDIS_RESIDENCE_EXPIRY_SECS,
-    )
-
-    first = resolver._get_residence("p_warm", ch_client)
-    second = resolver._get_residence("p_warm", ch_client)
-    assert first == ProjectDataResidence.MERGED_ONLY
-    assert second == ProjectDataResidence.MERGED_ONLY
-    assert residence_fn.call_count == 0
-
-    # 2. Cold Redis → CH populates both L2 and L1 (with the right TTL).
+def test_two_layer_cache_paths(monkeypatch):
+    """Cover L1 short-circuit, L2 hit + L1 promotion, cold-redis populate, EMPTY skip."""
     reset_project_residence_cache()
-    cold_redis = _FakeRedis()
-    _patch_redis(monkeypatch, cold_redis)
-    resolver2, ch2, fn2 = _make_resolver_with_residence(
-        ProjectDataResidence.BOTH
+    redis = _FakeRedis()
+
+    # --- 1. Cold CH fetch populates both layers; second call is pure L1 (no Redis I/O).
+    spy = MagicMock(wraps=redis)
+    resolver, ch_client, residence_fn = _wire(
+        monkeypatch, redis_obj=spy, residences=ProjectDataResidence.MERGED_ONLY
     )
-    monkeypatch.setattr(project_version, "get_project_data_residence", fn2)
+    assert (
+        resolver._get_residence("p_cold", ch_client)
+        == ProjectDataResidence.MERGED_ONLY
+    )
+    assert residence_fn.call_count == 1
+    cold_key = _residence_cache_key("p_cold")
+    assert redis.get(cold_key) == ProjectDataResidence.MERGED_ONLY.value
+    assert redis._store[cold_key][1] == REDIS_RESIDENCE_EXPIRY_SECS
 
-    result = resolver2._get_residence("p_cold", ch2)
-    assert result == ProjectDataResidence.BOTH
-    assert fn2.call_count == 1
-    key = _residence_cache_key("p_cold")
-    assert cold_redis.get(key) == ProjectDataResidence.BOTH.value
-    assert cold_redis._store[key][1] == REDIS_RESIDENCE_EXPIRY_SECS
+    spy.reset_mock()
+    assert (
+        resolver._get_residence("p_cold", ch_client)
+        == ProjectDataResidence.MERGED_ONLY
+    )
+    assert residence_fn.call_count == 1  # no extra CH call
+    spy.get.assert_not_called()
+    spy.set.assert_not_called()
 
-    # 3. EMPTY residence must NOT be cached at either layer.
+    # --- 2. Pre-populated Redis serves L2 (no CH); cleared L1 forces it.
+    reset_project_residence_cache()
+    redis.set(_residence_cache_key("p_warm"), ProjectDataResidence.BOTH.value)
+    resolver2, ch2, fn2 = _wire(
+        monkeypatch, redis_obj=redis, residences=ProjectDataResidence.COMPLETE_ONLY
+    )
+    assert resolver2._get_residence("p_warm", ch2) == ProjectDataResidence.BOTH
+    assert resolver2._get_residence("p_warm", ch2) == ProjectDataResidence.BOTH
+    assert fn2.call_count == 0  # never hit CH
+
+    # --- 3. EMPTY residence is never cached at either layer.
     reset_project_residence_cache()
     empty_redis = _FakeRedis()
-    _patch_redis(monkeypatch, empty_redis)
-    resolver3, ch3, fn3 = _make_resolver_with_residence(
-        [ProjectDataResidence.EMPTY, ProjectDataResidence.EMPTY]
+    resolver3, ch3, fn3 = _wire(
+        monkeypatch,
+        redis_obj=empty_redis,
+        residences=[ProjectDataResidence.EMPTY, ProjectDataResidence.EMPTY],
     )
-    monkeypatch.setattr(project_version, "get_project_data_residence", fn3)
-
-    assert resolver3._get_residence("p_empty", ch3) == ProjectDataResidence.EMPTY
-    assert resolver3._get_residence("p_empty", ch3) == ProjectDataResidence.EMPTY
-    # Both calls fall through — no caching.
+    assert resolver3._get_residence("p_e", ch3) == ProjectDataResidence.EMPTY
+    assert resolver3._get_residence("p_e", ch3) == ProjectDataResidence.EMPTY
     assert fn3.call_count == 2
-    assert empty_redis.get(_residence_cache_key("p_empty")) is None
+    assert empty_redis.get(_residence_cache_key("p_e")) is None
 
 
 @pytest.mark.disable_logging_error_check
-def test_get_residence_broken_redis_falls_back_to_clickhouse(
-    fresh_l1_cache, monkeypatch
-):
-    """Redis read/write/decode failures degrade gracefully to ClickHouse."""
-    # Connection errors on get/set.
+def test_redis_failure_modes_and_invalidation(monkeypatch):
+    """Broken-redis + stale-enum fall back to CH; invalidate clears L1+L2."""
+    reset_project_residence_cache()
+
+    # --- 1. Connection errors on get/set degrade to CH transparently.
     broken = MagicMock()
     broken.get.side_effect = ConnectionError("Redis down")
     broken.set.side_effect = ConnectionError("Redis down")
-    _patch_redis(monkeypatch, broken)
-    resolver, ch_client, residence_fn = _make_resolver_with_residence(
-        ProjectDataResidence.COMPLETE_ONLY
+    resolver, ch_client, fn = _wire(
+        monkeypatch, redis_obj=broken, residences=ProjectDataResidence.COMPLETE_ONLY
     )
-    monkeypatch.setattr(
-        project_version, "get_project_data_residence", residence_fn
-    )
-
     assert (
         resolver._get_residence("p_broken", ch_client)
         == ProjectDataResidence.COMPLETE_ONLY
     )
-    assert residence_fn.call_count == 1
+    assert fn.call_count == 1
 
-    # Stale/unknown enum value in Redis is treated as a miss.
+    # --- 2. Unknown enum value written by an older/newer build is treated as a miss.
     reset_project_residence_cache()
-    stale_redis = _FakeRedis()
-    stale_redis.set(_residence_cache_key("p_stale"), "future_value")
-    _patch_redis(monkeypatch, stale_redis)
-    resolver2, ch2, fn2 = _make_resolver_with_residence(
-        ProjectDataResidence.MERGED_ONLY
+    stale = _FakeRedis()
+    stale.set(_residence_cache_key("p_stale"), "future_value")
+    resolver2, ch2, fn2 = _wire(
+        monkeypatch, redis_obj=stale, residences=ProjectDataResidence.MERGED_ONLY
     )
-    monkeypatch.setattr(project_version, "get_project_data_residence", fn2)
-
     assert (
         resolver2._get_residence("p_stale", ch2)
         == ProjectDataResidence.MERGED_ONLY
     )
     assert fn2.call_count == 1
 
-
-@pytest.mark.disable_logging_error_check
-def test_invalidate_project_residence_cache_clears_both_layers(
-    fresh_l1_cache, monkeypatch
-):
-    """Invalidation drops L1 + L2 and forces a refetch from ClickHouse."""
+    # --- 3. invalidate clears both layers, forces refetch, and swallows delete errors.
+    reset_project_residence_cache()
     redis = _FakeRedis()
-    _patch_redis(monkeypatch, redis)
-    resolver, ch_client, residence_fn = _make_resolver_with_residence(
-        [ProjectDataResidence.MERGED_ONLY, ProjectDataResidence.COMPLETE_ONLY]
-    )
-    monkeypatch.setattr(
-        project_version, "get_project_data_residence", residence_fn
+    resolver3, ch3, fn3 = _wire(
+        monkeypatch,
+        redis_obj=redis,
+        residences=[
+            ProjectDataResidence.MERGED_ONLY,
+            ProjectDataResidence.COMPLETE_ONLY,
+        ],
     )
     key = _residence_cache_key("p_inv")
-
-    # Populate caches via a CH fetch.
     assert (
-        resolver._get_residence("p_inv", ch_client)
+        resolver3._get_residence("p_inv", ch3)
         == ProjectDataResidence.MERGED_ONLY
     )
     assert redis.get(key) == ProjectDataResidence.MERGED_ONLY.value
-    assert residence_fn.call_count == 1
 
-    # Invalidate clears L2 immediately and forces the next call back to CH.
     invalidate_project_residence_cache("p_inv")
     assert redis.get(key) is None
+    assert (
+        resolver3._get_residence("p_inv", ch3)
+        == ProjectDataResidence.COMPLETE_ONLY
+    )
+    assert fn3.call_count == 2
 
-    refreshed = resolver._get_residence("p_inv", ch_client)
-    assert refreshed == ProjectDataResidence.COMPLETE_ONLY
-    assert residence_fn.call_count == 2
-
-    # Broken Redis on delete must not raise.
-    broken = MagicMock()
-    broken.delete.side_effect = ConnectionError("Redis down")
-    _patch_redis(monkeypatch, broken)
-    invalidate_project_residence_cache("p_inv")
+    monkeypatch.setattr(
+        project_version,
+        "get_redis_client",
+        lambda: MagicMock(delete=MagicMock(side_effect=ConnectionError("down"))),
+    )
+    invalidate_project_residence_cache("p_inv")  # must not raise

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -2,6 +2,7 @@ import logging
 import threading
 
 import ddtrace
+import redis
 from cachetools import LRUCache
 from clickhouse_connect.driver.client import Client as CHClient
 
@@ -18,12 +19,17 @@ from weave.trace_server.project_version.types import (
     ReadTable,
     WriteTarget,
 )
+from weave.trace_server.redis_client import get_redis_client
 
 logger = logging.getLogger(__name__)
 
 PROJECT_RESIDENCE_CACHE_SIZE = 10_000
 
-# Global cache shared across all resolvers
+REDIS_RESIDENCE_KEY_PREFIX = "weave:project_residence:"
+# 5 minutes; bounds staleness in multi-instance deploys
+REDIS_RESIDENCE_EXPIRY_SECS = 300
+
+# Global cache shared across all resolvers. Keyed by project_id.
 _project_residence_cache: LRUCache[str, ProjectDataResidence] = LRUCache(
     maxsize=PROJECT_RESIDENCE_CACHE_SIZE
 )
@@ -31,7 +37,10 @@ _project_residence_cache_lock = threading.Lock()
 
 
 def reset_project_residence_cache() -> None:
-    """Clear the cached project data residence entries.
+    """Clear the in-process project data residence cache (L1).
+
+    L2 (Redis) is left alone; use `invalidate_project_residence_cache`
+    for a per-project L1+L2 eviction.
 
     Examples:
         >>> reset_project_residence_cache()
@@ -39,6 +48,19 @@ def reset_project_residence_cache() -> None:
     """
     with _project_residence_cache_lock:
         _project_residence_cache.clear()
+
+
+def invalidate_project_residence_cache(project_id: str) -> None:
+    """Remove a project from both L1 and L2 caches.
+
+    Only invalidates L1 in the *current* process — other replicas will still
+    see stale L1 entries until their own entry is evicted.
+    """
+    with _project_residence_cache_lock:
+        _project_residence_cache.pop(project_id, None)
+    redis_client = get_redis_client()
+    if redis_client is not None:
+        _l2_delete(redis_client, project_id)
 
 
 class TableRoutingResolver:
@@ -53,10 +75,24 @@ class TableRoutingResolver:
     def _get_residence(
         self, project_id: str, ch_client: CHClient
     ) -> ProjectDataResidence:
-        with _project_residence_cache_lock:
-            cached = _project_residence_cache.get(project_id)
+        """Resolve project data residence with a two-layer cache.
+
+        Read path: L1 (in-process LRU) -> L2 (Redis, if WEAVE_REDIS_URL is set)
+        -> ClickHouse. EMPTY residency is never cached at either layer because
+        the project could still grow into either table.
+        """
+        cached = _l1_get(project_id)
         if cached is not None:
+            set_current_span_dd_tags({"project_version.cache_hit": "L1"})
             return cached
+
+        redis_client = get_redis_client()
+        if redis_client is not None:
+            redis_val = _l2_get(redis_client, project_id)
+            if redis_val is not None:
+                _l1_set(project_id, redis_val)
+                set_current_span_dd_tags({"project_version.cache_hit": "L2"})
+                return redis_val
 
         # Only span the cache-miss path. Cache-hit calls are extremely high
         # volume and produce noisy DD spans with no useful information.
@@ -64,6 +100,7 @@ class TableRoutingResolver:
             residence = get_project_data_residence(project_id, ch_client)
 
             set_root_span_dd_tags({"project_version.fetch_residence": residence.value})
+            set_current_span_dd_tags({"project_version.cache_hit": "clickhouse"})
 
             # Log warning if we detect dual residency - data should only ever be in
             # calls_merged OR calls_complete, not both. This is handled gracefully but
@@ -81,8 +118,9 @@ class TableRoutingResolver:
 
             # Don't cache if project is empty, we could write to either table.
             if residence != ProjectDataResidence.EMPTY:
-                with _project_residence_cache_lock:
-                    _project_residence_cache[project_id] = residence
+                if redis_client is not None:
+                    _l2_set(redis_client, project_id, residence)
+                _l1_set(project_id, residence)
 
             return residence
 
@@ -214,3 +252,77 @@ class TableRoutingResolver:
             return WriteTarget.CALLS_COMPLETE
 
         raise ValueError(f"Invalid mode/residence: {self._mode}/{residence}")
+
+
+# ---------------------------------------------------------------------------
+# Cache-layer helpers
+# ---------------------------------------------------------------------------
+
+
+def _residence_cache_key(project_id: str) -> str:
+    return f"{REDIS_RESIDENCE_KEY_PREFIX}{project_id}"
+
+
+def _l1_get(project_id: str) -> ProjectDataResidence | None:
+    """Read residence from the in-process LRU cache."""
+    with _project_residence_cache_lock:
+        return _project_residence_cache.get(project_id)
+
+
+def _l1_set(project_id: str, residence: ProjectDataResidence) -> None:
+    """Write residence to the in-process LRU cache."""
+    with _project_residence_cache_lock:
+        _project_residence_cache[project_id] = residence
+
+
+def _l2_get(
+    redis_client: redis.Redis, project_id: str
+) -> ProjectDataResidence | None:
+    """Try to read residence from Redis. Returns None on miss, unknown value, or error."""
+    try:
+        val = redis_client.get(_residence_cache_key(project_id))
+        if val is None:
+            return None
+        return ProjectDataResidence(val)
+    except ValueError:
+        # Stale/unknown enum value written by a different code version. Treat
+        # as a miss and let ClickHouse re-resolve.
+        logger.warning(
+            "Unknown project residence value in Redis for project %s: %r",
+            project_id,
+            val,
+        )
+        return None
+    except Exception:
+        logger.exception(
+            "Redis L2 cache read failed for project %s", project_id
+        )
+        return None
+
+
+def _l2_set(
+    redis_client: redis.Redis,
+    project_id: str,
+    residence: ProjectDataResidence,
+) -> None:
+    """Try to write residence to Redis with TTL. Logs errors but does not raise."""
+    try:
+        redis_client.set(
+            _residence_cache_key(project_id),
+            residence.value,
+            ex=REDIS_RESIDENCE_EXPIRY_SECS,
+        )
+    except Exception:
+        logger.exception(
+            "Redis L2 cache write failed for project %s", project_id
+        )
+
+
+def _l2_delete(redis_client: redis.Redis, project_id: str) -> None:
+    """Try to delete a key from Redis. Logs errors but does not raise."""
+    try:
+        redis_client.delete(_residence_cache_key(project_id))
+    except Exception:
+        logger.exception(
+            "Redis L2 cache delete failed for project %s", project_id
+        )


### PR DESCRIPTION
## Summary
- Adds a Redis L2 cache layer to `TableRoutingResolver._get_residence`, mirroring the pattern already used in `ttl_settings.py`. Read path is now L1 (in-process LRU) -> L2 (Redis, when `WEAVE_REDIS_URL` is set) -> ClickHouse. ClickHouse hits should drop sharply in multi-replica deploys once one replica has resolved a project.
- `EMPTY` residency is still never cached at either layer (a project can still grow into either table).
- New `invalidate_project_residence_cache(project_id)` clears L1 + L2 for a project. `reset_project_residence_cache()` is L1-only and remains the test-helper.
- Redis failures (connect / read / write / unknown enum value) degrade gracefully to ClickHouse and never raise.

## Testing
unit tests cover L1 short-circuit, L2 hit + promote-to-L1, cold-Redis populate-both-layers, EMPTY-never-cached, broken-redis fallback, stale enum value fallback, and L1+L2 invalidation. CH-backed integration tests in the same file unchanged.