### PR TITLE
perf(weave): add parent_id bloom filter index on calls_merged

### DIFF
--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -30,6 +30,13 @@ def test_cte_chain_calls_merged() -> None:
     assert_raw_sql(
         cte,
         """
+            filter_candidate_ids AS (
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_0:String}
+                WHERE ifNull(calls_merged.parent_id, '') IN {pb_1:Array(String)}
+            ),
+
             predict_and_score_calls AS (
                 SELECT calls_merged.id AS call_id,
                     any(calls_merged.parent_id) AS eval_call_id,
@@ -42,8 +49,9 @@ def test_cte_chain_calls_merged() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
-                    OR calls_merged.parent_id IS NULL)
+                WHERE calls_merged.id IN filter_candidate_ids
+                    AND (calls_merged.parent_id IN {pb_1:Array(String)}
+                        OR calls_merged.parent_id IS NULL)
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
                     AND (position(calls_merged.op_name, {pb_2:String}) > 0
                         OR position(calls_merged.op_name, {pb_3:String}) > 0
@@ -199,6 +207,28 @@ def test_cte_chain_calls_complete() -> None:
             "pb_4": SENTINEL_EPOCH,
         },
     )
+
+
+def test_cte_chain_calls_complete_no_candidate_cte() -> None:
+    """calls_complete has a non-nullable parent_id with its own bloom index,
+    so it must NOT emit a filter_candidate_ids CTE. The candidate-CTE shape
+    exists only to let the idx_parent_id_bloom skip-index on calls_merged
+    fire around the OR-IS-NULL escape hatch.
+    """
+    pb = ParamBuilder("pb")
+    cte = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1"],
+        sort_by=None,
+        filters=None,
+        require_intersection=False,
+        limit=10,
+        offset=0,
+        pb=pb,
+        read_table="calls_complete",
+    )
+    assert "filter_candidate_ids" not in cte
+    assert "ifNull(calls_complete.parent_id" not in cte
 
 
 def test_cte_chain_sort_and_multi_eval_filters() -> None:
@@ -393,6 +423,13 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
     assert_raw_sql(
         cte,
         """
+            filter_candidate_ids AS (
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_0:String}
+                WHERE ifNull(calls_merged.parent_id, '') IN {pb_1:Array(String)}
+            ),
+
             predict_and_score_calls AS (
                 SELECT calls_merged.id AS call_id,
                     any(calls_merged.parent_id) AS eval_call_id,
@@ -405,8 +442,9 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
-                    OR calls_merged.parent_id IS NULL)
+                WHERE calls_merged.id IN filter_candidate_ids
+                    AND (calls_merged.parent_id IN {pb_1:Array(String)}
+                        OR calls_merged.parent_id IS NULL)
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
                     AND (position(calls_merged.op_name, {pb_2:String}) > 0
                         OR position(calls_merged.op_name, {pb_3:String}) > 0
@@ -493,7 +531,14 @@ def test_full_query_calls_merged() -> None:
     assert_raw_sql(
         sql,
         """
-        WITH predict_and_score_calls AS (
+        WITH filter_candidate_ids AS (
+                SELECT calls_merged.id AS id
+                FROM calls_merged
+                PREWHERE calls_merged.project_id = {pb_0:String}
+                WHERE ifNull(calls_merged.parent_id, '') IN {pb_1:Array(String)}
+            ),
+
+            predict_and_score_calls AS (
                 SELECT calls_merged.id AS call_id,
                     any(calls_merged.parent_id) AS eval_call_id,
                     any(calls_merged.inputs_dump) AS inputs_dump,
@@ -505,8 +550,9 @@ def test_full_query_calls_merged() -> None:
                     END AS row_digest
                 FROM calls_merged
                 PREWHERE calls_merged.project_id = {pb_0:String}
-                WHERE (calls_merged.parent_id IN {pb_1:Array(String)}
-                    OR calls_merged.parent_id IS NULL)
+                WHERE calls_merged.id IN filter_candidate_ids
+                    AND (calls_merged.parent_id IN {pb_1:Array(String)}
+                        OR calls_merged.parent_id IS NULL)
                     AND calls_merged.id NOT IN {pb_1:Array(String)}
                     AND (position(calls_merged.op_name, {pb_2:String}) > 0
                         OR position(calls_merged.op_name, {pb_3:String}) > 0

--- a/weave/trace_server/migrations/032_add_bloom_filter_parent_id_index.down.sql
+++ b/weave/trace_server/migrations/032_add_bloom_filter_parent_id_index.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE calls_merged DROP INDEX IF EXISTS idx_parent_id_bloom;

--- a/weave/trace_server/migrations/032_add_bloom_filter_parent_id_index.up.sql
+++ b/weave/trace_server/migrations/032_add_bloom_filter_parent_id_index.up.sql
@@ -1,0 +1,33 @@
+-- Migration 032: Add bloom filter index on ifNull(parent_id, '') to
+-- accelerate parent-scoped lookups in calls_merged.
+--
+-- The eval-drawer query (`/eval_results/query`) filters by
+-- `parent_id IN (eval_root_ids)` to find every predict_and_score child of
+-- an eval root. calls_merged is ordered by `(project_id, id)` with no
+-- skip-index on parent_id, so this currently scans every granule in the
+-- project's partition (multi-million-row hot projects → multi-second
+-- queries, p95 ~10s, p99 ~60s in prod).
+--
+-- The column is `SimpleAggregateFunction(any, Nullable(String))` because
+-- pre-merge rows in calls_merged can transiently be NULL until the
+-- AggregatingMergeTree merges parts. A bloom filter built directly on a
+-- Nullable column does not get pruned by `WHERE parent_id = 'x'` due to
+-- Nullable-equality semantics. Wrapping the index expression in
+-- `ifNull(parent_id, '')` (and matching the predicate in the query layer
+-- character-for-character) makes the comparison non-nullable on both
+-- sides so the index actually fires.
+--
+-- Pairs with the candidate-ids CTE rewrite in eval_results_query_builder
+-- (the existing query's `parent_id IN (...) OR parent_id IS NULL` shape
+-- prevents the index from firing on its own; the CTE isolates the tight
+-- IN-arm so the bloom can prune granules).
+ALTER TABLE calls_merged
+    ADD INDEX IF NOT EXISTS idx_parent_id_bloom
+        ifNull(parent_id, '') TYPE bloom_filter(0.01) GRANULARITY 1;
+
+-- Kick off background materialization for existing parts. mutations_sync
+-- defaults to 0, so this returns immediately and ClickHouse runs the
+-- mutation asynchronously instead of blocking the migration on a full-
+-- table reindex.
+ALTER TABLE calls_merged
+    MATERIALIZE INDEX idx_parent_id_bloom;

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -1,6 +1,7 @@
 """Query builder for the /eval_results endpoint.
 
 Generates ClickHouse CTEs for the eval_results CTE chain:
+  filter_candidate_ids             → (calls_merged only) tight bloom-prunable parent_id scan
   predict_and_score_calls          → filter to predict-and-score calls, extract row_digest
   predict_and_score_calls_resolved → (conditionally) LEFT JOIN table_rows so sort/filter on inputs.* can read the dataset row
   ranked_digests                   → GROUP BY row_digest, HAVING filters, ROW_NUMBER for sort
@@ -96,7 +97,21 @@ def build_predict_and_score_calls_cte(
     )
 
     if read_table == "calls_merged":
-        return f"""predict_and_score_calls AS (
+        # The candidate-ids CTE issues a tight `ifNull(parent_id, '') IN (...)`
+        # lookup against calls_merged so the idx_parent_id_bloom skip-index can
+        # prune granules. The outer predict_and_score_calls CTE then keeps the
+        # original `parent_id IN (...) OR parent_id IS NULL` predicate so we
+        # still pick up pre-merge end-rows whose parent_id has not yet merged.
+        # See migration 032; this CTE is the only shape that lets the bloom
+        # actually fire (the OR-IS-NULL arm alone disables index analysis).
+        return f"""filter_candidate_ids AS (
+    SELECT calls_merged.id AS id
+    FROM calls_merged
+    PREWHERE calls_merged.project_id = {project_id_param}
+    WHERE ifNull(calls_merged.parent_id, '') IN {eval_root_ids_param}
+),
+
+predict_and_score_calls AS (
     SELECT
         calls_merged.id AS call_id,
         any(calls_merged.parent_id) AS eval_call_id,
@@ -105,7 +120,8 @@ def build_predict_and_score_calls_cte(
         {row_digest_expr} AS row_digest
     FROM calls_merged
     PREWHERE calls_merged.project_id = {project_id_param}
-    WHERE (
+    WHERE calls_merged.id IN filter_candidate_ids
+    AND (
         calls_merged.parent_id IN {eval_root_ids_param}
         OR calls_merged.parent_id IS NULL
     )


### PR DESCRIPTION
Mirrors #6764 but for `parent_id`. Adds a `bloom_filter(0.01) GRANULARITY 1` skip-index on `ifNull(parent_id, '')` for `calls_merged`, plus the candidate-ids CTE rewrite in `eval_results_query_builder` so the index can actually fire on the eval-drawer query.

## Summary

- **Why**: `/eval_results/query` filters `parent_id IN (eval_root_ids)` to find every predict_and_score child of an eval. `calls_merged` is `ORDER BY (project_id, id)` with no skip-index on parent_id, so this scans every granule in the project's partition. In prod (DD): 654 calls in 7d, p50 611ms, **p95 9.1s, p99 59.6s, max 60.9s**. ClickHouse server-side stats on one slow trace: 5.87M rows read to return 130 rows, 2.18 GB memory. The fast variant (`calls_complete`, which already has `idx_parent_id` bloom from #022/#024) p95 1.3s on the same shape - confirmation that this is the lever.
- **Why the `ifNull` wrap**: same reasoning as #6764. `parent_id` on `calls_merged` is `SimpleAggregateFunction(any, Nullable(String))` because pre-merge rows are transiently NULL. A bloom on a Nullable column does not prune `WHERE parent_id IN (...)` due to Nullable-equality semantics. Wrapping both the index expression and the predicate as `ifNull(parent_id, '')` makes both sides non-nullable so the index fires. `calls_complete` keeps raw `parent_id` (non-nullable + its own bloom).
- **Why a candidate-ids CTE**: the existing query has `WHERE (parent_id IN (...) OR parent_id IS NULL)` to pick up pre-merge end-rows. The `OR IS NULL` arm disables index analysis entirely - `EXPLAIN indexes=1` shows the bloom listed but with `Granules: 663/663` (zero pruned) under that shape. The CTE issues a tight `ifNull(parent_id,'') IN (...)` against the index, then the outer arm re-reads matched ids with the original `OR parent_id IS NULL` predicate preserved for correctness on unmerged calls.

```sql
WITH filter_candidate_ids AS (
    SELECT calls_merged.id AS id
    FROM calls_merged
    PREWHERE calls_merged.project_id = {pid}
    WHERE ifNull(calls_merged.parent_id, '') IN {eval_root_ids}    -- bloom-pruned
),
predict_and_score_calls AS (
    SELECT ... FROM calls_merged
    PREWHERE calls_merged.project_id = {pid}
    WHERE calls_merged.id IN filter_candidate_ids
      AND (calls_merged.parent_id IN {eval_root_ids}
           OR calls_merged.parent_id IS NULL)
      AND ...
    GROUP BY (project_id, id)
    HAVING ...
)
```

`calls_complete` keeps the single-CTE shape - new test pins this so we don't regress.

Depends on: -

## Performance

Load test against local CH 26.3.2.3, 5M-row project, 1500 eval children across small (100) / med (500) / large (5000) evals. Three measured runs per row.

| eval size | query shape | rows_read | granules pruned | dur_ms |
| --- | --- | --: | --: | --: |
| small (100) | existing (no CTE) | 5,015,600 | 0% | 213 |
| small (100) | candidate-CTE baseline (no index) | 1,946,429 | 81% via PK | 61 |
| small (100) | **candidate-CTE + bloom** | **1,393,666** | **86% via bloom (92/663)** | **53** |
| med (500) | existing | 5,015,600 | 0% | 185 |
| med (500) | candidate-CTE + bloom | 3,756,392 | 45% via bloom (366/663) | 121 |
| large (5000) | existing | 5,015,600 | 0% | 177 |
| large (5000) | candidate-CTE + bloom | 6,527,850 | 0% via bloom, 35% marks via PK | 278 |

`EXPLAIN indexes=1` confirms the granule-pruning numbers. The index alone does nothing under the old query shape (CH skips it because of the OR-IS-NULL arm) - the CTE is what unlocks it. At default `index_granularity = 8192`, bloom effectiveness scales inversely with eval size: tiny evals win huge, very large evals (5k+ children) get no granule pruning because every granule contains a child. The CTE+id-IN-PK path still helps medium / large cases via primary-key narrowing, but the bloom contribution drops off.

Local timings are page-cache-hot so absolute numbers are not the prod story; the granule / row reductions are what should translate. Multi-TB prod replica `MATERIALIZE INDEX` on #031 (trace_id) completed in seconds with `mutations_sync=0` async, expect the same here.

## Testing

snapshot tests updated for the three `calls_merged` paths (`test_cte_chain_calls_merged`, `test_eval_filter_infers_cast_for_typed_literal_without_convert`, `test_full_query_calls_merged`). New `test_cte_chain_calls_complete_no_candidate_cte` pins the calls_complete-side single-CTE shape so we do not regress. Full `tests/trace_server/query_builder/` shard: 473 passed.