### PR TITLE
chore(weave_ts): Rename Turn#subagent --> Turn#startSubagent.

### DIFF
--- a/sdks/node/src/__tests__/genai/subagent.test.ts
+++ b/sdks/node/src/__tests__/genai/subagent.test.ts
@@ -9,7 +9,7 @@ describe('SubAgent', () => {
 
   it('emits a nested invoke_agent span as a child of the turn', () => {
     const turn = Turn.create({agentName: 'parent'});
-    const sub = turn.subagent({name: 'child-bot', model: 'gpt-4o'});
+    const sub = turn.startSubagent({name: 'child-bot', model: 'gpt-4o'});
     sub.end();
     turn.end();
 

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -73,7 +73,7 @@ export function startSubagent(opts: SubAgentInit): SubAgent {
       'weave.startSubagent() called without an active Turn or LLM. Call weave.startTurn() or weave.startLLM() first.'
     );
   }
-  return state.turn.subagent(opts);
+  return state.turn.startSubagent(opts);
 }
 
 /**

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -85,7 +85,7 @@ export class Turn {
     });
   }
 
-  subagent(opts: SubAgentInit): SubAgent {
+  startSubagent(opts: SubAgentInit): SubAgent {
     return SubAgent.create({
       ...opts,
       parentContext: this.context,


### PR DESCRIPTION
## Description

* Updates the `Turn` API to match the top-level `weave.startSubagent()` API.