### PR TITLE
fix(weave_ts): Fix semconv import.

### DIFF
--- a/sdks/node/src/evalLinkSpanProcessor.ts
+++ b/sdks/node/src/evalLinkSpanProcessor.ts
@@ -19,7 +19,7 @@ import {
   GENAI_SPAN_REF_ATTR_KEY,
   WEAVE_ATTRIBUTES_NAMESPACE,
 } from './constants';
-import {GEN_AI_ATTR} from './genai/semconv';
+import {ATTR_GEN_AI_OPERATION_NAME} from './genai/semconv';
 import {globalSingleton} from './utils/globalSingleton';
 import type {CallStackEntry, WeaveClient} from './weaveClient';
 
@@ -131,7 +131,7 @@ export class EvalLinkSpanProcessor implements SpanProcessor {
 
   onEnd(span: ReadableSpan): void {
     const attrs = span.attributes || {};
-    if (!(GEN_AI_ATTR.GEN_AI_OPERATION_NAME in attrs)) {
+    if (!(ATTR_GEN_AI_OPERATION_NAME in attrs)) {
       return;
     }
 


### PR DESCRIPTION
## Description

* #6878 introduced a reference to a value which was removed in #6931.

* Timing of the merges of these ^^ resulted in master breaking on:

```
    src/evalLinkSpanProcessor.ts:22:9 - error TS2305: Module '"./genai/semconv"' has no exported member 'GEN_AI_ATTR'.

    22 import {GEN_AI_ATTR} from './genai/semconv';
```





