### PR TITLE
fix(weave): rewrite PREWHERE -> WHERE to dodge CH 26.2 query_condition_cache bug

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -39,7 +39,7 @@ def test_query_baseline(read_table: ReadTable, expected_table: str) -> None:
         expected_query = f"""
             SELECT {expected_table}.id AS id
             FROM {expected_table}
-            PREWHERE {expected_table}.project_id = {{pb_0:String}}
+            WHERE {expected_table}.project_id = {{pb_0:String}}
             GROUP BY ({expected_table}.project_id, {expected_table}.id)
             HAVING (
                 ((
@@ -57,8 +57,7 @@ def test_query_baseline(read_table: ReadTable, expected_table: str) -> None:
         expected_query = f"""
             SELECT {expected_table}.id AS id
             FROM {expected_table}
-            PREWHERE {expected_table}.project_id = {{pb_1:String}}
-            WHERE 1
+            WHERE {expected_table}.project_id = {{pb_1:String}}
               AND ({expected_table}.deleted_at = {{pb_0:DateTime64(3)}})
         """
     if read_table == ReadTable.CALLS_MERGED:
@@ -82,7 +81,7 @@ def test_query_light_column() -> None:
             calls_merged.id AS id,
             any(calls_merged.started_at) AS started_at
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
+        WHERE calls_merged.project_id = {pb_0:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((
@@ -111,7 +110,7 @@ def test_query_heavy_column() -> None:
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
+        WHERE calls_merged.project_id = {pb_0:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((
@@ -147,8 +146,8 @@ def test_query_heavy_column_simple_filter() -> None:
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_1:String}
-            WHERE ((calls_merged.op_name IN {pb_0:Array(String)})
+            WHERE calls_merged.project_id = {pb_1:String}
+                AND ((calls_merged.op_name IN {pb_0:Array(String)})
                     OR (calls_merged.op_name IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
@@ -160,8 +159,8 @@ def test_query_heavy_column_simple_filter() -> None:
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_1:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_1:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         """,
         {"pb_0": ["a", "b"], "pb_1": "project"},
@@ -187,8 +186,8 @@ def test_query_heavy_column_simple_filter_with_order() -> None:
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_1:String}
-            WHERE ((calls_merged.op_name IN {pb_0:Array(String)})
+            WHERE calls_merged.project_id = {pb_1:String}
+                AND ((calls_merged.op_name IN {pb_0:Array(String)})
                     OR (calls_merged.op_name IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
@@ -201,8 +200,8 @@ def test_query_heavy_column_simple_filter_with_order() -> None:
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_1:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_1:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         ORDER BY any(calls_merged.started_at) DESC
         """,
@@ -230,8 +229,8 @@ def test_query_heavy_column_simple_filter_with_order_and_limit() -> None:
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_1:String}
-            WHERE ((calls_merged.op_name IN {pb_0:Array(String)})
+            WHERE calls_merged.project_id = {pb_1:String}
+                AND ((calls_merged.op_name IN {pb_0:Array(String)})
                     OR (calls_merged.op_name IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
@@ -246,8 +245,8 @@ def test_query_heavy_column_simple_filter_with_order_and_limit() -> None:
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_1:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_1:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         ORDER BY any(calls_merged.started_at) DESC
         """,
@@ -301,8 +300,8 @@ def test_query_heavy_column_simple_filter_with_order_and_limit_and_mixed_query_c
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_9:String}
-            WHERE ((calls_merged.op_name IN {pb_5:Array(String)})
+            WHERE calls_merged.project_id = {pb_9:String}
+                AND ((calls_merged.op_name IN {pb_5:Array(String)})
                     OR (calls_merged.op_name IS NULL))
                 AND (calls_merged.trace_id = {pb_6:String}
                     OR calls_merged.trace_id IS NULL)
@@ -327,8 +326,8 @@ def test_query_heavy_column_simple_filter_with_order_and_limit_and_mixed_query_c
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_9:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_9:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         ORDER BY any(calls_merged.started_at) DESC
         """,
@@ -365,7 +364,7 @@ def test_query_with_simple_feedback_sort() -> None:
                 {pb_4:String},
                 '/call/',
                 calls_merged.id))
-            PREWHERE
+            WHERE
                 calls_merged.project_id = {pb_4:String}
             GROUP BY
                 (calls_merged.project_id,
@@ -424,9 +423,9 @@ def test_query_with_simple_feedback_sort_with_op_name() -> None:
                 {pb_5:String},
                 '/call/',
                 calls_merged.id))
-            PREWHERE
+            WHERE
                 calls_merged.project_id = {pb_5:String}
-            WHERE ((calls_merged.op_name IN {pb_0:Array(String)})
+                AND ((calls_merged.op_name IN {pb_0:Array(String)})
                     OR (calls_merged.op_name IS NULL))
         GROUP BY
             (calls_merged.project_id,
@@ -461,9 +460,9 @@ def test_query_with_simple_feedback_sort_with_op_name() -> None:
                 {pb_5:String},
                 '/call/',
                 calls_merged.id))
-            PREWHERE
+            WHERE
                 calls_merged.project_id = {pb_5:String}
-            WHERE (calls_merged.id IN filtered_calls)
+                AND (calls_merged.id IN filtered_calls)
         GROUP BY
             (calls_merged.project_id,
             calls_merged.id)
@@ -525,7 +524,7 @@ def test_query_with_simple_feedback_filter() -> None:
             {pb_3:String},
             '/call/',
             calls_merged.id))
-        PREWHERE
+        WHERE
             calls_merged.project_id = {pb_3:String}
         GROUP BY
             (calls_merged.project_id,
@@ -576,7 +575,7 @@ def test_query_with_wildcard_feedback_filter() -> None:
             {pb_2:String},
             '/call/',
             calls_merged.id))
-        PREWHERE
+        WHERE
             calls_merged.project_id = {pb_2:String}
         GROUP BY
             (calls_merged.project_id,
@@ -624,7 +623,7 @@ def test_query_with_wildcard_feedback_filter_no_extra_path() -> None:
             {pb_1:String},
             '/call/',
             calls_merged.id))
-        PREWHERE
+        WHERE
             calls_merged.project_id = {pb_1:String}
         GROUP BY
             (calls_merged.project_id,
@@ -671,7 +670,7 @@ def test_query_with_simple_feedback_sort_and_filter() -> None:
             {pb_6:String},
             '/call/',
             calls_merged.id))
-        PREWHERE
+        WHERE
             calls_merged.project_id = {pb_6:String}
         GROUP BY
             (calls_merged.project_id,
@@ -742,9 +741,8 @@ def test_query_with_simple_feedback_filter_calls_complete() -> None:
             {pb_4:String},
             '/call/',
             calls_complete.id))
-        PREWHERE
+        WHERE
             calls_complete.project_id = {pb_4:String}
-        WHERE 1
         AND
             (((coalesce(nullIf(JSON_VALUE(CASE WHEN feedback.feedback_type = {pb_0:String} THEN feedback.payload_dump END,
             {pb_1:String}), 'null'), '') > coalesce(nullIf(JSON_VALUE(CASE WHEN feedback.feedback_type = {pb_0:String} THEN feedback.payload_dump END,
@@ -782,7 +780,7 @@ def test_calls_query_multiple_select_columns() -> None:
             any(calls_merged.inputs_dump) AS inputs_dump,
             any(calls_merged.output_dump) AS output_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
+        WHERE calls_merged.project_id = {pb_0:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((
@@ -828,8 +826,8 @@ def test_calls_query_with_predicate_filters() -> None:
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_4:String}
-            WHERE ((calls_merged.inputs_dump LIKE {pb_3:String} OR calls_merged.inputs_dump IS NULL))
+            WHERE calls_merged.project_id = {pb_4:String}
+                AND ((calls_merged.inputs_dump LIKE {pb_3:String} OR calls_merged.inputs_dump IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
                 ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
@@ -842,8 +840,8 @@ def test_calls_query_with_predicate_filters() -> None:
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_4:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_4:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         """,
         {
@@ -873,7 +871,7 @@ def test_query_with_summary_weave_status_sort() -> None:
             any(calls_merged.exception) AS exception,
             any(calls_merged.ended_at) AS ended_at
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_5:String}
+        WHERE calls_merged.project_id = {pb_5:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((
@@ -935,7 +933,7 @@ def test_query_with_summary_weave_status_sort_and_filter() -> None:
             any(calls_merged.exception) AS exception,
             any(calls_merged.ended_at) AS ended_at
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_5:String}
+        WHERE calls_merged.project_id = {pb_5:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((CASE
                 WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
@@ -998,8 +996,8 @@ def test_calls_query_with_predicate_filters_multiple_heavy_conditions() -> None:
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_7:String}
-            WHERE ((calls_merged.inputs_dump LIKE {pb_5:String} OR calls_merged.inputs_dump IS NULL)
+            WHERE calls_merged.project_id = {pb_7:String}
+                AND ((calls_merged.inputs_dump LIKE {pb_5:String} OR calls_merged.inputs_dump IS NULL)
                     AND (calls_merged.output_dump LIKE {pb_6:String} OR calls_merged.output_dump IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
@@ -1017,8 +1015,8 @@ def test_calls_query_with_predicate_filters_multiple_heavy_conditions() -> None:
             any(calls_merged.inputs_dump) AS inputs_dump,
             any(calls_merged.output_dump) AS output_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_7:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_7:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         """,
         {
@@ -1068,8 +1066,8 @@ def test_calls_query_with_or_between_start_and_end_fields() -> None:
             any(calls_merged.inputs_dump) AS inputs_dump,
             any(calls_merged.output_dump) AS output_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_6:String}
-        WHERE (((calls_merged.inputs_dump LIKE {pb_4:String} OR calls_merged.inputs_dump IS NULL)
+        WHERE calls_merged.project_id = {pb_6:String}
+            AND (((calls_merged.inputs_dump LIKE {pb_4:String} OR calls_merged.inputs_dump IS NULL)
                 OR (calls_merged.output_dump LIKE {pb_5:String} OR calls_merged.output_dump IS NULL)))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING ((
@@ -1148,8 +1146,8 @@ def test_calls_query_with_complex_heavy_filters() -> None:
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_12:String}
-            WHERE (
+            WHERE calls_merged.project_id = {pb_12:String}
+                AND (
                 (calls_merged.inputs_dump LIKE {pb_9:String} OR calls_merged.inputs_dump IS NULL)
                 AND ((calls_merged.output_dump LIKE {pb_10:String} OR calls_merged.output_dump IS NULL)
                     OR (lower(calls_merged.inputs_dump) LIKE {pb_11:String} OR calls_merged.inputs_dump IS NULL)))
@@ -1171,8 +1169,8 @@ def test_calls_query_with_complex_heavy_filters() -> None:
             any(calls_merged.inputs_dump) AS inputs_dump,
             any(calls_merged.output_dump) AS output_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_12:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_12:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         """,
         {
@@ -1214,8 +1212,8 @@ def test_calls_query_with_like_optimization() -> None:
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_3:String}
-        WHERE ((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
+        WHERE calls_merged.project_id = {pb_3:String}
+            AND ((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
@@ -1254,8 +1252,8 @@ def test_calls_query_with_like_optimization_contains() -> None:
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_3:String}
-        WHERE ((lower(calls_merged.inputs_dump) LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
+        WHERE calls_merged.project_id = {pb_3:String}
+            AND ((lower(calls_merged.inputs_dump) LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
@@ -1293,8 +1291,8 @@ def test_query_with_json_value_in_condition() -> None:
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_5:String}
-        WHERE (((calls_merged.inputs_dump LIKE {pb_3:String} OR calls_merged.inputs_dump LIKE {pb_4:String})
+        WHERE calls_merged.project_id = {pb_5:String}
+            AND (((calls_merged.inputs_dump LIKE {pb_3:String} OR calls_merged.inputs_dump LIKE {pb_4:String})
                 OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
@@ -1340,8 +1338,8 @@ def test_calls_query_with_like_optimization_calls_complete() -> None:
         SELECT
             calls_complete.id AS id
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_4:String}
-        WHERE (calls_complete.inputs_dump LIKE {pb_3:String})
+        WHERE calls_complete.project_id = {pb_4:String}
+            AND (calls_complete.inputs_dump LIKE {pb_3:String})
         AND
             (((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), '') = {pb_1:String}))
                  AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
@@ -1378,8 +1376,8 @@ def test_calls_query_with_like_optimization_contains_calls_complete() -> None:
         SELECT
             calls_complete.id AS id
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_4:String}
-        WHERE (lower(calls_complete.inputs_dump) LIKE {pb_3:String})
+        WHERE calls_complete.project_id = {pb_4:String}
+            AND (lower(calls_complete.inputs_dump) LIKE {pb_3:String})
         AND
             ((positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
                  AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
@@ -1415,8 +1413,8 @@ def test_calls_query_with_like_optimization_in_calls_complete() -> None:
         SELECT
             calls_complete.id AS id
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_6:String}
-        WHERE ((calls_complete.inputs_dump LIKE {pb_4:String} OR calls_complete.inputs_dump LIKE {pb_5:String}))
+        WHERE calls_complete.project_id = {pb_6:String}
+            AND ((calls_complete.inputs_dump LIKE {pb_4:String} OR calls_complete.inputs_dump LIKE {pb_5:String}))
         AND
             (((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), '') IN ({pb_1:String},{pb_2:String})))
                  AND ((calls_complete.deleted_at = {pb_3:DateTime64(3)})))
@@ -1488,8 +1486,8 @@ def test_calls_query_with_combined_like_optimizations_and_op_filter() -> None:
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_12:String}
-            WHERE ((calls_merged.op_name IN {pb_7:Array(String)})
+            WHERE calls_merged.project_id = {pb_12:String}
+                AND ((calls_merged.op_name IN {pb_7:Array(String)})
                     OR (calls_merged.op_name IS NULL))
                 AND ((calls_merged.attributes_dump LIKE {pb_8:String} OR calls_merged.attributes_dump IS NULL)
                     AND (lower(calls_merged.inputs_dump) LIKE {pb_9:String} OR calls_merged.inputs_dump IS NULL)
@@ -1511,8 +1509,8 @@ def test_calls_query_with_combined_like_optimizations_and_op_filter() -> None:
             any(calls_merged.attributes_dump) AS attributes_dump,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_12:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_12:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         """,
         {
@@ -1555,7 +1553,7 @@ def test_calls_query_with_unoptimizable_or_condition() -> None:
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_5:String}
+        WHERE calls_merged.project_id = {pb_5:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((
             (coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String})
@@ -1609,7 +1607,7 @@ def test_dynamic_json_filters_infer_casts_from_literals() -> None:
         """
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_12:String}
+        WHERE calls_merged.project_id = {pb_12:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((
             (toInt64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '')) > {pb_1:Int64})
@@ -1669,7 +1667,7 @@ def test_literal_inferred_casts_cover_feedback_and_mixed_numeric_in() -> None:
             {pb_3:String},
             '/call/',
             calls_merged.id))
-        PREWHERE calls_merged.project_id = {pb_3:String}
+        WHERE calls_merged.project_id = {pb_3:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((toFloat64OrNull(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump,
             feedback.feedback_type = {pb_0:String}),
@@ -1704,8 +1702,8 @@ def test_literal_inferred_casts_cover_feedback_and_mixed_numeric_in() -> None:
         """
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_6:String}
-        WHERE (((calls_merged.inputs_dump LIKE {pb_3:String}
+        WHERE calls_merged.project_id = {pb_6:String}
+            AND (((calls_merged.inputs_dump LIKE {pb_3:String}
             OR calls_merged.inputs_dump LIKE {pb_4:String}
             OR calls_merged.inputs_dump LIKE {pb_5:String})
             OR calls_merged.inputs_dump IS NULL))
@@ -1752,8 +1750,8 @@ def test_whole_number_float_eq_emits_int_form_like_prefilter() -> None:
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_4:String}
-        WHERE (((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump LIKE {pb_3:String}) OR calls_merged.inputs_dump IS NULL))
+        WHERE calls_merged.project_id = {pb_4:String}
+            AND (((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump LIKE {pb_3:String}) OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '')) = {pb_1:Float64}))
@@ -1795,8 +1793,8 @@ def test_bool_eq_emits_numeric_form_like_prefilter() -> None:
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_4:String}
-        WHERE (((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump LIKE {pb_3:String}) OR calls_merged.inputs_dump IS NULL))
+        WHERE calls_merged.project_id = {pb_4:String}
+            AND (((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump LIKE {pb_3:String}) OR calls_merged.inputs_dump IS NULL))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((multiIf(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = 'true', 1, coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = 'false', 0, toUInt8OrNull(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), ''))) = {pb_1:Bool}))
@@ -1832,7 +1830,7 @@ def test_calls_query_filter_by_empty_string() -> None:
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
+        WHERE calls_merged.project_id = {pb_2:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
@@ -1865,7 +1863,7 @@ def test_query_with_summary_weave_latency_ms_sort() -> None:
             any(calls_merged.started_at) AS started_at,
             any(calls_merged.ended_at) AS ended_at
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
+        WHERE calls_merged.project_id = {pb_0:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((
@@ -1910,7 +1908,7 @@ def test_query_with_summary_weave_latency_ms_filter() -> None:
             any(calls_merged.started_at) AS started_at,
             any(calls_merged.ended_at) AS ended_at
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_1:String}
+        WHERE calls_merged.project_id = {pb_1:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((CASE
               WHEN any(calls_merged.ended_at) IS NULL THEN NULL
@@ -1969,7 +1967,7 @@ def test_summary_weave_field_select_backtick_quoting(
                     ELSE (toUnixTimestamp64Milli(any({expected_table}.ended_at)) - toUnixTimestamp64Milli(any({expected_table}.started_at)))
                 END AS `summary.weave.latency_ms`
             FROM {expected_table}
-            PREWHERE {expected_table}.project_id = {{pb_5:String}}
+            WHERE {expected_table}.project_id = {{pb_5:String}}
             GROUP BY ({expected_table}.project_id, {expected_table}.id)
             HAVING (
                 ((any({expected_table}.deleted_at) IS NULL))
@@ -2009,8 +2007,7 @@ def test_summary_weave_field_select_backtick_quoting(
                     ELSE (toUnixTimestamp64Milli({expected_table}.ended_at) - toUnixTimestamp64Milli({expected_table}.started_at))
                 END AS `summary.weave.latency_ms`
             FROM {expected_table}
-            PREWHERE {expected_table}.project_id = {{pb_10:String}}
-            WHERE 1
+            WHERE {expected_table}.project_id = {{pb_10:String}}
               AND ({expected_table}.deleted_at = {{pb_9:DateTime64(3)}})
             """,
             {
@@ -2046,7 +2043,7 @@ def test_query_with_summary_weave_trace_name_sort() -> None:
             any(calls_merged.op_name) AS op_name,
             argMaxMerge(calls_merged.display_name) AS display_name
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
+        WHERE calls_merged.project_id = {pb_0:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((
@@ -2098,7 +2095,7 @@ def test_query_with_summary_weave_trace_name_filter() -> None:
             any(calls_merged.op_name) AS op_name,
             argMaxMerge(calls_merged.display_name) AS display_name
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_1:String}
+        WHERE calls_merged.project_id = {pb_1:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((CASE
                 WHEN argMaxMerge(calls_merged.display_name) IS NOT NULL AND argMaxMerge(calls_merged.display_name) != '' THEN argMaxMerge(calls_merged.display_name)
@@ -2169,7 +2166,7 @@ def test_storage_size_fields():
         FROM calls_merged_stats
         WHERE project_id = {pb_0:String}
         GROUP BY id) AS storage_size_tbl ON calls_merged.id = storage_size_tbl.id
-        PREWHERE calls_merged.project_id = {pb_0:String}
+        WHERE calls_merged.project_id = {pb_0:String}
         GROUP BY (calls_merged.project_id,
                 calls_merged.id)
         HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -2207,8 +2204,8 @@ def test_total_storage_size(with_filter: bool):
                 SELECT
                     calls_merged.id AS id
                 FROM calls_merged
-                PREWHERE calls_merged.project_id = {pb_1:String}
-                WHERE ((calls_merged.op_name IN {pb_0:Array(String)})
+                WHERE calls_merged.project_id = {pb_1:String}
+                    AND ((calls_merged.op_name IN {pb_0:Array(String)})
                     OR (calls_merged.op_name IS NULL))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -2236,8 +2233,8 @@ def test_total_storage_size(with_filter: bool):
             )
             GROUP BY trace_id) AS rolled_up_cms
             ON calls_merged.trace_id = rolled_up_cms.trace_id
-            PREWHERE calls_merged.project_id = {pb_1:String}
-            WHERE (calls_merged.id IN filtered_calls)
+            WHERE calls_merged.project_id = {pb_1:String}
+                AND (calls_merged.id IN filtered_calls)
             GROUP BY (calls_merged.project_id, calls_merged.id)
             """,
             {"pb_0": ["a", "b"], "pb_1": "test/project"},
@@ -2262,7 +2259,7 @@ def test_total_storage_size(with_filter: bool):
             WHERE project_id = {pb_0:String}
             GROUP BY trace_id) AS rolled_up_cms
             ON calls_merged.trace_id = rolled_up_cms.trace_id
-            PREWHERE calls_merged.project_id = {pb_0:String}
+            WHERE calls_merged.project_id = {pb_0:String}
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
                 ((any(calls_merged.deleted_at) IS NULL))
@@ -2309,8 +2306,8 @@ def test_datetime_optimization_simple() -> None:
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.sortable_datetime > {pb_1:String})
+        WHERE calls_merged.project_id = {pb_2:String}
+            AND (calls_merged.sortable_datetime > {pb_1:String})
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((any(calls_merged.started_at) > {pb_0:String}))
@@ -2347,8 +2344,8 @@ def test_datetime_optimization_lt_simple() -> None:
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.sortable_datetime < {pb_1:String})
+        WHERE calls_merged.project_id = {pb_2:String}
+            AND (calls_merged.sortable_datetime < {pb_1:String})
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((any(calls_merged.started_at) < {pb_0:String}))
@@ -2390,8 +2387,8 @@ def test_datetime_optimization_not_operation() -> None:
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (NOT (calls_merged.sortable_datetime >= {pb_1:String}))
+        WHERE calls_merged.project_id = {pb_2:String}
+            AND (NOT (calls_merged.sortable_datetime >= {pb_1:String}))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING ((
             (NOT ((any(calls_merged.started_at) >= {pb_0:String}))))
@@ -2474,8 +2471,8 @@ def test_datetime_optimization_multiple_conditions() -> None:
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_4:String}
-        WHERE (calls_merged.sortable_datetime > {pb_2:String}
+        WHERE calls_merged.project_id = {pb_4:String}
+            AND (calls_merged.sortable_datetime > {pb_2:String}
             AND NOT (calls_merged.sortable_datetime > {pb_3:String}))
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((any(calls_merged.started_at) > {pb_0:String}))
@@ -2530,7 +2527,7 @@ def test_datetime_optimization_invalid_field() -> None:
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
+        WHERE calls_merged.project_id = {pb_2:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
             ((any(calls_merged.wb_user_id) > {pb_0:Int64}))
@@ -2706,8 +2703,8 @@ def test_query_with_feedback_filter_and_datetime_and_string_filter() -> None:
             (SELECT calls_merged.id AS id
             FROM calls_merged
                             LEFT JOIN (SELECT * FROM feedback WHERE feedback.project_id = {pb_8:String} ) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_8:String}, '/call/', calls_merged.id))
-            PREWHERE calls_merged.project_id = {pb_8:String}
-            WHERE (calls_merged.sortable_datetime > {pb_7:String})
+            WHERE calls_merged.project_id = {pb_8:String}
+                AND (calls_merged.sortable_datetime > {pb_7:String})
                 AND ((calls_merged.inputs_dump LIKE {pb_6:String}
                     OR calls_merged.inputs_dump IS NULL))
             GROUP BY (calls_merged.project_id,
@@ -2719,8 +2716,8 @@ def test_query_with_feedback_filter_and_datetime_and_string_filter() -> None:
                 AND ((NOT ((any(calls_merged.started_at) IS NULL))))))
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_8:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_8:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                 calls_merged.id)
         """,
@@ -2750,8 +2747,8 @@ def test_trace_id_filter_in():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_1:String}
-        WHERE (calls_merged.trace_id IN {pb_0:Array(String)}
+        WHERE calls_merged.project_id = {pb_1:String}
+            AND (calls_merged.trace_id IN {pb_0:Array(String)}
                 OR calls_merged.trace_id IS NULL)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -2776,8 +2773,8 @@ def test_trace_id_filter_eq():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE ((calls_merged.op_name IN {pb_0:Array(String)})
+        WHERE calls_merged.project_id = {pb_2:String}
+            AND ((calls_merged.op_name IN {pb_0:Array(String)})
                 OR (calls_merged.op_name IS NULL))
             AND (calls_merged.trace_id = {pb_1:String}
                 OR calls_merged.trace_id IS NULL)
@@ -2803,8 +2800,8 @@ def test_wb_run_id_filter_eq():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.wb_run_id IN {pb_1:Array(String)}
+        WHERE calls_merged.project_id = {pb_2:String}
+            AND (calls_merged.wb_run_id IN {pb_1:Array(String)}
                 OR calls_merged.wb_run_id IS NULL)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -2835,8 +2832,8 @@ def test_trace_roots_only_filter_with_condition():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_1:String}
-        WHERE (calls_merged.parent_id IS NULL)
+        WHERE calls_merged.project_id = {pb_1:String}
+            AND (calls_merged.parent_id IS NULL)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((any(calls_merged.wb_user_id) = {pb_0:Int64}))
             AND ((any(calls_merged.deleted_at) IS NULL))
@@ -2858,8 +2855,8 @@ def test_parent_id_filter():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
+        WHERE calls_merged.project_id = {pb_2:String}
+            AND (calls_merged.parent_id IN {pb_1:Array(String)}
                 OR calls_merged.parent_id IS NULL)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -2889,8 +2886,8 @@ def test_input_output_refs_filter():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_4:String}
-        WHERE (((hasAny(calls_merged.input_refs, {pb_2:Array(String)})
+        WHERE calls_merged.project_id = {pb_4:String}
+            AND (((hasAny(calls_merged.input_refs, {pb_2:Array(String)})
                 OR length(calls_merged.input_refs) = 0)
             AND (hasAny(calls_merged.output_refs, {pb_3:Array(String)})
                 OR length(calls_merged.output_refs) = 0)))
@@ -2936,8 +2933,8 @@ def test_input_output_refs_filter_with_wildcards():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_6:String}
-        WHERE (((((hasAny(calls_merged.input_refs, {pb_4:Array(String)}))
+        WHERE calls_merged.project_id = {pb_6:String}
+            AND (((((hasAny(calls_merged.input_refs, {pb_4:Array(String)}))
                 OR (arrayExists(x -> startsWith(x, {pb_1:String}), calls_merged.input_refs)))
                 OR length(calls_merged.input_refs) = 0)
             AND (((hasAny(calls_merged.output_refs, {pb_5:Array(String)}))
@@ -2986,8 +2983,8 @@ def test_all_optimization_filters():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_12:String}
-        WHERE (calls_merged.parent_id IN {pb_11:Array(String)}
+        WHERE calls_merged.project_id = {pb_12:String}
+            AND (calls_merged.parent_id IN {pb_11:Array(String)}
                 OR calls_merged.parent_id IS NULL)
             AND ((calls_merged.op_name IN {pb_5:Array(String)})
                 OR (calls_merged.op_name IS NULL))
@@ -3199,8 +3196,8 @@ def test_thread_id_filter_eq():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.thread_id = {pb_1:String}
+        WHERE calls_merged.project_id = {pb_2:String}
+            AND (calls_merged.thread_id = {pb_1:String}
                 OR calls_merged.thread_id IS NULL)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -3224,8 +3221,8 @@ def test_thread_id_filter_in():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.thread_id IN {pb_1:Array(String)}
+        WHERE calls_merged.project_id = {pb_2:String}
+            AND (calls_merged.thread_id IN {pb_1:Array(String)}
                 OR calls_merged.thread_id IS NULL)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -3251,8 +3248,8 @@ def test_turn_id_filter_eq():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.turn_id = {pb_1:String}
+        WHERE calls_merged.project_id = {pb_2:String}
+            AND (calls_merged.turn_id = {pb_1:String}
                 OR calls_merged.turn_id IS NULL)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -3274,8 +3271,8 @@ def test_turn_id_filter_in():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.turn_id IN {pb_1:Array(String)}
+        WHERE calls_merged.project_id = {pb_2:String}
+            AND (calls_merged.turn_id IN {pb_1:Array(String)}
                 OR calls_merged.turn_id IS NULL)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -3306,8 +3303,8 @@ def test_thread_id_and_turn_id_filter_combined():
         SELECT
             calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_4:String}
-        WHERE (calls_merged.thread_id IN {pb_2:Array(String)}
+        WHERE calls_merged.project_id = {pb_4:String}
+            AND (calls_merged.thread_id IN {pb_2:Array(String)}
                 OR calls_merged.thread_id IS NULL)
             AND (calls_merged.turn_id IN {pb_3:Array(String)}
                 OR calls_merged.turn_id IS NULL)
@@ -3354,8 +3351,8 @@ def test_query_with_optimization_and_attributes_order() -> None:
             SELECT
                 calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_1:String}
-            WHERE ((calls_merged.op_name IN {pb_0:Array(String)})
+            WHERE calls_merged.project_id = {pb_1:String}
+                AND ((calls_merged.op_name IN {pb_0:Array(String)})
                     OR (calls_merged.op_name IS NULL))
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
@@ -3368,8 +3365,8 @@ def test_query_with_optimization_and_attributes_order() -> None:
             calls_merged.id AS id,
             any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_1:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_1:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id, calls_merged.id)
         ORDER BY any(calls_merged.started_at) ASC
         """,
@@ -3407,8 +3404,8 @@ def test_query_filter_with_escaped_dots_in_field_names() -> None:
         """
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_3:String}
-        WHERE ((calls_merged.output_dump LIKE {pb_2:String}
+        WHERE calls_merged.project_id = {pb_3:String}
+            AND ((calls_merged.output_dump LIKE {pb_2:String}
                 OR calls_merged.output_dump IS NULL))
         GROUP BY (calls_merged.project_id,
                 calls_merged.id)
@@ -3463,8 +3460,7 @@ def test_calls_complete_with_light_filter_and_order() -> None:
             calls_complete.started_at AS started_at,
             calls_complete.op_name AS op_name
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_3:String}
-        WHERE 1
+        WHERE calls_complete.project_id = {pb_3:String}
           AND (
             ((calls_complete.started_at > {pb_0:String}))
             AND ((calls_complete.wb_user_id = {pb_1:String}))
@@ -3529,8 +3525,8 @@ def test_calls_complete_with_hardcoded_filter_and_json_condition_and_summary_ord
             calls_complete.exception AS exception,
             calls_complete.ended_at AS ended_at
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_12:String}
-        WHERE ((calls_complete.op_name IN {pb_3:Array(String)})
+        WHERE calls_complete.project_id = {pb_12:String}
+            AND ((calls_complete.op_name IN {pb_3:Array(String)})
                 OR (calls_complete.op_name IS NULL))
             AND (calls_complete.trace_id = {pb_4:String}
                 OR calls_complete.trace_id IS NULL)
@@ -3588,9 +3584,8 @@ def test_query_with_simple_feedback_sort_calls_complete() -> None:
                 {pb_5:String},
                 '/call/',
                 calls_complete.id))
-            PREWHERE
+            WHERE
                 calls_complete.project_id = {pb_5:String}
-            WHERE 1
               AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
             ORDER BY
                 (NOT (JSONType(CASE WHEN feedback.feedback_type = {pb_1:String}
@@ -3646,8 +3641,8 @@ def test_calls_complete_with_refs_filter() -> None:
         SELECT
             calls_complete.id AS id
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_6:String}
-        WHERE (((((hasAny(calls_complete.input_refs, {pb_4:Array(String)}))
+        WHERE calls_complete.project_id = {pb_6:String}
+            AND (((((hasAny(calls_complete.input_refs, {pb_4:Array(String)}))
                 OR (arrayExists(x -> startsWith(x, {pb_2:String}), calls_complete.input_refs)))
                 OR length(calls_complete.input_refs) = 0)
             AND (hasAny(calls_complete.output_refs, {pb_5:Array(String)})
@@ -3705,9 +3700,8 @@ def test_calls_complete_with_feedback_filter() -> None:
             {pb_4:String},
             '/call/',
             calls_complete.id))
-        PREWHERE
+        WHERE
             calls_complete.project_id = {pb_4:String}
-        WHERE 1
           AND (((toFloat64OrNull(coalesce(nullIf(JSON_VALUE(CASE WHEN feedback.feedback_type = {pb_0:String}
             THEN feedback.payload_dump END,
             {pb_1:String}), 'null'), '')) > {pb_2:Float64}))
@@ -3759,8 +3753,8 @@ def test_query_with_summary_weave_status_filter_calls_complete() -> None:
         """
         SELECT
             calls_complete.id AS id
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_10:String}
-        WHERE 1
+        FROM calls_complete
+        WHERE calls_complete.project_id = {pb_10:String}
           AND (
             (((CASE
                 WHEN calls_complete.exception != {pb_5:String} THEN {pb_1:String}
@@ -3915,7 +3909,7 @@ def test_query_with_queue_filter_calls_merged() -> None:
         ) AS annotation_queue_items ON (
             annotation_queue_items.project_id = calls_merged.project_id
             AND annotation_queue_items.call_id = calls_merged.id)
-        PREWHERE
+        WHERE
             calls_merged.project_id = {pb_1:String}
         GROUP BY (calls_merged.project_id, calls_merged.id)
         HAVING (
@@ -3960,9 +3954,8 @@ def test_query_with_queue_filter_calls_complete() -> None:
         ) AS annotation_queue_items ON (
             annotation_queue_items.project_id = calls_complete.project_id
             AND annotation_queue_items.call_id = calls_complete.id)
-        PREWHERE
+        WHERE
             calls_complete.project_id = {pb_2:String}
-        WHERE 1
           AND (((annotation_queue_items.queue_id = {pb_0:String}))
        AND ((calls_complete.deleted_at = {pb_1:DateTime64(3)})))
         """,
@@ -4065,8 +4058,7 @@ def test_stats_query_calls_complete_flat_count() -> None:
         """
         SELECT count() AS count
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_1:String}
-        WHERE 1
+        WHERE calls_complete.project_id = {pb_1:String}
           AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
         """,
         {
@@ -4088,8 +4080,8 @@ def test_stats_query_calls_complete_flat_count_with_filter() -> None:
         """
         SELECT count() AS count
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_2:String}
-        WHERE ((calls_complete.op_name IN {pb_1:Array(String)})
+        WHERE calls_complete.project_id = {pb_2:String}
+            AND ((calls_complete.op_name IN {pb_1:Array(String)})
                OR (calls_complete.op_name IS NULL))
           AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
         """,
@@ -4125,8 +4117,7 @@ def test_stats_query_calls_complete_flat_with_total_storage_size() -> None:
             WHERE project_id = {pb_1:String}
             GROUP BY trace_id
         ) AS rolled_up_cms ON calls_complete.trace_id = rolled_up_cms.trace_id
-        PREWHERE calls_complete.project_id = {pb_1:String}
-        WHERE 1
+        WHERE calls_complete.project_id = {pb_1:String}
           AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
         """,
         {
@@ -4172,8 +4163,7 @@ def test_stats_query_calls_complete_with_feedback_filter_uses_count_distinct() -
             {pb_4:String},
             '/call/',
             calls_complete.id))
-        PREWHERE calls_complete.project_id = {pb_4:String}
-        WHERE 1
+        WHERE calls_complete.project_id = {pb_4:String}
           AND (((coalesce(nullIf(JSON_VALUE(CASE WHEN feedback.feedback_type = {pb_0:String}
             THEN feedback.payload_dump END,
             {pb_1:String}), 'null'), '') = {pb_2:String}))
@@ -4200,7 +4190,7 @@ def test_stats_query_calls_merged_uses_subquery() -> None:
         FROM (
             SELECT calls_merged.id AS id
             FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_0:String}
+            WHERE calls_merged.project_id = {pb_0:String}
             GROUP BY (calls_merged.project_id, calls_merged.id)
             HAVING (
                 ((any(calls_merged.deleted_at) IS NULL))
@@ -4240,8 +4230,7 @@ def test_latency_ms_sort_calls_complete_uses_sentinel_for_ended_at() -> None:
             calls_complete.started_at AS started_at,
             calls_complete.ended_at AS ended_at
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_2:String}
-        WHERE 1
+        WHERE calls_complete.project_id = {pb_2:String}
           AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
         ORDER BY CASE
             WHEN calls_complete.ended_at = {pb_1:DateTime64(6)} THEN NULL
@@ -4276,8 +4265,7 @@ def test_latency_ms_filter_calls_complete_uses_sentinel_for_ended_at() -> None:
             calls_complete.started_at AS started_at,
             calls_complete.ended_at AS ended_at
         FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_3:String}
-        WHERE 1
+        WHERE calls_complete.project_id = {pb_3:String}
           AND (((CASE
               WHEN calls_complete.ended_at = {pb_0:DateTime64(6)} THEN NULL
               ELSE (toUnixTimestamp64Milli(calls_complete.ended_at) - toUnixTimestamp64Milli(calls_complete.started_at))
@@ -4302,8 +4290,9 @@ def test_trace_roots_only_filter_calls_complete() -> None:
         cq,
         """
         SELECT calls_complete.id AS id
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_2:String}
-            WHERE (calls_complete.parent_id = {pb_1:String})
+        FROM calls_complete
+            WHERE calls_complete.project_id = {pb_2:String}
+                AND (calls_complete.parent_id = {pb_1:String})
               AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
         """,
         {
@@ -4334,8 +4323,8 @@ def test_trace_name_filter_calls_complete_uses_sentinel() -> None:
         """
         SELECT calls_complete.id AS id,
                calls_complete.display_name AS display_name
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_3:String}
-        WHERE 1
+        FROM calls_complete
+        WHERE calls_complete.project_id = {pb_3:String}
           AND (((CASE
                      WHEN calls_complete.display_name != {pb_0:String} THEN calls_complete.display_name
                      WHEN calls_complete.op_name IS NOT NULL
@@ -4377,8 +4366,8 @@ def test_not_eq_none_display_name_calls_complete() -> None:
         """
         SELECT calls_complete.id AS id,
                calls_complete.display_name AS display_name
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_2:String}
-        WHERE 1
+        FROM calls_complete
+        WHERE calls_complete.project_id = {pb_2:String}
           AND (((NOT ((calls_complete.display_name = {pb_0:String}))))
                AND ((calls_complete.deleted_at = {pb_1:DateTime64(3)})))
         """,
@@ -4409,8 +4398,9 @@ def test_hardcoded_filters_calls_complete() -> None:
         cq,
         """
         SELECT calls_complete.id AS id
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_14:String}
-        WHERE (calls_complete.id IN {pb_13:Array(String)})
+        FROM calls_complete
+        WHERE calls_complete.project_id = {pb_14:String}
+            AND (calls_complete.id IN {pb_13:Array(String)})
           AND (calls_complete.wb_run_id IN {pb_9:Array(String)}
                OR calls_complete.wb_run_id = {pb_10:String})
           AND (calls_complete.parent_id IN {pb_11:Array(String)}
@@ -4454,8 +4444,8 @@ def test_status_sort_calls_complete_uses_sentinels() -> None:
         cq,
         """
         SELECT calls_complete.id AS id
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_8:String}
-        WHERE 1
+        FROM calls_complete
+        WHERE calls_complete.project_id = {pb_8:String}
           AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
         ORDER BY CASE
                      WHEN calls_complete.exception != {pb_6:String} THEN {pb_2:String}
@@ -4506,7 +4496,7 @@ def test_query_with_reaction_eq_filter_calls_merged() -> None:
             {pb_3:String},
             '/call/',
             calls_merged.id))
-        PREWHERE
+        WHERE
             calls_merged.project_id = {pb_3:String}
         GROUP BY
             (calls_merged.project_id,
@@ -4558,7 +4548,7 @@ def test_query_with_note_contains_filter_calls_merged() -> None:
             {pb_3:String},
             '/call/',
             calls_merged.id))
-        PREWHERE
+        WHERE
             calls_merged.project_id = {pb_3:String}
         GROUP BY
             (calls_merged.project_id,
@@ -4610,7 +4600,7 @@ def test_query_with_annotation_filter_still_uses_anyif() -> None:
             {pb_3:String},
             '/call/',
             calls_merged.id))
-        PREWHERE
+        WHERE
             calls_merged.project_id = {pb_3:String}
         GROUP BY
             (calls_merged.project_id,

--- a/tests/trace_server/query_builder/test_costs_query.py
+++ b/tests/trace_server/query_builder/test_costs_query.py
@@ -28,8 +28,8 @@ def test_query_light_column_with_costs() -> None:
             filtered_calls AS (
                 SELECT calls_merged.id AS id
                 FROM calls_merged
-                PREWHERE calls_merged.project_id = {pb_1:String}
-                WHERE ((calls_merged.op_name IN {pb_0:Array(String)})
+                WHERE calls_merged.project_id = {pb_1:String}
+                    AND ((calls_merged.op_name IN {pb_0:Array(String)})
                         OR (calls_merged.op_name IS NULL))
                 GROUP BY (calls_merged.project_id, calls_merged.id)
                 HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -41,8 +41,8 @@ def test_query_light_column_with_costs() -> None:
                     calls_merged.id AS id,
                     any(calls_merged.started_at) AS started_at
                 FROM calls_merged
-                PREWHERE calls_merged.project_id = {pb_1:String}
-                WHERE (calls_merged.id IN filtered_calls)
+                WHERE calls_merged.project_id = {pb_1:String}
+                    AND (calls_merged.id IN filtered_calls)
                 GROUP BY (calls_merged.project_id, calls_merged.id)),
             llm_usage AS (
                 -- From the all_calls we get the usage data for LLMs
@@ -185,7 +185,8 @@ def test_query_with_costs_and_attributes_order() -> None:
         cq,
         """WITH filtered_calls AS
   (SELECT calls_merged.id AS id
-   FROM calls_merged PREWHERE calls_merged.project_id = {pb_5:String}
+   FROM calls_merged
+   WHERE calls_merged.project_id = {pb_5:String}
    GROUP BY (calls_merged.project_id,
              calls_merged.id)
    HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -207,8 +208,9 @@ def test_query_with_costs_and_attributes_order() -> None:
               WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
               ELSE {pb_3:String}
           END AS `summary.weave.status`
-   FROM calls_merged PREWHERE calls_merged.project_id = {pb_5:String}
-   WHERE (calls_merged.id IN filtered_calls)
+   FROM calls_merged
+   WHERE calls_merged.project_id = {pb_5:String}
+       AND (calls_merged.id IN filtered_calls)
    GROUP BY (calls_merged.project_id,
              calls_merged.id)
    ORDER BY (NOT (JSONType(any(calls_merged.attributes_dump)) = 'Null'
@@ -326,7 +328,8 @@ def test_query_with_costs_and_dynamic_summary_order() -> None:
         cq,
         """WITH filtered_calls AS
   (SELECT calls_merged.id AS id
-   FROM calls_merged PREWHERE calls_merged.project_id = {pb_2:String}
+   FROM calls_merged
+   WHERE calls_merged.project_id = {pb_2:String}
    GROUP BY (calls_merged.project_id,
              calls_merged.id)
    HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -337,8 +340,9 @@ def test_query_with_costs_and_dynamic_summary_order() -> None:
   (SELECT calls_merged.id AS id,
           any(calls_merged.started_at) AS started_at,
           any(calls_merged.summary_dump) AS summary_dump
-   FROM calls_merged PREWHERE calls_merged.project_id = {pb_2:String}
-   WHERE (calls_merged.id IN filtered_calls)
+   FROM calls_merged
+   WHERE calls_merged.project_id = {pb_2:String}
+       AND (calls_merged.id IN filtered_calls)
    GROUP BY (calls_merged.project_id,
              calls_merged.id)
    ORDER BY (NOT (JSONType(any(calls_merged.summary_dump), {pb_0:String}) = 'Null'
@@ -448,7 +452,7 @@ def test_query_with_costs_and_feedback_order() -> None:
             (SELECT calls_merged.id AS id
              FROM calls_merged
              LEFT JOIN (SELECT * FROM feedback WHERE feedback.project_id = {pb_4:String} ) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_4:String}, '/call/', calls_merged.id))
-             PREWHERE calls_merged.project_id = {pb_4:String}
+             WHERE calls_merged.project_id = {pb_4:String}
              GROUP BY (calls_merged.project_id,
                        calls_merged.id)
              HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -460,8 +464,8 @@ def test_query_with_costs_and_feedback_order() -> None:
                     any(calls_merged.started_at) AS started_at
              FROM calls_merged
              LEFT JOIN (SELECT * FROM feedback WHERE feedback.project_id = {pb_4:String} ) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_4:String}, '/call/', calls_merged.id))
-             PREWHERE calls_merged.project_id = {pb_4:String}
-             WHERE (calls_merged.id IN filtered_calls)
+             WHERE calls_merged.project_id = {pb_4:String}
+                 AND (calls_merged.id IN filtered_calls)
              GROUP BY (calls_merged.project_id,
                        calls_merged.id)
              ORDER BY (NOT (JSONType(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_1:String}, {pb_2:String}) = 'Null'
@@ -573,7 +577,7 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
             WITH filtered_calls AS
                 (SELECT calls_merged.id AS id
                  FROM calls_merged
-                 PREWHERE calls_merged.project_id = {pb_2:String}
+                 WHERE calls_merged.project_id = {pb_2:String}
                  GROUP BY (calls_merged.project_id,
                            calls_merged.id)
                  HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -585,8 +589,8 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
                         any(calls_merged.started_at) AS started_at,
                         any(calls_merged.attributes_dump) AS attributes_dump
                  FROM calls_merged
-                 PREWHERE calls_merged.project_id = {pb_2:String}
-                 WHERE (calls_merged.id IN filtered_calls)
+                 WHERE calls_merged.project_id = {pb_2:String}
+                     AND (calls_merged.id IN filtered_calls)
                  GROUP BY (calls_merged.project_id,
                            calls_merged.id)
                  ORDER BY (NOT (JSONType(any(calls_merged.attributes_dump), {pb_0:String}) = 'Null'
@@ -700,8 +704,9 @@ def test_query_calls_complete_with_costs_light_fields() -> None:
         WITH all_calls AS
           (SELECT calls_complete.id AS id,
                   calls_complete.started_at AS started_at
-           FROM calls_complete PREWHERE calls_complete.project_id = {pb_2:String}
-           WHERE ((calls_complete.op_name IN {pb_1:Array(String)})
+           FROM calls_complete
+           WHERE calls_complete.project_id = {pb_2:String}
+               AND ((calls_complete.op_name IN {pb_1:Array(String)})
                   OR (calls_complete.op_name IS NULL))
              AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})),
              llm_usage AS
@@ -805,8 +810,8 @@ def test_query_calls_complete_with_costs_and_attributes_order() -> None:
           (SELECT calls_complete.id AS id,
                   calls_complete.started_at AS started_at,
                   calls_complete.attributes_dump AS attributes_dump
-           FROM calls_complete PREWHERE calls_complete.project_id = {pb_3:String}
-           WHERE 1
+           FROM calls_complete
+           WHERE calls_complete.project_id = {pb_3:String}
              AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
            ORDER BY (NOT (JSONType(calls_complete.attributes_dump, {pb_1:String}) = 'Null'
                           OR JSONType(calls_complete.attributes_dump, {pb_1:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.attributes_dump, {pb_2:String}), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(calls_complete.attributes_dump, {pb_2:String}), 'null'), '')) ASC),
@@ -919,8 +924,8 @@ def test_query_calls_complete_with_costs_and_feedback_order() -> None:
            LEFT JOIN
              (SELECT *
               FROM feedback
-              WHERE feedback.project_id = {pb_5:String} ) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_5:String}, '/call/', calls_complete.id)) PREWHERE calls_complete.project_id = {pb_5:String}
-           WHERE 1
+              WHERE feedback.project_id = {pb_5:String} ) AS feedback ON (feedback.weave_ref = concat('weave-trace-internal:///', {pb_5:String}, '/call/', calls_complete.id))
+           WHERE calls_complete.project_id = {pb_5:String}
              AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
            ORDER BY (NOT (JSONType(CASE
                                        WHEN feedback.feedback_type = {pb_1:String} THEN feedback.payload_dump
@@ -1030,7 +1035,8 @@ def test_query_with_costs_and_summary_weave_trace_name_field() -> None:
         """
         WITH filtered_calls AS
           (SELECT calls_merged.id AS id
-           FROM calls_merged PREWHERE calls_merged.project_id = {pb_0:String}
+           FROM calls_merged
+           WHERE calls_merged.project_id = {pb_0:String}
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
            HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -1045,8 +1051,9 @@ def test_query_with_costs_and_summary_weave_trace_name_field() -> None:
                       ELSE any(calls_merged.op_name)
                   END AS `summary.weave.trace_name`,
                   any(calls_merged.started_at) AS started_at
-           FROM calls_merged PREWHERE calls_merged.project_id = {pb_0:String}
-           WHERE (calls_merged.id IN filtered_calls)
+           FROM calls_merged
+           WHERE calls_merged.project_id = {pb_0:String}
+               AND (calls_merged.id IN filtered_calls)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)),
              llm_usage AS
@@ -1155,8 +1162,8 @@ def test_query_calls_complete_with_costs_and_trace_name_order() -> None:
                            AND calls_complete.op_name LIKE 'weave-trace-internal:///%' THEN regexpExtract(toString(calls_complete.op_name), '/([^/:]*):', 1)
                       ELSE calls_complete.op_name
                   END AS `summary.weave.trace_name`
-           FROM calls_complete PREWHERE calls_complete.project_id = {pb_3:String}
-           WHERE 1
+           FROM calls_complete
+           WHERE calls_complete.project_id = {pb_3:String}
              AND (calls_complete.deleted_at = {pb_1:DateTime64(3)})
            ORDER BY CASE
                         WHEN calls_complete.display_name != {pb_2:String} THEN calls_complete.display_name

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -41,8 +41,8 @@ def test_cte_chain_calls_merged() -> None:
                         ELSE hex(SHA256(JSONExtractRaw(any(calls_merged.inputs_dump), 'example')))
                     END AS row_digest
                 FROM calls_merged
-                PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
+                WHERE calls_merged.project_id = {pb_0:String}
+                    AND (calls_merged.parent_id IN {pb_1:Array(String)}
                     OR calls_merged.parent_id IS NULL)
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
                     AND (position(calls_merged.op_name, {pb_2:String}) > 0
@@ -84,8 +84,8 @@ def test_cte_chain_calls_merged() -> None:
             page_resolved_inputs AS (
                 SELECT digest, any(val_dump) AS val_dump
                 FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
+                WHERE project_id = {pb_0:String}
+                    AND digest IN (SELECT row_digest FROM page_digests)
                 GROUP BY digest
             ),
 
@@ -139,8 +139,8 @@ def test_cte_chain_calls_complete() -> None:
                         ELSE hex(SHA256(JSONExtractRaw(calls_complete.inputs_dump, 'example')))
                     END AS row_digest
                 FROM calls_complete
-                PREWHERE calls_complete.project_id = {pb_0:String}
-                WHERE calls_complete.parent_id IN {pb_1:Array(String)}
+                WHERE calls_complete.project_id = {pb_0:String}
+                    AND calls_complete.parent_id IN {pb_1:Array(String)}
                     AND calls_complete.id NOT IN {pb_1:Array(String)}
                     AND (position(calls_complete.op_name, {pb_2:String}) > 0
                         OR position(calls_complete.op_name, {pb_3:String}) > 0)
@@ -174,8 +174,8 @@ def test_cte_chain_calls_complete() -> None:
             page_resolved_inputs AS (
                 SELECT digest, any(val_dump) AS val_dump
                 FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
+                WHERE project_id = {pb_0:String}
+                    AND digest IN (SELECT row_digest FROM page_digests)
                 GROUP BY digest
             ),
 
@@ -274,8 +274,8 @@ def test_cte_chain_sort_and_multi_eval_filters() -> None:
                         ELSE hex(SHA256(JSONExtractRaw(calls_complete.inputs_dump, 'example')))
                     END AS row_digest
                 FROM calls_complete
-                PREWHERE calls_complete.project_id = {pb_0:String}
-                WHERE calls_complete.parent_id IN {pb_1:Array(String)}
+                WHERE calls_complete.project_id = {pb_0:String}
+                    AND calls_complete.parent_id IN {pb_1:Array(String)}
                     AND calls_complete.id NOT IN {pb_1:Array(String)}
                     AND (position(calls_complete.op_name, {pb_2:String}) > 0
                         OR position(calls_complete.op_name, {pb_3:String}) > 0)
@@ -312,8 +312,8 @@ def test_cte_chain_sort_and_multi_eval_filters() -> None:
             page_resolved_inputs AS (
                 SELECT digest, any(val_dump) AS val_dump
                 FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
+                WHERE project_id = {pb_0:String}
+                    AND digest IN (SELECT row_digest FROM page_digests)
                 GROUP BY digest
             ),
 
@@ -373,8 +373,8 @@ def test_full_query_calls_merged() -> None:
                         ELSE hex(SHA256(JSONExtractRaw(any(calls_merged.inputs_dump), 'example')))
                     END AS row_digest
                 FROM calls_merged
-                PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
+                WHERE calls_merged.project_id = {pb_0:String}
+                    AND (calls_merged.parent_id IN {pb_1:Array(String)}
                     OR calls_merged.parent_id IS NULL)
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
                     AND (position(calls_merged.op_name, {pb_2:String}) > 0
@@ -415,8 +415,8 @@ def test_full_query_calls_merged() -> None:
             page_resolved_inputs AS (
                 SELECT digest, any(val_dump) AS val_dump
                 FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
+                WHERE project_id = {pb_0:String}
+                    AND digest IN (SELECT row_digest FROM page_digests)
                 GROUP BY digest
             ),
 
@@ -443,8 +443,8 @@ def test_full_query_calls_merged() -> None:
                     any(calls_merged.output_dump) AS output_dump,
                     any(calls_merged.summary_dump) AS summary_dump
                 FROM calls_merged
-                PREWHERE calls_merged.project_id = {pb_4:String}
-                WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
+                WHERE calls_merged.project_id = {pb_4:String}
+                    AND calls_merged.id IN (SELECT call_id FROM page_rows)
                 GROUP BY (calls_merged.project_id, calls_merged.id)
             )
         SELECT
@@ -506,8 +506,8 @@ def test_full_query_calls_complete() -> None:
                         ELSE hex(SHA256(JSONExtractRaw(calls_complete.inputs_dump, 'example')))
                     END AS row_digest
                 FROM calls_complete
-                PREWHERE calls_complete.project_id = {pb_0:String}
-                WHERE calls_complete.parent_id IN {pb_1:Array(String)}
+                WHERE calls_complete.project_id = {pb_0:String}
+                    AND calls_complete.parent_id IN {pb_1:Array(String)}
                     AND calls_complete.id NOT IN {pb_1:Array(String)}
                     AND (position(calls_complete.op_name, {pb_2:String}) > 0
                         OR position(calls_complete.op_name, {pb_3:String}) > 0)
@@ -541,8 +541,8 @@ def test_full_query_calls_complete() -> None:
             page_resolved_inputs AS (
                 SELECT digest, any(val_dump) AS val_dump
                 FROM table_rows
-                PREWHERE project_id = {pb_0:String}
-                WHERE digest IN (SELECT row_digest FROM page_digests)
+                WHERE project_id = {pb_0:String}
+                    AND digest IN (SELECT row_digest FROM page_digests)
                 GROUP BY digest
             ),
 

--- a/tests/trace_server/query_builder/test_obj_tags_query_builder.py
+++ b/tests/trace_server/query_builder/test_obj_tags_query_builder.py
@@ -38,9 +38,9 @@ def test_make_obj_version_exists_query():
     expected_query = """
         SELECT 1
         FROM object_versions
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
             AND object_id = {object_id: String}
-        WHERE digest = {digest: String}
+            AND digest = {digest: String}
         GROUP BY project_id, object_id, digest
         HAVING argMax(deleted_at, created_at) IS NULL
         LIMIT 1
@@ -60,7 +60,7 @@ def test_make_get_tags_query():
     expected_query = """
         SELECT object_id, digest, tag
         FROM tags
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
             AND object_id IN {object_ids: Array(String)}
         GROUP BY project_id, object_id, digest, tag
         HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
@@ -80,7 +80,7 @@ def test_make_get_aliases_query():
     expected_query = """
         SELECT object_id, argMax(digest, created_at) AS digest, alias
         FROM aliases
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
             AND object_id IN {object_ids: Array(String)}
         GROUP BY project_id, object_id, alias
         HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
@@ -99,9 +99,9 @@ def test_make_resolve_alias_query():
     expected_query = """
         SELECT argMax(digest, created_at) AS digest
         FROM aliases
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
             AND object_id = {object_id: String}
-        WHERE alias = {alias: String}
+            AND alias = {alias: String}
         GROUP BY project_id, object_id, alias
         HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
         LIMIT 1
@@ -129,8 +129,9 @@ WHERE (((main.project_id,
           (SELECT project_id,
                   object_id,
                   digest
-           FROM tags PREWHERE project_id = {project_id: String}
-           WHERE tag IN {filter_tags: Array(String)}
+           FROM tags
+           WHERE project_id = {project_id: String}
+               AND tag IN {filter_tags: Array(String)}
            GROUP BY project_id,
                     object_id,
                     digest,
@@ -159,8 +160,9 @@ WHERE (((main.project_id,
           (SELECT project_id,
                   object_id,
                   argMax(digest, created_at) AS digest
-           FROM aliases PREWHERE project_id = {project_id: String}
-           WHERE alias IN {filter_aliases: Array(String)}
+           FROM aliases
+           WHERE project_id = {project_id: String}
+               AND alias IN {filter_aliases: Array(String)}
            GROUP BY project_id,
                     object_id,
                     alias
@@ -204,7 +206,7 @@ def test_make_list_tags_query():
     expected_query = """
         SELECT tag
         FROM tags
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
         GROUP BY project_id, tag
         HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
         ORDER BY tag
@@ -222,7 +224,7 @@ def test_make_list_aliases_query():
     expected_query = """
         SELECT alias
         FROM aliases
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
         GROUP BY project_id, alias
         HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
         ORDER BY alias
@@ -247,8 +249,9 @@ WHERE (((is_latest = 1
            (SELECT project_id,
                    object_id,
                    argMax(digest, created_at) AS digest
-            FROM aliases PREWHERE project_id = {project_id: String}
-            WHERE alias IN {filter_aliases: Array(String)}
+            FROM aliases
+            WHERE project_id = {project_id: String}
+                AND alias IN {filter_aliases: Array(String)}
             GROUP BY project_id,
                      object_id,
                      alias

--- a/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
@@ -48,8 +48,8 @@ def test_object_ref_filter_simple() -> None:
              filtered_calls AS
           (SELECT calls_merged.id AS id
            FROM calls_merged
-           PREWHERE calls_merged.project_id = {pb_0:String}
-           WHERE (length(calls_merged.output_refs) > 0
+           WHERE calls_merged.project_id = {pb_0:String}
+               AND (length(calls_merged.output_refs) > 0
                   OR calls_merged.ended_at IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
@@ -64,8 +64,8 @@ def test_object_ref_filter_simple() -> None:
            ORDER BY any(calls_merged.started_at) DESC)
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_0:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)
         ORDER BY any(calls_merged.started_at) DESC
@@ -119,8 +119,8 @@ def test_object_ref_filter_lt() -> None:
              filtered_calls AS
           (SELECT calls_merged.id AS id
            FROM calls_merged
-           PREWHERE calls_merged.project_id = {pb_0:String}
-           WHERE (length(calls_merged.output_refs) > 0
+           WHERE calls_merged.project_id = {pb_0:String}
+               AND (length(calls_merged.output_refs) > 0
                   OR calls_merged.ended_at IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
@@ -135,8 +135,8 @@ def test_object_ref_filter_lt() -> None:
            ORDER BY any(calls_merged.started_at) DESC)
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_0:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)
         ORDER BY any(calls_merged.started_at) DESC
@@ -215,8 +215,8 @@ def test_object_ref_filter_nested() -> None:
              filtered_calls AS
           (SELECT calls_merged.id AS id
            FROM calls_merged
-           PREWHERE calls_merged.project_id = {pb_0:String}
-           WHERE (calls_merged.parent_id IS NULL)
+           WHERE calls_merged.project_id = {pb_0:String}
+               AND (calls_merged.parent_id IS NULL)
              AND (length(calls_merged.input_refs) > 0
                   OR calls_merged.started_at IS NULL)
            GROUP BY (calls_merged.project_id,
@@ -234,8 +234,8 @@ def test_object_ref_filter_nested() -> None:
            OFFSET 0)
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_0:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)
         ORDER BY any(calls_merged.started_at) DESC
@@ -332,8 +332,8 @@ def test_multiple_object_ref_filters() -> None:
              filtered_calls AS
           (SELECT calls_merged.id AS id
            FROM calls_merged
-           PREWHERE calls_merged.project_id = {pb_0:String}
-           WHERE (calls_merged.parent_id IS NULL)
+           WHERE calls_merged.project_id = {pb_0:String}
+               AND (calls_merged.parent_id IS NULL)
              AND (length(calls_merged.input_refs) > 0
                   OR calls_merged.started_at IS NULL)
            GROUP BY (calls_merged.project_id,
@@ -355,8 +355,8 @@ def test_multiple_object_ref_filters() -> None:
            ORDER BY any(calls_merged.started_at) DESC)
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_0:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)
         ORDER BY any(calls_merged.started_at) DESC
@@ -510,8 +510,8 @@ def test_object_ref_filter_duplicates_and_similar() -> None:
              filtered_calls AS
           (SELECT calls_merged.id AS id
            FROM calls_merged
-           PREWHERE calls_merged.project_id = {pb_0:String}
-           WHERE (calls_merged.parent_id IS NULL)
+           WHERE calls_merged.project_id = {pb_0:String}
+               AND (calls_merged.parent_id IS NULL)
              AND ((lower(calls_merged.inputs_dump) LIKE {pb_10:String}
                   OR calls_merged.inputs_dump IS NULL))
              AND (length(calls_merged.input_refs) > 0
@@ -553,8 +553,8 @@ def test_object_ref_filter_duplicates_and_similar() -> None:
            AND ((NOT ((any(calls_merged.started_at) IS NULL))))))
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_0:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)
         """,
@@ -690,8 +690,8 @@ def test_object_ref_filter_complex_mixed_conditions() -> None:
              filtered_calls AS (
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE ((calls_merged.op_name IN {pb_10:Array(String)})
+        WHERE calls_merged.project_id = {pb_0:String}
+            AND ((calls_merged.op_name IN {pb_10:Array(String)})
                OR (calls_merged.op_name IS NULL))
           AND (length(calls_merged.input_refs) > 0
                OR calls_merged.started_at IS NULL)
@@ -723,8 +723,8 @@ def test_object_ref_filter_complex_mixed_conditions() -> None:
         SELECT calls_merged.id AS id,
                any(calls_merged.inputs_dump) AS inputs_dump
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_0:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)
         ORDER BY any(calls_merged.started_at) DESC
@@ -777,7 +777,7 @@ def test_object_ref_order_by_simple() -> None:
            FROM calls_merged
            LEFT JOIN obj_filter_0 ON (coalesce(nullIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), 'null'), '') = obj_filter_0.ref
                                       OR regexpExtract(coalesce(nullIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), 'null'), ''), '/([^/]+)$', 1) = obj_filter_0.ref)
-           PREWHERE calls_merged.project_id = {pb_0:String}
+           WHERE calls_merged.project_id = {pb_0:String}
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
            HAVING (((any(calls_merged.deleted_at) IS NULL))
@@ -788,8 +788,8 @@ def test_object_ref_order_by_simple() -> None:
         FROM calls_merged
         LEFT JOIN obj_filter_0 ON (coalesce(nullIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), 'null'), '') = obj_filter_0.ref
                                    OR regexpExtract(coalesce(nullIf(JSON_VALUE(calls_merged.inputs_dump, {pb_2:String}), 'null'), ''), '/([^/]+)$', 1) = obj_filter_0.ref)
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_0:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)
         ORDER BY (NOT (JSONType(any(obj_filter_0.object_val_dump)) = 'Null'
@@ -853,8 +853,8 @@ def test_object_ref_filter_heavily_nested_keys() -> None:
              filtered_calls AS
           (SELECT calls_merged.id AS id
            FROM calls_merged
-           PREWHERE calls_merged.project_id = {pb_0:String}
-           WHERE (length(calls_merged.input_refs) > 0
+           WHERE calls_merged.project_id = {pb_0:String}
+               AND (length(calls_merged.input_refs) > 0
                   OR calls_merged.started_at IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
@@ -869,8 +869,8 @@ def test_object_ref_filter_heavily_nested_keys() -> None:
         )
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_0:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)
         """,
@@ -937,8 +937,8 @@ def test_object_ref_filter_complex_nested_path() -> None:
              filtered_calls AS
           (SELECT calls_merged.id AS id
            FROM calls_merged
-           PREWHERE calls_merged.project_id = {pb_0:String}
-           WHERE (calls_merged.parent_id IS NULL)
+           WHERE calls_merged.project_id = {pb_0:String}
+               AND (calls_merged.parent_id IS NULL)
              AND (length(calls_merged.input_refs) > 0
                   OR calls_merged.started_at IS NULL)
            GROUP BY (calls_merged.project_id,
@@ -954,8 +954,8 @@ def test_object_ref_filter_complex_nested_path() -> None:
            ORDER BY any(calls_merged.started_at) DESC)
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE (calls_merged.id IN filtered_calls)
+        WHERE calls_merged.project_id = {pb_0:String}
+            AND (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)
         ORDER BY any(calls_merged.started_at) DESC
@@ -1015,8 +1015,9 @@ def test_object_ref_filter_calls_complete() -> None:
            GROUP BY project_id,
                     digest)
         SELECT calls_complete.id AS id
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_0:String}
-        WHERE (length(calls_complete.output_refs) > 0
+        FROM calls_complete
+        WHERE calls_complete.project_id = {pb_0:String}
+            AND (length(calls_complete.output_refs) > 0
                OR calls_complete.ended_at = {pb_5:DateTime64(6)})
         AND (((coalesce(nullIf(JSON_VALUE(calls_complete.output_dump, {pb_3:String}), 'null'), '') IN
                    (SELECT ref
@@ -1098,8 +1099,9 @@ def test_object_ref_filter_calls_complete_mixed_conditions() -> None:
                     digest)
         SELECT calls_complete.id AS id,
                calls_complete.inputs_dump AS inputs_dump
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_0:String}
-        WHERE (calls_complete.parent_id = {pb_7:String})
+        FROM calls_complete
+        WHERE calls_complete.project_id = {pb_0:String}
+            AND (calls_complete.parent_id = {pb_7:String})
           AND (length(calls_complete.input_refs) > 0)
           AND (((((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_3:String}), 'null'), '') IN
                      (SELECT ref

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1687,31 +1687,20 @@ class CallsQuery(BaseModel):
         if self.read_table == ReadTable.CALLS_MERGED:
             group_by_sql = f"GROUP BY ({table_alias}.project_id, {table_alias}.id)"
 
-        # Use PREWHERE for project_id to filter data before reading from disk
-        # This is a ClickHouse optimization for high-selectivity filters
-        where_filters_sql = where_filters.to_sql()
-        # Strip leading "AND " from where_filters since PREWHERE handles the first condition
-        where_filters_stripped = re.sub(r"^\s*AND\s+", "", where_filters_sql)
+        # TODO(weave): revert to PREWHERE once CH bug is patched. CH 26.2's
+        # query_condition_cache returns wrong (under-counted) results for
+        # `PREWHERE pk-prefix WHERE non-pk IN [array]`; writing project_id in
+        # WHERE dodges the bug. `optimize_move_to_prewhere=1` still hoists it
+        # physically, so perf is preserved.
         where_clause = (
-            f"WHERE {where_filters_stripped}" if where_filters_stripped else ""
+            f"WHERE {table_alias}.project_id = {param_slot(project_param, 'String')}"
+            f"\n        {where_filters.to_sql()}"
         )
-
-        # Fix where_clause when empty but we have filter_sql
-        # For calls_complete, filter_sql starts with "AND "
-        # If where_clause is empty, set it to "WHERE 1" so filter_sql can append naturally
-        # TODO: optimize it further to make this condition builder smarter
-        if (
-            not where_clause
-            and filter_result.filter_sql
-            and self.read_table == ReadTable.CALLS_COMPLETE
-        ):
-            where_clause = "WHERE 1"
 
         having_sql = filter_result.filter_sql
 
         sql = f"""FROM {table_alias}
         {joins.to_sql()}
-        PREWHERE {table_alias}.project_id = {param_slot(project_param, "String")}
         {where_clause}
         {group_by_sql}
         {having_sql}

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -104,8 +104,8 @@ def build_predict_and_score_calls_cte(
         any(calls_merged.output_dump) AS output_dump,
         {row_digest_expr} AS row_digest
     FROM calls_merged
-    PREWHERE calls_merged.project_id = {project_id_param}
-    WHERE (
+    WHERE calls_merged.project_id = {project_id_param}
+    AND (
         calls_merged.parent_id IN {eval_root_ids_param}
         OR calls_merged.parent_id IS NULL
     )
@@ -132,8 +132,8 @@ def build_predict_and_score_calls_cte(
         calls_complete.output_dump,
         {row_digest_expr} AS row_digest
     FROM calls_complete
-    PREWHERE calls_complete.project_id = {project_id_param}
-    WHERE calls_complete.parent_id IN {eval_root_ids_param}
+    WHERE calls_complete.project_id = {project_id_param}
+      AND calls_complete.parent_id IN {eval_root_ids_param}
       AND calls_complete.id NOT IN {eval_root_ids_param}
       AND ({op_match_calls_complete})
       AND calls_complete.deleted_at = {deleted_at_sentinel_param}
@@ -166,8 +166,8 @@ def build_predict_and_score_calls_resolved_cte(
     LEFT JOIN (
         SELECT project_id, digest, any(val_dump) AS val_dump
         FROM table_rows
-        PREWHERE project_id = {project_id_param}
-        WHERE digest IN (SELECT row_digest FROM predict_and_score_calls)
+        WHERE project_id = {project_id_param}
+            AND digest IN (SELECT row_digest FROM predict_and_score_calls)
         GROUP BY project_id, digest
     ) AS tr ON tr.digest = predict_and_score_calls.row_digest
 )"""
@@ -392,11 +392,12 @@ page_digests AS (
 
 def build_page_resolved_inputs_cte(project_id_param: str) -> str:
     """Hydrate dataset-row val_dump for just the page's digests."""
+    # TODO(weave): revert to PREWHERE after CH #104781 patched.
     return f"""page_resolved_inputs AS (
     SELECT digest, any(val_dump) AS val_dump
     FROM table_rows
-    PREWHERE project_id = {project_id_param}
-    WHERE digest IN (SELECT row_digest FROM page_digests)
+    WHERE project_id = {project_id_param}
+        AND digest IN (SELECT row_digest FROM page_digests)
     GROUP BY digest
 )"""
 
@@ -437,8 +438,8 @@ def _build_page_calls_cte(project_id_param: str, read_table: str) -> str:
         any(calls_merged.output_dump) AS output_dump,
         any(calls_merged.summary_dump) AS summary_dump
     FROM calls_merged
-    PREWHERE calls_merged.project_id = {project_id_param}
-    WHERE calls_merged.id IN (SELECT call_id FROM page_rows)
+    WHERE calls_merged.project_id = {project_id_param}
+        AND calls_merged.id IN (SELECT call_id FROM page_rows)
     GROUP BY (calls_merged.project_id, calls_merged.id)
 )"""
     else:

--- a/weave/trace_server/query_builder/obj_tags_query_builder.py
+++ b/weave/trace_server/query_builder/obj_tags_query_builder.py
@@ -23,12 +23,13 @@ def make_obj_version_exists_query(
     Returns:
         A tuple of (sql_query, parameters).
     """
+    # TODO(weave): revert to PREWHERE after CH #104781 patched.
     query = """
         SELECT 1
         FROM object_versions
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
             AND object_id = {object_id: String}
-        WHERE digest = {digest: String}
+            AND digest = {digest: String}
         GROUP BY project_id, object_id, digest
         HAVING argMax(deleted_at, created_at) IS NULL
         LIMIT 1
@@ -54,10 +55,11 @@ def make_get_tags_query(
     Returns:
         A tuple of (sql_query, parameters).
     """
+    # TODO(weave): revert to PREWHERE after CH #104781 patched.
     query = """
         SELECT object_id, digest, tag
         FROM tags
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
             AND object_id IN {object_ids: Array(String)}
         GROUP BY project_id, object_id, digest, tag
         HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
@@ -86,10 +88,11 @@ def make_get_aliases_query(
     Returns:
         A tuple of (sql_query, parameters).
     """
+    # TODO(weave): revert to PREWHERE after CH #104781 patched.
     query = """
         SELECT object_id, argMax(digest, created_at) AS digest, alias
         FROM aliases
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
             AND object_id IN {object_ids: Array(String)}
         GROUP BY project_id, object_id, alias
         HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
@@ -112,10 +115,11 @@ def make_list_tags_query(
     Returns:
         A tuple of (sql_query, parameters).
     """
+    # TODO(weave): revert to PREWHERE after CH #104781 patched.
     query = """
         SELECT tag
         FROM tags
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
         GROUP BY project_id, tag
         HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
         ORDER BY tag
@@ -137,10 +141,11 @@ def make_list_aliases_query(
     Returns:
         A tuple of (sql_query, parameters).
     """
+    # TODO(weave): revert to PREWHERE after CH #104781 patched.
     query = """
         SELECT alias
         FROM aliases
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
         GROUP BY project_id, alias
         HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
         ORDER BY alias
@@ -166,12 +171,13 @@ def make_resolve_alias_query(
     Returns:
         A tuple of (sql_query, parameters).
     """
+    # TODO(weave): revert to PREWHERE after CH #104781 patched.
     query = """
         SELECT argMax(digest, created_at) AS digest
         FROM aliases
-        PREWHERE project_id = {project_id: String}
+        WHERE project_id = {project_id: String}
             AND object_id = {object_id: String}
-        WHERE alias = {alias: String}
+            AND alias = {alias: String}
         GROUP BY project_id, object_id, alias
         HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
         LIMIT 1

--- a/weave/trace_server/query_builder/objects_query_builder.py
+++ b/weave/trace_server/query_builder/objects_query_builder.py
@@ -245,12 +245,13 @@ class ObjectMetadataQueryBuilder:
 
     def add_tags_condition(self, tags: list[str]) -> None:
         t = self._main_table_alias
+        # TODO(weave): revert to PREWHERE after CH #104781 patched.
         self._conditions.append(f"""
             ({t}.project_id, {t}.object_id, {t}.digest) IN (
                 SELECT project_id, object_id, digest
                 FROM tags
-                PREWHERE project_id = {{project_id: String}}
-                WHERE tag IN {{filter_tags: Array(String)}}
+                WHERE project_id = {{project_id: String}}
+                    AND tag IN {{filter_tags: Array(String)}}
                 GROUP BY project_id, object_id, digest, tag
                 HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
             )
@@ -261,11 +262,12 @@ class ObjectMetadataQueryBuilder:
         t = self._main_table_alias
         non_latest = [a for a in aliases if a != "latest"]
         has_latest = "latest" in aliases
+        # TODO(weave): revert to PREWHERE after CH #104781 patched.
         alias_subquery = f"""({t}.project_id, {t}.object_id, {t}.digest) IN (
                     SELECT project_id, object_id, argMax(digest, created_at) AS digest
                     FROM aliases
-                    PREWHERE project_id = {{project_id: String}}
-                    WHERE alias IN {{filter_aliases: Array(String)}}
+                    WHERE project_id = {{project_id: String}}
+                        AND alias IN {{filter_aliases: Array(String)}}
                     GROUP BY project_id, object_id, alias
                     HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
                 )"""

--- a/weave/trace_server/query_builder/table_query_builder.py
+++ b/weave/trace_server/query_builder/table_query_builder.py
@@ -250,10 +250,11 @@ def make_table_rows_read_batch_query(
     """
     project_param = pb.add(project_id, None, "String")
     digests_param = pb.add(digests, None, "Array(String)")
+    # TODO(weave): revert to PREWHERE after CH #104781 patched.
     return f"""
         SELECT digest, any(val_dump) AS val_dump
         FROM table_rows
-        PREWHERE project_id = {project_param}
-        WHERE digest IN {digests_param}
+        WHERE project_id = {project_param}
+            AND digest IN {digests_param}
         GROUP BY project_id, digest
     """


### PR DESCRIPTION
## Summary
- ClickHouse 26.2+ defaults `use_query_condition_cache=1` and miscounts results for `PREWHERE pk-prefix WHERE non-pk IN [array]` queries, the exact shape every `calls_merged` / eval / obj read in trace_server emits. Filed upstream as a CH bug.
- Symptom on the bloom-filter-trace-id branch (#6764) is a `/call/read` returning None right after a successful `/call/start`.
- Rewrites every `PREWHERE pk WHERE ...` to a single `WHERE pk AND ...`. The planner still hoists pk predicates physically via `optimize_move_to_prewhere=1` (default on), so plans and read amplification are unchanged.
- Each callsite marked with a `TODO(weave): revert to PREWHERE...` so we can find them when upstream lands the fix.

## Testing
unit tests, full `tests/trace_server/query_builder/` green locally (456 passed).