### PR TITLE
chore(weave): always partition score_calls by project_id

### DIFF
--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -50,17 +50,6 @@ def kafka_producer_max_buffer_size() -> int | None:
         return None
 
 
-def kafka_partition_by_project_id() -> bool:
-    """Whether to partition Kafka messages by project_id.
-
-    When enabled, messages are partitioned by project_id to ensure all messages
-    for a given project go to the same partition. When disabled, messages are
-    distributed round-robin across partitions. Can be safely toggled without
-    having to rebalanc/re-partition the topic.
-    """
-    return os.environ.get("KAFKA_PARTITION_BY_PROJECT_ID", "false").lower() == "true"
-
-
 # Scoring worker settings
 
 

--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -24,7 +24,6 @@ from weave.trace_server.environment import (
     kafka_broker_port,
     kafka_client_password,
     kafka_client_user,
-    kafka_partition_by_project_id,
     kafka_producer_max_buffer_size,
 )
 
@@ -139,13 +138,12 @@ class KafkaProducer(ConfluentKafkaProducer):
         ):
             return
 
-        publish_key = req.project_id if kafka_partition_by_project_id() else None
         for i in range(0, len(req.call_ids), self.SCORE_CALLS_CHUNK_SIZE):
             chunk = req.call_ids[i : i + self.SCORE_CALLS_CHUNK_SIZE]
             self.produce(
                 topic=SCORE_CALLS_TOPIC,
                 value=req.model_copy(update={"call_ids": chunk}).model_dump_json(),
-                key=publish_key,
+                key=req.project_id,
             )
 
         if flush_immediately:


### PR DESCRIPTION
## Summary
- Every environment we ship sets `KAFKA_PARTITION_BY_PROJECT_ID=true`. The toggle is dead weight, so drop the env helper and the conditional in `produce_score_calls`; partitioning by project_id is now the default and only behavior.
- Companion to core PR https://github.com/wandb/core/pull/44107 which removes the helm key. This PR must land and roll out first so core's env var removal is a no-op.

## Testing
non-functional change in every env where the flag is currently set to true (prod-forest, zoo-qa). No tests reference the helper.