### PR TITLE
chore(weave_ts): GenAI API attr renaming

### DIFF
--- a/sdks/node/src/__tests__/genai/api.test.ts
+++ b/sdks/node/src/__tests__/genai/api.test.ts
@@ -14,7 +14,7 @@ import {
   getCurrentTurn,
   runIsolated,
 } from '../../genai/context';
-import {GEN_AI_ATTR} from '../../genai/semconv';
+import {ATTR_GEN_AI_CONVERSATION_ID} from '../../genai/semconv';
 
 import {
   findSpan,
@@ -51,7 +51,7 @@ describe('genai api (top-level functions)', () => {
     expect(llmSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
     expect(toolSpan.parentSpanId).toBe(llmSpan.spanContext().spanId);
     for (const s of spans) {
-      expect(s.attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe('conv-1');
+      expect(s.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('conv-1');
     }
   });
 

--- a/sdks/node/src/__tests__/genai/chain.test.ts
+++ b/sdks/node/src/__tests__/genai/chain.test.ts
@@ -1,4 +1,4 @@
-import {GEN_AI_ATTR} from '../../genai/semconv';
+import {ATTR_GEN_AI_CONVERSATION_ID} from '../../genai/semconv';
 import {Session} from '../../genai/session';
 
 import {
@@ -42,7 +42,7 @@ describe('end-to-end chain', () => {
 
     // Conversation id propagates everywhere.
     for (const s of spans) {
-      expect(s.attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe('conv-e2e');
+      expect(s.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('conv-e2e');
     }
   });
 });

--- a/sdks/node/src/__tests__/genai/llm.test.ts
+++ b/sdks/node/src/__tests__/genai/llm.test.ts
@@ -1,6 +1,18 @@
 import {SpanKind} from '@opentelemetry/api';
 
-import {GEN_AI_ATTR} from '../../genai/semconv';
+import {
+  ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_INPUT_MESSAGES,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_OUTPUT_MESSAGES,
+  ATTR_GEN_AI_PROVIDER_NAME,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
+} from '../../genai/semconv';
 import {Turn} from '../../genai/turn';
 
 import {
@@ -24,12 +36,10 @@ describe('LLM (via Turn.startLLM)', () => {
     const turnSpan = findSpan(spans, 'invoke_agent');
 
     expect(llmSpan.kind).toBe(SpanKind.CLIENT);
-    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OPERATION_NAME]).toBe('chat');
-    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_REQUEST_MODEL]).toBe('gpt-4o');
-    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_PROVIDER_NAME]).toBe('openai');
-    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe(
-      'conv-1'
-    );
+    expect(llmSpan.attributes[ATTR_GEN_AI_OPERATION_NAME]).toBe('chat');
+    expect(llmSpan.attributes[ATTR_GEN_AI_REQUEST_MODEL]).toBe('gpt-4o');
+    expect(llmSpan.attributes[ATTR_GEN_AI_PROVIDER_NAME]).toBe('openai');
+    expect(llmSpan.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('conv-1');
     expect(llmSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
     expect(llmSpan.spanContext().traceId).toBe(turnSpan.spanContext().traceId);
   });
@@ -51,25 +61,21 @@ describe('LLM (via Turn.startLLM)', () => {
 
     const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
     expect(
-      JSON.parse(
-        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES] as string
-      )
+      JSON.parse(llmSpan.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string)
     ).toEqual([{role: 'user', content: 'hi'}]);
     expect(
-      JSON.parse(
-        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES] as string
-      )
+      JSON.parse(llmSpan.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string)
     ).toEqual([{role: 'assistant', content: 'hello'}]);
-    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_INPUT_TOKENS]).toBe(10);
-    expect(llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_OUTPUT_TOKENS]).toBe(5);
+    expect(llmSpan.attributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS]).toBe(10);
+    expect(llmSpan.attributes[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]).toBe(5);
+    expect(llmSpan.attributes[ATTR_GEN_AI_USAGE_REASONING_OUTPUT_TOKENS]).toBe(
+      2
+    );
+    expect(llmSpan.attributes[ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]).toBe(
+      1
+    );
     expect(
-      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS]
-    ).toBe(2);
-    expect(
-      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]
-    ).toBe(1);
-    expect(
-      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]
+      llmSpan.attributes[ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]
     ).toBe(3);
   });
 
@@ -80,15 +86,9 @@ describe('LLM (via Turn.startLLM)', () => {
     turn.end();
 
     const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
-    expect(
-      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES]
-    ).toBeUndefined();
-    expect(
-      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES]
-    ).toBeUndefined();
-    expect(
-      llmSpan.attributes[GEN_AI_ATTR.GEN_AI_USAGE_INPUT_TOKENS]
-    ).toBeUndefined();
+    expect(llmSpan.attributes[ATTR_GEN_AI_INPUT_MESSAGES]).toBeUndefined();
+    expect(llmSpan.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES]).toBeUndefined();
+    expect(llmSpan.attributes[ATTR_GEN_AI_USAGE_INPUT_TOKENS]).toBeUndefined();
   });
 
   // ---------------------------------------------------------------------------
@@ -105,9 +105,7 @@ describe('LLM (via Turn.startLLM)', () => {
 
       const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
       expect(
-        JSON.parse(
-          llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES] as string
-        )
+        JSON.parse(llmSpan.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string)
       ).toEqual([{role: 'assistant', content: 'Hello!'}]);
     });
 
@@ -120,7 +118,7 @@ describe('LLM (via Turn.startLLM)', () => {
 
       const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
       const messages = JSON.parse(
-        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES] as string
+        llmSpan.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string
       );
       expect(messages).toEqual([
         {role: 'assistant', content: 'first'},
@@ -148,7 +146,7 @@ describe('LLM (via Turn.startLLM)', () => {
 
       const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
       const messages = JSON.parse(
-        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES] as string
+        llmSpan.attributes[ATTR_GEN_AI_OUTPUT_MESSAGES] as string
       );
       expect(messages).toHaveLength(1);
       // output() produced {role:'assistant', content:'hello'}; end() promoted
@@ -173,7 +171,7 @@ describe('LLM (via Turn.startLLM)', () => {
 
       const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
       const messages = JSON.parse(
-        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES] as string
+        llmSpan.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string
       );
       expect(messages).toHaveLength(1);
       expect(messages[0].role).toBe('user');
@@ -197,7 +195,7 @@ describe('LLM (via Turn.startLLM)', () => {
 
       const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
       const messages = JSON.parse(
-        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES] as string
+        llmSpan.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string
       );
       expect(messages[0].parts).toEqual([
         {type: 'uri', uri: 'https://example.com/a.png', modality: 'image'},
@@ -217,7 +215,7 @@ describe('LLM (via Turn.startLLM)', () => {
 
       const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
       const messages = JSON.parse(
-        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES] as string
+        llmSpan.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string
       );
       expect(messages[0].parts).toEqual([
         {
@@ -238,7 +236,7 @@ describe('LLM (via Turn.startLLM)', () => {
 
       const llmSpan = findSpan(getExporter().getFinishedSpans(), 'chat');
       const messages = JSON.parse(
-        llmSpan.attributes[GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES] as string
+        llmSpan.attributes[ATTR_GEN_AI_INPUT_MESSAGES] as string
       );
       expect(messages[0].parts).toEqual([
         {type: 'uri', uri: 'https://example.com/v.mp4', modality: 'video'},

--- a/sdks/node/src/__tests__/genai/session.test.ts
+++ b/sdks/node/src/__tests__/genai/session.test.ts
@@ -1,4 +1,7 @@
-import {GEN_AI_ATTR} from '../../genai/semconv';
+import {
+  ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_CONVERSATION_ID,
+} from '../../genai/semconv';
 import {Session} from '../../genai/session';
 
 import {setupExporterPerTest, setupGenAITestEnvironment} from './common';
@@ -19,10 +22,8 @@ describe('Session', () => {
     const spans = getExporter().getFinishedSpans();
     expect(spans).toHaveLength(1); // only the turn span
     expect(spans[0].name).toBe('invoke_agent');
-    expect(spans[0].attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe('s-1');
-    expect(spans[0].attributes[GEN_AI_ATTR.GEN_AI_AGENT_NAME]).toBe(
-      'weather-bot'
-    );
+    expect(spans[0].attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('s-1');
+    expect(spans[0].attributes[ATTR_GEN_AI_AGENT_NAME]).toBe('weather-bot');
   });
 
   it('auto-generates a sessionId when none is supplied', () => {

--- a/sdks/node/src/__tests__/genai/subagent.test.ts
+++ b/sdks/node/src/__tests__/genai/subagent.test.ts
@@ -1,4 +1,7 @@
-import {GEN_AI_ATTR} from '../../genai/semconv';
+import {
+  ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_REQUEST_MODEL,
+} from '../../genai/semconv';
 import {Turn} from '../../genai/turn';
 
 import {setupExporterPerTest, setupGenAITestEnvironment} from './common';
@@ -18,18 +21,16 @@ describe('SubAgent', () => {
     const subSpan = spans.find(
       s =>
         s.name === 'invoke_agent' &&
-        s.attributes[GEN_AI_ATTR.GEN_AI_AGENT_NAME] === 'child-bot'
+        s.attributes[ATTR_GEN_AI_AGENT_NAME] === 'child-bot'
     );
     const parentTurnSpan = spans.find(
       s =>
         s.name === 'invoke_agent' &&
-        s.attributes[GEN_AI_ATTR.GEN_AI_AGENT_NAME] === 'parent'
+        s.attributes[ATTR_GEN_AI_AGENT_NAME] === 'parent'
     );
     expect(subSpan).toBeDefined();
     expect(parentTurnSpan).toBeDefined();
     expect(subSpan!.parentSpanId).toBe(parentTurnSpan!.spanContext().spanId);
-    expect(subSpan!.attributes[GEN_AI_ATTR.GEN_AI_REQUEST_MODEL]).toBe(
-      'gpt-4o'
-    );
+    expect(subSpan!.attributes[ATTR_GEN_AI_REQUEST_MODEL]).toBe('gpt-4o');
   });
 });

--- a/sdks/node/src/__tests__/genai/tool.test.ts
+++ b/sdks/node/src/__tests__/genai/tool.test.ts
@@ -1,6 +1,13 @@
 import {SpanKind} from '@opentelemetry/api';
 
-import {GEN_AI_ATTR} from '../../genai/semconv';
+import {
+  ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
+  ATTR_GEN_AI_TOOL_CALL_ID,
+  ATTR_GEN_AI_TOOL_CALL_RESULT,
+  ATTR_GEN_AI_TOOL_NAME,
+} from '../../genai/semconv';
 import {Turn} from '../../genai/turn';
 
 import {
@@ -29,22 +36,16 @@ describe('Tool', () => {
     const turnSpan = findSpan(spans, 'invoke_agent');
 
     expect(toolSpan.kind).toBe(SpanKind.INTERNAL);
-    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_OPERATION_NAME]).toBe(
+    expect(toolSpan.attributes[ATTR_GEN_AI_OPERATION_NAME]).toBe(
       'execute_tool'
     );
-    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_TOOL_NAME]).toBe(
-      'get_weather'
-    );
-    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_TOOL_CALL_ID]).toBe('tc-1');
-    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_TOOL_CALL_ARGUMENTS]).toBe(
+    expect(toolSpan.attributes[ATTR_GEN_AI_TOOL_NAME]).toBe('get_weather');
+    expect(toolSpan.attributes[ATTR_GEN_AI_TOOL_CALL_ID]).toBe('tc-1');
+    expect(toolSpan.attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS]).toBe(
       '{"city":"Tokyo"}'
     );
-    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_TOOL_CALL_RESULT]).toBe(
-      '75F'
-    );
-    expect(toolSpan.attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe(
-      'conv-1'
-    );
+    expect(toolSpan.attributes[ATTR_GEN_AI_TOOL_CALL_RESULT]).toBe('75F');
+    expect(toolSpan.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('conv-1');
     expect(toolSpan.parentSpanId).toBe(turnSpan.spanContext().spanId);
   });
 

--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -1,6 +1,11 @@
 import {SpanKind, SpanStatusCode} from '@opentelemetry/api';
 
-import {GEN_AI_ATTR} from '../../genai/semconv';
+import {
+  ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_REQUEST_MODEL,
+} from '../../genai/semconv';
 import {Turn} from '../../genai/turn';
 
 import {
@@ -23,12 +28,10 @@ describe('Turn', () => {
 
     const span = findSpan(getExporter().getFinishedSpans(), 'invoke_agent');
     expect(span.kind).toBe(SpanKind.CLIENT);
-    expect(span.attributes[GEN_AI_ATTR.GEN_AI_OPERATION_NAME]).toBe(
-      'invoke_agent'
-    );
-    expect(span.attributes[GEN_AI_ATTR.GEN_AI_AGENT_NAME]).toBe('weather-bot');
-    expect(span.attributes[GEN_AI_ATTR.GEN_AI_REQUEST_MODEL]).toBe('gpt-4o');
-    expect(span.attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID]).toBe('conv-1');
+    expect(span.attributes[ATTR_GEN_AI_OPERATION_NAME]).toBe('invoke_agent');
+    expect(span.attributes[ATTR_GEN_AI_AGENT_NAME]).toBe('weather-bot');
+    expect(span.attributes[ATTR_GEN_AI_REQUEST_MODEL]).toBe('gpt-4o');
+    expect(span.attributes[ATTR_GEN_AI_CONVERSATION_ID]).toBe('conv-1');
     expect(span.parentSpanId).toBeUndefined();
   });
 

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -9,7 +9,20 @@ import {
 import type {ChildSpanContext} from './common';
 import {_getGenaiState} from './context';
 import {getWeaveTracer} from './provider';
-import {GEN_AI_ATTR, WEAVE_GENAI_TRACER_NAME} from './semconv';
+import {
+  ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_INPUT_MESSAGES,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_OUTPUT_MESSAGES,
+  ATTR_GEN_AI_PROVIDER_NAME,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
+  WEAVE_GENAI_TRACER_NAME,
+} from './semconv';
 import {SubAgent, type SubAgentInit} from './subagent';
 import {Tool, type ToolInit} from './tool';
 import type {Message, MessagePart, Modality, Reasoning, Usage} from './types';
@@ -58,14 +71,14 @@ export class LLM {
     }
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Record<string, string> = {
-      [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'chat',
-      [GEN_AI_ATTR.GEN_AI_REQUEST_MODEL]: opts.model,
+      [ATTR_GEN_AI_OPERATION_NAME]: 'chat',
+      [ATTR_GEN_AI_REQUEST_MODEL]: opts.model,
     };
     if (opts.providerName) {
-      attributes[GEN_AI_ATTR.GEN_AI_PROVIDER_NAME] = opts.providerName;
+      attributes[ATTR_GEN_AI_PROVIDER_NAME] = opts.providerName;
     }
     if (opts.conversationId) {
-      attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID] = opts.conversationId;
+      attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
     }
     const span = tracer.startSpan(
       'chat',
@@ -200,45 +213,39 @@ export class LLM {
 
     if (this.inputMessages.length > 0) {
       this.span.setAttribute(
-        GEN_AI_ATTR.GEN_AI_INPUT_MESSAGES,
+        ATTR_GEN_AI_INPUT_MESSAGES,
         JSON.stringify(this.inputMessages)
       );
     }
     if (this.outputMessages.length > 0) {
       this.span.setAttribute(
-        GEN_AI_ATTR.GEN_AI_OUTPUT_MESSAGES,
+        ATTR_GEN_AI_OUTPUT_MESSAGES,
         JSON.stringify(this.outputMessages)
       );
     }
 
     const u = this.usage;
     if (u.inputTokens !== undefined) {
-      this.span.setAttribute(
-        GEN_AI_ATTR.GEN_AI_USAGE_INPUT_TOKENS,
-        u.inputTokens
-      );
+      this.span.setAttribute(ATTR_GEN_AI_USAGE_INPUT_TOKENS, u.inputTokens);
     }
     if (u.outputTokens !== undefined) {
-      this.span.setAttribute(
-        GEN_AI_ATTR.GEN_AI_USAGE_OUTPUT_TOKENS,
-        u.outputTokens
-      );
+      this.span.setAttribute(ATTR_GEN_AI_USAGE_OUTPUT_TOKENS, u.outputTokens);
     }
     if (u.reasoningTokens !== undefined) {
       this.span.setAttribute(
-        GEN_AI_ATTR.GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
+        ATTR_GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
         u.reasoningTokens
       );
     }
     if (u.cacheCreationInputTokens !== undefined) {
       this.span.setAttribute(
-        GEN_AI_ATTR.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+        ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
         u.cacheCreationInputTokens
       );
     }
     if (u.cacheReadInputTokens !== undefined) {
       this.span.setAttribute(
-        GEN_AI_ATTR.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+        ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
         u.cacheReadInputTokens
       );
     }

--- a/sdks/node/src/genai/semconv.ts
+++ b/sdks/node/src/genai/semconv.ts
@@ -2,64 +2,82 @@
  * Constants for OpenTelemetry emitters in the Weave SDK that produce spans
  * conforming to the GenAI semantic conventions:
  * https://opentelemetry.io/docs/specs/semconv/gen-ai/
+ *
+ * Per the OpenTelemetry JS guidance for unstable (incubating) semconv, we copy
+ * the relevant definitions here verbatim — same identifier names, same string
+ * values — instead of importing from `@opentelemetry/semantic-conventions/
+ * incubating`. The incubating entry point can break across minor versions, so
+ * keeping a local copy lets us control when we absorb upstream changes.
+ *
+ * Refresh procedure: diff this file against the corresponding lines of
+ * `@opentelemetry/semantic-conventions` `experimental_attributes.ts` /
+ * `experimental_events.ts` (and `stable_attributes.ts` for `ATTR_ERROR_TYPE`).
+ * Tracked upstream version: 1.41.1.
+ *
+ * See https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv
  */
 
 // ---------------------------------------------------------------------------
-// Attribute key constants
+// Upstream attribute keys (verbatim copies)
 // ---------------------------------------------------------------------------
 
-/** GenAI semantic convention attribute keys. */
-export const GEN_AI_ATTR = {
-  GEN_AI_PROVIDER_NAME: 'gen_ai.provider.name',
-  GEN_AI_OPERATION_NAME: 'gen_ai.operation.name',
-  GEN_AI_AGENT_NAME: 'gen_ai.agent.name',
-  GEN_AI_REQUEST_MODEL: 'gen_ai.request.model',
-  GEN_AI_RESPONSE_MODEL: 'gen_ai.response.model',
-  GEN_AI_RESPONSE_FINISH_REASONS: 'gen_ai.response.finish_reasons',
-  GEN_AI_CONVERSATION_ID: 'gen_ai.conversation.id',
-  // Token usage
-  GEN_AI_USAGE_INPUT_TOKENS: 'gen_ai.usage.input_tokens',
-  GEN_AI_USAGE_OUTPUT_TOKENS: 'gen_ai.usage.output_tokens',
-  GEN_AI_USAGE_TOTAL_TOKENS: 'gen_ai.usage.total_tokens',
-  GEN_AI_USAGE_REASONING_OUTPUT_TOKENS: 'gen_ai.usage.reasoning.output_tokens',
-  GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS: 'gen_ai.usage.cache_read.input_tokens',
-  GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS:
-    'gen_ai.usage.cache_creation.input_tokens',
-  // Tool
-  GEN_AI_TOOL_NAME: 'gen_ai.tool.name',
-  GEN_AI_TOOL_CALL_ID: 'gen_ai.tool.call.id',
-  GEN_AI_TOOL_CALL_ARGUMENTS: 'gen_ai.tool.call.arguments',
-  GEN_AI_TOOL_CALL_RESULT: 'gen_ai.tool.call.result',
-  GEN_AI_OUTPUT_TYPE: 'gen_ai.output.type',
-  GEN_AI_INPUT_MESSAGES: 'gen_ai.input.messages',
-  GEN_AI_OUTPUT_MESSAGES: 'gen_ai.output.messages',
-  GEN_AI_SYSTEM_INSTRUCTIONS: 'gen_ai.system_instructions',
-} as const;
+export const ATTR_GEN_AI_AGENT_NAME = 'gen_ai.agent.name';
+export const ATTR_GEN_AI_CONVERSATION_ID = 'gen_ai.conversation.id';
+export const ATTR_GEN_AI_INPUT_MESSAGES = 'gen_ai.input.messages';
+export const ATTR_GEN_AI_OPERATION_NAME = 'gen_ai.operation.name';
+export const ATTR_GEN_AI_OUTPUT_MESSAGES = 'gen_ai.output.messages';
+export const ATTR_GEN_AI_OUTPUT_TYPE = 'gen_ai.output.type';
+export const ATTR_GEN_AI_PROVIDER_NAME = 'gen_ai.provider.name';
+export const ATTR_GEN_AI_REQUEST_MODEL = 'gen_ai.request.model';
+export const ATTR_GEN_AI_RESPONSE_FINISH_REASONS =
+  'gen_ai.response.finish_reasons';
+export const ATTR_GEN_AI_RESPONSE_MODEL = 'gen_ai.response.model';
+export const ATTR_GEN_AI_SYSTEM_INSTRUCTIONS = 'gen_ai.system_instructions';
+export const ATTR_GEN_AI_TOOL_CALL_ARGUMENTS = 'gen_ai.tool.call.arguments';
+export const ATTR_GEN_AI_TOOL_CALL_ID = 'gen_ai.tool.call.id';
+export const ATTR_GEN_AI_TOOL_CALL_RESULT = 'gen_ai.tool.call.result';
+export const ATTR_GEN_AI_TOOL_NAME = 'gen_ai.tool.name';
+export const ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS =
+  'gen_ai.usage.cache_creation.input_tokens';
+export const ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS =
+  'gen_ai.usage.cache_read.input_tokens';
+export const ATTR_GEN_AI_USAGE_INPUT_TOKENS = 'gen_ai.usage.input_tokens';
+export const ATTR_GEN_AI_USAGE_OUTPUT_TOKENS = 'gen_ai.usage.output_tokens';
+export const ATTR_GEN_AI_USAGE_REASONING_OUTPUT_TOKENS =
+  'gen_ai.usage.reasoning.output_tokens';
 
 // ---------------------------------------------------------------------------
-// Event name constants
+// Upstream event names (verbatim copies)
 // ---------------------------------------------------------------------------
 
-/** GenAI semantic convention span event names. */
-export const GEN_AI_EVENT = {
-  SYSTEM_MESSAGE: 'gen_ai.system.message',
-  USER_MESSAGE: 'gen_ai.user.message',
-  ASSISTANT_MESSAGE: 'gen_ai.assistant.message',
-  TOOL_MESSAGE: 'gen_ai.tool.message',
-  CONTENT_ATTR: 'gen_ai.event.content',
-} as const;
+export const EVENT_GEN_AI_ASSISTANT_MESSAGE = 'gen_ai.assistant.message';
+export const EVENT_GEN_AI_SYSTEM_MESSAGE = 'gen_ai.system.message';
+export const EVENT_GEN_AI_TOOL_MESSAGE = 'gen_ai.tool.message';
+export const EVENT_GEN_AI_USER_MESSAGE = 'gen_ai.user.message';
 
 // ---------------------------------------------------------------------------
-// General OTEL attribute keys
+// Upstream stable attribute keys
 // ---------------------------------------------------------------------------
 
-/** General OpenTelemetry attribute keys used alongside GenAI spans. */
-export const OTEL_ATTR = {
-  ERROR_TYPE: 'error.type',
-} as const;
+export const ATTR_ERROR_TYPE = 'error.type';
 
 // ---------------------------------------------------------------------------
-// Emitter identity
+// Weave extensions — NOT in upstream semconv
+// ---------------------------------------------------------------------------
+// These attribute keys are Weave-specific and have no counterpart in
+// `@opentelemetry/semantic-conventions`. Keep them here so the rest of the
+// file stays a clean copy of upstream and the diff against upstream is short.
+
+/** Total tokens for an LLM call. Upstream tracks only input / output /
+ *  reasoning separately. */
+export const ATTR_GEN_AI_USAGE_TOTAL_TOKENS = 'gen_ai.usage.total_tokens';
+
+/** Attribute key carrying serialized content inside a gen_ai.* span event
+ *  (e.g. on `gen_ai.system.message`). */
+export const ATTR_GEN_AI_EVENT_CONTENT = 'gen_ai.event.content';
+
+// ---------------------------------------------------------------------------
+// Emitter identity (Weave-specific, not a semconv constant)
 // ---------------------------------------------------------------------------
 
 /** Instrumentation-library name passed to `getWeaveTracer` by every emitter

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -2,7 +2,13 @@ import {type Span, SpanKind, SpanStatusCode} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
 import {getWeaveTracer} from './provider';
-import {GEN_AI_ATTR, WEAVE_GENAI_TRACER_NAME} from './semconv';
+import {
+  ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  WEAVE_GENAI_TRACER_NAME,
+} from './semconv';
 
 export interface SubAgentInit {
   name: string;
@@ -21,14 +27,14 @@ export class SubAgent {
   static create(opts: SubAgentInit & ChildSpanContext): SubAgent {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Record<string, string> = {
-      [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'invoke_agent',
-      [GEN_AI_ATTR.GEN_AI_AGENT_NAME]: opts.name,
+      [ATTR_GEN_AI_OPERATION_NAME]: 'invoke_agent',
+      [ATTR_GEN_AI_AGENT_NAME]: opts.name,
     };
     if (opts.model) {
-      attributes[GEN_AI_ATTR.GEN_AI_REQUEST_MODEL] = opts.model;
+      attributes[ATTR_GEN_AI_REQUEST_MODEL] = opts.model;
     }
     if (opts.conversationId) {
-      attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID] = opts.conversationId;
+      attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
     }
     const span = tracer.startSpan(
       'invoke_agent',

--- a/sdks/node/src/genai/tool.ts
+++ b/sdks/node/src/genai/tool.ts
@@ -2,7 +2,15 @@ import {type Span, SpanKind, SpanStatusCode} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
 import {getWeaveTracer} from './provider';
-import {GEN_AI_ATTR, WEAVE_GENAI_TRACER_NAME} from './semconv';
+import {
+  ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
+  ATTR_GEN_AI_TOOL_CALL_ID,
+  ATTR_GEN_AI_TOOL_CALL_RESULT,
+  ATTR_GEN_AI_TOOL_NAME,
+  WEAVE_GENAI_TRACER_NAME,
+} from './semconv';
 
 export interface ToolInit {
   name: string;
@@ -26,17 +34,17 @@ export class Tool {
   static create(opts: ToolInit & ChildSpanContext): Tool {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Record<string, string> = {
-      [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'execute_tool',
-      [GEN_AI_ATTR.GEN_AI_TOOL_NAME]: opts.name,
+      [ATTR_GEN_AI_OPERATION_NAME]: 'execute_tool',
+      [ATTR_GEN_AI_TOOL_NAME]: opts.name,
     };
     if (opts.toolCallId) {
-      attributes[GEN_AI_ATTR.GEN_AI_TOOL_CALL_ID] = opts.toolCallId;
+      attributes[ATTR_GEN_AI_TOOL_CALL_ID] = opts.toolCallId;
     }
     if (opts.args) {
-      attributes[GEN_AI_ATTR.GEN_AI_TOOL_CALL_ARGUMENTS] = opts.args;
+      attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] = opts.args;
     }
     if (opts.conversationId) {
-      attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID] = opts.conversationId;
+      attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
     }
     const span = tracer.startSpan(
       'execute_tool',
@@ -52,7 +60,7 @@ export class Tool {
     }
     this._ended = true;
     if (this.result !== undefined) {
-      this.span.setAttribute(GEN_AI_ATTR.GEN_AI_TOOL_CALL_RESULT, this.result);
+      this.span.setAttribute(ATTR_GEN_AI_TOOL_CALL_RESULT, this.result);
     }
     if (opts?.error) {
       this.span.recordException(opts.error);

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -10,7 +10,13 @@ import {
 import {_getGenaiState} from './context';
 import {LLM, type LLMInit} from './llm';
 import {getWeaveTracer} from './provider';
-import {GEN_AI_ATTR, WEAVE_GENAI_TRACER_NAME} from './semconv';
+import {
+  ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  WEAVE_GENAI_TRACER_NAME,
+} from './semconv';
 import {SubAgent, type SubAgentInit} from './subagent';
 import {Tool, type ToolInit} from './tool';
 
@@ -39,16 +45,16 @@ export class Turn {
     }
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);
     const attributes: Record<string, string> = {
-      [GEN_AI_ATTR.GEN_AI_OPERATION_NAME]: 'invoke_agent',
+      [ATTR_GEN_AI_OPERATION_NAME]: 'invoke_agent',
     };
     if (opts.agentName) {
-      attributes[GEN_AI_ATTR.GEN_AI_AGENT_NAME] = opts.agentName;
+      attributes[ATTR_GEN_AI_AGENT_NAME] = opts.agentName;
     }
     if (opts.model) {
-      attributes[GEN_AI_ATTR.GEN_AI_REQUEST_MODEL] = opts.model;
+      attributes[ATTR_GEN_AI_REQUEST_MODEL] = opts.model;
     }
     if (opts.conversationId) {
-      attributes[GEN_AI_ATTR.GEN_AI_CONVERSATION_ID] = opts.conversationId;
+      attributes[ATTR_GEN_AI_CONVERSATION_ID] = opts.conversationId;
     }
     // Pass ROOT_CONTEXT explicitly so Turn is always a root span — never
     // accidentally inherits a parent from some other OTel-instrumented

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -36,7 +36,28 @@ import {
 } from '@opentelemetry/api';
 
 import {getWeaveTracer} from '../genai/provider';
-import {GEN_AI_ATTR, OTEL_ATTR} from '../genai/semconv';
+import {
+  ATTR_ERROR_TYPE,
+  ATTR_GEN_AI_AGENT_NAME,
+  ATTR_GEN_AI_CONVERSATION_ID,
+  ATTR_GEN_AI_INPUT_MESSAGES,
+  ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_OUTPUT_MESSAGES,
+  ATTR_GEN_AI_PROVIDER_NAME,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_RESPONSE_FINISH_REASONS,
+  ATTR_GEN_AI_RESPONSE_MODEL,
+  ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
+  ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
+  ATTR_GEN_AI_TOOL_CALL_ID,
+  ATTR_GEN_AI_TOOL_CALL_RESULT,
+  ATTR_GEN_AI_TOOL_NAME,
+  ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_TOTAL_TOKENS,
+} from '../genai/semconv';
 
 import type {
   PiAgentMessage,
@@ -62,21 +83,16 @@ export interface OtelExtensionOptions {
 // Attribute keys — GenAI semconv keys from common, pi-specific keys below
 // ---------------------------------------------------------------------------
 
-const ATTR = {
-  ...GEN_AI_ATTR,
-  ...OTEL_ATTR,
-  // Pi-specific (not in GenAI spec)
-  PI_SESSION_CWD: 'pi.session.cwd',
-  PI_USAGE_COST_USD: 'pi.usage.cost_usd',
-  PI_COMPACTION_REASON: 'pi.compaction.reason',
-  PI_COMPACTION_ABORTED: 'pi.compaction.aborted',
-  PI_COMPACTION_WILL_RETRY: 'pi.compaction.will_retry',
-  PI_AUTO_RETRY_ATTEMPT: 'auto_retry.attempt',
-  PI_AUTO_RETRY_MAX_ATTEMPTS: 'auto_retry.max_attempts',
-  PI_AUTO_RETRY_ERROR_MESSAGE: 'auto_retry.error_message',
-  PI_AUTO_RETRY_SUCCESS: 'auto_retry.success',
-  PI_AUTO_RETRY_FINAL_ERROR: 'auto_retry.final_error',
-} as const;
+const ATTR_PI_SESSION_CWD = 'pi.session.cwd';
+const ATTR_PI_USAGE_COST_USD = 'pi.usage.cost_usd';
+const ATTR_PI_COMPACTION_REASON = 'pi.compaction.reason';
+const ATTR_PI_COMPACTION_ABORTED = 'pi.compaction.aborted';
+const ATTR_PI_COMPACTION_WILL_RETRY = 'pi.compaction.will_retry';
+const ATTR_PI_AUTO_RETRY_ATTEMPT = 'auto_retry.attempt';
+const ATTR_PI_AUTO_RETRY_MAX_ATTEMPTS = 'auto_retry.max_attempts';
+const ATTR_PI_AUTO_RETRY_ERROR_MESSAGE = 'auto_retry.error_message';
+const ATTR_PI_AUTO_RETRY_SUCCESS = 'auto_retry.success';
+const ATTR_PI_AUTO_RETRY_FINAL_ERROR = 'auto_retry.final_error';
 
 const TRACER_NAME = 'pi-coding-agent';
 
@@ -277,9 +293,9 @@ export class PiCodingAgentOtelAdapter {
       {
         kind: SpanKind.INTERNAL,
         attributes: {
-          [ATTR.GEN_AI_AGENT_NAME]: 'pi-coding-agent',
-          [ATTR.PI_SESSION_CWD]: ctx.cwd,
-          [ATTR.GEN_AI_CONVERSATION_ID]: this.conversationId,
+          [ATTR_GEN_AI_AGENT_NAME]: 'pi-coding-agent',
+          [ATTR_PI_SESSION_CWD]: ctx.cwd,
+          [ATTR_GEN_AI_CONVERSATION_ID]: this.conversationId,
         },
       },
       ROOT_CONTEXT
@@ -307,17 +323,17 @@ export class PiCodingAgentOtelAdapter {
       {
         kind: SpanKind.INTERNAL,
         attributes: {
-          [ATTR.GEN_AI_OPERATION_NAME]: 'invoke_agent',
-          [ATTR.GEN_AI_AGENT_NAME]: 'pi-coding-agent',
+          [ATTR_GEN_AI_OPERATION_NAME]: 'invoke_agent',
+          [ATTR_GEN_AI_AGENT_NAME]: 'pi-coding-agent',
           ...(model
             ? {
-                [ATTR.GEN_AI_PROVIDER_NAME]: resolveGenAiProviderName(
+                [ATTR_GEN_AI_PROVIDER_NAME]: resolveGenAiProviderName(
                   model.provider
                 ),
               }
             : {}),
           ...(this.conversationId
-            ? {[ATTR.GEN_AI_CONVERSATION_ID]: this.conversationId}
+            ? {[ATTR_GEN_AI_CONVERSATION_ID]: this.conversationId}
             : {}),
         },
       },
@@ -332,12 +348,12 @@ export class PiCodingAgentOtelAdapter {
     if (this.captureContent) {
       if (event.systemPrompt) {
         this.invokeAgentSpan.setAttribute(
-          ATTR.GEN_AI_SYSTEM_INSTRUCTIONS,
+          ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
           JSON.stringify([event.systemPrompt])
         );
       }
       this.invokeAgentSpan.setAttribute(
-        ATTR.GEN_AI_INPUT_MESSAGES,
+        ATTR_GEN_AI_INPUT_MESSAGES,
         JSON.stringify([{role: 'user', content: event.prompt}])
       );
     }
@@ -356,7 +372,7 @@ export class PiCodingAgentOtelAdapter {
         .map(mapPiMessage);
       if (assistantMessages.length > 0) {
         this.invokeAgentSpan.setAttribute(
-          ATTR.GEN_AI_OUTPUT_MESSAGES,
+          ATTR_GEN_AI_OUTPUT_MESSAGES,
           JSON.stringify(assistantMessages)
         );
       }
@@ -375,17 +391,17 @@ export class PiCodingAgentOtelAdapter {
       {
         kind: SpanKind.CLIENT,
         attributes: {
-          [ATTR.GEN_AI_OPERATION_NAME]: 'chat',
+          [ATTR_GEN_AI_OPERATION_NAME]: 'chat',
           ...(model
             ? {
-                [ATTR.GEN_AI_PROVIDER_NAME]: resolveGenAiProviderName(
+                [ATTR_GEN_AI_PROVIDER_NAME]: resolveGenAiProviderName(
                   model.provider
                 ),
-                [ATTR.GEN_AI_REQUEST_MODEL]: model.id,
+                [ATTR_GEN_AI_REQUEST_MODEL]: model.id,
               }
             : {}),
           ...(this.conversationId
-            ? {[ATTR.GEN_AI_CONVERSATION_ID]: this.conversationId}
+            ? {[ATTR_GEN_AI_CONVERSATION_ID]: this.conversationId}
             : {}),
         },
       },
@@ -415,13 +431,13 @@ export class PiCodingAgentOtelAdapter {
     }
     if (systemInstructions.length > 0) {
       this.chatSpan.setAttribute(
-        ATTR.GEN_AI_SYSTEM_INSTRUCTIONS,
+        ATTR_GEN_AI_SYSTEM_INSTRUCTIONS,
         JSON.stringify(systemInstructions)
       );
     }
     if (inputMessages.length > 0) {
       this.chatSpan.setAttribute(
-        ATTR.GEN_AI_INPUT_MESSAGES,
+        ATTR_GEN_AI_INPUT_MESSAGES,
         JSON.stringify(inputMessages)
       );
     }
@@ -439,19 +455,19 @@ export class PiCodingAgentOtelAdapter {
 
       if (this.chatSpan) {
         this.chatSpan.setAttributes({
-          [ATTR.GEN_AI_RESPONSE_MODEL]: event.message.model,
-          [ATTR.GEN_AI_RESPONSE_FINISH_REASONS]: [event.message.stopReason],
-          [ATTR.GEN_AI_USAGE_INPUT_TOKENS]: usage.input,
-          [ATTR.GEN_AI_USAGE_OUTPUT_TOKENS]: usage.output,
-          [ATTR.GEN_AI_USAGE_TOTAL_TOKENS]: usage.totalTokens,
-          [ATTR.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]: usage.cacheRead,
-          [ATTR.GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]: usage.cacheWrite,
-          [ATTR.PI_USAGE_COST_USD]: usage.cost.total,
+          [ATTR_GEN_AI_RESPONSE_MODEL]: event.message.model,
+          [ATTR_GEN_AI_RESPONSE_FINISH_REASONS]: [event.message.stopReason],
+          [ATTR_GEN_AI_USAGE_INPUT_TOKENS]: usage.input,
+          [ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]: usage.output,
+          [ATTR_GEN_AI_USAGE_TOTAL_TOKENS]: usage.totalTokens,
+          [ATTR_GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS]: usage.cacheRead,
+          [ATTR_GEN_AI_USAGE_CACHE_CREATION_INPUT_TOKENS]: usage.cacheWrite,
+          [ATTR_PI_USAGE_COST_USD]: usage.cost.total,
         });
 
         if (this.captureContent) {
           this.chatSpan.setAttribute(
-            ATTR.GEN_AI_OUTPUT_MESSAGES,
+            ATTR_GEN_AI_OUTPUT_MESSAGES,
             JSON.stringify([mapPiMessage(event.message)])
           );
         }
@@ -460,7 +476,7 @@ export class PiCodingAgentOtelAdapter {
           event.message.stopReason === 'error' &&
           event.message.errorMessage
         ) {
-          this.chatSpan.setAttribute(ATTR.ERROR_TYPE, 'llm_error');
+          this.chatSpan.setAttribute(ATTR_ERROR_TYPE, 'llm_error');
           this.chatSpan.setStatus({
             code: SpanStatusCode.ERROR,
             message: event.message.errorMessage,
@@ -475,15 +491,15 @@ export class PiCodingAgentOtelAdapter {
     event: Extract<PiExtensionEvent, {type: 'tool_call'}>
   ): void => {
     const attributes: Record<string, string> = {
-      [ATTR.GEN_AI_OPERATION_NAME]: 'execute_tool',
-      [ATTR.GEN_AI_TOOL_NAME]: event.toolName,
-      [ATTR.GEN_AI_TOOL_CALL_ID]: event.toolCallId,
+      [ATTR_GEN_AI_OPERATION_NAME]: 'execute_tool',
+      [ATTR_GEN_AI_TOOL_NAME]: event.toolName,
+      [ATTR_GEN_AI_TOOL_CALL_ID]: event.toolCallId,
     };
     if (this.conversationId) {
-      attributes[ATTR.GEN_AI_CONVERSATION_ID] = this.conversationId;
+      attributes[ATTR_GEN_AI_CONVERSATION_ID] = this.conversationId;
     }
     if (this.captureContent) {
-      attributes[ATTR.GEN_AI_TOOL_CALL_ARGUMENTS] = safeStringify(event.input);
+      attributes[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] = safeStringify(event.input);
     }
     const span = this.tracer.startSpan(
       `execute_tool ${event.toolName}`,
@@ -502,7 +518,7 @@ export class PiCodingAgentOtelAdapter {
     }
     this.toolSpans.delete(event.toolCallId);
     if (event.isError) {
-      span.setAttribute(ATTR.ERROR_TYPE, 'tool_error');
+      span.setAttribute(ATTR_ERROR_TYPE, 'tool_error');
       span.setStatus({
         code: SpanStatusCode.ERROR,
         message:
@@ -513,7 +529,7 @@ export class PiCodingAgentOtelAdapter {
     }
     if (this.captureContent) {
       span.setAttribute(
-        ATTR.GEN_AI_TOOL_CALL_RESULT,
+        ATTR_GEN_AI_TOOL_CALL_RESULT,
         safeStringify(event.content)
       );
     }
@@ -528,11 +544,11 @@ export class PiCodingAgentOtelAdapter {
       {
         kind: SpanKind.INTERNAL,
         attributes: {
-          [ATTR.PI_COMPACTION_REASON]: event.reason,
-          [ATTR.PI_COMPACTION_ABORTED]: event.aborted,
-          [ATTR.PI_COMPACTION_WILL_RETRY]: event.willRetry,
+          [ATTR_PI_COMPACTION_REASON]: event.reason,
+          [ATTR_PI_COMPACTION_ABORTED]: event.aborted,
+          [ATTR_PI_COMPACTION_WILL_RETRY]: event.willRetry,
           ...(this.conversationId
-            ? {[ATTR.GEN_AI_CONVERSATION_ID]: this.conversationId}
+            ? {[ATTR_GEN_AI_CONVERSATION_ID]: this.conversationId}
             : {}),
         },
       },
@@ -545,9 +561,9 @@ export class PiCodingAgentOtelAdapter {
     event: Extract<PiExtensionEvent, {type: 'auto_retry_start'}>
   ): void => {
     this.invokeAgentSpan?.addEvent('auto_retry_start', {
-      [ATTR.PI_AUTO_RETRY_ATTEMPT]: event.attempt,
-      [ATTR.PI_AUTO_RETRY_MAX_ATTEMPTS]: event.maxAttempts,
-      [ATTR.PI_AUTO_RETRY_ERROR_MESSAGE]: event.errorMessage,
+      [ATTR_PI_AUTO_RETRY_ATTEMPT]: event.attempt,
+      [ATTR_PI_AUTO_RETRY_MAX_ATTEMPTS]: event.maxAttempts,
+      [ATTR_PI_AUTO_RETRY_ERROR_MESSAGE]: event.errorMessage,
     });
   };
 
@@ -555,10 +571,10 @@ export class PiCodingAgentOtelAdapter {
     event: Extract<PiExtensionEvent, {type: 'auto_retry_end'}>
   ): void => {
     this.invokeAgentSpan?.addEvent('auto_retry_end', {
-      [ATTR.PI_AUTO_RETRY_SUCCESS]: event.success,
-      [ATTR.PI_AUTO_RETRY_ATTEMPT]: event.attempt,
+      [ATTR_PI_AUTO_RETRY_SUCCESS]: event.success,
+      [ATTR_PI_AUTO_RETRY_ATTEMPT]: event.attempt,
       ...(event.finalError
-        ? {[ATTR.PI_AUTO_RETRY_FINAL_ERROR]: event.finalError}
+        ? {[ATTR_PI_AUTO_RETRY_FINAL_ERROR]: event.finalError}
         : {}),
     });
   };
@@ -577,7 +593,7 @@ export class PiCodingAgentOtelAdapter {
   private endInvokeAgentSpan(): void {
     this.endChatSpan();
     for (const [, span] of this.toolSpans) {
-      span.setAttribute(ATTR.ERROR_TYPE, 'aborted');
+      span.setAttribute(ATTR_ERROR_TYPE, 'aborted');
       span.setStatus({
         code: SpanStatusCode.ERROR,
         message: 'Agent ended with open tool span',
@@ -587,10 +603,10 @@ export class PiCodingAgentOtelAdapter {
     this.toolSpans.clear();
     if (this.invokeAgentSpan) {
       this.invokeAgentSpan.setAttributes({
-        [ATTR.GEN_AI_USAGE_INPUT_TOKENS]: this.agentInputTokens,
-        [ATTR.GEN_AI_USAGE_OUTPUT_TOKENS]: this.agentOutputTokens,
-        [ATTR.GEN_AI_USAGE_TOTAL_TOKENS]: this.agentTotalTokens,
-        [ATTR.PI_USAGE_COST_USD]: this.agentCostUsd,
+        [ATTR_GEN_AI_USAGE_INPUT_TOKENS]: this.agentInputTokens,
+        [ATTR_GEN_AI_USAGE_OUTPUT_TOKENS]: this.agentOutputTokens,
+        [ATTR_GEN_AI_USAGE_TOTAL_TOKENS]: this.agentTotalTokens,
+        [ATTR_PI_USAGE_COST_USD]: this.agentCostUsd,
       });
       this.invokeAgentSpan.end();
       this.invokeAgentSpan = null;


### PR DESCRIPTION
# Align GenAI semconv constants with @opentelemetry/semantic-conventions

## Summary

Renames the local GenAI semconv constants in `sdks/node/src/genai/semconv.ts` to match upstream identifiers (`ATTR_GEN_AI_*`, `EVENT_GEN_AI_*`, `ATTR_ERROR_TYPE`), and propagates the rename through all call sites and tests. No wire-format change — string values are byte-identical.

## Why

[OTel JS guidance for unstable semconv](https://github.com/open-telemetry/opentelemetry-js/tree/main/semantic-conventions#unstable-semconv) recommends copying incubating definitions verbatim — same variable name, same value — instead of importing them. The old shape (`GEN_AI_ATTR.GEN_AI_PROVIDER_NAME`) preserved values but diverged on names, making diff-against-upstream and graduate-to-stable harder.

Simply put, this is the way that @opentelemetry/semantic-conventions recommends. In the future, to refresh the values, we only need to diff this file against the corresponding lines of * `@opentelemetry/semantic-conventions` `experimental_attributes.ts`.

This addresses this PR review comment: https://github.com/wandb/weave/pull/6847#discussion_r3268214854

## What changed

- `semconv.ts`: flat `ATTR_*` / `EVENT_*` exports matching upstream (tracked version:  @opentelemetry/semantic-conventions1.41.1). Two Weave-only extensions kept in a labeled section: `ATTR_GEN_AI_USAGE_TOTAL_TOKENS` and  `ATTR_GEN_AI_EVENT_CONTENT` (renamed from the mis-categorized  `GEN_AI_EVENT.CONTENT_ATTR`).
- All consumers updated: four emitters in `genai/`, seven test files,  and `integrations/piCodingAgent.ts` (its merged `ATTR` object was split into upstream imports + flat `ATTR_PI_*` locals).

## Test plan

- [x] `pnpm run build` — no new errors in modified files.
- [x] `pnpm test src/__tests__/genai` passes.
