### PR TITLE
fix(trace): return removed row from pop()

### DIFF
--- a/weave/trace/table.py
+++ b/weave/trace/table.py
@@ -53,6 +53,6 @@ class Table:  # noqa: PLW1641
             raise TypeError("Can only append dicts to tables")
         self.rows.append(row)
 
-    def pop(self, index: int) -> None:
-        """Remove a row at the given index from the table."""
-        self.rows.pop(index)
+    def pop(self, index: int) -> dict:
+        """Remove and return a row at the given index from the table."""
+        return self.rows.pop(index)

--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -602,10 +602,10 @@ class WeaveTable(Traceable):  # noqa: PLW1641
         self._mark_dirty()
         rows.append(val)
 
-    def pop(self, index: int) -> None:
+    def pop(self, index: int) -> dict:
         rows = self._inefficiently_materialize_rows_as_list()
         self._mark_dirty()
-        rows.pop(index)
+        return rows.pop(index)
 
     def unwrap(self) -> Any:
         return unwrap(list(self.rows))


### PR DESCRIPTION
## Description

Both `Table.pop()` in `weave/trace/table.py` and `WeaveTable.pop()` in
`weave/trace/vals.py` were declared `-> None` and discarded the return
value of the underlying `list.pop()` call. Python's `list.pop()` removes
**and returns** the element at the given index; these implementations
silently broke that contract, meaning any caller doing:

```python
row = my_table.pop(0)
```

would always receive `None` instead of the removed dict.

Fix: capture and return the result of the inner `list.pop()` in both
methods, and update their return type annotations from `-> None` to
`-> dict`.

## Testing

Verified by code inspection that both call sites previously discarded
the `list.pop()` return value. No existing tests cover `Table.pop()` or
`WeaveTable.pop()` (confirmed via grep), so no tests were broken. Manual
smoke-test of the corrected behaviour:

```python
t = Table([{"a": 1}, {"b": 2}])
row = t.pop(0)
assert row == {"a": 1}   # was None before the fix
assert len(t) == 1
```