### PR TITLE
fix(weave): allow linking all spans to a single eval call

### DIFF
--- a/tests/trace/test_eval_otel_linking.py
+++ b/tests/trace/test_eval_otel_linking.py
@@ -79,14 +79,57 @@ async def test_genai_span_ref_attached_to_eval_call(client, otel_setup):
 
     trial = res.rows[0].evaluations[0].trials[0]
     assert trial.genai_span_ref is not None
+    assert len(trial.genai_span_ref) == 1
     # OTel stores trace/span IDs as integers; W3C Trace Context represents them
     # as zero-padded hex: 32 hex chars for 128-bit trace IDs, 16 for 64-bit span IDs.
-    assert trial.genai_span_ref.trace_id == format(
+    assert trial.genai_span_ref[0].trace_id == format(
         genai_spans[0].context.trace_id, "032x"
     )
-    assert trial.genai_span_ref.span_id == format(
+    assert trial.genai_span_ref[0].span_id == format(
         genai_spans[0].context.span_id, "016x"
     )
+
+
+@pytest.mark.asyncio
+async def test_multiple_genai_span_refs_attached_to_eval_call(client, otel_setup):
+    """All GenAI OTel spans emitted during a prediction should be linked."""
+    exporter = otel_setup
+
+    @weave.op
+    async def model_predict(input) -> str:
+        _emit_genai_span("gpt-4o")
+        _emit_genai_span("gpt-4o-mini")
+        return input
+
+    evaluation = Evaluation(
+        dataset=[{"input": "1 + 1"}],
+        scorers=[],
+    )
+    await evaluation.evaluate(model_predict)
+    client.flush()
+
+    genai_spans = [
+        s
+        for s in exporter.get_finished_spans()
+        if s.attributes.get("gen_ai.operation.name")
+    ]
+    assert len(genai_spans) == 2
+
+    evaluate_call = next(iter(evaluation.evaluate.calls()))
+    res = client.server.eval_results_query(
+        tsi.EvalResultsQueryReq(
+            project_id=client.project_id,
+            evaluation_call_ids=[evaluate_call.id],
+            include_predict_and_score_children=False,
+        )
+    )
+
+    trial = res.rows[0].evaluations[0].trials[0]
+    assert trial.genai_span_ref is not None
+    assert {(r.trace_id, r.span_id) for r in trial.genai_span_ref} == {
+        (format(s.context.trace_id, "032x"), format(s.context.span_id, "016x"))
+        for s in genai_spans
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/trace_server/test_eval_results_genai_span_ref.py
+++ b/tests/trace_server/test_eval_results_genai_span_ref.py
@@ -59,10 +59,52 @@ def test_build_eval_rows_returns_genai_span_ref_without_children() -> None:
     )
 
     trial = rows[0].evaluations[0].trials[0]
-    assert trial.genai_span_ref == tsi.GenAISpanRef.model_validate(_genai_span_ref())
+    assert trial.genai_span_ref == [tsi.GenAISpanRef.model_validate(_genai_span_ref())]
 
 
-def test_build_trial_prefers_prediction_genai_span_ref() -> None:
+def test_eval_results_trial_wraps_legacy_single_genai_span_ref() -> None:
+    trial = tsi.EvalResultsTrial.model_validate(
+        {
+            "predict_and_score_call_id": "pas-1",
+            "genai_span_ref": _genai_span_ref(),
+        }
+    )
+
+    assert trial.genai_span_ref == [tsi.GenAISpanRef.model_validate(_genai_span_ref())]
+
+
+def test_build_eval_rows_returns_genai_span_ref_list_without_children() -> None:
+    predict_and_score_call = _call(
+        call_id="pas-1",
+        attributes={
+            constants.WEAVE_ATTRIBUTES_NAMESPACE: {
+                constants.GENAI_SPAN_REF_ATTR_KEY: [
+                    _genai_span_ref("agent-trace-1"),
+                    _genai_span_ref("agent-trace-2"),
+                ],
+            }
+        },
+        inputs={"example": {"x": 1}, "model": "model://agent"},
+        output={"output": "result", "scores": {}},
+    )
+
+    rows = eval_helpers.build_eval_rows(
+        [predict_and_score_call],
+        ["eval-1"],
+        {"pas-1": "row-1"},
+        include_raw_data_rows=False,
+        include_predict_and_score_children=False,
+    )
+
+    trial = rows[0].evaluations[0].trials[0]
+    assert trial.genai_span_ref is not None
+    assert [ref.trace_id for ref in trial.genai_span_ref] == [
+        "agent-trace-1",
+        "agent-trace-2",
+    ]
+
+
+def test_build_trial_combines_prediction_and_parent_genai_span_refs() -> None:
     predict_and_score_call = _call(
         call_id="pas-1",
         attributes={
@@ -94,7 +136,10 @@ def test_build_trial_prefers_prediction_genai_span_ref() -> None:
 
     trial = next(iter(row_eval_map.values()))["eval-1"].trials[0]
     assert trial.genai_span_ref is not None
-    assert trial.genai_span_ref.trace_id == "predict-trace"
+    assert [ref.trace_id for ref in trial.genai_span_ref] == [
+        "predict-trace",
+        "parent-trace",
+    ]
 
 
 def test_extract_genai_span_ref_ignores_malformed_refs() -> None:
@@ -110,4 +155,4 @@ def test_extract_genai_span_ref_ignores_malformed_refs() -> None:
             }
         )
 
-        assert eval_helpers.extract_genai_span_ref(call) is None
+        assert eval_helpers.extract_genai_span_refs(call) is None

--- a/tests/trace_server/test_eval_results_genai_span_ref.py
+++ b/tests/trace_server/test_eval_results_genai_span_ref.py
@@ -38,41 +38,6 @@ def _genai_span_ref(trace_id: str = "agent-trace-1") -> dict[str, Any]:
     }
 
 
-def test_build_eval_rows_returns_genai_span_ref_without_children() -> None:
-    predict_and_score_call = _call(
-        call_id="pas-1",
-        attributes={
-            constants.WEAVE_ATTRIBUTES_NAMESPACE: {
-                constants.GENAI_SPAN_REF_ATTR_KEY: _genai_span_ref(),
-            }
-        },
-        inputs={"example": {"x": 1}, "model": "model://agent"},
-        output={"output": "result", "scores": {}},
-    )
-
-    rows = eval_helpers.build_eval_rows(
-        [predict_and_score_call],
-        ["eval-1"],
-        {"pas-1": "row-1"},
-        include_raw_data_rows=False,
-        include_predict_and_score_children=False,
-    )
-
-    trial = rows[0].evaluations[0].trials[0]
-    assert trial.genai_span_ref == [tsi.GenAISpanRef.model_validate(_genai_span_ref())]
-
-
-def test_eval_results_trial_wraps_legacy_single_genai_span_ref() -> None:
-    trial = tsi.EvalResultsTrial.model_validate(
-        {
-            "predict_and_score_call_id": "pas-1",
-            "genai_span_ref": _genai_span_ref(),
-        }
-    )
-
-    assert trial.genai_span_ref == [tsi.GenAISpanRef.model_validate(_genai_span_ref())]
-
-
 def test_build_eval_rows_returns_genai_span_ref_list_without_children() -> None:
     predict_and_score_call = _call(
         call_id="pas-1",
@@ -109,7 +74,9 @@ def test_build_trial_combines_prediction_and_parent_genai_span_refs() -> None:
         call_id="pas-1",
         attributes={
             constants.WEAVE_ATTRIBUTES_NAMESPACE: {
-                constants.GENAI_SPAN_REF_ATTR_KEY: _genai_span_ref("parent-trace"),
+                constants.GENAI_SPAN_REF_ATTR_KEY: [
+                    _genai_span_ref("parent-trace"),
+                ],
             }
         },
         inputs={"example": {"x": 1}, "model": "model://agent"},
@@ -121,7 +88,9 @@ def test_build_trial_combines_prediction_and_parent_genai_span_refs() -> None:
         op_name="Agent.predict",
         attributes={
             constants.WEAVE_ATTRIBUTES_NAMESPACE: {
-                constants.GENAI_SPAN_REF_ATTR_KEY: _genai_span_ref("predict-trace"),
+                constants.GENAI_SPAN_REF_ATTR_KEY: [
+                    _genai_span_ref("predict-trace"),
+                ],
             }
         },
         inputs={"self": "model://agent", "inputs": {"x": 1}},
@@ -142,17 +111,40 @@ def test_build_trial_combines_prediction_and_parent_genai_span_refs() -> None:
     ]
 
 
-def test_extract_genai_span_ref_ignores_malformed_refs() -> None:
-    for raw_ref in (
-        {"span_id": "missing-trace-id"},
-        {"trace_id": "missing-span-id"},
+def test_extract_genai_span_refs_ignores_malformed_refs() -> None:
+    for raw_refs in (
+        [
+            {"span_id": "missing-trace-id"},
+        ],
+        [
+            {"trace_id": "missing-span-id"},
+        ],
     ):
         call = _call(
             attributes={
                 constants.WEAVE_ATTRIBUTES_NAMESPACE: {
-                    constants.GENAI_SPAN_REF_ATTR_KEY: raw_ref,
+                    constants.GENAI_SPAN_REF_ATTR_KEY: raw_refs,
                 }
             }
         )
 
         assert eval_helpers.extract_genai_span_refs(call) is None
+
+
+def test_extract_genai_span_refs_skips_invalid_items() -> None:
+    call = _call(
+        attributes={
+            constants.WEAVE_ATTRIBUTES_NAMESPACE: {
+                constants.GENAI_SPAN_REF_ATTR_KEY: [
+                    _genai_span_ref("valid-trace"),
+                    "not-a-ref",
+                    {"span_id": "missing-trace-id"},
+                    {"trace_id": "missing-span-id"},
+                ],
+            }
+        }
+    )
+
+    assert eval_helpers.extract_genai_span_refs(call) == [
+        tsi.GenAISpanRef.model_validate(_genai_span_ref("valid-trace"))
+    ]

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -509,7 +509,7 @@ def test_eval_results_query_returns_genai_span_ref_without_children(client):
     assert res.total_rows == 1
     trial = res.rows[0].evaluations[0].trials[0]
     assert trial.predict_call_id is None
-    assert trial.genai_span_ref == genai_span_ref
+    assert trial.genai_span_ref == [genai_span_ref]
 
 
 def test_eval_results_query_nonexistent_eval_root(client):

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -488,7 +488,7 @@ def test_eval_results_query_returns_genai_span_ref_without_children(client):
             inputs={"x": 1},
             output="result",
             evaluation_run_id=run.evaluation_run_id,
-            genai_span_ref=genai_span_ref,
+            genai_span_ref=[genai_span_ref],
         )
     )
     client.server.prediction_finish(

--- a/weave/evaluation/eval.py
+++ b/weave/evaluation/eval.py
@@ -86,10 +86,10 @@ def _attach_genai_span_ref_to_call_summary(
     call: Call,
     genai_span_ref: tsi.GenAISpanRef,
 ) -> None:
-    """Write a GenAISpanRef into call.summary so eval results can find it.
+    """Append a GenAISpanRef into call.summary so eval results can find it.
 
     Our EvalLinkSpanProcessor calls this to attach GenAISpanRef to an Eval
-    call. The trace server can than extract span refs from call summaries
+    call. The trace server can then extract span refs from call summaries
     by looking for the presence of the GenAISpanRef attribute key.
     """
     if call.summary is None:
@@ -100,7 +100,14 @@ def _attach_genai_span_ref_to_call_summary(
 
     weave_summary = call.summary[constants.WEAVE_ATTRIBUTES_NAMESPACE]
 
-    weave_summary[constants.GENAI_SPAN_REF_ATTR_KEY] = genai_span_ref.model_dump()
+    new_ref = genai_span_ref.model_dump()
+    existing = weave_summary.get(constants.GENAI_SPAN_REF_ATTR_KEY)
+    if isinstance(existing, list):
+        existing.append(new_ref)
+    elif isinstance(existing, dict):
+        weave_summary[constants.GENAI_SPAN_REF_ATTR_KEY] = [existing, new_ref]
+    else:
+        weave_summary[constants.GENAI_SPAN_REF_ATTR_KEY] = [new_ref]
 
 
 def _find_call_on_stack(op_names: str | tuple[str, ...]) -> Call | None:

--- a/weave/evaluation/eval.py
+++ b/weave/evaluation/eval.py
@@ -104,8 +104,6 @@ def _attach_genai_span_ref_to_call_summary(
     existing = weave_summary.get(constants.GENAI_SPAN_REF_ATTR_KEY)
     if isinstance(existing, list):
         existing.append(new_ref)
-    elif isinstance(existing, dict):
-        weave_summary[constants.GENAI_SPAN_REF_ATTR_KEY] = [existing, new_ref]
     else:
         weave_summary[constants.GENAI_SPAN_REF_ATTR_KEY] = [new_ref]
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -4575,13 +4575,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             PredictionCreateRes with the prediction_id
         """
         prediction_id = generate_id()
-        genai_span_ref = None
-        if isinstance(req.genai_span_ref, list):
-            genai_span_ref = [
-                ref.model_dump(exclude_none=True) for ref in req.genai_span_ref
-            ]
-        elif req.genai_span_ref is not None:
-            genai_span_ref = req.genai_span_ref.model_dump(exclude_none=True)
+        genai_span_ref = (
+            [ref.model_dump(exclude_none=True) for ref in req.genai_span_ref]
+            if req.genai_span_ref is not None
+            else None
+        )
 
         # Determine trace_id and parent_id based on evaluation_run_id
         if req.evaluation_run_id:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -4575,11 +4575,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             PredictionCreateRes with the prediction_id
         """
         prediction_id = generate_id()
-        genai_span_ref = (
-            req.genai_span_ref.model_dump(exclude_none=True)
-            if req.genai_span_ref is not None
-            else None
-        )
+        genai_span_ref = None
+        if isinstance(req.genai_span_ref, list):
+            genai_span_ref = [
+                ref.model_dump(exclude_none=True) for ref in req.genai_span_ref
+            ]
+        elif req.genai_span_ref is not None:
+            genai_span_ref = req.genai_span_ref.model_dump(exclude_none=True)
 
         # Determine trace_id and parent_id based on evaluation_run_id
         if req.evaluation_run_id:
@@ -4614,7 +4616,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 version=predict_and_score_op_res.digest,
             )
 
-            predict_and_score_weave_attrs = {
+            predict_and_score_weave_attrs: dict[str, Any] = {
                 constants.EVALUATION_RUN_PREDICT_CALL_ID_ATTR_KEY: prediction_id,
             }
             if genai_span_ref is not None:

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -299,8 +299,9 @@ def extract_genai_span_refs_from_weave_namespace(
     if not isinstance(weave_data, dict):
         return None
 
-    raw_ref = weave_data.get(constants.GENAI_SPAN_REF_ATTR_KEY)
-    raw_refs = raw_ref if isinstance(raw_ref, list) else [raw_ref]
+    raw_refs = weave_data.get(constants.GENAI_SPAN_REF_ATTR_KEY)
+    if not isinstance(raw_refs, list):
+        return None
 
     refs: list[tsi.GenAISpanRef] = []
     for item in raw_refs:

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -289,9 +289,9 @@ def best_effort_scorer_call_ids(
     return result
 
 
-def extract_genai_span_ref_from_weave_namespace(
+def extract_genai_span_refs_from_weave_namespace(
     data: dict[str, Any] | tsi.SummaryMap | None,
-) -> tsi.GenAISpanRef | None:
+) -> list[tsi.GenAISpanRef] | None:
     if not isinstance(data, dict):
         return None
 
@@ -300,23 +300,45 @@ def extract_genai_span_ref_from_weave_namespace(
         return None
 
     raw_ref = weave_data.get(constants.GENAI_SPAN_REF_ATTR_KEY)
-    if not isinstance(raw_ref, dict):
-        return None
+    raw_refs = raw_ref if isinstance(raw_ref, list) else [raw_ref]
 
-    try:
-        return tsi.GenAISpanRef.model_validate(raw_ref)
-    except ValidationError:
-        return None
+    refs: list[tsi.GenAISpanRef] = []
+    for item in raw_refs:
+        if not isinstance(item, dict):
+            continue
+        try:
+            refs.append(tsi.GenAISpanRef.model_validate(item))
+        except ValidationError:
+            continue
+    return refs or None
 
 
-def extract_genai_span_ref(call: tsi.CallSchema | None) -> tsi.GenAISpanRef | None:
-    """Extract an optional GenAI span ref from call attributes or summary."""
+def extract_genai_span_refs(
+    call: tsi.CallSchema | None,
+) -> list[tsi.GenAISpanRef] | None:
+    """Extract optional GenAI span refs from call attributes or summary."""
     if call is None:
         return None
 
-    return extract_genai_span_ref_from_weave_namespace(
+    return extract_genai_span_refs_from_weave_namespace(
         call.attributes
-    ) or extract_genai_span_ref_from_weave_namespace(call.summary)
+    ) or extract_genai_span_refs_from_weave_namespace(call.summary)
+
+
+def _combine_genai_span_refs(
+    predict_call: tsi.CallSchema | None,
+    predict_and_score_call: tsi.CallSchema,
+) -> list[tsi.GenAISpanRef] | None:
+    refs: list[tsi.GenAISpanRef] = []
+    seen: set[tuple[str, str]] = set()
+    for call in (predict_call, predict_and_score_call):
+        extracted = extract_genai_span_refs(call)
+        for ref in extracted or []:
+            key = (ref.trace_id, ref.span_id)
+            if key not in seen:
+                refs.append(ref)
+                seen.add(key)
+    return refs or None
 
 
 def _build_trial(
@@ -357,8 +379,7 @@ def _build_trial(
             predict_call.summary if predict_call else predict_and_score_call.summary
         ),
         scorer_call_ids=best_effort_scorer_call_ids(scores, trial_children),
-        genai_span_ref=extract_genai_span_ref(predict_call)
-        or extract_genai_span_ref(predict_and_score_call),
+        genai_span_ref=_combine_genai_span_refs(predict_call, predict_and_score_call),
     )
 
 

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -4208,11 +4208,13 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
             PredictionCreateRes with the prediction_id
         """
         prediction_id = generate_id()
-        genai_span_ref = (
-            req.genai_span_ref.model_dump(exclude_none=True)
-            if req.genai_span_ref is not None
-            else None
-        )
+        genai_span_ref = None
+        if isinstance(req.genai_span_ref, list):
+            genai_span_ref = [
+                ref.model_dump(exclude_none=True) for ref in req.genai_span_ref
+            ]
+        elif req.genai_span_ref is not None:
+            genai_span_ref = req.genai_span_ref.model_dump(exclude_none=True)
 
         # Determine trace_id and parent_id based on evaluation_run_id
         if req.evaluation_run_id:
@@ -4247,7 +4249,7 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                 version=predict_and_score_op_res.digest,
             )
 
-            predict_and_score_weave_attrs = {
+            predict_and_score_weave_attrs: dict[str, Any] = {
                 constants.EVALUATION_RUN_PREDICT_CALL_ID_ATTR_KEY: prediction_id,
             }
             if genai_span_ref is not None:

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -4208,13 +4208,11 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
             PredictionCreateRes with the prediction_id
         """
         prediction_id = generate_id()
-        genai_span_ref = None
-        if isinstance(req.genai_span_ref, list):
-            genai_span_ref = [
-                ref.model_dump(exclude_none=True) for ref in req.genai_span_ref
-            ]
-        elif req.genai_span_ref is not None:
-            genai_span_ref = req.genai_span_ref.model_dump(exclude_none=True)
+        genai_span_ref = (
+            [ref.model_dump(exclude_none=True) for ref in req.genai_span_ref]
+            if req.genai_span_ref is not None
+            else None
+        )
 
         # Determine trace_id and parent_id based on evaluation_run_id
         if req.evaluation_run_id:

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3,7 +3,14 @@ from collections.abc import Iterator
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, Protocol
 
-from pydantic import BaseModel, ConfigDict, Field, field_serializer, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
@@ -2534,6 +2541,9 @@ class GenAISpanRef(BaseModel):
     span_id: str
 
 
+GenAISpanRefValue = GenAISpanRef | list[GenAISpanRef]
+
+
 class PredictionCreateBody(BaseModel):
     """Request body for creating a Prediction via REST API.
 
@@ -2547,9 +2557,9 @@ class PredictionCreateBody(BaseModel):
         None,
         description="Optional evaluation run ID to link this prediction as a child call",
     )
-    genai_span_ref: GenAISpanRef | None = Field(
+    genai_span_ref: GenAISpanRefValue | None = Field(
         default=None,
-        description="Optional GenAI span reference produced by this prediction.",
+        description="Optional GenAI span reference(s) produced by this prediction.",
     )
 
 
@@ -2845,7 +2855,14 @@ class EvalResultsTrial(BaseModel):
     model_latency_seconds: float | None = None
     total_tokens: int | None = None
     scorer_call_ids: dict[str, str] = Field(default_factory=dict)
-    genai_span_ref: GenAISpanRef | None = None
+    genai_span_ref: list[GenAISpanRef] | None = None
+
+    @field_validator("genai_span_ref", mode="before")
+    @classmethod
+    def normalize_genai_span_ref(cls, value: Any) -> Any:
+        if value is None or isinstance(value, list):
+            return value
+        return [value]
 
 
 class EvalResultsRowEvaluation(BaseModel):

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -8,7 +8,6 @@ from pydantic import (
     ConfigDict,
     Field,
     field_serializer,
-    field_validator,
     model_validator,
 )
 from typing_extensions import TypedDict
@@ -2541,9 +2540,6 @@ class GenAISpanRef(BaseModel):
     span_id: str
 
 
-GenAISpanRefValue = GenAISpanRef | list[GenAISpanRef]
-
-
 class PredictionCreateBody(BaseModel):
     """Request body for creating a Prediction via REST API.
 
@@ -2557,7 +2553,7 @@ class PredictionCreateBody(BaseModel):
         None,
         description="Optional evaluation run ID to link this prediction as a child call",
     )
-    genai_span_ref: GenAISpanRefValue | None = Field(
+    genai_span_ref: list[GenAISpanRef] | None = Field(
         default=None,
         description="Optional GenAI span reference(s) produced by this prediction.",
     )
@@ -2856,13 +2852,6 @@ class EvalResultsTrial(BaseModel):
     total_tokens: int | None = None
     scorer_call_ids: dict[str, str] = Field(default_factory=dict)
     genai_span_ref: list[GenAISpanRef] | None = None
-
-    @field_validator("genai_span_ref", mode="before")
-    @classmethod
-    def normalize_genai_span_ref(cls, value: Any) -> Any:
-        if value is None or isinstance(value, list):
-            return value
-        return [value]
 
 
 class EvalResultsRowEvaluation(BaseModel):


### PR DESCRIPTION
The previous implementation assumes single span to single call, but we should actually capture all spans. This accumulates spans under a call and links them all. The frontend can then handle the returned list of spans appropriately.

A few notes:

* The assumption here is that `EvalLinkSpanProcessor` is attached _once_ to avoid duplicate spans getting attached. We don't do anything to enforce ref uniqueness so we can potentially store duplicate refs on an eval call. I think this okay though because the frontend can be smart about this and we don't have to worry about making the span processor more complex than it needs to be.
* This keeps the existing `genai_span_ref` attribute name, but we can just go with plural for the breaking change. I think I'm the only person with linked calls and it would basically just break the link in the frontend (e.g. it wouldn't show up). As-is this still has some backwards compatibility things which allow for singular (non-list) refs.