### PR TITLE
fix(weave): retry distributed DDL on transient 999

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -1504,7 +1504,7 @@ def test_ttl_operations_only_on_local_tables_distributed(distributed_migrator):
 
 @patch("tenacity.nap.time.sleep")
 def test_run_ddl_with_retry(mock_sleep, mock_costs):
-    """Verify retry behavior for transient CH errors (e.g. 517 CANNOT_ASSIGN_ALTER)."""
+    """Verify retry behavior for transient CH errors (517, 999)."""
     ch_client = _make_ch_client()
     migrator = trace_server_migrator.get_clickhouse_trace_server_migrator(ch_client)
     ch_client.command.reset_mock()
@@ -1513,6 +1513,11 @@ def test_run_ddl_with_retry(mock_sleep, mock_costs):
         "Code: 517. DB::Exception: Looks like this replica doesn't catchup "
         "with latest ALTER query updates: metadata version on replica is 2, "
         "while common metadata is 3. (CANNOT_ASSIGN_ALTER)"
+    )
+    error_999 = DatabaseError(
+        "Code: 999. Coordination::Exception: Coordination error: "
+        "Connection loss, path /clickhouse/task_queue/ddl/query-. "
+        "(KEEPER_EXCEPTION)"
     )
 
     # Succeeds immediately on clean call
@@ -1524,6 +1529,12 @@ def test_run_ddl_with_retry(mock_sleep, mock_costs):
     ch_client.command.side_effect = [error_517, error_517, None]
     migrator._run_ddl_with_retry("ALTER TABLE foo ADD COLUMN bar String")
     assert ch_client.command.call_count == 3
+    ch_client.command.reset_mock()
+
+    # Retries on 999 (KEEPER_EXCEPTION), then succeeds
+    ch_client.command.side_effect = [error_999, None]
+    migrator._run_ddl_with_retry("ALTER TABLE foo ADD COLUMN bar String")
+    assert ch_client.command.call_count == 2
     ch_client.command.reset_mock()
 
     # Gives up after max retries
@@ -1552,6 +1563,13 @@ def test_run_ddl_with_retry(mock_sleep, mock_costs):
 def test_is_transient_ch_error():
     """Verify transient error detection from ClickHouse DatabaseError messages."""
     assert _is_transient_ch_error(DatabaseError("Code: 517. DB::Exception: ..."))
+    assert _is_transient_ch_error(
+        DatabaseError(
+            "Code: 999. Coordination::Exception: Coordination error: "
+            "Connection loss, path /clickhouse/task_queue/ddl/query-. "
+            "(KEEPER_EXCEPTION)"
+        )
+    )
     assert not _is_transient_ch_error(DatabaseError("Code: 62. DB::Exception: ..."))
     assert not _is_transient_ch_error(DatabaseError("some other error"))
     assert not _is_transient_ch_error(DatabaseError(""))

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -468,14 +468,8 @@ def test_all_production_migrations_replicated(ch_client):
     _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")
 
 
-@pytest.mark.flaky(reruns=3)
 def test_all_production_migrations_distributed(ch_client):
-    """All production migrations apply cleanly in distributed mode.
-
-    Marked flaky: distributed DDL goes through the embedded Keeper's task
-    queue, which can hit transient KEEPER_EXCEPTION (code 999) under load.
-    The migrator's tenacity retry only covers code 517.
-    """
+    """All production migrations apply cleanly in distributed mode."""
     mgmt_db = _unique_name("db_mgmt_prod_dist")
     target_db = _unique_name("prod_dist")
     ch_client.track_db(mgmt_db)
@@ -531,14 +525,8 @@ def test_all_production_down_migrations_replicated(ch_client):
     migrator.apply_migrations(target_db, target_version=0)
 
 
-@pytest.mark.flaky(reruns=3)
 def test_all_production_down_migrations_distributed(ch_client):
-    """All production down migrations apply cleanly in distributed mode.
-
-    Marked flaky: distributed DDL goes through the embedded Keeper's task
-    queue, which can hit transient KEEPER_EXCEPTION (code 999) under load.
-    The migrator's tenacity retry only covers code 517.
-    """
+    """All production down migrations apply cleanly in distributed mode."""
     mgmt_db = _unique_name("db_mgmt_down_dist")
     target_db = _unique_name("down_dist")
     ch_client.track_db(mgmt_db)

--- a/tests/trace_server_migrator/test_migrator_functional.py
+++ b/tests/trace_server_migrator/test_migrator_functional.py
@@ -468,8 +468,14 @@ def test_all_production_migrations_replicated(ch_client):
     _assert_db_on_every_replica(ch_client, target_db, expected_engine="Atomic")
 
 
+@pytest.mark.flaky(reruns=3)
 def test_all_production_migrations_distributed(ch_client):
-    """All production migrations apply cleanly in distributed mode."""
+    """All production migrations apply cleanly in distributed mode.
+
+    Marked flaky: distributed DDL goes through the embedded Keeper's task
+    queue, which can hit transient KEEPER_EXCEPTION (code 999) under load.
+    The migrator's tenacity retry only covers code 517.
+    """
     mgmt_db = _unique_name("db_mgmt_prod_dist")
     target_db = _unique_name("prod_dist")
     ch_client.track_db(mgmt_db)
@@ -525,8 +531,14 @@ def test_all_production_down_migrations_replicated(ch_client):
     migrator.apply_migrations(target_db, target_version=0)
 
 
+@pytest.mark.flaky(reruns=3)
 def test_all_production_down_migrations_distributed(ch_client):
-    """All production down migrations apply cleanly in distributed mode."""
+    """All production down migrations apply cleanly in distributed mode.
+
+    Marked flaky: distributed DDL goes through the embedded Keeper's task
+    queue, which can hit transient KEEPER_EXCEPTION (code 999) under load.
+    The migrator's tenacity retry only covers code 517.
+    """
     mgmt_db = _unique_name("db_mgmt_down_dist")
     target_db = _unique_name("down_dist")
     ch_client.track_db(mgmt_db)

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -112,10 +112,13 @@ from weave.trace_server.migration_lock import (
 logger = logging.getLogger(__name__)
 
 # Retry configuration for transient ClickHouse errors during migrations.
-# Error 517 (CANNOT_ASSIGN_ALTER) occurs when a replica hasn't caught up with
-# the latest ALTER metadata — common on multi-replica managed ClickHouse clusters
-# when sequential DDL statements run faster than replication can propagate.
-_TRANSIENT_CH_ERROR_CODES = {517}
+# 517 (CANNOT_ASSIGN_ALTER): a replica hasn't caught up with the latest ALTER
+#   metadata. Common on multi-replica managed ClickHouse when sequential DDL
+#   runs faster than replication can propagate.
+# 999 (KEEPER_EXCEPTION): Keeper coordination error (e.g. "Connection loss"
+#   on /clickhouse/task_queue/ddl). Distributed DDL via ON CLUSTER goes through
+#   Keeper's task queue, which can briefly drop the connection under load.
+_TRANSIENT_CH_ERROR_CODES = {517, 999}
 _MAX_RETRIES = 3
 _RETRY_MAX_WAIT_SECONDS = 8
 _COMMAND_PREVIEW_LENGTH = 100
@@ -507,9 +510,10 @@ class BaseClickHouseTraceServerMigrator(ABC):
     def _run_ddl_with_retry(self, command: str) -> None:
         """Execute a DDL command with retry for transient replication errors.
 
-        On multi-replica clusters, sequential DDL can outpace metadata replication
-        causing error 517 (CANNOT_ASSIGN_ALTER). This retries with exponential
-        backoff for those known-transient codes.
+        Retries with exponential backoff for known-transient codes:
+        517 (CANNOT_ASSIGN_ALTER) when replicas lag the latest ALTER metadata,
+        and 999 (KEEPER_EXCEPTION) when ON CLUSTER DDL hits a transient Keeper
+        coordination error.
         """
         self.ch_client.command(command)
 


### PR DESCRIPTION
## Summary

`test_all_production_down_migrations_distributed` flaked with `KEEPER_EXCEPTION` (code 999, "Connection loss") on `/clickhouse/task_queue/ddl/`. RCA: the migrator's `_run_ddl_with_retry` already exists and retries with exponential backoff, but `_TRANSIENT_CH_ERROR_CODES` only contains `517` (`CANNOT_ASSIGN_ALTER`), so a transient Keeper hiccup during `ON CLUSTER` DDL bypasses the retry and bubbles out.

Fix the migrator, not the test:
- Add `999` to `_TRANSIENT_CH_ERROR_CODES`.
- Extend the existing `test_run_ddl_with_retry` and `test_is_transient_ch_error` unit tests to cover the new code.

This also helps prod, where the same transient Keeper error has the same shape.

Original failure ([CI job](https://github.com/wandb/weave/actions/runs/25877206695/job/76047450040?pr=6843)):
```
FAILED tests/trace_server_migrator/test_migrator_functional.py::test_all_production_down_migrations_distributed - clickhouse_connect.driver.exceptions.DatabaseError: Received ClickHouse exception, code: 999, server response: Code: 999. Coordination::Exception: Coordination error: Connection loss, path /clickhouse/task_queue/ddl/query-. (KEEPER_EXCEPTION)
```

## Testing

extends existing retry/transient-error unit tests with a 999 case.