### PR TITLE
chore(weave): 0.81.x server release patch 1

### DIFF
--- a/tests/trace_server/test_redis_client.py
+++ b/tests/trace_server/test_redis_client.py
@@ -56,3 +56,38 @@ def test_client_resolution_from_url(monkeypatch):
         monkeypatch.setenv("WEAVE_REDIS_URL", "redis://redis.example?master=gorilla")
         redis_client.get_redis_client()
         assert mock_sentinel.call_args.args[0] == [("redis.example", 26379)]
+
+
+@pytest.mark.disable_logging_error_check
+@pytest.mark.parametrize(
+    "bad_url",
+    [
+        # K8s manifest interpolation failure -> literal `$(REDIS_PORT)` in port slot.
+        "redis://redis.example:$(REDIS_PORT)$(REDIS_PARAMS)",
+        # Sentinel URL with the same interpolation failure.
+        "redis://redis.example:$(REDIS_PORT)?master=gorilla",
+        # Sentinel branch with no hostname -> our own ValueError.
+        "redis://?master=gorilla",
+        # Outright garbage that urlparse will choke on at port access.
+        "redis://host:not-a-number/0",
+    ],
+)
+def test_construction_failure_returns_none(monkeypatch, caplog, bad_url):
+    """Malformed URL must fall through to None, not raise.
+
+    Callers treat the L2 client as optional; a construction failure here
+    used to bubble up as a 500 on every request that touched
+    ``get_project_retention_days``. Now it's logged once and cached as None.
+    """
+    redis_client.get_redis_client.cache_clear()
+    monkeypatch.setenv("WEAVE_REDIS_URL", bad_url)
+    with caplog.at_level("ERROR", logger="weave.trace_server.redis_client"):
+        assert redis_client.get_redis_client() is None
+    assert any(
+        "Failed to construct Redis client" in rec.message for rec in caplog.records
+    )
+
+    # lru_cache should pin the None so a second call doesn't re-parse.
+    with patch.object(redis_client, "urlparse") as mock_urlparse:
+        assert redis_client.get_redis_client() is None
+        mock_urlparse.assert_not_called()

--- a/weave/trace_server/redis_client.py
+++ b/weave/trace_server/redis_client.py
@@ -1,12 +1,15 @@
 """Redis client for weave trace server."""
 
 import functools
+import logging
 from urllib.parse import parse_qs, urlparse
 
 import redis
 from redis.sentinel import Sentinel
 
 from weave.trace_server.environment import redis_url
+
+logger = logging.getLogger(__name__)
 
 # Redis here is an optional L2 cache in front of ClickHouse. When it's
 # unreachable we must fall through quickly; without explicit timeouts the
@@ -21,7 +24,12 @@ REDIS_SOCKET_TIMEOUT_SECS = 1
 def get_redis_client() -> redis.Redis | None:
     """Get the Redis client.
 
-    Returns None if Redis is not configured (WEAVE_REDIS_URL not set).
+    Returns None if Redis is not configured (WEAVE_REDIS_URL not set) or
+    if the URL is malformed in any way that prevents client construction.
+    Callers already treat the L2 cache as optional, so a construction
+    failure must fall through to ClickHouse-only rather than 500 every
+    request. The lru_cache means the None is also cached, so a misconfig
+    won't re-parse on every request until the process restarts.
 
     If the URL includes `?master=<name>`, the client is resolved via Redis
     Sentinel at the URL's host:port so writes always route to the current
@@ -32,27 +40,36 @@ def get_redis_client() -> redis.Redis | None:
     if not url:
         return None
 
-    parsed = urlparse(url)
-    master = parse_qs(parsed.query).get("master", [None])[0]
-    if not master:
-        return redis.from_url(
-            url,
+    try:
+        parsed = urlparse(url)
+        master = parse_qs(parsed.query).get("master", [None])[0]
+        if not master:
+            return redis.from_url(
+                url,
+                decode_responses=True,
+                socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
+                socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
+            )
+
+        if not parsed.hostname:
+            raise ValueError(f"WEAVE_REDIS_URL is missing a hostname: {url!r}")
+
+        sentinel = Sentinel(
+            [(parsed.hostname, parsed.port or 26379)],
+            socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
+            socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
+        )
+        return sentinel.master_for(
+            master,
             decode_responses=True,
             socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
             socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
         )
-
-    if not parsed.hostname:
-        raise ValueError(f"WEAVE_REDIS_URL is missing a hostname: {url!r}")
-
-    sentinel = Sentinel(
-        [(parsed.hostname, parsed.port or 26379)],
-        socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
-        socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
-    )
-    return sentinel.master_for(
-        master,
-        decode_responses=True,
-        socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
-        socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
-    )
+    except Exception:
+        # Construction failures (malformed URL, unresolvable sentinel, etc.)
+        # must not take down request handling. Log once and disable L2.
+        logger.exception(
+            "Failed to construct Redis client from WEAVE_REDIS_URL; "
+            "falling through to ClickHouse-only (no L2 cache)"
+        )
+        return None


### PR DESCRIPTION
## Summary
Cherry-picks accompanying core `server-release-0.81.x` patch 1. Not intended to merge to master — fixes already on master.

Cherry-picked from:
- #6837 — fix(weave): fail open when WEAVE_REDIS_URL is malformed

Branched off submodule SHA `ea28834b0f` (pinned on core `server-release-0.81.x`).

## Test plan
- [ ] CI green