### PR TITLE
perf(weave): force vertical merge on wide calls tables

### DIFF
--- a/weave/trace_server/migrations/031_vertical_merge_settings.down.sql
+++ b/weave/trace_server/migrations/031_vertical_merge_settings.down.sql
@@ -1,0 +1,22 @@
+-- Rollback Migration 031: reset vertical-merge tuning to cluster defaults.
+
+ALTER TABLE call_parts
+    RESET SETTING
+        vertical_merge_algorithm_min_columns_to_activate,
+        vertical_merge_algorithm_min_rows_to_activate,
+        vertical_merge_algorithm_min_bytes_to_activate,
+        merge_max_block_size;
+
+ALTER TABLE calls_merged
+    RESET SETTING
+        vertical_merge_algorithm_min_columns_to_activate,
+        vertical_merge_algorithm_min_rows_to_activate,
+        vertical_merge_algorithm_min_bytes_to_activate,
+        merge_max_block_size;
+
+ALTER TABLE calls_complete
+    RESET SETTING
+        vertical_merge_algorithm_min_columns_to_activate,
+        vertical_merge_algorithm_min_rows_to_activate,
+        vertical_merge_algorithm_min_bytes_to_activate,
+        merge_max_block_size;

--- a/weave/trace_server/migrations/031_vertical_merge_settings.up.sql
+++ b/weave/trace_server/migrations/031_vertical_merge_settings.up.sql
@@ -1,0 +1,41 @@
+-- Migration 031: Force vertical-merge algorithm on wide-row tables.
+--
+-- Only affects future merges. No data rewrite. Reversible via the .down.sql.
+--
+-- Background: on at least one production cluster a single Horizontal merge of
+-- ~27 GB / 1.57M rows on `calls_merged` was observed running ~32 minutes at 28%
+-- progress, with bytes_read_uncompressed / rows_read = ~17 KB/row. That is
+-- exactly the wide-row case where the Vertical algorithm is dramatically
+-- faster, but the cluster default `vertical_merge_algorithm_min_columns_to_activate=11`
+-- was preventing it from being chosen.
+--
+-- Settings applied here:
+--   vertical_merge_algorithm_min_columns_to_activate=1
+--   vertical_merge_algorithm_min_rows_to_activate=1
+--   vertical_merge_algorithm_min_bytes_to_activate=0
+--   merge_max_block_size=65536           (default 8192; bigger blocks = better throughput per thread)
+--
+-- Worst-case if vertical is not actually faster on a given cluster: the next
+-- merge picks vertical anyway and runs at roughly the same speed it would have
+-- under horizontal. RESET SETTING on each column reverts.
+
+ALTER TABLE call_parts
+    MODIFY SETTING
+        vertical_merge_algorithm_min_columns_to_activate = 1,
+        vertical_merge_algorithm_min_rows_to_activate = 1,
+        vertical_merge_algorithm_min_bytes_to_activate = 0,
+        merge_max_block_size = 65536;
+
+ALTER TABLE calls_merged
+    MODIFY SETTING
+        vertical_merge_algorithm_min_columns_to_activate = 1,
+        vertical_merge_algorithm_min_rows_to_activate = 1,
+        vertical_merge_algorithm_min_bytes_to_activate = 0,
+        merge_max_block_size = 65536;
+
+ALTER TABLE calls_complete
+    MODIFY SETTING
+        vertical_merge_algorithm_min_columns_to_activate = 1,
+        vertical_merge_algorithm_min_rows_to_activate = 1,
+        vertical_merge_algorithm_min_bytes_to_activate = 0,
+        merge_max_block_size = 65536;


### PR DESCRIPTION
## Summary

Adds migration 031 that sets the following on `call_parts`, `calls_merged`, and `calls_complete`:

- `vertical_merge_algorithm_min_columns_to_activate = 1` (default 11)
- `vertical_merge_algorithm_min_rows_to_activate = 1` (default 131072)
- `vertical_merge_algorithm_min_bytes_to_activate = 0`
- `merge_max_block_size = 65536` (default 8192)

Forces ClickHouse to pick the Vertical merge algorithm for these wide-row tables. The default column threshold of 11 was causing the engine to fall back to Horizontal even on schemas where each row is ~17 KB and column-by-column merging is much more efficient.

Context: a production cluster was observed running a single Horizontal merge on `calls_merged` for ~32 min at 28% progress (1.57M rows, 26.79 GB uncompressed, ~17 KB/row). A neighboring narrower table (`call_parts` at the time of investigation, post-mutation) was already merging Vertical and finishing in seconds. Lowering the activation thresholds is the safest single knob to flip.

Only applies to future merges, no data rewrite. Reversible via the `.down.sql` (`RESET SETTING ...`).

## Testing
todo!