### PR TITLE
fix(weave): include otel bytes in project trace_storage_size_bytes

### DIFF
--- a/tests/trace_server/query_builder/test_project_query_builder.py
+++ b/tests/trace_server/query_builder/test_project_query_builder.py
@@ -48,7 +48,8 @@ class TestMakeProjectStatsQuery:
                     COALESCE(attributes_size_bytes, 0) +
                     COALESCE(inputs_size_bytes, 0) +
                     COALESCE(output_size_bytes, 0) +
-                    COALESCE(summary_size_bytes, 0)
+                    COALESCE(summary_size_bytes, 0) +
+                    COALESCE(otel_dump_size_bytes, 0)
                     )
                     FROM calls_merged_stats
                     WHERE project_id = {pb_0: String}
@@ -76,7 +77,8 @@ class TestMakeProjectStatsQuery:
                     COALESCE(attributes_size_bytes, 0) +
                     COALESCE(inputs_size_bytes, 0) +
                     COALESCE(output_size_bytes, 0) +
-                    COALESCE(summary_size_bytes, 0)
+                    COALESCE(summary_size_bytes, 0) +
+                    COALESCE(otel_size_bytes, 0)
                     )
                     FROM calls_complete_stats
                     WHERE project_id = {pb_0: String}
@@ -170,7 +172,8 @@ class TestMakeProjectStatsQuery:
                     COALESCE(attributes_size_bytes, 0) +
                     COALESCE(inputs_size_bytes, 0) +
                     COALESCE(output_size_bytes, 0) +
-                    COALESCE(summary_size_bytes, 0)
+                    COALESCE(summary_size_bytes, 0) +
+                    COALESCE(otel_dump_size_bytes, 0)
                     )
                     FROM calls_merged_stats
                     WHERE project_id = {pb_0: String}
@@ -215,7 +218,8 @@ class TestMakeProjectStatsQuery:
                     COALESCE(attributes_size_bytes, 0) +
                     COALESCE(inputs_size_bytes, 0) +
                     COALESCE(output_size_bytes, 0) +
-                    COALESCE(summary_size_bytes, 0)
+                    COALESCE(summary_size_bytes, 0) +
+                    COALESCE(otel_size_bytes, 0)
                     )
                     FROM calls_complete_stats
                     WHERE project_id = {pb_0: String}
@@ -272,7 +276,8 @@ class TestMakeProjectStatsQuery:
                     COALESCE(attributes_size_bytes, 0) +
                     COALESCE(inputs_size_bytes, 0) +
                     COALESCE(output_size_bytes, 0) +
-                    COALESCE(summary_size_bytes, 0)
+                    COALESCE(summary_size_bytes, 0) +
+                    COALESCE(otel_dump_size_bytes, 0)
                     )
                     FROM calls_merged_stats
                     WHERE project_id = {pb_0: String}
@@ -283,6 +288,33 @@ class TestMakeProjectStatsQuery:
         assert_sql(
             query, expected_sql, pb.get_params(), {"pb_0": "malicious'--project"}
         )
+
+    def test_trace_storage_includes_otel_bytes_regression(self) -> None:
+        """trace_storage_size_bytes must sum OTEL bytes for both stats tables.
+
+        Dropping OTEL underreports project storage (the calls_merged_stats column
+        is `otel_dump_size_bytes`, calls_complete_stats is `otel_size_bytes`).
+        """
+        for read_table, expected_otel_col, other_otel_col in [
+            (ReadTable.CALLS_MERGED, "otel_dump_size_bytes", "otel_size_bytes"),
+            (ReadTable.CALLS_COMPLETE, "otel_size_bytes", "otel_dump_size_bytes"),
+        ]:
+            pb = ParamBuilder("pb")
+            query, _ = make_project_stats_query(
+                project_id="test_project",
+                pb=pb,
+                include_trace_storage_size=True,
+                include_objects_storage_size=False,
+                include_tables_storage_size=False,
+                include_files_storage_size=False,
+                read_table=read_table,
+            )
+            assert f"COALESCE({expected_otel_col}, 0)" in query, (
+                f"trace_storage sum missing OTEL bytes for {read_table}"
+            )
+            assert other_otel_col not in query, (
+                f"wrong OTEL column {other_otel_col} used for {read_table}"
+            )
 
     def test_only_objects_storage_with_calls_complete(self) -> None:
         """Verify non-trace storage works without including calls stats table."""

--- a/weave/trace_server/query_builder/project_query_builder.py
+++ b/weave/trace_server/query_builder/project_query_builder.py
@@ -41,6 +41,12 @@ def make_project_stats_query(
 
     table_config = TableConfig.from_read_table(read_table)
     calls_stats_table = table_config.stats_table_name
+    # calls_merged_stats and calls_complete_stats name the otel column differently
+    otel_size_column = (
+        "otel_dump_size_bytes"
+        if read_table == ReadTable.CALLS_MERGED
+        else "otel_size_bytes"
+    )
 
     columns = []
     sub_sqls = []
@@ -52,7 +58,8 @@ def make_project_stats_query(
                 COALESCE(attributes_size_bytes, 0) +
                 COALESCE(inputs_size_bytes, 0) +
                 COALESCE(output_size_bytes, 0) +
-                COALESCE(summary_size_bytes, 0)
+                COALESCE(summary_size_bytes, 0) +
+                COALESCE({otel_size_column}, 0)
                 )
                 FROM {calls_stats_table}
                 WHERE project_id = {{{project_id_param}: String}}


### PR DESCRIPTION
[WB-34615](https://coreweave.atlassian.net/browse/WB-34615)

## Summary
- The `/project/stats` SQL was summing `attributes + inputs + output + summary` for `trace_storage_size_bytes` and dropping the OTEL term, so the UI's "Traces storage" panel underreports project storage.
- For OTEL-heavy projects this is huge: on one real project, trace storage shows 6.1 GB but the true on-disk footprint is ~14.1 GB (8 GB of which is OTEL).
- Adds `COALESCE(otel_dump_size_bytes, 0)` for `calls_merged_stats` and `COALESCE(otel_size_bytes, 0)` for `calls_complete_stats` (the two tables use different column names -> same convention the gorilla billing query already uses).

## Testing
unit test + one new regression test (`test_trace_storage_includes_otel_bytes_regression`) that asserts OTEL appears in the sum for both `ReadTable` variants and that the wrong column isn't used.


[WB-34615]: https://coreweave.atlassian.net/browse/WB-34615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ