### PR TITLE
chore(weave_ts): PR 5 — LLM enrichment surface

### DIFF
--- a/sdks/node/src/__tests__/genai/llm.test.ts
+++ b/sdks/node/src/__tests__/genai/llm.test.ts
@@ -277,5 +277,46 @@ describe('LLM (via Turn.llm)', () => {
       llm.end();
       turn.end();
     });
+
+    it('accumulators called after end() warn and do not mutate state', () => {
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      llm.end();
+
+      llm.output('after end');
+      llm.think('after end');
+      llm.attachMedia({
+        content: 'x',
+        mimeType: 'audio/mp3',
+        modality: 'audio',
+      });
+      llm.attachMediaUrl('https://example.com/x', {modality: 'image'});
+      llm.record({inputMessages: [{role: 'user', content: 'after end'}]});
+
+      // One warning per method (warnOnce dedupes per key process-wide; each
+      // method uses a distinct key).
+      expect(warnSpy).toHaveBeenCalledTimes(5);
+      for (const method of [
+        'output',
+        'think',
+        'attachMedia',
+        'attachMediaUrl',
+        'record',
+      ]) {
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining(`LLM.${method}() called after end()`)
+        );
+      }
+
+      // State on the instance is untouched.
+      expect(llm.outputMessages).toEqual([]);
+      expect(llm.inputMessages).toEqual([]);
+      expect(llm.reasoning).toBeUndefined();
+
+      turn.end();
+      warnSpy.mockRestore();
+    });
   });
 });

--- a/sdks/node/src/__tests__/genai/llm.test.ts
+++ b/sdks/node/src/__tests__/genai/llm.test.ts
@@ -90,4 +90,192 @@ describe('LLM (via Turn.llm)', () => {
       llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_INPUT_TOKENS]
     ).toBeUndefined();
   });
+
+  // ---------------------------------------------------------------------------
+  // Enrichment surface
+  // ---------------------------------------------------------------------------
+
+  describe('enrichment', () => {
+    it('output(content) appends a new assistant message', () => {
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      llm.output('Hello!');
+      llm.end();
+      turn.end();
+
+      const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
+      expect(
+        JSON.parse(
+          llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES] as string
+        )
+      ).toEqual([{role: 'assistant', content: 'Hello!'}]);
+    });
+
+    it('each output() call adds its own assistant message', () => {
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      llm.output('first').output('second');
+      llm.end();
+      turn.end();
+
+      const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
+      const messages = JSON.parse(
+        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES] as string
+      );
+      expect(messages).toEqual([
+        {role: 'assistant', content: 'first'},
+        {role: 'assistant', content: 'second'},
+      ]);
+    });
+
+    it('think(content) accumulates into the reasoning field', () => {
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      llm.think('First, ').think('I need to check the weather.');
+      expect(llm.reasoning).toEqual({
+        content: 'First, I need to check the weather.',
+      });
+      llm.end();
+      turn.end();
+    });
+
+    it('end() folds reasoning into the last assistant message as a ReasoningPart', () => {
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      llm.output('hello').think('thinking out loud');
+      llm.end();
+      turn.end();
+
+      const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
+      const messages = JSON.parse(
+        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES] as string
+      );
+      expect(messages).toHaveLength(1);
+      // output() produced {role:'assistant', content:'hello'}; end() promoted
+      // it to parts and appended the ReasoningPart.
+      expect(messages[0].parts).toEqual([
+        {type: 'text', content: 'hello'},
+        {type: 'reasoning', content: 'thinking out loud'},
+      ]);
+    });
+
+    it('attachMedia({content, mimeType, modality}) appends a blob part to the last input message', () => {
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      llm.inputMessages = [{role: 'user', content: 'Listen to this:'}];
+      llm.attachMedia({
+        content: 'base64data',
+        mimeType: 'audio/mp3',
+        modality: 'audio',
+      });
+      llm.end();
+      turn.end();
+
+      const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
+      const messages = JSON.parse(
+        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES] as string
+      );
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('user');
+      expect(messages[0].parts).toEqual([
+        {type: 'text', content: 'Listen to this:'},
+        {
+          type: 'blob',
+          content: 'base64data',
+          mimeType: 'audio/mp3',
+          modality: 'audio',
+        },
+      ]);
+    });
+
+    it('attachMedia({uri, modality}) appends a uri part', () => {
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      llm.attachMedia({uri: 'https://example.com/a.png', modality: 'image'});
+      llm.end();
+      turn.end();
+
+      const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
+      const messages = JSON.parse(
+        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES] as string
+      );
+      expect(messages[0].parts).toEqual([
+        {type: 'uri', uri: 'https://example.com/a.png', modality: 'image'},
+      ]);
+    });
+
+    it('attachMedia({fileId, modality, mimeType}) appends a file part', () => {
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      llm.attachMedia({
+        fileId: 'f-123',
+        modality: 'document',
+        mimeType: 'application/pdf',
+      });
+      llm.end();
+      turn.end();
+
+      const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
+      const messages = JSON.parse(
+        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES] as string
+      );
+      expect(messages[0].parts).toEqual([
+        {
+          type: 'file',
+          fileId: 'f-123',
+          modality: 'document',
+          mimeType: 'application/pdf',
+        },
+      ]);
+    });
+
+    it('attachMediaUrl(url, opts) delegates to the uri form', () => {
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      llm.attachMediaUrl('https://example.com/v.mp4', {modality: 'video'});
+      llm.end();
+      turn.end();
+
+      const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
+      const messages = JSON.parse(
+        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES] as string
+      );
+      expect(messages[0].parts).toEqual([
+        {type: 'uri', uri: 'https://example.com/v.mp4', modality: 'video'},
+      ]);
+    });
+
+    it('record(opts) replaces the data fields', () => {
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      llm.inputMessages = [{role: 'user', content: 'will be replaced'}];
+      llm.record({
+        inputMessages: [{role: 'user', content: 'hi'}],
+        outputMessages: [{role: 'assistant', content: 'hello'}],
+        usage: {inputTokens: 7, outputTokens: 3},
+        reasoning: {content: 'thinking'},
+      });
+      expect(llm.inputMessages).toEqual([{role: 'user', content: 'hi'}]);
+      expect(llm.outputMessages).toEqual([
+        {role: 'assistant', content: 'hello'},
+      ]);
+      expect(llm.usage).toEqual({inputTokens: 7, outputTokens: 3});
+      expect(llm.reasoning).toEqual({content: 'thinking'});
+      llm.end();
+      turn.end();
+    });
+
+    it('chains: output / think / attachMedia / record all return `this`', () => {
+      const turn = Turn.create({});
+      const llm = turn.llm({model: 'gpt-4o'});
+      const result = llm
+        .output('hi')
+        .think('thoughts')
+        .attachMediaUrl('https://example.com/a.png', {modality: 'image'})
+        .record({usage: {inputTokens: 1}});
+      expect(result).toBe(llm);
+      llm.end();
+      turn.end();
+    });
+  });
 });

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -12,11 +12,24 @@ import {getWeaveTracer} from './provider';
 import {GEN_AI_ATTR, WEAVE_GENAI_TRACER_NAME} from './semconv';
 import {SubAgent, type SubAgentInit} from './subagent';
 import {Tool, type ToolInit} from './tool';
-import type {Message, Reasoning, Usage} from './types';
+import type {Message, MessagePart, Modality, Reasoning, Usage} from './types';
 
 export interface LLMInit {
   model: string;
   providerName?: string;
+}
+
+/** Discriminated union for `LLM.attachMedia`: pick one of content / uri / fileId. */
+export type AttachMediaOpts =
+  | {content: string; mimeType: string; modality: Modality}
+  | {uri: string; modality: Modality}
+  | {fileId: string; modality: Modality; mimeType?: string};
+
+export interface LLMRecordOpts {
+  inputMessages?: Message[];
+  outputMessages?: Message[];
+  usage?: Usage;
+  reasoning?: Reasoning;
 }
 
 export class LLM {
@@ -70,6 +83,72 @@ export class LLM {
     return llm;
   }
 
+  // ---------------------------------------------------------------------------
+  // Enrichment surface
+  // ---------------------------------------------------------------------------
+
+  /** Append an assistant message to the response. */
+  output(content: string): this {
+    this.outputMessages.push({role: 'assistant', content});
+    return this;
+  }
+
+  /** Set or extend the model's reasoning/chain-of-thought content. Accumulates
+   *  into `this.reasoning.content`. Folded into the last assistant message as
+   *  a `ReasoningPart` at serialization time, matching the Python SDK's
+   *  on-the-wire shape. */
+  think(content: string): this {
+    if (this.reasoning === undefined) {
+      this.reasoning = {content};
+    } else {
+      this.reasoning.content += content;
+    }
+    return this;
+  }
+
+  /** Attach a media part to the last input message. Pick exactly one of
+   *  `content` (inline base64 bytes), `uri` (URI reference), or `fileId`
+   *  (pre-uploaded file id). */
+  attachMedia(opts: AttachMediaOpts): this {
+    const parts = this._ensureLastInputParts();
+    let part: MessagePart;
+    if ('content' in opts) {
+      part = {type: 'blob', ...opts};
+    } else if ('uri' in opts) {
+      part = {type: 'uri', ...opts};
+    } else {
+      part = {type: 'file', ...opts};
+    }
+    parts.push(part);
+    return this;
+  }
+
+  /** Convenience for `attachMedia({uri, modality})`. */
+  attachMediaUrl(url: string, opts: {modality: Modality}): this {
+    return this.attachMedia({uri: url, modality: opts.modality});
+  }
+
+  /** Bulk-set any subset of the mutable fields. Replaces (does not merge). */
+  record(opts: LLMRecordOpts): this {
+    if (opts.inputMessages !== undefined) {
+      this.inputMessages = opts.inputMessages;
+    }
+    if (opts.outputMessages !== undefined) {
+      this.outputMessages = opts.outputMessages;
+    }
+    if (opts.usage !== undefined) {
+      this.usage = opts.usage;
+    }
+    if (opts.reasoning !== undefined) {
+      this.reasoning = opts.reasoning;
+    }
+    return this;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Child factories
+  // ---------------------------------------------------------------------------
+
   startTool(opts: ToolInit): Tool {
     return Tool.create({
       ...opts,
@@ -86,11 +165,23 @@ export class LLM {
     });
   }
 
+  // ---------------------------------------------------------------------------
+  // Lifecycle
+  // ---------------------------------------------------------------------------
+
   end(opts?: {error?: Error}): void {
     if (this._ended) {
       return;
     }
     this._ended = true;
+
+    // Fold reasoning into the last assistant message as a ReasoningPart so
+    // the wire format matches the Python SDK (which serializes reasoning
+    // inside gen_ai.output.messages, not as a separate attribute).
+    if (this.reasoning?.content) {
+      const parts = this._ensureLastAssistantParts();
+      parts.push({type: 'reasoning', content: this.reasoning.content});
+    }
 
     if (this.inputMessages.length > 0) {
       this.span.setAttribute(
@@ -150,4 +241,43 @@ export class LLM {
       state.llm = null;
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  /** Return the parts array of the last assistant message, creating both the
+   *  message and the parts array if needed. If the existing assistant message
+   *  has a `content` string but no parts, promote that content to a TextPart
+   *  so subsequent appends compose cleanly. */
+  private _ensureLastAssistantParts(): MessagePart[] {
+    let last = this.outputMessages[this.outputMessages.length - 1];
+    if (last === undefined || last.role !== 'assistant') {
+      last = {role: 'assistant'};
+      this.outputMessages.push(last);
+    }
+    return ensureParts(last);
+  }
+
+  /** Same as above, but for the last input message (creating a user message
+   *  if `inputMessages` is empty). Media parts attach here. */
+  private _ensureLastInputParts(): MessagePart[] {
+    let last = this.inputMessages[this.inputMessages.length - 1];
+    if (last === undefined) {
+      last = {role: 'user'};
+      this.inputMessages.push(last);
+    }
+    return ensureParts(last);
+  }
+}
+
+function ensureParts(msg: Message): MessagePart[] {
+  if (msg.parts === undefined) {
+    msg.parts = [];
+    if (msg.content !== undefined) {
+      msg.parts.push({type: 'text', content: msg.content});
+      msg.content = undefined;
+    }
+  }
+  return msg.parts;
 }

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -89,6 +89,9 @@ export class LLM {
 
   /** Append an assistant message to the response. */
   output(content: string): this {
+    if (this._warnIfEnded('output')) {
+      return this;
+    }
     this.outputMessages.push({role: 'assistant', content});
     return this;
   }
@@ -98,6 +101,9 @@ export class LLM {
    *  a `ReasoningPart` at serialization time, matching the Python SDK's
    *  on-the-wire shape. */
   think(content: string): this {
+    if (this._warnIfEnded('think')) {
+      return this;
+    }
     if (this.reasoning === undefined) {
       this.reasoning = {content};
     } else {
@@ -110,6 +116,9 @@ export class LLM {
    *  `content` (inline base64 bytes), `uri` (URI reference), or `fileId`
    *  (pre-uploaded file id). */
   attachMedia(opts: AttachMediaOpts): this {
+    if (this._warnIfEnded('attachMedia')) {
+      return this;
+    }
     const parts = this._ensureLastInputParts();
     let part: MessagePart;
     if ('content' in opts) {
@@ -125,11 +134,17 @@ export class LLM {
 
   /** Convenience for `attachMedia({uri, modality})`. */
   attachMediaUrl(url: string, opts: {modality: Modality}): this {
+    if (this._warnIfEnded('attachMediaUrl')) {
+      return this;
+    }
     return this.attachMedia({uri: url, modality: opts.modality});
   }
 
   /** Bulk-set any subset of the mutable fields. Replaces (does not merge). */
   record(opts: LLMRecordOpts): this {
+    if (this._warnIfEnded('record')) {
+      return this;
+    }
     if (opts.inputMessages !== undefined) {
       this.inputMessages = opts.inputMessages;
     }
@@ -268,6 +283,19 @@ export class LLM {
       this.inputMessages.push(last);
     }
     return ensureParts(last);
+  }
+
+  /** Warn if called after `end()`. Returns `true` if the caller should
+   *  short-circuit; the span is already closed, so any further mutation can
+   *  no longer reach the trace. */
+  private _warnIfEnded(method: string): boolean {
+    if (this._ended) {
+      console.warn(
+        `weave.LLM.${method}() called after end() — data will not be recorded on the span.`
+      );
+      return true;
+    }
+    return false;
   }
 }
 

--- a/sdks/node/src/genai/types.ts
+++ b/sdks/node/src/genai/types.ts
@@ -25,7 +25,7 @@ export type MessagePart =
     }
   | {type: 'tool_result'; toolCallId: string; result?: string}
   | {type: 'file'; fileId: string; mimeType?: string; modality: Modality}
-  | {type: 'image_blob'; content: string; mimeType: string}
+  | {type: 'blob'; content: string; mimeType: string; modality: Modality}
   | {type: 'uri'; uri: string; modality: Modality};
 
 export interface Usage {


### PR DESCRIPTION
## Summary

Adds the incremental data-population surface to the `LLM` class. These methods let callers build up the LLM's input/output content, usage, and reasoning incrementally between `create()` and `end()` — rather than constructing the full message arrays up front and assigning them directly to the mutable fields.

## Changes

**`src/genai/llm.ts`**

Five new public methods, each returning `this` for chaining:

| Method | Behaviour |
| --- | --- |
| `output(content: string)` | Pushes a new `{role: 'assistant', content}` message to `outputMessages`. Each call is a separate message — not accumulated into parts — matching the natural model where one `output()` call = one assistant turn. |
| `think(content: string)` | Accumulates into `this.reasoning.content` (creates the `Reasoning` object on the first call). At `end()`, the accumulated reasoning is folded into the **last** assistant output message as a `ReasoningPart` — matching the Python SDK's on-the-wire format where reasoning appears inside `gen_ai.output.messages`. |
| `attachMedia(opts: AttachMediaOpts)` | Appends a `MessagePart` to the last input message (creates a user message if `inputMessages` is empty). `AttachMediaOpts` is a **discriminated union** — pick exactly one of `{content, mimeType}` (→ `image_blob`), `{uri, modality}` (→ `uri`), or `{fileId, modality, mimeType?}` (→ `file`). |
| `attachMediaUrl(url, {modality})` | Convenience wrapper over `attachMedia({uri: url, modality})`. |
| `record(opts: LLMRecordOpts)` | Bulk-sets any subset of `inputMessages`, `outputMessages`, `usage`, `reasoning`. Replaces (not merges) each supplied field. Useful when the caller has the full response available at once rather than building incrementally. |


**`src/__tests__/genai/llm.test.ts`**

Add 10 new tests.

## Design notes

- **`output()`** **adds a new message, not a part.** Users who want a single message with mixed content (text + tool call, etc.) build the `Message` object themselves and push to `outputMessages` directly.
- **Reasoning is folded on the wire, not stored as a separate attribute.** The Python SDK serializes reasoning inside `gen_ai.output.messages` as a `ReasoningPart`. The TS SDK matches: `think()` / `reasoning` field accumulate client-side, and `end()` folds the content into the last output message before calling `JSON.stringify`.

## Test plan

- [x] `npx tsc -p tsconfig.cjs.json --noEmit`: clean.
- [x] `npx prettier --check`: clean.
- [x] All test cases pass.