### PR TITLE
fix(weave): fix project id format in prewhere condition helper

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -72,7 +72,7 @@ class TestMakeSpansCountQuery:
         query = make_spans_count_query(pb, AgentSpansQueryReq(project_id="p1"))
 
         expected = (
-            "SELECT count() FROM spans s PREWHERE s.project_id = {genai_0:String}"
+            "SELECT count() FROM spans s PREWHERE {genai_0:String} = s.project_id"
         )
         assert_sql(expected, {"genai_0": "p1"}, query, pb.get_params())
 
@@ -111,7 +111,7 @@ class TestMakeSpansCountQuery:
 
         expected = """
             SELECT count() FROM spans s
-            PREWHERE s.project_id = {genai_0:String}
+            PREWHERE {genai_0:String} = s.project_id
               AND s.started_at >= {genai_1:DateTime64(6)}
               AND s.started_at < {genai_2:DateTime64(6)}
             WHERE ((s.agent_name = {genai_3:String}) AND (s.custom_attrs_string[{genai_4:String}] = {genai_5:String}))
@@ -181,7 +181,7 @@ class TestMakeSpansListQuery:
         expected = f"""
             SELECT {SPANS_LIST_COLS}
             FROM spans s
-            PREWHERE s.project_id = {{genai_0:String}}
+            PREWHERE {{genai_0:String}} = s.project_id
             ORDER BY started_at DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
         """
@@ -201,7 +201,7 @@ class TestMakeSpansListQuery:
         expected = f"""
             SELECT {SPANS_LIST_COLS}
             FROM spans s
-            PREWHERE s.project_id = {{genai_0:String}}
+            PREWHERE {{genai_0:String}} = s.project_id
             ORDER BY input_tokens asc
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
         """
@@ -264,7 +264,7 @@ class TestMakeGroupedSpansCountQuery:
         expected = """
             SELECT count() FROM (
                 SELECT s.trace_id FROM spans s
-                PREWHERE s.project_id = {genai_0:String}
+                PREWHERE {genai_0:String} = s.project_id
                 GROUP BY s.trace_id
             )
         """
@@ -283,7 +283,7 @@ class TestMakeGroupedSpansCountQuery:
         expected = """
             SELECT count() FROM (
                 SELECT s.custom_attrs_string[{genai_1:String}] FROM spans s
-                PREWHERE s.project_id = {genai_0:String}
+                PREWHERE {genai_0:String} = s.project_id
                 GROUP BY s.custom_attrs_string[{genai_1:String}]
             )
         """
@@ -311,7 +311,7 @@ class TestMakeGroupedSpansListQuery:
             SELECT s.trace_id AS trace_id,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
-            PREWHERE s.project_id = {{genai_0:String}}
+            PREWHERE {{genai_0:String}} = s.project_id
             GROUP BY trace_id
             ORDER BY last_seen DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
@@ -339,7 +339,7 @@ class TestMakeGroupedSpansListQuery:
             SELECT s.conversation_id AS conversation_id,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
-            PREWHERE s.project_id = {{genai_0:String}}
+            PREWHERE {{genai_0:String}} = s.project_id
               AND s.started_at >= {{genai_1:DateTime64(6)}}
               AND s.started_at < {{genai_2:DateTime64(6)}}
             GROUP BY conversation_id
@@ -371,7 +371,7 @@ class TestMakeGroupedSpansListQuery:
             SELECT s.custom_attrs_string[{{genai_3:String}}] AS env,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
-            PREWHERE s.project_id = {{genai_0:String}}
+            PREWHERE {{genai_0:String}} = s.project_id
             GROUP BY env
             ORDER BY last_seen DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
@@ -403,7 +403,7 @@ class TestMakeGroupedSpansListQuery:
                    s.request_model AS request_model,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
-            PREWHERE s.project_id = {{genai_0:String}}
+            PREWHERE {{genai_0:String}} = s.project_id
             GROUP BY agent_name, request_model
             ORDER BY agent_name asc
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
@@ -468,7 +468,7 @@ class TestMakeGroupedSpansListQuery:
                    countIf(((s.operation_name = {genai_3:String}))) AS tool_calls,
                    avgOrNull(if((mapContains(s.custom_attrs_float, {genai_4:String})), toFloat64(s.custom_attrs_float[{genai_4:String}]), NULL)) AS avg_score
             FROM spans s
-            PREWHERE s.project_id = {genai_0:String}
+            PREWHERE {genai_0:String} = s.project_id
             GROUP BY conversation_id
             HAVING avgOrNull(if((mapContains(s.custom_attrs_float, {genai_5:String})), toFloat64(s.custom_attrs_float[{genai_5:String}]), NULL)) >= {genai_6:Float64}
             ORDER BY avg_score desc
@@ -530,7 +530,7 @@ class TestMakeGroupedSpansListQuery:
             SELECT s.conversation_id AS conversation_id,
                    countIf((mapContains(s.custom_attrs_bool, {genai_3:String})) AND s.custom_attrs_bool[{genai_3:String}] = 1) AS flagged_count
             FROM spans s
-            PREWHERE s.project_id = {genai_0:String}
+            PREWHERE {genai_0:String} = s.project_id
             GROUP BY conversation_id
             ORDER BY flagged_count DESC
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
@@ -670,7 +670,7 @@ class TestMakeTraceDetailSpansQuery:
 
         expected = f"""
             SELECT {CHAT_VIEW_COLS} FROM spans s
-            PREWHERE s.project_id = {{genai_0:String}}
+            PREWHERE {{genai_0:String}} = s.project_id
             WHERE s.trace_id = {{genai_1:String}}
             ORDER BY s.started_at ASC
         """
@@ -695,7 +695,7 @@ class TestMakeAgentsQueries:
         expected = """
             SELECT count() FROM (
                 SELECT agent_name FROM agents
-                PREWHERE project_id = {genai_0:String}
+                PREWHERE {genai_0:String} = project_id
                 GROUP BY agent_name
             )
         """
@@ -716,7 +716,7 @@ class TestMakeAgentsQueries:
                    min(first_seen) AS first_seen,
                    max(last_seen) AS last_seen
             FROM agents
-            PREWHERE project_id = {genai_0:String}
+            PREWHERE {genai_0:String} = project_id
             GROUP BY agent_name
             ORDER BY last_seen DESC, agent_name
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
@@ -745,7 +745,7 @@ class TestMakeAgentsQueries:
                    min(first_seen) AS first_seen,
                    max(last_seen) AS last_seen
             FROM agents
-            PREWHERE project_id = {genai_0:String}
+            PREWHERE {genai_0:String} = project_id
             WHERE agent_name = {genai_1:String}
             GROUP BY agent_name
             ORDER BY last_seen DESC, agent_name
@@ -775,7 +775,7 @@ class TestMakeAgentVersionsQueries:
         expected = """
             SELECT count() FROM (
                 SELECT agent_version FROM agent_versions
-                PREWHERE project_id = {genai_0:String}
+                PREWHERE {genai_0:String} = project_id
                 WHERE agent_name = {genai_1:String}
                 GROUP BY agent_version
             )
@@ -804,7 +804,7 @@ class TestMakeAgentVersionsQueries:
                    min(first_seen) AS first_seen,
                    max(last_seen) AS last_seen
             FROM agent_versions
-            PREWHERE project_id = {genai_0:String}
+            PREWHERE {genai_0:String} = project_id
             WHERE agent_name = {genai_1:String}
             GROUP BY agent_version
             ORDER BY last_seen DESC
@@ -837,7 +837,7 @@ class TestMakeMessageSearchQuery:
                    substring(content, 1, 500) AS content,
                    lower(hex(content_digest)) AS content_digest, started_at
             FROM messages
-            PREWHERE project_id = {genai_0:String}
+            PREWHERE {genai_0:String} = project_id
             WHERE content LIKE {genai_1:String}
             ORDER BY started_at DESC
             LIMIT {genai_2:UInt64} OFFSET {genai_3:UInt64}
@@ -869,7 +869,7 @@ class TestMakeMessageSearchQuery:
                    substring(content, 1, 500) AS content,
                    lower(hex(content_digest)) AS content_digest, started_at
             FROM messages
-            PREWHERE project_id = {genai_0:String}
+            PREWHERE {genai_0:String} = project_id
             WHERE content LIKE {genai_1:String}
               AND role IN {genai_2:Array(String)}
               AND agent_name = {genai_3:String}
@@ -901,7 +901,7 @@ class TestMakeMessageSearchQuery:
                    substring(content, 1, 500) AS content,
                    lower(hex(content_digest)) AS content_digest, started_at
             FROM messages
-            PREWHERE project_id = {genai_0:String}
+            PREWHERE {genai_0:String} = project_id
             WHERE content LIKE {genai_1:String}
               AND role IN {genai_2:Array(String)}
             ORDER BY started_at DESC
@@ -956,13 +956,13 @@ class TestMakeConversationChatSpansQuery:
             INNER JOIN (
                 SELECT trace_id, min(started_at) AS turn_started_at
                 FROM spans
-                PREWHERE project_id = {{genai_0:String}}
+                PREWHERE {{genai_0:String}} = project_id
                 WHERE conversation_id = {{genai_1:String}}
                 GROUP BY trace_id
                 ORDER BY turn_started_at DESC, trace_id DESC
                 LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
             ) t ON s.trace_id = t.trace_id
-            PREWHERE s.project_id = {{genai_0:String}}
+            PREWHERE {{genai_0:String}} = s.project_id
             ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
         """
         assert_sql(
@@ -987,13 +987,13 @@ class TestMakeConversationChatSpansQuery:
             INNER JOIN (
                 SELECT trace_id, min(started_at) AS turn_started_at
                 FROM spans
-                PREWHERE project_id = {{genai_0:String}}
+                PREWHERE {{genai_0:String}} = project_id
                 WHERE conversation_id = {{genai_1:String}}
                 GROUP BY trace_id
                 ORDER BY turn_started_at DESC, trace_id DESC
                 LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
             ) t ON s.trace_id = t.trace_id
-            PREWHERE s.project_id = {{genai_0:String}}
+            PREWHERE {{genai_0:String}} = s.project_id
             ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
         """
         assert_sql(
@@ -1024,7 +1024,7 @@ class TestMakeConversationChatTurnsCountQuery:
             SELECT count() FROM (
                 SELECT trace_id
                 FROM spans s
-                PREWHERE s.project_id = {genai_0:String}
+                PREWHERE {genai_0:String} = s.project_id
                 WHERE s.conversation_id = {genai_1:String}
                 GROUP BY trace_id
             )

--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -120,7 +120,7 @@ def test_ungrouped_stats_query_full_sql_shape() -> None:
         filtered_spans AS (
           SELECT *
           FROM spans s
-          PREWHERE s.project_id = {genai_0:String}
+          PREWHERE {genai_0:String} = s.project_id
             AND s.started_at >= {genai_1:DateTime64(6)}
             AND s.started_at < {genai_2:DateTime64(6)}
           WHERE (s.agent_name = {genai_3:String})
@@ -229,7 +229,7 @@ def test_grouped_stats_query_full_sql_shape() -> None:
         filtered_spans AS (
           SELECT *
           FROM spans s
-          PREWHERE s.project_id = {genai_0:String}
+          PREWHERE {genai_0:String} = s.project_id
             AND s.started_at >= {genai_1:DateTime64(6)}
             AND s.started_at < {genai_2:DateTime64(6)}
         ),
@@ -324,7 +324,7 @@ def test_basic_stats_query_uses_query_filter_and_bucket() -> None:
              filtered_spans AS
           (SELECT *
            FROM spans s
-           PREWHERE s.project_id = {genai_0:String}
+           PREWHERE {genai_0:String} = s.project_id
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)}
            WHERE (s.agent_name = {genai_3:String}) ),
@@ -393,7 +393,7 @@ def test_numeric_bucket_stats_query_uses_value_buckets() -> None:
         WITH filtered_spans AS
           (SELECT *
            FROM spans s
-           PREWHERE s.project_id = {genai_0:String}
+           PREWHERE {genai_0:String} = s.project_id
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)} ),
              value_rows AS
@@ -473,7 +473,7 @@ def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
         WITH filtered_spans AS
           (SELECT *
            FROM spans s
-           PREWHERE s.project_id = {genai_0:String}
+           PREWHERE {genai_0:String} = s.project_id
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)} ),
              value_rows AS
@@ -607,7 +607,7 @@ def test_group_by_custom_attr_and_metric_custom_attr() -> None:
              filtered_spans AS
           (SELECT *
            FROM spans s
-           PREWHERE s.project_id = {genai_0:String}
+           PREWHERE {genai_0:String} = s.project_id
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)} ),
              top_groups AS
@@ -690,7 +690,7 @@ def test_time_stats_apply_group_filters() -> None:
              filtered_spans AS
           (SELECT *
            FROM spans s
-           PREWHERE s.project_id = {genai_0:String}
+           PREWHERE {genai_0:String} = s.project_id
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)} ),
              qualified_groups_0 AS

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -691,9 +691,15 @@ def _optional_where_clause(where: str, *, prefix: str = " ") -> str:
     return f"{prefix}WHERE {where}" if where else ""
 
 
+def _project_filter_sql(column_sql: str, project_slot: str) -> str:
+    # ClickHouse 26.2 can prune internal base64 project ids incorrectly when the
+    # primary-key column is on the left side of the equality.
+    return f"{project_slot} = {column_sql}"
+
+
 def _spans_filter_sql(pb: ParamBuilder, req: AgentSpansQueryReq) -> _FilterSQL:
     pid_slot = pb.add(req.project_id, param_type="String")
-    prewhere_conditions = [f"s.project_id = {pid_slot}"]
+    prewhere_conditions = [_project_filter_sql("s.project_id", pid_slot)]
     add_time_filters(
         prewhere_conditions,
         pb,
@@ -741,7 +747,7 @@ def _search_filter_sql(pb: ParamBuilder, req: AgentSearchReq) -> _FilterSQL:
     pid_slot = pb.add(req.project_id, param_type="String")
     content_slot = pb.add(f"%{_escape_like_pattern(req.query)}%", param_type="String")
     prewhere_conditions = [
-        f"project_id = {pid_slot}",
+        _project_filter_sql("project_id", pid_slot),
     ]
     conditions = [
         f"content LIKE {content_slot}",
@@ -899,7 +905,7 @@ def make_trace_detail_spans_query(
     tid = pb.add(trace_id, param_type="String")
     return f"""
         SELECT {CHAT_VIEW_COLS} FROM spans s
-        PREWHERE s.project_id = {pid}
+        PREWHERE {_project_filter_sql("s.project_id", pid)}
         WHERE s.trace_id = {tid}
         ORDER BY s.started_at ASC
     """
@@ -915,7 +921,7 @@ def make_agents_count_query(pb: ParamBuilder, req: AgentsQueryReq) -> str:
     where = _agents_where(pb, req)
     where_sql = _optional_where_clause(where)
     return f"""SELECT count() FROM (
-        SELECT agent_name FROM agents PREWHERE project_id = {pid_slot}{where_sql} GROUP BY agent_name
+        SELECT agent_name FROM agents PREWHERE {_project_filter_sql("project_id", pid_slot)}{where_sql} GROUP BY agent_name
     )"""
 
 
@@ -938,7 +944,7 @@ def make_agents_list_query(pb: ParamBuilder, req: AgentsQueryReq) -> str:
                min(first_seen) AS first_seen,
                max(last_seen) AS last_seen
         FROM agents
-        PREWHERE project_id = {pid_slot}{where_sql}
+        PREWHERE {_project_filter_sql("project_id", pid_slot)}{where_sql}
         GROUP BY agent_name
         ORDER BY {order_by}
         LIMIT {limit_slot} OFFSET {offset_slot}
@@ -952,7 +958,7 @@ def make_agent_versions_count_query(
     aname = pb.add(req.agent_name, param_type="String")
     return (
         f"SELECT count() FROM ("
-        f"SELECT agent_version FROM agent_versions PREWHERE project_id = {pid}"
+        f"SELECT agent_version FROM agent_versions PREWHERE {_project_filter_sql('project_id', pid)}"
         f" WHERE agent_name = {aname} GROUP BY agent_version"
         f")"
     )
@@ -973,7 +979,7 @@ def make_agent_versions_list_query(pb: ParamBuilder, req: AgentVersionsQueryReq)
                min(first_seen) AS first_seen,
                max(last_seen) AS last_seen
         FROM agent_versions
-        PREWHERE project_id = {pid}
+        PREWHERE {_project_filter_sql("project_id", pid)}
         WHERE agent_name = {aname}
         GROUP BY agent_version
         ORDER BY last_seen DESC
@@ -1029,13 +1035,13 @@ def make_conversation_chat_spans_query(
         INNER JOIN (
             SELECT trace_id, min(started_at) AS turn_started_at
             FROM spans
-            PREWHERE project_id = {pid}
+            PREWHERE {_project_filter_sql("project_id", pid)}
             WHERE conversation_id = {cid}
             GROUP BY trace_id
             ORDER BY turn_started_at DESC, trace_id DESC
             LIMIT {limit_slot} OFFSET {offset_slot}
         ) t ON s.trace_id = t.trace_id
-        PREWHERE s.project_id = {pid}
+        PREWHERE {_project_filter_sql("s.project_id", pid)}
         ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
     """
 
@@ -1050,7 +1056,7 @@ def make_conversation_chat_turns_count_query(
         SELECT count() FROM (
             SELECT trace_id
             FROM spans s
-            PREWHERE s.project_id = {pid}
+            PREWHERE {_project_filter_sql("s.project_id", pid)}
             WHERE s.conversation_id = {cid}
             GROUP BY trace_id
         )

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -35,6 +35,7 @@ from weave.trace_server.calls_query_builder.stats_query_base import (
 from weave.trace_server.calls_query_builder.utils import param_slot, safely_format_sql
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_query_builder import (
+    _project_filter_sql,
     add_time_filters,
     ensure_group_filters_match,
     group_by_ref_alias,
@@ -376,7 +377,7 @@ def _spans_source_filter_sql(
     end: datetime.datetime,
 ) -> _SpanSourceFilterSQL:
     pid_slot = pb.add(req.project_id, param_type="String")
-    prewhere_conditions = [f"{_span_col(_COL_PROJECT_ID)} = {pid_slot}"]
+    prewhere_conditions = [_project_filter_sql(_span_col(_COL_PROJECT_ID), pid_slot)]
     add_time_filters(
         prewhere_conditions,
         pb,


### PR DESCRIPTION
## Summary

Fix agent query builders to emit project-id predicates with the bound parameter on the left side of the equality, e.g. `{project_id:String} = s.project_id`.

## Root cause

On local ClickHouse 26.2, predicates shaped as `s.project_id = {param:String}` can incorrectly prune internal base64 project ids when `project_id` is part of the primary key. This made the agent spans/list/search/chat APIs return no rows for projects that did have data. Reversing the equality preserves the same semantics but avoids the bad pruning behavior.

## Changes

- Add a shared project filter SQL helper for agent query builders.
- Apply it to agent spans, stats, message search, trace chat, conversation chat, agents, and agent version queries.
- Update SQL-shape tests to cover the new predicate form.

## Validation

- `python -m pytest tests/trace_server/query_builder/test_agent_query_builder.py tests/trace_server/query_builder/test_agent_stats_query_builder.py tests/trace_server/test_genai_agent_queries.py::test_conversation_chat_paginates_turns tests/trace_server/test_genai_agent_queries.py::test_conversation_chat_includes_child_spans_without_conversation_id tests/trace_server/test_genai_agent_queries.py::test_message_search tests/trace_server/test_genai_agent_queries.py::test_spans_insert_and_query`
- `nox -e lint`
- Verified against local trace-server data for `bcanfieldsherman/agents-lorem-ipsum`: param-left project filter returns 615 spans and conversation chat rows for the latest conversation.