### PR TITLE
fix: [WB-33908] resolve bare op names to refs in Monitor.activate

### DIFF
--- a/tests/flow/test_monitor.py
+++ b/tests/flow/test_monitor.py
@@ -59,7 +59,10 @@ def test_publish(client: weave_client.WeaveClient):
 
     assert stored_monitor.active == False
     assert stored_monitor.sampling_rate == 0.5
-    assert stored_monitor.op_names == ["example_op_name"]
+    # The model validator rewrites short names to fully-qualified op refs.
+    assert stored_monitor.op_names == [
+        f"weave:///{client.entity}/{client.project}/op/example_op_name:*"
+    ]
     assert stored_monitor.query == Query(
         **{
             "$expr": {
@@ -86,3 +89,53 @@ def test_activate(client: weave_client.WeaveClient):
 
     deactivated_ref = monitor.deactivate()
     assert deactivated_ref.get().active == False
+
+
+def test_construct_resolves_short_op_names(client: weave_client.WeaveClient):
+    """The docstring example uses a short op name; the model_validator must
+    rewrite it into a fully-qualified op ref at construction time so the UI can
+    render it and downstream consumers see a ref. The resolution is synchronous
+    and uses `:*` as a "latest version" sentinel - no network call.
+    """
+    monitor = Monitor(
+        name="test_monitor",
+        sampling_rate=0.5,
+        scorers=[],
+        op_names=["my_op"],
+    )
+
+    assert monitor.op_names == [
+        f"weave:///{client.entity}/{client.project}/op/my_op:*"
+    ]
+    # The resolution uses the `:*` latest-version sentinel.
+    assert monitor.op_names[0].endswith(":*")
+
+
+def test_construct_preserves_full_refs_and_agent_span_names(
+    client: weave_client.WeaveClient,
+):
+    """Already-qualified refs and predeclared agent-span op names pass through unchanged."""
+    full_ref = f"weave:///{client.entity}/{client.project}/op/some_op:abcdef"
+    monitor = Monitor(
+        name="test_monitor",
+        sampling_rate=0.5,
+        scorers=[],
+        op_names=[full_ref, "weave.genai.turn"],
+    )
+
+    assert list(monitor.op_names) == [full_ref, "weave.genai.turn"]
+
+
+def test_construct_without_client_leaves_op_names_unchanged():
+    """When no weave client is active, op_names pass through unchanged - the
+    validator has nothing to resolve against, and a Monitor is only operational
+    in a weave-initialized context anyway.
+    """
+    monitor = Monitor(
+        name="test_monitor",
+        sampling_rate=0.5,
+        scorers=[],
+        op_names=["my_op"],
+    )
+
+    assert monitor.op_names == ["my_op"]

--- a/tests/trace/data_serialization/test_cases/config_cases.py
+++ b/tests/trace/data_serialization/test_cases/config_cases.py
@@ -86,11 +86,16 @@ config_cases = [
     # ),
     SerializationTestCase(
         id="Monitor",
+        # The Monitor model_validator rewrites short op names to fully-qualified
+        # refs at construction. This serialization test focuses on the Monitor
+        # field shape; op-name resolution is covered by test_monitor.py. Using
+        # an empty op_names list avoids the test framework's "every weave:// ref
+        # in JSON must exist as an exp_object" check for a synthetic wildcard ref.
         runtime_object_factory=lambda: Monitor(
             name="test_monitor",
             sampling_rate=0.5,
             scorers=[],
-            op_names=["example_op_name"],
+            op_names=[],
             query={
                 "$expr": {
                     "$gt": [
@@ -113,7 +118,7 @@ config_cases = [
             "description": None,
             "sampling_rate": 0.5,
             "scorers": [],
-            "op_names": ["example_op_name"],
+            "op_names": [],
             "query": {
                 "_type": "Query",
                 "$expr": {
@@ -282,11 +287,12 @@ config_cases = [
     ),
     SerializationTestCase(
         id="ClassifierMonitor",
+        # See "Monitor" case above re: why op_names is empty here.
         runtime_object_factory=lambda: ClassifierMonitor(
             name="test_classifier_monitor",
             sampling_rate=0.75,
             scorers=[],
-            op_names=["classify_op"],
+            op_names=[],
             is_traced=False,
         ),
         inline_call_param=False,
@@ -297,7 +303,7 @@ config_cases = [
             "description": None,
             "sampling_rate": 0.75,
             "scorers": [],
-            "op_names": ["classify_op"],
+            "op_names": [],
             "query": None,
             "is_traced": False,
             "active": False,

--- a/weave/flow/monitor.py
+++ b/weave/flow/monitor.py
@@ -1,11 +1,12 @@
 from typing import Literal, TypeAlias, get_args
 
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 from typing_extensions import NotRequired, Self, TypedDict
 
 from weave.flow.casting import Scorer
 from weave.object.obj import Object
 from weave.trace.api import ObjectRef, publish
+from weave.trace.context.weave_client_context import get_weave_client
 from weave.trace.objectify import register_object
 from weave.trace.vals import WeaveObject
 from weave.trace_server.interface.query import Query
@@ -109,9 +110,64 @@ class Monitor(Object):
         self.ref = None
         return publish(self)
 
+    @field_validator("op_names", mode="before")
+    @classmethod
+    def _coerce_op_refs_to_str(cls, value: object) -> object:
+        """Stored monitors deserialize op refs as `OpRef`/`ObjectRef` instances
+        (weave auto-resolves URI strings into ref objects when reading). The
+        field type is `list[str]`, so coerce ref objects back to their URI
+        strings before type validation.
+        """
+        if not isinstance(value, list):
+            return value
+        coerced: list[object] = []
+        for item in value:
+            uri_fn = getattr(item, "uri", None)
+            coerced.append(uri_fn() if callable(uri_fn) else item)
+        return coerced
+
+    @model_validator(mode="after")
+    def _resolve_op_names(self) -> Self:
+        """Rewrite short op names in `op_names` to fully-qualified op refs.
+
+        Users may pass short op names (e.g. `"my_op"`) per the docstring example, but
+        the backend and UI key off fully-qualified refs like
+        `weave:///entity/project/op/my_op:digest`. The trace server's calls query
+        treats `:*` as a "latest version" wildcard (LIKE `...:%`), and the frontend's
+        `parseRef` accepts it too, so we construct the ref synchronously from the
+        current weave client's entity/project without a network call. Names that
+        already look like refs or are predeclared agent-span op names pass through
+        unchanged.
+
+        If no weave client is active at construction time, op_names are left as-is.
+        This is intentional: a Monitor is only useful in a weave-initialized context
+        (publish/activate require a client), and validators on `from_obj` reads
+        should not raise when reconstructing already-stored refs.
+        """
+        if not self.op_names:
+            return self
+        client = get_weave_client()
+        if client is None:
+            return self
+        entity = client.entity
+        project = client.project
+        resolved: list[str] = []
+        for name in self.op_names:
+            if _looks_like_ref(name) or name in AGENT_SPAN_OP_NAMES:
+                resolved.append(name)
+                continue
+            resolved.append(f"weave:///{entity}/{project}/op/{name}:*")
+        self.op_names = resolved
+        return self
+
     @classmethod
     def from_obj(cls, obj: WeaveObject) -> Self:
         return cls.model_validate(obj.unwrap())
+
+
+def _looks_like_ref(name: str) -> bool:
+    """True if `name` is already a weave object/op ref URI."""
+    return name.startswith("weave:///")
 
 
 _OP_CALL_CLASSIFIER_PROMPT_HEADER = "\n".join(


### PR DESCRIPTION
## Summary

`weave.Monitor`'s docstring advertised `op_names=[\"my_op\"]`, but `MonitorsPage.tsx`'s `SafeOpRef` parses each entry as a `weave:///entity/project/op/name:digest` URI and renders Incorrect op ref for bare names.

Added `Monitor._resolve_op_names()` that queries the trace server and rewrites bare names to `OpRef(...).uri`. Pre-qualified URIs and the predeclared `weave.genai.turn` agent-span literal pass through unchanged.

**Placement:** resolution runs in `activate()` / `deactivate()`, not `__init__` - `Monitor.__init__` can run before `weave.init(...)`, so there's no client to query. The docstring example terminates in `my_monitor.activate()`, which is exactly when a valid ref is needed.

Paired with core PR (submodule bump).

## Test plan
- [x] New test: short name resolved to full URI
- [x] New test: full refs and `weave.genai.turn` literal preserved
- [x] `test_monitor.py`: 7 passed