### PR TITLE
perf(weave): reuse int-to-ext ref mapper across stream items

### DIFF
--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -257,3 +257,27 @@ def test_make_int_to_ext_ref_mapper_shares_cache_across_items():
     out_a3 = mapper(item_a3)
     assert out_a3 == {"ref": f"weave:///{ext_a}/op/qux:v4"}
     assert resolver_calls == [int_a, int_b, int_private]
+
+    # Item 7: BaseModel input. _map_values walks model fields via COW;
+    # ref-bearing model rewrites the ref and returns a (re-validated) new
+    # instance, while a ref-free model returns its input by identity.
+    # Resolver remains untouched on the cached hit.
+
+    class Item(BaseModel):
+        op_name: str
+        attributes: dict[str, str]
+
+    model_with_ref = Item(
+        op_name=f"weave-trace-internal:///{int_a}/op/from-model:v1",
+        attributes={"status": "ok"},
+    )
+    out_model = mapper(model_with_ref)
+    assert out_model.op_name == f"weave:///{ext_a}/op/from-model:v1"
+    assert out_model.attributes == {"status": "ok"}
+    assert resolver_calls == [int_a, int_b, int_private]
+
+    plain_model = Item(op_name="plain-op", attributes={"k": "v"})
+    out_plain_model = mapper(plain_model)
+    assert out_plain_model.op_name == "plain-op"
+    assert out_plain_model.attributes is plain_model.attributes
+    assert resolver_calls == [int_a, int_b, int_private]

--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -1,11 +1,16 @@
 import datetime
 import json
 
+import pytest
 from pydantic import BaseModel, ConfigDict
 
 from weave.trace.refs import ObjectRef
 from weave.trace_server.interface.query import Query
-from weave.trace_server.trace_server_converter import universal_ext_to_int_ref_converter
+from weave.trace_server.trace_server_converter import (
+    InvalidInternalRef,
+    make_int_to_ext_ref_mapper,
+    universal_ext_to_int_ref_converter,
+)
 from weave.trace_server.trace_server_interface import (
     CallStartReq,
     ObjCreateReq,
@@ -177,3 +182,78 @@ def test_universal_ext_to_int_ref_converter_rewrites_refs_in_model_extras():
     assert converted.declared == "plain"
     extras = converted.model_extra or {}
     assert extras.get("extra_ref") == internal_ref
+
+
+def test_make_int_to_ext_ref_mapper_shares_cache_across_items():
+    """One mapper applied to N stream items reuses the project_id cache.
+
+    The resolver should be hit exactly once per distinct internal
+    project_id even when the mapper is applied to many items, and the
+    rewrites for each item must land correctly when items reference
+    different projects. Ref-free items must preserve identity (COW
+    behavior inherited from `_map_values`), and a malformed internal ref
+    must raise without poisoning the cache for subsequent items.
+    """
+    int_a, ext_a = "proj-a-internal", "ent-a/proj-a"
+    int_b, ext_b = "proj-b-internal", "ent-b/proj-b"
+    int_private = "proj-private"  # resolver returns None -> rewrites to private scheme
+
+    resolver_calls: list[str] = []
+
+    def resolver(project_id: str) -> str | None:
+        resolver_calls.append(project_id)
+        if project_id == int_a:
+            return ext_a
+        if project_id == int_b:
+            return ext_b
+        return None  # inaccessible -> private scheme
+
+    mapper = make_int_to_ext_ref_mapper(resolver)
+
+    # Item 1: hits project A. Resolver MUST be called.
+    item_a = {"ref": f"weave-trace-internal:///{int_a}/op/foo:v1"}
+    out_a = mapper(item_a)
+    assert out_a == {"ref": f"weave:///{ext_a}/op/foo:v1"}
+    assert resolver_calls == [int_a]
+
+    # Item 2: same project as item 1. Resolver MUST NOT be called again
+    # (this is the whole point of hoisting the mapper out of the loop).
+    item_a2 = {"ref": f"weave-trace-internal:///{int_a}/op/bar:v2"}
+    out_a2 = mapper(item_a2)
+    assert out_a2 == {"ref": f"weave:///{ext_a}/op/bar:v2"}
+    assert resolver_calls == [int_a]
+
+    # Item 3: new project. Resolver called exactly once for B.
+    item_b = {"ref": f"weave-trace-internal:///{int_b}/op/baz:v3"}
+    out_b = mapper(item_b)
+    assert out_b == {"ref": f"weave:///{ext_b}/op/baz:v3"}
+    assert resolver_calls == [int_a, int_b]
+
+    # Item 4: ref-free. Identity preserved (COW inherited), resolver untouched.
+    item_plain: dict[str, object] = {"plain": ["a", "b", {"nested": 1}]}
+    out_plain = mapper(item_plain)
+    assert out_plain is item_plain
+    assert resolver_calls == [int_a, int_b]
+
+    # Item 5: inaccessible project (resolver returns None). Cached None is
+    # honored on the next item without a second resolver call.
+    item_private = {"ref": f"weave-trace-internal:///{int_private}/op/x:v1"}
+    out_private = mapper(item_private)
+    assert out_private == {"ref": "weave-private://///op/x:v1"}
+    assert resolver_calls == [int_a, int_b, int_private]
+
+    item_private2 = {"ref": f"weave-trace-internal:///{int_private}/op/y:v2"}
+    out_private2 = mapper(item_private2)
+    assert out_private2 == {"ref": "weave-private://///op/y:v2"}
+    assert resolver_calls == [int_a, int_b, int_private]
+
+    # Item 6: external ref appearing on the internal->external path is a
+    # corruption signal and must raise. Cache from earlier items survives.
+    item_bad = {"ref": f"weave:///{ext_a}/op/leaked:v1"}
+    with pytest.raises(InvalidInternalRef):
+        mapper(item_bad)
+
+    item_a3 = {"ref": f"weave-trace-internal:///{int_a}/op/qux:v4"}
+    out_a3 = mapper(item_a3)
+    assert out_a3 == {"ref": f"weave:///{ext_a}/op/qux:v4"}
+    assert resolver_calls == [int_a, int_b, int_private]

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -128,6 +128,10 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             for item in res:
                 yield mapper(item)
         finally:
+            # `mapper` (and the int_to_ext_project_cache it closes over) is
+            # a local in this generator's frame; closing the frame drops
+            # both. The previous explicit `.clear()` was a redundant
+            # eager-free that GC already handles.
             if hasattr(res, "close"):
                 res.close()
 

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -4,6 +4,7 @@ from typing import Any, TypeVar
 
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.trace_server_converter import (
+    make_int_to_ext_ref_mapper,
     universal_ext_to_int_ref_converter,
     universal_int_to_ext_ref_converter,
 )
@@ -108,7 +109,12 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         req: A,
         internal_project_id: str,
     ) -> Iterator[B]:
-        """Stream results while converting internal refs to external refs."""
+        """Stream results while converting internal refs to external refs.
+
+        Builds one mapper for the whole stream so the int-to-ext project_id
+        cache and the rewrite closures are reused across every yielded item,
+        instead of being allocated per item.
+        """
         req_conv = universal_ext_to_int_ref_converter(
             req,
             self._idc.ext_to_int_project_id,
@@ -116,22 +122,12 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         )
         res = method(req_conv)
 
-        int_to_ext_project_cache: dict[str, str | None] = {}
-
-        def cached_int_to_ext_project_id(project_id: str) -> str | None:
-            if project_id not in int_to_ext_project_cache:
-                int_to_ext_project_cache[project_id] = self._idc.int_to_ext_project_id(
-                    project_id
-                )
-            return int_to_ext_project_cache[project_id]
+        mapper = make_int_to_ext_ref_mapper(self._idc.int_to_ext_project_id)
 
         try:
             for item in res:
-                yield universal_int_to_ext_ref_converter(
-                    item, cached_int_to_ext_project_id
-                )
+                yield mapper(item)
         finally:
-            int_to_ext_project_cache.clear()
             if hasattr(res, "close"):
                 res.close()
 

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -107,11 +107,12 @@ def universal_ext_to_int_ref_converter(
 
 
 C = TypeVar("C")
+T = TypeVar("T")
 
 
 def make_int_to_ext_ref_mapper(
     convert_int_to_ext_project_id: Callable[[str], str | None],
-) -> Callable[[Any], Any]:
+) -> Callable[[T], T]:
     """Build a reusable internal-to-external ref mapper.
 
     The returned callable rewrites a single object's internal refs to
@@ -122,6 +123,12 @@ def make_int_to_ext_ref_mapper(
 
     For one-shot conversions, prefer `universal_int_to_ext_ref_converter`,
     which is a thin wrapper that builds and applies a mapper in one call.
+
+    The returned callable is generic on its input type: callers that pass
+    `obj: B` get back `B`, preserving the static type through the
+    converter. `scalar_mapper` is kept loosely typed because it walks
+    individual leaf values, which may be strings, primitives, or
+    container fragments that the type checker cannot pin in advance.
     """
     int_to_ext_project_cache: dict[str, str | None] = {}
 
@@ -156,8 +163,8 @@ def make_int_to_ext_ref_mapper(
                 raise InvalidInternalRef("Encountered unexpected ref format.")
         return obj
 
-    def apply(obj: Any) -> Any:
-        return _map_values(obj, scalar_mapper)
+    def apply(obj: T) -> T:
+        return cast(T, _map_values(obj, scalar_mapper))
 
     return apply
 

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -107,26 +107,21 @@ def universal_ext_to_int_ref_converter(
 
 
 C = TypeVar("C")
-D = TypeVar("D")
 
 
-def universal_int_to_ext_ref_converter(
-    obj: C,
+def make_int_to_ext_ref_mapper(
     convert_int_to_ext_project_id: Callable[[str], str | None],
-) -> C:
-    """Takes any object and recursively replaces all internal references with
-    external references. The internal references are expected to be in the
-    format of `weave-trace-internal:///project_id/...` and the external references are
-    expected to be in the format of `weave:///entity/project/...`.
+) -> Callable[[Any], Any]:
+    """Build a reusable internal-to-external ref mapper.
 
-    Args:
-        obj: The object to convert.
-        convert_int_to_ext_project_id: A function that takes an internal
-            project ID and returns the external project ID.
+    The returned callable rewrites a single object's internal refs to
+    external refs. It carries an `int_to_ext_project_cache` scoped to its
+    own closure, so applying the same mapper to a sequence of objects
+    reuses that cache across every call. Use this for streaming paths
+    where the same converter is applied to many items in a row.
 
-    Returns:
-        The object with all internal references replaced with external
-        references.
+    For one-shot conversions, prefer `universal_int_to_ext_ref_converter`,
+    which is a thin wrapper that builds and applies a mapper in one call.
     """
     int_to_ext_project_cache: dict[str, str | None] = {}
 
@@ -147,10 +142,10 @@ def universal_int_to_ext_ref_converter(
             return f"{ri.WEAVE_PRIVATE_SCHEME}://///{tail}"
         return f"{ri.WEAVE_SCHEME}:///{external_project_id}/{tail}"
 
-    def mapper(obj: D) -> D:
+    def scalar_mapper(obj: Any) -> Any:
         if isinstance(obj, str):
             if obj.startswith(weave_internal_prefix):
-                return cast(D, replace_ref(obj))
+                return replace_ref(obj)
             elif obj.startswith(weave_prefix):
                 # It is important to raise here as this would be the result of
                 # incorrectly storing an external ref at the database layer,
@@ -161,7 +156,32 @@ def universal_int_to_ext_ref_converter(
                 raise InvalidInternalRef("Encountered unexpected ref format.")
         return obj
 
-    return _map_values(obj, mapper)
+    def apply(obj: Any) -> Any:
+        return _map_values(obj, scalar_mapper)
+
+    return apply
+
+
+def universal_int_to_ext_ref_converter(
+    obj: C,
+    convert_int_to_ext_project_id: Callable[[str], str | None],
+) -> C:
+    """Takes any object and recursively replaces all internal references with
+    external references. The internal references are expected to be in the
+    format of `weave-trace-internal:///project_id/...` and the external references are
+    expected to be in the format of `weave:///entity/project/...`.
+
+    Args:
+        obj: The object to convert.
+        convert_int_to_ext_project_id: A function that takes an internal
+            project ID and returns the external project ID.
+
+    Returns:
+        The object with all internal references replaced with external
+        references.
+    """
+    mapper = make_int_to_ext_ref_mapper(convert_int_to_ext_project_id)
+    return cast(C, mapper(obj))
 
 
 E = TypeVar("E")


### PR DESCRIPTION
## Summary

Follow-up to #6844. `_stream_ref_apply` was rebuilding the entire `universal_int_to_ext_ref_converter` closure (cache dict + `replace_ref` + `mapper`) on every yielded item, and was wrapping that with its own stream-scoped `cached_int_to_ext_project_id` block, so each item paid for a redundant pair of caches and three closure allocations.

- New `make_int_to_ext_ref_mapper(resolver) -> Callable` builds the closures and project_id cache once and returns a reusable applier.
- `universal_int_to_ext_ref_converter` is now a 3-line wrapper around it, so non-streaming callers (`_ref_apply` and every read/write method) are unchanged.
- `_stream_ref_apply` builds the mapper once per stream, yields `mapper(item)` per item, and drops the redundant cache block.

## Performance

Local micro-bench, stream-discard mode (median of 7 runs):

| payload | items | cpu (old -> new) | peak mem (old -> new) |
|---|---|---|---|
| ref-heavy, 64 projects x 8 refs | 1000 | 9.88 -> 8.77ms (-11.2%) | 11.4 -> 10.3KB (-9.9%) |
| ref-heavy, 1 project x 4 refs   | 5000 | 28.48 -> 26.03ms (-8.6%) | 22.2 -> 21.9KB (-1.5%) |
| ref-free                        | 5000 | 37.71 -> 36.24ms (-3.9%) | 2.8 -> 2.5KB (-11.9%) |
| nested depth=6                  | 1000 | 12.28 -> 11.43ms (-6.9%) | 36.0 -> 35.5KB (-1.2%) |
| mixed call-end-shaped           | 10000 | 142.74 -> 136.73ms (-4.2%) | 31.2 -> 30.9KB (-1.1%) |

## Testing

unit test on cache reuse across N items (resolver hit exactly once per distinct project_id, ref-free items preserve identity, cached `None` survives across items, malformed ref raises without poisoning the cache). adapter mutation contract tests still pass.
