### PR TITLE
fix(weave): agent spans query include_details + ext-to-int ref conversion

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -275,6 +275,39 @@ class TestMakeSpansListQuery:
                 ],
             )
 
+    def test_include_details_projects_detail_columns(self) -> None:
+        from weave.trace_server.query_builder.agent_query_builder import (
+            SPANS_DETAILS_COLS,
+        )
+
+        pb = ParamBuilder("genai")
+        query = make_spans_list_query(
+            pb, AgentSpansQueryReq(project_id="p1", include_details=True)
+        )
+
+        expected = f"""
+            SELECT {SPANS_LIST_COLS}, {SPANS_DETAILS_COLS}
+            FROM spans s
+            WHERE s.project_id = {{genai_0:String}}
+            ORDER BY started_at DESC
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """
+        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_include_details_rejected_with_group_by(self) -> None:
+        """SPANS_DETAILS_COLS is only projected on the ungrouped path. The
+        grouped branch ignores `include_details`, so the validator rejects
+        the combination instead of accepting it and quietly dropping the
+        heavy-fields projection.
+        """
+        with pytest.raises(ValidationError):
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="agent_name")],
+                include_details=True,
+            )
+
 
 # ============================================================================
 # make_spans_count_query (grouped)

--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -5,8 +5,8 @@ import pytest
 from pydantic import BaseModel, ConfigDict
 
 from weave.trace.refs import ObjectRef
-from weave.trace_server.interface.query import Query
 from weave.trace_server.errors import InvalidExternalRef
+from weave.trace_server.interface.query import Query
 from weave.trace_server.trace_server_converter import (
     replace_external_weave_ref,
     universal_ext_to_int_ref_converter,
@@ -199,15 +199,9 @@ def test_replace_external_weave_ref_uses_cache():
 
     cache: dict[str, str] = {}
 
-    a = replace_external_weave_ref(
-        "weave:///ent/proj/object/a:v1", converter, cache
-    )
-    b = replace_external_weave_ref(
-        "weave:///ent/proj/object/b:v1", converter, cache
-    )
-    c = replace_external_weave_ref(
-        "weave:///other/proj/object/c:v1", converter, cache
-    )
+    a = replace_external_weave_ref("weave:///ent/proj/object/a:v1", converter, cache)
+    b = replace_external_weave_ref("weave:///ent/proj/object/b:v1", converter, cache)
+    c = replace_external_weave_ref("weave:///other/proj/object/c:v1", converter, cache)
 
     assert a == "weave-trace-internal:///internal:ent/proj/object/a:v1"
     assert b == "weave-trace-internal:///internal:ent/proj/object/b:v1"
@@ -220,7 +214,7 @@ def test_replace_external_weave_ref_rejects_non_external_scheme():
     """Inputs not on the external scheme are a contract violation; the
     caller must precheck `startswith(weave_prefix)` before invoking.
     """
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid URI"):
         replace_external_weave_ref(
             "weave-trace-internal:///proj/object/a:v1", lambda p: p
         )

--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -1,11 +1,16 @@
 import datetime
 import json
 
+import pytest
 from pydantic import BaseModel, ConfigDict
 
 from weave.trace.refs import ObjectRef
 from weave.trace_server.interface.query import Query
-from weave.trace_server.trace_server_converter import universal_ext_to_int_ref_converter
+from weave.trace_server.errors import InvalidExternalRef
+from weave.trace_server.trace_server_converter import (
+    replace_external_weave_ref,
+    universal_ext_to_int_ref_converter,
+)
 from weave.trace_server.trace_server_interface import (
     CallStartReq,
     ObjCreateReq,
@@ -177,3 +182,54 @@ def test_universal_ext_to_int_ref_converter_rewrites_refs_in_model_extras():
     assert converted.declared == "plain"
     extras = converted.model_extra or {}
     assert extras.get("extra_ref") == internal_ref
+
+
+def test_replace_external_weave_ref_uses_cache():
+    """Shared cache amortizes ext→int_project_id lookups across calls.
+
+    Callers that walk many refs (e.g. an OTel batch with the same
+    entity/project on every span) pass a per-request dict so the
+    underlying converter runs once per distinct project_key.
+    """
+    calls: list[str] = []
+
+    def converter(project_key: str) -> str:
+        calls.append(project_key)
+        return f"internal:{project_key}"
+
+    cache: dict[str, str] = {}
+
+    a = replace_external_weave_ref(
+        "weave:///ent/proj/object/a:v1", converter, cache
+    )
+    b = replace_external_weave_ref(
+        "weave:///ent/proj/object/b:v1", converter, cache
+    )
+    c = replace_external_weave_ref(
+        "weave:///other/proj/object/c:v1", converter, cache
+    )
+
+    assert a == "weave-trace-internal:///internal:ent/proj/object/a:v1"
+    assert b == "weave-trace-internal:///internal:ent/proj/object/b:v1"
+    assert c == "weave-trace-internal:///internal:other/proj/object/c:v1"
+    # Same entity/project resolves once, distinct one resolves again.
+    assert calls == ["ent/proj", "other/proj"]
+
+
+def test_replace_external_weave_ref_rejects_non_external_scheme():
+    """Inputs not on the external scheme are a contract violation; the
+    caller must precheck `startswith(weave_prefix)` before invoking.
+    """
+    with pytest.raises(ValueError):
+        replace_external_weave_ref(
+            "weave-trace-internal:///proj/object/a:v1", lambda p: p
+        )
+
+
+def test_replace_external_weave_ref_rejects_malformed_tail():
+    """Refs missing the `entity/project/tail` triplet trip InvalidExternalRef
+    so the caller surfaces the bad payload rather than silently passing it
+    through.
+    """
+    with pytest.raises(InvalidExternalRef):
+        replace_external_weave_ref("weave:///just-entity", lambda p: p)

--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -162,9 +162,7 @@ def _make_otel_export_req_with_ref_attrs(
 
     def build_array_value(refs: list[str]) -> AnyValue:
         v = AnyValue()
-        v.array_value.values.extend(
-            [AnyValue(string_value=ref) for ref in refs]
-        )
+        v.array_value.values.extend([AnyValue(string_value=ref) for ref in refs])
         return v
 
     span = Span()
@@ -193,7 +191,7 @@ def _make_otel_export_req_with_ref_attrs(
     resource_spans.scope_spans.append(scope_spans)
 
     processed = tsi.ProcessedResourceSpans(
-        entity=project_id.split("/")[0],
+        entity=project_id.split("/", maxsplit=1)[0],
         project=project_id.split("/")[1],
         run_id=None,
         resource_spans=resource_spans,

--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -131,3 +131,244 @@ def test_adapter_does_not_mutate_req_when_inner_raises(
         getattr(adapter, method_name)(req)
 
     assert req.model_dump() == snapshot
+
+
+# --- genai_otel_export ext→int ref rewriting in OTel attribute values ---
+# Refs in the typed `weave.{content,artifact,object}_refs` OTel attribute
+# arrays are not reachable by the universal `_ref_apply` walker (the
+# protobuf ResourceSpans is `arbitrary_types_allowed=True`), so the
+# adapter rewrites them in place before forwarding to the inner server.
+
+
+def _make_otel_export_req_with_ref_attrs(
+    ext_refs_by_key: dict[str, list[str]],
+    *,
+    nest_under_kvlist: bool = False,
+    project_id: str = "ent/proj",
+) -> tsi.agent_types.GenAIOTelExportReq:
+    """Build a `GenAIOTelExportReq` carrying `weave.*_refs` OTel attrs.
+
+    When `nest_under_kvlist` is True, encodes attributes under a single
+    `weave` kvlist parent (the form some OTel SDKs emit) instead of the
+    flat-dotted `weave.object_refs` form.
+    """
+    from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+    from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+    from opentelemetry.proto.trace.v1.trace_pb2 import (
+        ResourceSpans,
+        ScopeSpans,
+        Span,
+    )
+
+    def build_array_value(refs: list[str]) -> AnyValue:
+        v = AnyValue()
+        v.array_value.values.extend(
+            [AnyValue(string_value=ref) for ref in refs]
+        )
+        return v
+
+    span = Span()
+    span.name = "test"
+    if nest_under_kvlist:
+        weave_kv = KeyValue(key="weave")
+        for short_key, refs in ext_refs_by_key.items():
+            child = KeyValue(key=short_key)
+            child.value.CopyFrom(build_array_value(refs))
+            weave_kv.value.kvlist_value.values.append(child)
+        span.attributes.append(weave_kv)
+    else:
+        for full_key, refs in ext_refs_by_key.items():
+            kv = KeyValue(key=full_key)
+            kv.value.CopyFrom(build_array_value(refs))
+            span.attributes.append(kv)
+    # Non-ref attributes must survive unchanged.
+    other = KeyValue(key="weave.raw_span_dump")
+    other.value.string_value = "weave:///should/not/be/rewritten"
+    span.attributes.append(other)
+
+    scope_spans = ScopeSpans()
+    scope_spans.spans.append(span)
+    resource_spans = ResourceSpans()
+    resource_spans.resource.CopyFrom(Resource())
+    resource_spans.scope_spans.append(scope_spans)
+
+    processed = tsi.ProcessedResourceSpans(
+        entity=project_id.split("/")[0],
+        project=project_id.split("/")[1],
+        run_id=None,
+        resource_spans=resource_spans,
+    )
+    return tsi.agent_types.GenAIOTelExportReq(
+        processed_spans=[processed], project_id=project_id, wb_user_id=None
+    )
+
+
+def _capture_genai_otel_export_req(
+    req: tsi.agent_types.GenAIOTelExportReq,
+) -> tsi.agent_types.GenAIOTelExportReq:
+    """Run the request through the adapter and return the req the inner
+    trace server actually received.
+    """
+    inner = MagicMock(spec=tsi.FullTraceServerInterface)
+    inner.genai_otel_export.return_value = tsi.agent_types.GenAIOTelExportRes()
+    adapter = ExternalTraceServer(inner, _EncodingIdConverter())
+    adapter.genai_otel_export(req)
+    assert inner.genai_otel_export.call_count == 1
+    return inner.genai_otel_export.call_args.args[0]
+
+
+def _ref_attr_values(
+    req: tsi.agent_types.GenAIOTelExportReq, attr_key: str
+) -> list[str]:
+    """Pull values out of a `weave.<short_key>` attribute, regardless of
+    whether they were encoded flat-dotted or nested under a `weave`
+    kvlist.
+    """
+    short_key = attr_key.split(".", 1)[1]
+    span = req.processed_spans[0].resource_spans.scope_spans[0].spans[0]
+    for kv in span.attributes:
+        if kv.key == attr_key and kv.value.HasField("array_value"):
+            return [v.string_value for v in kv.value.array_value.values]
+        if kv.key == "weave" and kv.value.HasField("kvlist_value"):
+            for child in kv.value.kvlist_value.values:
+                if child.key == short_key and child.value.HasField("array_value"):
+                    return [v.string_value for v in child.value.array_value.values]
+    raise AssertionError(f"no values for {attr_key}")
+
+
+def test_genai_otel_export_rewrites_flat_ref_attrs() -> None:
+    """Flat-dotted `weave.object_refs` array values are rewritten to
+    internal form before reaching the inner trace server.
+    """
+    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
+    req = _make_otel_export_req_with_ref_attrs(
+        {
+            "weave.object_refs": [
+                "weave:///ent/proj/object/a:v1",
+                "weave:///ent/proj/object/b:v1",
+            ],
+            "weave.content_refs": ["weave:///ent/proj/content/c"],
+        }
+    )
+
+    forwarded = _capture_genai_otel_export_req(req)
+
+    assert _ref_attr_values(forwarded, "weave.object_refs") == [
+        f"weave-trace-internal:///{internal_proj}/object/a:v1",
+        f"weave-trace-internal:///{internal_proj}/object/b:v1",
+    ]
+    assert _ref_attr_values(forwarded, "weave.content_refs") == [
+        f"weave-trace-internal:///{internal_proj}/content/c"
+    ]
+
+
+def test_genai_otel_export_rewrites_nested_kvlist_ref_attrs() -> None:
+    """The nested `weave` → `object_refs` kvlist form is rewritten too;
+    the walker descends through kvlist children and matches the dotted
+    full key.
+    """
+    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
+    req = _make_otel_export_req_with_ref_attrs(
+        {"object_refs": ["weave:///ent/proj/object/a:v1"]},
+        nest_under_kvlist=True,
+    )
+
+    forwarded = _capture_genai_otel_export_req(req)
+
+    assert _ref_attr_values(forwarded, "weave.object_refs") == [
+        f"weave-trace-internal:///{internal_proj}/object/a:v1"
+    ]
+
+
+def test_genai_otel_export_leaves_non_ref_attrs_untouched() -> None:
+    """Refs embedded in non-ref attributes (here `weave.raw_span_dump`)
+    must survive byte-for-byte — only the three typed-array ref keys are
+    rewritten.
+    """
+    req = _make_otel_export_req_with_ref_attrs(
+        {"weave.object_refs": ["weave:///ent/proj/object/a:v1"]}
+    )
+
+    forwarded = _capture_genai_otel_export_req(req)
+    span = forwarded.processed_spans[0].resource_spans.scope_spans[0].spans[0]
+    dump_kv = next(kv for kv in span.attributes if kv.key == "weave.raw_span_dump")
+    assert dump_kv.value.string_value == "weave:///should/not/be/rewritten"
+
+
+def test_genai_otel_export_skips_non_external_refs_in_array() -> None:
+    """Array elements that aren't on the external `weave:///` scheme pass
+    through unchanged; only matching prefixes are converted.
+    """
+    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
+    req = _make_otel_export_req_with_ref_attrs(
+        {
+            "weave.object_refs": [
+                "weave:///ent/proj/object/a:v1",
+                "weave-trace-internal:///already-internal/object/b:v1",
+                "not-a-ref-at-all",
+            ]
+        }
+    )
+
+    forwarded = _capture_genai_otel_export_req(req)
+    assert _ref_attr_values(forwarded, "weave.object_refs") == [
+        f"weave-trace-internal:///{internal_proj}/object/a:v1",
+        "weave-trace-internal:///already-internal/object/b:v1",
+        "not-a-ref-at-all",
+    ]
+
+
+def test_genai_otel_export_caches_project_id_lookup_across_batch() -> None:
+    """A single per-request cache means ext→int_project_id runs once per
+    distinct entity/project pair, even across many spans and many refs.
+    """
+    from opentelemetry.proto.common.v1.common_pb2 import AnyValue, KeyValue
+    from opentelemetry.proto.resource.v1.resource_pb2 import Resource
+    from opentelemetry.proto.trace.v1.trace_pb2 import (
+        ResourceSpans,
+        ScopeSpans,
+        Span,
+    )
+
+    class CountingIdConverter(_EncodingIdConverter):
+        def __init__(self) -> None:
+            self.ext_to_int_calls: list[str] = []
+
+        def ext_to_int_project_id(self, project_id: str) -> str:
+            self.ext_to_int_calls.append(project_id)
+            return super().ext_to_int_project_id(project_id)
+
+    # Three spans, each carrying two refs for the same entity/project.
+    scope_spans = ScopeSpans()
+    for _ in range(3):
+        span = Span()
+        kv = KeyValue(key="weave.object_refs")
+        kv.value.array_value.values.extend(
+            [
+                AnyValue(string_value="weave:///ent/proj/object/a:v1"),
+                AnyValue(string_value="weave:///ent/proj/object/b:v1"),
+            ]
+        )
+        span.attributes.append(kv)
+        scope_spans.spans.append(span)
+    resource_spans = ResourceSpans()
+    resource_spans.resource.CopyFrom(Resource())
+    resource_spans.scope_spans.append(scope_spans)
+    processed = tsi.ProcessedResourceSpans(
+        entity="ent",
+        project="proj",
+        run_id=None,
+        resource_spans=resource_spans,
+    )
+    req = tsi.agent_types.GenAIOTelExportReq(
+        processed_spans=[processed], project_id="ent/proj", wb_user_id=None
+    )
+
+    inner = MagicMock(spec=tsi.FullTraceServerInterface)
+    inner.genai_otel_export.return_value = tsi.agent_types.GenAIOTelExportRes()
+    converter = CountingIdConverter()
+    ExternalTraceServer(inner, converter).genai_otel_export(req)
+
+    # One call for `req.project_id` translation + exactly one more for the
+    # rewrite cache (not 6 — one per ref).
+    assert converter.ext_to_int_calls == ["ent/proj", "ent/proj"]

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -477,6 +477,10 @@ class AgentSpanSchema(BaseModel):
     wb_run_id: str | None = None
     wb_run_step: int | None = None
     wb_run_step_end: int | None = None
+    # Only populated when AgentSpansQueryReq.include_details is set; the raw
+    # OTel JSON dump for the span is large, so it's omitted from list queries
+    # by default.
+    raw_span_dump: str | None = None
 
 
 class AgentSortBy(BaseModel):
@@ -637,6 +641,10 @@ class AgentSpansQueryReq(BaseModel):
         max_length=MAX_AGENT_CUSTOM_ATTR_DISTRIBUTION_SPECS,
     )
     custom_attr_columns: list[AgentSpanValueRef] = Field(default_factory=list)
+    # When true, include heavy fields (messages, tool payloads, raw_span_dump,
+    # etc.) in each row. Intended for single-trace detail fetches; do not set
+    # for broad list queries.
+    include_details: bool = False
     sort_by: list[AgentSortBy] | None = None
     limit: int = Field(
         default=DEFAULT_AGENT_QUERY_LIMIT, ge=0, le=MAX_AGENT_QUERY_LIMIT

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -667,6 +667,10 @@ class AgentSpansQueryReq(BaseModel):
             raise ValueError(
                 "custom_attr_columns are only supported for ungrouped spans"
             )
+        if self.group_by and self.include_details:
+            raise ValueError(
+                "include_details is only supported for ungrouped spans"
+            )
         invalid_custom_attr_columns = [
             col.source
             for col in self.custom_attr_columns

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -668,9 +668,7 @@ class AgentSpansQueryReq(BaseModel):
                 "custom_attr_columns are only supported for ungrouped spans"
             )
         if self.group_by and self.include_details:
-            raise ValueError(
-                "include_details is only supported for ungrouped spans"
-            )
+            raise ValueError("include_details is only supported for ungrouped spans")
         invalid_custom_attr_columns = [
             col.source
             for col in self.custom_attr_columns

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1,12 +1,78 @@
 import abc
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from typing import Any, TypeVar
 
+from opentelemetry.proto.common.v1.common_pb2 import KeyValue
+
+from weave.shared import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.trace_server_converter import (
     universal_ext_to_int_ref_converter,
     universal_int_to_ext_ref_converter,
 )
+
+# OTel attribute keys whose values are typed `Array(String)` ref columns
+# in the agents `spans` table. Refs in these columns are surfaced as bare
+# strings by the read-path response, so they must be in internal form on
+# disk for the int→ext converter to round-trip them.
+_OTEL_REF_ATTR_KEYS = frozenset(
+    {
+        "weave.content_refs",
+        "weave.artifact_refs",
+        "weave.object_refs",
+    }
+)
+_WEAVE_EXT_PREFIX = ri.WEAVE_SCHEME + ":///"
+
+
+def _convert_external_weave_ref(
+    ref: str, ext_to_int_project_id: Callable[[str], str]
+) -> str:
+    """Rewrite a single `weave:///entity/project/tail` ref to internal form.
+
+    Anything else (other schemes, malformed refs, already-internal refs)
+    is returned unchanged.
+    """
+    if not ref.startswith(_WEAVE_EXT_PREFIX):
+        return ref
+    rest = ref[len(_WEAVE_EXT_PREFIX) :]
+    parts = rest.split("/", 2)
+    if len(parts) != 3:
+        return ref
+    entity, project, tail = parts
+    internal_project_id = ext_to_int_project_id(f"{entity}/{project}")
+    return f"{ri.WEAVE_INTERNAL_SCHEME}:///{internal_project_id}/{tail}"
+
+
+def _rewrite_otel_ref_attrs_inplace(
+    attrs: Iterable[KeyValue],
+    ext_to_int_project_id: Callable[[str], str],
+    prefix: str = "",
+) -> None:
+    """Recursively rewrite typed ref attributes from external to internal form.
+
+    OTel encodes attributes either flat (`weave.object_refs`) or nested as
+    a `kvlist_value` (top-level key `weave` with a child `object_refs`),
+    so we descend through `kvlist_value`s and accumulate dotted prefixes.
+    Only `Array(String)` values under the known ref keys are touched;
+    everything else (including refs embedded in event payloads, message
+    content, `raw_span_dump`, etc.) is left exactly as the client sent it.
+    """
+    for kv in attrs:
+        full_key = f"{prefix}{kv.key}" if prefix else kv.key
+        value = kv.value
+        if full_key in _OTEL_REF_ATTR_KEYS and value.HasField("array_value"):
+            for item in value.array_value.values:
+                if item.HasField("string_value"):
+                    item.string_value = _convert_external_weave_ref(
+                        item.string_value, ext_to_int_project_id
+                    )
+        elif value.HasField("kvlist_value"):
+            _rewrite_otel_ref_attrs_inplace(
+                value.kvlist_value.values,
+                ext_to_int_project_id,
+                prefix=f"{full_key}.",
+            )
 
 
 class IdConverter:
@@ -1164,6 +1230,18 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         req.project_id = self._idc.ext_to_int_project_id(req.project_id)
         if req.wb_user_id is not None:
             req.wb_user_id = self._idc.ext_to_int_user_id(req.wb_user_id)
+        # `_ref_apply`'s universal walker can't descend into the raw
+        # protobuf `ResourceSpans` payload, so the typed-ref OTel
+        # attribute values (`weave.content_refs`, `weave.artifact_refs`,
+        # `weave.object_refs`) escape the standard ext→int conversion.
+        # Rewrite them in-place here so the inner trace server sees a
+        # request that's already in internal-ref form, matching the
+        # invariant every other resolver relies on.
+        ext_to_int = self._idc.ext_to_int_project_id
+        for processed_span in req.processed_spans:
+            for scope_spans in processed_span.resource_spans.scope_spans:
+                for span in scope_spans.spans:
+                    _rewrite_otel_ref_attrs_inplace(span.attributes, ext_to_int)
         return self._internal_trace_server.genai_otel_export(req)
 
     def agent_spans_query(

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -4,11 +4,12 @@ from typing import Any, TypeVar
 
 from opentelemetry.proto.common.v1.common_pb2 import KeyValue
 
-from weave.shared import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.trace_server_converter import (
+    replace_external_weave_ref,
     universal_ext_to_int_ref_converter,
     universal_int_to_ext_ref_converter,
+    weave_prefix,
 )
 
 # OTel attribute keys whose values are typed `Array(String)` ref columns
@@ -22,31 +23,12 @@ _OTEL_REF_ATTR_KEYS = frozenset(
         "weave.object_refs",
     }
 )
-_WEAVE_EXT_PREFIX = ri.WEAVE_SCHEME + ":///"
-
-
-def _convert_external_weave_ref(
-    ref: str, ext_to_int_project_id: Callable[[str], str]
-) -> str:
-    """Rewrite a single `weave:///entity/project/tail` ref to internal form.
-
-    Anything else (other schemes, malformed refs, already-internal refs)
-    is returned unchanged.
-    """
-    if not ref.startswith(_WEAVE_EXT_PREFIX):
-        return ref
-    rest = ref[len(_WEAVE_EXT_PREFIX) :]
-    parts = rest.split("/", 2)
-    if len(parts) != 3:
-        return ref
-    entity, project, tail = parts
-    internal_project_id = ext_to_int_project_id(f"{entity}/{project}")
-    return f"{ri.WEAVE_INTERNAL_SCHEME}:///{internal_project_id}/{tail}"
 
 
 def _rewrite_otel_ref_attrs_inplace(
     attrs: Iterable[KeyValue],
     ext_to_int_project_id: Callable[[str], str],
+    cache: dict[str, str],
     prefix: str = "",
 ) -> None:
     """Recursively rewrite typed ref attributes from external to internal form.
@@ -57,20 +39,25 @@ def _rewrite_otel_ref_attrs_inplace(
     Only `Array(String)` values under the known ref keys are touched;
     everything else (including refs embedded in event payloads, message
     content, `raw_span_dump`, etc.) is left exactly as the client sent it.
+    `cache` is a shared per-request dict that memoizes ext→int project_id
+    lookups across every ref in the batch.
     """
     for kv in attrs:
         full_key = f"{prefix}{kv.key}" if prefix else kv.key
         value = kv.value
         if full_key in _OTEL_REF_ATTR_KEYS and value.HasField("array_value"):
             for item in value.array_value.values:
-                if item.HasField("string_value"):
-                    item.string_value = _convert_external_weave_ref(
-                        item.string_value, ext_to_int_project_id
+                if item.HasField("string_value") and item.string_value.startswith(
+                    weave_prefix
+                ):
+                    item.string_value = replace_external_weave_ref(
+                        item.string_value, ext_to_int_project_id, cache
                     )
         elif value.HasField("kvlist_value"):
             _rewrite_otel_ref_attrs_inplace(
                 value.kvlist_value.values,
                 ext_to_int_project_id,
+                cache,
                 prefix=f"{full_key}.",
             )
 
@@ -1236,12 +1223,17 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         # `weave.object_refs`) escape the standard ext→int conversion.
         # Rewrite them in-place here so the inner trace server sees a
         # request that's already in internal-ref form, matching the
-        # invariant every other resolver relies on.
+        # invariant every other resolver relies on. The cache is shared
+        # across every span in the batch so ext→int_project_id runs at
+        # most once per distinct entity/project pair per request.
         ext_to_int = self._idc.ext_to_int_project_id
+        project_id_cache: dict[str, str] = {}
         for processed_span in req.processed_spans:
             for scope_spans in processed_span.resource_spans.scope_spans:
                 for span in scope_spans.spans:
-                    _rewrite_otel_ref_attrs_inplace(span.attributes, ext_to_int)
+                    _rewrite_otel_ref_attrs_inplace(
+                        span.attributes, ext_to_int, project_id_cache
+                    )
         return self._internal_trace_server.genai_otel_export(req)
 
     def agent_spans_query(

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -262,9 +262,10 @@ def _projection(cols: list[str], *, table_alias: str | None = None) -> str:
     return ", ".join(cols)
 
 
-# Spans list query: lightweight table projection. Custom attrs and raw dumps
-# remain queryable/filterable server-side, but the UI does not need to hydrate
-# arbitrary Map/blob payloads for every span row.
+# Spans list query: scalar/short projection used for the spans table.
+# Custom-attr Maps and large blobs (messages, payloads, raw_span_dump) are
+# pulled in by `_SPANS_DETAILS_FIELD_NAMES` only when the caller opts in via
+# `include_details`.
 _SPANS_LIST_FIELD_NAMES = [
     "project_id",
     "trace_id",
@@ -288,6 +289,8 @@ _SPANS_LIST_FIELD_NAMES = [
     "input_tokens",
     "output_tokens",
     "reasoning_tokens",
+    "cache_creation_input_tokens",
+    "cache_read_input_tokens",
     "conversation_id",
     "conversation_name",
     "tool_name",
@@ -295,10 +298,50 @@ _SPANS_LIST_FIELD_NAMES = [
     "tool_call_id",
     "finish_reasons",
     "error_type",
+    "request_temperature",
+    "request_max_tokens",
+    "request_top_p",
+    "request_frequency_penalty",
+    "request_presence_penalty",
+    "request_seed",
+    "request_stop_sequences",
+    "request_choice_count",
+    "output_type",
+    "compaction_items_before",
+    "compaction_items_after",
+    "server_address",
+    "server_port",
     "wb_user_id",
     "wb_run_id",
+    "wb_run_step",
+    "wb_run_step_end",
 ]
 SPANS_LIST_COLS: str = _projection(_SPANS_LIST_FIELD_NAMES)
+
+# Detail-only fields: heavy text/array payloads. Included only when the
+# caller sets `include_details` (the span detail panel does this; the main
+# spans table does not).
+#
+# The `*_refs` columns are stored in internal-ref form by `extract_genai_span`
+# so the response-side int→ext converter can round-trip them. Pre-fix rows
+# may still hold external `weave:///` refs; those will trip the strict
+# converter at read time and need a backfill.
+_SPANS_DETAILS_FIELD_NAMES = [
+    "reasoning_content",
+    "tool_description",
+    "tool_definitions",
+    "input_messages",
+    "output_messages",
+    "system_instructions",
+    "tool_call_arguments",
+    "tool_call_result",
+    "compaction_summary",
+    "content_refs",
+    "artifact_refs",
+    "object_refs",
+    "raw_span_dump",
+]
+SPANS_DETAILS_COLS: str = _projection(_SPANS_DETAILS_FIELD_NAMES)
 
 
 def _custom_attr_field_name(ref: AgentSpanValueRef) -> str:
@@ -923,8 +966,9 @@ def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
         custom_attr_projection = _custom_attr_map_projection(
             pb, req.custom_attr_columns
         )
+        details_projection = f", {SPANS_DETAILS_COLS}" if req.include_details else ""
         return f"""
-            SELECT {SPANS_LIST_COLS}{custom_attr_projection}
+            SELECT {SPANS_LIST_COLS}{details_projection}{custom_attr_projection}
             FROM spans s
             WHERE {span_filters.where}
             ORDER BY {order_by}

--- a/weave/trace_server/trace_server_converter.py
+++ b/weave/trace_server/trace_server_converter.py
@@ -36,6 +36,35 @@ class InvalidInternalRef(ValueError):
     pass
 
 
+def replace_external_weave_ref(
+    ref_str: str,
+    convert_ext_to_int_project_id: Callable[[str], str],
+    cache: dict[str, str] | None = None,
+) -> str:
+    """Convert a single `weave:///entity/project/tail` ref to internal form.
+
+    Pass a shared `cache` dict to amortize ext→int project lookups across
+    repeated calls. Raises ``ValueError`` if the input does not start with
+    the external scheme prefix, and ``InvalidExternalRef`` if the tail does
+    not parse as ``entity/project/...``.
+    """
+    if not ref_str.startswith(weave_prefix):
+        raise ValueError(f"Invalid URI: {ref_str}")
+    rest = ref_str[len(weave_prefix) :]
+    parts = rest.split("/", 2)
+    if len(parts) != 3:
+        raise InvalidExternalRef(f"Invalid URI: {ref_str}")
+    entity, project, tail = parts
+    project_key = f"{entity}/{project}"
+    if cache is None:
+        internal_project_id = convert_ext_to_int_project_id(project_key)
+    else:
+        if project_key not in cache:
+            cache[project_key] = convert_ext_to_int_project_id(project_key)
+        internal_project_id = cache[project_key]
+    return f"{ri.WEAVE_INTERNAL_SCHEME}:///{internal_project_id}/{tail}"
+
+
 def universal_ext_to_int_ref_converter(
     obj: A,
     convert_ext_to_int_project_id: Callable[[str], str],
@@ -63,20 +92,9 @@ def universal_ext_to_int_ref_converter(
     ext_to_int_project_cache: dict[str, str] = {}
 
     def replace_ref(ref_str: str) -> str:
-        if not ref_str.startswith(weave_prefix):
-            raise ValueError(f"Invalid URI: {ref_str}")
-        rest = ref_str[len(weave_prefix) :]
-        parts = rest.split("/", 2)
-        if len(parts) != 3:
-            raise InvalidExternalRef(f"Invalid URI: {ref_str}")
-        entity, project, tail = parts
-        project_key = f"{entity}/{project}"
-        if project_key not in ext_to_int_project_cache:
-            ext_to_int_project_cache[project_key] = convert_ext_to_int_project_id(
-                project_key
-            )
-        internal_project_id = ext_to_int_project_cache[project_key]
-        return f"{ri.WEAVE_INTERNAL_SCHEME}:///{internal_project_id}/{tail}"
+        return replace_external_weave_ref(
+            ref_str, convert_ext_to_int_project_id, ext_to_int_project_cache
+        )
 
     def mapper(obj: B) -> B:
         if isinstance(obj, str):


### PR DESCRIPTION
## Summary

Two paired changes to the agents pipeline. Shipping together because (2) is a prerequisite for (1) to not 500.

1. **`include_details` flag on `AgentSpansQueryReq`.** Lets the span detail panel pull heavy per-row fields (messages, tool args/result, `system_instructions`, `compaction_summary`, the typed `*_refs` columns, `raw_span_dump`) without bloating the spans-table list query. Also expands the always-on scalar projection to include cheap fields the UI table already reads but the API was dropping on the floor (cache tokens, every `request_*` parameter, `output_type`, server addr/port, `wb_run_step*`, compaction counters).

2. **OTel ingest now converts the typed ref attributes ext→int.** In `external_to_internal_trace_server_adapter.genai_otel_export`, walk each span's protobuf `attributes` and rewrite the values of `weave.content_refs` / `weave.artifact_refs` / `weave.object_refs` from `weave:///entity/project/...` to `weave-trace-internal:///<project_id>/...` before forwarding the request to the inner trace server. Handles both flat-dotted (`weave.object_refs`) and nested-kvlist (`weave` → `object_refs`) OTel attribute encodings.

## Why the protobuf walk lives in the adapter

Every other resolver gets ext→int conversion for free by wrapping `_ref_apply`, whose `universal_ext_to_int_ref_converter` walks the request and rewrites any `weave:///` strings it finds. The walker handles `BaseModel` / `dict` / `list` / `tuple` / `set` and treats everything else as a scalar leaf.

`GenAIOTelExportReq.processed_spans[*].resource_spans` is a raw protobuf `ResourceSpans` (`arbitrary_types_allowed=True`), so the walker bounces off it — the refs inside the OTel attribute values escape conversion entirely. That's fine for fields the inner server stores as JSON blobs (the strict reader sees one string starting with `{`, no `weave://` prefix match), but it 500s every detail-mode query the moment the typed `Array(String)` ref columns get selected, because the read-path `int→ext` converter walks each list element as its own bare string and explicitly raises on `weave://`-prefixed values.

Pre-walking the protobuf in the adapter restores the invariant every other resolver relies on: the inner trace server receives a request that's already in internal-ref form. The inner trace server stays oblivious to ext/int — no signature changes anywhere downstream of the adapter.

## What's intentionally _not_ converted

- `raw_span_dump`, `attributes_dump`, `events_dump`, `resource_dump` — preserved byte-for-byte from the OTel sender. They're JSON strings, the strict reader doesn't trip on them, and they're meant to be a verbatim record of what the client emitted.
- Refs embedded inside message content / tool arguments / event payloads — same reasoning. The walker only touches values of the three known ref-typed attribute keys.
- Other schemes (e.g. `wandb-artifact://`) are left alone — `_convert_external_weave_ref` only rewrites strings that match `weave:///`.

## Why not just relax the read-path strict check?

That check is what catches genuine data corruption (refs stored in the wrong scheme on disk). The right fix is to make the on-disk invariant hold, not to weaken the invariant check.