### PR TITLE
feat(weave): Session SDK adapters + traced streaming helpers for OpenAI / Anthropic

### DIFF
--- a/tests/session/test_session_otel.py
+++ b/tests/session/test_session_otel.py
@@ -15,9 +15,16 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NoOpTracerProvider, StatusCode
 
+from weave.session.adapters.anthropic import (
+    message_from_anthropic_input,
+    record_anthropic_message,
+    traced_anthropic_messages_stream,
+)
 from weave.session.adapters.openai import (
     message_from_openai_responses_input,
     reasoning_from_openai_responses,
+    record_openai_responses,
+    traced_openai_responses_stream,
     usage_from_openai_responses,
 )
 from weave.session.session import (
@@ -2313,3 +2320,648 @@ class TestReasoningFromOpenAIResponses:
         )
         assert result is not None
         assert result.content == "kept\nalso kept"
+
+
+# ---------------------------------------------------------------------------
+# record_openai_responses — end-to-end "commit final response" adapter
+# ---------------------------------------------------------------------------
+
+
+def _fake_openai_response(
+    *,
+    output: list[Any] | None = None,
+    response_id: str = "resp_test",
+    model: str = "gpt-test",
+    status: str = "completed",
+    incomplete_reason: str = "",
+    usage: Any = None,
+) -> Any:
+    """Build a duck-typed Responses ``Response`` for adapter tests."""
+    incomplete_details: Any = None
+    if incomplete_reason:
+        incomplete_details = type("D", (), {"reason": incomplete_reason})()
+    return type(
+        "R",
+        (),
+        {
+            "output": list(output or []),
+            "id": response_id,
+            "model": model,
+            "status": status,
+            "incomplete_details": incomplete_details,
+            "usage": usage,
+        },
+    )()
+
+
+def _fake_responses_message_item(text_blocks: list[str]) -> Any:
+    contents = [type("C", (), {"text": t})() for t in text_blocks]
+    return type("M", (), {"type": "message", "content": contents})()
+
+
+def _fake_responses_function_call(call_id: str, name: str, arguments: str) -> Any:
+    return type(
+        "F",
+        (),
+        {
+            "type": "function_call",
+            "call_id": call_id,
+            "name": name,
+            "arguments": arguments,
+        },
+    )()
+
+
+def _fake_responses_reasoning(summary_texts: list[str]) -> Any:
+    summary = [{"text": t} for t in summary_texts]
+
+    class _R:
+        type = "reasoning"
+
+        def model_dump(self, *, exclude_none: bool = False) -> dict[str, Any]:
+            return {"type": "reasoning", "summary": summary}
+
+    return _R()
+
+
+def _fake_responses_usage(
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    reasoning_tokens: int = 0,
+    cached_tokens: int = 0,
+) -> Any:
+    out_details = type("D", (), {"reasoning_tokens": reasoning_tokens})()
+    in_details = type("D", (), {"cached_tokens": cached_tokens})()
+    return type(
+        "U",
+        (),
+        {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "output_tokens_details": out_details,
+            "input_tokens_details": in_details,
+        },
+    )()
+
+
+class TestRecordOpenAIResponses:
+    """``record_openai_responses`` commits a final Response to an ``LLM`` span.
+
+    Anchored at the OTel attribute boundary — the adapter is meaningful
+    only if every field lands on ``gen_ai.*`` on the emitted chat span.
+    """
+
+    def _record(
+        self,
+        otel_spans: InMemorySpanExporter,
+        *,
+        input_items: list[dict],
+        response: Any,
+    ) -> dict[str, Any]:
+        otel_spans.clear()
+        with start_session(agent_name="bot", session_id="sess") as s, s.start_turn():
+            with start_llm(model="gpt-test", provider_name="openai") as llm:
+                record_openai_responses(llm, input_items=input_items, response=response)
+        chat = [
+            sp for sp in otel_spans.get_finished_spans() if sp.name == "chat gpt-test"
+        ]
+        assert len(chat) == 1
+        return dict(chat[0].attributes or {})
+
+    def test_text_only_response(self, otel_spans: InMemorySpanExporter) -> None:
+        attrs = self._record(
+            otel_spans,
+            input_items=[{"role": "user", "content": "hi"}],
+            response=_fake_openai_response(
+                output=[_fake_responses_message_item(["hello"])],
+                response_id="r1",
+                model="gpt-test-2",
+                usage=_fake_responses_usage(input_tokens=3, output_tokens=2),
+            ),
+        )
+        in_msgs = json.loads(attrs["gen_ai.input.messages"])
+        out_msgs = json.loads(attrs["gen_ai.output.messages"])
+        assert in_msgs == [
+            {"role": "user", "parts": [{"type": "text", "content": "hi"}]}
+        ]
+        assert len(out_msgs) == 1
+        assert out_msgs[0]["role"] == "assistant"
+        assert out_msgs[0]["parts"] == [{"type": "text", "content": "hello"}]
+        assert attrs["gen_ai.response.id"] == "r1"
+        assert attrs["gen_ai.response.model"] == "gpt-test-2"
+        assert attrs["gen_ai.response.finish_reasons"] == ("stop",)
+        assert attrs["gen_ai.usage.input_tokens"] == 3
+        assert attrs["gen_ai.usage.output_tokens"] == 2
+
+    def test_tool_call_response(self, otel_spans: InMemorySpanExporter) -> None:
+        attrs = self._record(
+            otel_spans,
+            input_items=[{"role": "user", "content": "weather?"}],
+            response=_fake_openai_response(
+                output=[
+                    _fake_responses_message_item(["checking..."]),
+                    _fake_responses_function_call(
+                        "c1", "get_weather", '{"city":"NYC"}'
+                    ),
+                ],
+            ),
+        )
+        out_msgs = json.loads(attrs["gen_ai.output.messages"])
+        assert len(out_msgs) == 1
+        parts = out_msgs[0]["parts"]
+        assert parts[0] == {"type": "text", "content": "checking..."}
+        tool_part = parts[1]
+        assert tool_part["type"] == "tool_call"
+        assert tool_part["id"] == "c1"
+        assert tool_part["name"] == "get_weather"
+        assert json.loads(tool_part["arguments"]) == {"city": "NYC"}
+
+    def test_reasoning_lands_on_span(self, otel_spans: InMemorySpanExporter) -> None:
+        attrs = self._record(
+            otel_spans,
+            input_items=[{"role": "user", "content": "go"}],
+            response=_fake_openai_response(
+                output=[
+                    _fake_responses_reasoning(["step1", "step2"]),
+                    _fake_responses_message_item(["done"]),
+                ],
+            ),
+        )
+        out_msgs = json.loads(attrs["gen_ai.output.messages"])
+        # Reasoning is prepended as a ReasoningPart on the assistant message.
+        assert out_msgs[-1]["parts"][0] == {
+            "type": "reasoning",
+            "content": "step1\nstep2",
+        }
+
+    def test_incomplete_response_maps_to_length(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        attrs = self._record(
+            otel_spans,
+            input_items=[{"role": "user", "content": "x"}],
+            response=_fake_openai_response(
+                output=[_fake_responses_message_item(["partial"])],
+                status="incomplete",
+                incomplete_reason="max_output_tokens",
+            ),
+        )
+        assert attrs["gen_ai.response.finish_reasons"] == ("length",)
+
+    def test_failed_response_emits_status_as_finish_reason(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        attrs = self._record(
+            otel_spans,
+            input_items=[{"role": "user", "content": "x"}],
+            response=_fake_openai_response(output=[], status="failed"),
+        )
+        assert attrs["gen_ai.response.finish_reasons"] == ("failed",)
+
+    def test_empty_output_emits_no_output_messages_attr(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        attrs = self._record(
+            otel_spans,
+            input_items=[{"role": "user", "content": "x"}],
+            response=_fake_openai_response(output=[]),
+        )
+        assert "gen_ai.output.messages" not in attrs
+
+
+# ---------------------------------------------------------------------------
+# record_anthropic_message — end-to-end "commit final response" adapter
+# ---------------------------------------------------------------------------
+
+
+def _fake_anthropic_usage(
+    *,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    cache_creation_input_tokens: int | None = None,
+    cache_read_input_tokens: int | None = None,
+) -> Any:
+    return type(
+        "U",
+        (),
+        {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cache_creation_input_tokens": cache_creation_input_tokens,
+            "cache_read_input_tokens": cache_read_input_tokens,
+        },
+    )()
+
+
+def _fake_anthropic_message(
+    *,
+    content: list[Any] | None = None,
+    response_id: str = "msg_test",
+    model: str = "claude-test",
+    stop_reason: str | None = "end_turn",
+    usage: Any = None,
+) -> Any:
+    return type(
+        "M",
+        (),
+        {
+            "content": list(content or []),
+            "id": response_id,
+            "model": model,
+            "stop_reason": stop_reason,
+            "usage": usage or _fake_anthropic_usage(),
+        },
+    )()
+
+
+def _fake_anthropic_text_block(text: str) -> Any:
+    return type("T", (), {"type": "text", "text": text})()
+
+
+def _fake_anthropic_tool_use_block(block_id: str, name: str, input_args: Any) -> Any:
+    return type(
+        "TU",
+        (),
+        {"type": "tool_use", "id": block_id, "name": name, "input": input_args},
+    )()
+
+
+class TestRecordAnthropicMessage:
+    """``record_anthropic_message`` commits a final Message to an ``LLM`` span."""
+
+    def _record(
+        self,
+        otel_spans: InMemorySpanExporter,
+        *,
+        input_messages: list[dict],
+        system: str = "",
+        response: Any,
+    ) -> dict[str, Any]:
+        otel_spans.clear()
+        with start_session(agent_name="bot", session_id="sess") as s, s.start_turn():
+            with start_llm(model="claude-test", provider_name="anthropic") as llm:
+                record_anthropic_message(
+                    llm,
+                    input_messages=input_messages,
+                    system=system,
+                    response=response,
+                )
+        chat = [
+            sp
+            for sp in otel_spans.get_finished_spans()
+            if sp.name == "chat claude-test"
+        ]
+        assert len(chat) == 1
+        return dict(chat[0].attributes or {})
+
+    def test_text_only_response(self, otel_spans: InMemorySpanExporter) -> None:
+        attrs = self._record(
+            otel_spans,
+            input_messages=[{"role": "user", "content": "hi"}],
+            system="be helpful",
+            response=_fake_anthropic_message(
+                content=[_fake_anthropic_text_block("hello")],
+                response_id="m1",
+                model="claude-3-5",
+                stop_reason="end_turn",
+                usage=_fake_anthropic_usage(input_tokens=4, output_tokens=2),
+            ),
+        )
+        out_msgs = json.loads(attrs["gen_ai.output.messages"])
+        in_msgs = json.loads(attrs["gen_ai.input.messages"])
+        assert in_msgs == [
+            {"role": "user", "parts": [{"type": "text", "content": "hi"}]}
+        ]
+        assert len(out_msgs) == 1
+        assert out_msgs[0]["role"] == "assistant"
+        assert out_msgs[0]["parts"] == [{"type": "text", "content": "hello"}]
+        assert attrs["gen_ai.response.id"] == "m1"
+        assert attrs["gen_ai.response.model"] == "claude-3-5"
+        assert attrs["gen_ai.response.finish_reasons"] == ("stop",)
+        assert json.loads(attrs["gen_ai.system_instructions"]) == [
+            {"type": "text", "content": "be helpful"}
+        ]
+        assert attrs["gen_ai.usage.input_tokens"] == 4
+        assert attrs["gen_ai.usage.output_tokens"] == 2
+
+    def test_tool_use_response(self, otel_spans: InMemorySpanExporter) -> None:
+        attrs = self._record(
+            otel_spans,
+            input_messages=[{"role": "user", "content": "weather?"}],
+            response=_fake_anthropic_message(
+                content=[
+                    _fake_anthropic_text_block("checking..."),
+                    _fake_anthropic_tool_use_block(
+                        "tu1", "get_weather", {"city": "NYC"}
+                    ),
+                ],
+                stop_reason="tool_use",
+            ),
+        )
+        out_msgs = json.loads(attrs["gen_ai.output.messages"])
+        assert len(out_msgs) == 1
+        parts = out_msgs[0]["parts"]
+        assert parts[0] == {"type": "text", "content": "checking..."}
+        assert parts[1]["type"] == "tool_call"
+        assert parts[1]["id"] == "tu1"
+        assert parts[1]["name"] == "get_weather"
+        assert json.loads(parts[1]["arguments"]) == {"city": "NYC"}
+        assert attrs["gen_ai.response.finish_reasons"] == ("tool_calls",)
+
+    def test_max_tokens_maps_to_length(self, otel_spans: InMemorySpanExporter) -> None:
+        attrs = self._record(
+            otel_spans,
+            input_messages=[{"role": "user", "content": "x"}],
+            response=_fake_anthropic_message(
+                content=[_fake_anthropic_text_block("p")],
+                stop_reason="max_tokens",
+            ),
+        )
+        assert attrs["gen_ai.response.finish_reasons"] == ("length",)
+
+    def test_input_with_tool_result_splits_into_tool_message(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        attrs = self._record(
+            otel_spans,
+            input_messages=[
+                {"role": "user", "content": "weather?"},
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "calling tool"},
+                        {
+                            "type": "tool_use",
+                            "id": "tu1",
+                            "name": "get_weather",
+                            "input": {"city": "NYC"},
+                        },
+                    ],
+                },
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu1",
+                            "content": "sunny",
+                        }
+                    ],
+                },
+            ],
+            response=_fake_anthropic_message(
+                content=[_fake_anthropic_text_block("ok")]
+            ),
+        )
+        in_msgs = json.loads(attrs["gen_ai.input.messages"])
+        roles = [m["role"] for m in in_msgs]
+        assert roles == ["user", "assistant", "tool"]
+
+
+class TestMessageFromAnthropicInput:
+    """``message_from_anthropic_input`` round-trips Anthropic ``messages=`` payloads."""
+
+    def test_flat_user_text(self) -> None:
+        out = message_from_anthropic_input([{"role": "user", "content": "hello"}])
+        assert len(out) == 1
+        assert out[0].role == "user"
+        assert out[0].content == "hello"
+
+    def test_assistant_text_and_tool_use(self) -> None:
+        out = message_from_anthropic_input(
+            [
+                {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "text", "text": "reading..."},
+                        {
+                            "type": "tool_use",
+                            "id": "x",
+                            "name": "y",
+                            "input": {"k": "v"},
+                        },
+                    ],
+                }
+            ]
+        )
+        assert len(out) == 1
+        assert out[0].role == "assistant"
+        kinds = [p.type for p in out[0].parts]
+        assert kinds == ["text", "tool_call"]
+
+    def test_user_tool_result_promotes_to_tool_role(self) -> None:
+        out = message_from_anthropic_input(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "x",
+                            "content": "result",
+                        }
+                    ],
+                }
+            ]
+        )
+        assert len(out) == 1
+        assert out[0].role == "tool"
+        assert len(out[0].parts) == 1
+
+    def test_user_mixed_text_and_tool_result_splits(self) -> None:
+        out = message_from_anthropic_input(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "fyi"},
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "x",
+                            "content": "r",
+                        },
+                    ],
+                }
+            ]
+        )
+        assert [m.role for m in out] == ["user", "tool"]
+
+
+# ---------------------------------------------------------------------------
+# traced_openai_responses_stream / traced_anthropic_messages_stream
+# ---------------------------------------------------------------------------
+
+
+class _FakeOpenAIResponsesStream:
+    """Async-iterable stand-in for the OpenAI Responses streaming context.
+
+    Used as the value yielded by a mocked ``client.responses.stream`` so
+    the helper can iterate it and then call ``get_final_response()``.
+    """
+
+    def __init__(self, events: list[Any], final: Any) -> None:
+        self._events = events
+        self._final = final
+
+    def __aiter__(self) -> _FakeOpenAIResponsesStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+    async def get_final_response(self) -> Any:
+        return self._final
+
+
+class _FakeOpenAIClient:
+    """Minimal ``AsyncOpenAI`` stand-in routing ``responses.stream`` to a fake."""
+
+    def __init__(self, events: list[Any], final: Any) -> None:
+        self._events = events
+        self._final = final
+        self.received_kwargs: dict[str, Any] = {}
+
+    @property
+    def responses(self) -> _FakeOpenAIClient:
+        return self
+
+    def stream(self, **kwargs: Any) -> Any:
+        self.received_kwargs = dict(kwargs)
+        stream = _FakeOpenAIResponsesStream(list(self._events), self._final)
+        return _async_cm(stream)
+
+
+class _FakeAnthropicMessagesStream:
+    def __init__(self, events: list[Any], final: Any) -> None:
+        self._events = events
+        self._final = final
+
+    def __aiter__(self) -> _FakeAnthropicMessagesStream:
+        return self
+
+    async def __anext__(self) -> Any:
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+    async def get_final_message(self) -> Any:
+        return self._final
+
+
+class _FakeAnthropicClient:
+    def __init__(self, events: list[Any], final: Any) -> None:
+        self._events = events
+        self._final = final
+        self.received_kwargs: dict[str, Any] = {}
+
+    @property
+    def messages(self) -> _FakeAnthropicClient:
+        return self
+
+    def stream(self, **kwargs: Any) -> Any:
+        self.received_kwargs = dict(kwargs)
+        stream = _FakeAnthropicMessagesStream(list(self._events), self._final)
+        return _async_cm(stream)
+
+
+def _async_cm(value: Any) -> Any:
+    """Wrap a value in an ``async with``-compatible context manager."""
+
+    class _CM:
+        async def __aenter__(self_) -> Any:  # noqa: N805
+            return value
+
+        async def __aexit__(self_, *_exc: object) -> bool:  # noqa: N805
+            return False
+
+    return _CM()
+
+
+class TestTracedOpenAIResponsesStream:
+    """End-to-end: the helper emits one ``chat`` span per call with the
+    final response's attributes populated.
+    """
+
+    @pytest.mark.asyncio
+    async def test_opens_chat_span_and_records_final_response(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        final = _fake_openai_response(
+            output=[_fake_responses_message_item(["hello"])],
+            response_id="r1",
+            model="gpt-test",
+            usage=_fake_responses_usage(input_tokens=2, output_tokens=4),
+        )
+        client = _FakeOpenAIClient(events=["e1", "e2"], final=final)
+        seen_events: list[Any] = []
+        otel_spans.clear()
+        with start_session(agent_name="bot", session_id="sess") as s, s.start_turn():
+            async with traced_openai_responses_stream(
+                client=client,  # type: ignore[arg-type]
+                model="gpt-test",
+                instructions="be helpful",
+                input=[{"role": "user", "content": "hi"}],
+                tools=[{"name": "echo"}],
+            ) as stream:
+                async for event in stream:
+                    seen_events.append(event)
+        assert seen_events == ["e1", "e2"]
+        # Stream kwargs forwarded through to client.responses.stream.
+        assert client.received_kwargs["model"] == "gpt-test"
+        assert client.received_kwargs["instructions"] == "be helpful"
+        assert client.received_kwargs["tools"] == [{"name": "echo"}]
+        chat = [
+            sp for sp in otel_spans.get_finished_spans() if sp.name == "chat gpt-test"
+        ]
+        assert len(chat) == 1
+        attrs = dict(chat[0].attributes or {})
+        assert attrs["gen_ai.response.id"] == "r1"
+        assert attrs["gen_ai.response.model"] == "gpt-test"
+        assert attrs["gen_ai.response.finish_reasons"] == ("stop",)
+        assert attrs["gen_ai.usage.input_tokens"] == 2
+        assert attrs["gen_ai.usage.output_tokens"] == 4
+
+
+class TestTracedAnthropicMessagesStream:
+    @pytest.mark.asyncio
+    async def test_opens_chat_span_and_records_final_message(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        final = _fake_anthropic_message(
+            content=[_fake_anthropic_text_block("hi back")],
+            response_id="m1",
+            model="claude-test",
+            stop_reason="end_turn",
+            usage=_fake_anthropic_usage(input_tokens=5, output_tokens=3),
+        )
+        client = _FakeAnthropicClient(events=["e1"], final=final)
+        seen_events: list[Any] = []
+        otel_spans.clear()
+        with start_session(agent_name="bot", session_id="sess") as s, s.start_turn():
+            async with traced_anthropic_messages_stream(
+                client=client,  # type: ignore[arg-type]
+                model="claude-test",
+                system="be helpful",
+                messages=[{"role": "user", "content": "hi"}],
+                max_tokens=2048,
+            ) as stream:
+                async for event in stream:
+                    seen_events.append(event)
+        assert seen_events == ["e1"]
+        assert client.received_kwargs["model"] == "claude-test"
+        assert client.received_kwargs["system"] == "be helpful"
+        assert client.received_kwargs["max_tokens"] == 2048
+        chat = [
+            sp
+            for sp in otel_spans.get_finished_spans()
+            if sp.name == "chat claude-test"
+        ]
+        assert len(chat) == 1
+        attrs = dict(chat[0].attributes or {})
+        assert attrs["gen_ai.response.id"] == "m1"
+        assert attrs["gen_ai.response.finish_reasons"] == ("stop",)
+        assert attrs["gen_ai.usage.input_tokens"] == 5
+        assert attrs["gen_ai.usage.output_tokens"] == 3

--- a/weave/session/adapters/anthropic.py
+++ b/weave/session/adapters/anthropic.py
@@ -2,18 +2,62 @@
 
 Use these when manually instrumenting calls to ``client.messages.create``
 (the autopatched Anthropic integration handles conversion automatically).
+
+Public functions:
+
+- ``traced_anthropic_messages_stream(client, ...)`` — async context
+  manager that wraps a streaming ``client.messages.stream(...)`` call
+  with a weave chat span. Opens the stream + ``start_llm`` together,
+  yields the stream to the caller, and on close calls
+  ``stream.get_final_message()`` + ``record_anthropic_message``.
+- ``record_anthropic_message(llm, input_messages, system, response)`` —
+  lower-level helper that populates an existing ``LLM`` span from a
+  final ``Message``. Use when managing the span yourself.
+- ``message_from_anthropic_input(messages)`` — convert an Anthropic
+  ``messages=`` payload into a ``list[Message]`` ready to assign to
+  ``LLM.input_messages``.
+- ``usage_from_anthropic(message)`` — pull token counts off an
+  Anthropic ``Message``.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
 
-from weave.session.types import Usage
+from weave.session.types import (
+    Message,
+    MessagePart,
+    TextPart,
+    ToolCallPart,
+    ToolCallResponsePart,
+    Usage,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from anthropic import AsyncAnthropic
     from anthropic.types import Message as AnthropicMessage
 
-__all__ = ["usage_from_anthropic"]
+    from weave.session.session import LLM
+
+__all__ = [
+    "message_from_anthropic_input",
+    "record_anthropic_message",
+    "traced_anthropic_messages_stream",
+    "usage_from_anthropic",
+]
+
+
+# Map Anthropic ``stop_reason`` values to the GenAI semconv finish_reasons
+# vocabulary so cross-provider dashboards compare like-for-like.
+_STOP_REASON_TO_FINISH = {
+    "end_turn": "stop",
+    "stop_sequence": "stop",
+    "max_tokens": "length",
+    "tool_use": "tool_calls",
+}
 
 
 def usage_from_anthropic(message: AnthropicMessage) -> Usage:
@@ -29,3 +73,227 @@ def usage_from_anthropic(message: AnthropicMessage) -> Usage:
         cache_creation_input_tokens=usage.cache_creation_input_tokens or 0,
         cache_read_input_tokens=usage.cache_read_input_tokens or 0,
     )
+
+
+def message_from_anthropic_input(messages: list[dict[str, Any]]) -> list[Message]:
+    """Convert an Anthropic ``messages=`` payload into weave ``Message``s.
+
+    Handles the shapes that appear in the ``messages`` parameter to
+    ``client.messages.create``:
+
+    - ``{"role": "user"|"assistant", "content": "<str>"}`` becomes a flat
+      ``Message``.
+    - ``{"role": "assistant", "content": [<TextBlock|ToolUseBlock>...]}``
+      becomes an assistant ``Message`` with ``TextPart``s and
+      ``ToolCallPart``s combined in order.
+    - ``{"role": "user", "content": [<ToolResultBlock|TextBlock>...]}``
+      becomes a tool-result ``Message`` (when any ``tool_result`` block is
+      present) carrying ``ToolCallResponsePart``s; or a flat-text user
+      ``Message`` otherwise. Anthropic packages tool results inside a
+      ``role="user"`` message; we split those into ``role="tool"`` so the
+      weave Agents view renders them in the tool lane.
+    """
+    out: list[Message] = []
+    for item in messages:
+        role = item.get("role")
+        content = item.get("content")
+        if role == "user":
+            out.extend(_user_messages_from_content(content))
+        elif role == "assistant":
+            out.append(_assistant_message_from_content(content))
+    return out
+
+
+def record_anthropic_message(
+    llm: LLM,
+    *,
+    input_messages: list[dict[str, Any]],
+    system: str = "",
+    response: AnthropicMessage,
+) -> None:
+    """Populate an ``LLM`` span from a final Anthropic Messages ``Message``.
+
+    Symmetric to ``record_openai_responses`` in the OpenAI adapter. The
+    adapter owns the unpack from provider wire format to all ``gen_ai.*``
+    attributes — call sites pass the inputs that went into the request
+    plus the final response, and the LLM span gets every field set.
+    """
+    output_messages = _output_from_anthropic_message(response)
+    finish_reason = _STOP_REASON_TO_FINISH.get(
+        response.stop_reason or "", response.stop_reason or ""
+    )
+    # ``system_instructions`` is a direct field on ``LLM`` (Anthropic passes
+    # the system prompt out-of-band; OpenAI inlines it as a system message,
+    # so ``LLM.record`` does not expose it as a kwarg). Set it directly here.
+    if system:
+        llm.system_instructions = [system]
+    llm.record(
+        input_messages=message_from_anthropic_input(input_messages),
+        output_messages=output_messages,
+        usage=usage_from_anthropic(response),
+        response_id=response.id,
+        response_model=response.model,
+        finish_reasons=[finish_reason] if finish_reason else [],
+    )
+
+
+@asynccontextmanager
+async def traced_anthropic_messages_stream(
+    *,
+    client: AsyncAnthropic,
+    messages: list[dict[str, Any]],
+    model: str,
+    system: str = "",
+    **stream_kwargs: Any,
+) -> AsyncIterator[Any]:
+    """Wrap ``client.messages.stream(...)`` with a weave chat span.
+
+    Opens ``start_llm`` and ``client.messages.stream(...)`` together,
+    yields the stream context to the caller, and on close calls
+    ``stream.get_final_message()`` + ``record_anthropic_message`` so the
+    chat span gets every ``gen_ai.*`` attribute from one source of
+    truth.
+
+    ``model``, ``system``, and ``messages`` are passed to both the
+    streaming API and the span recorder. Extra ``stream_kwargs``
+    (``max_tokens``, ``tools``, …) are forwarded to
+    ``client.messages.stream``.
+
+    Example::
+
+        async with traced_anthropic_messages_stream(
+            client=self._client,
+            model=self._model_name,
+            system=self._instructions,
+            messages=messages,
+            max_tokens=self._max_tokens,
+            tools=self._build_api_tools(tools),
+        ) as stream:
+            async for event in stream:
+                ...
+    """
+    from weave.session.session import start_llm
+
+    with start_llm(
+        model=model,
+        provider_name="anthropic",
+        system_instructions=[system] if system else [],
+    ) as llm:
+        async with client.messages.stream(
+            model=model,
+            system=system,
+            messages=messages,
+            **stream_kwargs,
+        ) as stream:
+            yield stream
+            response = await stream.get_final_message()
+            record_anthropic_message(
+                llm,
+                input_messages=messages,
+                system=system,
+                response=response,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _user_messages_from_content(content: Any) -> list[Message]:
+    """Split a ``role="user"`` payload into user / tool messages.
+
+    Anthropic combines real user text with tool_result blocks under a
+    single ``role="user"`` envelope. Weave keeps them distinct so the
+    UI can render the tool lane separately.
+    """
+    if isinstance(content, str):
+        return [Message(role="user", content=content)]
+    if not isinstance(content, list):
+        return []
+
+    tool_responses: list[ToolCallResponsePart] = []
+    text_chunks: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "tool_result":
+            tool_responses.append(
+                ToolCallResponsePart(
+                    id=str(block.get("tool_use_id", "")),
+                    response=block.get("content", ""),
+                )
+            )
+        elif block_type == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                text_chunks.append(text)
+
+    messages: list[Message] = []
+    if text_chunks:
+        messages.append(Message(role="user", content="\n".join(text_chunks)))
+    if tool_responses:
+        parts: list[MessagePart] = list(tool_responses)
+        messages.append(Message(role="tool", parts=parts))
+    return messages
+
+
+def _assistant_message_from_content(content: Any) -> Message:
+    """Build an assistant ``Message`` from an Anthropic content payload."""
+    if isinstance(content, str):
+        return Message(role="assistant", content=content)
+    if not isinstance(content, list):
+        return Message(role="assistant", content="")
+
+    parts: list[MessagePart] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text:
+                parts.append(TextPart(content=text))
+        elif block_type == "tool_use":
+            parts.append(
+                ToolCallPart(
+                    id=str(block.get("id", "")),
+                    name=str(block.get("name", "")),
+                    arguments=block.get("input", ""),
+                )
+            )
+    if not parts:
+        return Message(role="assistant", content="")
+    return Message(role="assistant", parts=parts)
+
+
+def _output_from_anthropic_message(message: AnthropicMessage) -> list[Message]:
+    """Fold an Anthropic response's content blocks into one assistant ``Message``."""
+    text_parts: list[str] = []
+    tool_calls: list[ToolCallPart] = []
+    for block in message.content:
+        block_type = getattr(block, "type", "")
+        if block_type == "text":
+            text = getattr(block, "text", "")
+            if isinstance(text, str) and text:
+                text_parts.append(text)
+        elif block_type == "tool_use":
+            args = getattr(block, "input", "")
+            tool_calls.append(
+                ToolCallPart(
+                    id=getattr(block, "id", ""),
+                    name=getattr(block, "name", ""),
+                    arguments=args,
+                )
+            )
+    text = "\n".join(text_parts)
+    if not text and not tool_calls:
+        return []
+    if not tool_calls:
+        return [Message(role="assistant", content=text)]
+    parts: list[MessagePart] = []
+    if text:
+        parts.append(TextPart(content=text))
+    parts.extend(tool_calls)
+    return [Message(role="assistant", parts=parts)]

--- a/weave/session/adapters/openai.py
+++ b/weave/session/adapters/openai.py
@@ -5,6 +5,16 @@ Use these when manually instrumenting calls to ``client.responses.create``
 
 Public functions:
 
+- ``traced_openai_responses_stream(client, ...)`` — async context manager
+  that wraps a streaming ``client.responses.stream(...)`` call with a
+  weave chat span. Opens the stream + ``start_llm`` together, yields the
+  stream to the caller, and on close calls
+  ``stream.get_final_response()`` + ``record_openai_responses`` so the
+  span gets every ``gen_ai.*`` attribute populated from one source of
+  truth. Use this when you want one-line span emission around a stream.
+- ``record_openai_responses(llm, input_items, response)`` — lower-level
+  helper that populates an existing ``LLM`` span from a final Responses
+  ``Response``. Use when you need to manage the span yourself.
 - ``message_from_openai_responses_input(items)`` — convert the ``input=``
   list passed to ``client.responses.create`` into ``(messages, attachments)``
   ready to assign to ``LLM.input_messages`` / ``LLM.media_attachments``.
@@ -18,12 +28,15 @@ Public functions:
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
 from weave.session.types import (
     MediaAttachment,
     Message,
+    MessagePart,
     Reasoning,
+    TextPart,
     ToolCallPart,
     ToolCallResponsePart,
     Usage,
@@ -31,11 +44,18 @@ from weave.session.types import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from openai import AsyncOpenAI
     from openai.types.responses import Response
+
+    from weave.session.session import LLM
 
 __all__ = [
     "message_from_openai_responses_input",
     "reasoning_from_openai_responses",
+    "record_openai_responses",
+    "traced_openai_responses_stream",
     "usage_from_openai_responses",
 ]
 
@@ -155,9 +175,164 @@ def usage_from_openai_responses(response: Response) -> Usage:
     )
 
 
+def record_openai_responses(
+    llm: LLM,
+    *,
+    input_items: list[dict[str, Any]],
+    response: Response,
+) -> None:
+    """Populate an ``LLM`` span from a final OpenAI Responses ``Response``.
+
+    Single source of truth for the OpenAI → Weave mapping. Mirrors what
+    ``opentelemetry-instrumentation-openai-v2`` does in its stream
+    cleanup: accumulate chunks internally during streaming, then unpack
+    the final assembled object once at the end.
+
+    Sets ``input_messages`` / ``media_attachments`` from ``input_items``;
+    derives ``output_messages`` + ``reasoning`` from the response output
+    items; and writes ``usage`` / ``response_id`` / ``response_model`` /
+    ``finish_reasons`` from the response envelope.
+    """
+    input_messages, media_attachments = message_from_openai_responses_input(input_items)
+    output_messages, reasoning = _output_from_openai_responses(response)
+    llm.record(
+        input_messages=input_messages,
+        media_attachments=media_attachments,
+        output_messages=output_messages,
+        usage=usage_from_openai_responses(response),
+        reasoning=reasoning,
+        response_id=response.id,
+        response_model=response.model,
+        finish_reasons=_finish_reasons_from_openai_response(response),
+    )
+
+
+@asynccontextmanager
+async def traced_openai_responses_stream(
+    *,
+    client: AsyncOpenAI,
+    input: list[dict[str, Any]],
+    model: str,
+    instructions: str = "",
+    **stream_kwargs: Any,
+) -> AsyncIterator[Any]:
+    """Wrap ``client.responses.stream(...)`` with a weave chat span.
+
+    Opens ``start_llm`` and ``client.responses.stream(...)`` together,
+    yields the stream context to the caller, and on close calls
+    ``stream.get_final_response()`` + ``record_openai_responses`` so the
+    chat span gets every ``gen_ai.*`` attribute from one source of
+    truth. Use this when you want one-line span emission around a
+    streaming call.
+
+    ``model``, ``instructions``, and ``input`` are passed both to the
+    streaming API and to the span recorder. Extra ``stream_kwargs``
+    (``tools``, ``reasoning``, ``parallel_tool_calls``, …) are forwarded
+    to ``client.responses.stream``.
+
+    Example::
+
+        async with traced_openai_responses_stream(
+            client=self.client,
+            model=self._model_name,
+            instructions=self._instructions,
+            input=messages,
+            tools=self._build_api_tools(tools),
+            reasoning=Reasoning(effort="medium", summary="auto"),
+            parallel_tool_calls=True,
+        ) as stream:
+            async for event in stream:
+                ...
+    """
+    # Local import — avoids a hard ``weave.session.session`` dependency at
+    # module-import time and matches the pattern used by other adapters
+    # that need access to span constructors only when invoked.
+    from weave.session.session import start_llm
+
+    with start_llm(
+        model=model,
+        provider_name="openai",
+        system_instructions=[instructions] if instructions else [],
+    ) as llm:
+        async with client.responses.stream(
+            model=model,
+            instructions=instructions,
+            input=input,
+            **stream_kwargs,
+        ) as stream:
+            yield stream
+            response = await stream.get_final_response()
+            record_openai_responses(llm, input_items=input, response=response)
+
+
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+# Map OpenAI Responses ``incomplete_details.reason`` values to the GenAI
+# semconv ``gen_ai.response.finish_reasons`` vocabulary so dashboards built
+# against the standard can compare across providers.
+_RESPONSE_INCOMPLETE_TO_FINISH = {
+    "max_output_tokens": "length",
+    "content_filter": "content_filter",
+}
+
+
+def _finish_reasons_from_openai_response(response: Response) -> list[str]:
+    """Map a Responses API ``status`` / ``incomplete_details`` to finish_reasons."""
+    if response.status == "completed":
+        return ["stop"]
+    if response.status == "incomplete":
+        details = response.incomplete_details
+        reason = details.reason if details and details.reason else ""
+        return [_RESPONSE_INCOMPLETE_TO_FINISH.get(reason, reason or "incomplete")]
+    if response.status in {"failed", "cancelled"}:
+        return [response.status]
+    return []
+
+
+def _output_from_openai_responses(
+    response: Response,
+) -> tuple[list[Message], Reasoning | None]:
+    """Extract ``(output_messages, reasoning)`` from a Responses ``Response``.
+
+    Folds text + tool calls from ``response.output`` into a single
+    assistant ``Message`` (matching ``Message.assistant(text, tool_calls=...)``)
+    so the chat view renders them inline. Any ``reasoning`` items in the
+    output are flattened via ``reasoning_from_openai_responses``.
+    """
+    text_parts: list[str] = []
+    tool_calls: list[ToolCallPart] = []
+    reasoning: Reasoning | None = None
+    for item in response.output:
+        item_type = getattr(item, "type", "")
+        if item_type == "message":
+            for block in getattr(item, "content", []):
+                text = getattr(block, "text", None)
+                if isinstance(text, str) and text:
+                    text_parts.append(text)
+        elif item_type == "reasoning":
+            reasoning = reasoning_from_openai_responses(
+                item.model_dump(exclude_none=True)
+            )
+        elif item_type == "function_call":
+            tool_calls.append(
+                ToolCallPart(
+                    id=getattr(item, "call_id", ""),
+                    name=getattr(item, "name", ""),
+                    arguments=getattr(item, "arguments", ""),
+                )
+            )
+    text = "\n".join(text_parts)
+    if not text and not tool_calls:
+        return [], reasoning
+    if not tool_calls:
+        return [Message(role="assistant", content=text)], reasoning
+    parts: list[MessagePart] = []
+    if text:
+        parts.append(TextPart(content=text))
+    parts.extend(tool_calls)
+    return [Message(role="assistant", parts=parts)], reasoning
 
 
 def _to_tool_call_part(item: dict[str, Any]) -> ToolCallPart:


### PR DESCRIPTION
## Summary

Adds two layers of helpers for manually-instrumented agents using the Session SDK with the OpenAI Responses API or the Anthropic Messages API.

### Layer 1 — "commit final response" adapters

One-shot record functions that populate an ``LLM`` span from a final provider response object:

- **``record_openai_responses(llm, *, input_items, response)``** — derives ``input_messages`` / ``output_messages`` / ``reasoning`` / ``usage`` / ``response_id`` / ``response_model`` / ``finish_reasons`` from a Responses ``Response``. Handles ``completed`` / ``incomplete`` / ``failed`` / ``cancelled`` statuses per the GenAI semconv finish_reasons vocabulary.

- **``record_anthropic_message(llm, *, input_messages, system, response)``** — symmetric for the Anthropic Messages API. Maps ``stop_reason`` (``end_turn``/``stop_sequence`` → ``stop``, ``max_tokens`` → ``length``, ``tool_use`` → ``tool_calls``). Splits Anthropic's ``role="user"`` tool_result envelopes into ``role="tool"`` weave messages so the Agents view renders the tool lane correctly.

- **``message_from_anthropic_input(messages)``** — input-side equivalent of the existing ``message_from_openai_responses_input``.

### Layer 2 — traced stream context managers

``@asynccontextmanager`` helpers that wrap the provider's streaming call with a weave chat span in one ``async with`` block:

- **``traced_openai_responses_stream(client, *, model, instructions, input, **stream_kwargs)``** — opens ``start_llm`` and ``client.responses.stream(...)`` together, yields the stream, and on close calls ``stream.get_final_response()`` + ``record_openai_responses`` so the chat span gets every ``gen_ai.*`` attribute populated from one source of truth.

- **``traced_anthropic_messages_stream(client, *, model, system, messages, **stream_kwargs)``** — symmetric for ``client.messages.stream(...)``.

Manually-instrumented agents using these helpers stop carrying any provider/weave plumbing of their own — the wrapper is one ``async with`` replacing what was already an ``async with`` on the bare client. Example usage:

```python
async with traced_openai_responses_stream(
    client=self.client,
    model=self._model_name,
    instructions=self._instructions,
    input=messages,
    tools=self._build_api_tools(tools),
    reasoning=Reasoning(effort="medium", summary="auto"),
    parallel_tool_calls=True,
) as stream:
    async for event in stream:
        ...  # parse provider-specific events
```

## Why both layers

Layer 1 covers callers that already manage span lifetime themselves (e.g. wrappers around custom streaming code that doesn't fit ``client.responses.stream``). Layer 2 collapses the common case — "open span, open stream, iterate, record final, close" — into a single ``async with`` block.

## Test plan

- [x] ``uv run --group test python -m pytest tests/session/`` — 219 passed
- [x] ``uvx ruff check weave/session/adapters/ tests/session/test_session_otel.py`` — clean
- [x] ``uvx ruff format --check`` — clean