### PR TITLE
feat(weave): support multi-alias semantic convention keys

### DIFF
--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -366,9 +366,7 @@ def test_multi_alias_extraction_recognises_every_form() -> None:
     example; the same contract applies to any multi-alias semconv attribute.
     """
     for key in semconv.USAGE_REASONING_TOKENS.lookup_keys:
-        result = extract_genai_span(
-            _make_span(attrs={key: 42}), project_id="p1"
-        )
+        result = extract_genai_span(_make_span(attrs={key: 42}), project_id="p1")
         assert result.reasoning_tokens == 42, f"key {key!r} did not populate column"
 
 

--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -10,6 +10,7 @@ test since that's a separate code path (Status object vs attributes).
 import datetime
 from typing import Any
 
+from weave.trace_server.agents import semconv
 from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
 from weave.trace_server.opentelemetry.python_spans import (
     Resource,
@@ -355,6 +356,38 @@ def test_extract_custom_attrs_routes_bool_to_bool_map() -> None:
     assert "lorem.is_active" not in result.custom_attrs_string
     assert "lorem.is_active" not in result.custom_attrs_int
     assert "lorem.is_active" not in result.custom_attrs_float
+
+
+def test_multi_alias_extraction_recognises_every_form() -> None:
+    """For any attribute with multiple OTel aliases, the extractor must
+    populate its column from a span carrying the value under any recognised
+    key — canonical weave.* form, primary OTel alias, or any parallel /
+    historical alias. ``USAGE_REASONING_TOKENS`` is used here as a concrete
+    example; the same contract applies to any multi-alias semconv attribute.
+    """
+    for key in semconv.USAGE_REASONING_TOKENS.lookup_keys:
+        result = extract_genai_span(
+            _make_span(attrs={key: 42}), project_id="p1"
+        )
+        assert result.reasoning_tokens == 42, f"key {key!r} did not populate column"
+
+
+def test_multi_alias_extraction_canonical_weave_key_wins() -> None:
+    """When a span carries both the canonical weave.* key and parallel OTel
+    aliases, the weave.* value wins (extractor probes lookup_keys in order).
+    ``USAGE_REASONING_TOKENS`` is used here as a concrete example; the same
+    contract applies to any multi-alias semconv attribute.
+    """
+    result = extract_genai_span(
+        _make_span(
+            attrs={
+                semconv.USAGE_REASONING_TOKENS.key: 99,
+                **dict.fromkeys(semconv.USAGE_REASONING_TOKENS.gen_ai_aliases, 10),
+            }
+        ),
+        project_id="p1",
+    )
+    assert result.reasoning_tokens == 99
 
 
 def test_extract_custom_attrs_skips_non_finite_floats() -> None:

--- a/tests/trace_server/test_genai_semconv.py
+++ b/tests/trace_server/test_genai_semconv.py
@@ -18,3 +18,27 @@ def test_all_attribute_constants_are_registered() -> None:
 
 def test_filterable_columns_reference_registered_attributes() -> None:
     assert set(semconv.CANONICAL_KEY_TO_COLUMN).issubset(set(semconv.ATTRIBUTES))
+
+
+def test_multi_alias_lookup_keys_priority_order() -> None:
+    """``lookup_keys`` returns the canonical weave.* key first, then aliases
+    in declared order, so extraction probes the canonical name before any
+    parallel OTel form.
+    """
+    attr = semconv.Attribute(
+        key="weave.example",
+        type="string",
+        description="synthetic example with multiple aliases",
+        gen_ai_aliases=[
+            "gen_ai.example.primary",
+            "gen_ai.example.legacy",
+            "gen_ai.example.experimental",
+        ],
+    )
+
+    assert attr.lookup_keys == (
+        "weave.example",
+        "gen_ai.example.primary",
+        "gen_ai.example.legacy",
+        "gen_ai.example.experimental",
+    )

--- a/weave/trace_server/agents/semconv.py
+++ b/weave/trace_server/agents/semconv.py
@@ -28,12 +28,32 @@ AttributeType = Literal["string", "int", "float", "string[]", "json"]
 
 @dataclass(frozen=True, slots=True)
 class Attribute:
-    """A single semantic convention attribute."""
+    """A single semantic convention attribute.
+
+    ``gen_ai_alias`` is the *primary* OTel ``gen_ai.*`` wire key for this
+    attribute — usually whatever the upstream OpenTelemetry semconv has
+    standardised on. ``additional_aliases`` lets the server recognise
+    historical / parallel forms for the same column so old data and
+    clients-in-the-field keep parsing.
+
+    Concrete example: ``USAGE_REASONING_TOKENS`` below. The upstream OTel
+    spec landed on ``gen_ai.usage.reasoning.output_tokens``, but Weave
+    has years of data on the wire with ``gen_ai.usage.reasoning_tokens``
+    and ADK emits ``gen_ai.usage.experimental.reasoning_tokens``. All
+    three need to feed the same ``reasoning_tokens`` column without
+    forcing a discontinuity in stored data. Primary alias = canonical
+    upstream name (what new clients emit). Additional aliases = the two
+    historical forms (read-only at this layer).
+
+    The catalog is a recognizer registry; the OTel spec is the source of
+    truth, not this file.
+    """
 
     key: str  # canonical weave.* key
     type: AttributeType
     description: str
-    gen_ai_alias: str = ""  # OTel gen_ai.* equivalent, if any
+    gen_ai_alias: str = ""  # primary OTel gen_ai.* wire key, if any
+    additional_aliases: tuple[str, ...] = ()  # historical / parallel wire keys
 
     def __post_init__(self) -> None:
         """Validate that canonical attributes stay in the Weave namespace."""
@@ -44,13 +64,17 @@ class Attribute:
 
     @property
     def lookup_keys(self) -> tuple[str, ...]:
-        """Return (weave_key, gen_ai_alias) for use in attribute extraction.
+        """Return all recognized keys, ordered weave-canonical first.
 
-        The canonical weave.* key is always first so it takes priority.
+        Extraction probes them in order and uses the first non-None hit,
+        so callers can rely on the weave.* key winning over older aliases
+        when both are present on a span.
         """
+        keys: list[str] = [self.key]
         if self.gen_ai_alias:
-            return (self.key, self.gen_ai_alias)
-        return (self.key,)
+            keys.append(self.gen_ai_alias)
+        keys.extend(self.additional_aliases)
+        return tuple(keys)
 
 
 # ---------------------------------------------------------------------------
@@ -113,7 +137,18 @@ USAGE_REASONING_TOKENS = Attribute(
     "weave.usage.reasoning_tokens",
     "int",
     "Reasoning/thinking tokens",
-    "gen_ai.usage.reasoning_tokens",
+    # Canonical name from upstream OTel GenAI semconv
+    # (https://github.com/open-telemetry/semantic-conventions/pull/3383, merged
+    # 2026-04-27). The Python ``opentelemetry-semantic-conventions`` package
+    # had not picked it up at our floor of 0.62b1; switch to importing the
+    # constant once it ships.
+    "gen_ai.usage.reasoning.output_tokens",
+    additional_aliases=(
+        # Earlier Weave-internal name; old span data still uses this on the wire.
+        "gen_ai.usage.reasoning_tokens",
+        # What ADK emits natively before our integration enriches the span.
+        "gen_ai.usage.experimental.reasoning_tokens",
+    ),
 )
 USAGE_CACHE_CREATION_INPUT_TOKENS = Attribute(
     "weave.usage.cache_creation.input_tokens",
@@ -344,12 +379,16 @@ ATTRIBUTES: dict[str, Attribute] = {a.key: a for a in _DEFS}
 # attribute is known statically.
 SEMCONV_LOOKUP_KEYS: dict[str, tuple[str, ...]] = {a.key: a.lookup_keys for a in _DEFS}
 
-# Map from any recognized key (weave.* or gen_ai.*) to canonical weave.* key.
+# Map from any recognized key (weave.*, gen_ai.*, or legacy aliases) to
+# canonical weave.* key. ``additional_aliases`` participate too so old data
+# and pre-standardisation client emissions keep resolving.
 _ALIAS_TO_CANONICAL: dict[str, str] = {}
 for _a in _DEFS:
     _ALIAS_TO_CANONICAL[_a.key] = _a.key
     if _a.gen_ai_alias:
         _ALIAS_TO_CANONICAL[_a.gen_ai_alias] = _a.key
+    for _extra in _a.additional_aliases:
+        _ALIAS_TO_CANONICAL[_extra] = _a.key
 
 
 def resolve_alias_to_canonical(key: str) -> str | None:
@@ -423,6 +462,8 @@ CANONICAL_KEY_TO_COLUMN: dict[str, str] = {
 def _build_filterable_lookup() -> dict[str, str]:
     """Flatten CANONICAL_KEY_TO_COLUMN to also accept gen_ai.* aliases and
     prefix-stripped short-forms (`agent.name` alongside `weave.agent.name`).
+    Additional legacy aliases participate too so query callers can filter on
+    historical attribute names.
     """
     out: dict[str, str] = {}
     for canonical, col in CANONICAL_KEY_TO_COLUMN.items():
@@ -430,7 +471,9 @@ def _build_filterable_lookup() -> dict[str, str]:
         attr = ATTRIBUTES[canonical]
         if attr.gen_ai_alias:
             out[attr.gen_ai_alias] = col
-        for k in (canonical, attr.gen_ai_alias):
+        for extra in attr.additional_aliases:
+            out[extra] = col
+        for k in (canonical, attr.gen_ai_alias, *attr.additional_aliases):
             for prefix in ("weave.", "gen_ai."):
                 if k and k.startswith(prefix):
                     out[k[len(prefix) :]] = col

--- a/weave/trace_server/agents/semconv.py
+++ b/weave/trace_server/agents/semconv.py
@@ -291,9 +291,7 @@ ERROR_TYPE = Attribute("weave.error.type", "string", "Error type", ["error.type"
 SERVER_ADDRESS = Attribute(
     "weave.server.address", "string", "Server hostname", ["server.address"]
 )
-SERVER_PORT = Attribute(
-    "weave.server.port", "int", "Server port", ["server.port"]
-)
+SERVER_PORT = Attribute("weave.server.port", "int", "Server port", ["server.port"])
 
 # Weave-only extensions (no gen_ai.* alias)
 REASONING_CONTENT = Attribute(

--- a/weave/trace_server/agents/semconv.py
+++ b/weave/trace_server/agents/semconv.py
@@ -20,7 +20,7 @@ Usage:
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 AttributeType = Literal["string", "int", "float", "string[]", "json"]
@@ -31,16 +31,16 @@ class Attribute:
     """A single semantic convention attribute.
 
     ``gen_ai_aliases`` lists the OTel ``gen_ai.*`` wire key(s) for this
-    column — pass a string for a single alias, or a tuple when multiple
-    OTel forms must feed the same column. The first tuple entry is the
-    canonical upstream name; later entries are parallel forms recognised
-    on ingest. See ``USAGE_REASONING_TOKENS`` for an example.
+    column. The first entry is the canonical upstream name; later entries
+    are parallel forms recognised on ingest. See ``USAGE_REASONING_TOKENS``
+    for an example with multiple aliases.
     """
 
     key: str  # canonical weave.* key
     type: AttributeType
     description: str
-    gen_ai_aliases: str | tuple[str, ...] = ""  # OTel gen_ai.* equivalent(s), if any
+    # OTel gen_ai.* equivalent(s), if any
+    gen_ai_aliases: list[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Validate that canonical attributes stay in the Weave namespace."""
@@ -50,13 +50,6 @@ class Attribute:
             )
 
     @property
-    def aliases(self) -> tuple[str, ...]:
-        """``gen_ai_aliases`` normalised to a tuple (strings → 1-tuple)."""
-        if isinstance(self.gen_ai_aliases, str):
-            return (self.gen_ai_aliases,) if self.gen_ai_aliases else ()
-        return self.gen_ai_aliases
-
-    @property
     def lookup_keys(self) -> tuple[str, ...]:
         """Return all recognized keys, ordered weave-canonical first.
 
@@ -64,7 +57,7 @@ class Attribute:
         so callers can rely on the weave.* key winning over OTel aliases
         when both are present on a span.
         """
-        return (self.key, *self.aliases)
+        return (self.key, *self.gen_ai_aliases)
 
 
 # ---------------------------------------------------------------------------
@@ -75,59 +68,70 @@ OPERATION_NAME = Attribute(
     "weave.operation.name",
     "string",
     "Operation type (chat, invoke_agent, execute_tool, ...)",
-    "gen_ai.operation.name",
+    ["gen_ai.operation.name"],
 )
 PROVIDER_NAME = Attribute(
     "weave.provider.name",
     "string",
     "Provider: openai, anthropic, gcp.gemini, ...",
-    "gen_ai.provider.name",
+    ["gen_ai.provider.name"],
 )
 SYSTEM = Attribute(
-    "weave.system", "string", "Deprecated alias for provider.name", "gen_ai.system"
+    "weave.system",
+    "string",
+    "Deprecated alias for provider.name",
+    ["gen_ai.system"],
 )
 AGENT_NAME = Attribute(
-    "weave.agent.name", "string", "Agent display name", "gen_ai.agent.name"
+    "weave.agent.name", "string", "Agent display name", ["gen_ai.agent.name"]
 )
-AGENT_ID = Attribute("weave.agent.id", "string", "Agent identifier", "gen_ai.agent.id")
+AGENT_ID = Attribute(
+    "weave.agent.id", "string", "Agent identifier", ["gen_ai.agent.id"]
+)
 AGENT_DESCRIPTION = Attribute(
     "weave.agent.description",
     "string",
     "Agent description",
-    "gen_ai.agent.description",
+    ["gen_ai.agent.description"],
 )
 AGENT_VERSION = Attribute(
-    "weave.agent.version", "string", "Agent version", "gen_ai.agent.version"
+    "weave.agent.version", "string", "Agent version", ["gen_ai.agent.version"]
 )
 REQUEST_MODEL = Attribute(
-    "weave.request.model", "string", "Requested model name", "gen_ai.request.model"
+    "weave.request.model",
+    "string",
+    "Requested model name",
+    ["gen_ai.request.model"],
 )
 RESPONSE_MODEL = Attribute(
-    "weave.response.model", "string", "Actual model used", "gen_ai.response.model"
+    "weave.response.model",
+    "string",
+    "Actual model used",
+    ["gen_ai.response.model"],
 )
 RESPONSE_ID = Attribute(
     "weave.response.id",
     "string",
     "Provider response identifier",
-    "gen_ai.response.id",
+    ["gen_ai.response.id"],
 )
 USAGE_INPUT_TOKENS = Attribute(
     "weave.usage.input_tokens",
     "int",
     "Input tokens (includes cached)",
-    "gen_ai.usage.input_tokens",
+    ["gen_ai.usage.input_tokens"],
 )
 USAGE_OUTPUT_TOKENS = Attribute(
     "weave.usage.output_tokens",
     "int",
     "Output tokens",
-    "gen_ai.usage.output_tokens",
+    ["gen_ai.usage.output_tokens"],
 )
 USAGE_REASONING_TOKENS = Attribute(
     "weave.usage.reasoning_tokens",
     "int",
     "Reasoning/thinking tokens",
-    (
+    [
         # Canonical name from upstream OTel GenAI semconv
         # (https://github.com/open-telemetry/semantic-conventions/pull/3383,
         # merged 2026-04-27). The Python
@@ -140,148 +144,156 @@ USAGE_REASONING_TOKENS = Attribute(
         "gen_ai.usage.reasoning_tokens",
         # What ADK emits natively before our integration enriches the span.
         "gen_ai.usage.experimental.reasoning_tokens",
-    ),
+    ],
 )
 USAGE_CACHE_CREATION_INPUT_TOKENS = Attribute(
     "weave.usage.cache_creation.input_tokens",
     "int",
     "Tokens written to cache",
-    "gen_ai.usage.cache_creation.input_tokens",
+    ["gen_ai.usage.cache_creation.input_tokens"],
 )
 USAGE_CACHE_READ_INPUT_TOKENS = Attribute(
     "weave.usage.cache_read.input_tokens",
     "int",
     "Tokens served from cache",
-    "gen_ai.usage.cache_read.input_tokens",
+    ["gen_ai.usage.cache_read.input_tokens"],
 )
 CONVERSATION_ID = Attribute(
     "weave.conversation.id",
     "string",
     "Conversation or session ID",
-    "gen_ai.conversation.id",
+    ["gen_ai.conversation.id"],
 )
 CONVERSATION_NAME = Attribute(
     "weave.conversation.name",
     "string",
     "Human-readable conversation name",
-    "gen_ai.conversation.name",
+    ["gen_ai.conversation.name"],
 )
 TOOL_NAME = Attribute(
-    "weave.tool.name", "string", "Tool/function name", "gen_ai.tool.name"
+    "weave.tool.name", "string", "Tool/function name", ["gen_ai.tool.name"]
 )
 TOOL_TYPE = Attribute(
     "weave.tool.type",
     "string",
     "Tool type: function, extension, datastore",
-    "gen_ai.tool.type",
+    ["gen_ai.tool.type"],
 )
 TOOL_CALL_ID = Attribute(
-    "weave.tool.call.id", "string", "Tool call identifier", "gen_ai.tool.call.id"
+    "weave.tool.call.id",
+    "string",
+    "Tool call identifier",
+    ["gen_ai.tool.call.id"],
 )
 TOOL_DESCRIPTION = Attribute(
     "weave.tool.description",
     "string",
     "Tool description",
-    "gen_ai.tool.description",
+    ["gen_ai.tool.description"],
 )
 TOOL_DEFINITIONS = Attribute(
     "weave.tool.definitions",
     "json",
     "Available tool definitions",
-    "gen_ai.tool.definitions",
+    ["gen_ai.tool.definitions"],
 )
 TOOL_CALL_ARGUMENTS = Attribute(
     "weave.tool.call.arguments",
     "json",
     "Arguments passed to the tool",
-    "gen_ai.tool.call.arguments",
+    ["gen_ai.tool.call.arguments"],
 )
 TOOL_CALL_RESULT = Attribute(
     "weave.tool.call.result",
     "json",
     "Result returned by the tool",
-    "gen_ai.tool.call.result",
+    ["gen_ai.tool.call.result"],
 )
 REQUEST_TEMPERATURE = Attribute(
     "weave.request.temperature",
     "float",
     "Sampling temperature",
-    "gen_ai.request.temperature",
+    ["gen_ai.request.temperature"],
 )
 REQUEST_MAX_TOKENS = Attribute(
     "weave.request.max_tokens",
     "int",
     "Maximum output tokens",
-    "gen_ai.request.max_tokens",
+    ["gen_ai.request.max_tokens"],
 )
 REQUEST_TOP_P = Attribute(
     "weave.request.top_p",
     "float",
     "Nucleus sampling threshold",
-    "gen_ai.request.top_p",
+    ["gen_ai.request.top_p"],
 )
 REQUEST_FREQUENCY_PENALTY = Attribute(
     "weave.request.frequency_penalty",
     "float",
     "Frequency penalty",
-    "gen_ai.request.frequency_penalty",
+    ["gen_ai.request.frequency_penalty"],
 )
 REQUEST_PRESENCE_PENALTY = Attribute(
     "weave.request.presence_penalty",
     "float",
     "Presence penalty",
-    "gen_ai.request.presence_penalty",
+    ["gen_ai.request.presence_penalty"],
 )
 REQUEST_SEED = Attribute(
-    "weave.request.seed", "int", "Random seed", "gen_ai.request.seed"
+    "weave.request.seed", "int", "Random seed", ["gen_ai.request.seed"]
 )
 REQUEST_STOP_SEQUENCES = Attribute(
     "weave.request.stop_sequences",
     "string[]",
     "Stop sequences",
-    "gen_ai.request.stop_sequences",
+    ["gen_ai.request.stop_sequences"],
 )
 REQUEST_CHOICE_COUNT = Attribute(
     "weave.request.choice.count",
     "int",
     "Number of choices requested",
-    "gen_ai.request.choice.count",
+    ["gen_ai.request.choice.count"],
 )
 RESPONSE_FINISH_REASONS = Attribute(
     "weave.response.finish_reasons",
     "string[]",
     "Finish reasons",
-    "gen_ai.response.finish_reasons",
+    ["gen_ai.response.finish_reasons"],
 )
 OUTPUT_TYPE = Attribute(
     "weave.output.type",
     "string",
     "Output modality: text, json, image, speech",
-    "gen_ai.output.type",
+    ["gen_ai.output.type"],
 )
 INPUT_MESSAGES = Attribute(
-    "weave.input.messages", "json", "Input messages", "gen_ai.input.messages"
+    "weave.input.messages", "json", "Input messages", ["gen_ai.input.messages"]
 )
 OUTPUT_MESSAGES = Attribute(
-    "weave.output.messages", "json", "Output messages", "gen_ai.output.messages"
+    "weave.output.messages",
+    "json",
+    "Output messages",
+    ["gen_ai.output.messages"],
 )
 SYSTEM_INSTRUCTIONS = Attribute(
     "weave.system_instructions",
     "json",
     "System instructions",
-    "gen_ai.system_instructions",
+    ["gen_ai.system_instructions"],
 )
 COMPLETION = Attribute(
     "weave.completion",
     "json",
     "Output messages (pre-v1.36 format)",
-    "gen_ai.completion",
+    ["gen_ai.completion"],
 )
-ERROR_TYPE = Attribute("weave.error.type", "string", "Error type", "error.type")
+ERROR_TYPE = Attribute("weave.error.type", "string", "Error type", ["error.type"])
 SERVER_ADDRESS = Attribute(
-    "weave.server.address", "string", "Server hostname", "server.address"
+    "weave.server.address", "string", "Server hostname", ["server.address"]
 )
-SERVER_PORT = Attribute("weave.server.port", "int", "Server port", "server.port")
+SERVER_PORT = Attribute(
+    "weave.server.port", "int", "Server port", ["server.port"]
+)
 
 # Weave-only extensions (no gen_ai.* alias)
 REASONING_CONTENT = Attribute(
@@ -377,7 +389,7 @@ SEMCONV_LOOKUP_KEYS: dict[str, tuple[str, ...]] = {a.key: a.lookup_keys for a in
 _ALIAS_TO_CANONICAL: dict[str, str] = {}
 for _a in _DEFS:
     _ALIAS_TO_CANONICAL[_a.key] = _a.key
-    for _alias in _a.aliases:
+    for _alias in _a.gen_ai_aliases:
         _ALIAS_TO_CANONICAL[_alias] = _a.key
 
 
@@ -459,9 +471,9 @@ def _build_filterable_lookup() -> dict[str, str]:
     for canonical, col in CANONICAL_KEY_TO_COLUMN.items():
         out[canonical] = col
         attr = ATTRIBUTES[canonical]
-        for alias in attr.aliases:
+        for alias in attr.gen_ai_aliases:
             out[alias] = col
-        for k in (canonical, *attr.aliases):
+        for k in (canonical, *attr.gen_ai_aliases):
             for prefix in ("weave.", "gen_ai."):
                 if k.startswith(prefix):
                     out[k[len(prefix) :]] = col

--- a/weave/trace_server/agents/semconv.py
+++ b/weave/trace_server/agents/semconv.py
@@ -30,30 +30,17 @@ AttributeType = Literal["string", "int", "float", "string[]", "json"]
 class Attribute:
     """A single semantic convention attribute.
 
-    ``gen_ai_alias`` is the *primary* OTel ``gen_ai.*`` wire key for this
-    attribute — usually whatever the upstream OpenTelemetry semconv has
-    standardised on. ``additional_aliases`` lets the server recognise
-    historical / parallel forms for the same column so old data and
-    clients-in-the-field keep parsing.
-
-    Concrete example: ``USAGE_REASONING_TOKENS`` below. The upstream OTel
-    spec landed on ``gen_ai.usage.reasoning.output_tokens``, but Weave
-    has years of data on the wire with ``gen_ai.usage.reasoning_tokens``
-    and ADK emits ``gen_ai.usage.experimental.reasoning_tokens``. All
-    three need to feed the same ``reasoning_tokens`` column without
-    forcing a discontinuity in stored data. Primary alias = canonical
-    upstream name (what new clients emit). Additional aliases = the two
-    historical forms (read-only at this layer).
-
-    The catalog is a recognizer registry; the OTel spec is the source of
-    truth, not this file.
+    ``gen_ai_aliases`` lists the OTel ``gen_ai.*`` wire key(s) for this
+    column — pass a string for a single alias, or a tuple when multiple
+    OTel forms must feed the same column. The first tuple entry is the
+    canonical upstream name; later entries are parallel forms recognised
+    on ingest. See ``USAGE_REASONING_TOKENS`` for an example.
     """
 
     key: str  # canonical weave.* key
     type: AttributeType
     description: str
-    gen_ai_alias: str = ""  # primary OTel gen_ai.* wire key, if any
-    additional_aliases: tuple[str, ...] = ()  # historical / parallel wire keys
+    gen_ai_aliases: str | tuple[str, ...] = ""  # OTel gen_ai.* equivalent(s), if any
 
     def __post_init__(self) -> None:
         """Validate that canonical attributes stay in the Weave namespace."""
@@ -63,18 +50,21 @@ class Attribute:
             )
 
     @property
+    def aliases(self) -> tuple[str, ...]:
+        """``gen_ai_aliases`` normalised to a tuple (strings → 1-tuple)."""
+        if isinstance(self.gen_ai_aliases, str):
+            return (self.gen_ai_aliases,) if self.gen_ai_aliases else ()
+        return self.gen_ai_aliases
+
+    @property
     def lookup_keys(self) -> tuple[str, ...]:
         """Return all recognized keys, ordered weave-canonical first.
 
         Extraction probes them in order and uses the first non-None hit,
-        so callers can rely on the weave.* key winning over older aliases
+        so callers can rely on the weave.* key winning over OTel aliases
         when both are present on a span.
         """
-        keys: list[str] = [self.key]
-        if self.gen_ai_alias:
-            keys.append(self.gen_ai_alias)
-        keys.extend(self.additional_aliases)
-        return tuple(keys)
+        return (self.key, *self.aliases)
 
 
 # ---------------------------------------------------------------------------
@@ -137,14 +127,16 @@ USAGE_REASONING_TOKENS = Attribute(
     "weave.usage.reasoning_tokens",
     "int",
     "Reasoning/thinking tokens",
-    # Canonical name from upstream OTel GenAI semconv
-    # (https://github.com/open-telemetry/semantic-conventions/pull/3383, merged
-    # 2026-04-27). The Python ``opentelemetry-semantic-conventions`` package
-    # had not picked it up at our floor of 0.62b1; switch to importing the
-    # constant once it ships.
-    "gen_ai.usage.reasoning.output_tokens",
-    additional_aliases=(
-        # Earlier Weave-internal name; old span data still uses this on the wire.
+    (
+        # Canonical name from upstream OTel GenAI semconv
+        # (https://github.com/open-telemetry/semantic-conventions/pull/3383,
+        # merged 2026-04-27). The Python
+        # ``opentelemetry-semantic-conventions`` package had not picked it up
+        # at our floor of 0.62b1; switch to importing the constant once it
+        # ships.
+        "gen_ai.usage.reasoning.output_tokens",
+        # Earlier Weave-internal name emitted by the Session SDK before the
+        # upstream spec landed; spans on the wire still use this form.
         "gen_ai.usage.reasoning_tokens",
         # What ADK emits natively before our integration enriches the span.
         "gen_ai.usage.experimental.reasoning_tokens",
@@ -379,16 +371,14 @@ ATTRIBUTES: dict[str, Attribute] = {a.key: a for a in _DEFS}
 # attribute is known statically.
 SEMCONV_LOOKUP_KEYS: dict[str, tuple[str, ...]] = {a.key: a.lookup_keys for a in _DEFS}
 
-# Map from any recognized key (weave.*, gen_ai.*, or legacy aliases) to
-# canonical weave.* key. ``additional_aliases`` participate too so old data
-# and pre-standardisation client emissions keep resolving.
+# Map from any recognized key (weave.* or any registered gen_ai.* alias) to
+# canonical weave.* key. Every entry in ``gen_ai_aliases`` participates so
+# parallel client emissions all resolve to the same column.
 _ALIAS_TO_CANONICAL: dict[str, str] = {}
 for _a in _DEFS:
     _ALIAS_TO_CANONICAL[_a.key] = _a.key
-    if _a.gen_ai_alias:
-        _ALIAS_TO_CANONICAL[_a.gen_ai_alias] = _a.key
-    for _extra in _a.additional_aliases:
-        _ALIAS_TO_CANONICAL[_extra] = _a.key
+    for _alias in _a.aliases:
+        _ALIAS_TO_CANONICAL[_alias] = _a.key
 
 
 def resolve_alias_to_canonical(key: str) -> str | None:
@@ -462,20 +452,18 @@ CANONICAL_KEY_TO_COLUMN: dict[str, str] = {
 def _build_filterable_lookup() -> dict[str, str]:
     """Flatten CANONICAL_KEY_TO_COLUMN to also accept gen_ai.* aliases and
     prefix-stripped short-forms (`agent.name` alongside `weave.agent.name`).
-    Additional legacy aliases participate too so query callers can filter on
-    historical attribute names.
+    Every registered alias participates so query callers can filter on any
+    recognised attribute name.
     """
     out: dict[str, str] = {}
     for canonical, col in CANONICAL_KEY_TO_COLUMN.items():
         out[canonical] = col
         attr = ATTRIBUTES[canonical]
-        if attr.gen_ai_alias:
-            out[attr.gen_ai_alias] = col
-        for extra in attr.additional_aliases:
-            out[extra] = col
-        for k in (canonical, attr.gen_ai_alias, *attr.additional_aliases):
+        for alias in attr.aliases:
+            out[alias] = col
+        for k in (canonical, *attr.aliases):
             for prefix in ("weave.", "gen_ai."):
-                if k and k.startswith(prefix):
+                if k.startswith(prefix):
                     out[k[len(prefix) :]] = col
     return out
 


### PR DESCRIPTION
Add support for multi-alias semconv keys.

The main reason for this PR is to allow multiple semconv keys to map to a single concept on the server. This may happen for a number of reasons, including:
1. Promoting a key from incubating to main;
2. Two keys just happen to represent the same concept

One specific case of this is with reasoning tokens, which have two forms:
1. `gen_ai.usage.reasoning_tokens`; and
2. `gen_ai.usage.experimental.reasoning_tokens`