### PR TITLE
fix(weave_ts): add uv in npm publishing workflow

### DIFF
--- a/.github/workflows/publish_ts_sdk_npm.yaml
+++ b/.github/workflows/publish_ts_sdk_npm.yaml
@@ -61,6 +61,13 @@ jobs:
         working-directory: sdks/node
         run: pnpm install --frozen-lockfile
 
+      # The hostApps Jest project (src/__tests__/hostApps/) spawns the
+      # Python Weave trace-server mock via `uv run python -m trace_server_mock`
+      # in its globalSetup. uv is required on PATH; uv handles the Python
+      # toolchain itself.
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
       - name: Run tests
         working-directory: sdks/node
         env:


### PR DESCRIPTION
## Description

Adds `uv` installation to the TypeScript SDK npm publish workflow so that the `hostApps` Jest test suite can run successfully in CI.

The `hostApps` Jest project spawns a Python Weave trace-server mock via `uv run python -m trace_server_mock` in its `globalSetup`. Without `uv` available on `PATH`, these tests fail during the publish workflow.

## Testing

Successful run: https://github.com/wandb/weave/actions/runs/25702810049/job/75466451385

  
## Related PR
  
https://github.com/wandb/weave/pull/6771