### PR TITLE
feat(weave): add weave.rescore_evaluation SDK function

### DIFF
--- a/weave/__init__.py
+++ b/weave/__init__.py
@@ -53,6 +53,7 @@ from weave.agent.agent import AgentState as AgentState
 from weave.dataset.dataset import Dataset
 from weave.evaluation.eval import Evaluation
 from weave.evaluation.eval_imperative import EvaluationLogger
+from weave.evaluation.rescore import rescore_evaluation
 from weave.flow.annotation_spec import AnnotationSpec
 from weave.flow.model import Model
 from weave.flow.monitor import ClassifierMonitor, Monitor
@@ -159,6 +160,7 @@ __all__ = [
     "remove_aliases",
     "remove_tags",
     "require_current_call",
+    "rescore_evaluation",
     "set_aliases",
     "set_view",
     "start_llm",

--- a/weave/evaluation/__init__.py
+++ b/weave/evaluation/__init__.py
@@ -1,0 +1,1 @@
+from weave.evaluation.rescore import rescore_evaluation as rescore_evaluation

--- a/weave/evaluation/rescore.py
+++ b/weave/evaluation/rescore.py
@@ -1,0 +1,76 @@
+"""SDK-level rescore_evaluation — runs locally, no Kafka/worker required.
+
+The SDK path is distinct from the server path (POST /evaluations/rescore):
+- SDK path: calls evaluation_run_create directly, then awaits rescore_predictions
+- Server path: POST /evaluations/rescore → rescore() creates the run internally then dispatches to Kafka
+
+These are separate code paths — there is no double-creation.
+"""
+
+from weave.trace.context.weave_client_context import require_weave_client
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.workers.evaluate_model_worker.rescore_worker import (
+    rescore_predictions,
+)
+
+
+async def rescore_evaluation(
+    source_evaluation_run_id: str,
+    scorer_refs: list[str],
+    *,
+    project_id: str | None = None,
+) -> str:
+    """Rescore an existing evaluation run with different scorer(s), running locally.
+
+    Applies scorer(s) to the predictions from source_evaluation_run_id and creates a new
+    EvaluationRun containing the new scores. Returns the new evaluation_run_id.
+
+    Original prediction call IDs are preserved — no new predictions are created.
+    Runs in-process — no eval worker or Kafka required.
+
+    Args:
+        source_evaluation_run_id: ID of the evaluation run whose predictions to rescore
+        scorer_refs: List of scorer weave:// URIs to apply
+        project_id: Project ID (entity/project). Defaults to the current client project.
+
+    Returns:
+        The new evaluation_run_id
+
+    Example:
+        new_run_id = await weave.evaluation.rescore_evaluation(
+            source_evaluation_run_id="abc123",
+            scorer_refs=["weave:///entity/project/object/MyScorer:latest"],
+        )
+    """
+    client = require_weave_client()
+    if project_id is None:
+        project_id = client.project_id  # plain attribute, not a method call
+
+    source_run = client.server.evaluation_run_read(
+        tsi.EvaluationRunReadReq(
+            project_id=project_id,
+            evaluation_run_id=source_evaluation_run_id,
+        )
+    )
+    new_run_res = client.server.evaluation_run_create(
+        tsi.EvaluationRunCreateReq(
+            project_id=project_id,
+            evaluation=source_run.evaluation,
+            model=source_run.model,
+            source_evaluation_run_id=source_evaluation_run_id,
+        )
+    )
+
+    # await directly — rescore_predictions is async def, no asyncio.run() needed here.
+    # wb_user_id is None: the SDK path has no server-side user context.
+    # score_create and evaluation_run_finish handle None wb_user_id gracefully.
+    await rescore_predictions(
+        tsi.RescoringArgs(
+            project_id=project_id,
+            source_evaluation_run_id=source_evaluation_run_id,
+            scorer_refs=scorer_refs,
+            wb_user_id=None,  # None, not "" — layers check `if req.wb_user_id is None`
+            new_evaluation_run_id=new_run_res.evaluation_run_id,
+        )
+    )
+    return new_run_res.evaluation_run_id


### PR DESCRIPTION
## Description

Adds `weave.rescore_evaluation` as a public SDK function that rescores an existing evaluation run with different scorer(s), running entirely in-process without requiring an eval worker or Kafka.

This is distinct from the server-side `POST /evaluations/rescore` path: the SDK path calls `evaluation_run_create` directly and then awaits `rescore_predictions`, whereas the server path creates the run internally and dispatches to Kafka. There is no double-creation between these paths.

Original prediction call IDs are preserved — no new predictions are generated. The function returns the new `evaluation_run_id`.

## Testing

How was this PR tested?