### PR TITLE
chore(weave): trim spans on upsert_batch hot path

### DIFF
--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -206,7 +206,6 @@ def replace_base64_with_content_objects(
 R = TypeVar("R", bound=CallStartReq | CallEndReq | CallEndV2Req)
 
 
-@ddtrace.tracer.wrap(name="process_call_req_to_content")
 def process_call_req_to_content(
     req: R,
     trace_server: TraceServerInterface,
@@ -214,6 +213,9 @@ def process_call_req_to_content(
     """Process call inputs/outputs to replace base64 content.
 
     This is the main entry point for processing trace data before insertion.
+    Not wrapped in a tracer span: most invocations have no base64 payload and
+    do nothing. When base64 content is actually found and uploaded, the inner
+    ``store_content_object`` span surfaces the real work.
 
     Args:
         req: Call request (start, end, or end v2)
@@ -234,12 +236,14 @@ def process_call_req_to_content(
     return req
 
 
-@ddtrace.tracer.wrap(name="process_complete_call_to_content")
 def process_complete_call_to_content(
     complete_call: CompletedCallSchemaForInsert,
     trace_server: TraceServerInterface,
 ) -> CompletedCallSchemaForInsert:
     """Process a complete call to replace base64 content in inputs and outputs.
+
+    Not wrapped in a tracer span. See ``process_call_req_to_content`` for the
+    rationale: real work shows up as a ``store_content_object`` child span.
 
     Args:
         complete_call: Complete call schema with both inputs and outputs.

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -213,9 +213,6 @@ def process_call_req_to_content(
     """Process call inputs/outputs to replace base64 content.
 
     This is the main entry point for processing trace data before insertion.
-    Not wrapped in a tracer span: most invocations have no base64 payload and
-    do nothing. When base64 content is actually found and uploaded, the inner
-    ``store_content_object`` span surfaces the real work.
 
     Args:
         req: Call request (start, end, or end v2)
@@ -241,9 +238,6 @@ def process_complete_call_to_content(
     trace_server: TraceServerInterface,
 ) -> CompletedCallSchemaForInsert:
     """Process a complete call to replace base64 content in inputs and outputs.
-
-    Not wrapped in a tracer span. See ``process_call_req_to_content`` for the
-    rationale: real work shows up as a ``store_content_object`` child span.
 
     Args:
         complete_call: Complete call schema with both inputs and outputs.

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5833,9 +5833,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
     def _insert_file_chunks(
         self, file_chunks: list[FileChunkCreateCHInsertable]
     ) -> None:
-        # No tracer span: in batched mode this is just a list-append, and in
-        # flush-immediately mode the work is captured by the child ``_insert``
-        # span on the same ClickHouse call.
         if not self._flush_immediately:
             self._file_batch.extend(file_chunks)
             return

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5830,10 +5830,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         finally:
             self._file_batch = []
 
-    @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched._insert_file_chunks")
     def _insert_file_chunks(
         self, file_chunks: list[FileChunkCreateCHInsertable]
     ) -> None:
+        # No tracer span: in batched mode this is just a list-append, and in
+        # flush-immediately mode the work is captured by the child ``_insert``
+        # span on the same ClickHouse call.
         if not self._flush_immediately:
             self._file_batch.extend(file_chunks)
             return

--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -57,12 +57,8 @@ def get_project_retention_days(
     (argMax). A fall-through to ClickHouse is a full cache miss; if ClickHouse
     has no row for the project, returns RETENTION_DAYS_NO_TTL.
 
-    Only the cache-miss path is wrapped in a tracer span. L1 hits (the vast
-    majority of calls on the hot path) tag the parent span and return, to keep
-    Datadog span volume down.
-
     Redis client is resolved lazily via get_redis_client() (lru_cached
-    process singleton). ch_client must come from the calling thread, it is
+    process singleton). ch_client must come from the calling thread — it is
     a thread-local resource in ClickHouseTraceServer.
     """
     cached = _l1_get(project_id)

--- a/weave/trace_server/ttl_settings.py
+++ b/weave/trace_server/ttl_settings.py
@@ -47,7 +47,6 @@ _project_ttl_cache: TTLCache[str, int] = TTLCache(
 _project_ttl_cache_lock = threading.Lock()
 
 
-@ddtrace.tracer.wrap(name="ttl_settings.get_project_retention_days")
 def get_project_retention_days(
     project_id: str,
     ch_client: CHClient,
@@ -58,8 +57,12 @@ def get_project_retention_days(
     (argMax). A fall-through to ClickHouse is a full cache miss; if ClickHouse
     has no row for the project, returns RETENTION_DAYS_NO_TTL.
 
+    Only the cache-miss path is wrapped in a tracer span. L1 hits (the vast
+    majority of calls on the hot path) tag the parent span and return, to keep
+    Datadog span volume down.
+
     Redis client is resolved lazily via get_redis_client() (lru_cached
-    process singleton). ch_client must come from the calling thread — it is
+    process singleton). ch_client must come from the calling thread, it is
     a thread-local resource in ClickHouseTraceServer.
     """
     cached = _l1_get(project_id)
@@ -67,24 +70,24 @@ def get_project_retention_days(
         set_current_span_dd_tags({"ttl.cache_hit": "L1"})
         return cached
 
-    redis_client = get_redis_client()
-    if redis_client is not None:
-        redis_val = _l2_get(redis_client, project_id)
-        if redis_val is not None:
-            _l1_set(project_id, redis_val)
-            set_current_span_dd_tags({"ttl.cache_hit": "L2"})
-            return redis_val
+    with ddtrace.tracer.trace("ttl_settings.get_project_retention_days") as span:
+        redis_client = get_redis_client()
+        if redis_client is not None:
+            redis_val = _l2_get(redis_client, project_id)
+            if redis_val is not None:
+                _l1_set(project_id, redis_val)
+                span.set_tag("ttl.cache_hit", "L2")
+                return redis_val
 
-    retention_days = _query_clickhouse(ch_client, project_id)
-    set_current_span_dd_tags(
-        {"ttl.cache_hit": "clickhouse", "ttl.retention_days": retention_days}
-    )
+        retention_days = _query_clickhouse(ch_client, project_id)
+        span.set_tag("ttl.cache_hit", "clickhouse")
+        span.set_tag("ttl.retention_days", retention_days)
 
-    if redis_client is not None:
-        _l2_set(redis_client, project_id, retention_days)
-    _l1_set(project_id, retention_days)
+        if redis_client is not None:
+            _l2_set(redis_client, project_id, retention_days)
+        _l1_set(project_id, retention_days)
 
-    return retention_days
+        return retention_days
 
 
 def compute_expire_at(


### PR DESCRIPTION
## Summary

**Motivation**: prod is downsampling apm spans due to volume. let's clean up unnecessary stuff so we can trace more important things. 

Reduces Datadog span-byte volume on the hottest `/call/upsert_batch` path by dropping spurious per-item spans.

- `ttl_settings.get_project_retention_days`: stop spanning L1 cache hits (~99% of calls, 16 µs p50). Restores `ttl_settings.get_project_retention_days` wrapping the miss path only. Parent span still gets the `ttl.cache_hit:L1` tag.
- `process_call_req_to_content` / `process_complete_call_to_content`: drop decorators. Real work (`store_content_object`) is already separately spanned.
- `_insert_file_chunks`: drop decorator. It's a list-append in batch mode and a passthrough to the already-spanned `_insert` in flush-immediately mode.

Observed per-trace span counts on a typical 10-call `/call/upsert_batch`: 11x `ttl_settings.get_project_retention_days` (all L1 hits, 0.02 ms each) + 11x `process_call_req_to_content` (10 trivial + 1 real). After: 0 + 0 (plus the existing `store_content_object` when content is actually uploaded).

## Testing

no functional changes