### PR TITLE
chore(weave): add add_typed SDK helper for wandb.typed feedback

### DIFF
--- a/tests/trace/test_client_feedback.py
+++ b/tests/trace/test_client_feedback.py
@@ -225,6 +225,29 @@ def test_feedback_payload(client):
     assert payload["emoji"] == "🎱"
 
 
+def test_add_typed_feedback_api(client):
+    """Exercise the SDK helper for typed feedback end-to-end."""
+    call = client.create_call("x", {"a": 1})
+    client.finish_call(call, "ok")
+    trace_obj = client.get_call(call.id)
+
+    feedback_id = trace_obj.feedback.add_typed(
+        label="passes_safety_check", score=0.9, is_success=True
+    )
+    assert isinstance(feedback_id, str)
+
+    with pytest.raises(ValueError, match="at least one"):
+        trace_obj.feedback.add_typed()
+
+    feedbacks = list(trace_obj.feedback.refresh())
+    assert len(feedbacks) == 1
+    fb = feedbacks[0]
+    assert fb.feedback_type == "wandb.typed"
+    assert fb.label == "passes_safety_check"
+    assert fb.score == 0.9
+    assert fb.is_success is True
+
+
 def test_feedback_create_too_large(client):
     project_id = client.project_id
 

--- a/weave/trace/feedback.py
+++ b/weave/trace/feedback.py
@@ -196,6 +196,9 @@ class RefFeedbackQuery(FeedbackQuery):
         payload: dict[str, Any],
         creator: str | None,
         annotation_ref: str | None = None,
+        label: str | None = None,
+        score: float | None = None,
+        is_success: bool | None = None,
     ) -> str:
         freq = tsi.FeedbackCreateReq(
             project_id=to_project_id(self.entity, self.project),
@@ -203,6 +206,9 @@ class RefFeedbackQuery(FeedbackQuery):
             feedback_type=feedback_type,
             payload=payload,
             creator=creator,
+            label=label,
+            score=score,
+            is_success=is_success,
         )
         if annotation_ref:
             try:
@@ -251,6 +257,32 @@ class RefFeedbackQuery(FeedbackQuery):
                 "note": note,
             },
             creator=creator,
+        )
+
+    def add_typed(
+        self,
+        label: str | None = None,
+        score: float | None = None,
+        is_success: bool | None = None,
+        creator: str | None = None,
+    ) -> str:
+        """Add typed feedback (label, score, and/or is_success) to the ref.
+
+        At least one of `label`, `score`, or `is_success` must be provided.
+        Each call creates a single feedback row; callers wanting multiple
+        labels per ref should make multiple calls.
+        """
+        if label is None and score is None and is_success is None:
+            raise ValueError(
+                "add_typed requires at least one of label, score, or is_success"
+            )
+        return self._add(
+            "wandb.typed",
+            {},
+            creator=creator,
+            label=label,
+            score=score,
+            is_success=is_success,
         )
 
     def purge(self, feedback_id: str) -> None:


### PR DESCRIPTION
## Description

Wires the new `wandb.typed` feedback columns through the Python SDK. `RefFeedbackQuery._add` now forwards `label`/`score`/`is_success`, and a new public `add_typed(label=, score=, is_success=, creator=)` helper creates a single `wandb.typed` row (requires at least one typed value).

The HTTP endpoints (`/feedback/create`, `/batch/create`, `/query`, `/replace`, etc.) and the external/internal adapter already pass `FeedbackCreateReq` through unchanged, so the new fields ride along automatically and surface in query results via `TABLE_FEEDBACK.select()`.

Builds on #6869.

## Testing

- `uv run --group test python -m pytest tests/trace/test_feedback.py tests/trace/test_client_feedback.py tests/trace/test_annotation_feedback.py` (33 passed, SQLite)
- `uvx ruff check` on touched files