### PR TITLE
perf(weave): hoist per-batch project lookups in calls_complete

### DIFF
--- a/scripts/benchmarks/calls_complete_batch.py
+++ b/scripts/benchmarks/calls_complete_batch.py
@@ -130,12 +130,12 @@ def _time_calls_complete(iterations: int, batch_size: int, mode: str) -> list[fl
             return timings_ms
 
 
-def _summarize(label: str, timings_ms: list[float]) -> dict[str, float]:
+def _summarize(label: str, timings_ms: list[float]) -> dict[str, str | float]:
     s = sorted(timings_ms)
     n = len(s)
     return {
         "label": label,
-        "n": n,
+        "n": float(n),
         "min_ms": s[0],
         "median_ms": s[n // 2],
         "mean_ms": statistics.fmean(s),
@@ -144,15 +144,15 @@ def _summarize(label: str, timings_ms: list[float]) -> dict[str, float]:
     }
 
 
-def _print_markdown(rows: list[dict[str, float]]) -> None:
+def _print_markdown(rows: list[dict[str, str | float]]) -> None:
     print()
     print("| scenario | n | min ms | median ms | mean ms | p95 ms | max ms |")
     print("|---|---:|---:|---:|---:|---:|---:|")
     for r in rows:
         print(
-            f"| {r['label']} | {int(r['n'])} | {r['min_ms']:.2f} | "
-            f"{r['median_ms']:.2f} | {r['mean_ms']:.2f} | "
-            f"{r['p95_ms']:.2f} | {r['max_ms']:.2f} |"
+            f"| {r['label']} | {int(float(r['n']))} | {float(r['min_ms']):.2f} | "
+            f"{float(r['median_ms']):.2f} | {float(r['mean_ms']):.2f} | "
+            f"{float(r['p95_ms']):.2f} | {float(r['max_ms']):.2f} |"
         )
     print()
 
@@ -163,7 +163,7 @@ def main() -> None:
     parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
     args = parser.parse_args()
 
-    rows: list[dict[str, float]] = []
+    rows: list[dict[str, str | float]] = []
     for mode in ("warm", "cold"):
         # Reset caches between scenarios so each starts fresh.
         project_version.reset_project_residence_cache()

--- a/scripts/benchmarks/calls_complete_batch.py
+++ b/scripts/benchmarks/calls_complete_batch.py
@@ -1,0 +1,180 @@
+"""Microbench for `ClickHouseTraceServer.calls_complete` per-batch lookup hoisting.
+
+Background: Datadog trace `6a0c7d9900000000975ce4fb10f7c246` shows, inside a
+50-call batch to POST /traces/v2/.../calls/complete, 50 sequential
+`table_routing.resolve_v2_write_target` and `ttl_settings.get_project_retention_days`
+spans. Both lookups are L1-cached, but each call still pays the function-call +
+lock + cachetools-get + ddtrace span overhead -> ~3-5ms per cached hit, ~450ms
+wasted wall time per 50-call same-project batch.
+
+This bench exercises `calls_complete` against a stubbed CH client (no DB
+connection) so the only costs measured are the Python/ddtrace overhead of the
+hoist path. It compares one run to itself; to compare branches, run the script
+once on master and once on this branch and diff the median.
+
+Usage:
+    uv run python scripts/benchmarks/calls_complete_batch.py [--iterations 20] [--batch-size 50]
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import datetime as dt
+import statistics
+import time
+import uuid
+from unittest.mock import MagicMock, patch
+
+import ddtrace
+
+from weave.trace_server import clickhouse_trace_server_batched as chts
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.project_version import project_version
+from weave.trace_server.project_version.types import CallsStorageServerMode
+from weave.trace_server.ttl_settings import reset_ttl_cache
+
+DEFAULT_ITERATIONS = 20
+DEFAULT_BATCH_SIZE = 50
+
+
+def _make_complete_call(project_id: str) -> tsi.CompletedCallSchemaForInsert:
+    """Build a realistic-but-cheap complete-call payload."""
+    now = dt.datetime.now(dt.timezone.utc)
+    return tsi.CompletedCallSchemaForInsert(
+        project_id=project_id,
+        id=str(uuid.uuid4()),
+        trace_id=str(uuid.uuid4()),
+        op_name="bench_op",
+        started_at=now,
+        ended_at=now,
+        attributes={"env": "bench", "version": 1},
+        inputs={"prompt": "hello world", "n": 42},
+        output={"text": "ok"},
+        summary={"weave": {"latency_ms": 12}},
+    )
+
+
+def _make_mock_ch_client() -> MagicMock:
+    """Mock CH client. Residence query -> COMPLETE_ONLY; TTL query -> no TTL."""
+    mock_ch_client = MagicMock()
+    mock_ch_client.command.return_value = None
+    mock_ch_client.insert.return_value = MagicMock()
+
+    residence_result = MagicMock()
+    residence_result.result_rows = [(1, None)]  # COMPLETE_ONLY
+    residence_result.row_count = 1
+    residence_result.first_row = (1, None)
+
+    ttl_result = MagicMock()
+    ttl_result.result_rows = []
+    ttl_result.row_count = 0
+    ttl_result.first_row = None
+
+    def _route_query(sql, *args, **kwargs):
+        if "project_ttl_settings" in sql:
+            return ttl_result
+        return residence_result
+
+    mock_ch_client.query.side_effect = _route_query
+    return mock_ch_client
+
+
+def _time_calls_complete(iterations: int, batch_size: int, mode: str) -> list[float]:
+    """Run calls_complete `iterations` times against a same-project batch.
+
+    `mode` controls cache state per iteration:
+      - "warm":     populate L1 caches once before the loop (the steady-state
+                    production case for an active project)
+      - "cold":     clear L1 caches before each iteration (every batch's first
+                    lookup goes through to CH)
+    """
+    mock_ch_client = _make_mock_ch_client()
+    project_id = base64.b64encode(b"bench_entity/bench_project").decode()
+
+    with patch.object(
+        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = chts.ClickHouseTraceServer(host="bench_host")
+        server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
+
+        with (
+            patch.object(chts.ClickHouseTraceServer, "_insert_call_complete"),
+            patch.object(chts.ClickHouseTraceServer, "_insert_call_to_v1"),
+            patch.object(chts, "maybe_enqueue_minimal_call_end", return_value=None),
+        ):
+            if mode == "warm":
+                # Warm L1 caches so timed runs measure cached-hit overhead.
+                server.table_routing_resolver.resolve_v2_write_target(
+                    project_id, mock_ch_client
+                )
+                from weave.trace_server.ttl_settings import get_project_retention_days
+
+                get_project_retention_days(project_id, mock_ch_client)
+
+            timings_ms: list[float] = []
+            for _ in range(iterations):
+                if mode == "cold":
+                    project_version.reset_project_residence_cache()
+                    reset_ttl_cache()
+                batch = [_make_complete_call(project_id) for _ in range(batch_size)]
+                req = tsi.CallsUpsertCompleteReq(batch=batch)
+                # Wrap in an active DD span so `set_current_span_dd_tags` does real
+                # work (in prod each request has a parent HTTP span; without one
+                # the tag calls early-return and underestimate per-call overhead).
+                with ddtrace.tracer.trace("bench.calls_complete"):
+                    t0 = time.perf_counter_ns()
+                    server.calls_complete(req)
+                    t1 = time.perf_counter_ns()
+                timings_ms.append((t1 - t0) / 1_000_000.0)
+            return timings_ms
+
+
+def _summarize(label: str, timings_ms: list[float]) -> dict[str, float]:
+    s = sorted(timings_ms)
+    n = len(s)
+    return {
+        "label": label,
+        "n": n,
+        "min_ms": s[0],
+        "median_ms": s[n // 2],
+        "mean_ms": statistics.fmean(s),
+        "p95_ms": s[min(n - 1, int(n * 0.95))],
+        "max_ms": s[-1],
+    }
+
+
+def _print_markdown(rows: list[dict[str, float]]) -> None:
+    print()
+    print("| scenario | n | min ms | median ms | mean ms | p95 ms | max ms |")
+    print("|---|---:|---:|---:|---:|---:|---:|")
+    for r in rows:
+        print(
+            f"| {r['label']} | {int(r['n'])} | {r['min_ms']:.2f} | "
+            f"{r['median_ms']:.2f} | {r['mean_ms']:.2f} | "
+            f"{r['p95_ms']:.2f} | {r['max_ms']:.2f} |"
+        )
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--iterations", type=int, default=DEFAULT_ITERATIONS)
+    parser.add_argument("--batch-size", type=int, default=DEFAULT_BATCH_SIZE)
+    args = parser.parse_args()
+
+    rows: list[dict[str, float]] = []
+    for mode in ("warm", "cold"):
+        # Reset caches between scenarios so each starts fresh.
+        project_version.reset_project_residence_cache()
+        reset_ttl_cache()
+        label = f"calls_complete x{args.batch_size} ({mode} cache)"
+        print(f"[{label}] running {args.iterations} iterations...")
+        timings = _time_calls_complete(args.iterations, args.batch_size, mode=mode)
+        rows.append(_summarize(label, timings))
+
+    _print_markdown(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1880,3 +1880,173 @@ def test_alias_pointing_at_soft_deleted_version_yields_clean_failure(ch_server):
         f"pointed at a tombstoned version: {exc_info.value!r}.  Expected a "
         f"NotFoundError-family error mentioning 'not found' or 'deleted'."
     )
+
+
+# ---------------------------------------------------------------------------
+# calls_complete per-batch lookup hoisting
+# ---------------------------------------------------------------------------
+
+
+def _make_complete_call(project_id: str) -> tsi.CompletedCallSchemaForInsert:
+    now = dt.datetime.now(dt.timezone.utc)
+    return tsi.CompletedCallSchemaForInsert(
+        project_id=project_id,
+        id=str(uuid.uuid4()),
+        trace_id=str(uuid.uuid4()),
+        op_name="test_op",
+        started_at=now,
+        ended_at=now,
+        attributes={},
+        inputs={},
+        output=None,
+        summary={},
+    )
+
+
+def _make_batch_server_with_mocks(residence_rows):
+    """Build a ClickHouseTraceServer with a CH client mocking both residence + TTL queries.
+
+    `residence_rows` is the result_rows returned for the residence query. For
+    `_get_residence`: `[(None, None)]` = EMPTY, `[(1, None)]` = COMPLETE_ONLY.
+    The TTL query (`SELECT argMax(retention_days...)`) always returns 0 rows ->
+    RETENTION_DAYS_NO_TTL. Query routing is done by inspecting the SQL string.
+    """
+    mock_ch_client = MagicMock()
+    mock_ch_client.command.return_value = None
+    mock_ch_client.insert.return_value = MagicMock()
+
+    residence_result = MagicMock()
+    residence_result.result_rows = residence_rows
+    residence_result.row_count = len(residence_rows)
+    residence_result.first_row = residence_rows[0] if residence_rows else None
+
+    ttl_result = MagicMock()
+    ttl_result.result_rows = []
+    ttl_result.row_count = 0
+    ttl_result.first_row = None
+
+    def _route_query(sql, *args, **kwargs):
+        # TTL query selects from project_ttl_settings; residence query joins on
+        # calls_complete + calls_merged.
+        if "project_ttl_settings" in sql:
+            return ttl_result
+        return residence_result
+
+    mock_ch_client.query.side_effect = _route_query
+    return mock_ch_client
+
+
+@pytest.fixture
+def _clear_project_caches():
+    """Clear residence + TTL caches around each test to avoid cross-test leakage."""
+    from weave.trace_server.project_version.project_version import (
+        reset_project_residence_cache,
+    )
+    from weave.trace_server.ttl_settings import reset_ttl_cache
+
+    reset_project_residence_cache()
+    reset_ttl_cache()
+    yield
+    reset_project_residence_cache()
+    reset_ttl_cache()
+
+
+@pytest.mark.parametrize("n_projects", [1, 2, 50])
+@pytest.mark.usefixtures("_clear_project_caches")
+def test_calls_complete_hoists_per_batch_lookups(n_projects):
+    """For N distinct project_ids in a 50-call batch, resolver/TTL are called <=N times.
+
+    Verifies the hoist: cached projects (non-EMPTY residence) get exactly one
+    lookup per unique project_id, not one per call.
+    """
+    batch_size = 50
+    # COMPLETE_ONLY residence so the resolver caches the result -> hoisting kicks in.
+    mock_ch_client = _make_batch_server_with_mocks([(1, None)])
+
+    with patch.object(
+        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host")
+        # Force AUTO mode so resolver actually invokes _get_residence.
+        from weave.trace_server.project_version.types import CallsStorageServerMode
+
+        server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
+
+        project_ids = [
+            base64.b64encode(f"e/proj_{i}".encode()).decode() for i in range(n_projects)
+        ]
+        batch = [
+            _make_complete_call(project_ids[i % n_projects]) for i in range(batch_size)
+        ]
+
+        with (
+            patch.object(
+                chts.ClickHouseTraceServer, "_insert_call_complete"
+            ) as mock_insert_complete,
+            patch.object(chts.ClickHouseTraceServer, "_insert_call_to_v1"),
+            patch.object(
+                server.table_routing_resolver,
+                "resolve_v2_write_target",
+                wraps=server.table_routing_resolver.resolve_v2_write_target,
+            ) as spy_resolve,
+            patch(
+                "weave.trace_server.clickhouse_trace_server_batched.get_project_retention_days",
+                wraps=chts.get_project_retention_days,
+            ) as spy_ttl,
+        ):
+            server.calls_complete(tsi.CallsUpsertCompleteReq(batch=batch))
+
+        # Each unique project resolved at most once (G1, G2).
+        assert spy_resolve.call_count == n_projects, (
+            f"expected resolve_v2_write_target called {n_projects}x for {n_projects} "
+            f"unique projects in a {batch_size}-call batch, got {spy_resolve.call_count}"
+        )
+        assert spy_ttl.call_count == n_projects, (
+            f"expected get_project_retention_days called {n_projects}x for {n_projects} "
+            f"unique projects, got {spy_ttl.call_count}"
+        )
+        # All inserts happened.
+        assert mock_insert_complete.call_count == batch_size
+
+
+@pytest.mark.usefixtures("_clear_project_caches")
+def test_calls_complete_empty_residence_not_hoisted():
+    """EMPTY-residence projects must NOT cache across the batch (G5).
+
+    `_get_residence` skips caching when residence is EMPTY (project_version.py L73)
+    so subsequent calls re-query ClickHouse. The hoist must preserve this --
+    every call in a 5-call batch over a brand-new (EMPTY) project should
+    re-invoke the resolver.
+    """
+    batch_size = 5
+    # EMPTY residence: both has_complete and has_merged are NULL.
+    mock_ch_client = _make_batch_server_with_mocks([(None, None)])
+
+    with patch.object(
+        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        server = chts.ClickHouseTraceServer(host="test_host")
+        from weave.trace_server.project_version.types import CallsStorageServerMode
+
+        server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
+
+        project_id = base64.b64encode(b"e/brand_new_project").decode()
+        batch = [_make_complete_call(project_id) for _ in range(batch_size)]
+
+        with (
+            patch.object(chts.ClickHouseTraceServer, "_insert_call_complete"),
+            patch.object(chts.ClickHouseTraceServer, "_insert_call_to_v1"),
+            patch.object(
+                server.table_routing_resolver,
+                "resolve_v2_write_target",
+                wraps=server.table_routing_resolver.resolve_v2_write_target,
+            ) as spy_resolve,
+        ):
+            server.calls_complete(tsi.CallsUpsertCompleteReq(batch=batch))
+
+        # EMPTY residence is intentionally not cached at the resolver level,
+        # and the per-batch hoist must respect that -- every call re-resolves.
+        assert spy_resolve.call_count == batch_size, (
+            "EMPTY-residence projects must not be cached by the per-batch hoist; "
+            f"expected {batch_size} resolver calls, got {spy_resolve.call_count}"
+        )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -226,6 +226,7 @@ from weave.trace_server.opentelemetry.python_spans import Resource, Span
 from weave.trace_server.orm import ParamBuilder, Row
 from weave.trace_server.project_version.project_version import (
     TableRoutingResolver,
+    is_residence_cached,
 )
 from weave.trace_server.project_version.types import WriteTarget
 from weave.trace_server.query_builder import eval_results_query_builder
@@ -945,24 +946,36 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             {"weave_trace_server.insert_call_count": len(req.batch)}
         )
 
+        # Per-batch cache of (write_target, retention_days) keyed by project_id.
+        # Both lookups are L1-cached but every call still pays the function-call +
+        # lock + cachetools-get + ddtrace span cost (~3-5ms each), which dominates
+        # wall time for batches sharing a project. Hoist to one lookup per unique
+        # project_id. EMPTY-residence projects are intentionally NOT cached here
+        # (resolver skips caching them, see `_get_residence`) so semantics match.
+        batch_lookups: dict[str, tuple[WriteTarget, int]] = {}
+
         with self.call_batch():
             for complete_call in req.batch:
                 processed_complete_call = process_complete_call_to_content(
                     complete_call, self
                 )
 
-                # Determine write target based on project, this should be the same for all
-                # calls in the batch, subsequent calls just hit the in-memory cache. This
-                # is here for technical correctness, in case we relax project_id target
-                # constraints intra-batch
-                write_target = self.table_routing_resolver.resolve_v2_write_target(
-                    processed_complete_call.project_id,
-                    self.ch_client,
-                )
+                project_id = processed_complete_call.project_id
+                cached = batch_lookups.get(project_id)
+                if cached is not None:
+                    write_target, retention_days = cached
+                else:
+                    write_target = self.table_routing_resolver.resolve_v2_write_target(
+                        project_id, self.ch_client
+                    )
+                    retention_days = get_project_retention_days(
+                        project_id, self.ch_client
+                    )
+                    # Skip local caching for EMPTY-residence projects to preserve
+                    # the resolver's existing per-call re-query behavior.
+                    if is_residence_cached(project_id):
+                        batch_lookups[project_id] = (write_target, retention_days)
 
-                retention_days = get_project_retention_days(
-                    processed_complete_call.project_id, self.ch_client
-                )
                 ch_call = complete_call_to_ch_insertable(
                     processed_complete_call, retention_days
                 )

--- a/weave/trace_server/project_version/project_version.py
+++ b/weave/trace_server/project_version/project_version.py
@@ -41,6 +41,18 @@ def reset_project_residence_cache() -> None:
         _project_residence_cache.clear()
 
 
+def is_residence_cached(project_id: str) -> bool:
+    """Return True iff the project's residence is in the in-process cache.
+
+    EMPTY-residence projects are intentionally not cached (see `_get_residence`),
+    so a False result for a project that was just resolved means residence is
+    EMPTY and callers that hoist per-batch should fall back to per-call lookup
+    to preserve existing semantics.
+    """
+    with _project_residence_cache_lock:
+        return project_id in _project_residence_cache
+
+
 class TableRoutingResolver:
     """Resolver for determining which table to read from or write to based on project data residence.
 


### PR DESCRIPTION
## Summary
- `calls_complete` resolves write_target and retention_days per call, but both are L1-cached and the result is the same for every call in a same-project batch. The existing code comment even acknowledges this (\"this should be the same for all calls in the batch\"). Each cached hit still pays function-call + lock + cachetools-get + ddtrace span overhead -> ~3-5ms per call in prod, ~450ms wasted wall time for a 50-call batch (DD trace [6a0c7d9900000000975ce4fb10f7c246](https://app.datadoghq.com/apm/trace/6a0c7d9900000000975ce4fb10f7c246) shows 50 sequential `resolve_v2_write_target` spans aggregating to ~267ms and 50 `get_project_retention_days` spans aggregating to ~181ms).
- Hoist to one lookup per unique `project_id` per batch via a local dict. EMPTY-residence projects (resolver intentionally skips caching them so subsequent calls re-query CH, see `project_version.py:73`) fall back to per-call lookup via the new `is_residence_cached` helper -> existing semantics preserved.
- Single-call paths (`call_start`, `call_end`, `call_start_v2`, `call_end_v2`) unchanged.

## Performance
Local microbench (`scripts/benchmarks/calls_complete_batch.py`, 100 iterations, 50-call same-project batch, mocked CH client, ddtrace running but no agent). Local numbers underestimate the production gain because ddtrace's per-call agent communication is not exercised here.

| scenario | master median | branch median | delta |
|---|---:|---:|---:|
| 50-call batch, warm cache | 2.09 ms | 1.65 ms | -0.44 ms (-21%) |
| 50-call batch, cold cache | 2.16 ms | 1.70 ms | -0.46 ms (-21%) |

Resolver call counts (50-call batch, mock-verified in tests):

| project_ids | master | branch |
|---|---:|---:|
| 1 unique  | 50 | 1  |
| 2 unique  | 50 | 2  |
| 50 unique | 50 | 50 |

Production projection from DD trace [6a0c7d9900000000975ce4fb10f7c246](https://app.datadoghq.com/apm/trace/6a0c7d9900000000975ce4fb10f7c246): ~448 ms aggregate -> ~9 ms total post-hoist (one round-trip instead of 50). Local microbench cannot reproduce the ddtrace agent overhead.

## Testing
added mock-call-count + EMPTY-residence parametrize coverage in `test_clickhouse_trace_server_batched` (`test_calls_complete_hoists_per_batch_lookups[1|2|50]` + `test_calls_complete_empty_residence_not_hoisted`). All 30 batched tests pass under `--trace-server=sqlite`; the 11 skipped are CH-only.