### PR TITLE
fix(weave): make WeaveClient.flush() non-destructive to call-pair buffers

### DIFF
--- a/tests/trace_server_bindings/test_call_batch_processor.py
+++ b/tests/trace_server_bindings/test_call_batch_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import pathlib
+import time
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -209,6 +210,83 @@ def test_missing_trace_id_raises_value_error() -> None:
     with pytest.raises(ValueError, match="missing trace_id"):
         processor.enqueue([end_item])
 
+    with patch(
+        "weave.trace_server_bindings.call_batch_processor.FLUSH_TIMEOUT_SECONDS",
+        0.05,
+    ):
+        processor.stop_accepting_new_work_and_flush_queue()
+
+
+def test_drain_queue_skips_pending_pair_wait() -> None:
+    """User flush drains the send queue without waiting on pending pairs.
+
+    Pins WB-34557. Under `WEAVE_USE_CALLS_COMPLETE=true`, the old
+    `stop_accepting_new_work_and_flush_queue` path made `client.flush()`
+    hang up to FLUSH_TIMEOUT_SECONDS waiting for in-flight starts to pair.
+    The drain path used by `WeaveClient.flush()` must:
+      1. return quickly even when pending pairs exist,
+      2. leave _pending_starts / _pending_ends / _eager_call_ids untouched
+         so the bulk-endpoint pairing optimization survives the flush,
+      3. NOT orphan-send pending items (those still belong to in-flight calls).
+    """
+    complete_fn = MagicMock()
+    eager_fn = MagicMock()
+    processor = CallBatchProcessor(complete_fn, eager_fn, min_batch_interval=0.01)
+
+    # Simulate an in-flight non-eager call: start enqueued, end not yet.
+    pending_start = _make_start_item("call-1", "trace-1")
+    processor.enqueue([pending_start])
+    # And an in-flight eager call: start sent immediately, end not yet.
+    eager_start = _make_start_item("call-2", "trace-2")
+    processor.enqueue_start(eager_start, eager_call_start=True)
+
+    t0 = time.monotonic()
+    processor.drain_queue(timeout=5.0)
+    elapsed = time.monotonic() - t0
+
+    # Drain must return quickly — well under any pairing budget.
+    assert elapsed < 2.0, f"drain_queue blocked for {elapsed:.2f}s"
+
+    # Pending state preserved so pairing can still happen later.
+    assert "call-1" in processor._pending_starts
+    assert "call-2" in processor._eager_call_ids
+    # Neither processor was called with the still-in-flight non-eager start.
+    complete_fn.assert_not_called()
+    # The eager start was queued and sent immediately by enqueue_start;
+    # the eager processor may have already drained it. Either way, we did
+    # not orphan-send "call-1".
+    sent_items = [item for call in eager_fn.call_args_list for item in call.args[0]]
+    assert pending_start not in sent_items
+
+    # Processor is still accepting work.
+    assert processor.is_accepting_new_work()
+
+    # Cleanup
+    with patch(
+        "weave.trace_server_bindings.call_batch_processor.FLUSH_TIMEOUT_SECONDS",
+        0.05,
+    ):
+        processor.stop_accepting_new_work_and_flush_queue()
+
+
+def test_drain_queue_processes_already_paired_items() -> None:
+    """Drain still sends what's already paired and queued."""
+    complete_fn = MagicMock()
+    eager_fn = MagicMock()
+    processor = CallBatchProcessor(complete_fn, eager_fn, min_batch_interval=0.01)
+
+    # Pair up a call so it lands in the send queue.
+    processor.enqueue([_make_start_item("call-1", "trace-1")])
+    processor.enqueue([_make_end_item("call-1")])
+
+    processor.drain_queue(timeout=5.0)
+
+    complete_fn.assert_called_once()
+    batch = complete_fn.call_args[0][0]
+    assert len(batch) == 1
+    assert batch[0].req.id == "call-1"
+
+    # Cleanup
     with patch(
         "weave.trace_server_bindings.call_batch_processor.FLUSH_TIMEOUT_SECONDS",
         0.05,

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -2610,8 +2610,15 @@ class WeaveClient:
             self._wal = None
 
     def flush(self) -> None:
-        """Flushes background asynchronous tasks, safe to call multiple times."""
-        self._flush()
+        """Flushes background asynchronous tasks, safe to call multiple times.
+
+        Drains items already in the send queue. Items mid-pairing (a start
+        whose end has not yet been enqueued, e.g. an open `Evaluation.evaluate`
+        under `use_calls_complete=True`) stay in the processor's pending
+        buffers and are sent when their counterpart arrives — keeping the
+        bulk-endpoint optimization intact across repeated flushes.
+        """
+        self._flush(for_shutdown=False)
 
     def _flush_with_callback(
         self,
@@ -2704,20 +2711,34 @@ class WeaveClient:
         )
         callback(final_status)
 
-    def _flush(self) -> None:
-        """Used to wait until all currently enqueued jobs are processed."""
+    def _flush(self, *, for_shutdown: bool = True) -> None:
+        """Used to wait until all currently enqueued jobs are processed.
+
+        Args:
+            for_shutdown: If True (default — used by `finish()`), tear down
+                each processor, waiting up to its full pairing budget for
+                in-flight starts/ends to combine into bulk-endpoint writes,
+                then restart. If False (used by user-facing `flush()`), drain
+                the send queue without touching pending-pair state or
+                stopping the processor — preserves the bulk-endpoint
+                optimization across repeated user flushes.
+        """
         if not self.future_executor._in_thread_context.get():
             self.future_executor.flush()
         if self.future_executor_fastlane:
             self.future_executor_fastlane.flush()
         if self._server_call_processor:
-            self._server_call_processor.stop_accepting_new_work_and_flush_queue()
-            # Restart call processor processing thread after flushing
-            self._server_call_processor.accept_new_work()
+            if for_shutdown:
+                self._server_call_processor.stop_accepting_new_work_and_flush_queue()
+                self._server_call_processor.accept_new_work()
+            else:
+                self._server_call_processor.drain_queue()
         if self._server_feedback_processor:
-            self._server_feedback_processor.stop_accepting_new_work_and_flush_queue()
-            # Restart feedback processor processing thread after flushing
-            self._server_feedback_processor.accept_new_work()
+            if for_shutdown:
+                self._server_feedback_processor.stop_accepting_new_work_and_flush_queue()
+                self._server_feedback_processor.accept_new_work()
+            else:
+                self._server_feedback_processor.drain_queue()
         if self._wal is not None:
             self._wal.flush()
 

--- a/weave/trace_server_bindings/async_batch_processor.py
+++ b/weave/trace_server_bindings/async_batch_processor.py
@@ -152,6 +152,37 @@ class AsyncBatchProcessor(Generic[T]):
         self.processing_thread.join()
         self.health_check_thread.join()
 
+    def drain_queue(self, timeout: float = 60.0) -> None:
+        """Wait for the send queue to drain without shutting down the processor.
+
+        Use this for user-initiated `client.flush()`. Unlike
+        `stop_accepting_new_work_and_flush_queue`, this:
+
+        - leaves the processing thread running, so subsequent enqueues
+          continue to be batched and sent without restart cost
+        - does not touch any subclass-owned pending-pair state (e.g.
+          `CallBatchProcessor._pending_starts`), so the bulk-endpoint
+          pairing optimization survives flushes that happen mid-call
+
+        Returns when the queue is empty for a full poll interval, or when
+        `timeout` elapses (whichever comes first). Items that arrive after
+        return are picked up on the next flush.
+
+        Args:
+            timeout: Hard ceiling, in seconds. Belt-and-suspenders against
+                an unresponsive processor thread; a healthy processor empties
+                the queue at batch cadence and this should rarely be hit.
+        """
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self.queue.empty():
+                # One extra tick to let an in-flight batch finish its send
+                # before we declare the queue drained.
+                time.sleep(self.min_batch_interval)
+                if self.queue.empty():
+                    return
+            time.sleep(self.min_batch_interval)
+
     def accept_new_work(self) -> None:
         """Resumes accepting new work."""
         self.stop_accepting_work_event.clear()


### PR DESCRIPTION
## Summary
- `WeaveClient.flush()` routed through `_flush()`, which calls `stop_accepting_new_work_and_flush_queue` on every processor. That path is the *shutdown* path: it waits up to `FLUSH_TIMEOUT_SECONDS` (5 min) for in-flight starts/ends to pair into bulk-endpoint writes, orphan-sends what's left, then tears the processor thread down. Right call for shutdown — wrong call for an interactive `flush()` mid-evaluation, where the buffer always has an unpaired eager start (`Evaluation.evaluate`) and `flush()` stalls ~300s.
- Adds `AsyncBatchProcessor.drain_queue(timeout=60)`: waits for the send queue to drain, **does not touch subclass-owned pending-pair state**, **does not stop the processor**. The 5-minute pairing budget on shutdown is intentionally preserved — it's what lets pairs combine into the cheaper `/v2/.../calls/complete` bulk endpoint when the process is exiting.
- Routes `WeaveClient.flush()` through the new path via `_flush(for_shutdown=False)`. `client.finish()` keeps the old behavior.
- Fixes [WB-34557](https://coreweave.atlassian.net/browse/WB-34557).

## Reasoning — why two paths instead of just tuning the timeout

A previous draft of this PR shrank `FLUSH_TIMEOUT_SECONDS` from `5 * 60` to `2.0`. That was wrong: the 5-minute pairing wait isn't a bug, it's a perf feature. When the SDK is shutting down, we want to give in-flight ops as long as reasonable to finish so their start+end pair into a single `/calls/complete` write (one network call, one CH insert) instead of getting orphan-sent through the eager `/call/start` + `/call/end` pair (two calls, two inserts, more overhead). Trimming that budget for shutdown would cost real perf on every well-behaved process exit.

The actual bug is that `client.flush()` — which fires repeatedly during normal use, mid-eval, in agent loops, etc. — was incorrectly using the shutdown path. Two distinct call sites, two distinct semantics:

| | `client.finish()` | `client.flush()` |
|---|---|---|
| Intent | "I'm done. Send everything, even orphans." | "Make my already-finished writes visible. Don't disrupt in-flight calls." |
| Pending pairs | Wait up to 5 min, then orphan-send | Leave alone — they're still in-flight |
| Processor thread | Stop + restart (one-shot pattern) | Keep running |
| Frequency | Once per process (atexit) | Many times per process |

The new `drain_queue` is the second column. It:

1. **Skips the pairing wait.** The pending-pair buffer represents calls whose ends haven't been enqueued yet — by definition the user can't have *meant* to flush them, they're not finished writes. They stay in the buffer and pair naturally when their counterpart arrives.
2. **Doesn't stop the processor.** Repeated `flush()` calls would otherwise pay the thread restart cost every time.
3. **Has a generous 60s safety ceiling** in case the processor thread is unresponsive, but real flushes return at batch cadence (~10ms).

### Options considered

| Approach | Why not |
|---|---|
| Drop `FLUSH_TIMEOUT_SECONDS` to ~2s | Breaks the shutdown bulk-endpoint optimization, the very thing the timeout exists for. |
| Track eager call_ids and exclude them from the shutdown pairing-wait | Helps the eager case but doesn't fix non-eager mid-flush. The fix-flush-vs-finish split makes this moot. |
| Skip pairing wait entirely (one path) | Equivalent to point #1 for shutdown — same regression. |
| **Two paths** (this PR) | Each call site gets the semantics it actually wants. |

### What this doesn't fix
There's still a separate, smaller bug worth chasing: in some scenarios the SDK orphan-sends "1 unpaired end" on shutdown even from a minimal `EvaluationLogger(...)` + `client.flush()` repro. An end ending up in `_pending_ends` without its start passing through `_handle_start` first suggests an ordering bug in eager-start enqueue. Separate change — this PR makes user-flush stop pessimizing on it but doesn't root-cause it.

## Testing
unit tests: `test_drain_queue_skips_pending_pair_wait` asserts drain returns in <2s with pending items, leaves pending state intact, doesn't orphan-send, leaves the processor accepting work. `test_drain_queue_processes_already_paired_items` confirms paired items still flow through. Existing 11 tests for `CallBatchProcessor` unchanged.

Manually verified against qa-azure (`server-release-0.81.x`) with `WEAVE_USE_CALLS_COMPLETE=true`: mega smoke `imperative_eval` went from `[PASS] 304.76s` → `[PASS] 4.23s`. Shutdown path on the same project still hits the 5-min budget exactly as before.

[WB-34557]: https://coreweave.atlassian.net/browse/WB-34557?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ