### PR TITLE
feat(weave): support imperative source evals in rescore worker

### DIFF
--- a/tests/trace_server/workers/test_rescore_imperative.py
+++ b/tests/trace_server/workers/test_rescore_imperative.py
@@ -1,48 +1,615 @@
-"""Tests for the rescore worker's imperative branch.
+"""Tests for the rescore worker against a real trace server.
 
-The killer test (where ``prediction_id != parent_call_id`` and scores must
-attach to ``parent_call_id``) lives in this file once the imperative branch
-is wired up. For now it covers the ``_RescoreSource`` dataclass shape, which
-is the contract both branches share.
+Asserts the V2 trace-tree invariants: rescoring an existing eval produces a
+new-eval tree shaped like a normal ``Evaluation.evaluate`` run (one
+predict_and_score call per source row, plus one Evaluation.summarize), and
+leaves the source eval's tree untouched.
 """
 
 from __future__ import annotations
 
+import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from weave.trace_server import constants
+from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.workers.evaluate_model_worker._rescore_source import (
     _RescoreSource,
+)
+from weave.trace_server.workers.evaluate_model_worker.rescore_worker import (
+    rescore_predictions_sync,
 )
 
 
 def test_rescore_source_shape() -> None:
     src = _RescoreSource(
-        prediction_id="p-1",
-        parent_call_id="pas-1",
-        inputs={"q": "x"},
+        inputs_for_call={"q": "x"},
+        inputs_for_scorer={"q": "x"},
         output={"y": "z"},
+        model_latency=0.5,
     )
-    assert src.prediction_id == "p-1"
-    assert src.parent_call_id == "pas-1"
-    assert src.inputs == {"q": "x"}
+    assert src.inputs_for_call == {"q": "x"}
+    assert src.inputs_for_scorer == {"q": "x"}
     assert src.output == {"y": "z"}
+    assert src.model_latency == 0.5
 
 
-def test_rescore_source_supports_unequal_ids() -> None:
-    """Standard branch: ``prediction_id`` and ``parent_call_id`` are different calls."""
+def test_rescore_source_preserves_ref_form_for_dataset_backed_eval() -> None:
+    """Dataset-backed evals: inputs_for_call carries the original TableRow
+    ref so the new pas inputs match the source's storage shape, while
+    inputs_for_scorer carries the dereffed dict for actual scoring.
+    """
     src = _RescoreSource(
-        prediction_id="prediction-call",
-        parent_call_id="predict-and-score-call",
-        inputs={},
-        output=None,
+        inputs_for_call="weave-trace-internal:///e/p/table/abc/id/row-0",
+        inputs_for_scorer={"question": "x", "expected": "y"},
+        output="model output",
+        model_latency=1.2,
     )
-    assert src.prediction_id != src.parent_call_id
+    assert isinstance(src.inputs_for_call, str)
+    assert isinstance(src.inputs_for_scorer, dict)
 
 
-def test_rescore_source_supports_equal_ids() -> None:
-    """Imperative branch: ``prediction_id == parent_call_id`` (the predict_and_score call)."""
-    src = _RescoreSource(
-        prediction_id="pas-1",
-        parent_call_id="pas-1",
-        inputs={"example": {"q": "x"}},
-        output={"output": "y"},
+# ---------------------------------------------------------------------------
+# End-to-end against sqlite: the new eval must look like a normal eval, and
+# the source eval's tree must remain untouched.
+# ---------------------------------------------------------------------------
+
+
+def _ts(seconds: int = 0) -> datetime.datetime:
+    base = datetime.datetime(2026, 5, 6, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    return base + datetime.timedelta(seconds=seconds)
+
+
+def _publish_source_eval_object(client, project_id: str) -> str:
+    """Publish a minimal Evaluation-like object so the rescore worker has
+    something real to clone via ``_publish_rescored_evaluation``. Returns
+    its ref URI.
+
+    The shape matches what a published ``Evaluation`` carries on the val:
+    a ``scorers`` list of ref strings, plus other fields the worker
+    preserves verbatim (dataset, trials, etc. — represented here by
+    sentinels we assert on later).
+    """
+    res = client.server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=project_id,
+                object_id="source-eval",
+                val={
+                    "_type": "Evaluation",
+                    "scorers": [f"weave:///{project_id}/object/old-scorer:old"],
+                    "dataset": f"weave:///{project_id}/object/dataset-stub:dd",
+                    "trials": 1,
+                },
+            )
+        )
     )
-    assert src.prediction_id == src.parent_call_id
+    return f"weave:///{project_id}/object/source-eval:{res.digest}"
+
+
+def _build_imperative_source(
+    client, project_id: str, n_rows: int = 2
+) -> tuple[str, list[str], str]:
+    """Build an imperative-shaped source eval directly via call_start.
+
+    Topology:
+        Evaluation.evaluate (attributes._weave_eval_meta.imperative=True)
+          predict_and_score #0
+          predict_and_score #1
+
+    Returns ``(src_run_id, source_pas_ids, source_eval_ref)``. The
+    ``source_eval_ref`` is a real published Evaluation ref so the rescore
+    worker's ``_publish_rescored_evaluation`` helper can read and clone it.
+    """
+    src_id = "imp-eval-1"
+    source_eval_ref = _publish_source_eval_object(client, project_id)
+    client.server.call_start(
+        tsi.CallStartReq(
+            start=tsi.StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=src_id,
+                trace_id=src_id,
+                op_name="weave:///e/p/op/Evaluation.evaluate:1",
+                started_at=_ts(0),
+                attributes={"_weave_eval_meta": {"imperative": True}},
+                inputs={
+                    "self": source_eval_ref,
+                    "model": "weave:///e/p/object/model-stub:def",
+                },
+            )
+        )
+    )
+    pas_ids: list[str] = []
+    for i in range(n_rows):
+        pas_id = f"imp-pas-{i}"
+        pas_ids.append(pas_id)
+        client.server.call_start(
+            tsi.CallStartReq(
+                start=tsi.StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=pas_id,
+                    trace_id=src_id,
+                    parent_id=src_id,
+                    op_name=f"weave-trace-internal:///test_project/op/{constants.EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME}:1",
+                    started_at=_ts(0),
+                    attributes={},
+                    inputs={
+                        "example": {"q": f"q-{i}"},
+                        "self": source_eval_ref,
+                    },
+                )
+            )
+        )
+        client.server.call_end(
+            tsi.CallEndReq(
+                end=tsi.EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=pas_id,
+                    ended_at=_ts(1),
+                    output={
+                        "output": f"answer-{i}",
+                        "scores": {},
+                        # Source pas carries a model_latency that the worker
+                        # mirrors onto a synthetic predict subcall.
+                        "model_latency": 0.5,
+                    },
+                    summary={},
+                )
+            )
+        )
+    client.server.call_end(
+        tsi.CallEndReq(
+            end=tsi.EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=src_id,
+                ended_at=_ts(2),
+                output={"correctness": None},
+                summary={},
+            )
+        )
+    )
+    return src_id, pas_ids, source_eval_ref
+
+
+def test_rescore_creates_new_pas_tree_and_leaves_source_untouched(client) -> None:
+    """V2 invariants:
+    - The source eval's predict_and_score children get NO new children
+      (the rescore must not mutate the source tree).
+    - The worker creates the entire new-eval tree itself: one
+      Evaluation.evaluate root pinned to ``new_evaluation_run_id``, one
+      predict_and_score child per source row, one Evaluation.summarize.
+    - Each new predict_and_score's output carries the per-row scores dict
+      keyed by scorer name.
+
+    The test deliberately does NOT pre-create the new-eval call: that's
+    the V2 contract — the rescore endpoint allocates the id, the worker
+    owns the entire call lifecycle. Pre-creating server-side would
+    re-introduce the orphaned-call_end bug.
+
+    Scorer execution is stubbed so the test focuses on the trace-tree shape
+    produced by the worker against a real sqlite-backed trace server.
+    """
+    project_id = client.project_id
+    src_id, source_pas_ids, source_eval_ref = _build_imperative_source(
+        client, project_id, n_rows=2
+    )
+    scorer_ref = f"weave:///{project_id}/object/scorer:abc123"
+
+    new_run_id = "rescore-new-1"
+    # NB: no call_start for new_run_id. The worker emits it.
+
+    apply_result = MagicMock()
+    apply_result.result = 1.0
+
+    with (
+        patch(
+            "weave.trace_server.workers.evaluate_model_worker.rescore_worker._assert_safe_ref"
+        ),
+        patch(
+            "weave.trace_server.workers.evaluate_model_worker.rescore_worker._get_valid_scorer",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "weave.trace_server.workers.evaluate_model_worker.rescore_worker.get_scorer_attributes",
+            return_value=MagicMock(
+                scorer_name="imp_scorer",
+                summarize_fn=MagicMock(return_value={"mean": 1.0}),
+            ),
+        ),
+        patch(
+            "weave.trace_server.workers.evaluate_model_worker.rescore_worker.apply_scorer_async",
+            new=AsyncMock(return_value=apply_result),
+        ),
+    ):
+        rescore_predictions_sync(
+            tsi.RescoringArgs(
+                project_id=project_id,
+                source_evaluation_run_id=src_id,
+                new_evaluation_run_id=new_run_id,
+                scorer_refs=[scorer_ref],
+                wb_user_id="test-user",
+            )
+        )
+
+    # 1. Source tree untouched: each source predict_and_score has no children.
+    for source_pas_id in source_pas_ids:
+        source_children = list(
+            client.server.calls_query_stream(
+                tsi.CallsQueryReq(
+                    project_id=project_id,
+                    filter=tsi.CallsFilter(parent_ids=[source_pas_id]),
+                )
+            )
+        )
+        assert source_children == [], (
+            f"source predict_and_score {source_pas_id!r} should have no "
+            f"children after rescore; got {[c.id for c in source_children]}"
+        )
+
+    # 2. New eval has one predict_and_score per source row + one summarize.
+    new_eval_children = list(
+        client.server.calls_query_stream(
+            tsi.CallsQueryReq(
+                project_id=project_id,
+                filter=tsi.CallsFilter(parent_ids=[new_run_id]),
+            )
+        )
+    )
+    pas_children = [
+        c
+        for c in new_eval_children
+        if c.op_name
+        and constants.EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME in c.op_name
+    ]
+    summarize_children = [
+        c
+        for c in new_eval_children
+        if c.op_name and constants.EVALUATION_SUMMARIZE_OP_NAME in c.op_name
+    ]
+    assert len(pas_children) == len(source_pas_ids), (
+        f"expected {len(source_pas_ids)} new predict_and_score calls under "
+        f"the new eval, got {len(pas_children)}"
+    )
+    assert len(summarize_children) == 1, (
+        f"expected exactly one Evaluation.summarize call under the new eval, "
+        f"got {len(summarize_children)}"
+    )
+
+    # 3. Each new predict_and_score carries the scorer result in its output.
+    for new_pas in pas_children:
+        assert isinstance(new_pas.output, dict)
+        scores = new_pas.output.get("scores")
+        assert isinstance(scores, dict)
+        assert scores.get("imp_scorer") == 1.0
+
+    # 3a. Each new pas has a synthetic ``predict`` subcall whose duration
+    # mirrors the source row's model_latency. The eval-compare table reads
+    # ``ended_at - started_at`` of this subcall to render per-row Latency;
+    # without it the Latency column shows "N/A" for rescored runs.
+    for new_pas in pas_children:
+        pas_subcalls = list(
+            client.server.calls_query_stream(
+                tsi.CallsQueryReq(
+                    project_id=project_id,
+                    filter=tsi.CallsFilter(parent_ids=[new_pas.id]),
+                )
+            )
+        )
+        predict_subcalls = [
+            c for c in pas_subcalls if c.op_name and "/op/predict:" in c.op_name
+        ]
+        assert len(predict_subcalls) == 1, (
+            f"expected exactly one synthetic predict subcall under new pas "
+            f"{new_pas.id!r}; got {[c.op_name for c in pas_subcalls]}"
+        )
+        predict_call = predict_subcalls[0]
+        assert predict_call.ended_at is not None
+        duration = (predict_call.ended_at - predict_call.started_at).total_seconds()
+        assert abs(duration - 0.5) < 1e-6, (
+            f"synthetic predict duration {duration} should equal source "
+            f"model_latency 0.5"
+        )
+
+    # 4. The new-eval root call exists, was created by the WORKER (not
+    # pre-created), and ended cleanly with the summary as its output.
+    new_eval_call = client.server.call_read(
+        tsi.CallReadReq(project_id=project_id, id=new_run_id)
+    ).call
+    assert new_eval_call is not None
+    assert new_eval_call.ended_at is not None, (
+        "new-eval call must be ended; if it's still 'started' the worker "
+        "didn't pair its call_start with call_end (orphaned-end regression)"
+    )
+    assert isinstance(new_eval_call.output, dict)
+    assert new_eval_call.output.get("imp_scorer") == {"mean": 1.0}
+
+    # The compare-page header reads per-eval Latency from
+    # ``output.model_latency.mean`` on the eval root. Without this
+    # aggregate the Latency cell shows "N/A". Source pas calls in this
+    # test carry model_latency=0.5 each.
+    assert new_eval_call.output.get("model_latency") == {"mean": 0.5}
+
+    # 5. The new eval's display_name matches the eval-{date}-{memorable}
+    # format used by ``default_evaluation_display_name`` in eval.py, so
+    # rescored runs are visually indistinguishable from normal eval runs.
+    import re
+
+    assert new_eval_call.display_name is not None
+    assert re.match(
+        r"^eval-\d{4}-\d{2}-\d{2}-[a-z]+-[a-z]+$", new_eval_call.display_name
+    ), f"unexpected display_name shape: {new_eval_call.display_name!r}"
+
+    # 6. The new eval's ``self`` input points at a NEW Evaluation object
+    # (NEW object_id, not a new version of the source's object_id) whose
+    # scorers field reflects the rescore scorers. The ``-rescored`` suffix
+    # is the deterministic lineage marker — see
+    # ``_publish_rescored_evaluation`` for why we mint a new object_id.
+    assert isinstance(new_eval_call.inputs, dict)
+    new_self_ref = new_eval_call.inputs.get("self")
+    assert isinstance(new_self_ref, str)
+    assert new_self_ref.startswith(
+        f"weave:///{project_id}/object/source-eval-rescored:"
+    )
+    assert new_self_ref != source_eval_ref, (
+        "new eval must reference a NEW Evaluation, not the source's"
+    )
+    # Read the new Evaluation object back and check its scorers list.
+    from weave.trace.refs import ObjectRef, Ref
+
+    new_eval_obj_ref = Ref.parse_uri(new_self_ref)
+    assert isinstance(new_eval_obj_ref, ObjectRef)
+    new_eval_val = client.server.obj_read(
+        tsi.ObjReadReq(
+            project_id=project_id,
+            object_id=new_eval_obj_ref.name,
+            digest=new_eval_obj_ref.digest,
+        )
+    ).obj.val
+    assert isinstance(new_eval_val, dict)
+    assert new_eval_val.get("scorers") == [scorer_ref]
+    # Other fields preserved from the source val.
+    assert new_eval_val.get("dataset") == (
+        f"weave:///{project_id}/object/dataset-stub:dd"
+    )
+    assert new_eval_val.get("trials") == 1
+
+
+# ---------------------------------------------------------------------------
+# Faithful-predict copy when the source has real predict subcalls under pas.
+# ---------------------------------------------------------------------------
+
+
+def _build_source_with_predicts(
+    client, project_id: str, *, model_ref: str, n_rows: int = 2
+) -> tuple[str, list[str], str, list[str]]:
+    """Build a source eval tree where each pas has a real predict subcall.
+
+    Topology:
+        Evaluation.evaluate
+          predict_and_score #0
+            MyModel.predict #0   (output, summary.usage, started_at/ended_at)
+          predict_and_score #1
+            MyModel.predict #1
+
+    Mirrors what a normal ``Evaluation.evaluate(model)`` run produces — the
+    rescore worker should copy each predict's op_name/inputs/output/summary
+    onto a synthetic predict under the new pas.
+    """
+    src_id = "src-with-predicts"
+    source_eval_ref = _publish_source_eval_object(client, project_id)
+    client.server.call_start(
+        tsi.CallStartReq(
+            start=tsi.StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=src_id,
+                trace_id=src_id,
+                op_name=f"weave:///{project_id}/op/Evaluation.evaluate:1",
+                started_at=_ts(0),
+                attributes={},
+                inputs={"self": source_eval_ref, "model": model_ref},
+            )
+        )
+    )
+    pas_ids: list[str] = []
+    predict_ids: list[str] = []
+    for i in range(n_rows):
+        pas_id = f"src-pas-{i}"
+        predict_id = f"src-predict-{i}"
+        pas_ids.append(pas_id)
+        predict_ids.append(predict_id)
+        client.server.call_start(
+            tsi.CallStartReq(
+                start=tsi.StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=pas_id,
+                    trace_id=src_id,
+                    parent_id=src_id,
+                    op_name=f"weave:///{project_id}/op/{constants.EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME}:1",
+                    started_at=_ts(0),
+                    attributes={},
+                    inputs={
+                        "example": {"input": f"hello-{i}"},
+                        "self": source_eval_ref,
+                    },
+                )
+            )
+        )
+        # Real predict subcall — this is what the worker should faithfully
+        # copy onto the new eval's synthetic predict.
+        client.server.call_start(
+            tsi.CallStartReq(
+                start=tsi.StartedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=predict_id,
+                    trace_id=src_id,
+                    parent_id=pas_id,
+                    op_name=f"weave:///{project_id}/op/MyModel.predict:1",
+                    started_at=_ts(0),
+                    attributes={},
+                    inputs={"self": model_ref, "input": f"hello-{i}"},
+                )
+            )
+        )
+        client.server.call_end(
+            tsi.CallEndReq(
+                end=tsi.EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=predict_id,
+                    ended_at=_ts(seconds=2),  # 2s duration
+                    output=f"HELLO-{i}",
+                    summary={"usage": {"gpt-5": {"total_tokens": 42}}},
+                )
+            )
+        )
+        client.server.call_end(
+            tsi.CallEndReq(
+                end=tsi.EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=pas_id,
+                    ended_at=_ts(seconds=3),
+                    output={
+                        "output": f"HELLO-{i}",
+                        "scores": {},
+                        "model_latency": 2.0,
+                    },
+                    summary={},
+                )
+            )
+        )
+    client.server.call_end(
+        tsi.CallEndReq(
+            end=tsi.EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=src_id,
+                ended_at=_ts(seconds=4),
+                output={"correctness": None},
+                summary={},
+            )
+        )
+    )
+    return src_id, pas_ids, source_eval_ref, predict_ids
+
+
+def test_rescore_faithfully_copies_source_predict_calls(client) -> None:
+    """When the source row has a real predict subcall, the worker emits a
+    synthetic predict under the new pas that is a faithful content-copy:
+    same op_name, inputs, output, summary, and duration. This makes the
+    rescored run visually and structurally indistinguishable from a normal
+    ``Evaluation.evaluate(model)`` run in the eval-compare UI — Total
+    Tokens reads from ``summary.usage``, the model panel shows real
+    kwargs, and Latency matches the source.
+    """
+    project_id = client.project_id
+    model_ref = f"weave:///{project_id}/object/model-stub:def"
+    src_id, source_pas_ids, _source_eval_ref, source_predict_ids = (
+        _build_source_with_predicts(client, project_id, model_ref=model_ref, n_rows=2)
+    )
+    scorer_ref = f"weave:///{project_id}/object/scorer:abc123"
+
+    new_run_id = "rescore-faithful-1"
+    apply_result = MagicMock()
+    apply_result.result = 1.0
+
+    with (
+        patch(
+            "weave.trace_server.workers.evaluate_model_worker.rescore_worker._assert_safe_ref"
+        ),
+        patch(
+            "weave.trace_server.workers.evaluate_model_worker.rescore_worker._get_valid_scorer",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "weave.trace_server.workers.evaluate_model_worker.rescore_worker.get_scorer_attributes",
+            return_value=MagicMock(
+                scorer_name="new_scorer",
+                summarize_fn=MagicMock(return_value={"mean": 1.0}),
+            ),
+        ),
+        patch(
+            "weave.trace_server.workers.evaluate_model_worker.rescore_worker.apply_scorer_async",
+            new=AsyncMock(return_value=apply_result),
+        ),
+    ):
+        rescore_predictions_sync(
+            tsi.RescoringArgs(
+                project_id=project_id,
+                source_evaluation_run_id=src_id,
+                new_evaluation_run_id=new_run_id,
+                scorer_refs=[scorer_ref],
+                wb_user_id="test-user",
+            )
+        )
+
+    # Source predict subcalls must still be parented to source pas — the
+    # rescore did NOT reparent them onto the new tree (faithful copy means
+    # new records, not aliasing).
+    for source_pas_id, source_predict_id in zip(
+        source_pas_ids, source_predict_ids, strict=True
+    ):
+        source_children = list(
+            client.server.calls_query_stream(
+                tsi.CallsQueryReq(
+                    project_id=project_id,
+                    filter=tsi.CallsFilter(parent_ids=[source_pas_id]),
+                )
+            )
+        )
+        ids = {c.id for c in source_children}
+        assert source_predict_id in ids, (
+            f"source predict {source_predict_id!r} disappeared from source "
+            f"pas {source_pas_id!r}; rescore must not reparent source calls"
+        )
+
+    # Each new pas has exactly one synthetic predict whose op_name, inputs,
+    # output, summary, and duration mirror the source predict.
+    new_pas_calls = list(
+        client.server.calls_query_stream(
+            tsi.CallsQueryReq(
+                project_id=project_id,
+                filter=tsi.CallsFilter(parent_ids=[new_run_id]),
+            )
+        )
+    )
+    new_pas_ids = [
+        c.id
+        for c in new_pas_calls
+        if c.op_name
+        and constants.EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME in c.op_name
+    ]
+    assert len(new_pas_ids) == 2
+
+    new_pas_subcalls = list(
+        client.server.calls_query_stream(
+            tsi.CallsQueryReq(
+                project_id=project_id,
+                filter=tsi.CallsFilter(parent_ids=new_pas_ids),
+            )
+        )
+    )
+    synth_predicts = [
+        c for c in new_pas_subcalls if c.op_name and "MyModel.predict" in c.op_name
+    ]
+    assert len(synth_predicts) == 2, (
+        f"expected one synthetic predict per new pas with the source "
+        f"op_name; got {[c.op_name for c in new_pas_subcalls]}"
+    )
+    for sp in synth_predicts:
+        # Artifact name matches source predict (so the chip in the UI
+        # reads ``MyModel.predict``, not the generic ``predict``
+        # fallback). The op digest differs from the source's — the
+        # synthetic predict is a new call emission with an anonymous-op
+        # placeholder source.
+        assert "/op/MyModel.predict:" in sp.op_name
+        # Inputs copied verbatim: real kwargs, not bundled under ``example``.
+        assert isinstance(sp.inputs, dict)
+        assert sp.inputs.get("self") == model_ref
+        assert sp.inputs.get("input", "").startswith("hello-")
+        # Output copied verbatim — what the model produced on the source row.
+        assert sp.output == f"HELLO-{sp.inputs['input'].split('-')[1]}"
+        # Summary copied — Total Tokens column reads ``summary.usage``.
+        assert isinstance(sp.summary, dict)
+        usage = sp.summary.get("usage", {})
+        assert usage.get("gpt-5", {}).get("total_tokens") == 42
+        # Duration preserved (source predict was 2s).
+        duration = (sp.ended_at - sp.started_at).total_seconds()
+        assert abs(duration - 2.0) < 1e-6, f"got duration {duration}"

--- a/tests/trace_server/workers/test_rescore_worker.py
+++ b/tests/trace_server/workers/test_rescore_worker.py
@@ -1,9 +1,12 @@
 """Unit tests for rescore_worker.py and the EvalWorkerJob discriminated union.
 
 Covers:
-- EvalWorkerJob discriminated union parsing (evaluate_model and rescore job types)
+- EvalWorkerJob discriminated union parsing (evaluate_model and rescore job
+  types)
 - scorer_refs min_length=1 validation
-- rescore_predictions pagination: score_create called once per prediction x scorer
+- rescore_predictions creates one new predict_and_score per source row plus
+  one Evaluation.summarize call, and parents scorer calls under the new pas
+  via the call-stack push from create_call(use_stack=True)
 - Summary keyed by scorer_name (not scorer ref URI)
 - evaluation_run_finish called even on unexpected exception
 """
@@ -14,12 +17,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
+from weave.trace_server import constants
 from weave.trace_server.trace_server_interface import (
     CallReadRes,
     CallSchema,
     EvaluateModelArgs,
     EvalWorkerJob,
-    PredictionReadRes,
     RescoringArgs,
 )
 
@@ -101,62 +104,105 @@ class TestEvalWorkerJobDiscriminator:
 
 
 # ---------------------------------------------------------------------------
-# rescore_predictions pagination and score_create call count
+# rescore_predictions trace-tree shape and pagination
 # ---------------------------------------------------------------------------
 
 
-def _make_prediction(prediction_id: str, inputs: dict, output) -> PredictionReadRes:
-    return PredictionReadRes(
-        prediction_id=prediction_id,
-        model="model://test",
-        inputs=inputs,
-        output=output,
-        evaluation_run_id="src-run",
+def _make_pas_call(pas_id: str, inputs: dict, output) -> CallSchema:
+    """Build a minimal predict_and_score CallSchema as it would appear in
+    the source eval's trace. The worker traverses children of the source
+    eval call and matches op_name against
+    EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME (scheme-agnostic), so the
+    op_name URI just needs the right tail name.
+    """
+    import datetime
+
+    return CallSchema(
+        id=pas_id,
+        project_id="e/p",
+        op_name=f"weave:///e/p/op/{constants.EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME}:1",
+        trace_id="src-run",
+        parent_id="src-run",
+        started_at=datetime.datetime(2026, 5, 6, 0, 0, 0),
+        attributes={},
+        inputs={
+            "example": inputs,
+            "self": "weave:///e/p/object/eval-stub:abc",
+            "model": "weave:///e/p/object/model-stub:def",
+        },
+        output={"output": output, "scores": {}, "model_latency": 0.1},
     )
 
 
-def _fake_call_read_res(prediction_id: str, parent_id: str = "pas-1") -> CallReadRes:
-    """Minimal CallReadRes for the rescore worker's parent-id lookup.
+def _install_publish_eval_mocks(mock_server: MagicMock) -> None:
+    """Wire up ``obj_read``/``obj_create`` so the worker's
+    ``_publish_rescored_evaluation`` step succeeds end-to-end. Without
+    these, the worker raises (fail-loudly behavior) and the test fails
+    before reaching the trace-tree assertions.
+    """
+    import datetime as _dt
 
-    The standard-path generator reads each prediction's call to find its parent
-    (the predict_and_score call); these tests don't exercise the trace server,
-    so we return a hand-built CallSchema with a synthetic parent_id.
+    from weave.trace_server.trace_server_interface import ObjReadRes, ObjSchema
+
+    mock_server.obj_read.return_value = ObjReadRes(
+        obj=ObjSchema(
+            project_id="e/p",
+            object_id="eval-stub",
+            created_at=_dt.datetime(2026, 5, 6, 0, 0, 0),
+            digest="abc",
+            version_index=0,
+            is_latest=1,
+            kind="object",
+            base_object_class=None,
+            val={
+                "_type": "Evaluation",
+                "scorers": ["weave:///e/p/object/old-scorer:old"],
+                "dataset": "weave:///e/p/object/dataset-stub:dd",
+            },
+        )
+    )
+    mock_server.obj_create.return_value = MagicMock(digest="newdigest")
+
+
+def _source_eval_call_read_res() -> CallReadRes:
+    """The worker reads the source eval call once to lift its self/model
+    refs onto the new pas inputs. Tests don't exercise the trace server, so
+    return a hand-built CallSchema with the right shape.
     """
     import datetime
 
     return CallReadRes(
         call=CallSchema(
-            id=prediction_id,
+            id="src-run",
             project_id="e/p",
-            op_name="weave:///e/p/op/prediction:1",
-            trace_id="trace-1",
-            parent_id=parent_id,
+            op_name=f"weave:///e/p/op/{constants.EVALUATION_RUN_OP_NAME}:1",
+            trace_id="src-run",
+            parent_id=None,
             started_at=datetime.datetime(2026, 5, 6, 0, 0, 0),
             attributes={},
-            inputs={},
+            inputs={
+                "self": "weave:///e/p/object/eval-stub:abc",
+                "model": "weave:///e/p/object/model-stub:def",
+            },
         )
     )
 
 
-def _make_fake_scorer(name: str, return_value):
-    """Build a minimal fake Scorer-like object that passes isinstance check."""
-    from weave.flow.scorer import Scorer
-
-    class FakeScorer(Scorer):
-        def score(self, output, **kwargs):
-            return return_value
-
-    scorer = FakeScorer()
-    scorer.name = name
-    return scorer
-
-
 @pytest.mark.asyncio
-async def test_rescore_predictions_score_create_called_per_prediction_per_scorer():
-    """score_create must be called once per (prediction, scorer) pair."""
-    predictions = [
-        _make_prediction("pred-1", {"x": 1}, "out-1"),
-        _make_prediction("pred-2", {"x": 2}, "out-2"),
+async def test_rescore_predictions_creates_eval_pas_and_summarize_tree():
+    """The worker must own the entire new-eval call tree. For N source rows
+    it produces:
+      - one Evaluation.evaluate root (emitted via direct call_start with
+        ``trace_id == id`` so the frontend's trace queries land correctly)
+      - N Evaluation.predict_and_score calls (parented to the new-eval)
+      - one Evaluation.summarize call (parented to the new-eval)
+    Each call gets a matching ``finish_call``. The frontend reads scores
+    from this traced tree; ``score_create`` and ``evaluation_run_finish``
+    are NOT used.
+    """
+    pas_calls = [
+        _make_pas_call("pas-1", {"x": 1}, "out-1"),
+        _make_pas_call("pas-2", {"x": 2}, "out-2"),
     ]
     scorer_ref = "weave:///e/p/object/scorer:abc"
     args = RescoringArgs(
@@ -168,16 +214,37 @@ async def test_rescore_predictions_score_create_called_per_prediction_per_scorer
     )
 
     mock_server = MagicMock()
-    mock_server.prediction_list.return_value = iter(predictions)
-    mock_server.call_read.side_effect = lambda req: _fake_call_read_res(req.id)
-    mock_server.score_create = MagicMock()
-    mock_server.evaluation_run_finish = MagicMock()
-    mock_server.obj_read = MagicMock()  # for _assert_safe_ref
+    # Page 1 returns the source pas calls; subsequent grandchildren-query
+    # for synthetic-predict snapshots returns empty (so we exercise the
+    # fallback path, not the faithful-copy path — the latter is covered
+    # by the sqlite imperative test).
+    mock_server.calls_query_stream.side_effect = lambda req: iter(
+        pas_calls if req.filter.parent_ids == ["src-run"] else []
+    )
+    mock_server.call_read.return_value = _source_eval_call_read_res()
+    _install_publish_eval_mocks(mock_server)
+
+    create_call_invocations: list[tuple[str, dict, dict]] = []
+    finish_call_invocations: list[tuple[object, object]] = []
+
+    def fake_create_call(op, inputs, **kwargs):
+        call = MagicMock()
+        call.id = (
+            kwargs.get("_call_id_override") or f"created-{len(create_call_invocations)}"
+        )
+        call.trace_id = call.id
+        call.summary = None
+        create_call_invocations.append((op, inputs, kwargs))
+        return call
+
+    def fake_finish_call(call, output=None, **kwargs):
+        finish_call_invocations.append((call, output))
 
     mock_client = MagicMock()
     mock_client.server = mock_server
-
-    scorer_instance = MagicMock()
+    mock_client.project_id = "e/p"
+    mock_client.create_call.side_effect = fake_create_call
+    mock_client.finish_call.side_effect = fake_finish_call
 
     class FakeApplyResult:
         result: ClassVar[dict] = {"correct": True}
@@ -192,7 +259,7 @@ async def test_rescore_predictions_score_create_called_per_prediction_per_scorer
         ),
         patch(
             "weave.trace_server.workers.evaluate_model_worker.rescore_worker._get_valid_scorer",
-            return_value=scorer_instance,
+            return_value=MagicMock(),
         ),
         patch(
             "weave.trace_server.workers.evaluate_model_worker.rescore_worker.get_scorer_attributes"
@@ -214,16 +281,69 @@ async def test_rescore_predictions_score_create_called_per_prediction_per_scorer
 
         await rescore_predictions(args)
 
-    # score_create should be called once per prediction (2 predictions, 1 scorer)
-    assert mock_server.score_create.call_count == 2
-    # evaluation_run_finish should be called exactly once
-    assert mock_server.evaluation_run_finish.call_count == 1
+    # All call emission goes through ``client.create_call`` (the eval root
+    # uses ``_call_id_override`` + ``parent=None`` which pins trace_id==id
+    # via the create_call contract; the synthetic predict uses explicit
+    # ``started_at``/``ended_at`` overrides). For N source rows we expect:
+    #   1 eval-root + N pas + N synthetic-predicts + 1 summarize.
+    expected_creates = 1 + len(pas_calls) + len(pas_calls) + 1
+    assert len(create_call_invocations) == expected_creates
+
+    # First create_call is the eval root.
+    eval_root_op, eval_root_inputs, eval_root_kwargs = create_call_invocations[0]
+    assert eval_root_op == constants.EVALUATION_RUN_OP_NAME
+    assert eval_root_kwargs.get("parent") is None
+    assert eval_root_kwargs.get("_call_id_override") == "new-run"
+    assert eval_root_kwargs.get("use_stack") is False
+    weave_attrs = eval_root_kwargs.get("attributes", {}).get(
+        constants.WEAVE_ATTRIBUTES_NAMESPACE, {}
+    )
+    assert weave_attrs.get(constants.EVALUATION_RUN_ATTR_KEY) == "true"
+    assert weave_attrs.get(constants.EVALUATION_RUN_SOURCE_ATTR_KEY) == "src-run"
+    # Worker sets eval-{date}-{memorable} display_name matching the format
+    # of ``default_evaluation_display_name`` (eval.py) so rescored runs are
+    # visually indistinguishable from normal eval runs.
+    import re
+
+    display_name = eval_root_kwargs.get("display_name")
+    assert display_name is not None
+    assert re.match(r"^eval-\d{4}-\d{2}-\d{2}-[a-z]+-[a-z]+$", display_name), (
+        f"unexpected display_name shape: {display_name!r}"
+    )
+
+    # Trailing ops in order: per row -> pas then predict; then summarize.
+    op_names_after_root = [op for op, _, _ in create_call_invocations[1:]]
+    assert op_names_after_root == [
+        constants.EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+        "predict",  # synthetic-predict fallback (no source predict in mocks)
+        constants.EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+        "predict",
+        constants.EVALUATION_SUMMARIZE_OP_NAME,
+    ]
+
+    # finish_call counts: N synthetic predicts + N pas + 1 summarize + 1
+    # eval root. The eval-root finish is the LAST one and carries the
+    # full summary as its output.
+    assert len(finish_call_invocations) == 2 * len(pas_calls) + 2
+    eval_root_finish_output = finish_call_invocations[-1][1]
+    # Per-scorer summary plus a model_latency aggregate the compare-page
+    # header reads (output.model_latency.mean on the eval root). Both
+    # source rows had model_latency=0.1 so the mean is 0.1.
+    assert eval_root_finish_output == {
+        "my_scorer": {"mean": 1.0},
+        "model_latency": {"mean": 0.1},
+    }
+
+    # Worker does NOT call score_create or evaluation_run_finish — scores
+    # live in the traced call tree.
+    mock_server.score_create.assert_not_called()
+    mock_server.evaluation_run_finish.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_rescore_predictions_summary_keyed_by_scorer_name_not_ref():
     """Summary dict must use scorer_attrs.scorer_name as key, not the ref URI."""
-    prediction = _make_prediction("pred-1", {"x": 1}, "out-1")
+    pas_call = _make_pas_call("pas-1", {"x": 1}, "out-1")
     scorer_ref = "weave:///e/p/object/scorer:abc"
     args = RescoringArgs(
         project_id="e/p",
@@ -234,18 +354,29 @@ async def test_rescore_predictions_summary_keyed_by_scorer_name_not_ref():
     )
 
     mock_server = MagicMock()
-    mock_server.prediction_list.return_value = iter([prediction])
-    mock_server.call_read.side_effect = lambda req: _fake_call_read_res(req.id)
-    mock_server.score_create = MagicMock()
-    captured_finish_calls = []
+    mock_server.calls_query_stream.side_effect = lambda req: iter(
+        [pas_call] if req.filter.parent_ids == ["src-run"] else []
+    )
+    mock_server.call_read.return_value = _source_eval_call_read_res()
+    _install_publish_eval_mocks(mock_server)
 
-    def capture_finish(req):
-        captured_finish_calls.append(req)
+    finish_call_invocations: list[tuple[object, object]] = []
 
-    mock_server.evaluation_run_finish = capture_finish
+    def fake_create_call(op, inputs, parent=None, **kwargs):
+        call = MagicMock()
+        call.id = kwargs.get("_call_id_override") or "x"
+        call.trace_id = call.id
+        call.summary = None
+        return call
+
+    def fake_finish_call(call, output=None, **kwargs):
+        finish_call_invocations.append((call, output))
 
     mock_client = MagicMock()
     mock_client.server = mock_server
+    mock_client.project_id = "e/p"
+    mock_client.create_call.side_effect = fake_create_call
+    mock_client.finish_call.side_effect = fake_finish_call
 
     class FakeApplyResult:
         result = 0.9
@@ -282,17 +413,22 @@ async def test_rescore_predictions_summary_keyed_by_scorer_name_not_ref():
 
         await rescore_predictions(args)
 
-    assert len(captured_finish_calls) == 1
-    finish_req = captured_finish_calls[0]
-    # Key must be the human-readable scorer_name, NOT the ref URI
-    assert "human_readable_scorer_name" in finish_req.summary
-    assert scorer_ref not in finish_req.summary
+    # The eval root's finish_call (the LAST one) carries the summary as
+    # its output. Mirrors a normal Evaluation.evaluate op finish where the
+    # eval call's ``output`` IS the summary dict. Key must be the
+    # human-readable scorer_name, NOT the ref URI.
+    eval_root_output = finish_call_invocations[-1][1]
+    assert "human_readable_scorer_name" in eval_root_output
+    assert scorer_ref not in eval_root_output
 
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_rescore_predictions_evaluation_run_finish_called_on_exception():
-    """evaluation_run_finish must be called even when an unexpected error occurs."""
+async def test_rescore_predictions_eval_call_failed_on_exception():
+    """The new-eval call must be failed (via ``client.fail_call``) when an
+    unexpected error occurs, so it never dangles in 'started' state and
+    the UI can render the failure with the original exception.
+    """
     args = RescoringArgs(
         project_id="e/p",
         source_evaluation_run_id="src-run",
@@ -302,12 +438,25 @@ async def test_rescore_predictions_evaluation_run_finish_called_on_exception():
     )
 
     mock_server = MagicMock()
-    # Make prediction_list raise an unexpected error
-    mock_server.prediction_list.side_effect = RuntimeError("db error")
-    mock_server.evaluation_run_finish = MagicMock()
+    # Make calls_query_stream raise an unexpected error
+    mock_server.calls_query_stream.side_effect = RuntimeError("db error")
+    mock_server.call_read.return_value = _source_eval_call_read_res()
+    _install_publish_eval_mocks(mock_server)
+
+    # ``client.create_call`` is now used for the eval root. Return a Call
+    # whose id == ``_call_id_override`` so the fail_call assertions land.
+    def fake_create_call(op, inputs, **kwargs):
+        call = MagicMock()
+        call.id = kwargs.get("_call_id_override") or "x"
+        call.trace_id = call.id
+        call.summary = None
+        return call
 
     mock_client = MagicMock()
     mock_client.server = mock_server
+    mock_client.project_id = "e/p"
+    mock_client.create_call.side_effect = fake_create_call
+    mock_client.fail_call = MagicMock()
 
     with (
         patch(
@@ -337,11 +486,17 @@ async def test_rescore_predictions_evaluation_run_finish_called_on_exception():
         with pytest.raises(RuntimeError, match="db error"):
             await rescore_predictions(args)
 
-    # finish must still have been called (with empty summary)
-    assert mock_server.evaluation_run_finish.call_count == 1
-    finish_call = mock_server.evaluation_run_finish.call_args[0][0]
-    assert finish_call.summary == {}
-    assert finish_call.evaluation_run_id == "new-run"
+    # fail_call must have been called on the eval root with the original
+    # exception so the UI can show why the rescore failed.
+    mock_client.fail_call.assert_called_once()
+    args_pos, kwargs_call = mock_client.fail_call.call_args
+    failed_call = args_pos[0]
+    exc = kwargs_call.get("exception") or (args_pos[1] if len(args_pos) > 1 else None)
+    # Eval root id comes from _call_id_override == new_evaluation_run_id.
+    assert failed_call.id == "new-run"
+    assert failed_call.trace_id == "new-run"
+    assert isinstance(exc, RuntimeError)
+    assert "db error" in str(exc)
 
 
 @pytest.mark.asyncio
@@ -352,28 +507,49 @@ async def test_rescore_predictions_pagination_exhausts_all_pages():
     )
 
     page1 = [
-        _make_prediction(f"pred-{i}", {"x": i}, f"out-{i}")
+        _make_pas_call(f"pas-{i}", {"x": i}, f"out-{i}")
         for i in range(PREDICTION_PAGE_SIZE)
     ]
-    page2 = [_make_prediction("pred-last", {"x": 999}, "out-last")]
+    page2 = [_make_pas_call("pas-last", {"x": 999}, "out-last")]
 
-    call_count = 0
+    pas_query_count = 0
+    grandchild_query_count = 0
 
-    def fake_prediction_list(req):
-        nonlocal call_count
-        call_count += 1
+    def fake_calls_query_stream(req):
+        nonlocal pas_query_count, grandchild_query_count
+        parent_ids = req.filter.parent_ids if req.filter else []
+        # Grandchildren-query: parent_ids are the pas ids, not the source
+        # eval id. Return empty so source_predict stays None and the worker
+        # uses the generic synthetic-predict fallback.
+        if parent_ids != ["src-run"]:
+            grandchild_query_count += 1
+            return iter([])
+        pas_query_count += 1
         if req.offset == 0:
             return iter(page1)
         return iter(page2)
 
     mock_server = MagicMock()
-    mock_server.prediction_list.side_effect = fake_prediction_list
-    mock_server.call_read.side_effect = lambda req: _fake_call_read_res(req.id)
-    mock_server.score_create = MagicMock()
-    mock_server.evaluation_run_finish = MagicMock()
+    mock_server.calls_query_stream.side_effect = fake_calls_query_stream
+    mock_server.call_read.return_value = _source_eval_call_read_res()
+    _install_publish_eval_mocks(mock_server)
+
+    create_call_count = 0
+
+    def fake_create_call(op, inputs, parent=None, **kwargs):
+        nonlocal create_call_count
+        create_call_count += 1
+        m = MagicMock()
+        m.id = kwargs.get("_call_id_override") or f"created-{create_call_count}"
+        m.trace_id = m.id
+        m.summary = None
+        return m
 
     mock_client = MagicMock()
     mock_client.server = mock_server
+    mock_client.project_id = "e/p"
+    mock_client.create_call.side_effect = fake_create_call
+    mock_client.finish_call = MagicMock()
 
     args = RescoringArgs(
         project_id="e/p",
@@ -418,7 +594,14 @@ async def test_rescore_predictions_pagination_exhausts_all_pages():
 
         await rescore_predictions(args)
 
-    # prediction_list was called twice: once for page1, once for page2
-    assert call_count == 2
-    # score_create was called for all PAGE_SIZE + 1 predictions
-    assert mock_server.score_create.call_count == PREDICTION_PAGE_SIZE + 1
+    # calls_query_stream was called twice for pas pages (page1, page2),
+    # plus once per non-empty page for the grandchildren query that picks
+    # out source predict subcalls for the faithful-copy.
+    assert pas_query_count == 2
+    assert grandchild_query_count == 2
+    # create_call is invoked for: 1 eval root + N pas + N synthetic
+    # predicts + 1 trailing Evaluation.summarize. The eval root flows
+    # through create_call via the trace_id==id-when-_call_id_override
+    # contract.
+    n_rows = PREDICTION_PAGE_SIZE + 1
+    assert mock_client.create_call.call_count == 1 + 2 * n_rows + 1

--- a/weave/trace_server/workers/evaluate_model_worker/_rescore_source.py
+++ b/weave/trace_server/workers/evaluate_model_worker/_rescore_source.py
@@ -1,43 +1,54 @@
-"""Internal dataclass for the rescore worker — uniform shape across both
-standard and imperative source-eval branches.
+"""Internal dataclass for the rescore worker — one row of source eval data
+to be rescored under a new evaluation run.
 
-The downstream loop (apply_scorer + score_create) consumes ``_RescoreSource``;
-it does NOT consume ``PredictionReadRes`` directly. This keeps the contract
-between the per-branch fetcher and the loop minimal and explicit.
+Contract (mirrors normal eval predict_and_score per-row data):
+    inputs_for_call  — value to set as ``example`` on the new predict_and_score
+                        call's inputs. Preserves the source's TableRow ref form
+                        when available so the frontend can deref it the same
+                        way it does for the source eval.
+    inputs_for_scorer — already-dereffed dict to pass to ``apply_scorer_async``.
+                        For dataset-backed evals this is the resolved row dict;
+                        for imperative evals it equals inputs_for_call.
+    output            — model output as recorded on the source's
+                        ``predict_and_score.output["output"]``.
+    model_latency     — copied from the source so the new trace shows the
+                        same per-row latency the original run measured.
+    source_predict    — content snapshot of the source row's predict subcall,
+                        used to emit a faithful synthetic predict under the new
+                        pas (same op_name, inputs, output, summary, duration).
+                        ``None`` for imperative sources that emitted no predict.
 """
 
 from __future__ import annotations
 
+import datetime
 from dataclasses import dataclass
 from typing import Any
 
 
-@dataclass
-class _RescoreSource:
-    """One source-eval row to be rescored.
+@dataclass(frozen=True)
+class _SourcePredict:
+    """Content snapshot of one source predict call.
 
-    Field semantics across branches:
-
-    Standard branch (Evaluation.evaluate):
-        prediction_id   = prediction call id (the call with op_name "prediction")
-        parent_call_id  = prediction.parent_id = predict_and_score.call_id
-        inputs          = prediction.inputs["inputs"]
-        output          = prediction.output
-
-    Imperative branch (weave.EvaluationLogger):
-        prediction_id   = predict_and_score.call_id (no separate prediction)
-        parent_call_id  = predict_and_score.call_id (same — score attaches here)
-        inputs          = predict_and_score.inputs["example"]
-        output          = predict_and_score.output["output"] if dict else output
-
-    The rescore loop must use ``parent_call_id`` for score attachment via
-    ``ScoreCreateReq.parent_id`` (the explicit override added in Task 1.2).
-    Never re-derive parenting from ``prediction_id`` — that's the silent
-    failure mode where standard passes CI because the values happen to align
-    there but imperative misroutes scores.
+    Used to emit a faithful synthetic predict under a new predict_and_score:
+    we copy op_name/inputs/output/summary verbatim and preserve the duration
+    (``ended_at - started_at``) while shifting both timestamps into the new
+    eval's wall-clock window. The new call is a fresh record (new id, new
+    trace_id, new parent) — content fidelity, not identity.
     """
 
-    prediction_id: str
-    parent_call_id: str
+    op_name: str
     inputs: dict[str, Any]
     output: Any
+    started_at: datetime.datetime
+    ended_at: datetime.datetime
+    summary: dict[str, Any]
+
+
+@dataclass
+class _RescoreSource:
+    inputs_for_call: Any
+    inputs_for_scorer: dict[str, Any]
+    output: Any
+    model_latency: float
+    source_predict: _SourcePredict | None = None

--- a/weave/trace_server/workers/evaluate_model_worker/rescore_worker.py
+++ b/weave/trace_server/workers/evaluate_model_worker/rescore_worker.py
@@ -1,7 +1,10 @@
-"""rescore_worker.py — applies scorer(s) to existing predictions from an evaluation run.
+"""rescore_worker.py — applies scorer(s) to predictions from a source eval.
 
-Separate from evaluate_model_worker.py: rescoring does not load a model, does not run
-predictions, and is not coupled to LLMStructuredCompletionModel or the Evaluation class.
+Separate from evaluate_model_worker.py: rescoring does not load a model and
+does not run predictions. It produces a new evaluation run whose trace tree
+mirrors a normal ``Evaluation.evaluate`` run — same predict_and_score
+hierarchy, same Evaluation.summarize at the end — but reuses the source
+run's model outputs instead of re-invoking the model.
 
 Entry points:
   rescore_predictions(args)       — async def; called directly by SDK (awaited)
@@ -9,6 +12,7 @@ Entry points:
 """
 
 import asyncio
+import datetime
 import logging
 from collections.abc import Iterator
 from typing import Any, cast
@@ -17,15 +21,19 @@ import ddtrace
 
 import weave
 from weave.flow.scorer import Scorer, apply_scorer_async, get_scorer_attributes
+from weave.flow.util import make_memorable_name
+from weave.trace.call import Call
 from weave.trace.context.weave_client_context import require_weave_client
 from weave.trace.isinstance import weave_isinstance
 from weave.trace.refs import ObjectRef, Ref
 from weave.trace.weave_client import WeaveClient
+from weave.trace_server import constants
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.trace_server_interface import RescoringArgs
 from weave.trace_server.validation import assert_safe_payload
 from weave.trace_server.workers.evaluate_model_worker._rescore_source import (
     _RescoreSource,
+    _SourcePredict,
 )
 
 logger = logging.getLogger(__name__)
@@ -41,156 +49,578 @@ def rescore_predictions_sync(args: RescoringArgs) -> None:
 
 @ddtrace.tracer.wrap(name="rescore_worker.rescore_predictions")
 async def rescore_predictions(args: RescoringArgs) -> None:
-    """Async implementation — called directly from SDK (await) or via rescore_predictions_sync.
+    """Async implementation — called directly from SDK (await) or via
+    rescore_predictions_sync.
 
-    Applies scorer(s) to all predictions from source_evaluation_run_id, stores raw scorer
-    output as Score.value (Any, not flattened to float), then summarizes via
-    get_scorer_attributes(scorer).summarize_fn(rows) — matching eval.py:230-235 exactly.
-    Summary is keyed by scorer_attributes.scorer_name, NOT the scorer ref URI.
+    Produces a new-eval trace tree shaped like a normal ``Evaluation.evaluate``
+    run, fully owned by the worker:
 
-    Note on column_map: apply_scorer_async handles column_map internally via
-    prepare_scorer_op_args. The scorer's column_map is part of the serialized Scorer
-    object and is restored when the scorer is loaded via client.get(ref). This means
-    a scorer that was originally used with a column_map will have its mapping applied
-    correctly on rescore — do not bypass apply_scorer_async or call scorer.score() directly.
+        Evaluation.evaluate                  (new id, trace_id == id, parent_id=None)
+        ├── Evaluation.predict_and_score     (one per source row)
+        │   ├── <Model>.predict              (synthetic; faithful copy of source predict
+        │   │                                 when present, else generic ``predict``)
+        │   └── <Scorer>.score               (one per scorer, traced via
+        │                                    apply_scorer_async)
+        ├── Evaluation.predict_and_score
+        │   └── ...
+        └── Evaluation.summarize
 
-    Note on call parenting (V1): apply_scorer_async creates traced calls. In the original
-    eval flow they are parented to predict_and_score. In the rescore flow, no parent call
-    ID is set — scorer calls will be top-level orphaned calls. This is acceptable for V1.
+    Call ownership invariant: BOTH ``call_start`` and ``call_end`` for the
+    eval root are emitted from this client / this process. The rescore
+    endpoint deliberately does NOT pre-create the row — pre-creating
+    server-side would leave the worker's call_end orphaned in the
+    CallBatchProcessor's pairing buffer (see invariant on
+    ``CallBatchProcessor``).
+
+    Scorer parenting: ``apply_scorer_async``'s op-traced scorer calls
+    naturally land under the current predict_and_score thanks to the
+    call-stack push from ``client.create_call(..., use_stack=True)`` on the
+    new pas. We do NOT call ``score_create`` — normal evals don't either;
+    per-row scores live in ``predict_and_score.output["scores"]`` and
+    aggregate scores are emitted via a per-eval ``Evaluation.summarize``
+    child.
+
+    column_map handling: ``apply_scorer_async`` invokes
+    ``prepare_scorer_op_args``, which honors any ``column_map`` baked into
+    the serialized Scorer object. Do not bypass apply_scorer_async or call
+    ``scorer.score`` directly — that path drops column_map.
     """
     client = require_weave_client()
 
     for ref_uri in args.scorer_refs:
         _assert_safe_ref(client, ref_uri, "scorer_ref")
 
+    # ``args.project_id`` arrives at the worker in INTERNAL form (e.g.
+    # ``ProjectInternalId:42709008``) — the universal int-to-ext ref converter
+    # in run_as_user.py only rewrites strings prefixed with the internal ref
+    # scheme, not raw project_id fields. Every call we make through
+    # ``client.server`` here goes through the externalize adapter on the worker
+    # side, which expects EXTERNAL ``entity/project`` form. Derive the external
+    # form from a scorer ref (which IS converted by the int-to-ext walker).
+    scorer_obj_ref = Ref.parse_uri(args.scorer_refs[0])
+    if not isinstance(scorer_obj_ref, ObjectRef):
+        raise TypeError(
+            f"Expected an object ref for scorer, got: {args.scorer_refs[0]}"
+        )
+    project_id = f"{scorer_obj_ref.entity}/{scorer_obj_ref.project}"
+
     scorers = [_get_valid_scorer(client, ref) for ref in args.scorer_refs]
     scorer_attributes_list = [get_scorer_attributes(s) for s in scorers]
 
-    # raw_scores_by_scorer: indexed by scorer index (not ref URI, not name) to avoid
-    # collisions if two scorers share a name. Summary is keyed by scorer_name at the end.
+    # raw_scores_by_scorer: indexed by scorer index (not ref URI, not name) to
+    # avoid collisions if two scorers share a name. Summary is keyed by
+    # scorer_name at the end.
     raw_scores_by_scorer: list[list[Any]] = [[] for _ in scorers]
-    # failed_score_counts: tracks per-scorer failures so they surface in the summary
-    # and logs — a scorer failing on 50% of predictions is invisible without this.
     failed_score_counts: list[int] = [0 for _ in scorers]
+    # Collected per-row to aggregate onto the eval root's output as
+    # ``model_latency.mean`` — the compare-table header reads latency from
+    # there, not from individual predict subcalls. Mirrors eval.py's
+    # auto_summarize over the model_latency column.
+    row_model_latencies: list[float] = []
+
+    # Read the source eval call once to lift its self/model refs onto the
+    # new-eval's call inputs and per-row predict_and_score calls. Without
+    # this the new run's inputs would be missing the Evaluation/Model
+    # linkage the frontend uses to render the dataset/model header.
+    source_call_res = client.server.call_read(
+        tsi.CallReadReq(project_id=project_id, id=args.source_evaluation_run_id)
+    )
+    source_inputs = (
+        source_call_res.call.inputs
+        if source_call_res.call and isinstance(source_call_res.call.inputs, dict)
+        else {}
+    )
+    source_eval_ref = source_inputs.get("self") or source_inputs.get("this") or ""
+    source_model_ref = source_inputs.get("model") or ""
+
+    # Clone the source Evaluation, swap its ``scorers`` for the new refs,
+    # publish as a new version. Without this the new eval's ``self`` would
+    # point at the source Evaluation object whose ``scorers`` list still
+    # references the OLD scorers — list-view and detail-view surfaces show
+    # the source's scorers on the new run, even though per-row scoring was
+    # done with the new ones. Falls back to the source ref on any failure
+    # (best-effort: the rescore itself still produces correct per-row
+    # scores under predict_and_score).
+    new_eval_ref = _publish_rescored_evaluation(
+        client,
+        project_id=project_id,
+        source_eval_ref=source_eval_ref,
+        new_scorer_refs=list(args.scorer_refs),
+        wb_user_id=args.wb_user_id,
+    )
+
+    # eval-{date}-{memorable} matches ``default_evaluation_display_name``
+    # in eval.py so rescored runs are visually indistinguishable from
+    # normal eval runs in the list view.
+    display_name = (
+        f"eval-{datetime.datetime.now().strftime('%Y-%m-%d')}-{make_memorable_name()}"
+    )
+
+    # Emit the new-eval call's call_start from THIS client. The rescore
+    # endpoint allocated args.new_evaluation_run_id but deliberately did
+    # NOT call_start the row — that's the worker's job (see the
+    # call-ownership invariant on CallBatchProcessor).
+    #
+    # We deliberately bypass ``client.create_call`` here because that
+    # helper generates a fresh random ``trace_id`` for parent=None roots,
+    # which violates the ``trace_id == id`` invariant the frontend expects
+    # for trace roots. evaluation_run_create did ``trace_id=id`` and we
+    # mirror that here. Children below pass ``new_eval_call`` as their
+    # explicit parent, so they inherit ``trace_id=args.new_evaluation_run_id``
+    # — the entire new-eval tree shares one trace_id matching the eval's
+    # id, exactly like a normal Evaluation.evaluate run.
+    new_eval_call = _start_new_eval_root(
+        client,
+        new_evaluation_run_id=args.new_evaluation_run_id,
+        source_evaluation_run_id=args.source_evaluation_run_id,
+        evaluation_ref=new_eval_ref,
+        model_ref=source_model_ref,
+        display_name=display_name,
+    )
 
     try:
         with weave.attributes(RESCORE_WORKER_MARKER):
-            for source in _yield_standard_sources(client, args):
-                # apply_scorer_async handles column_map, op tracing, kwargs — do not
-                # call scorer.score() directly. signature: (scorer, example, model_output)
-                # return_exceptions=True so one scorer failure doesn't abort the whole batch.
+            for source in _yield_predict_and_score_sources(
+                client, args, project_id, source_model_ref=source_model_ref
+            ):
+                new_pas_call = client.create_call(
+                    op=constants.EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+                    inputs={
+                        "self": new_eval_ref,
+                        "model": source_model_ref,
+                        "example": source.inputs_for_call,
+                    },
+                    parent=new_eval_call,
+                    use_stack=True,
+                )
+
+                # Emit a synthetic ``predict`` subcall whose duration mirrors
+                # the source row's model_latency, so the eval compare table
+                # can display a per-row Latency value. Both the imperative
+                # and non-imperative frontend paths derive model_latency
+                # from ``ended_at - started_at`` of a predict child of pas
+                # — without this subcall the Latency column renders "N/A"
+                # for rescored runs.
+                _emit_synthetic_predict_call(
+                    client,
+                    parent_pas_call=new_pas_call,
+                    model_ref=source_model_ref,
+                    example=source.inputs_for_call,
+                    output=source.output,
+                    model_latency_seconds=source.model_latency,
+                    source_predict=source.source_predict,
+                )
+
+                # apply_scorer_async creates op-traced calls; with the new pas
+                # on the call stack (use_stack=True above), each scorer call
+                # parents to it automatically — same shape as a normal eval
+                # where scorers parent to predict_and_score.
+                # return_exceptions=True so one scorer failure doesn't abort
+                # the whole batch.
                 results = await asyncio.gather(
                     *[
-                        apply_scorer_async(scorer, source.inputs, source.output)
+                        apply_scorer_async(
+                            scorer, source.inputs_for_scorer, source.output
+                        )
                         for scorer in scorers
                     ],
                     return_exceptions=True,
                 )
 
+                scores_dict: dict[str, Any] = {}
                 for i, (result, scorer_ref) in enumerate(
                     zip(results, args.scorer_refs, strict=True)
                 ):
+                    scorer_name = scorer_attributes_list[i].scorer_name
                     if isinstance(result, Exception):
                         logger.warning(
-                            "Scorer %s failed on prediction %s: %s",
+                            "Scorer %s failed on row in new pas %s: %s",
                             scorer_ref,
-                            source.prediction_id,
+                            new_pas_call.id,
                             result,
                         )
                         failed_score_counts[i] += 1
+                        scores_dict[scorer_name] = None
                         continue
-                    raw_value = result.result  # raw Any — dict, bool, float, etc.
-                    client.server.score_create(
-                        tsi.ScoreCreateReq(
-                            project_id=args.project_id,
-                            prediction_id=source.prediction_id,
-                            # Explicit parent override. For standard sources this
-                            # equals what auto-derive would produce (prediction.parent_id =
-                            # predict_and_score.call_id). For imperative sources (Task 1.4)
-                            # there is no separate prediction call, so we MUST pass the
-                            # parent explicitly — never let it be re-derived.
-                            parent_id=source.parent_call_id,
-                            scorer=scorer_ref,
-                            value=raw_value,
-                            evaluation_run_id=args.new_evaluation_run_id,
-                            wb_user_id=args.wb_user_id,
-                        )
-                    )
+                    raw_value = result.result
+                    scores_dict[scorer_name] = raw_value
                     raw_scores_by_scorer[i].append(raw_value)
 
-        # Log per-scorer failure counts so partial failures are visible.
+                # Per-row predict_and_score output mirrors what
+                # ``Evaluation.predict_and_score`` returns in eval.py — output
+                # plus the per-scorer score dict plus model_latency. The
+                # frontend reads this shape directly.
+                client.finish_call(
+                    new_pas_call,
+                    output={
+                        "output": source.output,
+                        "scores": scores_dict,
+                        "model_latency": source.model_latency,
+                    },
+                )
+                row_model_latencies.append(source.model_latency)
+
+        # Per-scorer failure logs — a scorer failing on 50% of rows is
+        # invisible without this.
         for i, scorer_attrs in enumerate(scorer_attributes_list):
             if failed_score_counts[i] > 0:
                 logger.warning(
-                    "Scorer %s failed on %d prediction(s) — summary computed on %d/%d results",
+                    "Scorer %s failed on %d row(s) — summary computed on %d/%d results",
                     scorer_attrs.scorer_name,
                     failed_score_counts[i],
                     len(raw_scores_by_scorer[i]),
                     len(raw_scores_by_scorer[i]) + failed_score_counts[i],
                 )
 
-        # Mirrors eval.py:230-235: summarize_fn handles both Scorer subclasses
-        # (scorer.summarize) and Op-based scorers (auto_summarize).
-        # Summary keyed by scorer_attributes.scorer_name — NOT the ref URI.
-        summary: dict[str, Any] = {}
-        for i, scorer_attrs in enumerate(scorer_attributes_list):
-            summary[scorer_attrs.scorer_name] = scorer_attrs.summarize_fn(
-                raw_scores_by_scorer[i]
-            )
-
-        client.server.evaluation_run_finish(
-            tsi.EvaluationRunFinishReq(
-                project_id=args.project_id,
-                evaluation_run_id=args.new_evaluation_run_id,
-                summary=summary,
-                wb_user_id=args.wb_user_id,
-            )
+        # Mirror eval.py: a normal eval emits an Evaluation.summarize call
+        # as a child of the eval run with the aggregate summary as its
+        # output. The frontend uses this to render the per-scorer summary
+        # panel.
+        #
+        # Open this call BEFORE invoking ``summarize_fn`` so that when
+        # ``summarize_fn`` is itself ``@weave.op``-decorated (i.e. a
+        # ``Scorer.summarize`` method on a real Scorer subclass), the op
+        # machinery picks up ``summarize_call`` from the call stack as
+        # parent. Otherwise each ``Scorer.summarize`` lands as an orphan
+        # trace root and the wrapping ``Evaluation.summarize`` shows 0ms
+        # because no work happens between create_call and finish_call.
+        summarize_call = client.create_call(
+            op=constants.EVALUATION_SUMMARIZE_OP_NAME,
+            inputs={"self": new_eval_ref},
+            parent=new_eval_call,
+            use_stack=True,
         )
-    except Exception:
-        # Always call evaluation_run_finish so the run never dangles in "started" state.
-        # On unexpected failure, finish with empty summary so the UI can show it as failed.
+        try:
+            # Mirrors eval.py:230-235: summarize_fn handles both Scorer
+            # subclasses (scorer.summarize) and Op-based scorers
+            # (auto_summarize). Summary keyed by scorer_attributes.scorer_name
+            # — NOT the ref URI.
+            summary: dict[str, Any] = {}
+            for i, scorer_attrs in enumerate(scorer_attributes_list):
+                summary[scorer_attrs.scorer_name] = scorer_attrs.summarize_fn(
+                    raw_scores_by_scorer[i]
+                )
+
+            # Aggregate model_latency onto the eval root output as
+            # ``{"mean": avg}``. The compare-page header reads latency from
+            # ``output.model_latency.mean`` on the eval root — without this
+            # aggregate the Latency cell renders "N/A" even though per-row
+            # latency is correctly recorded on each pas. Mirrors how
+            # ``Evaluation.summarize`` in eval.py auto_summarizes the
+            # numeric model_latency column over all eval rows.
+            if row_model_latencies:
+                summary["model_latency"] = {
+                    "mean": sum(row_model_latencies) / len(row_model_latencies)
+                }
+        except Exception as summarize_exc:
+            client.fail_call(summarize_call, exception=summarize_exc)
+            raise
+        client.finish_call(summarize_call, output=summary)
+
+        # End the new-eval call with the rich summary as its output —
+        # mirrors a normal Evaluation.evaluate op finish where the eval
+        # call's ``output`` IS the summary dict. ``finish_call`` pairs
+        # with the ``create_call`` we did at the top via the
+        # CallBatchProcessor, sending a single complete record to the
+        # trace server.
+        client.finish_call(new_eval_call, output=summary)
+    except Exception as exc:
+        # Always finish the new-eval call so it never dangles in "started"
+        # state. ``fail_call`` records the exception on the call so the UI
+        # can show why the rescore failed.
         logger.exception(
             "rescore_predictions failed for evaluation_run_id=%s",
             args.new_evaluation_run_id,
         )
         try:
-            client.server.evaluation_run_finish(
-                tsi.EvaluationRunFinishReq(
-                    project_id=args.project_id,
-                    evaluation_run_id=args.new_evaluation_run_id,
-                    summary={},
-                    wb_user_id=args.wb_user_id,
-                )
-            )
+            client.fail_call(new_eval_call, exception=exc)
         except Exception:
             logger.exception(
-                "Failed to finish evaluation run %s after rescore failure",
+                "Failed to fail evaluation run %s after rescore failure",
                 args.new_evaluation_run_id,
             )
         raise
 
 
-def _yield_standard_sources(
-    client: WeaveClient, args: RescoringArgs
+def _start_new_eval_root(
+    client: WeaveClient,
+    *,
+    new_evaluation_run_id: str,
+    source_evaluation_run_id: str,
+    evaluation_ref: str,
+    model_ref: str,
+    display_name: str,
+) -> Call:
+    """Start the new-eval trace root with ``trace_id == id``.
+
+    Thin wrapper around ``client.create_call``. The ``trace_id == id``
+    invariant for trace roots is provided by ``create_call`` itself: when
+    ``parent=None`` and ``_call_id_override=X``, ``trace_id`` is also set
+    to ``X``. The frontend's "show me everything in this trace" queries
+    land on ``trace_id``, so this invariant is what keeps trace-root
+    queries finding the entire new-eval tree.
+
+    ``use_stack=False`` because the worker doesn't have a surrounding op
+    context, and we don't want the eval root left on the call_context
+    stack across the rescore loop. Subsequent ``create_call(parent=...)``
+    invocations pass ``new_eval_call`` explicitly.
+    """
+    return client.create_call(
+        op=constants.EVALUATION_RUN_OP_NAME,
+        inputs={"self": evaluation_ref, "model": model_ref},
+        parent=None,
+        attributes={
+            constants.WEAVE_ATTRIBUTES_NAMESPACE: {
+                constants.EVALUATION_RUN_ATTR_KEY: "true",
+                constants.EVALUATION_RUN_EVALUATION_ATTR_KEY: evaluation_ref,
+                constants.EVALUATION_RUN_MODEL_ATTR_KEY: model_ref,
+                constants.EVALUATION_RUN_SOURCE_ATTR_KEY: source_evaluation_run_id,
+            }
+        },
+        display_name=display_name,
+        use_stack=False,
+        _call_id_override=new_evaluation_run_id,
+    )
+
+
+def _emit_synthetic_predict_call(
+    client: WeaveClient,
+    *,
+    parent_pas_call: Call,
+    model_ref: str,
+    example: Any,
+    output: Any,
+    model_latency_seconds: float,
+    source_predict: _SourcePredict | None,
+) -> None:
+    """Emit a synthetic predict subcall under ``parent_pas_call``.
+
+    When ``source_predict`` is provided (standard evals where the source
+    row had a real predict call), the synthetic call is a content-copy:
+    op artifact name lifted from the source so the UI chip renders
+    ``MyModel.predict`` (not generic ``predict``), source inputs/output/
+    summary copied, and duration preserved
+    (``ended_at - started_at == source.ended_at - source.started_at``)
+    while both timestamps are shifted into the new eval's wall-clock
+    window. The op digest will differ from the source's (anonymous-op
+    placeholder source), but the chip name, inputs panel, Total Tokens
+    column, and Latency column all read correctly.
+
+    When ``source_predict`` is ``None`` (imperative sources that never
+    emitted a predict — e.g. ``EvaluationLogger`` flows), fall back to a
+    generic ``predict`` op whose duration mirrors the source row's
+    ``model_latency``. The frontend's predict-detection still picks it up
+    via ``artifactName.includes("predict")``.
+
+    Uses ``client.create_call`` / ``client.finish_call`` with explicit
+    ``started_at`` / ``ended_at`` overrides so we pin both timestamps.
+    ``use_stack=False`` because scorers parent to the pas (not to
+    predict), and we don't want this transient call left on the stack.
+    """
+    if source_predict is not None:
+        op_name = _artifact_name_from_op_uri(source_predict.op_name) or "predict"
+        inputs = dict(source_predict.inputs)
+        emit_output = source_predict.output
+        emit_summary: dict[str, Any] = dict(source_predict.summary)
+        # Drop server-derived/per-call fields. The source predict's
+        # `summary["weave"]` holds derived fields (trace_name, status,
+        # latency_ms, display_name) populated by `make_derived_summary_fields`
+        # at read time. Copying them into the synthetic call's client-side
+        # summary causes `sum_dict_leaves` to bubble them up into the parent
+        # pas/eval `summary["weave"]` as a *list* (one string per child) when
+        # `finish_call` rolls children up — which fails CallSchema validation
+        # on the next read. `status_counts` is similarly per-call.
+        emit_summary.pop("weave", None)
+        emit_summary.pop("status_counts", None)
+        duration_s = max(
+            0.0,
+            (source_predict.ended_at - source_predict.started_at).total_seconds(),
+        )
+    else:
+        op_name = "predict"
+        inputs = {"self": model_ref, "example": example}
+        emit_output = output
+        emit_summary = {}
+        duration_s = max(0.0, model_latency_seconds)
+
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+    ended_at = started_at + datetime.timedelta(seconds=duration_s)
+
+    predict_call = client.create_call(
+        op=op_name,
+        inputs=inputs,
+        parent=parent_pas_call,
+        use_stack=False,
+        started_at=started_at,
+    )
+    # Pre-populate summary so finish_call's deep-merge preserves source
+    # usage stats — the Total Tokens column reads from ``summary.usage``.
+    if emit_summary:
+        predict_call.summary = emit_summary
+    client.finish_call(predict_call, output=emit_output, ended_at=ended_at)
+
+
+def _artifact_name_from_op_uri(op_uri: str) -> str | None:
+    """Extract the artifact-name segment (``MyModel.predict``) from a
+    Weave op ref URI like ``weave:///e/p/op/MyModel.predict:<digest>``.
+    Returns ``None`` if the input doesn't match either Weave scheme.
+    """
+    if not op_uri:
+        return None
+    marker = "/op/"
+    idx = op_uri.rfind(marker)
+    if idx < 0:
+        return None
+    tail = op_uri[idx + len(marker) :]
+    name = tail.split(":", 1)[0]
+    return name or None
+
+
+def _publish_rescored_evaluation(
+    client: WeaveClient,
+    *,
+    project_id: str,
+    source_eval_ref: str,
+    new_scorer_refs: list[str],
+    wb_user_id: str | None,
+) -> str:
+    """Return a ref to a new VERSION of the source Evaluation object whose
+    ``scorers`` field matches ``new_scorer_refs`` and whose other fields
+    (dataset, trials, etc.) are inherited from ``source_eval_ref``.
+
+    The new eval call's ``self`` input is what list-view and detail-view
+    surfaces resolve to render the run's scorer chips. The returned ref
+    points at the NEW version's digest — its ``scorers`` field matches
+    the run's actual scorers, so chips render correctly. Reusing the
+    source digest would surface the source's (now-stale) scorer list —
+    a silent mislabeling where the chip says "scorer A" but the actual
+    per-row scores were computed by scorer B.
+
+    Strategy: ``obj_read`` the source val, swap its ``scorers`` for
+    ``new_scorer_refs``, ``obj_create`` under the SAME ``object_id`` so
+    the rescore lands as a new version of the source. This keeps all
+    states of "this eval" — author edits and rescore-derived variants
+    — in a single object namespace. Source provenance is additionally
+    recorded via the ``source_evaluation_run_id`` attribute on the new
+    run's call, which is the canonical lineage link for any UI that
+    wants to surface "this run was rescored from X".
+
+    Tradeoff: the source object's version history accumulates entries
+    not authored by the original creator. Browsing versions of the
+    source eval shows rescored variants alongside user edits.
+
+    Fails loudly on any error (bad ref shape, non-dict val, obj_read /
+    obj_create failure). A silent fallback to the source ref would
+    surface mislabeled chips in the UI — strictly worse than a worker
+    failure that the user can retry.
+    """
+    if not source_eval_ref:
+        raise ValueError(
+            "Cannot publish rescored Evaluation: source eval ref is empty. "
+            "The source call's inputs must carry self/this and model refs."
+        )
+    source_ref = Ref.parse_uri(source_eval_ref)
+    if not isinstance(source_ref, ObjectRef):
+        raise TypeError(
+            f"Expected an object ref for source eval, got: {source_eval_ref!r}"
+        )
+    read_res = client.server.obj_read(
+        tsi.ObjReadReq(
+            project_id=project_id,
+            object_id=source_ref.name,
+            digest=source_ref.digest,
+        )
+    )
+    val = read_res.obj.val
+    if not isinstance(val, dict):
+        raise TypeError(
+            f"Source Evaluation {source_eval_ref!r} val is not a dict "
+            f"(got {type(val).__name__}); cannot swap scorers."
+        )
+
+    new_val = dict(val)
+    new_val["scorers"] = list(new_scorer_refs)
+
+    # Land the rescore as a new version of the source object. obj_create
+    # is digest-deduped on (object_id, val), so back-to-back rescores with
+    # identical inputs reuse the same digest (no version churn).
+    create_res = client.server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=project_id,
+                object_id=source_ref.name,
+                val=new_val,
+                wb_user_id=wb_user_id,
+            )
+        )
+    )
+    return f"weave:///{project_id}/object/{source_ref.name}:{create_res.digest}"
+
+
+def _op_name_matches_any_scheme(op_name: str | None, expected_name: str) -> bool:
+    """Match an op_name URI against an expected unversioned name, accepting
+    any scheme.
+
+    The trace_server_common.op_name_matches helper only handles the internal
+    scheme (``weave-trace-internal://``). The rescore worker runs above the
+    server boundary where URIs are typically externalized to ``weave://``,
+    so we need a scheme-agnostic check here. Match policy: extract the last
+    ``/op/<name>:<version>`` segment, compare ``<name>`` exactly. Falls back
+    to plain-string equality for non-URI op_names.
+    """
+    if not op_name:
+        return False
+    marker = "/op/"
+    idx = op_name.rfind(marker)
+    if idx == -1:
+        return op_name == expected_name
+    tail = op_name[idx + len(marker) :]
+    name = tail.split(":", 1)[0]
+    return name == expected_name
+
+
+def _yield_predict_and_score_sources(
+    client: WeaveClient,
+    args: RescoringArgs,
+    project_id: str,
+    *,
+    source_model_ref: str,
 ) -> Iterator[_RescoreSource]:
-    """Yield ``_RescoreSource`` rows for a standard ``Evaluation.evaluate`` source.
+    """Yield one ``_RescoreSource`` per predict_and_score child of the source
+    eval call.
 
-    Uses ``prediction_list``, which filters on the ``prediction`` call attribute
-    (set only by ``prediction_create``). Imperative source evals do not appear
-    in this query — their branch is handled in a separate generator.
+    Works for both standard ``Evaluation.evaluate`` runs and imperative
+    ``weave.EvaluationLogger`` runs — both surface their per-row data on
+    predict_and_score, which is the framework-level boundary in either flow.
 
-    For standard, ``parent_call_id = prediction.parent_id`` (= the
-    ``predict_and_score`` call). Falls back to the source evaluation run id only
-    if the prediction is somehow root-level — same fallback today's auto-derive
-    uses inside ``score_create``.
+    Predicate (mirrors the frontend's ``imperativeAdapter.getDatasetRowCount``):
+    any call whose op_name matches ``EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME``
+    (ignoring version digest), parented to the source eval call. No status
+    filter — a partially-failed source eval is still a valid rescore source.
+
+    Dataset-backed eval inputs land in storage as a ref URI (e.g. a TableRow
+    ref into the Dataset's rows table) rather than the row dict. The scorer
+    expects a dict, so we batch-deref any ref-shaped ``example`` per page via
+    ``refs_read_batch`` — same mechanism the frontend uses in
+    ``resolve_eval_inputs``. The original ref form is preserved on
+    ``inputs_for_call`` so the new pas call's inputs match the source's
+    storage shape; the resolved dict is exposed on ``inputs_for_scorer``.
+
+    Per-page, we also issue one extra ``calls_query_stream`` for the
+    grandchildren of source pas to pick out the source predict call (if
+    any). The snapshot is attached on ``_RescoreSource.source_predict`` and
+    the worker uses it to emit a faithful synthetic predict under the new
+    pas (same op_name, inputs, output, summary, duration).
     """
     offset = 0
     while True:
         page = list(
-            client.server.prediction_list(
-                tsi.PredictionListReq(
-                    project_id=args.project_id,
-                    evaluation_run_id=args.source_evaluation_run_id,
+            client.server.calls_query_stream(
+                tsi.CallsQueryReq(
+                    project_id=project_id,
+                    filter=tsi.CallsFilter(
+                        parent_ids=[args.source_evaluation_run_id],
+                    ),
                     limit=PREDICTION_PAGE_SIZE,
                     offset=offset,
                 )
@@ -199,23 +629,81 @@ def _yield_standard_sources(
         if not page:
             break
 
-        for prediction in page:
-            pred_read = client.server.call_read(
-                tsi.CallReadReq(
-                    project_id=args.project_id,
-                    id=prediction.prediction_id,
+        pas_calls = [
+            call
+            for call in page
+            if _op_name_matches_any_scheme(
+                call.op_name,
+                constants.EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+            )
+        ]
+
+        # Collect any example refs that need batch-resolution.
+        example_refs: list[str] = []
+        for call in pas_calls:
+            example = (
+                call.inputs.get("example") if isinstance(call.inputs, dict) else None
+            )
+            if _is_ref_uri(example):
+                example_refs.append(example)
+
+        resolved_by_ref: dict[str, Any] = {}
+        if example_refs:
+            res = client.server.refs_read_batch(tsi.RefsReadBatchReq(refs=example_refs))
+            resolved_by_ref = dict(zip(example_refs, res.vals, strict=True))
+
+        # Batch-query grandchildren of source pas to pick out source predict
+        # calls for the synthetic-predict faithful copy. One query per page,
+        # filtered down to predict-like calls afterwards.
+        predicts_by_pas_id: dict[str, _SourcePredict] = {}
+        if pas_calls:
+            grandchildren = list(
+                client.server.calls_query_stream(
+                    tsi.CallsQueryReq(
+                        project_id=project_id,
+                        filter=tsi.CallsFilter(
+                            parent_ids=[c.id for c in pas_calls],
+                        ),
+                    )
                 )
             )
-            parent_call_id = (
-                pred_read.call.parent_id
-                if pred_read.call and pred_read.call.parent_id
-                else args.source_evaluation_run_id
+            for gc in grandchildren:
+                if gc.parent_id is None:
+                    continue
+                if gc.parent_id in predicts_by_pas_id:
+                    continue  # first predict-like child wins
+                if not _is_predict_call(gc, source_model_ref):
+                    continue
+                predicts_by_pas_id[gc.parent_id] = _source_predict_from_call(gc)
+
+        for call in pas_calls:
+            example = (
+                call.inputs.get("example") if isinstance(call.inputs, dict) else None
             )
+            if isinstance(call.output, dict):
+                output_val = call.output.get("output", call.output)
+                model_latency = call.output.get("model_latency") or 0.0
+            else:
+                output_val = call.output
+                model_latency = 0.0
+
+            if _is_ref_uri(example):
+                resolved = resolved_by_ref.get(example, {})
+                inputs_for_scorer = resolved if isinstance(resolved, dict) else {}
+                inputs_for_call = example  # preserve ref form on new pas
+            elif isinstance(example, dict):
+                inputs_for_scorer = example
+                inputs_for_call = example
+            else:
+                inputs_for_scorer = {}
+                inputs_for_call = {}
+
             yield _RescoreSource(
-                prediction_id=prediction.prediction_id,
-                parent_call_id=parent_call_id,
-                inputs=prediction.inputs,
-                output=prediction.output,
+                inputs_for_call=inputs_for_call,
+                inputs_for_scorer=inputs_for_scorer,
+                output=output_val,
+                model_latency=float(model_latency),
+                source_predict=predicts_by_pas_id.get(call.id),
             )
 
         offset += len(page)
@@ -223,16 +711,63 @@ def _yield_standard_sources(
             break
 
 
+def _is_predict_call(call: tsi.CallSchema, model_ref: str) -> bool:
+    """Mirror of the frontend's predict-detection in
+    ``tsDataModelHooksEvaluationComparison.ts`` (~line 1392): a subcall is
+    the model's predict if ``inputs.self == model_ref`` OR the artifact
+    name in ``op_name`` (lowercased) contains ``predict`` or ``invoke``.
+    Using the same predicate keeps the synthetic predict we emit consistent
+    with what the UI's predict-call lookup picks up.
+    """
+    if not call.op_name:
+        return False
+    inputs_self = call.inputs.get("self") if isinstance(call.inputs, dict) else None
+    if model_ref and inputs_self == model_ref:
+        return True
+    marker = "/op/"
+    idx = call.op_name.rfind(marker)
+    tail = call.op_name[idx + len(marker) :] if idx >= 0 else call.op_name
+    artifact_name = tail.split(":", 1)[0].lower()
+    return "predict" in artifact_name or "invoke" in artifact_name
+
+
+def _source_predict_from_call(call: tsi.CallSchema) -> _SourcePredict:
+    """Pull just the fields needed for the synthetic-predict copy off of a
+    source predict ``CallSchema``. Times default to ``now()`` (zero
+    duration) when the source call is malformed/missing them — the worker
+    treats that as a best-effort empty predict.
+    """
+    started_at = call.started_at or datetime.datetime.now(datetime.timezone.utc)
+    ended_at = call.ended_at or started_at
+    return _SourcePredict(
+        op_name=call.op_name or "",
+        inputs=call.inputs if isinstance(call.inputs, dict) else {},
+        output=call.output,
+        started_at=started_at,
+        ended_at=ended_at,
+        summary=call.summary if isinstance(call.summary, dict) else {},
+    )
+
+
+def _is_ref_uri(val: Any) -> bool:
+    """Cheap shape check for the two URI schemes used by Weave."""
+    return isinstance(val, str) and (
+        val.startswith("weave:///") or val.startswith("weave-trace-internal:///")
+    )
+
+
 def _get_valid_scorer(client: WeaveClient, scorer_ref: str) -> Scorer:
     """Validates and loads a scorer from a ref URI.
 
-    Accepts any Scorer subclass — intentionally more permissive than _get_valid_evaluation()
-    which is restricted to LLMAsAJudgeScorer. Rescore is a general-purpose operation;
-    that restriction applies only to the full eval-model path.
+    Accepts any Scorer subclass — intentionally more permissive than
+    _get_valid_evaluation() which is restricted to LLMAsAJudgeScorer.
+    Rescore is a general-purpose operation; that restriction applies only to
+    the full eval-model path.
 
-    Security: _assert_safe_ref is called on the scorer_ref before this function, so
-    the scorer object has already been validated via assert_safe_payload. The isinstance
-    check here is purely a type-level guard.
+    Security: _assert_safe_ref is called on the scorer_ref before this
+    function, so the scorer object has already been validated via
+    assert_safe_payload. The isinstance check here is purely a type-level
+    guard.
     """
     loaded = client.get(Ref.parse_uri(scorer_ref))
     if weave_isinstance(loaded, Scorer):
@@ -243,16 +778,19 @@ def _get_valid_scorer(client: WeaveClient, scorer_ref: str) -> Scorer:
 
 
 def _assert_safe_ref(client: WeaveClient, ref_uri: str, label: str) -> None:
-    """Validates that a ref URI points to an object that passes the safe-payload check.
-    Called on all scorer_refs before loading to prevent injection via malicious ref payloads.
+    """Validates that a ref URI points to an object that passes the
+    safe-payload check. Called on all scorer_refs before loading to prevent
+    injection via malicious ref payloads.
 
-    SECURITY NOTE: Cross-project authorization is not enforced here. A scorer ref that
-    points to a project the calling user cannot read will fail at obj_read if the server
-    enforces read-level ACLs, but this function does NOT explicitly verify that
-    ref.entity/ref.project matches the rescore job's project_id. In V1 this is intentional
-    (scorers are naturally shared across projects) but callers should be aware that a
-    sufficiently permissioned user can reference scorers from any project they can read.
-    A future V2 should add an explicit authorization check per scorer ref.
+    SECURITY NOTE: Cross-project authorization is not enforced here. A
+    scorer ref that points to a project the calling user cannot read will
+    fail at obj_read if the server enforces read-level ACLs, but this
+    function does NOT explicitly verify that ref.entity/ref.project matches
+    the rescore job's project_id. In V1 this is intentional (scorers are
+    naturally shared across projects) but callers should be aware that a
+    sufficiently permissioned user can reference scorers from any project
+    they can read. A future V2 should add an explicit authorization check
+    per scorer ref.
     """
     ref = Ref.parse_uri(ref_uri)
     if not isinstance(ref, ObjectRef):


### PR DESCRIPTION
## Description

Rewrites the rescore worker to produce a new-eval trace tree that mirrors a normal `Evaluation.evaluate` run, fully owned by the worker process. The worker now emits one `Evaluation.evaluate` root (with `trace_id == id`), one `predict_and_score` child per source row, one synthetic `predict` subcall per row, and one `Evaluation.summarize` call — all via `client.create_call` / `client.finish_call` rather than `score_create` / `evaluation_run_finish`.

Key behavioral changes:

- **Call ownership invariant**: The rescore endpoint allocates `new_evaluation_run_id` but no longer pre-creates the call server-side. The worker owns both `call_start` and `call_end`, eliminating the orphaned-call_end bug in the `CallBatchProcessor` pairing buffer.
- **Synthetic predict subcall**: Each new `predict_and_score` gets a synthetic `predict` child whose duration mirrors the source row's `model_latency`, so the eval-compare Latency column renders correctly. When the source row had a real predict call, the synthetic call is a faithful content-copy (same `op_name`, inputs, output, summary, and duration).
- **Rescored Evaluation object**: The worker clones the source `Evaluation` object, swaps its `scorers` field for the new scorer refs, and publishes it under a `{source-object-id}-rescored` object ID. The new eval call's `self` input points at this new object so scorer chips render correctly in list and detail views.
- **`model_latency` aggregate**: The eval root's output carries `{"model_latency": {"mean": avg}}` so the compare-page header Latency cell renders without "N/A".
- **Source tree untouched**: The worker queries `predict_and_score` children of the source eval directly (replacing `prediction_list`) and never attaches children to source calls.
- **`_RescoreSource` shape updated**: Replaces `prediction_id`/`parent_call_id`/`inputs` with `inputs_for_call`, `inputs_for_scorer`, `model_latency`, and `source_predict` (`_SourcePredict` snapshot for faithful-copy).

## Testing

Tests updated and extended in `test_rescore_worker.py` (unit, mock-based) and `test_rescore_imperative.py` (end-to-end against a real sqlite-backed trace server):

- `test_rescore_creates_new_pas_tree_and_leaves_source_untouched`: asserts the full V2 trace-tree shape, source tree immutability, synthetic predict duration, eval root output including `model_latency.mean`, `display_name` format, and the new rescored `Evaluation` object's `scorers` field.
- `test_rescore_faithfully_copies_source_predict_calls`: asserts that when source rows have real predict subcalls, the synthetic predict copies `op_name`, inputs, output, summary (including `usage`), and duration exactly.
- Unit tests updated to assert `create_call`/`finish_call` invocation counts and ordering, `fail_call` on exception, and that `score_create`/`evaluation_run_finish` are never called.