### PR TITLE
perf(weave): copy-on-write ref conversion in trace_server_converter

### DIFF
--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -1,0 +1,147 @@
+import datetime
+import json
+
+from weave.trace.refs import ObjectRef
+from weave.trace_server.interface.query import Query
+from weave.trace_server.trace_server_converter import universal_ext_to_int_ref_converter
+from weave.trace_server.trace_server_interface import (
+    CallStartReq,
+    ObjCreateReq,
+    ObjSchemaForInsert,
+    StartedCallSchemaForInsert,
+)
+
+
+def test_universal_ext_to_int_ref_converter_reuses_models_and_untouched_branches():
+    """COW: identity is preserved on subtrees with no ref rewrites."""
+    project_id = "entity/project"
+    internal_project_id = "internal-project"
+    external_ref = f"weave:///{project_id}/op/some-op:latest"
+    internal_ref = f"weave-trace-internal:///{internal_project_id}/op/some-op:latest"
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+
+    # No-op request: every container object should be reused by identity.
+    no_ref_req = CallStartReq(
+        start=StartedCallSchemaForInsert(
+            project_id=internal_project_id,
+            op_name="plain-op",
+            started_at=started_at,
+            attributes={"status": "ok"},
+            inputs={"nested": {"value": "plain"}},
+            otel_dump={"span": "plain"},
+        )
+    )
+    original_no_ref_start = no_ref_req.start
+    original_no_ref_inputs = no_ref_req.start.inputs
+    original_no_ref_nested = no_ref_req.start.inputs["nested"]
+
+    converted_no_ref = universal_ext_to_int_ref_converter(
+        no_ref_req, lambda project: internal_project_id
+    )
+
+    assert converted_no_ref is no_ref_req
+    assert converted_no_ref.start is original_no_ref_start
+    assert converted_no_ref.start.inputs is original_no_ref_inputs
+    assert converted_no_ref.start.inputs["nested"] is original_no_ref_nested
+
+    # One rewritten ref: only the path to the changed value rebuilds, the
+    # sibling subtree keeps identity.
+    changed_branch = {"payload": ["plain", external_ref]}
+    untouched_branch = {"keep": ["still", {"plain": "value"}]}
+    req = CallStartReq(
+        start=StartedCallSchemaForInsert(
+            project_id=internal_project_id,
+            op_name=external_ref,
+            started_at=started_at,
+            attributes={"status": "ok"},
+            inputs={
+                "changed": changed_branch,
+                "untouched": untouched_branch,
+            },
+            otel_dump={"span": "plain"},
+        )
+    )
+    original_start = req.start
+    original_inputs = req.start.inputs
+    original_changed_branch = req.start.inputs["changed"]
+    original_payload = req.start.inputs["changed"]["payload"]
+    original_untouched_branch = req.start.inputs["untouched"]
+    original_attributes = req.start.attributes
+    original_otel_dump = req.start.otel_dump
+
+    converted = universal_ext_to_int_ref_converter(
+        req, lambda project: internal_project_id
+    )
+
+    assert converted is req
+    assert converted.start is original_start
+    assert converted.start.attributes is original_attributes
+    assert converted.start.otel_dump is original_otel_dump
+    assert converted.start.inputs is not original_inputs
+    assert converted.start.inputs["changed"] is not original_changed_branch
+    assert converted.start.inputs["changed"]["payload"] is not original_payload
+    assert converted.start.inputs["untouched"] is original_untouched_branch
+    assert converted.start.op_name == internal_ref
+    assert converted.start.inputs["changed"]["payload"] == ["plain", internal_ref]
+
+    # The pre-walk objects must stay untouched (proves COW, not in-place edit).
+    assert original_payload == ["plain", external_ref]
+
+
+def test_universal_ext_to_int_ref_converter_handles_aliased_query_models():
+    """Query models with `$`-prefixed aliases still serialize via by_alias."""
+    project_id = "entity/project"
+    internal_project_id = "internal-project"
+    external_ref = f"weave:///{project_id}/object/name:digest"
+    internal_ref = f"weave-trace-internal:///{internal_project_id}/object/name:digest"
+
+    query = Query.model_validate(
+        {
+            "$expr": {
+                "$eq": [
+                    {"$literal": external_ref},
+                    {"$literal": "plain"},
+                ]
+            }
+        }
+    )
+    original_expr = query.expr_
+    original_eq = query.expr_.eq_
+    original_left_literal = query.expr_.eq_[0]
+
+    converted = universal_ext_to_int_ref_converter(
+        query, lambda project: internal_project_id
+    )
+
+    assert converted is query
+    assert converted.expr_ is original_expr
+    assert converted.expr_.eq_ is not original_eq
+    assert converted.expr_.eq_[0] is original_left_literal
+    aliased_query = converted.model_dump(by_alias=True)
+    assert aliased_query["$expr"]["$eq"][0]["$literal"] == internal_ref
+    assert aliased_query["$expr"]["$eq"][1]["$literal"] == "plain"
+
+
+def test_universal_ext_to_int_ref_converter_roundtrips_models_with_any_payloads():
+    """Nested dataclasses inside an `Any` field force the legacy roundtrip path."""
+    req = ObjCreateReq(
+        obj=ObjSchemaForInsert(
+            project_id="entity/project",
+            object_id="thing",
+            val={
+                "ref": ObjectRef(
+                    entity="entity",
+                    project="project",
+                    name="name",
+                    _digest="digest",
+                ).with_attr("_class_name")
+            },
+        )
+    )
+
+    converted = universal_ext_to_int_ref_converter(
+        req, lambda project: "internal-project"
+    )
+
+    assert isinstance(converted.obj.val["ref"], dict)
+    json.dumps(converted.obj.val)

--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -1,6 +1,8 @@
 import datetime
 import json
 
+from pydantic import BaseModel, ConfigDict
+
 from weave.trace.refs import ObjectRef
 from weave.trace_server.interface.query import Query
 from weave.trace_server.trace_server_converter import universal_ext_to_int_ref_converter
@@ -145,3 +147,33 @@ def test_universal_ext_to_int_ref_converter_roundtrips_models_with_any_payloads(
 
     assert isinstance(converted.obj.val["ref"], dict)
     json.dumps(converted.obj.val)
+
+
+def test_universal_ext_to_int_ref_converter_rewrites_refs_in_model_extras():
+    """Refs stored on a `extra='allow'` BaseModel must still be rewritten.
+
+    The legacy converter walked the `model_dump(by_alias=True)` output,
+    which includes fields collected into `model_extra`. The COW fast path
+    iterates `model_fields` only, so extras are silently skipped unless
+    `_walk_model` also walks them.
+    """
+    project_id = "entity/project"
+    internal_project_id = "internal-project"
+    external_ref = f"weave:///{project_id}/op/some-op:latest"
+    internal_ref = f"weave-trace-internal:///{internal_project_id}/op/some-op:latest"
+
+    class ExtraAllowed(BaseModel):
+        model_config = ConfigDict(extra="allow")
+        declared: str
+
+    model = ExtraAllowed.model_validate(
+        {"declared": "plain", "extra_ref": external_ref}
+    )
+
+    converted = universal_ext_to_int_ref_converter(
+        model, lambda project: internal_project_id
+    )
+
+    assert converted.declared == "plain"
+    extras = converted.model_extra or {}
+    assert extras.get("extra_ref") == internal_ref

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -273,6 +273,11 @@ def _walk_model(obj: BaseModel, func: Callable[[Any], Any]) -> _MapResult:
     is re-validated, so callers that bypassed validation via
     `model_construct(...)` still see the same shape they would have from
     the legacy round-trip.
+
+    Fields stashed by `extra='allow'` live in `model_extra` rather than
+    `model_fields`, so they are walked separately. `model_extra` is None
+    for models without `extra='allow'`, which makes the extras loop a
+    no-op in the common case.
     """
     updates: dict[str, Any] = {}
     fast_path_safe = True
@@ -283,6 +288,12 @@ def _walk_model(obj: BaseModel, func: Callable[[Any], Any]) -> _MapResult:
         result = _walk(current, func)
         if result.changed:
             updates[field_name] = result.value
+        fast_path_safe = fast_path_safe and result.fast_path_safe
+
+    for extra_name, extra_value in (obj.model_extra or {}).items():
+        result = _walk(extra_value, func)
+        if result.changed:
+            updates[extra_name] = result.value
         fast_path_safe = fast_path_safe and result.fast_path_safe
 
     if not fast_path_safe:

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -265,27 +265,44 @@ def _walk_set(obj: set, func: Callable[[Any], Any]) -> _MapResult:
 
 
 def _walk_model(obj: BaseModel, func: Callable[[Any], Any]) -> _MapResult:
-    """Rewrite model fields in place when safe; round-trip when not.
+    """Walk a pydantic model with copy-on-write semantics.
 
-    The fast path reads each field via getattr, walks it, and (if anything
-    changed) either mutates the model in place or, for `frozen=True`
-    models, uses `model_copy(update=...)`. Either way the resulting model
-    is re-validated, so callers that bypassed validation via
-    `model_construct(...)` still see the same shape they would have from
-    the legacy round-trip.
+    Three outcomes, in order:
+      1. A subtree tripped `fast_path_safe=False` (nested dataclass that
+         getattr/setattr can't round-trip cleanly) -> fall back to the
+         legacy model_dump / _walk / model_validate path.
+      2. Nothing changed -> return obj as-is, with one revalidation pass
+         so `model_construct`-bypassed instances still get the same
+         shape the legacy round-trip would have produced.
+      3. Something changed -> apply updates and revalidate.
+    """
+    updates, fast_path_safe = _collect_model_updates(obj, func)
 
-    Fields stashed by `extra='allow'` live in `model_extra` rather than
-    `model_fields`, so they are walked separately. `model_extra` is None
-    for models without `extra='allow'`, which makes the extras loop a
-    no-op in the common case.
+    if not fast_path_safe:
+        return _MapResult(_model_via_roundtrip(obj, func), True, True)
+    if not updates:
+        return _MapResult(obj.__class__.model_validate(obj), False, True)
+    return _MapResult(_apply_model_updates(obj, updates), True, True)
+
+
+def _collect_model_updates(
+    obj: BaseModel, func: Callable[[Any], Any]
+) -> tuple[dict[str, Any], bool]:
+    """Walk every declared field + every extra; collect what changed.
+
+    `model_fields` covers declared fields. `model_extra` covers anything
+    stashed by `extra='allow'` and is None for other models (so that
+    loop is a no-op in the common case). Both sets of keys are merged
+    into `updates` because setattr / model_copy(update=...) accept extra
+    keys for `extra='allow'` models.
     """
     updates: dict[str, Any] = {}
     fast_path_safe = True
+
     for field_name, field_info in obj.__class__.model_fields.items():
         if field_info.exclude is True:
             continue
-        current = getattr(obj, field_name)
-        result = _walk(current, func)
+        result = _walk(getattr(obj, field_name), func)
         if result.changed:
             updates[field_name] = result.value
         fast_path_safe = fast_path_safe and result.fast_path_safe
@@ -296,28 +313,33 @@ def _walk_model(obj: BaseModel, func: Callable[[Any], Any]) -> _MapResult:
             updates[extra_name] = result.value
         fast_path_safe = fast_path_safe and result.fast_path_safe
 
-    if not fast_path_safe:
-        return _MapResult(_model_via_roundtrip(obj, func), True, True)
+    return updates, fast_path_safe
 
-    if not updates:
-        return _MapResult(obj.__class__.model_validate(obj), False, True)
 
+def _apply_model_updates(obj: BaseModel, updates: dict[str, Any]) -> BaseModel:
+    """Apply `updates` to `obj`. Frozen models get a copy; others mutate.
+
+    Mutating in place preserves the outer model's identity so callers
+    that hold the reference see the rewrite without an extra allocation.
+    Either branch ends with model_validate so any pre-validation bypass
+    via model_construct still gets the shape the legacy round-trip would
+    have produced.
+    """
     if obj.__class__.model_config.get("frozen"):
         updated = obj.model_copy(update=updates)
-        return _MapResult(updated.__class__.model_validate(updated), True, True)
+        return updated.__class__.model_validate(updated)
 
-    # Non-frozen: mutate in place. The outer model keeps its identity and
-    # only the rewritten fields are replaced.
     for field_name, new_value in updates.items():
         setattr(obj, field_name, new_value)
-    return _MapResult(obj.__class__.model_validate(obj), True, True)
+    return obj.__class__.model_validate(obj)
 
 
 def _model_via_roundtrip(obj: BaseModel, func: Callable[[Any], Any]) -> BaseModel:
-    """Legacy path used when a model contains a nested dataclass.
+    """Fallback used when a model contains a nested dataclass.
 
-    `by_alias=True` is required: query models have Mongo-style aliased fields
-    (e.g. `$gt`) whose internal property names cannot round-trip without it.
+    `by_alias=True` is required: query models have Mongo-style aliased
+    fields (e.g. `$gt`) whose internal property names cannot round-trip
+    without it.
     """
     orig = obj.model_dump(by_alias=True)
     walked = _walk(orig, func)

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -1,5 +1,24 @@
+"""Helpers for converting trace refs with copy-on-write traversal.
+
+Trace request payloads pass through this module on every call_start /
+call_end so external `weave:///...` refs can be rewritten to internal
+`weave-trace-internal:///...` form (and vice versa). The naive recursion
+that used to live here cloned every container on every request, which
+dominated the hot path under load even when no refs were present.
+
+The traversal here is copy-on-write: subtrees that contain no rewrites
+return the original object, and a parent only allocates a new container
+once one of its children has actually changed. For ref-free payloads
+zero new objects are allocated.
+
+Pydantic models with nested dataclasses inside `Any` fields fall back to
+the legacy `model_dump` / `model_validate` round-trip, since Pydantic
+does not round-trip dataclasses safely through getattr / setattr.
+"""
+
+import dataclasses
 from collections.abc import Callable
-from typing import TypeVar, cast
+from typing import Any, NamedTuple, TypeVar, cast
 
 from pydantic import BaseModel
 
@@ -146,24 +165,149 @@ def universal_int_to_ext_ref_converter(
 
 
 E = TypeVar("E")
-F = TypeVar("F")
+
+
+class _MapResult(NamedTuple):
+    """Outcome of a single copy-on-write traversal step.
+
+    value:           the (possibly new) value at this node.
+    changed:         True if this subtree was rewritten; ancestors must clone.
+    fast_path_safe:  False once we have seen a nested dataclass inside an
+                     `Any` field. Models containing one have to fall back to
+                     the legacy model_dump / model_validate path because
+                     Pydantic does not round-trip dataclasses through
+                     getattr / setattr.
+    """
+
+    value: Any
+    changed: bool
+    fast_path_safe: bool
 
 
 def _map_values(obj: E, func: Callable[[E], E]) -> E:
+    """Apply `func` to every scalar in `obj`, reusing untouched subtrees."""
+    return cast(E, _walk(obj, cast(Callable[[Any], Any], func)).value)
+
+
+def _walk(obj: Any, func: Callable[[Any], Any]) -> _MapResult:
+    """Recursive copy-on-write dispatcher; one container kind per arm."""
     if isinstance(obj, BaseModel):
-        # `by_alias` is required since we have Mongo-style properties in the
-        # query models that are aliased to conform to start with `$`. Without
-        # this, the model_dump will use the internal property names which are
-        # not valid for the `model_validate` step.
-        orig = obj.model_dump(by_alias=True)
-        new = _map_values(orig, func)
-        return obj.model_validate(new)
+        return _walk_model(obj, func)
     if isinstance(obj, dict):
-        return cast(E, {k: _map_values(v, func) for k, v in obj.items()})
+        return _walk_mapping(obj, func)
     if isinstance(obj, list):
-        return cast(E, [_map_values(v, func) for v in obj])
+        return _walk_sequence(obj, func, rebuild=list)
     if isinstance(obj, tuple):
-        return cast(E, tuple(_map_values(v, func) for v in obj))
+        return _walk_sequence(obj, func, rebuild=tuple)
     if isinstance(obj, set):
-        return cast(E, {_map_values(v, func) for v in obj})
-    return func(obj)
+        return _walk_set(obj, func)
+
+    # Scalar leaf: ask the mapper for a replacement. Dataclasses are leaves
+    # too, but trip the fast-path flag so any ancestor model knows to
+    # round-trip via model_dump.
+    new_obj = func(obj)
+    if new_obj is not obj:
+        return _MapResult(new_obj, True, True)
+    return _MapResult(obj, False, not dataclasses.is_dataclass(obj))
+
+
+def _walk_mapping(obj: dict, func: Callable[[Any], Any]) -> _MapResult:
+    # Allocate a copy only on the first changed child, then write through it.
+    clone: dict | None = None
+    fast_path_safe = True
+    for key, value in obj.items():
+        result = _walk(value, func)
+        if result.changed:
+            if clone is None:
+                clone = dict(obj)
+            clone[key] = result.value
+        fast_path_safe = fast_path_safe and result.fast_path_safe
+    if clone is None:
+        return _MapResult(obj, False, fast_path_safe)
+    return _MapResult(clone, True, fast_path_safe)
+
+
+def _walk_sequence(
+    obj: Any,
+    func: Callable[[Any], Any],
+    rebuild: Callable[[list[Any]], Any],
+) -> _MapResult:
+    # Lists and tuples share an identical walk; only the final constructor
+    # differs (`list` returns the buffer, `tuple` freezes it).
+    clone: list[Any] | None = None
+    fast_path_safe = True
+    for index, value in enumerate(obj):
+        result = _walk(value, func)
+        if result.changed:
+            if clone is None:
+                clone = list(obj)
+            clone[index] = result.value
+        fast_path_safe = fast_path_safe and result.fast_path_safe
+    if clone is None:
+        return _MapResult(obj, False, fast_path_safe)
+    return _MapResult(rebuild(clone), True, fast_path_safe)
+
+
+def _walk_set(obj: set, func: Callable[[Any], Any]) -> _MapResult:
+    # Sets have no useful index to write through, so we collect into a list
+    # and rebuild only when something changed.
+    values: list[Any] = []
+    changed = False
+    fast_path_safe = True
+    for value in obj:
+        result = _walk(value, func)
+        values.append(result.value)
+        changed = changed or result.changed
+        fast_path_safe = fast_path_safe and result.fast_path_safe
+    if not changed:
+        return _MapResult(obj, False, fast_path_safe)
+    return _MapResult(set(values), True, fast_path_safe)
+
+
+def _walk_model(obj: BaseModel, func: Callable[[Any], Any]) -> _MapResult:
+    """Rewrite model fields in place when safe; round-trip when not.
+
+    The fast path reads each field via getattr, walks it, and (if anything
+    changed) either mutates the model in place or, for `frozen=True`
+    models, uses `model_copy(update=...)`. Either way the resulting model
+    is re-validated, so callers that bypassed validation via
+    `model_construct(...)` still see the same shape they would have from
+    the legacy round-trip.
+    """
+    updates: dict[str, Any] = {}
+    fast_path_safe = True
+    for field_name, field_info in obj.__class__.model_fields.items():
+        if field_info.exclude is True:
+            continue
+        current = getattr(obj, field_name)
+        result = _walk(current, func)
+        if result.changed:
+            updates[field_name] = result.value
+        fast_path_safe = fast_path_safe and result.fast_path_safe
+
+    if not fast_path_safe:
+        return _MapResult(_model_via_roundtrip(obj, func), True, True)
+
+    if not updates:
+        return _MapResult(obj.__class__.model_validate(obj), False, True)
+
+    if obj.__class__.model_config.get("frozen"):
+        updated = obj.model_copy(update=updates)
+        return _MapResult(updated.__class__.model_validate(updated), True, True)
+
+    # Non-frozen: mutate in place. The outer model keeps its identity and
+    # only the rewritten fields are replaced.
+    for field_name, new_value in updates.items():
+        setattr(obj, field_name, new_value)
+    return _MapResult(obj.__class__.model_validate(obj), True, True)
+
+
+def _model_via_roundtrip(obj: BaseModel, func: Callable[[Any], Any]) -> BaseModel:
+    """Legacy path used when a model contains a nested dataclass.
+
+    `by_alias=True` is required: query models have Mongo-style aliased fields
+    (e.g. `$gt`) whose internal property names cannot round-trip without it.
+    """
+    orig = obj.model_dump(by_alias=True)
+    walked = _walk(orig, func)
+    return obj.model_validate(walked.value)


### PR DESCRIPTION
## Summary
- The trace_server hot path runs every request payload through `universal_ext_to_int_ref_converter`, which cloned every dict / list / tuple / set / pydantic model on every request. Switch to copy-on-write: subtrees with no rewrites return by identity; only paths containing a rewritten ref allocate.
- For ref-free payloads zero new objects are allocated. For payloads with refs, only the path from the root to each rewrite is rebuilt.
- Reworked from the trace_server_converter portion of #6642 with inline review feedback addressed. The base64 piece of that PR landed via #6797; the clickhouse-row piece is up as #6843.

## Review feedback addressed
- Module docstring + per-function docstrings explain the COW strategy (neutralino1, jtschoonhoven)
- `_MapResult` NamedTuple replaces the unnamed `(value, changed, fully_supported)` triple (jtschoonhoven)
- Four near-identical container arms consolidated into three small helpers (`_walk_mapping`, `_walk_sequence` for list+tuple, `_walk_set`); the COW invariant lives in one place per container kind (jtschoonhoven: "logic gets pretty hairy")
- Inner helpers are typed `Any`, so `cast` is needed only once at the TypeVar boundary in `_map_values` (jtschoonhoven question on cast usage)

## Testing
new `tests/trace_server/test_trace_server_converter.py` covers (a) identity preservation on no-op + sibling-subtree-untouched walks, (b) aliased query models with `$`-prefixed fields, (c) the round-trip fallback when an `Any` field contains a nested dataclass. Existing `test_adapter_does_not_mutate_req_when_inner_raises` continues to enforce that the adapter boundary stays mutation-safe (it `model_copy(deep=True)`s before invoking the converter, so the in-place fast path is contained to the deep copy).