### PR TITLE
feat(weave): hold eager call_start to pair into complete

### DIFF
--- a/dev_docs/client_ingest_architecture.md
+++ b/dev_docs/client_ingest_architecture.md
@@ -21,7 +21,7 @@ How a `@weave.op` call gets from user code to the trace server. Written as groun
 | Feedback batching | `weave/trace_server_bindings/async_batch_processor.py` | AsyncBatchProcessor (used for feedback only) |
 | HTTP transport | `weave/trace_server_bindings/remote_http_trace_server.py` | dispatches single vs batch endpoints |
 | Oversize handling | `weave/trace_server_bindings/http_utils.py` | binary-tree split, 413 retry, repackage |
-| HTTP client | `weave/utils/http_requests.py` | httpx.Client singleton, unbounded conn pool |
+| HTTP client | `weave/utils/http_requests.py` | httpx.Client singleton; conn pool intentionally uncapped, concurrency controlled at processor layer |
 
 ## Diagram
 
@@ -203,7 +203,7 @@ Three sub-claims to test, in order:
 
 1. **The CallBatchProcessor queue is bounded (10K) but does not block; it drops.** Switching to unbounded changes the failure mode from drop-on-saturation to OOM-on-saturation, which is worse unless paired with disk/WAL backpressure. So "unbounded async ingest queue" is only safe if we add explicit backpressure (or a dedicated spill-to-disk).
 
-2. **call_end IS batched for the normal path.** It is NOT batched for the eager path. So "a sender that batches call_end" is really "make the eager path batch ends." The eager path exists because evaluations need immediate UI visibility on the start side; the end side does not have that constraint and could safely batch.
+2. **call_end IS batched for the normal path.** It is NOT batched for the eager path. So "a sender that batches call_end" is really "make the eager path go through the DB-friendly path whenever possible." The eager path exists because evaluations need immediate UI visibility on the start side; in practice most eager calls' ends arrive within a second of the start, so a brief hold window lets them pair into a `calls/complete` insert instead of two separate eager records.
 
 3. **The actual prod bottleneck is worker-pool saturation under network latency.** Neither of the above directly fixes that. The real lever is widening / splitting the FutureExecutor pool, or making `server.obj_create`/`server.call_X` truly fire-and-forget (no synchronous HTTP wait inside the worker).
 
@@ -222,3 +222,7 @@ Pre-commit measurements I'd want before picking a shape:
 - Ratio of eager-end POSTs to complete-call POSTs in a representative evaluation workload.
 
 The PR-6740 prod result (no win, possibly a regression) is the signal that we should not be moving more CPU into the FutureExecutor without addressing what the pool is competing on first.
+
+---
+
+_LAST_VERIFIED against commit `20c16d57946d4435bb4d2f9dc15b53df41da930b` (master HEAD at doc-add time). Line numbers above will rot; re-verify against current code when citing._

--- a/dev_docs/client_ingest_architecture.md
+++ b/dev_docs/client_ingest_architecture.md
@@ -1,0 +1,224 @@
+# Weave client ingest architecture
+
+How a `@weave.op` call gets from user code to the trace server. Written as ground for the "unbounded async ingest queue + batched call_end sender" refactor.
+
+## TL;DR
+- The hot path crosses **two independent async layers** (FutureExecutor + CallBatchProcessor) before any HTTP request, plus a sync prefix in the calling thread.
+- **Call starts and ends are already batched** via the `calls/complete` endpoint when `should_batch=True` (the default in `WeaveClient`). The CallBatchProcessor pairs starts with ends in memory and emits *complete* records.
+- **Eager calls (`@op(eager_call_start=True)`) are not batched.** Their start fires one POST, their end fires another POST, both via `v2/call/{start,end}`. Used by `Evaluation.evaluate` and anything that needs immediate UI visibility.
+- **Object saves (`obj_create`, `table_create`, `file_create`) are never batched.** Each is its own POST through the FutureExecutor pool.
+- **Calling thread does meaningful sync CPU work** in `create_call`/`finish_call` (`_save_nested_objects`, `map_to_refs`, summary deepcopy, redaction, input/output `to_json`). PR #6740 moves the output-side walk into the worker pool; the input side stays sync.
+- **Queues are bounded** (10K each) and drop-on-full to disk. They do **not** block the caller; defer/enqueue return immediately under saturation. So "global blocking queue" is a misnomer in this codebase, but the practical effect under sustained pressure is similar: throughput collapses or items are dropped.
+
+## Layers (top down)
+
+| Layer | Files | Owns |
+|---|---|---|
+| Decorator | `weave/trace/op.py` | sync/async/gen wrappers; entry to client |
+| Client | `weave/trace/weave_client.py` | create_call, finish_call, _save_nested_objects, _save_object_basic, _save_table |
+| Concurrency | `weave/trace/concurrent/futures.py` | FutureExecutor (general purpose) |
+| Call batching | `weave/trace_server_bindings/call_batch_processor.py` | CallBatchProcessor (pairs starts+ends -> complete) |
+| Feedback batching | `weave/trace_server_bindings/async_batch_processor.py` | AsyncBatchProcessor (used for feedback only) |
+| HTTP transport | `weave/trace_server_bindings/remote_http_trace_server.py` | dispatches single vs batch endpoints |
+| Oversize handling | `weave/trace_server_bindings/http_utils.py` | binary-tree split, 413 retry, repackage |
+| HTTP client | `weave/utils/http_requests.py` | httpx.Client singleton, unbounded conn pool |
+
+## Diagram
+
+```
+                                  USER CODE
+                          result = await my_op(args)
+                                     |
+                                     v
+       +=================================================================+
+       |   @weave.op wrapper  (weave/trace/op.py)                        |
+       |   _call_sync_func / _call_async_func / _call_sync_gen           |
+       +=================================================================+
+                                     |
+                                     v
+       +=================================================================+
+       | WeaveClient.create_call          [SYNC, calling thread]         |  (weave_client.py:903-1132)
+       |  - redact_sensitive_keys(inputs)                                |
+       |  - _save_nested_objects(inputs)  -- recursive Python walk;      |
+       |        deferred sub-saves go to FutureExecutor (see below)      |
+       |  - map_to_refs(inputs)           -- recursive Python walk       |
+       |  - to_json(inputs)               -- Python tree builder;        |
+       |        NO json.dumps; pydantic does that later                  |
+       |  - future_executor.defer(send_start_call)  -- non-blocking      |
+       +=================================================================+
+                                     |
+                  +------------------+------------------+
+                  | (calling thread continues into the user function)
+                  v
+                                                                ASYNC SIDE
+                                                                ----------
+
+       +=================================================================+
+       |  USER FUNCTION runs                                             |
+       +=================================================================+
+                                     |
+                                     v
+       +=================================================================+
+       | WeaveClient.finish_call          [SYNC, calling thread]         |  (weave_client.py:1135-1328)
+       |  - postprocess_output                                           |
+       |  - _save_nested_objects(output)  ** moved off-thread by PR 6740 |
+       |  - map_to_refs(output)           ** moved off-thread by PR 6740 |
+       |  - copy.deepcopy(call.summary), summary merge                   |
+       |  - exception_to_json_str                                        |
+       |  - future_executor.defer(send_end_call)  -- non-blocking        |
+       +=================================================================+
+
+
+                                                  ASYNC SIDE (FutureExecutor pool)
+                                                  --------------------------------
+
+       +=================================================================+
+       | FutureExecutor                                                  |  (futures.py:58-298)
+       |   ContextAwareThreadPoolExecutor                                |
+       |   max_workers = None  -> Python default (min(32, ncpu+4))       |
+       |   internal task queue: unbounded                                |
+       |   defer(): non-blocking submit -> Future                        |
+       |   then(): wait on futures, then submit g                        |
+       |   flush(): block until _active_futures drained                  |
+       |                                                                 |
+       |   Workers execute:                                              |
+       |     send_start_call -> server.call_start                        |
+       |     send_end_call   -> server.call_end                          |
+       |     send_obj_create -> server.obj_create  (1 POST each)         |
+       |     send_table_create / chunked variants                        |
+       |     digest computation (post-WAL)                               |
+       +=================================================================+
+                                     |
+                                     v
+       +=================================================================+
+       | RemoteHTTPTraceServer.call_start / call_end                     |  (remote_http_trace_server.py:691-717)
+       |   if self.should_batch:                                         |
+       |       call_processor.enqueue_start(StartBatchItem)              |  ----.
+       |       OR                                                        |       \
+       |       call_processor.enqueue([EndBatchItem])                    |        +--> CallBatchProcessor
+       |       return synthetic CallStartRes / CallEndRes immediately    |       /
+       |   else:                                                         |  ----'
+       |       POST /call/start  (single record)                         |  ----.
+       |       POST /call/end    (single record)                         |       +--> direct HTTP
+       |                                                                 |  ----'
+       |                                                                 |
+       | obj_create / table_create / file_create / cost_create:          |
+       |   ALWAYS direct, ONE POST per record (no batching)              |  ---->  direct HTTP
+       +=================================================================+
+                                     |
+                  +------------------+------------------+
+                  v                                     v
+
+                                          ASYNC SIDE (CallBatchProcessor thread)
+                                          ---------------------------------------
+
+       +=================================================================+
+       | CallBatchProcessor    extends AsyncBatchProcessor               |  (call_batch_processor.py:55+)
+       |                                                                 |
+       |   bounded Queue, maxsize=10_000  (drops to disk on full)        |
+       |                                                                 |
+       |   PAIRING STATE (in-memory dicts, separate from queue):         |
+       |     _pending_starts: {call_id -> StartBatchItem}                |
+       |     _pending_ends:   {call_id -> EndBatchItem}                  |
+       |     each capped at 10_000 (RuntimeError above limit)            |
+       |                                                                 |
+       |   enqueue_start(start):                                         |
+       |     if eager_call_start: queue as StartBatchItem (no pairing)   |
+       |     elif end pending:    pair -> queue CompleteBatchItem        |
+       |     else:                stash in _pending_starts               |
+       |                                                                 |
+       |   enqueue([end]):                                               |
+       |     if start was eager: queue as EndBatchItem (no pairing)      |
+       |     elif start pending: pair -> queue CompleteBatchItem         |
+       |     else:               stash in _pending_ends                  |
+       |                                                                 |
+       |   SINGLE processing thread, ticks on:                           |
+       |     batch_size >= MAX_BATCH_SIZE (1000)  OR                     |
+       |     time >= min_batch_interval (1.0s)                           |
+       |                                                                 |
+       |   _process_mixed_batch splits into:                             |
+       |     complete_items -> _flush_calls_complete                     |
+       |     eager_items    -> _flush_calls_eager                        |
+       |                                                                 |
+       |   On flush/shutdown: wait up to 5min for pending pairs,         |
+       |   then orphan-flush unpaired via v2 endpoints.                  |
+       +=================================================================+
+                                     |
+                  +------------------+------------------+
+                  v                                     v
+
+       +================================+   +===========================================+
+       | _flush_calls_complete          |   | _flush_calls_eager                        |
+       |  POST /v2/{e}/{p}/calls/complete|  |  for each item:                           |
+       |  body: { batch: [ ...N records ] }| |    POST /v2/{e}/{p}/call/start  (1 record)|
+       |  TRUE HTTP BATCH               |   |    or                                     |
+       |  413 -> binary split + retry   |   |    POST /v2/{e}/{p}/call/end    (1 record)|
+       |                                |   |  NO HTTP BATCH                            |
+       +================================+   +===========================================+
+                  |                                       |
+                  +--+                                 +--+
+                     v                                 v
+                                  +========================+
+                                  | httpx.Client (singleton)|  (utils/http_requests.py)
+                                  | unbounded conn pool     |
+                                  | unbounded keepalive     |
+                                  | sync POST (no asyncio)  |
+                                  +========================+
+                                              |
+                                              v
+                                  +========================+
+                                  |   trace-server         |
+                                  +========================+
+```
+
+## What's blocking, what isn't
+
+- **Calling thread blocks on:** the sync prefix of `create_call` and `finish_call`. Tunable knobs today: tracing_sample_rate, `postprocess_output` to strip payload, PR #6740 (moves output-side walks off-thread).
+- **`future_executor.defer(...)` does not block** the calling thread. ThreadPoolExecutor's internal queue is unbounded.
+- **`call_processor.enqueue(...)` does not block** the worker. On full queue it drops to disk and logs (rate-limited).
+- **The HTTP layer does not coalesce.** Each worker that lands inside `server.obj_create` / `server.table_create` issues its own POST. `requests`-style synchronous httpx; no async ingest.
+- **The worker pool is the de-facto bottleneck under network latency.** That is what the prod bench showed: PR #6740's deferred CPU lands in the same pool that's already blocked on `call_start`/`call_end`/`obj_create` POSTs. No backpressure mechanism, just queue depth.
+
+## What's already batched, what isn't
+
+| Path | Batched at HTTP? | Endpoint |
+|---|---|---|
+| Normal call start+end (should_batch=True, paired) | **Yes** | `calls/complete` |
+| Normal call start+end (should_batch=True, legacy) | **Yes** | `call/upsert_batch` |
+| Eager call start (`@op(eager_call_start=True)`) | **No** | `v2/call/start` (1 per POST) |
+| Eager call end | **No** | `v2/call/end` (1 per POST) |
+| Single call_start (should_batch=False) | No | `/call/start` |
+| Single call_end (should_batch=False) | No | `/call/end` |
+| obj_create | **No** | `/obj/create` |
+| table_create | **No** | `/table/create` |
+| file_create | **No** | `/files/create` |
+| feedback_create (should_batch=True) | **Yes** | `feedback/batch/create` |
+| cost_create | No | `/cost/create` |
+
+## Implications for the refactor
+
+The user's brief was: "Replace the global blocking queue with an unbounded async ingest queue + a sender that batches call_end. we already do batching."
+
+Three sub-claims to test, in order:
+
+1. **The CallBatchProcessor queue is bounded (10K) but does not block; it drops.** Switching to unbounded changes the failure mode from drop-on-saturation to OOM-on-saturation, which is worse unless paired with disk/WAL backpressure. So "unbounded async ingest queue" is only safe if we add explicit backpressure (or a dedicated spill-to-disk).
+
+2. **call_end IS batched for the normal path.** It is NOT batched for the eager path. So "a sender that batches call_end" is really "make the eager path batch ends." The eager path exists because evaluations need immediate UI visibility on the start side; the end side does not have that constraint and could safely batch.
+
+3. **The actual prod bottleneck is worker-pool saturation under network latency.** Neither of the above directly fixes that. The real lever is widening / splitting the FutureExecutor pool, or making `server.obj_create`/`server.call_X` truly fire-and-forget (no synchronous HTTP wait inside the worker).
+
+Concrete proposal-shapes worth scoping:
+
+- **Batch eager-call-end** (cheapest, ships independently). Add a `_flush_call_ends_eager` that aggregates EndBatchItems by `eager_call_start=True` flag. Single new HTTP endpoint `v2/calls/end_batch` or reuse `calls/upsert_batch` semantics with end-only items. Removes the 1-POST-per-end cost for evaluations.
+
+- **Replace the FutureExecutor's role for trace ingest with a dedicated single-purpose ingest queue.** Today FutureExecutor is shared by `send_start_call`, `send_end_call`, `send_obj_create`, `send_table_create`, digest computation, and arbitrary user-deferred work. A trace-ingest queue would: accept any (start | end | obj | table) item non-blocking; a dedicated worker thread does serialization + HTTP; backpressure spills to disk like CallBatchProcessor already does. This is essentially "extend CallBatchProcessor to also batch obj_create and table_create."
+
+- **Decouple serialization from network.** Today the FutureExecutor worker does both. If serialization moves to its own pool/thread, network-bound work can saturate independently. Useful diagnostic before committing: how much of worker CPU is `to_json` vs httpx.post?
+
+Pre-commit measurements I'd want before picking a shape:
+
+- Per-worker CPU breakdown (`to_json` walk vs httpx.post vs pydantic model_dump_json) over a 30s prod bench.
+- Queue depth over time in CallBatchProcessor and FutureExecutor (does either actually saturate, or just bottleneck on throughput?).
+- Ratio of eager-end POSTs to complete-call POSTs in a representative evaluation workload.
+
+The PR-6740 prod result (no win, possibly a regression) is the signal that we should not be moving more CPU into the FutureExecutor without addressing what the pool is competing on first.

--- a/tests/trace_server_bindings/test_call_batch_processor.py
+++ b/tests/trace_server_bindings/test_call_batch_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import pathlib
+import time
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -132,11 +133,35 @@ def test_start_end_pairing_orders(start_first: bool) -> None:
     eager_fn.assert_not_called()
 
 
-def test_eager_start_and_end_use_eager_processor() -> None:
-    """Eager starts and their ends should use the eager processor."""
+def test_eager_start_with_quick_end_pairs_into_complete() -> None:
+    """Eager start + end arriving within the hold window pair into a complete."""
     complete_fn = MagicMock()
     eager_fn = MagicMock()
-    processor = CallBatchProcessor(complete_fn, eager_fn, min_batch_interval=0.01)
+    processor = CallBatchProcessor(
+        complete_fn, eager_fn, min_batch_interval=0.01, eager_hold_window_seconds=1.0
+    )
+
+    start = _make_start_item("call-1", "trace-1")
+    end = _make_end_item("call-1")
+    processor.enqueue_start(start, eager_call_start=True)
+    processor.enqueue([end])
+    processor.stop_accepting_new_work_and_flush_queue()
+
+    complete_fn.assert_called_once()
+    batch = complete_fn.call_args[0][0]
+    assert len(batch) == 1
+    assert isinstance(batch[0], CompleteBatchItem)
+    assert batch[0].req.id == "call-1"
+    eager_fn.assert_not_called()
+
+
+def test_eager_start_with_zero_hold_window_uses_eager_immediately() -> None:
+    """eager_hold_window_seconds=0 preserves legacy immediate-eager behavior."""
+    complete_fn = MagicMock()
+    eager_fn = MagicMock()
+    processor = CallBatchProcessor(
+        complete_fn, eager_fn, min_batch_interval=0.01, eager_hold_window_seconds=0
+    )
 
     start = _make_start_item("call-1", "trace-1")
     end = _make_end_item("call-1")
@@ -148,6 +173,38 @@ def test_eager_start_and_end_use_eager_processor() -> None:
     eager_fn.assert_called_once()
     eager_items = eager_fn.call_args[0][0]
     assert {type(item) for item in eager_items} == {StartBatchItem, EndBatchItem}
+
+
+def test_eager_start_promoted_after_hold_window_expires() -> None:
+    """Eager start with no matching end is promoted via the eager v2 endpoint."""
+    complete_fn = MagicMock()
+    eager_fn = MagicMock()
+    processor = CallBatchProcessor(
+        complete_fn, eager_fn, min_batch_interval=0.01, eager_hold_window_seconds=0.05
+    )
+
+    start = _make_start_item("call-1", "trace-1")
+    processor.enqueue_start(start, eager_call_start=True)
+
+    # Start is held until the window expires.
+    assert "call-1" in processor._pending_starts
+    eager_fn.assert_not_called()
+
+    time.sleep(0.1)
+    processor._promote_expired_eager_starts()
+
+    assert "call-1" not in processor._pending_starts
+    assert "call-1" in processor._eager_call_ids
+
+    # The end, when it eventually arrives, should also route through eager.
+    end = _make_end_item("call-1")
+    processor.enqueue([end])
+    processor.stop_accepting_new_work_and_flush_queue()
+
+    complete_fn.assert_not_called()
+    eager_fn.assert_called()
+    sent_items = [item for call in eager_fn.call_args_list for item in call[0][0]]
+    assert {type(item) for item in sent_items} == {StartBatchItem, EndBatchItem}
 
 
 def test_complete_item_routes_to_complete_processor() -> None:

--- a/weave/trace_server_bindings/call_batch_processor.py
+++ b/weave/trace_server_bindings/call_batch_processor.py
@@ -50,15 +50,23 @@ DEFAULT_MAX_QUEUE_SIZE = 10_000
 FLUSH_POLL_INTERVAL_SECONDS = 0.1
 # Log every Nth dropped item to avoid log spam
 DROP_LOG_FREQUENCY = 1000
+# How long an eager-flagged start is held waiting for its end so the pair can
+# be sent as a single complete (DB-friendly insert) instead of two eager v2
+# records. If the end does not arrive within this window the start is sent
+# standalone via the eager path for UI visibility.
+DEFAULT_EAGER_HOLD_WINDOW_SECONDS = 1.0
 
 
 class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
     """Batch processor that pairs starts with ends to maximize complete calls.
 
     For normal ops: starts and ends are paired before sending as complete calls.
-    For eager ops (marked with @op(eager_call_start=True)): starts are sent immediately
-    via the legacy path, and ends are sent separately. This is useful for long-running
-    operations like evaluations that should be visible in the UI immediately.
+    For eager ops (marked with @op(eager_call_start=True)): the start is held
+    briefly (`eager_hold_window_seconds`) waiting for its end. If the end
+    arrives in the window, the pair flows through the complete path (one
+    DB-friendly insert via `calls/complete`). If the window expires, the
+    start is sent standalone via the eager v2 endpoint for UI visibility,
+    and its end (whenever it arrives) is sent via the eager v2 endpoint too.
     """
 
     def __init__(
@@ -71,6 +79,7 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
         max_pending_calls: int = DEFAULT_MAX_PENDING_CALLS,
         enable_disk_fallback: bool = False,
         disk_fallback_path: str = ".weave_client_dropped_items_log.jsonl",
+        eager_hold_window_seconds: float = DEFAULT_EAGER_HOLD_WINDOW_SECONDS,
     ) -> None:
         """Initialize the CallBatchProcessor.
 
@@ -83,8 +92,28 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
             max_pending_calls: Maximum pending unpaired calls before error.
             enable_disk_fallback: Write dropped items to disk if True.
             disk_fallback_path: Path for dropped items log file.
+            eager_hold_window_seconds: How long to hold an eager-flagged start
+                waiting for its end before falling back to the eager v2 send.
+                Set to 0 to send eager starts immediately (legacy behavior).
         """
-        # The parent class will use this for complete items
+        self.complete_processor_fn = complete_processor_fn
+        self.eager_processor_fn = eager_processor_fn
+        self.max_pending_calls = max_pending_calls
+        self.eager_hold_window_seconds = eager_hold_window_seconds
+
+        # Track pending starts/ends waiting for their counterpart.
+        # Each start entry carries an optional eager deadline (monotonic seconds);
+        # when set, the start falls back to eager standalone send if its end
+        # has not arrived by the deadline.
+        # Initialized BEFORE super().__init__ because the parent constructor
+        # starts the processing thread, which calls _get_next_batch ->
+        # _promote_expired_eager_starts and would otherwise see no attribute.
+        self._pending_starts: dict[str, tuple[StartBatchItem, float | None]] = {}
+        self._pending_ends: dict[str, EndBatchItem] = {}
+        self._eager_call_ids: TTLCache[str, bool] = TTLCache(
+            maxsize=max_pending_calls, ttl=EAGER_CALL_ID_TTL_SECONDS
+        )
+
         super().__init__(
             processor_fn=self._process_mixed_batch,
             max_batch_size=max_batch_size,
@@ -92,20 +121,6 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
             max_queue_size=max_queue_size,
             enable_disk_fallback=enable_disk_fallback,
             disk_fallback_path=disk_fallback_path,
-        )
-
-        self.complete_processor_fn = complete_processor_fn
-        self.eager_processor_fn = eager_processor_fn
-        self.max_pending_calls = max_pending_calls
-
-        # Track pending starts/ends waiting for their counterpart
-        self._pending_starts: dict[str, StartBatchItem] = {}
-        self._pending_ends: dict[str, EndBatchItem] = {}
-
-        # Track which calls were sent as eager (start sent immediately)
-        # Uses TTL cache to auto-expire entries to prevent unbounded growth
-        self._eager_call_ids: TTLCache[str, bool] = TTLCache(
-            maxsize=max_pending_calls, ttl=EAGER_CALL_ID_TTL_SECONDS
         )
 
     @property
@@ -200,7 +215,7 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
                     FLUSH_TIMEOUT_SECONDS,
                 )
                 while self._pending_starts:
-                    _, start_item = self._pending_starts.popitem()
+                    _, (start_item, _) = self._pending_starts.popitem()
                     self._queue_item(start_item)
 
             if self._pending_ends:
@@ -229,12 +244,14 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
     def _handle_start(
         self, item: StartBatchItem, *, eager_call_start: bool = False
     ) -> None:
-        """Handle a start item - pair with end if available, else hold or send eager.
+        """Handle a start item; pair with its end if already pending, else hold.
 
-        Args:
-            item: The start batch item.
-            eager_call_start: If True, send start immediately rather than batching.
-                Defined at op definition time via @op(eager_call_start=True).
+        Eager-flagged starts are also held briefly so a quickly-arriving end
+        can promote them into a complete (one DB-friendly insert) instead of
+        firing as a standalone v2 record. The fallback to standalone eager
+        send happens in `_promote_expired_eager_starts` when the hold window
+        expires. If `eager_hold_window_seconds` is 0, eager starts fire
+        immediately (legacy behavior).
         """
         call_id = item.req.start.id
 
@@ -242,45 +259,66 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
             logger.warning("Received start without call_id, dropping")
             return
 
-        if eager_call_start:
-            self._eager_call_ids[call_id] = True
-            self._queue_item(item)
-            # If end already arrived (race condition), queue it separately too
-            if call_id in self._pending_ends:
-                end_item = self._pending_ends.pop(call_id)
-                self._queue_item(end_item)  # Queue as EndBatchItem, not complete
-            return
-
-        # Check if we already have the end waiting
+        # End already waiting from a race condition; pair regardless of eager flag.
         if call_id in self._pending_ends:
             end_item = self._pending_ends.pop(call_id)
             complete_item = self._create_complete(item, end_item)
             self._queue_item(complete_item)
-        else:
-            # Hold the start until its end arrives
-            self._pending_starts[call_id] = item
+            return
+
+        if eager_call_start and self.eager_hold_window_seconds <= 0:
+            # Legacy behavior: fire eager start immediately, no hold window.
+            self._eager_call_ids[call_id] = True
+            self._queue_item(item)
+            return
+
+        deadline = (
+            time.monotonic() + self.eager_hold_window_seconds
+            if eager_call_start
+            else None
+        )
+        self._pending_starts[call_id] = (item, deadline)
 
     def _handle_end(self, item: EndBatchItem) -> None:
-        """Handle an end item - pair with start if available, else hold."""
+        """Handle an end item; pair with start if pending, else hold."""
         call_id = item.req.end.id
         if call_id is None:
             logger.warning("Received end without call_id, dropping")
             return
 
-        # Check if start was already sent
+        # Start was already promoted to eager standalone send; send end the same way.
         if call_id in self._eager_call_ids:
             self._eager_call_ids.pop(call_id, None)
-            self._queue_item(item)  # Send end via eager path
+            self._queue_item(item)
             return
 
-        # Check if we already have the start waiting
         if call_id in self._pending_starts:
-            start_item = self._pending_starts.pop(call_id)
+            start_item, _ = self._pending_starts.pop(call_id)
             complete_item = self._create_complete(start_item, item)
             self._queue_item(complete_item)
         else:
-            # Hold the end until its start arrives (handles race conditions)
             self._pending_ends[call_id] = item
+
+    def _promote_expired_eager_starts(self) -> None:
+        """Send any eager-flagged starts whose hold window has expired.
+
+        Called from the processing thread on every tick. Starts whose `(item,
+        deadline)` deadline is in the past are removed from `_pending_starts`,
+        recorded in `_eager_call_ids`, and queued as `StartBatchItem`s so they
+        flow through the eager v2 endpoint for UI visibility. Their eventual
+        end will then route through the eager path via `_handle_end`.
+        """
+        now = time.monotonic()
+        with self.lock:
+            expired_ids = [
+                call_id
+                for call_id, (_, deadline) in self._pending_starts.items()
+                if deadline is not None and deadline <= now
+            ]
+            for call_id in expired_ids:
+                start_item, _ = self._pending_starts.pop(call_id)
+                self._eager_call_ids[call_id] = True
+                self._queue_item(start_item)
 
     def _create_complete(
         self, start: StartBatchItem, end: EndBatchItem
@@ -342,6 +380,11 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
             if self._dropped_item_count % DROP_LOG_FREQUENCY == 1:
                 log_warning_with_sentry(error_message)
             self._write_item_to_disk(item, error_message)
+
+    def _get_next_batch(self) -> list[BatchItem]:
+        """Sweep expired eager starts, then collect the next batch from the queue."""
+        self._promote_expired_eager_starts()
+        return super()._get_next_batch()
 
     def _process_mixed_batch(self, batch: list[BatchItem]) -> None:
         """Process a mixed batch by splitting into complete and eager items.


### PR DESCRIPTION
## Summary
- Eager-flagged starts (`@op(eager_call_start=True)`, used by `Evaluation.evaluate` + `EvaluationLogger`) are held in `_pending_starts` for up to `eager_hold_window_seconds` (default 1.0s) waiting for their end. If the end arrives in the window, the pair flows through the existing `calls/complete` path as one `CompleteBatchItem` (one DB-friendly insert) instead of two separate v2/call/start + v2/call/end records.
- `_promote_expired_eager_starts` runs on every processor tick; starts whose hold deadline has passed are promoted to the eager v2 endpoint for UI visibility (legacy behavior). Their ends follow via the eager path as before.
- Adds `dev_docs/client_ingest_architecture.md` to document the ingest path this change touches.
- `eager_hold_window_seconds=0` preserves legacy immediate-eager dispatch.

## Testing
- `test_call_batch_processor.py`: new tests cover quick-end pairing, zero-hold-window legacy path, and promotion after window expiry. 13/13 in the file pass.
- `trace_server_bindings/` shard: 57/57 pass.