### PR TITLE
fix(weave): SDK 413 repackage on oversize call payloads

### DIFF
--- a/tests/trace/test_oversize_repackage.py
+++ b/tests/trace/test_oversize_repackage.py
@@ -1,19 +1,3 @@
-"""Tests for the SDK-side oversize-payload repackage helper.
-
-Covers the full surface used by all 4 production retry paths:
-- 413 detection
-- the greedy size-based walk (single oversize child, greedy batching of
-  medium siblings, oversize lists/strings/nested-under-oversize-parent)
-- `repackage_call_fields` field-level entry point (None / small / oversize)
-- `_try_repackage_call_item` dispatcher across all 3 batch item shapes
-- `_flush_calls_eager` end-to-end 413+retry through the v2 path
-- user warning surface
-
-The tests use the standard `client` fixture (real WeaveClient against the
-test trace server) so that `_save_object` returns real refs and we never
-need a fake client/ref stand-in.
-"""
-
 from __future__ import annotations
 
 import datetime
@@ -29,7 +13,6 @@ from weave.trace.oversize_repackage import (
     emit_user_warning,
     is_payload_too_large_error,
     repackage_call_fields,
-    repackage_oversize_payload,
 )
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.trace_server_interface import (
@@ -37,6 +20,7 @@ from weave.trace_server.trace_server_interface import (
     CallStartReq,
     CompletedCallSchemaForInsert,
     EndedCallSchemaForInsert,
+    EndedCallSchemaForInsertWithStartedAt,
     StartedCallSchemaForInsert,
 )
 from weave.trace_server_bindings.models import (
@@ -48,10 +32,6 @@ from weave.trace_server_bindings.remote_http_trace_server import (
     RemoteHTTPTraceServer,
     _try_repackage_call_item,
 )
-
-# ---------------------------------------------------------------------------
-# Helpers (top-level: no imports inside functions; reused across tests)
-# ---------------------------------------------------------------------------
 
 BIG_BLOB = "x" * (OVERSIZE_SUBTREE_BYTES * 2)
 
@@ -106,14 +86,21 @@ def _complete_item(
     return CompleteBatchItem(req=req)
 
 
-# ---------------------------------------------------------------------------
-# 413 detection + warning surface (small, no client needed)
-# ---------------------------------------------------------------------------
+def _end_req_with_started_at(*, output=None, summary=None) -> CallEndReq:
+    return CallEndReq(
+        end=EndedCallSchemaForInsertWithStartedAt(
+            project_id="ent/proj",
+            id="0199_end_id",
+            started_at=datetime.datetime(2026, 5, 1),
+            ended_at=datetime.datetime(2026, 5, 1, 0, 0, 1),
+            output=output,
+            summary=summary or {},
+        )
+    )
 
 
 def test_413_detection_only_matches_payload_too_large() -> None:
     assert is_payload_too_large_error(_make_http_error(413)) is True
-    # Anything else, including adjacent 4xx/5xx, must not match.
     for status in (400, 404, 500):
         assert is_payload_too_large_error(_make_http_error(status)) is False
     assert is_payload_too_large_error(ValueError("not an http error")) is False
@@ -131,31 +118,17 @@ def test_emit_user_warning_silent_when_empty_names_paths_otherwise(caplog) -> No
     assert "2 field(s)" in msg
     assert "summary.huge" in msg
     assert "output" in msg
-    assert "weave.publish" in msg  # guidance line
-
-
-# ---------------------------------------------------------------------------
-# Walk shapes — all the algorithmic cases in one assertion-rich test
-# ---------------------------------------------------------------------------
+    assert "weave.publish" in msg
 
 
 def test_walk_and_repackage_handles_all_shapes(client) -> None:
-    """One pass covering every branch the walk needs to take:
-    - under-threshold dict stays intact
-    - oversize child gets hoisted; small siblings stay inline
-    - many medium siblings get bundled via greedy batching
-    - oversize list is published whole
-    - oversize scalar string gets published
-    - nested oversize-under-oversize-parent hoists only the inner child
-    """
-    # Under threshold: returns input unchanged, no publish
+    """Covers under-threshold, oversize child, greedy bundle, oversize list/scalar, nested oversize."""
     obj = {"a": 1, "b": "small"}
     assert (
         _walk_and_repackage(obj, client=client, path=("summary",), repackaged=[])
         == obj
     )
 
-    # Oversize child + small siblings
     obj = {"small_a": 1, "small_b": "tiny", "huge": BIG_BLOB}
     paths: list[str] = []
     result = _walk_and_repackage(obj, client=client, path=("summary",), repackaged=paths)
@@ -164,7 +137,6 @@ def test_walk_and_repackage_handles_all_shapes(client) -> None:
     assert result["huge"].startswith("weave:///")
     assert paths == ["summary.huge"]
 
-    # Greedy batching: 4 tiny + 8 medium (~50KiB) siblings, threshold ~256KiB
     obj = {f"tiny_{i}": "z" for i in range(4)}
     for i in range(8):
         obj[f"med_{i}"] = "y" * 50_000
@@ -172,26 +144,20 @@ def test_walk_and_repackage_handles_all_shapes(client) -> None:
     assert all(result[f"tiny_{i}"] == "z" for i in range(4))
     assert OVERFLOW_BUNDLE_KEY in result
     assert result[OVERFLOW_BUNDLE_KEY].startswith("weave:///")
-    # Every medium sibling shows up either inline or inside the bundle ref
-    # (we don't dereference the ref here — coverage of bundle contents lives
-    # in the unit test for `_greedy_batch`).
     inline_meds = {k for k in result if k.startswith("med_")}
     assert inline_meds, "greedy batching should keep at least one medium inline"
 
-    # Oversize list -> published whole
     result = _walk_and_repackage(
         ["x" * 100_000] * 10, client=client, path=("output",), repackaged=[]
     )
     assert isinstance(result, str)
     assert result.startswith("weave:///")
 
-    # Oversize scalar string -> published
     result = _walk_and_repackage(
         BIG_BLOB, client=client, path=("summary", "blob"), repackaged=[]
     )
     assert result.startswith("weave:///")
 
-    # Nested oversize-under-oversize parent: only inner child hoists
     obj = {"nested": {"deep": BIG_BLOB}, "smaller": "z" * 10_000}
     result = _walk_and_repackage(obj, client=client, path=("summary",), repackaged=[])
     assert result["nested"]["deep"].startswith("weave:///")
@@ -199,71 +165,43 @@ def test_walk_and_repackage_handles_all_shapes(client) -> None:
     assert OVERFLOW_BUNDLE_KEY not in result
 
 
-# ---------------------------------------------------------------------------
-# Field-level entry point
-# ---------------------------------------------------------------------------
-
-
 def test_repackage_call_fields_passes_none_small_unchanged_and_hoists_oversize(
     client,
 ) -> None:
-    # Nones round-trip as None (not "{}").
     new_fields, repackaged = repackage_call_fields(
         client, fields={"summary": None, "output": None}
     )
     assert new_fields == {"summary": None, "output": None}
     assert repackaged == []
 
-    # Small values pass through identically.
     small = {"summary": {"weave": {"status": "ok"}}, "output": {"label": "ok"}}
     new_fields, repackaged = repackage_call_fields(client, fields=small)
     assert new_fields == small
     assert repackaged == []
 
-    # Oversize subtrees get hoisted; small siblings remain.
     new_fields, repackaged = repackage_call_fields(
         client,
         fields={
             "inputs": {"prompt": "small", "context": BIG_BLOB},
             "output": {"label": "ok"},
+            "summary": {"weave": {"usage": {"tokens": 5}}, "huge": BIG_BLOB},
         },
     )
     assert new_fields["inputs"]["prompt"] == "small"
     assert new_fields["inputs"]["context"].startswith("weave:///")
     assert new_fields["output"] == {"label": "ok"}
+    assert new_fields["summary"]["weave"]["usage"]["tokens"] == 5
+    assert new_fields["summary"]["huge"].startswith("weave:///")
     assert "inputs.context" in repackaged
-
-    # `repackage_oversize_payload` is just sugar over the above; verify
-    # summary + output are walked independently and both pick up refs.
-    new_summary, new_output, repackaged = repackage_oversize_payload(
-        client,
-        summary={"weave": {"usage": {"tokens": 5}}, "huge": BIG_BLOB},
-        output=BIG_BLOB,
-    )
-    assert new_summary["weave"]["usage"]["tokens"] == 5
-    assert new_summary["huge"].startswith("weave:///")
-    assert isinstance(new_output, str)
-    assert new_output.startswith("weave:///")
     assert "summary.huge" in repackaged
-    assert "output" in repackaged
-
-
-# ---------------------------------------------------------------------------
-# _try_repackage_call_item — the one dispatcher used by all 3 batched paths
-# ---------------------------------------------------------------------------
 
 
 def test_try_repackage_call_item_dispatches_all_three_item_shapes(
     client, monkeypatch
 ) -> None:
-    """One test verifies the dispatcher works for CompleteBatchItem,
-    StartBatchItem, and EndBatchItem, plus the two early-return paths
-    (no client, nothing to shrink). All 3 batched flush paths route through
-    this single function; covering it here is the full DRY contract.
-    """
+    """CompleteBatchItem, StartBatchItem, EndBatchItem + the two early-return paths."""
     monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
 
-    # CompleteBatchItem: output gets hoisted; inputs unchanged.
     item = _complete_item(
         inputs={"prompt": "small"},
         output={"label": "ok", "blob": BIG_BLOB},
@@ -274,17 +212,14 @@ def test_try_repackage_call_item_dispatches_all_three_item_shapes(
     assert new.req.output["blob"].startswith("weave:///")
     assert new.req.output["label"] == "ok"
     assert new.req.inputs == {"prompt": "small"}
-    # Source item unmodified
-    assert item.req.output["blob"] == BIG_BLOB
+    assert item.req.output["blob"] == BIG_BLOB  # source not mutated
 
-    # StartBatchItem: inputs get hoisted.
     item = _start_item(inputs={"prompt": BIG_BLOB, "tag": "t"})
     new = _try_repackage_call_item(item)
     assert isinstance(new, StartBatchItem)
     assert new.req.start.inputs["prompt"].startswith("weave:///")
     assert new.req.start.inputs["tag"] == "t"
 
-    # EndBatchItem: output gets hoisted, summary preserved.
     item = _end_item(output={"blob": BIG_BLOB, "label": "ok"}, summary={"keep": "small"})
     new = _try_repackage_call_item(item)
     assert isinstance(new, EndBatchItem)
@@ -292,7 +227,6 @@ def test_try_repackage_call_item_dispatches_all_three_item_shapes(
     assert new.req.end.output["label"] == "ok"
     assert new.req.end.summary == {"keep": "small"}
 
-    # Nothing oversize -> None (skip the retry, drop falls through).
     assert (
         _try_repackage_call_item(
             _end_item(output={"label": "ok"}, summary={"weave": {"status": "ok"}})
@@ -300,24 +234,31 @@ def test_try_repackage_call_item_dispatches_all_three_item_shapes(
         is None
     )
 
-    # No active client -> None.
     monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: None)
-    assert (
-        _try_repackage_call_item(_end_item(output={"blob": BIG_BLOB})) is None
+    assert _try_repackage_call_item(_end_item(output={"blob": BIG_BLOB})) is None
+
+
+def test_try_repackage_call_end_req_hoists_oversize_and_skips_small(client) -> None:
+    """Synchronous send_end_call path: oversize -> new req, small -> None."""
+    big_req = _end_req_with_started_at(
+        output={"blob": BIG_BLOB, "label": "ok"}, summary={"keep": "small"}
     )
+    new_req = client._try_repackage_call_end_req(big_req)
+    assert new_req is not None
+    assert new_req.end.output["blob"].startswith("weave:///")
+    assert new_req.end.output["label"] == "ok"
+    assert new_req.end.summary == {"keep": "small"}
 
-
-# ---------------------------------------------------------------------------
-# Eager flush (v2 single endpoints) — end-to-end 413 + retry
-# ---------------------------------------------------------------------------
+    small_req = _end_req_with_started_at(
+        output={"label": "ok"}, summary={"weave": {"status": "ok"}}
+    )
+    assert client._try_repackage_call_end_req(small_req) is None
 
 
 def test_flush_calls_eager_catches_413_repackages_and_retries(
     client, monkeypatch
 ) -> None:
-    """The v2 eager path: `_send_call_end_v2` returns 413 once, the eager
-    flush invokes `_try_repackage_call_item`, then resends and succeeds.
-    """
+    """v2 eager: 413 once, dispatcher repackages, resend succeeds."""
     monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
     server = RemoteHTTPTraceServer.__new__(RemoteHTTPTraceServer)
 
@@ -331,9 +272,6 @@ def test_flush_calls_eager_catches_413_repackages_and_retries(
         sent.append(end)
 
     monkeypatch.setattr(server, "_send_call_end_v2", fake_send_end, raising=False)
-    # Eager processor only inspects EndBatchItem.req.end / StartBatchItem.req.start
-    # and dispatches to _send_call_*_v2. Build an EndBatchItem whose req.end
-    # carries the started_at expected by the v2 endpoint contract.
     end_schema = tsi.EndedCallSchemaForInsertWithStartedAt(
         project_id="ent/proj",
         id="0199_end_id",
@@ -356,7 +294,7 @@ def test_flush_calls_eager_catches_413_repackages_and_retries(
 
 @pytest.mark.disable_logging_error_check
 def test_flush_calls_eager_drops_when_non_413(client, monkeypatch) -> None:
-    """Non-413 errors take the original drop path; no retry, no repackage."""
+    """Non-413 errors take the drop path; no retry, no repackage."""
     monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
     server = RemoteHTTPTraceServer.__new__(RemoteHTTPTraceServer)
 
@@ -369,7 +307,6 @@ def test_flush_calls_eager_drops_when_non_413(client, monkeypatch) -> None:
     monkeypatch.setattr(server, "_send_call_end_v2", fake_send_end, raising=False)
     item = _end_item(output={"blob": BIG_BLOB})
 
-    # Should not raise; drop logging happens internally.
     server._flush_calls_eager([item])
 
     assert state["calls"] == 1, "non-413 must not trigger a retry"

--- a/tests/trace/test_oversize_repackage.py
+++ b/tests/trace/test_oversize_repackage.py
@@ -1,436 +1,103 @@
 """Tests for the SDK-side oversize-payload repackage helper.
 
-Covers:
+Covers the full surface used by all 4 production retry paths:
 - 413 detection
-- greedy size-based extraction (small siblings stay inline, oversize
-  children get hoisted, medium siblings get batched into one ref)
-- the round trip through `repackage_oversize_payload`
-- the `send_end_call` retry: server returns 413 once, SDK repackages,
-  retry succeeds
+- the greedy size-based walk (single oversize child, greedy batching of
+  medium siblings, oversize lists/strings/nested-under-oversize-parent)
+- `repackage_call_fields` field-level entry point (None / small / oversize)
+- `_try_repackage_call_item` dispatcher across all 3 batch item shapes
+- `_flush_calls_eager` end-to-end 413+retry through the v2 path
+- user warning surface
+
+The tests use the standard `client` fixture (real WeaveClient against the
+test trace server) so that `_save_object` returns real refs and we never
+need a fake client/ref stand-in.
 """
 
 from __future__ import annotations
 
-from typing import Any
-from unittest.mock import MagicMock
+import datetime
 
 import httpx
 import pytest
 
-from weave.trace import oversize_repackage
+from weave.trace.context import weave_client_context
 from weave.trace.oversize_repackage import (
     OVERFLOW_BUNDLE_KEY,
     OVERSIZE_SUBTREE_BYTES,
-    _approx_size,
     _walk_and_repackage,
+    emit_user_warning,
     is_payload_too_large_error,
+    repackage_call_fields,
     repackage_oversize_payload,
 )
-
-
-class FakeRef:
-    def __init__(self, name: str, digest: str = "digest123") -> None:
-        self._name = name
-        self._digest = digest
-
-    def uri(self) -> str:
-        return f"weave:///fake/test/object/{self._name}:{self._digest}"
-
-
-class FakeClient:
-    """Stand-in for WeaveClient. Records every `_save_object` call so tests
-    can assert on what got published.
-    """
-
-    def __init__(self) -> None:
-        self.saved: list[tuple[str, Any]] = []
-
-    def _save_object(self, val: Any, name: str) -> FakeRef:
-        self.saved.append((name, val))
-        return FakeRef(name=name, digest=f"d{len(self.saved)}")
-
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.trace_server_interface import (
+    CallEndReq,
+    CallStartReq,
+    CompletedCallSchemaForInsert,
+    EndedCallSchemaForInsert,
+    StartedCallSchemaForInsert,
+)
+from weave.trace_server_bindings.models import (
+    CompleteBatchItem,
+    EndBatchItem,
+    StartBatchItem,
+)
+from weave.trace_server_bindings.remote_http_trace_server import (
+    RemoteHTTPTraceServer,
+    _try_repackage_call_item,
+)
 
 # ---------------------------------------------------------------------------
-# 413 detection
+# Helpers (top-level: no imports inside functions; reused across tests)
 # ---------------------------------------------------------------------------
 
-
-@pytest.mark.parametrize("status", [413])
-def test_is_413_detects_payload_too_large(status: int) -> None:
-    exc = httpx.HTTPStatusError(
-        "too big",
-        request=httpx.Request("POST", "http://x"),
-        response=httpx.Response(status),
-    )
-    assert is_payload_too_large_error(exc) is True
+BIG_BLOB = "x" * (OVERSIZE_SUBTREE_BYTES * 2)
 
 
-@pytest.mark.parametrize("status", [400, 401, 403, 404, 408, 500, 502, 503])
-def test_is_413_rejects_other_status_codes(status: int) -> None:
-    exc = httpx.HTTPStatusError(
-        "other",
-        request=httpx.Request("POST", "http://x"),
-        response=httpx.Response(status),
-    )
-    assert is_payload_too_large_error(exc) is False
-
-
-def test_is_413_rejects_non_http_exceptions() -> None:
-    assert is_payload_too_large_error(ValueError("boom")) is False
-
-
-# ---------------------------------------------------------------------------
-# _approx_size sanity
-# ---------------------------------------------------------------------------
-
-
-def test_approx_size_handles_unjsonable_objects() -> None:
-    # Sets aren't JSON-encodable; default=str rescues us.
-    assert _approx_size({"x": {1, 2, 3}}) > 0
-
-
-# ---------------------------------------------------------------------------
-# _walk_and_repackage shapes
-# ---------------------------------------------------------------------------
-
-
-def test_walk_under_threshold_returns_obj_unchanged() -> None:
-    client = FakeClient()
-    obj = {"a": 1, "b": "small"}
-    result = _walk_and_repackage(obj, client=client, path=("summary",), repackaged=[])
-    assert result == obj
-    assert client.saved == []
-
-
-def test_walk_hoists_individually_oversize_child() -> None:
-    """An oversize child becomes its own ref; small siblings stay inline."""
-    client = FakeClient()
-    obj = {
-        "small_a": 1,
-        "small_b": "tiny",
-        "huge": "x" * (OVERSIZE_SUBTREE_BYTES + 1000),
-    }
-    repackaged: list[str] = []
-    result = _walk_and_repackage(
-        obj, client=client, path=("summary",), repackaged=repackaged
-    )
-
-    assert result["small_a"] == 1
-    assert result["small_b"] == "tiny"
-    assert isinstance(result["huge"], str)
-    assert result["huge"].startswith("weave:///")
-    assert repackaged == ["summary.huge"]
-    # Only one publish, the huge child
-    assert len(client.saved) == 1
-    assert client.saved[0][0] == "summary_huge"
-
-
-def test_walk_greedy_batches_many_medium_siblings() -> None:
-    """The 500x100KiB case the reviewer flagged: many medium-sized
-    siblings, none individually over threshold. Greedy batching should
-    keep the smallest siblings inline and bundle the rest under
-    `_weave_overflow`.
-    """
-    client = FakeClient()
-    # 8 medium siblings (each ~50 KiB) + 4 tiny siblings.  Threshold is
-    # 256 KiB, so ~5 mediums fit inline and the rest should bundle.
-    obj: dict[str, Any] = {f"tiny_{i}": "z" for i in range(4)}
-    for i in range(8):
-        obj[f"med_{i}"] = "y" * 50_000
-
-    repackaged: list[str] = []
-    result = _walk_and_repackage(
-        obj, client=client, path=("summary",), repackaged=repackaged
-    )
-
-    assert isinstance(result, dict)
-    # All tiny siblings stay inline
-    for i in range(4):
-        assert result[f"tiny_{i}"] == "z"
-    # An overflow bundle ref is attached
-    assert OVERFLOW_BUNDLE_KEY in result
-    assert result[OVERFLOW_BUNDLE_KEY].startswith("weave:///")
-    # Exactly one publish (the bundle), not one per medium sibling
-    assert len(client.saved) == 1
-    assert client.saved[0][0] == f"summary_{OVERFLOW_BUNDLE_KEY}"
-    # The bundle contains the medium siblings that didn't fit
-    bundle = client.saved[0][1]
-    assert all(k.startswith("med_") for k in bundle)
-    # All medium siblings are accounted for (inline + bundled)
-    inline_meds = {k for k in result if k.startswith("med_")}
-    bundle_meds = set(bundle.keys())
-    assert inline_meds | bundle_meds == {f"med_{i}" for i in range(8)}
-
-
-def test_walk_publishes_oversize_list_whole() -> None:
-    client = FakeClient()
-    obj = ["x" * 100_000] * 10  # ~1 MB list
-    result = _walk_and_repackage(
-        obj, client=client, path=("output",), repackaged=[]
-    )
-    assert isinstance(result, str)
-    assert result.startswith("weave:///")
-    assert len(client.saved) == 1
-
-
-def test_walk_publishes_oversize_scalar_string() -> None:
-    client = FakeClient()
-    obj = "x" * (OVERSIZE_SUBTREE_BYTES + 1)
-    result = _walk_and_repackage(
-        obj, client=client, path=("summary", "blob"), repackaged=[]
-    )
-    assert result.startswith("weave:///")
-
-
-def test_walk_nested_oversize_under_oversize_parent() -> None:
-    """Parent dict is over threshold; one nested child is also individually
-    over threshold. The nested one should be hoisted individually, and the
-    remaining peers should not require greedy-batching (because removing
-    the hoisted child brought the parent under threshold).
-    """
-    client = FakeClient()
-    obj = {
-        "nested": {"deep": "y" * (OVERSIZE_SUBTREE_BYTES + 1000)},
-        "smaller": "z" * 10_000,
-    }
-    repackaged: list[str] = []
-    result = _walk_and_repackage(
-        obj, client=client, path=("summary",), repackaged=repackaged
-    )
-    # `nested.deep` got hoisted as its own ref
-    assert result["nested"]["deep"].startswith("weave:///")
-    # `smaller` stayed inline
-    assert result["smaller"] == "z" * 10_000
-    # No bundle key required at the top level
-    assert OVERFLOW_BUNDLE_KEY not in result
-
-
-# ---------------------------------------------------------------------------
-# repackage_oversize_payload (top-level entry point)
-# ---------------------------------------------------------------------------
-
-
-def test_repackage_returns_unchanged_when_under_threshold() -> None:
-    client = FakeClient()
-    summary = {"weave": {"usage": {"x": 1}}}
-    output = {"answer": "small"}
-    new_summary, new_output, repackaged = repackage_oversize_payload(
-        client, summary=summary, output=output
-    )
-    assert new_summary == summary
-    assert new_output == output
-    assert repackaged == []
-
-
-def test_repackage_extracts_summary_and_output_independently() -> None:
-    client = FakeClient()
-    summary = {
-        "weave": {"usage": {"tokens": 5}},
-        "huge": "x" * (OVERSIZE_SUBTREE_BYTES + 1000),
-    }
-    output = "y" * (OVERSIZE_SUBTREE_BYTES + 1000)
-
-    new_summary, new_output, repackaged = repackage_oversize_payload(
-        client, summary=summary, output=output
-    )
-
-    # Inline projection preserved in summary
-    assert new_summary["weave"]["usage"]["tokens"] == 5
-    assert new_summary["huge"].startswith("weave:///")
-    # Output became a single ref string
-    assert isinstance(new_output, str)
-    assert new_output.startswith("weave:///")
-    # Both paths recorded
-    assert "summary.huge" in repackaged
-    assert "output" in repackaged
-    assert len(client.saved) == 2
-
-
-# ---------------------------------------------------------------------------
-# Integration: send_end_call catches 413, repackages, retries once
-# ---------------------------------------------------------------------------
-
-
-def _make_413(message: str = "too large") -> httpx.HTTPStatusError:
+def _make_http_error(status: int) -> httpx.HTTPStatusError:
     return httpx.HTTPStatusError(
-        message,
-        request=httpx.Request("POST", "http://test"),
-        response=httpx.Response(413),
+        f"status {status}",
+        request=httpx.Request("POST", "http://x"),
+        response=httpx.Response(status),
     )
 
 
-def test_send_end_call_retries_after_413_and_repackages(monkeypatch) -> None:
-    """The end-to-end behavior the WB-34652 ticket asks for: a single 413
-    triggers repackage + one retry, then the call lands.
-    """
-    # 1. Simulate `self.server.call_end`: 413 the first time, ok the second.
-    call_log: list[Any] = []
-    response_state = {"call_count": 0}
-
-    def fake_call_end(req):
-        response_state["call_count"] += 1
-        if response_state["call_count"] == 1:
-            raise _make_413()
-        call_log.append(req)
-
-    fake_server = MagicMock()
-    fake_server.call_end.side_effect = fake_call_end
-
-    # 2. Build the slimmer payload helper so the closure-internal code
-    # exercises the real helper, not a stub.
-    fake_client = FakeClient()
-
-    # 3. Drive the exact try/except shape used by `send_end_call`. We can't
-    # easily exercise `WeaveClient.finish_call` end-to-end without a full
-    # test server, but the catch-and-retry block is small enough to mirror
-    # here exactly. If the production shape drifts, this test will need to
-    # follow.
-    project_id = "ent/proj"
-    merged_summary = {"big": "x" * (OVERSIZE_SUBTREE_BYTES + 1000), "tiny": 1}
-    output_json = {"small": True}
-
-    initial_req = MagicMock()
-    initial_req.end = MagicMock()
-    initial_req.end.summary = merged_summary
-    initial_req.end.output = output_json
-
-    caught_413 = False
-    try:
-        fake_server.call_end(initial_req)
-    except Exception as e:
-        caught_413 = is_payload_too_large_error(e)
-    assert caught_413, "expected first call to raise a 413"
-
-    new_summary, new_output, repackaged = repackage_oversize_payload(
-        fake_client, summary=merged_summary, output=output_json
+def _start_item(*, inputs=None, attributes=None) -> StartBatchItem:
+    start = StartedCallSchemaForInsert(
+        project_id="ent/proj",
+        id="0199_start_id",
+        trace_id="0199_trace_id",
+        op_name="op_name",
+        started_at=datetime.datetime(2026, 5, 1),
+        attributes=attributes or {},
+        inputs=inputs or {},
     )
-    assert repackaged, "expected repackage to identify oversize fields"
-
-    retry_req = MagicMock()
-    retry_req.end = MagicMock()
-    retry_req.end.summary = new_summary
-    retry_req.end.output = new_output
-    fake_server.call_end(retry_req)
-    oversize_repackage.emit_user_warning(repackaged)
-
-    assert response_state["call_count"] == 2
-    assert len(call_log) == 1
-    # The retry's summary has the big field replaced by a ref
-    retry_summary = call_log[0].end.summary
-    assert retry_summary["big"].startswith("weave:///")
-    assert retry_summary["tiny"] == 1
+    return StartBatchItem(req=CallStartReq(start=start))
 
 
-def test_send_end_call_does_not_retry_for_non_413(monkeypatch) -> None:
-    """Other errors propagate without triggering the repackage path."""
-    fake_client = FakeClient()
-    fake_server = MagicMock()
-    fake_server.call_end.side_effect = httpx.HTTPStatusError(
-        "boom",
-        request=httpx.Request("POST", "http://test"),
-        response=httpx.Response(500),
+def _end_item(*, output=None, summary=None) -> EndBatchItem:
+    end = EndedCallSchemaForInsert(
+        project_id="ent/proj",
+        id="0199_end_id",
+        ended_at=datetime.datetime(2026, 5, 1),
+        output=output,
+        summary=summary or {},
     )
-
-    with pytest.raises(httpx.HTTPStatusError) as excinfo:
-        fake_server.call_end(MagicMock())
-    assert not is_payload_too_large_error(excinfo.value)
-    assert fake_client.saved == []  # repackage never invoked
+    return EndBatchItem(req=CallEndReq(end=end))
 
 
-# ---------------------------------------------------------------------------
-# Warning surface
-# ---------------------------------------------------------------------------
-
-
-def test_emit_user_warning_is_silent_when_nothing_repackaged(caplog) -> None:
-    with caplog.at_level("WARNING"):
-        oversize_repackage.emit_user_warning([])
-    assert all("repackaged" not in r.message for r in caplog.records)
-
-
-def test_emit_user_warning_names_repackaged_paths(caplog) -> None:
-    with caplog.at_level("WARNING"):
-        oversize_repackage.emit_user_warning(
-            ["summary.weave.predictions", "output"]
-        )
-    msg = caplog.records[-1].getMessage()
-    assert "2 field(s)" in msg
-    assert "summary.weave.predictions" in msg
-    assert "output" in msg
-    assert "weave.publish" in msg  # guidance line
-
-
-# ---------------------------------------------------------------------------
-# repackage_call_fields
-# ---------------------------------------------------------------------------
-
-
-def test_repackage_call_fields_passes_through_none_values() -> None:
-    """None field values must round-trip as None, not '{}'."""
-    client = FakeClient()
-    new_fields, repackaged = oversize_repackage.repackage_call_fields(
-        client,  # type: ignore[arg-type]
-        fields={"summary": None, "output": None},
-    )
-    assert new_fields == {"summary": None, "output": None}
-    assert repackaged == []
-    assert client.saved == []
-
-
-def test_repackage_call_fields_returns_small_values_unchanged() -> None:
-    """Anything under the oversize threshold passes through identically."""
-    client = FakeClient()
-    new_fields, repackaged = oversize_repackage.repackage_call_fields(
-        client,  # type: ignore[arg-type]
-        fields={
-            "summary": {"weave": {"status": "success"}},
-            "output": {"label": "ok"},
-        },
-    )
-    assert new_fields == {
-        "summary": {"weave": {"status": "success"}},
-        "output": {"label": "ok"},
-    }
-    assert repackaged == []
-
-
-def test_repackage_call_fields_hoists_oversize_subtrees() -> None:
-    """A subtree above the threshold is published and replaced with a ref URI."""
-    client = FakeClient()
-    big = "x" * (OVERSIZE_SUBTREE_BYTES * 2)
-    new_fields, repackaged = oversize_repackage.repackage_call_fields(
-        client,  # type: ignore[arg-type]
-        fields={
-            "inputs": {"prompt": "small", "context": big},
-            "output": {"label": "ok"},
-        },
-    )
-    assert new_fields["inputs"]["prompt"] == "small"
-    assert new_fields["inputs"]["context"].startswith("weave:///")
-    assert new_fields["output"] == {"label": "ok"}
-    assert "inputs.context" in repackaged
-
-
-# ---------------------------------------------------------------------------
-# Batched-flush repackage closures (RemoteHTTPTraceServer)
-# ---------------------------------------------------------------------------
-
-
-def _complete_item(*, inputs=None, output=None, summary=None, attributes=None):
-    """Build a CompleteBatchItem for closure tests."""
-    import datetime as _dt
-    from weave.trace_server.trace_server_interface import (
-        CompletedCallSchemaForInsert,
-    )
-    from weave.trace_server_bindings.models import CompleteBatchItem
-
+def _complete_item(
+    *, inputs=None, attributes=None, output=None, summary=None
+) -> CompleteBatchItem:
     req = CompletedCallSchemaForInsert(
         project_id="ent/proj",
         id="0199_complete_id",
         trace_id="0199_trace_id",
         op_name="op_name",
-        started_at=_dt.datetime(2026, 5, 1),
-        ended_at=_dt.datetime(2026, 5, 1, 0, 0, 1),
+        started_at=datetime.datetime(2026, 5, 1),
+        ended_at=datetime.datetime(2026, 5, 1, 0, 0, 1),
         attributes=attributes or {},
         inputs=inputs or {},
         output=output,
@@ -439,116 +106,270 @@ def _complete_item(*, inputs=None, output=None, summary=None, attributes=None):
     return CompleteBatchItem(req=req)
 
 
-def _end_item(*, output=None, summary=None):
-    import datetime as _dt
-    from weave.trace_server.trace_server_interface import (
-        CallEndReq,
-        EndedCallSchemaForInsert,
-    )
-    from weave.trace_server_bindings.models import EndBatchItem
+# ---------------------------------------------------------------------------
+# 413 detection + warning surface (small, no client needed)
+# ---------------------------------------------------------------------------
 
-    end = EndedCallSchemaForInsert(
+
+def test_413_detection_only_matches_payload_too_large() -> None:
+    assert is_payload_too_large_error(_make_http_error(413)) is True
+    # Anything else, including adjacent 4xx/5xx, must not match.
+    for status in (400, 404, 500):
+        assert is_payload_too_large_error(_make_http_error(status)) is False
+    assert is_payload_too_large_error(ValueError("not an http error")) is False
+
+
+def test_emit_user_warning_silent_when_empty_names_paths_otherwise(caplog) -> None:
+    with caplog.at_level("WARNING"):
+        emit_user_warning([])
+    assert all("repackaged" not in r.message for r in caplog.records)
+
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        emit_user_warning(["summary.huge", "output"])
+    msg = caplog.records[-1].getMessage()
+    assert "2 field(s)" in msg
+    assert "summary.huge" in msg
+    assert "output" in msg
+    assert "weave.publish" in msg  # guidance line
+
+
+# ---------------------------------------------------------------------------
+# Walk shapes — all the algorithmic cases in one assertion-rich test
+# ---------------------------------------------------------------------------
+
+
+def test_walk_and_repackage_handles_all_shapes(client) -> None:
+    """One pass covering every branch the walk needs to take:
+    - under-threshold dict stays intact
+    - oversize child gets hoisted; small siblings stay inline
+    - many medium siblings get bundled via greedy batching
+    - oversize list is published whole
+    - oversize scalar string gets published
+    - nested oversize-under-oversize-parent hoists only the inner child
+    """
+    # Under threshold: returns input unchanged, no publish
+    obj = {"a": 1, "b": "small"}
+    assert (
+        _walk_and_repackage(obj, client=client, path=("summary",), repackaged=[])
+        == obj
+    )
+
+    # Oversize child + small siblings
+    obj = {"small_a": 1, "small_b": "tiny", "huge": BIG_BLOB}
+    paths: list[str] = []
+    result = _walk_and_repackage(obj, client=client, path=("summary",), repackaged=paths)
+    assert result["small_a"] == 1
+    assert result["small_b"] == "tiny"
+    assert result["huge"].startswith("weave:///")
+    assert paths == ["summary.huge"]
+
+    # Greedy batching: 4 tiny + 8 medium (~50KiB) siblings, threshold ~256KiB
+    obj = {f"tiny_{i}": "z" for i in range(4)}
+    for i in range(8):
+        obj[f"med_{i}"] = "y" * 50_000
+    result = _walk_and_repackage(obj, client=client, path=("summary",), repackaged=[])
+    assert all(result[f"tiny_{i}"] == "z" for i in range(4))
+    assert OVERFLOW_BUNDLE_KEY in result
+    assert result[OVERFLOW_BUNDLE_KEY].startswith("weave:///")
+    # Every medium sibling shows up either inline or inside the bundle ref
+    # (we don't dereference the ref here — coverage of bundle contents lives
+    # in the unit test for `_greedy_batch`).
+    inline_meds = {k for k in result if k.startswith("med_")}
+    assert inline_meds, "greedy batching should keep at least one medium inline"
+
+    # Oversize list -> published whole
+    result = _walk_and_repackage(
+        ["x" * 100_000] * 10, client=client, path=("output",), repackaged=[]
+    )
+    assert isinstance(result, str)
+    assert result.startswith("weave:///")
+
+    # Oversize scalar string -> published
+    result = _walk_and_repackage(
+        BIG_BLOB, client=client, path=("summary", "blob"), repackaged=[]
+    )
+    assert result.startswith("weave:///")
+
+    # Nested oversize-under-oversize parent: only inner child hoists
+    obj = {"nested": {"deep": BIG_BLOB}, "smaller": "z" * 10_000}
+    result = _walk_and_repackage(obj, client=client, path=("summary",), repackaged=[])
+    assert result["nested"]["deep"].startswith("weave:///")
+    assert result["smaller"] == "z" * 10_000
+    assert OVERFLOW_BUNDLE_KEY not in result
+
+
+# ---------------------------------------------------------------------------
+# Field-level entry point
+# ---------------------------------------------------------------------------
+
+
+def test_repackage_call_fields_passes_none_small_unchanged_and_hoists_oversize(
+    client,
+) -> None:
+    # Nones round-trip as None (not "{}").
+    new_fields, repackaged = repackage_call_fields(
+        client, fields={"summary": None, "output": None}
+    )
+    assert new_fields == {"summary": None, "output": None}
+    assert repackaged == []
+
+    # Small values pass through identically.
+    small = {"summary": {"weave": {"status": "ok"}}, "output": {"label": "ok"}}
+    new_fields, repackaged = repackage_call_fields(client, fields=small)
+    assert new_fields == small
+    assert repackaged == []
+
+    # Oversize subtrees get hoisted; small siblings remain.
+    new_fields, repackaged = repackage_call_fields(
+        client,
+        fields={
+            "inputs": {"prompt": "small", "context": BIG_BLOB},
+            "output": {"label": "ok"},
+        },
+    )
+    assert new_fields["inputs"]["prompt"] == "small"
+    assert new_fields["inputs"]["context"].startswith("weave:///")
+    assert new_fields["output"] == {"label": "ok"}
+    assert "inputs.context" in repackaged
+
+    # `repackage_oversize_payload` is just sugar over the above; verify
+    # summary + output are walked independently and both pick up refs.
+    new_summary, new_output, repackaged = repackage_oversize_payload(
+        client,
+        summary={"weave": {"usage": {"tokens": 5}}, "huge": BIG_BLOB},
+        output=BIG_BLOB,
+    )
+    assert new_summary["weave"]["usage"]["tokens"] == 5
+    assert new_summary["huge"].startswith("weave:///")
+    assert isinstance(new_output, str)
+    assert new_output.startswith("weave:///")
+    assert "summary.huge" in repackaged
+    assert "output" in repackaged
+
+
+# ---------------------------------------------------------------------------
+# _try_repackage_call_item — the one dispatcher used by all 3 batched paths
+# ---------------------------------------------------------------------------
+
+
+def test_try_repackage_call_item_dispatches_all_three_item_shapes(
+    client, monkeypatch
+) -> None:
+    """One test verifies the dispatcher works for CompleteBatchItem,
+    StartBatchItem, and EndBatchItem, plus the two early-return paths
+    (no client, nothing to shrink). All 3 batched flush paths route through
+    this single function; covering it here is the full DRY contract.
+    """
+    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
+
+    # CompleteBatchItem: output gets hoisted; inputs unchanged.
+    item = _complete_item(
+        inputs={"prompt": "small"},
+        output={"label": "ok", "blob": BIG_BLOB},
+        summary={"weave": {"status": "ok"}},
+    )
+    new = _try_repackage_call_item(item)
+    assert isinstance(new, CompleteBatchItem)
+    assert new.req.output["blob"].startswith("weave:///")
+    assert new.req.output["label"] == "ok"
+    assert new.req.inputs == {"prompt": "small"}
+    # Source item unmodified
+    assert item.req.output["blob"] == BIG_BLOB
+
+    # StartBatchItem: inputs get hoisted.
+    item = _start_item(inputs={"prompt": BIG_BLOB, "tag": "t"})
+    new = _try_repackage_call_item(item)
+    assert isinstance(new, StartBatchItem)
+    assert new.req.start.inputs["prompt"].startswith("weave:///")
+    assert new.req.start.inputs["tag"] == "t"
+
+    # EndBatchItem: output gets hoisted, summary preserved.
+    item = _end_item(output={"blob": BIG_BLOB, "label": "ok"}, summary={"keep": "small"})
+    new = _try_repackage_call_item(item)
+    assert isinstance(new, EndBatchItem)
+    assert new.req.end.output["blob"].startswith("weave:///")
+    assert new.req.end.output["label"] == "ok"
+    assert new.req.end.summary == {"keep": "small"}
+
+    # Nothing oversize -> None (skip the retry, drop falls through).
+    assert (
+        _try_repackage_call_item(
+            _end_item(output={"label": "ok"}, summary={"weave": {"status": "ok"}})
+        )
+        is None
+    )
+
+    # No active client -> None.
+    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: None)
+    assert (
+        _try_repackage_call_item(_end_item(output={"blob": BIG_BLOB})) is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Eager flush (v2 single endpoints) — end-to-end 413 + retry
+# ---------------------------------------------------------------------------
+
+
+def test_flush_calls_eager_catches_413_repackages_and_retries(
+    client, monkeypatch
+) -> None:
+    """The v2 eager path: `_send_call_end_v2` returns 413 once, the eager
+    flush invokes `_try_repackage_call_item`, then resends and succeeds.
+    """
+    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
+    server = RemoteHTTPTraceServer.__new__(RemoteHTTPTraceServer)
+
+    sent: list[tsi.EndedCallSchemaForInsertWithStartedAt] = []
+    state = {"calls": 0}
+
+    def fake_send_end(end):
+        state["calls"] += 1
+        if state["calls"] == 1:
+            raise _make_http_error(413)
+        sent.append(end)
+
+    monkeypatch.setattr(server, "_send_call_end_v2", fake_send_end, raising=False)
+    # Eager processor only inspects EndBatchItem.req.end / StartBatchItem.req.start
+    # and dispatches to _send_call_*_v2. Build an EndBatchItem whose req.end
+    # carries the started_at expected by the v2 endpoint contract.
+    end_schema = tsi.EndedCallSchemaForInsertWithStartedAt(
         project_id="ent/proj",
         id="0199_end_id",
-        ended_at=_dt.datetime(2026, 5, 1),
-        output=output,
-        summary=summary or {},
-    )
-    return EndBatchItem(req=CallEndReq(end=end))
-
-
-def test_repackage_complete_batch_item_repackages_output(monkeypatch) -> None:
-    """The CompleteBatchItem closure hoists oversize output subtrees and
-    returns a new item with refs inline.
-    """
-    from weave.trace.context import weave_client_context
-    from weave.trace_server_bindings.remote_http_trace_server import (
-        _repackage_complete_batch_item,
-    )
-
-    client = FakeClient()
-    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
-
-    big = "x" * (OVERSIZE_SUBTREE_BYTES * 2)
-    item = _complete_item(
-        inputs={"prompt": "small"},
-        output={"label": "ok", "blob": big},
-        summary={"weave": {"status": "success"}},
-    )
-
-    new_item = _repackage_complete_batch_item(item)
-
-    assert new_item is not None
-    assert new_item.req.output["blob"].startswith("weave:///")
-    assert new_item.req.output["label"] == "ok"
-    assert new_item.req.inputs == {"prompt": "small"}
-    # Original item not mutated.
-    assert item.req.output["blob"] == big
-
-
-def test_repackage_complete_batch_item_returns_none_when_nothing_to_shrink(
-    monkeypatch,
-) -> None:
-    from weave.trace.context import weave_client_context
-    from weave.trace_server_bindings.remote_http_trace_server import (
-        _repackage_complete_batch_item,
-    )
-
-    client = FakeClient()
-    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
-    item = _complete_item(
-        inputs={"prompt": "small"},
-        output={"label": "ok"},
-        summary={"weave": {"status": "success"}},
-    )
-    assert _repackage_complete_batch_item(item) is None
-    assert client.saved == []
-
-
-def test_repackage_complete_batch_item_returns_none_when_no_client(
-    monkeypatch,
-) -> None:
-    from weave.trace.context import weave_client_context
-    from weave.trace_server_bindings.remote_http_trace_server import (
-        _repackage_complete_batch_item,
-    )
-
-    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: None)
-    item = _complete_item(output={"blob": "x" * (OVERSIZE_SUBTREE_BYTES * 2)})
-    assert _repackage_complete_batch_item(item) is None
-
-
-def test_repackage_legacy_end_item_hoists_summary_and_output(monkeypatch) -> None:
-    from weave.trace.context import weave_client_context
-    from weave.trace_server_bindings.models import EndBatchItem
-    from weave.trace_server_bindings.remote_http_trace_server import (
-        _repackage_legacy_batch_item,
-    )
-
-    client = FakeClient()
-    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
-
-    big = "x" * (OVERSIZE_SUBTREE_BYTES * 2)
-    item = _end_item(
-        output={"blob": big, "label": "ok"},
+        started_at=datetime.datetime(2026, 5, 1),
+        ended_at=datetime.datetime(2026, 5, 1, 0, 0, 1),
+        output={"blob": BIG_BLOB, "label": "ok"},
         summary={"keep": "small"},
     )
+    item = EndBatchItem(req=CallEndReq(end=end_schema))
 
-    new_item = _repackage_legacy_batch_item(item)
+    server._flush_calls_eager([item])
 
-    assert isinstance(new_item, EndBatchItem)
-    assert new_item.req.end.output["blob"].startswith("weave:///")
-    assert new_item.req.end.output["label"] == "ok"
-    assert new_item.req.end.summary == {"keep": "small"}
+    assert state["calls"] == 2, "expected one 413 then one successful retry"
+    assert len(sent) == 1
+    resent = sent[0]
+    assert resent.output["blob"].startswith("weave:///")
+    assert resent.output["label"] == "ok"
+    assert resent.summary == {"keep": "small"}
 
 
-def test_repackage_legacy_returns_none_when_nothing_to_shrink(monkeypatch) -> None:
-    from weave.trace.context import weave_client_context
-    from weave.trace_server_bindings.remote_http_trace_server import (
-        _repackage_legacy_batch_item,
-    )
-
-    client = FakeClient()
+@pytest.mark.disable_logging_error_check
+def test_flush_calls_eager_drops_when_non_413(client, monkeypatch) -> None:
+    """Non-413 errors take the original drop path; no retry, no repackage."""
     monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
-    item = _end_item(output={"label": "ok"}, summary={"weave": {"status": "ok"}})
-    assert _repackage_legacy_batch_item(item) is None
+    server = RemoteHTTPTraceServer.__new__(RemoteHTTPTraceServer)
+
+    state = {"calls": 0}
+
+    def fake_send_end(end):
+        state["calls"] += 1
+        raise _make_http_error(500)
+
+    monkeypatch.setattr(server, "_send_call_end_v2", fake_send_end, raising=False)
+    item = _end_item(output={"blob": BIG_BLOB})
+
+    # Should not raise; drop logging happens internally.
+    server._flush_calls_eager([item])
+
+    assert state["calls"] == 1, "non-413 must not trigger a retry"

--- a/tests/trace/test_oversize_repackage.py
+++ b/tests/trace/test_oversize_repackage.py
@@ -1,0 +1,360 @@
+"""Tests for the SDK-side oversize-payload repackage helper.
+
+Covers:
+- 413 detection
+- greedy size-based extraction (small siblings stay inline, oversize
+  children get hoisted, medium siblings get batched into one ref)
+- the round trip through `repackage_oversize_payload`
+- the `send_end_call` retry: server returns 413 once, SDK repackages,
+  retry succeeds
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from weave.trace import oversize_repackage
+from weave.trace.oversize_repackage import (
+    OVERFLOW_BUNDLE_KEY,
+    OVERSIZE_SUBTREE_BYTES,
+    _approx_size,
+    _walk_and_repackage,
+    is_payload_too_large_error,
+    repackage_oversize_payload,
+)
+
+
+class FakeRef:
+    def __init__(self, name: str, digest: str = "digest123") -> None:
+        self._name = name
+        self._digest = digest
+
+    def uri(self) -> str:
+        return f"weave:///fake/test/object/{self._name}:{self._digest}"
+
+
+class FakeClient:
+    """Stand-in for WeaveClient. Records every `_save_object` call so tests
+    can assert on what got published.
+    """
+
+    def __init__(self) -> None:
+        self.saved: list[tuple[str, Any]] = []
+
+    def _save_object(self, val: Any, name: str) -> FakeRef:
+        self.saved.append((name, val))
+        return FakeRef(name=name, digest=f"d{len(self.saved)}")
+
+
+# ---------------------------------------------------------------------------
+# 413 detection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [413])
+def test_is_413_detects_payload_too_large(status: int) -> None:
+    exc = httpx.HTTPStatusError(
+        "too big",
+        request=httpx.Request("POST", "http://x"),
+        response=httpx.Response(status),
+    )
+    assert is_payload_too_large_error(exc) is True
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 408, 500, 502, 503])
+def test_is_413_rejects_other_status_codes(status: int) -> None:
+    exc = httpx.HTTPStatusError(
+        "other",
+        request=httpx.Request("POST", "http://x"),
+        response=httpx.Response(status),
+    )
+    assert is_payload_too_large_error(exc) is False
+
+
+def test_is_413_rejects_non_http_exceptions() -> None:
+    assert is_payload_too_large_error(ValueError("boom")) is False
+
+
+# ---------------------------------------------------------------------------
+# _approx_size sanity
+# ---------------------------------------------------------------------------
+
+
+def test_approx_size_handles_unjsonable_objects() -> None:
+    # Sets aren't JSON-encodable; default=str rescues us.
+    assert _approx_size({"x": {1, 2, 3}}) > 0
+
+
+# ---------------------------------------------------------------------------
+# _walk_and_repackage shapes
+# ---------------------------------------------------------------------------
+
+
+def test_walk_under_threshold_returns_obj_unchanged() -> None:
+    client = FakeClient()
+    obj = {"a": 1, "b": "small"}
+    result = _walk_and_repackage(obj, client=client, path=("summary",), repackaged=[])
+    assert result == obj
+    assert client.saved == []
+
+
+def test_walk_hoists_individually_oversize_child() -> None:
+    """An oversize child becomes its own ref; small siblings stay inline."""
+    client = FakeClient()
+    obj = {
+        "small_a": 1,
+        "small_b": "tiny",
+        "huge": "x" * (OVERSIZE_SUBTREE_BYTES + 1000),
+    }
+    repackaged: list[str] = []
+    result = _walk_and_repackage(
+        obj, client=client, path=("summary",), repackaged=repackaged
+    )
+
+    assert result["small_a"] == 1
+    assert result["small_b"] == "tiny"
+    assert isinstance(result["huge"], str)
+    assert result["huge"].startswith("weave:///")
+    assert repackaged == ["summary.huge"]
+    # Only one publish, the huge child
+    assert len(client.saved) == 1
+    assert client.saved[0][0] == "summary_huge"
+
+
+def test_walk_greedy_batches_many_medium_siblings() -> None:
+    """The 500x100KiB case the reviewer flagged: many medium-sized
+    siblings, none individually over threshold. Greedy batching should
+    keep the smallest siblings inline and bundle the rest under
+    `_weave_overflow`.
+    """
+    client = FakeClient()
+    # 8 medium siblings (each ~50 KiB) + 4 tiny siblings.  Threshold is
+    # 256 KiB, so ~5 mediums fit inline and the rest should bundle.
+    obj: dict[str, Any] = {f"tiny_{i}": "z" for i in range(4)}
+    for i in range(8):
+        obj[f"med_{i}"] = "y" * 50_000
+
+    repackaged: list[str] = []
+    result = _walk_and_repackage(
+        obj, client=client, path=("summary",), repackaged=repackaged
+    )
+
+    assert isinstance(result, dict)
+    # All tiny siblings stay inline
+    for i in range(4):
+        assert result[f"tiny_{i}"] == "z"
+    # An overflow bundle ref is attached
+    assert OVERFLOW_BUNDLE_KEY in result
+    assert result[OVERFLOW_BUNDLE_KEY].startswith("weave:///")
+    # Exactly one publish (the bundle), not one per medium sibling
+    assert len(client.saved) == 1
+    assert client.saved[0][0] == f"summary_{OVERFLOW_BUNDLE_KEY}"
+    # The bundle contains the medium siblings that didn't fit
+    bundle = client.saved[0][1]
+    assert all(k.startswith("med_") for k in bundle)
+    # All medium siblings are accounted for (inline + bundled)
+    inline_meds = {k for k in result if k.startswith("med_")}
+    bundle_meds = set(bundle.keys())
+    assert inline_meds | bundle_meds == {f"med_{i}" for i in range(8)}
+
+
+def test_walk_publishes_oversize_list_whole() -> None:
+    client = FakeClient()
+    obj = ["x" * 100_000] * 10  # ~1 MB list
+    result = _walk_and_repackage(
+        obj, client=client, path=("output",), repackaged=[]
+    )
+    assert isinstance(result, str)
+    assert result.startswith("weave:///")
+    assert len(client.saved) == 1
+
+
+def test_walk_publishes_oversize_scalar_string() -> None:
+    client = FakeClient()
+    obj = "x" * (OVERSIZE_SUBTREE_BYTES + 1)
+    result = _walk_and_repackage(
+        obj, client=client, path=("summary", "blob"), repackaged=[]
+    )
+    assert result.startswith("weave:///")
+
+
+def test_walk_nested_oversize_under_oversize_parent() -> None:
+    """Parent dict is over threshold; one nested child is also individually
+    over threshold. The nested one should be hoisted individually, and the
+    remaining peers should not require greedy-batching (because removing
+    the hoisted child brought the parent under threshold).
+    """
+    client = FakeClient()
+    obj = {
+        "nested": {"deep": "y" * (OVERSIZE_SUBTREE_BYTES + 1000)},
+        "smaller": "z" * 10_000,
+    }
+    repackaged: list[str] = []
+    result = _walk_and_repackage(
+        obj, client=client, path=("summary",), repackaged=repackaged
+    )
+    # `nested.deep` got hoisted as its own ref
+    assert result["nested"]["deep"].startswith("weave:///")
+    # `smaller` stayed inline
+    assert result["smaller"] == "z" * 10_000
+    # No bundle key required at the top level
+    assert OVERFLOW_BUNDLE_KEY not in result
+
+
+# ---------------------------------------------------------------------------
+# repackage_oversize_payload (top-level entry point)
+# ---------------------------------------------------------------------------
+
+
+def test_repackage_returns_unchanged_when_under_threshold() -> None:
+    client = FakeClient()
+    summary = {"weave": {"usage": {"x": 1}}}
+    output = {"answer": "small"}
+    new_summary, new_output, repackaged = repackage_oversize_payload(
+        client, summary=summary, output=output
+    )
+    assert new_summary == summary
+    assert new_output == output
+    assert repackaged == []
+
+
+def test_repackage_extracts_summary_and_output_independently() -> None:
+    client = FakeClient()
+    summary = {
+        "weave": {"usage": {"tokens": 5}},
+        "huge": "x" * (OVERSIZE_SUBTREE_BYTES + 1000),
+    }
+    output = "y" * (OVERSIZE_SUBTREE_BYTES + 1000)
+
+    new_summary, new_output, repackaged = repackage_oversize_payload(
+        client, summary=summary, output=output
+    )
+
+    # Inline projection preserved in summary
+    assert new_summary["weave"]["usage"]["tokens"] == 5
+    assert new_summary["huge"].startswith("weave:///")
+    # Output became a single ref string
+    assert isinstance(new_output, str)
+    assert new_output.startswith("weave:///")
+    # Both paths recorded
+    assert "summary.huge" in repackaged
+    assert "output" in repackaged
+    assert len(client.saved) == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration: send_end_call catches 413, repackages, retries once
+# ---------------------------------------------------------------------------
+
+
+def _make_413(message: str = "too large") -> httpx.HTTPStatusError:
+    return httpx.HTTPStatusError(
+        message,
+        request=httpx.Request("POST", "http://test"),
+        response=httpx.Response(413),
+    )
+
+
+def test_send_end_call_retries_after_413_and_repackages(monkeypatch) -> None:
+    """The end-to-end behavior the WB-34652 ticket asks for: a single 413
+    triggers repackage + one retry, then the call lands.
+    """
+    # 1. Simulate `self.server.call_end`: 413 the first time, ok the second.
+    call_log: list[Any] = []
+    response_state = {"call_count": 0}
+
+    def fake_call_end(req):
+        response_state["call_count"] += 1
+        if response_state["call_count"] == 1:
+            raise _make_413()
+        call_log.append(req)
+
+    fake_server = MagicMock()
+    fake_server.call_end.side_effect = fake_call_end
+
+    # 2. Build the slimmer payload helper so the closure-internal code
+    # exercises the real helper, not a stub.
+    fake_client = FakeClient()
+
+    # 3. Drive the exact try/except shape used by `send_end_call`. We can't
+    # easily exercise `WeaveClient.finish_call` end-to-end without a full
+    # test server, but the catch-and-retry block is small enough to mirror
+    # here exactly. If the production shape drifts, this test will need to
+    # follow.
+    project_id = "ent/proj"
+    merged_summary = {"big": "x" * (OVERSIZE_SUBTREE_BYTES + 1000), "tiny": 1}
+    output_json = {"small": True}
+
+    initial_req = MagicMock()
+    initial_req.end = MagicMock()
+    initial_req.end.summary = merged_summary
+    initial_req.end.output = output_json
+
+    caught_413 = False
+    try:
+        fake_server.call_end(initial_req)
+    except Exception as e:
+        caught_413 = is_payload_too_large_error(e)
+    assert caught_413, "expected first call to raise a 413"
+
+    new_summary, new_output, repackaged = repackage_oversize_payload(
+        fake_client, summary=merged_summary, output=output_json
+    )
+    assert repackaged, "expected repackage to identify oversize fields"
+
+    retry_req = MagicMock()
+    retry_req.end = MagicMock()
+    retry_req.end.summary = new_summary
+    retry_req.end.output = new_output
+    fake_server.call_end(retry_req)
+    oversize_repackage.emit_user_warning(repackaged)
+
+    assert response_state["call_count"] == 2
+    assert len(call_log) == 1
+    # The retry's summary has the big field replaced by a ref
+    retry_summary = call_log[0].end.summary
+    assert retry_summary["big"].startswith("weave:///")
+    assert retry_summary["tiny"] == 1
+
+
+def test_send_end_call_does_not_retry_for_non_413(monkeypatch) -> None:
+    """Other errors propagate without triggering the repackage path."""
+    fake_client = FakeClient()
+    fake_server = MagicMock()
+    fake_server.call_end.side_effect = httpx.HTTPStatusError(
+        "boom",
+        request=httpx.Request("POST", "http://test"),
+        response=httpx.Response(500),
+    )
+
+    with pytest.raises(httpx.HTTPStatusError) as excinfo:
+        fake_server.call_end(MagicMock())
+    assert not is_payload_too_large_error(excinfo.value)
+    assert fake_client.saved == []  # repackage never invoked
+
+
+# ---------------------------------------------------------------------------
+# Warning surface
+# ---------------------------------------------------------------------------
+
+
+def test_emit_user_warning_is_silent_when_nothing_repackaged(caplog) -> None:
+    with caplog.at_level("WARNING"):
+        oversize_repackage.emit_user_warning([])
+    assert all("repackaged" not in r.message for r in caplog.records)
+
+
+def test_emit_user_warning_names_repackaged_paths(caplog) -> None:
+    with caplog.at_level("WARNING"):
+        oversize_repackage.emit_user_warning(
+            ["summary.weave.predictions", "output"]
+        )
+    msg = caplog.records[-1].getMessage()
+    assert "2 field(s)" in msg
+    assert "summary.weave.predictions" in msg
+    assert "output" in msg
+    assert "weave.publish" in msg  # guidance line

--- a/tests/trace/test_oversize_repackage.py
+++ b/tests/trace/test_oversize_repackage.py
@@ -358,3 +358,197 @@ def test_emit_user_warning_names_repackaged_paths(caplog) -> None:
     assert "summary.weave.predictions" in msg
     assert "output" in msg
     assert "weave.publish" in msg  # guidance line
+
+
+# ---------------------------------------------------------------------------
+# repackage_call_fields
+# ---------------------------------------------------------------------------
+
+
+def test_repackage_call_fields_passes_through_none_values() -> None:
+    """None field values must round-trip as None, not '{}'."""
+    client = FakeClient()
+    new_fields, repackaged = oversize_repackage.repackage_call_fields(
+        client,  # type: ignore[arg-type]
+        fields={"summary": None, "output": None},
+    )
+    assert new_fields == {"summary": None, "output": None}
+    assert repackaged == []
+    assert client.saved == []
+
+
+def test_repackage_call_fields_returns_small_values_unchanged() -> None:
+    """Anything under the oversize threshold passes through identically."""
+    client = FakeClient()
+    new_fields, repackaged = oversize_repackage.repackage_call_fields(
+        client,  # type: ignore[arg-type]
+        fields={
+            "summary": {"weave": {"status": "success"}},
+            "output": {"label": "ok"},
+        },
+    )
+    assert new_fields == {
+        "summary": {"weave": {"status": "success"}},
+        "output": {"label": "ok"},
+    }
+    assert repackaged == []
+
+
+def test_repackage_call_fields_hoists_oversize_subtrees() -> None:
+    """A subtree above the threshold is published and replaced with a ref URI."""
+    client = FakeClient()
+    big = "x" * (OVERSIZE_SUBTREE_BYTES * 2)
+    new_fields, repackaged = oversize_repackage.repackage_call_fields(
+        client,  # type: ignore[arg-type]
+        fields={
+            "inputs": {"prompt": "small", "context": big},
+            "output": {"label": "ok"},
+        },
+    )
+    assert new_fields["inputs"]["prompt"] == "small"
+    assert new_fields["inputs"]["context"].startswith("weave:///")
+    assert new_fields["output"] == {"label": "ok"}
+    assert "inputs.context" in repackaged
+
+
+# ---------------------------------------------------------------------------
+# Batched-flush repackage closures (RemoteHTTPTraceServer)
+# ---------------------------------------------------------------------------
+
+
+def _complete_item(*, inputs=None, output=None, summary=None, attributes=None):
+    """Build a CompleteBatchItem for closure tests."""
+    import datetime as _dt
+    from weave.trace_server.trace_server_interface import (
+        CompletedCallSchemaForInsert,
+    )
+    from weave.trace_server_bindings.models import CompleteBatchItem
+
+    req = CompletedCallSchemaForInsert(
+        project_id="ent/proj",
+        id="0199_complete_id",
+        trace_id="0199_trace_id",
+        op_name="op_name",
+        started_at=_dt.datetime(2026, 5, 1),
+        ended_at=_dt.datetime(2026, 5, 1, 0, 0, 1),
+        attributes=attributes or {},
+        inputs=inputs or {},
+        output=output,
+        summary=summary or {},
+    )
+    return CompleteBatchItem(req=req)
+
+
+def _end_item(*, output=None, summary=None):
+    import datetime as _dt
+    from weave.trace_server.trace_server_interface import (
+        CallEndReq,
+        EndedCallSchemaForInsert,
+    )
+    from weave.trace_server_bindings.models import EndBatchItem
+
+    end = EndedCallSchemaForInsert(
+        project_id="ent/proj",
+        id="0199_end_id",
+        ended_at=_dt.datetime(2026, 5, 1),
+        output=output,
+        summary=summary or {},
+    )
+    return EndBatchItem(req=CallEndReq(end=end))
+
+
+def test_repackage_complete_batch_item_repackages_output(monkeypatch) -> None:
+    """The CompleteBatchItem closure hoists oversize output subtrees and
+    returns a new item with refs inline.
+    """
+    from weave.trace.context import weave_client_context
+    from weave.trace_server_bindings.remote_http_trace_server import (
+        _repackage_complete_batch_item,
+    )
+
+    client = FakeClient()
+    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
+
+    big = "x" * (OVERSIZE_SUBTREE_BYTES * 2)
+    item = _complete_item(
+        inputs={"prompt": "small"},
+        output={"label": "ok", "blob": big},
+        summary={"weave": {"status": "success"}},
+    )
+
+    new_item = _repackage_complete_batch_item(item)
+
+    assert new_item is not None
+    assert new_item.req.output["blob"].startswith("weave:///")
+    assert new_item.req.output["label"] == "ok"
+    assert new_item.req.inputs == {"prompt": "small"}
+    # Original item not mutated.
+    assert item.req.output["blob"] == big
+
+
+def test_repackage_complete_batch_item_returns_none_when_nothing_to_shrink(
+    monkeypatch,
+) -> None:
+    from weave.trace.context import weave_client_context
+    from weave.trace_server_bindings.remote_http_trace_server import (
+        _repackage_complete_batch_item,
+    )
+
+    client = FakeClient()
+    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
+    item = _complete_item(
+        inputs={"prompt": "small"},
+        output={"label": "ok"},
+        summary={"weave": {"status": "success"}},
+    )
+    assert _repackage_complete_batch_item(item) is None
+    assert client.saved == []
+
+
+def test_repackage_complete_batch_item_returns_none_when_no_client(
+    monkeypatch,
+) -> None:
+    from weave.trace.context import weave_client_context
+    from weave.trace_server_bindings.remote_http_trace_server import (
+        _repackage_complete_batch_item,
+    )
+
+    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: None)
+    item = _complete_item(output={"blob": "x" * (OVERSIZE_SUBTREE_BYTES * 2)})
+    assert _repackage_complete_batch_item(item) is None
+
+
+def test_repackage_legacy_end_item_hoists_summary_and_output(monkeypatch) -> None:
+    from weave.trace.context import weave_client_context
+    from weave.trace_server_bindings.models import EndBatchItem
+    from weave.trace_server_bindings.remote_http_trace_server import (
+        _repackage_legacy_batch_item,
+    )
+
+    client = FakeClient()
+    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
+
+    big = "x" * (OVERSIZE_SUBTREE_BYTES * 2)
+    item = _end_item(
+        output={"blob": big, "label": "ok"},
+        summary={"keep": "small"},
+    )
+
+    new_item = _repackage_legacy_batch_item(item)
+
+    assert isinstance(new_item, EndBatchItem)
+    assert new_item.req.end.output["blob"].startswith("weave:///")
+    assert new_item.req.end.output["label"] == "ok"
+    assert new_item.req.end.summary == {"keep": "small"}
+
+
+def test_repackage_legacy_returns_none_when_nothing_to_shrink(monkeypatch) -> None:
+    from weave.trace.context import weave_client_context
+    from weave.trace_server_bindings.remote_http_trace_server import (
+        _repackage_legacy_batch_item,
+    )
+
+    client = FakeClient()
+    monkeypatch.setattr(weave_client_context, "get_weave_client", lambda: client)
+    item = _end_item(output={"label": "ok"}, summary={"weave": {"status": "ok"}})
+    assert _repackage_legacy_batch_item(item) is None

--- a/tests/trace/test_oversize_repackage.py
+++ b/tests/trace/test_oversize_repackage.py
@@ -125,13 +125,14 @@ def test_walk_and_repackage_handles_all_shapes(client) -> None:
     """Covers under-threshold, oversize child, greedy bundle, oversize list/scalar, nested oversize."""
     obj = {"a": 1, "b": "small"}
     assert (
-        _walk_and_repackage(obj, client=client, path=("summary",), repackaged=[])
-        == obj
+        _walk_and_repackage(obj, client=client, path=("summary",), repackaged=[]) == obj
     )
 
     obj = {"small_a": 1, "small_b": "tiny", "huge": BIG_BLOB}
     paths: list[str] = []
-    result = _walk_and_repackage(obj, client=client, path=("summary",), repackaged=paths)
+    result = _walk_and_repackage(
+        obj, client=client, path=("summary",), repackaged=paths
+    )
     assert result["small_a"] == 1
     assert result["small_b"] == "tiny"
     assert result["huge"].startswith("weave:///")
@@ -220,7 +221,9 @@ def test_try_repackage_call_item_dispatches_all_three_item_shapes(
     assert new.req.start.inputs["prompt"].startswith("weave:///")
     assert new.req.start.inputs["tag"] == "t"
 
-    item = _end_item(output={"blob": BIG_BLOB, "label": "ok"}, summary={"keep": "small"})
+    item = _end_item(
+        output={"blob": BIG_BLOB, "label": "ok"}, summary={"keep": "small"}
+    )
     new = _try_repackage_call_item(item)
     assert isinstance(new, EndBatchItem)
     assert new.req.end.output["blob"].startswith("weave:///")

--- a/tests/trace_server_bindings/test_http_utils.py
+++ b/tests/trace_server_bindings/test_http_utils.py
@@ -42,13 +42,15 @@ def test_413_splits_batch_and_retries():
     assert len(sent_batches) == 2
 
 
-def _raises_413_once():
-    """Send fn factory: raises 413 on first call, succeeds afterwards."""
-    state = {"first": True}
+def _send_413(state: dict | None = None):
+    """Send fn factory. With `state=None`, always raises 413. Otherwise raises
+    on the first call only (uses `state["first"]` for bookkeeping).
+    """
 
     def send(data: bytes) -> None:
-        if state["first"]:
-            state["first"] = False
+        if state is None or state.get("first"):
+            if state is not None:
+                state["first"] = False
             raise httpx.HTTPStatusError(
                 "413", request=Mock(), response=Mock(status_code=413)
             )
@@ -56,119 +58,90 @@ def _raises_413_once():
     return send
 
 
-def test_repackage_callback_fires_on_413_with_single_item():
-    """A single-item batch that 413s and has a repackage callback that returns
-    a new item triggers exactly one resend with the repackaged item, no drop.
+def test_413_single_item_with_callback_repackages_and_retries_then_succeeds():
+    """Happy path for the new repackage hook: a single-item batch that 413s
+    invokes the callback, retries with the returned item, and does NOT drop.
     """
     dropped: list = []
+    encoded: list[bytes] = []
     repackage_calls: list = []
-    encoded_payloads: list[bytes] = []
 
     def repackage(item):
         repackage_calls.append(item)
         return {"item": item, "repackaged": True}
 
     def encode(batch):
-        encoded_payloads.append(repr(batch).encode())
-        return encoded_payloads[-1]
+        encoded.append(repr(batch).encode())
+        return encoded[-1]
 
     process_batch_with_retry(
         [{"item": "huge", "repackaged": False}],
         batch_name="calls_complete",
         remote_request_bytes_limit=100_000_000,
-        send_batch_fn=_raises_413_once(),
+        send_batch_fn=_send_413({"first": True}),
         processor_obj=None,
         encode_batch_fn=encode,
         log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
         repackage_oversize_fn=repackage,
     )
 
-    assert len(repackage_calls) == 1
-    assert repackage_calls[0] == {"item": "huge", "repackaged": False}
+    assert repackage_calls == [{"item": "huge", "repackaged": False}]
     # Two encode calls: original + repackaged.
-    assert len(encoded_payloads) == 2
-    assert b"'repackaged': True" in encoded_payloads[1]
+    assert len(encoded) == 2
+    assert b"'repackaged': True" in encoded[1]
     assert dropped == []
 
 
-def test_repackage_callback_returning_none_falls_through_to_drop():
-    """When the callback can't shrink the payload, drop the batch as before."""
-    dropped: list = []
+class _Tracker:
+    def __init__(self) -> None:
+        self.dropped: list = []
 
-    process_batch_with_retry(
-        [{"item": "tiny", "no": "shrink"}],
-        batch_name="calls",
-        remote_request_bytes_limit=100_000_000,
-        send_batch_fn=_raises_413_once(),
-        processor_obj=None,
-        encode_batch_fn=lambda b: str(b).encode(),
-        log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
-        repackage_oversize_fn=lambda item: None,
-    )
-
-    assert len(dropped) == 1
-    assert dropped[0][0] == [{"item": "tiny", "no": "shrink"}]
+    def log(self, batch, err) -> None:
+        self.dropped.append((batch, err))
 
 
-def test_repackage_callback_raising_falls_through_to_drop():
-    """When the callback itself raises, log and drop without crashing."""
-    dropped: list = []
+def _encode_repr(batch) -> bytes:
+    return str(batch).encode()
+
+
+@pytest.mark.disable_logging_error_check
+def test_413_single_item_falls_through_to_drop_for_all_unrecoverable_cases():
+    """Sad paths for the repackage hook: callback returns None, callback
+    raises, retry still 413, no callback supplied. All four collapse to the
+    same outcome - one entry in the drop log, no crash.
+    """
 
     def boom(item):
-        raise RuntimeError("save_object hit the network and timed out")
+        raise RuntimeError("save_object hit the network")
 
-    process_batch_with_retry(
-        [{"item": "huge"}],
-        batch_name="calls_complete",
-        remote_request_bytes_limit=100_000_000,
-        send_batch_fn=_raises_413_once(),
-        processor_obj=None,
-        encode_batch_fn=lambda b: str(b).encode(),
-        log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
-        repackage_oversize_fn=boom,
-    )
+    cases: list[tuple[str, dict]] = [
+        ("callback_returns_none", {"repackage_oversize_fn": lambda item: None}),
+        ("callback_raises", {"repackage_oversize_fn": boom}),
+        (
+            "retry_still_413",
+            {"repackage_oversize_fn": lambda item: {"item": "still_huge"}},
+        ),
+        ("no_callback", {}),
+    ]
 
-    assert len(dropped) == 1
-
-
-def test_repackage_retry_still_413_falls_through_to_drop():
-    """If the repackaged payload is also rejected, drop with the retry error."""
-    dropped: list = []
-
-    def always_413(data: bytes) -> None:
-        raise httpx.HTTPStatusError(
-            "413", request=Mock(), response=Mock(status_code=413)
+    for name, extra in cases:
+        tracker = _Tracker()
+        send_fn = (
+            _send_413(None)
+            if name == "retry_still_413"
+            else _send_413({"first": True})
         )
-
-    process_batch_with_retry(
-        [{"item": "huge"}],
-        batch_name="calls_complete",
-        remote_request_bytes_limit=100_000_000,
-        send_batch_fn=always_413,
-        processor_obj=None,
-        encode_batch_fn=lambda b: str(b).encode(),
-        log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
-        repackage_oversize_fn=lambda item: {"item": "smaller_but_still_huge"},
-    )
-
-    assert len(dropped) == 1
-
-
-def test_no_callback_preserves_existing_drop_behavior():
-    """When repackage_oversize_fn is omitted, 413 + len==1 still drops cleanly."""
-    dropped: list = []
-
-    process_batch_with_retry(
-        [{"item": "single"}],
-        batch_name="calls",
-        remote_request_bytes_limit=100_000_000,
-        send_batch_fn=_raises_413_once(),
-        processor_obj=None,
-        encode_batch_fn=lambda b: str(b).encode(),
-        log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
-    )
-
-    assert len(dropped) == 1
+        process_batch_with_retry(
+            [{"item": "huge"}],
+            batch_name="calls",
+            remote_request_bytes_limit=100_000_000,
+            send_batch_fn=send_fn,
+            processor_obj=None,
+            encode_batch_fn=_encode_repr,
+            log_dropped_fn=tracker.log,
+            **extra,
+        )
+        assert len(tracker.dropped) == 1, f"{name}: expected exactly one dropped batch"
 
 
 def test_calls_complete_mode_required_raises():

--- a/tests/trace_server_bindings/test_http_utils.py
+++ b/tests/trace_server_bindings/test_http_utils.py
@@ -42,6 +42,135 @@ def test_413_splits_batch_and_retries():
     assert len(sent_batches) == 2
 
 
+def _raises_413_once():
+    """Send fn factory: raises 413 on first call, succeeds afterwards."""
+    state = {"first": True}
+
+    def send(data: bytes) -> None:
+        if state["first"]:
+            state["first"] = False
+            raise httpx.HTTPStatusError(
+                "413", request=Mock(), response=Mock(status_code=413)
+            )
+
+    return send
+
+
+def test_repackage_callback_fires_on_413_with_single_item():
+    """A single-item batch that 413s and has a repackage callback that returns
+    a new item triggers exactly one resend with the repackaged item, no drop.
+    """
+    dropped: list = []
+    repackage_calls: list = []
+    encoded_payloads: list[bytes] = []
+
+    def repackage(item):
+        repackage_calls.append(item)
+        return {"item": item, "repackaged": True}
+
+    def encode(batch):
+        encoded_payloads.append(repr(batch).encode())
+        return encoded_payloads[-1]
+
+    process_batch_with_retry(
+        [{"item": "huge", "repackaged": False}],
+        batch_name="calls_complete",
+        remote_request_bytes_limit=100_000_000,
+        send_batch_fn=_raises_413_once(),
+        processor_obj=None,
+        encode_batch_fn=encode,
+        log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
+        repackage_oversize_fn=repackage,
+    )
+
+    assert len(repackage_calls) == 1
+    assert repackage_calls[0] == {"item": "huge", "repackaged": False}
+    # Two encode calls: original + repackaged.
+    assert len(encoded_payloads) == 2
+    assert b"'repackaged': True" in encoded_payloads[1]
+    assert dropped == []
+
+
+def test_repackage_callback_returning_none_falls_through_to_drop():
+    """When the callback can't shrink the payload, drop the batch as before."""
+    dropped: list = []
+
+    process_batch_with_retry(
+        [{"item": "tiny", "no": "shrink"}],
+        batch_name="calls",
+        remote_request_bytes_limit=100_000_000,
+        send_batch_fn=_raises_413_once(),
+        processor_obj=None,
+        encode_batch_fn=lambda b: str(b).encode(),
+        log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
+        repackage_oversize_fn=lambda item: None,
+    )
+
+    assert len(dropped) == 1
+    assert dropped[0][0] == [{"item": "tiny", "no": "shrink"}]
+
+
+def test_repackage_callback_raising_falls_through_to_drop():
+    """When the callback itself raises, log and drop without crashing."""
+    dropped: list = []
+
+    def boom(item):
+        raise RuntimeError("save_object hit the network and timed out")
+
+    process_batch_with_retry(
+        [{"item": "huge"}],
+        batch_name="calls_complete",
+        remote_request_bytes_limit=100_000_000,
+        send_batch_fn=_raises_413_once(),
+        processor_obj=None,
+        encode_batch_fn=lambda b: str(b).encode(),
+        log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
+        repackage_oversize_fn=boom,
+    )
+
+    assert len(dropped) == 1
+
+
+def test_repackage_retry_still_413_falls_through_to_drop():
+    """If the repackaged payload is also rejected, drop with the retry error."""
+    dropped: list = []
+
+    def always_413(data: bytes) -> None:
+        raise httpx.HTTPStatusError(
+            "413", request=Mock(), response=Mock(status_code=413)
+        )
+
+    process_batch_with_retry(
+        [{"item": "huge"}],
+        batch_name="calls_complete",
+        remote_request_bytes_limit=100_000_000,
+        send_batch_fn=always_413,
+        processor_obj=None,
+        encode_batch_fn=lambda b: str(b).encode(),
+        log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
+        repackage_oversize_fn=lambda item: {"item": "smaller_but_still_huge"},
+    )
+
+    assert len(dropped) == 1
+
+
+def test_no_callback_preserves_existing_drop_behavior():
+    """When repackage_oversize_fn is omitted, 413 + len==1 still drops cleanly."""
+    dropped: list = []
+
+    process_batch_with_retry(
+        [{"item": "single"}],
+        batch_name="calls",
+        remote_request_bytes_limit=100_000_000,
+        send_batch_fn=_raises_413_once(),
+        processor_obj=None,
+        encode_batch_fn=lambda b: str(b).encode(),
+        log_dropped_fn=lambda batch, err: dropped.append((batch, err)),
+    )
+
+    assert len(dropped) == 1
+
+
 def test_calls_complete_mode_required_raises():
     """Map calls_complete mode errors to CallsCompleteModeRequired."""
     response = httpx.Response(

--- a/tests/trace_server_bindings/test_http_utils.py
+++ b/tests/trace_server_bindings/test_http_utils.py
@@ -127,9 +127,7 @@ def test_413_single_item_falls_through_to_drop_for_all_unrecoverable_cases():
     for name, extra in cases:
         tracker = _Tracker()
         send_fn = (
-            _send_413(None)
-            if name == "retry_still_413"
-            else _send_413({"first": True})
+            _send_413(None) if name == "retry_still_413" else _send_413({"first": True})
         )
         process_batch_with_retry(
             [{"item": "huge"}],

--- a/weave/trace/oversize_repackage.py
+++ b/weave/trace/oversize_repackage.py
@@ -1,0 +1,153 @@
+"""Repackage oversize call payloads into refs and retry on HTTP 413.
+
+When the server rejects a call_end with 413, the SDK extracts the
+largest subtrees from `summary` and `output`, publishes each as a
+first-class weave object, and substitutes a `weave:///...` ref URI
+inline. The repackaged payload is then retried once.
+
+The user sees one warning describing which fields were repackaged
+and how to avoid the overhead next time (publish large artifacts
+upfront via `weave.publish(...)` before they enter the call).
+
+Companion to WB-34652. Defense-in-depth pair to the server-side spill
+in `weave/trace_server/summary_overflow.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+if TYPE_CHECKING:
+    from weave.trace.weave_client import WeaveClient
+
+logger = logging.getLogger(__name__)
+
+# Subtree byte threshold for extraction. Anything bigger gets published
+# as its own object and replaced inline with the resulting ref URI.
+# Picked well under the server's 3.5 MiB row limit so several oversize
+# subtrees can be repackaged independently.
+OVERSIZE_SUBTREE_BYTES = 256 * 1024
+
+
+def is_payload_too_large_error(exc: BaseException) -> bool:
+    """True iff `exc` is an HTTP 413 (payload too large) error."""
+    return (
+        isinstance(exc, httpx.HTTPStatusError)
+        and exc.response is not None
+        and exc.response.status_code == 413
+    )
+
+
+def _approx_size(value: Any) -> int:
+    """Cheap JSON-encoded byte estimate. Returns 0 for un-serializable."""
+    try:
+        return len(json.dumps(value, default=str).encode("utf-8"))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _safe_name_from_path(path: tuple[str, ...]) -> str:
+    parts = [p.replace("/", "_").replace(".", "_") for p in path if p]
+    return "_".join(parts) or "call_overflow"
+
+
+def _publish_subtree(
+    value: Any,
+    *,
+    client: WeaveClient,
+    path: tuple[str, ...],
+    repackaged: list[str],
+) -> str:
+    """Publish `value` as a weave object and return its ref URI."""
+    name = _safe_name_from_path(path)
+    ref = client._save_object(value, name=name)
+    repackaged.append(".".join(path))
+    return ref.uri()
+
+
+def _walk_and_repackage(
+    obj: Any,
+    *,
+    client: WeaveClient,
+    path: tuple[str, ...],
+    repackaged: list[str],
+) -> Any:
+    """Walk `obj`. When a subtree exceeds the threshold, descend into
+    dicts to find smaller offenders first; otherwise publish the whole
+    subtree as a weave object and replace it with its ref URI.
+    """
+    if _approx_size(obj) <= OVERSIZE_SUBTREE_BYTES:
+        return obj
+
+    if isinstance(obj, dict):
+        new_obj: dict[str, Any] = {}
+        for k, v in obj.items():
+            new_obj[k] = _walk_and_repackage(
+                v,
+                client=client,
+                path=path + (str(k),),
+                repackaged=repackaged,
+            )
+        if _approx_size(new_obj) <= OVERSIZE_SUBTREE_BYTES:
+            return new_obj
+        return _publish_subtree(new_obj, client=client, path=path, repackaged=repackaged)
+
+    return _publish_subtree(obj, client=client, path=path, repackaged=repackaged)
+
+
+def repackage_oversize_payload(
+    client: WeaveClient,
+    *,
+    summary: Any,
+    output: Any,
+) -> tuple[Any, Any, list[str]]:
+    """Walk `summary` and `output`, extracting and publishing oversize
+    subtrees. Returns `(slimmer_summary, slimmer_output, repackaged_paths)`.
+
+    `inputs` is intentionally not repackaged here: inputs are sent at
+    call_start, before the failure happens, so retroactive substitution
+    needs a separate update path.
+    """
+    repackaged: list[str] = []
+
+    new_summary: Any = summary
+    if summary is not None:
+        new_summary = _walk_and_repackage(
+            summary,
+            client=client,
+            path=("summary",),
+            repackaged=repackaged,
+        )
+        if not isinstance(new_summary, dict):
+            new_summary = {"_weave": {"summary_ref": new_summary}}
+
+    new_output: Any = output
+    if output is not None:
+        new_output = _walk_and_repackage(
+            output,
+            client=client,
+            path=("output",),
+            repackaged=repackaged,
+        )
+
+    return new_summary, new_output, repackaged
+
+
+def emit_user_warning(repackaged_paths: list[str]) -> None:
+    """One concise warning so the user knows the repackage happened
+    and can prevent it next time.
+    """
+    if not repackaged_paths:
+        return
+    logger.warning(
+        "weave: call payload exceeded the server size limit; "
+        "automatically repackaged %d field(s) into refs: %s. "
+        "To avoid this overhead, publish large artifacts upfront with "
+        "weave.publish(...) before they enter call inputs/outputs/summary.",
+        len(repackaged_paths),
+        ", ".join(repackaged_paths),
+    )

--- a/weave/trace/oversize_repackage.py
+++ b/weave/trace/oversize_repackage.py
@@ -1,16 +1,6 @@
-"""Repackage oversize call payloads into refs and retry on HTTP 413.
+"""SDK-side recovery for HTTP 413 by hoisting oversize call subtrees into refs.
 
-When the server rejects a call_end with 413, the SDK extracts the
-largest subtrees from `summary` and `output`, publishes each as a
-first-class weave object, and substitutes a `weave:///...` ref URI
-inline. The repackaged payload is then retried once.
-
-The user sees one warning describing which fields were repackaged
-and how to avoid the overhead next time (publish large artifacts
-upfront via `weave.publish(...)` before they enter the call).
-
-Companion to WB-34652. Defense-in-depth pair to the server-side spill
-in `weave/trace_server/summary_overflow.py`.
+Companion to WB-34652.
 """
 
 from __future__ import annotations
@@ -26,11 +16,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Subtree byte threshold for extraction. Anything bigger gets published
-# as its own object and replaced inline with the resulting ref URI.
-# Picked well under the server's 3.5 MiB row limit so several oversize
-# subtrees can be repackaged independently.
+# Subtrees above this threshold get hoisted into their own weave object.
 OVERSIZE_SUBTREE_BYTES = 256 * 1024
+
+# Reserved key for the bundled-overflow ref alongside inline survivors.
+OVERFLOW_BUNDLE_KEY = "_weave_overflow"
 
 
 def is_payload_too_large_error(exc: BaseException) -> bool:
@@ -43,7 +33,6 @@ def is_payload_too_large_error(exc: BaseException) -> bool:
 
 
 def _approx_size(value: Any) -> int:
-    """Cheap JSON-encoded byte estimate. Returns 0 for un-serializable."""
     try:
         return len(json.dumps(value, default=str).encode("utf-8"))
     except (TypeError, ValueError):
@@ -62,17 +51,10 @@ def _publish_subtree(
     path: tuple[str, ...],
     repackaged: list[str],
 ) -> str:
-    """Publish `value` as a weave object and return its ref URI."""
     name = _safe_name_from_path(path)
     ref = client._save_object(value, name=name)
     repackaged.append(".".join(path))
     return ref.uri()
-
-
-# Reserved key used to attach the overflow bundle alongside the inline
-# survivors. Chosen with a `_weave_` prefix so it sorts last in dict views
-# and is unlikely to collide with user-supplied keys.
-OVERFLOW_BUNDLE_KEY = "_weave_overflow"
 
 
 def _greedy_batch(
@@ -82,17 +64,7 @@ def _greedy_batch(
     path: tuple[str, ...],
     repackaged: list[str],
 ) -> Any:
-    """Smallest-first packing of `obj_dict`.
-
-    Walks children in ascending size order, keeping each inline until
-    inline_bytes would exceed `OVERSIZE_SUBTREE_BYTES`. Once the budget is
-    hit, every remaining (larger) child gets bundled into a single weave
-    object that's attached under `OVERFLOW_BUNDLE_KEY` as a ref URI.
-
-    This preserves the inline shape of small siblings (the common case for
-    a summary dict where one or two subtrees are huge), while batching
-    medium-sized siblings together to avoid N round-trips of `_save_object`.
-    """
+    """Smallest-first packing: keep small children inline, bundle the rest into one ref."""
     sized = sorted(
         ((k, v, _approx_size(v)) for k, v in obj_dict.items()),
         key=lambda triple: triple[2],
@@ -110,8 +82,7 @@ def _greedy_batch(
             overflow_bundle[k] = v
 
     if not overflow_bundle:
-        # JSON overhead pushed the dict over the threshold but every child
-        # individually fits. Fall back to publishing the whole thing.
+        # JSON overhead pushed the parent over the threshold but every child fits.
         return _publish_subtree(obj_dict, client=client, path=path, repackaged=repackaged)
 
     bundle_ref = _publish_subtree(
@@ -131,10 +102,7 @@ def _walk_and_repackage(
     path: tuple[str, ...],
     repackaged: list[str],
 ) -> Any:
-    """Walk `obj`. When a subtree exceeds the threshold, first recurse to
-    hoist out any individually-oversize nested children, then greedy-batch
-    the remaining medium-sized siblings under a single overflow ref.
-    """
+    """Recurse into dicts hoisting oversize children, then greedy-batch the rest."""
     if _approx_size(obj) <= OVERSIZE_SUBTREE_BYTES:
         return obj
 
@@ -154,58 +122,12 @@ def _walk_and_repackage(
     return _publish_subtree(obj, client=client, path=path, repackaged=repackaged)
 
 
-def repackage_oversize_payload(
-    client: WeaveClient,
-    *,
-    summary: Any,
-    output: Any,
-) -> tuple[Any, Any, list[str]]:
-    """Walk `summary` and `output`, extracting and publishing oversize
-    subtrees. Returns `(slimmer_summary, slimmer_output, repackaged_paths)`.
-
-    `inputs` is intentionally not repackaged here: inputs are sent at
-    call_start, before the failure happens, so retroactive substitution
-    needs a separate update path.
-    """
-    repackaged: list[str] = []
-
-    new_summary: Any = summary
-    if summary is not None:
-        new_summary = _walk_and_repackage(
-            summary,
-            client=client,
-            path=("summary",),
-            repackaged=repackaged,
-        )
-        if not isinstance(new_summary, dict):
-            new_summary = {"_weave": {"summary_ref": new_summary}}
-
-    new_output: Any = output
-    if output is not None:
-        new_output = _walk_and_repackage(
-            output,
-            client=client,
-            path=("output",),
-            repackaged=repackaged,
-        )
-
-    return new_summary, new_output, repackaged
-
-
 def repackage_call_fields(
     client: WeaveClient,
     *,
     fields: dict[str, Any],
 ) -> tuple[dict[str, Any], list[str]]:
-    """Walk each named value in `fields`, hoisting oversize subtrees out to
-    bucket-stored refs. Returns the new fields mapping (same keys as input)
-    and the dotted-path strings of every subtree that was repackaged.
-
-    Used from the batched flush path when the server rejects a call payload
-    with 413. Keys in `fields` correspond to schema fields on the call insert
-    schemas: `summary`, `output`, `inputs`, `attributes`. None values pass
-    through unchanged.
-    """
+    """Walk each named value in `fields`, hoisting oversize subtrees into refs."""
     repackaged: list[str] = []
     new_fields: dict[str, Any] = {}
     for name, value in fields.items():
@@ -219,9 +141,7 @@ def repackage_call_fields(
 
 
 def emit_user_warning(repackaged_paths: list[str]) -> None:
-    """One concise warning so the user knows the repackage happened
-    and can prevent it next time.
-    """
+    """One concise warning naming the fields that were repackaged."""
     if not repackaged_paths:
         return
     logger.warning(

--- a/weave/trace/oversize_repackage.py
+++ b/weave/trace/oversize_repackage.py
@@ -192,6 +192,32 @@ def repackage_oversize_payload(
     return new_summary, new_output, repackaged
 
 
+def repackage_call_fields(
+    client: WeaveClient,
+    *,
+    fields: dict[str, Any],
+) -> tuple[dict[str, Any], list[str]]:
+    """Walk each named value in `fields`, hoisting oversize subtrees out to
+    bucket-stored refs. Returns the new fields mapping (same keys as input)
+    and the dotted-path strings of every subtree that was repackaged.
+
+    Used from the batched flush path when the server rejects a call payload
+    with 413. Keys in `fields` correspond to schema fields on the call insert
+    schemas: `summary`, `output`, `inputs`, `attributes`. None values pass
+    through unchanged.
+    """
+    repackaged: list[str] = []
+    new_fields: dict[str, Any] = {}
+    for name, value in fields.items():
+        if value is None:
+            new_fields[name] = None
+            continue
+        new_fields[name] = _walk_and_repackage(
+            value, client=client, path=(name,), repackaged=repackaged
+        )
+    return new_fields, repackaged
+
+
 def emit_user_warning(repackaged_paths: list[str]) -> None:
     """One concise warning so the user knows the repackage happened
     and can prevent it next time.

--- a/weave/trace/oversize_repackage.py
+++ b/weave/trace/oversize_repackage.py
@@ -69,6 +69,61 @@ def _publish_subtree(
     return ref.uri()
 
 
+# Reserved key used to attach the overflow bundle alongside the inline
+# survivors. Chosen with a `_weave_` prefix so it sorts last in dict views
+# and is unlikely to collide with user-supplied keys.
+OVERFLOW_BUNDLE_KEY = "_weave_overflow"
+
+
+def _greedy_batch(
+    obj_dict: dict[str, Any],
+    *,
+    client: WeaveClient,
+    path: tuple[str, ...],
+    repackaged: list[str],
+) -> Any:
+    """Smallest-first packing of `obj_dict`.
+
+    Walks children in ascending size order, keeping each inline until
+    inline_bytes would exceed `OVERSIZE_SUBTREE_BYTES`. Once the budget is
+    hit, every remaining (larger) child gets bundled into a single weave
+    object that's attached under `OVERFLOW_BUNDLE_KEY` as a ref URI.
+
+    This preserves the inline shape of small siblings (the common case for
+    a summary dict where one or two subtrees are huge), while batching
+    medium-sized siblings together to avoid N round-trips of `_save_object`.
+    """
+    sized = sorted(
+        ((k, v, _approx_size(v)) for k, v in obj_dict.items()),
+        key=lambda triple: triple[2],
+    )
+
+    inline: dict[str, Any] = {}
+    overflow_bundle: dict[str, Any] = {}
+    inline_bytes = 0
+
+    for k, v, size in sized:
+        if inline_bytes + size <= OVERSIZE_SUBTREE_BYTES:
+            inline[k] = v
+            inline_bytes += size
+        else:
+            overflow_bundle[k] = v
+
+    if not overflow_bundle:
+        # JSON overhead pushed the dict over the threshold but every child
+        # individually fits. Fall back to publishing the whole thing.
+        return _publish_subtree(obj_dict, client=client, path=path, repackaged=repackaged)
+
+    bundle_ref = _publish_subtree(
+        overflow_bundle,
+        client=client,
+        path=path + (OVERFLOW_BUNDLE_KEY,),
+        repackaged=repackaged,
+    )
+    inline[OVERFLOW_BUNDLE_KEY] = bundle_ref
+    return inline
+
+
 def _walk_and_repackage(
     obj: Any,
     *,
@@ -76,9 +131,9 @@ def _walk_and_repackage(
     path: tuple[str, ...],
     repackaged: list[str],
 ) -> Any:
-    """Walk `obj`. When a subtree exceeds the threshold, descend into
-    dicts to find smaller offenders first; otherwise publish the whole
-    subtree as a weave object and replace it with its ref URI.
+    """Walk `obj`. When a subtree exceeds the threshold, first recurse to
+    hoist out any individually-oversize nested children, then greedy-batch
+    the remaining medium-sized siblings under a single overflow ref.
     """
     if _approx_size(obj) <= OVERSIZE_SUBTREE_BYTES:
         return obj
@@ -94,7 +149,7 @@ def _walk_and_repackage(
             )
         if _approx_size(new_obj) <= OVERSIZE_SUBTREE_BYTES:
             return new_obj
-        return _publish_subtree(new_obj, client=client, path=path, repackaged=repackaged)
+        return _greedy_batch(new_obj, client=client, path=path, repackaged=repackaged)
 
     return _publish_subtree(obj, client=client, path=path, repackaged=repackaged)
 

--- a/weave/trace/oversize_repackage.py
+++ b/weave/trace/oversize_repackage.py
@@ -83,7 +83,9 @@ def _greedy_batch(
 
     if not overflow_bundle:
         # JSON overhead pushed the parent over the threshold but every child fits.
-        return _publish_subtree(obj_dict, client=client, path=path, repackaged=repackaged)
+        return _publish_subtree(
+            obj_dict, client=client, path=path, repackaged=repackaged
+        )
 
     bundle_ref = _publish_subtree(
         overflow_bundle,

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -67,6 +67,11 @@ from weave.trace.op import (
 )
 from weave.trace.op import op as op_deco
 from weave.trace.op_protocol import Op
+from weave.trace.oversize_repackage import (
+    emit_user_warning,
+    is_payload_too_large_error,
+    repackage_oversize_payload,
+)
 from weave.trace.project_id_resolver import ProjectIdResolver
 from weave.trace.ref_util import get_ref, remove_ref, set_ref
 from weave.trace.refs import (
@@ -1266,8 +1271,32 @@ class WeaveClient:
             # WAL path: persist to disk; the sender replays to the server.
             if self._wal is not None:
                 self._wal.write("call_end", call_end_req)
-            else:
+                return
+
+            try:
                 self.server.call_end(call_end_req)
+            except Exception as e:
+                if not is_payload_too_large_error(e):
+                    raise
+                new_summary, new_output, repackaged = repackage_oversize_payload(
+                    self, summary=merged_summary, output=output_json
+                )
+                if not repackaged:
+                    raise
+                retry_req = CallEndReq(
+                    end=EndedCallSchemaForInsertWithStartedAt(
+                        project_id=project_id,
+                        id=call.id,
+                        started_at=call.started_at,
+                        ended_at=ended_at,
+                        output=new_output,
+                        summary=new_summary,
+                        exception=exception_str,
+                        wb_run_step_end=current_wb_run_step_end,
+                    )
+                )
+                self.server.call_end(retry_req)
+                emit_user_warning(repackaged)
 
         # For calls_complete path (non-eager CallBatchProcessor), print the call link
         # after finish_call, when the complete call is queued to the batch processor.

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -70,7 +70,7 @@ from weave.trace.op_protocol import Op
 from weave.trace.oversize_repackage import (
     emit_user_warning,
     is_payload_too_large_error,
-    repackage_oversize_payload,
+    repackage_call_fields,
 )
 from weave.trace.project_id_resolver import ProjectIdResolver
 from weave.trace.ref_util import get_ref, remove_ref, set_ref
@@ -1278,25 +1278,10 @@ class WeaveClient:
             except Exception as e:
                 if not is_payload_too_large_error(e):
                     raise
-                new_summary, new_output, repackaged = repackage_oversize_payload(
-                    self, summary=merged_summary, output=output_json
-                )
-                if not repackaged:
+                retry_req = self._try_repackage_call_end_req(call_end_req)
+                if retry_req is None:
                     raise
-                retry_req = CallEndReq(
-                    end=EndedCallSchemaForInsertWithStartedAt(
-                        project_id=project_id,
-                        id=call.id,
-                        started_at=call.started_at,
-                        ended_at=ended_at,
-                        output=new_output,
-                        summary=new_summary,
-                        exception=exception_str,
-                        wb_run_step_end=current_wb_run_step_end,
-                    )
-                )
                 self.server.call_end(retry_req)
-                emit_user_warning(repackaged)
 
         # For calls_complete path (non-eager CallBatchProcessor), print the call link
         # after finish_call, when the complete call is queued to the batch processor.
@@ -2037,6 +2022,19 @@ class WeaveClient:
     #  - creates an ObjectRef and attaches it to the object
     # `_save_op` and `_save_table` are the sister functions to `_save_object_basic`
     #  but for Ops and Tables respectively.
+
+    def _try_repackage_call_end_req(
+        self, call_end_req: CallEndReq
+    ) -> CallEndReq | None:
+        """Hoist oversize summary/output into refs and return a new req."""
+        end = call_end_req.end
+        new_fields, repackaged = repackage_call_fields(
+            self, fields={"summary": end.summary, "output": end.output}
+        )
+        if not repackaged:
+            return None
+        emit_user_warning(repackaged)
+        return CallEndReq(end=end.model_copy(update=new_fields))
 
     @trace_sentry.global_trace_sentry.watch()
     def _save_object(self, val: Any, name: str, branch: str = "latest") -> ObjectRef:

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -224,11 +224,6 @@ def process_batch_with_retry(
                 if repackaged_item is not None:
                     try:
                         send_batch_fn(encode_batch_fn([repackaged_item]))
-                        logger.info(
-                            "Repackaged oversize %s payload and retry succeeded",
-                            batch_name,
-                        )
-                        return
                     except Exception as retry_err:
                         logger.warning(
                             "Repackaged %s payload still rejected: %s",
@@ -236,6 +231,12 @@ def process_batch_with_retry(
                             retry_err,
                         )
                         e = retry_err
+                    else:
+                        logger.info(
+                            "Repackaged oversize %s payload and retry succeeded",
+                            batch_name,
+                        )
+                        return
 
         if not _is_retryable_exception(e):
             if log_dropped_fn:

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -96,6 +96,7 @@ def _split_and_process_halves(
     get_item_id_fn: Callable[[T], str] | None,
     log_dropped_fn: Callable[[list[T], Exception], None] | None,
     encode_batch_fn: Callable[[list[T]], bytes],
+    repackage_oversize_fn: Callable[[T], T | None] | None = None,
 ) -> None:
     """Split a batch in half and recursively process each half."""
     split_idx = len(batch) // 2
@@ -110,6 +111,7 @@ def _split_and_process_halves(
             get_item_id_fn=get_item_id_fn,
             log_dropped_fn=log_dropped_fn,
             encode_batch_fn=encode_batch_fn,
+            repackage_oversize_fn=repackage_oversize_fn,
         )
 
 
@@ -124,6 +126,7 @@ def process_batch_with_retry(
     get_item_id_fn: Callable[[T], str] | None = None,
     log_dropped_fn: Callable[[list[T], Exception], None] | None = None,
     encode_batch_fn: Callable[[list[T]], bytes],
+    repackage_oversize_fn: Callable[[T], T | None] | None = None,
 ) -> None:
     """Process a batch with common retry and error handling logic.
 
@@ -168,6 +171,7 @@ def process_batch_with_retry(
             get_item_id_fn=get_item_id_fn,
             log_dropped_fn=log_dropped_fn,
             encode_batch_fn=encode_batch_fn,
+            repackage_oversize_fn=repackage_oversize_fn,
         )
         return
 
@@ -186,24 +190,52 @@ def process_batch_with_retry(
         # Re-raise so caller can handle the upgrade to calls_complete mode
         raise
     except Exception as e:
-        # Handle 413 specially: server rejected as too large, split and retry
-        if _is_413_error(e) and len(batch) > 1:
-            logger.warning(
-                "Server returned 413 for %s batch of %s items, splitting and retrying",
-                batch_name,
-                len(batch),
-            )
-            _split_and_process_halves(
-                batch,
-                batch_name=batch_name,
-                remote_request_bytes_limit=remote_request_bytes_limit,
-                send_batch_fn=send_batch_fn,
-                processor_obj=processor_obj,
-                get_item_id_fn=get_item_id_fn,
-                log_dropped_fn=log_dropped_fn,
-                encode_batch_fn=encode_batch_fn,
-            )
-            return
+        # Handle 413 specially: server rejected as too large.
+        if _is_413_error(e):
+            if len(batch) > 1:
+                logger.warning(
+                    "Server returned 413 for %s batch of %s items, splitting and retrying",
+                    batch_name,
+                    len(batch),
+                )
+                _split_and_process_halves(
+                    batch,
+                    batch_name=batch_name,
+                    remote_request_bytes_limit=remote_request_bytes_limit,
+                    send_batch_fn=send_batch_fn,
+                    processor_obj=processor_obj,
+                    get_item_id_fn=get_item_id_fn,
+                    log_dropped_fn=log_dropped_fn,
+                    encode_batch_fn=encode_batch_fn,
+                    repackage_oversize_fn=repackage_oversize_fn,
+                )
+                return
+
+            # len(batch) == 1: can't split further. Try repackaging oversize
+            # subtrees into refs and resending once before dropping.
+            if repackage_oversize_fn is not None:
+                repackaged_item: T | None = None
+                try:
+                    repackaged_item = repackage_oversize_fn(batch[0])
+                except Exception:
+                    logger.exception(
+                        "Failed to repackage oversize %s payload", batch_name
+                    )
+                if repackaged_item is not None:
+                    try:
+                        send_batch_fn(encode_batch_fn([repackaged_item]))
+                        logger.info(
+                            "Repackaged oversize %s payload and retry succeeded",
+                            batch_name,
+                        )
+                        return
+                    except Exception as retry_err:
+                        logger.warning(
+                            "Repackaged %s payload still rejected: %s",
+                            batch_name,
+                            retry_err,
+                        )
+                        e = retry_err
 
         if not _is_retryable_exception(e):
             if log_dropped_fn:

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -57,9 +57,6 @@ logger = logging.getLogger(__name__)
 # DEFAULT_TIMEOUT = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)
 
 
-# Schema fields the repackager walks for each batch item shape. Inputs and
-# attributes only appear on starts (and the combined complete row); summary
-# and output only appear on ends (and the combined complete row).
 _REPACKAGEABLE_FIELDS: dict[type, tuple[str, ...]] = {
     CompleteBatchItem: ("inputs", "attributes", "output", "summary"),
     StartBatchItem: ("inputs", "attributes"),
@@ -70,18 +67,7 @@ _REPACKAGEABLE_FIELDS: dict[type, tuple[str, ...]] = {
 def _try_repackage_call_item(
     item: StartBatchItem | EndBatchItem | CompleteBatchItem,
 ) -> StartBatchItem | EndBatchItem | CompleteBatchItem | None:
-    """Repackage any oversize subtrees on a single batch item.
-
-    Walks the schema fields that exist on `item`'s shape, publishes oversize
-    subtrees as standalone weave objects, and substitutes their ref URIs
-    inline. Returns a new item of the same type, or None when there's no
-    current client or nothing crossed the threshold.
-
-    Used as the `repackage_oversize_fn` callback for both the `calls_merged`
-    flush (`/call/upsert_batch`) and `calls_complete` flush
-    (`/v2/<entity>/<project>/calls/complete`), and from `_flush_calls_eager`
-    for the per-item v2 single-call endpoints.
-    """
+    """Hoist oversize subtrees on a batched call item. Returns None when no active client or nothing oversize."""
     client = weave_client_context.get_weave_client()
     if client is None:
         return None
@@ -89,8 +75,6 @@ def _try_repackage_call_item(
     if field_names is None:
         return None
 
-    # CompleteBatchItem stores the schema directly on .req; Start/End wrap it
-    # one level deeper as .req.start / .req.end.
     schema = item.req if isinstance(item, CompleteBatchItem) else (
         item.req.start if isinstance(item, StartBatchItem) else item.req.end
     )
@@ -356,14 +340,11 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
                 # Re-raise so caller can handle the upgrade to calls_complete mode
                 raise
             except Exception as e:
-                # On 413, try repackaging oversize fields and resend once before
-                # giving up. Mirrors the same recovery that
-                # `process_batch_with_retry` performs for the batched flush paths.
                 if is_payload_too_large_error(e):
-                    repackaged = _try_repackage_call_item(item)
-                    if repackaged is not None:
+                    new_item = _try_repackage_call_item(item)
+                    if new_item is not None:
                         try:
-                            send(repackaged)
+                            send(new_item)
                             continue
                         except Exception as retry_err:
                             e = retry_err

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -10,7 +10,13 @@ from pydantic import BaseModel, Field, validate_call
 from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import Self
 
+from weave.trace.context import weave_client_context
 from weave.trace.env import weave_trace_server_url
+from weave.trace.oversize_repackage import (
+    emit_user_warning,
+    is_payload_too_large_error,
+    repackage_call_fields,
+)
 from weave.trace.settings import (
     max_calls_queue_size,
     should_enable_disk_fallback,
@@ -51,90 +57,59 @@ logger = logging.getLogger(__name__)
 # DEFAULT_TIMEOUT = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)
 
 
-def _repackage_complete_batch_item(
-    item: CompleteBatchItem,
-) -> CompleteBatchItem | None:
-    """Repackage oversize fields on a CompleteBatchItem before retry.
+# Schema fields the repackager walks for each batch item shape. Inputs and
+# attributes only appear on starts (and the combined complete row); summary
+# and output only appear on ends (and the combined complete row).
+_REPACKAGEABLE_FIELDS: dict[type, tuple[str, ...]] = {
+    CompleteBatchItem: ("inputs", "attributes", "output", "summary"),
+    StartBatchItem: ("inputs", "attributes"),
+    EndBatchItem: ("summary", "output"),
+}
 
-    Walks `inputs`, `attributes`, `output`, and `summary`. Subtrees larger
-    than the oversize threshold are published as standalone weave objects
-    and replaced inline with their ref URIs. Returns a new item, or None
-    when no field needed repackaging or there's no current client.
+
+def _try_repackage_call_item(
+    item: StartBatchItem | EndBatchItem | CompleteBatchItem,
+) -> StartBatchItem | EndBatchItem | CompleteBatchItem | None:
+    """Repackage any oversize subtrees on a single batch item.
+
+    Walks the schema fields that exist on `item`'s shape, publishes oversize
+    subtrees as standalone weave objects, and substitutes their ref URIs
+    inline. Returns a new item of the same type, or None when there's no
+    current client or nothing crossed the threshold.
+
+    Used as the `repackage_oversize_fn` callback for both the `calls_merged`
+    flush (`/call/upsert_batch`) and `calls_complete` flush
+    (`/v2/<entity>/<project>/calls/complete`), and from `_flush_calls_eager`
+    for the per-item v2 single-call endpoints.
     """
-    # Lazy imports avoid the circular trace -> trace_server_bindings -> trace path.
-    from weave.trace.context import weave_client_context
-    from weave.trace.oversize_repackage import (
-        emit_user_warning,
-        repackage_call_fields,
-    )
-
     client = weave_client_context.get_weave_client()
     if client is None:
         return None
-    complete = item.req
-    new_fields, repackaged = repackage_call_fields(
-        client,
-        fields={
-            "inputs": dict(complete.inputs or {}),
-            "attributes": dict(complete.attributes or {}),
-            "output": complete.output,
-            "summary": dict(complete.summary or {}),
-        },
+    field_names = _REPACKAGEABLE_FIELDS.get(type(item))
+    if field_names is None:
+        return None
+
+    # CompleteBatchItem stores the schema directly on .req; Start/End wrap it
+    # one level deeper as .req.start / .req.end.
+    schema = item.req if isinstance(item, CompleteBatchItem) else (
+        item.req.start if isinstance(item, StartBatchItem) else item.req.end
     )
+    fields: dict[str, Any] = {}
+    for name in field_names:
+        value = getattr(schema, name)
+        fields[name] = dict(value) if isinstance(value, dict) else value
+
+    new_fields, repackaged = repackage_call_fields(client, fields=fields)
     if not repackaged:
         return None
-    new_complete = complete.model_copy(update=new_fields)
     emit_user_warning(repackaged)
-    return CompleteBatchItem(req=new_complete)
 
-
-def _repackage_legacy_batch_item(
-    item: StartBatchItem | EndBatchItem,
-) -> StartBatchItem | EndBatchItem | None:
-    """Repackage oversize fields on a legacy batch item.
-
-    For an EndBatchItem, walks `summary` and `output`. For a StartBatchItem,
-    walks `inputs` and `attributes`. Returns a new item, or None when no
-    field needed repackaging or there's no current client.
-    """
-    from weave.trace.context import weave_client_context
-    from weave.trace.oversize_repackage import (
-        emit_user_warning,
-        repackage_call_fields,
-    )
-
-    client = weave_client_context.get_weave_client()
-    if client is None:
-        return None
-    if isinstance(item, EndBatchItem):
-        end = item.req.end
-        new_fields, repackaged = repackage_call_fields(
-            client,
-            fields={
-                "summary": dict(end.summary or {}),
-                "output": end.output,
-            },
-        )
-        if not repackaged:
-            return None
-        new_end = end.model_copy(update=new_fields)
-        emit_user_warning(repackaged)
-        return EndBatchItem(req=tsi.CallEndReq(end=new_end))
+    new_schema = schema.model_copy(update=new_fields)
+    if isinstance(item, CompleteBatchItem):
+        return CompleteBatchItem(req=new_schema)
     if isinstance(item, StartBatchItem):
-        start = item.req.start
-        new_fields, repackaged = repackage_call_fields(
-            client,
-            fields={
-                "inputs": dict(start.inputs or {}),
-                "attributes": dict(start.attributes or {}),
-            },
-        )
-        if not repackaged:
-            return None
-        new_start = start.model_copy(update=new_fields)
-        emit_user_warning(repackaged)
-        return StartBatchItem(req=tsi.CallStartReq(start=new_start))
-    return None
+        return StartBatchItem(req=tsi.CallStartReq(start=new_schema))
+    return EndBatchItem(req=tsi.CallEndReq(end=new_schema))
 
 
 class RemoteHTTPTraceServer(TraceServerClientInterface):
@@ -296,7 +271,7 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
                 get_item_id_fn=get_item_id,
                 log_dropped_fn=log_dropped_call_batch,
                 encode_batch_fn=encode_batch,
-                repackage_oversize_fn=_repackage_legacy_batch_item,
+                repackage_oversize_fn=_try_repackage_call_item,
             )
         except CallsCompleteModeRequired as e:
             # Project requires calls_complete mode - upgrade and re-enqueue the batch
@@ -368,16 +343,30 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         are exhausted, the item is logged and dropped, then processing continues
         with remaining items in the batch.
         """
+        def send(it: StartBatchItem | EndBatchItem) -> None:
+            if isinstance(it, StartBatchItem):
+                self._send_call_start_v2(it.req.start)
+            elif isinstance(it, EndBatchItem):
+                self._send_call_end_v2(it.req.end)
+
         for item in batch:
             try:
-                if isinstance(item, StartBatchItem):
-                    self._send_call_start_v2(item.req.start)
-                elif isinstance(item, EndBatchItem):
-                    self._send_call_end_v2(item.req.end)
+                send(item)
             except CallsCompleteModeRequired:
                 # Re-raise so caller can handle the upgrade to calls_complete mode
                 raise
             except Exception as e:
+                # On 413, try repackaging oversize fields and resend once before
+                # giving up. Mirrors the same recovery that
+                # `process_batch_with_retry` performs for the batched flush paths.
+                if is_payload_too_large_error(e):
+                    repackaged = _try_repackage_call_item(item)
+                    if repackaged is not None:
+                        try:
+                            send(repackaged)
+                            continue
+                        except Exception as retry_err:
+                            e = retry_err
                 log_dropped_call_batch([item], e)
 
     @with_retry
@@ -467,7 +456,7 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             get_item_id_fn=get_item_id,
             log_dropped_fn=log_dropped_call_batch,
             encode_batch_fn=encode_batch,
-            repackage_oversize_fn=_repackage_complete_batch_item,
+            repackage_oversize_fn=_try_repackage_call_item,
         )
 
     def get_call_processor(self) -> AsyncBatchProcessor | CallBatchProcessor | None:

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -51,6 +51,92 @@ logger = logging.getLogger(__name__)
 # DEFAULT_TIMEOUT = (DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT)
 
 
+def _repackage_complete_batch_item(
+    item: CompleteBatchItem,
+) -> CompleteBatchItem | None:
+    """Repackage oversize fields on a CompleteBatchItem before retry.
+
+    Walks `inputs`, `attributes`, `output`, and `summary`. Subtrees larger
+    than the oversize threshold are published as standalone weave objects
+    and replaced inline with their ref URIs. Returns a new item, or None
+    when no field needed repackaging or there's no current client.
+    """
+    # Lazy imports avoid the circular trace -> trace_server_bindings -> trace path.
+    from weave.trace.context import weave_client_context
+    from weave.trace.oversize_repackage import (
+        emit_user_warning,
+        repackage_call_fields,
+    )
+
+    client = weave_client_context.get_weave_client()
+    if client is None:
+        return None
+    complete = item.req
+    new_fields, repackaged = repackage_call_fields(
+        client,
+        fields={
+            "inputs": dict(complete.inputs or {}),
+            "attributes": dict(complete.attributes or {}),
+            "output": complete.output,
+            "summary": dict(complete.summary or {}),
+        },
+    )
+    if not repackaged:
+        return None
+    new_complete = complete.model_copy(update=new_fields)
+    emit_user_warning(repackaged)
+    return CompleteBatchItem(req=new_complete)
+
+
+def _repackage_legacy_batch_item(
+    item: StartBatchItem | EndBatchItem,
+) -> StartBatchItem | EndBatchItem | None:
+    """Repackage oversize fields on a legacy batch item.
+
+    For an EndBatchItem, walks `summary` and `output`. For a StartBatchItem,
+    walks `inputs` and `attributes`. Returns a new item, or None when no
+    field needed repackaging or there's no current client.
+    """
+    from weave.trace.context import weave_client_context
+    from weave.trace.oversize_repackage import (
+        emit_user_warning,
+        repackage_call_fields,
+    )
+
+    client = weave_client_context.get_weave_client()
+    if client is None:
+        return None
+    if isinstance(item, EndBatchItem):
+        end = item.req.end
+        new_fields, repackaged = repackage_call_fields(
+            client,
+            fields={
+                "summary": dict(end.summary or {}),
+                "output": end.output,
+            },
+        )
+        if not repackaged:
+            return None
+        new_end = end.model_copy(update=new_fields)
+        emit_user_warning(repackaged)
+        return EndBatchItem(req=tsi.CallEndReq(end=new_end))
+    if isinstance(item, StartBatchItem):
+        start = item.req.start
+        new_fields, repackaged = repackage_call_fields(
+            client,
+            fields={
+                "inputs": dict(start.inputs or {}),
+                "attributes": dict(start.attributes or {}),
+            },
+        )
+        if not repackaged:
+            return None
+        new_start = start.model_copy(update=new_fields)
+        emit_user_warning(repackaged)
+        return StartBatchItem(req=tsi.CallStartReq(start=new_start))
+    return None
+
+
 class RemoteHTTPTraceServer(TraceServerClientInterface):
     trace_server_url: str
 
@@ -210,6 +296,7 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
                 get_item_id_fn=get_item_id,
                 log_dropped_fn=log_dropped_call_batch,
                 encode_batch_fn=encode_batch,
+                repackage_oversize_fn=_repackage_legacy_batch_item,
             )
         except CallsCompleteModeRequired as e:
             # Project requires calls_complete mode - upgrade and re-enqueue the batch
@@ -380,6 +467,7 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             get_item_id_fn=get_item_id,
             log_dropped_fn=log_dropped_call_batch,
             encode_batch_fn=encode_batch,
+            repackage_oversize_fn=_repackage_complete_batch_item,
         )
 
     def get_call_processor(self) -> AsyncBatchProcessor | CallBatchProcessor | None:

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -75,8 +75,10 @@ def _try_repackage_call_item(
     if field_names is None:
         return None
 
-    schema = item.req if isinstance(item, CompleteBatchItem) else (
-        item.req.start if isinstance(item, StartBatchItem) else item.req.end
+    schema = (
+        item.req
+        if isinstance(item, CompleteBatchItem)
+        else (item.req.start if isinstance(item, StartBatchItem) else item.req.end)
     )
     fields: dict[str, Any] = {}
     for name in field_names:
@@ -327,6 +329,7 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         are exhausted, the item is logged and dropped, then processing continues
         with remaining items in the batch.
         """
+
         def send(it: StartBatchItem | EndBatchItem) -> None:
             if isinstance(it, StartBatchItem):
                 self._send_call_start_v2(it.req.start)


### PR DESCRIPTION
## Summary
- Implements [WB-34652](https://coreweave.atlassian.net/browse/WB-34652). Companion to WB-34650 (server-side handling).
- When the server rejects a single-call flush with 413, the SDK hoists oversize `inputs`/`attributes`/`output`/`summary` subtrees out as bucket-stored weave objects, substitutes inline `weave:///` refs, and retries once. Drops only when the repackaged retry also 413s.
- One shared `_try_repackage_call_item` dispatcher wired into all four production paths: `_flush_calls` (calls_merged upsert), `_flush_calls_complete` (calls_complete batch), `_flush_calls_eager` (v2 single-call start/end), and `WeaveClient.send_end_call` (synchronous `should_batch=False`).
- One user-facing warning per repackage names the affected fields and points at `weave.publish(...)` for prevention.

## Testing
end-to-end against tilt: 18/30/50 MiB single-call payloads land on both calls_merged and calls_complete paths (previously silent-dropped with 413). Unit tests in `tests/trace/test_oversize_repackage.py` and `tests/trace_server_bindings/test_http_utils.py` cover the walk shapes, the dispatcher across all three batch item types, the synchronous `send_end_call` helper, and the eager-flush 413+retry against a real client.

[WB-34652]: https://coreweave.atlassian.net/browse/WB-34652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ