### PR TITLE
chore(weave_ts): Rename Turn#tool --> Turn#startTool.

### DIFF
--- a/sdks/node/src/__tests__/genai/tool.test.ts
+++ b/sdks/node/src/__tests__/genai/tool.test.ts
@@ -13,9 +13,9 @@ describe('Tool', () => {
   setupGenAITestEnvironment();
   const getExporter = setupExporterPerTest();
 
-  it('attaches to the turn span when started via turn.tool() (flat)', () => {
+  it('attaches to the turn span when started via turn.startTool() (flat)', () => {
     const turn = Turn.create({conversationId: 'conv-1'});
-    const tool = turn.tool({
+    const tool = turn.startTool({
       name: 'get_weather',
       args: '{"city":"Tokyo"}',
       toolCallId: 'tc-1',

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -57,7 +57,7 @@ export function startTool(opts: ToolInit): Tool {
       'weave.startTool() called without an active Turn or LLM. Call weave.startTurn() or weave.startLLM() first.'
     );
   }
-  return state.turn.tool(opts);
+  return state.turn.startTool(opts);
 }
 
 /**

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -77,7 +77,7 @@ export class Turn {
     });
   }
 
-  tool(opts: ToolInit): Tool {
+  startTool(opts: ToolInit): Tool {
     return Tool.create({
       ...opts,
       parentContext: this.context,


### PR DESCRIPTION
## Description

* Updates the `Turn` API to match the top-level `weave.startTool()` API.