### PR TITLE
feat(weave): autopatch openai + anthropic to Session SDK LLM spans

### DIFF
--- a/tests/integrations/test_session_llm_bridge.py
+++ b/tests/integrations/test_session_llm_bridge.py
@@ -1,0 +1,272 @@
+"""Tests for the autopatch → Session SDK LLM-span bridge.
+
+These tests use mock callables in place of real OpenAI / Anthropic SDK
+methods so they run without network or VCR cassettes. The integration
+modules import the same helpers (``session_aware_sync`` /
+``session_aware_async``) on top of their existing accumulator wrappers,
+so verifying the helpers in isolation covers the load-bearing path
+without coupling tests to OpenAI/Anthropic response-pydantic shape.
+
+Span verification uses an in-memory OTel span exporter; assertions are
+at the OTel attribute level — the same shape consumers will see on the
+wire.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from weave.integrations._session_llm_bridge import (
+    session_aware_async,
+    session_aware_sync,
+)
+from weave.session import (
+    LLM,
+    Message,
+    Usage,
+    get_current_llm,
+    get_current_session,
+    get_current_turn,
+    start_session,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_contextvars():
+    yield
+    if (llm := get_current_llm()) is not None:
+        llm.end()
+    if (turn := get_current_turn()) is not None:
+        turn.end()
+    if (session := get_current_session()) is not None:
+        session.end()
+
+
+@pytest.fixture
+def otel_spans(monkeypatch: pytest.MonkeyPatch):
+    exporter = InMemorySpanExporter()
+    provider = SDKTracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+    yield exporter
+    provider.shutdown()
+
+
+def _populate_input(llm: LLM, kwargs: dict) -> None:
+    llm.input_messages = [Message(role="user", content=kwargs.get("prompt", ""))]
+
+
+def _populate_output(llm: LLM, response: Any) -> None:
+    llm.record(
+        output_messages=[Message.assistant(getattr(response, "text", ""))],
+        usage=Usage(input_tokens=10, output_tokens=20),
+        response_id=getattr(response, "id", ""),
+        finish_reasons=["stop"],
+    )
+
+
+def _model_from_kwargs(kwargs: dict) -> str:
+    return kwargs.get("model", "")
+
+
+@dataclass
+class _Resp:
+    text: str = "hi"
+    id: str = "r-1"
+
+
+class TestSessionAwareSyncNoTurn:
+    """When no Turn is active, the bridge must be a transparent passthrough."""
+
+    def test_passthrough_no_turn(self) -> None:
+        marker = object()
+        called_with: dict[str, Any] = {}
+
+        def fn(**kwargs: Any) -> object:
+            called_with.update(kwargs)
+            return marker
+
+        wrapped = session_aware_sync(
+            fn,
+            provider_name="openai",
+            model_from_kwargs=_model_from_kwargs,
+            on_input=_populate_input,
+            on_output=_populate_output,
+        )
+        result = wrapped(model="gpt-x", prompt="hi")
+        assert result is marker
+        assert called_with == {"model": "gpt-x", "prompt": "hi"}
+
+
+class TestSessionAwareSyncNonStreaming:
+    """With an active Turn, non-streaming responses produce a closed LLM span."""
+
+    def test_llm_span_lifecycle(self, otel_spans: InMemorySpanExporter) -> None:
+        resp = _Resp(text="hello", id="r-42")
+
+        def fn(**kwargs: Any) -> _Resp:
+            return resp
+
+        wrapped = session_aware_sync(
+            fn,
+            provider_name="openai",
+            model_from_kwargs=_model_from_kwargs,
+            on_input=_populate_input,
+            on_output=_populate_output,
+        )
+        with (
+            start_session(agent_name="bot", session_id="s1") as session,
+            session.start_turn(),
+        ):
+            result = wrapped(model="gpt-x", prompt="hi")
+        assert result is resp
+
+        chat_spans = [
+            sp for sp in otel_spans.get_finished_spans() if sp.name == "chat gpt-x"
+        ]
+        assert len(chat_spans) == 1
+        attrs = dict(chat_spans[0].attributes or {})
+        assert attrs.get("gen_ai.provider.name") == "openai"
+        assert attrs.get("gen_ai.response.id") == "r-42"
+        assert attrs.get("gen_ai.usage.input_tokens") == 10
+        assert attrs.get("gen_ai.usage.output_tokens") == 20
+
+    def test_exception_records_error_and_closes_span(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        class Boom(RuntimeError):
+            pass
+
+        def fn(**kwargs: Any) -> _Resp:
+            raise Boom("nope")
+
+        wrapped = session_aware_sync(
+            fn,
+            provider_name="openai",
+            model_from_kwargs=_model_from_kwargs,
+            on_input=_populate_input,
+            on_output=_populate_output,
+        )
+        with (
+            pytest.raises(Boom),
+            start_session(agent_name="bot", session_id="s1") as s,
+            s.start_turn(),
+        ):
+            wrapped(model="gpt-x", prompt="hi")
+
+        chat_spans = [
+            sp for sp in otel_spans.get_finished_spans() if sp.name == "chat gpt-x"
+        ]
+        assert len(chat_spans) == 1
+        assert chat_spans[0].status.status_code.name == "ERROR"
+
+
+class TestSessionAwareSyncStreaming:
+    """Streaming responses keep the LLM span open until iterator exhaustion."""
+
+    def test_stream_closes_span_at_end(self, otel_spans: InMemorySpanExporter) -> None:
+        chunks = [_Resp(text=f"chunk-{i}", id=f"r-{i}") for i in range(3)]
+
+        def fn(**kwargs: Any) -> Iterator[_Resp]:
+            yield from chunks
+
+        def acc(state: Any, value: _Resp) -> _Resp:
+            # accumulate by keeping the last value seen
+            return value
+
+        wrapped = session_aware_sync(
+            fn,
+            provider_name="openai",
+            model_from_kwargs=_model_from_kwargs,
+            on_input=_populate_input,
+            on_output=_populate_output,
+            is_streaming=lambda kwargs: bool(kwargs.get("stream")),
+            accumulator=acc,
+        )
+        seen: list[_Resp] = []
+        with start_session(agent_name="bot", session_id="s1") as s, s.start_turn():
+            for chunk in wrapped(model="gpt-x", prompt="hi", stream=True):
+                seen.append(chunk)
+        assert [c.text for c in seen] == ["chunk-0", "chunk-1", "chunk-2"]
+        chat_spans = [
+            sp for sp in otel_spans.get_finished_spans() if sp.name == "chat gpt-x"
+        ]
+        assert len(chat_spans) == 1
+        attrs = dict(chat_spans[0].attributes or {})
+        # ``on_output`` ran with the last accumulated chunk.
+        assert attrs.get("gen_ai.response.id") == "r-2"
+
+
+class TestSessionAwareAsync:
+    """Async variant: same lifecycle invariants, awaited rather than called."""
+
+    @pytest.mark.asyncio
+    async def test_async_non_streaming(self, otel_spans: InMemorySpanExporter) -> None:
+        resp = _Resp(text="hello", id="r-7")
+
+        async def fn(**kwargs: Any) -> _Resp:
+            return resp
+
+        wrapped = session_aware_async(
+            fn,
+            provider_name="anthropic",
+            model_from_kwargs=_model_from_kwargs,
+            on_input=_populate_input,
+            on_output=_populate_output,
+        )
+        with start_session(agent_name="bot", session_id="s1") as s, s.start_turn():
+            result = await wrapped(model="claude-x", prompt="hi")
+        assert result is resp
+        chat_spans = [
+            sp for sp in otel_spans.get_finished_spans() if sp.name == "chat claude-x"
+        ]
+        assert len(chat_spans) == 1
+        attrs = dict(chat_spans[0].attributes or {})
+        assert attrs.get("gen_ai.provider.name") == "anthropic"
+        assert attrs.get("gen_ai.response.id") == "r-7"
+
+    @pytest.mark.asyncio
+    async def test_async_streaming_closes_span(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        chunks = [_Resp(text=f"c{i}", id=f"r-{i}") for i in range(2)]
+
+        async def fn(**kwargs: Any) -> AsyncIterator[_Resp]:
+            async def _gen() -> AsyncIterator[_Resp]:
+                for c in chunks:
+                    yield c
+
+            return _gen()
+
+        def acc(state: Any, value: _Resp) -> _Resp:
+            return value
+
+        wrapped = session_aware_async(
+            fn,
+            provider_name="anthropic",
+            model_from_kwargs=_model_from_kwargs,
+            on_input=_populate_input,
+            on_output=_populate_output,
+            is_streaming=lambda kwargs: bool(kwargs.get("stream")),
+            accumulator=acc,
+        )
+        seen: list[_Resp] = []
+        with start_session(agent_name="bot", session_id="s1") as s, s.start_turn():
+            stream = await wrapped(model="claude-x", prompt="hi", stream=True)
+            async for chunk in stream:
+                seen.append(chunk)
+        assert [c.text for c in seen] == ["c0", "c1"]
+        chat_spans = [
+            sp for sp in otel_spans.get_finished_spans() if sp.name == "chat claude-x"
+        ]
+        assert len(chat_spans) == 1
+        attrs = dict(chat_spans[0].attributes or {})
+        assert attrs.get("gen_ai.response.id") == "r-1"

--- a/weave/integrations/_session_llm_bridge.py
+++ b/weave/integrations/_session_llm_bridge.py
@@ -1,0 +1,321 @@
+"""Bridge a vendor-SDK autopatch into a Session SDK ``LLM`` span.
+
+Every weave vendor integration (openai, anthropic, ...) already patches
+provider client methods (``responses.create``, ``messages.create``, ...)
+to emit a legacy ``@weave.op`` call. This module layers a Session SDK
+``LLM`` span over those patches whenever an outer ``Turn`` is active in
+context — so wb_agent-style code that opens a ``start_session`` /
+``start_turn`` gets full ``gen_ai.*`` OTel coverage without writing
+``start_llm``/``llm.record`` by hand at every call site.
+
+Vendor specifics (request-shape → ``LLM.input_messages``, response-shape
+→ ``LLM.output_messages``/``usage``/``response_id``/``finish_reasons``)
+live in the integration module; this bridge owns the span lifecycle:
+open, populate inputs, run the call, populate outputs (post-accumulation
+for streams), close — including error handling for sync, async,
+non-streaming, and streaming.
+"""
+
+from __future__ import annotations
+
+import inspect
+import types
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
+from functools import wraps
+from typing import Any
+
+from typing_extensions import Self
+
+from weave.session import LLM, get_current_turn
+
+LlmInputCb = Callable[[LLM, dict], None]
+LlmOutputCb = Callable[[LLM, Any], None]
+ModelGetter = Callable[[dict], str]
+StreamCheck = Callable[[dict], bool]
+Accumulator = Callable[[Any, Any], Any]
+
+
+def session_aware_sync(
+    fn: Callable[..., Any],
+    *,
+    provider_name: str,
+    model_from_kwargs: ModelGetter,
+    on_input: LlmInputCb,
+    on_output: LlmOutputCb,
+    is_streaming: StreamCheck | None = None,
+    accumulator: Accumulator | None = None,
+) -> Callable[..., Any]:
+    """Wrap a sync callable with Session SDK LLM span emission.
+
+    When no ``Turn`` is active in context this is a transparent
+    passthrough. With an active Turn:
+
+    - Opens an ``LLM`` span with model + provider before the call.
+    - Calls ``on_input(llm, kwargs)`` to populate request-side fields.
+    - Calls ``fn(...)`` and, for non-streaming responses, immediately
+      calls ``on_output(llm, response)`` and closes the span.
+    - For streaming responses (``is_streaming(kwargs)`` returns True),
+      wraps the returned iterator in ``_SyncStreamAdapter``; the span
+      stays open until the stream is exhausted, then ``on_output`` runs
+      on the accumulated final value.
+    - Any exception records the error on the span and re-raises.
+
+    ``accumulator`` is required only when ``is_streaming`` may return
+    True; the bridge runs it in parallel with the integration's own
+    accumulator to obtain the final response shape.
+    """
+
+    @wraps(fn)
+    def _inner(*args: Any, **kwargs: Any) -> Any:
+        turn = get_current_turn()
+        if turn is None:
+            return fn(*args, **kwargs)
+        llm = turn.llm(model=model_from_kwargs(kwargs), provider_name=provider_name)
+        # Manual span lifecycle: streaming returns an iterator that must
+        # keep the span open until exhaustion. ``with llm:`` would close
+        # before the user iterates. Closing is handled by ``end()`` calls
+        # in the non-streaming branch below or by the stream adapters.
+        llm.__enter__()  # noqa: PLC2801
+        try:
+            on_input(llm, kwargs)
+            result = fn(*args, **kwargs)
+        except BaseException as exc:
+            _close_with_error(llm, exc)
+            raise
+        if is_streaming and is_streaming(kwargs):
+            if accumulator is None:
+                raise RuntimeError("session_aware_sync: streaming requires accumulator")
+            return _SyncStreamAdapter(result, llm, accumulator, on_output)
+        _close_with_output(llm, result, on_output)
+        return result
+
+    return _inner
+
+
+def session_aware_async(
+    fn: Callable[..., Awaitable[Any]],
+    *,
+    provider_name: str,
+    model_from_kwargs: ModelGetter,
+    on_input: LlmInputCb,
+    on_output: LlmOutputCb,
+    is_streaming: StreamCheck | None = None,
+    accumulator: Accumulator | None = None,
+) -> Callable[..., Awaitable[Any]]:
+    """Async counterpart to ``session_aware_sync``.
+
+    The returned coroutine awaits ``fn``; for streaming returns the
+    awaited result is wrapped in ``_AsyncStreamAdapter`` (async
+    iterator). Same lifecycle and error guarantees as the sync path.
+    """
+
+    @wraps(fn)
+    async def _inner(*args: Any, **kwargs: Any) -> Any:
+        turn = get_current_turn()
+        if turn is None:
+            return await fn(*args, **kwargs)
+        llm = turn.llm(model=model_from_kwargs(kwargs), provider_name=provider_name)
+        # Manual span lifecycle: streaming returns an iterator that must
+        # keep the span open until exhaustion. ``with llm:`` would close
+        # before the user iterates. Closing is handled by ``end()`` calls
+        # in the non-streaming branch below or by the stream adapters.
+        llm.__enter__()  # noqa: PLC2801
+        try:
+            on_input(llm, kwargs)
+            result = await fn(*args, **kwargs)
+        except BaseException as exc:
+            _close_with_error(llm, exc)
+            raise
+        if is_streaming and is_streaming(kwargs):
+            if accumulator is None:
+                raise RuntimeError(
+                    "session_aware_async: streaming requires accumulator"
+                )
+            return _AsyncStreamAdapter(result, llm, accumulator, on_output)
+        _close_with_output(llm, result, on_output)
+        return result
+
+    return _inner
+
+
+def _close_with_output(llm: LLM, result: Any, on_output: LlmOutputCb) -> None:
+    try:
+        on_output(llm, result)
+    finally:
+        if not llm._ended:
+            llm.end()
+
+
+def _close_with_error(llm: LLM, exc: BaseException) -> None:
+    try:
+        llm._record_otel_error(exc)
+    finally:
+        if not llm._ended:
+            llm.end()
+
+
+class _SyncStreamAdapter:
+    """Iterator shim that closes a Session SDK LLM span at stream end.
+
+    Wraps the iterator returned by a streaming SDK call (after the
+    integration's own ``_add_accumulator`` wrapping). Accumulates a
+    parallel copy of the stream into a final response shape so the
+    Session SDK ``on_output`` callback can populate the span before
+    ``llm.end()`` fires. The integration's own accumulator continues
+    to drive ``@weave.op`` call recording independently — this shim
+    is purely for the ``LLM`` span lifecycle.
+
+    Delegates all other attributes to the wrapped iterator so any
+    SDK-specific helpers (``get_final_response``, ``text_stream``, ...)
+    keep working.
+    """
+
+    def __init__(
+        self,
+        wrapped: Iterator[Any],
+        llm: LLM,
+        accumulator: Accumulator,
+        on_output: LlmOutputCb,
+    ) -> None:
+        self._wrapped = wrapped
+        self._llm = llm
+        self._accumulator = accumulator
+        self._on_output = on_output
+        self._acc: Any = None
+        self._closed = False
+
+    def __iter__(self) -> Iterator[Any]:
+        return self
+
+    def __next__(self) -> Any:
+        try:
+            value = next(self._wrapped)
+        except StopIteration:
+            self._close()
+            raise
+        except BaseException as exc:
+            _close_with_error(self._llm, exc)
+            self._closed = True
+            raise
+        try:
+            self._acc = self._accumulator(self._acc, value)
+        except BaseException:
+            # Accumulator failure must not break the user's iteration —
+            # the underlying op call is still completing fine.
+            pass
+        return value
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> bool:
+        if exc_val is not None:
+            _close_with_error(self._llm, exc_val)
+            self._closed = True
+        else:
+            self._close()
+        return False
+
+    def __del__(self) -> None:
+        # Safety net for callers that drop the iterator without
+        # iterating to exhaustion or using ``with``.
+        if not self._closed:
+            self._close()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._wrapped, name)
+
+    def _close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._acc is not None:
+                self._on_output(self._llm, self._acc)
+        finally:
+            if not self._llm._ended:
+                self._llm.end()
+
+
+class _AsyncStreamAdapter:
+    """Async counterpart to ``_SyncStreamAdapter``."""
+
+    def __init__(
+        self,
+        wrapped: AsyncIterator[Any],
+        llm: LLM,
+        accumulator: Accumulator,
+        on_output: LlmOutputCb,
+    ) -> None:
+        self._wrapped = wrapped
+        self._llm = llm
+        self._accumulator = accumulator
+        self._on_output = on_output
+        self._acc: Any = None
+        self._closed = False
+
+    def __aiter__(self) -> AsyncIterator[Any]:
+        return self
+
+    async def __anext__(self) -> Any:
+        try:
+            value = await self._wrapped.__anext__()
+        except StopAsyncIteration:
+            self._close()
+            raise
+        except BaseException as exc:
+            _close_with_error(self._llm, exc)
+            self._closed = True
+            raise
+        try:
+            self._acc = self._accumulator(self._acc, value)
+        except BaseException:
+            pass
+        return value
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: types.TracebackType | None,
+    ) -> bool:
+        if exc_val is not None:
+            _close_with_error(self._llm, exc_val)
+            self._closed = True
+        else:
+            self._close()
+        return False
+
+    def __getattr__(self, name: str) -> Any:
+        underlying = getattr(self._wrapped, name)
+        if not inspect.iscoroutinefunction(underlying):
+            return underlying
+
+        # When the SDK exposes a coroutine method that ultimately
+        # returns the final aggregated result (e.g. ``get_final_response``
+        # on openai's Responses stream), we want the stream lifecycle to
+        # close after that method awaits. Wrap to do exactly that.
+        async def _wrapped_method(*args: Any, **kwargs: Any) -> Any:
+            value = await underlying(*args, **kwargs)
+            return value
+
+        return _wrapped_method
+
+    def _close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            if self._acc is not None:
+                self._on_output(self._llm, self._acc)
+        finally:
+            if not self._llm._ended:
+                self._llm.end()

--- a/weave/integrations/anthropic/anthropic_sdk.py
+++ b/weave/integrations/anthropic/anthropic_sdk.py
@@ -22,7 +22,18 @@ from anthropic.types.beta import (
 )
 
 import weave
+from weave.integrations._session_llm_bridge import (
+    session_aware_async,
+    session_aware_sync,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
+from weave.session import LLM
+from weave.session.adapters.anthropic import (
+    finish_reasons_from_anthropic,
+    input_messages_from_anthropic,
+    output_messages_from_anthropic,
+    usage_from_anthropic,
+)
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import _add_accumulator, _IteratorWrapper
 
@@ -88,15 +99,57 @@ def should_use_accumulator(inputs: dict) -> bool:
     return isinstance(inputs, dict) and bool(inputs.get("stream"))
 
 
+def _anthropic_populate_input(llm: LLM, kwargs: dict) -> None:
+    messages = kwargs.get("messages")
+    if isinstance(messages, list):
+        llm.input_messages = input_messages_from_anthropic(messages)
+    system = kwargs.get("system")
+    if isinstance(system, str) and system:
+        llm.system_instructions = [system]
+    elif isinstance(system, list):
+        instructions = [
+            block.get("text", "") if isinstance(block, dict) else "" for block in system
+        ]
+        instructions = [s for s in instructions if s]
+        if instructions:
+            llm.system_instructions = instructions
+
+
+def _anthropic_populate_output(llm: LLM, response: Message | None) -> None:
+    if response is None:
+        return
+    llm.record(
+        output_messages=output_messages_from_anthropic(response),
+        usage=usage_from_anthropic(response),
+        response_id=getattr(response, "id", "") or "",
+        response_model=getattr(response, "model", "") or "",
+        finish_reasons=finish_reasons_from_anthropic(response),
+    )
+
+
+def _anthropic_model_from_kwargs(kwargs: dict) -> str:
+    model = kwargs.get("model")
+    return str(model) if model else ""
+
+
 def create_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
         """We need to do this so we can check if `stream` is used."""
         op_kwargs = settings.model_dump()
         op = weave.op(fn, **op_kwargs)
-        return _add_accumulator(
+        op_with_acc = _add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: anthropic_accumulator,
             should_accumulate=should_use_accumulator,
+        )
+        return session_aware_sync(
+            op_with_acc,
+            provider_name="anthropic",
+            model_from_kwargs=_anthropic_model_from_kwargs,
+            on_input=_anthropic_populate_input,
+            on_output=_anthropic_populate_output,
+            is_streaming=should_use_accumulator,
+            accumulator=anthropic_accumulator,
         )
 
     return wrapper
@@ -117,10 +170,19 @@ def create_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]
         "We need to do this so we can check if `stream` is used"
         op_kwargs = settings.model_dump()
         op = weave.op(_fn_wrapper(fn), **op_kwargs)
-        return _add_accumulator(
+        op_with_acc = _add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: anthropic_accumulator,
             should_accumulate=should_use_accumulator,
+        )
+        return session_aware_async(
+            op_with_acc,
+            provider_name="anthropic",
+            model_from_kwargs=_anthropic_model_from_kwargs,
+            on_input=_anthropic_populate_input,
+            on_output=_anthropic_populate_output,
+            is_streaming=should_use_accumulator,
+            accumulator=anthropic_accumulator,
         )
 
     return wrapper

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -26,7 +26,19 @@ from openai.types.chat.chat_completion_message_tool_call import (
 )
 
 import weave
+from weave.integrations._session_llm_bridge import (
+    session_aware_async,
+    session_aware_sync,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
+from weave.session import LLM
+from weave.session.adapters.openai import (
+    finish_reasons_from_openai_responses,
+    message_from_openai_responses_input,
+    output_messages_from_openai_responses,
+    reasoning_from_openai_responses_output,
+    usage_from_openai_responses,
+)
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import (
     _add_accumulator,
@@ -727,6 +739,34 @@ def responses_on_finish_post_processor(value: Response | None) -> dict | None:
     return dump
 
 
+def _responses_populate_input(llm: LLM, kwargs: dict) -> None:
+    input_data = kwargs.get("input")
+    if not input_data:
+        return
+    messages, attachments = message_from_openai_responses_input(input_data)
+    llm.input_messages = messages
+    if attachments:
+        llm.media_attachments = attachments
+
+
+def _responses_populate_output(llm: LLM, response: Response | None) -> None:
+    if response is None:
+        return
+    llm.record(
+        output_messages=output_messages_from_openai_responses(response),
+        usage=usage_from_openai_responses(response),
+        response_id=getattr(response, "id", "") or "",
+        response_model=getattr(response, "model", "") or "",
+        finish_reasons=finish_reasons_from_openai_responses(response),
+        reasoning=reasoning_from_openai_responses_output(response),
+    )
+
+
+def _responses_model_from_kwargs(kwargs: dict) -> str:
+    model = kwargs.get("model")
+    return str(model) if model else ""
+
+
 def create_wrapper_responses_sync(
     settings: OpSettings,
 ) -> Callable[[Callable], Callable]:
@@ -740,11 +780,20 @@ def create_wrapper_responses_sync(
         op = weave.op(_inner, **op_kwargs)
         op._set_on_input_handler(openai_on_input_handler)
         op._set_on_finish_handler(openai_on_finish)
-        return _add_accumulator(
+        op_with_acc = _add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: responses_accumulator,
             should_accumulate=should_use_responses_accumulator,
             on_finish_post_processor=responses_on_finish_post_processor,
+        )
+        return session_aware_sync(
+            op_with_acc,
+            provider_name="openai",
+            model_from_kwargs=_responses_model_from_kwargs,
+            on_input=_responses_populate_input,
+            on_output=_responses_populate_output,
+            is_streaming=should_use_responses_accumulator,
+            accumulator=responses_accumulator,
         )
 
     return wrapper
@@ -763,11 +812,20 @@ def create_wrapper_responses_async(
         op = weave.op(_inner, **op_kwargs)
         op._set_on_input_handler(openai_on_input_handler)
         op._set_on_finish_handler(openai_on_finish)
-        return _add_accumulator(
+        op_with_acc = _add_accumulator(
             op,  # type: ignore
             make_accumulator=lambda inputs: responses_accumulator,
             should_accumulate=should_use_responses_accumulator,
             on_finish_post_processor=responses_on_finish_post_processor,
+        )
+        return session_aware_async(
+            op_with_acc,
+            provider_name="openai",
+            model_from_kwargs=_responses_model_from_kwargs,
+            on_input=_responses_populate_input,
+            on_output=_responses_populate_output,
+            is_streaming=should_use_responses_accumulator,
+            accumulator=responses_accumulator,
         )
 
     return wrapper

--- a/weave/session/adapters/anthropic.py
+++ b/weave/session/adapters/anthropic.py
@@ -1,19 +1,25 @@
 """Adapters from Anthropic's wire format to the Weave Session SDK types.
 
-Use these when manually instrumenting calls to ``client.messages.create``
-(the autopatched Anthropic integration handles conversion automatically).
+Used internally by the autopatched Anthropic integration to populate
+``LLM`` spans from request / response data; also exposed publicly for
+agents that prefer to instrument manually.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
-from weave.session.types import Usage
+from weave.session.types import Message, ToolCallPart, ToolCallResponsePart, Usage
 
 if TYPE_CHECKING:
     from anthropic.types import Message as AnthropicMessage
 
-__all__ = ["usage_from_anthropic"]
+__all__ = [
+    "finish_reasons_from_anthropic",
+    "input_messages_from_anthropic",
+    "output_messages_from_anthropic",
+    "usage_from_anthropic",
+]
 
 
 def usage_from_anthropic(message: AnthropicMessage) -> Usage:
@@ -29,3 +35,118 @@ def usage_from_anthropic(message: AnthropicMessage) -> Usage:
         cache_creation_input_tokens=usage.cache_creation_input_tokens or 0,
         cache_read_input_tokens=usage.cache_read_input_tokens or 0,
     )
+
+
+def input_messages_from_anthropic(
+    messages: list[dict[str, Any]],
+) -> list[Message]:
+    """Convert the ``messages=`` list passed to ``client.messages.create``.
+
+    Anthropic's request shape is ``[{"role": "user"|"assistant", "content":
+    <str|blocks>}, ...]``. String content is taken as-is; structured
+    content blocks are walked for ``text`` (text payloads),
+    ``tool_use`` (assistant tool-call invocations), and ``tool_result``
+    (user-message-encoded tool responses). Returned messages preserve
+    role and contain either flat text or structured ``parts``.
+    """
+    out: list[Message] = []
+    for item in messages:
+        role = item.get("role")
+        content = item.get("content")
+        if isinstance(content, str):
+            out.append(Message(role=str(role or "user"), content=content))
+            continue
+        if not isinstance(content, list):
+            continue
+        text_parts: list[str] = []
+        tool_calls: list[ToolCallPart] = []
+        tool_responses: list[ToolCallResponsePart] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = block.get("type")
+            if block_type == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    text_parts.append(text)
+            elif block_type == "tool_use":
+                tool_calls.append(
+                    ToolCallPart(
+                        id=str(block.get("id", "")),
+                        name=str(block.get("name", "")),
+                        arguments=block.get("input", "") or "",
+                    )
+                )
+            elif block_type == "tool_result":
+                tool_responses.append(
+                    ToolCallResponsePart(
+                        id=str(block.get("tool_use_id", "")),
+                        response=block.get("content", "") or "",
+                    )
+                )
+        text = "\n".join(text_parts)
+        if role == "assistant" and (text or tool_calls):
+            out.append(Message.assistant(text, tool_calls=tool_calls or None))
+        elif tool_responses:
+            out.append(Message(role="tool", parts=list(tool_responses)))
+        elif role:
+            out.append(Message(role=str(role), content=text))
+    return out
+
+
+def output_messages_from_anthropic(
+    message: AnthropicMessage,
+) -> list[Message]:
+    """Assemble the assistant ``Message`` from an Anthropic Messages
+    ``Message`` response.
+
+    Walks ``message.content`` for ``TextBlock`` and ``ToolUseBlock``
+    entries, coalescing both into one ``Message.assistant(text,
+    tool_calls=...)``. Returns ``[]`` when no text and no tool calls
+    (e.g. an empty response) so callers can pipe through to
+    ``LLM.record(output_messages=...)`` unconditionally.
+    """
+    text_parts: list[str] = []
+    tool_calls: list[ToolCallPart] = []
+    for block in message.content or []:
+        block_type = getattr(block, "type", None)
+        if block_type == "text":
+            text = getattr(block, "text", "")
+            if text:
+                text_parts.append(text)
+        elif block_type == "tool_use":
+            tool_calls.append(
+                ToolCallPart(
+                    id=getattr(block, "id", "") or "",
+                    name=getattr(block, "name", "") or "",
+                    arguments=getattr(block, "input", "") or "",
+                )
+            )
+    text = "\n".join(text_parts)
+    if not text and not tool_calls:
+        return []
+    return [Message.assistant(text, tool_calls=tool_calls or None)]
+
+
+_STOP_REASON_TO_FINISH = {
+    "end_turn": "stop",
+    "stop_sequence": "stop",
+    "max_tokens": "length",
+    "tool_use": "tool_calls",
+    "pause_turn": "pause_turn",
+    "refusal": "content_filter",
+}
+
+
+def finish_reasons_from_anthropic(message: AnthropicMessage) -> list[str]:
+    """Map Anthropic's ``stop_reason`` to OTel ``gen_ai.response.finish_reasons``.
+
+    Anthropic reports a single stop reason (``end_turn``,
+    ``max_tokens``, ``tool_use``, etc.); OTel uses a small fixed
+    vocabulary. Unknown reasons pass through unchanged so we don't
+    drop signal during SDK upgrades that introduce new values.
+    """
+    stop = message.stop_reason
+    if not stop:
+        return []
+    return [_STOP_REASON_TO_FINISH.get(stop, stop)]

--- a/weave/session/adapters/openai.py
+++ b/weave/session/adapters/openai.py
@@ -1,15 +1,25 @@
 """Adapters from OpenAI's wire format to the Weave Session SDK types.
 
-Use these when manually instrumenting calls to ``client.responses.create``
-(the autopatched OpenAI integration handles conversion automatically).
+Used internally by the autopatched OpenAI integration to populate
+``LLM`` spans from request / response data; also exposed publicly for
+agents that prefer to instrument manually.
 
 Public functions:
 
 - ``message_from_openai_responses_input(items)`` — convert the ``input=``
   list passed to ``client.responses.create`` into ``(messages, attachments)``
   ready to assign to ``LLM.input_messages`` / ``LLM.media_attachments``.
+- ``output_messages_from_openai_responses(response)`` — assemble the
+  assistant ``Message`` list from a Responses ``Response.output``.
+- ``finish_reasons_from_openai_responses(response)`` — map
+  ``Response.status`` / ``incomplete_details.reason`` into the OTel
+  ``gen_ai.response.finish_reasons`` vocabulary.
 - ``reasoning_from_openai_responses(part)`` — flatten a Responses
   ``reasoning`` item into a ``Reasoning`` (or ``None`` if empty).
+- ``reasoning_from_openai_responses_output(response)`` — pluck the
+  reasoning item out of ``Response.output`` and flatten via
+  ``reasoning_from_openai_responses``. Convenience wrapper for callers
+  holding a whole ``Response``.
 - ``usage_from_openai_responses(response)`` — pull token counts off a
   Responses ``Response``. Tolerates missing ``usage`` and missing
   ``input_tokens_details`` / ``output_tokens_details`` (both can be
@@ -34,8 +44,11 @@ if TYPE_CHECKING:
     from openai.types.responses import Response
 
 __all__ = [
+    "finish_reasons_from_openai_responses",
     "message_from_openai_responses_input",
+    "output_messages_from_openai_responses",
     "reasoning_from_openai_responses",
+    "reasoning_from_openai_responses_output",
     "usage_from_openai_responses",
 ]
 
@@ -129,6 +142,91 @@ def reasoning_from_openai_responses(part: dict[str, Any] | None) -> Reasoning | 
         s.get("text", "") for s in summaries if isinstance(s, dict) and s.get("text")
     )
     return Reasoning(content=text) if text else None
+
+
+def output_messages_from_openai_responses(response: Response) -> list[Message]:
+    """Assemble the assistant ``Message`` list from a Responses ``Response``.
+
+    ``response.output`` is a heterogeneous list of items: ``message``
+    (assistant text in ``output_text`` blocks), ``function_call``
+    (tool-call invocations), and ``reasoning`` (chain-of-thought summary
+    items, surfaced separately via ``reasoning_from_openai_responses``).
+
+    All assistant text and tool calls collapse into a single
+    ``Message.assistant(text, tool_calls=...)`` so the chat-view shape
+    matches what wb_agent and the Sessions UI expect: one assistant
+    message per LLM turn carrying both narration and tool invocations.
+    Returns ``[]`` when the response has no assistant text and no tool
+    calls (e.g. reasoning-only output) so callers can pipe through to
+    ``LLM.record(output_messages=...)`` unconditionally.
+    """
+    text_parts: list[str] = []
+    tool_calls: list[ToolCallPart] = []
+    for item in response.output or []:
+        item_type = getattr(item, "type", None)
+        if item_type == "message":
+            for block in getattr(item, "content", []) or []:
+                if getattr(block, "type", None) == "output_text":
+                    text = getattr(block, "text", "")
+                    if text:
+                        text_parts.append(text)
+        elif item_type == "function_call":
+            tool_calls.append(
+                ToolCallPart(
+                    id=getattr(item, "call_id", "") or "",
+                    name=getattr(item, "name", "") or "",
+                    arguments=getattr(item, "arguments", "") or "",
+                )
+            )
+    text = "\n".join(text_parts)
+    if not text and not tool_calls:
+        return []
+    return [Message.assistant(text, tool_calls=tool_calls or None)]
+
+
+_RESPONSE_INCOMPLETE_TO_FINISH = {
+    "max_output_tokens": "length",
+    "content_filter": "content_filter",
+}
+
+
+def finish_reasons_from_openai_responses(response: Response) -> list[str]:
+    """Map a Responses ``Response.status`` to OTel ``finish_reasons``.
+
+    OpenAI's Responses API reports completion via ``status`` and (when
+    incomplete) ``incomplete_details.reason``. OTel GenAI conventions
+    use a small fixed vocabulary (``stop``, ``length``,
+    ``content_filter``, ``tool_calls``, ``error``). This function maps
+    between them. Tool-call termination is not signaled as a finish
+    reason in Responses — callers infer it from
+    ``output_messages[*].tool_calls`` being non-empty.
+    """
+    if response.status == "completed":
+        return ["stop"]
+    if response.status == "incomplete":
+        reason = ""
+        if response.incomplete_details and response.incomplete_details.reason:
+            reason = response.incomplete_details.reason
+        return [_RESPONSE_INCOMPLETE_TO_FINISH.get(reason, reason or "incomplete")]
+    if response.status in {"failed", "cancelled"}:
+        return [response.status]
+    return []
+
+
+def reasoning_from_openai_responses_output(
+    response: Response,
+) -> Reasoning | None:
+    """Find the reasoning item in ``Response.output`` and flatten it.
+
+    Convenience wrapper over ``reasoning_from_openai_responses`` for
+    callers holding the whole ``Response``. Returns the first reasoning
+    item (Responses currently emits at most one per call) flattened via
+    ``model_dump``, or ``None`` if no reasoning was emitted.
+    """
+    for item in response.output or []:
+        if getattr(item, "type", None) == "reasoning":
+            return reasoning_from_openai_responses(item.model_dump())
+    return None
 
 
 def usage_from_openai_responses(response: Response) -> Usage:


### PR DESCRIPTION
**Draft for early review — exploring the design before fleshing out remaining paths.**

## Why

Today the openai / anthropic autopatches emit only legacy \`@weave.op\` call objects (visible in the Traces tab). Code running inside an active Session SDK \`Turn\` gets nothing on the Agents tab from the LLM call — agents had to manually call \`weave.start_llm(...)\` and \`llm.record(...)\` with hand-mapped messages / usage / finish_reasons.

That violates the industry pattern: every comparable SDK (LangSmith, Langfuse, Logfire, Braintrust, Traceloop, Datadog LLM Obs, AgentOps, OpenAI Agents SDK) makes LLM-call instrumentation a side effect of the integration patch. The user writes \`client.responses.create(...)\` and the span lands. This PR lands that for weave.

Concrete motivation: wandb/core#43000 needed ~300 lines of \`start_llm\`/\`llm.record\` boilerplate in a downstream agent service to get the Sessions UI populated. After this PR lands, that's a weave version bump.

## What

**New shared bridge: \`weave/integrations/_session_llm_bridge.py\`.**

\`session_aware_sync\` / \`session_aware_async\` wrap an existing \`_add_accumulator\`-decorated op. The wrapper is a transparent passthrough when no Turn is active. With one, it:

- Opens an \`LLM\` span keyed on the integration's model + provider.
- Runs caller-provided \`on_input(llm, kwargs)\` to populate request-side fields.
- Calls the wrapped op.
- For non-streaming: runs \`on_output(llm, response)\` and \`llm.end()\` before returning.
- For streaming: returns a \`_SyncStreamAdapter\` / \`_AsyncStreamAdapter\` that holds the span open until iteration exhausts, then runs \`on_output\` on the accumulated final value.
- On exception (sync, async, or mid-stream): records the error on the span, closes, re-raises.

**OpenAI \`responses.create\` (sync + async)**: wires \`session_aware_*\` with \`provider_name=\"openai\"\` and the new adapter helpers. Streaming uses the existing \`responses_accumulator\` to derive the final \`Response\`.

**Anthropic \`messages.create\` (sync + async)**: same shape. Also pulls \`system\` from kwargs into \`llm.system_instructions\`. Fixes the zero-token-count behavior that wb_agent's \`wba_claude\` was working around.

**Adapter additions** (these were missing; everything except output extraction already existed):
- \`weave.session.adapters.openai\`: \`output_messages_from_openai_responses\`, \`finish_reasons_from_openai_responses\`, \`reasoning_from_openai_responses_output\`.
- \`weave.session.adapters.anthropic\`: \`input_messages_from_anthropic\`, \`output_messages_from_anthropic\`, \`finish_reasons_from_anthropic\`.

## Test plan

\`tests/integrations/test_session_llm_bridge.py\` covers the bridge in isolation with mock callables (no VCR cassettes needed):

- No-Turn passthrough leaves call args / return value untouched.
- Active-Turn non-streaming opens span, populates inputs, runs call, populates outputs, closes — verified at the OTel attribute level (\`gen_ai.provider.name\`, \`gen_ai.response.id\`, \`gen_ai.usage.*\`).
- Active-Turn streaming closes span after iteration exhausts, with \`on_output\` running on the accumulated final value.
- Async non-streaming + async streaming mirror the sync paths.
- Exceptions during the call record \`ERROR\` status on the span and re-raise.

Existing openai / anthropic integration tests are unaffected — the bridge is a no-op when no Turn is active, so legacy \`@weave.op\` recording continues unchanged.

## Out of scope (follow-ups)

This is a draft scoped to the most-used paths so we can review the bridge design before fleshing out the rest:

- [ ] OpenAI \`chat.completions.create\` sync + async (needs \`message_from_openai_chat_completions_input\` adapter).
- [ ] OpenAI \`responses.stream\` context-manager surface (separate patch path, uses an \`_IteratorWrapper\` subclass).
- [ ] Anthropic \`messages.stream\` context-manager surface.
- [ ] Promote \`@weave.op(kind=\"tool\")\` to auto-emit \`Tool\` spans when a Turn is active — separate PR; lets tool functions get tracing from the same decorator that already wraps them.

## Industry survey backing the approach

| SDK | Auto-instruments LLM SDK? | Primary user API |
|---|---|---|
| LangSmith | Yes (\`wrap_openai\`) | \`@traceable\` decorator |
| Langfuse | Yes (drop-in \`from langfuse.openai import openai\`) | \`@observe()\` decorator |
| Logfire | Yes (\`logfire.instrument_openai()\`) | \`logfire.span()\` + \`@logfire.instrument\` |
| Braintrust | Yes (\`wrap_openai\`) | \`@traced\` decorator |
| Traceloop / OpenLLMetry | Yes (OTel auto-instrumentors) | \`@workflow\` / \`@task\` / \`@agent\` / \`@tool\` |
| Datadog LLM Obs | Yes (auto-instruments) | \`@workflow\`/\`@agent\`/\`@llm\`/\`@tool\` |
| OpenAI Agents SDK | Yes (built into runner) | No user code needed |

None of these expose \`start_llm(...)\` with hand-mapped messages / usage as the primary API. The pattern this PR lands matches the consensus.