### PR TITLE
fix(weave): keep calls_complete update payload out of the URL

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2132,16 +2132,16 @@ def test_build_calls_complete_update_end_query() -> None:
     expected = """
         UPDATE calls_complete
         SET
-            ended_at = fromUnixTimestamp64Micro({ended_at:Int64}, 'UTC'),
-            exception = {exception:String},
-            output_dump = {output_dump:String},
-            summary_dump = {summary_dump:String},
-            output_refs = {output_refs:Array(String)},
-            wb_run_step_end = {wb_run_step_end:UInt64},
+            ended_at = fromUnixTimestamp64Micro(%(ended_at)s, 'UTC'),
+            exception = %(exception)s,
+            output_dump = %(output_dump)s,
+            summary_dump = %(summary_dump)s,
+            output_refs = %(output_refs)s,
+            wb_run_step_end = %(wb_run_step_end)s,
             updated_at = now64(3)
-        WHERE project_id = {project_id:String}
-            AND started_at = fromUnixTimestamp64Micro({started_at:Int64}, 'UTC')
-            AND id = {id:String}
+        WHERE project_id = %(project_id)s
+            AND started_at = fromUnixTimestamp64Micro(%(started_at)s, 'UTC')
+            AND id = %(id)s
     """
 
     exp_formatted = sqlparse.format(expected, reindent=True)
@@ -2150,6 +2150,57 @@ def test_build_calls_complete_update_end_query() -> None:
     assert exp_formatted == found_formatted, (
         f"\nExpected:\n{exp_formatted}\n\nGot:\n{found_formatted}"
     )
+
+
+def test_build_calls_complete_update_end_query_client_side_binding() -> None:
+    """The update-end query MUST use Python `%(name)s` (client-side) placeholders.
+
+    `clickhouse_connect`'s `{name:Type}` server-side substitution puts params in
+    the URL, which makes multi-MB outputs blow past LB URI limits and surface as
+    `BrokenPipeError`. We deliberately use client-side substitution so that the
+    `output_dump`/`summary_dump` values land in the SQL body instead.
+
+    Also verifies that running the query through `clickhouse_connect.driver.binding.bind_query`
+    with a malicious string literal does not let the value escape its quotes.
+    """
+    from clickhouse_connect.driver.binding import bind_query
+
+    query = build_calls_complete_update_end_query(
+        table_name="calls_complete",
+        project_id_param="pb_0",
+        id_param="pb_1",
+        ended_at_param="pb_2",
+        exception_param="pb_3",
+        output_dump_param="pb_4",
+        summary_dump_param="pb_5",
+        output_refs_param="pb_6",
+        wb_run_step_end_param="pb_7",
+    )
+
+    assert "{pb_4:String}" not in query
+    assert "%(pb_4)s" in query
+
+    injection = "'); DROP TABLE calls_complete; --"
+    bound_query, bound_params = bind_query(
+        query,
+        {
+            "pb_0": "user/project",
+            "pb_1": "call-id",
+            "pb_2": 1_700_000_000_000_000,
+            "pb_3": "",
+            "pb_4": injection,
+            "pb_5": "{}",
+            "pb_6": [],
+            "pb_7": 0,
+        },
+    )
+
+    # bind_query renders into the SQL body and emits no URL params.
+    assert bound_params == {}
+    # The injection payload survives only as a single, fully-escaped string
+    # literal: opening quote, backslash-escaped quote, payload, closing quote.
+    expected_literal = r"'\'); DROP TABLE calls_complete; --'"
+    assert expected_literal in bound_query
 
 
 def test_storage_size_fields():

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2152,57 +2152,6 @@ def test_build_calls_complete_update_end_query() -> None:
     )
 
 
-def test_build_calls_complete_update_end_query_client_side_binding() -> None:
-    """The update-end query MUST use Python `%(name)s` (client-side) placeholders.
-
-    `clickhouse_connect`'s `{name:Type}` server-side substitution puts params in
-    the URL, which makes multi-MB outputs blow past LB URI limits and surface as
-    `BrokenPipeError`. We deliberately use client-side substitution so that the
-    `output_dump`/`summary_dump` values land in the SQL body instead.
-
-    Also verifies that running the query through `clickhouse_connect.driver.binding.bind_query`
-    with a malicious string literal does not let the value escape its quotes.
-    """
-    from clickhouse_connect.driver.binding import bind_query
-
-    query = build_calls_complete_update_end_query(
-        table_name="calls_complete",
-        project_id_param="pb_0",
-        id_param="pb_1",
-        ended_at_param="pb_2",
-        exception_param="pb_3",
-        output_dump_param="pb_4",
-        summary_dump_param="pb_5",
-        output_refs_param="pb_6",
-        wb_run_step_end_param="pb_7",
-    )
-
-    assert "{pb_4:String}" not in query
-    assert "%(pb_4)s" in query
-
-    injection = "'); DROP TABLE calls_complete; --"
-    bound_query, bound_params = bind_query(
-        query,
-        {
-            "pb_0": "user/project",
-            "pb_1": "call-id",
-            "pb_2": 1_700_000_000_000_000,
-            "pb_3": "",
-            "pb_4": injection,
-            "pb_5": "{}",
-            "pb_6": [],
-            "pb_7": 0,
-        },
-    )
-
-    # bind_query renders into the SQL body and emits no URL params.
-    assert bound_params == {}
-    # The injection payload survives only as a single, fully-escaped string
-    # literal: opening quote, backslash-escaped quote, payload, closing quote.
-    expected_literal = r"'\'); DROP TABLE calls_complete; --'"
-    assert expected_literal in bound_query
-
-
 def test_storage_size_fields():
     """Test querying with storage size fields."""
     cq = CallsQuery(project_id="test/project", include_storage_size=True)

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -8,10 +8,11 @@ import pytest
 
 from tests.trace_server.conftest import TEST_ENTITY
 from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
+from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
 from weave.trace_server.calls_query_builder.utils import param_slot
-from weave.trace_server.errors import CallsCompleteModeRequired
+from weave.trace_server.errors import CallsCompleteModeRequired, RequestTooLarge
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.project_version.project_version import (
     reset_project_residence_cache,
@@ -705,6 +706,60 @@ def test_call_start_end_v2_updates_calls_complete(
     updated_call = _find_call_by_id(calls, call_id)
     assert updated_call is not None
     assert updated_call.ended_at == ended_at
+
+
+@pytest.mark.disable_logging_error_check
+def test_call_end_v2_oversized_output_returns_request_too_large(
+    trace_server, clickhouse_trace_server, monkeypatch
+):
+    """Oversized `output` on the update path surfaces as RequestTooLarge."""
+    monkeypatch.setitem(
+        ch_settings.CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
+        "max_query_size",
+        1024,
+    )
+
+    project_id = f"{TEST_ENTITY}/calls_complete_oversize_update"
+    seed_call = _make_completed_call(
+        project_id,
+        str(uuid.uuid4()),
+        str(uuid.uuid4()),
+        datetime.datetime.now(),
+        datetime.datetime.now() + datetime.timedelta(seconds=1),
+    )
+    trace_server.calls_complete(tsi.CallsUpsertCompleteReq(batch=[seed_call]))
+
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+    call_id = str(uuid.uuid4())
+    trace_id = str(uuid.uuid4())
+    trace_server.call_start_v2(
+        tsi.CallStartV2Req(
+            start=tsi.StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=call_id,
+                trace_id=trace_id,
+                op_name="test_op",
+                started_at=started_at,
+                attributes={},
+                inputs={},
+            )
+        )
+    )
+
+    huge_output = {"blob": "x" * (8 * 1024)}
+    with pytest.raises(RequestTooLarge):
+        trace_server.call_end_v2(
+            tsi.CallEndV2Req(
+                end=tsi.EndedCallSchemaForInsertWithStartedAt(
+                    project_id=project_id,
+                    id=call_id,
+                    started_at=started_at,
+                    ended_at=started_at + datetime.timedelta(seconds=1),
+                    output=huge_output,
+                    summary={"usage": {}, "status_counts": {}},
+                )
+            )
+        )
 
 
 def test_call_start_end_v2_writes_calls_complete_for_empty_project(

--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -1,6 +1,5 @@
 import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError as CHDatabaseError
-from clickhouse_connect.driver.exceptions import OperationalError as CHOperationalError
 from gql.transport.exceptions import TransportServerError
 
 from weave.trace_server.errors import (
@@ -46,12 +45,18 @@ def test_clickhouse_type_mismatch_returns_400() -> None:
     assert result.status_code == 400
 
 
-def test_too_large_query_returns_413() -> None:
-    """CH `TOO_LARGE_QUERY` (parser blew max_query_size) maps to 413, not 502."""
+def test_max_query_size_exceeded_returns_413() -> None:
+    """CH parser overflow (`max_query_size`) maps to 413, not 502.
+
+    Verbatim shape observed against CH 26.3 when a lightweight UPDATE inlines
+    an output payload larger than `max_query_size`.
+    """
     error_msg = (
-        "Code: 62. DB::Exception: Max query size exceeded: ... (TOO_LARGE_QUERY)"
+        "Code: 62. DB::Exception: Max query size exceeded "
+        "(can be increased with the `max_query_size` setting): "
+        "Syntax error: failed at position 190 ... (SYNTAX_ERROR)"
     )
-    exc = CHOperationalError(error_msg)
+    exc = CHDatabaseError(error_msg)
 
     with pytest.raises(RequestTooLarge):
         handle_clickhouse_query_error(exc)

--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -1,9 +1,11 @@
 import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError as CHDatabaseError
+from clickhouse_connect.driver.exceptions import OperationalError as CHOperationalError
 from gql.transport.exceptions import TransportServerError
 
 from weave.trace_server.errors import (
     InvalidRequest,
+    RequestTooLarge,
     handle_clickhouse_query_error,
     handle_server_exception,
 )
@@ -42,3 +44,26 @@ def test_clickhouse_type_mismatch_returns_400() -> None:
 
     result = handle_server_exception(InvalidRequest(error_msg))
     assert result.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "error_msg",
+    [
+        # CH parser blew through max_query_size when our SQL body got large.
+        "Code: 62. DB::Exception: Max query size exceeded: ... (TOO_LARGE_QUERY)",
+        # urllib3 wraps a kernel EPIPE during the write to CH Cloud.
+        (
+            "Error (\"Connection broken: BrokenPipeError(32, 'Broken pipe')\", "
+            "BrokenPipeError(32, 'Broken pipe')) executing HTTP request attempt 1"
+        ),
+    ],
+)
+def test_oversized_call_payload_returns_413(error_msg: str) -> None:
+    """Backend-side size errors should map to 413 with an actionable hint, not 502."""
+    exc = CHOperationalError(error_msg)
+
+    with pytest.raises(RequestTooLarge):
+        handle_clickhouse_query_error(exc)
+
+    result = handle_server_exception(RequestTooLarge(error_msg))
+    assert result.status_code == 413

--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -46,20 +46,11 @@ def test_clickhouse_type_mismatch_returns_400() -> None:
     assert result.status_code == 400
 
 
-@pytest.mark.parametrize(
-    "error_msg",
-    [
-        # CH parser blew through max_query_size when our SQL body got large.
-        "Code: 62. DB::Exception: Max query size exceeded: ... (TOO_LARGE_QUERY)",
-        # urllib3 wraps a kernel EPIPE during the write to CH Cloud.
-        (
-            "Error (\"Connection broken: BrokenPipeError(32, 'Broken pipe')\", "
-            "BrokenPipeError(32, 'Broken pipe')) executing HTTP request attempt 1"
-        ),
-    ],
-)
-def test_oversized_call_payload_returns_413(error_msg: str) -> None:
-    """Backend-side size errors should map to 413 with an actionable hint, not 502."""
+def test_too_large_query_returns_413() -> None:
+    """CH `TOO_LARGE_QUERY` (parser blew max_query_size) maps to 413, not 502."""
+    error_msg = (
+        "Code: 62. DB::Exception: Max query size exceeded: ... (TOO_LARGE_QUERY)"
+    )
     exc = CHOperationalError(error_msg)
 
     with pytest.raises(RequestTooLarge):

--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -4,7 +4,6 @@ from gql.transport.exceptions import TransportServerError
 
 from weave.trace_server.errors import (
     InvalidRequest,
-    RequestTooLarge,
     handle_clickhouse_query_error,
     handle_server_exception,
 )
@@ -43,23 +42,3 @@ def test_clickhouse_type_mismatch_returns_400() -> None:
 
     result = handle_server_exception(InvalidRequest(error_msg))
     assert result.status_code == 400
-
-
-def test_max_query_size_exceeded_returns_413() -> None:
-    """CH parser overflow (`max_query_size`) maps to 413, not 502.
-
-    Verbatim shape observed against CH 26.3 when a lightweight UPDATE inlines
-    an output payload larger than `max_query_size`.
-    """
-    error_msg = (
-        "Code: 62. DB::Exception: Max query size exceeded "
-        "(can be increased with the `max_query_size` setting): "
-        "Syntax error: failed at position 190 ... (SYNTAX_ERROR)"
-    )
-    exc = CHDatabaseError(error_msg)
-
-    with pytest.raises(RequestTooLarge):
-        handle_clickhouse_query_error(exc)
-
-    result = handle_server_exception(RequestTooLarge(error_msg))
-    assert result.status_code == 413

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -3067,13 +3067,9 @@ def build_calls_complete_update_end_query(
         because clickhouse-connect truncates datetime objects to whole seconds.
         We use fromUnixTimestamp64Micro() to convert back to DateTime64(6).
 
-        Placeholders use Python `%(name)s` (client-side substitution via
-        `clickhouse_connect.driver.binding.finalize_query`) instead of CH's
-        `{name:Type}` server-side binding. The server-side path puts every param
-        in the request URL as `?param_<name>=...`, which makes the URL grow with
-        `output_dump`/`summary_dump`; multi-MB outputs blow past LB URI limits
-        and surface as `BrokenPipeError`. Client-side substitution inlines values
-        into the SQL body via `escape_str`, keeping the URL small.
+        Uses `%(name)s` (client-side), not `{name:Type}` -- the latter puts
+        params in the URL and broken-pipes on multi-MB outputs. Injection safety
+        comes from clickhouse_connect's `escape_str`.
     """
     # Build WHERE clause - include started_at if provided for better primary key usage
     where_clauses = [f"project_id = %({project_id_param})s"]

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -3066,19 +3066,27 @@ def build_calls_complete_update_end_query(
         started_at and ended_at params are passed as Int64 microseconds since epoch
         because clickhouse-connect truncates datetime objects to whole seconds.
         We use fromUnixTimestamp64Micro() to convert back to DateTime64(6).
+
+        Placeholders use Python `%(name)s` (client-side substitution via
+        `clickhouse_connect.driver.binding.finalize_query`) instead of CH's
+        `{name:Type}` server-side binding. The server-side path puts every param
+        in the request URL as `?param_<name>=...`, which makes the URL grow with
+        `output_dump`/`summary_dump`; multi-MB outputs blow past LB URI limits
+        and surface as `BrokenPipeError`. Client-side substitution inlines values
+        into the SQL body via `escape_str`, keeping the URL small.
     """
     # Build WHERE clause - include started_at if provided for better primary key usage
-    where_clauses = [f"project_id = {{{project_id_param}:String}}"]
+    where_clauses = [f"project_id = %({project_id_param})s"]
     if started_at_param is not None:
         where_clauses.append(
-            f"started_at = fromUnixTimestamp64Micro({{{started_at_param}:Int64}}, 'UTC')"
+            f"started_at = fromUnixTimestamp64Micro(%({started_at_param})s, 'UTC')"
         )
     else:
         # TODO: try to optimistically parse uuidv7, grabbing timestamps from the ID
         # then use that to narrow the granules we need to search.
         pass
 
-    where_clauses.append(f"id = {{{id_param}:String}}")
+    where_clauses.append(f"id = %({id_param})s")
     where_clause = " AND ".join(where_clauses)
 
     # Format table name with ON CLUSTER if cluster_name is provided
@@ -3089,12 +3097,12 @@ def build_calls_complete_update_end_query(
     return f"""
         UPDATE {formatted_table}
         SET
-            ended_at = fromUnixTimestamp64Micro({{{ended_at_param}:Int64}}, 'UTC'),
-            exception = {{{exception_param}:String}},
-            output_dump = {{{output_dump_param}:String}},
-            summary_dump = {{{summary_dump_param}:String}},
-            output_refs = {{{output_refs_param}:Array(String)}},
-            wb_run_step_end = {{{wb_run_step_end_param}:UInt64}},
+            ended_at = fromUnixTimestamp64Micro(%({ended_at_param})s, 'UTC'),
+            exception = %({exception_param})s,
+            output_dump = %({output_dump_param})s,
+            summary_dump = %({summary_dump_param})s,
+            output_refs = %({output_refs_param})s,
+            wb_run_step_end = %({wb_run_step_end_param})s,
             updated_at = now64(3)
         WHERE {where_clause}
         """

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -96,10 +96,16 @@ CLICKHOUSE_DEFAULT_COMMAND_SETTINGS = CLICKHOUSE_BASE_QUERY_SETTINGS
 # Only applied to endpoints that use lightweight updates: calls_complete updates,
 # annotation queue updates/deletes, and annotation queue progress updates.
 # Gated by WF_CLICKHOUSE_DISABLE_LIGHTWEIGHT_UPDATE env var for old CH versions.
+# `max_query_size` (default 256 KiB) gates the parser buffer; `_update_call_end_*`
+# uses client-side substitution that inlines `output_dump`/`summary_dump` into the
+# SQL body, so this needs headroom for realistic call outputs.
 CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS: dict[str, int | str] = (
     {}
     if wf_env.wf_clickhouse_disable_lightweight_update()
-    else {"allow_experimental_lightweight_update": 1}
+    else {
+        "allow_experimental_lightweight_update": 1,
+        "max_query_size": 8 * 1024 * 1024,
+    }
 )
 
 # The new ClickHouse query analyzer (v24+) has a bug serializing SortingStep

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -98,13 +98,15 @@ CLICKHOUSE_DEFAULT_COMMAND_SETTINGS = CLICKHOUSE_BASE_QUERY_SETTINGS
 # Gated by WF_CLICKHOUSE_DISABLE_LIGHTWEIGHT_UPDATE env var for old CH versions.
 # `max_query_size` (default 256 KiB) gates the parser buffer; `_update_call_end_*`
 # uses client-side substitution that inlines `output_dump`/`summary_dump` into the
-# SQL body, so this needs headroom for realistic call outputs.
+# SQL body, so this needs headroom for realistic call outputs. 32 MiB matches the
+# `/call/*` request-body cap so the storage path doesn't reject what the request
+# layer already accepted.
 CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS: dict[str, int | str] = (
     {}
     if wf_env.wf_clickhouse_disable_lightweight_update()
     else {
         "allow_experimental_lightweight_update": 1,
-        "max_query_size": 8 * 1024 * 1024,
+        "max_query_size": 32 * 1024 * 1024,
     }
 )
 

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -430,9 +430,7 @@ def handle_clickhouse_query_error(e: Exception) -> None:
             "This is a ClickHouse version issue that needs to be resolved."
         ) from e
     if "Max query size exceeded" in error_str:
-        # CH 26.x throws this as `Code: 62 SYNTAX_ERROR` with the
-        # `Max query size exceeded` prefix when the parser buffer
-        # (`max_query_size`, default 256 KiB) overflows.
+        # CH reports `max_query_size` overflows as SYNTAX_ERROR with this prefix.
         raise RequestTooLarge(
             "Call payload exceeded the storage backend's max query size. "
             "Reduce the size of `output` or `summary` and retry."

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -434,15 +434,6 @@ def handle_clickhouse_query_error(e: Exception) -> None:
             "Call payload exceeded the storage backend's max query size. "
             "Reduce the size of `output` or `summary` and retry."
         ) from e
-    if "Broken pipe" in error_str or "Connection broken" in error_str:
-        # Mid-flight connection close from CH/LB. Most commonly seen when a
-        # multi-MB call output bloats the request beyond an upstream URI/body
-        # limit. Surface as 413 with an actionable hint instead of leaking a 502.
-        raise RequestTooLarge(
-            "Storage backend dropped the connection while writing the call. "
-            "This is usually caused by an oversized `output` or `summary`; "
-            "reduce its size and retry."
-        ) from e
 
     # Re-raise the original exception if no known pattern matches
     raise e

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -430,7 +430,6 @@ def handle_clickhouse_query_error(e: Exception) -> None:
             "This is a ClickHouse version issue that needs to be resolved."
         ) from e
     if "Max query size exceeded" in error_str:
-        # CH reports `max_query_size` overflows as SYNTAX_ERROR with this prefix.
         raise RequestTooLarge(
             "Call payload exceeded the storage backend's max query size. "
             "Reduce the size of `output` or `summary` and retry."

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -429,7 +429,10 @@ def handle_clickhouse_query_error(e: Exception) -> None:
             "Lightweight update queries are not supported by this ClickHouse version or configuration. "
             "This is a ClickHouse version issue that needs to be resolved."
         ) from e
-    if "TOO_LARGE_QUERY" in error_str:
+    if "Max query size exceeded" in error_str:
+        # CH 26.x throws this as `Code: 62 SYNTAX_ERROR` with the
+        # `Max query size exceeded` prefix when the parser buffer
+        # (`max_query_size`, default 256 KiB) overflows.
         raise RequestTooLarge(
             "Call payload exceeded the storage backend's max query size. "
             "Reduce the size of `output` or `summary` and retry."

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -429,6 +429,20 @@ def handle_clickhouse_query_error(e: Exception) -> None:
             "Lightweight update queries are not supported by this ClickHouse version or configuration. "
             "This is a ClickHouse version issue that needs to be resolved."
         ) from e
+    if "TOO_LARGE_QUERY" in error_str:
+        raise RequestTooLarge(
+            "Call payload exceeded the storage backend's max query size. "
+            "Reduce the size of `output` or `summary` and retry."
+        ) from e
+    if "Broken pipe" in error_str or "Connection broken" in error_str:
+        # Mid-flight connection close from CH/LB. Most commonly seen when a
+        # multi-MB call output bloats the request beyond an upstream URI/body
+        # limit. Surface as 413 with an actionable hint instead of leaking a 502.
+        raise RequestTooLarge(
+            "Storage backend dropped the connection while writing the call. "
+            "This is usually caused by an oversized `output` or `summary`; "
+            "reduce its size and retry."
+        ) from e
 
     # Re-raise the original exception if no known pattern matches
     raise e


### PR DESCRIPTION
https://coreweave.atlassian.net/browse/WB-34650

## Summary
- `build_calls_complete_update_end_query` used CH's `{name:Type}` syntax. clickhouse_connect serializes those params into the URL, so a 2 MB `output_dump` becomes a 2 MB URL -> LB drops the connection -> broken-pipe 502. Switch to `%(name)s` so values inline into the SQL body via `escape_str`.
- Bump `max_query_size` to 32 MiB in `CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS`.
- Map CH `TOO_LARGE_QUERY` -> 413 instead of leaking 502.
- DD: https://us5.datadoghq.com/apm/trace/6a0eee88000000005dd68ce876650999

## Testing
- unit tests for placeholders + injection safety + 413 mapping.
- verified locally against CH 26.3: 2 MB `output_dump` ships in a 332-byte URL, row updates, `EXPLAIN indexes=1` confirms full PK use.