### PR TITLE
chore(weave): Document manually-updated type in generated traceServerApi.ts

### DIFF
--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -435,6 +435,7 @@ export interface EndedCallSchemaForInsert {
   /** Exception */
   exception?: string | null;
   /** Output */
+  // TODO: This type is manually updated at the moment. https://github.com/wandb/weave/pull/6195/changes#r2850346035
   output?: any;
   summary: SummaryInsertMap;
 }


### PR DESCRIPTION
## Description

* Followup from #6905 -- running `pnpm generate-api` changes this field based on the OpenAPI spec, which breaks the build. Documenting the fact that this one's currently manually maintained so it's easier to catch when regenerating code.