### PR TITLE
chore(weave): Env vars for host allowlist & URL policy

### DIFF
--- a/tests/trace_server/test_environment.py
+++ b/tests/trace_server/test_environment.py
@@ -4,6 +4,9 @@ import pytest
 
 from weave.trace_server.environment import (
     DEFAULT_REMOTE_SCORER_HTTP_TIMEOUT_SECONDS,
+    REMOTE_SCORER_ALLOW_INSECURE_HTTP_ENV,
+    REMOTE_SCORER_ALLOWED_HOSTS_ENV,
+    REMOTE_SCORER_VALIDATE_HOSTS_ENV,
     VALID_CALLS_SHARD_KEYS,
     kafka_producer_max_buffer_size,
     wf_clickhouse_calls_shard_key,
@@ -11,9 +14,12 @@ from weave.trace_server.environment import (
     wf_scoring_worker_debounced_scoring_max_call_history,
     wf_scoring_worker_debounced_scoring_max_sampling_rate,
     wf_scoring_worker_kafka_consumer_group_id_override,
+    wf_scoring_worker_remote_scorer_allow_insecure_http,
+    wf_scoring_worker_remote_scorer_allowed_hosts,
     wf_scoring_worker_remote_scorer_bearer_token,
     wf_scoring_worker_remote_scorer_enabled,
     wf_scoring_worker_remote_scorer_http_timeout_seconds,
+    wf_scoring_worker_remote_scorer_validate_hosts,
 )
 
 
@@ -205,3 +211,61 @@ def test_wf_scoring_worker_remote_scorer_http_timeout_seconds(monkeypatch):
     assert wf_scoring_worker_remote_scorer_http_timeout_seconds() == (
         DEFAULT_REMOTE_SCORER_HTTP_TIMEOUT_SECONDS
     )
+
+
+@pytest.mark.disable_logging_error_check
+def test_wf_scoring_worker_remote_scorer_allowed_hosts(monkeypatch):
+    """Allowed hosts are comma-separated exact host or host:port strings."""
+    key = REMOTE_SCORER_ALLOWED_HOSTS_ENV
+    monkeypatch.delenv(key, raising=False)
+    assert wf_scoring_worker_remote_scorer_allowed_hosts() == []
+
+    monkeypatch.setenv(key, "")
+    assert wf_scoring_worker_remote_scorer_allowed_hosts() == []
+
+    monkeypatch.setenv(key, "scoring.example.com, api.example.com:8443 ,, localhost ")
+    assert wf_scoring_worker_remote_scorer_allowed_hosts() == [
+        "scoring.example.com",
+        "api.example.com:8443",
+        "localhost",
+    ]
+
+
+@pytest.mark.disable_logging_error_check
+def test_wf_scoring_worker_remote_scorer_validate_hosts(monkeypatch):
+    """Host validation is enabled by default; only case-insensitive false disables it."""
+    key = REMOTE_SCORER_VALIDATE_HOSTS_ENV
+    monkeypatch.delenv(key, raising=False)
+    assert wf_scoring_worker_remote_scorer_validate_hosts() is True
+
+    monkeypatch.setenv(key, "false")
+    assert wf_scoring_worker_remote_scorer_validate_hosts() is False
+    monkeypatch.setenv(key, "False")
+    assert wf_scoring_worker_remote_scorer_validate_hosts() is False
+
+    monkeypatch.setenv(key, "true")
+    assert wf_scoring_worker_remote_scorer_validate_hosts() is True
+    monkeypatch.setenv(key, "")
+    assert wf_scoring_worker_remote_scorer_validate_hosts() is True
+    monkeypatch.setenv(key, "0")
+    assert wf_scoring_worker_remote_scorer_validate_hosts() is True
+
+
+@pytest.mark.disable_logging_error_check
+def test_wf_scoring_worker_remote_scorer_allow_insecure_http(monkeypatch):
+    """Insecure HTTP is disabled by default; only case-insensitive true enables it."""
+    key = REMOTE_SCORER_ALLOW_INSECURE_HTTP_ENV
+    monkeypatch.delenv(key, raising=False)
+    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is False
+
+    monkeypatch.setenv(key, "true")
+    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is True
+    monkeypatch.setenv(key, "True")
+    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is True
+
+    monkeypatch.setenv(key, "false")
+    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is False
+    monkeypatch.setenv(key, "")
+    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is False
+    monkeypatch.setenv(key, "1")
+    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is False

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -165,6 +165,11 @@ def wf_scoring_worker_remote_scorer_bearer_token() -> str | None:
 
 
 DEFAULT_REMOTE_SCORER_HTTP_TIMEOUT_SECONDS = 30.0
+REMOTE_SCORER_ALLOWED_HOSTS_ENV = "WF_SCORING_WORKER_REMOTE_SCORER_ALLOWED_HOSTS"
+REMOTE_SCORER_VALIDATE_HOSTS_ENV = "WF_SCORING_WORKER_REMOTE_SCORER_VALIDATE_HOSTS"
+REMOTE_SCORER_ALLOW_INSECURE_HTTP_ENV = (
+    "WF_SCORING_WORKER_REMOTE_SCORER_ALLOW_INSECURE_HTTP"
+)
 
 
 def wf_scoring_worker_remote_scorer_enabled() -> bool:
@@ -193,6 +198,40 @@ def wf_scoring_worker_remote_scorer_http_timeout_seconds() -> float:
     except ValueError:
         return DEFAULT_REMOTE_SCORER_HTTP_TIMEOUT_SECONDS
     return value if value > 0 else DEFAULT_REMOTE_SCORER_HTTP_TIMEOUT_SECONDS
+
+
+def wf_scoring_worker_remote_scorer_allowed_hosts() -> list[str]:
+    """Hosts allowed for outbound remote scorer HTTP requests.
+
+    Values are comma-separated exact ``host``, ``host:port``, or URL origin
+    entries. Empty and whitespace-only entries are ignored. The worker fails
+    closed when this list is empty and remote scoring attempts to make an
+    outbound request.
+    """
+    raw = os.environ.get(REMOTE_SCORER_ALLOWED_HOSTS_ENV)
+    if raw is None:
+        return []
+    return [entry.strip() for entry in raw.split(",") if entry.strip()]
+
+
+def wf_scoring_worker_remote_scorer_validate_hosts() -> bool:
+    """Whether the worker enforces remote scorer host allowlist validation.
+
+    Defaults to true. Set to ``false`` only for controlled development or
+    emergency operational bypasses; HTTPS policy still applies independently.
+    """
+    return os.environ.get(REMOTE_SCORER_VALIDATE_HOSTS_ENV, "true").lower() != "false"
+
+
+def wf_scoring_worker_remote_scorer_allow_insecure_http() -> bool:
+    """Whether remote scorer URLs may use insecure ``http``.
+
+    This is intended as an explicit operator waiver for local/dev testing. The
+    worker still applies the host allowlist when this is enabled.
+    """
+    return (
+        os.environ.get(REMOTE_SCORER_ALLOW_INSECURE_HTTP_ENV, "false").lower() == "true"
+    )
 
 
 # Clickhouse Settings


### PR DESCRIPTION
## Description

[WB-34379](https://coreweave.atlassian.net/browse/WB-34379)

Add environment variables to support remote scoring host and url policies

## Testing

How was this PR tested?
unit tests, manual testing


[WB-34379]: https://coreweave.atlassian.net/browse/WB-34379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ