### PR TITLE
fix: [WB-33909] drop @op from RemoteScorer.score / summarize

### DIFF
--- a/tests/scorers/test_remote_scorer.py
+++ b/tests/scorers/test_remote_scorer.py
@@ -7,6 +7,7 @@ from weave.scorers.remote_scorer import (
     RemoteScorer,
     _validate_remote_scorer_endpoint_url,
 )
+from weave.trace.object_record import pydantic_object_record
 
 
 def test_remote_scorer_fields() -> None:
@@ -110,3 +111,36 @@ def test_remote_scorer_score_raises_not_implemented() -> None:
         "RemoteScorer is run by the Weave scoring worker against your HTTPS "
         "endpoint; score() is not part of that path."
     )
+
+
+def test_remote_scorer_summarize_raises_not_implemented() -> None:
+    rs = RemoteScorer(endpoint_url="https://scoring.example.com/v1/score")
+    with pytest.raises(NotImplementedError):
+        rs.summarize([])
+
+
+def test_remote_scorer_object_record_omits_op_methods() -> None:
+    """Regression test for WB-33909.
+
+    Programmatic publish of ``RemoteScorer`` previously embedded ``score`` and
+    ``summarize`` as ``@op`` method attributes on the published object. The
+    scoring worker's safety check (``_assert_safe_scorer_payload``) follows
+    those op refs and rejects the resulting ``CustomWeaveType(Op)`` payload,
+    causing online monitors to be skipped. ``RemoteScorer`` must therefore
+    expose no ``@op`` members, matching the slim UI-created payload shape.
+    """
+    rs = RemoteScorer(
+        name="policy_remote",
+        endpoint_url="https://scoring.example.com/v1/score",
+        config={"threshold": 0.9},
+    )
+    obj_rec = pydantic_object_record(rs)
+    assert obj_rec._class_name == "RemoteScorer"
+    # No @op methods should leak into the serialized object's attributes;
+    # they would otherwise be published as op refs.
+    assert "score" not in obj_rec.__dict__
+    assert "summarize" not in obj_rec.__dict__
+    # Data fields stay intact.
+    assert obj_rec.__dict__["endpoint_url"] == "https://scoring.example.com/v1/score"
+    assert obj_rec.__dict__["config"] == {"threshold": 0.9}
+    assert obj_rec.__dict__["name"] == "policy_remote"

--- a/weave/scorers/remote_scorer.py
+++ b/weave/scorers/remote_scorer.py
@@ -7,7 +7,6 @@ from pydantic import Field, field_validator
 
 from weave.flow.scorer import Scorer
 from weave.trace.objectify import register_object
-from weave.trace.op import op
 
 
 @register_object
@@ -63,15 +62,36 @@ class RemoteScorer(Scorer):
         description="Optional customer-defined JSON-serializable configuration.",
     )
 
-    @op
     def score(self, *, output: Any, **kwargs: Any) -> Any:
-        """Override for the Scorer.score function containing a more specific error.
+        """Local invocation is not supported; raise to make the contract explicit.
 
         Not used for remote scoring; the Weave scoring worker performs the HTTP request.
+
+        Intentionally NOT decorated with ``@op``: during publish, the Weave SDK
+        walks each ``@op`` method on the object and serializes it as an op ref.
+        Following that ref later (e.g. in the scoring worker's
+        ``_assert_safe_scorer_payload`` check) yields a ``CustomWeaveType(Op)``
+        payload, which the worker rejects as unsafe and the monitor is skipped.
+        Since RemoteScorer's score/summarize are never executed locally, leaving
+        them as plain methods keeps them out of the published object's fields
+        (matching the UI-created payload shape). See WB-33909.
         """
         raise NotImplementedError(
             "RemoteScorer is run by the Weave scoring worker against your HTTPS "
             "endpoint; score() is not part of that path."
+        )
+
+    def summarize(self, score_rows: list) -> dict | None:
+        """Local invocation is not supported; raise to make the contract explicit.
+
+        Intentionally NOT decorated with ``@op`` for the same reason as
+        :meth:`score`. The base ``Scorer.summarize`` is an op; overriding it
+        with a plain method prevents it from being picked up by
+        ``getmembers(obj, is_op)`` during publish. See WB-33909.
+        """
+        raise NotImplementedError(
+            "RemoteScorer summaries are computed by the Weave scoring worker; "
+            "summarize() is not part of that path."
         )
 
 


### PR DESCRIPTION
## Summary

`weave.publish(RemoteScorer(...))` via the SDK produced a payload with `score` / `summarize` fields pointing at op refs, which the scoring worker's `_assert_safe_scorer_payload` then rejected as unsafe - monitors silently skipped.

Root cause: `pydantic_object_record` walks `getmembers(..., is_op)` and attaches every `@op` method to the resulting `ObjectRecord`. `RemoteScorer.score` was `@op` and inherited `Scorer.summarize` is also `@op`.

Fix: drop `@op` from `RemoteScorer.score` and override `summarize` as a plain method raising `NotImplementedError`. `RemoteScorer` is invoked exclusively over HTTP in the scoring worker, so removing `@op` has no functional impact.

**Why integration tests didn't catch it:** `make_remote_scorer_monitor_and_ref` builds `RemoteScorer` in-process and injects `internal_ref` directly, bypassing the `weave.publish` + `pydantic_object_record` path. Worth exercising the publish path in integration tests as a follow-up.

Paired with core PR (submodule bump).

## Test plan
- [x] New regression test fails on old code, passes on new
- [x] `test_remote_scorer.py`: 21 passed
- [x] `test_server_object_creation_utils.py`: 6 passed