### PR TITLE
chore(weave): EvaluationLogger init: avoid __dict__

### DIFF
--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -689,12 +689,10 @@ class EvaluationLogger:
         eval_attributes: dict[str, Any] | None = None,
         scorers: list[str] | None = None,
     ) -> None:
-        # _eval_meta may have been seeded by _create_with_meta()
-        try:
-            eval_meta = self._eval_meta
-        except AttributeError:
-            eval_meta = {}
-        self._eval_meta = {**eval_meta, **IMPERATIVE_EVAL_META_MARKER}
+        self._eval_meta = {
+            **(self._client_eval_meta or {}),
+            **IMPERATIVE_EVAL_META_MARKER,
+        }
 
         self.name = name
         self.scorers = scorers
@@ -803,6 +801,10 @@ class EvaluationLogger:
             use_stack=False,  # Don't push to global stack to prevent nesting
         )
 
+    # Pre-seeded by _create_with_meta() to inject caller-provided fields into
+    # _eval_meta during __init__.
+    _client_eval_meta: dict[str, Any] | None = None
+
     @classmethod
     def _create_with_meta(
         cls,
@@ -820,7 +822,7 @@ class EvaluationLogger:
         Note: Semi-internal; used by wandb/wandb SDK.
         """
         instance = cls.__new__(cls)
-        instance._eval_meta = eval_meta
+        instance._client_eval_meta = eval_meta
         EvaluationLogger.__init__(
             instance,
             name=name,

--- a/weave/evaluation/eval_imperative.py
+++ b/weave/evaluation/eval_imperative.py
@@ -689,9 +689,11 @@ class EvaluationLogger:
         eval_attributes: dict[str, Any] | None = None,
         scorers: list[str] | None = None,
     ) -> None:
-        eval_meta = {}
-        if "_eval_meta" in self.__dict__:
-            eval_meta = self.__dict__["_eval_meta"]
+        # _eval_meta may have been seeded by _create_with_meta()
+        try:
+            eval_meta = self._eval_meta
+        except AttributeError:
+            eval_meta = {}
         self._eval_meta = {**eval_meta, **IMPERATIVE_EVAL_META_MARKER}
 
         self.name = name


### PR DESCRIPTION
## Description

- #6739 introduced a `__dict__` check in the `EvaluationLogger` `__init__` to look for an attribute that `_create_with_meta` may have added. Replace it with passing the initial eval in a class-defined default none field, which is cleaner. Passing in a separate field so `_eval_meta` itself doesn't have to be None-able.

## Testing

- [x] Passes existing unit tests (no functional change)
- [x] Manually tested with both regular constructor and `_create_with_meta` flows.