### PR TITLE
chore(weave): add scorer_* columns to feedback table (031)

### DIFF
--- a/weave/trace_server/migrations/031_add_scorer_feedback_columns.down.sql
+++ b/weave/trace_server/migrations/031_add_scorer_feedback_columns.down.sql
@@ -1,5 +1,7 @@
 ALTER TABLE feedback
-    DROP COLUMN scorer_tags,
-    DROP COLUMN scorer_ratings,
-    DROP COLUMN scorer_reasons,
-    DROP COLUMN scorer_confidences;
+    DROP COLUMN IF EXISTS scorer_tags,
+    DROP COLUMN IF EXISTS scorer_tag_reasons,
+    DROP COLUMN IF EXISTS scorer_tag_confidences,
+    DROP COLUMN IF EXISTS scorer_ratings,
+    DROP COLUMN IF EXISTS scorer_rating_reasons,
+    DROP COLUMN IF EXISTS scorer_rating_confidences;

--- a/weave/trace_server/migrations/031_add_scorer_feedback_columns.down.sql
+++ b/weave/trace_server/migrations/031_add_scorer_feedback_columns.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE feedback
+    DROP COLUMN scorer_tags,
+    DROP COLUMN scorer_ratings,
+    DROP COLUMN scorer_reasons,
+    DROP COLUMN scorer_confidences;

--- a/weave/trace_server/migrations/031_add_scorer_feedback_columns.up.sql
+++ b/weave/trace_server/migrations/031_add_scorer_feedback_columns.up.sql
@@ -1,0 +1,15 @@
+/*
+Typed columns for `wandb.agent_monitor` scorer feedback. Non-null with empty
+defaults, so existing rows need no backfill.
+
+- `scorer_tags`: string labels assigned by a scorer.
+- `scorer_ratings`: numeric scores keyed by rating name (e.g. `_rating_`).
+    LowCardinality keys — the set of rating names is small.
+- `scorer_reasons`: optional reason text, keyed by `tag.<name>` / `rating.<name>`.
+- `scorer_confidences`: optional confidence per tag/rating, same key convention.
+*/
+ALTER TABLE feedback
+    ADD COLUMN scorer_tags Array(String) DEFAULT [],
+    ADD COLUMN scorer_ratings Map(LowCardinality(String), Float64) DEFAULT map(),
+    ADD COLUMN scorer_reasons Map(String, String) DEFAULT map(),
+    ADD COLUMN scorer_confidences Map(String, Float64) DEFAULT map();

--- a/weave/trace_server/migrations/031_add_scorer_feedback_columns.up.sql
+++ b/weave/trace_server/migrations/031_add_scorer_feedback_columns.up.sql
@@ -2,14 +2,20 @@
 Typed columns for `wandb.agent_monitor` scorer feedback. Non-null with empty
 defaults, so existing rows need no backfill.
 
+Reasons and confidences are split by whether they attach to a tag or a rating.
+Map keys are the plain tag/rating name (no `tag.<name>` / `rating.<name>` prefix).
+
 - `scorer_tags`: string labels assigned by a scorer.
+- `scorer_tag_reasons`: optional reason text per tag, keyed by tag name.
+- `scorer_tag_confidences`: optional confidence per tag, keyed by tag name.
 - `scorer_ratings`: numeric scores keyed by rating name (e.g. `_rating_`).
-    LowCardinality keys — the set of rating names is small.
-- `scorer_reasons`: optional reason text, keyed by `tag.<name>` / `rating.<name>`.
-- `scorer_confidences`: optional confidence per tag/rating, same key convention.
+- `scorer_rating_reasons`: optional reason text per rating, keyed by rating name.
+- `scorer_rating_confidences`: optional confidence per rating, keyed by rating name.
 */
 ALTER TABLE feedback
-    ADD COLUMN scorer_tags Array(String) DEFAULT [],
-    ADD COLUMN scorer_ratings Map(LowCardinality(String), Float64) DEFAULT map(),
-    ADD COLUMN scorer_reasons Map(String, String) DEFAULT map(),
-    ADD COLUMN scorer_confidences Map(String, Float64) DEFAULT map();
+    ADD COLUMN IF NOT EXISTS scorer_tags               Array(String)         DEFAULT [],
+    ADD COLUMN IF NOT EXISTS scorer_tag_reasons        Map(String, String)   DEFAULT map(),
+    ADD COLUMN IF NOT EXISTS scorer_tag_confidences    Map(String, Float64)  DEFAULT map(),
+    ADD COLUMN IF NOT EXISTS scorer_ratings            Map(String, Float64)  DEFAULT map(),
+    ADD COLUMN IF NOT EXISTS scorer_rating_reasons     Map(String, String)   DEFAULT map(),
+    ADD COLUMN IF NOT EXISTS scorer_rating_confidences Map(String, Float64)  DEFAULT map();


### PR DESCRIPTION
## Description

Adds four typed columns to the \`feedback\` table:

- \`scorer_tags\` \`Array(String)\`
- \`scorer_ratings\` \`Map(String), Float64)\`
- \`scorer_reasons\` \`Map(String, String)\`
- \`scorer_confidences\` \`Map(String, Float64)\`

Non-null with empty defaults so existing rows need no backfill. data layer only — no readers or writers touch the columns yet.

This is in effort to enable stronger-typed agent scoring.

## Testing

Applied locally with \`make migrate_local\`; up + down both verified.