### PR TITLE
feat(weave): Session SDK respects is_tracing_setting_disabled

### DIFF
--- a/tests/session/test_session_otel.py
+++ b/tests/session/test_session_otel.py
@@ -51,6 +51,8 @@ from weave.session.session_otel import (
     invoke_agent_attributes,
     llm_attributes,
 )
+from weave.trace.context import weave_client_context
+from weave.trace.context.call_context import tracing_disabled
 
 
 @pytest.fixture(autouse=True)
@@ -65,8 +67,29 @@ def _reset_contextvars():
         session.end()
 
 
+_STUB_WEAVE_CLIENT = object()
+
+
+def _get_stub_weave_client() -> object:
+    return _STUB_WEAVE_CLIENT
+
+
 @pytest.fixture
-def otel_spans(monkeypatch: pytest.MonkeyPatch):
+def _weave_client_stub(monkeypatch: pytest.MonkeyPatch):
+    """Stub ``get_weave_client`` so ``is_tracing_setting_disabled()`` returns False.
+
+    The Session SDK's OTel emission is gated on ``is_tracing_setting_disabled()``,
+    which returns True when no client is initialized. Tests that exercise span
+    emission need a non-None client; we monkeypatch the lookup rather than
+    install a real client to keep these tests isolated from server fixtures.
+    """
+    monkeypatch.setattr(
+        weave_client_context, "get_weave_client", _get_stub_weave_client
+    )
+
+
+@pytest.fixture
+def otel_spans(monkeypatch: pytest.MonkeyPatch, _weave_client_stub):
     """Provide an in-memory span exporter for capturing OTel spans.
 
     Overrides the global OTel tracer provider for the duration of the test.
@@ -2313,3 +2336,79 @@ class TestReasoningFromOpenAIResponses:
         )
         assert result is not None
         assert result.content == "kept\nalso kept"
+
+
+class TestRespectsTracingSettingDisabled:
+    """Session SDK OTel emission must honor ``is_tracing_setting_disabled()``.
+
+    Three independent conditions disable tracing repo-wide; the Session SDK
+    has to respect each, so a user toggling weave off doesn't get surprise
+    spans from ``start_session`` / ``start_turn`` / ``log_turn``.
+    """
+
+    def test_weave_disabled_env_suppresses_spans(
+        self,
+        otel_spans: InMemorySpanExporter,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("WEAVE_DISABLED", "true")
+        with start_session(agent_name="bot", session_id="sess") as s, s.start_turn():
+            with start_llm(model="gpt-4o") as llm:
+                llm.record(output_messages=[Message(role="assistant", content="hi")])
+        assert otel_spans.get_finished_spans() == ()
+
+    def test_no_weave_client_suppresses_spans(
+        self,
+        otel_spans: InMemorySpanExporter,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: None)
+        with start_session(agent_name="bot", session_id="sess") as s, s.start_turn():
+            with start_llm(model="gpt-4o") as llm:
+                llm.record(output_messages=[Message(role="assistant", content="hi")])
+        assert otel_spans.get_finished_spans() == ()
+
+    def test_tracing_disabled_contextmanager_suppresses_spans(
+        self,
+        otel_spans: InMemorySpanExporter,
+    ) -> None:
+        with tracing_disabled():
+            with (
+                start_session(agent_name="bot", session_id="sess") as s,
+                s.start_turn(),
+            ):
+                with start_llm(model="gpt-4o") as llm:
+                    llm.record(
+                        output_messages=[Message(role="assistant", content="hi")]
+                    )
+        assert otel_spans.get_finished_spans() == ()
+
+    def test_log_turn_suppressed_when_disabled(
+        self,
+        otel_spans: InMemorySpanExporter,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """``log_turn`` is a separate emission path from the context-manager API."""
+        monkeypatch.setenv("WEAVE_DISABLED", "true")
+        result = log_turn(
+            session_id="sess",
+            agent_name="bot",
+            messages=[Message(role="user", content="hi")],
+            spans=[LLM(model="gpt-4o")],
+        )
+        assert result.span_count == 0
+        assert result.trace_ids == []
+        assert otel_spans.get_finished_spans() == ()
+
+    def test_re_enables_after_contextmanager_exits(
+        self,
+        otel_spans: InMemorySpanExporter,
+    ) -> None:
+        """The contextmanager guard must not leak — spans resume after exit."""
+        with tracing_disabled():
+            with start_session(agent_name="bot", session_id="off") as s, s.start_turn():
+                pass
+        with start_session(agent_name="bot", session_id="on") as s, s.start_turn():
+            pass
+        names = [sp.name for sp in otel_spans.get_finished_spans()]
+        assert "invoke_agent bot" in names

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -41,6 +41,7 @@ from weave.session.types import (
     Usage,
     _parse_data_url,
 )
+from weave.trace.op import is_tracing_setting_disabled
 
 # OTel imports — kept top-level under a try/except guard so the module
 # loads cleanly when opentelemetry is not installed. When unavailable,
@@ -129,7 +130,7 @@ class _SpanBase(BaseModel):
         OTel span timestamp matches the user-visible start, not the moment
         ``__enter__`` happened to run.
         """
-        if not _OTEL_AVAILABLE:
+        if not _OTEL_AVAILABLE or is_tracing_setting_disabled():
             return
         tracer = otel_trace.get_tracer(_TRACER_NAME)
         kwargs: dict[str, Any] = {}
@@ -901,9 +902,10 @@ def _emit_span_now(
     Used by the batch-logging path (``log_turn`` / ``log_session``) to
     create children of a parent span without attaching them to the calling
     thread's OTel context. Returns the finished Span so the caller can
-    read trace_id / span_id, or None if OTel is unavailable.
+    read trace_id / span_id, or None if OTel is unavailable or tracing is
+    disabled.
     """
-    if not _OTEL_AVAILABLE:
+    if not _OTEL_AVAILABLE or is_tracing_setting_disabled():
         return None
     tracer = otel_trace.get_tracer(_TRACER_NAME)
     kwargs: dict[str, Any] = {}
@@ -1022,7 +1024,7 @@ def log_turn(
     Falls back to the earliest/latest child timestamp, then ``now()``, when
     the turn doesn't supply its own.
     """
-    if not _OTEL_AVAILABLE:
+    if not _OTEL_AVAILABLE or is_tracing_setting_disabled():
         return LogResult(session_id=session_id)
 
     resolved_spans = spans or []
@@ -1103,7 +1105,7 @@ def log_session(
     ``session_id`` if empty. By default each turn gets its own OTel trace.
     """
     sid = session_id or str(uuid.uuid4())
-    if not _OTEL_AVAILABLE:
+    if not _OTEL_AVAILABLE or is_tracing_setting_disabled():
         return LogResult(session_id=sid)
 
     trace_ids: list[str] = []

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -1024,7 +1024,7 @@ def log_turn(
     Falls back to the earliest/latest child timestamp, then ``now()``, when
     the turn doesn't supply its own.
     """
-    if not _OTEL_AVAILABLE or is_tracing_setting_disabled():
+    if not _OTEL_AVAILABLE:
         return LogResult(session_id=session_id)
 
     resolved_spans = spans or []
@@ -1105,7 +1105,7 @@ def log_session(
     ``session_id`` if empty. By default each turn gets its own OTel trace.
     """
     sid = session_id or str(uuid.uuid4())
-    if not _OTEL_AVAILABLE or is_tracing_setting_disabled():
+    if not _OTEL_AVAILABLE:
         return LogResult(session_id=sid)
 
     trace_ids: list[str] = []


### PR DESCRIPTION
## Summary

The new gen-AI OTel Session SDK (`start_session`, `start_turn`, `log_turn`, `log_session`) was the only weave tracing surface that ignored `is_tracing_setting_disabled()`. `@weave.op`, `weave_client`, and `EvaluationLogger` all consult it, so users who:

- set `WEAVE_DISABLED=true`,
- forgot to call `weave.init()`, or
- entered a `weave.tracing_disabled()` block

were still emitting Session SDK spans to whatever global OTel `TracerProvider` was installed. This PR wires the Session SDK into the same kill switch the rest of weave uses.

## Changes

Two correctness-essential guards in `weave/session/session.py`:

- `_SpanBase._start_otel_span` — covers all context-manager paths (`Session` / `Turn` / `LLM` / `Tool` / `SubAgent`).
- `_emit_span_now` — covers `log_turn` / `log_session`, which bypass `_start_otel_span`.

`_end_otel_span` / `_record_otel_error` already early-exit when `_otel_span is None`, so guarding the start path covers them transitively. `log_turn`'s existing `if turn_span is None: return …` branch handles the disabled case via `_emit_span_now`'s gate, so no top-level guard there is needed either.

Tests in `tests/session/test_session_otel.py`:

- New `TestRespectsTracingSettingDisabled` covering each of the three disabled conditions plus `log_turn` and contextmanager re-enable.
- Updated `otel_spans` fixture to stub `get_weave_client` — emission tests now need a non-None client to satisfy the new guard.

Import is cycle-safe: `weave/__init__.py` loads `weave.trace.api` → `weave.trace.op` before `weave.session.session`, so `from weave.trace.op import is_tracing_setting_disabled` adds no new module load cost in the typical case.

## Tradeoff worth flagging

`is_tracing_setting_disabled()` returns `True` when no Weave client is initialized, with a one-time `UNINITIALIZED_MSG` warning. That changes behavior for callers using the Session SDK as a **standalone OTel emitter** without `weave.init()` (e.g., wiring `start_session` into a user's own OTel pipeline) — spans no longer emit.

If standalone use is intended to keep working, the guard should drop the no-client branch and check only `should_disable_weave()` + `get_tracing_enabled()`. I went with the full function here per the literal spec; happy to narrow it if standalone is a supported pattern.

## Test plan

- [x] `uvx ruff check weave/session/session.py tests/session/test_session_otel.py` — clean
- [x] `uvx ruff format` — clean
- [x] `uv run --group test python -m pytest tests/session/ -q` — 208 passed
- [ ] CI green