### PR TITLE
chore(weave): add typed columns (label, score, is_success) to feedback table

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -197,6 +197,9 @@ def test_annotation_feedback(client: WeaveClient) -> None:
         "call_ref": None,
         "trigger_ref": None,
         "queue_id": None,
+        "label": None,
+        "score": None,
+        "is_success": None,
     }
 
 
@@ -348,7 +351,87 @@ def test_runnable_feedback(client: WeaveClient) -> None:
         "call_ref": call_ref,
         "trigger_ref": trigger_ref,
         "queue_id": None,
+        "label": None,
+        "score": None,
+        "is_success": None,
     }
+
+
+def test_typed_feedback(client: WeaveClient) -> None:
+    """Test feedback creation with typed (label/score/is_success) columns."""
+    project_id = client.project_id
+    weave_ref = f"weave:///{project_id}/call/cal_id_123"
+
+    # Case 1: wandb.typed requires at least one typed value
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type="wandb.typed",
+                payload={},
+            )
+        )
+
+    # Case 2: typed columns are not allowed on non-typed feedback
+    for kwargs in (
+        {"label": "passes"},
+        {"score": 0.5},
+        {"is_success": True},
+    ):
+        with pytest.raises(InvalidRequest):
+            client.server.feedback_create(
+                tsi.FeedbackCreateReq(
+                    project_id=project_id,
+                    weave_ref=weave_ref,
+                    feedback_type="custom",
+                    payload={},
+                    **kwargs,
+                )
+            )
+
+    # Case 3: label too long
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type="wandb.typed",
+                payload={},
+                label="x" * 200,
+            )
+        )
+
+    # Success cases. Multiple rows per ref are allowed (e.g. one per label).
+    for kwargs in (
+        {"label": "passes_safety_check"},
+        {"score": 0.87},
+        {"is_success": True},
+        {"label": "tone_warm", "score": 0.42, "is_success": False},
+    ):
+        create_res = client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type="wandb.typed",
+                payload={},
+                **kwargs,
+            )
+        )
+        assert create_res.id is not None
+
+    query_res = client.server.feedback_query(
+        tsi.FeedbackQueryReq(
+            project_id=project_id,
+            fields=["feedback_type", "label", "score", "is_success"],
+        )
+    )
+    assert len(query_res.result) == 4
+    assert all(r["feedback_type"] == "wandb.typed" for r in query_res.result)
+    labels = sorted(
+        (r["label"] for r in query_res.result), key=lambda x: (x is None, x)
+    )
+    assert labels == ["passes_safety_check", "tone_warm", None, None]
 
 
 async def populate_feedback(client: WeaveClient) -> None:

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -18,12 +18,14 @@ from weave.trace_server.interface.builtin_object_classes.annotation_spec import 
 from weave.trace_server.interface.feedback_types import (
     ANNOTATION_FEEDBACK_TYPE_PREFIX,
     FEEDBACK_PAYLOAD_SCHEMAS,
+    MAX_TYPED_FEEDBACK_LABEL_LENGTH,
     REACTION_FEEDBACK_TYPE,
     RUNNABLE_FEEDBACK_TYPE_PREFIX,
     AnnotationPayloadSchema,
     RunnablePayloadSchema,
     feedback_type_is_annotation,
     feedback_type_is_runnable,
+    feedback_type_is_typed,
 )
 from weave.trace_server.orm import Column, Row, Table
 from weave.trace_server.refs_internal_server_util import ensure_ref_is_valid
@@ -48,6 +50,9 @@ TABLE_FEEDBACK = Table(
         Column("call_ref", "string", nullable=True),
         Column("trigger_ref", "string", nullable=True),
         Column("queue_id", "string", nullable=True),
+        Column("label", "string", nullable=True),
+        Column("score", "float", nullable=True),
+        Column("is_success", "bool", nullable=True),
     ],
 )
 
@@ -155,6 +160,26 @@ def validate_feedback_create_req(
     elif req.trigger_ref:
         raise InvalidRequest("trigger_ref is not allowed for non-runnable feedback")
 
+    # Validate the typed columns. At least one of (label, score, is_success)
+    # must be present on `wandb.typed` feedback and they must not appear on
+    # any other feedback type.
+    has_typed_value = (
+        req.label is not None or req.score is not None or req.is_success is not None
+    )
+    if feedback_type_is_typed(req.feedback_type):
+        if not has_typed_value:
+            raise InvalidRequest(
+                "wandb.typed feedback requires at least one of label, score, or is_success"
+            )
+        if req.label is not None and len(req.label) > MAX_TYPED_FEEDBACK_LABEL_LENGTH:
+            raise InvalidRequest(
+                f"label must be at most {MAX_TYPED_FEEDBACK_LABEL_LENGTH} characters"
+            )
+    elif has_typed_value:
+        raise InvalidRequest(
+            "label, score, and is_success are only allowed on wandb.typed feedback"
+        )
+
     # Validate the ref formats (we could even query the DB to ensure they exist and are valid)
     if req.annotation_ref:
         parsed = ensure_ref_is_valid(req.annotation_ref, (ri.InternalObjectRef,))
@@ -257,6 +282,9 @@ def format_feedback_to_row(
         "call_ref": feedback_req.call_ref,
         "trigger_ref": feedback_req.trigger_ref,
         "queue_id": feedback_req.queue_id,
+        "label": feedback_req.label,
+        "score": feedback_req.score,
+        "is_success": feedback_req.is_success,
     }
 
 

--- a/weave/trace_server/interface/feedback_types.py
+++ b/weave/trace_server/interface/feedback_types.py
@@ -15,6 +15,11 @@ class FeedbackPayloadNoteReq(BaseModel):
 
 REACTION_FEEDBACK_TYPE = "wandb.reaction.1"
 NOTE_FEEDBACK_TYPE = "wandb.note.1"
+TYPED_FEEDBACK_TYPE = "wandb.typed"
+
+# Max length of the `label` column on typed feedback. Labels are intended to
+# behave like tags, not free-form strings.
+MAX_TYPED_FEEDBACK_LABEL_LENGTH = 128
 
 # Feedback types where multiple entries can exist per call per type.
 # When filtering on these, we use groupArrayIf (collect all values) + has()
@@ -48,6 +53,10 @@ def feedback_type_is_annotation(feedback_type: str) -> bool:
 
 def feedback_type_is_runnable(feedback_type: str) -> bool:
     return feedback_type.startswith(RUNNABLE_FEEDBACK_TYPE_PREFIX)
+
+
+def feedback_type_is_typed(feedback_type: str) -> bool:
+    return feedback_type == TYPED_FEEDBACK_TYPE
 
 
 def runnable_feedback_selector(name: str) -> str:

--- a/weave/trace_server/migrations/031_add_typed_feedback_columns.down.sql
+++ b/weave/trace_server/migrations/031_add_typed_feedback_columns.down.sql
@@ -1,0 +1,4 @@
+ALTER TABLE feedback
+    DROP COLUMN label,
+    DROP COLUMN score,
+    DROP COLUMN is_success;

--- a/weave/trace_server/migrations/031_add_typed_feedback_columns.up.sql
+++ b/weave/trace_server/migrations/031_add_typed_feedback_columns.up.sql
@@ -1,0 +1,26 @@
+/*
+This migration adds the following typed columns to the feedback table:
+- `label`: A short string tag.
+- `score`: A numeric score.
+- `is_success`: A boolean pass/fail.
+
+Scorer results are currently written to `payload_dump` as opaque JSON. That
+makes results hard to display, hard to filter, and slow to query at scale.
+
+These columns are populated by a new `wandb.typed` feedback type. Existing
+feedback types are unchanged.
+*/
+ALTER TABLE feedback
+    /*
+    `label`: A short string tag associated with a ref (similar to Signals).
+    Multiple typed feedback rows may share the same weave_ref with different labels.
+    */
+    ADD COLUMN label Nullable(String) DEFAULT NULL,
+    /*
+    `score`: A numeric score associated with a ref.
+    */
+    ADD COLUMN score Nullable(Float64) DEFAULT NULL,
+    /*
+    `is_success`: A boolean pass/fail associated with a ref.
+    */
+    ADD COLUMN is_success Nullable(Bool) DEFAULT NULL;

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -97,6 +97,7 @@ ColumnType = Literal[
     "datetime",
     "json",  # Represented as string in ClickHouse
     "float",
+    "bool",
 ]
 
 

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1176,6 +1176,21 @@ class FeedbackCreateReq(BaseModelStrict):
         description="The annotation queue ID this feedback was created from. References annotation_queues.id. NULL when feedback is created outside of queues.",
         examples=["018f1f2a-9c2b-7d3e-b5a1-8c9d2e4f6a7b"],
     )
+    label: str | None = Field(
+        default=None,
+        description="Short tag-like string. Only allowed on `wandb.typed` feedback.",
+        examples=["passes_safety_check"],
+    )
+    score: float | None = Field(
+        default=None,
+        description="Numeric score. Only allowed on `wandb.typed` feedback.",
+        examples=[0.87],
+    )
+    is_success: bool | None = Field(
+        default=None,
+        description="Boolean pass/fail. Only allowed on `wandb.typed` feedback.",
+        examples=[True],
+    )
 
     # wb_user_id is automatically populated by the server
     wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)


### PR DESCRIPTION
## Description

Add a `wandb.typed` feedback type backed by three new ClickHouse columns on `feedback`: `label` (`Nullable(String)`), `score` (`Nullable(Float64)`), and `is_success` (`Nullable(Bool)`). Scorer results today land in `payload_dump` as opaque JSON, which is awkward to display, filter on, and query at scale. Typed columns are the foundation for a structured agent-scoring UI; existing feedback types are unchanged.

Includes migration 031, `FeedbackCreateReq` schema additions, validation that `wandb.typed` requires at least one typed value (and that typed values are rejected on other feedback types), and a `"bool"` `ColumnType` so SQLite/ORM follow along.

## Testing

- `uv run --group test python -m pytest tests/trace/test_feedback.py tests/trace/test_client_feedback.py tests/trace/test_annotation_feedback.py` (32 passed, SQLite)
- `uvx ruff check` on touched files