### PR TITLE
chore(weave_ts): Relocate semconv, add types and new semconv keys

### DIFF
--- a/sdks/node/src/genai/index.ts
+++ b/sdks/node/src/genai/index.ts
@@ -1,0 +1,16 @@
+/**
+ * Weave GenAI session SDK — module entry point.
+ *
+ * The runtime surface (Session / Turn / LLM / Tool / SubAgent and the
+ * top-level `startSession` / `startTurn` / ... functions) lands in later
+ * PRs. This PR ships the data types only.
+ */
+
+export type {
+  Message,
+  MessagePart,
+  Modality,
+  Reasoning,
+  Role,
+  Usage,
+} from './types';

--- a/sdks/node/src/genai/types.ts
+++ b/sdks/node/src/genai/types.ts
@@ -1,0 +1,41 @@
+/**
+ * Public data types for the Weave GenAI session SDK.
+ */
+
+export type Role = 'user' | 'assistant' | 'system' | 'tool';
+
+export type Modality = 'image' | 'audio' | 'video' | 'document';
+
+export interface Message {
+  role: Role;
+  content?: string;
+  toolCallId?: string;
+  toolName?: string;
+  parts?: MessagePart[];
+}
+
+export type MessagePart =
+  | {type: 'text'; content: string}
+  | {type: 'reasoning'; content: string}
+  | {
+      type: 'tool_call';
+      toolCallId: string;
+      toolName: string;
+      arguments?: string;
+    }
+  | {type: 'tool_result'; toolCallId: string; result?: string}
+  | {type: 'file'; fileId: string; mimeType?: string; modality: Modality}
+  | {type: 'image_blob'; content: string; mimeType: string}
+  | {type: 'uri'; uri: string; modality: Modality};
+
+export interface Usage {
+  inputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+  cacheCreationInputTokens?: number;
+  cacheReadInputTokens?: number;
+}
+
+export interface Reasoning {
+  content: string;
+}

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -41,7 +41,7 @@ import {
 import {getGlobalClient} from '../clientApi';
 import {getWandbConfigs} from '../wandb/settings';
 
-import {GEN_AI_ATTR, GEN_AI_EVENT, OTEL_ATTR} from './common/genai';
+import {GEN_AI_ATTR, GEN_AI_EVENT, OTEL_ATTR} from '../otel/semconv';
 
 import type {
   PiAgentMessage,

--- a/sdks/node/src/otel/semconv.ts
+++ b/sdks/node/src/otel/semconv.ts
@@ -1,6 +1,6 @@
 /**
- * Shared constants for OpenTelemetry integrations that emit spans conforming
- * to the GenAI semantic conventions:
+ * Constants for OpenTelemetry emitters in the Weave SDK that produce spans
+ * conforming to the GenAI semantic conventions:
  * https://opentelemetry.io/docs/specs/semconv/gen-ai/
  */
 
@@ -21,6 +21,7 @@ export const GEN_AI_ATTR = {
   GEN_AI_USAGE_INPUT_TOKENS: 'gen_ai.usage.input_tokens',
   GEN_AI_USAGE_OUTPUT_TOKENS: 'gen_ai.usage.output_tokens',
   GEN_AI_USAGE_TOTAL_TOKENS: 'gen_ai.usage.total_tokens',
+  GEN_AI_USAGE_REASONING_TOKENS: 'gen_ai.usage.reasoning_tokens',
   GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS: 'gen_ai.usage.cache_read.input_tokens',
   GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS:
     'gen_ai.usage.cache_creation.input_tokens',
@@ -28,6 +29,8 @@ export const GEN_AI_ATTR = {
   GEN_AI_TOOL_NAME: 'gen_ai.tool.name',
   GEN_AI_TOOL_CALL_ID: 'gen_ai.tool.call.id',
   GEN_AI_OUTPUT_TYPE: 'gen_ai.output.type',
+  GEN_AI_INPUT_MESSAGES: 'gen_ai.input.messages',
+  GEN_AI_OUTPUT_MESSAGES: 'gen_ai.output.messages',
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -50,4 +53,16 @@ export const GEN_AI_EVENT = {
 /** General OpenTelemetry attribute keys used alongside GenAI spans. */
 export const OTEL_ATTR = {
   ERROR_TYPE: 'error.type',
+} as const;
+
+// ---------------------------------------------------------------------------
+// Resource attribute keys
+// ---------------------------------------------------------------------------
+
+/** Resource-level attributes attached to every span emitted by this SDK. */
+export const WEAVE_RESOURCE_ATTR = {
+  WANDB_ENTITY: 'wandb.entity',
+  WANDB_PROJECT: 'wandb.project',
+  WEAVE_SDK_VERSION: 'weave.sdk.version',
+  WEAVE_SDK_LANGUAGE: 'weave.sdk.language',
 } as const;

--- a/sdks/node/src/otel/semconv.ts
+++ b/sdks/node/src/otel/semconv.ts
@@ -21,7 +21,7 @@ export const GEN_AI_ATTR = {
   GEN_AI_USAGE_INPUT_TOKENS: 'gen_ai.usage.input_tokens',
   GEN_AI_USAGE_OUTPUT_TOKENS: 'gen_ai.usage.output_tokens',
   GEN_AI_USAGE_TOTAL_TOKENS: 'gen_ai.usage.total_tokens',
-  GEN_AI_USAGE_REASONING_TOKENS: 'gen_ai.usage.reasoning_tokens',
+  GEN_AI_USAGE_REASONING_OUTPUT_TOKENS: 'gen_ai.usage.reasoning.output_tokens',
   GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS: 'gen_ai.usage.cache_read.input_tokens',
   GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS:
     'gen_ai.usage.cache_creation.input_tokens',
@@ -53,16 +53,4 @@ export const GEN_AI_EVENT = {
 /** General OpenTelemetry attribute keys used alongside GenAI spans. */
 export const OTEL_ATTR = {
   ERROR_TYPE: 'error.type',
-} as const;
-
-// ---------------------------------------------------------------------------
-// Resource attribute keys
-// ---------------------------------------------------------------------------
-
-/** Resource-level attributes attached to every span emitted by this SDK. */
-export const WEAVE_RESOURCE_ATTR = {
-  WANDB_ENTITY: 'wandb.entity',
-  WANDB_PROJECT: 'wandb.project',
-  WEAVE_SDK_VERSION: 'weave.sdk.version',
-  WEAVE_SDK_LANGUAGE: 'weave.sdk.language',
 } as const;

--- a/sdks/node/src/otel/weaveResource.ts
+++ b/sdks/node/src/otel/weaveResource.ts
@@ -1,0 +1,11 @@
+/**
+ * Weave-specific OTel resource attribute keys attached to every span this
+ * SDK emits. Not part of the GenAI semconv spec.
+ */
+
+export const WEAVE_RESOURCE_ATTR = {
+  WANDB_ENTITY: 'wandb.entity',
+  WANDB_PROJECT: 'wandb.project',
+  WEAVE_SDK_VERSION: 'weave.sdk.version',
+  WEAVE_SDK_LANGUAGE: 'weave.sdk.language',
+} as const;


### PR DESCRIPTION
### Summary

Foundation PR for the new GenAI session SDK under `src/genai/`. No runtime behavior yet — this lands data types, relocates the OTel GenAI semconv constants out of the integrations folder so a future shared OTel module can consume them, and adds the new attribute keys the SDK will need.

### Changes

- **Relocate `src/integrations/common/genai.ts` → `src/otel/semconv.ts`.**
  The constants in that file aren't integration-specific; they're the OTel GenAI semconv key namespace. Both the future `src/genai/` module and the   existing `piCodingAgent` integration should pull from one place.
- **New semconv keys** added to the relocated file:
  - `gen_ai.input.messages`, `gen_ai.output.messages` — Python SDK encodes message lists as JSON-string attributes; the TS SDK will mirror that for cross-SDK parity.
  - `gen_ai.usage.reasoning_tokens`.
  - New `WEAVE_RESOURCE_ATTR` bundle: `wandb.entity`, `wandb.project`,  `weave.sdk.version`, `weave.sdk.language` — resource attributes the  server uses to fingerprint emitter origin.
- **New data types** in `src/genai/types.ts`: `Message`, `MessagePart`,  `Modality`, `Reasoning`, `Role`, `Usage`. Plain TS interfaces, no Zod.
- **Module entry** at `src/genai/index.ts` — type-only re-exports for now;  runtime surface lands in later PRs.

### Tests

All compile and tests still pass. No new tests yet. 