### PR TITLE
feat(weave): Session SDK respects global settings

### DIFF
--- a/tests/session/conftest.py
+++ b/tests/session/conftest.py
@@ -1,0 +1,44 @@
+"""Shared fixtures for Session SDK tests."""
+
+from __future__ import annotations
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from weave.session.session import (
+    get_current_llm,
+    get_current_session,
+    get_current_turn,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_contextvars():
+    """Reset contextvar state after each test to prevent leakage."""
+    yield
+    if (llm := get_current_llm()) is not None:
+        llm.end()
+    if (turn := get_current_turn()) is not None:
+        turn.end()
+    if (session := get_current_session()) is not None:
+        session.end()
+
+
+@pytest.fixture
+def otel_spans(monkeypatch: pytest.MonkeyPatch):
+    """Provide an in-memory span exporter for capturing OTel spans.
+
+    Overrides the global OTel tracer provider for the duration of the test.
+    Uses ``monkeypatch.setattr`` on the private ``_TRACER_PROVIDER`` symbol
+    rather than ``set_tracer_provider`` to avoid the "set once" warning
+    and to guarantee restoration of the prior value.
+    """
+    exporter = InMemorySpanExporter()
+    provider = SDKTracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
+    yield exporter
+    provider.shutdown()

--- a/tests/session/test_session.py
+++ b/tests/session/test_session.py
@@ -26,19 +26,6 @@ from weave.session.session import (
     start_turn,
 )
 
-
-@pytest.fixture(autouse=True)
-def _reset_contextvars():
-    """Reset contextvar state after each test to prevent leakage."""
-    yield
-    if (llm := get_current_llm()) is not None:
-        llm.end()
-    if (turn := get_current_turn()) is not None:
-        turn.end()
-    if (session := get_current_session()) is not None:
-        session.end()
-
-
 # ---------------------------------------------------------------------------
 # Data types
 # ---------------------------------------------------------------------------

--- a/tests/session/test_session_otel.py
+++ b/tests/session/test_session_otel.py
@@ -10,8 +10,6 @@ from typing import Any
 
 import pytest
 from opentelemetry import trace as otel_trace
-from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
-from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NoOpTracerProvider, StatusCode
 
@@ -37,9 +35,6 @@ from weave.session.session import (
     Turn,
     UriPart,
     Usage,
-    get_current_llm,
-    get_current_session,
-    get_current_turn,
     log_session,
     log_turn,
     start_llm,
@@ -51,35 +46,6 @@ from weave.session.session_otel import (
     invoke_agent_attributes,
     llm_attributes,
 )
-
-
-@pytest.fixture(autouse=True)
-def _reset_contextvars():
-    """Reset contextvar state after each test to prevent leakage."""
-    yield
-    if (llm := get_current_llm()) is not None:
-        llm.end()
-    if (turn := get_current_turn()) is not None:
-        turn.end()
-    if (session := get_current_session()) is not None:
-        session.end()
-
-
-@pytest.fixture
-def otel_spans(monkeypatch: pytest.MonkeyPatch):
-    """Provide an in-memory span exporter for capturing OTel spans.
-
-    Overrides the global OTel tracer provider for the duration of the test.
-    Uses ``monkeypatch.setattr`` on the private ``_TRACER_PROVIDER`` symbol
-    rather than ``set_tracer_provider`` to avoid the "set once" warning
-    and to guarantee restoration of the prior value.
-    """
-    exporter = InMemorySpanExporter()
-    provider = SDKTracerProvider()
-    provider.add_span_processor(SimpleSpanProcessor(exporter))
-    monkeypatch.setattr(otel_trace, "_TRACER_PROVIDER", provider)
-    yield exporter
-    provider.shutdown()
 
 
 def _emit_llm_with(

--- a/tests/session/test_session_settings.py
+++ b/tests/session/test_session_settings.py
@@ -9,6 +9,12 @@ Covers four settings + one bug fix:
   ``weave.*`` metadata attrs on every span (matches ``@op`` defaults).
 - Reasoning leak fix — ``LLM.reasoning`` is now gated by ``include_content``
   in both streaming (``LLM.end``) and batch (``_attrs_for_span``) paths.
+
+Mocking strategy: tests that need redaction patch ``_get_engines`` with
+stub Presidio engines (see ``fake_presidio`` fixture). The real
+``redact_pii`` / ``redact_pii_string`` code paths run — only the external
+NLP dependency is stubbed. Tests that need to assert "no redaction
+happens" patch ``_get_engines`` and assert it isn't called.
 """
 
 from __future__ import annotations
@@ -16,6 +22,7 @@ from __future__ import annotations
 import platform
 import sys
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 from unittest.mock import patch
 
@@ -35,25 +42,45 @@ from weave.session.session import (
 )
 from weave.trace.settings import override_settings
 
+_PII_EMAIL = "alice@example.com"
+_REDACTED_EMAIL = "<EMAIL>"
 
-def _email_substitutor() -> Callable[[Any], Any]:
-    """Recursive ``alice@example.com → <EMAIL>`` substitutor.
 
-    Stand-in for the real ``redact_pii``: walks dicts and lists like
-    Presidio does, but does plain string substitution so tests don't
-    need the NLP stack installed.
+@dataclass
+class _FakeEntity:
+    start: int
+    end: int
+
+
+@dataclass
+class _FakeResult:
+    text: str
+
+
+class _FakeAnalyzer:
+    def analyze(self, *, text: str, **_: Any) -> list[_FakeEntity]:
+        i = text.find(_PII_EMAIL)
+        return [_FakeEntity(i, i + len(_PII_EMAIL))] if i >= 0 else []
+
+
+class _FakeAnonymizer:
+    def anonymize(self, *, text: str, analyzer_results: Any) -> _FakeResult:
+        return _FakeResult(text.replace(_PII_EMAIL, _REDACTED_EMAIL))
+
+
+@pytest.fixture
+def fake_presidio(monkeypatch: pytest.MonkeyPatch):
+    """Replace Presidio engines with stubs that substitute ``_PII_EMAIL`` → ``_REDACTED_EMAIL``.
+
+    Patches ``_get_engines`` (the single dependency on Presidio) so the
+    real ``redact_pii`` / ``redact_pii_string`` code paths run end-to-end
+    against deterministic engines. Lets tests assert on resulting span
+    attrs without installing the NLP stack.
     """
-
-    def _walk(value: Any) -> Any:
-        if isinstance(value, str):
-            return value.replace("alice@example.com", "<EMAIL>")
-        if isinstance(value, dict):
-            return {k: _walk(v) for k, v in value.items()}
-        if isinstance(value, list):
-            return [_walk(x) for x in value]
-        return value
-
-    return _walk
+    monkeypatch.setattr(
+        "weave.utils.pii_redaction._get_engines",
+        lambda: (_FakeAnalyzer(), _FakeAnonymizer()),
+    )
 
 
 def _spans_with_prefix(otel_spans: InMemorySpanExporter, prefix: str) -> list[Any]:
@@ -61,7 +88,7 @@ def _spans_with_prefix(otel_spans: InMemorySpanExporter, prefix: str) -> list[An
 
 
 # ---------------------------------------------------------------------------
-# disabled — runtime span emission
+# WEAVE_DISABLED — runtime span emission suppressed in streaming + batch
 # ---------------------------------------------------------------------------
 
 
@@ -76,7 +103,7 @@ def test_disabled_streaming_emits_no_spans(otel_spans: InMemorySpanExporter):
     assert otel_spans.get_finished_spans() == ()
 
 
-def _exercise_log_turn() -> Any:
+def _user_func_log_turn() -> Any:
     return log_turn(
         session_id="s",
         agent_name="a",
@@ -84,7 +111,7 @@ def _exercise_log_turn() -> Any:
     )
 
 
-def _exercise_log_session() -> Any:
+def _user_func_log_session() -> Any:
     return log_session(
         turns=[Turn(agent_name="a", messages=[Message(role="user", content="hi")])],
         session_id="s",
@@ -92,98 +119,103 @@ def _exercise_log_session() -> Any:
 
 
 @pytest.mark.parametrize(
-    "exercise",
+    "user_func",
     [
-        pytest.param(_exercise_log_turn, id="log_turn"),
-        pytest.param(_exercise_log_session, id="log_session"),
+        pytest.param(_user_func_log_turn, id="log_turn"),
+        pytest.param(_user_func_log_session, id="log_session"),
     ],
 )
 def test_disabled_batch_emits_no_spans(
-    exercise: Callable[[], Any], otel_spans: InMemorySpanExporter
+    user_func: Callable[[], Any], otel_spans: InMemorySpanExporter
 ):
     with override_settings(disabled=True):
-        result = exercise()
+        result = user_func()
     assert result.span_count == 0
     assert otel_spans.get_finished_spans() == ()
 
 
 # ---------------------------------------------------------------------------
-# redact_pii — applied across streaming + batch paths
+# WEAVE_REDACT_PII — applied across streaming + batch paths
+#
+# Each helper below sets up a session that emits PII through one code path.
+# The test runs the helper under ``redact_pii=True`` and asserts that the
+# resulting span's content attrs are redacted (no raw email, ``<EMAIL>``
+# present).
 # ---------------------------------------------------------------------------
 
 
-def _redact_streaming_tool() -> None:
+def _streaming_tool_with_pii() -> None:
     with start_session(session_id="s") as sess, sess.start_turn() as t:
         with t.tool(name="lookup") as tool:
-            tool.arguments = '{"email":"alice@example.com"}'
-            tool.result = "found alice@example.com"
+            tool.arguments = f'{{"email":"{_PII_EMAIL}"}}'
+            tool.result = f"found {_PII_EMAIL}"
 
 
-def _redact_streaming_llm_messages() -> None:
+def _streaming_llm_messages_with_pii() -> None:
     with start_session(session_id="s") as sess, sess.start_turn() as t:
         with t.llm(
-            model="gpt-4o", system_instructions=["contact alice@example.com"]
+            model="gpt-4o", system_instructions=[f"contact {_PII_EMAIL}"]
         ) as llm:
-            llm.input_messages = [Message(role="user", content="alice@example.com")]
+            llm.input_messages = [Message(role="user", content=_PII_EMAIL)]
             llm.output_messages = [
-                Message(role="assistant", content="hi alice@example.com")
+                Message(role="assistant", content=f"hi {_PII_EMAIL}")
             ]
 
 
-def _redact_streaming_llm_reasoning() -> None:
+def _streaming_llm_reasoning_with_pii() -> None:
     """Regression case for the pre-existing leak: reasoning bypassing redaction."""
     with start_session(session_id="s") as sess, sess.start_turn() as t:
         with t.llm(model="gpt-4o") as llm:
-            llm.reasoning = Reasoning(content="think about alice@example.com")
+            llm.reasoning = Reasoning(content=f"think about {_PII_EMAIL}")
             llm.output_messages = [Message(role="assistant", content="ok")]
 
 
-def _redact_streaming_turn() -> None:
+def _streaming_turn_with_pii() -> None:
     with start_session(session_id="s") as sess:
-        with sess.start_turn(user_message="alice@example.com"):
+        with sess.start_turn(user_message=_PII_EMAIL):
             pass
 
 
-def _redact_batch_turn_messages() -> None:
+def _batch_turn_messages_with_pii() -> None:
     log_turn(
         session_id="s",
         agent_name="a",
-        messages=[Message(role="user", content="alice@example.com")],
+        messages=[Message(role="user", content=_PII_EMAIL)],
     )
 
 
-def _redact_batch_child_llm() -> None:
+def _batch_child_llm_with_pii() -> None:
     log_turn(
         session_id="s",
         agent_name="a",
         spans=[
             LLM(
                 model="gpt-4o",
-                input_messages=[Message(role="user", content="alice@example.com")],
+                input_messages=[Message(role="user", content=_PII_EMAIL)],
             ),
         ],
     )
 
 
-def _redact_batch_child_tool() -> None:
+def _batch_child_tool_with_pii() -> None:
     log_turn(
         session_id="s",
         agent_name="a",
-        spans=[Tool(name="lookup", arguments='{"email":"alice@example.com"}')],
+        spans=[Tool(name="lookup", arguments=f'{{"email":"{_PII_EMAIL}"}}')],
     )
 
 
 @pytest.mark.parametrize(
-    ("exercise", "span_prefix", "checked_keys"),
+    ("user_func", "span_prefix", "checked_keys"),
     [
         pytest.param(
-            _redact_streaming_tool,
+            _streaming_tool_with_pii,
             "execute_tool",
             ("gen_ai.tool.call.arguments", "gen_ai.tool.call.result"),
             id="streaming_tool",
         ),
         pytest.param(
-            _redact_streaming_llm_messages,
+            _streaming_llm_messages_with_pii,
             "chat",
             (
                 "gen_ai.input.messages",
@@ -193,31 +225,31 @@ def _redact_batch_child_tool() -> None:
             id="streaming_llm_messages",
         ),
         pytest.param(
-            _redact_streaming_llm_reasoning,
+            _streaming_llm_reasoning_with_pii,
             "chat",
             ("gen_ai.output.messages",),
             id="streaming_llm_reasoning",
         ),
         pytest.param(
-            _redact_streaming_turn,
+            _streaming_turn_with_pii,
             "invoke_agent",
             ("gen_ai.input.messages",),
             id="streaming_turn",
         ),
         pytest.param(
-            _redact_batch_turn_messages,
+            _batch_turn_messages_with_pii,
             "invoke_agent",
             ("gen_ai.input.messages",),
             id="batch_turn_messages",
         ),
         pytest.param(
-            _redact_batch_child_llm,
+            _batch_child_llm_with_pii,
             "chat",
             ("gen_ai.input.messages",),
             id="batch_child_llm",
         ),
         pytest.param(
-            _redact_batch_child_tool,
+            _batch_child_tool_with_pii,
             "execute_tool",
             ("gen_ai.tool.call.arguments",),
             id="batch_child_tool",
@@ -225,98 +257,92 @@ def _redact_batch_child_tool() -> None:
     ],
 )
 def test_redact_pii_applied(
-    exercise: Callable[[], None],
+    user_func: Callable[[], None],
     span_prefix: str,
     checked_keys: tuple[str, ...],
     otel_spans: InMemorySpanExporter,
+    fake_presidio: None,
 ):
-    """redact_pii=True applies redaction across streaming + batch paths."""
-    substitutor = _email_substitutor()
+    """redact_pii=True routes content through real redact_pii / redact_pii_string."""
     with override_settings(redact_pii=True):
-        with (
-            patch("weave.utils.pii_redaction.redact_pii", side_effect=substitutor),
-            patch(
-                "weave.utils.pii_redaction.redact_pii_string", side_effect=substitutor
-            ),
-        ):
-            exercise()
+        user_func()
 
     spans = _spans_with_prefix(otel_spans, span_prefix)
     assert len(spans) == 1, f"expected 1 {span_prefix} span, got {len(spans)}"
     attrs = dict(spans[0].attributes)
     for key in checked_keys:
-        assert "alice@example.com" not in attrs[key], key
-        assert "<EMAIL>" in attrs[key], key
+        assert _PII_EMAIL not in attrs[key], key
+        assert _REDACTED_EMAIL in attrs[key], key
 
 
 # ---------------------------------------------------------------------------
-# include_content=False — Presidio skipped, content dropped
+# include_content=False — content dropped at source, Presidio never loaded
 # ---------------------------------------------------------------------------
 
 
-def _ic_off_tool() -> None:
+def _content_off_tool() -> None:
     with start_session(session_id="s", include_content=False) as sess:
         with sess.start_turn() as t:
             with t.tool(name="lookup") as tool:
-                tool.arguments = '{"email":"alice@example.com"}'
+                tool.arguments = f'{{"email":"{_PII_EMAIL}"}}'
 
 
-def _ic_off_llm() -> None:
+def _content_off_llm() -> None:
     with start_session(session_id="s", include_content=False) as sess:
         with sess.start_turn() as t:
             with t.llm(model="gpt-4o") as llm:
-                llm.input_messages = [Message(role="user", content="alice@example.com")]
+                llm.input_messages = [Message(role="user", content=_PII_EMAIL)]
                 llm.reasoning = Reasoning(content="think")
 
 
-def _ic_off_turn() -> None:
+def _content_off_turn() -> None:
     with start_session(session_id="s", include_content=False) as sess:
-        with sess.start_turn(user_message="alice@example.com"):
+        with sess.start_turn(user_message=_PII_EMAIL):
             pass
 
 
-def _ic_off_log_turn() -> None:
+def _content_off_log_turn() -> None:
     log_turn(
         session_id="s",
         agent_name="a",
         include_content=False,
-        messages=[Message(role="user", content="alice@example.com")],
-        spans=[Tool(name="lookup", arguments='{"email":"alice@example.com"}')],
+        messages=[Message(role="user", content=_PII_EMAIL)],
+        spans=[Tool(name="lookup", arguments=f'{{"email":"{_PII_EMAIL}"}}')],
     )
 
 
 @pytest.mark.parametrize(
-    "exercise",
+    "user_func",
     [
-        pytest.param(_ic_off_tool, id="tool"),
-        pytest.param(_ic_off_llm, id="llm"),
-        pytest.param(_ic_off_turn, id="turn"),
-        pytest.param(_ic_off_log_turn, id="log_turn"),
+        pytest.param(_content_off_tool, id="tool"),
+        pytest.param(_content_off_llm, id="llm"),
+        pytest.param(_content_off_turn, id="turn"),
+        pytest.param(_content_off_log_turn, id="log_turn"),
     ],
 )
 def test_include_content_false_skips_presidio(
-    exercise: Callable[[], None],
+    user_func: Callable[[], None],
     otel_spans: InMemorySpanExporter,
 ):
-    """include_content=False drops content at source; Presidio is never called."""
+    """Content dropped upstream → Presidio engines must never load.
+
+    Patching ``_get_engines`` and asserting it isn't called is the meaningful
+    invariant: no NLP cost paid on content that's already gone.
+    """
     with override_settings(redact_pii=True):
-        with (
-            patch("weave.utils.pii_redaction.redact_pii") as mock_redact,
-            patch("weave.utils.pii_redaction.redact_pii_string") as mock_redact_str,
-        ):
-            exercise()
-    mock_redact.assert_not_called()
-    mock_redact_str.assert_not_called()
+        with patch("weave.utils.pii_redaction._get_engines") as mock_get_engines:
+            user_func()
+    mock_get_engines.assert_not_called()
 
 
-def _reasoning_streaming() -> None:
+def _reasoning_content_off_streaming() -> None:
     with start_session(session_id="s", include_content=False) as sess:
         with sess.start_turn() as t:
             with t.llm(model="gpt-4o") as llm:
                 llm.reasoning = Reasoning(content="sensitive reasoning")
 
 
-def _reasoning_batch() -> None:
+def _reasoning_content_off_batch() -> None:
     log_turn(
         session_id="s",
         agent_name="a",
@@ -326,24 +352,24 @@ def _reasoning_batch() -> None:
 
 
 @pytest.mark.parametrize(
-    "exercise",
+    "user_func",
     [
-        pytest.param(_reasoning_streaming, id="streaming"),
-        pytest.param(_reasoning_batch, id="batch"),
+        pytest.param(_reasoning_content_off_streaming, id="streaming"),
+        pytest.param(_reasoning_content_off_batch, id="batch"),
     ],
 )
 def test_include_content_false_drops_reasoning(
-    exercise: Callable[[], None], otel_spans: InMemorySpanExporter
+    user_func: Callable[[], None], otel_spans: InMemorySpanExporter
 ):
     """Regression: LLM.reasoning used to bypass include_content and leak into output.messages."""
-    exercise()
+    user_func()
     chat_spans = _spans_with_prefix(otel_spans, "chat")
     attrs = dict(chat_spans[0].attributes)
     assert "gen_ai.output.messages" not in attrs
 
 
 # ---------------------------------------------------------------------------
-# capture_client_info / capture_system_info
+# WEAVE_CAPTURE_CLIENT_INFO / WEAVE_CAPTURE_SYSTEM_INFO
 # ---------------------------------------------------------------------------
 
 # Sentinel for presence-only checks (value exists, content not asserted).
@@ -428,36 +454,25 @@ def test_capture_info_on_batch_path(otel_spans: InMemorySpanExporter):
 # ---------------------------------------------------------------------------
 
 
-def test_settings_independent(otel_spans: InMemorySpanExporter):
+def test_settings_independent(otel_spans: InMemorySpanExporter, fake_presidio: None):
     """redact_pii=True + capture_*=False produces redacted content without weave.* attrs."""
-    substitutor = _email_substitutor()
     with override_settings(
         redact_pii=True, capture_client_info=False, capture_system_info=False
     ):
-        with (
-            patch("weave.utils.pii_redaction.redact_pii", side_effect=substitutor),
-            patch(
-                "weave.utils.pii_redaction.redact_pii_string", side_effect=substitutor
-            ),
-        ):
-            with start_session(session_id="s") as sess, sess.start_turn() as t:
-                with t.tool(name="lookup") as tool:
-                    tool.arguments = "alice@example.com"
+        with start_session(session_id="s") as sess, sess.start_turn() as t:
+            with t.tool(name="lookup") as tool:
+                tool.arguments = _PII_EMAIL
 
     tool_spans = _spans_with_prefix(otel_spans, "execute_tool")
     attrs = dict(tool_spans[0].attributes)
-    assert "<EMAIL>" in attrs["gen_ai.tool.call.arguments"]
+    assert _REDACTED_EMAIL in attrs["gen_ai.tool.call.arguments"]
     assert "weave.client_version" not in attrs
 
 
 def test_defaults_skip_redaction(otel_spans: InMemorySpanExporter):
-    """With defaults (redact_pii=False), redaction primitives are never called."""
-    with (
-        patch("weave.utils.pii_redaction.redact_pii") as mock_redact,
-        patch("weave.utils.pii_redaction.redact_pii_string") as mock_redact_str,
-    ):
+    """With defaults (redact_pii=False), Presidio engines are never loaded."""
+    with patch("weave.utils.pii_redaction._get_engines") as mock_get_engines:
         with start_session(session_id="s") as sess, sess.start_turn() as t:
             with t.tool(name="x") as tool:
-                tool.arguments = "alice@example.com"
-    mock_redact.assert_not_called()
-    mock_redact_str.assert_not_called()
+                tool.arguments = _PII_EMAIL
+    mock_get_engines.assert_not_called()

--- a/tests/session/test_session_settings.py
+++ b/tests/session/test_session_settings.py
@@ -1,0 +1,463 @@
+"""Tests that the Session SDK respects weave global settings.
+
+Covers four settings + one bug fix:
+
+- ``WEAVE_DISABLED`` — silences span emission in streaming + batch paths.
+- ``WEAVE_REDACT_PII`` — routes content fields through ``redact_pii`` /
+  ``redact_pii_string`` so Session SDK redaction matches ``@op``.
+- ``WEAVE_CAPTURE_CLIENT_INFO`` / ``WEAVE_CAPTURE_SYSTEM_INFO`` — emits
+  ``weave.*`` metadata attrs on every span (matches ``@op`` defaults).
+- Reasoning leak fix — ``LLM.reasoning`` is now gated by ``include_content``
+  in both streaming (``LLM.end``) and batch (``_attrs_for_span``) paths.
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from weave import version
+from weave.session.session import (
+    LLM,
+    Message,
+    Reasoning,
+    Tool,
+    Turn,
+    log_session,
+    log_turn,
+    start_session,
+)
+from weave.trace.settings import override_settings
+
+
+def _email_substitutor() -> Callable[[Any], Any]:
+    """Recursive ``alice@example.com → <EMAIL>`` substitutor.
+
+    Stand-in for the real ``redact_pii``: walks dicts and lists like
+    Presidio does, but does plain string substitution so tests don't
+    need the NLP stack installed.
+    """
+
+    def _walk(value: Any) -> Any:
+        if isinstance(value, str):
+            return value.replace("alice@example.com", "<EMAIL>")
+        if isinstance(value, dict):
+            return {k: _walk(v) for k, v in value.items()}
+        if isinstance(value, list):
+            return [_walk(x) for x in value]
+        return value
+
+    return _walk
+
+
+def _spans_with_prefix(otel_spans: InMemorySpanExporter, prefix: str) -> list[Any]:
+    return [s for s in otel_spans.get_finished_spans() if s.name.startswith(prefix)]
+
+
+# ---------------------------------------------------------------------------
+# disabled — runtime span emission
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_streaming_emits_no_spans(otel_spans: InMemorySpanExporter):
+    with override_settings(disabled=True):
+        with start_session(agent_name="a", session_id="s") as s:
+            with s.start_turn() as t:
+                with t.llm(model="gpt-4o"):
+                    pass
+                with t.tool(name="search"):
+                    pass
+    assert otel_spans.get_finished_spans() == ()
+
+
+def _exercise_log_turn() -> Any:
+    return log_turn(
+        session_id="s",
+        agent_name="a",
+        messages=[Message(role="user", content="hi")],
+    )
+
+
+def _exercise_log_session() -> Any:
+    return log_session(
+        turns=[Turn(agent_name="a", messages=[Message(role="user", content="hi")])],
+        session_id="s",
+    )
+
+
+@pytest.mark.parametrize(
+    "exercise",
+    [
+        pytest.param(_exercise_log_turn, id="log_turn"),
+        pytest.param(_exercise_log_session, id="log_session"),
+    ],
+)
+def test_disabled_batch_emits_no_spans(
+    exercise: Callable[[], Any], otel_spans: InMemorySpanExporter
+):
+    with override_settings(disabled=True):
+        result = exercise()
+    assert result.span_count == 0
+    assert otel_spans.get_finished_spans() == ()
+
+
+# ---------------------------------------------------------------------------
+# redact_pii — applied across streaming + batch paths
+# ---------------------------------------------------------------------------
+
+
+def _redact_streaming_tool() -> None:
+    with start_session(session_id="s") as sess, sess.start_turn() as t:
+        with t.tool(name="lookup") as tool:
+            tool.arguments = '{"email":"alice@example.com"}'
+            tool.result = "found alice@example.com"
+
+
+def _redact_streaming_llm_messages() -> None:
+    with start_session(session_id="s") as sess, sess.start_turn() as t:
+        with t.llm(
+            model="gpt-4o", system_instructions=["contact alice@example.com"]
+        ) as llm:
+            llm.input_messages = [Message(role="user", content="alice@example.com")]
+            llm.output_messages = [
+                Message(role="assistant", content="hi alice@example.com")
+            ]
+
+
+def _redact_streaming_llm_reasoning() -> None:
+    """Regression case for the pre-existing leak: reasoning bypassing redaction."""
+    with start_session(session_id="s") as sess, sess.start_turn() as t:
+        with t.llm(model="gpt-4o") as llm:
+            llm.reasoning = Reasoning(content="think about alice@example.com")
+            llm.output_messages = [Message(role="assistant", content="ok")]
+
+
+def _redact_streaming_turn() -> None:
+    with start_session(session_id="s") as sess:
+        with sess.start_turn(user_message="alice@example.com"):
+            pass
+
+
+def _redact_batch_turn_messages() -> None:
+    log_turn(
+        session_id="s",
+        agent_name="a",
+        messages=[Message(role="user", content="alice@example.com")],
+    )
+
+
+def _redact_batch_child_llm() -> None:
+    log_turn(
+        session_id="s",
+        agent_name="a",
+        spans=[
+            LLM(
+                model="gpt-4o",
+                input_messages=[Message(role="user", content="alice@example.com")],
+            ),
+        ],
+    )
+
+
+def _redact_batch_child_tool() -> None:
+    log_turn(
+        session_id="s",
+        agent_name="a",
+        spans=[Tool(name="lookup", arguments='{"email":"alice@example.com"}')],
+    )
+
+
+@pytest.mark.parametrize(
+    ("exercise", "span_prefix", "checked_keys"),
+    [
+        pytest.param(
+            _redact_streaming_tool,
+            "execute_tool",
+            ("gen_ai.tool.call.arguments", "gen_ai.tool.call.result"),
+            id="streaming_tool",
+        ),
+        pytest.param(
+            _redact_streaming_llm_messages,
+            "chat",
+            (
+                "gen_ai.input.messages",
+                "gen_ai.output.messages",
+                "gen_ai.system_instructions",
+            ),
+            id="streaming_llm_messages",
+        ),
+        pytest.param(
+            _redact_streaming_llm_reasoning,
+            "chat",
+            ("gen_ai.output.messages",),
+            id="streaming_llm_reasoning",
+        ),
+        pytest.param(
+            _redact_streaming_turn,
+            "invoke_agent",
+            ("gen_ai.input.messages",),
+            id="streaming_turn",
+        ),
+        pytest.param(
+            _redact_batch_turn_messages,
+            "invoke_agent",
+            ("gen_ai.input.messages",),
+            id="batch_turn_messages",
+        ),
+        pytest.param(
+            _redact_batch_child_llm,
+            "chat",
+            ("gen_ai.input.messages",),
+            id="batch_child_llm",
+        ),
+        pytest.param(
+            _redact_batch_child_tool,
+            "execute_tool",
+            ("gen_ai.tool.call.arguments",),
+            id="batch_child_tool",
+        ),
+    ],
+)
+def test_redact_pii_applied(
+    exercise: Callable[[], None],
+    span_prefix: str,
+    checked_keys: tuple[str, ...],
+    otel_spans: InMemorySpanExporter,
+):
+    """redact_pii=True applies redaction across streaming + batch paths."""
+    substitutor = _email_substitutor()
+    with override_settings(redact_pii=True):
+        with (
+            patch("weave.utils.pii_redaction.redact_pii", side_effect=substitutor),
+            patch(
+                "weave.utils.pii_redaction.redact_pii_string", side_effect=substitutor
+            ),
+        ):
+            exercise()
+
+    spans = _spans_with_prefix(otel_spans, span_prefix)
+    assert len(spans) == 1, f"expected 1 {span_prefix} span, got {len(spans)}"
+    attrs = dict(spans[0].attributes)
+    for key in checked_keys:
+        assert "alice@example.com" not in attrs[key], key
+        assert "<EMAIL>" in attrs[key], key
+
+
+# ---------------------------------------------------------------------------
+# include_content=False — Presidio skipped, content dropped
+# ---------------------------------------------------------------------------
+
+
+def _ic_off_tool() -> None:
+    with start_session(session_id="s", include_content=False) as sess:
+        with sess.start_turn() as t:
+            with t.tool(name="lookup") as tool:
+                tool.arguments = '{"email":"alice@example.com"}'
+
+
+def _ic_off_llm() -> None:
+    with start_session(session_id="s", include_content=False) as sess:
+        with sess.start_turn() as t:
+            with t.llm(model="gpt-4o") as llm:
+                llm.input_messages = [Message(role="user", content="alice@example.com")]
+                llm.reasoning = Reasoning(content="think")
+
+
+def _ic_off_turn() -> None:
+    with start_session(session_id="s", include_content=False) as sess:
+        with sess.start_turn(user_message="alice@example.com"):
+            pass
+
+
+def _ic_off_log_turn() -> None:
+    log_turn(
+        session_id="s",
+        agent_name="a",
+        include_content=False,
+        messages=[Message(role="user", content="alice@example.com")],
+        spans=[Tool(name="lookup", arguments='{"email":"alice@example.com"}')],
+    )
+
+
+@pytest.mark.parametrize(
+    "exercise",
+    [
+        pytest.param(_ic_off_tool, id="tool"),
+        pytest.param(_ic_off_llm, id="llm"),
+        pytest.param(_ic_off_turn, id="turn"),
+        pytest.param(_ic_off_log_turn, id="log_turn"),
+    ],
+)
+def test_include_content_false_skips_presidio(
+    exercise: Callable[[], None],
+    otel_spans: InMemorySpanExporter,
+):
+    """include_content=False drops content at source; Presidio is never called."""
+    with override_settings(redact_pii=True):
+        with (
+            patch("weave.utils.pii_redaction.redact_pii") as mock_redact,
+            patch("weave.utils.pii_redaction.redact_pii_string") as mock_redact_str,
+        ):
+            exercise()
+    mock_redact.assert_not_called()
+    mock_redact_str.assert_not_called()
+
+
+def _reasoning_streaming() -> None:
+    with start_session(session_id="s", include_content=False) as sess:
+        with sess.start_turn() as t:
+            with t.llm(model="gpt-4o") as llm:
+                llm.reasoning = Reasoning(content="sensitive reasoning")
+
+
+def _reasoning_batch() -> None:
+    log_turn(
+        session_id="s",
+        agent_name="a",
+        include_content=False,
+        spans=[LLM(model="gpt-4o", reasoning=Reasoning(content="sensitive"))],
+    )
+
+
+@pytest.mark.parametrize(
+    "exercise",
+    [
+        pytest.param(_reasoning_streaming, id="streaming"),
+        pytest.param(_reasoning_batch, id="batch"),
+    ],
+)
+def test_include_content_false_drops_reasoning(
+    exercise: Callable[[], None], otel_spans: InMemorySpanExporter
+):
+    """Regression: LLM.reasoning used to bypass include_content and leak into output.messages."""
+    exercise()
+    chat_spans = _spans_with_prefix(otel_spans, "chat")
+    attrs = dict(chat_spans[0].attributes)
+    assert "gen_ai.output.messages" not in attrs
+
+
+# ---------------------------------------------------------------------------
+# capture_client_info / capture_system_info
+# ---------------------------------------------------------------------------
+
+# Sentinel for presence-only checks (value exists, content not asserted).
+_PRESENT = object()
+
+
+@pytest.mark.parametrize(
+    ("client_info", "system_info", "expected_present", "expected_absent"),
+    [
+        pytest.param(
+            True,
+            False,
+            {
+                "weave.client_version": version.VERSION,
+                "weave.source": "python-sdk",
+                "weave.sys_version": sys.version,
+            },
+            ("weave.os_name",),
+            id="client_only",
+        ),
+        pytest.param(
+            False,
+            True,
+            {"weave.os_name": platform.system(), "weave.os_release": _PRESENT},
+            ("weave.client_version",),
+            id="system_only",
+        ),
+        pytest.param(
+            False,
+            False,
+            {},
+            ("weave.client_version", "weave.os_name"),
+            id="both_off",
+        ),
+    ],
+)
+def test_capture_info_settings(
+    client_info: bool,
+    system_info: bool,
+    expected_present: dict[str, Any],
+    expected_absent: tuple[str, ...],
+    otel_spans: InMemorySpanExporter,
+):
+    with override_settings(
+        capture_client_info=client_info, capture_system_info=system_info
+    ):
+        with start_session(session_id="s") as sess:
+            with sess.start_turn() as t:
+                with t.tool(name="x"):
+                    pass
+
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) >= 2  # turn + tool
+    for span in spans:
+        attrs = dict(span.attributes)
+        for key, expected in expected_present.items():
+            if expected is _PRESENT:
+                assert key in attrs, f"{key} missing on span {span.name}"
+            else:
+                assert attrs.get(key) == expected, f"{key} mismatch on {span.name}"
+        for key in expected_absent:
+            assert key not in attrs, f"{key} unexpectedly present on {span.name}"
+
+
+def test_capture_info_on_batch_path(otel_spans: InMemorySpanExporter):
+    """Batch (log_turn) path uses a separate emit path — same invariant."""
+    with override_settings(capture_client_info=True):
+        log_turn(
+            session_id="s",
+            agent_name="a",
+            spans=[LLM(model="gpt-4o")],
+        )
+
+    spans = otel_spans.get_finished_spans()
+    assert len(spans) == 2  # turn + child llm
+    for s in spans:
+        assert s.attributes.get("weave.client_version") == version.VERSION
+
+
+# ---------------------------------------------------------------------------
+# Independence + defaults
+# ---------------------------------------------------------------------------
+
+
+def test_settings_independent(otel_spans: InMemorySpanExporter):
+    """redact_pii=True + capture_*=False produces redacted content without weave.* attrs."""
+    substitutor = _email_substitutor()
+    with override_settings(
+        redact_pii=True, capture_client_info=False, capture_system_info=False
+    ):
+        with (
+            patch("weave.utils.pii_redaction.redact_pii", side_effect=substitutor),
+            patch(
+                "weave.utils.pii_redaction.redact_pii_string", side_effect=substitutor
+            ),
+        ):
+            with start_session(session_id="s") as sess, sess.start_turn() as t:
+                with t.tool(name="lookup") as tool:
+                    tool.arguments = "alice@example.com"
+
+    tool_spans = _spans_with_prefix(otel_spans, "execute_tool")
+    attrs = dict(tool_spans[0].attributes)
+    assert "<EMAIL>" in attrs["gen_ai.tool.call.arguments"]
+    assert "weave.client_version" not in attrs
+
+
+def test_defaults_skip_redaction(otel_spans: InMemorySpanExporter):
+    """With defaults (redact_pii=False), redaction primitives are never called."""
+    with (
+        patch("weave.utils.pii_redaction.redact_pii") as mock_redact,
+        patch("weave.utils.pii_redaction.redact_pii_string") as mock_redact_str,
+    ):
+        with start_session(session_id="s") as sess, sess.start_turn() as t:
+            with t.tool(name="x") as tool:
+                tool.arguments = "alice@example.com"
+    mock_redact.assert_not_called()
+    mock_redact_str.assert_not_called()

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -43,7 +43,7 @@ from weave.session.types import (
 )
 from weave.trace.settings import should_disable_weave, should_redact_pii
 from weave.utils import pii_redaction
-from weave.utils.capture_info import get_capture_info_items
+from weave.utils.capture_info import get_capture_info
 
 # OTel imports — kept top-level under a try/except guard so the module
 # loads cleanly when opentelemetry is not installed. When unavailable,
@@ -110,13 +110,13 @@ __all__ = [
 _TRACER_NAME = "weave.session"
 
 
-def _capture_info_attrs() -> dict[str, Any]:
+def _capture_info_attrs() -> dict[str, str]:
     """Build weave.* client / system info attrs, gated by settings.
 
     Per-span (not OTel ``Resource``) so env-var toggles take effect on
     every emit, matching ``@op`` semantics in ``weave_client.py``.
     """
-    return {f"weave.{k}": v for k, v in get_capture_info_items()}
+    return {f"weave.{k}": v for k, v in get_capture_info().items()}
 
 
 class _SpanBase(BaseModel):

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -453,7 +453,7 @@ class LLM(_SpanBase):
                 system_instructions = pii_redaction.redact_system_instructions(
                     system_instructions
                 )
-                if reasoning is not None and reasoning.content:
+                if reasoning.content:
                     reasoning = Reasoning(
                         content=pii_redaction.redact_pii_string(reasoning.content)
                     )

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -41,6 +41,9 @@ from weave.session.types import (
     Usage,
     _parse_data_url,
 )
+from weave.trace.settings import should_disable_weave, should_redact_pii
+from weave.utils import pii_redaction
+from weave.utils.capture_info import get_capture_info_items
 
 # OTel imports — kept top-level under a try/except guard so the module
 # loads cleanly when opentelemetry is not installed. When unavailable,
@@ -107,6 +110,15 @@ __all__ = [
 _TRACER_NAME = "weave.session"
 
 
+def _capture_info_attrs() -> dict[str, Any]:
+    """Build weave.* client / system info attrs, gated by settings.
+
+    Per-span (not OTel ``Resource``) so env-var toggles take effect on
+    every emit, matching ``@op`` semantics in ``weave_client.py``.
+    """
+    return {f"weave.{k}": v for k, v in get_capture_info_items()}
+
+
 class _SpanBase(BaseModel):
     """Shared config for span classes that use ``model`` as a field name."""
 
@@ -129,7 +141,7 @@ class _SpanBase(BaseModel):
         OTel span timestamp matches the user-visible start, not the moment
         ``__enter__`` happened to run.
         """
-        if not _OTEL_AVAILABLE:
+        if not _OTEL_AVAILABLE or should_disable_weave():
             return
         tracer = otel_trace.get_tracer(_TRACER_NAME)
         kwargs: dict[str, Any] = {}
@@ -196,6 +208,36 @@ class Tool(_SpanBase):
 
     _ended: bool = PrivateAttr(default=False)
 
+    def _build_attrs(self, *, session_id: str, include_content: bool) -> dict[str, Any]:
+        """Build the full OTel attribute dict for this tool span.
+
+        Single chokepoint shared by streaming (``end``) and batch
+        (``_attrs_for_span``). Strips arguments/result when content is
+        gated off; otherwise routes them through ``redact_pii_string``
+        when redaction is enabled.
+        """
+        if include_content:
+            arguments = self.arguments
+            result = self.result
+            if should_redact_pii():
+                arguments = pii_redaction.redact_pii_string(arguments)
+                result = pii_redaction.redact_pii_string(result)
+        else:
+            arguments = ""
+            result = ""
+        attrs = execute_tool_attributes(
+            tool_name=self.name,
+            conversation_id=session_id,
+            tool_call_arguments=arguments,
+            tool_call_result=result,
+            tool_call_id=self.tool_call_id,
+            tool_type=self.tool_type,
+            tool_description=self.tool_description,
+            tool_definitions=self.tool_definitions,
+        )
+        attrs.update(_capture_info_attrs())
+        return attrs
+
     def end(self) -> None:
         if self._ended:
             return
@@ -206,17 +248,10 @@ class Tool(_SpanBase):
             elapsed = self.ended_at - self.started_at
             self.duration_ms = int(elapsed.total_seconds() * 1000)
 
-        session = _current_session.get()
-        include = session.include_content if session else True
-        attrs = execute_tool_attributes(
-            tool_name=self.name,
-            conversation_id=session.session_id if session else "",
-            tool_call_arguments=self.arguments if include else "",
-            tool_call_result=self.result if include else "",
-            tool_call_id=self.tool_call_id,
-            tool_type=self.tool_type,
-            tool_description=self.tool_description,
-            tool_definitions=self.tool_definitions,
+        session = get_current_session()
+        attrs = self._build_attrs(
+            session_id=session.session_id if session else "",
+            include_content=session.include_content if session else True,
         )
         self._end_otel_span(attrs)
 
@@ -392,24 +427,52 @@ class LLM(_SpanBase):
             self.output_type = output_type
         return self
 
-    def end(self) -> None:
-        if self._ended:
-            return
-        self._ended = True
-        self.ended_at = datetime.now(timezone.utc)
+    def _build_attrs(self, *, session_id: str, include_content: bool) -> dict[str, Any]:
+        """Build the full OTel attribute dict for this chat span.
 
-        session = _current_session.get()
-        include = session.include_content if session else True
+        Single chokepoint shared by streaming (``end``) and batch
+        (``_attrs_for_span``). All five content-bearing fields go
+        ``None`` when content is gated off — notably this includes
+        ``reasoning``, which previously bypassed the gate and leaked
+        into ``gen_ai.output.messages``.
+        """
+        input_messages: list[Message] | None
+        output_messages: list[Message] | None
+        system_instructions: list[str] | None
+        media_attachments: list[MediaAttachment] | None
+        reasoning: Reasoning | None
+        if include_content:
+            input_messages = self.input_messages
+            output_messages = self.output_messages
+            system_instructions = self.system_instructions
+            media_attachments = self.media_attachments
+            reasoning = self.reasoning
+            if should_redact_pii():
+                input_messages = pii_redaction.redact_messages(input_messages)
+                output_messages = pii_redaction.redact_messages(output_messages)
+                system_instructions = pii_redaction.redact_system_instructions(
+                    system_instructions
+                )
+                if reasoning is not None and reasoning.content:
+                    reasoning = Reasoning(
+                        content=pii_redaction.redact_pii_string(reasoning.content)
+                    )
+        else:
+            input_messages = None
+            output_messages = None
+            system_instructions = None
+            media_attachments = None
+            reasoning = None
         attrs = llm_attributes(
             model=self.model,
             provider_name=self.provider_name,
-            conversation_id=session.session_id if session else "",
-            input_messages=self.input_messages if include else None,
-            output_messages=self.output_messages if include else None,
-            media_attachments=self.media_attachments if include else None,
-            system_instructions=self.system_instructions if include else None,
+            conversation_id=session_id,
+            input_messages=input_messages,
+            output_messages=output_messages,
+            media_attachments=media_attachments,
+            system_instructions=system_instructions,
             usage=self.usage,
-            reasoning=self.reasoning,
+            reasoning=reasoning,
             finish_reasons=self.finish_reasons,
             response_id=self.response_id,
             response_model=self.response_model,
@@ -422,6 +485,20 @@ class LLM(_SpanBase):
             request_seed=self.request_seed,
             request_stop_sequences=self.request_stop_sequences,
             request_choice_count=self.request_choice_count,
+        )
+        attrs.update(_capture_info_attrs())
+        return attrs
+
+    def end(self) -> None:
+        if self._ended:
+            return
+        self._ended = True
+        self.ended_at = datetime.now(timezone.utc)
+
+        session = get_current_session()
+        attrs = self._build_attrs(
+            session_id=session.session_id if session else "",
+            include_content=session.include_content if session else True,
         )
 
         if self._token is not None:
@@ -493,21 +570,35 @@ class SubAgent(_SpanBase):
         """Start a tool execution within this sub-agent."""
         return Tool(name=name, arguments=arguments, tool_call_id=tool_call_id)
 
+    def _build_attrs(self, *, session_id: str, session_name: str) -> dict[str, Any]:
+        """Build the full OTel attribute dict for this sub-agent span.
+
+        Sub-agents have no content fields — the dispatch only needs
+        identifiers and capture-info. Shared between streaming (``end``)
+        and batch (``_attrs_for_span``).
+        """
+        attrs = invoke_agent_attributes(
+            agent_name=self.name,
+            model=self.model,
+            conversation_id=session_id,
+            conversation_name=session_name,
+            agent_id=self.agent_id,
+            agent_description=self.agent_description,
+            agent_version=self.agent_version,
+        )
+        attrs.update(_capture_info_attrs())
+        return attrs
+
     def end(self) -> None:
         if self._ended:
             return
         self._ended = True
         self.ended_at = datetime.now(timezone.utc)
 
-        session = _current_session.get()
-        attrs = invoke_agent_attributes(
-            agent_name=self.name,
-            model=self.model,
-            conversation_id=session.session_id if session else "",
-            conversation_name=session.session_name if session else "",
-            agent_id=self.agent_id,
-            agent_description=self.agent_description,
-            agent_version=self.agent_version,
+        session = get_current_session()
+        attrs = self._build_attrs(
+            session_id=session.session_id if session else "",
+            session_name=session.session_name if session else "",
         )
         self._end_otel_span(attrs)
 
@@ -594,23 +685,46 @@ class Turn(_SpanBase):
         """Start a sub-agent invocation (nested invoke_agent span, same trace)."""
         return SubAgent(name=name, model=model or self.model)
 
+    def _build_attrs(
+        self, *, session_id: str, session_name: str, include_content: bool
+    ) -> dict[str, Any]:
+        """Build the full OTel attribute dict for this turn span.
+
+        Shared by streaming (``end``) and batch (``log_turn``). The Turn
+        carries user messages; ``include_content=False`` strips them at
+        source so Presidio is never called for already-dropped content.
+        """
+        messages: list[Message] | None
+        if include_content:
+            messages = self.messages
+            if should_redact_pii():
+                messages = pii_redaction.redact_messages(messages)
+        else:
+            messages = None
+        attrs = invoke_agent_attributes(
+            agent_name=self.agent_name,
+            conversation_id=session_id,
+            conversation_name=session_name,
+            model=self.model,
+            input_messages=messages,
+            agent_id=self.agent_id,
+            agent_description=self.agent_description,
+            agent_version=self.agent_version,
+        )
+        attrs.update(_capture_info_attrs())
+        return attrs
+
     def end(self) -> None:
         if self._ended:
             return
         self._ended = True
         self.ended_at = datetime.now(timezone.utc)
 
-        session = _current_session.get()
-        include = session.include_content if session else True
-        attrs = invoke_agent_attributes(
-            agent_name=self.agent_name,
-            conversation_id=session.session_id if session else "",
-            conversation_name=session.session_name if session else "",
-            model=self.model,
-            input_messages=self.messages if include else None,
-            agent_id=self.agent_id,
-            agent_description=self.agent_description,
-            agent_version=self.agent_version,
+        session = get_current_session()
+        attrs = self._build_attrs(
+            session_id=session.session_id if session else "",
+            session_name=session.session_name if session else "",
+            include_content=session.include_content if session else True,
         )
 
         if self._token is not None:
@@ -950,55 +1064,22 @@ def _attrs_for_span(
     session_name: str,
     include_content: bool,
 ) -> tuple[str, dict[str, Any]]:
-    """Build (otel_span_name, attribute_dict) for a child span."""
+    """Build (otel_span_name, attribute_dict) for a child span.
+
+    Delegates to each class's ``_build_attrs`` so streaming (``.end()``)
+    and batch (``log_turn``) produce byte-identical output.
+    """
     if isinstance(span, LLM):
-        attrs = llm_attributes(
-            model=span.model,
-            provider_name=span.provider_name,
-            conversation_id=session_id,
-            input_messages=span.input_messages if include_content else None,
-            output_messages=span.output_messages if include_content else None,
-            media_attachments=span.media_attachments if include_content else None,
-            system_instructions=span.system_instructions if include_content else None,
-            usage=span.usage,
-            reasoning=span.reasoning,
-            finish_reasons=span.finish_reasons,
-            response_id=span.response_id,
-            response_model=span.response_model,
-            output_type=span.output_type,
-            request_temperature=span.request_temperature,
-            request_max_tokens=span.request_max_tokens,
-            request_top_p=span.request_top_p,
-            request_frequency_penalty=span.request_frequency_penalty,
-            request_presence_penalty=span.request_presence_penalty,
-            request_seed=span.request_seed,
-            request_stop_sequences=span.request_stop_sequences,
-            request_choice_count=span.request_choice_count,
+        return f"chat {span.model}", span._build_attrs(
+            session_id=session_id, include_content=include_content
         )
-        return f"chat {span.model}", attrs
     if isinstance(span, Tool):
-        attrs = execute_tool_attributes(
-            tool_name=span.name,
-            conversation_id=session_id,
-            tool_call_arguments=span.arguments if include_content else "",
-            tool_call_result=span.result if include_content else "",
-            tool_call_id=span.tool_call_id,
-            tool_type=span.tool_type,
-            tool_description=span.tool_description,
-            tool_definitions=span.tool_definitions,
+        return f"execute_tool {span.name}", span._build_attrs(
+            session_id=session_id, include_content=include_content
         )
-        return f"execute_tool {span.name}", attrs
-    # SubAgent
-    attrs = invoke_agent_attributes(
-        agent_name=span.name,
-        model=span.model,
-        conversation_id=session_id,
-        conversation_name=session_name,
-        agent_id=span.agent_id,
-        agent_description=span.agent_description,
-        agent_version=span.agent_version,
+    return f"invoke_agent {span.name}", span._build_attrs(
+        session_id=session_id, session_name=session_name
     )
-    return f"invoke_agent {span.name}", attrs
 
 
 def log_turn(
@@ -1022,7 +1103,7 @@ def log_turn(
     Falls back to the earliest/latest child timestamp, then ``now()``, when
     the turn doesn't supply its own.
     """
-    if not _OTEL_AVAILABLE:
+    if not _OTEL_AVAILABLE or should_disable_weave():
         return LogResult(session_id=session_id)
 
     resolved_spans = spans or []
@@ -1041,15 +1122,10 @@ def log_turn(
         continue_parent_trace=continue_parent_trace,
     )
 
-    turn_attrs = invoke_agent_attributes(
-        agent_name=turn.agent_name,
-        conversation_id=session_id,
-        conversation_name=session_name,
-        model=turn.model,
-        input_messages=turn.messages if include_content else None,
-        agent_id=turn.agent_id,
-        agent_description=turn.agent_description,
-        agent_version=turn.agent_version,
+    turn_attrs = turn._build_attrs(
+        session_id=session_id,
+        session_name=session_name,
+        include_content=include_content,
     )
 
     parent_ctx = Context() if not continue_parent_trace else None
@@ -1103,7 +1179,7 @@ def log_session(
     ``session_id`` if empty. By default each turn gets its own OTel trace.
     """
     sid = session_id or str(uuid.uuid4())
-    if not _OTEL_AVAILABLE:
+    if not _OTEL_AVAILABLE or should_disable_weave():
         return LogResult(session_id=sid)
 
     trace_ids: list[str] = []

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -6,9 +6,7 @@ import datetime
 import json
 import logging
 import os
-import platform
 import re
-import sys
 import time
 from collections.abc import Callable, Sequence
 from concurrent.futures import Future
@@ -18,7 +16,6 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 import pydantic
 from httpx import HTTPStatusError as HTTPError
 
-from weave import version
 from weave.chat.chat import Chat
 from weave.chat.inference_models import InferenceModels
 from weave.durability.wal_manager import WALManager
@@ -89,8 +86,6 @@ from weave.trace.serialization.serialize import (
 from weave.trace.serialization.serializer import get_serializer_for_obj
 from weave.trace.settings import (
     client_parallelism,
-    should_capture_client_info,
-    should_capture_system_info,
     should_print_call_link,
     should_redact_pii,
     should_use_parallel_table_upload,
@@ -188,6 +183,7 @@ from weave.trace_server_bindings.link_asset_to_registry import (
 )
 from weave.trace_server_bindings.models import StartBatchItem
 from weave.utils.attributes_dict import AttributesDict
+from weave.utils.capture_info import get_capture_info_items
 from weave.utils.dict_utils import sum_dict_leaves, zip_dicts
 from weave.utils.exception import exception_to_json_str
 from weave.utils.project_id import from_project_id, to_project_id
@@ -971,14 +967,8 @@ class WeaveClient:
         # per-call attributes. Per-call attributes take precedence over the client defaults.
         attributes_dict = AttributesDict(**zip_dicts(self.attributes, attributes))
 
-        if should_capture_client_info():
-            attributes_dict._set_weave_item("client_version", version.VERSION)
-            attributes_dict._set_weave_item("source", "python-sdk")
-            attributes_dict._set_weave_item("sys_version", sys.version)
-        if should_capture_system_info():
-            attributes_dict._set_weave_item("os_name", platform.system())
-            attributes_dict._set_weave_item("os_version", platform.version())
-            attributes_dict._set_weave_item("os_release", platform.release())
+        for k, v in get_capture_info_items():
+            attributes_dict._set_weave_item(k, v)
 
         # Skip the future allocation once the op's digest is resolved (any
         # call after the first). Reading `.uri` directly is a no-op string

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -183,7 +183,7 @@ from weave.trace_server_bindings.link_asset_to_registry import (
 )
 from weave.trace_server_bindings.models import StartBatchItem
 from weave.utils.attributes_dict import AttributesDict
-from weave.utils.capture_info import get_capture_info_items
+from weave.utils.capture_info import get_capture_info
 from weave.utils.dict_utils import sum_dict_leaves, zip_dicts
 from weave.utils.exception import exception_to_json_str
 from weave.utils.project_id import from_project_id, to_project_id
@@ -967,7 +967,7 @@ class WeaveClient:
         # per-call attributes. Per-call attributes take precedence over the client defaults.
         attributes_dict = AttributesDict(**zip_dicts(self.attributes, attributes))
 
-        for k, v in get_capture_info_items():
+        for k, v in get_capture_info().items():
             attributes_dict._set_weave_item(k, v)
 
         # Skip the future allocation once the op's digest is resolved (any

--- a/weave/utils/capture_info.py
+++ b/weave/utils/capture_info.py
@@ -18,27 +18,20 @@ from weave.trace.settings import (
 from weave.version import VERSION
 
 
-def get_capture_info_items() -> list[tuple[str, str]]:
-    """Return weave.* (subkey, value) pairs gated by capture-info settings.
+def get_capture_info() -> dict[str, str]:
+    """Return weave.* metadata keys (unprefixed), gated by capture-info settings.
 
-    Subkeys are unprefixed (``client_version``, not ``weave.client_version``)
+    Keys are unprefixed (``client_version``, not ``weave.client_version``)
     so call sites can prefix or nest as their attribute shape requires.
+    Both settings can independently include or exclude their key group.
     """
-    items: list[tuple[str, str]] = []
+    info: dict[str, str] = {}
     if should_capture_client_info():
-        items.extend(
-            [
-                ("client_version", VERSION),
-                ("source", "python-sdk"),
-                ("sys_version", sys.version),
-            ]
-        )
+        info["client_version"] = VERSION
+        info["source"] = "python-sdk"
+        info["sys_version"] = sys.version
     if should_capture_system_info():
-        items.extend(
-            [
-                ("os_name", platform.system()),
-                ("os_version", platform.version()),
-                ("os_release", platform.release()),
-            ]
-        )
-    return items
+        info["os_name"] = platform.system()
+        info["os_version"] = platform.version()
+        info["os_release"] = platform.release()
+    return info

--- a/weave/utils/capture_info.py
+++ b/weave/utils/capture_info.py
@@ -1,0 +1,44 @@
+"""Shared client/system info capture — used by both @op tracer and Session SDK.
+
+Returns ``weave.*`` metadata key/value pairs gated by
+``should_capture_client_info()`` / ``should_capture_system_info()``. Call
+sites apply their own key prefix (``"weave."`` dotted vs nested
+``_WeaveKeyDict``), but the gating + value sources stay in one place.
+"""
+
+from __future__ import annotations
+
+import platform
+import sys
+
+from weave.trace.settings import (
+    should_capture_client_info,
+    should_capture_system_info,
+)
+from weave.version import VERSION
+
+
+def get_capture_info_items() -> list[tuple[str, str]]:
+    """Return weave.* (subkey, value) pairs gated by capture-info settings.
+
+    Subkeys are unprefixed (``client_version``, not ``weave.client_version``)
+    so call sites can prefix or nest as their attribute shape requires.
+    """
+    items: list[tuple[str, str]] = []
+    if should_capture_client_info():
+        items.extend(
+            [
+                ("client_version", VERSION),
+                ("source", "python-sdk"),
+                ("sys_version", sys.version),
+            ]
+        )
+    if should_capture_system_info():
+        items.extend(
+            [
+                ("os_name", platform.system()),
+                ("os_version", platform.version()),
+                ("os_release", platform.release()),
+            ]
+        )
+    return items

--- a/weave/utils/pii_redaction.py
+++ b/weave/utils/pii_redaction.py
@@ -109,7 +109,9 @@ def redact_pii(
 def redact_pii_string(data: str) -> str:
     """Redact PII in a single string."""
     if not data:
-        return data  # _get_engines() is uncached; skip the engine-load cost on empty defaults
+        # Short-circuit empty input — _get_engines() is uncached and traces
+        # commonly contain empty strings, so loading Presidio every call is costly.
+        return data
     analyzer, anonymizer = _get_engines()
     entities = _get_redaction_entities()
     results = analyzer.analyze(text=data, language="en", entities=entities)
@@ -117,7 +119,7 @@ def redact_pii_string(data: str) -> str:
     return redacted.text
 
 
-def redact_messages(messages: list[Message] | None) -> list[Message] | None:
+def redact_messages(messages: list[Message]) -> list[Message]:
     """Redact PII in each Message via dump → redact → revalidate.
 
     Routes through the same recursive ``redact_pii`` used by ``@op`` so
@@ -135,10 +137,8 @@ def redact_messages(messages: list[Message] | None) -> list[Message] | None:
     return redacted
 
 
-def redact_system_instructions(
-    instructions: list[str] | None,
-) -> list[str] | None:
-    """Redact each system instruction. None/empty in → same out."""
+def redact_system_instructions(instructions: list[str]) -> list[str]:
+    """Redact each system instruction. Empty in → same out."""
     if not instructions:
         return instructions
     return [redact_pii_string(instruction) for instruction in instructions]

--- a/weave/utils/pii_redaction.py
+++ b/weave/utils/pii_redaction.py
@@ -117,7 +117,7 @@ def redact_pii_string(data: str) -> str:
     return redacted.text
 
 
-def redact_messages(msgs: list[Message] | None) -> list[Message] | None:
+def redact_messages(messages: list[Message] | None) -> list[Message] | None:
     """Redact PII in each Message via dump → redact → revalidate.
 
     Routes through the same recursive ``redact_pii`` used by ``@op`` so
@@ -125,21 +125,23 @@ def redact_messages(msgs: list[Message] | None) -> list[Message] | None:
     (``role``, part ``type``) aren't matched by Presidio's default
     recognizers, so the round-trip preserves the typed shape.
     """
-    if not msgs:
-        return msgs
-    out: list[Message] = []
-    for m in msgs:
-        dumped = m.model_dump()
-        redacted = cast(dict[str, Any], redact_pii(dumped))
-        out.append(Message.model_validate(redacted))
-    return out
+    if not messages:
+        return messages
+    redacted: list[Message] = []
+    for message in messages:
+        dumped = message.model_dump()
+        redacted_dump = cast(dict[str, Any], redact_pii(dumped))
+        redacted.append(Message.model_validate(redacted_dump))
+    return redacted
 
 
-def redact_system_instructions(insts: list[str] | None) -> list[str] | None:
+def redact_system_instructions(
+    instructions: list[str] | None,
+) -> list[str] | None:
     """Redact each system instruction. None/empty in → same out."""
-    if not insts:
-        return insts
-    return [redact_pii_string(s) for s in insts]
+    if not instructions:
+        return instructions
+    return [redact_pii_string(instruction) for instruction in instructions]
 
 
 def track_pii_redaction_enabled(

--- a/weave/utils/pii_redaction.py
+++ b/weave/utils/pii_redaction.py
@@ -1,12 +1,49 @@
+"""PII redaction — used by both @op tracer and Session SDK.
+
+Two layers:
+
+- ``redact_pii`` / ``redact_pii_string`` are the primitives that walk
+  dicts, lists, and dataclasses applying Presidio.
+- ``redact_messages`` / ``redact_system_instructions`` are the Session
+  SDK helpers shaped for typed Message payloads (dump → redact →
+  revalidate).
+
+``presidio`` is an optional dependency gated by ``WEAVE_REDACT_PII``.
+Imports happen inside ``_get_engines`` so the module loads without it —
+matches the pattern in ``weave/scorers/presidio_guardrail.py``. Lets
+tests ``mock.patch`` the redaction functions without installing the
+NLP stack, and lets users who never enable redaction skip the install.
+"""
+
+from __future__ import annotations
+
 import dataclasses
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
-from presidio_analyzer import AnalyzerEngine
-from presidio_anonymizer import AnonymizerEngine
-
+from weave.session.types import Message
 from weave.telemetry import trace_sentry
 from weave.trace.settings import redact_pii_exclude_fields, redact_pii_fields
 from weave.utils.sanitize import REDACTED_VALUE, redact_dataclass_fields, should_redact
+
+if TYPE_CHECKING:
+    from presidio_analyzer import AnalyzerEngine
+    from presidio_anonymizer import AnonymizerEngine
+
+_PRESIDIO_INSTALL_HINT = (
+    "presidio is required for PII redaction. "
+    "Install with `pip install 'weave[presidio]'`."
+)
+
+
+def _get_engines() -> tuple[AnalyzerEngine, AnonymizerEngine]:
+    """Lazy-load presidio engines, re-raising with a friendly install hint."""
+    try:
+        from presidio_analyzer import AnalyzerEngine
+        from presidio_anonymizer import AnonymizerEngine
+    except ImportError as e:
+        raise ImportError(_PRESIDIO_INSTALL_HINT) from e
+    return AnalyzerEngine(), AnonymizerEngine()
+
 
 DEFAULT_REDACTED_FIELDS = [
     "CREDIT_CARD",
@@ -39,8 +76,7 @@ def _get_redaction_entities() -> list[str]:
 def redact_pii(
     data: dict[str, Any] | str,
 ) -> dict[str, Any] | str:
-    analyzer = AnalyzerEngine()
-    anonymizer = AnonymizerEngine()
+    analyzer, anonymizer = _get_engines()
     entities = _get_redaction_entities()
 
     def redact_recursive(value: Any) -> Any:
@@ -71,12 +107,39 @@ def redact_pii(
 
 
 def redact_pii_string(data: str) -> str:
-    analyzer = AnalyzerEngine()
-    anonymizer = AnonymizerEngine()
+    """Redact PII in a single string. Empty in → empty out (skips Presidio)."""
+    if not data:
+        return data
+    analyzer, anonymizer = _get_engines()
     entities = _get_redaction_entities()
     results = analyzer.analyze(text=data, language="en", entities=entities)
     redacted = anonymizer.anonymize(text=data, analyzer_results=results)
     return redacted.text
+
+
+def redact_messages(msgs: list[Message] | None) -> list[Message] | None:
+    """Redact PII in each Message via dump → redact → revalidate.
+
+    Routes through the same recursive ``redact_pii`` used by ``@op`` so
+    Session SDK content is redacted identically. Discriminator literals
+    (``role``, part ``type``) aren't matched by Presidio's default
+    recognizers, so the round-trip preserves the typed shape.
+    """
+    if not msgs:
+        return msgs
+    out: list[Message] = []
+    for m in msgs:
+        dumped = m.model_dump()
+        redacted = cast(dict[str, Any], redact_pii(dumped))
+        out.append(Message.model_validate(redacted))
+    return out
+
+
+def redact_system_instructions(insts: list[str] | None) -> list[str] | None:
+    """Redact each system instruction. None/empty in → same out."""
+    if not insts:
+        return insts
+    return [redact_pii_string(s) for s in insts]
 
 
 def track_pii_redaction_enabled(

--- a/weave/utils/pii_redaction.py
+++ b/weave/utils/pii_redaction.py
@@ -107,9 +107,9 @@ def redact_pii(
 
 
 def redact_pii_string(data: str) -> str:
-    """Redact PII in a single string. Empty in → empty out (skips Presidio)."""
+    """Redact PII in a single string."""
     if not data:
-        return data
+        return data  # _get_engines() is uncached; skip the engine-load cost on empty defaults
     analyzer, anonymizer = _get_engines()
     entities = _get_redaction_entities()
     results = analyzer.analyze(text=data, language="en", entities=entities)


### PR DESCRIPTION
Replaces #6846 — fresh single-commit version off master, with the unresolved review feedback from #6846 pre-applied.

Wires four Weave global settings into the Session SDK so it matches `@op`, and fixes a reasoning leak.

## Changes

- **`WEAVE_DISABLED`** — silences Session SDK spans (streaming + batch).
- **`WEAVE_REDACT_PII`** — redacts Tool args/result, LLM input/output messages, system instructions, LLM reasoning, and Turn messages. Routes through the existing `weave.utils.pii_redaction` primitives. Skips Presidio entirely when `include_content=False`.
- **`WEAVE_CAPTURE_CLIENT_INFO` / `WEAVE_CAPTURE_SYSTEM_INFO`** — stamps `weave.*` metadata (version, source, OS info) on every Session span.
- **Bug fix** — `LLM.reasoning` was leaking into `gen_ai.output.messages` even when `include_content=False`. Now gated correctly.

## Shape

Each span class has a single `_build_attrs()` shared between the streaming (`.end()`) and batch (`log_turn`) paths, so the two can't drift.

`weave/utils/capture_info.py` is new — shared by Session SDK + `weave_client.py` for the `weave.*` attr gating.

## Refactor commit applies #6846 review feedback up front

To avoid another round of review on the same points, the second commit pre-applies the unresolved comments from #6846:

- `capture_info`: return `dict[str, str]` instead of `list[tuple[str, str]]` — keys are specific, dict gives accurate typing without TypedDict boilerplate.
- `pii_redaction`: drop abbreviations — `msgs`→`messages`, `insts`→`instructions`, `m`→`message`, `s`→`instruction`.
- Tests: patch `_get_engines` (the single Presidio dependency) instead of the high-level `redact_pii` / `redact_pii_string`. Real redaction code paths now run end-to-end against deterministic stub engines via a new `fake_presidio` fixture. `include_content=False` tests now assert `_get_engines` isn't called — matches the actual cost (no NLP engine loading on already-dropped content).
- Test helpers: `_redact_streaming_*` → `_streaming_*_with_pii`; helpers set up SDK usage, the SUT does redaction. `_ic_off_*` → `_content_off_*` for clarity. `exercise` → `user_func`.

## Tests

22 settings tests in `tests/session/test_session_settings.py`, all passing. Full session suite (225 tests) passes. `tests/trace/test_trace_settings.py` (40 tests) also passes — validates `@op`'s use of `capture_info` still works after the rename.