### PR TITLE
chore(weave_ts): Core classes: Session, Turn, LLM, Tool, SubAgent (manual start/end)

### DIFF
--- a/sdks/node/src/__tests__/genai/chain.test.ts
+++ b/sdks/node/src/__tests__/genai/chain.test.ts
@@ -11,18 +11,18 @@ describe('end-to-end chain', () => {
   setupGenAITestEnvironment();
   const getExporter = setupExporterPerTest();
 
-  it('session → turn → llm → tool wires the full parent-child trace', async () => {
-    const session = await Session.create({
+  it('session → turn → llm → tool wires the full parent-child trace', () => {
+    const session = Session.create({
       agentName: 'weather-bot',
       sessionId: 'conv-e2e',
     });
-    const turn = await session.startTurn();
-    const llm = await turn.llm({model: 'gpt-4o'});
-    const tool = await llm.startTool({name: 'get_weather'});
-    await tool.end();
-    await llm.end();
-    await turn.end();
-    await session.end();
+    const turn = session.startTurn();
+    const llm = turn.llm({model: 'gpt-4o'});
+    const tool = llm.startTool({name: 'get_weather'});
+    tool.end();
+    llm.end();
+    turn.end();
+    session.end();
 
     const spans = getExporter().getFinishedSpans();
     expect(spans).toHaveLength(3);

--- a/sdks/node/src/__tests__/genai/chain.test.ts
+++ b/sdks/node/src/__tests__/genai/chain.test.ts
@@ -1,0 +1,48 @@
+import {GEN_AI_ATTR} from '../../genai/semconv';
+import {Session} from '../../genai/session';
+
+import {
+  findSpan,
+  setupExporterPerTest,
+  setupGenAITestEnvironment,
+} from './common';
+
+describe('end-to-end chain', () => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('session → turn → llm → tool wires the full parent-child trace', async () => {
+    const session = await Session.create({
+      agentName: 'weather-bot',
+      sessionId: 'conv-e2e',
+    });
+    const turn = await session.startTurn();
+    const llm = await turn.llm({model: 'gpt-4o'});
+    const tool = await llm.startTool({name: 'get_weather'});
+    await tool.end();
+    await llm.end();
+    await turn.end();
+    await session.end();
+
+    const spans = getExporter().getFinishedSpans();
+    expect(spans).toHaveLength(3);
+    const turnSpan = findSpan(spans, 'invoke_agent');
+    const llmSpan = findSpan(spans, 'chat');
+    const toolSpan = findSpan(spans, 'execute_tool');
+
+    // All three share the same trace id.
+    const traceId = turnSpan.spanContext().traceId;
+    expect(llmSpan.spanContext().traceId).toBe(traceId);
+    expect(toolSpan.spanContext().traceId).toBe(traceId);
+
+    // Parent-child chain.
+    expect(turnSpan.parentSpanId).toBeUndefined();
+    expect(llmSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
+    expect(toolSpan.parentSpanId).toBe(llmSpan.spanContext().spanId);
+
+    // Conversation id propagates everywhere.
+    for (const s of spans) {
+      expect(s.attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe('conv-e2e');
+    }
+  });
+});

--- a/sdks/node/src/__tests__/genai/common.ts
+++ b/sdks/node/src/__tests__/genai/common.ts
@@ -1,0 +1,105 @@
+import {
+  InMemorySpanExporter,
+  type ReadableSpan,
+  SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base';
+
+import {setGlobalClient} from '../../clientApi';
+import {Api as TraceServerApi} from '../../generated/traceServerApi';
+import {PROVIDER_HOLDER_SYMBOL_NAME} from '../../genai/provider';
+import {Settings, type SettingsInit} from '../../settings';
+import {WandbServerApi} from '../../wandb/wandbServerApi';
+import {WeaveClient} from '../../weaveClient';
+
+export const TEST_BASE_URL = 'http://localhost:8080';
+export const TEST_PROJECT = 'test-entity/test-project';
+
+export function installFakeClient(settings: SettingsInit = {}): WeaveClient {
+  const traceServerApi = {baseUrl: TEST_BASE_URL} as TraceServerApi<any>;
+  const client = new WeaveClient(
+    traceServerApi,
+    {} as WandbServerApi,
+    TEST_PROJECT,
+    new Settings(
+      settings.printCallLink ?? true,
+      settings.globalAttributes ?? {},
+      settings.genai ?? {}
+    )
+  );
+  setGlobalClient(client);
+  return client;
+}
+
+export function clearGlobalClient(): void {
+  // setGlobalClient is typed for a real client, but the underlying holder
+  // accepts null. Tests need this to exercise the "weave.init() not called"
+  // branch.
+  setGlobalClient(null as unknown as WeaveClient);
+}
+
+// Reach into the global singleton's holder directly to reset its state.
+export function resetProviderSingleton(): void {
+  const holder = (globalThis as Record<symbol, unknown>)[
+    Symbol.for(PROVIDER_HOLDER_SYMBOL_NAME)
+  ] as {provider: unknown; beforeExitRegistered: boolean} | undefined;
+  if (holder) {
+    holder.provider = null;
+    holder.beforeExitRegistered = false;
+  }
+}
+
+/**
+ * Install the standard before/after-each pattern for GenAI tests: stubs
+ * `WANDB_API_KEY` (so the provider's OTLP exporter can be built), resets
+ * the provider singleton, and clears the global Weave client. Call inside
+ * the consumer's `describe` block.
+ */
+export function setupGenAITestEnvironment(): void {
+  const originalApiKey = process.env.WANDB_API_KEY;
+
+  beforeEach(() => {
+    process.env.WANDB_API_KEY = 'test-api-key';
+    resetProviderSingleton();
+    clearGlobalClient();
+  });
+
+  afterEach(() => {
+    resetProviderSingleton();
+    clearGlobalClient();
+    if (originalApiKey === undefined) {
+      delete process.env.WANDB_API_KEY;
+    } else {
+      process.env.WANDB_API_KEY = originalApiKey;
+    }
+  });
+}
+
+/** Find a finished span by name; throw with a helpful message if missing. */
+export function findSpan(spans: ReadableSpan[], name: string): ReadableSpan {
+  const span = spans.find(s => s.name === name);
+  if (!span) {
+    throw new Error(
+      `no span named '${name}' (saw: ${spans.map(s => s.name).join(', ')})`
+    );
+  }
+  return span;
+}
+
+/**
+ * Per-test setup that installs a fresh `InMemorySpanExporter` + fake client.
+ * Returns a getter so tests can read `getExporter().getFinishedSpans()` after
+ * spans are ended.
+ *
+ * Call inside a describe block, after `setupGenAITestEnvironment()` so the
+ * API key and singleton resets happen first.
+ */
+export function setupExporterPerTest(): () => InMemorySpanExporter {
+  let current: InMemorySpanExporter;
+  beforeEach(() => {
+    current = new InMemorySpanExporter();
+    installFakeClient({
+      genai: {spanProcessor: new SimpleSpanProcessor(current)},
+    });
+  });
+  return () => current;
+}

--- a/sdks/node/src/__tests__/genai/llm.test.ts
+++ b/sdks/node/src/__tests__/genai/llm.test.ts
@@ -13,11 +13,11 @@ describe('LLM (via Turn.llm)', () => {
   setupGenAITestEnvironment();
   const getExporter = setupExporterPerTest();
 
-  it("emits a 'chat' span as a child of the turn's invoke_agent span", async () => {
-    const turn = await Turn.create({agentName: 'a', conversationId: 'conv-1'});
-    const llm = await turn.llm({model: 'gpt-4o', providerName: 'openai'});
-    await llm.end();
-    await turn.end();
+  it("emits a 'chat' span as a child of the turn's invoke_agent span", () => {
+    const turn = Turn.create({agentName: 'a', conversationId: 'conv-1'});
+    const llm = turn.llm({model: 'gpt-4o', providerName: 'openai'});
+    llm.end();
+    turn.end();
 
     const spans = getExporter().getFinishedSpans();
     const llmSpan = findSpan(spans, 'chat');
@@ -34,9 +34,9 @@ describe('LLM (via Turn.llm)', () => {
     expect(llmSpan.spanContext().traceId).toBe(turnSpan.spanContext().traceId);
   });
 
-  it('serializes input/output messages and usage at end()', async () => {
-    const turn = await Turn.create({});
-    const llm = await turn.llm({model: 'gpt-4o'});
+  it('serializes input/output messages and usage at end()', () => {
+    const turn = Turn.create({});
+    const llm = turn.llm({model: 'gpt-4o'});
     llm.inputMessages = [{role: 'user', content: 'hi'}];
     llm.outputMessages = [{role: 'assistant', content: 'hello'}];
     llm.usage = {
@@ -46,8 +46,8 @@ describe('LLM (via Turn.llm)', () => {
       cacheReadInputTokens: 1,
       cacheCreationInputTokens: 3,
     };
-    await llm.end();
-    await turn.end();
+    llm.end();
+    turn.end();
 
     const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
     expect(
@@ -73,11 +73,11 @@ describe('LLM (via Turn.llm)', () => {
     ).toBe(3);
   });
 
-  it("omits message + usage attributes when fields aren't populated", async () => {
-    const turn = await Turn.create({});
-    const llm = await turn.llm({model: 'gpt-4o'});
-    await llm.end();
-    await turn.end();
+  it("omits message + usage attributes when fields aren't populated", () => {
+    const turn = Turn.create({});
+    const llm = turn.llm({model: 'gpt-4o'});
+    llm.end();
+    turn.end();
 
     const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
     expect(

--- a/sdks/node/src/__tests__/genai/llm.test.ts
+++ b/sdks/node/src/__tests__/genai/llm.test.ts
@@ -1,0 +1,93 @@
+import {SpanKind} from '@opentelemetry/api';
+
+import {GEN_AI_ATTR} from '../../genai/semconv';
+import {Turn} from '../../genai/turn';
+
+import {
+  findSpan,
+  setupExporterPerTest,
+  setupGenAITestEnvironment,
+} from './common';
+
+describe('LLM (via Turn.llm)', () => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it("emits a 'chat' span as a child of the turn's invoke_agent span", async () => {
+    const turn = await Turn.create({agentName: 'a', conversationId: 'conv-1'});
+    const llm = await turn.llm({model: 'gpt-4o', providerName: 'openai'});
+    await llm.end();
+    await turn.end();
+
+    const spans = getExporter().getFinishedSpans();
+    const llmSpan = findSpan(spans, 'chat');
+    const turnSpan = findSpan(spans, 'invoke_agent');
+
+    expect(llmSpan.kind).toBe(SpanKind.CLIENT);
+    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OPERATION_NAME]).toBe('chat');
+    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_REQUEST_MODEL]).toBe('gpt-4o');
+    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_PROVIDER_NAME]).toBe('openai');
+    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe(
+      'conv-1'
+    );
+    expect(llmSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
+    expect(llmSpan.spanContext().traceId).toBe(turnSpan.spanContext().traceId);
+  });
+
+  it('serializes input/output messages and usage at end()', async () => {
+    const turn = await Turn.create({});
+    const llm = await turn.llm({model: 'gpt-4o'});
+    llm.inputMessages = [{role: 'user', content: 'hi'}];
+    llm.outputMessages = [{role: 'assistant', content: 'hello'}];
+    llm.usage = {
+      inputTokens: 10,
+      outputTokens: 5,
+      reasoningTokens: 2,
+      cacheReadInputTokens: 1,
+      cacheCreationInputTokens: 3,
+    };
+    await llm.end();
+    await turn.end();
+
+    const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
+    expect(
+      JSON.parse(
+        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES] as string
+      )
+    ).toEqual([{role: 'user', content: 'hi'}]);
+    expect(
+      JSON.parse(
+        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES] as string
+      )
+    ).toEqual([{role: 'assistant', content: 'hello'}]);
+    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_INPUT_TOKENS]).toBe(10);
+    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_OUTPUT_TOKENS]).toBe(5);
+    expect(
+      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS]
+    ).toBe(2);
+    expect(
+      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
+    ).toBe(1);
+    expect(
+      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]
+    ).toBe(3);
+  });
+
+  it("omits message + usage attributes when fields aren't populated", async () => {
+    const turn = await Turn.create({});
+    const llm = await turn.llm({model: 'gpt-4o'});
+    await llm.end();
+    await turn.end();
+
+    const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
+    expect(
+      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES]
+    ).toBeUndefined();
+    expect(
+      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES]
+    ).toBeUndefined();
+    expect(
+      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_INPUT_TOKENS]
+    ).toBeUndefined();
+  });
+});

--- a/sdks/node/src/__tests__/genai/provider.test.ts
+++ b/sdks/node/src/__tests__/genai/provider.test.ts
@@ -4,75 +4,15 @@ import {
   SimpleSpanProcessor,
 } from '@opentelemetry/sdk-trace-base';
 
-import {setGlobalClient} from '../../clientApi';
-import {Api as TraceServerApi} from '../../generated/traceServerApi';
 import {flushOTel} from '../../genai/flush';
-import {
-  getWeaveTracer,
-  getWeaveTracerProvider,
-  PROVIDER_HOLDER_SYMBOL_NAME,
-} from '../../genai/provider';
+import {getWeaveTracer, getWeaveTracerProvider} from '../../genai/provider';
 import {WEAVE_RESOURCE_ATTR} from '../../genai/weaveResource';
-import {Settings, type SettingsInit} from '../../settings';
 import {packageVersion} from '../../utils/packageVersion';
-import {WandbServerApi} from '../../wandb/wandbServerApi';
-import {WeaveClient} from '../../weaveClient';
 
-const TEST_BASE_URL = 'http://localhost:8080';
-const TEST_PROJECT = 'test-entity/test-project';
-
-function installFakeClient(settings: SettingsInit = {}): WeaveClient {
-  const traceServerApi = {baseUrl: TEST_BASE_URL} as TraceServerApi<any>;
-  const client = new WeaveClient(
-    traceServerApi,
-    {} as WandbServerApi,
-    TEST_PROJECT,
-    new Settings(
-      settings.printCallLink ?? true,
-      settings.globalAttributes ?? {},
-      settings.genai ?? {}
-    )
-  );
-  setGlobalClient(client);
-  return client;
-}
-
-function clearGlobalClient(): void {
-  // setGlobalClient is typed for a real client, but the underlying holder
-  // accepts null. Tests need this to exercise the "weave.init() not called"
-  // branch.
-  setGlobalClient(null);
-}
-
-// Reach into the global singleton's holder directly to reset its state.
-function resetProviderSingleton(): void {
-  const holder = (globalThis as Record<symbol, unknown>)[
-    Symbol.for(PROVIDER_HOLDER_SYMBOL_NAME)
-  ] as {provider: unknown; beforeExitRegistered: boolean} | undefined;
-  if (holder) {
-    holder.provider = null;
-    holder.beforeExitRegistered = false;
-  }
-}
+import {installFakeClient, setupGenAITestEnvironment} from './common';
 
 describe('otel/provider', () => {
-  const originalApiKey = process.env.WANDB_API_KEY;
-
-  beforeEach(() => {
-    process.env.WANDB_API_KEY = 'test-api-key';
-    resetProviderSingleton();
-    clearGlobalClient();
-  });
-
-  afterEach(() => {
-    resetProviderSingleton();
-    clearGlobalClient();
-    if (originalApiKey === undefined) {
-      delete process.env.WANDB_API_KEY;
-    } else {
-      process.env.WANDB_API_KEY = originalApiKey;
-    }
-  });
+  setupGenAITestEnvironment();
 
   it('returns a non-recording tracer when weave.init() has not been called', () => {
     const tracer = getWeaveTracer('weave-genai');

--- a/sdks/node/src/__tests__/genai/session.test.ts
+++ b/sdks/node/src/__tests__/genai/session.test.ts
@@ -1,0 +1,32 @@
+import {GEN_AI_ATTR} from '../../genai/semconv';
+import {Session} from '../../genai/session';
+
+import {setupExporterPerTest, setupGenAITestEnvironment} from './common';
+
+describe('Session', () => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('emits no span of its own but propagates sessionId as gen_ai.conversation.id', async () => {
+    const session = await Session.create({
+      agentName: 'weather-bot',
+      sessionId: 's-1',
+    });
+    const turn = await session.startTurn();
+    await turn.end();
+    await session.end();
+
+    const spans = getExporter().getFinishedSpans();
+    expect(spans).toHaveLength(1); // only the turn span
+    expect(spans[0].name).toBe('invoke_agent');
+    expect(spans[0].attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe('s-1');
+    expect(spans[0].attributes[GEN_AI_ATTR.GEN_AI_AGENT_NAME]).toBe(
+      'weather-bot'
+    );
+  });
+
+  it('auto-generates a sessionId when none is supplied', async () => {
+    const session = await Session.create({});
+    expect(session.sessionId).toBeTruthy();
+  });
+});

--- a/sdks/node/src/__tests__/genai/session.test.ts
+++ b/sdks/node/src/__tests__/genai/session.test.ts
@@ -7,14 +7,14 @@ describe('Session', () => {
   setupGenAITestEnvironment();
   const getExporter = setupExporterPerTest();
 
-  it('emits no span of its own but propagates sessionId as gen_ai.conversation.id', async () => {
-    const session = await Session.create({
+  it('emits no span of its own but propagates sessionId as gen_ai.conversation.id', () => {
+    const session = Session.create({
       agentName: 'weather-bot',
       sessionId: 's-1',
     });
-    const turn = await session.startTurn();
-    await turn.end();
-    await session.end();
+    const turn = session.startTurn();
+    turn.end();
+    session.end();
 
     const spans = getExporter().getFinishedSpans();
     expect(spans).toHaveLength(1); // only the turn span
@@ -25,8 +25,8 @@ describe('Session', () => {
     );
   });
 
-  it('auto-generates a sessionId when none is supplied', async () => {
-    const session = await Session.create({});
+  it('auto-generates a sessionId when none is supplied', () => {
+    const session = Session.create({});
     expect(session.sessionId).toBeTruthy();
   });
 });

--- a/sdks/node/src/__tests__/genai/subagent.test.ts
+++ b/sdks/node/src/__tests__/genai/subagent.test.ts
@@ -7,11 +7,11 @@ describe('SubAgent', () => {
   setupGenAITestEnvironment();
   const getExporter = setupExporterPerTest();
 
-  it('emits a nested invoke_agent span as a child of the turn', async () => {
-    const turn = await Turn.create({agentName: 'parent'});
-    const sub = await turn.subagent({name: 'child-bot', model: 'gpt-4o'});
-    await sub.end();
-    await turn.end();
+  it('emits a nested invoke_agent span as a child of the turn', () => {
+    const turn = Turn.create({agentName: 'parent'});
+    const sub = turn.subagent({name: 'child-bot', model: 'gpt-4o'});
+    sub.end();
+    turn.end();
 
     const spans = getExporter().getFinishedSpans();
     // Two spans, both named 'invoke_agent'. Differentiate by agent name.

--- a/sdks/node/src/__tests__/genai/subagent.test.ts
+++ b/sdks/node/src/__tests__/genai/subagent.test.ts
@@ -1,0 +1,35 @@
+import {GEN_AI_ATTR} from '../../genai/semconv';
+import {Turn} from '../../genai/turn';
+
+import {setupExporterPerTest, setupGenAITestEnvironment} from './common';
+
+describe('SubAgent', () => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('emits a nested invoke_agent span as a child of the turn', async () => {
+    const turn = await Turn.create({agentName: 'parent'});
+    const sub = await turn.subagent({name: 'child-bot', model: 'gpt-4o'});
+    await sub.end();
+    await turn.end();
+
+    const spans = getExporter().getFinishedSpans();
+    // Two spans, both named 'invoke_agent'. Differentiate by agent name.
+    const subSpan = spans.find(
+      s =>
+        s.name === 'invoke_agent' &&
+        s.attributes[GEN_AI_ATTR.GEN_AI_AGENT_NAME] === 'child-bot'
+    );
+    const parentTurnSpan = spans.find(
+      s =>
+        s.name === 'invoke_agent' &&
+        s.attributes[GEN_AI_ATTR.GEN_AI_AGENT_NAME] === 'parent'
+    );
+    expect(subSpan).toBeDefined();
+    expect(parentTurnSpan).toBeDefined();
+    expect(subSpan!.parentSpanId).toBe(parentTurnSpan!.spanContext().spanId);
+    expect(subSpan!.attributes[GEN_AI_ATTR.GEN_AI_REQUEST_MODEL]).toBe(
+      'gpt-4o'
+    );
+  });
+});

--- a/sdks/node/src/__tests__/genai/tool.test.ts
+++ b/sdks/node/src/__tests__/genai/tool.test.ts
@@ -13,16 +13,16 @@ describe('Tool', () => {
   setupGenAITestEnvironment();
   const getExporter = setupExporterPerTest();
 
-  it('attaches to the turn span when started via turn.tool() (flat)', async () => {
-    const turn = await Turn.create({conversationId: 'conv-1'});
-    const tool = await turn.tool({
+  it('attaches to the turn span when started via turn.tool() (flat)', () => {
+    const turn = Turn.create({conversationId: 'conv-1'});
+    const tool = turn.tool({
       name: 'get_weather',
       args: '{"city":"Tokyo"}',
       toolCallId: 'tc-1',
     });
     tool.result = '75F';
-    await tool.end();
-    await turn.end();
+    tool.end();
+    turn.end();
 
     const spans = getExporter().getFinishedSpans();
     const toolSpan = findSpan(spans, 'execute_tool');
@@ -48,13 +48,13 @@ describe('Tool', () => {
     expect(toolSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
   });
 
-  it('attaches to the LLM span when started via llm.startTool() (nested)', async () => {
-    const turn = await Turn.create({});
-    const llm = await turn.llm({model: 'gpt-4o'});
-    const tool = await llm.startTool({name: 'get_weather'});
-    await tool.end();
-    await llm.end();
-    await turn.end();
+  it('attaches to the LLM span when started via llm.startTool() (nested)', () => {
+    const turn = Turn.create({});
+    const llm = turn.llm({model: 'gpt-4o'});
+    const tool = llm.startTool({name: 'get_weather'});
+    tool.end();
+    llm.end();
+    turn.end();
 
     const spans = getExporter().getFinishedSpans();
     const toolSpan = findSpan(spans, 'execute_tool');

--- a/sdks/node/src/__tests__/genai/tool.test.ts
+++ b/sdks/node/src/__tests__/genai/tool.test.ts
@@ -1,0 +1,64 @@
+import {SpanKind} from '@opentelemetry/api';
+
+import {GEN_AI_ATTR} from '../../genai/semconv';
+import {Turn} from '../../genai/turn';
+
+import {
+  findSpan,
+  setupExporterPerTest,
+  setupGenAITestEnvironment,
+} from './common';
+
+describe('Tool', () => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('attaches to the turn span when started via turn.tool() (flat)', async () => {
+    const turn = await Turn.create({conversationId: 'conv-1'});
+    const tool = await turn.tool({
+      name: 'get_weather',
+      args: '{"city":"Tokyo"}',
+      toolCallId: 'tc-1',
+    });
+    tool.result = '75F';
+    await tool.end();
+    await turn.end();
+
+    const spans = getExporter().getFinishedSpans();
+    const toolSpan = findSpan(spans, 'execute_tool');
+    const turnSpan = findSpan(spans, 'invoke_agent');
+
+    expect(toolSpan.kind).toBe(SpanKind.INTERNAL);
+    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_OPERATION_NAME]).toBe(
+      'execute_tool'
+    );
+    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_TOOL_NAME]).toBe(
+      'get_weather'
+    );
+    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_TOOL_CALL_ID]).toBe('tc-1');
+    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_TOOL_CALL_ARGUMENTS]).toBe(
+      '{"city":"Tokyo"}'
+    );
+    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_TOOL_CALL_RESULT]).toBe(
+      '75F'
+    );
+    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe(
+      'conv-1'
+    );
+    expect(toolSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
+  });
+
+  it('attaches to the LLM span when started via llm.startTool() (nested)', async () => {
+    const turn = await Turn.create({});
+    const llm = await turn.llm({model: 'gpt-4o'});
+    const tool = await llm.startTool({name: 'get_weather'});
+    await tool.end();
+    await llm.end();
+    await turn.end();
+
+    const spans = getExporter().getFinishedSpans();
+    const toolSpan = findSpan(spans, 'execute_tool');
+    const llmSpan = findSpan(spans, 'chat');
+    expect(toolSpan.parentSpanId).toBe(llmSpan.spanContext().spanId);
+  });
+});

--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -13,13 +13,13 @@ describe('Turn', () => {
   setupGenAITestEnvironment();
   const getExporter = setupExporterPerTest();
 
-  it('emits an invoke_agent span with GenAI agent / model attributes', async () => {
-    const turn = await Turn.create({
+  it('emits an invoke_agent span with GenAI agent / model attributes', () => {
+    const turn = Turn.create({
       agentName: 'weather-bot',
       model: 'gpt-4o',
       conversationId: 'conv-1',
     });
-    await turn.end();
+    turn.end();
 
     const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
     expect(span.kind).toBe(SpanKind.CLIENT);
@@ -32,16 +32,16 @@ describe('Turn', () => {
     expect(span.parentSpanId).toBeUndefined();
   });
 
-  it('end() is idempotent', async () => {
-    const turn = await Turn.create({});
-    await turn.end();
-    await turn.end();
+  it('end() is idempotent', () => {
+    const turn = Turn.create({});
+    turn.end();
+    turn.end();
     expect(getExporter().getFinishedSpans()).toHaveLength(1);
   });
 
-  it('records the error and sets ERROR status when end({ error }) is called', async () => {
-    const turn = await Turn.create({});
-    await turn.end({error: new Error('boom')});
+  it('records the error and sets ERROR status when end({ error }) is called', () => {
+    const turn = Turn.create({});
+    turn.end({error: new Error('boom')});
     const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
     expect(span.status.code).toBe(SpanStatusCode.ERROR);
     expect(span.status.message).toBe('boom');

--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -1,0 +1,50 @@
+import {SpanKind, SpanStatusCode} from '@opentelemetry/api';
+
+import {GEN_AI_ATTR} from '../../genai/semconv';
+import {Turn} from '../../genai/turn';
+
+import {
+  findSpan,
+  setupExporterPerTest,
+  setupGenAITestEnvironment,
+} from './common';
+
+describe('Turn', () => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('emits an invoke_agent span with GenAI agent / model attributes', async () => {
+    const turn = await Turn.create({
+      agentName: 'weather-bot',
+      model: 'gpt-4o',
+      conversationId: 'conv-1',
+    });
+    await turn.end();
+
+    const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
+    expect(span.kind).toBe(SpanKind.CLIENT);
+    expect(span.attributes[GEN_AI_ATTR.GEN_AI_OPERATION_NAME]).toBe(
+      'invoke_agent'
+    );
+    expect(span.attributes[GEN_AI_ATTR.GEN_AI_AGENT_NAME]).toBe('weather-bot');
+    expect(span.attributes[GEN_AI_ATTR.GEN_AI_REQUEST_MODEL]).toBe('gpt-4o');
+    expect(span.attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe('conv-1');
+    expect(span.parentSpanId).toBeUndefined();
+  });
+
+  it('end() is idempotent', async () => {
+    const turn = await Turn.create({});
+    await turn.end();
+    await turn.end();
+    expect(getExporter().getFinishedSpans()).toHaveLength(1);
+  });
+
+  it('records the error and sets ERROR status when end({ error }) is called', async () => {
+    const turn = await Turn.create({});
+    await turn.end({error: new Error('boom')});
+    const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
+    expect(span.status.code).toBe(SpanStatusCode.ERROR);
+    expect(span.status.message).toBe('boom');
+    expect(span.events.some(e => e.name === 'exception')).toBe(true);
+  });
+});

--- a/sdks/node/src/genai/common.ts
+++ b/sdks/node/src/genai/common.ts
@@ -1,0 +1,11 @@
+import type {Context} from '@opentelemetry/api';
+
+/**
+ * Internal options threaded from a parent emitter into a child class's
+ * `create()` factory. Carries the OTel parent Context (which already has
+ * the parent span attached) and the propagating conversation id.
+ */
+export interface ChildSpanContext {
+  parentContext: Context;
+  conversationId?: string;
+}

--- a/sdks/node/src/genai/index.ts
+++ b/sdks/node/src/genai/index.ts
@@ -1,10 +1,15 @@
 /**
  * Weave GenAI session SDK — module entry point.
  *
- * The runtime surface (Session / Turn / LLM / Tool / SubAgent and the
- * top-level `startSession` / `startTurn` / ... functions) lands in later
- * PRs. This PR ships the data types only.
+ * The top-level `weave.startSession` / `startTurn` / ... functions and the
+ * AsyncLocalStorage-backed `getCurrent*` accessors land in a later PR.
  */
+
+export {LLM, type LLMInit} from './llm';
+export {Session, type SessionInit} from './session';
+export {SubAgent, type SubAgentInit} from './subagent';
+export {Tool, type ToolInit} from './tool';
+export {Turn, type TurnInit} from './turn';
 
 export type {
   Message,

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -16,7 +16,6 @@ import type {Message, Reasoning, Usage} from './types';
 export interface LLMInit {
   model: string;
   providerName?: string;
-  systemInstructions?: string[];
 }
 
 export class LLM {
@@ -33,8 +32,7 @@ export class LLM {
     private readonly context: Context,
     private readonly conversationId: string,
     public readonly model: string,
-    public readonly providerName: string,
-    public readonly systemInstructions: string[]
+    public readonly providerName: string
   ) {}
 
   static create(opts: LLMInit & ChildSpanContext): LLM {
@@ -59,8 +57,7 @@ export class LLM {
       trace.setSpan(opts.parentContext, span),
       opts.conversationId ?? '',
       opts.model,
-      opts.providerName ?? '',
-      opts.systemInstructions ?? []
+      opts.providerName ?? ''
     );
   }
 

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -1,0 +1,141 @@
+import {
+  type Context,
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+} from '@opentelemetry/api';
+
+import type {ChildSpanContext} from './common';
+import {getWeaveTracer} from './provider';
+import {GEN_AI_ATTR, WEAVE_GENAI_TRACER_NAME} from './semconv';
+import {SubAgent, type SubAgentInit} from './subagent';
+import {Tool, type ToolInit} from './tool';
+import type {Message, Reasoning, Usage} from './types';
+
+export interface LLMInit {
+  model: string;
+  providerName?: string;
+  systemInstructions?: string[];
+}
+
+export class LLM {
+  /** Mutable data populated between `create()` and `end()`. */
+  inputMessages: Message[] = [];
+  outputMessages: Message[] = [];
+  usage: Usage = {};
+  reasoning?: Reasoning;
+
+  private _ended = false;
+
+  private constructor(
+    private readonly span: Span,
+    private readonly context: Context,
+    private readonly conversationId: string,
+    public readonly model: string,
+    public readonly providerName: string,
+    public readonly systemInstructions: string[]
+  ) {}
+
+  static async create(opts: LLMInit & ChildSpanContext): Promise<LLM> {
+    const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
+    const attributes: Record<string, string> = {
+      [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'chat',
+      [GEN_AI_ATTR.GEN_AI_REQUEST_MODEL]: opts.model,
+    };
+    if (opts.providerName) {
+      attributes[GEN_AI_ATTR.GEN_AI_PROVIDER_NAME] = opts.providerName;
+    }
+    if (opts.conversationId) {
+      attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID] = opts.conversationId;
+    }
+    const span = tracer.startSpan(
+      'chat',
+      {kind: SpanKind.CLIENT, attributes},
+      opts.parentContext
+    );
+    return new LLM(
+      span,
+      trace.setSpan(opts.parentContext, span),
+      opts.conversationId ?? '',
+      opts.model,
+      opts.providerName ?? '',
+      opts.systemInstructions ?? []
+    );
+  }
+
+  async startTool(opts: ToolInit): Promise<Tool> {
+    return Tool.create({
+      ...opts,
+      parentContext: this.context,
+      conversationId: this.conversationId,
+    });
+  }
+
+  async startSubagent(opts: SubAgentInit): Promise<SubAgent> {
+    return SubAgent.create({
+      ...opts,
+      parentContext: this.context,
+      conversationId: this.conversationId,
+    });
+  }
+
+  async end(opts?: {error?: Error}): Promise<void> {
+    if (this._ended) return;
+    this._ended = true;
+
+    if (this.inputMessages.length > 0) {
+      this.span.setAttribute(
+        GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES,
+        JSON.stringify(this.inputMessages)
+      );
+    }
+    if (this.outputMessages.length > 0) {
+      this.span.setAttribute(
+        GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES,
+        JSON.stringify(this.outputMessages)
+      );
+    }
+
+    const u = this.usage;
+    if (u.inputTokens !== undefined) {
+      this.span.setAttribute(
+        GEN_AI_ATTR.GEN_AI_USAGE_INPUT_TOKENS,
+        u.inputTokens
+      );
+    }
+    if (u.outputTokens !== undefined) {
+      this.span.setAttribute(
+        GEN_AI_ATTR.GEN_AI_USAGE_OUTPUT_TOKENS,
+        u.outputTokens
+      );
+    }
+    if (u.reasoningTokens !== undefined) {
+      this.span.setAttribute(
+        GEN_AI_ATTR.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
+        u.reasoningTokens
+      );
+    }
+    if (u.cacheCreationInputTokens !== undefined) {
+      this.span.setAttribute(
+        GEN_AI_ATTR.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+        u.cacheCreationInputTokens
+      );
+    }
+    if (u.cacheReadInputTokens !== undefined) {
+      this.span.setAttribute(
+        GEN_AI_ATTR.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+        u.cacheReadInputTokens
+      );
+    }
+
+    if (opts?.error) {
+      this.span.recordException(opts.error);
+      this.span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: opts.error.message,
+      });
+    }
+    this.span.end();
+  }
+}

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -37,7 +37,7 @@ export class LLM {
     public readonly systemInstructions: string[]
   ) {}
 
-  static async create(opts: LLMInit & ChildSpanContext): Promise<LLM> {
+  static create(opts: LLMInit & ChildSpanContext): LLM {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Record<string, string> = {
       [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'chat',
@@ -64,7 +64,7 @@ export class LLM {
     );
   }
 
-  async startTool(opts: ToolInit): Promise<Tool> {
+  startTool(opts: ToolInit): Tool {
     return Tool.create({
       ...opts,
       parentContext: this.context,
@@ -72,7 +72,7 @@ export class LLM {
     });
   }
 
-  async startSubagent(opts: SubAgentInit): Promise<SubAgent> {
+  startSubagent(opts: SubAgentInit): SubAgent {
     return SubAgent.create({
       ...opts,
       parentContext: this.context,
@@ -80,8 +80,10 @@ export class LLM {
     });
   }
 
-  async end(opts?: {error?: Error}): Promise<void> {
-    if (this._ended) return;
+  end(opts?: {error?: Error}): void {
+    if (this._ended) {
+      return;
+    }
     this._ended = true;
 
     if (this.inputMessages.length > 0) {

--- a/sdks/node/src/genai/semconv.ts
+++ b/sdks/node/src/genai/semconv.ts
@@ -28,6 +28,8 @@ export const GEN_AI_ATTR = {
   // Tool
   GEN_AI_TOOL_NAME: 'gen_ai.tool.name',
   GEN_AI_TOOL_CALL_ID: 'gen_ai.tool.call.id',
+  GEN_AI_TOOL_CALL_ARGUMENTS: 'gen_ai.tool.call.arguments',
+  GEN_AI_TOOL_CALL_RESULT: 'gen_ai.tool.call.result',
   GEN_AI_OUTPUT_TYPE: 'gen_ai.output.type',
   GEN_AI_INPUT_MESSAGES: 'gen_ai.input.messages',
   GEN_AI_OUTPUT_MESSAGES: 'gen_ai.output.messages',
@@ -54,3 +56,11 @@ export const GEN_AI_EVENT = {
 export const OTEL_ATTR = {
   ERROR_TYPE: 'error.type',
 } as const;
+
+// ---------------------------------------------------------------------------
+// Emitter identity
+// ---------------------------------------------------------------------------
+
+/** Instrumentation-library name passed to `getWeaveTracer` by every emitter
+ *  in the GenAI session SDK. */
+export const WEAVE_GENAI_TRACER_NAME = 'weave-genai';

--- a/sdks/node/src/genai/session.ts
+++ b/sdks/node/src/genai/session.ts
@@ -21,7 +21,7 @@ export class Session {
     public readonly sessionId: string
   ) {}
 
-  static async create(opts: SessionInit = {}): Promise<Session> {
+  static create(opts: SessionInit = {}): Session {
     return new Session(
       opts.agentName ?? '',
       opts.model ?? '',
@@ -29,7 +29,7 @@ export class Session {
     );
   }
 
-  async startTurn(opts: TurnInit = {}): Promise<Turn> {
+  startTurn(opts: TurnInit = {}): Turn {
     return Turn.create({
       agentName: opts.agentName ?? this.agentName,
       model: opts.model ?? this.model,
@@ -38,7 +38,7 @@ export class Session {
     });
   }
 
-  async end(): Promise<void> {
+  end(): void {
     // Session emits no span; this exists only to mirror the start/end
     // symmetry of the other classes.
   }

--- a/sdks/node/src/genai/session.ts
+++ b/sdks/node/src/genai/session.ts
@@ -33,7 +33,6 @@ export class Session {
     return Turn.create({
       agentName: opts.agentName ?? this.agentName,
       model: opts.model ?? this.model,
-      userMessage: opts.userMessage,
       conversationId: this.sessionId,
     });
   }

--- a/sdks/node/src/genai/session.ts
+++ b/sdks/node/src/genai/session.ts
@@ -1,0 +1,45 @@
+import {uuidv7} from 'uuidv7';
+
+import {Turn, type TurnInit} from './turn';
+
+export interface SessionInit {
+  agentName?: string;
+  model?: string;
+  /** Conversation ID propagated to every span under this session as
+   *  `gen_ai.conversation.id`. Auto-generated if omitted. */
+  sessionId?: string;
+}
+
+/**
+ * A Session groups Turns under a single `gen_ai.conversation.id`. It is not
+ * itself an OTel span — children stamp the conversation id onto theirs.
+ */
+export class Session {
+  private constructor(
+    public readonly agentName: string,
+    public readonly model: string,
+    public readonly sessionId: string
+  ) {}
+
+  static async create(opts: SessionInit = {}): Promise<Session> {
+    return new Session(
+      opts.agentName ?? '',
+      opts.model ?? '',
+      opts.sessionId ?? uuidv7()
+    );
+  }
+
+  async startTurn(opts: TurnInit = {}): Promise<Turn> {
+    return Turn.create({
+      agentName: opts.agentName ?? this.agentName,
+      model: opts.model ?? this.model,
+      userMessage: opts.userMessage,
+      conversationId: this.sessionId,
+    });
+  }
+
+  async end(): Promise<void> {
+    // Session emits no span; this exists only to mirror the start/end
+    // symmetry of the other classes.
+  }
+}

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -18,9 +18,7 @@ export class SubAgent {
     public readonly model: string
   ) {}
 
-  static async create(
-    opts: SubAgentInit & ChildSpanContext
-  ): Promise<SubAgent> {
+  static create(opts: SubAgentInit & ChildSpanContext): SubAgent {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Record<string, string> = {
       [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'invoke_agent',
@@ -40,8 +38,10 @@ export class SubAgent {
     return new SubAgent(span, opts.name, opts.model ?? '');
   }
 
-  async end(opts?: {error?: Error}): Promise<void> {
-    if (this._ended) return;
+  end(opts?: {error?: Error}): void {
+    if (this._ended) {
+      return;
+    }
     this._ended = true;
     if (opts?.error) {
       this.span.recordException(opts.error);

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -1,0 +1,55 @@
+import {type Span, SpanKind, SpanStatusCode} from '@opentelemetry/api';
+
+import type {ChildSpanContext} from './common';
+import {getWeaveTracer} from './provider';
+import {GEN_AI_ATTR, WEAVE_GENAI_TRACER_NAME} from './semconv';
+
+export interface SubAgentInit {
+  name: string;
+  model?: string;
+}
+
+export class SubAgent {
+  private _ended = false;
+
+  private constructor(
+    private readonly span: Span,
+    public readonly name: string,
+    public readonly model: string
+  ) {}
+
+  static async create(
+    opts: SubAgentInit & ChildSpanContext
+  ): Promise<SubAgent> {
+    const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
+    const attributes: Record<string, string> = {
+      [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'invoke_agent',
+      [GEN_AI_ATTR.GEN_AI_AGENT_NAME]: opts.name,
+    };
+    if (opts.model) {
+      attributes[GEN_AI_ATTR.GEN_AI_REQUEST_MODEL] = opts.model;
+    }
+    if (opts.conversationId) {
+      attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID] = opts.conversationId;
+    }
+    const span = tracer.startSpan(
+      'invoke_agent',
+      {kind: SpanKind.CLIENT, attributes},
+      opts.parentContext
+    );
+    return new SubAgent(span, opts.name, opts.model ?? '');
+  }
+
+  async end(opts?: {error?: Error}): Promise<void> {
+    if (this._ended) return;
+    this._ended = true;
+    if (opts?.error) {
+      this.span.recordException(opts.error);
+      this.span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: opts.error.message,
+      });
+    }
+    this.span.end();
+  }
+}

--- a/sdks/node/src/genai/tool.ts
+++ b/sdks/node/src/genai/tool.ts
@@ -23,7 +23,7 @@ export class Tool {
     public readonly toolCallId: string
   ) {}
 
-  static async create(opts: ToolInit & ChildSpanContext): Promise<Tool> {
+  static create(opts: ToolInit & ChildSpanContext): Tool {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Record<string, string> = {
       [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'execute_tool',
@@ -46,7 +46,7 @@ export class Tool {
     return new Tool(span, opts.name, opts.args ?? '', opts.toolCallId ?? '');
   }
 
-  async end(opts?: {error?: Error}): Promise<void> {
+  end(opts?: {error?: Error}): void {
     if (this._ended) {
       return;
     }

--- a/sdks/node/src/genai/tool.ts
+++ b/sdks/node/src/genai/tool.ts
@@ -1,0 +1,66 @@
+import {type Span, SpanKind, SpanStatusCode} from '@opentelemetry/api';
+
+import type {ChildSpanContext} from './common';
+import {getWeaveTracer} from './provider';
+import {GEN_AI_ATTR, WEAVE_GENAI_TRACER_NAME} from './semconv';
+
+export interface ToolInit {
+  name: string;
+  args?: string;
+  toolCallId?: string;
+}
+
+export class Tool {
+  /** Free-form result captured before `end()`. */
+  result?: string;
+
+  private _ended = false;
+
+  private constructor(
+    private readonly span: Span,
+    public readonly name: string,
+    public readonly args: string,
+    public readonly toolCallId: string
+  ) {}
+
+  static async create(opts: ToolInit & ChildSpanContext): Promise<Tool> {
+    const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
+    const attributes: Record<string, string> = {
+      [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'execute_tool',
+      [GEN_AI_ATTR.GEN_AI_TOOL_NAME]: opts.name,
+    };
+    if (opts.toolCallId) {
+      attributes[GEN_AI_ATTR.GEN_AI_TOOL_CALL_ID] = opts.toolCallId;
+    }
+    if (opts.args) {
+      attributes[GEN_AI_ATTR.GEN_AI_TOOL_CALL_ARGUMENTS] = opts.args;
+    }
+    if (opts.conversationId) {
+      attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID] = opts.conversationId;
+    }
+    const span = tracer.startSpan(
+      'execute_tool',
+      {kind: SpanKind.INTERNAL, attributes},
+      opts.parentContext
+    );
+    return new Tool(span, opts.name, opts.args ?? '', opts.toolCallId ?? '');
+  }
+
+  async end(opts?: {error?: Error}): Promise<void> {
+    if (this._ended) {
+      return;
+    }
+    this._ended = true;
+    if (this.result !== undefined) {
+      this.span.setAttribute(GEN_AI_ATTR.GEN_AI_TOOL_CALL_RESULT, this.result);
+    }
+    if (opts?.error) {
+      this.span.recordException(opts.error);
+      this.span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: opts.error.message,
+      });
+    }
+    this.span.end();
+  }
+}

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -1,0 +1,102 @@
+import {
+  type Context,
+  ROOT_CONTEXT,
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+} from '@opentelemetry/api';
+
+import {LLM, type LLMInit} from './llm';
+import {getWeaveTracer} from './provider';
+import {GEN_AI_ATTR, WEAVE_GENAI_TRACER_NAME} from './semconv';
+import {SubAgent, type SubAgentInit} from './subagent';
+import {Tool, type ToolInit} from './tool';
+
+export interface TurnInit {
+  agentName?: string;
+  model?: string;
+  userMessage?: string;
+}
+
+export class Turn {
+  private _ended = false;
+
+  private constructor(
+    private readonly span: Span,
+    private readonly context: Context,
+    private readonly conversationId: string,
+    public readonly agentName: string,
+    public readonly model: string
+  ) {}
+
+  static async create(
+    opts: TurnInit & {conversationId?: string} = {}
+  ): Promise<Turn> {
+    const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
+    const attributes: Record<string, string> = {
+      [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'invoke_agent',
+    };
+    if (opts.agentName) {
+      attributes[GEN_AI_ATTR.GEN_AI_AGENT_NAME] = opts.agentName;
+    }
+    if (opts.model) {
+      attributes[GEN_AI_ATTR.GEN_AI_REQUEST_MODEL] = opts.model;
+    }
+    if (opts.conversationId) {
+      attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID] = opts.conversationId;
+    }
+    // Pass ROOT_CONTEXT explicitly so Turn is always a root span — never
+    // accidentally inherits a parent from some other OTel-instrumented
+    // library's active context.
+    const span = tracer.startSpan(
+      'invoke_agent',
+      {kind: SpanKind.CLIENT, attributes},
+      ROOT_CONTEXT
+    );
+    return new Turn(
+      span,
+      trace.setSpan(ROOT_CONTEXT, span),
+      opts.conversationId ?? '',
+      opts.agentName ?? '',
+      opts.model ?? ''
+    );
+  }
+
+  async llm(opts: LLMInit): Promise<LLM> {
+    return LLM.create({
+      ...opts,
+      parentContext: this.context,
+      conversationId: this.conversationId,
+    });
+  }
+
+  async tool(opts: ToolInit): Promise<Tool> {
+    return Tool.create({
+      ...opts,
+      parentContext: this.context,
+      conversationId: this.conversationId,
+    });
+  }
+
+  async subagent(opts: SubAgentInit): Promise<SubAgent> {
+    return SubAgent.create({
+      ...opts,
+      parentContext: this.context,
+      conversationId: this.conversationId,
+    });
+  }
+
+  async end(opts?: {error?: Error}): Promise<void> {
+    if (this._ended) return;
+    this._ended = true;
+    if (opts?.error) {
+      this.span.recordException(opts.error);
+      this.span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: opts.error.message,
+      });
+    }
+    this.span.end();
+  }
+}

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -30,9 +30,7 @@ export class Turn {
     public readonly model: string
   ) {}
 
-  static async create(
-    opts: TurnInit & {conversationId?: string} = {}
-  ): Promise<Turn> {
+  static create(opts: TurnInit & {conversationId?: string} = {}): Turn {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Record<string, string> = {
       [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'invoke_agent',
@@ -63,7 +61,7 @@ export class Turn {
     );
   }
 
-  async llm(opts: LLMInit): Promise<LLM> {
+  llm(opts: LLMInit): LLM {
     return LLM.create({
       ...opts,
       parentContext: this.context,
@@ -71,7 +69,7 @@ export class Turn {
     });
   }
 
-  async tool(opts: ToolInit): Promise<Tool> {
+  tool(opts: ToolInit): Tool {
     return Tool.create({
       ...opts,
       parentContext: this.context,
@@ -79,7 +77,7 @@ export class Turn {
     });
   }
 
-  async subagent(opts: SubAgentInit): Promise<SubAgent> {
+  subagent(opts: SubAgentInit): SubAgent {
     return SubAgent.create({
       ...opts,
       parentContext: this.context,
@@ -87,8 +85,10 @@ export class Turn {
     });
   }
 
-  async end(opts?: {error?: Error}): Promise<void> {
-    if (this._ended) return;
+  end(opts?: {error?: Error}): void {
+    if (this._ended) {
+      return;
+    }
     this._ended = true;
     if (opts?.error) {
       this.span.recordException(opts.error);

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -16,7 +16,6 @@ import {Tool, type ToolInit} from './tool';
 export interface TurnInit {
   agentName?: string;
   model?: string;
-  userMessage?: string;
 }
 
 export class Turn {

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -24,6 +24,27 @@ export {
   createOtelExtension,
 } from './integrations';
 export {flushOTel} from './genai/flush';
+// Type-only: consumers can name these in their own signatures, but the
+// runtime values aren't reachable — construction is private to the SDK's
+// top-level entry-point functions.
+export type {
+  LLM,
+  LLMInit,
+  Message,
+  MessagePart,
+  Modality,
+  Reasoning,
+  Role,
+  Session,
+  SessionInit,
+  SubAgent,
+  SubAgentInit,
+  Tool,
+  ToolInit,
+  Turn,
+  TurnInit,
+  Usage,
+} from './genai';
 export {weaveAudio, weaveImage, WeaveAudio, WeaveImage} from './media';
 export {op} from './op';
 export * from './types';


### PR DESCRIPTION
### Summary

Lands the five GenAI session classes and their chained child-creation methods. Manual `start()` / `.end({ error? })` is the primary idiom (no ALS yet — that's PR 4). The Session→Turn→LLM→Tool/SubAgent hierarchy is fully traceable end-to-end via the chained form. Classes are exposed as **types only** at the package boundary so consumers can name them in their own signatures but cannot construct them directly — construction is private to the SDK's top-level entry points (which land in PR 4).

### Changes

- **New class files:**
  - `src/genai/session.ts` — no span, propagates `sessionId` (UUID v7 if not supplied) as `gen_ai.conversation.id` to every child.
  - `src/genai/turn.ts` — emits `invoke_agent` root span (always rooted at `ROOT_CONTEXT`, so external OTel context can never accidentally  parent us). Owns chained `llm()` / `tool()` / `subagent()` factories.
  - `src/genai/llm.ts` — emits `chat` span as child of Turn. Mutable  `inputMessages` / `outputMessages` / `usage` / `reasoning` fields  populated by the user between `create()` and `end()`; serialized to span attributes (GenAI semconv) on close. Owns chained  `startTool()` / `startSubagent()` for the nested form.
  - `src/genai/tool.ts` — emits `execute_tool` span. `result?: string`  field for free-form output capture.
  - `src/genai/subagent.ts` — emits nested `invoke_agent` span.
- **`src/genai/common.ts`** — `ChildSpanContext { parentContext: Context;  conversationId?: string }` threaded from parent to child. Each non-leaf class stores its own derived `Context` and passes it down  (children build on parents' context rather than reconstructing from `ROOT_CONTEXT` + parent span).
- **Tool parent resolution** (design §6.3): both forms supported.
  - `turn.tool(...)` — Tool is a sibling of LLM under Turn (flat).
  - `llm.startTool(...)` — Tool is a child of the LLM span (nested).
- **Public type contract** in `src/index.ts`: `export type { ... }` for the five class types plus init types and data types.
- **`WEAVE_GENAI_TRACER_NAME = 'weave-genai'`** added to `src/genai/semconv.ts`.
- **New Tests** — per-class test files under `src/__tests__/genai/`

### Design notes

- Static `create()` factories sit on the class but are unreachable from consumer code because the class is exported as `export type` only. This lets the chained methods inside the package construct via `LLM.create()` while keeping `LLM.create(...)` invisible to consumers — they go through the top-level entry points (PR 4) or chained calls.
- `tool.result` is a public mutable field (set before `end()`), matching the Python SDK's `step.usage = Usage(...)` field-assignment pattern.

### Tested

- [x] Typecheck clean across both build configs.
- [x] Prettier clean.
- [x] All unit tests pass.