### PR TITLE
fix(weave): use singleton IN for agent project filters

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -72,7 +72,7 @@ class TestMakeSpansCountQuery:
         query = make_spans_count_query(pb, AgentSpansQueryReq(project_id="p1"))
 
         expected = (
-            "SELECT count() FROM spans s PREWHERE {genai_0:String} = s.project_id"
+            "SELECT count() FROM spans s PREWHERE s.project_id IN ({genai_0:String})"
         )
         assert_sql(expected, {"genai_0": "p1"}, query, pb.get_params())
 
@@ -111,7 +111,7 @@ class TestMakeSpansCountQuery:
 
         expected = """
             SELECT count() FROM spans s
-            PREWHERE {genai_0:String} = s.project_id
+            PREWHERE s.project_id IN ({genai_0:String})
               AND s.started_at >= {genai_1:DateTime64(6)}
               AND s.started_at < {genai_2:DateTime64(6)}
             WHERE ((s.agent_name = {genai_3:String}) AND (s.custom_attrs_string[{genai_4:String}] = {genai_5:String}))
@@ -181,7 +181,7 @@ class TestMakeSpansListQuery:
         expected = f"""
             SELECT {SPANS_LIST_COLS}
             FROM spans s
-            PREWHERE {{genai_0:String}} = s.project_id
+            PREWHERE s.project_id IN ({{genai_0:String}})
             ORDER BY started_at DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
         """
@@ -201,7 +201,7 @@ class TestMakeSpansListQuery:
         expected = f"""
             SELECT {SPANS_LIST_COLS}
             FROM spans s
-            PREWHERE {{genai_0:String}} = s.project_id
+            PREWHERE s.project_id IN ({{genai_0:String}})
             ORDER BY input_tokens asc
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
         """
@@ -264,7 +264,7 @@ class TestMakeGroupedSpansCountQuery:
         expected = """
             SELECT count() FROM (
                 SELECT s.trace_id FROM spans s
-                PREWHERE {genai_0:String} = s.project_id
+                PREWHERE s.project_id IN ({genai_0:String})
                 GROUP BY s.trace_id
             )
         """
@@ -283,7 +283,7 @@ class TestMakeGroupedSpansCountQuery:
         expected = """
             SELECT count() FROM (
                 SELECT s.custom_attrs_string[{genai_1:String}] FROM spans s
-                PREWHERE {genai_0:String} = s.project_id
+                PREWHERE s.project_id IN ({genai_0:String})
                 GROUP BY s.custom_attrs_string[{genai_1:String}]
             )
         """
@@ -311,7 +311,7 @@ class TestMakeGroupedSpansListQuery:
             SELECT s.trace_id AS trace_id,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
-            PREWHERE {{genai_0:String}} = s.project_id
+            PREWHERE s.project_id IN ({{genai_0:String}})
             GROUP BY trace_id
             ORDER BY last_seen DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
@@ -339,7 +339,7 @@ class TestMakeGroupedSpansListQuery:
             SELECT s.conversation_id AS conversation_id,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
-            PREWHERE {{genai_0:String}} = s.project_id
+            PREWHERE s.project_id IN ({{genai_0:String}})
               AND s.started_at >= {{genai_1:DateTime64(6)}}
               AND s.started_at < {{genai_2:DateTime64(6)}}
             GROUP BY conversation_id
@@ -371,7 +371,7 @@ class TestMakeGroupedSpansListQuery:
             SELECT s.custom_attrs_string[{{genai_3:String}}] AS env,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
-            PREWHERE {{genai_0:String}} = s.project_id
+            PREWHERE s.project_id IN ({{genai_0:String}})
             GROUP BY env
             ORDER BY last_seen DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
@@ -403,7 +403,7 @@ class TestMakeGroupedSpansListQuery:
                    s.request_model AS request_model,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
-            PREWHERE {{genai_0:String}} = s.project_id
+            PREWHERE s.project_id IN ({{genai_0:String}})
             GROUP BY agent_name, request_model
             ORDER BY agent_name asc
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
@@ -468,7 +468,7 @@ class TestMakeGroupedSpansListQuery:
                    countIf(((s.operation_name = {genai_3:String}))) AS tool_calls,
                    avgOrNull(if((mapContains(s.custom_attrs_float, {genai_4:String})), toFloat64(s.custom_attrs_float[{genai_4:String}]), NULL)) AS avg_score
             FROM spans s
-            PREWHERE {genai_0:String} = s.project_id
+            PREWHERE s.project_id IN ({genai_0:String})
             GROUP BY conversation_id
             HAVING avgOrNull(if((mapContains(s.custom_attrs_float, {genai_5:String})), toFloat64(s.custom_attrs_float[{genai_5:String}]), NULL)) >= {genai_6:Float64}
             ORDER BY avg_score desc
@@ -530,7 +530,7 @@ class TestMakeGroupedSpansListQuery:
             SELECT s.conversation_id AS conversation_id,
                    countIf((mapContains(s.custom_attrs_bool, {genai_3:String})) AND s.custom_attrs_bool[{genai_3:String}] = 1) AS flagged_count
             FROM spans s
-            PREWHERE {genai_0:String} = s.project_id
+            PREWHERE s.project_id IN ({genai_0:String})
             GROUP BY conversation_id
             ORDER BY flagged_count DESC
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
@@ -670,7 +670,7 @@ class TestMakeTraceDetailSpansQuery:
 
         expected = f"""
             SELECT {CHAT_VIEW_COLS} FROM spans s
-            PREWHERE {{genai_0:String}} = s.project_id
+            PREWHERE s.project_id IN ({{genai_0:String}})
             WHERE s.trace_id = {{genai_1:String}}
             ORDER BY s.started_at ASC
         """
@@ -695,7 +695,7 @@ class TestMakeAgentsQueries:
         expected = """
             SELECT count() FROM (
                 SELECT agent_name FROM agents
-                PREWHERE {genai_0:String} = project_id
+                PREWHERE project_id IN ({genai_0:String})
                 GROUP BY agent_name
             )
         """
@@ -716,7 +716,7 @@ class TestMakeAgentsQueries:
                    min(first_seen) AS first_seen,
                    max(last_seen) AS last_seen
             FROM agents
-            PREWHERE {genai_0:String} = project_id
+            PREWHERE project_id IN ({genai_0:String})
             GROUP BY agent_name
             ORDER BY last_seen DESC, agent_name
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
@@ -745,7 +745,7 @@ class TestMakeAgentsQueries:
                    min(first_seen) AS first_seen,
                    max(last_seen) AS last_seen
             FROM agents
-            PREWHERE {genai_0:String} = project_id
+            PREWHERE project_id IN ({genai_0:String})
             WHERE agent_name = {genai_1:String}
             GROUP BY agent_name
             ORDER BY last_seen DESC, agent_name
@@ -775,7 +775,7 @@ class TestMakeAgentVersionsQueries:
         expected = """
             SELECT count() FROM (
                 SELECT agent_version FROM agent_versions
-                PREWHERE {genai_0:String} = project_id
+                PREWHERE project_id IN ({genai_0:String})
                 WHERE agent_name = {genai_1:String}
                 GROUP BY agent_version
             )
@@ -804,7 +804,7 @@ class TestMakeAgentVersionsQueries:
                    min(first_seen) AS first_seen,
                    max(last_seen) AS last_seen
             FROM agent_versions
-            PREWHERE {genai_0:String} = project_id
+            PREWHERE project_id IN ({genai_0:String})
             WHERE agent_name = {genai_1:String}
             GROUP BY agent_version
             ORDER BY last_seen DESC
@@ -837,7 +837,7 @@ class TestMakeMessageSearchQuery:
                    substring(content, 1, 500) AS content,
                    lower(hex(content_digest)) AS content_digest, started_at
             FROM messages
-            PREWHERE {genai_0:String} = project_id
+            PREWHERE project_id IN ({genai_0:String})
             WHERE content LIKE {genai_1:String}
             ORDER BY started_at DESC
             LIMIT {genai_2:UInt64} OFFSET {genai_3:UInt64}
@@ -869,7 +869,7 @@ class TestMakeMessageSearchQuery:
                    substring(content, 1, 500) AS content,
                    lower(hex(content_digest)) AS content_digest, started_at
             FROM messages
-            PREWHERE {genai_0:String} = project_id
+            PREWHERE project_id IN ({genai_0:String})
             WHERE content LIKE {genai_1:String}
               AND role IN {genai_2:Array(String)}
               AND agent_name = {genai_3:String}
@@ -901,7 +901,7 @@ class TestMakeMessageSearchQuery:
                    substring(content, 1, 500) AS content,
                    lower(hex(content_digest)) AS content_digest, started_at
             FROM messages
-            PREWHERE {genai_0:String} = project_id
+            PREWHERE project_id IN ({genai_0:String})
             WHERE content LIKE {genai_1:String}
               AND role IN {genai_2:Array(String)}
             ORDER BY started_at DESC
@@ -956,13 +956,13 @@ class TestMakeConversationChatSpansQuery:
             INNER JOIN (
                 SELECT trace_id, min(started_at) AS turn_started_at
                 FROM spans
-                PREWHERE {{genai_0:String}} = project_id
+                PREWHERE project_id IN ({{genai_0:String}})
                 WHERE conversation_id = {{genai_1:String}}
                 GROUP BY trace_id
                 ORDER BY turn_started_at DESC, trace_id DESC
                 LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
             ) t ON s.trace_id = t.trace_id
-            PREWHERE {{genai_0:String}} = s.project_id
+            PREWHERE s.project_id IN ({{genai_0:String}})
             ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
         """
         assert_sql(
@@ -987,13 +987,13 @@ class TestMakeConversationChatSpansQuery:
             INNER JOIN (
                 SELECT trace_id, min(started_at) AS turn_started_at
                 FROM spans
-                PREWHERE {{genai_0:String}} = project_id
+                PREWHERE project_id IN ({{genai_0:String}})
                 WHERE conversation_id = {{genai_1:String}}
                 GROUP BY trace_id
                 ORDER BY turn_started_at DESC, trace_id DESC
                 LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
             ) t ON s.trace_id = t.trace_id
-            PREWHERE {{genai_0:String}} = s.project_id
+            PREWHERE s.project_id IN ({{genai_0:String}})
             ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
         """
         assert_sql(
@@ -1024,7 +1024,7 @@ class TestMakeConversationChatTurnsCountQuery:
             SELECT count() FROM (
                 SELECT trace_id
                 FROM spans s
-                PREWHERE {genai_0:String} = s.project_id
+                PREWHERE s.project_id IN ({genai_0:String})
                 WHERE s.conversation_id = {genai_1:String}
                 GROUP BY trace_id
             )

--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -120,7 +120,7 @@ def test_ungrouped_stats_query_full_sql_shape() -> None:
         filtered_spans AS (
           SELECT *
           FROM spans s
-          PREWHERE {genai_0:String} = s.project_id
+          PREWHERE s.project_id IN ({genai_0:String})
             AND s.started_at >= {genai_1:DateTime64(6)}
             AND s.started_at < {genai_2:DateTime64(6)}
           WHERE (s.agent_name = {genai_3:String})
@@ -229,7 +229,7 @@ def test_grouped_stats_query_full_sql_shape() -> None:
         filtered_spans AS (
           SELECT *
           FROM spans s
-          PREWHERE {genai_0:String} = s.project_id
+          PREWHERE s.project_id IN ({genai_0:String})
             AND s.started_at >= {genai_1:DateTime64(6)}
             AND s.started_at < {genai_2:DateTime64(6)}
         ),
@@ -324,7 +324,7 @@ def test_basic_stats_query_uses_query_filter_and_bucket() -> None:
              filtered_spans AS
           (SELECT *
            FROM spans s
-           PREWHERE {genai_0:String} = s.project_id
+           PREWHERE s.project_id IN ({genai_0:String})
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)}
            WHERE (s.agent_name = {genai_3:String}) ),
@@ -393,7 +393,7 @@ def test_numeric_bucket_stats_query_uses_value_buckets() -> None:
         WITH filtered_spans AS
           (SELECT *
            FROM spans s
-           PREWHERE {genai_0:String} = s.project_id
+           PREWHERE s.project_id IN ({genai_0:String})
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)} ),
              value_rows AS
@@ -473,7 +473,7 @@ def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
         WITH filtered_spans AS
           (SELECT *
            FROM spans s
-           PREWHERE {genai_0:String} = s.project_id
+           PREWHERE s.project_id IN ({genai_0:String})
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)} ),
              value_rows AS
@@ -607,7 +607,7 @@ def test_group_by_custom_attr_and_metric_custom_attr() -> None:
              filtered_spans AS
           (SELECT *
            FROM spans s
-           PREWHERE {genai_0:String} = s.project_id
+           PREWHERE s.project_id IN ({genai_0:String})
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)} ),
              top_groups AS
@@ -690,7 +690,7 @@ def test_time_stats_apply_group_filters() -> None:
              filtered_spans AS
           (SELECT *
            FROM spans s
-           PREWHERE {genai_0:String} = s.project_id
+           PREWHERE s.project_id IN ({genai_0:String})
              AND s.started_at >= {genai_1:DateTime64(6)}
              AND s.started_at < {genai_2:DateTime64(6)} ),
              qualified_groups_0 AS

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -692,9 +692,10 @@ def _optional_where_clause(where: str, *, prefix: str = " ") -> str:
 
 
 def _project_filter_sql(column_sql: str, project_slot: str) -> str:
-    # ClickHouse 26.2 can prune internal base64 project ids incorrectly when the
-    # primary-key column is on the left side of the equality.
-    return f"{project_slot} = {column_sql}"
+    # ClickHouse 26.2 can prune internal base64 project ids incorrectly through
+    # the equality predicate read path. A singleton IN predicate keeps primary
+    # key pruning but returns the correct rows.
+    return f"{column_sql} IN ({project_slot})"
 
 
 def _spans_filter_sql(pb: ParamBuilder, req: AgentSpansQueryReq) -> _FilterSQL:


### PR DESCRIPTION
## Summary
- Change the shared agent project filter helper from equality to a singleton `IN` predicate.
- Update agent query builder and stats query builder SQL-shape tests to expect `project_id IN ({param})`.

## Why
PR #6817 fixed only the operand order, but local ClickHouse 26.2 still returned zero rows for both equality forms on the internal base64 project id:

- `project_id = {p:String}` returned 0
- `{p:String} = project_id` returned 0
- `project_id IN ({p:String})` returned the expected 615 rows

`EXPLAIN indexes=1` for the singleton `IN` form still shows primary-key pruning on `project_id`, so this keeps the fast path without hitting the broken equality predicate read path.

## Testing
- `/Users/ben/repos/core/services/weave-python/weave-public/.venv/bin/python -m pytest tests/trace_server/query_builder/test_agent_query_builder.py tests/trace_server/query_builder/test_agent_stats_query_builder.py tests/trace_server/test_genai_agent_queries.py::test_conversation_chat_paginates_turns tests/trace_server/test_genai_agent_queries.py::test_conversation_chat_includes_child_spans_without_conversation_id tests/trace_server/test_genai_agent_queries.py::test_message_search tests/trace_server/test_genai_agent_queries.py::test_spans_insert_and_query`
- `nox -e lint`
- Local ClickHouse checks against `bcanfieldsherman/agents-lorem-ipsum` trace-server data
