### PR TITLE
chore(weave): add gemini-3.1-flash-lite stable model costs

### DIFF
--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -25678,5 +25678,45 @@
       "cache_creation_input": 0.0,
       "created_at": "2026-05-07 10:19:33"
     }
+  ],
+  "gemini-3.1-flash-lite": [
+    {
+      "provider": "vertex_ai-language-models",
+      "input": 2.5e-07,
+      "output": 1.5e-06,
+      "cache_read_input": 2.5e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-05-19 10:13:20"
+    }
+  ],
+  "gemini/gemini-3.1-flash-lite": [
+    {
+      "provider": "gemini",
+      "input": 2.5e-07,
+      "output": 1.5e-06,
+      "cache_read_input": 2.5e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-05-19 10:13:20"
+    }
+  ],
+  "vertex_ai/gemini-3.1-flash-lite": [
+    {
+      "provider": "vertex_ai-language-models",
+      "input": 2.5e-07,
+      "output": 1.5e-06,
+      "cache_read_input": 2.5e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-05-19 10:13:20"
+    }
+  ],
+  "openrouter/google/gemini-3.1-flash-lite": [
+    {
+      "provider": "openrouter",
+      "input": 2.5e-07,
+      "output": 1.5e-06,
+      "cache_read_input": 2.5e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-05-19 10:13:20"
+    }
   ]
 }

--- a/weave/trace_server/model_providers/model_providers.json
+++ b/weave/trace_server/model_providers/model_providers.json
@@ -2662,6 +2662,10 @@
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
+  "gemini-3.1-flash-lite": {
+    "litellm_provider": "vertex_ai-language-models",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
   "gemini-3.1-flash-lite-preview": {
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
@@ -2866,6 +2870,10 @@
     "deprecated_date": "2026-01-29T21:44:57.324444"
   },
   "gemini/gemini-3-pro-preview": {
+    "litellm_provider": "gemini",
+    "api_key_name": "GEMINI_API_KEY"
+  },
+  "gemini/gemini-3.1-flash-lite": {
     "litellm_provider": "gemini",
     "api_key_name": "GEMINI_API_KEY"
   },
@@ -4535,6 +4543,10 @@
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },
   "vertex_ai/gemini-3.1-flash-image-preview": {
+    "litellm_provider": "vertex_ai-language-models",
+    "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
+  },
+  "vertex_ai/gemini-3.1-flash-lite": {
     "litellm_provider": "vertex_ai-language-models",
     "api_key_name": "VERTEXAI_JSON_CREDENTIALS"
   },


### PR DESCRIPTION
## JIRA Issue(s)

[WB-34501](https://coreweave.atlassian.net/browse/WB-34501)

## Description

Google graduated `gemini-3.1-flash-lite` from preview to general availability on 2026-05-07, with the stable model id `gemini-3.1-flash-lite` (no `-preview` suffix) now served from the same endpoints as before. Our `cost_checkpoint.json` and `model_providers.json` still only know about the `-preview` variants, so any customer or internal call that uses the stable model id today gets recorded with `$0` cost in Weave's UI and Datadog cost panels.

This PR adds the stable-name rows alongside the existing preview rows so cost attribution catches up with the GA. All four name variants we keep for the preview model (bare `gemini-3.1-flash-lite`, plus the `gemini/`, `vertex_ai/`, and `openrouter/google/` prefixed forms) get a corresponding stable-name entry in `cost_checkpoint.json`. The three prefixed variants that already exist in `model_providers.json` also get their stable-name siblings there. `openrouter/google/gemini-3.1-flash-lite` is intentionally added only to `cost_checkpoint.json` — that prefix is absent for every gemini model in `model_providers.json` today, so adding it would be a one-off departure from the file's existing shape.

The cost-loader in `update_costs.py` keeps these manual entries safe across future automated syncs from litellm. It compares the upstream row against the most recent stored row and only appends a new historical entry when costs differ, capped at three entries per model. If litellm later publishes the same numbers, nothing changes; if they diverge by some rounding, the sync appends a fresh row and the hand-added one stays as historical context.

The numeric values stored in `cost_checkpoint.json` are USD-per-token, so `$0.25 per 1M input tokens` becomes `0.25 / 1_000_000 = 2.5e-07`. Every value can be cross-checked against the public sources linked in the table below — all four sources converge on the same numbers, and each table cell carries the link the reviewer should open to verify that exact value.

| JSON field | Public price | Stored value | Source |
|---|---|---|---|
| `input` | $0.25 per 1M input tokens | `2.5e-07` | [Google blog post (2026-03-03)](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-flash-lite/) — "Priced at $0.25/1M input tokens and $1.50/1M output tokens" · [Google API pricing](https://ai.google.dev/gemini-api/docs/pricing) · [OpenRouter listing](https://openrouter.ai/google/gemini-3.1-flash-lite) — "Input Price. $0.25 per 1M" |
| `output` | $1.50 per 1M output tokens | `1.5e-06` | [Google blog post (2026-03-03)](https://blog.google/innovation-and-ai/models-and-research/gemini-models/gemini-3-1-flash-lite/) · [Google API pricing](https://ai.google.dev/gemini-api/docs/pricing) — "Output price (including thinking tokens) ... $1.50" · [OpenRouter listing](https://openrouter.ai/google/gemini-3.1-flash-lite) — "Output Price. $1.50 per 1M" |
| `cache_read_input` | $0.025 per 1M cached input tokens | `2.5e-08` | [Google API pricing](https://ai.google.dev/gemini-api/docs/pricing) — "Context caching price ... $0.025 (text / image / video)" |
| `cache_creation_input` | not billed | `0.0` | Google does not bill cache-creation on this model family; this also mirrors what the existing `-preview` rows already store in the same file |
| `provider` | — | `vertex_ai-language-models` (bare and `vertex_ai/` keys) · `gemini` (`gemini/` key) · `openrouter` (`openrouter/google/` key) | each new row uses the same `provider` value as its `-preview` sibling already in `cost_checkpoint.json` |
| `created_at` | — | `2026-05-19 10:13:20` | the timestamp at which this row was added (matches the `datetime.now()` format the `update_costs.py` sync script writes) |

Stable model-id GA confirmation: [Firebase AI Logic models page](https://firebase.google.com/docs/ai-logic/models) — `gemini-3.1-flash-lite`: "Stable version of Gemini 3.1 Flash‑Lite, Stable, 2026-05-07"; [OpenRouter listing](https://openrouter.ai/google/gemini-3.1-flash-lite) — "Released May 7, 2026."

## Why this approach

The team's existing pattern for adding new models is exactly this: a hand-edit of `cost_checkpoint.json` (appended at the end) plus a `model_providers.json` insertion next to the closest existing sibling, alphabetical-ish within each provider section. PR #6781 ("Add grok 4.3") is the most recent reference. Following that pattern keeps the diff identical in shape to the half-dozen recent merges and minimizes reviewer overhead. The change is strictly additive — no rows removed, no fields renamed.

## Testing

Both JSON files re-parse cleanly via the real loader at `weave.trace_server.costs.insert_costs.load_costs_from_json()`. The loader returns 2,559 models (up from 2,555, +4 as expected) and the four new stable keys round-trip through the `CostDetails` typed-dict shape with the costs the file declares.

The full suite under `tests/trace_server/costs/` passes locally (`uv run --group test python -m pytest tests/trace_server/costs/ -v` → 18 passed in 0.08s) and `uvx ruff check` on the touched directories passes too.


[WB-34501]: https://coreweave.atlassian.net/browse/WB-34501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ