### PR TITLE
chore(weave): Mark weave tests that depend on weave side effects and not the client

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -546,6 +546,20 @@ def client(zero_stack, request, trace_server, caching_client_isolation):
 
 
 @pytest.fixture
+def weave_active(client):
+    """Side-effect-only dependency on the `client` fixture.
+
+    Some tests don't reference the client object directly, but their body
+    uses `weave.publish` / `weave.ref` / `@weave.op` / `Evaluation` / etc.,
+    which all require a global Weave client to be set. Those tests declare
+    `weave_active` instead of `client` so the dependency on the *side effect*
+    (the global client being installed) is explicit at the call site, and so
+    we can later swap in a lighter setup without touching each test.
+    """
+    return client
+
+
+@pytest.fixture
 def no_autoflush(client):
     """Disable per-method autoflush for speed; call client.flush() before reads."""
     client.set_autoflush(False)

--- a/tests/flow/test_casting.py
+++ b/tests/flow/test_casting.py
@@ -8,7 +8,7 @@ from weave.trace.op import is_op
 
 
 @pytest.fixture
-def valid_dataset(client, request):
+def valid_dataset(weave_active, request):
     data = [{"a": 1, "b": 2}, {"a": 3, "b": 4}]
 
     if request.param == "dataset":
@@ -26,7 +26,7 @@ def valid_dataset(client, request):
 
 
 @pytest.fixture
-def valid_scorer(client, request):
+def valid_scorer(weave_active, request):
     if request.param == "scorer":
 
         class MyScorer(weave.Scorer):

--- a/tests/flow/test_dataset_flow.py
+++ b/tests/flow/test_dataset_flow.py
@@ -1,7 +1,7 @@
 import weave
 
 
-def test_dataset(client):
+def test_dataset(weave_active):
     d = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
     ref = weave.publish(d)
     d2 = weave.ref(ref.uri).get()

--- a/tests/flow/test_evaluation_imperative.py
+++ b/tests/flow/test_evaluation_imperative.py
@@ -507,7 +507,7 @@ async def test_various_input_forms(client, evaluation_logger_kwargs, scorer, sco
     assert len(calls) == expected_num_calls * 2
 
 
-def test_passing_dict_requires_name_with_scorer(client):
+def test_passing_dict_requires_name_with_scorer(weave_active):
     ev = weave.EvaluationLogger()
     pred = ev.log_prediction(inputs={}, output=None)
     with pytest.raises(ValueError, match="Your dict must contain a `name` key."):
@@ -518,7 +518,7 @@ def test_passing_dict_requires_name_with_scorer(client):
 
 
 @pytest.mark.disable_logging_error_check
-def test_passing_dict_requires_name_with_model(client):
+def test_passing_dict_requires_name_with_model(weave_active):
     with pytest.raises(ValueError, match="Your dict must contain a `name` key."):
         ev = weave.EvaluationLogger(model={"something": "else"})
 
@@ -573,7 +573,7 @@ def test_evaluation_no_auto_summarize_with_custom_dict(client):
     }
 
 
-def test_evaluation_logger_model_inference_method_handling(client):
+def test_evaluation_logger_model_inference_method_handling(weave_active):
     """Test that EvaluationLogger correctly handles models with and without inference methods.
 
     This test validates the fix where EvaluationLogger only adds a predict method
@@ -622,7 +622,7 @@ def test_evaluation_logger_model_inference_method_handling(client):
     ev2.finish()
 
 
-def test_evaluation_logger_model_with_different_inference_method_names(client):
+def test_evaluation_logger_model_with_different_inference_method_names(weave_active):
     """Test that EvaluationLogger handles models with different inference method names."""
 
     class ModelWithInfer(Model):
@@ -1153,7 +1153,7 @@ def test_log_example_with_empty_scores(client):
     assert predict_and_score_call.output["scores"] == {}
 
 
-def test_log_example_after_finalization_raises_error(client):
+def test_log_example_after_finalization_raises_error(weave_active):
     """Test that log_example raises ValueError when called after finalization."""
     ev = EvaluationLogger()
 
@@ -1179,7 +1179,7 @@ def test_log_example_after_finalization_raises_error(client):
         )
 
 
-def test_log_example_after_log_summary_raises_error(client):
+def test_log_example_after_log_summary_raises_error(weave_active):
     """Test that log_example raises ValueError when called after log_summary."""
     ev = EvaluationLogger()
 
@@ -1205,7 +1205,7 @@ def test_log_example_after_log_summary_raises_error(client):
         )
 
 
-def test_evaluation_logger_with_weave_disabled(client, monkeypatch):
+def test_evaluation_logger_with_weave_disabled(weave_active, monkeypatch):
     """Test that EvaluationLogger works when WEAVE_DISABLED=true (WB-32259)."""
     monkeypatch.setenv("WEAVE_DISABLED", "true")
 

--- a/tests/flow/test_monitor.py
+++ b/tests/flow/test_monitor.py
@@ -37,7 +37,7 @@ def test_out_of_range_sampling_rate():
         )
 
 
-def test_publish(client: weave_client.WeaveClient):
+def test_publish(weave_active: weave_client.WeaveClient):
     monitor = Monitor(
         name="test_monitor",
         sampling_rate=0.5,
@@ -72,7 +72,7 @@ def test_publish(client: weave_client.WeaveClient):
     )
 
 
-def test_activate(client: weave_client.WeaveClient):
+def test_activate(weave_active: weave_client.WeaveClient):
     monitor = Monitor(
         name="test_monitor",
         sampling_rate=0.5,

--- a/tests/flow/test_monitor.py
+++ b/tests/flow/test_monitor.py
@@ -3,7 +3,6 @@ from pydantic import ValidationError
 
 from weave.flow.monitor import Monitor
 from weave.scorers import ValidJSONScorer
-from weave.trace import weave_client
 from weave.trace.api import publish
 from weave.trace_server.interface.query import Query
 
@@ -37,7 +36,7 @@ def test_out_of_range_sampling_rate():
         )
 
 
-def test_publish(weave_active: weave_client.WeaveClient):
+def test_publish(weave_active):
     monitor = Monitor(
         name="test_monitor",
         sampling_rate=0.5,
@@ -72,7 +71,7 @@ def test_publish(weave_active: weave_client.WeaveClient):
     )
 
 
-def test_activate(weave_active: weave_client.WeaveClient):
+def test_activate(weave_active):
     monitor = Monitor(
         name="test_monitor",
         sampling_rate=0.5,

--- a/tests/flow/test_objectify.py
+++ b/tests/flow/test_objectify.py
@@ -41,7 +41,7 @@ def obj(request):
         return weave.EasyPrompt("Hello world!")
 
 
-def test_ref_get(client, obj):
+def test_ref_get(weave_active, obj):
     ref = weave.publish(obj)
 
     obj_cls = type(obj)
@@ -121,7 +121,7 @@ def resolve_ref_futures(ref: RefWithExtra) -> RefWithExtra:
     return ref
 
 
-def test_drill_down_dataset_refs_same_after_publishing(client):
+def test_drill_down_dataset_refs_same_after_publishing(weave_active):
     ds = weave.Dataset(
         name="test",
         rows=[{"a": {"b": 1}}, {"a": {"b": 2}}, {"a": {"b": 3}}],

--- a/tests/flow/test_weaveflow.py
+++ b/tests/flow/test_weaveflow.py
@@ -7,7 +7,7 @@ from pydantic import Field
 import weave
 
 
-def test_weaveflow_op_wandb(client):
+def test_weaveflow_op_wandb(weave_active):
     @weave.op
     def custom_adder(a: int, b: int) -> int:
         return a + b
@@ -16,7 +16,7 @@ def test_weaveflow_op_wandb(client):
     assert res == 3
 
 
-def test_weaveflow_op_wandb_return_list(client):
+def test_weaveflow_op_wandb_return_list(weave_active):
     @weave.op
     def custom_adder(a: int, b: int) -> list[int]:
         return [a + b]
@@ -25,7 +25,7 @@ def test_weaveflow_op_wandb_return_list(client):
     assert res == [3]
 
 
-def test_weaveflow_object_wandb_with_opmethod(client):
+def test_weaveflow_object_wandb_with_opmethod(weave_active):
     class ATestObj(weave.Object):
         a: int
 
@@ -38,7 +38,7 @@ def test_weaveflow_object_wandb_with_opmethod(client):
     assert res == 3
 
 
-def test_weaveflow_nested_op(client):
+def test_weaveflow_nested_op(weave_active):
     @weave.op
     def adder(a: int, b: int) -> int:
         return a + b
@@ -52,7 +52,7 @@ def test_weaveflow_nested_op(client):
 
 
 @pytest.mark.asyncio
-async def test_async_ops(client):
+async def test_async_ops(weave_active):
     @weave.op
     async def async_op_add1(v: int) -> int:
         return v + 1
@@ -70,7 +70,7 @@ async def test_async_ops(client):
     assert len(list(async_op_add1.calls())) == 5
 
 
-def test_weaveflow_publish_numpy(client):
+def test_weaveflow_publish_numpy(weave_active):
     v = {"a": np.array([[1, 2, 3], [4, 5, 6]])}
     ref = weave.publish(v, "dict-with-numpy")
 
@@ -167,7 +167,7 @@ def test_construct_eval_with_dataset_get(client):
     weave.Evaluation(dataset=dataset2)
 
 
-def test_weave_op_mutates_and_returns_same_object(client):
+def test_weave_op_mutates_and_returns_same_object(weave_active):
     class Thing(weave.Object):
         tools: list = Field(default_factory=list)
 

--- a/tests/integrations/litellm/litellm_test.py
+++ b/tests/integrations/litellm/litellm_test.py
@@ -240,7 +240,7 @@ async def test_litellm_quickstart_stream_async(
     allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_model_predict(
-    weave_active: weave.trace.weave_client.WeaveClient, patch_litellm: None
+    weave_active, patch_litellm: None
 ) -> None:
     class TranslatorModel(weave.Model):
         model: str

--- a/tests/integrations/litellm/litellm_test.py
+++ b/tests/integrations/litellm/litellm_test.py
@@ -239,9 +239,7 @@ async def test_litellm_quickstart_stream_async(
     filter_headers=["authorization", "x-api-key"],
     allowed_hosts=["api.wandb.ai", "localhost"],
 )
-def test_model_predict(
-    weave_active, patch_litellm: None
-) -> None:
+def test_model_predict(weave_active, patch_litellm: None) -> None:
     class TranslatorModel(weave.Model):
         model: str
         temperature: float

--- a/tests/integrations/litellm/litellm_test.py
+++ b/tests/integrations/litellm/litellm_test.py
@@ -240,7 +240,7 @@ async def test_litellm_quickstart_stream_async(
     allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_model_predict(
-    client: weave.trace.weave_client.WeaveClient, patch_litellm: None
+    weave_active: weave.trace.weave_client.WeaveClient, patch_litellm: None
 ) -> None:
     class TranslatorModel(weave.Model):
         model: str

--- a/tests/integrations/pandas_test/test_dataset_pandas.py
+++ b/tests/integrations/pandas_test/test_dataset_pandas.py
@@ -4,7 +4,7 @@ import weave
 from weave import Dataset
 
 
-def test_op_save_with_global_df(client):
+def test_op_save_with_global_df(weave_active):
     df = pd.DataFrame({"a": ["a", "b", "c"]})
 
     @weave.op
@@ -23,7 +23,7 @@ def test_op_save_with_global_df(client):
     assert call.output == "a"
 
 
-def test_dataset(client):
+def test_dataset(weave_active):
     rows = [{"a": 1, "b": 2}, {"a": 3, "b": 4}, {"a": 5, "b": 6}]
     ds = Dataset(rows=rows)
     df = ds.to_pandas()
@@ -37,7 +37,7 @@ def test_dataset(client):
     assert ds.rows == ds2.rows
 
 
-def test_calls_to_dataframe(client):
+def test_calls_to_dataframe(weave_active):
     @weave.op
     def greet(name: str, age: int) -> str:
         return f"Hello, {name}! You are {age} years old."

--- a/tests/scorers/test_call_apply_scorer.py
+++ b/tests/scorers/test_call_apply_scorer.py
@@ -214,7 +214,7 @@ async def test_async_scorer_obj(client: WeaveClient):
 
 
 @pytest.mark.asyncio
-async def test_scorer_with_weave_scorer_result_output(client: WeaveClient):
+async def test_scorer_with_weave_scorer_result_output(weave_active: WeaveClient):
     @weave.op
     def predict(x):
         return x + 1

--- a/tests/scorers/test_call_apply_scorer.py
+++ b/tests/scorers/test_call_apply_scorer.py
@@ -214,7 +214,7 @@ async def test_async_scorer_obj(client: WeaveClient):
 
 
 @pytest.mark.asyncio
-async def test_scorer_with_weave_scorer_result_output(weave_active: WeaveClient):
+async def test_scorer_with_weave_scorer_result_output(weave_active):
     @weave.op
     def predict(x):
         return x + 1

--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -458,7 +458,7 @@ def test_annotation_spec_validate_return_value():
     assert not enum_spec.value_is_valid(123)
 
 
-def test_annotation_feedback_sdk(client):
+def test_annotation_feedback_sdk(weave_active):
     number_spec = AnnotationSpec(
         name="Number Rating",
         field_schema={

--- a/tests/trace/test_call_object.py
+++ b/tests/trace/test_call_object.py
@@ -1,7 +1,7 @@
 import weave
 
 
-def test_call_to_dict(client):
+def test_call_to_dict(weave_active):
     @weave.op
     def greet(name: str, age: int) -> str:
         return f"Hello {name}, you are {age}!"

--- a/tests/trace/test_client_side_digests.py
+++ b/tests/trace/test_client_side_digests.py
@@ -282,7 +282,7 @@ class TestDataCorrectness:
         assert got.size == (32, 32)
         assert got.getpixel((0, 0)) == (255, 0, 0)
 
-    def test_get_without_explicit_flush(self, weave_active: WeaveClient, fast_path: None):
+    def test_get_without_explicit_flush(self, weave_active, fast_path: None):
         """ref.get() must work without an explicit _flush() call.
 
         In production, the FutureExecutor resolves deferred work when the

--- a/tests/trace/test_client_side_digests.py
+++ b/tests/trace/test_client_side_digests.py
@@ -282,7 +282,7 @@ class TestDataCorrectness:
         assert got.size == (32, 32)
         assert got.getpixel((0, 0)) == (255, 0, 0)
 
-    def test_get_without_explicit_flush(self, client: WeaveClient, fast_path: None):
+    def test_get_without_explicit_flush(self, weave_active: WeaveClient, fast_path: None):
         """ref.get() must work without an explicit _flush() call.
 
         In production, the FutureExecutor resolves deferred work when the

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1716,7 +1716,7 @@ def test_attributes_on_ops(client):
     }
 
 
-def test_dataset_row_type(client):
+def test_dataset_row_type(weave_active):
     d = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
     with pytest.raises(ValidationError):
         d = weave.Dataset(rows=[])
@@ -1775,7 +1775,7 @@ def test_dataclass_support(client):
     }
 
 
-def test_op_retrieval(client):
+def test_op_retrieval(weave_active):
     @weave.op
     def my_op(a: int) -> int:
         return a + 1
@@ -1787,7 +1787,7 @@ def test_op_retrieval(client):
 
 
 @pytest.mark.flaky(reruns=3)
-def test_bound_op_retrieval(client):
+def test_bound_op_retrieval(weave_active):
     class CustomType(weave.Object):
         a: int
 
@@ -1812,7 +1812,7 @@ def test_bound_op_retrieval(client):
 
 
 @pytest.mark.skip("Not implemented: general bound op designation")
-def test_bound_op_retrieval_no_self(client):
+def test_bound_op_retrieval_no_self(weave_active):
     class CustomTypeWithoutSelf(weave.Object):
         a: int
 
@@ -1830,7 +1830,7 @@ def test_bound_op_retrieval_no_self(client):
         my_op2 = my_op_ref.get()
 
 
-def test_dataset_row_ref(client):
+def test_dataset_row_ref(weave_active):
     d = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
     ref = weave.publish(d)
     d2 = weave.ref(ref.uri).get()
@@ -2018,7 +2018,7 @@ def test_unknown_input_and_output_types(client):
     assert inner_res.calls[0].output == repr(res)
 
 
-def test_unknown_attribute(client):
+def test_unknown_attribute(weave_active):
     class MyUnknownClass:
         val: int
 
@@ -3133,7 +3133,7 @@ def test_in_operation(client):
         assert res[i].id == call_ids[i]
 
 
-def test_call_has_client_version(client):
+def test_call_has_client_version(weave_active):
     @weave.op
     def test():
         return 1
@@ -3143,7 +3143,7 @@ def test_call_has_client_version(client):
     assert "client_version" in c.attributes["weave"]
 
 
-def test_user_cannot_modify_call_weave_dict(client):
+def test_user_cannot_modify_call_weave_dict(weave_active):
     @weave.op
     def test():
         call = require_current_call()
@@ -3174,7 +3174,7 @@ def test_user_cannot_modify_call_weave_dict(client):
     # but at that point you're on your own :)
 
 
-def test_calls_iter_slice(client):
+def test_calls_iter_slice(weave_active):
     @weave.op
     def func(x):
         return x
@@ -3187,7 +3187,7 @@ def test_calls_iter_slice(client):
     assert len(calls_subset) == 3
 
 
-def test_calls_iter_cached(client):
+def test_calls_iter_cached(weave_active):
     @weave.op
     def func(x):
         return x
@@ -3214,7 +3214,7 @@ def test_calls_iter_cached(client):
         assert elapsed_times[0] > elapsed_times[2] * 3
 
 
-def test_calls_iter_different_value_same_page_cached(client):
+def test_calls_iter_different_value_same_page_cached(weave_active):
     @weave.op
     def func(x):
         return x
@@ -4137,7 +4137,7 @@ async def test_op_sampling_inheritance_async_generator(client):
     assert len(client.get_calls()) == 0
 
 
-def test_op_sampling_invalid_rates(client):
+def test_op_sampling_invalid_rates(weave_active):
     with pytest.raises(ValueError, match="tracing_sample_rate must be between 0 and 1"):
 
         @weave.op(tracing_sample_rate=-0.5)
@@ -4157,7 +4157,7 @@ def test_op_sampling_invalid_rates(client):
             pass
 
 
-def test_op_sampling_child_follows_parent(client):
+def test_op_sampling_child_follows_parent(weave_active):
     parent_calls = 0
     child_calls = 0
 
@@ -4744,7 +4744,7 @@ def test_call_query_stream_with_invalid_filter_field(client):
         weave.Evaluation(dataset=weave.Dataset(rows=[{"a": 1, "b": 2}])),
     ],
 )
-def test_get_object_from_uri(client, obj):
+def test_get_object_from_uri(weave_active, obj):
     ref = weave.publish(obj)
     uri = ref.uri
 
@@ -4752,7 +4752,7 @@ def test_get_object_from_uri(client, obj):
 
 
 @pytest.mark.flaky(reruns=3)
-def test_get_object_from_uri_non_registered_object(client):
+def test_get_object_from_uri_non_registered_object(weave_active):
     class MyModel(weave.Model):
         a: int
         b: float = 2.0
@@ -5460,7 +5460,7 @@ def test_get_calls_filter_by_thread_ids_only(client):
     assert all(call.thread_id == f"thread_a_{unique}" for call in calls_thread_a)
 
 
-def test_thread_context_error_handling(client):
+def test_thread_context_error_handling(weave_active):
     """Test that ThreadContext is properly managed even when exceptions occur."""
     import weave
     from weave.trace.context import call_context

--- a/tests/trace/test_dataset.py
+++ b/tests/trace/test_dataset.py
@@ -5,7 +5,7 @@ from tests.trace.test_evaluate import Dataset
 from weave.trace.context.tests_context import raise_on_captured_errors
 
 
-def test_basic_dataset_lifecycle(client):
+def test_basic_dataset_lifecycle(weave_active):
     for _i in range(2):
         dataset = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
         ref = weave.publish(dataset)
@@ -17,7 +17,7 @@ def test_basic_dataset_lifecycle(client):
         )
 
 
-def test_dataset_iteration(client):
+def test_dataset_iteration(weave_active):
     dataset = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
     rows = list(dataset)
     assert rows == [{"a": 5, "b": 6}, {"a": 7, "b": 10}]
@@ -27,7 +27,7 @@ def test_dataset_iteration(client):
     assert rows2 == rows
 
 
-def test_pythonic_access(client):
+def test_pythonic_access(weave_active):
     rows = [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}]
     ds = weave.Dataset(rows=rows)
     assert len(ds) == 5
@@ -141,7 +141,7 @@ def test_dataset_from_calls(client):
     assert rows[1]["output"] == "Hello Bob, you are 25!"
 
 
-def test_dataset_caching(client):
+def test_dataset_caching(weave_active):
     ds = weave.Dataset(rows=[{"a": i} for i in range(200)])
     ref = weave.publish(ds)
 
@@ -151,7 +151,7 @@ def test_dataset_caching(client):
         assert len(ds2) == 200
 
 
-def test_dataset_select(client):
+def test_dataset_select(weave_active):
     original_rows = [{"id": i, "val": i * 2} for i in range(10)]
     ds = weave.Dataset(
         name="dataset-select-test",
@@ -210,7 +210,7 @@ def test_dataset_select(client):
         ds.select([-1])
 
 
-def test_add_rows(client):
+def test_add_rows(weave_active):
     ds = weave.Dataset(name="test", rows=[{"a": i} for i in range(10)])
     ref = weave.publish(ds)
 
@@ -232,13 +232,13 @@ def test_add_rows(client):
     assert ds3.rows == ds4.rows
 
 
-def test_add_rows_to_unsaved_dataset(client):
+def test_add_rows_to_unsaved_dataset(weave_active):
     ds = weave.Dataset(rows=[{"a": i} for i in range(10)])
     with pytest.raises(TypeError):
         ds.add_rows([{"a": 10}])
 
 
-def test_hf_conversion(client):
+def test_hf_conversion(weave_active):
     try:
         from datasets import Dataset as HFDataset
         from datasets import DatasetDict as HFDatasetDict

--- a/tests/trace/test_deepcopy.py
+++ b/tests/trace/test_deepcopy.py
@@ -44,7 +44,7 @@ def test_deepcopy_weavelist(client):
     assert id(res) != id(lst)
 
 
-def test_deepcopy_weavelist_e2e(client):
+def test_deepcopy_weavelist_e2e(weave_active):
     lst = [1, 2, 3]
     ref = weave.publish(lst)
     lst2 = ref.get()
@@ -60,7 +60,7 @@ def test_deepcopy_weavedict(client):
     assert id(res) != id(d)
 
 
-def test_deepcopy_weavedict_e2e(client):
+def test_deepcopy_weavedict_e2e(weave_active):
     d = {"a": 1, "b": 2}
     ref = weave.publish(d)
     d2 = ref.get()
@@ -83,7 +83,7 @@ def test_deepcopy_weaveobject(client, example_class):
     assert id(res) != id(o)
 
 
-def test_deepcopy_weaveobject_e2e(client, example_class):
+def test_deepcopy_weaveobject_e2e(weave_active, example_class):
     cls, expected_record = example_class
 
     o = cls()
@@ -110,7 +110,7 @@ def test_deepcopy_boxed(boxed_val):
     assert id(res) != id(boxed_val)
 
 
-def test_deepcopy_boxed_model_e2e(client):
+def test_deepcopy_boxed_model_e2e(weave_active):
     class Model(weave.Model):
         system_prompt: str = "You are a helpful assistant."  # this will get boxed
 

--- a/tests/trace/test_dictifiable.py
+++ b/tests/trace/test_dictifiable.py
@@ -1,7 +1,7 @@
 import weave
 
 
-def test_dictifiable(client):
+def test_dictifiable(weave_active):
     class NonDictifiable:  # noqa: B903
         attr: int
 

--- a/tests/trace/test_evaluate.py
+++ b/tests/trace/test_evaluate.py
@@ -38,7 +38,7 @@ def example_to_model_input(example):
 
 
 @pytest.mark.asyncio
-async def test_evaluate_callable_as_model(client):
+async def test_evaluate_callable_as_model(weave_active):
     @weave.op
     async def model_predict(input) -> str:
         return eval(input)
@@ -52,7 +52,7 @@ async def test_evaluate_callable_as_model(client):
 
 
 @pytest.mark.asyncio
-async def test_predict_can_receive_other_params(client):
+async def test_predict_can_receive_other_params(weave_active):
     @weave.op
     async def model_predict(input, target) -> str:
         return eval(input) + target
@@ -72,7 +72,7 @@ async def test_predict_can_receive_other_params(client):
 
 
 @pytest.mark.asyncio
-async def test_can_preprocess_model_input(client):
+async def test_can_preprocess_model_input(weave_active):
     @weave.op
     async def model_predict(x) -> str:
         return eval(x)
@@ -91,7 +91,7 @@ async def test_can_preprocess_model_input(client):
 
 
 @pytest.mark.asyncio
-async def test_evaluate_rows_only(client):
+async def test_evaluate_rows_only(weave_active):
     evaluation = Evaluation(
         dataset=dataset_rows,
         scorers=[score],
@@ -118,7 +118,7 @@ async def test_evaluate_other_model_method_names():
 
 
 @pytest.mark.asyncio
-async def test_score_as_class(client):
+async def test_score_as_class(weave_active):
     class MyScorer(weave.Scorer):
         @weave.op
         def score(self, target, output):
@@ -140,7 +140,7 @@ async def test_score_as_class(client):
 
 
 @pytest.mark.asyncio
-async def test_score_with_custom_summarize(client):
+async def test_score_with_custom_summarize(weave_active):
     class MyScorer(weave.Scorer):
         @weave.op
         def summarize(self, score_rows):
@@ -193,7 +193,7 @@ async def test_score_with_custom_summarize(client):
     ],
 )
 async def test_basic_evaluation_with_scorer_styles(
-    client, scorers, expected_output_key
+    weave_active, scorers, expected_output_key
 ):
     # Define all possible scorers
     @weave.op
@@ -304,7 +304,7 @@ async def test_scorer_name_sanitization(scorer_name):
 
 
 @pytest.mark.asyncio
-async def test_sync_eval_parallelism(client):
+async def test_sync_eval_parallelism(weave_active):
     @weave.op
     def sync_op(a):
         time.sleep(1)
@@ -342,7 +342,7 @@ async def test_sync_eval_parallelism(client):
 
 
 @pytest.mark.asyncio
-async def test_evaluation_from_weaveobject_missing_evaluation_name(client):
+async def test_evaluation_from_weaveobject_missing_evaluation_name(weave_active):
     dataset_rows = [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
     dataset = Dataset(rows=dataset_rows)
 
@@ -447,7 +447,7 @@ async def test_evaluate_table_lazy_iter(client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_evaluate_table_order(client):
+async def test_evaluate_table_order(weave_active):
     """Test that evaluation results maintain the original order of the dataset
     when using a published dataset with images.
     """
@@ -507,7 +507,7 @@ async def test_evaluate_table_order(client):
 
 
 @pytest.mark.asyncio
-async def test_evaluate_with_pydantic_summary(client):
+async def test_evaluate_with_pydantic_summary(weave_active):
     class MyScorerSummary(BaseModel):
         awesome: int
 

--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -38,7 +38,7 @@ def example_to_model_input(example):
 
 
 @pytest.mark.asyncio
-async def test_evaluate_callable_as_model(client):
+async def test_evaluate_callable_as_model(weave_active):
     @weave.op
     async def model_predict(input) -> str:
         return eval(input)
@@ -52,7 +52,7 @@ async def test_evaluate_callable_as_model(client):
 
 
 @pytest.mark.asyncio
-async def test_predict_can_receive_other_params(client):
+async def test_predict_can_receive_other_params(weave_active):
     @weave.op
     async def model_predict(input, target) -> str:
         return eval(input) + target
@@ -72,7 +72,7 @@ async def test_predict_can_receive_other_params(client):
 
 
 @pytest.mark.asyncio
-async def test_can_preprocess_model_input(client):
+async def test_can_preprocess_model_input(weave_active):
     @weave.op
     async def model_predict(x) -> str:
         return eval(x)
@@ -91,7 +91,7 @@ async def test_can_preprocess_model_input(client):
 
 
 @pytest.mark.asyncio
-async def test_evaluate_rows_only(client):
+async def test_evaluate_rows_only(weave_active):
     evaluation = Evaluation(
         dataset=dataset_rows,
         scorers=[score_oldstyle],
@@ -102,7 +102,7 @@ async def test_evaluate_rows_only(client):
 
 
 @pytest.mark.asyncio
-async def test_evaluate_both_styles(client):
+async def test_evaluate_both_styles(weave_active):
     evaluation = Evaluation(
         dataset=dataset_rows,
         scorers=[score_oldstyle, score_newstyle],
@@ -134,7 +134,7 @@ async def test_evaluate_other_model_method_names():
 
 
 @pytest.mark.asyncio
-async def test_score_as_class(client):
+async def test_score_as_class(weave_active):
     class MyScorerOldstyle(weave.Scorer):
         @weave.op
         def score(self, model_output, target):
@@ -156,7 +156,7 @@ async def test_score_as_class(client):
 
 
 @pytest.mark.asyncio
-async def test_score_with_custom_summarize(client):
+async def test_score_with_custom_summarize(weave_active):
     class MyScorerOldstyle(weave.Scorer):
         @weave.op
         def summarize(self, score_rows):
@@ -183,7 +183,7 @@ async def test_score_with_custom_summarize(client):
 
 
 @pytest.mark.asyncio
-async def test_multiclass_f1_score(client):
+async def test_multiclass_f1_score(weave_active):
     evaluation = Evaluation(
         dataset=[{"target": {"a": False, "b": True}, "pred": {"a": True, "b": False}}],
         scorers=[MultiTaskBinaryClassificationF1(class_names=["a", "b"])],

--- a/tests/trace/test_evaluation_ref_get.py
+++ b/tests/trace/test_evaluation_ref_get.py
@@ -8,7 +8,7 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 )
 
 
-def test_publish_and_load_evaluation(client):
+def test_publish_and_load_evaluation(weave_active):
     """This test just verifies the round trip for the evaluation.
 
     We do not actually run it here,

--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -636,7 +636,7 @@ def make_test_eval():
 
 
 @pytest.mark.asyncio
-async def test_eval_supports_model_as_op(client):
+async def test_eval_supports_model_as_op(weave_active):
     @weave.op
     def function_model(sentence: str) -> dict:
         return ""
@@ -658,7 +658,7 @@ class MyTestModel(Model):
 
 
 @pytest.mark.asyncio
-async def test_eval_supports_model_class(client):
+async def test_eval_supports_model_class(weave_active):
     evaluation = make_test_eval()
 
     model = MyTestModel()
@@ -671,7 +671,7 @@ async def test_eval_supports_model_class(client):
 
 
 @pytest.mark.asyncio
-async def test_eval_supports_non_op_funcs(client):
+async def test_eval_supports_non_op_funcs(weave_active):
     def function_model(sentence: str) -> dict:
         return ""
 
@@ -702,7 +702,7 @@ async def test_eval_supports_non_op_funcs(client):
 
 
 @pytest.mark.asyncio
-async def test_eval_is_robust_to_missing_values(client):
+async def test_eval_is_robust_to_missing_values(weave_active):
     # At least 1 None
     # All dicts have "d": None
     resp = [

--- a/tests/trace/test_llm_as_a_judge_scorer.py
+++ b/tests/trace/test_llm_as_a_judge_scorer.py
@@ -11,7 +11,7 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 )
 
 
-def test_publish_and_load_scorer_with_prompt_ref(client):
+def test_publish_and_load_scorer_with_prompt_ref(weave_active):
     """Test that LLMAsAJudgeScorer with a MessagesPrompt ref can be published and loaded.
 
     When the scorer is loaded via weave.get(), the scoring_prompt ref string

--- a/tests/trace/test_obj_tags_aliases.py
+++ b/tests/trace/test_obj_tags_aliases.py
@@ -1370,7 +1370,7 @@ def test_sdk_set_aliases_error_nonexistent(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
-def test_weave_tag_functions(weave_active: WeaveClient):
+def test_weave_tag_functions(weave_active):
     """weave.add_tags, remove_tags, get_tags, list_tags — full lifecycle."""
     ref = weave.publish({"data": "test"}, name="tl_tags")
 
@@ -1912,7 +1912,7 @@ def test_delete_non_current_version_leaves_latest_unchanged(
 # ---------------------------------------------------------------------------
 
 
-def test_full_lifecycle(weave_active: WeaveClient):
+def test_full_lifecycle(weave_active):
     """Comprehensive lifecycle: publish, tag, alias, resolve, reassign, remove, verify lists."""
     ref_v0 = weave.publish({"v": 0}, name="lifecycle_obj")
     ref_v1 = weave.publish({"v": 1}, name="lifecycle_obj")
@@ -1951,7 +1951,7 @@ def test_full_lifecycle(weave_active: WeaveClient):
     assert "reviewed" in all_tags
 
 
-def test_publish_with_tags_and_aliases(weave_active: WeaveClient):
+def test_publish_with_tags_and_aliases(weave_active):
     """Tags and aliases set at publish time work with resolution."""
     weave.publish({"v": 0}, name="pub_resolve")
     weave.publish(

--- a/tests/trace/test_obj_tags_aliases.py
+++ b/tests/trace/test_obj_tags_aliases.py
@@ -1370,7 +1370,7 @@ def test_sdk_set_aliases_error_nonexistent(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
-def test_weave_tag_functions(client: WeaveClient):
+def test_weave_tag_functions(weave_active: WeaveClient):
     """weave.add_tags, remove_tags, get_tags, list_tags — full lifecycle."""
     ref = weave.publish({"data": "test"}, name="tl_tags")
 
@@ -1912,7 +1912,7 @@ def test_delete_non_current_version_leaves_latest_unchanged(
 # ---------------------------------------------------------------------------
 
 
-def test_full_lifecycle(client: WeaveClient):
+def test_full_lifecycle(weave_active: WeaveClient):
     """Comprehensive lifecycle: publish, tag, alias, resolve, reassign, remove, verify lists."""
     ref_v0 = weave.publish({"v": 0}, name="lifecycle_obj")
     ref_v1 = weave.publish({"v": 1}, name="lifecycle_obj")
@@ -1951,7 +1951,7 @@ def test_full_lifecycle(client: WeaveClient):
     assert "reviewed" in all_tags
 
 
-def test_publish_with_tags_and_aliases(client: WeaveClient):
+def test_publish_with_tags_and_aliases(weave_active: WeaveClient):
     """Tags and aliases set at publish time work with resolution."""
     weave.publish({"v": 0}, name="pub_resolve")
     weave.publish(

--- a/tests/trace/test_op_accumulator.py
+++ b/tests/trace/test_op_accumulator.py
@@ -297,7 +297,9 @@ async def test_resilience_to_accumulator_accumulation_errors_async(
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_should_accumulate_errors(weave_active, log_collector):
+def test_resilience_to_accumulator_should_accumulate_errors(
+    weave_active, log_collector
+):
     def do_test():
         @weave.op
         def simple_op():

--- a/tests/trace/test_op_accumulator.py
+++ b/tests/trace/test_op_accumulator.py
@@ -155,7 +155,7 @@ def test_process_exit_closes_unfinished_iterator_wrapper(tmp_path):
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_make_accumulator_errors(client, log_collector):
+def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_collector):
     def do_test():
         @weave.op
         def simple_op():
@@ -188,7 +188,7 @@ def test_resilience_to_accumulator_make_accumulator_errors(client, log_collector
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_make_accumulator_errors_async(
-    client, log_collector
+    weave_active, log_collector
 ):
     async def do_test():
         @weave.op
@@ -222,7 +222,7 @@ async def test_resilience_to_accumulator_make_accumulator_errors_async(
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_accumulation_errors(client, log_collector):
+def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collector):
     def do_test():
         @weave.op
         def simple_op():
@@ -259,7 +259,7 @@ def test_resilience_to_accumulator_accumulation_errors(client, log_collector):
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_accumulation_errors_async(
-    client, log_collector
+    weave_active, log_collector
 ):
     async def do_test():
         @weave.op
@@ -297,7 +297,7 @@ async def test_resilience_to_accumulator_accumulation_errors_async(
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_should_accumulate_errors(client, log_collector):
+def test_resilience_to_accumulator_should_accumulate_errors(weave_active, log_collector):
     def do_test():
         @weave.op
         def simple_op():
@@ -339,7 +339,7 @@ def test_resilience_to_accumulator_should_accumulate_errors(client, log_collecto
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_should_accumulate_errors_async(
-    client, log_collector
+    weave_active, log_collector
 ):
     async def do_test():
         @weave.op
@@ -389,7 +389,7 @@ async def test_resilience_to_accumulator_should_accumulate_errors_async(
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_on_finish_post_processor_errors(
-    client, log_collector
+    weave_active, log_collector
 ):
     def do_test():
         @weave.op
@@ -434,7 +434,7 @@ def test_resilience_to_accumulator_on_finish_post_processor_errors(
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
-    client, log_collector
+    weave_active, log_collector
 ):
     async def do_test():
         @weave.op
@@ -478,7 +478,7 @@ async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
         assert log.msg.startswith("Error capturing call output")
 
 
-def test_resilience_to_accumulator_internal_errors(client):
+def test_resilience_to_accumulator_internal_errors(weave_active):
     def do_test():
         @weave.op(accumulator=lambda *args, **kwargs: {})
         def simple_op():
@@ -500,7 +500,7 @@ def test_resilience_to_accumulator_internal_errors(client):
 
 
 @pytest.mark.asyncio
-async def test_resilience_to_accumulator_internal_errors_async(client):
+async def test_resilience_to_accumulator_internal_errors_async(weave_active):
     async def do_test():
         @weave.op(accumulator=lambda *args, **kwargs: {})
         async def simple_op():

--- a/tests/trace/test_op_call_method.py
+++ b/tests/trace/test_op_call_method.py
@@ -2,7 +2,7 @@ import weave
 import weave.trace.call
 
 
-def test_op_call_method(client):
+def test_op_call_method(weave_active):
     @weave.op
     def add(a, b):
         return a + b

--- a/tests/trace/test_op_coroutines.py
+++ b/tests/trace/test_op_coroutines.py
@@ -7,7 +7,7 @@ import weave
 from weave.trace.call import Call
 
 
-def test_sync_val(client):
+def test_sync_val(weave_active):
     @weave.op
     def sync_val():
         return 1
@@ -19,7 +19,7 @@ def test_sync_val(client):
     assert res == 1
 
 
-def test_sync_val_method(client):
+def test_sync_val_method(weave_active):
     class TestClass:
         @weave.op
         def sync_val(self):
@@ -34,7 +34,7 @@ def test_sync_val_method(client):
 
 
 @pytest.mark.asyncio
-async def test_sync_coro(client):
+async def test_sync_coro(weave_active):
     @weave.op
     def sync_coro():
         return asyncio.to_thread(lambda: 1)
@@ -49,7 +49,7 @@ async def test_sync_coro(client):
 
 
 @pytest.mark.asyncio
-async def test_sync_coro_method(client):
+async def test_sync_coro_method(weave_active):
     class TestClass:
         @weave.op
         def sync_coro(self):
@@ -66,7 +66,7 @@ async def test_sync_coro_method(client):
 
 
 @pytest.mark.asyncio
-async def test_async_coro(client):
+async def test_async_coro(weave_active):
     @weave.op
     async def async_coro():
         return asyncio.to_thread(lambda: 1)
@@ -83,7 +83,7 @@ async def test_async_coro(client):
 
 
 @pytest.mark.asyncio
-async def test_async_coro_method(client):
+async def test_async_coro_method(weave_active):
     class TestClass:
         @weave.op
         async def async_coro(self):
@@ -103,7 +103,7 @@ async def test_async_coro_method(client):
 
 
 @pytest.mark.asyncio
-async def test_async_awaited_coro(client):
+async def test_async_awaited_coro(weave_active):
     @weave.op
     async def async_awaited_coro():
         return await asyncio.to_thread(lambda: 1)
@@ -117,7 +117,7 @@ async def test_async_awaited_coro(client):
 
 
 @pytest.mark.asyncio
-async def test_async_awaited_coro_method(client):
+async def test_async_awaited_coro_method(weave_active):
     class TestClass:
         @weave.op
         async def async_awaited_coro(self):
@@ -133,7 +133,7 @@ async def test_async_awaited_coro_method(client):
 
 
 @pytest.mark.asyncio
-async def test_async_val(client):
+async def test_async_val(weave_active):
     @weave.op
     async def async_val():
         return 1
@@ -147,7 +147,7 @@ async def test_async_val(client):
 
 
 @pytest.mark.asyncio
-async def test_async_val_method(client):
+async def test_async_val_method(weave_active):
     class TestClass:
         @weave.op
         async def async_val(self):
@@ -162,7 +162,7 @@ async def test_async_val_method(client):
     assert res == 1
 
 
-def test_sync_with_exception(client):
+def test_sync_with_exception(weave_active):
     @weave.op
     def sync_with_exception():
         raise ValueError("test")
@@ -175,7 +175,7 @@ def test_sync_with_exception(client):
     assert res is None
 
 
-def test_sync_with_exception_method(client):
+def test_sync_with_exception_method(weave_active):
     class TestClass:
         @weave.op
         def sync_with_exception(self):
@@ -191,7 +191,7 @@ def test_sync_with_exception_method(client):
 
 
 @pytest.mark.asyncio
-async def test_async_with_exception(client):
+async def test_async_with_exception(weave_active):
     @weave.op
     async def async_with_exception():
         raise ValueError("test")
@@ -205,7 +205,7 @@ async def test_async_with_exception(client):
 
 
 @pytest.mark.asyncio
-async def test_async_with_exception_method(client):
+async def test_async_with_exception_method(weave_active):
     class TestClass:
         @weave.op
         async def async_with_exception(self):

--- a/tests/trace/test_op_decorator_behaviour.py
+++ b/tests/trace/test_op_decorator_behaviour.py
@@ -62,7 +62,7 @@ def py_obj():
     return B()
 
 
-def test_sync_func(client, func):
+def test_sync_func(weave_active, func):
     assert func(1) == 2
 
     ref = weave.publish(func)
@@ -71,7 +71,7 @@ def test_sync_func(client, func):
     assert func2(1) == 2
 
 
-def test_sync_func_call(client, func):
+def test_sync_func_call(weave_active, func):
     res, call = func.call(1)
     assert isinstance(call, Call)
     assert call.inputs == {"a": 1}
@@ -89,7 +89,7 @@ def test_sync_func_call(client, func):
 
 
 @pytest.mark.asyncio
-async def test_async_func(client, afunc):
+async def test_async_func(weave_active, afunc):
     assert await afunc(1) == 2
 
     ref = weave.publish(afunc)
@@ -99,7 +99,7 @@ async def test_async_func(client, afunc):
 
 
 @pytest.mark.asyncio
-async def test_async_func_call(client, afunc):
+async def test_async_func_call(weave_active, afunc):
     res, call = await afunc.call(1)
     assert isinstance(call, Call)
     assert call.inputs == {"a": 1}
@@ -116,7 +116,7 @@ async def test_async_func_call(client, afunc):
     assert res2 == 2
 
 
-def test_sync_method(client, weave_obj, py_obj):
+def test_sync_method(weave_active, weave_obj, py_obj):
     assert weave_obj.method(1) == 2
     assert py_obj.method(1) == 2
 
@@ -125,7 +125,7 @@ def test_sync_method(client, weave_obj, py_obj):
         weave_obj_method2 = weave_obj_method_ref.get()
 
 
-def test_sync_method_call(client, weave_obj, py_obj):
+def test_sync_method_call(weave_active, weave_obj, py_obj):
     res, call = weave_obj.method.call(weave_obj, 1)
     assert isinstance(call, Call)
     assert call.inputs == {
@@ -150,7 +150,7 @@ def test_sync_method_call(client, weave_obj, py_obj):
 
 
 @pytest.mark.asyncio
-async def test_async_method(client, weave_obj, py_obj):
+async def test_async_method(weave_active, weave_obj, py_obj):
     assert await weave_obj.amethod(1) == 2
     assert await py_obj.amethod(1) == 2
 
@@ -160,7 +160,7 @@ async def test_async_method(client, weave_obj, py_obj):
 
 
 @pytest.mark.asyncio
-async def test_async_method_call(client, weave_obj, py_obj):
+async def test_async_method_call(weave_active, weave_obj, py_obj):
     res, call = await weave_obj.amethod.call(weave_obj, 1)
     assert isinstance(call, Call)
     assert call.inputs == {
@@ -212,7 +212,7 @@ def test_async_method_patching_passes_inspection(weave_obj, py_obj):
     assert inspect.ismethod(py_obj.amethod)
 
 
-def test_sync_method_calls(client, weave_obj):
+def test_sync_method_calls(weave_active, weave_obj):
     for x in range(3):
         weave_obj.method(x)
 
@@ -226,7 +226,7 @@ def test_sync_method_calls(client, weave_obj):
 
 
 @pytest.mark.asyncio
-async def test_async_method_calls(client, weave_obj):
+async def test_async_method_calls(weave_active, weave_obj):
     for x in range(3):
         await weave_obj.amethod(x)
 
@@ -240,7 +240,7 @@ async def test_async_method_calls(client, weave_obj):
 
 
 @pytest.mark.asyncio
-async def test_gotten_object_method_is_callable(client, weave_obj):
+async def test_gotten_object_method_is_callable(weave_active, weave_obj):
     ref = weave.publish(weave_obj)
 
     weave_obj2 = ref.get()
@@ -249,7 +249,7 @@ async def test_gotten_object_method_is_callable(client, weave_obj):
 
 
 @pytest.mark.asyncio
-async def test_gotten_object_method_is_callable_with_call_func(client, weave_obj):
+async def test_gotten_object_method_is_callable_with_call_func(weave_active, weave_obj):
     ref = weave.publish(weave_obj)
 
     weave_obj2 = ref.get()

--- a/tests/trace/test_op_versioning.py
+++ b/tests/trace/test_op_versioning.py
@@ -460,7 +460,7 @@ def test_op_nested_function(
     assert weave.ref(ref.uri).get()(2) == 5
 
 
-def test_op_basic_execution(client):
+def test_op_basic_execution(weave_active):
     @weave.op
     def adder(v: int) -> int:
         return v + 1

--- a/tests/trace/test_publish_round_trip.py
+++ b/tests/trace/test_publish_round_trip.py
@@ -26,7 +26,7 @@ def test_publish_round_trip_query_object(client) -> None:
     assert query_2 == query
 
 
-def test_publish_round_trip_register_object_nested(client) -> None:
+def test_publish_round_trip_register_object_nested(weave_active) -> None:
     class Inner(BaseModel):
         name: str
 
@@ -47,7 +47,7 @@ def test_publish_round_trip_register_object_nested(client) -> None:
     assert outer == outer_gotten
 
 
-def test_round_trip_unwrap(client) -> None:
+def test_round_trip_unwrap(weave_active) -> None:
     data = {
         "a": 1,
         "b": [

--- a/tests/trace/test_redaction.py
+++ b/tests/trace/test_redaction.py
@@ -5,7 +5,7 @@ from weave.trace.weave_client import redact_sensitive_keys
 from weave.utils import sanitize
 
 
-def test_code_capture_redacts_sensitive_values(client):
+def test_code_capture_redacts_sensitive_values(weave_active):
     api_key = "123"
 
     @weave.op

--- a/tests/trace/test_ref_trace.py
+++ b/tests/trace/test_ref_trace.py
@@ -5,7 +5,7 @@ import pytest
 import weave
 
 
-def test_ref_hashable(client):
+def test_ref_hashable(weave_active):
     class Thing(weave.Object):
         val: int
 
@@ -24,7 +24,7 @@ def test_ref_hashable(client):
     }
 
 
-def test_ref_immutable(client):
+def test_ref_immutable(weave_active):
     class Thing(weave.Object):
         val: int
 

--- a/tests/trace/test_saved_view.py
+++ b/tests/trace/test_saved_view.py
@@ -134,7 +134,7 @@ def test_filter_op_without_client():
         )
 
 
-def test_filter_op_with_client(client):
+def test_filter_op_with_client(weave_active):
     view = weave.SavedView("traces", "My saved view").filter_op(
         "Evaluation.predict_and_score"
     )
@@ -218,13 +218,13 @@ def test_column_manipulation():
     assert view.base.definition.columns[0].path == ["inputs", "foo"]
 
 
-def test_saved_view_create(client):
+def test_saved_view_create(weave_active):
     view = weave.SavedView("traces", "My saved view").hide_column("feedback").save()
     assert view.label == "My saved view"
     assert isinstance(view.ref, ObjectRef)
 
 
-def test_saved_view_load(client):
+def test_saved_view_load(weave_active):
     saved_view = weave.SavedView("traces", "My saved view")
     saved_view.show_column("attributes.weave.client_version")
     saved_view.save()

--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -261,7 +261,7 @@ def test_to_json_object_excludes_ref(client) -> None:
     assert "ref" not in serialized
 
 
-def test_to_json_function_with_memory_address_in_op(client) -> None:
+def test_to_json_function_with_memory_address_in_op(weave_active) -> None:
     opaque = object()
 
     @weave.op

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -75,7 +75,7 @@ def test_disabled_env(client):
     )
 
 
-def test_publish_when_disabled(client, monkeypatch):
+def test_publish_when_disabled(weave_active, monkeypatch):
     """Test that weave.publish() returns a dummy ref when WEAVE_DISABLED=true."""
     monkeypatch.setenv("WEAVE_DISABLED", "true")
 
@@ -91,7 +91,7 @@ def test_publish_when_disabled(client, monkeypatch):
     assert ref.digest == "DISABLED"
 
 
-def test_publish_when_disabled_uses_obj_name(client, monkeypatch):
+def test_publish_when_disabled_uses_obj_name(weave_active, monkeypatch):
     """Test that publish uses object's name attribute when no explicit name given."""
     monkeypatch.setenv("WEAVE_DISABLED", "true")
 
@@ -108,7 +108,7 @@ def test_publish_when_disabled_uses_obj_name(client, monkeypatch):
     assert ref.name == "my_obj"
 
 
-def test_publish_when_disabled_uses_class_name(client, monkeypatch):
+def test_publish_when_disabled_uses_class_name(weave_active, monkeypatch):
     """Test that publish uses class name when object has no name attribute."""
     monkeypatch.setenv("WEAVE_DISABLED", "true")
 
@@ -125,7 +125,7 @@ def test_publish_when_disabled_uses_class_name(client, monkeypatch):
     assert ref.name == "MyClass"
 
 
-def test_publish_when_disabled_ignores_tags_aliases(client, monkeypatch):
+def test_publish_when_disabled_ignores_tags_aliases(weave_active, monkeypatch):
     """Tags and aliases should be silently ignored when weave is disabled."""
     monkeypatch.setenv("WEAVE_DISABLED", "true")
 
@@ -177,7 +177,7 @@ def test_print_call_link_env(client):
     del os.environ["WEAVE_PRINT_CALL_LINK"]
 
 
-def test_should_capture_code_setting(client):
+def test_should_capture_code_setting(weave_active):
     replace_settings(UserSettings(capture_code=False))
 
     @weave.op
@@ -203,7 +203,7 @@ def test_should_capture_code_setting(client):
     assert "Code-capture was disabled" not in code3
 
 
-def test_should_capture_code_env(client):
+def test_should_capture_code_env(weave_active):
     os.environ["WEAVE_CAPTURE_CODE"] = "false"
 
     @weave.op

--- a/tests/trace/test_tracing_resilience.py
+++ b/tests/trace/test_tracing_resilience.py
@@ -29,7 +29,7 @@ def reset_call_context():
     call_context._call_stack.reset(token)
 
 
-def test_resilience_to_user_code_errors(client):
+def test_resilience_to_user_code_errors(weave_active):
     def do_test():
         @weave.op
         def throws():
@@ -82,7 +82,7 @@ def test_resilience_to_server_errors(client_with_throwing_server, log_collector)
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_output_handler_errors(client, log_collector):
+def test_resilience_to_output_handler_errors(weave_active, log_collector):
     def do_test():
         @weave.op
         def simple_op():
@@ -113,7 +113,7 @@ def test_resilience_to_output_handler_errors(client, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_output_handler_errors_async(client, log_collector):
+async def test_resilience_to_output_handler_errors_async(weave_active, log_collector):
     async def do_test():
         @weave.op
         async def simple_op():
@@ -143,7 +143,7 @@ async def test_resilience_to_output_handler_errors_async(client, log_collector):
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_make_accumulator_errors(client, log_collector):
+def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_collector):
     def do_test():
         @weave.op
         def simple_op():
@@ -176,7 +176,7 @@ def test_resilience_to_accumulator_make_accumulator_errors(client, log_collector
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_make_accumulator_errors_async(
-    client, log_collector
+    weave_active, log_collector
 ):
     async def do_test():
         @weave.op
@@ -210,7 +210,7 @@ async def test_resilience_to_accumulator_make_accumulator_errors_async(
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_accumulation_errors(client, log_collector):
+def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collector):
     def do_test():
         @weave.op
         def simple_op():
@@ -247,7 +247,7 @@ def test_resilience_to_accumulator_accumulation_errors(client, log_collector):
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_accumulation_errors_async(
-    client, log_collector
+    weave_active, log_collector
 ):
     async def do_test():
         @weave.op
@@ -285,7 +285,7 @@ async def test_resilience_to_accumulator_accumulation_errors_async(
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_should_accumulate_errors(client, log_collector):
+def test_resilience_to_accumulator_should_accumulate_errors(weave_active, log_collector):
     def do_test():
         @weave.op
         def simple_op():
@@ -327,7 +327,7 @@ def test_resilience_to_accumulator_should_accumulate_errors(client, log_collecto
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_should_accumulate_errors_async(
-    client, log_collector
+    weave_active, log_collector
 ):
     async def do_test():
         @weave.op
@@ -377,7 +377,7 @@ async def test_resilience_to_accumulator_should_accumulate_errors_async(
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_on_finish_post_processor_errors(
-    client, log_collector
+    weave_active, log_collector
 ):
     def do_test():
         @weave.op
@@ -422,7 +422,7 @@ def test_resilience_to_accumulator_on_finish_post_processor_errors(
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
-    client, log_collector
+    weave_active, log_collector
 ):
     async def do_test():
         @weave.op
@@ -466,7 +466,7 @@ async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
         assert log.msg.startswith("Error capturing call output")
 
 
-def test_resilience_to_accumulator_internal_errors(client):
+def test_resilience_to_accumulator_internal_errors(weave_active):
     def do_test():
         @weave.op(accumulator=lambda *args, **kwargs: {})
         def simple_op():
@@ -488,7 +488,7 @@ def test_resilience_to_accumulator_internal_errors(client):
 
 
 @pytest.mark.asyncio
-async def test_resilience_to_accumulator_internal_errors_async(client):
+async def test_resilience_to_accumulator_internal_errors_async(weave_active):
     async def do_test():
         @weave.op(accumulator=lambda *args, **kwargs: {})
         async def simple_op():
@@ -533,7 +533,7 @@ def _bad_finish_handler(call, output, exception):
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_postprocess_inputs_errors(client, log_collector):
+def test_resilience_to_postprocess_inputs_errors(weave_active, log_collector):
     """Test that errors in postprocess_inputs don't crash the user's program."""
 
     @weave.op(postprocess_inputs=_bad_postprocess_inputs)
@@ -551,7 +551,7 @@ def test_resilience_to_postprocess_inputs_errors(client, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_postprocess_inputs_errors_async(client, log_collector):
+async def test_resilience_to_postprocess_inputs_errors_async(weave_active, log_collector):
     """Test that errors in postprocess_inputs don't crash async ops."""
 
     @weave.op(postprocess_inputs=_bad_postprocess_inputs)
@@ -568,7 +568,7 @@ async def test_resilience_to_postprocess_inputs_errors_async(client, log_collect
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_postprocess_output_errors(client, log_collector):
+def test_resilience_to_postprocess_output_errors(weave_active, log_collector):
     """Test that errors in postprocess_output don't crash the user's program."""
 
     @weave.op(postprocess_output=_bad_postprocess_output)
@@ -586,7 +586,7 @@ def test_resilience_to_postprocess_output_errors(client, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_postprocess_output_errors_async(client, log_collector):
+async def test_resilience_to_postprocess_output_errors_async(weave_active, log_collector):
     """Test that errors in postprocess_output don't crash async ops."""
 
     @weave.op(postprocess_output=_bad_postprocess_output)
@@ -603,7 +603,7 @@ async def test_resilience_to_postprocess_output_errors_async(client, log_collect
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_call_display_name_errors(client, log_collector):
+def test_resilience_to_call_display_name_errors(weave_active, log_collector):
     """Test that errors in call_display_name callable don't crash the user's program."""
 
     @weave.op(call_display_name=_bad_display_name)
@@ -621,7 +621,7 @@ def test_resilience_to_call_display_name_errors(client, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_call_display_name_errors_async(client, log_collector):
+async def test_resilience_to_call_display_name_errors_async(weave_active, log_collector):
     """Test that errors in call_display_name callable don't crash async ops."""
 
     @weave.op(call_display_name=_bad_display_name)
@@ -638,7 +638,7 @@ async def test_resilience_to_call_display_name_errors_async(client, log_collecto
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_on_input_handler_errors(client, log_collector):
+def test_resilience_to_on_input_handler_errors(weave_active, log_collector):
     """Test that errors in _on_input_handler don't crash the user's program."""
 
     @weave.op
@@ -658,7 +658,7 @@ def test_resilience_to_on_input_handler_errors(client, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_on_input_handler_errors_async(client, log_collector):
+async def test_resilience_to_on_input_handler_errors_async(weave_active, log_collector):
     """Test that errors in _on_input_handler don't crash async ops."""
 
     @weave.op
@@ -677,7 +677,7 @@ async def test_resilience_to_on_input_handler_errors_async(client, log_collector
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_on_finish_handler_errors(client, log_collector):
+def test_resilience_to_on_finish_handler_errors(weave_active, log_collector):
     """Test that errors in _on_finish_handler don't crash the user's program."""
 
     @weave.op
@@ -697,7 +697,7 @@ def test_resilience_to_on_finish_handler_errors(client, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_on_finish_handler_errors_async(client, log_collector):
+async def test_resilience_to_on_finish_handler_errors_async(weave_active, log_collector):
     """Test that errors in _on_finish_handler don't crash async ops."""
 
     @weave.op
@@ -739,7 +739,7 @@ def _make_leaking_create_call():
 
 
 @pytest.mark.disable_logging_error_check
-def test_create_call_leak_restores_call_stack_sync(client, monkeypatch, log_collector):
+def test_create_call_leak_restores_call_stack_sync(weave_active, monkeypatch, log_collector):
     """If _create_call pushes a call then throws, the stack must be cleaned up."""
 
     @weave.op
@@ -756,7 +756,7 @@ def test_create_call_leak_restores_call_stack_sync(client, monkeypatch, log_coll
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_create_call_leak_restores_call_stack_async(
-    client, monkeypatch, log_collector
+    weave_active, monkeypatch, log_collector
 ):
     """Async variant: leaked call from _create_call is cleaned up."""
 
@@ -773,7 +773,7 @@ async def test_create_call_leak_restores_call_stack_async(
 
 @pytest.mark.disable_logging_error_check
 def test_create_call_leak_restores_call_stack_sync_gen(
-    client, monkeypatch, log_collector
+    weave_active, monkeypatch, log_collector
 ):
     """Sync generator variant: leaked call from _create_call is cleaned up."""
 
@@ -791,7 +791,7 @@ def test_create_call_leak_restores_call_stack_sync_gen(
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_create_call_leak_restores_call_stack_async_gen(
-    client, monkeypatch, log_collector
+    weave_active, monkeypatch, log_collector
 ):
     """Async generator variant: leaked call from _create_call is cleaned up."""
 
@@ -809,7 +809,7 @@ async def test_create_call_leak_restores_call_stack_async_gen(
 
 
 @pytest.mark.disable_logging_error_check
-def test_create_call_leak_preserves_parent_call(client, monkeypatch, log_collector):
+def test_create_call_leak_preserves_parent_call(weave_active, monkeypatch, log_collector):
     """When a nested op's _create_call leaks, the parent call must remain current."""
     inner_saw_parent = None
 

--- a/tests/trace/test_tracing_resilience.py
+++ b/tests/trace/test_tracing_resilience.py
@@ -285,7 +285,9 @@ async def test_resilience_to_accumulator_accumulation_errors_async(
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_should_accumulate_errors(weave_active, log_collector):
+def test_resilience_to_accumulator_should_accumulate_errors(
+    weave_active, log_collector
+):
     def do_test():
         @weave.op
         def simple_op():
@@ -551,7 +553,9 @@ def test_resilience_to_postprocess_inputs_errors(weave_active, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_postprocess_inputs_errors_async(weave_active, log_collector):
+async def test_resilience_to_postprocess_inputs_errors_async(
+    weave_active, log_collector
+):
     """Test that errors in postprocess_inputs don't crash async ops."""
 
     @weave.op(postprocess_inputs=_bad_postprocess_inputs)
@@ -586,7 +590,9 @@ def test_resilience_to_postprocess_output_errors(weave_active, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_postprocess_output_errors_async(weave_active, log_collector):
+async def test_resilience_to_postprocess_output_errors_async(
+    weave_active, log_collector
+):
     """Test that errors in postprocess_output don't crash async ops."""
 
     @weave.op(postprocess_output=_bad_postprocess_output)
@@ -621,7 +627,9 @@ def test_resilience_to_call_display_name_errors(weave_active, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_call_display_name_errors_async(weave_active, log_collector):
+async def test_resilience_to_call_display_name_errors_async(
+    weave_active, log_collector
+):
     """Test that errors in call_display_name callable don't crash async ops."""
 
     @weave.op(call_display_name=_bad_display_name)
@@ -697,7 +705,9 @@ def test_resilience_to_on_finish_handler_errors(weave_active, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_on_finish_handler_errors_async(weave_active, log_collector):
+async def test_resilience_to_on_finish_handler_errors_async(
+    weave_active, log_collector
+):
     """Test that errors in _on_finish_handler don't crash async ops."""
 
     @weave.op
@@ -739,7 +749,9 @@ def _make_leaking_create_call():
 
 
 @pytest.mark.disable_logging_error_check
-def test_create_call_leak_restores_call_stack_sync(weave_active, monkeypatch, log_collector):
+def test_create_call_leak_restores_call_stack_sync(
+    weave_active, monkeypatch, log_collector
+):
     """If _create_call pushes a call then throws, the stack must be cleaned up."""
 
     @weave.op
@@ -809,7 +821,9 @@ async def test_create_call_leak_restores_call_stack_async_gen(
 
 
 @pytest.mark.disable_logging_error_check
-def test_create_call_leak_preserves_parent_call(weave_active, monkeypatch, log_collector):
+def test_create_call_leak_preserves_parent_call(
+    weave_active, monkeypatch, log_collector
+):
     """When a nested op's _create_call leaks, the parent call must remain current."""
     inner_saw_parent = None
 

--- a/tests/trace/test_wal_client_writes.py
+++ b/tests/trace/test_wal_client_writes.py
@@ -315,12 +315,12 @@ class TestWALDisabled:
         """Default client should have _wal=None."""
         assert client._wal is None
 
-    def test_publish_works_without_wal(self, client):
+    def test_publish_works_without_wal(self, weave_active):
         """publish() should succeed and return a ref when WAL is disabled."""
         ref = weave.publish({"key": "value"}, name="no_wal_obj")
         assert ref is not None
 
-    def test_dataset_publish_works_without_wal(self, client):
+    def test_dataset_publish_works_without_wal(self, weave_active):
         """Dataset publish should succeed when WAL is disabled."""
         ds = weave.Dataset(name="no_wal_ds", rows=[{"x": 1}])
         ref = weave.publish(ds, name="no_wal_ds")

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -1106,7 +1106,7 @@ def test_dataset_rows_ref(client):
 
 @pytest.mark.skip("failing in ci, due to some kind of /tmp file slowness?")
 @pytest.mark.asyncio
-async def test_evaluate(client):
+async def test_evaluate(weave_active):
     @weave.op
     async def model_predict(input) -> str:
         return eval(input)
@@ -1386,7 +1386,7 @@ def test_isinstance_checks(client):
     assert y3 is None
 
 
-def test_summary_tokens(client):
+def test_summary_tokens(weave_active):
     @weave.op
     def model_a(text):
         result = "a: " + text
@@ -1433,7 +1433,7 @@ def test_summary_tokens(client):
 
 
 @pytest.mark.skip("descendent error tracking disabled until we fix UI")
-def test_summary_descendents(client):
+def test_summary_descendents(weave_active):
     @weave.op
     def model_a(text):
         return "a: " + text
@@ -2019,7 +2019,7 @@ def test_object_version_read(client):
 
 
 @pytest.mark.asyncio
-async def test_op_calltime_display_name(client):
+async def test_op_calltime_display_name(weave_active):
     @weave.op
     def my_op(a: int) -> int:
         return a
@@ -2040,7 +2040,7 @@ async def test_op_calltime_display_name(client):
     assert call.display_name == "custom_display_name"
 
 
-def test_long_display_names_are_elided(client):
+def test_long_display_names_are_elided(weave_active):
     @weave.op(call_display_name="a" * 2048)
     def func():
         pass
@@ -2118,7 +2118,7 @@ def test_object_deletion(client):
     assert len(versions.objs) == 0
 
 
-def test_recursive_object_deletion(client):
+def test_recursive_object_deletion(weave_active):
     # Create a bunch of objects that refer to each other
     obj1 = {"a": 5}
     obj1_ref = weave.publish(obj1, "obj1")
@@ -2148,7 +2148,7 @@ def test_recursive_object_deletion(client):
     assert obj3_ref.get() == {"c": obj2}
 
 
-def test_delete_op_version(client):
+def test_delete_op_version(weave_active):
     @weave.op
     def my_op(a: int) -> int:
         return a

--- a/tests/trace/test_weave_client_mutations.py
+++ b/tests/trace/test_weave_client_mutations.py
@@ -4,7 +4,7 @@ from pydantic import Field
 import weave
 
 
-def test_object_mutation_saving(client):
+def test_object_mutation_saving(weave_active):
     class Thing(weave.Object):
         a: str
         b: int
@@ -29,7 +29,7 @@ def test_object_mutation_saving(client):
     assert thing3.c == 4.2
 
 
-def test_list_mutation_saving(client):
+def test_list_mutation_saving(weave_active):
     lst = [1, 2, 3]
     ref = weave.publish(lst)
 
@@ -46,7 +46,7 @@ def test_list_mutation_saving(client):
     assert lst3 == [100, 2, 3, 4, 5, 6]
 
 
-def test_dict_mutation_saving(client):
+def test_dict_mutation_saving(weave_active):
     # TODO: Today we assume all the keys must be str?
     d = {"a": 1, "b": 2}
     ref = weave.publish(d)
@@ -62,7 +62,7 @@ def test_dict_mutation_saving(client):
     assert d3 == {"a": 1, "b": "new_value", "new_key": 3}
 
 
-def test_object_mutation_saving_nested(client):
+def test_object_mutation_saving_nested(weave_active):
     class A(weave.Object):
         b: int = 1
 
@@ -89,7 +89,7 @@ def test_object_mutation_saving_nested(client):
     assert d3.c.a.b == 3
 
 
-def test_list_mutation_saving_nested(client):
+def test_list_mutation_saving_nested(weave_active):
     lst = [1, 2, 3]
     ref = weave.publish(lst)
 
@@ -109,7 +109,7 @@ def test_list_mutation_saving_nested(client):
     assert lst5 == [1, 2, 3, [4, 5, 6]]
 
 
-def test_dict_mutation_saving_nested(client):
+def test_dict_mutation_saving_nested(weave_active):
     d = {"a": 1, "b": 2}
     ref = weave.publish(d)
 
@@ -133,7 +133,7 @@ def test_dict_mutation_saving_nested(client):
     }
 
 
-def test_object_mutation_saving_nested_lists_and_dicts(client):
+def test_object_mutation_saving_nested_lists_and_dicts(weave_active):
     class A(weave.Object):
         b: int
 
@@ -185,7 +185,7 @@ def test_object_mutation_saving_nested_lists_and_dicts(client):
     assert g3.b.f == {"d": {"e": "f"}}
 
 
-def test_list_mutation_saving_nested_objects(client):
+def test_list_mutation_saving_nested_objects(weave_active):
     class A(weave.Object):
         b: int
 
@@ -203,7 +203,7 @@ def test_list_mutation_saving_nested_objects(client):
     assert lst3[2].b == 3
 
 
-def test_list_mutation_saving_nested_dicts(client):
+def test_list_mutation_saving_nested_dicts(weave_active):
     lst = [{"a": {"b": 1}}, {"a": {"b": 2}}]
     ref = weave.publish(lst)
 
@@ -218,7 +218,7 @@ def test_list_mutation_saving_nested_dicts(client):
     assert lst3[2]["a"]["b"] == 3
 
 
-def test_dict_mutation_saving_nested_objects(client):
+def test_dict_mutation_saving_nested_objects(weave_active):
     class A(weave.Object):
         b: int
 
@@ -235,7 +235,7 @@ def test_dict_mutation_saving_nested_objects(client):
     assert d3["c"].b == 3
 
 
-def test_dict_mutation_saving_nested_lists(client):
+def test_dict_mutation_saving_nested_lists(weave_active):
     d = {"a": [1, 2], "b": [3, 4]}
     ref = weave.publish(d)
 
@@ -249,7 +249,7 @@ def test_dict_mutation_saving_nested_lists(client):
     assert d3["c"] == [5, 6]
 
 
-def test_table_mutation_saving_append_rows(client):
+def test_table_mutation_saving_append_rows(weave_active):
     t = weave.Table(rows=[{"a": 1, "b": 2}])
     t.append({"a": 3, "b": 4})
     ref = weave.publish(t)
@@ -270,7 +270,7 @@ def test_table_mutation_saving_append_rows(client):
     ]
 
 
-def test_table_mutation_saving_pop_rows(client):
+def test_table_mutation_saving_pop_rows(weave_active):
     t = weave.Table(
         rows=[
             {"a": 1, "b": 2},
@@ -293,7 +293,7 @@ def test_table_mutation_saving_pop_rows(client):
     assert t3.rows == [{"a": 5, "b": 6}]
 
 
-def test_table_mutation_saving_replace_rows(client):
+def test_table_mutation_saving_replace_rows(weave_active):
     t = weave.Table(
         rows=[
             {"a": 1, "b": 2},
@@ -310,7 +310,7 @@ def test_table_mutation_saving_replace_rows(client):
     assert t3.rows == [{"a": 5, "b": 6}]
 
 
-def test_table_cant_append_bad_data(client):
+def test_table_cant_append_bad_data(weave_active):
     t = weave.Table(rows=[{"a": 1, "b": 2}])
     with pytest.raises(TypeError):
         t.append(1)
@@ -325,7 +325,7 @@ def test_table_cant_append_bad_data(client):
         t2.append([1, 2, 3])
 
 
-def test_table_cant_set_bad_data(client):
+def test_table_cant_set_bad_data(weave_active):
     t = weave.Table(rows=[{"a": 1, "b": 2}])
     with pytest.raises(ValueError, match="must be (a list of )?dicts"):
         t.rows = [1, 2, 3]

--- a/tests/trace/test_weave_client_threaded.py
+++ b/tests/trace/test_weave_client_threaded.py
@@ -10,7 +10,7 @@ import weave
 
 
 @pytest.fixture
-def flask_server(client):
+def flask_server(weave_active):
     app = Flask(__name__)
     server_port = 6789
     host = "127.0.0.1"
@@ -41,7 +41,7 @@ def test_flask_server(flask_server):
     assert response.text == "FkWFKCRcl9wsGp3yclN7v1IIAICTPenpZYrWo0otI4Y"
 
 
-def test_weave_client_global_accessible_in_thread(client):
+def test_weave_client_global_accessible_in_thread(weave_active):
     def thread_func(q: queue.Queue):
         try:
             d = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])

--- a/tests/trace/test_weave_object_vals.py
+++ b/tests/trace/test_weave_object_vals.py
@@ -13,7 +13,7 @@ def test_weaveobject_properties():
     assert to.x == 1
 
 
-def test_weaveobject_access_after_init_termination(client):
+def test_weaveobject_access_after_init_termination(weave_active):
     my_obj = None
 
     class MyObj(weave.Object):

--- a/tests/trace/type_handlers/Content/test_content.py
+++ b/tests/trace/type_handlers/Content/test_content.py
@@ -10,7 +10,6 @@ from util import generate_media
 import weave
 from weave import Dataset
 from weave.trace.table import Table
-from weave.trace.weave_client import WeaveClient
 from weave.type_wrappers.Content.content import Content
 from weave.utils import http_requests as _http_requests
 
@@ -369,7 +368,7 @@ class TestWeaveContent:
         content2 = Content.from_bytes(file_bytes, extension="txt", encoding="latin-1")
         assert content2.encoding == "latin-1"
 
-    def test_content_save_and_retrieve(self, image_file, weave_active: WeaveClient):
+    def test_content_save_and_retrieve(self, image_file, weave_active):
         """Test publishing and retrieving Content objects."""
         content = Content.from_path(image_file)
 
@@ -386,7 +385,7 @@ class TestWeaveContent:
         assert retrieved.size == content.size
 
     def test_content_in_dataset(
-        self, image_file, audio_file, video_file, pdf_file, weave_active: WeaveClient
+        self, image_file, audio_file, video_file, pdf_file, weave_active
     ):
         """Test Content objects as dataset values."""
         rows = []
@@ -419,7 +418,7 @@ class TestWeaveContent:
             original_data = original_files[row["name"]]
             assert row["content"].data == original_data
 
-    def test_content_postprocessing(self, weave_active: WeaveClient):
+    def test_content_postprocessing(self, weave_active):
         """Test that Content postprocessing works correctly in ops."""
 
         @weave.op

--- a/tests/trace/type_handlers/Content/test_content.py
+++ b/tests/trace/type_handlers/Content/test_content.py
@@ -369,7 +369,7 @@ class TestWeaveContent:
         content2 = Content.from_bytes(file_bytes, extension="txt", encoding="latin-1")
         assert content2.encoding == "latin-1"
 
-    def test_content_save_and_retrieve(self, image_file, client: WeaveClient):
+    def test_content_save_and_retrieve(self, image_file, weave_active: WeaveClient):
         """Test publishing and retrieving Content objects."""
         content = Content.from_path(image_file)
 
@@ -386,7 +386,7 @@ class TestWeaveContent:
         assert retrieved.size == content.size
 
     def test_content_in_dataset(
-        self, image_file, audio_file, video_file, pdf_file, client: WeaveClient
+        self, image_file, audio_file, video_file, pdf_file, weave_active: WeaveClient
     ):
         """Test Content objects as dataset values."""
         rows = []
@@ -419,7 +419,7 @@ class TestWeaveContent:
             original_data = original_files[row["name"]]
             assert row["content"].data == original_data
 
-    def test_content_postprocessing(self, client: WeaveClient):
+    def test_content_postprocessing(self, weave_active: WeaveClient):
         """Test that Content postprocessing works correctly in ops."""
 
         @weave.op

--- a/tests/trace/type_handlers/Image/image_test.py
+++ b/tests/trace/type_handlers/Image/image_test.py
@@ -51,7 +51,7 @@ def test_img(request) -> Image.Image:
         img.close()
 
 
-def test_image_publish(weave_active: WeaveClient, test_img: Image.Image) -> None:
+def test_image_publish(weave_active, test_img: Image.Image) -> None:
     weave.publish(test_img)
 
     ref = get_ref(test_img)

--- a/tests/trace/type_handlers/Image/image_test.py
+++ b/tests/trace/type_handlers/Image/image_test.py
@@ -51,7 +51,7 @@ def test_img(request) -> Image.Image:
         img.close()
 
 
-def test_image_publish(client: WeaveClient, test_img: Image.Image) -> None:
+def test_image_publish(weave_active: WeaveClient, test_img: Image.Image) -> None:
     weave.publish(test_img)
 
     ref = get_ref(test_img)
@@ -194,7 +194,7 @@ def make_random_image(image_size: tuple[int, int] = (64, 64)):
 
 
 @pytest.fixture
-def dataset_ref(client):
+def dataset_ref(weave_active):
     # This fixture represents a saved dataset containing images
     n_rows = 5
     rows = [{"img": make_random_image()} for _ in range(n_rows)]
@@ -205,7 +205,7 @@ def dataset_ref(client):
 
 
 @pytest.mark.asyncio
-async def test_images_in_dataset_for_evaluation(client, dataset_ref):
+async def test_images_in_dataset_for_evaluation(weave_active, dataset_ref):
     dataset = dataset_ref.get()
     evaluation = weave.Evaluation(dataset=dataset)
 
@@ -245,7 +245,7 @@ async def test_many_images_will_consistently_log():
     assert "Task failed" not in res.stderr
 
 
-def test_images_in_load_of_dataset(client):
+def test_images_in_load_of_dataset(weave_active):
     n_rows = 5
     rows = [{"img": make_random_image()} for _ in range(n_rows)]
     dataset = weave.Dataset(rows=rows)
@@ -261,7 +261,7 @@ def test_images_in_load_of_dataset(client):
             gotten_row["img"].close()
 
 
-def test_images_in_dataset_without_client(client):
+def test_images_in_dataset_without_client(weave_active):
     """Regression test for WB-21596: datasets with images should be iterable
     without an active global client (e.g. after ref.get() auto-init cleanup).
     """

--- a/tests/trace/type_handlers/Video/video_test.py
+++ b/tests/trace/type_handlers/Video/video_test.py
@@ -52,7 +52,7 @@ def test_save_invalid_clip(tmp_path: Path, test_video: VideoClip, filename: str)
 
 
 def test_video_with_no_ext_converted(
-    client: WeaveClient, tmp_path: Path, test_video: VideoClip
+    weave_active: WeaveClient, tmp_path: Path, test_video: VideoClip
 ):
     video_path = str(tmp_path / "test.mp4")
     # Save an mp4 video
@@ -95,7 +95,7 @@ def test_weave_op_video(tmp_path: Path, test_video: VideoClip):
     assert os.path.getsize(result) > 0
 
 
-def test_video_publish(client: WeaveClient, test_video: VideoClip) -> None:
+def test_video_publish(weave_active: WeaveClient, test_video: VideoClip) -> None:
     ref = weave.publish(test_video)
     assert ref is not None
 
@@ -194,7 +194,7 @@ def video_as_input_and_output_part(in_video: VideoClip) -> dict:
     return {"out_video": in_video}
 
 
-def test_video_as_call_io(client: WeaveClient, test_video: VideoClip) -> None:
+def test_video_as_call_io(weave_active: WeaveClient, test_video: VideoClip) -> None:
     non_published_video = video_as_solo_output(publish_first=False, video=test_video)
     video_dict = video_as_input_and_output_part(non_published_video)
 
@@ -326,7 +326,7 @@ def make_random_video(video_size: tuple[int, int] = (64, 64), duration: float = 
 
 
 @pytest.fixture
-def dataset_ref(client):
+def dataset_ref(weave_active):
     # This fixture represents a saved dataset containing videos
     n_rows = 3
     rows = weave.Table([{"video": make_random_video()} for _ in range(n_rows)])
@@ -337,7 +337,7 @@ def dataset_ref(client):
 
 
 @pytest.mark.asyncio
-async def test_videos_in_dataset_for_evaluation(client, dataset_ref):
+async def test_videos_in_dataset_for_evaluation(weave_active, dataset_ref):
     dataset = dataset_ref.get()
     evaluation = weave.Evaluation(dataset=dataset)
 
@@ -359,7 +359,7 @@ async def test_videos_in_dataset_for_evaluation(client, dataset_ref):
             row["video"].close()
 
 
-def test_videos_in_load_of_dataset(client):
+def test_videos_in_load_of_dataset(weave_active):
     n_rows = 3
     # Create smaller duration videos to avoid encoding issues
     videos = [make_random_video(duration=0.1) for _ in range(n_rows)]
@@ -418,7 +418,7 @@ def test_video_format_from_filename():
     reason="moviepy library uses /dev/null on Windows which doesn't exist",
 )
 def test_multiple_video_formats(
-    client: WeaveClient, tmp_path: Path, test_video: VideoClip
+    weave_active: WeaveClient, tmp_path: Path, test_video: VideoClip
 ):
     """Test that we can publish videos of different formats in the same session."""
     sample_mp4_path = str(tmp_path / "test.mp4")

--- a/tests/trace/type_handlers/Video/video_test.py
+++ b/tests/trace/type_handlers/Video/video_test.py
@@ -417,9 +417,7 @@ def test_video_format_from_filename():
     sys.platform == "win32",
     reason="moviepy library uses /dev/null on Windows which doesn't exist",
 )
-def test_multiple_video_formats(
-    weave_active, tmp_path: Path, test_video: VideoClip
-):
+def test_multiple_video_formats(weave_active, tmp_path: Path, test_video: VideoClip):
     """Test that we can publish videos of different formats in the same session."""
     sample_mp4_path = str(tmp_path / "test.mp4")
     sample_gif_path = str(tmp_path / "test.gif")

--- a/tests/trace/type_handlers/Video/video_test.py
+++ b/tests/trace/type_handlers/Video/video_test.py
@@ -52,7 +52,7 @@ def test_save_invalid_clip(tmp_path: Path, test_video: VideoClip, filename: str)
 
 
 def test_video_with_no_ext_converted(
-    weave_active: WeaveClient, tmp_path: Path, test_video: VideoClip
+    weave_active, tmp_path: Path, test_video: VideoClip
 ):
     video_path = str(tmp_path / "test.mp4")
     # Save an mp4 video
@@ -95,7 +95,7 @@ def test_weave_op_video(tmp_path: Path, test_video: VideoClip):
     assert os.path.getsize(result) > 0
 
 
-def test_video_publish(weave_active: WeaveClient, test_video: VideoClip) -> None:
+def test_video_publish(weave_active, test_video: VideoClip) -> None:
     ref = weave.publish(test_video)
     assert ref is not None
 
@@ -194,7 +194,7 @@ def video_as_input_and_output_part(in_video: VideoClip) -> dict:
     return {"out_video": in_video}
 
 
-def test_video_as_call_io(weave_active: WeaveClient, test_video: VideoClip) -> None:
+def test_video_as_call_io(weave_active, test_video: VideoClip) -> None:
     non_published_video = video_as_solo_output(publish_first=False, video=test_video)
     video_dict = video_as_input_and_output_part(non_published_video)
 
@@ -418,7 +418,7 @@ def test_video_format_from_filename():
     reason="moviepy library uses /dev/null on Windows which doesn't exist",
 )
 def test_multiple_video_formats(
-    weave_active: WeaveClient, tmp_path: Path, test_video: VideoClip
+    weave_active, tmp_path: Path, test_video: VideoClip
 ):
     """Test that we can publish videos of different formats in the same session."""
     sample_mp4_path = str(tmp_path / "test.mp4")

--- a/tests/trace/type_handlers/test_type_handler_safety.py
+++ b/tests/trace/type_handlers/test_type_handler_safety.py
@@ -11,7 +11,7 @@ import weave
 from tests.trace.test_utils import FailingSaveType
 
 
-def test_op_output_with_failing_serializer_does_not_raise(client, failing_serializer):
+def test_op_output_with_failing_serializer_does_not_raise(weave_active, failing_serializer):
     """Requirement: Op functions must return their values even when serialization fails
     Interface: @weave.op decorated function returning an object with failing type handler
     Given: An @weave.op function returns an object whose type handler save raises an exception
@@ -31,7 +31,7 @@ def test_op_output_with_failing_serializer_does_not_raise(client, failing_serial
     assert result.value == "hello"
 
 
-def test_op_input_with_failing_serializer_does_not_raise(client, failing_serializer):
+def test_op_input_with_failing_serializer_does_not_raise(weave_active, failing_serializer):
     """Requirement: Op functions must execute normally even when input serialization fails
     Interface: @weave.op decorated function accepting an object with failing type handler
     Given: An @weave.op function accepts an object whose type handler save raises an exception

--- a/tests/trace/type_handlers/test_type_handler_safety.py
+++ b/tests/trace/type_handlers/test_type_handler_safety.py
@@ -11,7 +11,9 @@ import weave
 from tests.trace.test_utils import FailingSaveType
 
 
-def test_op_output_with_failing_serializer_does_not_raise(weave_active, failing_serializer):
+def test_op_output_with_failing_serializer_does_not_raise(
+    weave_active, failing_serializer
+):
     """Requirement: Op functions must return their values even when serialization fails
     Interface: @weave.op decorated function returning an object with failing type handler
     Given: An @weave.op function returns an object whose type handler save raises an exception
@@ -31,7 +33,9 @@ def test_op_output_with_failing_serializer_does_not_raise(weave_active, failing_
     assert result.value == "hello"
 
 
-def test_op_input_with_failing_serializer_does_not_raise(weave_active, failing_serializer):
+def test_op_input_with_failing_serializer_does_not_raise(
+    weave_active, failing_serializer
+):
     """Requirement: Op functions must execute normally even when input serialization fails
     Interface: @weave.op decorated function accepting an object with failing type handler
     Given: An @weave.op function accepts an object whose type handler save raises an exception


### PR DESCRIPTION
Some tests don't need the weave client specifically, even though they use the `client` fixture.  They instead depend on some side effect of client initialization.  This PR makes it clear what those tests are so we can we better segment these tests in future