### PR TITLE
fix(weave): strip query params before redis.from_url

### DIFF
--- a/tests/trace_server/test_redis_client.py
+++ b/tests/trace_server/test_redis_client.py
@@ -33,7 +33,10 @@ def test_client_resolution_from_url(monkeypatch):
         monkeypatch.setenv("WEAVE_REDIS_URL", "redis://redis.example:6379")
         client = redis_client.get_redis_client()
         mock_from_url.assert_called_once_with(
-            "redis://redis.example:6379", decode_responses=True, **timeouts
+            "redis://redis.example:6379",
+            decode_responses=True,
+            ssl_ca_certs=None,
+            **timeouts,
         )
         assert client is mock_from_url.return_value
 
@@ -87,13 +90,16 @@ def test_direct_url_strips_wandb_query_params(monkeypatch):
             **timeouts,
         )
 
-    # tls=true without caCertPath -> rediss:// scheme, no ssl_ca_certs kwarg.
+    # tls=true without caCertPath -> rediss:// scheme, ssl_ca_certs stays None.
     with patch.object(redis_client.redis, "from_url") as mock_from_url:
         redis_client.get_redis_client.cache_clear()
         monkeypatch.setenv("WEAVE_REDIS_URL", "redis://host:6379?tls=true")
         redis_client.get_redis_client()
         mock_from_url.assert_called_once_with(
-            "rediss://host:6379", decode_responses=True, **timeouts
+            "rediss://host:6379",
+            decode_responses=True,
+            ssl_ca_certs=None,
+            **timeouts,
         )
 
     # Non-tls wandb params are still stripped, scheme left as-is.
@@ -102,7 +108,10 @@ def test_direct_url_strips_wandb_query_params(monkeypatch):
         monkeypatch.setenv("WEAVE_REDIS_URL", "redis://host:6379?ttlInSeconds=604800")
         redis_client.get_redis_client()
         mock_from_url.assert_called_once_with(
-            "redis://host:6379", decode_responses=True, **timeouts
+            "redis://host:6379",
+            decode_responses=True,
+            ssl_ca_certs=None,
+            **timeouts,
         )
 
 

--- a/tests/trace_server/test_redis_client.py
+++ b/tests/trace_server/test_redis_client.py
@@ -58,6 +58,54 @@ def test_client_resolution_from_url(monkeypatch):
         assert mock_sentinel.call_args.args[0] == [("redis.example", 26379)]
 
 
+def test_direct_url_strips_wandb_query_params(monkeypatch):
+    """Wandb-specific query params must not leak into redis-py kwargs.
+
+    The Go connector at `services/connectors/redis.go` consumes params like
+    `tls`, `caCertPath`, `ttlInSeconds`. redis-py treats unknown URL params as
+    Connection.__init__ kwargs, so leaving them in raises `AbstractConnection.
+    __init__() got an unexpected keyword argument 'tls'` at first command.
+    """
+    timeouts = {
+        "socket_connect_timeout": redis_client.REDIS_CONNECT_TIMEOUT_SECS,
+        "socket_timeout": redis_client.REDIS_SOCKET_TIMEOUT_SECS,
+    }
+
+    # tls=true rewrites the scheme to rediss:// and adds ssl_ca_certs.
+    with patch.object(redis_client.redis, "from_url") as mock_from_url:
+        redis_client.get_redis_client.cache_clear()
+        monkeypatch.setenv(
+            "WEAVE_REDIS_URL",
+            "redis://:pw@host:6378?tls=true&ttlInSeconds=604800"
+            "&caCertPath=/etc/ssl/certs/server_ca.pem",
+        )
+        redis_client.get_redis_client()
+        mock_from_url.assert_called_once_with(
+            "rediss://:pw@host:6378",
+            decode_responses=True,
+            ssl_ca_certs="/etc/ssl/certs/server_ca.pem",
+            **timeouts,
+        )
+
+    # tls=true without caCertPath -> rediss:// scheme, no ssl_ca_certs kwarg.
+    with patch.object(redis_client.redis, "from_url") as mock_from_url:
+        redis_client.get_redis_client.cache_clear()
+        monkeypatch.setenv("WEAVE_REDIS_URL", "redis://host:6379?tls=true")
+        redis_client.get_redis_client()
+        mock_from_url.assert_called_once_with(
+            "rediss://host:6379", decode_responses=True, **timeouts
+        )
+
+    # Non-tls wandb params are still stripped, scheme left as-is.
+    with patch.object(redis_client.redis, "from_url") as mock_from_url:
+        redis_client.get_redis_client.cache_clear()
+        monkeypatch.setenv("WEAVE_REDIS_URL", "redis://host:6379?ttlInSeconds=604800")
+        redis_client.get_redis_client()
+        mock_from_url.assert_called_once_with(
+            "redis://host:6379", decode_responses=True, **timeouts
+        )
+
+
 @pytest.mark.disable_logging_error_check
 @pytest.mark.parametrize(
     "bad_url",

--- a/weave/trace_server/redis_client.py
+++ b/weave/trace_server/redis_client.py
@@ -42,13 +42,31 @@ def get_redis_client() -> redis.Redis | None:
 
     try:
         parsed = urlparse(url)
-        master = parse_qs(parsed.query).get("master", [None])[0]
+        query = parse_qs(parsed.query)
+        master = query.get("master", [None])[0]
         if not master:
+            # WEAVE_REDIS_URL may carry wandb-specific query params (tls,
+            # caCertPath, ttlInSeconds, poolSize, ...) consumed by the Go
+            # connector at `services/connectors/redis.go`. redis-py forwards
+            # unknown URL params straight into Connection.__init__ kwargs and
+            # blows up at first command with `AbstractConnection.__init__() got
+            # an unexpected keyword argument 'tls'`. Strip the whole querystring
+            # and translate the bits redis-py understands.
+            tls = query.get("tls", [None])[0] == "true"
+            ca_cert_path = query.get("caCertPath", [None])[0]
+            if tls:
+                # redis-py picks SSLConnection from the URL scheme, not kwargs.
+                parsed = parsed._replace(scheme="rediss")
+            clean_url = parsed._replace(query="").geturl()
+            ssl_kwargs: dict[str, str] = {}
+            if tls and ca_cert_path:
+                ssl_kwargs["ssl_ca_certs"] = ca_cert_path
             return redis.from_url(
-                url,
+                clean_url,
                 decode_responses=True,
                 socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
                 socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
+                **ssl_kwargs,
             )
 
         if not parsed.hostname:

--- a/weave/trace_server/redis_client.py
+++ b/weave/trace_server/redis_client.py
@@ -45,17 +45,10 @@ def get_redis_client() -> redis.Redis | None:
         query = parse_qs(parsed.query)
         master = query.get("master", [None])[0]
         if not master:
-            # WEAVE_REDIS_URL may carry wandb-specific query params (tls,
-            # caCertPath, ttlInSeconds, poolSize, ...) consumed by the Go
-            # connector at `services/connectors/redis.go`. redis-py forwards
-            # unknown URL params straight into Connection.__init__ kwargs and
-            # blows up at first command with `AbstractConnection.__init__() got
-            # an unexpected keyword argument 'tls'`. Strip the whole querystring
-            # and translate the bits redis-py understands.
+            # Strip Go-connector query params; redis-py forwards unknowns as kwargs.
             tls = query.get("tls", [None])[0] == "true"
             ca_cert_path = query.get("caCertPath", [None])[0]
             if tls:
-                # redis-py picks SSLConnection from the URL scheme, not kwargs.
                 parsed = parsed._replace(scheme="rediss")
             clean_url = parsed._replace(query="").geturl()
             ssl_kwargs: dict[str, str] = {}

--- a/weave/trace_server/redis_client.py
+++ b/weave/trace_server/redis_client.py
@@ -51,15 +51,12 @@ def get_redis_client() -> redis.Redis | None:
             if tls:
                 parsed = parsed._replace(scheme="rediss")
             clean_url = parsed._replace(query="").geturl()
-            ssl_kwargs: dict[str, str] = {}
-            if tls and ca_cert_path:
-                ssl_kwargs["ssl_ca_certs"] = ca_cert_path
             return redis.from_url(
                 clean_url,
                 decode_responses=True,
                 socket_connect_timeout=REDIS_CONNECT_TIMEOUT_SECS,
                 socket_timeout=REDIS_SOCKET_TIMEOUT_SECS,
-                **ssl_kwargs,
+                ssl_ca_certs=ca_cert_path if tls else None,
             )
 
         if not parsed.hostname:


### PR DESCRIPTION
## Summary
- `WEAVE_REDIS_URL` on single-tenant GCP carries Go-connector params (`tls`, `caCertPath`, `ttlInSeconds`, `poolSize`, ...). redis-py forwards unknown URL params straight to `Connection.__init__`, so the direct (non-Sentinel) client dies at first command:
  ```
  TypeError: AbstractConnection.__init__() got an unexpected keyword argument 'tls'
  ```
- Strip the whole querystring before `redis.from_url`, then translate `tls=true` to the `rediss://` scheme and `caCertPath` to `ssl_ca_certs`. Sentinel path was already safe (it builds from `parsed.hostname`/`parsed.port`, never the raw URL).
- `redis.from_url` itself succeeds; the failure only surfaces lazily at first command inside `pool.get_connection()`, so the `except Exception` in `get_redis_client` doesn't catch it and every TTL lookup spams the traceback into Datadog while silently falling through to ClickHouse.

## Testing
unit tests cover tls + caCertPath + ttlInSeconds together, tls alone, and a non-tls param round-trip.