### PR TITLE
fix(weave): make ObjectRecord subscriptable for str.format templates

### DIFF
--- a/tests/trace/test_object_record.py
+++ b/tests/trace/test_object_record.py
@@ -3,36 +3,29 @@ import pytest
 from weave.trace.object_record import ObjectRecord
 
 
-def test_object_record_getitem_returns_attribute():
-    rec = ObjectRecord({"_class_name": "Foo", "x": 1, "y": "hi"})
-    assert rec["x"] == 1
-    assert rec["y"] == "hi"
-
-
-def test_object_record_getitem_raises_keyerror_for_missing():
-    rec = ObjectRecord({"_class_name": "Foo", "x": 1})
-    with pytest.raises(KeyError, match="missing"):
-        rec["missing"]
-
-
-def test_object_record_str_format_with_subscript():
-    """Regression: scoring prompts use `{var[field]}` subscript syntax.
-
-    When a Weave call's input/output deserializes into an ObjectRecord, the
-    private weave-worker's scoring prompt formatter calls
-    `template.format(**inputs)`, which evaluates `inputs[var][field]` via
-    `__getitem__`. Without this, format raised
-    `TypeError: 'ObjectRecord' object is not subscriptable`.
+def test_object_record_supports_subscript_for_str_format():
+    """Regression: ObjectRecord must support __getitem__ so prompt templates
+    using `{x[field]}` subscript syntax work. Without this, `str.format` on
+    an ObjectRecord raised `TypeError: 'ObjectRecord' object is not
+    subscriptable` — observed in weave-worker's
+    scoring_worker._format_scoring_prompt.
 
     The `.format()` calls below are the behavior under test, so the UP032
     autofix to f-strings is suppressed.
     """
     rec = ObjectRecord({"_class_name": "Output", "answer": "42", "score": 0.9})
+
+    # Direct subscript access mirrors attribute access.
+    assert rec["answer"] == "42"
+    assert rec["score"] == 0.9
+
+    # Missing keys raise KeyError (dict semantics), not TypeError.
+    with pytest.raises(KeyError, match="missing"):
+        rec["missing"]
+
+    # Production scenario: str.format with subscript syntax.
     assert "{out[answer]}".format(out=rec) == "42"  # noqa: UP032
-    assert "score={out[score]}".format(out=rec) == "score=0.9"  # noqa: UP032
 
-
-def test_object_record_str_format_nested():
-    inner = ObjectRecord({"_class_name": "Inner", "name": "Alice"})
-    outer = ObjectRecord({"_class_name": "Outer", "user": inner})
-    assert "{x[user][name]}".format(x=outer) == "Alice"  # noqa: UP032
+    # Nested ObjectRecord subscripting recurses naturally.
+    outer = ObjectRecord({"_class_name": "Outer", "inner": rec})
+    assert "{x[inner][answer]}".format(x=outer) == "42"  # noqa: UP032

--- a/tests/trace/test_object_record.py
+++ b/tests/trace/test_object_record.py
@@ -1,0 +1,38 @@
+import pytest
+
+from weave.trace.object_record import ObjectRecord
+
+
+def test_object_record_getitem_returns_attribute():
+    rec = ObjectRecord({"_class_name": "Foo", "x": 1, "y": "hi"})
+    assert rec["x"] == 1
+    assert rec["y"] == "hi"
+
+
+def test_object_record_getitem_raises_keyerror_for_missing():
+    rec = ObjectRecord({"_class_name": "Foo", "x": 1})
+    with pytest.raises(KeyError, match="missing"):
+        rec["missing"]
+
+
+def test_object_record_str_format_with_subscript():
+    """Regression: scoring prompts use `{var[field]}` subscript syntax.
+
+    When a Weave call's input/output deserializes into an ObjectRecord, the
+    private weave-worker's scoring prompt formatter calls
+    `template.format(**inputs)`, which evaluates `inputs[var][field]` via
+    `__getitem__`. Without this, format raised
+    `TypeError: 'ObjectRecord' object is not subscriptable`.
+
+    The `.format()` calls below are the behavior under test, so the UP032
+    autofix to f-strings is suppressed.
+    """
+    rec = ObjectRecord({"_class_name": "Output", "answer": "42", "score": 0.9})
+    assert "{out[answer]}".format(out=rec) == "42"  # noqa: UP032
+    assert "score={out[score]}".format(out=rec) == "score=0.9"  # noqa: UP032
+
+
+def test_object_record_str_format_nested():
+    inner = ObjectRecord({"_class_name": "Inner", "name": "Alice"})
+    outer = ObjectRecord({"_class_name": "Outer", "user": inner})
+    assert "{x[user][name]}".format(x=outer) == "Alice"  # noqa: UP032

--- a/weave/trace/object_record.py
+++ b/weave/trace/object_record.py
@@ -36,6 +36,14 @@ class ObjectRecord:  # noqa: PLW1641
                 return False
         return True
 
+    def __getitem__(self, key: str) -> Any:
+        # Mirror attribute access so templates using `{x[field]}` subscript
+        # syntax work the same as `{x.field}`. Without this, `str.format` on
+        # an ObjectRecord raises `TypeError: 'ObjectRecord' object is not
+        # subscriptable` — for example, when a scoring prompt formats over a
+        # call's deserialized inputs/output.
+        return self.__dict__[key]
+
     def map_values(self, fn: Callable) -> ObjectRecord:
         return ObjectRecord({k: fn(v) for k, v in self.__dict__.items()})
 


### PR DESCRIPTION
## Background

### The actors

**`ObjectRecord`** (`weave/trace/object_record.py`) is Weave's wrapper for "I deserialized a user object from the trace database but I don't have its original class available." When a user logs a call whose input is, say, a custom pydantic `BaseModel`, the class definition lives in their code — not in Weave's. So Weave stores the attributes, and on retrieval reconstructs a generic stand-in that hangs those attributes off itself via `setattr`. You can read fields with `obj.answer`, `obj.score`, etc. But it does **not** behave like a dict — there is no `__getitem__`.

**Python's `str.format`** has two ways to drill into a value:

```python
"{x.field}".format(x=val)   # attribute access  → val.field
"{x[field]}".format(x=val)  # subscript access  → val["field"]
```

They look interchangeable. They are not. The second one calls `__getitem__`.

### The collision

The scoring system lets users write prompt templates like:

```
Was this output correct?
Question: {inputs[question]}
Answer:   {output[answer]}
```

Then the worker fetches the call's `inputs`/`output` from the trace DB and runs:

```python
prompt.format(**inputs_with_defaults)
```

- If the user originally logged `{"question": "..."}` as a plain dict → roundtrips as a dict → `inputs["question"]` works.
- If they logged a pydantic model or dataclass → roundtrips as an `ObjectRecord` → `inputs["question"]` calls `ObjectRecord.__getitem__("question")` → no such method → `TypeError: 'ObjectRecord' object is not subscriptable`.

The user's template is unchanged. The user's intent is unchanged. The thing that changed is the runtime type of the value, which the user has zero control over — it's determined by Weave's serialization layer.

### Why it surfaced

This was a regression flagged in Datadog with ~734 occurrences over the past week. First seen ~2 months ago at `ae0963a`, dormant, then resurging 5 days ago at `62e783a` — likely a new scorer rollout or a change in how call inputs are unwrapped before reaching the formatter.

Stack trace observed in `weave-worker`:

```
File "/weave/src/workers/scoring_worker.py", line 1083, in _do_score_call
File "/weave/src/workers/scoring_worker.py", line 1274, in _do_score_call_llm_as_a_judge
    updated_scoring_prompt = _format_scoring_prompt(
        scorer.scoring_prompt, inputs_with_defaults
    )
File "/weave/src/workers/scoring_worker.py", line 1164, in _format_scoring_prompt
    scoring_prompt = scoring_prompt.format(**inputs_with_defaults)
TypeError: 'ObjectRecord' object is not subscriptable
```

The same vulnerable `template.format(**inputs)` pattern exists in the public SDK at:

- `weave/scorers/llm_as_a_judge_scorer.py:66` — `LLMAsAJudgeScorer.score`
- `weave/prompt/prompt.py:146` — `format_message_with_template_vars` (used by `MessagesPrompt.format`)

…so this isn't worker-only; any user code path that runs a prompt template over deserialized call inputs/output can hit it.

## Fix

Add `__getitem__` to `ObjectRecord` delegating to `self.__dict__[key]`. Now `obj["field"]` behaves the same as `obj.field`.

```python
def __getitem__(self, key: str) -> Any:
    # Mirror attribute access so templates using `{x[field]}` subscript
    # syntax work the same as `{x.field}`. Without this, `str.format` on
    # an ObjectRecord raises `TypeError: 'ObjectRecord' object is not
    # subscriptable` — for example, when a scoring prompt formats over a
    # call's deserialized inputs/output.
    return self.__dict__[key]
```

Why this is the right level:

- **Purely additive.** `ObjectRecord` had no `__getitem__` previously, so no existing code path can change behavior — only previously-broken code starts working.
- **Single fix, three call sites.** It repairs `weave-worker`'s `_format_scoring_prompt`, `LLMAsAJudgeScorer.score`, and `MessagesPrompt.format` in one place. The worker installs the Weave SDK as a dependency, so on the next SDK release it picks up this fix with no worker-side change.
- **Recurses naturally.** Nested `ObjectRecord` values inside an `ObjectRecord` work too — `{x[user][name]}` is two `__getitem__` calls, both satisfied by the same one-line implementation.
- **Matches existing semantics.** `ObjectRecord.unwrap()` already converts the record back to a plain dict, so treating it dict-like for read-only access aligns with the class's existing posture.

## Test plan

New file `tests/trace/test_object_record.py` with one regression test, `test_object_record_supports_subscript_for_str_format`, which fails with the exact production `TypeError` before the patch and passes after. It covers:

- Direct subscript access mirrors attribute access (`rec["answer"]` returns the stored attribute).
- Missing keys raise `KeyError` (dict semantics), not `TypeError`.
- Production scenario: `"{out[answer]}".format(out=record)`.
- Nested `ObjectRecord` subscripting (`{x[inner][answer]}`) recurses through `__getitem__`.

Regression check on existing tests that touch `ObjectRecord`:

- [x] `tests/trace/test_object_record.py` (1 new test)
- [x] `tests/trace/test_serialize_encoders.py`
- [x] `tests/trace/test_deepcopy.py`
- [x] `tests/trace/test_llm_as_a_judge_scorer.py`
- [x] **114 tests pass total, no regressions**
- [x] `uvx ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)