### PR TITLE
feat(weave): add ContentAdaptable adapter API to Content with Google GenAI adapters

### DIFF
--- a/tests/trace/type_handlers/Content/test_content_adapters.py
+++ b/tests/trace/type_handlers/Content/test_content_adapters.py
@@ -1,0 +1,407 @@
+"""Tests for the ContentAdaptable extension API."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from weave.type_wrappers.Content.content import (
+    Content,
+    ContentAdaptable,
+    _content_adapters,
+    register_content_adapter,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_adapter_registry():
+    """Snapshot and restore the global adapter list around each test."""
+    before = list(_content_adapters)
+    yield
+    _content_adapters[:] = before
+
+
+# ── Dummy adapter for unit tests ────────────────────────────────────────
+
+
+class DummyAdaptable(ContentAdaptable):
+    kind: str
+    payload: str
+
+    def to_content(self) -> Content:
+        return Content.from_text(self.payload)
+
+
+# ── ContentAdaptable base ───────────────────────────────────────────────
+
+
+class TestContentAdaptable:
+    def test_subclass_validates(self):
+        obj = DummyAdaptable.model_validate({"kind": "dummy", "payload": "hello"})
+        assert obj.kind == "dummy"
+        assert obj.payload == "hello"
+
+    def test_subclass_rejects_missing_fields(self):
+        with pytest.raises(ValidationError):
+            DummyAdaptable.model_validate({"kind": "dummy"})
+
+    def test_extra_fields_allowed(self):
+        obj = DummyAdaptable.model_validate(
+            {"kind": "dummy", "payload": "hi", "extra": 123}
+        )
+        assert obj.payload == "hi"
+
+    def test_to_content(self):
+        obj = DummyAdaptable(kind="dummy", payload="test")
+        content = obj.to_content()
+        assert content.as_string() == "test"
+
+
+# ── is_content_like ─────────────────────────────────────────────────────
+
+
+class TestIsContentLike:
+    def test_registered_adapter_matches_dict(self):
+        register_content_adapter(DummyAdaptable)
+        assert Content.is_content_like({"kind": "dummy", "payload": "hello"})
+
+    def test_unregistered_adapter_not_matched(self):
+        assert not Content.is_content_like({"kind": "dummy", "payload": "hello"})
+
+    def test_validated_model_instance_matches(self):
+        obj = DummyAdaptable(kind="dummy", payload="hello")
+        assert Content.is_content_like(obj)
+
+    def test_builtin_types(self):
+        assert Content.is_content_like("hello")
+        assert Content.is_content_like(b"bytes")
+
+    def test_rejects_unknown_types(self):
+        assert not Content.is_content_like(42)
+        assert not Content.is_content_like(None)
+        assert not Content.is_content_like([1, 2, 3])
+
+    def test_dict_not_matching_any_adapter(self):
+        register_content_adapter(DummyAdaptable)
+        assert not Content.is_content_like({"unrelated": "dict"})
+
+
+# ── _from_guess with adapters ───────────────────────────────────────────
+
+
+class TestFromGuessWithAdapter:
+    def test_from_guess_with_validated_model(self):
+        register_content_adapter(DummyAdaptable)
+        obj = DummyAdaptable(kind="dummy", payload="typed input")
+        content = Content._from_guess(obj)
+        assert content.as_string() == "typed input"
+
+    def test_from_guess_validates_raw_dict(self):
+        register_content_adapter(DummyAdaptable)
+        content = Content._from_guess({"kind": "dummy", "payload": "raw dict"})
+        assert content.as_string() == "raw dict"
+
+    def test_from_guess_falls_back_to_builtins(self):
+        register_content_adapter(DummyAdaptable)
+        content = Content._from_guess("plain text input")
+        assert content.as_string() == "plain text input"
+
+    def test_from_guess_adapter_priority(self):
+        """First matching adapter wins."""
+
+        class HighPriority(ContentAdaptable):
+            kind: str
+
+            def to_content(self) -> Content:
+                return Content.from_text("high priority")
+
+        register_content_adapter(HighPriority)
+        register_content_adapter(DummyAdaptable)
+
+        content = Content._from_guess({"kind": "dummy", "payload": "low priority"})
+        assert content.as_string() == "high priority"
+
+
+# ── OTel GenAI blob adapter ─────────────────────────────────────────────
+
+
+class TestGenAIBlobAdapter:
+    @pytest.fixture(autouse=True)
+    def _register_genai_adapter(self):
+        import weave.type_wrappers.Content.adapters  # noqa: F401
+
+    def test_blob_dict_is_content_like(self):
+        blob = {"type": "blob", "data": "AAAA", "mime_type": "image/png"}
+        assert Content.is_content_like(blob)
+
+    def test_blob_dict_missing_fields_not_content_like(self):
+        assert not Content.is_content_like({"type": "blob"})
+        assert not Content.is_content_like({"type": "blob", "data": "AAAA"})
+        assert not Content.is_content_like(
+            {"type": "blob", "mime_type": "image/png"}
+        )
+
+    def test_non_blob_dict_not_content_like(self):
+        assert not Content.is_content_like({"type": "text", "content": "hi"})
+
+    def test_from_guess_converts_blob(self):
+        raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        b64 = base64.b64encode(raw).decode("ascii")
+        blob = {"type": "blob", "data": b64, "mime_type": "image/png"}
+
+        content = Content._from_guess(blob)
+        assert content.data == raw
+        assert content.mimetype == "image/png"
+
+    def test_from_guess_with_validated_genai_blob(self):
+        from weave.type_wrappers.Content.adapters import GenAIBlob
+
+        raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        b64 = base64.b64encode(raw).decode("ascii")
+        blob = GenAIBlob(type="blob", data=b64, mime_type="image/png")
+
+        content = Content._from_guess(blob)
+        assert content.data == raw
+        assert content.mimetype == "image/png"
+
+
+# ── Google Part adapters ────────────────────────────────────────────────
+
+
+class TestGooglePartAdapters:
+    """Test every Google Part adapter can convert its field to Content."""
+
+    @pytest.fixture(autouse=True)
+    def _register_adapters(self):
+        import weave.type_wrappers.Content.adapters  # noqa: F401
+
+    # -- inline_data (active by default) ----------------------------------
+
+    def test_inline_data_from_base64_string(self):
+        from weave.type_wrappers.Content.adapters import GooglePartInlineData
+
+        raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        b64 = base64.b64encode(raw).decode("ascii")
+        adapter = GooglePartInlineData.model_validate(
+            {"inline_data": {"data": b64, "mime_type": "image/png"}}
+        )
+        content = adapter.to_content()
+        assert content.data == raw
+        assert content.mimetype == "image/png"
+        assert content.metadata["adapter_type"] == "google:part:inline_data"
+
+    def test_inline_data_from_raw_bytes(self):
+        from weave.type_wrappers.Content.adapters import GooglePartInlineData
+
+        raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * 100
+        adapter = GooglePartInlineData.model_validate(
+            {"inline_data": {"data": raw, "mime_type": "image/png"}}
+        )
+        content = adapter.to_content()
+        assert content.data == raw
+
+    def test_inline_data_via_from_guess(self):
+        part = {"inline_data": {"data": "AAAA", "mime_type": "image/png"}}
+        assert Content.is_content_like(part)
+        content = Content._from_guess(part)
+        assert content.metadata["adapter_type"] == "google:part:inline_data"
+
+    # -- text -------------------------------------------------------------
+
+    def test_text_adapter(self):
+        from weave.type_wrappers.Content.adapters import GooglePartText
+
+        adapter = GooglePartText(text="Hello world")
+        content = adapter.to_content()
+        assert content.as_string() == "Hello world"
+        assert content.metadata["adapter_type"] == "google:part:text"
+
+    # -- file_data --------------------------------------------------------
+
+    def test_file_data_adapter(self):
+        from weave.type_wrappers.Content.adapters import GooglePartFileData
+
+        adapter = GooglePartFileData.model_validate(
+            {
+                "file_data": {
+                    "file_uri": "gs://bucket/image.png",
+                    "mime_type": "image/png",
+                }
+            }
+        )
+        content = adapter.to_content()
+        payload = json.loads(content.as_string())
+        assert payload["file_uri"] == "gs://bucket/image.png"
+        assert content.metadata["adapter_type"] == "google:part:file_data"
+
+    # -- executable_code --------------------------------------------------
+
+    def test_executable_code_adapter(self):
+        from weave.type_wrappers.Content.adapters import GooglePartExecutableCode
+
+        adapter = GooglePartExecutableCode.model_validate(
+            {"executable_code": {"code": "print('hi')", "language": "PYTHON"}}
+        )
+        content = adapter.to_content()
+        assert content.as_string() == "print('hi')"
+        assert content.metadata["language"] == "PYTHON"
+
+    # -- code_execution_result --------------------------------------------
+
+    def test_code_execution_result_adapter(self):
+        from weave.type_wrappers.Content.adapters import (
+            GooglePartCodeExecutionResult,
+        )
+
+        adapter = GooglePartCodeExecutionResult.model_validate(
+            {"code_execution_result": {"outcome": "SUCCESS", "output": "hi\n"}}
+        )
+        content = adapter.to_content()
+        assert content.as_string() == "hi\n"
+        assert content.metadata["outcome"] == "SUCCESS"
+
+    # -- function_call ----------------------------------------------------
+
+    def test_function_call_adapter(self):
+        from weave.type_wrappers.Content.adapters import GooglePartFunctionCall
+
+        adapter = GooglePartFunctionCall.model_validate(
+            {"function_call": {"name": "get_weather", "args": {"city": "NYC"}}}
+        )
+        content = adapter.to_content()
+        payload = json.loads(content.as_string())
+        assert payload["name"] == "get_weather"
+        assert payload["args"]["city"] == "NYC"
+
+    # -- function_response ------------------------------------------------
+
+    def test_function_response_adapter(self):
+        from weave.type_wrappers.Content.adapters import (
+            GooglePartFunctionResponse,
+        )
+
+        adapter = GooglePartFunctionResponse.model_validate(
+            {
+                "function_response": {
+                    "name": "get_weather",
+                    "response": {"temp": 72},
+                }
+            }
+        )
+        content = adapter.to_content()
+        payload = json.loads(content.as_string())
+        assert payload["response"]["temp"] == 72
+
+    # -- thought ----------------------------------------------------------
+
+    def test_thought_adapter(self):
+        from weave.type_wrappers.Content.adapters import GooglePartThought
+
+        adapter = GooglePartThought(thought=True)
+        content = adapter.to_content()
+        assert content.as_string() == "True"
+
+    # -- thought_signature ------------------------------------------------
+
+    def test_thought_signature_adapter(self):
+        from weave.type_wrappers.Content.adapters import (
+            GooglePartThoughtSignature,
+        )
+
+        sig = b"\xde\xad\xbe\xef"
+        adapter = GooglePartThoughtSignature(thought_signature=sig)
+        content = adapter.to_content()
+        assert content.data == sig
+
+    # -- tool_call / tool_response ----------------------------------------
+
+    def test_tool_call_adapter(self):
+        from weave.type_wrappers.Content.adapters import GooglePartToolCall
+
+        adapter = GooglePartToolCall(tool_call={"id": "tc_1", "name": "search"})
+        content = adapter.to_content()
+        assert json.loads(content.as_string())["id"] == "tc_1"
+
+    def test_tool_response_adapter(self):
+        from weave.type_wrappers.Content.adapters import GooglePartToolResponse
+
+        adapter = GooglePartToolResponse(
+            tool_response={"id": "tc_1", "output": "done"}
+        )
+        content = adapter.to_content()
+        assert json.loads(content.as_string())["output"] == "done"
+
+    # -- video_metadata ---------------------------------------------------
+
+    def test_video_metadata_adapter(self):
+        from weave.type_wrappers.Content.adapters import GooglePartVideoMetadata
+
+        adapter = GooglePartVideoMetadata(
+            video_metadata={"start_offset": "0s", "end_offset": "5s"}
+        )
+        content = adapter.to_content()
+        assert json.loads(content.as_string())["start_offset"] == "0s"
+
+    # -- media_resolution / part_metadata ---------------------------------
+
+    def test_media_resolution_adapter(self):
+        from weave.type_wrappers.Content.adapters import (
+            GooglePartMediaResolution,
+        )
+
+        adapter = GooglePartMediaResolution(
+            media_resolution={"level": "MEDIUM"}
+        )
+        content = adapter.to_content()
+        assert json.loads(content.as_string())["level"] == "MEDIUM"
+
+    def test_part_metadata_adapter(self):
+        from weave.type_wrappers.Content.adapters import GooglePartMetadata
+
+        adapter = GooglePartMetadata(part_metadata={"source": "upload"})
+        content = adapter.to_content()
+        assert json.loads(content.as_string())["source"] == "upload"
+
+
+class TestActiveConversionList:
+    """Only adapters in ACTIVE_GOOGLE_PART_CONVERSIONS are registered."""
+
+    @pytest.fixture(autouse=True)
+    def _register_adapters(self):
+        import weave.type_wrappers.Content.adapters  # noqa: F401
+
+    def test_active_inline_data_matches(self):
+        part = {"inline_data": {"data": "AAAA", "mime_type": "image/png"}}
+        assert Content.is_content_like(part)
+
+    def test_active_file_data_matches(self):
+        part = {
+            "file_data": {
+                "file_uri": "gs://bucket/img.png",
+                "mime_type": "image/png",
+            }
+        }
+        assert Content.is_content_like(part)
+
+    def test_inactive_adapter_does_not_match(self):
+        """Text adapter exists but is not in the active set."""
+        part = {"text": "Hello"}
+        assert not Content.is_content_like(part)
+
+    def test_inactive_adapter_still_works_directly(self):
+        from weave.type_wrappers.Content.adapters import GooglePartText
+
+        content = GooglePartText(text="direct call").to_content()
+        assert content.as_string() == "direct call"
+
+    def test_can_activate_adapter_at_runtime(self):
+        from weave.type_wrappers.Content.adapters import GooglePartText
+
+        register_content_adapter(GooglePartText)
+        part = {"text": "now active"}
+        assert Content.is_content_like(part)
+        content = Content._from_guess(part)
+        assert content.as_string() == "now active"

--- a/tests/trace/type_handlers/Content/test_content_adapters.py
+++ b/tests/trace/type_handlers/Content/test_content_adapters.py
@@ -140,9 +140,7 @@ class TestGenAIBlobAdapter:
     def test_blob_dict_missing_fields_not_content_like(self):
         assert not Content.is_content_like({"type": "blob"})
         assert not Content.is_content_like({"type": "blob", "data": "AAAA"})
-        assert not Content.is_content_like(
-            {"type": "blob", "mime_type": "image/png"}
-        )
+        assert not Content.is_content_like({"type": "blob", "mime_type": "image/png"})
 
     def test_non_blob_dict_not_content_like(self):
         assert not Content.is_content_like({"type": "text", "content": "hi"})
@@ -328,9 +326,7 @@ class TestGooglePartAdapters:
     def test_tool_response_adapter(self):
         from weave.type_wrappers.Content.adapters import GooglePartToolResponse
 
-        adapter = GooglePartToolResponse(
-            tool_response={"id": "tc_1", "output": "done"}
-        )
+        adapter = GooglePartToolResponse(tool_response={"id": "tc_1", "output": "done"})
         content = adapter.to_content()
         assert json.loads(content.as_string())["output"] == "done"
 
@@ -352,9 +348,7 @@ class TestGooglePartAdapters:
             GooglePartMediaResolution,
         )
 
-        adapter = GooglePartMediaResolution(
-            media_resolution={"level": "MEDIUM"}
-        )
+        adapter = GooglePartMediaResolution(media_resolution={"level": "MEDIUM"})
         content = adapter.to_content()
         assert json.loads(content.as_string())["level"] == "MEDIUM"
 

--- a/weave/type_wrappers/Content/__init__.py
+++ b/weave/type_wrappers/Content/__init__.py
@@ -1,1 +1,5 @@
 from weave.type_wrappers.Content.content import Content as Content
+from weave.type_wrappers.Content.content import ContentAdaptable as ContentAdaptable
+from weave.type_wrappers.Content.content import (
+    register_content_adapter as register_content_adapter,
+)

--- a/weave/type_wrappers/Content/adapters.py
+++ b/weave/type_wrappers/Content/adapters.py
@@ -1,0 +1,287 @@
+"""Built-in ContentAdaptable implementations.
+
+Adapters for:
+* OTel GenAI blob parts  (flat span-attribute format)
+* Google GenAI SDK Part types  (nested ``{field: {...}}`` format)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Literal
+
+from pydantic import BaseModel
+
+from weave.type_wrappers.Content.content import (
+    Content,
+    ContentAdaptable,
+    register_content_adapter,
+)
+
+# ---------------------------------------------------------------------------
+# OTel GenAI blob adapter  (flat span-attribute format)
+# ---------------------------------------------------------------------------
+
+
+class GenAIBlob(ContentAdaptable):
+    """Google GenAI OTel blob part.
+
+    Spans encode binary data as::
+
+        {"type": "blob", "data": "<base64>", "mime_type": "image/png"}
+    """
+
+    type: Literal["blob"]
+    data: str
+    mime_type: str
+
+    def to_content(self) -> Content:
+        return Content.from_base64(self.data, mimetype=self.mime_type)
+
+
+# ---------------------------------------------------------------------------
+# Google GenAI SDK Part sub-models
+# ---------------------------------------------------------------------------
+
+
+class _BlobModel(BaseModel):
+    data: str | bytes
+    mime_type: str
+
+
+class _FileDataModel(BaseModel):
+    file_uri: str
+    mime_type: str
+    display_name: str | None = None
+
+
+class _ExecutableCodeModel(BaseModel):
+    code: str
+    language: str | None = None
+
+
+class _CodeExecutionResultModel(BaseModel):
+    outcome: str | None = None
+    output: str
+
+
+class _FunctionCallModel(BaseModel):
+    name: str
+    args: dict[str, Any] | None = None
+
+
+class _FunctionResponseModel(BaseModel):
+    name: str
+    response: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Google Part adapters — one per Part field type
+# ---------------------------------------------------------------------------
+
+
+class GooglePartInlineData(ContentAdaptable):
+    inline_data: _BlobModel
+
+    def to_content(self) -> Content:
+        d = self.inline_data
+        if isinstance(d.data, bytes):
+            return Content.from_bytes(
+                d.data,
+                mimetype=d.mime_type,
+                metadata={"adapter_type": "google:part:inline_data"},
+            )
+        return Content.from_base64(
+            d.data,
+            mimetype=d.mime_type,
+            metadata={"adapter_type": "google:part:inline_data"},
+        )
+
+
+class GooglePartText(ContentAdaptable):
+    text: str
+
+    def to_content(self) -> Content:
+        return Content.from_text(
+            self.text,
+            metadata={"adapter_type": "google:part:text"},
+        )
+
+
+class GooglePartFileData(ContentAdaptable):
+    file_data: _FileDataModel
+
+    def to_content(self) -> Content:
+        return Content.from_text(
+            json.dumps(self.file_data.model_dump()),
+            mimetype="application/json",
+            metadata={"adapter_type": "google:part:file_data"},
+        )
+
+
+class GooglePartExecutableCode(ContentAdaptable):
+    executable_code: _ExecutableCodeModel
+
+    def to_content(self) -> Content:
+        meta: dict[str, Any] = {"adapter_type": "google:part:executable_code"}
+        if self.executable_code.language:
+            meta["language"] = self.executable_code.language
+        return Content.from_text(self.executable_code.code, metadata=meta)
+
+
+class GooglePartCodeExecutionResult(ContentAdaptable):
+    code_execution_result: _CodeExecutionResultModel
+
+    def to_content(self) -> Content:
+        meta: dict[str, Any] = {
+            "adapter_type": "google:part:code_execution_result",
+        }
+        if self.code_execution_result.outcome:
+            meta["outcome"] = self.code_execution_result.outcome
+        return Content.from_text(self.code_execution_result.output, metadata=meta)
+
+
+class GooglePartFunctionCall(ContentAdaptable):
+    function_call: _FunctionCallModel
+
+    def to_content(self) -> Content:
+        payload = {
+            "name": self.function_call.name,
+            "args": self.function_call.args,
+        }
+        return Content.from_text(
+            json.dumps(payload),
+            mimetype="application/json",
+            metadata={"adapter_type": "google:part:function_call"},
+        )
+
+
+class GooglePartFunctionResponse(ContentAdaptable):
+    function_response: _FunctionResponseModel
+
+    def to_content(self) -> Content:
+        payload = {
+            "name": self.function_response.name,
+            "response": self.function_response.response,
+        }
+        return Content.from_text(
+            json.dumps(payload),
+            mimetype="application/json",
+            metadata={"adapter_type": "google:part:function_response"},
+        )
+
+
+class GooglePartThought(ContentAdaptable):
+    thought: bool
+
+    def to_content(self) -> Content:
+        return Content.from_text(
+            str(self.thought),
+            metadata={"adapter_type": "google:part:thought"},
+        )
+
+
+class GooglePartThoughtSignature(ContentAdaptable):
+    thought_signature: bytes
+
+    def to_content(self) -> Content:
+        return Content.from_bytes(
+            self.thought_signature,
+            metadata={"adapter_type": "google:part:thought_signature"},
+        )
+
+
+class GooglePartVideoMetadata(ContentAdaptable):
+    video_metadata: dict[str, Any]
+
+    def to_content(self) -> Content:
+        return Content.from_text(
+            json.dumps(self.video_metadata),
+            mimetype="application/json",
+            metadata={"adapter_type": "google:part:video_metadata"},
+        )
+
+
+class GooglePartToolCall(ContentAdaptable):
+    tool_call: dict[str, Any]
+
+    def to_content(self) -> Content:
+        return Content.from_text(
+            json.dumps(self.tool_call),
+            mimetype="application/json",
+            metadata={"adapter_type": "google:part:tool_call"},
+        )
+
+
+class GooglePartToolResponse(ContentAdaptable):
+    tool_response: dict[str, Any]
+
+    def to_content(self) -> Content:
+        return Content.from_text(
+            json.dumps(self.tool_response),
+            mimetype="application/json",
+            metadata={"adapter_type": "google:part:tool_response"},
+        )
+
+
+class GooglePartMediaResolution(ContentAdaptable):
+    media_resolution: dict[str, Any]
+
+    def to_content(self) -> Content:
+        return Content.from_text(
+            json.dumps(self.media_resolution),
+            mimetype="application/json",
+            metadata={"adapter_type": "google:part:media_resolution"},
+        )
+
+
+class GooglePartMetadata(ContentAdaptable):
+    part_metadata: dict[str, Any]
+
+    def to_content(self) -> Content:
+        return Content.from_text(
+            json.dumps(self.part_metadata),
+            mimetype="application/json",
+            metadata={"adapter_type": "google:part:part_metadata"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Registry of all Google Part adapters (keyed by Part field name)
+# ---------------------------------------------------------------------------
+
+GOOGLE_PART_ADAPTERS: dict[str, type[ContentAdaptable]] = {
+    "inline_data": GooglePartInlineData,
+    "text": GooglePartText,
+    "file_data": GooglePartFileData,
+    "executable_code": GooglePartExecutableCode,
+    "code_execution_result": GooglePartCodeExecutionResult,
+    "function_call": GooglePartFunctionCall,
+    "function_response": GooglePartFunctionResponse,
+    "thought": GooglePartThought,
+    "thought_signature": GooglePartThoughtSignature,
+    "video_metadata": GooglePartVideoMetadata,
+    "tool_call": GooglePartToolCall,
+    "tool_response": GooglePartToolResponse,
+    "media_resolution": GooglePartMediaResolution,
+    "part_metadata": GooglePartMetadata,
+}
+
+# Part types whose data should be stored as weave Content objects.
+# Add or remove entries to control which Part types trigger conversion
+# without touching the adapter implementations above.
+ACTIVE_GOOGLE_PART_CONVERSIONS: set[str] = {
+    "inline_data",
+    "file_data",
+}
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+# OTel blob adapter (always active)
+register_content_adapter(GenAIBlob)
+
+# Google Part adapters (only active subset)
+for _part_name in ACTIVE_GOOGLE_PART_CONVERSIONS:
+    register_content_adapter(GOOGLE_PART_ADAPTERS[_part_name])

--- a/weave/type_wrappers/Content/content.py
+++ b/weave/type_wrappers/Content/content.py
@@ -541,7 +541,9 @@ class Content(BaseModel, Generic[T]):
                     return validated.to_content()  # type: ignore[return-value]
                 except Exception:
                     continue
-            raise ValueError(f"No registered adapter matched dict with keys: {sorted(input.keys())}")
+            raise ValueError(
+                f"No registered adapter matched dict with keys: {sorted(input.keys())}"
+            )
 
         # First check if it is a path, we only check validity for str scenario
         # because we have dedicated error message for invalid path

--- a/weave/type_wrappers/Content/content.py
+++ b/weave/type_wrappers/Content/content.py
@@ -12,7 +12,13 @@ from pathlib import Path
 from typing import Annotated, Any, Generic
 from urllib.parse import quote_from_bytes, urlparse
 
-from pydantic import BaseModel, Field, PrivateAttr, field_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    PrivateAttr,
+    field_serializer,
+)
 from typing_extensions import Self, TypeVar
 
 from weave.trace.refs import Ref
@@ -37,6 +43,29 @@ logger = logging.getLogger(__name__)
 # Dummy typevar to allow for passing mimetype/extension through annotated content
 # e.x. Content["pdf"] or Content["application/pdf"]
 T = TypeVar("T", bound=str)
+
+
+class ContentAdaptable(BaseModel):
+    """Base for Pydantic models that can be converted to Content.
+
+    Subclass this, declare fields for your input shape, and implement
+    ``to_content``.  Then call ``register_content_adapter(YourModel)``
+    so that ``Content._from_guess`` and ``Content.is_content_like``
+    pick it up automatically via Pydantic validation.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    def to_content(self) -> Content:
+        raise NotImplementedError
+
+
+_content_adapters: list[type[ContentAdaptable]] = []
+
+
+def register_content_adapter(adapter: type[ContentAdaptable]) -> None:
+    """Register a :class:`ContentAdaptable` model so ``Content._from_guess`` can convert its objects."""
+    _content_adapters.append(adapter)
 
 
 class Content(BaseModel, Generic[T]):
@@ -472,13 +501,48 @@ class Content(BaseModel, Generic[T]):
         return cls.model_construct(**resolved_args)
 
     @classmethod
+    def is_content_like(cls, obj: Any) -> bool:
+        """Return True if *obj* can be converted to Content.
+
+        Tries Pydantic validation against registered
+        :class:`ContentAdaptable` models first, then falls back to the
+        built-in type checks (path, base64, str, bytes).
+        """
+        if isinstance(obj, (Content, ContentAdaptable)):
+            return True
+        if isinstance(obj, dict):
+            for adapter in _content_adapters:
+                try:
+                    adapter.model_validate(obj)
+                except Exception:
+                    continue
+                else:
+                    return True
+            return False
+        return isinstance(obj, (bytes, str, Path))
+
+    @classmethod
     def _from_guess(
         cls: type[Self],
-        input: ValidContentInputs,
+        input: ValidContentInputs | ContentAdaptable,
         /,
         extension: str | None = None,
         mimetype: str | None = None,
     ) -> Self:
+        # Already-validated adapter model
+        if isinstance(input, ContentAdaptable):
+            return input.to_content()  # type: ignore[return-value]
+
+        # Raw dict — try each registered adapter via Pydantic validation
+        if isinstance(input, dict):
+            for adapter in _content_adapters:
+                try:
+                    validated = adapter.model_validate(input)
+                    return validated.to_content()  # type: ignore[return-value]
+                except Exception:
+                    continue
+            raise ValueError(f"No registered adapter matched dict with keys: {sorted(input.keys())}")
+
         # First check if it is a path, we only check validity for str scenario
         # because we have dedicated error message for invalid path
         if isinstance(input, Path) or (isinstance(input, str) and is_valid_path(input)):


### PR DESCRIPTION
- Adds `ContentAdaptable` base class and `register_content_adapter()` so external formats can be converted to `Content` via Pydantic validation
- `Content.is_content_like()` and `Content._from_guess()` now try registered adapters before built-in type checks
- Ships adapters for OTel GenAI blob parts and all Google GenAI SDK Part types (inline_data, file_data, text, executable_code, etc.)
- Only `inline_data` and `file_data` are active by default; others can be activated at runtime via `register_content_adapter()`
- Full test suite for the adapter API, GenAI blob adapter, and all Google Part adapters