### PR TITLE
fix(weave_ts): render individual turns when integrating w/pi coding agent SDK.

### DIFF
--- a/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
@@ -92,56 +92,50 @@ function startTurn(emit: EmitFn, ctx = DEFAULT_CTX) {
 // ---------------------------------------------------------------------------
 
 describe('PiCodingAgentOtelAdapter', () => {
-  // ── Session span ──────────────────────────────────────────────────────────
-
-  describe('session span', () => {
-    it('starts with correct attributes', () => {
+  describe('invoke_agent span', () => {
+    it('emits with correct attributes', () => {
       const {exporter, emit} = makeExporterAndAdapter();
       startSession(emit);
+
+      // Prompt
+      emit('before_agent_start', {prompt: 'tell me a joke', systemPrompt: 'sys'});
+      emit('agent_end', {messages: []});
+
       emit('session_shutdown');
 
       const span = exporter
         .getFinishedSpans()
-        .find(s => s.name === 'pi.coding_agent.session');
-      expect(span).toBeDefined();
-      expect(span!.kind).toBe(SpanKind.INTERNAL);
+        .find(s => s.name === 'invoke_agent pi-coding-agent');
       expect(span!.attributes['gen_ai.agent.name']).toBe('pi-coding-agent');
+      expect(span!.attributes['gen_ai.provider.name']).toBe('anthropic');
       expect(span!.attributes['gen_ai.conversation.id']).toBe(
         'test-session-id'
       );
       expect(span!.attributes['pi.session.cwd']).toBe('/home/user/project');
     });
 
-    it('is ended by session_shutdown', () => {
+    it('emits one trace per prompt, linked by conversation id', () => {
       const {exporter, emit} = makeExporterAndAdapter();
       startSession(emit);
-      expect(exporter.getFinishedSpans()).toHaveLength(0);
-      emit('session_shutdown');
-      expect(
-        exporter
-          .getFinishedSpans()
-          .find(s => s.name === 'pi.coding_agent.session')
-      ).toBeDefined();
-    });
-  });
-
-  // ── invoke_agent span ─────────────────────────────────────────────────────
-
-  describe('invoke_agent span', () => {
-    it('has correct attributes and is a child of the session span', () => {
-      const {exporter, emit} = makeExporterAndAdapter();
-      startInvoke(emit);
+      // Prompt 1
+      emit('before_agent_start', {prompt: 'first', systemPrompt: 'sys'});
+      emit('agent_end', {messages: []});
+      // Prompt 2
+      emit('before_agent_start', {prompt: 'second', systemPrompt: 'sys'});
       emit('agent_end', {messages: []});
       emit('session_shutdown');
 
-      const spans = exporter.getFinishedSpans();
-      const session = spans.find(s => s.name === 'pi.coding_agent.session')!;
-      const invoke = spans.find(
-        s => s.name === 'invoke_agent pi-coding-agent'
-      )!;
-      expect(invoke.parentSpanId).toBe(session.spanContext().spanId);
-      expect(invoke.attributes['gen_ai.provider.name']).toBe('anthropic');
-      expect(invoke.attributes['gen_ai.conversation.id']).toBe(
+      const invokes = exporter
+        .getFinishedSpans()
+        .filter(s => s.name === 'invoke_agent pi-coding-agent');
+      expect(invokes).toHaveLength(2);
+      expect(invokes[0].spanContext().traceId).not.toBe(
+        invokes[1].spanContext().traceId
+      );
+      expect(invokes[0].attributes['gen_ai.conversation.id']).toBe(
+        'test-session-id'
+      );
+      expect(invokes[1].attributes['gen_ai.conversation.id']).toBe(
         'test-session-id'
       );
     });
@@ -473,7 +467,7 @@ describe('PiCodingAgentOtelAdapter', () => {
   // ── compaction span ───────────────────────────────────────────────────────
 
   describe('compaction span', () => {
-    it('emits pi.coding_agent.compaction as child of session', () => {
+    it('emits pi.coding_agent.compaction as a root span', () => {
       const {exporter, emit} = makeExporterAndAdapter();
       startSession(emit);
       emit('session_compact', {
@@ -483,11 +477,11 @@ describe('PiCodingAgentOtelAdapter', () => {
       });
       emit('session_shutdown');
 
-      const spans = exporter.getFinishedSpans();
-      const session = spans.find(s => s.name === 'pi.coding_agent.session')!;
-      const compact = spans.find(s => s.name === 'pi.coding_agent.compaction')!;
+      const compact = exporter
+        .getFinishedSpans()
+        .find(s => s.name === 'pi.coding_agent.compaction')!;
       expect(compact).toBeDefined();
-      expect(compact.parentSpanId).toBe(session.spanContext().spanId);
+      expect(compact.parentSpanId).toBeUndefined();
       expect(compact.attributes['pi.compaction.reason']).toBe('context_limit');
       expect(compact.attributes['pi.compaction.aborted']).toBe(false);
       expect(compact.attributes['pi.compaction.will_retry']).toBe(false);

--- a/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/piCodingAgent.test.ts
@@ -98,7 +98,10 @@ describe('PiCodingAgentOtelAdapter', () => {
       startSession(emit);
 
       // Prompt
-      emit('before_agent_start', {prompt: 'tell me a joke', systemPrompt: 'sys'});
+      emit('before_agent_start', {
+        prompt: 'tell me a joke',
+        systemPrompt: 'sys',
+      });
       emit('agent_end', {messages: []});
 
       emit('session_shutdown');

--- a/sdks/node/src/integrations/piCodingAgent.ts
+++ b/sdks/node/src/integrations/piCodingAgent.ts
@@ -210,13 +210,16 @@ export class PiCodingAgentOtelAdapter {
   private readonly tracer: Tracer;
   private readonly captureContent: boolean;
 
-  // Session-level span
-  private sessionSpan: Span | null = null;
-  private sessionCtx: Context = ROOT_CONTEXT;
-
-  // Per-prompt span (gen_ai.invoke_agent) — one per user prompt → response cycle
+  // Per-prompt span (gen_ai.invoke_agent) — one per user prompt → response
+  // cycle. Each is started under ROOT_CONTEXT so every prompt gets its own
+  // trace id; sibling prompts in the same conversation are linked via
+  // `gen_ai.conversation.id`, not a shared parent span.
   private invokeAgentSpan: Span | null = null;
   private invokeAgentCtx: Context = ROOT_CONTEXT;
+
+  // cwd captured at session_start; stamped on each invoke_agent span as
+  // pi.session.cwd.
+  private sessionCwd: string | null = null;
 
   // Per-LLM-turn span (gen_ai.chat) — one per LLM API call within a cycle
   private chatSpan: Span | null = null;
@@ -249,7 +252,7 @@ export class PiCodingAgentOtelAdapter {
       // still open when the event loop drains must be ended before the
       // GenAI provider's own beforeExit handler flushes the exporter.
       process.once('beforeExit', () => {
-        this.endSessionSpan();
+        this.endInvokeAgentSpan();
       });
     }
   }
@@ -288,23 +291,11 @@ export class PiCodingAgentOtelAdapter {
   ): void => {
     this.currentModel = ctx.model ?? null;
     this.conversationId = ctx.sessionManager.getSessionId();
-    this.sessionSpan = this.tracer.startSpan(
-      'pi.coding_agent.session',
-      {
-        kind: SpanKind.INTERNAL,
-        attributes: {
-          [ATTR_GEN_AI_AGENT_NAME]: 'pi-coding-agent',
-          [ATTR_PI_SESSION_CWD]: ctx.cwd,
-          [ATTR_GEN_AI_CONVERSATION_ID]: this.conversationId,
-        },
-      },
-      ROOT_CONTEXT
-    );
-    this.sessionCtx = trace.setSpan(ROOT_CONTEXT, this.sessionSpan);
+    this.sessionCwd = ctx.cwd;
   };
 
   private onSessionShutdown = (): void => {
-    this.endSessionSpan();
+    this.endInvokeAgentSpan();
   };
 
   private onModelSelect = (
@@ -335,11 +326,12 @@ export class PiCodingAgentOtelAdapter {
           ...(this.conversationId
             ? {[ATTR_GEN_AI_CONVERSATION_ID]: this.conversationId}
             : {}),
+          ...(this.sessionCwd ? {[ATTR_PI_SESSION_CWD]: this.sessionCwd} : {}),
         },
       },
-      this.sessionCtx
+      ROOT_CONTEXT
     );
-    this.invokeAgentCtx = trace.setSpan(this.sessionCtx, this.invokeAgentSpan);
+    this.invokeAgentCtx = trace.setSpan(ROOT_CONTEXT, this.invokeAgentSpan);
     this.agentInputTokens = 0;
     this.agentOutputTokens = 0;
     this.agentTotalTokens = 0;
@@ -552,7 +544,7 @@ export class PiCodingAgentOtelAdapter {
             : {}),
         },
       },
-      this.sessionCtx
+      ROOT_CONTEXT
     );
     span.end();
   };
@@ -611,15 +603,6 @@ export class PiCodingAgentOtelAdapter {
       this.invokeAgentSpan.end();
       this.invokeAgentSpan = null;
       this.invokeAgentCtx = ROOT_CONTEXT;
-    }
-  }
-
-  private endSessionSpan(): void {
-    this.endInvokeAgentSpan();
-    if (this.sessionSpan) {
-      this.sessionSpan.end();
-      this.sessionSpan = null;
-      this.sessionCtx = ROOT_CONTEXT;
     }
   }
 }


### PR DESCRIPTION
## Description

* Context: at the moment, integrations with the pi.dev SDK collapse all user prompts in a session into a single turn:

<img width="3816" height="1644" alt="image" src="https://github.com/user-attachments/assets/83dee780-42f3-4aef-a329-13c04e1840f9" />

* Add'l context [here](https://coreweave.slack.com/archives/C03BSTEBD7F/p1779465737604069)

* This change teases out some existing grouping beneath an aribtrary `pi.coding_agent.session` to align with the latest OTel events expected by Weave.

* After this change, we are able to see multiple turns in the UI as expected:

<img width="1718" height="1136" alt="Screenshot 2026-05-22 at 5 01 58 PM" src="https://github.com/user-attachments/assets/7cea6c51-ef9d-40a7-a486-8fd670ac7e9a" />


