### PR TITLE
chore(weave): add @neutralino1 to clickhouse migrations codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @wandb/weave-team
 /docs/ @wandb/docs-team @wandb/weave-team
-/weave/trace_server/migrations @tssweeney @gtarpenning
+/weave/trace_server/migrations @tssweeney @gtarpenning @neutralino1


### PR DESCRIPTION
## Summary
- Adds `@neutralino1` as a codeowner of `/weave/trace_server/migrations` alongside `@tssweeney` and `@gtarpenning`.

## Testing
non-functional change