### PR TITLE
fix(weave): persist expand_columns in SavedViewDefinition

### DIFF
--- a/tests/trace/test_saved_view.py
+++ b/tests/trace/test_saved_view.py
@@ -235,6 +235,19 @@ def test_saved_view_load(client):
     assert loaded_view.base.definition.cols["attributes.weave.client_version"] is True
 
 
+def test_saved_view_expand_columns_round_trip(client):
+    # A view that filters on `inputs.self.base_model_name` needs `inputs.self`
+    # in `expand_columns` for the trace server to join through the ref at query
+    # time. Persist + reload must preserve the field, otherwise the saved view
+    # reloads with the filter intact but the join missing and returns 0 rows.
+    saved_view = weave.SavedView("traces", "Filter on nested ref")
+    saved_view.base.definition.expand_columns = ["inputs.self"]
+    saved_view.save()
+    uri = saved_view.ref.uri
+    loaded_view = weave.SavedView.load(uri)
+    assert loaded_view.base.definition.expand_columns == ["inputs.self"]
+
+
 def test_saved_view_column_pinning():
     view = weave.SavedView("traces", "My saved view")
 

--- a/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
+++ b/weave/trace_server/interface/builtin_object_classes/generated/generated_builtin_object_class_schemas.json
@@ -2589,6 +2589,21 @@
           "default": null,
           "title": "Column Order"
         },
+        "expand_columns": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Expand Columns"
+        },
         "header_depth": {
           "anyOf": [
             {

--- a/weave/trace_server/interface/builtin_object_classes/saved_view.py
+++ b/weave/trace_server/interface/builtin_object_classes/saved_view.py
@@ -91,6 +91,14 @@ class SavedViewDefinition(BaseModel):
     # Used by the frontend to persist user-defined column ordering.
     column_order: list[str] | None = Field(default=None)
 
+    # Paths to columns whose values are refs to other objects and that must be
+    # dereferenced for filtering / sorting / display to work. Mirrors the
+    # `expand_columns` field of `CallsQueryReq` — when a saved view filters on
+    # a sub-field of a referenced object (e.g. `inputs.self.base_model_name`),
+    # the parent ref path (`inputs.self`) must be in this list so the trace
+    # server joins through to the referenced object at query time.
+    expand_columns: list[str] | None = Field(default=None)
+
     header_depth: int | None = Field(default=None)
 
     pin: Pin | None = Field(default=None)


### PR DESCRIPTION
## Description

When a user saves a Weave traces view with a filter on a sub-field of a referenced object — say `inputs.self.base_model_name contains "claude"` where `self` is a `weave.Model` reference — the saved view round-trip loses the join hint that lets the trace server resolve that ref at query time. The frontend already carries the hint in the URL as `expandRefCols`, but the persisted `SavedViewDefinition` had no slot for it, so pydantic silently dropped the field on the way in and reloading the saved view returned zero rows even though the filter chip was preserved.

This change adds `expand_columns: list[str] | None` to `SavedViewDefinition`, mirroring the existing `expand_columns` field on `CallsQueryReq`. The trace server already knows what to do with this list — at query time it walks each path, joins through the referenced object, and the filter / sort over the sub-field works as it did at create time. The accompanying frontend PR in `wandb/core` writes the field on save and restores it to `expandRefCols` on load so the rest of the table machinery picks it up the way it always has from the URL.

The visible reproduction and the before/after screenshots live on the companion PR: [wandb/core#44157](https://github.com/wandb/core/pull/44157). Tracking ticket: [WB-34441](https://coreweave.atlassian.net/browse/WB-34441). Original report: [Slack thread](https://coreweave.slack.com/archives/C0880TX4U5V/p1778882889944459).

## Why this approach

A saved view is the single source of truth for what the user wants to see. If it carries `filter`, `query`, `sort_by`, and column visibility but not the ref-expansion list those fields depend on, those fields are effectively unsaveable for any view that touches a nested ref — and the failure mode is silent (empty result table). Persisting `expand_columns` in the same place as `filter` and `sort_by` keeps the field next to the state that requires it, and reuses the same `list[str]` shape the trace server already accepts.

## Testing

Added `test_saved_view_expand_columns_round_trip` in `tests/trace/test_saved_view.py` that asserts the field is preserved through `save()` and `weave.SavedView.load()`. The existing 15 tests in that file continue to pass:

```
tests/trace/test_saved_view.py ................                          [100%]
============================== 16 passed in 3.04s ==============================
```

## Backward compatibility

The field is optional with a default of `None`. Existing saved views, which do not carry the field, validate and load unchanged; the only behavioral difference is that newly saved views that filter on nested ref paths now restore their join hint on reload.

[WB-34441]: https://coreweave.atlassian.net/browse/WB-34441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ