### PR TITLE
feat(weave): add wandb.agent_monitor feedback type

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -363,6 +363,134 @@ def test_runnable_feedback(client: WeaveClient) -> None:
     }
 
 
+def test_agent_monitor_feedback(client: WeaveClient) -> None:
+    """End-to-end create/query for wandb.agent_monitor feedback with typed scorer columns."""
+    project_id = client.project_id
+    feedback_type = "wandb.agent_monitor"
+    weave_ref = f"weave:///{project_id}/call/call_id_123"
+    runnable_name = "my_scorer"
+    runnable_ref = f"weave:///{project_id}/object/{runnable_name}:obj_id_123"
+    call_ref = f"weave:///{project_id}/call/call_id_123"
+    trigger_ref = f"weave:///{project_id}/object/{runnable_name}:trigger_id_123"
+    payload = {"value": ["nsfw"], "reason": ["explicit language"]}
+
+    # Case 1: runnable_ref is required.
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type=feedback_type,
+                payload=payload,
+                scorer_tags=["nsfw"],
+            )
+        )
+
+    # Case 2: call_ref is required.
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type=feedback_type,
+                payload=payload,
+                runnable_ref=runnable_ref,
+            )
+        )
+
+    # Case 3: trigger_ref is required.
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type=feedback_type,
+                payload=payload,
+                runnable_ref=runnable_ref,
+                call_ref=call_ref,
+            )
+        )
+
+    # Case 4: scorer_* fields rejected on non-agent-monitor feedback types
+    # (non-empty value).
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type="custom",
+                payload={},
+                scorer_tags=["nsfw"],
+            )
+        )
+
+    # Success: write tags, a rating, and reasons/confidences keyed by name.
+    create_res = client.server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type=feedback_type,
+            payload=payload,
+            runnable_ref=runnable_ref,
+            call_ref=call_ref,
+            trigger_ref=trigger_ref,
+            scorer_tags=["nsfw", "high-quality"],
+            scorer_tag_reasons={"nsfw": "explicit language"},
+            scorer_tag_confidences={"nsfw": 0.95},
+            scorer_ratings={"_rating_": 0.87},
+            scorer_rating_reasons={"_rating_": "very confident response"},
+            scorer_rating_confidences={"_rating_": 0.92},
+        )
+    )
+    assert create_res.id is not None
+
+    query_res = client.server.feedback_query(
+        tsi.FeedbackQueryReq(project_id=project_id)
+    )
+    assert len(query_res.result) == 1
+    row = query_res.result[0]
+    assert row["feedback_type"] == feedback_type
+    assert row["payload"] == payload
+    assert row["scorer_tags"] == ["nsfw", "high-quality"]
+    assert row["scorer_tag_reasons"] == {"nsfw": "explicit language"}
+    assert row["scorer_tag_confidences"] == {"nsfw": 0.95}
+    assert row["scorer_ratings"] == {"_rating_": 0.87}
+    assert row["scorer_rating_reasons"] == {"_rating_": "very confident response"}
+    assert row["scorer_rating_confidences"] == {"_rating_": 0.92}
+
+
+def test_agent_monitor_feedback_empty_defaults(client: WeaveClient) -> None:
+    """A minimal agent_monitor row (no typed scorer fields) round-trips with empty defaults."""
+    project_id = client.project_id
+    weave_ref = f"weave:///{project_id}/call/call_id_123"
+    runnable_ref = f"weave:///{project_id}/object/my_scorer:obj_id_123"
+    call_ref = f"weave:///{project_id}/call/call_id_123"
+    trigger_ref = f"weave:///{project_id}/object/my_scorer:trigger_id_123"
+
+    create_res = client.server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type="wandb.agent_monitor",
+            payload={"value": None},
+            runnable_ref=runnable_ref,
+            call_ref=call_ref,
+            trigger_ref=trigger_ref,
+        )
+    )
+    assert create_res.id is not None
+
+    query_res = client.server.feedback_query(
+        tsi.FeedbackQueryReq(project_id=project_id)
+    )
+    assert query_res.result[0]["scorer_tags"] == []
+    assert query_res.result[0]["scorer_tag_reasons"] == {}
+    assert query_res.result[0]["scorer_tag_confidences"] == {}
+    assert query_res.result[0]["scorer_ratings"] == {}
+    assert query_res.result[0]["scorer_rating_reasons"] == {}
+    assert query_res.result[0]["scorer_rating_confidences"] == {}
+
+
 async def populate_feedback(client: WeaveClient) -> None:
     @weave.op
     def my_scorer(x: int, output: int) -> int:
@@ -808,6 +936,44 @@ def test_feedback_replace(client) -> None:
     new_feedback = next(f for f in feedbacks if f["id"] == replaced_feedback.id)
     assert new_feedback["feedback_type"] == "reaction"
     assert new_feedback["payload"] == {"emoji": "👍"}
+
+
+def test_feedback_replace_validates_before_purge(client) -> None:
+    """Replace must reject invalid payloads BEFORE deleting the existing row."""
+    project_id = client.project_id
+    weave_ref = f"weave:///{project_id}/obj/123:abc"
+
+    initial = client.server.feedback_create(
+        FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type="reaction",
+            payload={"emoji": "👍"},
+            wb_user_id="test_user",
+        )
+    )
+
+    # The replace payload would fail validation (non-empty scorer_tags on a
+    # non-agent-monitor type). Without validate-before-purge, the purge would
+    # run first and destroy the original row.
+    with pytest.raises(InvalidRequest):
+        client.server.feedback_replace(
+            FeedbackReplaceReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type="reaction",
+                payload={"emoji": "👍"},
+                feedback_id=initial.id,
+                wb_user_id="test_user",
+                scorer_tags=["nsfw"],
+            )
+        )
+
+    # The original row must still be there.
+    query_res = client.server.feedback_query(
+        FeedbackQueryReq(project_id=project_id, fields=["id"])
+    )
+    assert [r["id"] for r in query_res.result] == [initial.id]
 
 
 def test_get_feedback_with_dict_query(client) -> None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6228,7 +6228,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         return tsi.FeedbackPurgeRes()
 
     def feedback_replace(self, req: tsi.FeedbackReplaceReq) -> tsi.FeedbackReplaceRes:
-        # To replace, first purge, then if successful, create.
+        # Validate the replacement payload before purging — if validation
+        # rejects we want the old row preserved, not destroyed. This duplicates
+        # the validation that feedback_create() runs internally (one extra
+        # ref-lookup network call on annotation/agent-monitor paths), which is
+        # acceptable to preserve the no-data-loss guarantee on replace.
+        create_req = tsi.FeedbackCreateReq(**req.model_dump(exclude={"feedback_id"}))
+        validate_feedback_create_req(create_req, self)
         query = tsi.Query(
             **{
                 "$expr": {
@@ -6244,7 +6250,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             query=query,
         )
         self.feedback_purge(purge_request)
-        create_req = tsi.FeedbackCreateReq(**req.model_dump(exclude={"feedback_id"}))
         create_result = self.feedback_create(create_req)
         return tsi.FeedbackReplaceRes(
             id=create_result.id,

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -22,6 +22,7 @@ from weave.trace_server.interface.feedback_types import (
     RUNNABLE_FEEDBACK_TYPE_PREFIX,
     AnnotationPayloadSchema,
     RunnablePayloadSchema,
+    feedback_type_is_agent_monitor,
     feedback_type_is_annotation,
     feedback_type_is_runnable,
 )
@@ -154,12 +155,38 @@ def validate_feedback_create_req(
             raise InvalidRequest(
                 f"Invalid payload for feedback_type {req.feedback_type}: {e}"
             ) from e
+    elif feedback_type_is_agent_monitor(req.feedback_type):
+        if not req.runnable_ref:
+            raise InvalidRequest("runnable_ref is required for agent monitor feedback")
+        if req.call_ref is None:
+            raise InvalidRequest("call_ref is required for agent monitor feedback")
+        if req.trigger_ref is None:
+            raise InvalidRequest("trigger_ref is required for agent monitor feedback")
     elif req.runnable_ref:
         raise InvalidRequest("runnable_ref is not allowed for non-runnable feedback")
     elif req.call_ref:
         raise InvalidRequest("call_ref is not allowed for non-runnable feedback")
     elif req.trigger_ref:
         raise InvalidRequest("trigger_ref is not allowed for non-runnable feedback")
+
+    # Typed scorer columns are reserved for agent monitor feedback.
+    scorer_fields_set = any(
+        getattr(req, name)
+        for name in (
+            "scorer_tags",
+            "scorer_tag_reasons",
+            "scorer_tag_confidences",
+            "scorer_ratings",
+            "scorer_rating_reasons",
+            "scorer_rating_confidences",
+        )
+    )
+    if scorer_fields_set and not feedback_type_is_agent_monitor(req.feedback_type):
+        raise InvalidRequest(
+            "scorer_tags, scorer_tag_reasons, scorer_tag_confidences, "
+            "scorer_ratings, scorer_rating_reasons, and scorer_rating_confidences "
+            "are only allowed on wandb.agent_monitor feedback"
+        )
 
     # Validate the ref formats (we could even query the DB to ensure they exist and are valid)
     if req.annotation_ref:

--- a/weave/trace_server/interface/feedback_types.py
+++ b/weave/trace_server/interface/feedback_types.py
@@ -51,6 +51,10 @@ def feedback_type_is_runnable(feedback_type: str) -> bool:
     return feedback_type.startswith(RUNNABLE_FEEDBACK_TYPE_PREFIX)
 
 
+def feedback_type_is_agent_monitor(feedback_type: str) -> bool:
+    return feedback_type == AGENT_MONITOR_FEEDBACK_TYPE
+
+
 def runnable_feedback_selector(name: str) -> str:
     return f"feedback.[{RUNNABLE_FEEDBACK_TYPE_PREFIX}.{name}]"
 

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -2718,6 +2718,10 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
         return tsi.FeedbackPurgeRes()
 
     def feedback_replace(self, req: tsi.FeedbackReplaceReq) -> tsi.FeedbackReplaceRes:
+        # Validate the replacement payload before purging — if validation
+        # rejects we want the old row preserved, not destroyed.
+        create_req = tsi.FeedbackCreateReq(**req.model_dump(exclude={"feedback_id"}))
+        validate_feedback_create_req(create_req, self)
         purge_request = tsi.FeedbackPurgeReq(
             project_id=req.project_id,
             query={
@@ -2730,7 +2734,6 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
             },
         )
         self.feedback_purge(purge_request)
-        create_req = tsi.FeedbackCreateReq(**req.model_dump(exclude={"feedback_id"}))
         create_result = self.feedback_create(create_req)
 
         return tsi.FeedbackReplaceRes(


### PR DESCRIPTION
## Description

Adds the \`wandb.agent_monitor\` feedback_type. Scorer identity comes from \`runnable_ref\` (no \`.<name>\` suffix like \`wandb.runnable.*\`).

Validation:
- Requires \`runnable_ref\`.
- Requires \`call_ref\` when \`runnable_ref\` is an op-ref.
- Rejects \`scorer_tags\` / \`scorer_ratings\` / \`scorer_reasons\` / \`scorer_confidences\` on any other feedback_type, including explicit empty containers.

## Testing

Unit tests.