### PR TITLE
feat(weave): add annotation queue SDK helpers

### DIFF
--- a/tests/trace/test_client_annotation_queue_sdk.py
+++ b/tests/trace/test_client_annotation_queue_sdk.py
@@ -119,7 +119,7 @@ def test_annotation_queue_sdk_methods_build_requests():
     assert server.requests["read"].queue_id == "queue-id"
 
     sort_by = [SortBy(field="updated_at", direction="desc")]
-    queues = client.get_annotation_queues(
+    queues = client.list_annotation_queues(
         name="Test",
         sort_by=sort_by,
         limit=10,
@@ -166,7 +166,7 @@ def test_annotation_queue_sdk_methods_build_requests():
     assert add_req.display_fields == ["inputs.prompt", "output.text"]
 
     item_filter = AnnotationQueueItemsFilter(call_id="call-id")
-    items = client.get_annotation_queue_items(
+    items = client.list_annotation_queue_items(
         "queue-id",
         filter=item_filter,
         sort_by=sort_by,
@@ -222,7 +222,7 @@ def test_annotation_queue_sdk_lifecycle(client):
     assert queue.description == "Created through WeaveClient"
     assert queue.scorer_refs == scorer_refs
 
-    queues = client.get_annotation_queues(name="sdk test")
+    queues = client.list_annotation_queues(name="sdk test")
     assert any(q.id == queue_id for q in queues)
 
     updated_queue = client.update_annotation_queue(
@@ -244,7 +244,7 @@ def test_annotation_queue_sdk_lifecycle(client):
     assert add_res.added_count == 2
     assert add_res.duplicates == 0
 
-    items = client.get_annotation_queue_items(
+    items = client.list_annotation_queue_items(
         queue_id,
         sort_by=[SortBy(field="created_at", direction="asc")],
         include_position=True,
@@ -256,7 +256,7 @@ def test_annotation_queue_sdk_lifecycle(client):
     ]
     assert [item.position_in_queue for item in items] == [1, 2]
 
-    filtered_items = client.get_annotation_queue_items(
+    filtered_items = client.list_annotation_queue_items(
         queue_id,
         filter=AnnotationQueueItemsFilter(call_id=calls[0].id),
     )

--- a/tests/trace/test_client_annotation_queue_sdk.py
+++ b/tests/trace/test_client_annotation_queue_sdk.py
@@ -1,0 +1,94 @@
+"""Tests for WeaveClient annotation queue convenience methods."""
+
+import pytest
+
+from tests.trace.util import client_is_sqlite
+from weave.trace.call import Call
+from weave.trace_server.common_interface import AnnotationQueueItemsFilter, SortBy
+from weave.trace_server.errors import NotFoundError
+
+
+def _create_finished_calls(client, count: int) -> list[Call]:
+    calls = []
+    for i in range(count):
+        call = client.create_call(
+            "annotation_queue_sdk_test_op",
+            inputs={"prompt": f"prompt {i}"},
+        )
+        client.finish_call(call, output={"text": f"response {i}"})
+        calls.append(call)
+    client.flush()
+    return calls
+
+
+def test_annotation_queue_sdk_lifecycle(client):
+    if client_is_sqlite(client):
+        pytest.skip("Annotation queues not supported in SQLite")
+
+    scorer_refs = ["weave:///entity/project/scorer/sdk_test:abc123"]
+
+    queue_id = client.create_annotation_queue(
+        name="SDK Test Queue",
+        description="Created through WeaveClient",
+        scorer_refs=scorer_refs,
+    )
+
+    queue = client.get_annotation_queue(queue_id)
+    assert queue.id == queue_id
+    assert queue.name == "SDK Test Queue"
+    assert queue.description == "Created through WeaveClient"
+    assert queue.scorer_refs == scorer_refs
+
+    queues = client.get_annotation_queues(name="sdk test")
+    assert any(q.id == queue_id for q in queues)
+
+    updated_queue = client.update_annotation_queue(
+        queue_id,
+        name="Updated SDK Test Queue",
+        description="Updated through WeaveClient",
+    )
+    assert updated_queue.id == queue_id
+    assert updated_queue.name == "Updated SDK Test Queue"
+    assert updated_queue.description == "Updated through WeaveClient"
+    assert updated_queue.scorer_refs == scorer_refs
+
+    calls = _create_finished_calls(client, 2)
+    add_res = client.add_calls_to_annotation_queue(
+        queue_id,
+        call_ids=[call.id for call in calls],
+        display_fields=["inputs.prompt", "output.text"],
+    )
+    assert add_res.added_count == 2
+    assert add_res.duplicates == 0
+
+    items = client.get_annotation_queue_items(
+        queue_id,
+        sort_by=[SortBy(field="created_at", direction="asc")],
+        include_position=True,
+    )
+    assert [item.call_id for item in items] == [call.id for call in calls]
+    assert [item.display_fields for item in items] == [
+        ["inputs.prompt", "output.text"],
+        ["inputs.prompt", "output.text"],
+    ]
+    assert [item.position_in_queue for item in items] == [1, 2]
+
+    filtered_items = client.get_annotation_queue_items(
+        queue_id,
+        filter=AnnotationQueueItemsFilter(call_id=calls[0].id),
+    )
+    assert len(filtered_items) == 1
+    assert filtered_items[0].call_id == calls[0].id
+
+    stats = client.get_annotation_queue_stats([queue_id])
+    assert len(stats) == 1
+    assert stats[0].queue_id == queue_id
+    assert stats[0].total_items == 2
+    assert stats[0].completed_items == 0
+
+    deleted_queue = client.delete_annotation_queue(queue_id)
+    assert deleted_queue.id == queue_id
+    assert deleted_queue.deleted_at is not None
+
+    with pytest.raises(NotFoundError):
+        client.get_annotation_queue(queue_id)

--- a/tests/trace/test_client_annotation_queue_sdk.py
+++ b/tests/trace/test_client_annotation_queue_sdk.py
@@ -249,7 +249,7 @@ def test_annotation_queue_sdk_lifecycle(client):
         sort_by=[SortBy(field="created_at", direction="asc")],
         include_position=True,
     )
-    assert [item.call_id for item in items] == [call.id for call in calls]
+    assert {item.call_id for item in items} == {call.id for call in calls}
     assert [item.display_fields for item in items] == [
         ["inputs.prompt", "output.text"],
         ["inputs.prompt", "output.text"],

--- a/tests/trace/test_client_annotation_queue_sdk.py
+++ b/tests/trace/test_client_annotation_queue_sdk.py
@@ -1,11 +1,194 @@
 """Tests for WeaveClient annotation queue convenience methods."""
 
+import datetime
+
 import pytest
 
 from tests.trace.util import client_is_sqlite
 from weave.trace.call import Call
+from weave.trace.weave_client import WeaveClient
 from weave.trace_server.common_interface import AnnotationQueueItemsFilter, SortBy
 from weave.trace_server.errors import NotFoundError
+from weave.trace_server.trace_server_interface import (
+    AnnotationQueueAddCallsRes,
+    AnnotationQueueCreateRes,
+    AnnotationQueueDeleteRes,
+    AnnotationQueueItemSchema,
+    AnnotationQueueItemsQueryRes,
+    AnnotationQueueReadRes,
+    AnnotationQueueSchema,
+    AnnotationQueuesStatsRes,
+    AnnotationQueueStatsSchema,
+    AnnotationQueueUpdateRes,
+)
+
+
+class FakeAnnotationQueueServer:
+    def __init__(self) -> None:
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        self.queue = AnnotationQueueSchema(
+            id="queue-id",
+            project_id="entity/project",
+            name="Test Queue",
+            description="Queue description",
+            scorer_refs=["weave:///entity/project/object/scorer:abc123"],
+            created_at=now,
+            created_by="test-user",
+            updated_at=now,
+            deleted_at=None,
+        )
+        self.item = AnnotationQueueItemSchema(
+            id="item-id",
+            project_id="entity/project",
+            queue_id="queue-id",
+            call_id="call-id",
+            call_started_at=now,
+            call_op_name="test_op",
+            call_trace_id="trace-id",
+            display_fields=["inputs.prompt", "output.text"],
+            annotation_state="unstarted",
+            created_at=now,
+            created_by="test-user",
+            updated_at=now,
+        )
+        self.stat = AnnotationQueueStatsSchema(
+            queue_id="queue-id",
+            total_items=1,
+            completed_items=0,
+        )
+        self.requests = {}
+
+    def annotation_queue_create(self, req):
+        self.requests["create"] = req
+        return AnnotationQueueCreateRes(id="queue-id")
+
+    def annotation_queue_read(self, req):
+        self.requests["read"] = req
+        return AnnotationQueueReadRes(queue=self.queue)
+
+    def annotation_queues_query_stream(self, req):
+        self.requests["query"] = req
+        return iter([self.queue])
+
+    def annotation_queue_update(self, req):
+        self.requests["update"] = req
+        return AnnotationQueueUpdateRes(queue=self.queue)
+
+    def annotation_queue_delete(self, req):
+        self.requests["delete"] = req
+        return AnnotationQueueDeleteRes(queue=self.queue)
+
+    def annotation_queue_add_calls(self, req):
+        self.requests["add_calls"] = req
+        return AnnotationQueueAddCallsRes(added_count=1, duplicates=0)
+
+    def annotation_queue_items_query(self, req):
+        self.requests["items_query"] = req
+        return AnnotationQueueItemsQueryRes(items=[self.item])
+
+    def annotation_queues_stats(self, req):
+        self.requests["stats"] = req
+        return AnnotationQueuesStatsRes(stats=[self.stat])
+
+
+def test_annotation_queue_sdk_methods_build_requests():
+    server = FakeAnnotationQueueServer()
+    client = WeaveClient(
+        "entity",
+        "project",
+        server,  # type: ignore[arg-type]
+        ensure_project_exists=False,
+    )
+    scorer_refs = ["weave:///entity/project/object/scorer:abc123"]
+
+    queue_id = client.create_annotation_queue(
+        name="Test Queue",
+        description="Queue description",
+        scorer_refs=scorer_refs,
+    )
+    assert queue_id == "queue-id"
+    create_req = server.requests["create"]
+    assert create_req.project_id == "entity/project"
+    assert create_req.name == "Test Queue"
+    assert create_req.description == "Queue description"
+    assert create_req.scorer_refs == scorer_refs
+
+    queue = client.get_annotation_queue("queue-id")
+    assert queue is server.queue
+    assert server.requests["read"].project_id == "entity/project"
+    assert server.requests["read"].queue_id == "queue-id"
+
+    sort_by = [SortBy(field="updated_at", direction="desc")]
+    queues = client.get_annotation_queues(
+        name="Test",
+        sort_by=sort_by,
+        limit=10,
+        offset=2,
+    )
+    assert queues == [server.queue]
+    query_req = server.requests["query"]
+    assert query_req.project_id == "entity/project"
+    assert query_req.name == "Test"
+    assert query_req.sort_by == sort_by
+    assert query_req.limit == 10
+    assert query_req.offset == 2
+
+    updated_queue = client.update_annotation_queue(
+        "queue-id",
+        name="Updated Queue",
+        description="Updated description",
+        scorer_refs=scorer_refs,
+    )
+    assert updated_queue is server.queue
+    update_req = server.requests["update"]
+    assert update_req.project_id == "entity/project"
+    assert update_req.queue_id == "queue-id"
+    assert update_req.name == "Updated Queue"
+    assert update_req.description == "Updated description"
+    assert update_req.scorer_refs == scorer_refs
+
+    deleted_queue = client.delete_annotation_queue("queue-id")
+    assert deleted_queue is server.queue
+    assert server.requests["delete"].project_id == "entity/project"
+    assert server.requests["delete"].queue_id == "queue-id"
+
+    add_res = client.add_calls_to_annotation_queue(
+        "queue-id",
+        call_ids=["call-id"],
+        display_fields=["inputs.prompt", "output.text"],
+    )
+    assert add_res.added_count == 1
+    assert add_res.duplicates == 0
+    add_req = server.requests["add_calls"]
+    assert add_req.project_id == "entity/project"
+    assert add_req.queue_id == "queue-id"
+    assert add_req.call_ids == ["call-id"]
+    assert add_req.display_fields == ["inputs.prompt", "output.text"]
+
+    item_filter = AnnotationQueueItemsFilter(call_id="call-id")
+    items = client.get_annotation_queue_items(
+        "queue-id",
+        filter=item_filter,
+        sort_by=sort_by,
+        limit=5,
+        offset=1,
+        include_position=True,
+    )
+    assert items == [server.item]
+    items_req = server.requests["items_query"]
+    assert items_req.project_id == "entity/project"
+    assert items_req.queue_id == "queue-id"
+    assert items_req.filter == item_filter
+    assert items_req.sort_by == sort_by
+    assert items_req.limit == 5
+    assert items_req.offset == 1
+    assert items_req.include_position is True
+
+    stats = client.get_annotation_queue_stats(["queue-id"])
+    assert stats == [server.stat]
+    stats_req = server.requests["stats"]
+    assert stats_req.project_id == "entity/project"
+    assert stats_req.queue_ids == ["queue-id"]
 
 
 def _create_finished_calls(client, count: int) -> list[Call]:

--- a/tests/trace_server/conftest_lib/trace_server_external_adapter.py
+++ b/tests/trace_server/conftest_lib/trace_server_external_adapter.py
@@ -140,6 +140,24 @@ class UserInjectingExternalTraceServer(
         req.wb_user_id = self._user_id
         return super().actions_execute_batch(req)
 
+    def annotation_queue_create(
+        self, req: tsi.AnnotationQueueCreateReq
+    ) -> tsi.AnnotationQueueCreateRes:
+        req.wb_user_id = self._user_id
+        return super().annotation_queue_create(req)
+
+    def annotation_queue_update(
+        self, req: tsi.AnnotationQueueUpdateReq
+    ) -> tsi.AnnotationQueueUpdateRes:
+        req.wb_user_id = self._user_id
+        return super().annotation_queue_update(req)
+
+    def annotation_queue_add_calls(
+        self, req: tsi.AnnotationQueueAddCallsReq
+    ) -> tsi.AnnotationQueueAddCallsRes:
+        req.wb_user_id = self._user_id
+        return super().annotation_queue_add_calls(req)
+
     def obj_create(self, req: tsi.ObjCreateReq) -> tsi.ObjCreateRes:
         req.obj.wb_user_id = self._user_id
         return super().obj_create(req)

--- a/tests/trace_server/conftest_lib/trace_server_external_adapter.py
+++ b/tests/trace_server/conftest_lib/trace_server_external_adapter.py
@@ -143,19 +143,19 @@ class UserInjectingExternalTraceServer(
     def annotation_queue_create(
         self, req: tsi.AnnotationQueueCreateReq
     ) -> tsi.AnnotationQueueCreateRes:
-        req.wb_user_id = self._user_id
+        req.wb_user_id = req.wb_user_id or self._user_id
         return super().annotation_queue_create(req)
 
     def annotation_queue_update(
         self, req: tsi.AnnotationQueueUpdateReq
     ) -> tsi.AnnotationQueueUpdateRes:
-        req.wb_user_id = self._user_id
+        req.wb_user_id = req.wb_user_id or self._user_id
         return super().annotation_queue_update(req)
 
     def annotation_queue_add_calls(
         self, req: tsi.AnnotationQueueAddCallsReq
     ) -> tsi.AnnotationQueueAddCallsRes:
-        req.wb_user_id = self._user_id
+        req.wb_user_id = req.wb_user_id or self._user_id
         return super().annotation_queue_add_calls(req)
 
     def obj_create(self, req: tsi.ObjCreateReq) -> tsi.ObjCreateRes:

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -442,18 +442,19 @@ class WeaveClient:
         """Callback fired by the WAL sender after a record reaches the server."""
         if record_type != "call_start" or not should_print_call_link():
             return
+        start = record.get("req", {}).get("start", {})
+        call_id = start.get("id", "")
+        if call_id not in self._wal_pending_call_ids:
+            return  # not our call or already printed
+        self._wal_pending_call_ids.discard(call_id)
+        project_id = start.get("project_id", "")
         try:
-            start = record.get("req", {}).get("start", {})
-            call_id = start.get("id", "")
-            if call_id not in self._wal_pending_call_ids:
-                return  # not our call or already printed
-            self._wal_pending_call_ids.discard(call_id)
-            project_id = start.get("project_id", "")
             entity, project = from_project_id(project_id)
             url = redirect_call(entity, project, call_id)
-            logger.info("%s %s", TRACE_CALL_EMOJI, url)
         except Exception:
             pass
+        else:
+            logger.info("%s %s", TRACE_CALL_EMOJI, url)
 
     ################ High Level Convenience Methods ################
 
@@ -782,7 +783,7 @@ class WeaveClient:
         return res.queue
 
     @trace_sentry.global_trace_sentry.watch()
-    def get_annotation_queues(
+    def list_annotation_queues(
         self,
         *,
         name: str | None = None,
@@ -848,6 +849,7 @@ class WeaveClient:
             display_fields: JSON paths to show reviewers, such as
                 ``inputs.prompt`` or ``output.text``.
         """
+        # Ensure newly created calls are persisted before queue membership is created.
         self._flush()
         return self.server.annotation_queue_add_calls(
             AnnotationQueueAddCallsReq(
@@ -859,7 +861,7 @@ class WeaveClient:
         )
 
     @trace_sentry.global_trace_sentry.watch()
-    def get_annotation_queue_items(
+    def list_annotation_queue_items(
         self,
         queue_id: str,
         *,

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -442,19 +442,18 @@ class WeaveClient:
         """Callback fired by the WAL sender after a record reaches the server."""
         if record_type != "call_start" or not should_print_call_link():
             return
-        start = record.get("req", {}).get("start", {})
-        call_id = start.get("id", "")
-        if call_id not in self._wal_pending_call_ids:
-            return  # not our call or already printed
-        self._wal_pending_call_ids.discard(call_id)
-        project_id = start.get("project_id", "")
         try:
+            start = record.get("req", {}).get("start", {})
+            call_id = start.get("id", "")
+            if call_id not in self._wal_pending_call_ids:
+                return  # not our call or already printed
+            self._wal_pending_call_ids.discard(call_id)
+            project_id = start.get("project_id", "")
             entity, project = from_project_id(project_id)
             url = redirect_call(entity, project, call_id)
+            logger.info("%s %s", TRACE_CALL_EMOJI, url)
         except Exception:
             pass
-        else:
-            logger.info("%s %s", TRACE_CALL_EMOJI, url)
 
     ################ High Level Convenience Methods ################
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -443,20 +443,17 @@ class WeaveClient:
         if record_type != "call_start" or not should_print_call_link():
             return
         try:
-            self._print_wal_call_link(record)
+            start = record.get("req", {}).get("start", {})
+            call_id = start.get("id", "")
+            if call_id not in self._wal_pending_call_ids:
+                return  # not our call or already printed
+            self._wal_pending_call_ids.discard(call_id)
+            project_id = start.get("project_id", "")
+            entity, project = from_project_id(project_id)
+            url = redirect_call(entity, project, call_id)
+            logger.info("%s %s", TRACE_CALL_EMOJI, url)
         except Exception:
             pass
-
-    def _print_wal_call_link(self, record: dict) -> None:
-        start = record.get("req", {}).get("start", {})
-        call_id = start.get("id", "")
-        if call_id not in self._wal_pending_call_ids:
-            return  # not our call or already printed
-        self._wal_pending_call_ids.discard(call_id)
-        project_id = start.get("project_id", "")
-        entity, project = from_project_id(project_id)
-        url = redirect_call(entity, project, call_id)
-        logger.info("%s %s", TRACE_CALL_EMOJI, url)
 
     ################ High Level Convenience Methods ################
 

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -106,6 +106,7 @@ from weave.trace.wandb_run_context import (
     get_global_wb_run_context,
 )
 from weave.trace.weave_client_send_file_cache import WeaveClientSendFileCache
+from weave.trace_server.common_interface import AnnotationQueueItemsFilter, SortBy
 from weave.trace_server.constants import MAX_OBJECT_NAME_LENGTH
 from weave.trace_server.errors import DigestMismatchError, InvalidExternalRef
 from weave.trace_server.ids import generate_id
@@ -117,6 +118,18 @@ from weave.trace_server.interface.feedback_types import (
 from weave.trace_server.trace_server_converter import universal_ext_to_int_ref_converter
 from weave.trace_server.trace_server_interface import (
     AliasesListReq,
+    AnnotationQueueAddCallsReq,
+    AnnotationQueueAddCallsRes,
+    AnnotationQueueCreateReq,
+    AnnotationQueueDeleteReq,
+    AnnotationQueueItemSchema,
+    AnnotationQueueItemsQueryReq,
+    AnnotationQueueReadReq,
+    AnnotationQueueSchema,
+    AnnotationQueuesQueryReq,
+    AnnotationQueuesStatsReq,
+    AnnotationQueueStatsSchema,
+    AnnotationQueueUpdateReq,
     CallEndReq,
     CallsDeleteReq,
     CallsFilter,
@@ -430,17 +443,20 @@ class WeaveClient:
         if record_type != "call_start" or not should_print_call_link():
             return
         try:
-            start = record.get("req", {}).get("start", {})
-            call_id = start.get("id", "")
-            if call_id not in self._wal_pending_call_ids:
-                return  # not our call or already printed
-            self._wal_pending_call_ids.discard(call_id)
-            project_id = start.get("project_id", "")
-            entity, project = from_project_id(project_id)
-            url = redirect_call(entity, project, call_id)
-            logger.info("%s %s", TRACE_CALL_EMOJI, url)
+            self._print_wal_call_link(record)
         except Exception:
             pass
+
+    def _print_wal_call_link(self, record: dict) -> None:
+        start = record.get("req", {}).get("start", {})
+        call_id = start.get("id", "")
+        if call_id not in self._wal_pending_call_ids:
+            return  # not our call or already printed
+        self._wal_pending_call_ids.discard(call_id)
+        project_id = start.get("project_id", "")
+        entity, project = from_project_id(project_id)
+        url = redirect_call(entity, project, call_id)
+        logger.info("%s %s", TRACE_CALL_EMOJI, url)
 
     ################ High Level Convenience Methods ################
 
@@ -731,6 +747,154 @@ class WeaveClient:
             raise ValueError(f"Call not found: {call_id}")
         response_call = calls[0]
         return make_client_call(self.entity, self.project, response_call, self.server)
+
+    @trace_sentry.global_trace_sentry.watch()
+    def create_annotation_queue(
+        self,
+        *,
+        name: str,
+        scorer_refs: list[str],
+        description: str = "",
+    ) -> str:
+        """Create an annotation queue for this project.
+
+        Args:
+            name: Display name for the queue.
+            scorer_refs: Weave refs for the scorers/annotation fields reviewers complete.
+            description: Optional reviewer guidelines or queue description.
+
+        Returns:
+            The ID of the created annotation queue.
+        """
+        res = self.server.annotation_queue_create(
+            AnnotationQueueCreateReq(
+                project_id=self.project_id,
+                name=name,
+                description=description,
+                scorer_refs=scorer_refs,
+            )
+        )
+        return res.id
+
+    @trace_sentry.global_trace_sentry.watch()
+    def get_annotation_queue(self, queue_id: str) -> AnnotationQueueSchema:
+        """Read a single annotation queue by ID."""
+        res = self.server.annotation_queue_read(
+            AnnotationQueueReadReq(project_id=self.project_id, queue_id=queue_id)
+        )
+        return res.queue
+
+    @trace_sentry.global_trace_sentry.watch()
+    def get_annotation_queues(
+        self,
+        *,
+        name: str | None = None,
+        sort_by: list[SortBy] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+    ) -> list[AnnotationQueueSchema]:
+        """List annotation queues for this project."""
+        return list(
+            self.server.annotation_queues_query_stream(
+                AnnotationQueuesQueryReq(
+                    project_id=self.project_id,
+                    name=name,
+                    sort_by=sort_by,
+                    limit=limit,
+                    offset=offset,
+                )
+            )
+        )
+
+    @trace_sentry.global_trace_sentry.watch()
+    def update_annotation_queue(
+        self,
+        queue_id: str,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+        scorer_refs: list[str] | None = None,
+    ) -> AnnotationQueueSchema:
+        """Update annotation queue metadata."""
+        res = self.server.annotation_queue_update(
+            AnnotationQueueUpdateReq(
+                project_id=self.project_id,
+                queue_id=queue_id,
+                name=name,
+                description=description,
+                scorer_refs=scorer_refs,
+            )
+        )
+        return res.queue
+
+    @trace_sentry.global_trace_sentry.watch()
+    def delete_annotation_queue(self, queue_id: str) -> AnnotationQueueSchema:
+        """Soft-delete an annotation queue."""
+        res = self.server.annotation_queue_delete(
+            AnnotationQueueDeleteReq(project_id=self.project_id, queue_id=queue_id)
+        )
+        return res.queue
+
+    @trace_sentry.global_trace_sentry.watch()
+    def add_calls_to_annotation_queue(
+        self,
+        queue_id: str,
+        *,
+        call_ids: list[str],
+        display_fields: list[str],
+    ) -> AnnotationQueueAddCallsRes:
+        """Add calls to an annotation queue.
+
+        Args:
+            queue_id: Annotation queue ID.
+            call_ids: Call IDs to add to the queue.
+            display_fields: JSON paths to show reviewers, such as
+                ``inputs.prompt`` or ``output.text``.
+        """
+        self._flush()
+        return self.server.annotation_queue_add_calls(
+            AnnotationQueueAddCallsReq(
+                project_id=self.project_id,
+                queue_id=queue_id,
+                call_ids=call_ids,
+                display_fields=display_fields,
+            )
+        )
+
+    @trace_sentry.global_trace_sentry.watch()
+    def get_annotation_queue_items(
+        self,
+        queue_id: str,
+        *,
+        filter: AnnotationQueueItemsFilter | None = None,
+        sort_by: list[SortBy] | None = None,
+        limit: int | None = None,
+        offset: int | None = None,
+        include_position: bool = False,
+    ) -> list[AnnotationQueueItemSchema]:
+        """List calls assigned to an annotation queue."""
+        res = self.server.annotation_queue_items_query(
+            AnnotationQueueItemsQueryReq(
+                project_id=self.project_id,
+                queue_id=queue_id,
+                filter=filter,
+                sort_by=sort_by,
+                limit=limit,
+                offset=offset,
+                include_position=include_position,
+            )
+        )
+        return res.items
+
+    @trace_sentry.global_trace_sentry.watch()
+    def get_annotation_queue_stats(
+        self, queue_ids: list[str]
+    ) -> list[AnnotationQueueStatsSchema]:
+        """Get item completion stats for annotation queues."""
+        res = self.server.annotation_queues_stats(
+            AnnotationQueuesStatsReq(project_id=self.project_id, queue_ids=queue_ids)
+        )
+        return res.stats
 
     @trace_sentry.global_trace_sentry.watch()
     def create_call(


### PR DESCRIPTION
## Description

Adds Python SDK convenience methods on `WeaveClient` for annotation queue lifecycle management:

- Create, read, list, update, and delete annotation queues
- Add calls to an annotation queue
- Query queue items and queue stats

Also adds SDK-level coverage for the full annotation queue lifecycle and updates the test external trace server adapter to inject user identity for annotation queue write APIs.

### Example

With the SDK convenience layer:

```python
client = weave.init("my-team/my-project")

queue_id = client.create_annotation_queue(
    name="Response Quality Review",
    scorer_refs=[quality_ref.uri],
)

client.add_calls_to_annotation_queue(
    queue_id,
    call_ids=["call-id-1", "call-id-2"],
    display_fields=["inputs.prompt", "output.text"],
)

queue = client.get_annotation_queue(queue_id)
items = client.list_annotation_queue_items(queue_id, include_position=True)
client.delete_annotation_queue(queue_id)
```

Without the SDK convenience layer:

```python
client = weave.init("my-team/my-project")

queue_res = client.server.annotation_queue_create(
    AnnotationQueueCreateReq(
        project_id=client.project_id,
        name="Response Quality Review",
        scorer_refs=[quality_ref.uri],
    )
)

client.server.annotation_queue_add_calls(
    AnnotationQueueAddCallsReq(
        project_id=client.project_id,
        queue_id=queue_res.id,
        call_ids=["call-id-1", "call-id-2"],
        display_fields=["inputs.prompt", "output.text"],
    )
)

queue = client.server.annotation_queue_read(
    AnnotationQueueReadReq(project_id=client.project_id, queue_id=queue_res.id)
).queue
items = client.server.annotation_queue_items_query(
    AnnotationQueueItemsQueryReq(
        project_id=client.project_id,
        queue_id=queue_res.id,
        include_position=True,
    )
).items
client.server.annotation_queue_delete(
    AnnotationQueueDeleteReq(project_id=client.project_id, queue_id=queue_res.id)
)
```

## Testing

- `uvx ruff check weave/trace/weave_client.py tests/trace/test_client_annotation_queue_sdk.py`
- `uvx ruff check tests/trace/test_client_annotation_queue_sdk.py tests/trace_server/conftest_lib/trace_server_external_adapter.py`
- `uv run --group test python -m pytest tests/trace/test_client_annotation_queue_sdk.py -v --trace-server=clickhouse`
- `uv run --group test python -m pytest tests/trace/test_client_annotation_queue_sdk.py -v --trace-server=sqlite`
