### PR TITLE
chore(weave_ts): Rework the piCodingAgent integration to send to the new ingestion endpoint

### DIFF
--- a/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
@@ -146,7 +146,7 @@ describe('PiCodingAgentOtelAdapter', () => {
       );
     });
 
-    it('adds gen_ai.user.message event when captureContent is true', () => {
+    it('sets gen_ai.input.messages and gen_ai.system_instructions when captureContent is true', () => {
       const {exporter, emit} = makeExporterAndAdapter();
       startInvoke(emit, 'what time is it?');
       emit('agent_end', {messages: []});
@@ -155,26 +155,51 @@ describe('PiCodingAgentOtelAdapter', () => {
       const invoke = exporter
         .getFinishedSpans()
         .find(s => s.name === 'invoke_agent pi-coding-agent')!;
-      expect(invoke.events).toHaveLength(2);
-      expect(invoke.events[0].name).toBe('gen_ai.system.message');
-
-      expect(invoke.events[1].name).toBe('gen_ai.user.message');
-      const userContent = JSON.parse(
-        invoke.events[1].attributes!['gen_ai.event.content'] as string
+      const inputMessages = JSON.parse(
+        invoke.attributes['gen_ai.input.messages'] as string
       );
-      expect(userContent.content).toBe('what time is it?');
+      expect(inputMessages).toEqual([
+        {role: 'user', content: 'what time is it?'},
+      ]);
+      const systemInstructions = JSON.parse(
+        invoke.attributes['gen_ai.system_instructions'] as string
+      );
+      expect(systemInstructions).toEqual(['be helpful']);
     });
 
-    it('omits event content when captureContent is false', () => {
-      const {exporter, emit} = makeExporterAndAdapter({captureContent: false});
+    it('sets gen_ai.output.messages from assistant messages in agent_end', () => {
+      const {exporter, emit} = makeExporterAndAdapter();
       startInvoke(emit, 'what time is it?');
-      emit('agent_end', {messages: []});
+      emit('agent_end', {messages: [MOCK_ASSISTANT_MSG]});
       emit('session_shutdown');
 
       const invoke = exporter
         .getFinishedSpans()
         .find(s => s.name === 'invoke_agent pi-coding-agent')!;
-      expect(invoke.events).toHaveLength(0);
+      const outputMessages = JSON.parse(
+        invoke.attributes['gen_ai.output.messages'] as string
+      );
+      expect(outputMessages).toHaveLength(1);
+      expect(outputMessages[0].role).toBe('assistant');
+      expect(outputMessages[0].parts[0]).toEqual({
+        type: 'text',
+        content: 'Hello!',
+      });
+      expect(outputMessages[0].finish_reason).toBe('stop');
+    });
+
+    it('omits message attributes when captureContent is false', () => {
+      const {exporter, emit} = makeExporterAndAdapter({captureContent: false});
+      startInvoke(emit, 'what time is it?');
+      emit('agent_end', {messages: [MOCK_ASSISTANT_MSG]});
+      emit('session_shutdown');
+
+      const invoke = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'invoke_agent pi-coding-agent')!;
+      expect(invoke.attributes['gen_ai.input.messages']).toBeUndefined();
+      expect(invoke.attributes['gen_ai.output.messages']).toBeUndefined();
+      expect(invoke.attributes['gen_ai.system_instructions']).toBeUndefined();
     });
 
     it('aggregates usage across multiple turns', () => {
@@ -266,7 +291,7 @@ describe('PiCodingAgentOtelAdapter', () => {
       );
     });
 
-    it('adds gen_ai.system.message event from context', () => {
+    it('sets gen_ai.system_instructions and gen_ai.input.messages from context', () => {
       const {exporter, emit} = makeExporterAndAdapter();
       startTurn(emit);
       emit('context', {
@@ -282,17 +307,17 @@ describe('PiCodingAgentOtelAdapter', () => {
       const chat = exporter
         .getFinishedSpans()
         .find(s => s.name.startsWith('chat '))!;
-      const sysEvent = chat.events.find(
-        e => e.name === 'gen_ai.system.message'
+      const systemInstructions = JSON.parse(
+        chat.attributes['gen_ai.system_instructions'] as string
       );
-      expect(sysEvent).toBeDefined();
-      const content = JSON.parse(
-        sysEvent!.attributes!['gen_ai.event.content'] as string
+      expect(systemInstructions).toEqual(['You are a helpful assistant.']);
+      const inputMessages = JSON.parse(
+        chat.attributes['gen_ai.input.messages'] as string
       );
-      expect(content[0].role).toBe('system');
+      expect(inputMessages).toEqual([{role: 'user', content: 'hello'}]);
     });
 
-    it('skips gen_ai.system.message when no system messages in context', () => {
+    it('skips gen_ai.system_instructions when no system messages in context', () => {
       const {exporter, emit} = makeExporterAndAdapter();
       startTurn(emit);
       emit('context', {messages: [{role: 'user', content: 'hello'}]});
@@ -303,15 +328,12 @@ describe('PiCodingAgentOtelAdapter', () => {
       const chat = exporter
         .getFinishedSpans()
         .find(s => s.name.startsWith('chat '))!;
-      expect(
-        chat.events.find(e => e.name === 'gen_ai.system.message')
-      ).toBeUndefined();
+      expect(chat.attributes['gen_ai.system_instructions']).toBeUndefined();
     });
 
-    it('adds gen_ai.assistant.message event on message_end', () => {
+    it('sets gen_ai.output.messages on turn_end with assistant content', () => {
       const {exporter, emit} = makeExporterAndAdapter();
       startTurn(emit);
-      emit('message_end', {message: MOCK_ASSISTANT_MSG});
       emit('turn_end', {turnIndex: 0, message: MOCK_ASSISTANT_MSG});
       emit('agent_end', {messages: []});
       emit('session_shutdown');
@@ -319,21 +341,22 @@ describe('PiCodingAgentOtelAdapter', () => {
       const chat = exporter
         .getFinishedSpans()
         .find(s => s.name.startsWith('chat '))!;
-      const assistantEvent = chat.events.find(
-        e => e.name === 'gen_ai.assistant.message'
+      const outputMessages = JSON.parse(
+        chat.attributes['gen_ai.output.messages'] as string
       );
-      expect(assistantEvent).toBeDefined();
-      const content = JSON.parse(
-        assistantEvent!.attributes!['gen_ai.event.content'] as string
-      );
-      expect(content.role).toBe('assistant');
+      expect(outputMessages).toHaveLength(1);
+      expect(outputMessages[0].role).toBe('assistant');
+      expect(outputMessages[0].parts[0]).toEqual({
+        type: 'text',
+        content: 'Hello!',
+      });
+      expect(outputMessages[0].finish_reason).toBe('stop');
     });
 
-    it('omits event content when captureContent is false', () => {
+    it('omits message attributes when captureContent is false', () => {
       const {exporter, emit} = makeExporterAndAdapter({captureContent: false});
       startTurn(emit);
       emit('context', {messages: [{role: 'system', content: 'sys'}]});
-      emit('message_end', {message: MOCK_ASSISTANT_MSG});
       emit('turn_end', {turnIndex: 0, message: MOCK_ASSISTANT_MSG});
       emit('agent_end', {messages: []});
       emit('session_shutdown');
@@ -341,16 +364,16 @@ describe('PiCodingAgentOtelAdapter', () => {
       const chat = exporter
         .getFinishedSpans()
         .find(s => s.name.startsWith('chat '))!;
-      for (const event of chat.events) {
-        expect(event.attributes?.['gen_ai.event.content']).toBeUndefined();
-      }
+      expect(chat.attributes['gen_ai.input.messages']).toBeUndefined();
+      expect(chat.attributes['gen_ai.output.messages']).toBeUndefined();
+      expect(chat.attributes['gen_ai.system_instructions']).toBeUndefined();
     });
   });
 
   // ── tool spans ────────────────────────────────────────────────────────────
 
   describe('tool spans', () => {
-    it('has correct attributes, is a sibling of chat, and adds tool message event', () => {
+    it('has correct attributes, is a sibling of chat, and sets tool call arguments and result', () => {
       const {exporter, emit} = makeExporterAndAdapter();
       startTurn(emit);
       emit('tool_call', {
@@ -378,12 +401,35 @@ describe('PiCodingAgentOtelAdapter', () => {
       expect(tool.attributes['gen_ai.tool.name']).toBe('bash');
       expect(tool.attributes['gen_ai.tool.call.id']).toBe('call-1');
       expect(tool.attributes['gen_ai.conversation.id']).toBe('test-session-id');
-      const toolEvent = tool.events.find(e => e.name === 'gen_ai.tool.message');
-      expect(toolEvent).toBeDefined();
-      const content = JSON.parse(
-        toolEvent!.attributes!['gen_ai.event.content'] as string
+      expect(tool.attributes['gen_ai.tool.call.arguments']).toBe(
+        JSON.stringify({cmd: 'ls'})
       );
-      expect(content.content).toBe('file.ts');
+      expect(tool.attributes['gen_ai.tool.call.result']).toBe('file.ts');
+    });
+
+    it('omits tool arguments and result when captureContent is false', () => {
+      const {exporter, emit} = makeExporterAndAdapter({captureContent: false});
+      startTurn(emit);
+      emit('tool_call', {
+        toolCallId: 'call-1',
+        toolName: 'bash',
+        input: {cmd: 'ls'},
+      });
+      emit('tool_result', {
+        toolCallId: 'call-1',
+        toolName: 'bash',
+        content: 'file.ts',
+        isError: false,
+      });
+      emit('turn_end', {turnIndex: 0, message: MOCK_ASSISTANT_MSG});
+      emit('agent_end', {messages: []});
+      emit('session_shutdown');
+
+      const tool = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'execute_tool bash')!;
+      expect(tool.attributes['gen_ai.tool.call.arguments']).toBeUndefined();
+      expect(tool.attributes['gen_ai.tool.call.result']).toBeUndefined();
     });
 
     it('sets error attributes on tool_result with isError', () => {

--- a/sdks/node/src/genai/semconv.ts
+++ b/sdks/node/src/genai/semconv.ts
@@ -33,6 +33,7 @@ export const GEN_AI_ATTR = {
   GEN_AI_OUTPUT_TYPE: 'gen_ai.output.type',
   GEN_AI_INPUT_MESSAGES: 'gen_ai.input.messages',
   GEN_AI_OUTPUT_MESSAGES: 'gen_ai.output.messages',
+  GEN_AI_SYSTEM_INSTRUCTIONS: 'gen_ai.system_instructions',
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -5,6 +5,9 @@
  * the full agent lifecycle, conforming to the GenAI semantic conventions:
  * https://opentelemetry.io/docs/specs/semconv/gen-ai/
  *
+ * Spans are exported through the shared Weave GenAI tracer, which targets
+ * `/agents/otel/v1/traces` on the trace server.
+ *
  * Usage:
  * ```typescript
  * import { init } from 'weave';
@@ -31,17 +34,9 @@ import {
   SpanStatusCode,
   trace,
 } from '@opentelemetry/api';
-import {OTLPTraceExporter} from '@opentelemetry/exporter-trace-otlp-proto';
-import {Resource} from '@opentelemetry/resources';
-import {
-  BasicTracerProvider,
-  SimpleSpanProcessor,
-} from '@opentelemetry/sdk-trace-base';
 
-import {getGlobalClient} from '../clientApi';
-import {getWandbConfigs} from '../wandb/settings';
-
-import {GEN_AI_ATTR, GEN_AI_EVENT, OTEL_ATTR} from '../genai/semconv';
+import {getWeaveTracer} from '../genai/provider';
+import {GEN_AI_ATTR, OTEL_ATTR} from '../genai/semconv';
 
 import type {
   PiAgentMessage,
@@ -83,6 +78,30 @@ const ATTR = {
   PI_AUTO_RETRY_FINAL_ERROR: 'auto_retry.final_error',
 } as const;
 
+const TRACER_NAME = 'pi-coding-agent';
+
+// ---------------------------------------------------------------------------
+// Message shape understood by the Weave GenAI extractor
+// (see weave/trace_server/opentelemetry/genai_extraction.py)
+// ---------------------------------------------------------------------------
+
+type WeaveMessagePart =
+  | {type: 'text'; content: string}
+  | {type: 'reasoning'; content: string}
+  | {
+      type: 'tool_call';
+      toolCallId: string;
+      toolName: string;
+      arguments?: string;
+    };
+
+interface WeaveMessage {
+  role: string;
+  content?: string;
+  parts?: WeaveMessagePart[];
+  finish_reason?: string;
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -115,6 +134,52 @@ function resolveGenAiProviderName(provider: string): string {
 /** Type assertion: narrows a PiAgentMessage to PiAssistantMessage. */
 function isAssistant(msg: PiAgentMessage): msg is PiAssistantMessage {
   return msg.role === 'assistant';
+}
+
+function mapAssistantParts(
+  content: PiAssistantMessage['content']
+): WeaveMessagePart[] {
+  return content.map(part => {
+    if (part.type === 'text') {
+      return {type: 'text', content: part.text};
+    }
+    if (part.type === 'thinking') {
+      return {type: 'reasoning', content: part.thinking};
+    }
+    // toolCall
+    return {
+      type: 'tool_call',
+      toolCallId: part.id,
+      toolName: part.name,
+      arguments: safeStringify(part.arguments),
+    };
+  });
+}
+
+function mapPiMessage(msg: PiAgentMessage): WeaveMessage {
+  if (isAssistant(msg)) {
+    return {
+      role: 'assistant',
+      parts: mapAssistantParts(msg.content),
+      finish_reason: msg.stopReason,
+    };
+  }
+  const content = msg.content;
+  return {
+    role: msg.role,
+    content: typeof content === 'string' ? content : safeStringify(content),
+  };
+}
+
+function safeStringify(val: unknown): string {
+  if (typeof val === 'string') {
+    return val;
+  }
+  try {
+    return JSON.stringify(val);
+  } catch {
+    return String(val);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -161,65 +226,15 @@ export class PiCodingAgentOtelAdapter {
     if (opts.tracer) {
       this.tracer = opts.tracer;
     } else {
-      const client = getGlobalClient();
-      if (client) {
-        try {
-          const [entity, project] = client.projectId.split('/');
-          const {apiKey} = getWandbConfigs();
-          const endpoint = `${client.traceServerApi.baseUrl}/otel/v1/traces`;
-
-          const authHeader = `Basic ${Buffer.from(`api:${apiKey}`).toString('base64')}`;
-          const provider = new BasicTracerProvider({
-            resource: new Resource({
-              'wandb.entity': entity,
-              'wandb.project': project,
-            }),
-            spanProcessors: [
-              new SimpleSpanProcessor(
-                new OTLPTraceExporter({
-                  url: endpoint,
-                  headers: {
-                    Authorization: authHeader,
-                    project_id: client.projectId,
-                  },
-                })
-              ),
-            ],
-          });
-
-          this.tracer = provider.getTracer('pi-coding-agent-weave-ext');
-
-          // Ensure all spans are flushed before the process exits.
-          // The pi agent doesn't await async shutdown handlers, so
-          // endSessionSpan may not complete. This hook catches the
-          // event loop draining and flushes any remaining spans.
-          process.once('beforeExit', async () => {
-            this.endInvokeAgentSpan();
-            if (this.sessionSpan) {
-              this.sessionSpan.end();
-              this.sessionSpan = null;
-              this.sessionCtx = ROOT_CONTEXT;
-            }
-            await provider.shutdown().catch(err => {
-              console.warn(
-                '[weave] OTEL provider shutdown failed; some spans may not have been flushed.',
-                err instanceof Error ? err.message : err
-              );
-            });
-          });
-        } catch (err) {
-          console.warn(
-            '[weave] OTEL auto-configure failed; spans will not be sent. Check WANDB_API_KEY.',
-            err instanceof Error ? err.message : err
-          );
-          this.tracer = trace.getTracer('pi-coding-agent-weave-ext');
-        }
-      } else {
-        console.warn(
-          '[weave] No Weave client; spans will not be sent. Call weave.init() first or pass { tracer }.'
-        );
-        this.tracer = trace.getTracer('pi-coding-agent-weave-ext');
-      }
+      // The shared Weave GenAI tracer targets /agents/otel/v1/traces and
+      // owns auth, resource attrs, batching, and beforeExit flush.
+      this.tracer = getWeaveTracer(TRACER_NAME);
+      // Pi does not await async session_shutdown handlers, so any spans
+      // still open when the event loop drains must be ended before the
+      // GenAI provider's own beforeExit handler flushes the exporter.
+      process.once('beforeExit', () => {
+        this.endSessionSpan();
+      });
     }
   }
 
@@ -238,7 +253,6 @@ export class PiCodingAgentOtelAdapter {
     pi.on('before_agent_start', this.onBeforeAgentStart);
     pi.on('context', this.onContext);
     pi.on('turn_start', this.onTurnStart);
-    pi.on('message_end', this.onMessageEnd);
     pi.on('turn_end', this.onTurnEnd);
     pi.on('agent_end', this.onAgentEnd);
     pi.on('tool_call', this.onToolCall);
@@ -317,23 +331,36 @@ export class PiCodingAgentOtelAdapter {
 
     if (this.captureContent) {
       if (event.systemPrompt) {
-        this.invokeAgentSpan.addEvent(GEN_AI_EVENT.SYSTEM_MESSAGE, {
-          [GEN_AI_EVENT.CONTENT_ATTR]: JSON.stringify({
-            role: 'system',
-            content: event.systemPrompt,
-          }),
-        });
+        this.invokeAgentSpan.setAttribute(
+          ATTR.GEN_AI_SYSTEM_INSTRUCTIONS,
+          JSON.stringify([event.systemPrompt])
+        );
       }
-      this.invokeAgentSpan.addEvent(GEN_AI_EVENT.USER_MESSAGE, {
-        [GEN_AI_EVENT.CONTENT_ATTR]: JSON.stringify({
-          role: 'user',
-          content: event.prompt,
-        }),
-      });
+      this.invokeAgentSpan.setAttribute(
+        ATTR.GEN_AI_INPUT_MESSAGES,
+        JSON.stringify([{role: 'user', content: event.prompt}])
+      );
     }
   };
 
-  private onAgentEnd = (): void => {
+  private onAgentEnd = (
+    event: Extract<PiExtensionEvent, {type: 'agent_end'}>
+  ): void => {
+    if (
+      this.captureContent &&
+      this.invokeAgentSpan &&
+      event.messages.length > 0
+    ) {
+      const assistantMessages = event.messages
+        .filter(m => m.role === 'assistant')
+        .map(mapPiMessage);
+      if (assistantMessages.length > 0) {
+        this.invokeAgentSpan.setAttribute(
+          ATTR.GEN_AI_OUTPUT_MESSAGES,
+          JSON.stringify(assistantMessages)
+        );
+      }
+    }
     this.endInvokeAgentSpan();
   };
 
@@ -369,37 +396,35 @@ export class PiCodingAgentOtelAdapter {
   private onContext = (
     event: Extract<PiExtensionEvent, {type: 'context'}>
   ): void => {
-    if (!this.chatSpan) return;
-    const systemMessages = event.messages.filter(m => m.role === 'system');
-    if (systemMessages.length === 0) return;
-    this.chatSpan.addEvent(
-      GEN_AI_EVENT.SYSTEM_MESSAGE,
-      this.captureContent
-        ? {
-            [GEN_AI_EVENT.CONTENT_ATTR]: JSON.stringify(
-              systemMessages.map(m => ({role: 'system', content: m.content}))
-            ),
-          }
-        : {}
-    );
-  };
-
-  private onMessageEnd = (
-    event: Extract<PiExtensionEvent, {type: 'message_end'}>
-  ): void => {
-    if (!this.chatSpan) return;
-    if (!isAssistant(event.message)) return;
-    this.chatSpan.addEvent(
-      GEN_AI_EVENT.ASSISTANT_MESSAGE,
-      this.captureContent
-        ? {
-            [GEN_AI_EVENT.CONTENT_ATTR]: JSON.stringify({
-              role: 'assistant',
-              content: event.message.content,
-            }),
-          }
-        : {}
-    );
+    if (!this.chatSpan || !this.captureContent) {
+      return;
+    }
+    const systemInstructions: string[] = [];
+    const inputMessages: WeaveMessage[] = [];
+    for (const msg of event.messages) {
+      if (msg.role === 'system') {
+        const content = msg.content;
+        const text =
+          typeof content === 'string' ? content : safeStringify(content);
+        if (text) {
+          systemInstructions.push(text);
+        }
+        continue;
+      }
+      inputMessages.push(mapPiMessage(msg));
+    }
+    if (systemInstructions.length > 0) {
+      this.chatSpan.setAttribute(
+        ATTR.GEN_AI_SYSTEM_INSTRUCTIONS,
+        JSON.stringify(systemInstructions)
+      );
+    }
+    if (inputMessages.length > 0) {
+      this.chatSpan.setAttribute(
+        ATTR.GEN_AI_INPUT_MESSAGES,
+        JSON.stringify(inputMessages)
+      );
+    }
   };
 
   private onTurnEnd = (
@@ -424,6 +449,13 @@ export class PiCodingAgentOtelAdapter {
           [ATTR.PI_USAGE_COST_USD]: usage.cost.total,
         });
 
+        if (this.captureContent) {
+          this.chatSpan.setAttribute(
+            ATTR.GEN_AI_OUTPUT_MESSAGES,
+            JSON.stringify([mapPiMessage(event.message)])
+          );
+        }
+
         if (
           event.message.stopReason === 'error' &&
           event.message.errorMessage
@@ -442,19 +474,20 @@ export class PiCodingAgentOtelAdapter {
   private onToolCall = (
     event: Extract<PiExtensionEvent, {type: 'tool_call'}>
   ): void => {
+    const attributes: Record<string, string> = {
+      [ATTR.GEN_AI_OPERATION_NAME]: 'execute_tool',
+      [ATTR.GEN_AI_TOOL_NAME]: event.toolName,
+      [ATTR.GEN_AI_TOOL_CALL_ID]: event.toolCallId,
+    };
+    if (this.conversationId) {
+      attributes[ATTR.GEN_AI_CONVERSATION_ID] = this.conversationId;
+    }
+    if (this.captureContent) {
+      attributes[ATTR.GEN_AI_TOOL_CALL_ARGUMENTS] = safeStringify(event.input);
+    }
     const span = this.tracer.startSpan(
       `execute_tool ${event.toolName}`,
-      {
-        kind: SpanKind.INTERNAL,
-        attributes: {
-          [ATTR.GEN_AI_OPERATION_NAME]: 'execute_tool',
-          [ATTR.GEN_AI_TOOL_NAME]: event.toolName,
-          [ATTR.GEN_AI_TOOL_CALL_ID]: event.toolCallId,
-          ...(this.conversationId
-            ? {[ATTR.GEN_AI_CONVERSATION_ID]: this.conversationId}
-            : {}),
-        },
-      },
+      {kind: SpanKind.INTERNAL, attributes},
       this.invokeAgentCtx
     );
     this.toolSpans.set(event.toolCallId, span);
@@ -464,7 +497,9 @@ export class PiCodingAgentOtelAdapter {
     event: Extract<PiExtensionEvent, {type: 'tool_result'}>
   ): void => {
     const span = this.toolSpans.get(event.toolCallId);
-    if (!span) return;
+    if (!span) {
+      return;
+    }
     this.toolSpans.delete(event.toolCallId);
     if (event.isError) {
       span.setAttribute(ATTR.ERROR_TYPE, 'tool_error');
@@ -473,16 +508,14 @@ export class PiCodingAgentOtelAdapter {
         message:
           typeof event.content === 'string'
             ? event.content
-            : JSON.stringify(event.content),
+            : safeStringify(event.content),
       });
     }
     if (this.captureContent) {
-      span.addEvent(GEN_AI_EVENT.TOOL_MESSAGE, {
-        [GEN_AI_EVENT.CONTENT_ATTR]: JSON.stringify({
-          role: 'tool',
-          content: event.content,
-        }),
-      });
+      span.setAttribute(
+        ATTR.GEN_AI_TOOL_CALL_RESULT,
+        safeStringify(event.content)
+      );
     }
     span.end();
   };
@@ -584,8 +617,8 @@ export class PiCodingAgentOtelAdapter {
  * agent lifecycle, conforming to the GenAI semantic conventions.
  *
  * When `weave.init(...)` has been called, spans are automatically exported
- * to the Weave trace server. Otherwise, configure your own TracerProvider
- * before calling this function.
+ * to the Weave trace server at `/agents/otel/v1/traces`. Otherwise, pass a
+ * custom `tracer` in `opts`.
  *
  * @example
  * ```typescript


### PR DESCRIPTION
# Rework piCodingAgent integration to use the GenAI ingest endpoint

## Summary

Two changes, so pi-coding-agent sessions actually show up in the Agents tab with content populated:

1. **Reuse the shared GenAI exporter.** The adapter built its own `BasicTracerProvider` + `OTLPTraceExporter` pointing at `/otel/v1/traces`. That endpoint doesn't feed the Agents ClickHouse table. Dropped the bespoke setup and switched to `getWeaveTracer('pi-coding-agent')` from `genai/provider.ts`, which already targets `/agents/otel/v1/traces` and owns auth, resource attrs, batching, and flush.
2. **Emit message content as attributes, not events.** The GenAI extractor reads `gen_ai.input.messages`, `gen_ai.output.messages`, `gen_ai.system_instructions`, `gen_ai.tool.call.arguments`, `gen_ai.tool.call.result` as JSON-string **attributes** — the old `gen_ai.*.message` span events get stored only in `events_dump` and never reach the structured columns. Replaced all four message events with the equivalent attribute writes on `invoke_agent`, `chat`, and `execute_tool` spans, with a small helper that maps pi's content parts into the shape the extractor understands.

## Screenshot

<img width="1897" height="822" alt="image" src="https://github.com/user-attachments/assets/cedeb2cb-2f78-45b3-9398-28a3dd16ebc2" />


## Test plan

- [x] `npx jest src/__tests__/integrations/piCodingAgent.test.ts` — 18/18 pass (tests updated to assert on the new attributes).
- [x] `npm run build` clean.
- [x] Smoked a real pi app and confirm spans land in the Agents tab with messages and tool args/results populated.