### PR TITLE
chore(weave): remove dead lint-flagged code in two pre-existing files

### DIFF
--- a/weave/integrations/openai_realtime/state_exporter.py
+++ b/weave/integrations/openai_realtime/state_exporter.py
@@ -843,11 +843,8 @@ class StateExporter(BaseModel):
                     pass
 
             def _cb() -> None:
-                try:
-                    self._advance_fifo()
-                finally:
-                    # If more remain and head not ready, a new timer will be scheduled
-                    pass
+                # If more remain and head not ready, a new timer will be scheduled
+                self._advance_fifo()
 
             self.fifo_timer = threading.Timer(FIFO_TIMER_INTERVAL_SECONDS, _cb)
             self.fifo_timer.start()

--- a/weave/trace/serialization/op_type.py
+++ b/weave/trace/serialization/op_type.py
@@ -406,26 +406,20 @@ def _get_code_deps(
                     code.append(get_source_notebook_safe(var_value))
 
                     warnings += fn_warnings
+            # For now, if the function is in another module.
+            # we just import it. This is ok for libraries, but not
+            # if the user has functions declared within their
+            # package but outside of the op module.
+            elif is_op(var_value):
+                warnings.append(
+                    f"Cross-module op dependencies are not yet serializable {var_value}"
+                )
             else:
-                # For now, if the function is in another module.
-                # we just import it. This is ok for libraries, but not
-                # if the user has functions declared within their
-                # package but outside of the op module.
-                if var_value.__module__.split(".")[0] == fn.__module__.split(".")[0]:
-                    pass
+                import_line = f"from {var_value.__module__} import {var_value.__name__}"
+                if var_value.__name__ != var_name:
+                    import_line += f" as {var_name}"
 
-                if is_op(var_value):
-                    warnings.append(
-                        f"Cross-module op dependencies are not yet serializable {var_value}"
-                    )
-                else:
-                    import_line = (
-                        f"from {var_value.__module__} import {var_value.__name__}"
-                    )
-                    if var_value.__name__ != var_name:
-                        import_line += f" as {var_name}"
-
-                    import_code.append(import_line)
+                import_code.append(import_line)
 
         else:
             # Code saving for Ops using TypedDict and NotRequired was failing on Python 3.9


### PR DESCRIPTION
## Summary

Removes two pre-existing dead-code patterns that ruff flags as errors on master. Discovered while running broader lint on a feature branch — both errors exist independent of any feature work, so they're carved into this small chore PR.

## Issues fixed

1. **`weave/integrations/openai_realtime/state_exporter.py:848` — `RUF072` empty `finally` clause.** The `try` had no `except` and the `finally` body was just `pass` + a comment. Replaced with a direct call, kept the explanatory comment.

   ```python
   # before
   def _cb() -> None:
       try:
           self._advance_fifo()
       finally:
           # If more remain and head not ready, a new timer will be scheduled
           pass

   # after
   def _cb() -> None:
       # If more remain and head not ready, a new timer will be scheduled
       self._advance_fifo()
   ```

2. **`weave/trace/serialization/op_type.py:414` — `RUF050` empty `if` statement.** The dead `if X: pass` block looked like an unfinished TODO marker (no else, no body). Removed it. The remaining `else: if is_op(...)` was then collapsed into `elif is_op(...)` per `PLR5501`. Behavior preserved (verified by tracing the truth table).

## Test plan

- [x] `uvx ruff check weave/ tests/` clean (was 2 errors, now 0)
- [x] `uvx ruff format --check` clean
- [x] `tests/trace/test_serialize.py` passes (12/12)
- [x] `import weave` works
- [ ] CI passes