### PR TITLE
feat(weave): typed scorer feedback columns, agent_monitor type, and query filters

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -198,9 +198,11 @@ def test_annotation_feedback(client: WeaveClient) -> None:
         "trigger_ref": None,
         "queue_id": None,
         "scorer_tags": [],
+        "scorer_tag_reasons": {},
+        "scorer_tag_confidences": {},
         "scorer_ratings": {},
-        "scorer_reasons": {},
-        "scorer_confidences": {},
+        "scorer_rating_reasons": {},
+        "scorer_rating_confidences": {},
     }
 
 
@@ -353,9 +355,11 @@ def test_runnable_feedback(client: WeaveClient) -> None:
         "trigger_ref": trigger_ref,
         "queue_id": None,
         "scorer_tags": [],
+        "scorer_tag_reasons": {},
+        "scorer_tag_confidences": {},
         "scorer_ratings": {},
-        "scorer_reasons": {},
-        "scorer_confidences": {},
+        "scorer_rating_reasons": {},
+        "scorer_rating_confidences": {},
     }
 
 

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -363,6 +363,134 @@ def test_runnable_feedback(client: WeaveClient) -> None:
     }
 
 
+def test_agent_monitor_feedback(client: WeaveClient) -> None:
+    """End-to-end create/query for wandb.agent_monitor feedback with typed scorer columns."""
+    project_id = client.project_id
+    feedback_type = "wandb.agent_monitor"
+    weave_ref = f"weave:///{project_id}/call/call_id_123"
+    runnable_name = "my_scorer"
+    runnable_ref = f"weave:///{project_id}/object/{runnable_name}:obj_id_123"
+    call_ref = f"weave:///{project_id}/call/call_id_123"
+    trigger_ref = f"weave:///{project_id}/object/{runnable_name}:trigger_id_123"
+    payload = {"value": ["nsfw"], "reason": ["explicit language"]}
+
+    # Case 1: runnable_ref is required.
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type=feedback_type,
+                payload=payload,
+                scorer_tags=["nsfw"],
+            )
+        )
+
+    # Case 2: call_ref is required.
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type=feedback_type,
+                payload=payload,
+                runnable_ref=runnable_ref,
+            )
+        )
+
+    # Case 3: trigger_ref is required.
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type=feedback_type,
+                payload=payload,
+                runnable_ref=runnable_ref,
+                call_ref=call_ref,
+            )
+        )
+
+    # Case 4: scorer_* fields rejected on non-agent-monitor feedback types
+    # (non-empty value).
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type="custom",
+                payload={},
+                scorer_tags=["nsfw"],
+            )
+        )
+
+    # Success: write tags, a rating, and reasons/confidences keyed by name.
+    create_res = client.server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type=feedback_type,
+            payload=payload,
+            runnable_ref=runnable_ref,
+            call_ref=call_ref,
+            trigger_ref=trigger_ref,
+            scorer_tags=["nsfw", "high-quality"],
+            scorer_tag_reasons={"nsfw": "explicit language"},
+            scorer_tag_confidences={"nsfw": 0.95},
+            scorer_ratings={"_rating_": 0.87},
+            scorer_rating_reasons={"_rating_": "very confident response"},
+            scorer_rating_confidences={"_rating_": 0.92},
+        )
+    )
+    assert create_res.id is not None
+
+    query_res = client.server.feedback_query(
+        tsi.FeedbackQueryReq(project_id=project_id)
+    )
+    assert len(query_res.result) == 1
+    row = query_res.result[0]
+    assert row["feedback_type"] == feedback_type
+    assert row["payload"] == payload
+    assert row["scorer_tags"] == ["nsfw", "high-quality"]
+    assert row["scorer_tag_reasons"] == {"nsfw": "explicit language"}
+    assert row["scorer_tag_confidences"] == {"nsfw": 0.95}
+    assert row["scorer_ratings"] == {"_rating_": 0.87}
+    assert row["scorer_rating_reasons"] == {"_rating_": "very confident response"}
+    assert row["scorer_rating_confidences"] == {"_rating_": 0.92}
+
+
+def test_agent_monitor_feedback_empty_defaults(client: WeaveClient) -> None:
+    """A minimal agent_monitor row (no typed scorer fields) round-trips with empty defaults."""
+    project_id = client.project_id
+    weave_ref = f"weave:///{project_id}/call/call_id_123"
+    runnable_ref = f"weave:///{project_id}/object/my_scorer:obj_id_123"
+    call_ref = f"weave:///{project_id}/call/call_id_123"
+    trigger_ref = f"weave:///{project_id}/object/my_scorer:trigger_id_123"
+
+    create_res = client.server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type="wandb.agent_monitor",
+            payload={"value": None},
+            runnable_ref=runnable_ref,
+            call_ref=call_ref,
+            trigger_ref=trigger_ref,
+        )
+    )
+    assert create_res.id is not None
+
+    query_res = client.server.feedback_query(
+        tsi.FeedbackQueryReq(project_id=project_id)
+    )
+    assert query_res.result[0]["scorer_tags"] == []
+    assert query_res.result[0]["scorer_tag_reasons"] == {}
+    assert query_res.result[0]["scorer_tag_confidences"] == {}
+    assert query_res.result[0]["scorer_ratings"] == {}
+    assert query_res.result[0]["scorer_rating_reasons"] == {}
+    assert query_res.result[0]["scorer_rating_confidences"] == {}
+
+
 async def populate_feedback(client: WeaveClient) -> None:
     @weave.op
     def my_scorer(x: int, output: int) -> int:
@@ -808,6 +936,44 @@ def test_feedback_replace(client) -> None:
     new_feedback = next(f for f in feedbacks if f["id"] == replaced_feedback.id)
     assert new_feedback["feedback_type"] == "reaction"
     assert new_feedback["payload"] == {"emoji": "👍"}
+
+
+def test_feedback_replace_validates_before_purge(client) -> None:
+    """Replace must reject invalid payloads BEFORE deleting the existing row."""
+    project_id = client.project_id
+    weave_ref = f"weave:///{project_id}/obj/123:abc"
+
+    initial = client.server.feedback_create(
+        FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type="reaction",
+            payload={"emoji": "👍"},
+            wb_user_id="test_user",
+        )
+    )
+
+    # The replace payload would fail validation (non-empty scorer_tags on a
+    # non-agent-monitor type). Without validate-before-purge, the purge would
+    # run first and destroy the original row.
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_replace(
+            FeedbackReplaceReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type="reaction",
+                payload={"emoji": "👍"},
+                feedback_id=initial.id,
+                wb_user_id="test_user",
+                scorer_tags=["nsfw"],
+            )
+        )
+
+    # The original row must still be there.
+    query_res = client.server.feedback_query(
+        FeedbackQueryReq(project_id=project_id, fields=["id"])
+    )
+    assert [r["id"] for r in query_res.result] == [initial.id]
 
 
 def test_get_feedback_with_dict_query(client) -> None:

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -491,6 +491,221 @@ def test_agent_monitor_feedback_empty_defaults(client: WeaveClient) -> None:
     assert query_res.result[0]["scorer_rating_confidences"] == {}
 
 
+def test_agent_monitor_feedback_filters(client: WeaveClient) -> None:
+    """Filter agent_monitor rows by typed scorer columns.
+
+    Covers each access pattern the proposal calls out:
+      - `$contains` on `scorer_tags` → array membership (`has` / `json_each`)
+      - dotted access on `scorer_ratings.<name>` → typed map value lookup
+      - dotted access on `scorer_tag_reasons.<name>` for reason equality
+    """
+    project_id = client.project_id
+    runnable_ref = f"weave:///{project_id}/object/my_scorer:obj_id_123"
+    call_ref = f"weave:///{project_id}/call/call_id_123"
+    trigger_ref = f"weave:///{project_id}/object/my_scorer:trigger_id_123"
+
+    def _create(weave_ref_suffix: str, **scorer_kwargs):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=f"weave:///{project_id}/call/{weave_ref_suffix}",
+                feedback_type="wandb.agent_monitor",
+                payload={"value": scorer_kwargs.get("scorer_tags", [])},
+                runnable_ref=runnable_ref,
+                call_ref=call_ref,
+                trigger_ref=trigger_ref,
+                **scorer_kwargs,
+            )
+        )
+
+    _create("a", scorer_tags=["nsfw"], scorer_ratings={"_rating_": 0.9})
+    _create(
+        "b",
+        scorer_tags=["high-quality"],
+        scorer_ratings={"_rating_": 0.4},
+        scorer_tag_reasons={"high-quality": "well formatted"},
+    )
+    _create("c")  # empty defaults
+
+    def _query(query_dict) -> list[dict]:
+        res = client.server.feedback_query(
+            tsi.FeedbackQueryReq(project_id=project_id, query=Query(**query_dict))
+        )
+        return res.result
+
+    # $contains on scorer_tags — must use array membership, not substring.
+    matches = _query(
+        {
+            "$expr": {
+                "$contains": {
+                    "input": {"$getField": "scorer_tags"},
+                    "substr": {"$literal": "nsfw"},
+                }
+            }
+        }
+    )
+    assert {m["weave_ref"].rsplit("/", 1)[-1] for m in matches} == {"a"}
+
+    # Substring-style false positive should NOT match. "ns" appears inside
+    # "nsfw" but `has()` requires exact tag equality.
+    matches = _query(
+        {
+            "$expr": {
+                "$contains": {
+                    "input": {"$getField": "scorer_tags"},
+                    "substr": {"$literal": "ns"},
+                }
+            }
+        }
+    )
+    assert matches == []
+
+    # case_insensitive $contains must still match. Without the case-insensitive
+    # branch the array path falls back to exact equality and misses tags that
+    # differ only in case.
+    _create("upper", scorer_tags=["NSFW"])
+    matches = _query(
+        {
+            "$expr": {
+                "$contains": {
+                    "input": {"$getField": "scorer_tags"},
+                    "substr": {"$literal": "nsfw"},
+                    "case_insensitive": True,
+                }
+            }
+        }
+    )
+    assert {m["weave_ref"].rsplit("/", 1)[-1] for m in matches} == {"a", "upper"}
+
+    # Map value lookup with numeric comparison.
+    matches = _query(
+        {
+            "$expr": {
+                "$gt": [
+                    {"$getField": "scorer_ratings._rating_"},
+                    {"$literal": 0.5},
+                ]
+            }
+        }
+    )
+    assert {m["weave_ref"].rsplit("/", 1)[-1] for m in matches} == {"a"}
+
+    # Map value lookup on scorer_tag_reasons keyed by tag name.
+    matches = _query(
+        {
+            "$expr": {
+                "$eq": [
+                    {"$getField": "scorer_tag_reasons.high-quality"},
+                    {"$literal": "well formatted"},
+                ]
+            }
+        }
+    )
+    assert {m["weave_ref"].rsplit("/", 1)[-1] for m in matches} == {"b"}
+
+    # Regression: ClickHouse Map(*, Float64) returns 0 for missing keys,
+    # which would otherwise match `== 0` filters and surface every row
+    # without a rating as a "zero rating" row. Row 'c' has no rating and
+    # must not match an equality-against-zero filter.
+    matches = _query(
+        {
+            "$expr": {
+                "$eq": [
+                    {"$getField": "scorer_ratings._rating_"},
+                    {"$literal": 0},
+                ]
+            }
+        }
+    )
+    assert matches == []
+
+    # Same regression for Map(*, String) — missing keys would otherwise
+    # read as "" and match an `== ""` filter.
+    matches = _query(
+        {
+            "$expr": {
+                "$eq": [
+                    {"$getField": "scorer_tag_reasons.missing"},
+                    {"$literal": ""},
+                ]
+            }
+        }
+    )
+    assert matches == []
+
+
+def test_agent_monitor_feedback_sort_by_map_column(client: WeaveClient) -> None:
+    """Sorting by a map-column key (e.g. `scorer_ratings._rating_`) must work.
+
+    Regression: the ORDER BY path used to pass the field name into the
+    function's `cast` slot, which silently no-op'd for pre-existing column
+    types but raised on the new map_string_string branch. Locks in the
+    fix so future refactors don't reintroduce that mismatch.
+    """
+    project_id = client.project_id
+    runnable_ref = f"weave:///{project_id}/object/my_scorer:obj_id_123"
+    call_ref = f"weave:///{project_id}/call/call_id_123"
+    trigger_ref = f"weave:///{project_id}/object/my_scorer:trigger_id_123"
+
+    # Reasons in alphabetical order match the rating order so a single
+    # set of rows exercises both Map(*, Float64) and Map(*, String) sorts.
+    rows = [
+        ("low", 0.1, "alpha"),
+        ("mid", 0.5, "beta"),
+        ("high", 0.9, "gamma"),
+    ]
+    for suffix, rating, reason in rows:
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=f"weave:///{project_id}/call/{suffix}",
+                feedback_type="wandb.agent_monitor",
+                payload={"value": rating},
+                runnable_ref=runnable_ref,
+                call_ref=call_ref,
+                trigger_ref=trigger_ref,
+                scorer_ratings={"_rating_": rating},
+                scorer_rating_reasons={"_rating_": reason},
+            )
+        )
+
+    asc = client.server.feedback_query(
+        tsi.FeedbackQueryReq(
+            project_id=project_id,
+            sort_by=[SortBy(field="scorer_ratings._rating_", direction="asc")],
+        )
+    )
+    assert [r["weave_ref"].rsplit("/", 1)[-1] for r in asc.result] == [
+        "low",
+        "mid",
+        "high",
+    ]
+
+    desc = client.server.feedback_query(
+        tsi.FeedbackQueryReq(
+            project_id=project_id,
+            sort_by=[SortBy(field="scorer_ratings._rating_", direction="desc")],
+        )
+    )
+    assert [r["weave_ref"].rsplit("/", 1)[-1] for r in desc.result] == [
+        "high",
+        "mid",
+        "low",
+    ]
+
+    by_reason = client.server.feedback_query(
+        tsi.FeedbackQueryReq(
+            project_id=project_id,
+            sort_by=[SortBy(field="scorer_rating_reasons._rating_", direction="asc")],
+        )
+    )
+    assert [r["weave_ref"].rsplit("/", 1)[-1] for r in by_reason.result] == [
+        "low",
+        "mid",
+        "high",
+    ]
+
+
 async def populate_feedback(client: WeaveClient) -> None:
     @weave.op
     def my_scorer(x: int, output: int) -> int:

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -197,6 +197,10 @@ def test_annotation_feedback(client: WeaveClient) -> None:
         "call_ref": None,
         "trigger_ref": None,
         "queue_id": None,
+        "scorer_tags": [],
+        "scorer_ratings": {},
+        "scorer_reasons": {},
+        "scorer_confidences": {},
     }
 
 
@@ -348,6 +352,10 @@ def test_runnable_feedback(client: WeaveClient) -> None:
         "call_ref": call_ref,
         "trigger_ref": trigger_ref,
         "queue_id": None,
+        "scorer_tags": [],
+        "scorer_ratings": {},
+        "scorer_reasons": {},
+        "scorer_confidences": {},
     }
 
 

--- a/tests/trace_server/test_agent_feedback_helpers.py
+++ b/tests/trace_server/test_agent_feedback_helpers.py
@@ -1,14 +1,43 @@
 from weave.shared import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.trace_server_common import (
+    FEEDBACK_QUERY_FIELDS,
     group_agent_feedback_by_target,
     make_agent_feedback_query_req,
+    make_feedback_query_req,
 )
 
 
 def _extract_ref_literals(req) -> list[str]:
     expr = req.query.model_dump(by_alias=True)["$expr"]
     return [lit["$literal"] for lit in expr["$in"][1]]
+
+
+def test_feedback_query_fields_include_typed_scorer_columns():
+    """Calls/agent-chat feedback hydration goes through FEEDBACK_QUERY_FIELDS.
+    The typed scorer columns must be in this list or wandb.agent_monitor
+    rows surface to the UI without their tags/ratings/reasons/confidences.
+    """
+    typed_columns = (
+        "scorer_tags",
+        "scorer_tag_reasons",
+        "scorer_tag_confidences",
+        "scorer_ratings",
+        "scorer_rating_reasons",
+        "scorer_rating_confidences",
+    )
+    for column in typed_columns:
+        assert column in FEEDBACK_QUERY_FIELDS
+
+    # Both helpers must request these columns — they're the two paths that
+    # fold feedback into calls / agent chat responses.
+    calls_req = make_feedback_query_req(
+        project_id="p", calls=[{"project_id": "p", "id": "c1"}]
+    )
+    agent_req = make_agent_feedback_query_req(project_id="p", refs=[])
+    for column in typed_columns:
+        assert column in calls_req.fields
+        assert column in agent_req.fields
 
 
 def test_make_agent_feedback_query_req_unions_arbitrary_ref_kinds():

--- a/tests/trace_server/test_orm.py
+++ b/tests/trace_server/test_orm.py
@@ -141,10 +141,9 @@ def test_array_string_column_round_trip_clickhouse():
     # ClickHouse driver accepts native list; ORM must not JSON-encode it.
     assert prepared.data == [["a", ["x", "y"]]]
     # Reading back a CH row returns a native list and ORM passes it through.
-    assert table.tuple_to_row(("a", ["x", "y"]), ["id", "tags"]) == {
-        "id": "a",
-        "tags": ["x", "y"],
-    }
+    assert table.tuple_to_row(
+        ("a", ["x", "y"]), ["id", "tags"], database_type="clickhouse"
+    ) == {"id": "a", "tags": ["x", "y"]}
 
 
 def test_array_string_column_round_trip_sqlite():
@@ -154,10 +153,9 @@ def test_array_string_column_round_trip_sqlite():
     # SQLite has no Array type — ORM must JSON-encode the list to TEXT.
     assert prepared.data == [["a", '["x", "y"]']]
     # And decode on the way out.
-    assert table.tuple_to_row(("a", '["x", "y"]'), ["id", "tags"]) == {
-        "id": "a",
-        "tags": ["x", "y"],
-    }
+    assert table.tuple_to_row(
+        ("a", '["x", "y"]'), ["id", "tags"], database_type="sqlite"
+    ) == {"id": "a", "tags": ["x", "y"]}
 
 
 def test_map_string_float_column_round_trip():
@@ -174,14 +172,12 @@ def test_map_string_float_column_round_trip():
         database_type="sqlite"
     )
     assert sqlite_prepared.data == [["a", '{"_rating_": 0.87}']]
-    assert table.tuple_to_row(("a", payload), ["id", "ratings"]) == {
-        "id": "a",
-        "ratings": payload,
-    }
-    assert table.tuple_to_row(("a", '{"_rating_": 0.87}'), ["id", "ratings"]) == {
-        "id": "a",
-        "ratings": payload,
-    }
+    assert table.tuple_to_row(
+        ("a", payload), ["id", "ratings"], database_type="clickhouse"
+    ) == {"id": "a", "ratings": payload}
+    assert table.tuple_to_row(
+        ("a", '{"_rating_": 0.87}'), ["id", "ratings"], database_type="sqlite"
+    ) == {"id": "a", "ratings": payload}
 
 
 def test_select_basic():

--- a/tests/trace_server/test_orm.py
+++ b/tests/trace_server/test_orm.py
@@ -81,27 +81,35 @@ def test_transform_external_field_to_internal_field():
 
     # Transforming a column that doesn't exist should raise
     with pytest.raises(ValueError, match="Unknown field"):
-        _transform_external_field_to_internal_field("foo", all_columns, json_columns)
+        _transform_external_field_to_internal_field(
+            "foo", all_columns=all_columns, json_columns=json_columns
+        )
 
     result = _transform_external_field_to_internal_field(
-        "id", all_columns, json_columns
+        "id", all_columns=all_columns, json_columns=json_columns
     )
     assert result[0] == "id"
     assert result[2] == {"id"}
     result = _transform_external_field_to_internal_field(
-        "payload", all_columns, json_columns
+        "payload", all_columns=all_columns, json_columns=json_columns
     )
     assert result[0] == "payload_dump"
     assert result[2] == {"payload_dump"}
     pb = ParamBuilder(prefix="pb", database_type="sqlite")
     result = _transform_external_field_to_internal_field(
-        "payload.address", all_columns, json_columns, param_builder=pb
+        "payload.address",
+        all_columns=all_columns,
+        json_columns=json_columns,
+        param_builder=pb,
     )
     assert result[0] == "json_extract(payload_dump, :pb_0)"
     assert result[2] == {"payload_dump"}
     pb = ParamBuilder(prefix="pb", database_type="clickhouse")
     result = _transform_external_field_to_internal_field(
-        "payload.address", all_columns, json_columns, param_builder=pb
+        "payload.address",
+        all_columns=all_columns,
+        json_columns=json_columns,
+        param_builder=pb,
     )
     assert result[0] == "toString(JSON_VALUE(payload_dump, {pb_0:String}))"
     assert result[2] == {"payload_dump"}

--- a/tests/trace_server/test_orm.py
+++ b/tests/trace_server/test_orm.py
@@ -134,6 +134,56 @@ def test_table_drop_sql():
     assert table.drop_sql() == "DROP TABLE IF EXISTS users"
 
 
+def test_array_string_column_round_trip_clickhouse():
+    table = Table("t", [Column("id", "string"), Column("tags", "array_string")])
+    insert = table.insert({"id": "a", "tags": ["x", "y"]})
+    prepared = insert.prepare(database_type="clickhouse")
+    # ClickHouse driver accepts native list; ORM must not JSON-encode it.
+    assert prepared.data == [["a", ["x", "y"]]]
+    # Reading back a CH row returns a native list and ORM passes it through.
+    assert table.tuple_to_row(("a", ["x", "y"]), ["id", "tags"]) == {
+        "id": "a",
+        "tags": ["x", "y"],
+    }
+
+
+def test_array_string_column_round_trip_sqlite():
+    table = Table("t", [Column("id", "string"), Column("tags", "array_string")])
+    insert = table.insert({"id": "a", "tags": ["x", "y"]})
+    prepared = insert.prepare(database_type="sqlite")
+    # SQLite has no Array type — ORM must JSON-encode the list to TEXT.
+    assert prepared.data == [["a", '["x", "y"]']]
+    # And decode on the way out.
+    assert table.tuple_to_row(("a", '["x", "y"]'), ["id", "tags"]) == {
+        "id": "a",
+        "tags": ["x", "y"],
+    }
+
+
+def test_map_string_float_column_round_trip():
+    table = Table(
+        "t",
+        [Column("id", "string"), Column("ratings", "map_string_float")],
+    )
+    payload = {"_rating_": 0.87}
+    ch_prepared = table.insert({"id": "a", "ratings": payload}).prepare(
+        database_type="clickhouse"
+    )
+    assert ch_prepared.data == [["a", payload]]
+    sqlite_prepared = table.insert({"id": "a", "ratings": payload}).prepare(
+        database_type="sqlite"
+    )
+    assert sqlite_prepared.data == [["a", '{"_rating_": 0.87}']]
+    assert table.tuple_to_row(("a", payload), ["id", "ratings"]) == {
+        "id": "a",
+        "ratings": payload,
+    }
+    assert table.tuple_to_row(("a", '{"_rating_": 0.87}'), ["id", "ratings"]) == {
+        "id": "a",
+        "ratings": payload,
+    }
+
+
 def test_select_basic():
     table = Table(
         "users",

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6256,7 +6256,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return tsi.FeedbackPurgeRes()
 
     def feedback_replace(self, req: tsi.FeedbackReplaceReq) -> tsi.FeedbackReplaceRes:
-        # To replace, first purge, then if successful, create.
+        # Validate the replacement payload before purging — if validation
+        # rejects we want the old row preserved, not destroyed. This duplicates
+        # the validation that feedback_create() runs internally (one extra
+        # ref-lookup network call on annotation/agent-monitor paths), which is
+        # acceptable to preserve the no-data-loss guarantee on replace.
+        create_req = tsi.FeedbackCreateReq(**req.model_dump(exclude={"feedback_id"}))
+        validate_feedback_create_req(create_req, self)
         query = tsi.Query(
             **{
                 "$expr": {
@@ -6272,7 +6278,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             query=query,
         )
         self.feedback_purge(purge_request)
-        create_req = tsi.FeedbackCreateReq(**req.model_dump(exclude={"feedback_id"}))
         create_result = self.feedback_create(create_req)
         return tsi.FeedbackReplaceRes(
             id=create_result.id,

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6148,7 +6148,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         prepared = query.prepare(database_type="clickhouse")
         query_result = self.ch_client.query(prepared.sql, prepared.parameters)
         results = LLM_TOKEN_PRICES_TABLE.tuples_to_rows(
-            query_result.result_rows, prepared.fields
+            query_result.result_rows, prepared.fields, database_type="clickhouse"
         )
         return tsi.CostQueryRes(results=results)
 
@@ -6238,7 +6238,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         prepared = query.prepare(database_type="clickhouse")
         query_result = self.ch_client.query(prepared.sql, prepared.parameters)
         result = TABLE_FEEDBACK.tuples_to_rows(
-            query_result.result_rows, prepared.fields
+            query_result.result_rows, prepared.fields, database_type="clickhouse"
         )
         return tsi.FeedbackQueryRes(result=result)
 

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -49,9 +49,11 @@ TABLE_FEEDBACK = Table(
         Column("trigger_ref", "string", nullable=True),
         Column("queue_id", "string", nullable=True),
         Column("scorer_tags", "array_string"),
+        Column("scorer_tag_reasons", "map_string_string"),
+        Column("scorer_tag_confidences", "map_string_float"),
         Column("scorer_ratings", "map_string_float"),
-        Column("scorer_reasons", "map_string_string"),
-        Column("scorer_confidences", "map_string_float"),
+        Column("scorer_rating_reasons", "map_string_string"),
+        Column("scorer_rating_confidences", "map_string_float"),
     ],
 )
 
@@ -262,9 +264,11 @@ def format_feedback_to_row(
         "trigger_ref": feedback_req.trigger_ref,
         "queue_id": feedback_req.queue_id,
         "scorer_tags": feedback_req.scorer_tags or [],
+        "scorer_tag_reasons": feedback_req.scorer_tag_reasons or {},
+        "scorer_tag_confidences": feedback_req.scorer_tag_confidences or {},
         "scorer_ratings": feedback_req.scorer_ratings or {},
-        "scorer_reasons": feedback_req.scorer_reasons or {},
-        "scorer_confidences": feedback_req.scorer_confidences or {},
+        "scorer_rating_reasons": feedback_req.scorer_rating_reasons or {},
+        "scorer_rating_confidences": feedback_req.scorer_rating_confidences or {},
     }
 
 

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -22,6 +22,7 @@ from weave.trace_server.interface.feedback_types import (
     RUNNABLE_FEEDBACK_TYPE_PREFIX,
     AnnotationPayloadSchema,
     RunnablePayloadSchema,
+    feedback_type_is_agent_monitor,
     feedback_type_is_annotation,
     feedback_type_is_runnable,
 )
@@ -154,12 +155,38 @@ def validate_feedback_create_req(
             raise InvalidRequest(
                 f"Invalid payload for feedback_type {req.feedback_type}: {e}"
             ) from e
+    elif feedback_type_is_agent_monitor(req.feedback_type):
+        if not req.runnable_ref:
+            raise InvalidRequest("runnable_ref is required for agent monitor feedback")
+        if req.call_ref is None:
+            raise InvalidRequest("call_ref is required for agent monitor feedback")
+        if req.trigger_ref is None:
+            raise InvalidRequest("trigger_ref is required for agent monitor feedback")
     elif req.runnable_ref:
         raise InvalidRequest("runnable_ref is not allowed for non-runnable feedback")
     elif req.call_ref:
         raise InvalidRequest("call_ref is not allowed for non-runnable feedback")
     elif req.trigger_ref:
         raise InvalidRequest("trigger_ref is not allowed for non-runnable feedback")
+
+    # Typed scorer columns are reserved for agent monitor feedback.
+    scorer_fields_set = any(
+        getattr(req, name)
+        for name in (
+            "scorer_tags",
+            "scorer_tag_reasons",
+            "scorer_tag_confidences",
+            "scorer_ratings",
+            "scorer_rating_reasons",
+            "scorer_rating_confidences",
+        )
+    )
+    if scorer_fields_set and not feedback_type_is_agent_monitor(req.feedback_type):
+        raise InvalidRequest(
+            "scorer_tags, scorer_tag_reasons, scorer_tag_confidences, "
+            "scorer_ratings, scorer_rating_reasons, and scorer_rating_confidences "
+            "are only allowed on wandb.agent_monitor feedback"
+        )
 
     # Validate the ref formats (we could even query the DB to ensure they exist and are valid)
     if req.annotation_ref:

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -263,12 +263,12 @@ def format_feedback_to_row(
         "call_ref": feedback_req.call_ref,
         "trigger_ref": feedback_req.trigger_ref,
         "queue_id": feedback_req.queue_id,
-        "scorer_tags": feedback_req.scorer_tags or [],
-        "scorer_tag_reasons": feedback_req.scorer_tag_reasons or {},
-        "scorer_tag_confidences": feedback_req.scorer_tag_confidences or {},
-        "scorer_ratings": feedback_req.scorer_ratings or {},
-        "scorer_rating_reasons": feedback_req.scorer_rating_reasons or {},
-        "scorer_rating_confidences": feedback_req.scorer_rating_confidences or {},
+        "scorer_tags": feedback_req.scorer_tags,
+        "scorer_tag_reasons": feedback_req.scorer_tag_reasons,
+        "scorer_tag_confidences": feedback_req.scorer_tag_confidences,
+        "scorer_ratings": feedback_req.scorer_ratings,
+        "scorer_rating_reasons": feedback_req.scorer_rating_reasons,
+        "scorer_rating_confidences": feedback_req.scorer_rating_confidences,
     }
 
 

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -48,6 +48,10 @@ TABLE_FEEDBACK = Table(
         Column("call_ref", "string", nullable=True),
         Column("trigger_ref", "string", nullable=True),
         Column("queue_id", "string", nullable=True),
+        Column("scorer_tags", "array_string"),
+        Column("scorer_ratings", "map_string_float"),
+        Column("scorer_reasons", "map_string_string"),
+        Column("scorer_confidences", "map_string_float"),
     ],
 )
 
@@ -257,6 +261,10 @@ def format_feedback_to_row(
         "call_ref": feedback_req.call_ref,
         "trigger_ref": feedback_req.trigger_ref,
         "queue_id": feedback_req.queue_id,
+        "scorer_tags": feedback_req.scorer_tags or [],
+        "scorer_ratings": feedback_req.scorer_ratings or {},
+        "scorer_reasons": feedback_req.scorer_reasons or {},
+        "scorer_confidences": feedback_req.scorer_confidences or {},
     }
 
 

--- a/weave/trace_server/interface/feedback_types.py
+++ b/weave/trace_server/interface/feedback_types.py
@@ -51,6 +51,10 @@ def feedback_type_is_runnable(feedback_type: str) -> bool:
     return feedback_type.startswith(RUNNABLE_FEEDBACK_TYPE_PREFIX)
 
 
+def feedback_type_is_agent_monitor(feedback_type: str) -> bool:
+    return feedback_type == AGENT_MONITOR_FEEDBACK_TYPE
+
+
 def runnable_feedback_selector(name: str) -> str:
     return f"feedback.[{RUNNABLE_FEEDBACK_TYPE_PREFIX}.{name}]"
 

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -99,9 +99,9 @@ ColumnType = Literal[
     "float",
     # Array(String) in ClickHouse; JSON text in SQLite.
     "array_string",
-    # Map(*, String) in ClickHouse; JSON text in SQLite.
+    # Map(String, String) in ClickHouse; JSON text in SQLite.
     "map_string_string",
-    # Map(*, Float64) in ClickHouse; JSON text in SQLite.
+    # Map(String, Float64) in ClickHouse; JSON text in SQLite.
     "map_string_float",
 ]
 
@@ -193,7 +193,12 @@ class Table:
         if database_type == "sqlite":
             return f"DELETE FROM {self.name}"
 
-    def tuple_to_row(self, tup: tuple, fields: list[str]) -> Row:
+    def tuple_to_row(
+        self,
+        tup: tuple,
+        fields: list[str],
+        database_type: DatabaseType,
+    ) -> Row:
         d = {}
         for i, field in enumerate(fields):
             normalized_field = field[:-5] if field.endswith("_dump") else field
@@ -201,18 +206,28 @@ class Table:
             col_type = self.col_types.get(normalized_field)
             if col_type == "json":
                 d[normalized_field] = json.loads(value)
-            elif col_type in _JSON_TEXT_BACKED_COL_TYPES and isinstance(value, str):
-                # SQLite stores Array/Map columns as JSON text; ClickHouse returns
-                # them as native list/dict already, so only decode on string values.
+            elif col_type in _JSON_TEXT_BACKED_COL_TYPES and database_type == "sqlite":
+                # SQLite stores Array/Map columns as JSON text; ClickHouse
+                # returns them as native list/dict already.
+                if not isinstance(value, str):
+                    raise ValueError(
+                        f"Unexpected value for {normalized_field}: "
+                        f"expected str, got {type(value).__name__}"
+                    )
                 d[normalized_field] = json.loads(value)
             else:
                 d[normalized_field] = value
         return d
 
-    def tuples_to_rows(self, tuples: list[tuple], fields: list[str]) -> Rows:
+    def tuples_to_rows(
+        self,
+        tuples: list[tuple],
+        fields: list[str],
+        database_type: DatabaseType,
+    ) -> Rows:
         rows = []
         for t in tuples:
-            rows.append(self.tuple_to_row(t, fields))
+            rows.append(self.tuple_to_row(t, fields, database_type))
         return rows
 
 

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -47,7 +47,7 @@ class ParamBuilder:
         param_builder_count += 1
         self._params: dict[str, Any] = {}
         self._prefix = (prefix or f"pb_{param_builder_count}") + "_"
-        self._database_type = database_type
+        self.database_type = database_type
         self._param_to_name: dict[Any, str] = {}
 
     def add_param(self, param_value: Any) -> str:
@@ -76,7 +76,7 @@ class ParamBuilder:
         """
         param_name = param_name or self._prefix + str(len(self._params))
         self._params[param_name] = param_value
-        if self._database_type == "clickhouse":
+        if self.database_type == "clickhouse":
             ptype = param_type or python_value_to_ch_type(param_value)
             return f"{{{param_name}:{ptype}}}"
         return ":" + param_name
@@ -159,12 +159,22 @@ class Table:
     # Fields derived from cols
     col_types: dict[str, ColumnType]
     json_cols: list[str]
+    array_string_cols: list[str]
+    map_string_cols: list[str]
+    map_float_cols: list[str]
 
     def __init__(self, name: str, cols: Columns | None = None):
         self.name = name
         self.cols = cols or []
         self.col_types = {c.name: c.type for c in self.cols}
         self.json_cols = [c.name for c in self.cols if c.type == "json"]
+        self.array_string_cols = [c.name for c in self.cols if c.type == "array_string"]
+        self.map_string_cols = [
+            c.name for c in self.cols if c.type == "map_string_string"
+        ]
+        self.map_float_cols = [
+            c.name for c in self.cols if c.type == "map_string_float"
+        ]
 
     def create_sql(self) -> str:
         sql = f"CREATE TABLE IF NOT EXISTS {self.name} (\n"
@@ -347,7 +357,7 @@ class Select:
         param_builder: ParamBuilder | None = None,
     ) -> PreparedSelect:
         param_builder = param_builder or ParamBuilder(None, database_type)
-        assert database_type == param_builder._database_type
+        assert database_type == param_builder.database_type
 
         sql = ""
         if self.action == "SELECT":
@@ -355,8 +365,10 @@ class Select:
             internal_fields = [
                 _transform_external_field_to_internal_field(
                     f,
-                    self.all_columns,
-                    self.table.json_cols,
+                    all_columns=self.all_columns,
+                    json_columns=self.table.json_cols,
+                    map_string_columns=self.table.map_string_cols,
+                    map_float_columns=self.table.map_float_cols,
                     param_builder=param_builder,
                 )[0]
                 for f in fieldnames
@@ -376,7 +388,13 @@ class Select:
         # Returns {join type} JOIN {table name} ON {join condition}
         for j in self.joins:
             query_conds, fields_used = _process_query_to_conditions(
-                j.query, self.all_columns, self.table.json_cols, param_builder
+                j.query,
+                all_columns=self.all_columns,
+                json_columns=self.table.json_cols,
+                array_string_columns=self.table.array_string_cols,
+                map_string_columns=self.table.map_string_cols,
+                map_float_columns=self.table.map_float_cols,
+                param_builder=param_builder,
             )
             joined = combine_conditions(query_conds, "AND")
             sql += f"\n{j.join_type + ' ' if j.join_type else ''}JOIN {j.table.name} ON {joined}"
@@ -389,7 +407,13 @@ class Select:
             conditions = [f"project_id = {param_project_id}"]
         if self._query:
             query_conds, fields_used = _process_query_to_conditions(
-                self._query, self.all_columns, self.table.json_cols, param_builder
+                self._query,
+                all_columns=self.all_columns,
+                json_columns=self.table.json_cols,
+                array_string_columns=self.table.array_string_cols,
+                map_string_columns=self.table.map_string_cols,
+                map_float_columns=self.table.map_float_cols,
+                param_builder=param_builder,
             )
             conditions.extend(query_conds)
 
@@ -401,8 +425,10 @@ class Select:
             internal_fields = [
                 _transform_external_field_to_internal_field(
                     f,
-                    self.all_columns,
-                    self.table.json_cols,
+                    all_columns=self.all_columns,
+                    json_columns=self.table.json_cols,
+                    map_string_columns=self.table.map_string_cols,
+                    map_float_columns=self.table.map_float_cols,
                     param_builder=param_builder,
                 )[0]
                 for f in self._group_by
@@ -418,6 +444,7 @@ class Select:
                 # For each order by field, if it is a dynamic field, we generate
                 # 3 order by terms: one for existence, one for float casting, and one for string casting.
                 # The effect of this is that we will have stable sorting for nullable, mixed-type fields.
+                options: list[tuple[tsi_query.CastTo | None, str]]
                 if _is_dynamic_field(field, self.table.json_cols):
                     # Prioritize existence, then cast to double, then str
                     options = [
@@ -426,7 +453,9 @@ class Select:
                         ("string", direction),
                     ]
                 else:
-                    options = [(field, direction)]
+                    # Static columns don't need a cast; the function ignores
+                    # the param when no JSON/Map extraction is happening.
+                    options = [(None, direction)]
 
                 # For each option, build the order by term
                 for cast, direct in options:
@@ -438,9 +467,11 @@ class Select:
                         _,
                     ) = _transform_external_field_to_internal_field(
                         field,
-                        self.all_columns,
-                        self.table.json_cols,
-                        cast,
+                        all_columns=self.all_columns,
+                        json_columns=self.table.json_cols,
+                        map_string_columns=self.table.map_string_cols,
+                        map_float_columns=self.table.map_float_cols,
+                        cast=cast,
                         param_builder=param_builder,
                     )
                     order_parts.append(f"{inner_field} {direct}")
@@ -637,20 +668,39 @@ def quote_json_path_parts(parts: list[str]) -> str:
 
 def _transform_external_field_to_internal_field(
     field: str,
-    all_columns: Sequence[str],
-    json_columns: Sequence[str],
-    cast: str | None = None,
+    *,
+    all_columns: Sequence[str] = (),
+    json_columns: Sequence[str] = (),
+    map_string_columns: Sequence[str] = (),
+    map_float_columns: Sequence[str] = (),
+    cast: tsi_query.CastTo | None = None,
     param_builder: ParamBuilder | None = None,
 ) -> tuple[str, ParamBuilder, set[str]]:
-    """Transforms a request for a dot-notation field to a clickhouse field."""
+    """Transforms a request for a dot-notation field to a clickhouse field.
+
+    For Map(String, *) columns, a dotted path like `scorer_ratings._rating_`
+    resolves to a typed map access (`col['key']` in ClickHouse,
+    `json_extract(col, '$."key"')` in SQLite). Bare references to a map
+    column pass through to the column itself.
+    """
     param_builder = param_builder or ParamBuilder()
     raw_fields_used = set()
     json_path = None
+    map_access_key: str | None = None
+    for prefix in (*map_string_columns, *map_float_columns):
+        if field == prefix:
+            # Bare map column — return as-is and let the caller compare it.
+            break
+        if field.startswith(prefix + "."):
+            map_access_key = field[len(prefix) + 1 :]
+            raw_fields_used.add(field)
+            field = prefix
+            break
     for prefix in json_columns:
         if field == prefix:
             field = prefix + "_dump"
         elif field.startswith(prefix + "."):
-            json_path = quote_json_path(field[len(prefix + ".") :])
+            json_path = quote_json_path(field[len(prefix) + 1 :])
             field = prefix + "_dump"
 
     # pops of table_prefix
@@ -677,12 +727,30 @@ def _transform_external_field_to_internal_field(
         raise ValueError(f"Unknown field: {field}")
 
     raw_fields_used.add(unprefixed_field)
-    if json_path is not None:
+    if map_access_key is not None:
+        is_sqlite = param_builder.database_type == "sqlite"
+        if is_sqlite:
+            json_path_val = quote_json_path_parts([map_access_key])
+            json_path_param = param_builder.add(json_path_val, None, "String")
+            field = f"json_extract({field}, {json_path_param})"
+        else:
+            key_param = param_builder.add(map_access_key, None, "String")
+            # Missing CH map keys default to 0 / "" — guard with mapContains
+            # so absent keys read as NULL (matches SQLite's json_extract).
+            field = f"if(mapContains({field}, {key_param}), {field}[{key_param}], NULL)"
+            # Pass-through casts (string/exists/None) are always safe.
+            # Numeric `OrNull` casts only work on String inputs, so skip them
+            # for `Map(String, Float64)` columns where the value is already
+            # numeric.
+            map_col_was_string = unprefixed_field.split(".", 1)[0] in map_string_columns
+            if map_col_was_string or cast in {None, "string", "exists"}:
+                field = clickhouse_cast(field, cast)
+    elif json_path is not None:
         json_path_param = param_builder.add(json_path, None, "String")
         if cast == "exists":
             field = "(JSON_EXISTS(" + field + ", " + json_path_param + "))"
         else:
-            is_sqlite = param_builder._database_type == "sqlite"
+            is_sqlite = param_builder.database_type == "sqlite"
             json_func = "json_extract(" if is_sqlite else "JSON_VALUE("
             field = json_func + field + ", " + json_path_param + ")"
             if not is_sqlite:
@@ -694,10 +762,30 @@ def _transform_external_field_to_internal_field(
     return field, param_builder, raw_fields_used
 
 
+def _operand_array_string_column(
+    operand: tsi_query.Operand, array_string_columns: Sequence[str]
+) -> str | None:
+    """Return the column name if `operand` is a bare $getField on an
+    Array(String) column, else None. Used by ContainsOperation to switch
+    from substring search to array membership.
+    """
+    if not array_string_columns:
+        return None
+    if isinstance(operand, tsi_query.GetFieldOperator):
+        name = operand.get_field_
+        if name in array_string_columns:
+            return name
+    return None
+
+
 def _process_query_to_conditions(
     query: tsi.Query,
-    all_columns: Sequence[str],
-    json_columns: Sequence[str],
+    *,
+    all_columns: Sequence[str] = (),
+    json_columns: Sequence[str] = (),
+    array_string_columns: Sequence[str] = (),
+    map_string_columns: Sequence[str] = (),
+    map_float_columns: Sequence[str] = (),
     param_builder: ParamBuilder | None = None,
     field_resolver: Callable[[str, ParamBuilder], tuple[str, set[str]]] | None = None,
 ) -> tuple[list[str], set[str]]:
@@ -755,23 +843,52 @@ def _process_query_to_conditions(
             rhs_part = ",".join(process_operand(op) for op in operation.in_[1])
             cond = f"({lhs_part} IN ({rhs_part}))"
         elif isinstance(operation, tsi_query.ContainsOperation):
-            lhs_part = process_operand(operation.contains_.input)
-            rhs_part = process_operand(operation.contains_.substr)
-            is_sqlite = pb._database_type == "sqlite"
-
-            if is_sqlite:
-                # SQLite uses INSTR function and doesn't have case-insensitive variant
-                if operation.contains_.case_insensitive:
-                    # For case-insensitive, convert both to lowercase
-                    cond = f"INSTR(LOWER({lhs_part}), LOWER({rhs_part})) > 0"
+            # If LHS is a bare Array(String) column, treat $contains as array
+            # membership, not substring search — `has(col, value)` in CH and
+            # a json_each subquery in SQLite. Falls back to the string-contains
+            # behavior for every other operand shape.
+            array_col = _operand_array_string_column(
+                operation.contains_.input, array_string_columns
+            )
+            if array_col is not None:
+                rhs_part = process_operand(operation.contains_.substr)
+                raw_fields_used.add(array_col)
+                case_insensitive = operation.contains_.case_insensitive
+                if pb.database_type == "sqlite":
+                    if case_insensitive:
+                        cond = (
+                            f"EXISTS (SELECT 1 FROM json_each({array_col}) "
+                            f"WHERE LOWER(value) = LOWER({rhs_part}))"
+                        )
+                    else:
+                        cond = (
+                            f"EXISTS (SELECT 1 FROM json_each({array_col}) "
+                            f"WHERE value = {rhs_part})"
+                        )
+                elif case_insensitive:
+                    cond = (
+                        f"arrayExists(x -> lower(x) = lower({rhs_part}), {array_col})"
+                    )
                 else:
-                    cond = f"INSTR({lhs_part}, {rhs_part}) > 0"
+                    cond = f"has({array_col}, {rhs_part})"
             else:
-                # ClickHouse uses position/positionCaseInsensitive
-                position_operation = "position"
-                if operation.contains_.case_insensitive:
-                    position_operation = "positionCaseInsensitive"
-                cond = f"{position_operation}({lhs_part}, {rhs_part}) > 0"
+                lhs_part = process_operand(operation.contains_.input)
+                rhs_part = process_operand(operation.contains_.substr)
+                is_sqlite = pb.database_type == "sqlite"
+
+                if is_sqlite:
+                    # SQLite uses INSTR function and doesn't have case-insensitive variant
+                    if operation.contains_.case_insensitive:
+                        # For case-insensitive, convert both to lowercase
+                        cond = f"INSTR(LOWER({lhs_part}), LOWER({rhs_part})) > 0"
+                    else:
+                        cond = f"INSTR({lhs_part}, {rhs_part}) > 0"
+                else:
+                    # ClickHouse uses position/positionCaseInsensitive
+                    position_operation = "position"
+                    if operation.contains_.case_insensitive:
+                        position_operation = "positionCaseInsensitive"
+                    cond = f"{position_operation}({lhs_part}, {rhs_part}) > 0"
         else:
             raise TypeError(f"Unknown operation type: {operation}")
 
@@ -805,7 +922,7 @@ def _process_query_to_conditions(
                 # SQL, so the cast has to be reapplied here for the typed
                 # comparison to type-check in CH. Sqlite drops the cast for
                 # the same reason it's dropped in the JSON extraction path.
-                if cast is not None and pb._database_type == "clickhouse":
+                if cast is not None and pb.database_type == "clickhouse":
                     field = clickhouse_cast_json_value(field, cast)
             else:
                 (
@@ -813,7 +930,13 @@ def _process_query_to_conditions(
                     _,
                     fields_used,
                 ) = _transform_external_field_to_internal_field(
-                    operand.get_field_, all_columns, json_columns, cast, pb
+                    operand.get_field_,
+                    all_columns=all_columns,
+                    json_columns=json_columns,
+                    map_string_columns=map_string_columns,
+                    map_float_columns=map_float_columns,
+                    cast=cast,
+                    param_builder=pb,
                 )
             raw_fields_used.update(fields_used)
             return field

--- a/weave/trace_server/orm.py
+++ b/weave/trace_server/orm.py
@@ -97,7 +97,22 @@ ColumnType = Literal[
     "datetime",
     "json",  # Represented as string in ClickHouse
     "float",
+    # Array(String) in ClickHouse; JSON text in SQLite.
+    "array_string",
+    # Map(*, String) in ClickHouse; JSON text in SQLite.
+    "map_string_string",
+    # Map(*, Float64) in ClickHouse; JSON text in SQLite.
+    "map_string_float",
 ]
+
+# Column types that ClickHouse stores natively as Array/Map but SQLite stores
+# as JSON-encoded text. The ClickHouse driver round-trips these as native
+# Python list/dict, so coercion is only needed on the SQLite path.
+_JSON_TEXT_BACKED_COL_TYPES: set[ColumnType] = {
+    "array_string",
+    "map_string_string",
+    "map_string_float",
+}
 
 
 class Column:
@@ -183,10 +198,12 @@ class Table:
         for i, field in enumerate(fields):
             normalized_field = field[:-5] if field.endswith("_dump") else field
             value = tup[i]
-            if (
-                normalized_field in self.col_types
-                and self.col_types[normalized_field] == "json"
-            ):
+            col_type = self.col_types.get(normalized_field)
+            if col_type == "json":
+                d[normalized_field] = json.loads(value)
+            elif col_type in _JSON_TEXT_BACKED_COL_TYPES and isinstance(value, str):
+                # SQLite stores Array/Map columns as JSON text; ClickHouse returns
+                # them as native list/dict already, so only decode on string values.
                 d[normalized_field] = json.loads(value)
             else:
                 d[normalized_field] = value
@@ -461,10 +478,15 @@ class Insert:
         for row in self.rows:
             r: list[Any] = []
             for field in given_column_names:
-                if (
-                    field in self.table.col_types
-                    and self.table.col_types[field] == "json"
+                col_type = self.table.col_types.get(field)
+                if col_type == "json":
+                    r.append(json.dumps(row[field]))
+                elif (
+                    col_type in _JSON_TEXT_BACKED_COL_TYPES
+                    and database_type == "sqlite"
                 ):
+                    # SQLite has no Array/Map types; store as JSON text. The
+                    # ClickHouse driver accepts native list/dict directly.
                     r.append(json.dumps(row[field]))
                 else:
                     r.append(row[field])

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -69,7 +69,7 @@ def _sort_filter_uses_inputs(
     pb = ParamBuilder()
     for f in filters:
         _process_query_to_conditions(
-            f.query, [], [], param_builder=pb, field_resolver=collector
+            f.query, param_builder=pb, field_resolver=collector
         )
     return found
 
@@ -337,7 +337,7 @@ def _build_having_clause(
         for f in filters:
             resolver = _make_field_resolver(f.evaluation_call_id)
             conditions, _ = _process_query_to_conditions(
-                f.query, [], [], param_builder=pb, field_resolver=resolver
+                f.query, param_builder=pb, field_resolver=resolver
             )
             having_parts.extend(conditions)
 

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -2718,6 +2718,10 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         return tsi.FeedbackPurgeRes()
 
     def feedback_replace(self, req: tsi.FeedbackReplaceReq) -> tsi.FeedbackReplaceRes:
+        # Validate the replacement payload before purging — if validation
+        # rejects we want the old row preserved, not destroyed.
+        create_req = tsi.FeedbackCreateReq(**req.model_dump(exclude={"feedback_id"}))
+        validate_feedback_create_req(create_req, self)
         purge_request = tsi.FeedbackPurgeReq(
             project_id=req.project_id,
             query={
@@ -2730,7 +2734,6 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
             },
         )
         self.feedback_purge(purge_request)
-        create_req = tsi.FeedbackCreateReq(**req.model_dump(exclude={"feedback_id"}))
         create_result = self.feedback_create(create_req)
 
         return tsi.FeedbackReplaceRes(

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -2696,7 +2696,9 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         query = query.limit(req.limit).offset(req.offset)
         prepared = query.prepare(database_type="sqlite")
         r = cursor.execute(prepared.sql, prepared.parameters)
-        result = TABLE_FEEDBACK.tuples_to_rows(r.fetchall(), prepared.fields)
+        result = TABLE_FEEDBACK.tuples_to_rows(
+            r.fetchall(), prepared.fields, database_type="sqlite"
+        )
         return tsi.FeedbackQueryRes(result=result)
 
     def feedback_purge(self, req: tsi.FeedbackPurgeReq) -> tsi.FeedbackPurgeRes:
@@ -2855,7 +2857,9 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         query = query.limit(req.limit).offset(req.offset)
         prepared = query.prepare(database_type="sqlite")
         result = cursor.execute(prepared.sql, prepared.parameters)
-        rows = LLM_TOKEN_PRICES_TABLE.tuples_to_rows(result.fetchall(), prepared.fields)
+        rows = LLM_TOKEN_PRICES_TABLE.tuples_to_rows(
+            result.fetchall(), prepared.fields, database_type="sqlite"
+        )
         return tsi.CostQueryRes(results=rows)
 
     def cost_purge(self, req: tsi.CostPurgeReq) -> tsi.CostPurgeRes:

--- a/weave/trace_server/trace_server_common.py
+++ b/weave/trace_server/trace_server_common.py
@@ -23,6 +23,12 @@ FEEDBACK_QUERY_FIELDS = [
     "call_ref",
     "trigger_ref",
     "annotation_ref",
+    "scorer_tags",
+    "scorer_tag_reasons",
+    "scorer_tag_confidences",
+    "scorer_ratings",
+    "scorer_rating_reasons",
+    "scorer_rating_confidences",
 ]
 
 

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1188,7 +1188,7 @@ class FeedbackCreateReq(BaseModelStrict):
         examples=["018f1f2a-9c2b-7d3e-b5a1-8c9d2e4f6a7b"],
     )
 
-    # typed scorer outputs and populated by agent-monitor scorers
+    # typed scorer outputs; populated by agent-monitor scorers
     scorer_tags: list[str] | None = Field(
         default=None,
         description="Tags applied to the ref by a scorer, e.g. ['nsfw', 'pii'].",

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1189,33 +1189,33 @@ class FeedbackCreateReq(BaseModelStrict):
     )
 
     # typed scorer outputs; populated by agent-monitor scorers
-    scorer_tags: list[str] | None = Field(
-        default=None,
+    scorer_tags: list[str] = Field(
+        default_factory=list,
         description="Tags applied to the ref by a scorer",
         examples=[["nsfw", "high-quality"]],
     )
-    scorer_tag_reasons: dict[str, str] | None = Field(
-        default=None,
+    scorer_tag_reasons: dict[str, str] = Field(
+        default_factory=dict,
         description="reason text per tag, keyed by tag name",
         examples=[{"nsfw": "Contains explicit language"}],
     )
-    scorer_tag_confidences: dict[str, float] | None = Field(
-        default=None,
+    scorer_tag_confidences: dict[str, float] = Field(
+        default_factory=dict,
         description="confidence (0-1) per tag, keyed by tag name",
         examples=[{"nsfw": 0.92}],
     )
-    scorer_ratings: dict[str, float] | None = Field(
-        default=None,
+    scorer_ratings: dict[str, float] = Field(
+        default_factory=dict,
         description="numeric ratings (0-1) keyed by rating name",
         examples=[{"_rating_": 0.87}],
     )
-    scorer_rating_reasons: dict[str, str] | None = Field(
-        default=None,
+    scorer_rating_reasons: dict[str, str] = Field(
+        default_factory=dict,
         description="reason text per rating, keyed by rating name",
         examples=[{"_rating_": "very confident response"}],
     )
-    scorer_rating_confidences: dict[str, float] | None = Field(
-        default=None,
+    scorer_rating_confidences: dict[str, float] = Field(
+        default_factory=dict,
         description="confidence (0-1) per rating, keyed by rating name",
         examples=[{"_rating_": 0.92}],
     )

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1191,23 +1191,33 @@ class FeedbackCreateReq(BaseModelStrict):
     # typed scorer outputs; populated by agent-monitor scorers
     scorer_tags: list[str] | None = Field(
         default=None,
-        description="Tags applied to the ref by a scorer, e.g. ['nsfw', 'pii'].",
+        description="Tags applied to the ref by a scorer",
         examples=[["nsfw", "high-quality"]],
+    )
+    scorer_tag_reasons: dict[str, str] | None = Field(
+        default=None,
+        description="reason text per tag, keyed by tag name",
+        examples=[{"nsfw": "Contains explicit language"}],
+    )
+    scorer_tag_confidences: dict[str, float] | None = Field(
+        default=None,
+        description="confidence (0-1) per tag, keyed by tag name",
+        examples=[{"nsfw": 0.92}],
     )
     scorer_ratings: dict[str, float] | None = Field(
         default=None,
-        description="Numeric ratings (0-1) keyed by name, e.g. {'_rating_': 0.87}.",
+        description="numeric ratings (0-1) keyed by rating name",
         examples=[{"_rating_": 0.87}],
     )
-    scorer_reasons: dict[str, str] | None = Field(
+    scorer_rating_reasons: dict[str, str] | None = Field(
         default=None,
-        description="Optional reason text keyed by 'tag.<name>' or 'rating.<name>'.",
-        examples=[{"tag.nsfw": "Contains explicit language"}],
+        description="reason text per rating, keyed by rating name",
+        examples=[{"_rating_": "very confident response"}],
     )
-    scorer_confidences: dict[str, float] | None = Field(
+    scorer_rating_confidences: dict[str, float] | None = Field(
         default=None,
-        description="Optional confidence (0-1) keyed by 'tag.<name>' or 'rating.<name>'.",
-        examples=[{"rating._rating_": 0.92}],
+        description="confidence (0-1) per rating, keyed by rating name",
+        examples=[{"_rating_": 0.92}],
     )
 
     # wb_user_id is automatically populated by the server

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1188,8 +1188,7 @@ class FeedbackCreateReq(BaseModelStrict):
         examples=["018f1f2a-9c2b-7d3e-b5a1-8c9d2e4f6a7b"],
     )
 
-    # Typed scorer outputs. Populated by agent-monitor scorers and left as
-    # empty defaults otherwise. See migration 031 for column shapes.
+    # typed scorer outputs and populated by agent-monitor scorers
     scorer_tags: list[str] | None = Field(
         default=None,
         description="Tags applied to the ref by a scorer, e.g. ['nsfw', 'pii'].",

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1188,6 +1188,29 @@ class FeedbackCreateReq(BaseModelStrict):
         examples=["018f1f2a-9c2b-7d3e-b5a1-8c9d2e4f6a7b"],
     )
 
+    # Typed scorer outputs. Populated by agent-monitor scorers and left as
+    # empty defaults otherwise. See migration 031 for column shapes.
+    scorer_tags: list[str] | None = Field(
+        default=None,
+        description="Tags applied to the ref by a scorer, e.g. ['nsfw', 'pii'].",
+        examples=[["nsfw", "high-quality"]],
+    )
+    scorer_ratings: dict[str, float] | None = Field(
+        default=None,
+        description="Numeric ratings (0-1) keyed by name, e.g. {'_rating_': 0.87}.",
+        examples=[{"_rating_": 0.87}],
+    )
+    scorer_reasons: dict[str, str] | None = Field(
+        default=None,
+        description="Optional reason text keyed by 'tag.<name>' or 'rating.<name>'.",
+        examples=[{"tag.nsfw": "Contains explicit language"}],
+    )
+    scorer_confidences: dict[str, float] | None = Field(
+        default=None,
+        description="Optional confidence (0-1) keyed by 'tag.<name>' or 'rating.<name>'.",
+        examples=[{"rating._rating_": 0.92}],
+    )
+
     # wb_user_id is automatically populated by the server
     wb_user_id: str | None = Field(None, description=WB_USER_ID_DESCRIPTION)
 


### PR DESCRIPTION
## Description

Backend support for the typed scorer feedback schema ([proposal](https://www.notion.so/wandbai/Scorer-Feedback-Schema-Proposal-361e2f5c7ef38013a18bc254a40b43b5)). Builds on the migration in #6906 (already merged). Collapses the former stack of #6908 / #6909 / #6918 into one PR.

**Typed columns wiring**
- ORM gains `array_string`, `map_string_string`, `map_string_float` column types. ClickHouse round-trips them as native list/dict; SQLite stores JSON text and decodes on read.
- `TABLE_FEEDBACK`, `FeedbackCreateReq`, `format_feedback_to_row`, and `FEEDBACK_QUERY_FIELDS` expose the six `scorer_*` columns (`scorer_tags`, `scorer_tag_reasons`, `scorer_tag_confidences`, `scorer_ratings`, `scorer_rating_reasons`, `scorer_rating_confidences`). Fields are non-nullable with empty-container defaults.

**`wandb.agent_monitor` feedback type**
- New feedback type; scorer identity comes from `runnable_ref` (no `.<name>` suffix).
- Validation requires `runnable_ref`, `call_ref`, and `trigger_ref`. The `scorer_*` columns are rejected (when non-empty) on any other feedback type.
- `feedback_replace` validates the replacement payload before purging so a rejected replace can't destroy the existing row.

**Query filters**
- `$contains` on an `Array(String)` column compiles to `has(col, value)` (CH) / `json_each` subquery (SQLite), with case-insensitive support. Falls back to substring search for non-array operands.
- Dotted access on a `Map(String, *)` column resolves to a typed map lookup (`col['key']` on CH guarded by `mapContains`, `json_extract` on SQLite), so missing keys read as NULL instead of CH's `0`/`""` defaults.

## Testing

Unit tests, against both SQLite and ClickHouse backends.