### PR TITLE
feat(weave): default calls_complete to True for everyone

### DIFF
--- a/tests/trace_server_bindings/test_http_behavior_remote.py
+++ b/tests/trace_server_bindings/test_http_behavior_remote.py
@@ -23,7 +23,6 @@ from tests.trace_server_bindings.conftest import (
     generate_start,
 )
 from weave.trace.display.term import configure_logger
-from weave.trace.settings import should_use_calls_complete
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcessor
 from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
@@ -136,14 +135,6 @@ def test_calls_complete_batch_endpoint_and_payload(mock_post, monkeypatch):
     payload = json.loads(sent_data.decode("utf-8"))
     expected = tsi.CallsUpsertCompleteReq(batch=[complete]).model_dump(mode="json")
     assert payload == expected
-
-
-def test_calls_complete_entity_allowlist(monkeypatch):
-    """Allowlisted entities opt into calls_complete even with env var unset."""
-    monkeypatch.delenv("WEAVE_USE_CALLS_COMPLETE", raising=False)
-    assert should_use_calls_complete("wandb") is True
-    assert should_use_calls_complete("acme") is False
-    assert should_use_calls_complete(None) is False
 
 
 @patch("weave.utils.http_requests.post")
@@ -313,8 +304,9 @@ def test_other_error_retry(mock_post, unbatched_server, monkeypatch):
 
 
 @patch("weave.utils.http_requests.post")
-def test_timeout_retry_mechanism(mock_post, success_response):
+def test_timeout_retry_mechanism(mock_post, success_response, monkeypatch):
     """Test that timeouts trigger the retry mechanism."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "false")
     server = RemoteHTTPTraceServer("http://example.com", should_batch=True)
 
     # Mock server to raise errors twice, then succeed
@@ -335,8 +327,9 @@ def test_timeout_retry_mechanism(mock_post, success_response):
 
 
 @pytest.fixture
-def fast_retrying_server():
+def fast_retrying_server(monkeypatch):
     """Create a RemoteHTTPTraceServer with fast retry settings for testing."""
+    monkeypatch.setenv("WEAVE_USE_CALLS_COMPLETE", "false")
     server = RemoteHTTPTraceServer("http://example.com", should_batch=True)
     fast_retry = tenacity.retry(
         wait=tenacity.wait_fixed(0.1),

--- a/tests/trace_server_bindings/test_trace_server_bindings.py
+++ b/tests/trace_server_bindings/test_trace_server_bindings.py
@@ -226,7 +226,12 @@ def test_drop_data_when_queue_is_full(server, server_class, log_collector):
     mock_queue.put_nowait.side_effect = Full
     server.call_processor.queue = mock_queue
 
-    server.call_start(tsi.CallStartReq(start=generate_start()))
+    # Send a paired start+end so CallBatchProcessor (default) queues the
+    # complete item. A lone start would sit in `_pending_starts` and never
+    # hit the queue.
+    req_start, req_end = generate_call_start_end_pair(id="test-call-id")
+    server.call_start(req_start)
+    server.call_end(req_end)
 
     # Verify that the put_nowait method was called (meaning we tried to enqueue the item)
     mock_queue.put_nowait.assert_called_once()

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -107,7 +107,7 @@ def init(
                 - `use_calls_complete` (bool): Uses an optimized write path that batches complete
                     call data (start and end) into a single request instead of separate start/end requests.
                     This reduces server load and improves performance, especially for short-lived ops.
-                    Default: `False`
+                    Default: `True`
         autopatch_settings: (Deprecated) Configuration for autopatch integrations. Use explicit patching instead.
         postprocess_inputs: A function applied to the inputs of every op traced by this client.
         postprocess_output: A function applied to the output of every op traced by this client.

--- a/weave/trace/settings.py
+++ b/weave/trace/settings.py
@@ -45,12 +45,6 @@ from typing_extensions import Unpack
 DEFAULT_RETRY_MAX_INTERVAL_SECONDS = 60 * 5  # 5 minutes
 SETTINGS_PREFIX = "WEAVE_"
 
-# Entities that auto-opt-in to the calls_complete write path, independent of
-# the WEAVE_USE_CALLS_COMPLETE env var. This lets us dogfood calls_complete on
-# wandb-internal projects first so any regressions land on us, not customers.
-# Expand the allowlist (or flip the env default) once we have confidence.
-CALLS_COMPLETE_ENTITY_ALLOWLIST: frozenset[str] = frozenset({"wandb"})
-
 
 # Attention Devs:
 # To add a new setting:
@@ -258,21 +252,18 @@ class UserSettings:
     Can be overridden with the environment variable `WEAVE_USE_STAINLESS_SERVER`
     """
 
-    use_calls_complete: bool = False
+    use_calls_complete: bool = True
     """
     Toggles use of the calls_complete write path for new calls.
 
-    If True, uses the new calls_complete endpoint which batches complete calls
-    (with both start and end information) together before sending to the server.
-    This reduces the number of write operations and improves performance.
+    If True (default), uses the calls_complete endpoint which batches complete
+    calls (with both start and end information) together before sending to the
+    server. This reduces the number of write operations and improves performance.
 
-    If False (default), uses the legacy call_start/call_end endpoints which
-    send start and end events separately.
+    If False, uses the legacy call_start/call_end endpoints which send start
+    and end events separately.
 
     Can be overridden with the environment variable `WEAVE_USE_CALLS_COMPLETE`.
-
-    Note: entities in `CALLS_COMPLETE_ENTITY_ALLOWLIST` auto-opt-in regardless
-    of this setting (see `should_use_calls_complete`).
     """
 
     enable_client_side_digests: bool = False
@@ -600,17 +591,11 @@ def should_use_stainless_server() -> bool:
     )
 
 
-def should_use_calls_complete(entity: str | None = None) -> bool:
-    """Returns whether the calls_complete write path should be used.
-
-    True if the `use_calls_complete` setting/env var is enabled, OR if
-    `entity` is in `CALLS_COMPLETE_ENTITY_ALLOWLIST` (dogfood gate).
-    """
-    if _env_or_default(
+def should_use_calls_complete() -> bool:
+    """Returns whether the calls_complete write path should be used."""
+    return _env_or_default(
         "use_calls_complete", _current_settings.get().use_calls_complete
-    ):
-        return True
-    return entity is not None and entity in CALLS_COMPLETE_ENTITY_ALLOWLIST
+    )
 
 
 def should_enable_client_side_digests() -> bool:

--- a/weave/trace/weave_init.py
+++ b/weave/trace/weave_init.py
@@ -215,7 +215,7 @@ def init_weave(
         wandb_run_id = f"{entity_name}/{project_name}/{wb_run_context.run_id}"
         check_wandb_run_matches(wandb_run_id, entity_name, project_name)
 
-    remote_server = init_weave_get_server(api_key, entity=entity_name)
+    remote_server = init_weave_get_server(api_key)
     server_info = _get_server_info(remote_server)
     if server_info is None:
         raise RuntimeError(
@@ -326,8 +326,6 @@ def init_weave_disabled(
 def init_weave_get_server(
     api_key: str | None = None,
     should_batch: bool = True,
-    *,
-    entity: str | None = None,
 ) -> TraceServerClientInterface:
     res: TraceServerClientInterface
     if should_use_stainless_server():
@@ -337,9 +335,7 @@ def init_weave_get_server(
 
         res = StainlessRemoteHTTPTraceServer.from_env(should_batch)
     else:
-        # `entity` enables the wandb/* dogfood gate for the calls_complete
-        # write path; StainlessRemoteHTTPTraceServer does not use it.
-        res = RemoteHTTPTraceServer.from_env(should_batch, entity=entity)
+        res = RemoteHTTPTraceServer.from_env(should_batch)
     if api_key is not None:
         res.set_auth(("api", api_key))
     return res

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -63,12 +63,11 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         remote_request_bytes_limit: int = REMOTE_REQUEST_BYTES_LIMIT,
         auth: tuple[str, str] | None = None,
         extra_headers: dict[str, str] | None = None,
-        entity: str | None = None,
     ):
         super().__init__()
         self.trace_server_url = trace_server_url
         self.should_batch = should_batch
-        self.use_calls_complete = should_use_calls_complete(entity) and should_batch
+        self.use_calls_complete = should_use_calls_complete() and should_batch
         self.call_processor: AsyncBatchProcessor | CallBatchProcessor | None = None
         self.feedback_processor: AsyncBatchProcessor | None = None
         if self.should_batch:
@@ -104,8 +103,8 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         )
 
     @classmethod
-    def from_env(cls, should_batch: bool = False, entity: str | None = None) -> Self:
-        return cls(weave_trace_server_url(), should_batch, entity=entity)
+    def from_env(cls, should_batch: bool = False) -> Self:
+        return cls(weave_trace_server_url(), should_batch)
 
     def set_auth(self, auth: tuple[str, str]) -> None:
         self._auth = auth


### PR DESCRIPTION
## Summary
- Flips the `use_calls_complete` setting default from `False` to `True` so every entity writes calls via the new calls_complete path, not just the wandb dogfood allowlist.
- Removes the `CALLS_COMPLETE_ENTITY_ALLOWLIST` shim and the `entity` plumbing through `init_weave_get_server` -> `RemoteHTTPTraceServer.from_env` / `__init__` that existed only to power that gate.

## Testing
- \`uv run --group test python -m pytest tests/trace_server_bindings/\` (55 passed)
- adjusted \`test_drop_data_when_queue_is_full\` to send a paired start+end so it actually queues under \`CallBatchProcessor\`