### PR TITLE
perf(weave): defer Call.set_display_name to future_executor

### DIFF
--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -3,6 +3,7 @@ import json
 import platform
 import re
 import sys
+import threading
 import time
 import uuid
 
@@ -825,6 +826,62 @@ def test_call_display_name(client):
     call0.set_display_name(None)
     call0 = client.get_call(call0.id)
     assert call0.display_name is None
+
+
+def test_set_display_name_does_not_block_caller(client, no_autoflush):
+    """set_display_name must defer the server PATCH to future_executor.
+
+    Wraps the live server in a gate that blocks `call_update` until released,
+    then asserts the caller returns before the gate opens, that
+    `call.display_name` updates synchronously in-memory, and that the PATCH
+    eventually fires with the elided new name once the gate releases and the
+    executor drains.
+    """
+    gate = threading.Event()
+    seen: list[tsi.CallUpdateReq] = []
+
+    class GatedServer:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def call_update(self, req):
+            seen.append(req)
+            gate.wait(timeout=5.0)
+            return self._inner.call_update(req)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+    real_server = client.server
+    call = client.create_call("x", {"a": 1})
+    client.flush()  # drain start_call before installing the gate
+
+    client.server = GatedServer(real_server)
+    try:
+        start = time.perf_counter()
+        call.set_display_name("new_name")
+        caller_elapsed = time.perf_counter() - start
+
+        # Caller did not block on the PATCH; the closure is queued on the
+        # future_executor and the gated call_update is still waiting.
+        assert caller_elapsed < 1.0, (
+            f"set_display_name blocked caller for {caller_elapsed:.2f}s; "
+            "expected near-instant return (deferred via future_executor)"
+        )
+        # In-memory display_name is updated synchronously so user code that
+        # reads call.display_name right after the set sees the new value.
+        assert call.display_name == "new_name"
+
+        # Release the gate and drain the executor; the PATCH should now land
+        # with the elided new name.
+        gate.set()
+        client.flush()
+        assert len(seen) == 1
+        assert seen[0].call_id == call.id
+        assert seen[0].display_name == "new_name"
+    finally:
+        gate.set()
+        client.server = real_server
 
 
 def test_dataset_calls(client):

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -2666,13 +2666,16 @@ class WeaveClient:
         # Removing call display name, use "" for db representation
         if display_name is None:
             display_name = ""
-        self.server.call_update(
-            CallUpdateReq(
-                project_id=self.project_id,
-                call_id=call.id,
-                display_name=elide_display_name(display_name),
-            )
+        req = CallUpdateReq(
+            project_id=self.project_id,
+            call_id=call.id,
+            display_name=elide_display_name(display_name),
         )
+
+        def send_call_update() -> None:
+            self.server.call_update(req)
+
+        self.future_executor.defer(send_call_update)
 
     def _remove_call_display_name(self, call: Call) -> None:
         self._set_call_display_name(call, None)


### PR DESCRIPTION
[WB-34688](https://coreweave.atlassian.net/browse/WB-34688)

## Summary
`Call.set_display_name` was the lone write path in `WeaveClient` that hit the server synchronously on the caller's thread. Every other write (start_call, finish_call, file_create, table_create, score_call, obj_create) defers via `future_executor`. This PR brings `_set_call_display_name` in line with that pattern.

Found by Zubin while chasing a +73% latency gap vs. ideal in evals. Setting the display name per row (driven by the dataset) was paying the full HTTP RTT on each scorer thread. Slack: https://weightsandbiases.slack.com/archives/C0AJJN95T0W/p1779469885653109?thread_ts=1779417394.167029&cid=C0AJJN95T0W

In-memory `call.display_name` still updates immediately (call.py:210), so reads of the same `Call` object after `set_display_name` return the new value without waiting for the network. Reads back through the server are now eventually consistent, matching `finish_call`'s existing model.

Tradeoff worth noting: HTTP errors from the PATCH no longer raise on the caller thread; they surface on the next `client.flush()` (same as every other deferred write today).

## Performance
Repro: N concurrent `set_display_name` calls against a fake server that sleeps 50ms per `call_update`, caller pool of 10 workers.

| N  | caller wall (before) | caller wall (after) | speedup |
| -- | -------------------- | ------------------- | ------- |
| 23 | 161.8 ms             | 2.6 ms              | 62x     |
| 50 | 271.1 ms             | 3.1 ms              | 87x     |
| 60 | 325.3 ms             | 2.6 ms              | 125x    |

All N `server.call_update` PATCHes still fire (verified by counter).

## Testing
new regression test `test_set_display_name_does_not_block_caller` wraps the live server in a `threading.Event` gate, asserts the caller returns near-instantly while the gate is closed, that in-memory `call.display_name` updates synchronously, and that the PATCH lands with the new name after release + flush. Confirmed fails on master (caller blocks 5s) and passes with the fix. Existing display_name suite (`test_call_display_name`, `test_op_calltime_display_name`, `test_long_display_names_are_elided`, `test_calls_query_sort_by_display_name_prioritized`) still passes.

[WB-34688]: https://coreweave.atlassian.net/browse/WB-34688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ