### PR TITLE
fix(weave): NOT(contains) over-filtering on heavy fields

### DIFF
--- a/tests/trace_server/query_builder/test_optimization_builder.py
+++ b/tests/trace_server/query_builder/test_optimization_builder.py
@@ -8,9 +8,11 @@ from weave.trace_server.calls_query_builder.optimization_builder import (
     HeavyFieldOptimizationProcessor,
     _maybe_use_null_check,
     apply_processor,
+    process_query_to_optimization_sql,
 )
 from weave.trace_server.calls_query_builder.utils import NotContext
 from weave.trace_server.interface import query as tsi_query
+from weave.trace_server.project_version.types import ReadTable
 
 
 @pytest.mark.parametrize("table_alias", ["calls_merged", "calls_complete"])
@@ -187,27 +189,79 @@ def test_heavy_field_eq_inside_not_skips_optimization() -> None:
     assert result is None
 
 
-def test_heavy_field_eq_inside_not_without_null_check() -> None:
-    """On calls_complete (use_null_check=False), NOT optimization works normally."""
-    pb = ParamBuilder()
-    processor = HeavyFieldOptimizationProcessor(
-        pb, "calls_complete", use_null_check=False
+@pytest.mark.parametrize(
+    "inner_op",
+    [
+        pytest.param(
+            {"$eq": [{"$getField": "inputs.x"}, {"$literal": "wandb"}]},
+            id="eq",
+        ),
+        pytest.param(
+            {
+                "$contains": {
+                    "input": {"$getField": "inputs.turn.wandb_entity"},
+                    "substr": {"$literal": "wandb"},
+                }
+            },
+            id="contains",
+        ),
+        pytest.param(
+            {
+                "$in": [
+                    {"$getField": "inputs.x"},
+                    [{"$literal": "a"}, {"$literal": "b"}],
+                ]
+            },
+            id="in",
+        ),
+    ],
+)
+def test_not_heavy_field_skips_pre_filter_on_calls_complete(inner_op: dict) -> None:
+    """Regression for WB-34043: NOT($contains/$eq/$in heavy) over-filtered.
+
+    The heavy-field LIKE pattern is a SUPERSET of the real predicate (it
+    can match the literal in any key/value of the JSON dump). The
+    pre-aggregation contract in `process_query_to_optimization_sql`
+    requires the optimizer SQL to be identical or LESS restrictive than
+    the post-aggregation HAVING. Wrapping a superset in NOT yields a
+    SUBSET, which violates the contract and drops valid rows.
+
+    The reporter ran `not contains "wandb"` on inputs.turn.wandb_entity
+    and got 13 rows instead of ~142; the LIKE pattern `%"%wandb%"%` also
+    matched the JSON key `"wandb_entity"` present in every row.
+
+    This test reproduces the exact query shape (gt started_at AND not
+    <heavy op>) through the public optimizer entry point. It must emit
+    no heavy-field pre-filter, on both `calls_complete` (the bug path,
+    use_null_check=False) and `calls_merged` (already covered indirectly
+    by the null-check branch, asserted here for symmetry).
+    """
+    conditions = [
+        Condition(
+            operand=tsi_query.GtOperation.model_validate(
+                {"$gt": [{"$getField": "started_at"}, {"$literal": 1775275200}]}
+            )
+        ),
+        Condition(operand=tsi_query.NotOperation.model_validate({"$not": [inner_op]})),
+    ]
+
+    pb_complete = ParamBuilder()
+    result_complete = process_query_to_optimization_sql(
+        conditions, pb_complete, "calls_complete", ReadTable.CALLS_COMPLETE
+    )
+    assert result_complete.heavy_filter_opt_sql is None, (
+        f"calls_complete: pre-filter inside NOT would emit a SUBSET and "
+        f"over-filter, got: {result_complete.heavy_filter_opt_sql}"
     )
 
-    op = tsi_query.NotOperation.model_validate(
-        {
-            "$not": [
-                {"$eq": [{"$getField": "attributes.some_key"}, {"$literal": "true"}]}
-            ]
-        }
+    pb_merged = ParamBuilder()
+    result_merged = process_query_to_optimization_sql(
+        conditions, pb_merged, "calls_merged", ReadTable.CALLS_MERGED
     )
-    result = apply_processor(processor, op)
-
-    # No null check needed for calls_complete, so the NOT optimization is safe
-    assert result is not None
-    assert "NOT" in result
-    assert "LIKE" in result
-    assert "IS NULL" not in result
+    assert result_merged.heavy_filter_opt_sql is None, (
+        f"calls_merged: pre-filter inside NOT would emit a SUBSET and "
+        f"over-filter, got: {result_merged.heavy_filter_opt_sql}"
+    )
 
 
 def test_heavy_field_contains_inside_not_skips_optimization() -> None:

--- a/weave/trace_server/calls_query_builder/optimization_builder.py
+++ b/weave/trace_server/calls_query_builder/optimization_builder.py
@@ -710,26 +710,31 @@ def _maybe_use_null_check(
     table_alias: str,
     use_null_check: bool,
 ) -> str | None:
-    """Conditionally append `...OR IS NULL` to a SQL condition.
-    When querying calls_merged, we must pass through certain null values
-    (see `_field_requires_null_check`).
+    """Finalize a heavy-field LIKE condition for the calls pre-filter.
 
-    Returns a wrapped condition e.g. "x LIKE '%y%' OR t.attributes_dump IS NULL";
-    Returns None if the the null check cannot be safely applied (see note below).
+    Two responsibilities:
+    1. Bail entirely when inside a NOT context. Heavy-field LIKE patterns
+       are SUPERSETS of the real predicate (the LIKE can match the literal
+       in unrelated JSON keys/values within the dump). Wrapping a superset
+       in NOT produces a SUBSET, which violates the pre-filter contract in
+       `process_query_to_optimization_sql` (must be identical or less
+       restrictive than the post-aggregation HAVING) and drops valid rows.
+       See WB-34043.
+    2. Append `OR ... IS NULL` for start/end fields on calls_merged so
+       unmerged call parts are not filtered out before aggregation.
+
+    Returns None when no safe pre-filter can be emitted.
 
     Args:
-        condition: The condition to wrap with `OR IS NULL`, e.g. "x LIKE '%y%'".
-        field: The column name to add the `IS NULL` check to, e.g. "attributes_dump".
+        condition: The condition to finalize, e.g. "x LIKE '%y%'".
+        field: The column name being filtered, e.g. "inputs_dump".
         table_alias: The table name to use in SQL.
         use_null_check: Whether to add OR IS NULL for start/end fields.
             True for calls_merged (unmerged parts may have NULL fields).
             False for calls_complete (every row is a complete call).
     """
+    if NotContext.is_in_not_context():
+        return None
     if use_null_check and _field_requires_null_check(field):
-        if NotContext.is_in_not_context():
-            # Inside "NOT (...)", adding "OR IS NULL" would invert to "AND IS NOT NULL"
-            # which is the opposite of the intention here. There is no way to safely
-            # include null values inside a "NOT" so we skip the optimization entirely.
-            return None
         return f"({condition} OR {table_alias}.{field} IS NULL)"
     return condition


### PR DESCRIPTION
[WB-34043](https://coreweave.atlassian.net/browse/WB-34043)

## Summary
- `$not [$contains/$eq/$in heavy]` was over-filtering on `calls_complete`. The heavy-field LIKE optimizer emits a SUPERSET pre-filter; wrapping a superset in NOT yields a SUBSET, dropping valid rows before HAVING runs.
- The NOT-context guard already existed on `calls_merged` (use_null_check=True) but only as a side effect of the null-check branch. This PR hoists the guard to the top of `_maybe_use_null_check` so it applies regardless of table.
-  Reporter saw `not contains "wandb"` return 13 rows instead of ~142; the LIKE pattern `'%"%wandb%"%'` matched the JSON key `"wandb_entity"` in every row.

Failing test landed first as 41018054ac (TDD); fix is in bedc33f0d1.

## Testing
one parametrized regression test through `process_query_to_optimization_sql` reproducing the exact WB-34043 query shape (`gt started_at AND not <heavy op>`) across `$contains` / `$eq` / `$in`, asserting no pre-filter is emitted on either `calls_complete` or `calls_merged`. Also drops an existing test that asserted the buggy NOT(LIKE) shape was "safe on calls_complete"; it confused null-safety with superset-safety.

[WB-34043]: https://coreweave.atlassian.net/browse/WB-34043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ