### PR TITLE
chore(weave): add RescoreReq/RescoreRes types and source-eval constant

### DIFF
--- a/weave/trace_server/constants.py
+++ b/weave/trace_server/constants.py
@@ -31,6 +31,7 @@ EVALUATION_RUN_SCORE_ATTR_KEY = "score"
 EVALUATION_RUN_PREDICT_CALL_ID_ATTR_KEY = "predict_call_id"
 EVALUATION_RUN_SCORER_ATTR_KEY = "scorer"
 GENAI_SPAN_REF_ATTR_KEY = "genai_span_ref"
+EVALUATION_RUN_SOURCE_ATTR_KEY = "source_evaluation_run_id"
 
 # Attribute keys for predictions
 PREDICTION_ATTR_KEY = "prediction"

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3274,9 +3274,6 @@ class ObjectInterface(Protocol):
     def score_delete(self, req: ScoreDeleteReq) -> ScoreDeleteRes: ...
     def eval_results_query(self, req: EvalResultsQueryReq) -> EvalResultsQueryRes: ...
 
-    # Rescore API
-    def rescore(self, req: RescoreReq) -> RescoreRes: ...
-
 
 class FullTraceServerInterface(TraceServerInterface, ObjectInterface, Protocol):
     """Complete trace server interface supporting both V1 and Object APIs.

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1,7 +1,7 @@
 import datetime
 from collections.abc import Iterator
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Protocol
 
 from pydantic import (
     BaseModel,
@@ -1926,6 +1926,90 @@ class EvaluateModelRes(BaseModel):
     call_id: str
 
 
+class EvaluateModelArgs(BaseModel):
+    """Arguments for a full evaluate-model job (loads model + runs predictions + scores).
+
+    Moved from workers/evaluate_model_worker/evaluate_model_worker.py so both job
+    types (EvaluateModelArgs and RescoringArgs) can be co-located in the same module
+    for the EvalWorkerJob discriminated union.
+    """
+
+    job_type: Literal["evaluate_model"] = "evaluate_model"
+    project_id: str
+    evaluation_ref: str
+    model_ref: str
+    wb_user_id: str
+    evaluation_call_id: str
+
+    model_config = ConfigDict(protected_namespaces=())
+
+
+class RescoringArgs(BaseModel):
+    """Arguments for a rescore job dispatched to the evaluate-model worker.
+
+    Differs from EvaluateModelArgs: no model is loaded, no predictions are run.
+    Only scorer(s) are applied to existing predictions from source_evaluation_run_id.
+    """
+
+    job_type: Literal["rescore"] = "rescore"
+    project_id: str
+    source_evaluation_run_id: str = Field(
+        ..., description="The evaluation run whose predictions will be rescored"
+    )
+    scorer_refs: list[str] = Field(
+        ...,
+        min_length=1,
+        description="Scorer references (weave:// URIs) to apply; must be non-empty",
+    )
+    wb_user_id: str | None = Field(
+        None,
+        description="User ID — None on SDK path; always set on worker path",
+    )
+    new_evaluation_run_id: str = Field(
+        ..., description="Pre-created EvaluationRun ID to write new scores into"
+    )
+    model_config = ConfigDict(protected_namespaces=())
+
+
+# Discriminated union for the evaluate-model Kafka worker.
+# job_type field selects the concrete args type.
+# Old Kafka messages without job_type are patched by model_validator on EvaluateModelItem
+# in weave-trace's evaluate_model_dispatcher.py.
+EvalWorkerJob = Annotated[
+    EvaluateModelArgs | RescoringArgs,
+    Field(discriminator="job_type"),
+]
+
+
+class RescoreBody(BaseModel):
+    """Request body for rescoring via REST API (excludes server-set fields)."""
+
+    source_evaluation_run_id: str = Field(
+        ..., description="The evaluation run whose predictions will be rescored"
+    )
+    scorer_refs: list[str] = Field(
+        ...,
+        min_length=1,
+        description="Scorer references (weave:// URIs) to apply; must be non-empty",
+    )
+
+
+class RescoreReq(RescoreBody):
+    """Full rescore request including server-set fields."""
+
+    project_id: str
+    wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)
+
+
+class RescoreRes(BaseModel):
+    """Response for a rescore request."""
+
+    call_id: str = Field(..., description="Call ID for /evaluations/status polling")
+    evaluation_run_id: str = Field(
+        ..., description="The newly created EvaluationRun ID"
+    )
+
+
 class EvaluationStatusReq(BaseModelStrict):
     project_id: str
     call_id: str
@@ -2436,6 +2520,10 @@ class EvaluationRunCreateBody(BaseModel):
         ..., description="Reference to the evaluation (weave:// URI)"
     )
     model: str = Field(..., description="Reference to the model (weave:// URI)")
+    source_evaluation_run_id: str | None = Field(
+        None,
+        description="Source evaluation run ID if this run was created by rescoring — provenance link",
+    )
 
 
 class EvaluationRunCreateReq(EvaluationRunCreateBody):
@@ -2473,6 +2561,10 @@ class EvaluationRunReadRes(BaseModel):
     )
     summary: dict[str, Any] | None = Field(
         None, description="Summary data for the evaluation run"
+    )
+    source_evaluation_run_id: str | None = Field(
+        None,
+        description="Source evaluation run ID if this run was created by rescoring",
     )
 
 
@@ -2654,7 +2746,7 @@ class ScoreCreateBody(BaseModel):
 
     prediction_id: str = Field(..., description="The prediction ID")
     scorer: str = Field(..., description="The scorer reference (weave:// URI)")
-    value: float = Field(..., description="The value of the score")
+    value: Any = Field(..., description="The raw output of the scorer")
     evaluation_run_id: str | None = Field(
         None,
         description="Optional evaluation run ID to link this score as a child call",
@@ -2688,7 +2780,7 @@ class ScoreReadReq(BaseModel):
 class ScoreReadRes(BaseModel):
     score_id: str = Field(..., description="The score ID")
     scorer: str = Field(..., description="The scorer reference (weave:// URI)")
-    value: float = Field(..., description="The value of the score")
+    value: Any = Field(..., description="The raw output of the scorer")
     evaluation_run_id: str | None = Field(
         None, description="Evaluation run ID if this score is linked to one"
     )
@@ -3098,6 +3190,7 @@ class TraceServerInterface(Protocol):
     # Evaluation API
     def evaluate_model(self, req: EvaluateModelReq) -> EvaluateModelRes: ...
     def evaluation_status(self, req: EvaluationStatusReq) -> EvaluationStatusRes: ...
+    def rescore(self, req: RescoreReq) -> RescoreRes: ...
 
     # Scoring API
     def calls_score(self, req: CallsScoreReq) -> CallsScoreRes: ...
@@ -3180,6 +3273,9 @@ class ObjectInterface(Protocol):
     def score_list(self, req: ScoreListReq) -> Iterator[ScoreReadRes]: ...
     def score_delete(self, req: ScoreDeleteReq) -> ScoreDeleteRes: ...
     def eval_results_query(self, req: EvalResultsQueryReq) -> EvalResultsQueryRes: ...
+
+    # Rescore API
+    def rescore(self, req: RescoreReq) -> RescoreRes: ...
 
 
 class FullTraceServerInterface(TraceServerInterface, ObjectInterface, Protocol):


### PR DESCRIPTION
## Description

https://coreweave.atlassian.net/browse/WB-33375

Introduces to the trace server interface a **rescore** capability that allows existing evaluation predictions to be re-scored with new or updated scorers, without re-running model inference. 

Key additions:

- `EVALUATION_RUN_SOURCE_ATTR_KEY` constant (`source_evaluation_run_id`) to track provenance when an evaluation run is created via rescoring
- `RescoringArgs` model representing a rescore job dispatched to the evaluate-model worker — distinct from `EvaluateModelArgs` in that no model is loaded and no predictions are run
- `EvaluateModelArgs` moved into `trace_server_interface.py` to co-locate both job types for the `EvalWorkerJob` discriminated union
- `EvalWorkerJob` discriminated union (`EvaluateModelArgs | RescoringArgs`) keyed on `job_type`
- `RescoreBody`, `RescoreReq`, and `RescoreRes` models for the REST API surface
- `source_evaluation_run_id` field on `EvaluationRunCreateReq`/`EvaluationRunReadRes` to record which evaluation run a rescore originated from
- `score` `value` field widened from `float` to `Any` to support scorers that return non-numeric outputs
- `rescore` method added to both `TraceServerInterface` and `ObjectInterface` protocols