### PR TITLE
chore(weave): Condense settings into one contextvar

### DIFF
--- a/tests/integrations/litellm/client_completions_create_test.py
+++ b/tests/integrations/litellm/client_completions_create_test.py
@@ -1,22 +1,12 @@
 import os
-from contextlib import contextmanager
 from unittest.mock import patch
 
 from litellm.types.utils import ModelResponse
 
 from tests.trace.util import client_is_sqlite
-from weave.trace.settings import _context_vars
+from weave.trace.settings import override
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
-
-
-@contextmanager
-def with_tracing_disabled():
-    token = _context_vars["disabled"].set(True)
-    try:
-        yield
-    finally:
-        _context_vars["disabled"].reset(token)
 
 
 def test_completions_create(client):
@@ -86,7 +76,7 @@ def test_completions_create(client):
 
     # Have to do this since we run the tests in the same process as the server
     # and the inner litellm gets patched!
-    with with_tracing_disabled():
+    with override(disabled=True):
         with secret_fetcher_context(DummySecretFetcher()):
             with patch("litellm.completion") as mock_completion:
                 mock_completion.return_value = ModelResponse.model_validate(

--- a/tests/integrations/litellm/client_completions_create_test.py
+++ b/tests/integrations/litellm/client_completions_create_test.py
@@ -76,20 +76,20 @@ def test_completions_create(client):
 
     # Have to do this since we run the tests in the same process as the server
     # and the inner litellm gets patched!
-    with override(disabled=True):
-        with secret_fetcher_context(DummySecretFetcher()):
-            with patch("litellm.completion") as mock_completion:
-                mock_completion.return_value = ModelResponse.model_validate(
-                    mock_response
-                )
-                res = client.server.completions_create(
-                    tsi.CompletionsCreateReq.model_validate(
-                        {
-                            "project_id": client.project_id,
-                            "inputs": inputs,
-                        }
-                    )
-                )
+    with (
+        override(disabled=True),
+        secret_fetcher_context(DummySecretFetcher()),
+        patch("litellm.completion") as mock_completion,
+    ):
+        mock_completion.return_value = ModelResponse.model_validate(mock_response)
+        res = client.server.completions_create(
+            tsi.CompletionsCreateReq.model_validate(
+                {
+                    "project_id": client.project_id,
+                    "inputs": inputs,
+                }
+            )
+        )
 
     assert res.response == mock_response
     calls = list(client.get_calls())

--- a/tests/integrations/litellm/client_completions_create_test.py
+++ b/tests/integrations/litellm/client_completions_create_test.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from litellm.types.utils import ModelResponse
 
 from tests.trace.util import client_is_sqlite
-from weave.trace.settings import override
+from weave.trace.settings import override_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
 
@@ -77,7 +77,7 @@ def test_completions_create(client):
     # Have to do this since we run the tests in the same process as the server
     # and the inner litellm gets patched!
     with (
-        override(disabled=True),
+        override_settings(disabled=True),
         secret_fetcher_context(DummySecretFetcher()),
         patch("litellm.completion") as mock_completion,
     ):

--- a/tests/trace/test_client_side_digests.py
+++ b/tests/trace/test_client_side_digests.py
@@ -20,6 +20,7 @@ from weave.shared.digest import (
 )
 from weave.trace.settings import (
     UserSettings,
+    override,
     parse_and_apply_settings,
 )
 from weave.trace.weave_client import (
@@ -376,15 +377,14 @@ class TestConvertRefsToInternal:
         is disabled — get_internal_project_id returns None.
         """
         # Ensure the setting is off so the resolver returns None
-        parse_and_apply_settings(UserSettings(enable_client_side_digests=False))
+        with override(enable_client_side_digests=False):
+            json_val = {
+                "key": "value",
+                "ref": f"weave:///{client.entity}/{client.project}/object/foo:abc123",
+            }
 
-        json_val = {
-            "key": "value",
-            "ref": f"weave:///{client.entity}/{client.project}/object/foo:abc123",
-        }
-
-        with pytest.raises(NoInternalProjectIDError):
-            client._convert_refs_to_internal(json_val)
+            with pytest.raises(NoInternalProjectIDError):
+                client._convert_refs_to_internal(json_val)
 
     def test_raises_for_cross_project_ref(
         self, client: WeaveClient, fast_path: None

--- a/tests/trace/test_client_side_digests.py
+++ b/tests/trace/test_client_side_digests.py
@@ -376,15 +376,17 @@ class TestConvertRefsToInternal:
         This happens when the feature flag is off (default) or the resolver
         is disabled — get_internal_project_id returns None.
         """
-        # Ensure the setting is off so the resolver returns None
-        with override(enable_client_side_digests=False):
-            json_val = {
-                "key": "value",
-                "ref": f"weave:///{client.entity}/{client.project}/object/foo:abc123",
-            }
+        json_val = {
+            "key": "value",
+            "ref": f"weave:///{client.entity}/{client.project}/object/foo:abc123",
+        }
 
-            with pytest.raises(NoInternalProjectIDError):
-                client._convert_refs_to_internal(json_val)
+        # Ensure the setting is off so the resolver returns None
+        with (
+            override(enable_client_side_digests=False),
+            pytest.raises(NoInternalProjectIDError),
+        ):
+            client._convert_refs_to_internal(json_val)
 
     def test_raises_for_cross_project_ref(
         self, client: WeaveClient, fast_path: None

--- a/tests/trace/test_client_side_digests.py
+++ b/tests/trace/test_client_side_digests.py
@@ -20,7 +20,7 @@ from weave.shared.digest import (
 )
 from weave.trace.settings import (
     UserSettings,
-    override,
+    override_settings,
     parse_and_apply_settings,
 )
 from weave.trace.weave_client import (
@@ -383,7 +383,7 @@ class TestConvertRefsToInternal:
 
         # Ensure the setting is off so the resolver returns None
         with (
-            override(enable_client_side_digests=False),
+            override_settings(enable_client_side_digests=False),
             pytest.raises(NoInternalProjectIDError),
         ):
             client._convert_refs_to_internal(json_val)

--- a/tests/trace/test_project_id_resolver.py
+++ b/tests/trace/test_project_id_resolver.py
@@ -9,14 +9,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from weave.trace.project_id_resolver import ProjectIdResolver, ResolverDisabledError
-from weave.trace.settings import override
 from weave.trace_server.errors import DigestMismatchError
 
 
 @pytest.fixture(autouse=True)
-def enable_client_side_digests():
-    with override(enable_client_side_digests=True):
-        yield
+def enable_client_side_digests(monkeypatch):
+    monkeypatch.setenv("WEAVE_ENABLE_CLIENT_SIDE_DIGESTS", "true")
 
 
 def _make_resolver(internal_id: str) -> ProjectIdResolver:

--- a/tests/trace/test_project_id_resolver.py
+++ b/tests/trace/test_project_id_resolver.py
@@ -9,18 +9,14 @@ from unittest.mock import MagicMock
 import pytest
 
 from weave.trace.project_id_resolver import ProjectIdResolver, ResolverDisabledError
-from weave.trace.settings import (
-    UserSettings,
-    parse_and_apply_settings,
-)
+from weave.trace.settings import override
 from weave.trace_server.errors import DigestMismatchError
 
 
 @pytest.fixture(autouse=True)
 def enable_client_side_digests():
-    parse_and_apply_settings(UserSettings(enable_client_side_digests=True))
-    yield
-    parse_and_apply_settings(UserSettings())
+    with override(enable_client_side_digests=True):
+        yield
 
 
 def _make_resolver(internal_id: str) -> ProjectIdResolver:

--- a/tests/trace/test_sentry_disable.py
+++ b/tests/trace/test_sentry_disable.py
@@ -5,7 +5,7 @@ The wandb SDK's own Sentry wrapper (`wandb/analytics/sentry.py`) reads
 disable outbound error reporting. The Weave SDK's parallel wrapper must
 behave the same way so that a single env var disables both.
 
-Truthy / falsy semantics match the canonical `_str2bool_truthy` helper in
+Truthy / falsy semantics match the canonical `_parse_bool` helper in
 `weave/trace/settings.py` (i.e. only `yes`, `true`, `1`, `on` keep reporting
 enabled; everything else, including unrecognized values, disables it).
 """

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -472,188 +472,170 @@ def test_log_level_env(client_creator):
     del os.environ["WEAVE_LOG_LEVEL"]
 
 
-# ---------------------------------------------------------------------------
-# Tests for the deepened settings module: replace_settings(), override(),
-# env-overlay precedence, dict input.
-#
-# Many tests in this file leak WEAVE_* env vars across runs.  These new tests
-# request `clean_settings_env` so they start from a known-clean state.
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture
 def clean_settings_env(monkeypatch):
     """Strip all WEAVE_* env vars and reset settings to defaults for the test."""
-    for key in list(os.environ):
-        if key.startswith("WEAVE_"):
-            monkeypatch.delenv(key, raising=False)
-    replace_settings(None)
-    yield
-    replace_settings(None)
-
-
-def test_replace_settings_installs_snapshot(clean_settings_env):
-    replace_settings(UserSettings(disabled=True, print_call_link=False))
-    assert should_disable_weave() is True
-    assert should_print_call_link() is False
-
-
-def test_replace_settings_resets_unmentioned_fields(clean_settings_env):
-    replace_settings(UserSettings(disabled=True, print_call_link=False))
-    # Replacing with a fresh UserSettings(disabled=True) should NOT preserve
-    # print_call_link=False — replace-all semantics.
-    replace_settings(UserSettings(disabled=True))
-    assert should_disable_weave() is True
-    assert should_print_call_link() is True
-
-
-def test_replace_settings_none_resets_to_defaults(clean_settings_env):
-    replace_settings(UserSettings(disabled=True))
-    assert should_disable_weave() is True
-    replace_settings(None)
-    assert should_disable_weave() is False
-
-
-def test_replace_settings_no_args_resets_to_defaults(clean_settings_env):
-    replace_settings(UserSettings(disabled=True))
+    weave_keys = [k for k in os.environ if k.startswith("WEAVE_")]
+    for key in weave_keys:
+        monkeypatch.delenv(key, raising=False)
     replace_settings()
-    assert should_disable_weave() is False
+    yield
+    replace_settings()
 
 
-def test_replace_settings_dict_input(clean_settings_env):
-    replace_settings({"disabled": True, "redact_pii": True})
-    assert should_disable_weave() is True
-    assert should_redact_pii() is True
-
-
-def test_replace_settings_dict_unknown_field_raises(clean_settings_env):
-    with pytest.raises(TypeError):
-        replace_settings({"definitely_not_a_real_field": True})
-
-
-def test_replace_settings_invalid_type_raises(clean_settings_env):
-    with pytest.raises(TypeError):
-        replace_settings(42)
-
-
-def test_override_scopes_one_field(clean_settings_env):
-    replace_settings(UserSettings(print_call_link=False))
-    assert should_disable_weave() is False
-    with override(disabled=True):
+@pytest.mark.usefixtures("clean_settings_env")
+class TestReplaceSettings:
+    def test_installs_snapshot(self):
+        replace_settings(UserSettings(disabled=True, print_call_link=False))
         assert should_disable_weave() is True
-        # Other fields keep the surrounding snapshot's values
         assert should_print_call_link() is False
-    assert should_disable_weave() is False
-    assert should_print_call_link() is False
 
-
-def test_override_nested(clean_settings_env):
-    with override(disabled=True):
-        assert should_disable_weave() is True
-        with override(print_call_link=False):
-            assert should_disable_weave() is True
-            assert should_print_call_link() is False
+    def test_resets_unmentioned_fields(self):
+        replace_settings(UserSettings(disabled=True, print_call_link=False))
+        # Replacing with a fresh UserSettings(disabled=True) should NOT
+        # preserve print_call_link=False — replace-all semantics.
+        replace_settings(UserSettings(disabled=True))
         assert should_disable_weave() is True
         assert should_print_call_link() is True
-    assert should_disable_weave() is False
+
+    def test_none_resets_to_defaults(self):
+        replace_settings(UserSettings(disabled=True))
+        assert should_disable_weave() is True
+        replace_settings(None)
+        assert should_disable_weave() is False
+
+    def test_no_args_resets_to_defaults(self):
+        replace_settings(UserSettings(disabled=True))
+        replace_settings()
+        assert should_disable_weave() is False
+
+    def test_dict_input(self):
+        replace_settings({"disabled": True, "redact_pii": True})
+        assert should_disable_weave() is True
+        assert should_redact_pii() is True
+
+    def test_dict_unknown_field_raises(self):
+        with pytest.raises(TypeError):
+            replace_settings({"definitely_not_a_real_field": True})
+
+    def test_invalid_type_raises(self):
+        with pytest.raises(TypeError):
+            replace_settings(42)
 
 
-def test_override_unknown_field_raises(clean_settings_env):
-    with pytest.raises(TypeError):
-        with override(not_a_real_field=True):
-            pass
-
-
-def test_env_var_wins_over_snapshot(clean_settings_env, monkeypatch):
-    replace_settings(UserSettings(disabled=False))
-    assert should_disable_weave() is False
-    monkeypatch.setenv("WEAVE_DISABLED", "true")
-    assert should_disable_weave() is True
-
-
-def test_env_var_change_takes_effect_immediately(clean_settings_env, monkeypatch):
-    """Q2 contract: users may flip env vars mid-process and reads pick it up."""
-    assert should_disable_weave() is False
-    monkeypatch.setenv("WEAVE_DISABLED", "true")
-    assert should_disable_weave() is True
-    monkeypatch.setenv("WEAVE_DISABLED", "false")
-    assert should_disable_weave() is False
-    monkeypatch.delenv("WEAVE_DISABLED")
-    assert should_disable_weave() is False
-
-
-def test_empty_env_var_falls_through_to_snapshot(clean_settings_env, monkeypatch):
-    """An env var that exists but is empty is treated as unset."""
-    replace_settings(UserSettings(disabled=True))
-    monkeypatch.setenv("WEAVE_DISABLED", "")
-    assert should_disable_weave() is True
-
-
-def test_env_overlay_coerces_int(clean_settings_env, monkeypatch):
-    monkeypatch.setenv("WEAVE_MAX_CALLS_QUEUE_SIZE", "42")
-    assert max_calls_queue_size() == 42
-
-
-def test_env_overlay_coerces_float(clean_settings_env, monkeypatch):
-    monkeypatch.setenv("WEAVE_HTTP_TIMEOUT", "12.5")
-    assert http_timeout() == 12.5
-
-
-def test_env_overlay_coerces_list(clean_settings_env, monkeypatch):
-    monkeypatch.setenv("WEAVE_REDACT_PII_FIELDS", "a,b,c")
-    assert redact_pii_fields() == ["a", "b", "c"]
-
-
-def test_env_overlay_coerces_optional_int(clean_settings_env, monkeypatch):
-    monkeypatch.setenv("WEAVE_CLIENT_PARALLELISM", "7")
-    assert client_parallelism() == 7
-
-
-def test_parse_and_apply_settings_is_alias_for_replace_settings(clean_settings_env):
-    """Back-compat: the prior public name still works."""
-    parse_and_apply_settings(UserSettings(disabled=True))
-    assert should_disable_weave() is True
-    parse_and_apply_settings(None)
-    assert should_disable_weave() is False
-
-
-def test_user_settings_is_frozen():
-    settings = UserSettings()
-    with pytest.raises(dataclasses.FrozenInstanceError):
-        settings.disabled = True
-
-
-def test_user_settings_rejects_unknown_kwargs():
-    with pytest.raises(TypeError):
-        UserSettings(not_a_field=True)
-
-
-def test_settings_overrides_matches_user_settings():
-    """The _SettingsOverrides TypedDict that types override(**fields) must
-    mirror UserSettings exactly (same names, same types).  Drift means the
-    types lie to callers.
-    """
-    user_settings_hints = typing.get_type_hints(UserSettings)
-    overrides_hints = typing.get_type_hints(_SettingsOverrides)
-    assert user_settings_hints == overrides_hints, (
-        "_SettingsOverrides drift: add/update fields to match UserSettings"
-    )
-
-
-def test_override_in_async_context_does_not_leak(clean_settings_env):
-    """Each async context gets its own override stack."""
-
-    async def child():
+@pytest.mark.usefixtures("clean_settings_env")
+class TestOverride:
+    def test_scopes_one_field(self):
+        replace_settings(UserSettings(print_call_link=False))
+        assert should_disable_weave() is False
         with override(disabled=True):
             assert should_disable_weave() is True
-            await asyncio.sleep(0)
+            # Other fields keep the surrounding snapshot's values
+            assert should_print_call_link() is False
+        assert should_disable_weave() is False
+        assert should_print_call_link() is False
+
+    def test_nested(self):
+        with override(disabled=True):
             assert should_disable_weave() is True
-
-    async def parent():
-        # Parent does not override; child should see its own override; parent
-        # should not see leakage.
+            with override(print_call_link=False):
+                assert should_disable_weave() is True
+                assert should_print_call_link() is False
+            assert should_disable_weave() is True
+            assert should_print_call_link() is True
         assert should_disable_weave() is False
-        await child()
+
+    def test_unknown_field_raises(self):
+        with pytest.raises(TypeError), override(not_a_real_field=True):
+            pass
+
+    def test_async_context_does_not_leak(self):
+        """Each async context gets its own override stack."""
+
+        async def child():
+            with override(disabled=True):
+                assert should_disable_weave() is True
+                await asyncio.sleep(0)
+                assert should_disable_weave() is True
+
+        async def parent():
+            # Parent does not override; child should see its own override;
+            # parent should not see leakage.
+            assert should_disable_weave() is False
+            await child()
+            assert should_disable_weave() is False
+
+        asyncio.run(parent())
+
+
+@pytest.mark.usefixtures("clean_settings_env")
+class TestEnvOverlay:
+    def test_env_var_wins_over_snapshot(self, monkeypatch):
+        replace_settings(UserSettings(disabled=False))
+        assert should_disable_weave() is False
+        monkeypatch.setenv("WEAVE_DISABLED", "true")
+        assert should_disable_weave() is True
+
+    def test_env_var_change_takes_effect_immediately(self, monkeypatch):
+        """Q2 contract: users may flip env vars mid-process and reads pick it up."""
+        assert should_disable_weave() is False
+        monkeypatch.setenv("WEAVE_DISABLED", "true")
+        assert should_disable_weave() is True
+        monkeypatch.setenv("WEAVE_DISABLED", "false")
+        assert should_disable_weave() is False
+        monkeypatch.delenv("WEAVE_DISABLED")
         assert should_disable_weave() is False
 
-    asyncio.run(parent())
+    def test_empty_env_var_falls_through_to_snapshot(self, monkeypatch):
+        """An env var that exists but is empty is treated as unset."""
+        replace_settings(UserSettings(disabled=True))
+        monkeypatch.setenv("WEAVE_DISABLED", "")
+        assert should_disable_weave() is True
+
+    def test_coerces_int(self, monkeypatch):
+        monkeypatch.setenv("WEAVE_MAX_CALLS_QUEUE_SIZE", "42")
+        assert max_calls_queue_size() == 42
+
+    def test_coerces_float(self, monkeypatch):
+        monkeypatch.setenv("WEAVE_HTTP_TIMEOUT", "12.5")
+        assert http_timeout() == 12.5
+
+    def test_coerces_list(self, monkeypatch):
+        monkeypatch.setenv("WEAVE_REDACT_PII_FIELDS", "a,b,c")
+        assert redact_pii_fields() == ["a", "b", "c"]
+
+    def test_coerces_optional_int(self, monkeypatch):
+        monkeypatch.setenv("WEAVE_CLIENT_PARALLELISM", "7")
+        assert client_parallelism() == 7
+
+
+@pytest.mark.usefixtures("clean_settings_env")
+class TestBackCompat:
+    def test_parse_and_apply_settings_is_alias_for_replace_settings(self):
+        """Back-compat: the prior public name still works."""
+        parse_and_apply_settings(UserSettings(disabled=True))
+        assert should_disable_weave() is True
+        parse_and_apply_settings(None)
+        assert should_disable_weave() is False
+
+
+class TestUserSettingsValue:
+    def test_is_frozen(self):
+        settings = UserSettings()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            settings.disabled = True
+
+    def test_rejects_unknown_kwargs(self):
+        with pytest.raises(TypeError):
+            UserSettings(not_a_field=True)
+
+    def test_settings_overrides_typeddict_matches_user_settings(self):
+        """The _SettingsOverrides TypedDict that types override(**fields) must
+        mirror UserSettings exactly (same names, same types).  Drift means the
+        types lie to callers.
+        """
+        user_settings_hints = typing.get_type_hints(UserSettings)
+        overrides_hints = typing.get_type_hints(_SettingsOverrides)
+        assert user_settings_hints == overrides_hints, (
+            "_SettingsOverrides drift: add/update fields to match UserSettings"
+        )

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -1,8 +1,10 @@
+import asyncio
 import dataclasses
 import logging
 import os
 import time
 import timeit
+import typing
 from unittest import mock
 
 import pytest
@@ -18,6 +20,7 @@ from weave.trace.constants import TRACE_CALL_EMOJI, TRACE_OBJECT_EMOJI
 from weave.trace.display.term import configure_logger
 from weave.trace.settings import (
     UserSettings,
+    _SettingsOverrides,
     client_parallelism,
     http_timeout,
     max_calls_queue_size,
@@ -625,9 +628,20 @@ def test_user_settings_rejects_unknown_kwargs():
         UserSettings(not_a_field=True)
 
 
+def test_settings_overrides_matches_user_settings():
+    """The _SettingsOverrides TypedDict that types override(**fields) must
+    mirror UserSettings exactly (same names, same types).  Drift means the
+    types lie to callers.
+    """
+    user_settings_hints = typing.get_type_hints(UserSettings)
+    overrides_hints = typing.get_type_hints(_SettingsOverrides)
+    assert user_settings_hints == overrides_hints, (
+        "_SettingsOverrides drift: add/update fields to match UserSettings"
+    )
+
+
 def test_override_in_async_context_does_not_leak(clean_settings_env):
     """Each async context gets its own override stack."""
-    import asyncio
 
     async def child():
         with override(disabled=True):

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -1,3 +1,4 @@
+import dataclasses
 import logging
 import os
 import time
@@ -15,7 +16,15 @@ from tests.trace.util import (
 )
 from weave.trace.constants import TRACE_CALL_EMOJI, TRACE_OBJECT_EMOJI
 from weave.trace.display.term import configure_logger
-from weave.trace.settings import UserSettings, parse_and_apply_settings
+from weave.trace.settings import (
+    UserSettings,
+    apply,
+    current,
+    override,
+    parse_and_apply_settings,
+    should_disable_weave,
+    should_print_call_link,
+)
 from weave.trace.weave_client import get_parallelism_settings
 from weave.utils.retry import with_retry
 
@@ -454,3 +463,196 @@ def test_log_level_env(client_creator):
 
     # Clean up after test
     del os.environ["WEAVE_LOG_LEVEL"]
+
+
+# ---------------------------------------------------------------------------
+# Tests for the deepened settings module: current(), apply(), override(),
+# env-overlay precedence, dict input.
+#
+# Many tests in this file leak WEAVE_* env vars across runs.  These new tests
+# request `clean_settings_env` so they start from a known-clean state.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def clean_settings_env(monkeypatch):
+    """Strip all WEAVE_* env vars and reset settings to defaults for the test."""
+    for key in list(os.environ):
+        if key.startswith("WEAVE_"):
+            monkeypatch.delenv(key, raising=False)
+    apply(None)
+    yield
+    apply(None)
+
+
+def test_current_returns_view_over_snapshot(clean_settings_env):
+    apply(UserSettings(disabled=True, print_call_link=False))
+    view = current()
+    assert view.disabled is True
+    assert view.print_call_link is False
+
+
+def test_apply_replace_all_resets_unmentioned_fields(clean_settings_env):
+    apply(UserSettings(disabled=True, print_call_link=False))
+    # Applying a fresh UserSettings(disabled=True) should NOT preserve
+    # print_call_link=False — replace-all semantics.
+    apply(UserSettings(disabled=True))
+    assert current().disabled is True
+    assert current().print_call_link is True
+
+
+def test_apply_none_resets_to_defaults(clean_settings_env):
+    apply(UserSettings(disabled=True))
+    assert current().disabled is True
+    apply(None)
+    assert current().disabled is False
+
+
+def test_apply_no_args_resets_to_defaults(clean_settings_env):
+    apply(UserSettings(disabled=True))
+    apply()
+    assert current().disabled is False
+
+
+def test_apply_dict_input(clean_settings_env):
+    apply({"disabled": True, "redact_pii": True})
+    assert current().disabled is True
+    assert current().redact_pii is True
+
+
+def test_apply_dict_unknown_field_raises(clean_settings_env):
+    with pytest.raises(TypeError):
+        apply({"definitely_not_a_real_field": True})
+
+
+def test_apply_invalid_type_raises(clean_settings_env):
+    with pytest.raises(TypeError):
+        apply(42)
+
+
+def test_override_scopes_one_field(clean_settings_env):
+    apply(UserSettings(print_call_link=False))
+    assert current().disabled is False
+    with override(disabled=True):
+        assert current().disabled is True
+        # Other fields keep the surrounding snapshot's values
+        assert current().print_call_link is False
+    assert current().disabled is False
+    assert current().print_call_link is False
+
+
+def test_override_nested(clean_settings_env):
+    with override(disabled=True):
+        assert current().disabled is True
+        with override(print_call_link=False):
+            assert current().disabled is True
+            assert current().print_call_link is False
+        assert current().disabled is True
+        assert current().print_call_link is True
+    assert current().disabled is False
+
+
+def test_override_unknown_field_raises(clean_settings_env):
+    with pytest.raises(TypeError):
+        with override(not_a_real_field=True):
+            pass
+
+
+def test_env_var_wins_over_snapshot(clean_settings_env, monkeypatch):
+    apply(UserSettings(disabled=False))
+    assert current().disabled is False
+    monkeypatch.setenv("WEAVE_DISABLED", "true")
+    assert current().disabled is True
+    assert should_disable_weave() is True
+
+
+def test_env_var_change_takes_effect_immediately(clean_settings_env, monkeypatch):
+    """Q2 contract: users may flip env vars mid-process and reads pick it up."""
+    assert current().disabled is False
+    monkeypatch.setenv("WEAVE_DISABLED", "true")
+    assert current().disabled is True
+    monkeypatch.setenv("WEAVE_DISABLED", "false")
+    assert current().disabled is False
+    monkeypatch.delenv("WEAVE_DISABLED")
+    assert current().disabled is False
+
+
+def test_empty_env_var_falls_through_to_snapshot(clean_settings_env, monkeypatch):
+    """An env var that exists but is empty is treated as unset."""
+    apply(UserSettings(disabled=True))
+    monkeypatch.setenv("WEAVE_DISABLED", "")
+    assert current().disabled is True
+    assert should_disable_weave() is True
+
+
+def test_env_overlay_coerces_int(clean_settings_env, monkeypatch):
+    monkeypatch.setenv("WEAVE_MAX_CALLS_QUEUE_SIZE", "42")
+    assert current().max_calls_queue_size == 42
+
+
+def test_env_overlay_coerces_float(clean_settings_env, monkeypatch):
+    monkeypatch.setenv("WEAVE_HTTP_TIMEOUT", "12.5")
+    assert current().http_timeout == 12.5
+
+
+def test_env_overlay_coerces_list(clean_settings_env, monkeypatch):
+    monkeypatch.setenv("WEAVE_REDACT_PII_FIELDS", "a,b,c")
+    assert current().redact_pii_fields == ["a", "b", "c"]
+
+
+def test_env_overlay_coerces_optional_int(clean_settings_env, monkeypatch):
+    monkeypatch.setenv("WEAVE_CLIENT_PARALLELISM", "7")
+    assert current().client_parallelism == 7
+
+
+def test_accessor_function_matches_current_attr(clean_settings_env):
+    """Back-compat: should_X() returns the same value as current().X."""
+    apply(UserSettings(disabled=True, print_call_link=False))
+    assert should_disable_weave() == current().disabled
+    assert should_print_call_link() == current().print_call_link
+
+
+def test_unknown_field_access_raises_attribute_error(clean_settings_env):
+    view = current()
+    missing_name = "not_a_real_field"
+    with pytest.raises(AttributeError):
+        getattr(view, missing_name)
+
+
+def test_parse_and_apply_settings_is_alias_for_apply(clean_settings_env):
+    """Back-compat: the prior public name still works."""
+    parse_and_apply_settings(UserSettings(disabled=True))
+    assert current().disabled is True
+    parse_and_apply_settings(None)
+    assert current().disabled is False
+
+
+def test_user_settings_is_frozen():
+    settings = UserSettings()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        settings.disabled = True
+
+
+def test_user_settings_rejects_unknown_kwargs():
+    with pytest.raises(TypeError):
+        UserSettings(not_a_field=True)
+
+
+def test_override_in_async_context_does_not_leak(clean_settings_env):
+    """Each async context gets its own override stack."""
+    import asyncio
+
+    async def child():
+        with override(disabled=True):
+            assert current().disabled is True
+            await asyncio.sleep(0)
+            assert current().disabled is True
+
+    async def parent():
+        # Parent does not override; child should see its own override; parent
+        # should not see leakage.
+        assert current().disabled is False
+        await child()
+        assert current().disabled is False
+
+    asyncio.run(parent())

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -24,7 +24,7 @@ from weave.trace.settings import (
     client_parallelism,
     http_timeout,
     max_calls_queue_size,
-    override,
+    override_settings,
     parse_and_apply_settings,
     redact_pii_fields,
     replace_settings,
@@ -524,11 +524,11 @@ class TestReplaceSettings:
 
 
 @pytest.mark.usefixtures("clean_settings_env")
-class TestOverride:
+class TestOverrideSettings:
     def test_scopes_one_field(self):
         replace_settings(UserSettings(print_call_link=False))
         assert should_disable_weave() is False
-        with override(disabled=True):
+        with override_settings(disabled=True):
             assert should_disable_weave() is True
             # Other fields keep the surrounding snapshot's values
             assert should_print_call_link() is False
@@ -536,9 +536,9 @@ class TestOverride:
         assert should_print_call_link() is False
 
     def test_nested(self):
-        with override(disabled=True):
+        with override_settings(disabled=True):
             assert should_disable_weave() is True
-            with override(print_call_link=False):
+            with override_settings(print_call_link=False):
                 assert should_disable_weave() is True
                 assert should_print_call_link() is False
             assert should_disable_weave() is True
@@ -546,14 +546,14 @@ class TestOverride:
         assert should_disable_weave() is False
 
     def test_unknown_field_raises(self):
-        with pytest.raises(TypeError), override(not_a_real_field=True):
+        with pytest.raises(TypeError), override_settings(not_a_real_field=True):
             pass
 
     def test_async_context_does_not_leak(self):
         """Each async context gets its own override stack."""
 
         async def child():
-            with override(disabled=True):
+            with override_settings(disabled=True):
                 assert should_disable_weave() is True
                 await asyncio.sleep(0)
                 assert should_disable_weave() is True
@@ -630,9 +630,9 @@ class TestUserSettingsValue:
             UserSettings(not_a_field=True)
 
     def test_settings_overrides_typeddict_matches_user_settings(self):
-        """The _SettingsOverrides TypedDict that types override(**fields) must
-        mirror UserSettings exactly (same names, same types).  Drift means the
-        types lie to callers.
+        """The _SettingsOverrides TypedDict that types override_settings(**fields)
+        must mirror UserSettings exactly (same names, same types).  Drift means
+        the types lie to callers.
         """
         user_settings_hints = typing.get_type_hints(UserSettings)
         overrides_hints = typing.get_type_hints(_SettingsOverrides)

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -18,12 +18,16 @@ from weave.trace.constants import TRACE_CALL_EMOJI, TRACE_OBJECT_EMOJI
 from weave.trace.display.term import configure_logger
 from weave.trace.settings import (
     UserSettings,
-    apply,
-    current,
+    client_parallelism,
+    http_timeout,
+    max_calls_queue_size,
     override,
     parse_and_apply_settings,
+    redact_pii_fields,
+    replace_settings,
     should_disable_weave,
     should_print_call_link,
+    should_redact_pii,
 )
 from weave.trace.weave_client import get_parallelism_settings
 from weave.utils.retry import with_retry
@@ -466,7 +470,7 @@ def test_log_level_env(client_creator):
 
 
 # ---------------------------------------------------------------------------
-# Tests for the deepened settings module: current(), apply(), override(),
+# Tests for the deepened settings module: replace_settings(), override(),
 # env-overlay precedence, dict input.
 #
 # Many tests in this file leak WEAVE_* env vars across runs.  These new tests
@@ -480,76 +484,75 @@ def clean_settings_env(monkeypatch):
     for key in list(os.environ):
         if key.startswith("WEAVE_"):
             monkeypatch.delenv(key, raising=False)
-    apply(None)
+    replace_settings(None)
     yield
-    apply(None)
+    replace_settings(None)
 
 
-def test_current_returns_view_over_snapshot(clean_settings_env):
-    apply(UserSettings(disabled=True, print_call_link=False))
-    view = current()
-    assert view.disabled is True
-    assert view.print_call_link is False
+def test_replace_settings_installs_snapshot(clean_settings_env):
+    replace_settings(UserSettings(disabled=True, print_call_link=False))
+    assert should_disable_weave() is True
+    assert should_print_call_link() is False
 
 
-def test_apply_replace_all_resets_unmentioned_fields(clean_settings_env):
-    apply(UserSettings(disabled=True, print_call_link=False))
-    # Applying a fresh UserSettings(disabled=True) should NOT preserve
+def test_replace_settings_resets_unmentioned_fields(clean_settings_env):
+    replace_settings(UserSettings(disabled=True, print_call_link=False))
+    # Replacing with a fresh UserSettings(disabled=True) should NOT preserve
     # print_call_link=False — replace-all semantics.
-    apply(UserSettings(disabled=True))
-    assert current().disabled is True
-    assert current().print_call_link is True
+    replace_settings(UserSettings(disabled=True))
+    assert should_disable_weave() is True
+    assert should_print_call_link() is True
 
 
-def test_apply_none_resets_to_defaults(clean_settings_env):
-    apply(UserSettings(disabled=True))
-    assert current().disabled is True
-    apply(None)
-    assert current().disabled is False
+def test_replace_settings_none_resets_to_defaults(clean_settings_env):
+    replace_settings(UserSettings(disabled=True))
+    assert should_disable_weave() is True
+    replace_settings(None)
+    assert should_disable_weave() is False
 
 
-def test_apply_no_args_resets_to_defaults(clean_settings_env):
-    apply(UserSettings(disabled=True))
-    apply()
-    assert current().disabled is False
+def test_replace_settings_no_args_resets_to_defaults(clean_settings_env):
+    replace_settings(UserSettings(disabled=True))
+    replace_settings()
+    assert should_disable_weave() is False
 
 
-def test_apply_dict_input(clean_settings_env):
-    apply({"disabled": True, "redact_pii": True})
-    assert current().disabled is True
-    assert current().redact_pii is True
+def test_replace_settings_dict_input(clean_settings_env):
+    replace_settings({"disabled": True, "redact_pii": True})
+    assert should_disable_weave() is True
+    assert should_redact_pii() is True
 
 
-def test_apply_dict_unknown_field_raises(clean_settings_env):
+def test_replace_settings_dict_unknown_field_raises(clean_settings_env):
     with pytest.raises(TypeError):
-        apply({"definitely_not_a_real_field": True})
+        replace_settings({"definitely_not_a_real_field": True})
 
 
-def test_apply_invalid_type_raises(clean_settings_env):
+def test_replace_settings_invalid_type_raises(clean_settings_env):
     with pytest.raises(TypeError):
-        apply(42)
+        replace_settings(42)
 
 
 def test_override_scopes_one_field(clean_settings_env):
-    apply(UserSettings(print_call_link=False))
-    assert current().disabled is False
+    replace_settings(UserSettings(print_call_link=False))
+    assert should_disable_weave() is False
     with override(disabled=True):
-        assert current().disabled is True
+        assert should_disable_weave() is True
         # Other fields keep the surrounding snapshot's values
-        assert current().print_call_link is False
-    assert current().disabled is False
-    assert current().print_call_link is False
+        assert should_print_call_link() is False
+    assert should_disable_weave() is False
+    assert should_print_call_link() is False
 
 
 def test_override_nested(clean_settings_env):
     with override(disabled=True):
-        assert current().disabled is True
+        assert should_disable_weave() is True
         with override(print_call_link=False):
-            assert current().disabled is True
-            assert current().print_call_link is False
-        assert current().disabled is True
-        assert current().print_call_link is True
-    assert current().disabled is False
+            assert should_disable_weave() is True
+            assert should_print_call_link() is False
+        assert should_disable_weave() is True
+        assert should_print_call_link() is True
+    assert should_disable_weave() is False
 
 
 def test_override_unknown_field_raises(clean_settings_env):
@@ -559,72 +562,56 @@ def test_override_unknown_field_raises(clean_settings_env):
 
 
 def test_env_var_wins_over_snapshot(clean_settings_env, monkeypatch):
-    apply(UserSettings(disabled=False))
-    assert current().disabled is False
+    replace_settings(UserSettings(disabled=False))
+    assert should_disable_weave() is False
     monkeypatch.setenv("WEAVE_DISABLED", "true")
-    assert current().disabled is True
     assert should_disable_weave() is True
 
 
 def test_env_var_change_takes_effect_immediately(clean_settings_env, monkeypatch):
     """Q2 contract: users may flip env vars mid-process and reads pick it up."""
-    assert current().disabled is False
+    assert should_disable_weave() is False
     monkeypatch.setenv("WEAVE_DISABLED", "true")
-    assert current().disabled is True
+    assert should_disable_weave() is True
     monkeypatch.setenv("WEAVE_DISABLED", "false")
-    assert current().disabled is False
+    assert should_disable_weave() is False
     monkeypatch.delenv("WEAVE_DISABLED")
-    assert current().disabled is False
+    assert should_disable_weave() is False
 
 
 def test_empty_env_var_falls_through_to_snapshot(clean_settings_env, monkeypatch):
     """An env var that exists but is empty is treated as unset."""
-    apply(UserSettings(disabled=True))
+    replace_settings(UserSettings(disabled=True))
     monkeypatch.setenv("WEAVE_DISABLED", "")
-    assert current().disabled is True
     assert should_disable_weave() is True
 
 
 def test_env_overlay_coerces_int(clean_settings_env, monkeypatch):
     monkeypatch.setenv("WEAVE_MAX_CALLS_QUEUE_SIZE", "42")
-    assert current().max_calls_queue_size == 42
+    assert max_calls_queue_size() == 42
 
 
 def test_env_overlay_coerces_float(clean_settings_env, monkeypatch):
     monkeypatch.setenv("WEAVE_HTTP_TIMEOUT", "12.5")
-    assert current().http_timeout == 12.5
+    assert http_timeout() == 12.5
 
 
 def test_env_overlay_coerces_list(clean_settings_env, monkeypatch):
     monkeypatch.setenv("WEAVE_REDACT_PII_FIELDS", "a,b,c")
-    assert current().redact_pii_fields == ["a", "b", "c"]
+    assert redact_pii_fields() == ["a", "b", "c"]
 
 
 def test_env_overlay_coerces_optional_int(clean_settings_env, monkeypatch):
     monkeypatch.setenv("WEAVE_CLIENT_PARALLELISM", "7")
-    assert current().client_parallelism == 7
+    assert client_parallelism() == 7
 
 
-def test_accessor_function_matches_current_attr(clean_settings_env):
-    """Back-compat: should_X() returns the same value as current().X."""
-    apply(UserSettings(disabled=True, print_call_link=False))
-    assert should_disable_weave() == current().disabled
-    assert should_print_call_link() == current().print_call_link
-
-
-def test_unknown_field_access_raises_attribute_error(clean_settings_env):
-    view = current()
-    missing_name = "not_a_real_field"
-    with pytest.raises(AttributeError):
-        getattr(view, missing_name)
-
-
-def test_parse_and_apply_settings_is_alias_for_apply(clean_settings_env):
+def test_parse_and_apply_settings_is_alias_for_replace_settings(clean_settings_env):
     """Back-compat: the prior public name still works."""
     parse_and_apply_settings(UserSettings(disabled=True))
-    assert current().disabled is True
+    assert should_disable_weave() is True
     parse_and_apply_settings(None)
-    assert current().disabled is False
+    assert should_disable_weave() is False
 
 
 def test_user_settings_is_frozen():
@@ -644,15 +631,15 @@ def test_override_in_async_context_does_not_leak(clean_settings_env):
 
     async def child():
         with override(disabled=True):
-            assert current().disabled is True
+            assert should_disable_weave() is True
             await asyncio.sleep(0)
-            assert current().disabled is True
+            assert should_disable_weave() is True
 
     async def parent():
         # Parent does not override; child should see its own override; parent
         # should not see leakage.
-        assert current().disabled is False
+        assert should_disable_weave() is False
         await child()
-        assert current().disabled is False
+        assert should_disable_weave() is False
 
     asyncio.run(parent())

--- a/tests/trace/test_wal_client_writes.py
+++ b/tests/trace/test_wal_client_writes.py
@@ -30,7 +30,7 @@ from weave.durability.wal_sender import (
 )
 from weave.durability.wal_writer import JSONLWALWriter
 from weave.trace import weave_client
-from weave.trace.settings import UserSettings, override
+from weave.trace.settings import UserSettings, override_settings
 from weave.trace_server import trace_server_interface as tsi
 
 
@@ -503,7 +503,7 @@ class TestWALClientApiKeyNamespacing:
     def test_wal_directory_is_namespaced_by_api_key(self, client):
         """When api_key is provided, the WAL dir includes an HMAC subdirectory."""
         api_key = "wk-test-key-for-wal-namespacing"
-        with override(enable_wal=True, disable_wal_sender=True):
+        with override_settings(enable_wal=True, disable_wal_sender=True):
             wc = weave_client.WeaveClient(
                 client.entity,
                 client.project,
@@ -520,7 +520,7 @@ class TestWALClientApiKeyNamespacing:
 
     def test_wal_directory_not_namespaced_without_api_key(self, client):
         """When api_key is None, the WAL dir is the flat entity/project path."""
-        with override(enable_wal=True, disable_wal_sender=True):
+        with override_settings(enable_wal=True, disable_wal_sender=True):
             wc = weave_client.WeaveClient(
                 client.entity,
                 client.project,

--- a/tests/trace/test_wal_client_writes.py
+++ b/tests/trace/test_wal_client_writes.py
@@ -17,7 +17,6 @@ import pytest
 from PIL import Image
 
 import weave
-import weave.trace.settings
 from weave.durability.wal_client_id import compute_client_id
 from weave.durability.wal_consumer import JSONLWALConsumer
 from weave.durability.wal_directory_manager import FileWALDirectoryManager
@@ -31,7 +30,7 @@ from weave.durability.wal_sender import (
 )
 from weave.durability.wal_writer import JSONLWALWriter
 from weave.trace import weave_client
-from weave.trace.settings import UserSettings
+from weave.trace.settings import UserSettings, override
 from weave.trace_server import trace_server_interface as tsi
 
 
@@ -504,38 +503,32 @@ class TestWALClientApiKeyNamespacing:
     def test_wal_directory_is_namespaced_by_api_key(self, client):
         """When api_key is provided, the WAL dir includes an HMAC subdirectory."""
         api_key = "wk-test-key-for-wal-namespacing"
-        settings = UserSettings(enable_wal=True, disable_wal_sender=True)
-        weave.trace.settings.parse_and_apply_settings(settings)
-
-        wc = weave_client.WeaveClient(
-            client.entity,
-            client.project,
-            client.server,
-            ensure_project_exists=False,
-            api_key=api_key,
-        )
-        try:
-            assert wc._wal is not None
-            expected_suffix = compute_client_id(api_key)
-            assert wc._wal.wal_dir.endswith(expected_suffix)
-        finally:
-            wc._wal.close()
-            weave.trace.settings.parse_and_apply_settings(UserSettings())
+        with override(enable_wal=True, disable_wal_sender=True):
+            wc = weave_client.WeaveClient(
+                client.entity,
+                client.project,
+                client.server,
+                ensure_project_exists=False,
+                api_key=api_key,
+            )
+            try:
+                assert wc._wal is not None
+                expected_suffix = compute_client_id(api_key)
+                assert wc._wal.wal_dir.endswith(expected_suffix)
+            finally:
+                wc._wal.close()
 
     def test_wal_directory_not_namespaced_without_api_key(self, client):
         """When api_key is None, the WAL dir is the flat entity/project path."""
-        settings = UserSettings(enable_wal=True, disable_wal_sender=True)
-        weave.trace.settings.parse_and_apply_settings(settings)
-
-        wc = weave_client.WeaveClient(
-            client.entity,
-            client.project,
-            client.server,
-            ensure_project_exists=False,
-        )
-        try:
-            assert wc._wal is not None
-            assert wc._wal.wal_dir.endswith(wc.project)
-        finally:
-            wc._wal.close()
-            weave.trace.settings.parse_and_apply_settings(UserSettings())
+        with override(enable_wal=True, disable_wal_sender=True):
+            wc = weave_client.WeaveClient(
+                client.entity,
+                client.project,
+                client.server,
+                ensure_project_exists=False,
+            )
+            try:
+                assert wc._wal is not None
+                assert wc._wal.wal_dir.endswith(wc.project)
+            finally:
+                wc._wal.close()

--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -1,13 +1,12 @@
 import os
 import uuid
-from contextlib import contextmanager
 from datetime import datetime
 from unittest.mock import patch
 
 from litellm.types.utils import ModelResponse
 
 from tests.trace.util import client_is_sqlite
-from weave.trace.settings import _context_vars
+from weave.trace.settings import override
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError
 from weave.trace_server.interface.builtin_object_classes.provider import (
@@ -19,15 +18,6 @@ from weave.trace_server.llm_completion import get_custom_provider_info
 from weave.trace_server.secret_fetcher_context import (
     _secret_fetcher_context,
 )
-
-
-@contextmanager
-def with_tracing_disabled():
-    token = _context_vars["disabled"].set(True)
-    try:
-        yield
-    finally:
-        _context_vars["disabled"].reset(token)
 
 
 class DummySecretFetcher:
@@ -315,7 +305,7 @@ def test_custom_provider_completions_create(client):
     mock_response = create_mock_completion_response(model_name=model_name)
 
     # Run test with tracing disabled to avoid interference
-    with with_tracing_disabled():
+    with override(disabled=True):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
@@ -443,7 +433,7 @@ def test_custom_provider_ollama_model(client):
         prompt_tokens=11,
     )
 
-    with with_tracing_disabled():
+    with override(disabled=True):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
@@ -528,7 +518,7 @@ def test_custom_provider_trailing_slash_normalization(client):
         content="Hello!",
     )
 
-    with with_tracing_disabled():
+    with override(disabled=True):
         mock_secret_fetcher, token = setup_test_environment()
         try:
             with patch(
@@ -622,7 +612,7 @@ def test_error_handling_custom_provider(client):
     def mock_obj_read(req):
         raise NotFoundError("Test error fetching provider")
 
-    with with_tracing_disabled():
+    with override(disabled=True):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
@@ -665,7 +655,7 @@ def test_custom_provider_invalid_model_format(client):
         "messages": [{"role": "user", "content": "Hello, world!"}],
     }
 
-    with with_tracing_disabled():
+    with override(disabled=True):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:

--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from litellm.types.utils import ModelResponse
 
 from tests.trace.util import client_is_sqlite
-from weave.trace.settings import override
+from weave.trace.settings import override_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError
 from weave.trace_server.interface.builtin_object_classes.provider import (
@@ -305,7 +305,7 @@ def test_custom_provider_completions_create(client):
     mock_response = create_mock_completion_response(model_name=model_name)
 
     # Run test with tracing disabled to avoid interference
-    with override(disabled=True):
+    with override_settings(disabled=True):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
@@ -433,7 +433,7 @@ def test_custom_provider_ollama_model(client):
         prompt_tokens=11,
     )
 
-    with override(disabled=True):
+    with override_settings(disabled=True):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
@@ -518,7 +518,7 @@ def test_custom_provider_trailing_slash_normalization(client):
         content="Hello!",
     )
 
-    with override(disabled=True):
+    with override_settings(disabled=True):
         mock_secret_fetcher, token = setup_test_environment()
         try:
             with patch(
@@ -612,7 +612,7 @@ def test_error_handling_custom_provider(client):
     def mock_obj_read(req):
         raise NotFoundError("Test error fetching provider")
 
-    with override(disabled=True):
+    with override_settings(disabled=True):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
@@ -655,7 +655,7 @@ def test_custom_provider_invalid_model_format(client):
         "messages": [{"role": "user", "content": "Hello, world!"}],
     }
 
-    with override(disabled=True):
+    with override_settings(disabled=True):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:

--- a/weave/telemetry/trace_sentry.py
+++ b/weave/telemetry/trace_sentry.py
@@ -18,7 +18,7 @@ import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal
 
-from weave.trace.settings import _str2bool_truthy
+from weave.trace.settings import _parse_bool
 
 try:
     import sentry_sdk  # type: ignore
@@ -50,7 +50,7 @@ def _error_reporting_enabled() -> bool:
     that customers who already disable error reporting for the `wandb` SDK get
     the same behavior here. Default is enabled when the variable is unset.
     """
-    return _str2bool_truthy(os.environ.get("WANDB_ERROR_REPORTING", "true"))
+    return _parse_bool(os.getenv("WANDB_ERROR_REPORTING", "true"))
 
 
 def _safe_noop(func: Callable) -> Callable:

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -1,21 +1,36 @@
 """Settings for Weave.
 
-## `disabled`
+The settings module exposes a process-level configuration value, scoped per
+async-context via a single :class:`ContextVar`.  Read settings via
+:func:`current` (returns a :class:`SettingsView` with environment-variable
+overlay) or one of the back-compat accessor functions (e.g.
+:func:`should_disable_weave`).  Mutate via :func:`apply` (replace-all) or
+:func:`override` (scoped patch).
 
-* Environment Variable: `WEAVE_DISABLED`
-* Settings Key: `disabled`
-* Default: `False`
-* Type: `bool`
+Each field's environment variable is ``WEAVE_<FIELD_NAME>`` (uppercased), e.g.
+``WEAVE_DISABLED`` for the ``disabled`` field.  Environment variables override
+the snapshot on every read.
 
-If True, all weave ops will behave like regular functions and no network requests will be made.
+## ``disabled``
+
+* Environment Variable: ``WEAVE_DISABLED``
+* Settings Key: ``disabled``
+* Default: ``False``
+* Type: ``bool``
+
+If True, all weave ops will behave like regular functions and no network
+requests will be made.
 """
 
-import os
-from contextvars import ContextVar
-from pathlib import Path
-from typing import Any, Literal
+from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, PrivateAttr
+import os
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Literal, get_args, get_origin, get_type_hints
 
 DEFAULT_RETRY_MAX_INTERVAL_SECONDS = 60 * 5  # 5 minutes
 SETTINGS_PREFIX = "WEAVE_"
@@ -26,17 +41,19 @@ SETTINGS_PREFIX = "WEAVE_"
 # Expand the allowlist (or flip the env default) once we have confidence.
 CALLS_COMPLETE_ENTITY_ALLOWLIST: frozenset[str] = frozenset({"wandb"})
 
+
 # Attention Devs:
-# To add new settings:
+# To add a new setting:
 # 1. Add a new field to `UserSettings`
-# 2. Add a new `should_{xyz}` function
+# 2. Add a thin accessor (e.g. `def should_xyz() -> bool: return current().xyz`)
 
 
-class UserSettings(BaseModel):
+@dataclass(frozen=True, slots=True)
+class UserSettings:
     """User configuration for Weave.
 
-    All configs can be overridden with environment variables.  The precedence is
-    environment variables > `weave.trace.settings.UserSettings`.
+    All configs can be overridden with environment variables.  The precedence
+    is environment variables > ``UserSettings`` instance > defaults.
     """
 
     disabled: bool = False
@@ -93,7 +110,7 @@ class UserSettings(BaseModel):
     Can be overridden with the environment variable `WEAVE_REDACT_PII`
     """
 
-    redact_pii_fields: list[str] = []
+    redact_pii_fields: list[str] = field(default_factory=list)
     """List of fields to redact.
 
     If redact_pii is True, this list of fields will be redacted.
@@ -104,7 +121,7 @@ class UserSettings(BaseModel):
     Can be overridden with the environment variable `WEAVE_REDACT_PII_FIELDS`
     """
 
-    redact_pii_exclude_fields: list[str] = []
+    redact_pii_exclude_fields: list[str] = field(default_factory=list)
     """List of PII entity types to exclude from redaction.
 
     Only applies when `redact_pii` is True. Entities in this list are removed from the redaction set.
@@ -161,6 +178,7 @@ class UserSettings(BaseModel):
     Can be overridden with the environment variable `WEAVE_SCORERS_DIR`
 
     """
+
     max_calls_queue_size: int = 100_000
     """
     Sets the maximum size of the calls queue.  Defaults to 100_000.
@@ -276,34 +294,133 @@ class UserSettings(BaseModel):
     Can be overridden with the environment variable `WEAVE_DISABLE_WAL_SENDER`
     """
 
-    model_config = ConfigDict(extra="forbid")
-    _is_first_apply: bool = PrivateAttr(True)
 
-    def _reset(self) -> None:
-        for name, field in self.model_fields.items():
-            setattr(self, name, field.default)
+# Resolve string annotations once at import; used for env-var coercion.
+_FIELD_TYPES: dict[str, Any] = get_type_hints(UserSettings)
+_FIELD_NAMES: frozenset[str] = frozenset(_FIELD_TYPES)
 
-    def apply(self) -> None:
-        if self._is_first_apply:
-            self._is_first_apply = False
-        else:
-            self._reset()
+# UserSettings is a frozen dataclass, so this instance is immutable and safe
+# to share as the ContextVar default.
+_DEFAULT_SETTINGS = UserSettings()
 
-        for name in self.model_fields:
-            context_var = _context_vars[name]
-            context_var.set(getattr(self, name))
+_current_settings: ContextVar[UserSettings] = ContextVar(
+    "weave_settings", default=_DEFAULT_SETTINGS
+)
+
+
+def _parse_bool(v: str) -> bool:
+    return v.lower() in {"yes", "true", "1", "on"}
+
+
+# Back-compat alias for callers outside this module.
+_str2bool_truthy = _parse_bool
+
+
+def _parse_env_value(raw: str, annotation: Any) -> Any:
+    """Coerce an environment-variable string into the field's declared type."""
+    origin = get_origin(annotation)
+    if origin is None:
+        if annotation is bool:
+            return _parse_bool(raw)
+        if annotation is int:
+            return int(raw)
+        if annotation is float:
+            return float(raw)
+        # str, Literal[...] fall through and return the raw string
+        return raw
+    # list[X] / tuple[X] — split on comma. Checked before Optional handling
+    # because `get_args(list[str])` is `(str,)` which would otherwise look like
+    # a single-arm Optional.
+    if origin in {list, tuple}:
+        return raw.split(",")
+    # Optional[X] / X | None — pick the non-None arm
+    non_none_args = [a for a in get_args(annotation) if a is not type(None)]
+    if len(non_none_args) == 1:
+        return _parse_env_value(raw, non_none_args[0])
+    return raw
+
+
+class SettingsView:
+    """Read-only view over a :class:`UserSettings` snapshot, with env overlay.
+
+    For every field, an environment variable named ``WEAVE_<FIELD_NAME>``
+    overrides the snapshot's value when set to a truthy string (an empty env
+    var falls through to the snapshot, matching the prior helpers' behavior).
+    """
+
+    __slots__ = ("_snapshot",)
+
+    def __init__(self, snapshot: UserSettings) -> None:
+        self._snapshot = snapshot
+
+    def __getattr__(self, name: str) -> Any:
+        if name not in _FIELD_NAMES:
+            raise AttributeError(f"UserSettings has no field {name!r}")
+        if env := os.getenv(f"{SETTINGS_PREFIX}{name.upper()}"):
+            return _parse_env_value(env, _FIELD_TYPES[name])
+        return getattr(self._snapshot, name)
+
+
+def current() -> SettingsView:
+    """Return a view over the current settings snapshot."""
+    return SettingsView(_current_settings.get())
+
+
+def apply(settings: UserSettings | dict[str, Any] | None = None) -> None:
+    """Replace the current settings snapshot.
+
+    Pass a :class:`UserSettings` instance, a dict (constructed via
+    ``UserSettings(**d)``), or None to reset to defaults.
+    """
+    if settings is None:
+        snapshot = UserSettings()
+    elif isinstance(settings, UserSettings):
+        snapshot = settings
+    elif isinstance(settings, dict):
+        snapshot = UserSettings(**settings)
+    else:
+        raise TypeError(
+            f"settings must be UserSettings, dict, or None; got {type(settings).__name__}"
+        )
+    _current_settings.set(snapshot)
+
+
+# Back-compat alias for the prior public API.
+parse_and_apply_settings = apply
+
+
+@contextmanager
+def override(**fields: Any) -> Iterator[SettingsView]:
+    """Scope a partial settings override to the current async context.
+
+    Example::
+
+        with override(disabled=True):
+            ...
+    """
+    new_snapshot = replace(_current_settings.get(), **fields)
+    token = _current_settings.set(new_snapshot)
+    try:
+        yield SettingsView(new_snapshot)
+    finally:
+        _current_settings.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Accessor functions (back-compat).  New code can call `current().<field>`.
+# ---------------------------------------------------------------------------
 
 
 def should_disable_weave() -> bool:
-    return _should("disabled")
+    return current().disabled
 
 
 def should_print_call_link() -> bool:
-    return _should("print_call_link")
+    return current().print_call_link
 
 
 def log_level() -> str:
-    return _optional_str("log_level") or "INFO"
+    return current().log_level or "INFO"
 
 
 def display_viewer() -> str:
@@ -312,102 +429,102 @@ def display_viewer() -> str:
     Returns:
         The display viewer to use (auto, rich, or print).
     """
-    return _optional_str("display_viewer") or "auto"
+    return current().display_viewer or "auto"
 
 
 def should_capture_code() -> bool:
-    return _should("capture_code")
+    return current().capture_code
 
 
 def should_capture_client_info() -> bool:
-    return _should("capture_client_info")
+    return current().capture_client_info
 
 
 def should_capture_system_info() -> bool:
-    return _should("capture_system_info")
+    return current().capture_system_info
 
 
 def client_parallelism() -> int | None:
-    return _optional_int("client_parallelism")
+    return current().client_parallelism
 
 
 def should_redact_pii() -> bool:
-    return _should("redact_pii")
+    return current().redact_pii
 
 
 def redact_pii_fields() -> list[str]:
-    return _list_str("redact_pii_fields")
+    return current().redact_pii_fields
 
 
 def redact_pii_exclude_fields() -> list[str]:
-    return _list_str("redact_pii_exclude_fields")
+    return current().redact_pii_exclude_fields
 
 
 def use_server_cache() -> bool:
-    return _should("use_server_cache")
+    return current().use_server_cache
 
 
 def server_cache_size_limit() -> int:
-    return _optional_int("server_cache_size_limit") or 1_000_000_000
+    return current().server_cache_size_limit or 1_000_000_000
 
 
 def server_cache_dir() -> str | None:
-    return _optional_str("server_cache_dir")
+    return current().server_cache_dir
 
 
 def scorers_dir() -> str:
-    return _optional_str("scorers_dir")  # type: ignore
+    return current().scorers_dir
 
 
 def max_calls_queue_size() -> int:
-    max_queue_size = _optional_int("max_calls_queue_size")
-    if max_queue_size is None:
+    value = current().max_calls_queue_size
+    if value is None:
         return 100_000
-    return max_queue_size
+    return value
 
 
 def retry_max_attempts() -> int:
     """Returns the maximum number of retry attempts."""
-    max_attempts = _optional_int("retry_max_attempts")
-    if max_attempts is None:
+    value = current().retry_max_attempts
+    if value is None:
         return 3
-    return max_attempts
+    return value
 
 
 def retry_max_interval() -> float:
     """Returns the maximum interval between retries in seconds."""
-    max_interval = _optional_float("retry_max_interval")
-    if max_interval is None:
+    value = current().retry_max_interval
+    if value is None:
         return DEFAULT_RETRY_MAX_INTERVAL_SECONDS
-    return max_interval
+    return value
 
 
 def should_enable_disk_fallback() -> bool:
     """Returns whether disk fallback should be enabled for dropped items."""
-    return _should("enable_disk_fallback")
+    return current().enable_disk_fallback
 
 
 def should_use_parallel_table_upload() -> bool:
     """Returns whether parallel table upload chunking should be used."""
-    return _should("use_parallel_table_upload")
+    return current().use_parallel_table_upload
 
 
 def should_implicitly_patch_integrations() -> bool:
     """Returns whether implicit patching of integrations is enabled."""
-    return _should("implicitly_patch_integrations")
+    return current().implicitly_patch_integrations
 
 
 def http_timeout() -> float:
     """Returns the HTTP request timeout in seconds."""
-    timeout = _optional_float("http_timeout")
-    if timeout is None:
+    value = current().http_timeout
+    if value is None:
         return 30.0
-    return timeout
+    return value
 
 
 def should_use_stainless_server() -> bool:
     """Returns whether the stainless-generated HTTP client should be used."""
-    return _should("use_stainless_server")
+    return current().use_stainless_server
 
 
 def should_use_calls_complete(entity: str | None = None) -> bool:
@@ -416,74 +533,21 @@ def should_use_calls_complete(entity: str | None = None) -> bool:
     True if the `use_calls_complete` setting/env var is enabled, OR if
     `entity` is in `CALLS_COMPLETE_ENTITY_ALLOWLIST` (dogfood gate).
     """
-    if _should("use_calls_complete"):
+    if current().use_calls_complete:
         return True
     return entity is not None and entity in CALLS_COMPLETE_ENTITY_ALLOWLIST
 
 
 def should_enable_client_side_digests() -> bool:
     """Returns whether client-side digest computation should be used."""
-    return _should("enable_client_side_digests")
+    return current().enable_client_side_digests
 
 
 def should_enable_wal() -> bool:
     """Returns whether the Write-Ahead Log should be used."""
-    return _should("enable_wal")
+    return current().enable_wal
 
 
 def should_disable_wal_sender() -> bool:
     """Returns whether the WAL sender thread should be disabled."""
-    return _should("disable_wal_sender")
-
-
-def parse_and_apply_settings(
-    settings: UserSettings | dict[str, Any] | None = None,
-) -> None:
-    if isinstance(settings, UserSettings):
-        user_settings = settings
-    elif isinstance(settings, dict):
-        user_settings = UserSettings.model_validate(settings)
-    else:
-        user_settings = UserSettings()
-
-    user_settings.apply()
-
-
-_context_vars = {
-    name: ContextVar(name, default=field.default)
-    for name, field in UserSettings.model_fields.items()
-}
-
-
-def _str2bool_truthy(v: str) -> bool:
-    return v.lower() in {"yes", "true", "1", "on"}
-
-
-def _should(name: str) -> bool:
-    if env := os.getenv(f"{SETTINGS_PREFIX}{name.upper()}"):
-        return _str2bool_truthy(env)
-    return _context_vars[name].get()
-
-
-def _optional_int(name: str) -> int | None:
-    if env := os.getenv(f"{SETTINGS_PREFIX}{name.upper()}"):
-        return int(env)
-    return _context_vars[name].get()
-
-
-def _list_str(name: str) -> list[str]:
-    if env := os.getenv(f"{SETTINGS_PREFIX}{name.upper()}"):
-        return env.split(",")
-    return _context_vars[name].get() or []
-
-
-def _optional_str(name: str) -> str | None:
-    if env := os.getenv(f"{SETTINGS_PREFIX}{name.upper()}"):
-        return env
-    return _context_vars[name].get()
-
-
-def _optional_float(name: str) -> float | None:
-    if env := os.getenv(f"{SETTINGS_PREFIX}{name.upper()}"):
-        return float(env)
-    return _context_vars[name].get()
+    return current().disable_wal_sender

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -29,7 +29,18 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Literal, TypeVar, cast, get_args, get_origin, get_type_hints
+from typing import (
+    Any,
+    Literal,
+    TypedDict,
+    TypeVar,
+    cast,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
+
+from typing_extensions import Unpack
 
 DEFAULT_RETRY_MAX_INTERVAL_SECONDS = 60 * 5  # 5 minutes
 SETTINGS_PREFIX = "WEAVE_"
@@ -44,7 +55,10 @@ CALLS_COMPLETE_ENTITY_ALLOWLIST: frozenset[str] = frozenset({"wandb"})
 # Attention Devs:
 # To add a new setting:
 # 1. Add a new field to `UserSettings`
-# 2. Add a thin accessor (e.g.
+# 2. Mirror the same name/type on `_SettingsOverrides` below (TypedDict can't
+#    be derived from a dataclass while preserving mypy validation).  Drift is
+#    caught by `test_settings_overrides_matches_user_settings`.
+# 3. Add a thin accessor (e.g.
 #    `def should_xyz() -> bool:
 #         return _env_or_default("xyz", _current_settings.get().xyz)`)
 
@@ -55,6 +69,11 @@ class UserSettings:
 
     All configs can be overridden with environment variables.  The precedence
     is environment variables > ``UserSettings`` instance > defaults.
+
+    KEEP IN SYNC WITH :class:`_SettingsOverrides` below.  Each field added,
+    removed, or retyped here must be mirrored there so :func:`override`'s
+    typed kwargs stay accurate.  The :func:`test_settings_overrides_matches_user_settings`
+    test fails on drift.
     """
 
     disabled: bool = False
@@ -296,6 +315,49 @@ class UserSettings:
     """
 
 
+class _SettingsOverrides(TypedDict, total=False):
+    """Typed kwargs accepted by :func:`override`.
+
+    KEEP IN SYNC WITH :class:`UserSettings` above.  This TypedDict mirrors
+    every field on ``UserSettings``; mypy needs the field list spelled out
+    statically (it can't introspect through ``get_type_hints(UserSettings)``
+    or a dict comprehension).  All keys are optional (``total=False``) so
+    ``override`` can accept any subset of fields.
+
+    The :func:`test_settings_overrides_matches_user_settings` test asserts
+    that this TypedDict and ``UserSettings`` declare exactly the same
+    name → type mapping.
+    """
+
+    disabled: bool
+    print_call_link: bool
+    log_level: str
+    display_viewer: Literal["auto", "rich", "print"]
+    capture_code: bool
+    implicitly_patch_integrations: bool
+    redact_pii: bool
+    redact_pii_fields: list[str]
+    redact_pii_exclude_fields: list[str]
+    capture_client_info: bool
+    capture_system_info: bool
+    client_parallelism: int | None
+    use_server_cache: bool
+    server_cache_size_limit: int
+    server_cache_dir: str | None
+    scorers_dir: str
+    max_calls_queue_size: int
+    retry_max_interval: float
+    retry_max_attempts: int
+    enable_disk_fallback: bool
+    use_parallel_table_upload: bool
+    http_timeout: float
+    use_stainless_server: bool
+    use_calls_complete: bool
+    enable_client_side_digests: bool
+    enable_wal: bool
+    disable_wal_sender: bool
+
+
 # Resolve string annotations once at import; used for env-var coercion.
 _FIELD_TYPES: dict[str, Any] = get_type_hints(UserSettings)
 _FIELD_NAMES: frozenset[str] = frozenset(_FIELD_TYPES)
@@ -382,13 +444,16 @@ parse_and_apply_settings = replace_settings
 
 
 @contextmanager
-def override(**fields: Any) -> Iterator[UserSettings]:
+def override(**fields: Unpack[_SettingsOverrides]) -> Iterator[UserSettings]:
     """Scope a partial settings change to the current async context.
 
     Example::
 
         with override(disabled=True):
             ...
+
+    Only valid :class:`UserSettings` field names are accepted, and each value
+    is checked against the field's declared type.
     """
     new_snapshot = replace(_current_settings.get(), **fields)
     token = _current_settings.set(new_snapshot)

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -526,9 +526,7 @@ def redact_pii_exclude_fields() -> list[str]:
 
 
 def use_server_cache() -> bool:
-    return _env_or_default(
-        "use_server_cache", _current_settings.get().use_server_cache
-    )
+    return _env_or_default("use_server_cache", _current_settings.get().use_server_cache)
 
 
 def server_cache_size_limit() -> int:
@@ -538,9 +536,7 @@ def server_cache_size_limit() -> int:
 
 
 def server_cache_dir() -> str | None:
-    return _env_or_default(
-        "server_cache_dir", _current_settings.get().server_cache_dir
-    )
+    return _env_or_default("server_cache_dir", _current_settings.get().server_cache_dir)
 
 
 def scorers_dir() -> str:

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -4,7 +4,7 @@ The settings module exposes a process-level configuration value, scoped per
 async-context via a single :class:`ContextVar`.  Read settings via the
 field-named accessor functions (e.g. :func:`should_disable_weave`).  Mutate
 via :func:`replace_settings` (replace-all snapshot install, used at init) or
-:func:`override` (scoped partial change for the current async context).
+:func:`override_settings` (scoped partial change for the current async context).
 
 Each field's environment variable is ``WEAVE_<FIELD_NAME>`` (uppercased), e.g.
 ``WEAVE_DISABLED`` for the ``disabled`` field.  Environment variables override
@@ -71,7 +71,7 @@ class UserSettings:
     is environment variables > ``UserSettings`` instance > defaults.
 
     KEEP IN SYNC WITH :class:`_SettingsOverrides` below.  Each field added,
-    removed, or retyped here must be mirrored there so :func:`override`'s
+    removed, or retyped here must be mirrored there so :func:`override_settings`'s
     typed kwargs stay accurate.  The :func:`test_settings_overrides_matches_user_settings`
     test fails on drift.
     """
@@ -316,13 +316,13 @@ class UserSettings:
 
 
 class _SettingsOverrides(TypedDict, total=False):
-    """Typed kwargs accepted by :func:`override`.
+    """Typed kwargs accepted by :func:`override_settings`.
 
     KEEP IN SYNC WITH :class:`UserSettings` above.  This TypedDict mirrors
     every field on ``UserSettings``; mypy needs the field list spelled out
     statically (it can't introspect through ``get_type_hints(UserSettings)``
     or a dict comprehension).  All keys are optional (``total=False``) so
-    ``override`` can accept any subset of fields.
+    ``override_settings`` can accept any subset of fields.
 
     The :func:`test_settings_overrides_matches_user_settings` test asserts
     that this TypedDict and ``UserSettings`` declare exactly the same
@@ -424,7 +424,7 @@ def replace_settings(
 
     Pass a :class:`UserSettings` instance, a dict (constructed via
     ``UserSettings(**d)``), or None to reset to defaults.  This wipes every
-    field — to change a subset, use :func:`override` instead.
+    field — to change a subset, use :func:`override_settings` instead.
     """
     if settings is None:
         snapshot = UserSettings()
@@ -444,12 +444,14 @@ parse_and_apply_settings = replace_settings
 
 
 @contextmanager
-def override(**fields: Unpack[_SettingsOverrides]) -> Iterator[UserSettings]:
+def override_settings(
+    **fields: Unpack[_SettingsOverrides],
+) -> Iterator[UserSettings]:
     """Scope a partial settings change to the current async context.
 
     Example::
 
-        with override(disabled=True):
+        with override_settings(disabled=True):
             ...
 
     Only valid :class:`UserSettings` field names are accepted, and each value

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -1,11 +1,10 @@
 """Settings for Weave.
 
 The settings module exposes a process-level configuration value, scoped per
-async-context via a single :class:`ContextVar`.  Read settings via
-:func:`current` (returns a :class:`SettingsView` with environment-variable
-overlay) or one of the back-compat accessor functions (e.g.
-:func:`should_disable_weave`).  Mutate via :func:`apply` (replace-all) or
-:func:`override` (scoped patch).
+async-context via a single :class:`ContextVar`.  Read settings via the
+field-named accessor functions (e.g. :func:`should_disable_weave`).  Mutate
+via :func:`replace_settings` (replace-all snapshot install, used at init) or
+:func:`override` (scoped partial change for the current async context).
 
 Each field's environment variable is ``WEAVE_<FIELD_NAME>`` (uppercased), e.g.
 ``WEAVE_DISABLED`` for the ``disabled`` field.  Environment variables override
@@ -30,7 +29,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Literal, get_args, get_origin, get_type_hints
+from typing import Any, Literal, TypeVar, get_args, get_origin, get_type_hints
 
 DEFAULT_RETRY_MAX_INTERVAL_SECONDS = 60 * 5  # 5 minutes
 SETTINGS_PREFIX = "WEAVE_"
@@ -45,7 +44,9 @@ CALLS_COMPLETE_ENTITY_ALLOWLIST: frozenset[str] = frozenset({"wandb"})
 # Attention Devs:
 # To add a new setting:
 # 1. Add a new field to `UserSettings`
-# 2. Add a thin accessor (e.g. `def should_xyz() -> bool: return current().xyz`)
+# 2. Add a thin accessor (e.g.
+#    `def should_xyz() -> bool:
+#         return _env_or_default("xyz", _current_settings.get().xyz)`)
 
 
 @dataclass(frozen=True, slots=True)
@@ -298,6 +299,9 @@ class UserSettings:
 # Resolve string annotations once at import; used for env-var coercion.
 _FIELD_TYPES: dict[str, Any] = get_type_hints(UserSettings)
 _FIELD_NAMES: frozenset[str] = frozenset(_FIELD_TYPES)
+_ENV_KEYS: dict[str, str] = {
+    name: f"{SETTINGS_PREFIX}{name.upper()}" for name in _FIELD_NAMES
+}
 
 # UserSettings is a frozen dataclass, so this instance is immutable and safe
 # to share as the ContextVar default.
@@ -310,10 +314,6 @@ _current_settings: ContextVar[UserSettings] = ContextVar(
 
 def _parse_bool(v: str) -> bool:
     return v.lower() in {"yes", "true", "1", "on"}
-
-
-# Back-compat alias for callers outside this module.
-_str2bool_truthy = _parse_bool
 
 
 def _parse_env_value(raw: str, annotation: Any) -> Any:
@@ -340,37 +340,29 @@ def _parse_env_value(raw: str, annotation: Any) -> Any:
     return raw
 
 
-class SettingsView:
-    """Read-only view over a :class:`UserSettings` snapshot, with env overlay.
+_T = TypeVar("_T")
 
-    For every field, an environment variable named ``WEAVE_<FIELD_NAME>``
-    overrides the snapshot's value when set to a truthy string (an empty env
-    var falls through to the snapshot, matching the prior helpers' behavior).
+
+def _env_or_default(name: str, default: _T) -> _T:
+    """Return the env-var value for *name* if set, else *default*.
+
+    The field's runtime type annotation is looked up from :data:`_FIELD_TYPES`
+    and used to coerce the env-var string.  Empty env-var strings fall through
+    to the default — matching the prior helpers' truthy-check semantics.
     """
-
-    __slots__ = ("_snapshot",)
-
-    def __init__(self, snapshot: UserSettings) -> None:
-        self._snapshot = snapshot
-
-    def __getattr__(self, name: str) -> Any:
-        if name not in _FIELD_NAMES:
-            raise AttributeError(f"UserSettings has no field {name!r}")
-        if env := os.getenv(f"{SETTINGS_PREFIX}{name.upper()}"):
-            return _parse_env_value(env, _FIELD_TYPES[name])
-        return getattr(self._snapshot, name)
+    if env := os.getenv(_ENV_KEYS[name]):
+        return _parse_env_value(env, _FIELD_TYPES[name])  # type: ignore[no-any-return]
+    return default
 
 
-def current() -> SettingsView:
-    """Return a view over the current settings snapshot."""
-    return SettingsView(_current_settings.get())
-
-
-def apply(settings: UserSettings | dict[str, Any] | None = None) -> None:
-    """Replace the current settings snapshot.
+def replace_settings(
+    settings: UserSettings | dict[str, Any] | None = None,
+) -> None:
+    """Replace the current settings snapshot wholesale.
 
     Pass a :class:`UserSettings` instance, a dict (constructed via
-    ``UserSettings(**d)``), or None to reset to defaults.
+    ``UserSettings(**d)``), or None to reset to defaults.  This wipes every
+    field — to change a subset, use :func:`override` instead.
     """
     if settings is None:
         snapshot = UserSettings()
@@ -386,12 +378,12 @@ def apply(settings: UserSettings | dict[str, Any] | None = None) -> None:
 
 
 # Back-compat alias for the prior public API.
-parse_and_apply_settings = apply
+parse_and_apply_settings = replace_settings
 
 
 @contextmanager
-def override(**fields: Any) -> Iterator[SettingsView]:
-    """Scope a partial settings override to the current async context.
+def override(**fields: Any) -> Iterator[UserSettings]:
+    """Scope a partial settings change to the current async context.
 
     Example::
 
@@ -401,130 +393,148 @@ def override(**fields: Any) -> Iterator[SettingsView]:
     new_snapshot = replace(_current_settings.get(), **fields)
     token = _current_settings.set(new_snapshot)
     try:
-        yield SettingsView(new_snapshot)
+        yield new_snapshot
     finally:
         _current_settings.reset(token)
 
 
 # ---------------------------------------------------------------------------
-# Accessor functions (back-compat).  New code can call `current().<field>`.
+# Accessor functions — the public read API.  Each reads from the env-var
+# overlay first, then from the current snapshot.
 # ---------------------------------------------------------------------------
 
 
 def should_disable_weave() -> bool:
-    return current().disabled
+    return _env_or_default("disabled", _current_settings.get().disabled)
 
 
 def should_print_call_link() -> bool:
-    return current().print_call_link
+    return _env_or_default("print_call_link", _current_settings.get().print_call_link)
 
 
 def log_level() -> str:
-    return current().log_level or "INFO"
+    return _env_or_default("log_level", _current_settings.get().log_level)
 
 
 def display_viewer() -> str:
-    """Returns the configured display viewer.
-
-    Returns:
-        The display viewer to use (auto, rich, or print).
-    """
-    return current().display_viewer or "auto"
+    """Returns the configured display viewer (auto, rich, or print)."""
+    return _env_or_default("display_viewer", _current_settings.get().display_viewer)
 
 
 def should_capture_code() -> bool:
-    return current().capture_code
+    return _env_or_default("capture_code", _current_settings.get().capture_code)
 
 
 def should_capture_client_info() -> bool:
-    return current().capture_client_info
+    return _env_or_default(
+        "capture_client_info", _current_settings.get().capture_client_info
+    )
 
 
 def should_capture_system_info() -> bool:
-    return current().capture_system_info
+    return _env_or_default(
+        "capture_system_info", _current_settings.get().capture_system_info
+    )
 
 
 def client_parallelism() -> int | None:
-    return current().client_parallelism
+    return _env_or_default(
+        "client_parallelism", _current_settings.get().client_parallelism
+    )
 
 
 def should_redact_pii() -> bool:
-    return current().redact_pii
+    return _env_or_default("redact_pii", _current_settings.get().redact_pii)
 
 
 def redact_pii_fields() -> list[str]:
-    return current().redact_pii_fields
+    return _env_or_default(
+        "redact_pii_fields", _current_settings.get().redact_pii_fields
+    )
 
 
 def redact_pii_exclude_fields() -> list[str]:
-    return current().redact_pii_exclude_fields
+    return _env_or_default(
+        "redact_pii_exclude_fields",
+        _current_settings.get().redact_pii_exclude_fields,
+    )
 
 
 def use_server_cache() -> bool:
-    return current().use_server_cache
+    return _env_or_default(
+        "use_server_cache", _current_settings.get().use_server_cache
+    )
 
 
 def server_cache_size_limit() -> int:
-    return current().server_cache_size_limit or 1_000_000_000
+    return _env_or_default(
+        "server_cache_size_limit", _current_settings.get().server_cache_size_limit
+    )
 
 
 def server_cache_dir() -> str | None:
-    return current().server_cache_dir
+    return _env_or_default(
+        "server_cache_dir", _current_settings.get().server_cache_dir
+    )
 
 
 def scorers_dir() -> str:
-    return current().scorers_dir
+    return _env_or_default("scorers_dir", _current_settings.get().scorers_dir)
 
 
 def max_calls_queue_size() -> int:
-    value = current().max_calls_queue_size
-    if value is None:
-        return 100_000
-    return value
+    return _env_or_default(
+        "max_calls_queue_size", _current_settings.get().max_calls_queue_size
+    )
 
 
 def retry_max_attempts() -> int:
     """Returns the maximum number of retry attempts."""
-    value = current().retry_max_attempts
-    if value is None:
-        return 3
-    return value
+    return _env_or_default(
+        "retry_max_attempts", _current_settings.get().retry_max_attempts
+    )
 
 
 def retry_max_interval() -> float:
     """Returns the maximum interval between retries in seconds."""
-    value = current().retry_max_interval
-    if value is None:
-        return DEFAULT_RETRY_MAX_INTERVAL_SECONDS
-    return value
+    return _env_or_default(
+        "retry_max_interval", _current_settings.get().retry_max_interval
+    )
 
 
 def should_enable_disk_fallback() -> bool:
     """Returns whether disk fallback should be enabled for dropped items."""
-    return current().enable_disk_fallback
+    return _env_or_default(
+        "enable_disk_fallback", _current_settings.get().enable_disk_fallback
+    )
 
 
 def should_use_parallel_table_upload() -> bool:
     """Returns whether parallel table upload chunking should be used."""
-    return current().use_parallel_table_upload
+    return _env_or_default(
+        "use_parallel_table_upload",
+        _current_settings.get().use_parallel_table_upload,
+    )
 
 
 def should_implicitly_patch_integrations() -> bool:
     """Returns whether implicit patching of integrations is enabled."""
-    return current().implicitly_patch_integrations
+    return _env_or_default(
+        "implicitly_patch_integrations",
+        _current_settings.get().implicitly_patch_integrations,
+    )
 
 
 def http_timeout() -> float:
     """Returns the HTTP request timeout in seconds."""
-    value = current().http_timeout
-    if value is None:
-        return 30.0
-    return value
+    return _env_or_default("http_timeout", _current_settings.get().http_timeout)
 
 
 def should_use_stainless_server() -> bool:
     """Returns whether the stainless-generated HTTP client should be used."""
-    return current().use_stainless_server
+    return _env_or_default(
+        "use_stainless_server", _current_settings.get().use_stainless_server
+    )
 
 
 def should_use_calls_complete(entity: str | None = None) -> bool:
@@ -533,21 +543,28 @@ def should_use_calls_complete(entity: str | None = None) -> bool:
     True if the `use_calls_complete` setting/env var is enabled, OR if
     `entity` is in `CALLS_COMPLETE_ENTITY_ALLOWLIST` (dogfood gate).
     """
-    if current().use_calls_complete:
+    if _env_or_default(
+        "use_calls_complete", _current_settings.get().use_calls_complete
+    ):
         return True
     return entity is not None and entity in CALLS_COMPLETE_ENTITY_ALLOWLIST
 
 
 def should_enable_client_side_digests() -> bool:
     """Returns whether client-side digest computation should be used."""
-    return current().enable_client_side_digests
+    return _env_or_default(
+        "enable_client_side_digests",
+        _current_settings.get().enable_client_side_digests,
+    )
 
 
 def should_enable_wal() -> bool:
     """Returns whether the Write-Ahead Log should be used."""
-    return current().enable_wal
+    return _env_or_default("enable_wal", _current_settings.get().enable_wal)
 
 
 def should_disable_wal_sender() -> bool:
     """Returns whether the WAL sender thread should be disabled."""
-    return current().disable_wal_sender
+    return _env_or_default(
+        "disable_wal_sender", _current_settings.get().disable_wal_sender
+    )

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -29,7 +29,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
 from pathlib import Path
-from typing import Any, Literal, TypeVar, get_args, get_origin, get_type_hints
+from typing import Any, Literal, TypeVar, cast, get_args, get_origin, get_type_hints
 
 DEFAULT_RETRY_MAX_INTERVAL_SECONDS = 60 * 5  # 5 minutes
 SETTINGS_PREFIX = "WEAVE_"
@@ -351,7 +351,7 @@ def _env_or_default(name: str, default: _T) -> _T:
     to the default — matching the prior helpers' truthy-check semantics.
     """
     if env := os.getenv(_ENV_KEYS[name]):
-        return _parse_env_value(env, _FIELD_TYPES[name])  # type: ignore[no-any-return]
+        return cast(_T, _parse_env_value(env, _FIELD_TYPES[name]))
     return default
 
 


### PR DESCRIPTION
Previously we had multiple contextvars for settings, but since they are all settings, it's easier to just have one