### PR TITLE
refactor(weave): introduce _RescoreSource dataclass for rescore worker

### DIFF
--- a/tests/trace_server/workers/test_rescore_imperative.py
+++ b/tests/trace_server/workers/test_rescore_imperative.py
@@ -1,0 +1,48 @@
+"""Tests for the rescore worker's imperative branch.
+
+The killer test (where ``prediction_id != parent_call_id`` and scores must
+attach to ``parent_call_id``) lives in this file once the imperative branch
+is wired up. For now it covers the ``_RescoreSource`` dataclass shape, which
+is the contract both branches share.
+"""
+
+from __future__ import annotations
+
+from weave.trace_server.workers.evaluate_model_worker._rescore_source import (
+    _RescoreSource,
+)
+
+
+def test_rescore_source_shape() -> None:
+    src = _RescoreSource(
+        prediction_id="p-1",
+        parent_call_id="pas-1",
+        inputs={"q": "x"},
+        output={"y": "z"},
+    )
+    assert src.prediction_id == "p-1"
+    assert src.parent_call_id == "pas-1"
+    assert src.inputs == {"q": "x"}
+    assert src.output == {"y": "z"}
+
+
+def test_rescore_source_supports_unequal_ids() -> None:
+    """Standard branch: ``prediction_id`` and ``parent_call_id`` are different calls."""
+    src = _RescoreSource(
+        prediction_id="prediction-call",
+        parent_call_id="predict-and-score-call",
+        inputs={},
+        output=None,
+    )
+    assert src.prediction_id != src.parent_call_id
+
+
+def test_rescore_source_supports_equal_ids() -> None:
+    """Imperative branch: ``prediction_id == parent_call_id`` (the predict_and_score call)."""
+    src = _RescoreSource(
+        prediction_id="pas-1",
+        parent_call_id="pas-1",
+        inputs={"example": {"q": "x"}},
+        output={"output": "y"},
+    )
+    assert src.prediction_id == src.parent_call_id

--- a/tests/trace_server/workers/test_rescore_worker.py
+++ b/tests/trace_server/workers/test_rescore_worker.py
@@ -15,6 +15,8 @@ import pytest
 from pydantic import ValidationError
 
 from weave.trace_server.trace_server_interface import (
+    CallReadRes,
+    CallSchema,
     EvaluateModelArgs,
     EvalWorkerJob,
     PredictionReadRes,
@@ -113,6 +115,29 @@ def _make_prediction(prediction_id: str, inputs: dict, output) -> PredictionRead
     )
 
 
+def _fake_call_read_res(prediction_id: str, parent_id: str = "pas-1") -> CallReadRes:
+    """Minimal CallReadRes for the rescore worker's parent-id lookup.
+
+    The standard-path generator reads each prediction's call to find its parent
+    (the predict_and_score call); these tests don't exercise the trace server,
+    so we return a hand-built CallSchema with a synthetic parent_id.
+    """
+    import datetime
+
+    return CallReadRes(
+        call=CallSchema(
+            id=prediction_id,
+            project_id="e/p",
+            op_name="weave:///e/p/op/prediction:1",
+            trace_id="trace-1",
+            parent_id=parent_id,
+            started_at=datetime.datetime(2026, 5, 6, 0, 0, 0),
+            attributes={},
+            inputs={},
+        )
+    )
+
+
 def _make_fake_scorer(name: str, return_value):
     """Build a minimal fake Scorer-like object that passes isinstance check."""
     from weave.flow.scorer import Scorer
@@ -144,6 +169,7 @@ async def test_rescore_predictions_score_create_called_per_prediction_per_scorer
 
     mock_server = MagicMock()
     mock_server.prediction_list.return_value = iter(predictions)
+    mock_server.call_read.side_effect = lambda req: _fake_call_read_res(req.id)
     mock_server.score_create = MagicMock()
     mock_server.evaluation_run_finish = MagicMock()
     mock_server.obj_read = MagicMock()  # for _assert_safe_ref
@@ -209,6 +235,7 @@ async def test_rescore_predictions_summary_keyed_by_scorer_name_not_ref():
 
     mock_server = MagicMock()
     mock_server.prediction_list.return_value = iter([prediction])
+    mock_server.call_read.side_effect = lambda req: _fake_call_read_res(req.id)
     mock_server.score_create = MagicMock()
     captured_finish_calls = []
 
@@ -341,6 +368,7 @@ async def test_rescore_predictions_pagination_exhausts_all_pages():
 
     mock_server = MagicMock()
     mock_server.prediction_list.side_effect = fake_prediction_list
+    mock_server.call_read.side_effect = lambda req: _fake_call_read_res(req.id)
     mock_server.score_create = MagicMock()
     mock_server.evaluation_run_finish = MagicMock()
 

--- a/weave/trace_server/workers/evaluate_model_worker/_rescore_source.py
+++ b/weave/trace_server/workers/evaluate_model_worker/_rescore_source.py
@@ -1,0 +1,43 @@
+"""Internal dataclass for the rescore worker — uniform shape across both
+standard and imperative source-eval branches.
+
+The downstream loop (apply_scorer + score_create) consumes ``_RescoreSource``;
+it does NOT consume ``PredictionReadRes`` directly. This keeps the contract
+between the per-branch fetcher and the loop minimal and explicit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class _RescoreSource:
+    """One source-eval row to be rescored.
+
+    Field semantics across branches:
+
+    Standard branch (Evaluation.evaluate):
+        prediction_id   = prediction call id (the call with op_name "prediction")
+        parent_call_id  = prediction.parent_id = predict_and_score.call_id
+        inputs          = prediction.inputs["inputs"]
+        output          = prediction.output
+
+    Imperative branch (weave.EvaluationLogger):
+        prediction_id   = predict_and_score.call_id (no separate prediction)
+        parent_call_id  = predict_and_score.call_id (same — score attaches here)
+        inputs          = predict_and_score.inputs["example"]
+        output          = predict_and_score.output["output"] if dict else output
+
+    The rescore loop must use ``parent_call_id`` for score attachment via
+    ``ScoreCreateReq.parent_id`` (the explicit override added in Task 1.2).
+    Never re-derive parenting from ``prediction_id`` — that's the silent
+    failure mode where standard passes CI because the values happen to align
+    there but imperative misroutes scores.
+    """
+
+    prediction_id: str
+    parent_call_id: str
+    inputs: dict[str, Any]
+    output: Any

--- a/weave/trace_server/workers/evaluate_model_worker/rescore_worker.py
+++ b/weave/trace_server/workers/evaluate_model_worker/rescore_worker.py
@@ -10,6 +10,7 @@ Entry points:
 
 import asyncio
 import logging
+from collections.abc import Iterator
 from typing import Any, cast
 
 import ddtrace
@@ -23,6 +24,9 @@ from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.trace_server_interface import RescoringArgs
 from weave.trace_server.validation import assert_safe_payload
+from weave.trace_server.workers.evaluate_model_worker._rescore_source import (
+    _RescoreSource,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -71,63 +75,48 @@ async def rescore_predictions(args: RescoringArgs) -> None:
 
     try:
         with weave.attributes(RESCORE_WORKER_MARKER):
-            offset = 0
-            while True:
-                page = list(
-                    client.server.prediction_list(
-                        tsi.PredictionListReq(
-                            project_id=args.project_id,
-                            evaluation_run_id=args.source_evaluation_run_id,
-                            limit=PREDICTION_PAGE_SIZE,
-                            offset=offset,
-                        )
-                    )
+            for source in _yield_standard_sources(client, args):
+                # apply_scorer_async handles column_map, op tracing, kwargs — do not
+                # call scorer.score() directly. signature: (scorer, example, model_output)
+                # return_exceptions=True so one scorer failure doesn't abort the whole batch.
+                results = await asyncio.gather(
+                    *[
+                        apply_scorer_async(scorer, source.inputs, source.output)
+                        for scorer in scorers
+                    ],
+                    return_exceptions=True,
                 )
-                if not page:
-                    break
 
-                for prediction in page:
-                    # apply_scorer_async handles column_map, op tracing, kwargs — do not
-                    # call scorer.score() directly. signature: (scorer, example, model_output)
-                    # return_exceptions=True so one scorer failure doesn't abort the whole batch.
-                    results = await asyncio.gather(
-                        *[
-                            apply_scorer_async(
-                                scorer, prediction.inputs, prediction.output
-                            )
-                            for scorer in scorers
-                        ],
-                        return_exceptions=True,
-                    )
-
-                    for i, (result, scorer_ref) in enumerate(
-                        zip(results, args.scorer_refs, strict=True)
-                    ):
-                        if isinstance(result, Exception):
-                            logger.warning(
-                                "Scorer %s failed on prediction %s: %s",
-                                scorer_ref,
-                                prediction.prediction_id,
-                                result,
-                            )
-                            failed_score_counts[i] += 1
-                            continue
-                        raw_value = result.result  # raw Any — dict, bool, float, etc.
-                        client.server.score_create(
-                            tsi.ScoreCreateReq(
-                                project_id=args.project_id,
-                                prediction_id=prediction.prediction_id,
-                                scorer=scorer_ref,
-                                value=raw_value,
-                                evaluation_run_id=args.new_evaluation_run_id,
-                                wb_user_id=args.wb_user_id,
-                            )
+                for i, (result, scorer_ref) in enumerate(
+                    zip(results, args.scorer_refs, strict=True)
+                ):
+                    if isinstance(result, Exception):
+                        logger.warning(
+                            "Scorer %s failed on prediction %s: %s",
+                            scorer_ref,
+                            source.prediction_id,
+                            result,
                         )
-                        raw_scores_by_scorer[i].append(raw_value)
-
-                offset += len(page)
-                if len(page) < PREDICTION_PAGE_SIZE:
-                    break
+                        failed_score_counts[i] += 1
+                        continue
+                    raw_value = result.result  # raw Any — dict, bool, float, etc.
+                    client.server.score_create(
+                        tsi.ScoreCreateReq(
+                            project_id=args.project_id,
+                            prediction_id=source.prediction_id,
+                            # Explicit parent override. For standard sources this
+                            # equals what auto-derive would produce (prediction.parent_id =
+                            # predict_and_score.call_id). For imperative sources (Task 1.4)
+                            # there is no separate prediction call, so we MUST pass the
+                            # parent explicitly — never let it be re-derived.
+                            parent_id=source.parent_call_id,
+                            scorer=scorer_ref,
+                            value=raw_value,
+                            evaluation_run_id=args.new_evaluation_run_id,
+                            wb_user_id=args.wb_user_id,
+                        )
+                    )
+                    raw_scores_by_scorer[i].append(raw_value)
 
         # Log per-scorer failure counts so partial failures are visible.
         for i, scorer_attrs in enumerate(scorer_attributes_list):
@@ -179,6 +168,59 @@ async def rescore_predictions(args: RescoringArgs) -> None:
                 args.new_evaluation_run_id,
             )
         raise
+
+
+def _yield_standard_sources(
+    client: WeaveClient, args: RescoringArgs
+) -> Iterator[_RescoreSource]:
+    """Yield ``_RescoreSource`` rows for a standard ``Evaluation.evaluate`` source.
+
+    Uses ``prediction_list``, which filters on the ``prediction`` call attribute
+    (set only by ``prediction_create``). Imperative source evals do not appear
+    in this query — their branch is handled in a separate generator.
+
+    For standard, ``parent_call_id = prediction.parent_id`` (= the
+    ``predict_and_score`` call). Falls back to the source evaluation run id only
+    if the prediction is somehow root-level — same fallback today's auto-derive
+    uses inside ``score_create``.
+    """
+    offset = 0
+    while True:
+        page = list(
+            client.server.prediction_list(
+                tsi.PredictionListReq(
+                    project_id=args.project_id,
+                    evaluation_run_id=args.source_evaluation_run_id,
+                    limit=PREDICTION_PAGE_SIZE,
+                    offset=offset,
+                )
+            )
+        )
+        if not page:
+            break
+
+        for prediction in page:
+            pred_read = client.server.call_read(
+                tsi.CallReadReq(
+                    project_id=args.project_id,
+                    id=prediction.prediction_id,
+                )
+            )
+            parent_call_id = (
+                pred_read.call.parent_id
+                if pred_read.call and pred_read.call.parent_id
+                else args.source_evaluation_run_id
+            )
+            yield _RescoreSource(
+                prediction_id=prediction.prediction_id,
+                parent_call_id=parent_call_id,
+                inputs=prediction.inputs,
+                output=prediction.output,
+            )
+
+        offset += len(page)
+        if len(page) < PREDICTION_PAGE_SIZE:
+            break
 
 
 def _get_valid_scorer(client: WeaveClient, scorer_ref: str) -> Scorer:


### PR DESCRIPTION
## Description

Introduces a `_RescoreSource` dataclass as a shared contract between the standard (`Evaluation.evaluate`) and imperative (`weave.EvaluationLogger`) rescore branches. This ensures scores are always attached to the correct `parent_call_id` rather than being re-derived from `prediction_id`, which silently misroutes scores in the imperative branch where no separate prediction call exists.

Extracts the pagination and prediction-fetching logic from `rescore_predictions` into a dedicated `_yield_standard_sources` generator that explicitly reads each prediction's parent call via `call_read` and populates `_RescoreSource.parent_call_id`. The `score_create` call now passes `parent_id` explicitly from `_RescoreSource.parent_call_id` instead of relying on auto-derivation.

## Testing

Unit tests were added and updated to cover:
- The shape and field semantics of `_RescoreSource` for both standard and imperative branches (equal and unequal `prediction_id`/`parent_call_id`).
- Existing rescore worker tests updated to stub `call_read` via `_fake_call_read_res`, ensuring the standard path continues to pass with the new explicit parent lookup.