### PR TITLE
chore(weave_ts): add sdks/node/examples/agent.ts

### DIFF
--- a/sdks/node/examples/agent.ts
+++ b/sdks/node/examples/agent.ts
@@ -52,7 +52,7 @@ async function callLLM({
 }: {
   messages: Message[];
   tools: OpenAI.Chat.Completions.ChatCompletionTool[];
-  userMessage?: Message;
+  userMessage?: OpenAI.Chat.Completions.ChatCompletionUserMessageParam;
 }): Promise<OpenAI.Chat.Completions.ChatCompletionMessage> {
   const llm = weave.startLLM({model: MODEL, providerName: 'openai'});
 
@@ -106,13 +106,12 @@ async function runTurn(
   history: Message[],
   prompt: string
 ): Promise<string | null> {
-  const userMessage = {role: 'user' as const, content: prompt};
-  history.push(userMessage);
+  history.push({role: 'user', content: prompt});
 
   const turn = weave.startTurn({model: MODEL});
   try {
     let msg = await callLLM({
-      userMessage: userMessage,
+      userMessage: {role: 'user', content: prompt},
       messages: history,
       tools: [wikipediaTool],
     });

--- a/sdks/node/examples/agent.ts
+++ b/sdks/node/examples/agent.ts
@@ -7,28 +7,33 @@ const openai = new OpenAI();
 // --- Wikipedia tool ---
 
 async function wikipediaSearch({query}: {query: string}): Promise<string> {
-  const searchUrl = `https://en.wikipedia.org/w/api.php?action=opensearch&limit=1&format=json&search=${encodeURIComponent(query)}`;
-  const searchResp = await fetch(searchUrl);
-  const searchData = await searchResp.json();
-  const title = searchData?.[1]?.[0];
-  if (!title) return `No Wikipedia results for "${query}".`;
-
-  const summaryUrl = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`;
-  const summaryResp = await fetch(summaryUrl);
-  const summaryData = await summaryResp.json();
-  return summaryData.extract ?? `No summary available for "${title}".`;
+  const params = new URLSearchParams({
+    action: 'query',
+    generator: 'search',
+    gsrsearch: query,
+    gsrlimit: '1',
+    prop: 'extracts',
+    exintro: '1',
+    explaintext: '1',
+    format: 'json',
+  });
+  const resp = await fetch(`https://en.wikipedia.org/w/api.php?${params}`, {
+    headers: {'User-Agent': 'weave-demo'},
+  });
+  const data = await resp.json();
+  const pages = data.query.pages as Record<string, {extract: string}>;
+  return Object.values(pages)[0].extract;
 }
 
 const wikipediaTool: OpenAI.Chat.Completions.ChatCompletionTool = {
   type: 'function',
   function: {
     name: 'wikipedia_search',
-    description:
-      'Search Wikipedia and return a short summary for the top result.',
+    description: 'Search Wikipedia for a topic and return its intro paragraph.',
     parameters: {
       type: 'object',
       properties: {
-        query: {type: 'string', description: 'Search query'},
+        query: {type: 'string'},
       },
       required: ['query'],
     },
@@ -40,11 +45,23 @@ const wikipediaTool: OpenAI.Chat.Completions.ChatCompletionTool = {
 type Message = OpenAI.Chat.Completions.ChatCompletionMessageParam;
 type ToolCall = OpenAI.Chat.Completions.ChatCompletionMessageToolCall;
 
-async function callLLM(
-  messages: Message[],
-  tools?: OpenAI.Chat.Completions.ChatCompletionTool[]
-): Promise<OpenAI.Chat.Completions.ChatCompletionMessage> {
+async function callLLM({
+  messages,
+  tools,
+  userMessage,
+}: {
+  messages: Message[];
+  tools: OpenAI.Chat.Completions.ChatCompletionTool[];
+  userMessage?: Message;
+}): Promise<OpenAI.Chat.Completions.ChatCompletionMessage> {
   const llm = weave.startLLM({model: MODEL, providerName: 'openai'});
+
+  if (userMessage) {
+    llm.inputMessages = [
+      {role: 'user', content: userMessage.content as string},
+    ];
+  }
+
   try {
     const resp = await openai.chat.completions.create({
       model: MODEL,
@@ -86,18 +103,23 @@ async function executeToolCalls(
 
 async function runTurn(
   history: Message[],
-  userMessage: string
+  prompt: string
 ): Promise<string | null> {
-  history.push({role: 'user', content: userMessage});
+  const userMessage = {role: 'user' as const, content: prompt};
+  history.push(userMessage);
 
   const turn = weave.startTurn({model: MODEL});
   try {
-    let msg = await callLLM(history, [wikipediaTool]);
+    let msg = await callLLM({
+      userMessage: userMessage,
+      messages: history,
+      tools: [wikipediaTool],
+    });
     history.push(msg);
 
     while (msg.tool_calls?.length) {
       await executeToolCalls(msg.tool_calls, history);
-      msg = await callLLM(history, [wikipediaTool]);
+      msg = await callLLM({messages: history, tools: [wikipediaTool]});
       history.push(msg);
     }
 
@@ -113,7 +135,13 @@ async function main() {
   const session = weave.startSession({agentName: 'research-bot'});
   try {
     console.log(`session_id = ${session.sessionId}\n`);
-    const history: Message[] = [];
+    const history: Message[] = [
+      {
+        role: 'system',
+        content:
+          'Always use the wikipedia_search tool to look up facts before answering. Do not rely on your own knowledge.',
+      },
+    ];
     const questions = [
       'List the names of a couple dinosaurs that were carnivores.',
       'List a couple more that were herbivores.',

--- a/sdks/node/examples/agent.ts
+++ b/sdks/node/examples/agent.ts
@@ -67,6 +67,7 @@ async function callLLM({
       model: MODEL,
       messages,
       tools,
+      parallel_tool_calls: false,
     });
     const msg = resp.choices[0].message;
     llm.output(msg.content ?? '');

--- a/sdks/node/examples/agent.ts
+++ b/sdks/node/examples/agent.ts
@@ -1,0 +1,132 @@
+import {OpenAI} from 'openai';
+import * as weave from 'weave';
+
+const MODEL = 'gpt-4o-mini';
+const openai = new OpenAI();
+
+// --- Wikipedia tool ---
+
+async function wikipediaSearch({query}: {query: string}): Promise<string> {
+  const searchUrl = `https://en.wikipedia.org/w/api.php?action=opensearch&limit=1&format=json&search=${encodeURIComponent(query)}`;
+  const searchResp = await fetch(searchUrl);
+  const searchData = await searchResp.json();
+  const title = searchData?.[1]?.[0];
+  if (!title) return `No Wikipedia results for "${query}".`;
+
+  const summaryUrl = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`;
+  const summaryResp = await fetch(summaryUrl);
+  const summaryData = await summaryResp.json();
+  return summaryData.extract ?? `No summary available for "${title}".`;
+}
+
+const wikipediaTool: OpenAI.Chat.Completions.ChatCompletionTool = {
+  type: 'function',
+  function: {
+    name: 'wikipedia_search',
+    description:
+      'Search Wikipedia and return a short summary for the top result.',
+    parameters: {
+      type: 'object',
+      properties: {
+        query: {type: 'string', description: 'Search query'},
+      },
+      required: ['query'],
+    },
+  },
+};
+
+// --- Agent helpers ---
+
+type Message = OpenAI.Chat.Completions.ChatCompletionMessageParam;
+type ToolCall = OpenAI.Chat.Completions.ChatCompletionMessageToolCall;
+
+async function callLLM(
+  messages: Message[],
+  tools?: OpenAI.Chat.Completions.ChatCompletionTool[]
+): Promise<OpenAI.Chat.Completions.ChatCompletionMessage> {
+  const llm = weave.startLLM({model: MODEL, providerName: 'openai'});
+  try {
+    const resp = await openai.chat.completions.create({
+      model: MODEL,
+      messages,
+      tools,
+    });
+    const msg = resp.choices[0].message;
+    llm.output(msg.content ?? '');
+    llm.record({
+      usage: {
+        inputTokens: resp.usage?.prompt_tokens,
+        outputTokens: resp.usage?.completion_tokens,
+      },
+    });
+    return msg;
+  } finally {
+    llm.end();
+  }
+}
+
+async function executeToolCalls(
+  toolCalls: ToolCall[],
+  history: Message[]
+): Promise<void> {
+  for (const tc of toolCalls) {
+    const tool = weave.startTool({
+      name: tc.function.name,
+      args: tc.function.arguments,
+      toolCallId: tc.id,
+    });
+    try {
+      tool.result = await wikipediaSearch(JSON.parse(tc.function.arguments));
+      history.push({role: 'tool', tool_call_id: tc.id, content: tool.result!});
+    } finally {
+      tool.end();
+    }
+  }
+}
+
+async function runTurn(
+  history: Message[],
+  userMessage: string
+): Promise<string | null> {
+  history.push({role: 'user', content: userMessage});
+
+  const turn = weave.startTurn({model: MODEL});
+  try {
+    let msg = await callLLM(history, [wikipediaTool]);
+    history.push(msg);
+
+    while (msg.tool_calls?.length) {
+      await executeToolCalls(msg.tool_calls, history);
+      msg = await callLLM(history, [wikipediaTool]);
+      history.push(msg);
+    }
+
+    return msg.content;
+  } finally {
+    turn.end();
+  }
+}
+
+async function main() {
+  await weave.init('examples');
+
+  const session = weave.startSession({agentName: 'research-bot'});
+  try {
+    console.log(`session_id = ${session.sessionId}\n`);
+    const history: Message[] = [];
+    const questions = [
+      'List the names of a couple dinosaurs that were carnivores.',
+      'List a couple more that were herbivores.',
+      'Summarize what we discussed in one sentence.',
+    ];
+    for (const question of questions) {
+      console.log(`USER:  ${question}`);
+      const answer = await runTurn(history, question);
+      console.log(`AGENT: ${answer}\n`);
+    }
+  } finally {
+    session.end();
+  }
+}
+
+main();

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -64,6 +64,11 @@ export class Turn {
       {kind: SpanKind.CLIENT, attributes},
       ROOT_CONTEXT
     );
+
+    span.addEvent('gen_ai.user.message', {
+      'gen_ai.event.content': JSON.stringify({content: 'testing, 1, 2, 3'}),
+    });
+
     const turn = new Turn(
       span,
       trace.setSpan(ROOT_CONTEXT, span),

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -64,11 +64,6 @@ export class Turn {
       {kind: SpanKind.CLIENT, attributes},
       ROOT_CONTEXT
     );
-
-    span.addEvent('gen_ai.user.message', {
-      'gen_ai.event.content': JSON.stringify({content: 'testing, 1, 2, 3'}),
-    });
-
     const turn = new Turn(
       span,
       trace.setSpan(ROOT_CONTEXT, span),


### PR DESCRIPTION
## Description

* Adds a quick port of @rgao-coreweave's Python agent example (https://colab.research.google.com/drive/1lqPraqf3pvKGG9gNtnfIC1ucHOoYtayz?usp=sharing) to `examples/` to feel out the TS APIs, and see data make its way into the UI.

* Example:

```bash
➜  node git:(master) pnpm tsx examples/agent.ts                                 
Initializing project: benmocha-/examples
session_id = 019e5046-35f3-7801-b64e-e5bf5671a517

USER:  List the names of a couple dinosaurs that were carnivores.
AGENT: A couple of carnivorous dinosaurs are Tyrannosaurus and Giganotosaurus, both of which are part of the Theropoda clade.

USER:  List a couple more that were herbivores.
AGENT: A couple of herbivorous dinosaurs are Triceratops and Stegosaurus, both of which belong to the Ornithischia clade.

USER:  Summarize what we discussed in one sentence.
AGENT: We discussed carnivorous dinosaurs such as Tyrannosaurus and Giganotosaurus, as well as herbivorous dinosaurs like Triceratops and Stegosaurus.
```

* Resulting in:

<img width="1572" height="1053" alt="Screenshot 2026-05-22 at 10 21 09 AM" src="https://github.com/user-attachments/assets/ddb820e8-48ef-46e1-8172-fc53ab13e717" />




