### PR TITLE
fix(weave): handle coexisting JSON string and dotted OTel attribute keys

### DIFF
--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -925,6 +925,28 @@ class TestAttributes:
             {"role": "assistant", "content": "hello", "extra": True}
         ]
 
+    def test_expand_attributes_nested_list_merge_preserves_dotted_only_elements(self):
+        """A nested-list element present only in dotted attrs must survive a later JSON blob.
+
+        Top-level completion lists are index-merged, but _deep_merge clobbers nested
+        lists (base[key] = value), so a second tool_call sent only via dotted keys is
+        silently dropped when the gen_ai.completion JSON blob is emitted after the
+        dotted attributes. Same data, different OTel emission order -> a tool call
+        vanishes from the stored call.
+        """
+        flat_attrs = [
+            ("gen_ai.completion.0.tool_calls.0.id", "call_0"),
+            ("gen_ai.completion.0.tool_calls.1.id", "call_1"),
+            ("gen_ai.completion.0.tool_calls.1.type", "function"),
+            (
+                "gen_ai.completion",
+                '[{"role": "assistant", "tool_calls": [{"id": "call_0", "type": "function"}]}]',
+            ),
+        ]
+        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
+        tool_calls = result["gen_ai"]["completion"][0]["tool_calls"]
+        assert [tc["id"] for tc in tool_calls] == ["call_0", "call_1"]
+
 
 def create_attributes(d: dict[str, Any]):
     return expand_attributes(d.items())

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -915,7 +915,10 @@ class TestAttributes:
         """JSON string arriving after dotted subkeys should merge in extra fields."""
         flat_attrs = [
             ("gen_ai.completion.0.role", "assistant"),
-            ("gen_ai.completion", '[{"role": "assistant", "content": "hello", "extra": true}]'),
+            (
+                "gen_ai.completion",
+                '[{"role": "assistant", "content": "hello", "extra": true}]',
+            ),
         ]
         result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
         assert result["gen_ai"]["completion"] == [
@@ -2075,9 +2078,7 @@ def test_otel_export_json_string_and_dotted_completion_keys(
     response = client.server.otel_export(export_req)
     assert isinstance(response, tsi.OTelExportRes)
 
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(project_id=project_id)
-    )
+    res = client.server.calls_query(tsi.CallsQueryReq(project_id=project_id))
     # BUG: span is silently rejected — this assert fails (0 calls instead of 1)
     assert len(res.calls) == 1, (
         f"Expected 1 call but got {len(res.calls)}. "

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -877,6 +877,51 @@ class TestAttributes:
             assert "gen_ai.prompt" in msg
             assert "Do not" in msg or "Invalid attribute structure" in msg
 
+    def test_expand_attributes_json_string_and_dotted_subkeys_coexist(self):
+        """JSON string + dotted subkeys for the same path should merge, not conflict."""
+        flat_attrs = [
+            ("gen_ai.completion", '[{"role": "assistant", "content": "hello"}]'),
+            ("gen_ai.completion.0.role", "assistant"),
+        ]
+        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
+        assert result["gen_ai"]["completion"] == [
+            {"role": "assistant", "content": "hello"}
+        ]
+
+    def test_expand_attributes_dotted_subkeys_then_json_string_coexist(self):
+        """Same merge but with reversed attribute ordering."""
+        flat_attrs = [
+            ("gen_ai.completion.0.role", "assistant"),
+            ("gen_ai.completion.0.content", "hello"),
+            ("gen_ai.completion", '[{"role": "assistant", "content": "hello"}]'),
+        ]
+        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
+        assert result["gen_ai"]["completion"] == [
+            {"role": "assistant", "content": "hello"}
+        ]
+
+    def test_expand_attributes_dotted_subkeys_override_json_string(self):
+        """Dotted subkeys arriving after JSON string should win at leaves."""
+        flat_attrs = [
+            ("gen_ai.completion", '[{"role": "assistant", "content": "original"}]'),
+            ("gen_ai.completion.0.content", "overridden"),
+        ]
+        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
+        assert result["gen_ai"]["completion"] == [
+            {"role": "assistant", "content": "overridden"}
+        ]
+
+    def test_expand_attributes_json_string_adds_fields_to_dotted(self):
+        """JSON string arriving after dotted subkeys should merge in extra fields."""
+        flat_attrs = [
+            ("gen_ai.completion.0.role", "assistant"),
+            ("gen_ai.completion", '[{"role": "assistant", "content": "hello", "extra": true}]'),
+        ]
+        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
+        assert result["gen_ai"]["completion"] == [
+            {"role": "assistant", "content": "hello", "extra": True}
+        ]
+
 
 def create_attributes(d: dict[str, Any]):
     return expand_attributes(d.items())
@@ -1980,3 +2025,71 @@ def test_otel_span_wandb_attributes_and_data_routing(
     client.server.calls_delete(
         tsi.CallsDeleteReq(project_id=project_id, call_ids=[call.id], wb_user_id=None)
     )
+
+
+def test_otel_export_json_string_and_dotted_completion_keys(
+    client: weave_client.WeaveClient,
+):
+    """Repro: gen_ai.completion as JSON string + gen_ai.completion.0.role silently drops span.
+
+    When an OTel exporter sends both:
+      - gen_ai.completion = '[{"role": "assistant", "content": "hello"}]' (JSON string)
+      - gen_ai.completion.0.role = "assistant" (dotted subkey)
+    the JSON string is auto-parsed into a list, then _validate_structure raises
+    AttributePathConflictError because list is not dict. The span is rejected —
+    otel_export returns 200 but no call appears in the database.
+    """
+    export_req = create_test_export_request()
+    project_id = client.project_id
+    export_req.project_id = project_id
+    export_req.wb_user_id = "abcd123"
+
+    processed_spans_list = export_req.processed_spans
+    span = processed_spans_list[0].resource_spans.scope_spans[0].spans[0]
+    del span.attributes[:]
+
+    kv_json = KeyValue()
+    kv_json.key = "gen_ai.completion"
+    kv_json.value.string_value = json.dumps(
+        [{"role": "assistant", "content": "Quantum computing uses qubits."}]
+    )
+    span.attributes.append(kv_json)
+
+    kv_role = KeyValue()
+    kv_role.key = "gen_ai.completion.0.role"
+    kv_role.value.string_value = "assistant"
+    span.attributes.append(kv_role)
+
+    kv_content = KeyValue()
+    kv_content.key = "gen_ai.completion.0.content"
+    kv_content.value.string_value = "Quantum computing uses qubits."
+    span.attributes.append(kv_content)
+
+    kv_model = KeyValue()
+    kv_model.key = "gen_ai.response.model"
+    kv_model.value.string_value = "gpt-4"
+    span.attributes.append(kv_model)
+
+    export_req.processed_spans = processed_spans_list
+
+    response = client.server.otel_export(export_req)
+    assert isinstance(response, tsi.OTelExportRes)
+
+    res = client.server.calls_query(
+        tsi.CallsQueryReq(project_id=project_id)
+    )
+    # BUG: span is silently rejected — this assert fails (0 calls instead of 1)
+    assert len(res.calls) == 1, (
+        f"Expected 1 call but got {len(res.calls)}. "
+        "The span was silently rejected due to AttributePathConflictError "
+        "when gen_ai.completion (auto-parsed JSON list) conflicts with "
+        "gen_ai.completion.0.role dotted subkey."
+    )
+
+    call = res.calls[0]
+    assert call.output is not None
+    assert "gen_ai.completion" in call.output
+    completions = call.output["gen_ai.completion"]
+    assert isinstance(completions, list)
+    assert len(completions) == 1
+    assert completions[0]["role"] == "assistant"

--- a/weave/trace_server/opentelemetry/helpers.py
+++ b/weave/trace_server/opentelemetry/helpers.py
@@ -151,10 +151,20 @@ def _list_to_numeric_dict(lst: list) -> dict[str, Any]:
 
 
 def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> None:
-    """Deep merge override into base in-place. Override values win at leaves."""
+    """Deep merge override into base in-place. Override values win at leaves.
+
+    When a key holds a structured value (dict or list) on both sides, merge it
+    recursively via _merge_structure so nested lists index-merge (preserving
+    elements present in only one encoding) instead of being clobbered. Otherwise
+    the override value wins.
+    """
     for key, value in override.items():
-        if key in base and isinstance(base[key], dict) and isinstance(value, dict):
-            _deep_merge(base[key], value)
+        if (
+            key in base
+            and isinstance(base[key], (dict, list))
+            and isinstance(value, (dict, list))
+        ):
+            _merge_structure(base, key, value)
         else:
             base[key] = value
 

--- a/weave/trace_server/opentelemetry/helpers.py
+++ b/weave/trace_server/opentelemetry/helpers.py
@@ -145,13 +145,29 @@ def _get_value_from_nested_dict(d: dict[str, Any], key: str) -> Any:
     return current
 
 
+def _list_to_numeric_dict(lst: list) -> dict[str, Any]:
+    """Convert a list to a dict with numeric string keys (inverse of convert_numeric_keys_to_list)."""
+    return {str(i): v for i, v in enumerate(lst)}
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> None:
+    """Deep merge override into base in-place. Override values win at leaves."""
+    for key, value in override.items():
+        if key in base and isinstance(base[key], dict) and isinstance(value, dict):
+            _deep_merge(base[key], value)
+        else:
+            base[key] = value
+
+
 def _validate_structure(d: dict[str, Any], key: str, value: Any) -> None:
     """Ensure setting `value` at dot-path `key` won't corrupt structure.
 
     Validation rules:
     - Disallow placing a primitive at a path that already contains a mapping
       (dict or list).
-    - Disallow descending into a non-dict value for any parent segment.
+    - Disallow descending into a non-dict value for any parent segment
+      (unless the value is a list and the next path segment is a numeric index,
+      which represents redundant OTel attribute encoding).
     - Disallow overwriting an existing mapping at the leaf with a primitive
       when subkeys already exist for that path.
     """
@@ -185,6 +201,9 @@ def _validate_structure(d: dict[str, Any], key: str, value: Any) -> None:
         # we detect that we must descend into a non-dict (primitive) value.
         parent_path = ".".join(parts[: i + 1])
         if part in current and not isinstance(current[part], dict):
+            if isinstance(current[part], list) and parts[i + 1].isdigit():
+                current = _list_to_numeric_dict(current[part])
+                continue
             # We must descend, but parent is a primitive -> conflict
             raise AttributePathConflictError(
                 parent_key=parent_path,
@@ -218,18 +237,46 @@ def _validate_structure(d: dict[str, Any], key: str, value: Any) -> None:
             )
 
 
+def _merge_structure(current: dict, key: str, value: Any) -> None:
+    """Merge a structured value (dict/list) into an existing structured value at key."""
+    existing = current[key]
+    base = _list_to_numeric_dict(existing) if isinstance(existing, list) else existing
+    override = _list_to_numeric_dict(value) if isinstance(value, list) else value
+    _deep_merge(base, override)
+    current[key] = base
+
+
 def _set_value_in_nested_dict(d: dict[str, Any], key: str, value: Any) -> None:
     """Set a value in a nested dictionary using a dot-separated key."""
     _validate_structure(d, key, value)
     if "." not in key:
+        if (
+            key in d
+            and isinstance(d[key], (dict, list))
+            and isinstance(value, (dict, list))
+        ):
+            _merge_structure(d, key, value)
+            return
         d[key] = value
         return
 
     parts = key.split(".")
     current = d
     for part in parts[:-1]:
+        existing = current.get(part)
+        if isinstance(existing, list):
+            current[part] = _list_to_numeric_dict(existing)
         current = current.setdefault(part, {})
-    current[parts[-1]] = value
+
+    last = parts[-1]
+    if (
+        last in current
+        and isinstance(current[last], (dict, list))
+        and isinstance(value, (dict, list))
+    ):
+        _merge_structure(current, last, value)
+        return
+    current[last] = value
 
 
 def convert_numeric_keys_to_list(


### PR DESCRIPTION
- When an OTel exporter sends both `gen_ai.completion` as a JSON string and `gen_ai.completion.0.role` as a dotted subkey, the span was silently rejected due to `AttributePathConflictError`
- Adds `_list_to_numeric_dict` to convert lists to numeric-keyed dicts so `_validate_structure` can descend into them
- Adds `_deep_merge` and `_merge_structure` so structured values (JSON string → parsed list, dotted subkeys → nested dict) merge instead of conflicting
- Unit tests for all merge orderings + integration test confirming the span is no longer dropped

- Fixes WB-34637