### PR TITLE
chore(weave): allow limited calls_query_stats 

### DIFF
--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -247,6 +247,12 @@ export interface CallsQueryStatsReq {
 export interface CallsQueryStatsRes {
   /** Count */
   count: number;
+  /**
+   * Has More
+   * True when count saturated the request's limit (caller-supplied or the server's defense-in-depth ceiling). Clients should render the count as e.g. '10,000+'.
+   * @default false
+   */
+  has_more?: boolean;
 }
 
 /** ContainsOperation */

--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -1290,7 +1290,15 @@
         "title": "CallsQueryStatsReq"
       },
       "CallsQueryStatsRes": {
-        "properties": {"count": {"type": "integer", "title": "Count"}},
+        "properties": {
+          "count": {"type": "integer", "title": "Count"},
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More",
+            "default": false,
+            "description": "True when count saturated the request's limit (caller-supplied or the server's defense-in-depth ceiling). Clients should render the count as e.g. '10,000+'."
+          }
+        },
         "type": "object",
         "required": ["count"],
         "title": "CallsQueryStatsRes"

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4192,18 +4192,22 @@ def test_stats_query_calls_complete_with_feedback_filter_uses_count_distinct() -
     )
 
 
-def test_stats_query_calls_merged_caps_at_default_max_limit() -> None:
-    """Caller didn't pass a limit -> cap at DEFAULT_STATS_MAX_LIMIT, emit
-    `has_more`, and request the streaming-aggregate setting.
+def test_stats_query_calls_merged_no_caller_limit_skips_cap() -> None:
+    """No caller-supplied limit -> no server cap, no setting, has_more=0.
+
+    TODO: when the server-side defense-in-depth cap is re-enabled in
+    `build_calls_stats_query`, restore the cap assertions (settings ==
+    {"optimize_aggregation_in_order": 1}, has_more = toUInt8(count() >= 1M),
+    inner LIMIT 1000000).
     """
     req = tsi.CallsQueryStatsReq(project_id="project")
     pb = ParamBuilder("pb")
     query, _columns, settings = build_calls_stats_query(req, pb, ReadTable.CALLS_MERGED)
-    assert settings == {"optimize_aggregation_in_order": 1}
+    assert settings == {}
     assert_stats_sql(
         req,
         """
-        SELECT count() AS count, toUInt8(count() >= 1000000) AS has_more
+        SELECT count() AS count, toUInt8(0) AS has_more
         FROM (
             SELECT calls_merged.id AS id
             FROM calls_merged
@@ -4214,7 +4218,6 @@ def test_stats_query_calls_merged_caps_at_default_max_limit() -> None:
                 AND
                 ((NOT ((any(calls_merged.started_at) IS NULL))))
             )
-            LIMIT 1000000
         )
         """,
         {"pb_0": "project"},

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4195,10 +4195,9 @@ def test_stats_query_calls_complete_with_feedback_filter_uses_count_distinct() -
 def test_stats_query_calls_merged_no_caller_limit_skips_cap() -> None:
     """No caller-supplied limit -> no server cap, no setting, has_more=0.
 
-    TODO: when the server-side defense-in-depth cap is re-enabled in
-    `build_calls_stats_query`, restore the cap assertions (settings ==
-    {"optimize_aggregation_in_order": 1}, has_more = toUInt8(count() >= 1M),
-    inner LIMIT 1000000).
+    When the cap deferred behind `DEFAULT_STATS_MAX_LIMIT` is re-enabled, this
+    test should assert the streaming-aggregate setting + inner `LIMIT 1000000`
+    + `has_more = toUInt8(count() >= 1000000)`.
     """
     req = tsi.CallsQueryStatsReq(project_id="project")
     pb = ParamBuilder("pb")
@@ -4266,7 +4265,7 @@ def test_stats_query_calls_merged_no_cap_when_summing_storage() -> None:
     )
     assert settings == {}
     assert "LIMIT" not in query
-    assert "has_more" in query
+    assert "toUInt8(0) AS has_more" in query
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -16,6 +16,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     build_calls_complete_delete_query,
     build_calls_complete_update_end_query,
     build_calls_complete_update_query,
+    build_calls_stats_query,
 )
 from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH
 from weave.trace_server.errors import InvalidFieldError
@@ -4063,7 +4064,7 @@ def test_stats_query_calls_complete_flat_count() -> None:
     assert_stats_sql(
         req,
         """
-        SELECT count() AS count
+        SELECT count() AS count, toUInt8(0) AS has_more
         FROM calls_complete
         PREWHERE calls_complete.project_id = {pb_1:String}
         WHERE 1
@@ -4086,7 +4087,7 @@ def test_stats_query_calls_complete_flat_count_with_filter() -> None:
     assert_stats_sql(
         req,
         """
-        SELECT count() AS count
+        SELECT count() AS count, toUInt8(0) AS has_more
         FROM calls_complete
         PREWHERE calls_complete.project_id = {pb_2:String}
         WHERE ((calls_complete.op_name IN {pb_1:Array(String)})
@@ -4112,6 +4113,7 @@ def test_stats_query_calls_complete_flat_with_total_storage_size() -> None:
         req,
         """
         SELECT count() AS count,
+               toUInt8(0) AS has_more,
                sum(coalesce(CASE
                    WHEN calls_complete.parent_id = {pb_2:String}
                         THEN rolled_up_cms.total_storage_size_bytes
@@ -4163,7 +4165,7 @@ def test_stats_query_calls_complete_with_feedback_filter_uses_count_distinct() -
     assert_stats_sql(
         req,
         """
-        SELECT count(DISTINCT calls_complete.id) AS count
+        SELECT count(DISTINCT calls_complete.id) AS count, toUInt8(0) AS has_more
         FROM calls_complete
         LEFT JOIN (
             SELECT * FROM feedback WHERE feedback.project_id = {pb_4:String}
@@ -4190,13 +4192,18 @@ def test_stats_query_calls_complete_with_feedback_filter_uses_count_distinct() -
     )
 
 
-def test_stats_query_calls_merged_uses_subquery() -> None:
-    """Stats query on calls_merged should use subquery wrapping (GROUP BY requires it)."""
+def test_stats_query_calls_merged_caps_at_default_max_limit() -> None:
+    """Caller didn't pass a limit -> cap at DEFAULT_STATS_MAX_LIMIT, emit
+    `has_more`, and request the streaming-aggregate setting.
+    """
     req = tsi.CallsQueryStatsReq(project_id="project")
+    pb = ParamBuilder("pb")
+    query, _columns, settings = build_calls_stats_query(req, pb, ReadTable.CALLS_MERGED)
+    assert settings == {"optimize_aggregation_in_order": 1}
     assert_stats_sql(
         req,
         """
-        SELECT count()
+        SELECT count() AS count, toUInt8(count() >= 1000000) AS has_more
         FROM (
             SELECT calls_merged.id AS id
             FROM calls_merged
@@ -4207,11 +4214,56 @@ def test_stats_query_calls_merged_uses_subquery() -> None:
                 AND
                 ((NOT ((any(calls_merged.started_at) IS NULL))))
             )
+            LIMIT 1000000
         )
         """,
         {"pb_0": "project"},
         read_table=ReadTable.CALLS_MERGED,
     )
+
+
+def test_stats_query_calls_merged_caller_limit_keeps_setting() -> None:
+    """Caller-supplied limit also triggers the streaming-aggregate setting and
+    `has_more` reflects saturation against the caller's limit.
+    """
+    req = tsi.CallsQueryStatsReq(project_id="project", limit=5)
+    pb = ParamBuilder("pb")
+    query, _columns, settings = build_calls_stats_query(req, pb, ReadTable.CALLS_MERGED)
+    assert settings == {"optimize_aggregation_in_order": 1}
+    assert_stats_sql(
+        req,
+        """
+        SELECT count() AS count, toUInt8(count() >= 5) AS has_more
+        FROM (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_0:String}
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((any(calls_merged.deleted_at) IS NULL))
+                AND
+                ((NOT ((any(calls_merged.started_at) IS NULL))))
+            )
+            LIMIT 5
+        )
+        """,
+        {"pb_0": "project"},
+        read_table=ReadTable.CALLS_MERGED,
+    )
+
+
+def test_stats_query_calls_merged_no_cap_when_summing_storage() -> None:
+    """include_total_storage_size needs every row, so no cap and no setting."""
+    req = tsi.CallsQueryStatsReq(
+        project_id="project",
+        include_total_storage_size=True,
+    )
+    query, _columns, settings = build_calls_stats_query(
+        req, ParamBuilder("pb"), ReadTable.CALLS_MERGED
+    )
+    assert settings == {}
+    assert "LIMIT" not in query
+    assert "has_more" in query
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trace_server/query_builder/utils.py
+++ b/tests/trace_server/query_builder/utils.py
@@ -169,7 +169,7 @@ def assert_stats_sql(
         read_table: Which table to query (calls_merged or calls_complete)
     """
     pb = ParamBuilder("pb")
-    query, _columns = build_calls_stats_query(req, pb, read_table)
+    query, _columns, _settings = build_calls_stats_query(req, pb, read_table)
     params = pb.get_params()
 
     exp_formatted = sqlparse.format(exp_query, reindent=True).strip()

--- a/tests/trace_server/test_sqlite_trace_server.py
+++ b/tests/trace_server/test_sqlite_trace_server.py
@@ -120,6 +120,60 @@ def _make_server_with_call(
     return server, call_id
 
 
+def test_sqlite_calls_query_stats_sets_has_more_when_limit_saturates():
+    """Backend-equivalence with the CH path: has_more must be True when
+    count==limit (caller's count is truncated) and False otherwise. Sqlite
+    previously returned the Pydantic default (False) regardless, which makes
+    a dev frontend hitting sqlite silently disagree with prod on the "X+" cap.
+    """
+    server = slts.SqliteTraceServer(":memory:")
+    server.drop_tables()
+    server.setup_tables()
+    try:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        for i in range(3):
+            server.call_start(
+                tsi.CallStartReq(
+                    start=tsi.StartedCallSchemaForInsert(
+                        project_id="test_project",
+                        id=f"call_{i}",
+                        trace_id=f"trace_{i}",
+                        op_name="op",
+                        started_at=now,
+                        attributes={},
+                        inputs={},
+                    )
+                )
+            )
+            server.call_end(
+                tsi.CallEndReq(
+                    end=tsi.EndedCallSchemaForInsert(
+                        project_id="test_project",
+                        id=f"call_{i}",
+                        ended_at=now,
+                        output=None,
+                        summary={},
+                    )
+                )
+            )
+
+        # 3 calls, limit=2 -> count==2, has_more=True (truncated).
+        truncated = server.calls_query_stats(
+            tsi.CallsQueryStatsReq(project_id="test_project", limit=2)
+        )
+        assert truncated.count == 2
+        assert truncated.has_more is True
+
+        # 3 calls, limit=10 -> count==3, has_more=False (room to spare).
+        exact = server.calls_query_stats(
+            tsi.CallsQueryStatsReq(project_id="test_project", limit=10)
+        )
+        assert exact.count == 3
+        assert exact.has_more is False
+    finally:
+        server.close()
+
+
 def test_sqlite_storage_size_bytes_populated_on_call_end():
     """storage_size_bytes column is populated when a call is started then ended."""
     server, call_id = _make_server_with_call(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -87,8 +87,10 @@ logger = logging.getLogger(__name__)
 CTE_FILTERED_CALLS = "filtered_calls"
 CTE_ALL_CALLS = "all_calls"
 
-# Defense-in-depth cap for stats counts on calls_merged; protects callers that
-# forgot to set their own limit. UI clients should pass a smaller `limit`.
+# Deferred: server-side defense-in-depth cap for unfiltered calls_merged stats.
+# Wired up in `build_calls_stats_query` but currently commented out; callers
+# without a `limit` still get an exact count. Flip this on when we see real
+# >>1M-count requests in the wild.
 DEFAULT_STATS_MAX_LIMIT = 1_000_000
 
 
@@ -2794,8 +2796,8 @@ def build_calls_stats_query(
         )
         return (query, aggregated_columns.keys(), settings)
 
-    # TODO: re-enable server-side defense-in-depth cap. Disabled for now so
-    # callers without a `limit` get an exact count instead of a silent ceiling.
+    # Deferred (see DEFAULT_STATS_MAX_LIMIT): uncomment to apply the server-side
+    # cap when the caller didn't pass a limit.
     # if req.limit is None and not req.include_total_storage_size:
     #     req = req.model_copy(update={"limit": DEFAULT_STATS_MAX_LIMIT})
     if req.limit is not None:

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -87,6 +87,10 @@ logger = logging.getLogger(__name__)
 CTE_FILTERED_CALLS = "filtered_calls"
 CTE_ALL_CALLS = "all_calls"
 
+# Defense-in-depth cap for stats counts on calls_merged; protects callers that
+# forgot to set their own limit. UI clients should pass a smaller `limit`.
+DEFAULT_STATS_MAX_LIMIT = 1_000_000
+
 
 @dataclass(frozen=True, slots=True)
 class FilterConditionsResult:
@@ -2753,11 +2757,10 @@ def build_calls_stats_query(
     req: tsi.CallsQueryStatsReq,
     param_builder: ParamBuilder,
     read_table: ReadTable = ReadTable.CALLS_MERGED,
-) -> tuple[str, KeysView[str]]:
+) -> tuple[str, KeysView[str], dict[str, int | str]]:
     """Build a stats query for calls, automatically using optimized queries when possible.
 
     This function handles both optimized special-case queries and the general case.
-    Returns a tuple of (query_sql, column_names).
 
     Args:
         req: The stats query request
@@ -2765,13 +2768,17 @@ def build_calls_stats_query(
         read_table: Which calls table to read from
 
     Returns:
-        Tuple of (SQL query string, column names in the result)
+        Tuple of (SQL query string, column names in the result, ClickHouse
+        query settings to apply at execution time).
     """
-    aggregated_columns = {"count": "count()"}
+    aggregated_columns: dict[str, str] = {
+        "count": "count()",
+        "has_more": "toUInt8(0)",
+    }
+    settings: dict[str, int | str] = {}
 
-    # Try optimized special case queries first
     if opt_query := _try_optimized_stats_query(req, param_builder, read_table):
-        return (opt_query, aggregated_columns.keys())
+        return (opt_query, aggregated_columns.keys(), settings)
 
     if req.include_total_storage_size:
         aggregated_columns["total_storage_size_bytes"] = (
@@ -2785,14 +2792,20 @@ def build_calls_stats_query(
         query = _build_calls_complete_stats_query(
             req, param_builder, aggregated_columns
         )
-        return (query, aggregated_columns.keys())
+        return (query, aggregated_columns.keys(), settings)
 
-    # For calls_merged, use subquery wrapping (GROUP BY requires materialization)
+    # include_total_storage_size needs every row, so skip the cap there.
+    if req.limit is None and not req.include_total_storage_size:
+        req = req.model_copy(update={"limit": DEFAULT_STATS_MAX_LIMIT})
+    if req.limit is not None:
+        aggregated_columns["has_more"] = f"toUInt8(count() >= {req.limit})"
+        settings["optimize_aggregation_in_order"] = 1
+
     cq = _build_stats_calls_query(req, read_table)
     inner_query = cq.as_sql(param_builder)
-    calls_query_sql = f"SELECT {', '.join(aggregated_columns[k] for k in aggregated_columns)} FROM ({inner_query})"
+    calls_query_sql = f"SELECT {', '.join(aggregated_columns[k] + ' AS ' + k for k in aggregated_columns)} FROM ({inner_query})"
 
-    return (calls_query_sql, aggregated_columns.keys())
+    return (calls_query_sql, aggregated_columns.keys(), settings)
 
 
 def _build_stats_calls_query(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -2794,9 +2794,10 @@ def build_calls_stats_query(
         )
         return (query, aggregated_columns.keys(), settings)
 
-    # include_total_storage_size needs every row, so skip the cap there.
-    if req.limit is None and not req.include_total_storage_size:
-        req = req.model_copy(update={"limit": DEFAULT_STATS_MAX_LIMIT})
+    # TODO: re-enable server-side defense-in-depth cap. Disabled for now so
+    # callers without a `limit` get an exact count instead of a silent ceiling.
+    # if req.limit is None and not req.include_total_storage_size:
+    #     req = req.model_copy(update={"limit": DEFAULT_STATS_MAX_LIMIT})
     if req.limit is not None:
         aggregated_columns["has_more"] = f"toUInt8(count() >= {req.limit})"
         settings["optimize_aggregation_in_order"] = 1

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1151,8 +1151,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             req.project_id, self.ch_client
         )
         pb = ParamBuilder()
-        query, columns = build_calls_stats_query(req, pb, read_table)
-        raw_res = self._query(query, pb.get_params())
+        query, columns, settings = build_calls_stats_query(req, pb, read_table)
+        raw_res = self._query(query, pb.get_params(), settings=settings or None)
 
         res_dict = (
             dict(zip(columns, raw_res.result_rows[0], strict=False))
@@ -1162,6 +1162,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.CallsQueryStatsRes(
             count=res_dict.get("count", 0),
+            has_more=bool(res_dict.get("has_more", 0)),
             total_storage_size_bytes=res_dict.get("total_storage_size_bytes"),
         )
 

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1604,8 +1604,10 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                 include_total_storage_size=req.include_total_storage_size,
             )
         ).calls
+        count = len(calls)
         return tsi.CallsQueryStatsRes(
-            count=len(calls),
+            count=count,
+            has_more=req.limit is not None and count >= req.limit,
             total_storage_size_bytes=sum(
                 call.total_storage_size_bytes
                 for call in calls

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -660,6 +660,8 @@ class CallsQueryStatsReq(BaseModelStrict):
 
 class CallsQueryStatsRes(BaseModel):
     count: int
+    # True when count saturated the request's limit; clients render as "<count>+".
+    has_more: bool = False
     total_storage_size_bytes: int | None = None
 
 


### PR DESCRIPTION
## Summary
- Add `has_more: bool` to `CallsQueryStatsRes`, projected in-SQL as `toUInt8(count() >= limit)` so the FE can render "X+" without a second round-trip. Defaults to `False` so older clients ignore it.
- Sqlite mirrors `has_more` (computed in Python from `len(calls) >= req.limit`) so a dev frontend on sqlite doesn't silently disagree with prod on the "X+" cap.
- The 1M defense-in-depth cap is **deferred**: `DEFAULT_STATS_MAX_LIMIT` and the re-enable block are wired up but commented out, so callers without a limit still get an exact count. Flip on when we see real >>1M-count requests.

## Performance
Bench on local CH (10M rows / 5M ids, 2 events/call + 1% deletes, best of 3, wall / read), with caller-supplied limit:

| variant | stats count (LIMIT 1M) |
|---|---|
| PROD baseline | 376ms / 251MB |
| shipped | 212ms / 72MB |
| gain vs prod | **1.8x / 3.5x** |

## Testing
- New stats-builder tests for the no-limit, caller-limit, and `include_total_storage_size` branches; updated four `calls_complete` SQL assertions for the new `has_more` column.
- New sqlite test covering `has_more` saturation parity with CH.
- Matching FE PR: https://github.com/wandb/core/pull/44185
- Split out: the `sort_by=[]` no-sort signal + stream-path setting injection live in https://github.com/wandb/weave/pull/6885.