### PR TITLE
fix(weave): SDK str(ref) returns URI so scorer leaderboard matches

### DIFF
--- a/tests/trace/test_ref_trace.py
+++ b/tests/trace/test_ref_trace.py
@@ -3,6 +3,96 @@ from dataclasses import FrozenInstanceError
 import pytest
 
 import weave
+from weave.trace.refs import (
+    AgentConversationRef,
+    AgentSpanRef,
+    AgentTurnRef,
+    CallRef,
+    ObjectRef,
+    OpRef,
+    TableRef,
+)
+
+
+@pytest.mark.parametrize(
+    ("ref", "expected_uri"),
+    [
+        (
+            ObjectRef(
+                entity="e", project="p", name="obj", _digest="dig", _extra=()
+            ),
+            "weave:///e/p/object/obj:dig",
+        ),
+        (
+            OpRef(entity="e", project="p", name="op", _digest="dig", _extra=()),
+            "weave:///e/p/op/op:dig",
+        ),
+        (
+            CallRef(entity="e", project="p", id="call-id", _extra=()),
+            "weave:///e/p/call/call-id",
+        ),
+        (
+            TableRef(entity="e", project="p", _digest="dig"),
+            "weave:///e/p/table/dig",
+        ),
+        (
+            AgentTurnRef(entity="e", project="p", trace_id="t"),
+            "weave:///e/p/agent_turn/t",
+        ),
+        (
+            AgentConversationRef(entity="e", project="p", conversation_id="c"),
+            "weave:///e/p/agent_conversation/c",
+        ),
+        (
+            AgentSpanRef(entity="e", project="p", span_id="s"),
+            "weave:///e/p/agent_span/s",
+        ),
+    ],
+)
+def test_str_returns_uri(ref, expected_uri):
+    assert str(ref) == expected_uri
+    assert f"{ref}" == expected_uri
+    assert f"{ref!s}" == expected_uri
+
+
+def test_repr_is_unchanged_dataclass_form():
+    # repr() must keep the verbose dataclass form for debugging; only str()
+    # was changed to the URI.
+    ref = ObjectRef(
+        entity="e", project="p", name="obj", _digest="dig", _extra=()
+    )
+    assert repr(ref).startswith("ObjectRef(")
+    assert "_digest='dig'" in repr(ref)
+
+
+def test_str_round_trips_through_parse_uri():
+    original = ObjectRef(
+        entity="e", project="p", name="obj", _digest="dig", _extra=()
+    )
+    from weave.trace.refs import Ref
+
+    parsed = Ref.parse_uri(str(original))
+    assert parsed == original
+
+
+def test_leaderboard_column_accepts_str_of_ref():
+    # LeaderboardColumn.evaluation_object_ref is typed as RefStr (= str), so
+    # pydantic accepts any string. str(ref) now produces a URI, so a column
+    # built from str(ref) matches calls keyed by ref.uri() downstream.
+    from weave.trace_server.interface.builtin_object_classes.leaderboard import (
+        LeaderboardColumn,
+    )
+
+    ref = ObjectRef(
+        entity="e", project="p", name="Eval", _digest="dig", _extra=()
+    )
+    col = LeaderboardColumn(
+        evaluation_object_ref=str(ref),
+        scorer_name="score",
+        summary_metric_path="x.mean",
+    )
+    assert col.evaluation_object_ref == "weave:///e/p/object/Eval:dig"
+    assert col.evaluation_object_ref.startswith("weave:///")
 
 
 def test_ref_hashable(weave_active):

--- a/tests/trace/test_ref_trace.py
+++ b/tests/trace/test_ref_trace.py
@@ -18,9 +18,7 @@ from weave.trace.refs import (
     ("ref", "expected_uri"),
     [
         (
-            ObjectRef(
-                entity="e", project="p", name="obj", _digest="dig", _extra=()
-            ),
+            ObjectRef(entity="e", project="p", name="obj", _digest="dig", _extra=()),
             "weave:///e/p/object/obj:dig",
         ),
         (
@@ -58,17 +56,13 @@ def test_str_returns_uri(ref, expected_uri):
 def test_repr_is_unchanged_dataclass_form():
     # repr() must keep the verbose dataclass form for debugging; only str()
     # was changed to the URI.
-    ref = ObjectRef(
-        entity="e", project="p", name="obj", _digest="dig", _extra=()
-    )
+    ref = ObjectRef(entity="e", project="p", name="obj", _digest="dig", _extra=())
     assert repr(ref).startswith("ObjectRef(")
     assert "_digest='dig'" in repr(ref)
 
 
 def test_str_round_trips_through_parse_uri():
-    original = ObjectRef(
-        entity="e", project="p", name="obj", _digest="dig", _extra=()
-    )
+    original = ObjectRef(entity="e", project="p", name="obj", _digest="dig", _extra=())
     from weave.trace.refs import Ref
 
     parsed = Ref.parse_uri(str(original))
@@ -83,9 +77,7 @@ def test_leaderboard_column_accepts_str_of_ref():
         LeaderboardColumn,
     )
 
-    ref = ObjectRef(
-        entity="e", project="p", name="Eval", _digest="dig", _extra=()
-    )
+    ref = ObjectRef(entity="e", project="p", name="Eval", _digest="dig", _extra=())
     col = LeaderboardColumn(
         evaluation_object_ref=str(ref),
         scorer_name="score",

--- a/weave/trace/refs.py
+++ b/weave/trace/refs.py
@@ -30,6 +30,9 @@ class Ref:
     def uri(self) -> str:
         raise NotImplementedError
 
+    def __str__(self) -> str:
+        return self.uri
+
     def as_param_dict(self) -> dict:
         return asdict(self)
 


### PR DESCRIPTION
## JIRA Issue(s)

[WB-34720](https://coreweave.atlassian.net/browse/WB-34720) — surfaced while reproducing [WB-29527](https://coreweave.atlassian.net/browse/WB-29527) (separate UI-side leaderboard bug).

## Description

You write this — the obvious way to add a column to a leaderboard:

```python
ref = weave.publish(my_eval)
col = LeaderboardColumn(
    evaluation_object_ref=str(ref),
    scorer_name="correctness",
    summary_metric_path="correct.mean",
)
leaderboard = Leaderboard(columns=[col])
weave.publish(leaderboard)
```

It publishes fine. No errors anywhere. But the leaderboard in the UI shows **"No leaderboard submissions found"** forever, no matter how many eval runs you do. The matching path in `get_leaderboard_results` filters eval calls by `evaluation_object_ref`, expecting a Weave URI like `weave:///entity/project/object/Eval:digest`.

The problem is `str(ref)`. It does **not** return the URI:

```
>>> str(ref)
"ObjectRef(entity='ent', project='proj', name='Eval', _digest='DIGEST', _extra=())"
>>> ref.uri()
'weave:///ent/proj/object/Eval:DIGEST'
```

Pydantic accepts the repr because `RefStr` is literally `RefStr = str` with no validator. The leaderboard stores the repr. The matcher then looks for a URI, finds the repr, matches nothing.

The reason `str(ref)` behaves like that is that none of the seven `Ref` subclasses in `weave/trace/refs.py` defines `__str__`, so Python falls back to the auto-generated `__repr__` from `@dataclass(frozen=True)`.

The fix is one method on the `Ref` base class:

```python
def __str__(self) -> str:
    return self.uri
```

All seven subclasses (`ObjectRef`, `OpRef`, `CallRef`, `TableRef`, `AgentTurnRef`, `AgentConversationRef`, `AgentSpanRef`) inherit it. `__repr__` is untouched — debuggers and tracebacks still show the verbose dataclass form. (`DeletedRef.__repr__` already routes through `self.uri`, so the URI-as-display intent was always there for at least one class.)

There is a second silent victim in the SDK that this same fix also closes: `RefJSONEncoder.default` in `weave/trace/serialization/op_type.py:177` builds `f"weave.ref('{o!s}')"` for code generation. It expects a URI; before this PR it baked the dataclass repr into the generated Python.

## Why this approach

The other option was to turn `RefStr` into a pydantic-validated type (`Annotated[str, AfterValidator(...)]`) that rejects non-URI strings. As defence-in-depth, that is appealing.

The reason I did not bundle it here: any leaderboard or saved view already persisted with a malformed `evaluation_object_ref` (from this exact bug reproduced before the fix lands) would fail to deserialise once a strict validator ships. That is a regression for affected users — a silent bug becomes a hard load failure. Worth doing in its own PR with a migration story.

Fixing `__str__` is purely additive: old data still loads, and new code that does the obvious `str(ref)` thing now gets a URI.

## Why it is safe

A repo-wide search for the literal string `"ObjectRef("` returns zero hits. No test, docstring, or production callsite pins on the dataclass repr appearing inside a string.

The only existing `str(ref)` usages are three `weave.ref(str(ref)).get()` lines inside `@pytest.mark.skip` blocks in `tests/trace/test_op_versioning.py`, and the assertions in `tests/trace/test_ref_json_encoder.py` that pass today only because both sides of the comparison are equally broken — after this change they pass for the right reason.

Error-message f-strings like `f"Expected ObjectRef, got {ref}"` shift from the verbose repr to the URI, which is more useful in an error anyway.

## Testing

New parametrised test in `tests/trace/test_ref_trace.py` covers `str(ref)`, `f"{ref}"`, and `f"{ref!s}"` for all seven `Ref` subclasses, plus three focused tests: `repr(ref)` still produces the dataclass form, `Ref.parse_uri(str(ref)) == ref` round-trips, and the exact `LeaderboardColumn(evaluation_object_ref=str(ref))` scenario above.

Locally: 12 new tests pass, the 8 existing `test_ref_json_encoder.py` tests pass, and 113 serialisation-related tests pass. All trace, trace_server, and flow shards green in CI on Linux 3.10/3.11/3.13 and Windows.

## Backward compatibility

`__repr__` is unchanged, so debugger output, tracebacks, and `%r` formatting all keep the verbose dataclass form. `str(ref)` and `f"{ref}"` now return a URI, but nothing in the repo depended on the old form. Persisted data is not touched.

[WB-34720]: https://coreweave.atlassian.net/browse/WB-34720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-29527]: https://coreweave.atlassian.net/browse/WB-29527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ