### PR TITLE
fix(weave): filter by otel attributes

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -8,6 +8,7 @@ from weave.shared.trace_server_interface_util import (
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.calls_query_builder.calls_query_builder import (
     AggregatedDataSizeField,
+    CallsMergedOtelSpanField,
     CallsQuery,
     HardCodedFilter,
     ParamBuilder,
@@ -16,6 +17,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     build_calls_complete_delete_query,
     build_calls_complete_update_end_query,
     build_calls_complete_update_query,
+    get_field_by_name,
 )
 from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH
 from weave.trace_server.errors import InvalidFieldError
@@ -4626,6 +4628,59 @@ def test_query_with_annotation_filter_still_uses_anyif() -> None:
             "pb_0": "wandb.annotation.rating",
             "pb_1": '$."value"',
             "pb_2": "good",
+            "pb_3": "project",
+        },
+    )
+
+
+def test_attributes_otel_span_field_resolves_to_otel_span_field() -> None:
+    """`attributes.otel_span[.path]` resolves to CallsMergedOtelSpanField."""
+    bare = get_field_by_name("attributes.otel_span")
+    assert isinstance(bare, CallsMergedOtelSpanField)
+    assert bare.extra_path is None
+
+    nested = get_field_by_name("attributes.otel_span.attributes.gen_ai.model")
+    assert isinstance(nested, CallsMergedOtelSpanField)
+    assert nested.extra_path == ["attributes", "gen_ai", "model"]
+
+
+def test_attributes_otel_span_filter_reads_otel_dump_with_legacy_fallback() -> None:
+    """Filter on `attributes.otel_span.*` reads otel_dump, falling back to
+    attributes_dump.$.otel_span.* for pre-migration-020 rows.
+    """
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.EqOperation.model_validate(
+            {
+                "$eq": [
+                    {"$getField": "attributes.otel_span.attributes.gen_ai.model"},
+                    {"$literal": "gpt-4"},
+                ]
+            }
+        )
+    )
+
+    assert_sql(
+        cq,
+        """
+        SELECT
+            calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING (
+            ((if(any(calls_merged.otel_dump) IS NULL,
+                coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_1:String}), 'null'), ''),
+                coalesce(nullIf(JSON_VALUE(any(calls_merged.otel_dump), {pb_0:String}), 'null'), '')) = {pb_2:String}))
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+        )
+        """,
+        {
+            "pb_0": '$."attributes"."gen_ai"."model"',
+            "pb_1": '$."otel_span"."attributes"."gen_ai"."model"',
+            "pb_2": "gpt-4",
             "pb_3": "project",
         },
     )

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -1980,3 +1980,74 @@ def test_otel_span_wandb_attributes_and_data_routing(
     client.server.calls_delete(
         tsi.CallsDeleteReq(project_id=project_id, call_ids=[call.id], wb_user_id=None)
     )
+
+
+def test_otel_attributes_otel_span_filter(client: weave_client.WeaveClient):
+    """Filter on attributes.otel_span.* paths must hit otel_dump.
+
+    Pre-migration-020 calls keep the span at attributes.$.otel_span, post-
+    migration calls put it in otel_dump; the read path masks the difference.
+    Filters need the same affordance.
+    """
+    export_req = create_test_export_request()
+    project_id = client.project_id
+    export_req.project_id = project_id
+    export_req.wb_user_id = "abcd123"
+
+    processed_spans_list = export_req.processed_spans
+    span = processed_spans_list[0].resource_spans.scope_spans[0].spans[0]
+    del span.attributes[:]
+
+    kv = KeyValue()
+    kv.key = "gen_ai.response.model"
+    kv.value.string_value = "gpt-4"
+    span.attributes.append(kv)
+
+    export_req.processed_spans = processed_spans_list
+    client.server.otel_export(export_req)
+
+    matching = client.server.calls_query(
+        tsi.CallsQueryReq(
+            project_id=project_id,
+            query={
+                "$expr": {
+                    "$eq": [
+                        {
+                            "$getField": (
+                                "attributes.otel_span.attributes.gen_ai.response.model"
+                            )
+                        },
+                        {"$literal": "gpt-4"},
+                    ]
+                }
+            },
+        )
+    )
+    assert len(matching.calls) == 1
+
+    miss = client.server.calls_query(
+        tsi.CallsQueryReq(
+            project_id=project_id,
+            query={
+                "$expr": {
+                    "$eq": [
+                        {
+                            "$getField": (
+                                "attributes.otel_span.attributes.gen_ai.response.model"
+                            )
+                        },
+                        {"$literal": "claude-3"},
+                    ]
+                }
+            },
+        )
+    )
+    assert len(miss.calls) == 0
+
+    client.server.calls_delete(
+        tsi.CallsDeleteReq(
+            project_id=project_id,
+            call_ids=[matching.calls[0].id],
+            wb_user_id=None,
+        )
+    )

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -2074,7 +2074,9 @@ def test_otel_attributes_otel_span_filter_legacy_fallback(
                 op_name="legacy_otel_op",
                 attributes={
                     "otel_span": {
-                        "attributes": {"gen_ai": {"response": {"model": "claude-legacy"}}}
+                        "attributes": {
+                            "gen_ai": {"response": {"model": "claude-legacy"}}
+                        }
                     }
                 },
                 inputs={},

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -2051,3 +2051,81 @@ def test_otel_attributes_otel_span_filter(client: weave_client.WeaveClient):
             wb_user_id=None,
         )
     )
+
+
+def test_otel_attributes_otel_span_filter_legacy_fallback(
+    client: weave_client.WeaveClient,
+):
+    """Pre-migration-020 rows store OTel data at attributes.$.otel_span.
+
+    Filters on attributes.otel_span.* must still find them via the
+    `attributes_dump` fallback when otel_dump is unset.
+    """
+    project_id = client.project_id
+    call_id = str(uuid.uuid4())
+
+    client.server.call_start(
+        tsi.CallStartReq(
+            start=tsi.StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=call_id,
+                trace_id=call_id,
+                started_at=datetime.now(),
+                op_name="legacy_otel_op",
+                attributes={
+                    "otel_span": {
+                        "attributes": {"gen_ai": {"response": {"model": "claude-legacy"}}}
+                    }
+                },
+                inputs={},
+                wb_user_id="abcd123",
+            )
+        )
+    )
+
+    matching = client.server.calls_query(
+        tsi.CallsQueryReq(
+            project_id=project_id,
+            query={
+                "$expr": {
+                    "$eq": [
+                        {
+                            "$getField": (
+                                "attributes.otel_span.attributes.gen_ai.response.model"
+                            )
+                        },
+                        {"$literal": "claude-legacy"},
+                    ]
+                }
+            },
+        )
+    )
+    assert len(matching.calls) == 1
+    assert matching.calls[0].id == call_id
+
+    miss = client.server.calls_query(
+        tsi.CallsQueryReq(
+            project_id=project_id,
+            query={
+                "$expr": {
+                    "$eq": [
+                        {
+                            "$getField": (
+                                "attributes.otel_span.attributes.gen_ai.response.model"
+                            )
+                        },
+                        {"$literal": "gpt-4"},
+                    ]
+                }
+            },
+        )
+    )
+    assert len(miss.calls) == 0
+
+    client.server.calls_delete(
+        tsi.CallsDeleteReq(
+            project_id=project_id,
+            call_ids=[call_id],
+            wb_user_id=None,
+        )
+    )

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -258,6 +258,47 @@ class CallsMergedDynamicField(CallsMergedAggField):
         return True
 
 
+class CallsMergedOtelSpanField(CallsMergedField):
+    """OTel span field that reads from `otel_dump` with a legacy fallback.
+
+    Migration 020 moved OTel data into a dedicated `otel_dump` column. Calls
+    ingested before that migration still carry the full span inline at
+    `attributes_dump.$.otel_span.*`. The read path injects either source back
+    into `attributes["otel_span"]` so the client never knows the difference;
+    this field gives filters the same affordance.
+    """
+
+    extra_path: list[str] | None = None
+
+    def as_sql(
+        self,
+        pb: ParamBuilder,
+        table_alias: str,
+        cast: tsi_query.CastTo | None = None,
+        use_agg_fn: bool = True,
+    ) -> str:
+        otel_root = maybe_agg(f"{table_alias}.otel_dump", use_agg_fn)
+        attr_root = maybe_agg(f"{table_alias}.attributes_dump", use_agg_fn)
+        otel_sql = json_dump_field_as_sql(
+            pb, table_alias, otel_root, self.extra_path, cast=None
+        )
+        legacy_path = ["otel_span", *(self.extra_path or [])]
+        attr_sql = json_dump_field_as_sql(
+            pb, table_alias, attr_root, legacy_path, cast=None
+        )
+        sql = f"if({otel_root} IS NULL, {attr_sql}, {otel_sql})"
+        return clickhouse_cast(sql, cast)
+
+    def with_path(self, path: list[str]) -> "CallsMergedOtelSpanField":
+        return CallsMergedOtelSpanField(
+            field=self.field,
+            extra_path=[*(self.extra_path or []), *path],
+        )
+
+    def is_heavy(self) -> bool:
+        return True
+
+
 class CallsMergedSummaryField(CallsMergedField):
     """Field class for computed summary values."""
 
@@ -1842,6 +1883,16 @@ def get_field_by_name(name: str) -> CallsMergedField:
             # Handle summary.weave.* fields
             summary_field = name[len("summary.weave.") :]
             return CallsMergedSummaryField(field=name, summary_field=summary_field)
+        elif name == "attributes.otel_span" or name.startswith("attributes.otel_span."):
+            # OTel span data lives in `otel_dump` post-migration 020 (and
+            # legacy projects keep it under `attributes_dump.$.otel_span.*`).
+            # The read path masks the storage split by re-injecting otel_dump
+            # back as attributes["otel_span"]; do the same on the filter side.
+            sub = name[len("attributes.otel_span") :].lstrip(".")
+            field = CallsMergedOtelSpanField(field="otel_dump")
+            if sub:
+                return field.with_path(split_escaped_field_path(sub))
+            return field
         else:
             field_parts = split_escaped_field_path(name)
             start_part = field_parts[0]
@@ -2276,6 +2327,7 @@ def process_query_to_conditions(
                     CallsMergedAggField,
                     CallsMergedFeedbackPayloadField,
                     CallsMergedQueueItemField,
+                    CallsMergedOtelSpanField,
                 ),
             ):
                 field = structured_field.as_sql(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -276,18 +276,28 @@ class CallsMergedOtelSpanField(CallsMergedField):
         table_alias: str,
         cast: tsi_query.CastTo | None = None,
         use_agg_fn: bool = True,
+        read_table: "ReadTable" = ReadTable.CALLS_MERGED,
     ) -> str:
         otel_root = maybe_agg(f"{table_alias}.otel_dump", use_agg_fn)
         attr_root = maybe_agg(f"{table_alias}.attributes_dump", use_agg_fn)
+        # Push the cast down into each branch so JSON_VALUE results are
+        # converted with `clickhouse_cast_json_value` semantics (the 'true'/'false'
+        # multiIf for bool, etc.), not the outer `clickhouse_cast` wrapper.
         otel_sql = json_dump_field_as_sql(
-            pb, table_alias, otel_root, self.extra_path, cast=None
+            pb, table_alias, otel_root, self.extra_path, cast=cast
         )
         legacy_path = ["otel_span", *(self.extra_path or [])]
         attr_sql = json_dump_field_as_sql(
-            pb, table_alias, attr_root, legacy_path, cast=None
+            pb, table_alias, attr_root, legacy_path, cast=cast
         )
-        sql = f"if({otel_root} IS NULL, {attr_sql}, {otel_sql})"
-        return clickhouse_cast(sql, cast)
+        # `otel_dump` is a sentinel field (see ch_sentinel_values.py): on
+        # calls_complete it's non-nullable with `''` as the sentinel, so a raw
+        # `IS NULL` would always be false there. Route through null_check_sql
+        # so the dispatch is correct for both read tables.
+        otel_null_check = ch_sentinel_values.null_check_sql(
+            "otel_dump", otel_root, read_table, pb
+        )
+        return f"if({otel_null_check}, {attr_sql}, {otel_sql})"
 
     def with_path(self, path: list[str]) -> "CallsMergedOtelSpanField":
         return CallsMergedOtelSpanField(
@@ -666,6 +676,7 @@ class OrderField(BaseModel):
                 QueryBuilderDynamicField,
                 CallsMergedDynamicField,
                 CallsMergedFeedbackPayloadField,
+                CallsMergedOtelSpanField,
             ),
         ):
             # Prioritize existence, then cast to double, then str
@@ -728,6 +739,14 @@ class OrderField(BaseModel):
         parts = []
         for cast_to, direction in options:
             if isinstance(self.field, CallsMergedSummaryField):
+                field_sql = self.field.as_sql(
+                    pb,
+                    table_alias,
+                    cast_to,
+                    use_agg_fn=use_agg_fn,
+                    read_table=read_table,
+                )
+            elif isinstance(self.field, CallsMergedOtelSpanField):
                 field_sql = self.field.as_sql(
                     pb,
                     table_alias,
@@ -1001,7 +1020,14 @@ class CallsQuery(BaseModel):
             if isinstance(field_obj, CallsMergedFeedbackPayloadField):
                 continue
 
-            if isinstance(
+            if isinstance(field_obj, CallsMergedOtelSpanField):
+                # Order expression coalesces `otel_dump` with `attributes_dump.$.otel_span.*`
+                # so both base columns need to live in the CTE.
+                for base_name in ("otel_dump", "attributes_dump"):
+                    base_field = get_field_by_name(base_name)
+                    if base_field not in select_fields:
+                        select_fields.append(base_field)
+            elif isinstance(
                 field_obj,
                 (CallsMergedDynamicField, QueryBuilderDynamicField),
             ):
@@ -2169,6 +2195,15 @@ def process_query_to_conditions(
                     cast=cast,
                     use_agg_fn=use_agg_fn,
                 )
+            if isinstance(structured_field, CallsMergedOtelSpanField):
+                raw_fields_used[structured_field.field] = structured_field
+                return structured_field.as_sql(
+                    param_builder,
+                    table_alias,
+                    cast=cast,
+                    use_agg_fn=use_agg_fn,
+                    read_table=read_table,
+                )
             if (
                 isinstance(structured_field, CallsMergedFeedbackPayloadField)
                 and structured_field.feedback_type != "*"
@@ -2320,6 +2355,13 @@ def process_query_to_conditions(
                     use_agg_fn=use_agg_fn,
                     read_table=read_table,
                 )
+            elif isinstance(structured_field, CallsMergedOtelSpanField):
+                field = structured_field.as_sql(
+                    param_builder,
+                    table_alias,
+                    use_agg_fn=use_agg_fn,
+                    read_table=read_table,
+                )
             elif isinstance(
                 structured_field,
                 (
@@ -2327,7 +2369,6 @@ def process_query_to_conditions(
                     CallsMergedAggField,
                     CallsMergedFeedbackPayloadField,
                     CallsMergedQueueItemField,
-                    CallsMergedOtelSpanField,
                 ),
             ):
                 field = structured_field.as_sql(

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -5302,6 +5302,22 @@ def _transform_external_calls_field_to_internal_calls_field(
         else:
             json_path = quote_json_path(field[len("output.") :])
         field = "output"
+    elif field == "attributes.otel_span" or field.startswith("attributes.otel_span."):
+        # Migration 020 moved OTel data into `otel_dump`. The read path injects
+        # it back as attributes["otel_span"] regardless of where it lives, so
+        # the filter path needs the same affordance: prefer otel_dump, fall
+        # back to attributes.$.otel_span for pre-migration rows.
+        sub = field[len("attributes.otel_span") :].lstrip(".")
+        otel_path = "$" if not sub else quote_json_path(sub)
+        legacy_inner = "otel_span" if not sub else f"otel_span.{sub}"
+        legacy_path = quote_json_path(legacy_inner)
+        sql_type = "TEXT"
+        if cast is not None:
+            sql_type = _sqlite_sql_type_for_cast(cast)
+        otel_extract = f"json_extract(otel_dump, '{otel_path}')"
+        legacy_extract = f"json_extract(attributes, '{legacy_path}')"
+        coalesced = f"coalesce({otel_extract}, {legacy_extract})"
+        return f"CAST({coalesced} AS {sql_type})"
     elif field == "attributes" or field.startswith("attributes."):
         if field == "attributes":
             json_path = "$"

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -5311,13 +5311,29 @@ def _transform_external_calls_field_to_internal_calls_field(
         otel_path = "$" if not sub else quote_json_path(sub)
         legacy_inner = "otel_span" if not sub else f"otel_span.{sub}"
         legacy_path = quote_json_path(legacy_inner)
+        # Mirror the ClickHouse `if(otel_dump IS NULL, attr, otel)` dispatch
+        # via a CASE so legacy rows (otel_dump unset) fall through to the
+        # attributes column. We pick the type from the same branch to keep
+        # the inferred-cast pipeline below honest.
+        otel_extract = f"json_extract(otel_dump, '{otel_path}')"
+        legacy_extract = f"json_extract(attributes, '{legacy_path}')"
+        otel_type = f"json_type(otel_dump, '{otel_path}')"
+        legacy_type = f"json_type(attributes, '{legacy_path}')"
+        json_extract_sql = (
+            f"CASE WHEN otel_dump IS NULL THEN {legacy_extract} ELSE {otel_extract} END"
+        )
+        json_type_sql = (
+            f"CASE WHEN otel_dump IS NULL THEN {legacy_type} ELSE {otel_type} END"
+        )
         sql_type = "TEXT"
         if cast is not None:
             sql_type = _sqlite_sql_type_for_cast(cast)
-        otel_extract = f"json_extract(otel_dump, '{otel_path}')"
-        legacy_extract = f"json_extract(attributes, '{legacy_path}')"
-        coalesced = f"coalesce({otel_extract}, {legacy_extract})"
-        return f"CAST({coalesced} AS {sql_type})"
+        result = f"CAST({json_extract_sql} AS {sql_type})"
+        if cast in {"int", "double", "bool"}:
+            result = _sqlite_inferred_json_cast_sql(
+                json_extract_sql, json_type_sql, cast, sql_type
+            )
+        return result
     elif field == "attributes" or field.startswith("attributes."):
         if field == "attributes":
             json_path = "$"


### PR DESCRIPTION
## Summary
- [WB-30788](https://coreweave.atlassian.net/browse/WB-30788): filtering on OTel span fields under attributes returns 0 rows on new projects.
- Migration 020 (#5642) moved OTel data from `attributes_dump.$.otel_span.*` into a dedicated `otel_dump` column. The read path injects it back as `call.attributes["otel_span"]` so clients still see the same shape, but the filter path in `calls_query_builder.get_field_by_name` was still resolving `attributes.otel_span.*` against `attributes_dump`, where the data no longer lives.
- New `CallsMergedOtelSpanField` reads from `otel_dump` with a per-row fallback to `attributes_dump.$.otel_span.*` so pre-#5642 projects keep working. Mirror the redirect in `sqlite_trace_server`.

## Testing
- Unit: SQL assertion that `attributes.otel_span.attributes.gen_ai.model = "gpt-4"` resolves to `if(any(otel_dump) IS NULL, JSON_VALUE(attributes_dump, '$.otel_span.attributes.gen_ai.model'), JSON_VALUE(otel_dump, '$.attributes.gen_ai.model'))`.
- E2E: OTel export + filter through `calls_query`, both sqlite and clickhouse backends.

[WB-30788]: https://coreweave.atlassian.net/browse/WB-30788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ