### PR TITLE
Add centralized sampling rules

### DIFF
--- a/tests/flow/test_monitor.py
+++ b/tests/flow/test_monitor.py
@@ -5,6 +5,7 @@ from weave.flow.monitor import Monitor
 from weave.scorers import ValidJSONScorer
 from weave.trace import weave_client
 from weave.trace.api import publish
+from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.interface.query import Query
 
 
@@ -83,6 +84,24 @@ def test_activate(client: weave_client.WeaveClient):
 
     activated_ref = monitor.activate()
     assert activated_ref.get().active == True
+    active_sampling_snapshot = client.server.sampling_rules_read(
+        tsi.SamplingRulesReadReq(
+            project_id=client.project_id,
+            consumer="monitor",
+            monitor_id="test_monitor",
+        )
+    )
+    assert [(rule.scope, rule.rate) for rule in active_sampling_snapshot.rules] == [
+        ("monitor:test_monitor", 0.5)
+    ]
 
     deactivated_ref = monitor.deactivate()
     assert deactivated_ref.get().active == False
+    inactive_sampling_snapshot = client.server.sampling_rules_read(
+        tsi.SamplingRulesReadReq(
+            project_id=client.project_id,
+            consumer="monitor",
+            monitor_id="test_monitor",
+        )
+    )
+    assert inactive_sampling_snapshot.rules == []

--- a/tests/trace/test_sampling.py
+++ b/tests/trace/test_sampling.py
@@ -1,0 +1,194 @@
+import datetime
+
+import httpx
+
+import weave
+from weave.trace.sampling import (
+    SAMPLING_DECISION_ATTRIBUTE,
+    decide_project_sampling,
+    find_matching_rule,
+    xxh64_int,
+)
+from weave.trace.sampling_client import SamplingClient
+from weave.trace_server import trace_server_interface as tsi
+
+
+def _rule(
+    scope: str,
+    op_pattern: str,
+    rate: float,
+    updated_at: datetime.datetime,
+) -> tsi.SamplingRuleSchema:
+    return tsi.SamplingRuleSchema(
+        scope=scope,
+        op_pattern=op_pattern,
+        rate=rate,
+        updated_at=updated_at,
+    )
+
+
+def test_sampling_matcher_hash_and_exemptions():
+    project_id = "entity/project"
+    now = datetime.datetime.now(datetime.timezone.utc)
+    rules = [
+        _rule(f"project:{project_id}", "", 0.9, now),
+        _rule(f"project:{project_id}", "openai.*", 0.5, now),
+        _rule(f"project:{project_id}", "openai.chat.*", 0.25, now),
+        _rule(f"project:{project_id}", "openai.chat.create", 0.1, now),
+        _rule(f"project:{project_id}", "same.*", 0.4, now),
+        _rule(
+            f"project:{project_id}",
+            "same.?",
+            0.3,
+            now + datetime.timedelta(seconds=1),
+        ),
+    ]
+    snapshot = tsi.SamplingRulesSnapshotRes(
+        project_id=project_id,
+        rules=rules,
+        etag="sha256-test",
+        snapshot_updated_at=now,
+    )
+
+    # Specificity: exact, longest glob prefix, empty catch-all, then updated_at tie-break.
+    assert find_matching_rule(rules, "openai.chat.create").rate == 0.1
+    assert (
+        find_matching_rule(
+            rules, f"weave:///{project_id}/op/openai.chat.create:deadbeef"
+        ).rate
+        == 0.1
+    )
+    assert find_matching_rule(rules, "openai.chat.stream").rate == 0.25
+    assert find_matching_rule(rules, "anthropic.messages").rate == 0.9
+    assert find_matching_rule(rules, "same.x").rate == 0.3
+
+    # Hash implementation matches the xxh64 seed-0 public empty-string vector.
+    assert xxh64_int(b"", seed=0) == 0xEF46DB3751D8E999
+
+    # Server-shipped exemptions keep evaluation traffic regardless of matching rules.
+    op_exempt = decide_project_sampling(
+        snapshot,
+        trace_id="trace-1",
+        op_name="weave.Evaluation.predict",
+        attributes={},
+    )
+    attr_exempt = decide_project_sampling(
+        snapshot,
+        trace_id="trace-1",
+        op_name="openai.chat.create",
+        attributes={"weave": {"eval": True}},
+    )
+    assert op_exempt.keep is True
+    assert attr_exempt.keep is True
+    assert attr_exempt.reason == "exempt"
+
+
+def test_sdk_sampling_drop_disables_nested_tracing(client):
+    client.server.sampling_rules_update(
+        tsi.SamplingRulesUpdateReq(
+            project_id=client.project_id,
+            scope=f"project:{client.project_id}",
+            op_pattern="",
+            rate=0.0,
+            wb_user_id="test-user",
+        )
+    )
+    client.sampling_client._refresh_once()
+    snapshot = client.sampling_client._get_snapshot()
+    assert snapshot is not None
+    assert client.sampling_client._started is True
+    assert [(rule.scope, rule.op_pattern, rule.rate) for rule in snapshot.rules] == [
+        (f"project:{client.project_id}", "", 0.0)
+    ]
+    assert (
+        decide_project_sampling(
+            snapshot,
+            trace_id="trace-1",
+            op_name="parent",
+            attributes={},
+        ).keep
+        is False
+    )
+
+    @weave.op
+    def child() -> str:
+        return "child"
+
+    @weave.op
+    def parent() -> str:
+        return child()
+
+    decisions = []
+    original_decide_root = client.sampling_client.decide_root
+
+    def recording_decide_root(**kwargs):
+        current_snapshot = client.sampling_client._get_snapshot()
+        assert current_snapshot is not None
+        assert current_snapshot.rules
+        decision = original_decide_root(**kwargs)
+        decisions.append(decision)
+        return decision
+
+    client.sampling_client.decide_root = recording_decide_root
+    try:
+        assert parent() == "child"
+        assert len(decisions) == 1
+        assert decisions[0].keep is False
+    finally:
+        client.sampling_client.decide_root = original_decide_root
+    client.flush()
+    assert list(client.get_calls()) == []
+    assert (
+        client.server.objs_query(
+            tsi.ObjQueryReq(
+                project_id=client.project_id,
+                filter=tsi.ObjectVersionFilter(is_op=True),
+            )
+        ).objs
+        == []
+    )
+
+    client.server.sampling_rules_update(
+        tsi.SamplingRulesUpdateReq(
+            project_id=client.project_id,
+            scope=f"project:{client.project_id}",
+            op_pattern="",
+            rate=1.0,
+            enabled=False,
+            wb_user_id="test-user",
+        )
+    )
+    client.sampling_client._refresh_once()
+
+    assert parent() == "child"
+    client.flush()
+    calls = list(client.get_calls())
+    assert len(calls) == 2
+    root = next(call for call in calls if call.parent_id is None)
+    assert root.attributes[SAMPLING_DECISION_ATTRIBUTE] == "keep"
+    child_call = next(call for call in calls if call.parent_id == root.id)
+    assert child_call.attributes[SAMPLING_DECISION_ATTRIBUTE] == "keep"
+
+
+def test_sampling_client_fails_open_for_http_errors():
+    class MissingSamplingEndpointServer:
+        def sampling_rules_read(self, req: tsi.SamplingRulesReadReq):
+            request = httpx.Request("POST", "http://trace-server/sampling/rules/read")
+            response = httpx.Response(404, request=request)
+            raise httpx.HTTPStatusError(
+                "sampling endpoint missing",
+                request=request,
+                response=response,
+            )
+
+    sampling_client = SamplingClient(MissingSamplingEndpointServer(), "entity/project")
+    try:
+        decision = sampling_client.decide_root(
+            trace_id="trace-1",
+            op_name="expensive_op",
+            attributes={},
+        )
+    finally:
+        sampling_client.close()
+
+    assert decision.keep is True

--- a/tests/trace_server/test_sampling_rules.py
+++ b/tests/trace_server/test_sampling_rules.py
@@ -1,0 +1,121 @@
+import pytest
+
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.errors import InvalidRequest
+from weave.trace_server.sqlite_trace_server import SqliteTraceServer
+
+
+def test_sqlite_sampling_rules_update_read_filter_and_delete():
+    server = SqliteTraceServer(":memory:")
+    server.drop_tables()
+    server.setup_tables()
+    project_id = "entity/project"
+
+    empty = server.sampling_rules_read(
+        tsi.SamplingRulesReadReq(project_id=project_id, consumer="sdk")
+    )
+    assert empty.rules == []
+    assert empty.default_rate == 1.0
+    assert empty.schema_version == 1
+
+    project_snapshot = server.sampling_rules_update(
+        tsi.SamplingRulesUpdateReq(
+            project_id=project_id,
+            scope=f"project:{project_id}",
+            op_pattern="",
+            rate=0.25,
+            wb_user_id="user-1",
+        )
+    )
+    assert [(rule.scope, rule.op_pattern, rule.rate) for rule in project_snapshot.rules] == [
+        (f"project:{project_id}", "", 0.25)
+    ]
+
+    server.sampling_rules_update(
+        tsi.SamplingRulesUpdateReq(
+            project_id=project_id,
+            scope="monitor:mon-1",
+            op_pattern="openai.*",
+            rate=0.5,
+            wb_user_id="monitor:mon-1",
+        )
+    )
+
+    # SDK consumers never see monitor rules; monitor workers see only their own monitor.
+    sdk_snapshot = server.sampling_rules_read(
+        tsi.SamplingRulesReadReq(project_id=project_id, consumer="sdk")
+    )
+    monitor_1_snapshot = server.sampling_rules_read(
+        tsi.SamplingRulesReadReq(
+            project_id=project_id, consumer="monitor", monitor_id="mon-1"
+        )
+    )
+    monitor_2_snapshot = server.sampling_rules_read(
+        tsi.SamplingRulesReadReq(
+            project_id=project_id, consumer="monitor", monitor_id="mon-2"
+        )
+    )
+    assert [rule.scope for rule in sdk_snapshot.rules] == [f"project:{project_id}"]
+    assert [rule.scope for rule in monitor_1_snapshot.rules] == [
+        "monitor:mon-1",
+        f"project:{project_id}",
+    ]
+    assert [rule.scope for rule in monitor_2_snapshot.rules] == [
+        f"project:{project_id}"
+    ]
+
+    server.sampling_rules_update(
+        tsi.SamplingRulesUpdateReq(
+            project_id=project_id,
+            scope="monitor:mon-1",
+            op_pattern="openai.*",
+            rate=0.5,
+            enabled=False,
+            wb_user_id="monitor:mon-1",
+        )
+    )
+    deleted_snapshot = server.sampling_rules_read(
+        tsi.SamplingRulesReadReq(
+            project_id=project_id, consumer="monitor", monitor_id="mon-1"
+        )
+    )
+    assert [rule.scope for rule in deleted_snapshot.rules] == [f"project:{project_id}"]
+
+
+def test_sampling_rule_validation_rejects_bad_writes():
+    server = SqliteTraceServer(":memory:")
+    server.drop_tables()
+    server.setup_tables()
+    project_id = "entity/project"
+
+    with pytest.raises(InvalidRequest, match="rate must be between 0 and 1"):
+        server.sampling_rules_update(
+            tsi.SamplingRulesUpdateReq(
+                project_id=project_id,
+                scope=f"project:{project_id}",
+                op_pattern="openai.*",
+                rate=1.1,
+                wb_user_id="user-1",
+            )
+        )
+
+    with pytest.raises(InvalidRequest, match="wb_user_id is required"):
+        server.sampling_rules_update(
+            tsi.SamplingRulesUpdateReq(
+                project_id=project_id,
+                scope=f"project:{project_id}",
+                op_pattern="openai.*",
+                rate=0.5,
+            )
+        )
+
+    with pytest.raises(InvalidRequest, match="no-op"):
+        server.sampling_rules_update(
+            tsi.SamplingRulesUpdateReq(
+                project_id=project_id,
+                scope=f"project:{project_id}",
+                op_pattern="",
+                rate=1.0,
+                wb_user_id="user-1",
+            )
+        )

--- a/weave/flow/monitor.py
+++ b/weave/flow/monitor.py
@@ -1,13 +1,14 @@
-from typing import Literal, TypeAlias, get_args
+from typing import Any, Literal, TypeAlias, cast, get_args
 
 from pydantic import Field
 from typing_extensions import NotRequired, Self, TypedDict
 
 from weave.flow.casting import Scorer
 from weave.object.obj import Object
-from weave.trace.api import ObjectRef, publish
+from weave.trace.api import ObjectRef, get_client, publish
 from weave.trace.objectify import register_object
 from weave.trace.vals import WeaveObject
+from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.interface.query import Query
 
 DebounceAggregationField: TypeAlias = Literal["trace_id", "thread_id"]
@@ -95,9 +96,14 @@ class Monitor(Object):
         Returns:
             The ref to the monitor.
         """
+        sampling_rate = self._sampling_rate_value()
+        self.sampling_rate = sampling_rate
         self.active = True
         self.ref = None
-        return publish(self)
+        ref = publish(self)
+        self.sampling_rate = sampling_rate
+        self._sync_sampling_rule(ref, sampling_rate)
+        return ref
 
     def deactivate(self) -> ObjectRef:
         """Deactivates the monitor.
@@ -105,9 +111,38 @@ class Monitor(Object):
         Returns:
             The ref to the monitor.
         """
+        sampling_rate = self._sampling_rate_value()
+        self.sampling_rate = sampling_rate
         self.active = False
         self.ref = None
-        return publish(self)
+        ref = publish(self)
+        self.sampling_rate = sampling_rate
+        self._sync_sampling_rule(ref, sampling_rate)
+        return ref
+
+    def _sync_sampling_rule(self, ref: ObjectRef, sampling_rate: float) -> None:
+        client = get_client()
+        if client is None:
+            return
+        try:
+            client.server.sampling_rules_update(
+                tsi.SamplingRulesUpdateReq(
+                    project_id=client.project_id,
+                    scope=f"monitor:{ref.name}",
+                    op_pattern="",
+                    rate=sampling_rate,
+                    enabled=self.active and sampling_rate < 1.0,
+                    wb_user_id=f"monitor:{ref.name}",
+                )
+            )
+        except NotImplementedError:
+            return
+
+    def _sampling_rate_value(self) -> float:
+        value = cast(Any, self.sampling_rate)
+        if isinstance(value, ObjectRef):
+            value = value.get(objectify=False)
+        return float(value)
 
     @classmethod
     def from_obj(cls, obj: WeaveObject) -> Self:

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -486,6 +486,12 @@ def _call_sync_func(
         res = func(*args, **kwargs)
         return res, call
 
+    if is_placeholder_call(call):
+        with tracing_disabled():
+            res = func(*args, **kwargs)
+            call.output = res
+            return res, call
+
     # Execute the op and process the result
     client = weave_client_context.require_weave_client()
     has_finished = False
@@ -614,6 +620,12 @@ async def _call_async_func(
         )
         res = await func(*args, **kwargs)
         return res, call
+
+    if is_placeholder_call(call):
+        with tracing_disabled():
+            res = await func(*args, **kwargs)
+            call.output = res
+            return res, call
 
     # Execute the op and process the result
     client = weave_client_context.require_weave_client()
@@ -750,6 +762,17 @@ def _call_sync_gen(
         )
         gen = func(*args, **kwargs)
         return gen, call
+
+    if is_placeholder_call(call):
+        gen = func(*args, **kwargs)
+
+        def untraced_gen() -> Generator[Any]:
+            with tracing_disabled():
+                yield from gen
+
+        wrapped_gen = untraced_gen()
+        call.output = wrapped_gen
+        return wrapped_gen, call
 
     # Execute the op and get the generator
     client = weave_client_context.require_weave_client()
@@ -972,6 +995,18 @@ def _call_async_gen(
         )
         gen = func(*args, **kwargs)
         return gen, call
+
+    if is_placeholder_call(call):
+        gen = func(*args, **kwargs)
+
+        async def untraced_gen() -> AsyncIterator[Any]:
+            with tracing_disabled():
+                async for item in gen:
+                    yield item
+
+        wrapped_gen = untraced_gen()
+        call.output = wrapped_gen
+        return wrapped_gen, call
 
     # Execute the op and get the generator
     client = weave_client_context.require_weave_client()

--- a/weave/trace/sampling.py
+++ b/weave/trace/sampling.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import datetime
+import fnmatch
+import logging
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+from weave.trace.refs import OpRef
+from weave.trace_server import trace_server_interface as tsi
+
+logger = logging.getLogger(__name__)
+
+SAMPLING_DECISION_ATTRIBUTE = "weave.sampling.decision"
+SAMPLING_RULE_SCOPE_ATTRIBUTE = "weave.sampling.rule_scope"
+SAMPLING_RULE_OP_PATTERN_ATTRIBUTE = "weave.sampling.rule_op_pattern"
+
+SAMPLING_KEEP = "keep"
+SAMPLING_DROP = "drop"
+
+PROJECT_SCOPE_PREFIX = "project:"
+MONITOR_SCOPE_PREFIX = "monitor:"
+
+_MASK_64 = 0xFFFFFFFFFFFFFFFF
+_XXH64_PRIME_1 = 11400714785074694791
+_XXH64_PRIME_2 = 14029467366897019727
+_XXH64_PRIME_3 = 1609587929392839161
+_XXH64_PRIME_4 = 9650029242287828579
+_XXH64_PRIME_5 = 2870177450012600261
+_HASH_DENOMINATOR = float(1 << 64)
+
+
+@dataclass(frozen=True)
+class SamplingDecision:
+    keep: bool
+    rule: tsi.SamplingRuleSchema | None = None
+    reason: str = "default_keep"
+    hash_value: float | None = None
+
+    @property
+    def decision_attribute(self) -> str:
+        return SAMPLING_KEEP if self.keep else SAMPLING_DROP
+
+
+def default_sampling_snapshot(project_id: str) -> tsi.SamplingRulesSnapshotRes:
+    now = datetime.datetime.now(datetime.timezone.utc)
+    return tsi.SamplingRulesSnapshotRes(
+        project_id=project_id,
+        rules=[],
+        etag=build_sampling_etag([]),
+        snapshot_updated_at=now,
+    )
+
+
+def build_sampling_etag(rules: list[tsi.SamplingRuleSchema]) -> str:
+    import hashlib
+    import json
+
+    identity_tuples = sorted(
+        (rule.scope, rule.op_pattern, rule.rate) for rule in rules
+    )
+    payload = json.dumps(identity_tuples, separators=(",", ":"), sort_keys=True)
+    return f"sha256-{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
+
+
+def validate_glob_pattern(pattern: str) -> None:
+    try:
+        _compile_glob(pattern)
+    except re.error as exc:
+        raise ValueError(f"Invalid glob pattern {pattern!r}: {exc}") from exc
+
+
+def decide_project_sampling(
+    snapshot: tsi.SamplingRulesSnapshotRes | None,
+    *,
+    trace_id: str,
+    op_name: str,
+    attributes: dict[str, Any] | None = None,
+) -> SamplingDecision:
+    if snapshot is None or not snapshot.rules:
+        return SamplingDecision(keep=True)
+    if _is_exempt(snapshot, op_name, attributes or {}):
+        return SamplingDecision(keep=True, reason="exempt")
+
+    rule = find_matching_rule(snapshot.rules, op_name, scope_prefix=PROJECT_SCOPE_PREFIX)
+    return _decision_for_rule(snapshot.project_id, trace_id, rule)
+
+
+def decide_monitor_sampling(
+    snapshot: tsi.SamplingRulesSnapshotRes | None,
+    *,
+    trace_id: str,
+    op_name: str,
+    monitor_id: str,
+    attributes: dict[str, Any] | None = None,
+) -> SamplingDecision:
+    if snapshot is None or not snapshot.rules:
+        return SamplingDecision(keep=True)
+    if _is_exempt(snapshot, op_name, attributes or {}):
+        return SamplingDecision(keep=True, reason="exempt")
+
+    rule = find_matching_rule(
+        snapshot.rules,
+        op_name,
+        exact_scope=f"{MONITOR_SCOPE_PREFIX}{monitor_id}",
+    )
+    return _decision_for_rule(snapshot.project_id, trace_id, rule)
+
+
+def find_matching_rule(
+    rules: list[tsi.SamplingRuleSchema],
+    op_name: str,
+    *,
+    scope_prefix: str | None = None,
+    exact_scope: str | None = None,
+) -> tsi.SamplingRuleSchema | None:
+    candidates: list[tuple[tuple[int, int, float, str], tsi.SamplingRuleSchema]] = []
+    op_name_candidates = _op_name_candidates(op_name)
+    for rule in rules:
+        if exact_scope is not None and rule.scope != exact_scope:
+            continue
+        if scope_prefix is not None and not rule.scope.startswith(scope_prefix):
+            continue
+        specificity = _best_pattern_specificity(rule.op_pattern, op_name_candidates)
+        if specificity is None:
+            continue
+        candidates.append(
+            (
+                (
+                    specificity[0],
+                    specificity[1],
+                    _updated_at_sort_value(rule.updated_at),
+                    rule.op_pattern,
+                ),
+                rule,
+            )
+        )
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: item[0])[1]
+
+
+def apply_sampling_attributes(
+    attributes: dict[str, Any], decision: SamplingDecision
+) -> None:
+    attributes[SAMPLING_DECISION_ATTRIBUTE] = decision.decision_attribute
+    if decision.rule is not None:
+        attributes[SAMPLING_RULE_SCOPE_ATTRIBUTE] = decision.rule.scope
+        attributes[SAMPLING_RULE_OP_PATTERN_ATTRIBUTE] = decision.rule.op_pattern
+
+
+def sampling_hash_ratio(
+    *,
+    trace_id: str,
+    project_id: str,
+    scope: str,
+    op_pattern: str,
+) -> float:
+    identity = f"{trace_id}|{project_id}|{scope}|{op_pattern}"
+    return xxh64_int(identity.encode("utf-8"), seed=0) / _HASH_DENOMINATOR
+
+
+def xxh64_int(data: bytes, seed: int = 0) -> int:
+    length = len(data)
+    index = 0
+
+    if length >= 32:
+        v1 = (seed + _XXH64_PRIME_1 + _XXH64_PRIME_2) & _MASK_64
+        v2 = (seed + _XXH64_PRIME_2) & _MASK_64
+        v3 = seed & _MASK_64
+        v4 = (seed - _XXH64_PRIME_1) & _MASK_64
+
+        limit = length - 32
+        while index <= limit:
+            v1 = _xxh64_round(v1, _read_u64(data, index))
+            index += 8
+            v2 = _xxh64_round(v2, _read_u64(data, index))
+            index += 8
+            v3 = _xxh64_round(v3, _read_u64(data, index))
+            index += 8
+            v4 = _xxh64_round(v4, _read_u64(data, index))
+            index += 8
+
+        h64 = (
+            _rotl64(v1, 1) + _rotl64(v2, 7) + _rotl64(v3, 12) + _rotl64(v4, 18)
+        ) & _MASK_64
+        h64 = _xxh64_merge_round(h64, v1)
+        h64 = _xxh64_merge_round(h64, v2)
+        h64 = _xxh64_merge_round(h64, v3)
+        h64 = _xxh64_merge_round(h64, v4)
+    else:
+        h64 = (seed + _XXH64_PRIME_5) & _MASK_64
+
+    h64 = (h64 + length) & _MASK_64
+
+    while index <= length - 8:
+        k1 = _xxh64_round(0, _read_u64(data, index))
+        h64 ^= k1
+        h64 = ((_rotl64(h64, 27) * _XXH64_PRIME_1) + _XXH64_PRIME_4) & _MASK_64
+        index += 8
+
+    if index <= length - 4:
+        h64 ^= (_read_u32(data, index) * _XXH64_PRIME_1) & _MASK_64
+        h64 = ((_rotl64(h64, 23) * _XXH64_PRIME_2) + _XXH64_PRIME_3) & _MASK_64
+        index += 4
+
+    while index < length:
+        h64 ^= (data[index] * _XXH64_PRIME_5) & _MASK_64
+        h64 = (_rotl64(h64, 11) * _XXH64_PRIME_1) & _MASK_64
+        index += 1
+
+    h64 ^= h64 >> 33
+    h64 = (h64 * _XXH64_PRIME_2) & _MASK_64
+    h64 ^= h64 >> 29
+    h64 = (h64 * _XXH64_PRIME_3) & _MASK_64
+    h64 ^= h64 >> 32
+    return h64 & _MASK_64
+
+
+def _decision_for_rule(
+    project_id: str, trace_id: str, rule: tsi.SamplingRuleSchema | None
+) -> SamplingDecision:
+    if rule is None:
+        return SamplingDecision(keep=True)
+    hash_value = sampling_hash_ratio(
+        trace_id=trace_id,
+        project_id=project_id,
+        scope=rule.scope,
+        op_pattern=rule.op_pattern,
+    )
+    return SamplingDecision(
+        keep=hash_value < rule.rate,
+        rule=rule,
+        reason="rule",
+        hash_value=hash_value,
+    )
+
+
+def _is_exempt(
+    snapshot: tsi.SamplingRulesSnapshotRes, op_name: str, attributes: dict[str, Any]
+) -> bool:
+    exemptions = snapshot.exemptions
+    for pattern in exemptions.op_patterns:
+        if _glob_matches(pattern, op_name):
+            return True
+    return any(_has_attribute_key(attributes, key) for key in exemptions.attribute_keys)
+
+
+def _has_attribute_key(attributes: dict[str, Any], key: str) -> bool:
+    if key in attributes:
+        return True
+    current: Any = attributes
+    for part in key.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return False
+        current = current[part]
+    return True
+
+
+def _pattern_specificity(pattern: str, op_name: str) -> tuple[int, int] | None:
+    if pattern == "":
+        return (0, 0)
+    if pattern == op_name:
+        return (2, len(pattern))
+    if _has_glob_magic(pattern) and _glob_matches(pattern, op_name):
+        return (1, _non_star_prefix_len(pattern))
+    return None
+
+
+def _best_pattern_specificity(
+    pattern: str, op_name_candidates: tuple[str, ...]
+) -> tuple[int, int] | None:
+    specificities = [
+        specificity
+        for candidate in op_name_candidates
+        if (specificity := _pattern_specificity(pattern, candidate)) is not None
+    ]
+    if not specificities:
+        return None
+    return max(specificities)
+
+
+def _op_name_candidates(op_name: str) -> tuple[str, ...]:
+    if not op_name.startswith("weave:///"):
+        return (op_name,)
+    try:
+        op_ref = OpRef.parse_uri(op_name)
+    except (TypeError, ValueError):
+        return (op_name,)
+    return (op_name, op_ref.name)
+
+
+def _has_glob_magic(pattern: str) -> bool:
+    return any(ch in pattern for ch in "*?[")
+
+
+def _non_star_prefix_len(pattern: str) -> int:
+    star_index = pattern.find("*")
+    if star_index == -1:
+        return len(pattern)
+    return star_index
+
+
+def _glob_matches(pattern: str, value: str) -> bool:
+    if pattern == "":
+        return True
+    try:
+        return bool(_compile_glob(pattern).match(value))
+    except re.error:
+        logger.warning("Ignoring invalid sampling glob pattern: %s", pattern)
+        return False
+
+
+@lru_cache(maxsize=1024)
+def _compile_glob(pattern: str) -> re.Pattern[str]:
+    return re.compile(fnmatch.translate(pattern))
+
+
+def _updated_at_sort_value(value: datetime.datetime) -> float:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=datetime.timezone.utc)
+    return value.timestamp()
+
+
+def _rotl64(value: int, bits: int) -> int:
+    return ((value << bits) | (value >> (64 - bits))) & _MASK_64
+
+
+def _read_u64(data: bytes, index: int) -> int:
+    return int.from_bytes(data[index : index + 8], "little")
+
+
+def _read_u32(data: bytes, index: int) -> int:
+    return int.from_bytes(data[index : index + 4], "little")
+
+
+def _xxh64_round(acc: int, lane: int) -> int:
+    acc = (acc + lane * _XXH64_PRIME_2) & _MASK_64
+    acc = _rotl64(acc, 31)
+    acc = (acc * _XXH64_PRIME_1) & _MASK_64
+    return acc
+
+
+def _xxh64_merge_round(acc: int, value: int) -> int:
+    acc ^= _xxh64_round(0, value)
+    acc = ((acc * _XXH64_PRIME_1) + _XXH64_PRIME_4) & _MASK_64
+    return acc

--- a/weave/trace/sampling_client.py
+++ b/weave/trace/sampling_client.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any
+
+from httpx import HTTPError
+from pydantic import ValidationError
+
+from weave.trace.sampling import (
+    SamplingDecision,
+    decide_project_sampling,
+)
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server_bindings.client_interface import TraceServerClientInterface
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SAMPLING_REFRESH_SECONDS = 300.0
+DEFAULT_SAMPLING_FETCH_TIMEOUT_MS = 250.0
+STALE_ON_FAILURE_SECONDS = 30.0
+
+
+class SamplingClient:
+    def __init__(
+        self,
+        server: TraceServerClientInterface,
+        project_id: str,
+    ) -> None:
+        self._server = server
+        self._project_id = project_id
+        self._snapshot: tsi.SamplingRulesSnapshotRes | None = None
+        self._last_success_monotonic: float | None = None
+        self._started = False
+        self._stop_event = threading.Event()
+        self._first_refresh_complete = threading.Event()
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._fail_open_reasons_logged: set[str] = set()
+        self._refresh_generation = 0
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+        self._thread = threading.Thread(
+            target=self._refresh_loop,
+            name="weave-sampling-refresh",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def close(self) -> None:
+        self._stop_event.set()
+
+    def decide_root(
+        self,
+        *,
+        trace_id: str,
+        op_name: str,
+        attributes: dict[str, Any] | None,
+    ) -> SamplingDecision:
+        self.start()
+        self._first_refresh_complete.wait(_fetch_timeout_seconds())
+        snapshot = self._get_snapshot()
+        return decide_project_sampling(
+            snapshot,
+            trace_id=trace_id,
+            op_name=op_name,
+            attributes=attributes,
+        )
+
+    def _get_snapshot(self) -> tsi.SamplingRulesSnapshotRes | None:
+        with self._lock:
+            snapshot = self._snapshot
+            last_success = self._last_success_monotonic
+        if snapshot is None or last_success is None:
+            return None
+        stale_deadline = _refresh_seconds() + STALE_ON_FAILURE_SECONDS
+        if time.monotonic() - last_success > stale_deadline:
+            self._log_fail_open_once("snapshot_stale")
+            return None
+        return snapshot
+
+    def _refresh_loop(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._refresh_once()
+            except (
+                NotImplementedError,
+                HTTPError,
+                OSError,
+                TimeoutError,
+                ValidationError,
+                ValueError,
+            ):
+                self._log_fail_open_once("snapshot_fetch_error")
+                logger.debug("Failed to refresh Weave sampling rules", exc_info=True)
+            finally:
+                self._first_refresh_complete.set()
+            self._stop_event.wait(_refresh_seconds())
+
+    def _refresh_once(self) -> None:
+        with self._lock:
+            self._refresh_generation += 1
+            refresh_generation = self._refresh_generation
+        snapshot = self._server.sampling_rules_read(
+            tsi.SamplingRulesReadReq(project_id=self._project_id, consumer="sdk")
+        )
+        if not _snapshot_is_supported(snapshot):
+            self._log_fail_open_once("hash_unsupported")
+            with self._lock:
+                if refresh_generation != self._refresh_generation:
+                    return
+                self._snapshot = None
+                self._last_success_monotonic = None
+            return
+        with self._lock:
+            if refresh_generation != self._refresh_generation:
+                return
+            self._snapshot = snapshot
+            self._last_success_monotonic = time.monotonic()
+
+    def _log_fail_open_once(self, reason: str) -> None:
+        if reason in self._fail_open_reasons_logged:
+            return
+        self._fail_open_reasons_logged.add(reason)
+        logger.warning("Weave sampling fail-open: %s", reason)
+
+
+def _snapshot_is_supported(snapshot: tsi.SamplingRulesSnapshotRes) -> bool:
+    try:
+        return (
+            snapshot.schema_version == 1
+            and snapshot.hash.algorithm == "xxh64"
+            and snapshot.hash.seed == 0
+        )
+    except AttributeError:
+        return False
+
+
+def _refresh_seconds() -> float:
+    raw = os.getenv("WEAVE_SAMPLING_REFRESH_S")
+    if raw is None:
+        return DEFAULT_SAMPLING_REFRESH_SECONDS
+    try:
+        return max(float(raw), 1.0)
+    except ValueError:
+        logger.warning(
+            "Invalid WEAVE_SAMPLING_REFRESH_S=%r; using default %s",
+            raw,
+            DEFAULT_SAMPLING_REFRESH_SECONDS,
+        )
+        return DEFAULT_SAMPLING_REFRESH_SECONDS
+
+
+def _fetch_timeout_seconds() -> float:
+    raw = os.getenv("WEAVE_SAMPLING_FETCH_TIMEOUT_MS")
+    if raw is None:
+        return DEFAULT_SAMPLING_FETCH_TIMEOUT_MS / 1000.0
+    try:
+        return max(float(raw), 0.0) / 1000.0
+    except ValueError:
+        logger.warning(
+            "Invalid WEAVE_SAMPLING_FETCH_TIMEOUT_MS=%r; using default %s",
+            raw,
+            DEFAULT_SAMPLING_FETCH_TIMEOUT_MS,
+        )
+        return DEFAULT_SAMPLING_FETCH_TIMEOUT_MS / 1000.0

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -81,6 +81,13 @@ from weave.trace.registry_links import (
     parse_registry_target_path,
     resolve_prompt_ref,
 )
+from weave.trace.sampling import (
+    SAMPLING_DECISION_ATTRIBUTE,
+    SAMPLING_RULE_OP_PATTERN_ATTRIBUTE,
+    SAMPLING_RULE_SCOPE_ATTRIBUTE,
+    apply_sampling_attributes,
+)
+from weave.trace.sampling_client import SamplingClient
 from weave.trace.serialization.serialize import (
     from_json,
     isinstance_namedtuple,
@@ -408,6 +415,9 @@ class WeaveClient:
         if hasattr(self.server, "get_feedback_processor"):
             self._server_feedback_processor = self.server.get_feedback_processor()
         self.send_file_cache = WeaveClientSendFileCache()
+        self.sampling_client = SamplingClient(self.server, self.project_id)
+        if self.entity != "DISABLED" and self.project != "DISABLED":
+            self.sampling_client.start()
 
         self._wal: WALManager | None = None
         self._wal_pending_call_ids: set[str] = set()
@@ -773,8 +783,6 @@ class WeaveClient:
             op = self._anonymous_ops[op]
 
         unbound_op = maybe_unbind_method(op)
-        op_def_ref = self._save_op(unbound_op)
-
         inputs_sensitive_keys_redacted = redact_sensitive_keys(inputs)
 
         if op.postprocess_inputs:
@@ -784,9 +792,6 @@ class WeaveClient:
 
         if self.postprocess_inputs:
             inputs_postprocessed = self.postprocess_inputs(inputs_postprocessed)
-
-        self._save_nested_objects(inputs_postprocessed)
-        inputs_with_refs = map_to_refs(inputs_postprocessed)
 
         if parent is None and use_stack:
             parent = call_context.get_current_call()
@@ -813,6 +818,31 @@ class WeaveClient:
             attributes_dict._set_weave_item("os_name", platform.system())
             attributes_dict._set_weave_item("os_version", platform.version())
             attributes_dict._set_weave_item("os_release", platform.release())
+
+        if parent is None:
+            sampling_decision = self.sampling_client.decide_root(
+                trace_id=trace_id,
+                op_name=unbound_op.name,
+                attributes=attributes_dict.unwrap(),
+            )
+            if not sampling_decision.keep:
+                return placeholder_call()
+            apply_sampling_attributes(attributes_dict, sampling_decision)
+        elif parent.attributes:
+            for sampling_attribute in (
+                SAMPLING_DECISION_ATTRIBUTE,
+                SAMPLING_RULE_SCOPE_ATTRIBUTE,
+                SAMPLING_RULE_OP_PATTERN_ATTRIBUTE,
+            ):
+                if sampling_attribute in parent.attributes:
+                    attributes_dict[sampling_attribute] = parent.attributes[
+                        sampling_attribute
+                    ]
+
+        op_def_ref = self._save_op(unbound_op)
+
+        self._save_nested_objects(inputs_postprocessed)
+        inputs_with_refs = map_to_refs(inputs_postprocessed)
 
         op_name_future = self.future_executor.defer(lambda: op_def_ref.uri)
 
@@ -2613,6 +2643,7 @@ class WeaveClient:
         if self._wal is not None:
             self._wal.close()
             self._wal = None
+        self.sampling_client.close()
 
     def flush(self) -> None:
         """Flushes background asynchronous tasks, safe to call multiple times."""

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -273,6 +273,12 @@ from weave.trace_server.query_builder.table_query_builder import (
     make_table_stats_basic_query,
     make_table_stats_query_with_storage_size,
 )
+from weave.trace_server.sampling_rules import (
+    get_sampling_rules_snapshot,
+    invalidate_sampling_rules_cache,
+    query_clickhouse_sampling_rules,
+    validate_sampling_rule_update,
+)
 from weave.trace_server.secret_fetcher_context import _secret_fetcher_context
 from weave.trace_server.threads_query_builder import make_threads_query
 from weave.trace_server.token_costs import (
@@ -2671,6 +2677,58 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         invalidate_ttl_cache(req.project_id)
         return tsi.ProjectTTLSettingsUpdateRes(retention_days=req.retention_days)
+
+    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.sampling_rules_read")
+    def sampling_rules_read(
+        self, req: tsi.SamplingRulesReadReq
+    ) -> tsi.SamplingRulesSnapshotRes:
+        return get_sampling_rules_snapshot(
+            req.project_id,
+            req.consumer,
+            req.monitor_id,
+            self.ch_client,
+        )
+
+    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.sampling_rules_update")
+    def sampling_rules_update(
+        self, req: tsi.SamplingRulesUpdateReq
+    ) -> tsi.SamplingRulesSnapshotRes:
+        try:
+            active_rules = query_clickhouse_sampling_rules(self.ch_client, req.project_id)
+            op_pattern = validate_sampling_rule_update(req, active_rules)
+        except ValueError as exc:
+            raise InvalidRequest(str(exc)) from exc
+
+        self.ch_client.insert(
+            "sampling_rules",
+            data=[
+                [
+                    req.project_id,
+                    req.scope,
+                    op_pattern,
+                    req.rate,
+                    1 if req.enabled else 0,
+                    datetime.datetime.now(datetime.timezone.utc),
+                    req.wb_user_id,
+                ]
+            ],
+            column_names=[
+                "project_id",
+                "scope",
+                "op_pattern",
+                "rate",
+                "enabled",
+                "updated_at",
+                "updated_by",
+            ],
+        )
+        invalidate_sampling_rules_cache(req.project_id)
+        return get_sampling_rules_snapshot(
+            req.project_id,
+            "monitor",
+            None,
+            self.ch_client,
+        )
 
     def threads_query_stream(
         self, req: tsi.ThreadsQueryReq

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -2,6 +2,7 @@ import abc
 from collections.abc import Callable, Iterator
 from typing import Any, TypeVar
 
+from weave.trace.sampling import build_sampling_etag
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.trace_server_converter import (
     universal_ext_to_int_ref_converter,
@@ -669,6 +670,44 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         return self._ref_apply(
             self._internal_trace_server.project_ttl_settings_update, req, req.project_id
         )
+
+    def sampling_rules_read(
+        self, req: tsi.SamplingRulesReadReq
+    ) -> tsi.SamplingRulesSnapshotRes:
+        req = req.model_copy(deep=True)
+        external_project_id = req.project_id
+        internal_project_id = self._idc.ext_to_int_project_id(external_project_id)
+        req.project_id = internal_project_id
+        res = self._ref_apply(
+            self._internal_trace_server.sampling_rules_read, req, req.project_id
+        )
+        res.project_id = external_project_id
+        for rule in res.rules:
+            if rule.scope == f"project:{internal_project_id}":
+                rule.scope = f"project:{external_project_id}"
+        res.etag = build_sampling_etag(res.rules)
+        return res
+
+    def sampling_rules_update(
+        self, req: tsi.SamplingRulesUpdateReq
+    ) -> tsi.SamplingRulesSnapshotRes:
+        req = req.model_copy(deep=True)
+        external_project_id = req.project_id
+        internal_project_id = self._idc.ext_to_int_project_id(external_project_id)
+        req.project_id = internal_project_id
+        if req.scope == f"project:{external_project_id}":
+            req.scope = f"project:{internal_project_id}"
+        if req.wb_user_id is not None and not req.wb_user_id.startswith("monitor:"):
+            req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
+        res = self._ref_apply(
+            self._internal_trace_server.sampling_rules_update, req, req.project_id
+        )
+        res.project_id = external_project_id
+        for rule in res.rules:
+            if rule.scope == f"project:{internal_project_id}":
+                rule.scope = f"project:{external_project_id}"
+        res.etag = build_sampling_etag(res.rules)
+        return res
 
     def threads_query_stream(
         self, req: tsi.ThreadsQueryReq

--- a/weave/trace_server/migrations/031_add_sampling_rules.down.sql
+++ b/weave/trace_server/migrations/031_add_sampling_rules.down.sql
@@ -1,0 +1,3 @@
+-- Rollback Migration 031: Remove centralized sampling rules
+
+DROP TABLE IF EXISTS sampling_rules;

--- a/weave/trace_server/migrations/031_add_sampling_rules.up.sql
+++ b/weave/trace_server/migrations/031_add_sampling_rules.up.sql
@@ -1,0 +1,19 @@
+-- Migration 031: Add centralized sampling rules
+--
+-- Stores per-project sampling rules as an append-only audit log. The latest
+-- active state is read with argMax(rate/enabled, updated_at), mirroring
+-- project_ttl_settings.
+
+CREATE TABLE sampling_rules (
+    project_id   String,
+    scope        LowCardinality(String),
+    op_pattern   String DEFAULT '',
+    rate         Float64,
+    enabled      UInt8 DEFAULT 1,
+    updated_at   DateTime64(3) DEFAULT now64(3),
+    updated_by   String DEFAULT ''
+) ENGINE = MergeTree()
+ORDER BY (project_id, scope, op_pattern, updated_at)
+SETTINGS
+    enable_block_number_column = 1,
+    enable_block_offset_column = 1;

--- a/weave/trace_server/sampling_rules.py
+++ b/weave/trace_server/sampling_rules.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import datetime
+import logging
+import threading
+
+import ddtrace
+import redis
+from cachetools import TTLCache
+from clickhouse_connect.driver.client import Client as CHClient
+from pydantic import ValidationError
+
+from weave.trace.sampling import build_sampling_etag, validate_glob_pattern
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.datadog import set_current_span_dd_tags
+from weave.trace_server.redis_client import get_redis_client
+
+logger = logging.getLogger(__name__)
+
+SAMPLING_RULE_CACHE_SIZE = 10_000
+SAMPLING_RULE_CACHE_TTL_SECS = 300
+REDIS_SAMPLING_KEY_PREFIX = "weave:sampling:"
+REDIS_SAMPLING_EXPIRY_SECS = 300
+MAX_ACTIVE_SAMPLING_RULES_PER_PROJECT = 200
+
+PROJECT_SCOPE_PREFIX = "project:"
+MONITOR_SCOPE_PREFIX = "monitor:"
+
+_sampling_snapshot_cache: TTLCache[
+    tuple[str, tsi.SamplingConsumer, str | None], tsi.SamplingRulesSnapshotRes
+] = TTLCache(maxsize=SAMPLING_RULE_CACHE_SIZE, ttl=SAMPLING_RULE_CACHE_TTL_SECS)
+_sampling_cache_generation: dict[str, int] = {}
+_sampling_snapshot_cache_lock = threading.Lock()
+
+
+@ddtrace.tracer.wrap(name="sampling_rules.get_sampling_rules_snapshot")
+def get_sampling_rules_snapshot(
+    project_id: str,
+    consumer: tsi.SamplingConsumer,
+    monitor_id: str | None,
+    ch_client: CHClient,
+) -> tsi.SamplingRulesSnapshotRes:
+    cached = _l1_get(project_id, consumer, monitor_id)
+    if cached is not None:
+        set_current_span_dd_tags({"sampling.cache_hit": "L1"})
+        return cached
+
+    redis_client = get_redis_client()
+    if redis_client is not None:
+        redis_snapshot = _l2_get(redis_client, project_id, consumer, monitor_id)
+        if redis_snapshot is not None:
+            _l1_set(project_id, consumer, monitor_id, redis_snapshot)
+            set_current_span_dd_tags({"sampling.cache_hit": "L2"})
+            return redis_snapshot
+
+    generation = _cache_generation(project_id)
+    all_rules = query_clickhouse_sampling_rules(ch_client, project_id)
+    snapshot = build_sampling_rules_snapshot(project_id, consumer, monitor_id, all_rules)
+    set_current_span_dd_tags(
+        {"sampling.cache_hit": "clickhouse", "sampling.rule_count": len(snapshot.rules)}
+    )
+
+    if _cache_generation(project_id) == generation:
+        if redis_client is not None:
+            _l2_set(redis_client, snapshot, consumer, monitor_id)
+        _l1_set(project_id, consumer, monitor_id, snapshot)
+    return snapshot
+
+
+@ddtrace.tracer.wrap(name="sampling_rules.query_clickhouse")
+def query_clickhouse_sampling_rules(
+    ch_client: CHClient, project_id: str
+) -> list[tsi.SamplingRuleSchema]:
+    result = ch_client.query(
+        "SELECT "
+        "scope, "
+        "op_pattern, "
+        "argMax(rate, updated_at) AS rate, "
+        "argMax(enabled, updated_at) AS is_enabled, "
+        "max(updated_at) AS latest_updated_at "
+        "FROM sampling_rules "
+        "WHERE project_id = {project_id:String} "
+        "GROUP BY scope, op_pattern "
+        "HAVING is_enabled = 1 "
+        "ORDER BY scope, op_pattern",
+        parameters={"project_id": project_id},
+    )
+    rules: list[tsi.SamplingRuleSchema] = []
+    for scope, op_pattern, rate, _enabled, updated_at in result.result_rows:
+        try:
+            normalized_pattern = normalize_op_pattern(op_pattern)
+            validate_glob_pattern(normalized_pattern)
+        except ValueError:
+            logger.exception(
+                "Dropping invalid sampling rule from snapshot for project=%s scope=%s op_pattern=%s",
+                project_id,
+                scope,
+                op_pattern,
+            )
+            continue
+        rules.append(
+            tsi.SamplingRuleSchema(
+                scope=str(scope),
+                op_pattern=normalized_pattern,
+                rate=float(rate),
+                updated_at=_coerce_datetime(updated_at),
+            )
+        )
+    return rules
+
+
+def build_sampling_rules_snapshot(
+    project_id: str,
+    consumer: tsi.SamplingConsumer,
+    monitor_id: str | None,
+    all_rules: list[tsi.SamplingRuleSchema],
+) -> tsi.SamplingRulesSnapshotRes:
+    filtered_rules = _filter_rules_for_consumer(all_rules, consumer, monitor_id)
+    latest_updated_at = max(
+        (rule.updated_at for rule in filtered_rules),
+        default=datetime.datetime.now(datetime.timezone.utc),
+    )
+    return tsi.SamplingRulesSnapshotRes(
+        project_id=project_id,
+        rules=filtered_rules,
+        etag=build_sampling_etag(filtered_rules),
+        snapshot_updated_at=latest_updated_at,
+        ttl_seconds=SAMPLING_RULE_CACHE_TTL_SECS,
+    )
+
+
+def validate_sampling_rule_update(
+    req: tsi.SamplingRulesUpdateReq,
+    active_rules: list[tsi.SamplingRuleSchema],
+) -> str:
+    op_pattern = normalize_op_pattern(req.op_pattern)
+    if not 0 <= req.rate <= 1:
+        raise ValueError("rate must be between 0 and 1")
+    if not req.wb_user_id:
+        raise ValueError("wb_user_id is required for audit trail")
+    validate_scope(req.project_id, req.scope)
+    validate_glob_pattern(op_pattern)
+    if req.enabled and req.rate >= 1.0 and op_pattern == "":
+        raise ValueError('rate=1.0 with an empty op_pattern is a no-op')
+
+    projected = {(rule.scope, rule.op_pattern): rule for rule in active_rules}
+    key = (req.scope, op_pattern)
+    if req.enabled:
+        projected[key] = tsi.SamplingRuleSchema(
+            scope=req.scope,
+            op_pattern=op_pattern,
+            rate=req.rate,
+            updated_at=datetime.datetime.now(datetime.timezone.utc),
+        )
+    else:
+        projected.pop(key, None)
+    if len(projected) > MAX_ACTIVE_SAMPLING_RULES_PER_PROJECT:
+        raise ValueError(
+            f"active sampling rules per project cannot exceed {MAX_ACTIVE_SAMPLING_RULES_PER_PROJECT}"
+        )
+    return op_pattern
+
+
+def normalize_op_pattern(op_pattern: str | None) -> str:
+    return op_pattern or ""
+
+
+def validate_scope(project_id: str, scope: str) -> None:
+    if scope == f"{PROJECT_SCOPE_PREFIX}{project_id}":
+        return
+    if scope.startswith(MONITOR_SCOPE_PREFIX) and len(scope) > len(MONITOR_SCOPE_PREFIX):
+        return
+    if scope.startswith("org:"):
+        return
+    raise ValueError(
+        "scope must be project:<project_id>, monitor:<monitor_id>, or reserved org:<org_id>"
+    )
+
+
+def invalidate_sampling_rules_cache(project_id: str) -> None:
+    with _sampling_snapshot_cache_lock:
+        _sampling_cache_generation[project_id] = (
+            _sampling_cache_generation.get(project_id, 0) + 1
+        )
+        for key in list(_sampling_snapshot_cache.keys()):
+            if key[0] == project_id:
+                _sampling_snapshot_cache.pop(key, None)
+
+    redis_client = get_redis_client()
+    if redis_client is not None:
+        _l2_delete_project(redis_client, project_id)
+
+
+def reset_sampling_rules_cache() -> None:
+    with _sampling_snapshot_cache_lock:
+        _sampling_snapshot_cache.clear()
+        _sampling_cache_generation.clear()
+
+
+def _filter_rules_for_consumer(
+    rules: list[tsi.SamplingRuleSchema],
+    consumer: tsi.SamplingConsumer,
+    monitor_id: str | None,
+) -> list[tsi.SamplingRuleSchema]:
+    if consumer == "sdk":
+        return [rule for rule in rules if not rule.scope.startswith(MONITOR_SCOPE_PREFIX)]
+    if consumer == "monitor":
+        if monitor_id is None:
+            return rules
+        monitor_scope = f"{MONITOR_SCOPE_PREFIX}{monitor_id}"
+        return [
+            rule
+            for rule in rules
+            if rule.scope.startswith(PROJECT_SCOPE_PREFIX) or rule.scope == monitor_scope
+        ]
+    raise ValueError(f"Unknown sampling consumer: {consumer}")
+
+
+def _cache_key(
+    project_id: str, consumer: tsi.SamplingConsumer, monitor_id: str | None
+) -> tuple[str, tsi.SamplingConsumer, str | None]:
+    return (project_id, consumer, monitor_id)
+
+
+def _cache_generation(project_id: str) -> int:
+    with _sampling_snapshot_cache_lock:
+        return _sampling_cache_generation.get(project_id, 0)
+
+
+def _redis_cache_key(
+    project_id: str, consumer: tsi.SamplingConsumer, monitor_id: str | None
+) -> str:
+    monitor_part = monitor_id or "_"
+    return f"{REDIS_SAMPLING_KEY_PREFIX}{consumer}:{project_id}:{monitor_part}"
+
+
+def _l1_get(
+    project_id: str, consumer: tsi.SamplingConsumer, monitor_id: str | None
+) -> tsi.SamplingRulesSnapshotRes | None:
+    with _sampling_snapshot_cache_lock:
+        return _sampling_snapshot_cache.get(_cache_key(project_id, consumer, monitor_id))
+
+
+def _l1_set(
+    project_id: str,
+    consumer: tsi.SamplingConsumer,
+    monitor_id: str | None,
+    snapshot: tsi.SamplingRulesSnapshotRes,
+) -> None:
+    with _sampling_snapshot_cache_lock:
+        _sampling_snapshot_cache[_cache_key(project_id, consumer, monitor_id)] = snapshot
+
+
+def _l2_get(
+    redis_client: redis.Redis,
+    project_id: str,
+    consumer: tsi.SamplingConsumer,
+    monitor_id: str | None,
+) -> tsi.SamplingRulesSnapshotRes | None:
+    try:
+        raw = redis_client.get(_redis_cache_key(project_id, consumer, monitor_id))
+        if raw is None:
+            return None
+        if not isinstance(raw, (str, bytes, bytearray)):
+            return None
+        return tsi.SamplingRulesSnapshotRes.model_validate_json(raw)
+    except (redis.RedisError, TypeError, UnicodeDecodeError, ValidationError, ValueError):
+        logger.exception("Redis sampling cache read failed for project %s", project_id)
+    return None
+
+
+def _l2_set(
+    redis_client: redis.Redis,
+    snapshot: tsi.SamplingRulesSnapshotRes,
+    consumer: tsi.SamplingConsumer,
+    monitor_id: str | None,
+) -> None:
+    try:
+        redis_client.set(
+            _redis_cache_key(snapshot.project_id, consumer, monitor_id),
+            snapshot.model_dump_json(),
+            ex=REDIS_SAMPLING_EXPIRY_SECS,
+        )
+    except (redis.RedisError, TypeError, ValueError):
+        logger.exception(
+            "Redis sampling cache write failed for project %s", snapshot.project_id
+        )
+
+
+def _l2_delete_project(redis_client: redis.Redis, project_id: str) -> None:
+    try:
+        pattern = f"{REDIS_SAMPLING_KEY_PREFIX}*:{project_id}:*"
+        keys = list(redis_client.scan_iter(match=pattern))
+        if keys:
+            redis_client.delete(*keys)
+    except redis.RedisError:
+        logger.exception("Redis sampling cache delete failed for project %s", project_id)
+
+
+def _coerce_datetime(value: datetime.datetime | str) -> datetime.datetime:
+    if isinstance(value, datetime.datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value
+    return datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -63,6 +63,13 @@ from weave.trace_server.methods.sqlite_feedback_stats import (
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
 from weave.trace_server.opentelemetry.python_spans import Resource, Span
 from weave.trace_server.orm import Row, quote_json_path, quote_json_path_parts
+from weave.trace_server.sampling_rules import (
+    build_sampling_rules_snapshot,
+    invalidate_sampling_rules_cache,
+    normalize_op_pattern,
+    validate_glob_pattern,
+    validate_sampling_rule_update,
+)
 from weave.trace_server.threads_query_builder import make_threads_query_sqlite
 from weave.trace_server.token_costs import (
     DEFAULT_PRICING_LEVEL_ID,
@@ -337,6 +344,7 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         cursor.execute(TABLE_FEEDBACK.drop_sql())
         cursor.execute("DROP TABLE IF EXISTS calls")
         cursor.execute("DROP TABLE IF EXISTS project_ttl_settings")
+        cursor.execute("DROP TABLE IF EXISTS sampling_rules")
         cursor.execute("DROP TABLE IF EXISTS objects")
         cursor.execute("DROP TABLE IF EXISTS tables")
         cursor.execute("DROP TABLE IF EXISTS table_rows")
@@ -382,6 +390,19 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
             CREATE TABLE IF NOT EXISTS project_ttl_settings (
                 project_id TEXT NOT NULL,
                 retention_days INTEGER NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+                updated_by TEXT NOT NULL DEFAULT ''
+            )
+            """
+        )
+        cursor.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sampling_rules (
+                project_id TEXT NOT NULL,
+                scope TEXT NOT NULL,
+                op_pattern TEXT NOT NULL DEFAULT '',
+                rate REAL NOT NULL,
+                enabled INTEGER NOT NULL DEFAULT 1,
                 updated_at TEXT NOT NULL DEFAULT (datetime('now')),
                 updated_by TEXT NOT NULL DEFAULT ''
             )
@@ -500,6 +521,48 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         )
         row = cursor.fetchone()
         return int(row[0]) if row is not None else RETENTION_DAYS_NO_TTL
+
+    def _get_active_sampling_rules(
+        self, project_id: str
+    ) -> list[tsi.SamplingRuleSchema]:
+        _, cursor = get_conn_cursor(self.db_path)
+        cursor.execute(
+            "SELECT scope, op_pattern, rate, enabled, updated_at FROM sampling_rules "
+            "WHERE project_id = ? ORDER BY updated_at ASC, rowid ASC",
+            (project_id,),
+        )
+        latest: dict[tuple[str, str], tuple[float, int, str]] = {}
+        for scope, op_pattern, rate, enabled, updated_at in cursor.fetchall():
+            normalized_pattern = normalize_op_pattern(op_pattern)
+            latest[str(scope), normalized_pattern] = (
+                float(rate),
+                int(enabled),
+                str(updated_at),
+            )
+
+        rules: list[tsi.SamplingRuleSchema] = []
+        for (scope, op_pattern), (rate, enabled, updated_at) in latest.items():
+            if enabled != 1:
+                continue
+            try:
+                validate_glob_pattern(op_pattern)
+            except ValueError:
+                logger.exception(
+                    "Dropping invalid sampling rule from snapshot for project=%s scope=%s op_pattern=%s",
+                    project_id,
+                    scope,
+                    op_pattern,
+                )
+                continue
+            rules.append(
+                tsi.SamplingRuleSchema(
+                    scope=scope,
+                    op_pattern=op_pattern,
+                    rate=rate,
+                    updated_at=datetime.datetime.fromisoformat(updated_at),
+                )
+            )
+        return sorted(rules, key=lambda rule: (rule.scope, rule.op_pattern))
 
     def _compute_call_expire_at(
         self, project_id: str, anchor: datetime.datetime
@@ -2891,6 +2954,50 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         conn.commit()
         invalidate_ttl_cache(req.project_id)
         return tsi.ProjectTTLSettingsUpdateRes(retention_days=req.retention_days)
+
+    def sampling_rules_read(
+        self, req: tsi.SamplingRulesReadReq
+    ) -> tsi.SamplingRulesSnapshotRes:
+        active_rules = self._get_active_sampling_rules(req.project_id)
+        return build_sampling_rules_snapshot(
+            req.project_id,
+            req.consumer,
+            req.monitor_id,
+            active_rules,
+        )
+
+    def sampling_rules_update(
+        self, req: tsi.SamplingRulesUpdateReq
+    ) -> tsi.SamplingRulesSnapshotRes:
+        try:
+            active_rules = self._get_active_sampling_rules(req.project_id)
+            op_pattern = validate_sampling_rule_update(req, active_rules)
+        except ValueError as exc:
+            raise InvalidRequest(str(exc)) from exc
+
+        conn, cursor = get_conn_cursor(self.db_path)
+        updated_at = datetime.datetime.now(datetime.timezone.utc).isoformat(
+            timespec="microseconds"
+        )
+        cursor.execute(
+            "INSERT INTO sampling_rules "
+            "(project_id, scope, op_pattern, rate, enabled, updated_at, updated_by) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                req.project_id,
+                req.scope,
+                op_pattern,
+                req.rate,
+                1 if req.enabled else 0,
+                updated_at,
+                req.wb_user_id,
+            ),
+        )
+        conn.commit()
+        invalidate_sampling_rules_cache(req.project_id)
+        return self.sampling_rules_read(
+            tsi.SamplingRulesReadReq(project_id=req.project_id, consumer="monitor")
+        )
 
     def threads_query_stream(
         self, req: tsi.ThreadsQueryReq

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1590,6 +1590,60 @@ class ProjectTTLSettingsUpdateRes(BaseModel):
     retention_days: int | None
 
 
+# Sampling API
+# ============
+
+SamplingConsumer = Literal["sdk", "monitor"]
+
+
+class SamplingRuleSchema(BaseModel):
+    scope: str
+    op_pattern: str = ""
+    rate: float
+    updated_at: datetime.datetime
+
+
+class SamplingExemptions(BaseModel):
+    evaluation_trace: bool = True
+    op_patterns: list[str] = Field(default_factory=lambda: ["weave.Evaluation.*"])
+    attribute_keys: list[str] = Field(default_factory=lambda: ["weave.eval"])
+
+
+class SamplingHashSpec(BaseModel):
+    algorithm: str = "xxh64"
+    seed: int = 0
+    identity_fields: list[str] = Field(
+        default_factory=lambda: ["project_id", "scope", "op_pattern"]
+    )
+
+
+class SamplingRulesSnapshotRes(BaseModel):
+    project_id: str
+    rules: list[SamplingRuleSchema] = Field(default_factory=list)
+    exemptions: SamplingExemptions = Field(default_factory=SamplingExemptions)
+    default_rate: float = 1.0
+    hash: SamplingHashSpec = Field(default_factory=SamplingHashSpec)
+    etag: str
+    snapshot_updated_at: datetime.datetime
+    ttl_seconds: int = 300
+    schema_version: int = 1
+
+
+class SamplingRulesReadReq(BaseModelStrict):
+    project_id: str
+    consumer: SamplingConsumer = "sdk"
+    monitor_id: str | None = None
+
+
+class SamplingRulesUpdateReq(BaseModelStrict):
+    project_id: str
+    scope: str
+    op_pattern: str | None = ""
+    rate: float
+    enabled: bool = True
+    wb_user_id: str | None = None
+
+
 # Annotation Queue API
 # =====================
 # These schemas support the queue-based call annotation system.
@@ -3030,6 +3084,15 @@ class TraceServerInterface(Protocol):
     def project_ttl_settings_update(
         self, req: ProjectTTLSettingsUpdateReq
     ) -> ProjectTTLSettingsUpdateRes: ...
+
+    # Sampling API
+    def sampling_rules_read(
+        self, req: SamplingRulesReadReq
+    ) -> SamplingRulesSnapshotRes: ...
+
+    def sampling_rules_update(
+        self, req: SamplingRulesUpdateReq
+    ) -> SamplingRulesSnapshotRes: ...
 
     # Thread API
     def threads_query_stream(self, req: ThreadsQueryReq) -> Iterator[ThreadSchema]: ...

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -1028,6 +1028,26 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             tsi.ProjectTTLSettingsUpdateRes,
         )
 
+    def sampling_rules_read(
+        self, req: tsi.SamplingRulesReadReq
+    ) -> tsi.SamplingRulesSnapshotRes:
+        return self._generic_request(
+            "/sampling/rules/read",
+            req,
+            tsi.SamplingRulesReadReq,
+            tsi.SamplingRulesSnapshotRes,
+        )
+
+    def sampling_rules_update(
+        self, req: tsi.SamplingRulesUpdateReq
+    ) -> tsi.SamplingRulesSnapshotRes:
+        return self._generic_request(
+            "/sampling/rules/update",
+            req,
+            tsi.SamplingRulesUpdateReq,
+            tsi.SamplingRulesSnapshotRes,
+        )
+
     def threads_query_stream(
         self, req: tsi.ThreadsQueryReq
     ) -> Iterator[tsi.ThreadSchema]:

--- a/weave/trace_server_bindings/stainless_remote_http_trace_server.py
+++ b/weave/trace_server_bindings/stainless_remote_http_trace_server.py
@@ -1270,6 +1270,22 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
         )
 
     @validate_call
+    def sampling_rules_read(
+        self, req: tsi.SamplingRulesReadReq
+    ) -> tsi.SamplingRulesSnapshotRes:
+        raise NotImplementedError(
+            "sampling_rules_read is not yet implemented in stainless client"
+        )
+
+    @validate_call
+    def sampling_rules_update(
+        self, req: tsi.SamplingRulesUpdateReq
+    ) -> tsi.SamplingRulesSnapshotRes:
+        raise NotImplementedError(
+            "sampling_rules_update is not yet implemented in stainless client"
+        )
+
+    @validate_call
     def threads_query_stream(
         self, req: tsi.ThreadsQueryReq
     ) -> Iterator[tsi.ThreadSchema]:


### PR DESCRIPTION
## Summary
- add centralized sampling rule models, storage, validation, and read/update trace-server methods
- add SDK sampling client and deterministic rule matcher with fail-open behavior
- dual-write monitor activation sampling rules and prevent sampled-out roots from saving op objects

## Tests
- uv run --group test pytest ../weave-python/weave-public/tests/trace/test_sampling.py ../weave-python/weave-public/tests/trace_server/test_sampling_rules.py ../weave-python/weave-public/tests/flow/test_monitor.py -vv
- uv run --with ruff ruff check weave/flow/monitor.py weave/trace/sampling.py weave/trace/sampling_client.py weave/trace/weave_client.py weave/trace_server/sampling_rules.py tests/flow/test_monitor.py tests/trace/test_sampling.py tests/trace_server/test_sampling_rules.py
- uv run --with mypy mypy weave/flow/monitor.py weave/trace/sampling.py weave/trace/sampling_client.py weave/trace_server/sampling_rules.py