### PR TITLE
perf(weave): honor sort_by=[] as no-sort, stream-aggregate setting

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -27,6 +27,7 @@ from weave.trace_server.clickhouse_schema import (
     CallStartCHInsertable,
 )
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
+from weave.trace_server.project_version.types import ReadTable
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
 
 
@@ -85,6 +86,66 @@ def test_clickhouse_storage_size_query_generation():
         )  # First argument should be the query
         # with mocks, we don't have any params generated
         assert call_args[1] == {}  # Second argument should be project_id
+
+
+@pytest.mark.parametrize(
+    ("sort_by", "limit", "expected_orders", "expect_streaming_setting"),
+    [
+        pytest.param(
+            None,
+            100,
+            [("started_at", "asc"), ("id", "asc")],
+            False,
+            id="none-uses-default-order",
+        ),
+        pytest.param([], 100, [], True, id="empty-list-disables-sort"),
+        pytest.param([], None, [], False, id="empty-list-no-limit-no-setting"),
+        pytest.param(
+            [tsi.SortBy(field="started_at", direction="desc")],
+            100,
+            [("started_at", "desc"), ("id", "desc")],
+            False,
+            id="user-sort-disables-setting",
+        ),
+    ],
+)
+def test_clickhouse_calls_query_stream_sort_modes(
+    sort_by, limit, expected_orders, expect_streaming_setting
+):
+    """sort_by=None keeps default order; [] is explicit no-sort and engages
+    optimize_aggregation_in_order; a user-supplied sort defeats the setting.
+    """
+    with (
+        patch(
+            "weave.trace_server.clickhouse_trace_server_batched.CallsQuery",
+            autospec=True,
+        ) as mock_cq,
+        patch.object(chts.ClickHouseTraceServer, "_query_stream") as mock_query_stream,
+        patch.object(
+            chts.ClickHouseTraceServer, "_mint_client", return_value=MagicMock()
+        ),
+    ):
+        mock_calls_query = Mock()
+        mock_calls_query.order_fields = []
+        mock_calls_query.select_fields = []
+        mock_calls_query.add_order.side_effect = lambda field, direction: (
+            mock_calls_query.order_fields.append((field, direction))
+        )
+        mock_cq.return_value = mock_calls_query
+        mock_query_stream.return_value = []
+
+        req = tsi.CallsQueryReq(project_id="p", sort_by=sort_by, limit=limit)
+        server = chts.ClickHouseTraceServer(host="h")
+        with patch.object(
+            server.table_routing_resolver,
+            "resolve_read_table",
+            return_value=ReadTable.CALLS_MERGED,
+        ):
+            list(server.calls_query_stream(req))
+
+        assert mock_calls_query.order_fields == expected_orders
+        settings = mock_query_stream.call_args.kwargs.get("settings") or {}
+        assert ("optimize_aggregation_in_order" in settings) == expect_streaming_setting
 
 
 def test_clickhouse_calls_query_stream_empty_thread_ids_against_real_clickhouse(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -227,7 +227,7 @@ from weave.trace_server.orm import ParamBuilder, Row
 from weave.trace_server.project_version.project_version import (
     TableRoutingResolver,
 )
-from weave.trace_server.project_version.types import WriteTarget
+from weave.trace_server.project_version.types import ReadTable, WriteTarget
 from weave.trace_server.query_builder import eval_results_query_builder
 from weave.trace_server.query_builder.annotation_queues_query_builder import (
     make_annotator_progress_insert_query,
@@ -1522,8 +1522,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         if req.query is not None:
             cq.add_condition(req.query.expr_)
 
-        # Sort with empty list results in no sorting
-        if req.sort_by:
+        # sort_by=None -> default order; sort_by=[] -> explicit no sort
+        # (falls through with no order_fields, enabling stream-aggregate-in-order).
+        if req.sort_by is None:
+            cq.add_order("started_at", "asc")
+            cq.add_order("id", "asc")
+        elif len(req.sort_by) > 0:
             for sort_by in req.sort_by:
                 cq.add_order(sort_by.field, sort_by.direction)
             # If user isn't already sorting by id, add id as secondary sort for consistency.
@@ -1534,13 +1538,19 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     cq.add_order("id", last_sort.direction)
                 else:
                     cq.add_order("id", "desc")
-        else:
-            cq.add_order("started_at", "asc")
-            cq.add_order("id", "asc")
         if req.limit is not None:
             cq.set_limit(req.limit)
         if req.offset is not None:
             cq.set_offset(req.offset)
+
+        # Stream the GROUP BY in (project_id, id) order so LIMIT short-circuits;
+        # ORDER BY defeats this so we only inject when no order fields are set.
+        if (
+            read_table == ReadTable.CALLS_MERGED
+            and req.limit is not None
+            and len(cq.order_fields) == 0
+        ):
+            settings = ch_settings.update_settings_for_aggregation_in_order(settings)
 
         pb = ParamBuilder()
         raw_res = self._query_stream(cq.as_sql(pb), pb.get_params(), settings=settings)

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -158,3 +158,17 @@ def update_settings_for_async_insert(
     if settings is not None:
         merged_settings.update(settings)
     return merged_settings
+
+
+# Streams the GROUP BY in (project_id, id) order so a LIMIT short-circuits.
+# Only safe when there is no ORDER BY — ClickHouse otherwise inserts a
+# SortingTransform after the in-order aggregate that nullifies the win.
+CLICKHOUSE_AGGREGATION_IN_ORDER_SETTINGS: dict[str, int | str] = {
+    "optimize_aggregation_in_order": 1,
+}
+
+
+def update_settings_for_aggregation_in_order(
+    settings: dict[str, int | str] | None = None,
+) -> dict[str, int | str]:
+    return {**(settings or {}), **CLICKHOUSE_AGGREGATION_IN_ORDER_SETTINGS}


### PR DESCRIPTION
## Summary
- Treat `sort_by=None` as default order, `sort_by=[]` as an explicit no-sort signal on the streaming endpoint.
- When `calls_merged` + LIMIT + no order fields, inject `optimize_aggregation_in_order=1` so ClickHouse streams the GROUP BY in `(project_id, id)` order. ORDER BY defeats this, so we only inject when `order_fields` is empty.
- The matching FE auto-engages this when the user filters on heavy fields (`inputs.*`/`output.*`/`summary.*`/`attributes.*`).

## Performance
Bench on local CH (10M rows / 5M ids, 2 events/call + 1% deletes, best of 3, wall / read):

| variant | stream pagination (LIMIT 100) | stream + heavy filter (LIMIT 100) |
|---|---|---|
| PROD baseline | 548ms / 320MB | 694ms / 524MB |
| PROD + setting alone (no no-sort) | 1088ms / 320MB (regresses 2x) | -- |
| no-sort alone | 263ms / 320MB | 345ms / 524MB |
| shipped (no-sort + setting) | 53ms / 37MB | 260ms / 139MB |
| gain vs prod | **10x / 9x** | **2.7x / 3.8x** |

The setting alone (with ORDER BY) regresses because ClickHouse inserts a SortingTransform after the in-order aggregate. The no-sort signal is what unlocks the streaming win.

## Testing
- Parametrized unit tests for the four `sort_by` shapes (None / [] / user / no-limit) against expected order fields and setting injection (`test_clickhouse_calls_query_stream_sort_modes`).
- Matching FE PR: https://github.com/wandb/core/pull/44245