### PR TITLE
feat(weave): add grouped span custom attr distributions

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -18,6 +18,7 @@ from weave.trace_server.agents.types import (
     AgentGroupByRef,
     AgentSearchReq,
     AgentSortBy,
+    AgentSpanGroupDistributionSpec,
     AgentSpanGroupFilter,
     AgentSpanMeasureSpec,
     AgentSpansQueryReq,
@@ -42,6 +43,8 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_conversation_chat_turns_count_query,
     make_custom_attrs_schema_query,
     make_message_search_query,
+    make_span_group_categorical_distributions_query,
+    make_span_group_numeric_distributions_query,
     make_spans_count_query,
     make_spans_list_query,
     make_trace_detail_spans_query,
@@ -514,6 +517,7 @@ class TestMakeGroupedSpansListQuery:
 
         expected = """
             SELECT s.conversation_id AS conversation_id,
+                   {_GROUPED_AGG_TAIL},
                    count() AS spans,
                    countIf(((s.operation_name = {genai_3:String}))) AS tool_calls,
                    avgOrNull(if((mapContains(s.custom_attrs_float, {genai_4:String})), toFloat64(s.custom_attrs_float[{genai_4:String}]), NULL)) AS avg_score
@@ -524,6 +528,7 @@ class TestMakeGroupedSpansListQuery:
             ORDER BY avg_score desc
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
         """
+        expected = expected.replace("{_GROUPED_AGG_TAIL}", _GROUPED_AGG_TAIL)
         expected_params = {
             "genai_0": "p1",
             "genai_1": 100,
@@ -578,6 +583,7 @@ class TestMakeGroupedSpansListQuery:
 
         expected = """
             SELECT s.conversation_id AS conversation_id,
+                   {_GROUPED_AGG_TAIL},
                    countIf((mapContains(s.custom_attrs_bool, {genai_3:String})) AND s.custom_attrs_bool[{genai_3:String}] = 1) AS flagged_count
             FROM spans s
             WHERE s.project_id = {genai_0:String}
@@ -585,6 +591,7 @@ class TestMakeGroupedSpansListQuery:
             ORDER BY flagged_count DESC
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
         """
+        expected = expected.replace("{_GROUPED_AGG_TAIL}", _GROUPED_AGG_TAIL)
         expected_params = {
             "genai_0": "p1",
             "genai_1": 100,
@@ -592,6 +599,41 @@ class TestMakeGroupedSpansListQuery:
             "genai_3": "flagged",
         }
         assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_dynamic_measure_rejects_fixed_field_alias_collision(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match="measure aliases collide with grouped row fields: \\['span_count'\\]",
+        ):
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+                measures=[
+                    AgentSpanMeasureSpec(
+                        alias="span_count",
+                        aggregation="count",
+                    )
+                ],
+            )
+
+    def test_dynamic_measure_rejects_group_key_alias_collision(self) -> None:
+        with pytest.raises(
+            ValidationError,
+            match=(
+                "measure aliases collide with grouped row fields: "
+                "\\['conversation_id'\\]"
+            ),
+        ):
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+                measures=[
+                    AgentSpanMeasureSpec(
+                        alias="conversation_id",
+                        aggregation="count",
+                    )
+                ],
+            )
 
     def test_group_filter_rejects_mismatched_datetime_bound(self) -> None:
         pb = ParamBuilder("genai")
@@ -641,6 +683,204 @@ class TestMakeGroupedSpansListQuery:
                     ],
                 ),
             )
+
+
+# ============================================================================
+# make_span_group_*_distribution_query
+# ============================================================================
+
+
+class TestMakeSpanGroupDistributionQueries:
+    def test_numeric_distributions_query_batches_specs(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_span_group_numeric_distributions_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+            ),
+            ["conv-a", None, 12],
+            [
+                AgentSpanGroupDistributionSpec(
+                    alias="score_distribution",
+                    value=AgentSpanValueRef(source="custom_attrs_float", key="score"),
+                    bins=4,
+                ),
+                AgentSpanGroupDistributionSpec(
+                    alias="latency_distribution",
+                    value=AgentSpanValueRef(source="custom_attrs_int", key="latency"),
+                    bins=3,
+                ),
+            ],
+        )
+
+        expected = """
+            WITH
+              value_rows AS (
+                SELECT group_key,
+                       alias,
+                       bins,
+                       value
+                FROM (
+                  SELECT toString(s.conversation_id) AS group_key,
+                         tupleElement(spec, 1) AS alias,
+                         tupleElement(spec, 4) AS bins,
+                         multiIf(tupleElement(spec, 2) = 'custom_attrs_int', toFloat64(s.custom_attrs_int[tupleElement(spec, 3)]), tupleElement(spec, 2) = 'custom_attrs_float', toFloat64(s.custom_attrs_float[tupleElement(spec, 3)]), NULL) AS value
+                  FROM spans s
+                  ARRAY JOIN array(tuple({genai_2:String}, {genai_3:String}, {genai_4:String}, {genai_5:UInt64}), tuple({genai_6:String}, {genai_7:String}, {genai_8:String}, {genai_9:UInt64})) AS spec
+                  WHERE s.project_id = {genai_0:String}
+                    AND toString(s.conversation_id) IN {genai_1:Array(String)}
+                    AND multiIf(tupleElement(spec, 2) = 'custom_attrs_int', mapContains(s.custom_attrs_int, tupleElement(spec, 3)), tupleElement(spec, 2) = 'custom_attrs_float', mapContains(s.custom_attrs_float, tupleElement(spec, 3)), false)
+                )
+                WHERE isNotNull(value)
+                  AND isFinite(value)
+              ),
+              bounds AS (
+                SELECT group_key,
+                       alias,
+                       bins,
+                       min(value) AS min_value,
+                       max(value) AS max_value,
+                       count() AS present_count
+                FROM value_rows
+                GROUP BY group_key, alias, bins
+              ),
+              all_buckets AS (
+                SELECT group_key,
+                       alias,
+                       bins,
+                       toUInt64(bucket_index) AS bucket_index
+                FROM bounds
+                ARRAY JOIN range(bins) AS bucket_index
+              ),
+              aggregated AS (
+                SELECT value_rows.group_key AS group_key,
+                       value_rows.alias AS alias,
+                       if(bounds.max_value = bounds.min_value, toUInt64(0), toUInt64(least(toFloat64(bounds.bins) - 1.0, floor((value_rows.value - bounds.min_value) / if(bounds.max_value > bounds.min_value, (bounds.max_value - bounds.min_value) / toFloat64(bounds.bins), 1.0))))) AS bucket_index,
+                       count() AS bin_count
+                FROM value_rows
+                INNER JOIN bounds
+                  ON value_rows.group_key = bounds.group_key
+                 AND value_rows.alias = bounds.alias
+                GROUP BY group_key, alias, bucket_index
+              )
+            SELECT bounds.group_key AS group_key,
+                   bounds.alias AS alias,
+                   all_buckets.bucket_index AS bucket_index,
+                   if(bounds.max_value = bounds.min_value, bounds.min_value, bounds.min_value + toFloat64(all_buckets.bucket_index) * if(bounds.max_value > bounds.min_value, (bounds.max_value - bounds.min_value) / toFloat64(bounds.bins), 1.0)) AS bucket_min,
+                   if(bounds.max_value = bounds.min_value, bounds.max_value, if(all_buckets.bucket_index = bounds.bins - toUInt64(1), bounds.max_value, bounds.min_value + toFloat64(all_buckets.bucket_index + 1) * if(bounds.max_value > bounds.min_value, (bounds.max_value - bounds.min_value) / toFloat64(bounds.bins), 1.0))) AS bucket_max,
+                   ifNull(aggregated.bin_count, 0) AS count,
+                   bounds.present_count AS present_count
+            FROM bounds
+            INNER JOIN all_buckets
+              ON all_buckets.group_key = bounds.group_key
+             AND all_buckets.alias = bounds.alias
+            LEFT JOIN aggregated
+              ON aggregated.group_key = bounds.group_key
+             AND aggregated.alias = bounds.alias
+             AND aggregated.bucket_index = all_buckets.bucket_index
+            WHERE bounds.present_count > 0
+              AND (
+                bounds.max_value > bounds.min_value
+                OR all_buckets.bucket_index = 0
+              )
+            ORDER BY group_key ASC, alias ASC, bucket_index ASC
+        """
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": ["conv-a", "", "12"],
+            "genai_2": "score_distribution",
+            "genai_3": "custom_attrs_float",
+            "genai_4": "score",
+            "genai_5": 4,
+            "genai_6": "latency_distribution",
+            "genai_7": "custom_attrs_int",
+            "genai_8": "latency",
+            "genai_9": 3,
+        }
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_categorical_distributions_query_batches_specs(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_span_group_categorical_distributions_query(
+            pb,
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+            ),
+            ["conv-a"],
+            [
+                AgentSpanGroupDistributionSpec(
+                    alias="env_distribution",
+                    value=AgentSpanValueRef(source="custom_attrs_string", key="env"),
+                    top_n=2,
+                ),
+                AgentSpanGroupDistributionSpec(
+                    alias="cached_distribution",
+                    value=AgentSpanValueRef(source="custom_attrs_bool", key="cached"),
+                    top_n=2,
+                ),
+            ],
+        )
+
+        expected = """
+            WITH
+              value_counts AS (
+                SELECT group_key,
+                       alias,
+                       raw_value,
+                       top_n,
+                       count() AS value_count
+                FROM (
+                  SELECT toString(s.conversation_id) AS group_key,
+                         tupleElement(spec, 1) AS alias,
+                         tupleElement(spec, 4) AS top_n,
+                         multiIf(tupleElement(spec, 2) = 'custom_attrs_bool', if(s.custom_attrs_bool[tupleElement(spec, 3)] = 1, 'true', 'false'), tupleElement(spec, 2) = 'custom_attrs_string', toString(s.custom_attrs_string[tupleElement(spec, 3)]), '') AS raw_value
+                  FROM spans s
+                  ARRAY JOIN array(tuple({genai_2:String}, {genai_3:String}, {genai_4:String}, {genai_5:UInt64}), tuple({genai_6:String}, {genai_7:String}, {genai_8:String}, {genai_9:UInt64})) AS spec
+                  WHERE s.project_id = {genai_0:String}
+                    AND toString(s.conversation_id) IN {genai_1:Array(String)}
+                    AND multiIf(tupleElement(spec, 2) = 'custom_attrs_string', mapContains(s.custom_attrs_string, tupleElement(spec, 3)), tupleElement(spec, 2) = 'custom_attrs_bool', mapContains(s.custom_attrs_bool, tupleElement(spec, 3)), false)
+                )
+                GROUP BY group_key, alias, raw_value, top_n
+              ),
+              ranked AS (
+                SELECT group_key,
+                       alias,
+                       raw_value,
+                       top_n,
+                       value_count,
+                       sum(value_count) OVER (
+                         PARTITION BY group_key, alias
+                       ) AS present_count,
+                       row_number() OVER (
+                         PARTITION BY group_key, alias
+                         ORDER BY value_count DESC, raw_value ASC
+                       ) AS value_rank
+                FROM value_counts
+              )
+            SELECT group_key,
+                   alias,
+                   substring(raw_value, 1, 256) AS value,
+                   value_count AS count,
+                   present_count
+            FROM ranked
+            WHERE value_rank <= top_n
+            ORDER BY group_key ASC, alias ASC, count DESC, raw_value ASC
+        """
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": ["conv-a"],
+            "genai_2": "env_distribution",
+            "genai_3": "custom_attrs_string",
+            "genai_4": "env",
+            "genai_5": 2,
+            "genai_6": "cached_distribution",
+            "genai_7": "custom_attrs_bool",
+            "genai_8": "cached",
+            "genai_9": 2,
+        }
+        assert_sql(expected, expected_params, query, pb.get_params())
 
 
 # ============================================================================

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -22,6 +22,7 @@ from weave.trace_server.agents.types import (
     AgentGroupByRef,
     AgentSearchReq,
     AgentSortBy,
+    AgentSpanGroupDistributionSpec,
     AgentSpanGroupFilter,
     AgentSpanMeasureSpec,
     AgentSpansQueryReq,
@@ -294,6 +295,205 @@ def test_group_by_conversation_id_filters_numeric_aggregates(ch_server):
     assert conv_a in by_conv
     assert conv_b not in by_conv
     assert res.total_count == 1
+
+
+def test_group_by_conversation_id_custom_attr_measures(ch_server):
+    """Conversation groups return built-in aggregates plus custom attr metrics."""
+    project_id = _make_project_id("convs_cattr_metrics")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    conv_a = f"conv-{uuid.uuid4().hex[:8]}"
+    conv_b = f"conv-{uuid.uuid4().hex[:8]}"
+    avg_score = AgentSpanMeasureSpec(
+        alias="custom_float_score_avg",
+        aggregation="avg",
+        value=AgentSpanValueRef(source="custom_attrs_float", key="score"),
+        value_type="number",
+    )
+
+    spans = [
+        _make_span(
+            project_id,
+            conversation_id=conv_a,
+            conversation_name="Alpha Chat",
+            custom_attrs_float={"score": 0.9},
+            custom_attrs_bool={"cached": True},
+            custom_attrs_string={"env": "prod"},
+            started_at=now,
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv_a,
+            conversation_name="Alpha Chat",
+            custom_attrs_float={"score": 0.7},
+            custom_attrs_bool={"cached": False},
+            custom_attrs_string={"env": "prod"},
+            started_at=now + datetime.timedelta(seconds=1),
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv_b,
+            conversation_name="Beta Chat",
+            custom_attrs_float={"score": 0.2},
+            custom_attrs_bool={"cached": False},
+            custom_attrs_string={"env": "dev"},
+            started_at=now + datetime.timedelta(seconds=2),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+            measures=[
+                avg_score,
+                AgentSpanMeasureSpec(
+                    alias="custom_bool_cached_true",
+                    aggregation="count_true",
+                    value=AgentSpanValueRef(source="custom_attrs_bool", key="cached"),
+                ),
+                AgentSpanMeasureSpec(
+                    alias="custom_string_env_distinct",
+                    aggregation="count_distinct",
+                    value=AgentSpanValueRef(source="custom_attrs_string", key="env"),
+                ),
+            ],
+            group_filters=[AgentSpanGroupFilter(measure=avg_score, min=0.7)],
+            sort_by=[
+                AgentSortBy(field="custom_float_score_avg", direction="desc"),
+            ],
+        )
+    )
+
+    assert res.total_count == 1
+    assert len(res.groups) == 1
+    row = res.groups[0]
+    assert row.group_keys["conversation_id"] == conv_a
+    assert row.span_count == 2
+    assert row.conversation_names == ["Alpha Chat"]
+    assert abs(float(row.metrics["custom_float_score_avg"]) - 0.8) < 0.0001
+    assert row.metrics["custom_bool_cached_true"] == 1
+    assert row.metrics["custom_string_env_distinct"] == 1
+
+
+def test_conversation_custom_attr_distributions(ch_server):
+    """Grouped spans query returns custom attr distributions by conversation."""
+    project_id = _make_project_id("convs_cattr_dists")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    conv_a = f"conv-{uuid.uuid4().hex[:8]}"
+    conv_b = f"conv-{uuid.uuid4().hex[:8]}"
+
+    spans = [
+        _make_span(
+            project_id,
+            conversation_id=conv_a,
+            custom_attrs_float={"score": 0.1},
+            custom_attrs_int={"latency": 10},
+            custom_attrs_string={"env": "prod"},
+            custom_attrs_bool={"cached": True},
+            started_at=now,
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv_a,
+            custom_attrs_float={"score": 0.9},
+            custom_attrs_int={"latency": 30},
+            custom_attrs_string={"env": "prod"},
+            custom_attrs_bool={"cached": False},
+            started_at=now + datetime.timedelta(seconds=1),
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv_a,
+            custom_attrs_string={"env": "dev"},
+            started_at=now + datetime.timedelta(seconds=2),
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv_b,
+            custom_attrs_float={"score": 0.4},
+            custom_attrs_int={"latency": 20},
+            custom_attrs_string={"env": "staging"},
+            custom_attrs_bool={"cached": True},
+            started_at=now + datetime.timedelta(seconds=3),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+            group_distributions=[
+                AgentSpanGroupDistributionSpec(
+                    alias="custom_float_score_distribution",
+                    value=AgentSpanValueRef(source="custom_attrs_float", key="score"),
+                    bins=2,
+                ),
+                AgentSpanGroupDistributionSpec(
+                    alias="custom_int_latency_distribution",
+                    value=AgentSpanValueRef(source="custom_attrs_int", key="latency"),
+                    bins=2,
+                ),
+                AgentSpanGroupDistributionSpec(
+                    alias="custom_string_env_distribution",
+                    value=AgentSpanValueRef(source="custom_attrs_string", key="env"),
+                    top_n=2,
+                ),
+                AgentSpanGroupDistributionSpec(
+                    alias="custom_bool_cached_distribution",
+                    value=AgentSpanValueRef(source="custom_attrs_bool", key="cached"),
+                    top_n=2,
+                ),
+            ],
+        )
+    )
+
+    by_conversation = {row.group_keys["conversation_id"]: row for row in res.groups}
+
+    score_a = by_conversation[conv_a].distributions["custom_float_score_distribution"]
+    assert score_a.total_count == 3
+    assert score_a.present_count == 2
+    assert score_a.missing_count == 1
+    assert [bin.count for bin in score_a.bins] == [1, 1]
+    assert score_a.bins[0].min == 0.1
+    assert score_a.bins[-1].max == 0.9
+
+    latency_a = by_conversation[conv_a].distributions["custom_int_latency_distribution"]
+    assert latency_a.total_count == 3
+    assert latency_a.present_count == 2
+    assert latency_a.missing_count == 1
+    assert [bin.count for bin in latency_a.bins] == [1, 1]
+    assert latency_a.bins[0].min == 10
+    assert latency_a.bins[-1].max == 30
+
+    env_a = by_conversation[conv_a].distributions["custom_string_env_distribution"]
+    assert env_a.present_count == 3
+    assert env_a.other_count == 0
+    assert [(value.value, value.count) for value in env_a.values] == [
+        ("prod", 2),
+        ("dev", 1),
+    ]
+
+    cached_a = by_conversation[conv_a].distributions["custom_bool_cached_distribution"]
+    assert cached_a.present_count == 2
+    assert cached_a.missing_count == 1
+    assert [(value.value, value.count) for value in cached_a.values] == [
+        ("false", 1),
+        ("true", 1),
+    ]
+
+    score_b = by_conversation[conv_b].distributions["custom_float_score_distribution"]
+    assert score_b.total_count == 1
+    assert score_b.present_count == 1
+    assert len(score_b.bins) == 1
+    assert score_b.bins[0].count == 1
+
+    latency_b = by_conversation[conv_b].distributions["custom_int_latency_distribution"]
+    assert latency_b.total_count == 1
+    assert latency_b.present_count == 1
+    assert len(latency_b.bins) == 1
+    assert latency_b.bins[0].count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trace_server/test_genai_agent_query_handler.py
+++ b/tests/trace_server/test_genai_agent_query_handler.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from weave.trace_server.agents.clickhouse import AgentQueryHandler
+from weave.trace_server.agents.types import (
+    AgentGroupByRef,
+    AgentSpanGroupDistributionSpec,
+    AgentSpansQueryReq,
+    AgentSpanValueRef,
+)
+from weave.trace_server.trace_server_interface import FeedbackQueryRes
+
+
+@dataclass
+class _FakeQueryResult:
+    column_names: list[str]
+    result_rows: list[tuple[Any, ...]]
+
+
+def test_group_distributions_are_hydrated_with_batched_queries() -> None:
+    req = AgentSpansQueryReq(
+        project_id="p1",
+        group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+        group_distributions=[
+            AgentSpanGroupDistributionSpec(
+                alias="score_distribution",
+                value=AgentSpanValueRef(source="custom_attrs_float", key="score"),
+                bins=2,
+            ),
+            AgentSpanGroupDistributionSpec(
+                alias="latency_distribution",
+                value=AgentSpanValueRef(source="custom_attrs_int", key="latency"),
+                bins=3,
+            ),
+            AgentSpanGroupDistributionSpec(
+                alias="env_distribution",
+                value=AgentSpanValueRef(source="custom_attrs_string", key="env"),
+                top_n=2,
+            ),
+            AgentSpanGroupDistributionSpec(
+                alias="cached_distribution",
+                value=AgentSpanValueRef(source="custom_attrs_bool", key="cached"),
+                top_n=2,
+            ),
+        ],
+    )
+    grouped_row_columns = [
+        "conversation_id",
+        "span_count",
+        "invocation_count",
+        "conversation_count",
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_duration_ms",
+        "error_count",
+        "agent_names",
+        "agent_versions",
+        "provider_names",
+        "request_models",
+        "conversation_names",
+        "first_seen",
+        "last_seen",
+    ]
+    results = [
+        _FakeQueryResult(column_names=[], result_rows=[(1,)]),
+        _FakeQueryResult(
+            column_names=grouped_row_columns,
+            result_rows=[
+                (
+                    "conv-a",
+                    3,
+                    0,
+                    1,
+                    0,
+                    0,
+                    0,
+                    0,
+                    [],
+                    [],
+                    [],
+                    [],
+                    [],
+                    None,
+                    None,
+                )
+            ],
+        ),
+        _FakeQueryResult(
+            column_names=["group_key", "total_count"],
+            result_rows=[("conv-a", 3)],
+        ),
+        _FakeQueryResult(
+            column_names=[
+                "group_key",
+                "alias",
+                "bucket_index",
+                "bucket_min",
+                "bucket_max",
+                "count",
+                "present_count",
+            ],
+            result_rows=[
+                ("conv-a", "score_distribution", 0, 0.1, 0.5, 2, 2),
+                ("conv-a", "latency_distribution", 0, 10.0, 20.0, 1, 1),
+            ],
+        ),
+        _FakeQueryResult(
+            column_names=["group_key", "alias", "value", "count", "present_count"],
+            result_rows=[
+                ("conv-a", "env_distribution", "prod", 2, 3),
+                ("conv-a", "cached_distribution", "true", 1, 1),
+            ],
+        ),
+    ]
+    calls: list[tuple[str, dict[str, Any]]] = []
+
+    def query(sql: str, params: dict[str, Any]) -> _FakeQueryResult:
+        calls.append((sql, params))
+        return results.pop(0)
+
+    handler = AgentQueryHandler(query, lambda req: FeedbackQueryRes(result=[]))
+
+    res = handler.spans_query(req)
+
+    assert len(calls) == 5
+    assert not results
+
+    numeric_params = calls[3][1]
+    assert "score_distribution" in numeric_params.values()
+    assert "latency_distribution" in numeric_params.values()
+
+    categorical_params = calls[4][1]
+    assert "env_distribution" in categorical_params.values()
+    assert "cached_distribution" in categorical_params.values()
+
+    group = res.groups[0]
+    assert [bin.count for bin in group.distributions["score_distribution"].bins] == [2]
+    assert [bin.count for bin in group.distributions["latency_distribution"].bins] == [
+        1
+    ]
+    assert [
+        (v.value, v.count) for v in group.distributions["env_distribution"].values
+    ] == [("prod", 2)]
+    assert [
+        (v.value, v.count) for v in group.distributions["cached_distribution"].values
+    ] == [("true", 1)]

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -29,9 +29,11 @@ from weave.trace_server.agents.schema import (
     AgentSpanCHInsertable,
 )
 from weave.trace_server.agents.types import (
+    AGENT_CUSTOM_ATTR_SOURCE_VALUE_TYPES,
     AgentConversationChatReq,
     AgentConversationChatRes,
     AgentCustomAttrSchemaItem,
+    AgentCustomAttrSource,
     AgentCustomAttrsSchemaReq,
     AgentCustomAttrsSchemaRes,
     AgentSchema,
@@ -39,6 +41,9 @@ from weave.trace_server.agents.types import (
     AgentSearchMatchedMessage,
     AgentSearchReq,
     AgentSearchRes,
+    AgentSpanGroupDistributionBin,
+    AgentSpanGroupDistributionItem,
+    AgentSpanGroupDistributionValue,
     AgentSpanGroupRow,
     AgentSpanSchema,
     AgentSpansQueryReq,
@@ -71,11 +76,16 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_conversation_chat_turns_count_query,
     make_custom_attrs_schema_query,
     make_message_search_query,
+    make_span_group_categorical_distributions_query,
+    make_span_group_distribution_counts_query,
+    make_span_group_numeric_distributions_query,
     make_spans_count_query,
     make_spans_list_query,
     make_trace_detail_spans_query,
+    safe_float,
     safe_int,
     safe_str,
+    span_group_distribution_key,
 )
 from weave.trace_server.query_builder.agent_stats_query_builder import (
     build_agent_span_stats_query,
@@ -151,6 +161,8 @@ class AgentQueryHandler:
         aliases = [group_by_ref_alias(ref) for ref in req.group_by]
         measure_aliases = [measure.alias for measure in req.measures]
         groups = [_hydrate_group_row(r, aliases, measure_aliases) for r in rows]
+        if req.group_distributions:
+            self._hydrate_group_distributions(req, groups, aliases[0])
         return AgentSpansQueryRes(groups=groups, total_count=total)
 
     def spans_stats(self, req: AgentSpanStatsReq) -> AgentSpanStatsRes:
@@ -190,6 +202,108 @@ class AgentQueryHandler:
             offset=req.offset,
             has_more=len(rows) > req.limit,
         )
+
+    def _hydrate_group_distributions(
+        self,
+        req: AgentSpansQueryReq,
+        groups: list[AgentSpanGroupRow],
+        group_alias: str,
+    ) -> None:
+        """Attach requested custom attribute distributions to returned groups."""
+        # TODO: Split item setup and row hydration into smaller testable helpers.
+        if not groups:
+            return
+
+        groups_by_key = {
+            span_group_distribution_key(group.group_keys.get(group_alias)): group
+            for group in groups
+        }
+        group_values = [group.group_keys.get(group_alias) for group in groups]
+        pb = ParamBuilder(PARAM_NAMESPACE)
+        counts_sql = make_span_group_distribution_counts_query(pb, req, group_values)
+        total_counts = {
+            safe_str(row.get("group_key")): safe_int(row.get("total_count"))
+            for row in _rows_as_dicts(self._query(counts_sql, pb.get_params()))
+        }
+
+        items: dict[tuple[str, str], AgentSpanGroupDistributionItem] = {}
+        for group_key, group in groups_by_key.items():
+            for spec in req.group_distributions:
+                total_count = total_counts.get(group_key, 0)
+                source = cast("AgentCustomAttrSource", spec.value.source)
+                item = AgentSpanGroupDistributionItem(
+                    alias=spec.alias,
+                    source=source,
+                    key=spec.value.key,
+                    value_type=AGENT_CUSTOM_ATTR_SOURCE_VALUE_TYPES[source],
+                    total_count=total_count,
+                    # Start at total_count; distribution rows below subtract
+                    # present values for groups where the custom attr exists.
+                    missing_count=total_count,
+                )
+                items[group_key, spec.alias] = item
+                group.distributions[spec.alias] = item
+
+        numeric_specs = [
+            spec
+            for spec in req.group_distributions
+            if spec.value.source in {"custom_attrs_int", "custom_attrs_float"}
+        ]
+        if numeric_specs:
+            pb = ParamBuilder(PARAM_NAMESPACE)
+            sql = make_span_group_numeric_distributions_query(
+                pb, req, group_values, numeric_specs
+            )
+            for row in _rows_as_dicts(self._query(sql, pb.get_params())):
+                key = (safe_str(row.get("group_key")), safe_str(row.get("alias")))
+                distribution_item = items.get(key)
+                if distribution_item is None:
+                    continue
+                distribution_item.present_count = safe_int(row.get("present_count"))
+                distribution_item.missing_count = max(
+                    0,
+                    distribution_item.total_count - distribution_item.present_count,
+                )
+                distribution_item.bins.append(
+                    AgentSpanGroupDistributionBin(
+                        index=safe_int(row.get("bucket_index")),
+                        min=safe_float(row.get("bucket_min")),
+                        max=safe_float(row.get("bucket_max")),
+                        count=safe_int(row.get("count")),
+                    )
+                )
+
+        categorical_specs = [
+            spec
+            for spec in req.group_distributions
+            if spec.value.source in {"custom_attrs_string", "custom_attrs_bool"}
+        ]
+        if categorical_specs:
+            pb = ParamBuilder(PARAM_NAMESPACE)
+            sql = make_span_group_categorical_distributions_query(
+                pb, req, group_values, categorical_specs
+            )
+            for row in _rows_as_dicts(self._query(sql, pb.get_params())):
+                key = (safe_str(row.get("group_key")), safe_str(row.get("alias")))
+                distribution_item = items.get(key)
+                if distribution_item is None:
+                    continue
+                distribution_item.present_count = safe_int(row.get("present_count"))
+                distribution_item.missing_count = max(
+                    0,
+                    distribution_item.total_count - distribution_item.present_count,
+                )
+                distribution_item.values.append(
+                    AgentSpanGroupDistributionValue(
+                        value=safe_str(row.get("value")),
+                        count=safe_int(row.get("count")),
+                    )
+                )
+
+        for item in items.values():
+            if item.values:
+                top_count = sum(value.count for value in item.values)
+                item.other_count = max(0, item.present_count - top_count)
 
     # ------------------------------------------------------------------
     # AMT-backed agents queries

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -11,7 +11,7 @@ import datetime
 import logging
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar, cast
+from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, TypeVar, cast
 
 from weave.shared import refs_internal as ri
 from weave.trace_server.agents.chat_view import build_trace_chat
@@ -33,7 +33,6 @@ from weave.trace_server.agents.types import (
     AgentConversationChatReq,
     AgentConversationChatRes,
     AgentCustomAttrSchemaItem,
-    AgentCustomAttrSource,
     AgentCustomAttrsSchemaReq,
     AgentCustomAttrsSchemaRes,
     AgentSchema,
@@ -60,6 +59,7 @@ from weave.trace_server.agents.types import (
     AgentVersionsQueryRes,
     GenAIOTelExportReq,
     GenAIOTelExportRes,
+    group_by_ref_alias,
 )
 from weave.trace_server.datadog import record_db_insert
 from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
@@ -67,7 +67,6 @@ from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
 from weave.trace_server.opentelemetry.python_spans import Resource, Span
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_query_builder import (
-    group_by_ref_alias,
     make_agent_versions_count_query,
     make_agent_versions_list_query,
     make_agents_count_query,
@@ -122,6 +121,13 @@ PaginatedReqT = TypeVar(
     AgentConversationChatReq,
 )
 PARAM_NAMESPACE = "genai"
+
+
+class _SpanGroupDistKey(NamedTuple):
+    """Lookup key for distribution items: one per (group row, dist alias)."""
+
+    group_key: str
+    alias: str
 
 
 @dataclass(frozen=True)
@@ -226,11 +232,11 @@ class AgentQueryHandler:
             for row in _rows_as_dicts(self._query(counts_sql, pb.get_params()))
         }
 
-        items: dict[tuple[str, str], AgentSpanGroupDistributionItem] = {}
+        items: dict[_SpanGroupDistKey, AgentSpanGroupDistributionItem] = {}
         for group_key, group in groups_by_key.items():
             for spec in req.group_distributions:
                 total_count = total_counts.get(group_key, 0)
-                source = cast("AgentCustomAttrSource", spec.value.source)
+                source = spec.custom_attr_source()
                 item = AgentSpanGroupDistributionItem(
                     alias=spec.alias,
                     source=source,
@@ -241,9 +247,11 @@ class AgentQueryHandler:
                     # present values for groups where the custom attr exists.
                     missing_count=total_count,
                 )
-                items[group_key, spec.alias] = item
+                items[_SpanGroupDistKey(group_key, spec.alias)] = item
                 group.distributions[spec.alias] = item
 
+        # TODO: Run the numeric and categorical distribution queries in parallel
+        # — they're independent and each is the slowest piece of this hydrate.
         numeric_specs = [
             spec
             for spec in req.group_distributions
@@ -255,7 +263,9 @@ class AgentQueryHandler:
                 pb, req, group_values, numeric_specs
             )
             for row in _rows_as_dicts(self._query(sql, pb.get_params())):
-                key = (safe_str(row.get("group_key")), safe_str(row.get("alias")))
+                key = _SpanGroupDistKey(
+                    safe_str(row.get("group_key")), safe_str(row.get("alias"))
+                )
                 distribution_item = items.get(key)
                 if distribution_item is None:
                     continue
@@ -284,7 +294,9 @@ class AgentQueryHandler:
                 pb, req, group_values, categorical_specs
             )
             for row in _rows_as_dicts(self._query(sql, pb.get_params())):
-                key = (safe_str(row.get("group_key")), safe_str(row.get("alias")))
+                key = _SpanGroupDistKey(
+                    safe_str(row.get("group_key")), safe_str(row.get("alias"))
+                )
                 distribution_item = items.get(key)
                 if distribution_item is None:
                     continue
@@ -300,6 +312,8 @@ class AgentQueryHandler:
                     )
                 )
 
+        # Categorical queries return only the top-N values per group; anything
+        # beyond that lands in `other_count` so the UI can show a remainder slice.
         for item in items.values():
             if item.values:
                 top_count = sum(value.count for value in item.values)

--- a/weave/trace_server/agents/constants.py
+++ b/weave/trace_server/agents/constants.py
@@ -13,6 +13,9 @@ DEFAULT_AGENT_QUERY_LIMIT = 100
 MAX_AGENT_QUERY_LIMIT = 10_000
 DEFAULT_AGENT_CUSTOM_ATTR_SCHEMA_LIMIT = 200
 MAX_AGENT_CUSTOM_ATTR_SCHEMA_LIMIT = 2_000
+MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_SPECS = 20
+MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_BINS = 50
+MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_TOP_N = 20
 DEFAULT_SEARCH_LIMIT = 20
 MAX_SEARCH_LIMIT = 1000
 MAX_AGENT_STATS_RANGE_DAYS = 31
@@ -58,6 +61,39 @@ SEARCH_CONTENT_PREVIEW_CHARS = 500
 
 # Displayed conversation_id bucket for spans with no `gen_ai.conversation.id`.
 NO_CONVERSATION_LABEL = "__NO_CONVERSATION__"
+
+# ---------------------------------------------------------------------------
+# Grouped spans
+# ---------------------------------------------------------------------------
+
+# Aggregate aliases produced by grouped spans list queries.
+SPAN_GROUP_AGGREGATE_COLS: frozenset[str] = frozenset(
+    {
+        "span_count",
+        "invocation_count",
+        "conversation_count",
+        "total_input_tokens",
+        "total_cache_creation_input_tokens",
+        "total_cache_read_input_tokens",
+        "total_output_tokens",
+        "total_reasoning_tokens",
+        "total_duration_ms",
+        "error_count",
+        "first_seen",
+        "last_seen",
+    }
+)
+SPAN_GROUP_RESULT_COLS: frozenset[str] = SPAN_GROUP_AGGREGATE_COLS.union(
+    frozenset(
+        {
+            "agent_names",
+            "agent_versions",
+            "provider_names",
+            "request_models",
+            "conversation_names",
+        }
+    )
+)
 
 # ---------------------------------------------------------------------------
 # Ingest

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -98,6 +98,8 @@ AGENT_CUSTOM_ATTR_SOURCES: frozenset[AgentCustomAttrSource] = frozenset(
 )
 
 _IDENT_RE = r"^[a-zA-Z_][a-zA-Z0-9_]*$"
+# AgentGroupByRef sources that resolve to a plain span column rather than a
+# typed custom-attribute map; used to pick alias/value resolution paths.
 _FIELD_GROUP_BY_SOURCES = {"field", "column"}
 AGENT_SPAN_STATS_DERIVED_VALUE_TYPES: dict[
     AgentSpanStatsDerivedMetric, AgentSpanStatsValueType
@@ -506,7 +508,12 @@ class AgentGroupByRef(BaseModel):
     alias: str | None = None  # output key in AgentSpanGroupRow.group_keys
 
 
-def _group_by_ref_alias(ref: AgentGroupByRef) -> str:
+def group_by_ref_alias(ref: AgentGroupByRef) -> str:
+    """Return the SQL-safe output alias for a group-by ref.
+
+    Used for both request validation here and SQL projection in the query
+    builder, so both call sites agree on what shows up in `group_keys`.
+    """
     if ref.alias is not None:
         return ref.alias
     if ref.source in _FIELD_GROUP_BY_SOURCES:
@@ -528,10 +535,29 @@ class AgentSpanGroupDistributionSpec(BaseModel):
             raise ValueError("distribution specs must reference custom attr sources")
         return self
 
+    def custom_attr_source(self) -> AgentCustomAttrSource:
+        """Return ``value.source`` narrowed to ``AgentCustomAttrSource``.
+
+        The model validator guarantees this at construction time; this helper
+        re-checks each literal so callers avoid `cast()` at use sites.
+        """
+        source = self.value.source
+        if source == "custom_attrs_string":
+            return source
+        if source == "custom_attrs_int":
+            return source
+        if source == "custom_attrs_float":
+            return source
+        if source == "custom_attrs_bool":
+            return source
+        raise ValueError(f"distribution spec source is not custom attr: {source!r}")
+
 
 class AgentSpanGroupDistributionBin(BaseModel):
     """One numeric histogram bin for a custom attribute in a span group."""
 
+    # 0-based bucket position within the histogram; clients render bins in
+    # `index` order so this can double as a stable sort key.
     index: int
     min: float
     max: float
@@ -647,7 +673,7 @@ class AgentSpansQueryReq(BaseModel):
         if duplicate_aliases:
             raise ValueError(f"duplicate measure aliases: {duplicate_aliases!r}")
         if self.group_by:
-            group_aliases = [_group_by_ref_alias(ref) for ref in self.group_by]
+            group_aliases = [group_by_ref_alias(ref) for ref in self.group_by]
             reserved = SPAN_GROUP_RESULT_COLS.union(frozenset(group_aliases))
             measure_alias_collisions = sorted(
                 {

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -12,17 +12,22 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import (
     DEFAULT_AGENT_CUSTOM_ATTR_SCHEMA_LIMIT,
     DEFAULT_AGENT_QUERY_LIMIT,
     DEFAULT_AGENT_STATS_GROUP_LIMIT,
     DEFAULT_SEARCH_LIMIT,
+    MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_BINS,
+    MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_SPECS,
+    MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_TOP_N,
     MAX_AGENT_CUSTOM_ATTR_SCHEMA_LIMIT,
     MAX_AGENT_QUERY_LIMIT,
     MAX_AGENT_STATS_GROUP_LIMIT,
     MAX_AGENT_STATS_RANGE_DAYS,
     MAX_CONVERSATION_CHAT_TURNS,
     MAX_SEARCH_LIMIT,
+    SPAN_GROUP_RESULT_COLS,
 )
 from weave.trace_server.agents.schema import (
     NormalizedMessage,
@@ -93,6 +98,7 @@ AGENT_CUSTOM_ATTR_SOURCES: frozenset[AgentCustomAttrSource] = frozenset(
 )
 
 _IDENT_RE = r"^[a-zA-Z_][a-zA-Z0-9_]*$"
+_FIELD_GROUP_BY_SOURCES = {"field", "column"}
 AGENT_SPAN_STATS_DERIVED_VALUE_TYPES: dict[
     AgentSpanStatsDerivedMetric, AgentSpanStatsValueType
 ] = {
@@ -500,6 +506,60 @@ class AgentGroupByRef(BaseModel):
     alias: str | None = None  # output key in AgentSpanGroupRow.group_keys
 
 
+def _group_by_ref_alias(ref: AgentGroupByRef) -> str:
+    if ref.alias is not None:
+        return ref.alias
+    if ref.source in _FIELD_GROUP_BY_SOURCES:
+        return semconv.FILTERABLE_KEY_TO_COLUMN.get(ref.key, ref.key)
+    return ref.key
+
+
+class AgentSpanGroupDistributionSpec(BaseModel):
+    """One custom attribute distribution to compute per returned span group."""
+
+    alias: str = Field(pattern=_IDENT_RE)
+    value: AgentSpanValueRef
+    bins: int = Field(default=12, ge=1, le=MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_BINS)
+    top_n: int = Field(default=5, ge=1, le=MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_TOP_N)
+
+    @model_validator(mode="after")
+    def validate_distribution_spec(self) -> AgentSpanGroupDistributionSpec:
+        if self.value.source not in AGENT_CUSTOM_ATTR_SOURCES:
+            raise ValueError("distribution specs must reference custom attr sources")
+        return self
+
+
+class AgentSpanGroupDistributionBin(BaseModel):
+    """One numeric histogram bin for a custom attribute in a span group."""
+
+    index: int
+    min: float
+    max: float
+    count: int
+
+
+class AgentSpanGroupDistributionValue(BaseModel):
+    """One categorical custom attribute value count in a span group."""
+
+    value: str
+    count: int
+
+
+class AgentSpanGroupDistributionItem(BaseModel):
+    """Distribution data for one span-group/custom-attribute pair."""
+
+    alias: str
+    source: AgentCustomAttrSource
+    key: str
+    value_type: AgentCustomAttrValueType
+    total_count: int = 0
+    present_count: int = 0
+    missing_count: int = 0
+    other_count: int = 0
+    bins: list[AgentSpanGroupDistributionBin] = Field(default_factory=list)
+    values: list[AgentSpanGroupDistributionValue] = Field(default_factory=list)
+
+
 class AgentSpanGroupRow(BaseModel):
     """A single row in a grouped spans query response.
 
@@ -526,6 +586,9 @@ class AgentSpanGroupRow(BaseModel):
     first_seen: datetime.datetime | None = None
     last_seen: datetime.datetime | None = None
     metrics: dict[str, AgentSpanStatsCell] = Field(default_factory=dict)
+    distributions: dict[str, AgentSpanGroupDistributionItem] = Field(
+        default_factory=dict
+    )
 
 
 class AgentSpansQueryReq(BaseModel):
@@ -543,6 +606,10 @@ class AgentSpansQueryReq(BaseModel):
     group_by: list[AgentGroupByRef] | None = None
     measures: list[AgentSpanMeasureSpec] = Field(default_factory=list)
     group_filters: list[AgentSpanGroupFilter] = Field(default_factory=list)
+    group_distributions: list[AgentSpanGroupDistributionSpec] = Field(
+        default_factory=list,
+        max_length=MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_SPECS,
+    )
     custom_attr_columns: list[AgentSpanValueRef] = Field(default_factory=list)
     sort_by: list[AgentSortBy] | None = None
     limit: int = Field(
@@ -554,8 +621,14 @@ class AgentSpansQueryReq(BaseModel):
 
     @model_validator(mode="after")
     def validate_spans_query_request(self) -> AgentSpansQueryReq:
-        if (self.measures or self.group_filters) and not self.group_by:
-            raise ValueError("grouped measures and group filters require group_by")
+        if (
+            self.measures or self.group_filters or self.group_distributions
+        ) and not self.group_by:
+            raise ValueError(
+                "grouped measures, distributions, and filters require group_by"
+            )
+        if self.group_distributions and len(self.group_by or []) != 1:
+            raise ValueError("group_distributions currently support one group_by ref")
         if self.group_by and self.custom_attr_columns:
             raise ValueError(
                 "custom_attr_columns are only supported for ungrouped spans"
@@ -573,6 +646,35 @@ class AgentSpansQueryReq(BaseModel):
         )
         if duplicate_aliases:
             raise ValueError(f"duplicate measure aliases: {duplicate_aliases!r}")
+        if self.group_by:
+            group_aliases = [_group_by_ref_alias(ref) for ref in self.group_by]
+            reserved = SPAN_GROUP_RESULT_COLS.union(frozenset(group_aliases))
+            measure_alias_collisions = sorted(
+                {
+                    measure.alias
+                    for measure in self.measures
+                    if measure.alias in reserved
+                }
+            )
+            if measure_alias_collisions:
+                raise ValueError(
+                    "measure aliases collide with grouped row fields: "
+                    f"{measure_alias_collisions!r}"
+                )
+        distribution_aliases = [
+            distribution.alias for distribution in self.group_distributions
+        ]
+        duplicate_distribution_aliases = sorted(
+            {
+                alias
+                for alias in distribution_aliases
+                if distribution_aliases.count(alias) > 1
+            }
+        )
+        if duplicate_distribution_aliases:
+            raise ValueError(
+                f"duplicate distribution aliases: {duplicate_distribution_aliases!r}"
+            )
         return self
 
 

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -15,7 +15,7 @@ import datetime
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any, NamedTuple, cast
+from typing import Any, Callable, NamedTuple, TypeAlias
 
 from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import (
@@ -43,6 +43,7 @@ from weave.trace_server.agents.types import (
     AgentSpanValueRef,
     AgentsQueryReq,
     AgentVersionsQueryReq,
+    group_by_ref_alias,
 )
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_custom_attrs import (
@@ -185,7 +186,7 @@ _CUSTOM_ATTR_SCHEMA_SOURCES: tuple[tuple[str, str], ...] = tuple(
     AGENT_CUSTOM_ATTR_SOURCE_VALUE_TYPES.items()
 )
 
-SpanGroupKeyValue = str | int | float | bool | None
+SpanGroupKeyValue: TypeAlias = str | int | float | bool | None
 
 
 class SpanGroupDistributionContext(NamedTuple):
@@ -508,15 +509,6 @@ def resolve_agent_span_field_column(field: str) -> str:
     return semconv.FILTERABLE_KEY_TO_COLUMN.get(field, field)
 
 
-def group_by_ref_alias(ref: AgentGroupByRef) -> str:
-    """Return the SQL-safe output alias for a group-by ref."""
-    if ref.alias is not None:
-        return ref.alias
-    if ref.source in _FIELD_GROUP_BY_SOURCES:
-        return resolve_agent_span_field_column(ref.key)
-    return ref.key
-
-
 # ---------------------------------------------------------------------------
 # Span value and grouped measure resolution
 # ---------------------------------------------------------------------------
@@ -718,6 +710,10 @@ def _ensure_group_measure_aliases_do_not_collide(
     group_aliases: list[str], measures: list[AgentSpanMeasureSpec]
 ) -> None:
     """Reject dynamic measure aliases that would overwrite grouped row fields."""
+    # TODO: surface this as a 4xx instead of a 500. The same check runs in
+    # AgentSpansQueryReq's pydantic validator (which becomes a 422), so this
+    # branch is defense-in-depth — but if it ever does fire we should map it
+    # to a structured client error rather than letting ValueError bubble out.
     reserved = SPAN_GROUP_RESULT_COLS.union(frozenset(group_aliases))
     collisions = sorted(
         {measure.alias for measure in measures if measure.alias in reserved}
@@ -1056,14 +1052,10 @@ def _span_group_distribution_specs_array_sql(
     pb: ParamBuilder,
     specs: Sequence[AgentSpanGroupDistributionSpec],
     *,
-    limit_attr: str,
+    get_limit: Callable[[AgentSpanGroupDistributionSpec], int],
 ) -> str:
     spec_tuples = [
-        _span_group_distribution_spec_tuple_sql(
-            pb,
-            spec,
-            limit_value=cast(int, getattr(spec, limit_attr)),
-        )
+        _span_group_distribution_spec_tuple_sql(pb, spec, limit_value=get_limit(spec))
         for spec in specs
     ]
     return f"array({', '.join(spec_tuples)})"
@@ -1087,16 +1079,6 @@ def make_span_group_distribution_counts_query(
     """
 
 
-def make_span_group_numeric_distribution_query(
-    pb: ParamBuilder,
-    req: AgentSpansQueryReq,
-    group_values: Sequence[SpanGroupKeyValue],
-    spec: AgentSpanGroupDistributionSpec,
-) -> str:
-    """Build per-group histograms for one numeric custom attribute."""
-    return make_span_group_numeric_distributions_query(pb, req, group_values, [spec])
-
-
 def make_span_group_numeric_distributions_query(
     pb: ParamBuilder,
     req: AgentSpansQueryReq,
@@ -1114,7 +1096,7 @@ def make_span_group_numeric_distributions_query(
     specs_sql = _span_group_distribution_specs_array_sql(
         pb,
         numeric_specs,
-        limit_attr="bins",
+        get_limit=lambda spec: spec.bins,
     )
     spec_alias_sql = "tupleElement(spec, 1)"
     spec_source_sql = "tupleElement(spec, 2)"
@@ -1229,18 +1211,6 @@ def make_span_group_numeric_distributions_query(
     """
 
 
-def make_span_group_categorical_distribution_query(
-    pb: ParamBuilder,
-    req: AgentSpansQueryReq,
-    group_values: Sequence[SpanGroupKeyValue],
-    spec: AgentSpanGroupDistributionSpec,
-) -> str:
-    """Build per-group top value counts for one categorical custom attr."""
-    return make_span_group_categorical_distributions_query(
-        pb, req, group_values, [spec]
-    )
-
-
 def make_span_group_categorical_distributions_query(
     pb: ParamBuilder,
     req: AgentSpansQueryReq,
@@ -1260,7 +1230,7 @@ def make_span_group_categorical_distributions_query(
     specs_sql = _span_group_distribution_specs_array_sql(
         pb,
         categorical_specs,
-        limit_attr="top_n",
+        get_limit=lambda spec: spec.top_n,
     )
     spec_alias_sql = "tupleElement(spec, 1)"
     spec_source_sql = "tupleElement(spec, 2)"

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -13,9 +13,9 @@ from __future__ import annotations
 
 import datetime
 import re
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from typing import Any, Callable, NamedTuple, TypeAlias
+from typing import Any, NamedTuple, TypeAlias
 
 from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import (

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -15,12 +15,14 @@ import datetime
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, NamedTuple, cast
 
 from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import (
     OP_INVOKE_AGENT,
     SEARCH_CONTENT_PREVIEW_CHARS,
+    SPAN_GROUP_AGGREGATE_COLS,
+    SPAN_GROUP_RESULT_COLS,
 )
 from weave.trace_server.agents.types import (
     AGENT_CUSTOM_ATTR_SOURCE_VALUE_TYPES,
@@ -29,6 +31,7 @@ from weave.trace_server.agents.types import (
     AgentGroupByRef,
     AgentSearchReq,
     AgentSortBy,
+    AgentSpanGroupDistributionSpec,
     AgentSpanGroupFilter,
     AgentSpanMeasureSpec,
     AgentSpanSchema,
@@ -81,24 +84,6 @@ SPAN_GROUP_BY_COLS: frozenset[str] = SPAN_FILTERABLE_COLS.union(
     )
 )
 
-# Aggregate aliases produced by a grouped spans list query.
-SPAN_GROUP_AGGREGATE_COLS: frozenset[str] = frozenset(
-    {
-        "span_count",
-        "invocation_count",
-        "conversation_count",
-        "total_input_tokens",
-        "total_cache_creation_input_tokens",
-        "total_cache_read_input_tokens",
-        "total_output_tokens",
-        "total_reasoning_tokens",
-        "total_duration_ms",
-        "error_count",
-        "first_seen",
-        "last_seen",
-    }
-)
-
 SPAN_SORTABLE_COLS: frozenset[str] = SPAN_FILTERABLE_COLS.union(
     frozenset(
         {
@@ -149,6 +134,14 @@ _SOURCE_CUSTOM_ATTRS_STRING = "custom_attrs_string"
 _SOURCE_CUSTOM_ATTRS_INT = "custom_attrs_int"
 _SOURCE_CUSTOM_ATTRS_FLOAT = "custom_attrs_float"
 _SOURCE_CUSTOM_ATTRS_BOOL = "custom_attrs_bool"
+_NUMERIC_DISTRIBUTION_SOURCES = {
+    _SOURCE_CUSTOM_ATTRS_INT,
+    _SOURCE_CUSTOM_ATTRS_FLOAT,
+}
+_CATEGORICAL_DISTRIBUTION_SOURCES = {
+    _SOURCE_CUSTOM_ATTRS_STRING,
+    _SOURCE_CUSTOM_ATTRS_BOOL,
+}
 
 _AGG_SUM: AgentSpanStatsAggregation = "sum"
 _AGG_AVG: AgentSpanStatsAggregation = "avg"
@@ -191,6 +184,14 @@ _CUSTOM_ATTR_VALUE_TYPES: dict[str, AgentSpanStatsValueType] = {
 _CUSTOM_ATTR_SCHEMA_SOURCES: tuple[tuple[str, str], ...] = tuple(
     AGENT_CUSTOM_ATTR_SOURCE_VALUE_TYPES.items()
 )
+
+SpanGroupKeyValue = str | int | float | bool | None
+
+
+class SpanGroupDistributionContext(NamedTuple):
+    group_key_sql: str
+    group_values_slot: str
+
 
 _CORE_SPAN_VALUE_TYPES: dict[str, AgentSpanStatsColumnValueType] = {
     "trace_id": _VALUE_TYPE_STRING,
@@ -713,6 +714,20 @@ def ensure_group_filters_match(
             )
 
 
+def _ensure_group_measure_aliases_do_not_collide(
+    group_aliases: list[str], measures: list[AgentSpanMeasureSpec]
+) -> None:
+    """Reject dynamic measure aliases that would overwrite grouped row fields."""
+    reserved = SPAN_GROUP_RESULT_COLS.union(frozenset(group_aliases))
+    collisions = sorted(
+        {measure.alias for measure in measures if measure.alias in reserved}
+    )
+    if collisions:
+        raise ValueError(
+            f"measure aliases collide with grouped row fields: {collisions!r}"
+        )
+
+
 def group_filters_having_sql(
     pb: ParamBuilder,
     filters: list[AgentSpanGroupFilter],
@@ -765,7 +780,8 @@ def _and_conditions(*conditions: str) -> str:
 
 
 def _spans_filter_sql(
-    pb: ParamBuilder, req: AgentSpansQueryReq | AgentCustomAttrsSchemaReq
+    pb: ParamBuilder,
+    req: AgentSpansQueryReq | AgentCustomAttrsSchemaReq,
 ) -> _FilterSQL:
     pid_slot = pb.add(req.project_id, param_type="String")
     where_conditions = [_project_filter_sql("s.project_id", pid_slot)]
@@ -876,6 +892,8 @@ def make_spans_count_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
     if not req.group_by:
         return f"SELECT count() FROM spans s WHERE {span_filters.where}"
     resolved = resolve_group_by(pb, req.group_by)
+    aliases = [alias for _, alias in resolved]
+    _ensure_group_measure_aliases_do_not_collide(aliases, req.measures)
     group_exprs = ", ".join(expr for expr, _ in resolved)
     group_filters = span_group_filters(
         req.group_filters,
@@ -919,21 +937,21 @@ def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
 
     resolved = resolve_group_by(pb, req.group_by)
     aliases = [a for _, a in resolved]
+    _ensure_group_measure_aliases_do_not_collide(aliases, req.measures)
     select_group_cols = ", ".join(f"{expr} AS {alias}" for expr, alias in resolved)
     group_by_clause = ", ".join(aliases)
 
     measure_sqls = [span_measure_sql(measure, pb) for measure in req.measures]
-    aggregate_selects = (
-        ",\n               ".join(
-            f"{measure.aggregate_sql} AS {measure.alias}" for measure in measure_sqls
-        )
-        if measure_sqls
-        else _GROUPED_SPAN_AGGREGATES
+    dynamic_aggregate_selects = ",\n               ".join(
+        f"{measure.aggregate_sql} AS {measure.alias}" for measure in measure_sqls
     )
-    sortable = (
-        frozenset(aliases).union(measure.alias for measure in measure_sqls)
-        if measure_sqls
-        else SPAN_GROUP_AGGREGATE_COLS.union(frozenset(aliases))
+    aggregate_selects = _GROUPED_SPAN_AGGREGATES
+    if dynamic_aggregate_selects:
+        aggregate_selects = (
+            f"{aggregate_selects},\n               {dynamic_aggregate_selects}"
+        )
+    sortable = SPAN_GROUP_AGGREGATE_COLS.union(frozenset(aliases)).union(
+        measure.alias for measure in measure_sqls
     )
     default_order_by = (
         f"{measure_sqls[0].alias} DESC" if measure_sqls else "last_seen DESC"
@@ -994,6 +1012,319 @@ def make_custom_attrs_schema_query(
         GROUP BY source, key, value_type
         ORDER BY span_count DESC, key ASC, source ASC
         LIMIT {limit_slot} OFFSET {offset_slot}
+    """
+
+
+def span_group_distribution_key(value: SpanGroupKeyValue) -> str:
+    """Call `str(value)` or return an empty string for None."""
+    return "" if value is None else str(value)
+
+
+def _span_group_distribution_context(
+    pb: ParamBuilder,
+    req: AgentSpansQueryReq,
+    group_values: Sequence[SpanGroupKeyValue],
+) -> SpanGroupDistributionContext:
+    if not req.group_by or len(req.group_by) != 1:
+        raise ValueError("span group distributions require exactly one group_by ref")
+    group_expr, _ = resolve_group_by(pb, req.group_by)[0]
+    group_key_sql = f"toString({group_expr})"
+    group_values_slot = pb.add(
+        [span_group_distribution_key(value) for value in group_values],
+        param_type="Array(String)",
+    )
+    return SpanGroupDistributionContext(
+        group_key_sql=group_key_sql,
+        group_values_slot=group_values_slot,
+    )
+
+
+def _span_group_distribution_spec_tuple_sql(
+    pb: ParamBuilder,
+    spec: AgentSpanGroupDistributionSpec,
+    *,
+    limit_value: int,
+) -> str:
+    alias_slot = pb.add(spec.alias, param_type="String")
+    source_slot = pb.add(spec.value.source, param_type="String")
+    key_slot = pb.add(spec.value.key, param_type="String")
+    limit_slot = pb.add(limit_value, param_type="UInt64")
+    return f"tuple({alias_slot}, {source_slot}, {key_slot}, {limit_slot})"
+
+
+def _span_group_distribution_specs_array_sql(
+    pb: ParamBuilder,
+    specs: Sequence[AgentSpanGroupDistributionSpec],
+    *,
+    limit_attr: str,
+) -> str:
+    spec_tuples = [
+        _span_group_distribution_spec_tuple_sql(
+            pb,
+            spec,
+            limit_value=cast(int, getattr(spec, limit_attr)),
+        )
+        for spec in specs
+    ]
+    return f"array({', '.join(spec_tuples)})"
+
+
+def make_span_group_distribution_counts_query(
+    pb: ParamBuilder,
+    req: AgentSpansQueryReq,
+    group_values: Sequence[SpanGroupKeyValue],
+) -> str:
+    """Count filtered spans per returned group row."""
+    span_filters = _spans_filter_sql(pb, req)
+    context = _span_group_distribution_context(pb, req, group_values)
+    return f"""
+        SELECT {context.group_key_sql} AS group_key,
+               count() AS total_count
+        FROM spans s
+        WHERE {span_filters.where}
+          AND {context.group_key_sql} IN {context.group_values_slot}
+        GROUP BY group_key
+    """
+
+
+def make_span_group_numeric_distribution_query(
+    pb: ParamBuilder,
+    req: AgentSpansQueryReq,
+    group_values: Sequence[SpanGroupKeyValue],
+    spec: AgentSpanGroupDistributionSpec,
+) -> str:
+    """Build per-group histograms for one numeric custom attribute."""
+    return make_span_group_numeric_distributions_query(pb, req, group_values, [spec])
+
+
+def make_span_group_numeric_distributions_query(
+    pb: ParamBuilder,
+    req: AgentSpansQueryReq,
+    group_values: Sequence[SpanGroupKeyValue],
+    specs: Sequence[AgentSpanGroupDistributionSpec],
+) -> str:
+    """Build per-group histograms for numeric custom attributes."""
+    numeric_specs = [
+        spec for spec in specs if spec.value.source in _NUMERIC_DISTRIBUTION_SOURCES
+    ]
+    if not numeric_specs:
+        raise ValueError("numeric span group distributions require numeric specs")
+    span_filters = _spans_filter_sql(pb, req)
+    context = _span_group_distribution_context(pb, req, group_values)
+    specs_sql = _span_group_distribution_specs_array_sql(
+        pb,
+        numeric_specs,
+        limit_attr="bins",
+    )
+    spec_alias_sql = "tupleElement(spec, 1)"
+    spec_source_sql = "tupleElement(spec, 2)"
+    spec_key_sql = "tupleElement(spec, 3)"
+    spec_bins_sql = "tupleElement(spec, 4)"
+    map_contains_sql = (
+        f"multiIf({spec_source_sql} = '{_SOURCE_CUSTOM_ATTRS_INT}', "
+        f"mapContains(s.{_SOURCE_CUSTOM_ATTRS_INT}, {spec_key_sql}), "
+        f"{spec_source_sql} = '{_SOURCE_CUSTOM_ATTRS_FLOAT}', "
+        f"mapContains(s.{_SOURCE_CUSTOM_ATTRS_FLOAT}, {spec_key_sql}), "
+        "false)"
+    )
+    value_sql = (
+        f"multiIf({spec_source_sql} = '{_SOURCE_CUSTOM_ATTRS_INT}', "
+        f"toFloat64(s.{_SOURCE_CUSTOM_ATTRS_INT}[{spec_key_sql}]), "
+        f"{spec_source_sql} = '{_SOURCE_CUSTOM_ATTRS_FLOAT}', "
+        f"toFloat64(s.{_SOURCE_CUSTOM_ATTRS_FLOAT}[{spec_key_sql}]), "
+        "NULL)"
+    )
+    bucket_width_sql = (
+        "if(bounds.max_value > bounds.min_value, "
+        "(bounds.max_value - bounds.min_value) / toFloat64(bounds.bins), 1.0)"
+    )
+    bucket_index_sql = (
+        "if(bounds.max_value = bounds.min_value, toUInt64(0), "
+        "toUInt64(least(toFloat64(bounds.bins) - 1.0, floor("
+        f"(value_rows.value - bounds.min_value) / {bucket_width_sql}))))"
+    )
+    bucket_min_sql = (
+        "if(bounds.max_value = bounds.min_value, bounds.min_value, "
+        f"bounds.min_value + toFloat64(all_buckets.bucket_index) * "
+        f"{bucket_width_sql})"
+    )
+    bucket_max_sql = (
+        "if(bounds.max_value = bounds.min_value, bounds.max_value, "
+        "if(all_buckets.bucket_index = bounds.bins - toUInt64(1), "
+        "bounds.max_value, "
+        "bounds.min_value + toFloat64(all_buckets.bucket_index + 1) * "
+        f"{bucket_width_sql}))"
+    )
+    return f"""
+        WITH
+          value_rows AS (
+            SELECT group_key,
+                   alias,
+                   bins,
+                   value
+            FROM (
+              SELECT {context.group_key_sql} AS group_key,
+                     {spec_alias_sql} AS alias,
+                     {spec_bins_sql} AS bins,
+                     {value_sql} AS value
+              FROM spans s
+              ARRAY JOIN {specs_sql} AS spec
+              WHERE {span_filters.where}
+                AND {context.group_key_sql} IN {context.group_values_slot}
+                AND {map_contains_sql}
+            )
+            WHERE isNotNull(value)
+              AND isFinite(value)
+          ),
+          bounds AS (
+            SELECT group_key,
+                   alias,
+                   bins,
+                   min(value) AS min_value,
+                   max(value) AS max_value,
+                   count() AS present_count
+            FROM value_rows
+            GROUP BY group_key, alias, bins
+          ),
+          all_buckets AS (
+            SELECT group_key,
+                   alias,
+                   bins,
+                   toUInt64(bucket_index) AS bucket_index
+            FROM bounds
+            ARRAY JOIN range(bins) AS bucket_index
+          ),
+          aggregated AS (
+            SELECT value_rows.group_key AS group_key,
+                   value_rows.alias AS alias,
+                   {bucket_index_sql} AS bucket_index,
+                   count() AS bin_count
+            FROM value_rows
+            INNER JOIN bounds
+              ON value_rows.group_key = bounds.group_key
+             AND value_rows.alias = bounds.alias
+            GROUP BY group_key, alias, bucket_index
+          )
+        SELECT bounds.group_key AS group_key,
+               bounds.alias AS alias,
+               all_buckets.bucket_index AS bucket_index,
+               {bucket_min_sql} AS bucket_min,
+               {bucket_max_sql} AS bucket_max,
+               ifNull(aggregated.bin_count, 0) AS count,
+               bounds.present_count AS present_count
+        FROM bounds
+        INNER JOIN all_buckets
+          ON all_buckets.group_key = bounds.group_key
+         AND all_buckets.alias = bounds.alias
+        LEFT JOIN aggregated
+          ON aggregated.group_key = bounds.group_key
+         AND aggregated.alias = bounds.alias
+         AND aggregated.bucket_index = all_buckets.bucket_index
+        WHERE bounds.present_count > 0
+          AND (
+            bounds.max_value > bounds.min_value
+            OR all_buckets.bucket_index = 0
+          )
+        ORDER BY group_key ASC, alias ASC, bucket_index ASC
+    """
+
+
+def make_span_group_categorical_distribution_query(
+    pb: ParamBuilder,
+    req: AgentSpansQueryReq,
+    group_values: Sequence[SpanGroupKeyValue],
+    spec: AgentSpanGroupDistributionSpec,
+) -> str:
+    """Build per-group top value counts for one categorical custom attr."""
+    return make_span_group_categorical_distributions_query(
+        pb, req, group_values, [spec]
+    )
+
+
+def make_span_group_categorical_distributions_query(
+    pb: ParamBuilder,
+    req: AgentSpansQueryReq,
+    group_values: Sequence[SpanGroupKeyValue],
+    specs: Sequence[AgentSpanGroupDistributionSpec],
+) -> str:
+    """Build per-group top value counts for categorical custom attrs."""
+    categorical_specs = [
+        spec for spec in specs if spec.value.source in _CATEGORICAL_DISTRIBUTION_SOURCES
+    ]
+    if not categorical_specs:
+        raise ValueError(
+            "categorical span group distributions require categorical specs"
+        )
+    span_filters = _spans_filter_sql(pb, req)
+    context = _span_group_distribution_context(pb, req, group_values)
+    specs_sql = _span_group_distribution_specs_array_sql(
+        pb,
+        categorical_specs,
+        limit_attr="top_n",
+    )
+    spec_alias_sql = "tupleElement(spec, 1)"
+    spec_source_sql = "tupleElement(spec, 2)"
+    spec_key_sql = "tupleElement(spec, 3)"
+    spec_top_n_sql = "tupleElement(spec, 4)"
+    map_contains_sql = (
+        f"multiIf({spec_source_sql} = '{_SOURCE_CUSTOM_ATTRS_STRING}', "
+        f"mapContains(s.{_SOURCE_CUSTOM_ATTRS_STRING}, {spec_key_sql}), "
+        f"{spec_source_sql} = '{_SOURCE_CUSTOM_ATTRS_BOOL}', "
+        f"mapContains(s.{_SOURCE_CUSTOM_ATTRS_BOOL}, {spec_key_sql}), "
+        "false)"
+    )
+    value_sql = (
+        f"multiIf({spec_source_sql} = '{_SOURCE_CUSTOM_ATTRS_BOOL}', "
+        f"if(s.{_SOURCE_CUSTOM_ATTRS_BOOL}[{spec_key_sql}] = 1, 'true', 'false'), "
+        f"{spec_source_sql} = '{_SOURCE_CUSTOM_ATTRS_STRING}', "
+        f"toString(s.{_SOURCE_CUSTOM_ATTRS_STRING}[{spec_key_sql}]), "
+        "''"
+        ")"
+    )
+    return f"""
+        WITH
+          value_counts AS (
+            SELECT group_key,
+                   alias,
+                   raw_value,
+                   top_n,
+                   count() AS value_count
+            FROM (
+              SELECT {context.group_key_sql} AS group_key,
+                     {spec_alias_sql} AS alias,
+                     {spec_top_n_sql} AS top_n,
+                     {value_sql} AS raw_value
+              FROM spans s
+              ARRAY JOIN {specs_sql} AS spec
+              WHERE {span_filters.where}
+                AND {context.group_key_sql} IN {context.group_values_slot}
+                AND {map_contains_sql}
+            )
+            GROUP BY group_key, alias, raw_value, top_n
+          ),
+          ranked AS (
+            SELECT group_key,
+                   alias,
+                   raw_value,
+                   top_n,
+                   value_count,
+                   sum(value_count) OVER (
+                     PARTITION BY group_key, alias
+                   ) AS present_count,
+                   row_number() OVER (
+                     PARTITION BY group_key, alias
+                     ORDER BY value_count DESC, raw_value ASC
+                   ) AS value_rank
+            FROM value_counts
+          )
+        SELECT group_key,
+               alias,
+               substring(raw_value, 1, 256) AS value,
+               value_count AS count,
+               present_count
+        FROM ranked
+        WHERE value_rank <= top_n
+        ORDER BY group_key ASC, alias ASC, count DESC, raw_value ASC
     """
 
 

--- a/weave/trace_server/query_builder/agent_stats_query_builder.py
+++ b/weave/trace_server/query_builder/agent_stats_query_builder.py
@@ -27,6 +27,7 @@ from weave.trace_server.agents.types import (
     AgentSpanStatsNumericBucketSpec,
     AgentSpanStatsReq,
     AgentSpanStatsValueType,
+    group_by_ref_alias,
 )
 from weave.trace_server.calls_query_builder.stats_query_base import (
     auto_select_granularity_seconds,
@@ -38,7 +39,6 @@ from weave.trace_server.query_builder.agent_query_builder import (
     _project_filter_sql,
     add_time_filters,
     ensure_group_filters_match,
-    group_by_ref_alias,
     group_filters_having_sql,
     resolve_agent_span_field_column,
     resolve_group_by,


### PR DESCRIPTION
## Description

Extends grouped agent span queries so each returned group can include requested value distributions alongside the normal grouped result data. This lets callers fetch a page of grouped spans and, for each visible group, also get compact distributions for selected fields.

The immediate use case is the agents UI: when grouping by conversation, turn, or similar span dimensions, we need to render custom attribute summaries in tables and filters without adding a separate conversation-specific API path.

Supported distribution shapes:

- numeric values return histogram bins
- string and bool values return top value counts plus other/missing counts
- distributions are keyed by caller-provided aliases on each grouped span row

## Testing

- `uv run pytest tests/trace_server/test_genai_agent_queries.py -k conversation_custom_attr_distributions`
- `uv run prek run --hook-stage=pre-push ruff-check --files weave/trace_server/agents/clickhouse.py tests/trace_server/test_genai_agent_queries.py`
- `uv run prek run --hook-stage=pre-push mypy --files weave/trace_server/agents/clickhouse.py tests/trace_server/test_genai_agent_queries.py`
- `uv run prek run --hook-stage=pre-push ty --files weave/trace_server/agents/clickhouse.py tests/trace_server/test_genai_agent_queries.py`
- `nox -e lint`