### PR TITLE
perf(weave): skip per-insert model_dump in ch_call_to_row helpers

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -12,11 +12,16 @@ import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError, ProgrammingError
 
 from tests.trace_server.test_project_version import make_project_id
+from weave.trace_server import ch_sentinel_values
 from weave.trace_server import clickhouse_trace_server_batched as chts
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER
-from weave.trace_server.clickhouse.schema_converters import ch_call_to_row
+from weave.trace_server.clickhouse.schema_converters import (
+    ch_call_to_row,
+    ch_complete_call_to_row,
+)
 from weave.trace_server.clickhouse_schema import (
+    ALL_CALL_COMPLETE_INSERT_COLUMNS,
     ALL_CALL_INSERT_COLUMNS,
     CallCompleteCHInsertable,
     CallStartCHInsertable,
@@ -241,6 +246,61 @@ def test_ch_call_to_row_sentinelizes_expire_at_for_v1_insert_paths():
     explicit_expire = datetime(2025, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
     start_with_ttl = start.model_copy(update={"expire_at": explicit_expire})
     assert ch_call_to_row(start_with_ttl)[expire_at_idx] == explicit_expire
+
+
+def test_ch_row_helpers_match_model_dump_baseline():
+    """ch_call_to_row / ch_complete_call_to_row read fields via getattr instead of
+    model_dump() to skip per-insert dict allocation. The row contents must stay
+    byte-for-byte identical to the previous model_dump-based implementation.
+    """
+    started_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+    project_id = base64.b64encode(b"test_project").decode("ascii")
+    explicit_expire = datetime(2025, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+    start = CallStartCHInsertable(
+        project_id=project_id,
+        id="0193f7a5-1234-7000-8000-000000000010",
+        trace_id="0193f7a5-1234-7000-8000-000000000011",
+        op_name="test_op",
+        display_name="display",
+        started_at=started_at,
+        attributes_dump="{}",
+        inputs_dump="{}",
+        input_refs=[f"weave-trace-internal:///{project_id}/object/name:digest"],
+        output_refs=[],
+        wb_user_id="dXNlci1pZA==",
+        wb_run_id="dXNlci1pZA==:run",
+        wb_run_step=1,
+    )
+    start_with_ttl = start.model_copy(update={"expire_at": explicit_expire})
+    complete = CallCompleteCHInsertable(
+        project_id=project_id,
+        id="0193f7a5-1234-7000-8000-000000000012",
+        trace_id="0193f7a5-1234-7000-8000-000000000013",
+        op_name="test_op",
+        started_at=started_at,
+        ended_at=started_at,
+        attributes_dump="{}",
+        inputs_dump="{}",
+        output_dump="null",
+        summary_dump="{}",
+    )
+
+    for call in (start, start_with_ttl, complete):
+        dumped = call.model_dump()
+        expected = [
+            ch_sentinel_values.to_ch_value(col, dumped.get(col))
+            if col in ch_sentinel_values.SENTINEL_IN_CALLS_MERGED_FIELDS
+            else dumped.get(col)
+            for col in ALL_CALL_INSERT_COLUMNS
+        ]
+        assert ch_call_to_row(call) == expected
+
+    expected_complete = [
+        ch_sentinel_values.to_ch_value(col, complete.model_dump().get(col))
+        for col in ALL_CALL_COMPLETE_INSERT_COLUMNS
+    ]
+    assert ch_complete_call_to_row(complete) == expected_complete
 
 
 def test_clickhouse_distributed_mode_properties():

--- a/weave/trace_server/clickhouse/schema_converters.py
+++ b/weave/trace_server/clickhouse/schema_converters.py
@@ -111,14 +111,14 @@ def ch_call_to_row(ch_call: CallCHInsertable | CallCompleteCHInsertable) -> list
     in `_insert_call_to_v1`, used when a project has not yet migrated to the
     calls_complete schema.
     """
-    # Read fields via getattr instead of model_dump() to avoid allocating an
-    # intermediate dict on every insert; model_dump in the default python mode
-    # passes through native datetime/list/str values unchanged, so the values
-    # going into ClickHouse are identical.
+    # Read fields off the instance __dict__ to skip both the model_dump() copy
+    # and getattr's AttributeError-on-default path (~1us per absent column on
+    # partial insertables like CallEndCHInsertable).
+    d = ch_call.__dict__
     return [
-        ch_sentinel_values.to_ch_value(col, getattr(ch_call, col, None))
+        ch_sentinel_values.to_ch_value(col, d.get(col))
         if col in ch_sentinel_values.SENTINEL_IN_CALLS_MERGED_FIELDS
-        else getattr(ch_call, col, None)
+        else d.get(col)
         for col in ALL_CALL_INSERT_COLUMNS
     ]
 
@@ -279,9 +279,10 @@ def start_end_calls_to_ch_complete_insertable(
 
 def ch_complete_call_to_row(ch_call: CallCompleteCHInsertable) -> list[Any]:
     """Convert a CallCompleteCHInsertable to a row for batch insertion."""
-    # See `ch_call_to_row` for why we skip `model_dump()` here.
+    # See `ch_call_to_row` for why we read via __dict__.
+    d = ch_call.__dict__
     return [
-        ch_sentinel_values.to_ch_value(col, getattr(ch_call, col, None))
+        ch_sentinel_values.to_ch_value(col, d.get(col))
         for col in ALL_CALL_COMPLETE_INSERT_COLUMNS
     ]
 

--- a/weave/trace_server/clickhouse/schema_converters.py
+++ b/weave/trace_server/clickhouse/schema_converters.py
@@ -111,11 +111,14 @@ def ch_call_to_row(ch_call: CallCHInsertable | CallCompleteCHInsertable) -> list
     in `_insert_call_to_v1`, used when a project has not yet migrated to the
     calls_complete schema.
     """
-    call_dict = ch_call.model_dump()
+    # Read fields via getattr instead of model_dump() to avoid allocating an
+    # intermediate dict on every insert; model_dump in the default python mode
+    # passes through native datetime/list/str values unchanged, so the values
+    # going into ClickHouse are identical.
     return [
-        ch_sentinel_values.to_ch_value(col, call_dict.get(col))
+        ch_sentinel_values.to_ch_value(col, getattr(ch_call, col, None))
         if col in ch_sentinel_values.SENTINEL_IN_CALLS_MERGED_FIELDS
-        else call_dict.get(col)
+        else getattr(ch_call, col, None)
         for col in ALL_CALL_INSERT_COLUMNS
     ]
 
@@ -276,9 +279,9 @@ def start_end_calls_to_ch_complete_insertable(
 
 def ch_complete_call_to_row(ch_call: CallCompleteCHInsertable) -> list[Any]:
     """Convert a CallCompleteCHInsertable to a row for batch insertion."""
-    call_dict = ch_call.model_dump()
+    # See `ch_call_to_row` for why we skip `model_dump()` here.
     return [
-        ch_sentinel_values.to_ch_value(col, call_dict.get(col))
+        ch_sentinel_values.to_ch_value(col, getattr(ch_call, col, None))
         for col in ALL_CALL_COMPLETE_INSERT_COLUMNS
     ]
 


### PR DESCRIPTION
## Summary
- `ch_call_to_row` and `ch_complete_call_to_row` were allocating a fresh dict per inserted call via `model_dump()` just to pull a fixed column list back out. Read them with `getattr` instead, dropping the per-call dict on the upsert_batch hot path.
- Carved out of #6642. The base64 chunk of that PR has since landed via #6797; the ref-converter chunk is a separate follow-up.

## Testing
new `test_ch_row_helpers_match_model_dump_baseline` asserts byte-for-byte row equivalence vs. the old model_dump implementation across start, complete, and TTL'd insertables; existing `test_ch_call_to_row_sentinelizes_expire_at_for_v1_insert_paths` continues to cover the sentinel path.