### PR TITLE
feat(weave): convert GenAI blob parts to Content and render in agents chat view

### DIFF
--- a/tests/trace/type_handlers/Content/test_content_adapters.py
+++ b/tests/trace/type_handlers/Content/test_content_adapters.py
@@ -140,9 +140,7 @@ class TestGenAIBlobAdapter:
     def test_blob_dict_missing_fields_not_content_like(self):
         assert not Content.is_content_like({"type": "blob"})
         assert not Content.is_content_like({"type": "blob", "data": "AAAA"})
-        assert not Content.is_content_like(
-            {"type": "blob", "mime_type": "image/png"}
-        )
+        assert not Content.is_content_like({"type": "blob", "mime_type": "image/png"})
 
     def test_non_blob_dict_not_content_like(self):
         assert not Content.is_content_like({"type": "text", "content": "hi"})
@@ -328,9 +326,7 @@ class TestGooglePartAdapters:
     def test_tool_response_adapter(self):
         from weave.type_wrappers.Content.adapters import GooglePartToolResponse
 
-        adapter = GooglePartToolResponse(
-            tool_response={"id": "tc_1", "output": "done"}
-        )
+        adapter = GooglePartToolResponse(tool_response={"id": "tc_1", "output": "done"})
         content = adapter.to_content()
         assert json.loads(content.as_string())["output"] == "done"
 
@@ -352,9 +348,7 @@ class TestGooglePartAdapters:
             GooglePartMediaResolution,
         )
 
-        adapter = GooglePartMediaResolution(
-            media_resolution={"level": "MEDIUM"}
-        )
+        adapter = GooglePartMediaResolution(media_resolution={"level": "MEDIUM"})
         content = adapter.to_content()
         assert json.loads(content.as_string())["level"] == "MEDIUM"
 

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -12,6 +12,7 @@ from weave.trace_server.base64_content_conversion import (
     is_data_uri,
     process_call_req_to_content,
     replace_base64_with_content_objects,
+    replace_genai_content_blobs_in_span_attrs,
     store_content_object,
 )
 from weave.trace_server.trace_server_interface import (
@@ -514,6 +515,224 @@ class TestThresholdAndStructuralIdentity:
         # unchanged regardless of the SDK copy.
         assert processed.start.inputs == inputs_before
         assert trace_server.file_create.call_count == 0
+
+
+class TestGenAIContentBlobConversion:
+    """Test conversion of Google GenAI-style blob parts in span attributes."""
+
+    @staticmethod
+    def _make_trace_server():
+        ts = MagicMock()
+        ts.file_create = MagicMock(
+            side_effect=lambda req: FileCreateRes(digest=f"digest_{req.name}")
+        )
+        return ts
+
+    @staticmethod
+    def _make_png_b64(size: int = 12000) -> str:
+        raw = b"\x89PNG\r\n\x1a\n" + b"\x00" * size
+        return base64.b64encode(raw).decode("ascii")
+
+    def test_blob_part_in_input_messages_flat(self):
+        """Flat attribute key: gen_ai.input.messages as a JSON string."""
+        ts = self._make_trace_server()
+        b64 = self._make_png_b64()
+        messages = json.dumps(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"content": "Describe this image.", "type": "text"},
+                        {"data": b64, "mime_type": "image/png", "type": "blob"},
+                    ],
+                }
+            ]
+        )
+        attrs = {"gen_ai.input.messages": messages}
+
+        replace_genai_content_blobs_in_span_attrs(attrs, "proj", ts)
+
+        result_messages = json.loads(attrs["gen_ai.input.messages"])
+        text_part = result_messages[0]["parts"][0]
+        blob_part = result_messages[0]["parts"][1]
+
+        assert text_part["content"] == "Describe this image."
+        assert blob_part["_type"] == "CustomWeaveType"
+        assert "files" in blob_part
+        assert ts.file_create.call_count == 2
+
+        # Verify content_refs populated for chat view media rendering
+        content_refs = attrs["weave.content_refs"]
+        assert len(content_refs) == 1
+        ref = json.loads(content_refs[0])
+        assert ref["digest"] == "digest_content"
+        assert ref["media_type"].startswith("image/")
+        assert ref["role"] == "user"
+        assert ref["size_bytes"] > 0
+
+    def test_blob_part_in_output_messages_flat(self):
+        """Flat attribute key: gen_ai.output.messages with audio blob."""
+        ts = self._make_trace_server()
+        audio_data = b"\x00\x01" * 6000
+        b64 = base64.b64encode(audio_data).decode("ascii")
+        messages = json.dumps(
+            [
+                {
+                    "role": "assistant",
+                    "parts": [
+                        {
+                            "data": b64,
+                            "mime_type": "audio/L16;codec=pcm;rate=24000",
+                            "type": "blob",
+                        },
+                    ],
+                }
+            ]
+        )
+        attrs = {"gen_ai.output.messages": messages}
+
+        replace_genai_content_blobs_in_span_attrs(attrs, "proj", ts)
+
+        result_messages = json.loads(attrs["gen_ai.output.messages"])
+        blob_part = result_messages[0]["parts"][0]
+        assert blob_part["_type"] == "CustomWeaveType"
+        assert ts.file_create.call_count == 2
+
+        content_refs = attrs["weave.content_refs"]
+        assert len(content_refs) == 1
+        ref = json.loads(content_refs[0])
+        assert ref["role"] == "assistant"
+        assert ref["size_bytes"] > 0
+
+    def test_blob_part_in_nested_attrs(self):
+        """Nested attribute structure: gen_ai -> input -> messages."""
+        ts = self._make_trace_server()
+        b64 = self._make_png_b64()
+        messages = json.dumps(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"data": b64, "mime_type": "image/png", "type": "blob"},
+                    ],
+                }
+            ]
+        )
+        attrs = {"gen_ai": {"input": {"messages": messages}}}
+
+        replace_genai_content_blobs_in_span_attrs(attrs, "proj", ts)
+
+        result_messages = json.loads(attrs["gen_ai"]["input"]["messages"])
+        assert result_messages[0]["parts"][0]["_type"] == "CustomWeaveType"
+        # content_refs are written to the weave namespace (nested)
+        assert len(attrs["weave"]["content_refs"]) == 1
+
+    def test_non_blob_parts_untouched(self):
+        """Text parts and other part types are not modified."""
+        ts = self._make_trace_server()
+        messages = json.dumps(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"content": "Hello", "type": "text"},
+                        {"content": "Some reasoning", "type": "reasoning"},
+                    ],
+                }
+            ]
+        )
+        attrs = {"gen_ai.input.messages": messages}
+
+        replace_genai_content_blobs_in_span_attrs(attrs, "proj", ts)
+
+        result_messages = json.loads(attrs["gen_ai.input.messages"])
+        assert result_messages[0]["parts"][0] == {"content": "Hello", "type": "text"}
+        assert result_messages[0]["parts"][1] == {
+            "content": "Some reasoning",
+            "type": "reasoning",
+        }
+        assert ts.file_create.call_count == 0
+
+    def test_no_message_attrs_is_noop(self):
+        """Attributes without gen_ai message keys are untouched."""
+        ts = self._make_trace_server()
+        attrs = {"code.function.name": "some_func", "gen_ai.request.model": "gemini"}
+
+        result = replace_genai_content_blobs_in_span_attrs(attrs, "proj", ts)
+
+        assert result is attrs
+        assert ts.file_create.call_count == 0
+
+    def test_already_parsed_list_messages(self):
+        """Messages that are already a list (not JSON string) are handled."""
+        ts = self._make_trace_server()
+        b64 = self._make_png_b64()
+        messages = [
+            {
+                "role": "user",
+                "parts": [
+                    {"data": b64, "mime_type": "image/png", "type": "blob"},
+                ],
+            }
+        ]
+        attrs = {"gen_ai.input.messages": messages}
+
+        replace_genai_content_blobs_in_span_attrs(attrs, "proj", ts)
+
+        blob_part = attrs["gen_ai.input.messages"][0]["parts"][0]
+        assert blob_part["_type"] == "CustomWeaveType"
+
+    def test_multiple_blobs_in_same_message(self):
+        """Multiple blob parts in a single message are all converted."""
+        ts = self._make_trace_server()
+        b64_1 = self._make_png_b64(10000)
+        b64_2 = self._make_png_b64(11000)
+        messages = json.dumps(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"content": "Compare these.", "type": "text"},
+                        {"data": b64_1, "mime_type": "image/png", "type": "blob"},
+                        {"data": b64_2, "mime_type": "image/jpeg", "type": "blob"},
+                    ],
+                }
+            ]
+        )
+        attrs = {"gen_ai.input.messages": messages}
+
+        replace_genai_content_blobs_in_span_attrs(attrs, "proj", ts)
+
+        result_messages = json.loads(attrs["gen_ai.input.messages"])
+        assert result_messages[0]["parts"][0]["content"] == "Compare these."
+        assert result_messages[0]["parts"][1]["_type"] == "CustomWeaveType"
+        assert result_messages[0]["parts"][2]["_type"] == "CustomWeaveType"
+        # 2 blobs × 2 file_create calls each (content + metadata)
+        assert ts.file_create.call_count == 4
+
+    def test_blob_without_data_is_skipped(self):
+        """A blob part missing the data field is left unchanged."""
+        ts = self._make_trace_server()
+        messages = json.dumps(
+            [
+                {
+                    "role": "user",
+                    "parts": [
+                        {"mime_type": "image/png", "type": "blob"},
+                    ],
+                }
+            ]
+        )
+        attrs = {"gen_ai.input.messages": messages}
+
+        replace_genai_content_blobs_in_span_attrs(attrs, "proj", ts)
+
+        result_messages = json.loads(attrs["gen_ai.input.messages"])
+        assert result_messages[0]["parts"][0] == {
+            "mime_type": "image/png",
+            "type": "blob",
+        }
+        assert ts.file_create.call_count == 0
 
 
 if __name__ == "__main__":

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -455,9 +455,34 @@ def _compute_duration_ms(started_at: datetime | None, ended_at: datetime | None)
     return max(0, int(delta.total_seconds() * 1000))
 
 
-def _content_refs(span: AgentSpanSchema) -> list[str]:
-    """Return opaque content handles for UI-side attachment rendering."""
-    return [str(r) for r in (span.content_refs or []) if r]
+def _content_refs(span: AgentSpanSchema, *, role: str | None = None) -> list[str]:
+    """Return opaque content handles for UI-side attachment rendering.
+
+    When *role* is given, only refs whose ``role`` field matches are returned.
+    This prevents an image from the user's input appearing on the assistant
+    bubble (and vice-versa).
+    """
+    import json as _json
+
+    refs: list[str] = [str(r) for r in (span.content_refs or []) if r]
+    if role is None:
+        return refs
+    filtered = []
+    for r in refs:
+        try:
+            parsed = _json.loads(r)
+            if parsed.get("role") == role:
+                filtered.append(r)
+        except (ValueError, TypeError):
+            filtered.append(r)
+    logger.debug(
+        "content_refs for span %s role=%s: %d/%d refs",
+        span.span_id,
+        role,
+        len(filtered),
+        len(refs),
+    )
+    return filtered
 
 
 def _sum_descendant_tokens(node: SpanNode) -> TokenTotals:
@@ -499,7 +524,7 @@ def _find_user_message(spans: list[AgentSpanSchema]) -> AgentChatMessage | None:
                 started_at=s.started_at,
                 user_message=AgentChatUserMessage(
                     text=text,
-                    content_refs=_content_refs(s),
+                    content_refs=_content_refs(s, role="user"),
                 ),
             )
     return None
@@ -549,6 +574,6 @@ def _emit_assistant_message(
             output_tokens=totals.output_tokens or span.output_tokens,
             duration_ms=_compute_duration_ms(span.started_at, span.ended_at),
             status=span.status_code,
-            content_refs=_content_refs(span),
+            content_refs=_content_refs(span, role="assistant"),
         ),
     )

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -88,6 +88,7 @@ from weave.trace_server.trace_server_common import (
 from weave.trace_server.trace_server_interface import (
     FeedbackQueryReq,
     FeedbackQueryRes,
+    TraceServerInterface,
 )
 
 if TYPE_CHECKING:
@@ -430,9 +431,11 @@ class AgentWriteHandler:
     """Write-side operations for agent data.
 
     Takes a `ch_client` for `insert` calls, which have no query wrapper.
+    Optionally takes a `trace_server` for file storage (Content conversion).
     """
 
     _ch_client: CHClient
+    _trace_server: TraceServerInterface | None = None
 
     # ------------------------------------------------------------------
     # OTel ingest
@@ -469,6 +472,20 @@ class AgentWriteHandler:
                         rejected += 1
                         errors.append(str(e))
                         continue
+
+                    if self._trace_server is not None:
+                        from weave.trace_server.base64_content_conversion import (
+                            replace_genai_content_blobs_in_span_attrs,
+                        )
+
+                        try:
+                            replace_genai_content_blobs_in_span_attrs(
+                                span.attributes,
+                                req.project_id,
+                                self._trace_server,
+                            )
+                        except Exception:
+                            logger.exception("Failed to convert GenAI blobs for span")
 
                     try:
                         genai_row = extract_genai_span(

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -391,25 +391,37 @@ def _replace_blobs_in_messages(
             if not isinstance(part, dict) or not Content.is_content_like(part):
                 continue
             try:
-                content_obj = Content._from_guess(part)
-                ref = store_content_object(content_obj, project_id, trace_server)
-                parts[i] = ref
+                ref_json = _convert_part(part, i, role, project_id, trace_server)
+                parts[i] = ref_json[0]
+                content_refs.append(ref_json[1])
                 modified = True
-                ref_entry = {
-                    "digest": ref["files"]["content"],
-                    "media_type": content_obj.mimetype,
-                    "role": role,
-                    "size_bytes": content_obj.size,
-                }
-                content_refs.append(json.dumps(ref_entry))
-                logger.debug(
-                    "Converted content part %d: role=%s, mime=%s, size=%d, digest=%s",
-                    i,
-                    role,
-                    content_obj.mimetype,
-                    content_obj.size,
-                    ref["files"]["content"],
-                )
             except Exception as e:
                 logger.warning("Failed to convert part to Content: %s", e)
     return modified, content_refs
+
+
+def _convert_part(
+    part: dict[str, Any],
+    index: int,
+    role: str,
+    project_id: str,
+    trace_server: TraceServerInterface,
+) -> tuple[dict[str, Any], str]:
+    """Convert a single content-like part to a stored Content ref."""
+    content_obj = Content._from_guess(part)
+    ref = store_content_object(content_obj, project_id, trace_server)
+    ref_entry = {
+        "digest": ref["files"]["content"],
+        "media_type": content_obj.mimetype,
+        "role": role,
+        "size_bytes": content_obj.size,
+    }
+    logger.debug(
+        "Converted content part %d: role=%s, mime=%s, size=%d, digest=%s",
+        index,
+        role,
+        content_obj.mimetype,
+        content_obj.size,
+        ref["files"]["content"],
+    )
+    return ref, json.dumps(ref_entry)

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -11,6 +11,8 @@ from typing import Any, TypeVar
 
 import ddtrace
 
+import weave.type_wrappers.Content.adapters  # noqa: F401 — registers adapters
+from weave.trace_server.opentelemetry.helpers import get_attribute
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallEndV2Req,
@@ -253,3 +255,161 @@ def process_complete_call_to_content(
         complete_call.output, complete_call.project_id, trace_server
     )
     return complete_call
+
+
+# ---------------------------------------------------------------------------
+# GenAI content blob conversion
+# ---------------------------------------------------------------------------
+
+_GENAI_MESSAGE_ATTR_KEYS = {
+    "gen_ai.input.messages": "user",
+    "gen_ai.output.messages": "assistant",
+}
+
+_CONTENT_REFS_KEY = "weave.content_refs"
+
+
+def _is_flat_dict(data: dict[str, Any]) -> bool:
+    """Return True if the dict uses dotted keys (flat), False if nested."""
+    return any("." in k for k in data)
+
+
+def _set_attribute(data: dict[str, Any], key: str, value: Any) -> None:
+    """Set a value in a potentially nested or flat dict, mirroring get_attribute."""
+    if key in data:
+        data[key] = value
+        return
+    if _is_flat_dict(data):
+        data[key] = value
+        return
+    segments = key.split(".")
+    current: Any = data
+    for seg in segments[:-1]:
+        if isinstance(current, dict) and seg in current:
+            current = current[seg]
+        elif isinstance(current, dict):
+            current[seg] = {}
+            current = current[seg]
+        else:
+            return
+    if isinstance(current, dict):
+        current[segments[-1]] = value
+
+
+@ddtrace.tracer.wrap(name="replace_genai_content_blobs_in_span_attrs")
+def replace_genai_content_blobs_in_span_attrs(
+    attrs: dict[str, Any],
+    project_id: str,
+    trace_server: TraceServerInterface,
+) -> dict[str, Any]:
+    """Replace Google GenAI-style blob parts with stored Content objects.
+
+    Google GenAI OTel spans encode binary data (images, audio) as message
+    parts with ``{"type": "blob", "data": "<base64>", "mime_type": "..."}``.
+    This function walks ``gen_ai.input.messages`` and
+    ``gen_ai.output.messages``, converts each blob part into a
+    ``weave.Content`` object persisted in file storage, and replaces the
+    inline blob with a Content reference dict.
+
+    Also populates ``weave.content_refs`` with metadata so the chat view
+    can render the stored media.
+
+    Modifies *attrs* in place and returns it.
+    """
+    all_content_refs: list[str] = []
+
+    for key, default_role in _GENAI_MESSAGE_ATTR_KEYS.items():
+        raw = get_attribute(attrs, key)
+        if raw is None:
+            continue
+
+        messages = raw
+        was_string = isinstance(raw, str)
+        if was_string:
+            try:
+                messages = json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+        if not isinstance(messages, list):
+            continue
+
+        modified, refs = _replace_blobs_in_messages(
+            messages, project_id, trace_server, default_role
+        )
+        all_content_refs.extend(refs)
+        if modified:
+            new_val = json.dumps(messages) if was_string else messages
+            _set_attribute(attrs, key, new_val)
+            logger.debug(
+                "Replaced %d blob part(s) in %s for project %s",
+                len(refs),
+                key,
+                project_id,
+            )
+
+    if all_content_refs:
+        existing = get_attribute(attrs, _CONTENT_REFS_KEY)
+        if isinstance(existing, list):
+            existing.extend(all_content_refs)
+        else:
+            _set_attribute(attrs, _CONTENT_REFS_KEY, all_content_refs)
+        logger.debug(
+            "Set %d content_refs on span attrs: %s",
+            len(all_content_refs),
+            [json.loads(r)["role"] for r in all_content_refs],
+        )
+
+    return attrs
+
+
+def _replace_blobs_in_messages(
+    messages: list[Any],
+    project_id: str,
+    trace_server: TraceServerInterface,
+    default_role: str,
+) -> tuple[bool, list[str]]:
+    """Walk message parts and replace content-like entries with Content refs.
+
+    Uses ``Content.is_content_like`` so that any registered
+    :class:`ContentAdapter` (e.g. Google GenAI blobs) is handled
+    automatically.
+
+    Returns (modified, content_ref_strings) where each content_ref_string
+    is a JSON-serialized ContentRef for the ``weave.content_refs`` attribute.
+    """
+    modified = False
+    content_refs: list[str] = []
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", default_role)
+        parts = msg.get("parts")
+        if not isinstance(parts, list):
+            continue
+        for i, part in enumerate(parts):
+            if not isinstance(part, dict) or not Content.is_content_like(part):
+                continue
+            try:
+                content_obj = Content._from_guess(part)
+                ref = store_content_object(content_obj, project_id, trace_server)
+                parts[i] = ref
+                modified = True
+                ref_entry = {
+                    "digest": ref["files"]["content"],
+                    "media_type": content_obj.mimetype,
+                    "role": role,
+                    "size_bytes": content_obj.size,
+                }
+                content_refs.append(json.dumps(ref_entry))
+                logger.debug(
+                    "Converted content part %d: role=%s, mime=%s, size=%d, digest=%s",
+                    i,
+                    role,
+                    content_obj.mimetype,
+                    content_obj.size,
+                    ref["files"]["content"],
+                )
+            except Exception as e:
+                logger.warning("Failed to convert part to Content: %s", e)
+    return modified, content_refs

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -82,6 +82,7 @@ from weave.trace_server.agents.types import (
 from weave.trace_server.base64_content_conversion import (
     process_call_req_to_content,
     process_complete_call_to_content,
+    replace_genai_content_blobs_in_span_attrs,
 )
 from weave.trace_server.call_stats_helpers import (
     rows_to_bucket_dicts,
@@ -747,6 +748,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                         )
                         error_messages.append(f"Rejected span ({span_ident}): {e!s}")
                         continue
+
+                    try:
+                        replace_genai_content_blobs_in_span_attrs(
+                            span.attributes, req.project_id, self
+                        )
+                    except Exception:
+                        logger.exception("Failed to convert GenAI blobs for span")
 
                     calls.append(
                         span.to_call(
@@ -6750,7 +6758,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     @tag_db_insert_path("genai_otel_export")
     def genai_otel_export(self, req: GenAIOTelExportReq) -> GenAIOTelExportRes:
-        res, span_rows = AgentWriteHandler(self.ch_client).insert_otel_spans(req)
+        res, span_rows = AgentWriteHandler(self.ch_client, self).insert_otel_spans(req)
 
         # Return early without emitting kafka events if online eval or agent scoring are disabled
         if not wf_env.wf_enable_online_eval() or not wf_env.wf_enable_agent_scoring():

--- a/weave/type_wrappers/Content/content.py
+++ b/weave/type_wrappers/Content/content.py
@@ -541,7 +541,9 @@ class Content(BaseModel, Generic[T]):
                     return validated.to_content()  # type: ignore[return-value]
                 except Exception:
                     continue
-            raise ValueError(f"No registered adapter matched dict with keys: {sorted(input.keys())}")
+            raise ValueError(
+                f"No registered adapter matched dict with keys: {sorted(input.keys())}"
+            )
 
         # First check if it is a path, we only check validity for str scenario
         # because we have dedicated error message for invalid path


### PR DESCRIPTION
- Adds `replace_genai_content_blobs_in_span_attrs()` to walk `gen_ai.input/output.messages` and convert content-like parts to stored Content objects
- Populates `weave.content_refs` with role/digest/media_type metadata for chat view rendering
- Wires blob conversion into both `ClickHouseTraceServer.otel_export` and `AgentWriteHandler.insert_otel_spans`
- Filters `_content_refs()` by role so user images don't appear on assistant bubbles and vice versa
- Tests for flat/nested attrs, multiple blobs, missing data, non-blob passthrough