### PR TITLE
fix(weave): distinguish 429 rate limit types using Retry-After header in Node SDK

### DIFF
--- a/sdks/node/src/utils/__tests__/retry.test.ts
+++ b/sdks/node/src/utils/__tests__/retry.test.ts
@@ -1,0 +1,162 @@
+import {createFetchWithRetry, parseRetryAfterMs} from '../retry';
+
+// ---------------------------------------------------------------------------
+// parseRetryAfterMs
+// ---------------------------------------------------------------------------
+
+function headersFrom(record: Record<string, string>): Headers {
+  return new Headers(record);
+}
+
+describe('parseRetryAfterMs', () => {
+  test('returns null when Retry-After header is absent', () => {
+    expect(parseRetryAfterMs(headersFrom({}))).toBeNull();
+  });
+
+  test('returns milliseconds for a positive numeric value', () => {
+    expect(parseRetryAfterMs(headersFrom({'retry-after': '30'}))).toBe(30_000);
+    expect(parseRetryAfterMs(headersFrom({'retry-after': '0'}))).toBe(0);
+  });
+
+  test('returns null for a negative numeric value', () => {
+    // Negative values are invalid per RFC 7231 and must not be used as a delay
+    expect(parseRetryAfterMs(headersFrom({'retry-after': '-1'}))).toBeNull();
+  });
+
+  test('returns positive ms for a future HTTP date', () => {
+    const future = new Date(Date.now() + 45_000).toUTCString();
+    const result = parseRetryAfterMs(headersFrom({'retry-after': future}));
+    // Allow ±2 s for test execution time
+    expect(result).toBeGreaterThan(43_000);
+    expect(result).toBeLessThan(47_000);
+  });
+
+  test('clamps past HTTP dates to 0', () => {
+    const past = new Date(Date.now() - 5_000).toUTCString();
+    expect(parseRetryAfterMs(headersFrom({'retry-after': past}))).toBe(0);
+  });
+
+  test('returns null for an unparseable string', () => {
+    expect(
+      parseRetryAfterMs(headersFrom({'retry-after': 'not-a-date'}))
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createFetchWithRetry — 429 Retry-After classification
+// ---------------------------------------------------------------------------
+
+function make429(retryAfter?: string): Response {
+  const headers = new Headers({'content-type': 'application/json'});
+  if (retryAfter !== undefined) {
+    headers.set('retry-after', retryAfter);
+  }
+  return new Response(null, {status: 429, headers});
+}
+
+function makeOk(): Response {
+  return new Response(null, {status: 200});
+}
+
+describe('createFetchWithRetry — 429 behaviour', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.restoreAllMocks();
+  });
+
+  test('long Retry-After (>60 s) returns immediately without retrying', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(make429('600'));
+    jest.spyOn(global, 'fetch').mockImplementation(mockFetch);
+
+    const fetchWithRetry = createFetchWithRetry({
+      retryOnStatus: () => true,
+    });
+
+    const responsePromise = fetchWithRetry('https://example.com');
+    // Advance timers — no setTimeout should fire for the quota-exhaustion case
+    await jest.runAllTimersAsync();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(429);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // no retries
+  });
+
+  test('short Retry-After (≤60 s) retries after the specified delay', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce(make429('30'))
+      .mockResolvedValue(makeOk());
+    jest.spyOn(global, 'fetch').mockImplementation(mockFetch);
+
+    const fetchWithRetry = createFetchWithRetry({
+      retryOnStatus: () => true,
+    });
+
+    const responsePromise = fetchWithRetry('https://example.com');
+    await jest.runAllTimersAsync();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('no Retry-After header retries with exponential backoff', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce(make429())
+      .mockResolvedValue(makeOk());
+    jest.spyOn(global, 'fetch').mockImplementation(mockFetch);
+
+    const fetchWithRetry = createFetchWithRetry({
+      retryOnStatus: () => true,
+    });
+
+    const responsePromise = fetchWithRetry('https://example.com');
+    await jest.runAllTimersAsync();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('retryOnStatus returning false for 429 skips Retry-After logic entirely', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(make429('600'));
+    jest.spyOn(global, 'fetch').mockImplementation(mockFetch);
+
+    // Caller explicitly opts out of retrying 429
+    const fetchWithRetry = createFetchWithRetry({
+      retryOnStatus: (status: number) => status !== 429,
+    });
+
+    const responsePromise = fetchWithRetry('https://example.com');
+    await jest.runAllTimersAsync();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(429);
+    expect(mockFetch).toHaveBeenCalledTimes(1); // returned immediately
+  });
+
+  test('negative Retry-After value is treated as no header (exponential backoff)', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce(make429('-1'))
+      .mockResolvedValue(makeOk());
+    jest.spyOn(global, 'fetch').mockImplementation(mockFetch);
+
+    const fetchWithRetry = createFetchWithRetry({
+      retryOnStatus: () => true,
+    });
+
+    const responsePromise = fetchWithRetry('https://example.com');
+    await jest.runAllTimersAsync();
+    const response = await responsePromise;
+
+    expect(response.status).toBe(200);
+    expect(mockFetch).toHaveBeenCalledTimes(2); // retried via backoff
+  });
+});

--- a/sdks/node/src/utils/__tests__/retry.test.ts
+++ b/sdks/node/src/utils/__tests__/retry.test.ts
@@ -86,15 +86,19 @@ describe('createFetchWithRetry — 429 behaviour', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1); // no retries
   });
 
-  test('short Retry-After (≤60 s) retries after the specified delay', async () => {
+  test('short Retry-After (≤60 s) uses the server-specified delay, not exponential backoff', async () => {
     const mockFetch = jest
       .fn()
       .mockResolvedValueOnce(make429('30'))
       .mockResolvedValue(makeOk());
     jest.spyOn(global, 'fetch').mockImplementation(mockFetch);
 
+    // Capture setTimeout calls to inspect the actual delay used
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+
     const fetchWithRetry = createFetchWithRetry({
       retryOnStatus: () => true,
+      maxDelay: 60_000, // above 30 s so the cap does not mask the assertion
     });
 
     const responsePromise = fetchWithRetry('https://example.com');
@@ -103,6 +107,11 @@ describe('createFetchWithRetry — 429 behaviour', () => {
 
     expect(response.status).toBe(200);
     expect(mockFetch).toHaveBeenCalledTimes(2);
+
+    // The retry delay must be the server-specified 30 s (30000 ms).
+    // Exponential backoff at attempt 0 would be baseDelay * 2^0 = 100 ms — a clearly different value.
+    const observedDelays = setTimeoutSpy.mock.calls.map(([, delay]) => delay);
+    expect(observedDelays).toContain(30_000);
   });
 
   test('no Retry-After header retries with exponential backoff', async () => {

--- a/sdks/node/src/utils/retry.ts
+++ b/sdks/node/src/utils/retry.ts
@@ -1,3 +1,7 @@
+// Retry-After values above this threshold (in seconds) indicate quota/billing
+// exhaustion — do not retry in that case.
+const RETRY_AFTER_STOP_THRESHOLD_SECONDS = 60;
+
 type RetryOptions = {
   maxRetries?: number;
   baseDelay?: number;
@@ -5,6 +9,26 @@ type RetryOptions = {
   maxRetryTime?: number;
   retryOnStatus?: (status: number) => boolean;
 };
+
+/**
+ * Parse the Retry-After header and return the delay in milliseconds.
+ * Returns null if the header is absent or unparseable.
+ */
+function parseRetryAfterMs(headers: Headers): number | null {
+  const retryAfter = headers.get('retry-after');
+  if (!retryAfter) return null;
+
+  // Retry-After can be a number of seconds or an HTTP date
+  const seconds = Number(retryAfter);
+  if (!isNaN(seconds)) return seconds * 1000;
+
+  const date = new Date(retryAfter);
+  if (!isNaN(date.getTime())) {
+    return Math.max(0, date.getTime() - Date.now());
+  }
+
+  return null;
+}
 
 export function createFetchWithRetry(options: RetryOptions = {}) {
   const {
@@ -24,6 +48,44 @@ export function createFetchWithRetry(options: RetryOptions = {}) {
       const startTime = Date.now();
       try {
         const response = await fetch(...fetchParams);
+
+        // For 429 responses, inspect Retry-After to classify the rate limit:
+        // - Long Retry-After (> threshold) → quota/billing exhaustion, do not retry
+        // - Short Retry-After → transient pressure, wait the specified duration
+        // - No Retry-After → transient pressure, use exponential backoff
+        if (response.status === 429) {
+          const retryAfterMs = parseRetryAfterMs(response.headers);
+          const retryAfterSeconds =
+            retryAfterMs !== null ? retryAfterMs / 1000 : null;
+
+          if (
+            retryAfterSeconds !== null &&
+            retryAfterSeconds > RETRY_AFTER_STOP_THRESHOLD_SECONDS
+          ) {
+            // Quota/billing exhaustion — surface immediately, do not retry
+            console.log(
+              `Return code: 429 with Retry-After: ${retryAfterSeconds}s (exceeds threshold). Not retrying.`
+            );
+            return response;
+          }
+
+          if (
+            attempt === maxRetries ||
+            Date.now() - startTime > maxRetryTime
+          ) {
+            return response;
+          }
+
+          const delay =
+            retryAfterMs !== null
+              ? Math.min(retryAfterMs, maxDelay)
+              : Math.min(baseDelay * 2 ** attempt, maxDelay);
+
+          console.log(`Return code: 429. Retrying fetch after ${delay}ms`);
+          await new Promise(resolve => setTimeout(resolve, delay));
+          attempt++;
+          continue;
+        }
 
         if (
           response.ok ||

--- a/sdks/node/src/utils/retry.ts
+++ b/sdks/node/src/utils/retry.ts
@@ -20,7 +20,7 @@ function parseRetryAfterMs(headers: Headers): number | null {
 
   // Retry-After can be a number of seconds or an HTTP date
   const seconds = Number(retryAfter);
-  if (!isNaN(seconds)) return seconds * 1000;
+  if (!isNaN(seconds) && seconds >= 0) return seconds * 1000;
 
   const date = new Date(retryAfter);
   if (!isNaN(date.getTime())) {
@@ -49,11 +49,12 @@ export function createFetchWithRetry(options: RetryOptions = {}) {
       try {
         const response = await fetch(...fetchParams);
 
-        // For 429 responses, inspect Retry-After to classify the rate limit:
+        // For 429 responses, inspect Retry-After to classify the rate limit,
+        // but only if the caller has not disabled retries for this status code.
         // - Long Retry-After (> threshold) → quota/billing exhaustion, do not retry
         // - Short Retry-After → transient pressure, wait the specified duration
         // - No Retry-After → transient pressure, use exponential backoff
-        if (response.status === 429) {
+        if (response.status === 429 && retryOnStatus(response.status)) {
           const retryAfterMs = parseRetryAfterMs(response.headers);
           const retryAfterSeconds =
             retryAfterMs !== null ? retryAfterMs / 1000 : null;

--- a/sdks/node/src/utils/retry.ts
+++ b/sdks/node/src/utils/retry.ts
@@ -14,13 +14,18 @@ type RetryOptions = {
  * Parse the Retry-After header and return the delay in milliseconds.
  * Returns null if the header is absent or unparseable.
  */
-function parseRetryAfterMs(headers: Headers): number | null {
+export function parseRetryAfterMs(headers: Headers): number | null {
   const retryAfter = headers.get('retry-after');
   if (!retryAfter) return null;
 
-  // Retry-After can be a number of seconds or an HTTP date
+  // Retry-After can be a number of seconds or an HTTP date.
+  // Handle the numeric case first — if the value is a valid number but
+  // negative, reject it explicitly rather than letting it fall through to
+  // the date parser (e.g. new Date('-1') parses as 1 BCE and returns 0).
   const seconds = Number(retryAfter);
-  if (!isNaN(seconds) && seconds >= 0) return seconds * 1000;
+  if (!isNaN(seconds)) {
+    return seconds >= 0 ? seconds * 1000 : null;
+  }
 
   const date = new Date(retryAfter);
   if (!isNaN(date.getTime())) {


### PR DESCRIPTION
## Problem

Fixes #6543

The Node SDK retry logic in \`sdks/node/src/utils/retry.ts\` treats all 429 responses identically — it always retries with exponential backoff regardless of the \`Retry-After\` header. This means:

- **Quota/billing exhaustion** (long \`Retry-After\`, e.g. 600s) → retried anyway, amplifying pressure
- **Transient pressure** (short \`Retry-After\`, e.g. 30s) → retried with wrong delay (exponential backoff instead of the server-specified wait)

When Weave traces LLM calls at volume and hits a quota exhaustion 429, the SDK retries instead of surfacing the failure immediately — making things worse.

## Fix

Added \`Retry-After\` header inspection to \`retry.ts\`:

1. **Long \`Retry-After\` (> 60s)** → quota/billing exhaustion, return immediately without retrying
2. **Short \`Retry-After\` (≤ 60s)** → use the server-specified delay instead of exponential backoff
3. **No \`Retry-After\`** → existing exponential backoff behaviour (unchanged)

Also added a \`parseRetryAfterMs()\` helper that handles both numeric seconds and HTTP-date formats per the spec.

## Bug fix included

During testing, a negative-value edge case was found: a \`Retry-After: -1\` value passed the numeric \`seconds >= 0\` guard (false), fell through to the HTTP-date parser, was interpreted as year 1 BCE by \`new Date('-1')\`, and returned \`0\` instead of \`null\`. Fixed by returning \`null\` explicitly for any numeric value below zero before reaching the date parser.

## Changes

- \`sdks/node/src/utils/retry.ts\` — \`Retry-After\` classification logic + \`parseRetryAfterMs()\` helper (exported); negative-value edge case fixed
- \`sdks/node/src/utils/__tests__/retry.test.ts\` — 11 tests covering: numeric seconds, HTTP date format, negative value, no header, over-threshold (>60s) stops retries, short value uses server delay (not backoff), and \`retryOnStatus\` disabling 429 retries