### PR TITLE
feat(weave_ts): add Turn.setAttribute and Turn.addEvent

### DIFF
--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -51,3 +51,70 @@ describe('Turn', () => {
     expect(span.events.some(e => e.name === 'exception')).toBe(true);
   });
 });
+
+describe('Turn.setAttribute', () => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('writes an attribute to the underlying span', () => {
+    const turn = Turn.create({});
+    turn.setAttribute('weave.cost.usd', 0.42);
+    turn.end();
+    const spans = getExporter().getFinishedSpans();
+    expect(findSpan(spans, 'invoke_agent').attributes['weave.cost.usd']).toBe(
+      0.42
+    );
+  });
+
+  it('returns this for chaining', () => {
+    const turn = Turn.create({});
+    expect(turn.setAttribute('k', 'v')).toBe(turn);
+    turn.end();
+  });
+
+  it('is a no-op after end()', () => {
+    const turn = Turn.create({});
+    turn.end();
+    turn.setAttribute('after.end', 'x');
+    const spans = getExporter().getFinishedSpans();
+    expect(
+      findSpan(spans, 'invoke_agent').attributes['after.end']
+    ).toBeUndefined();
+  });
+});
+
+describe('Turn.addEvent', () => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('writes a named event with attributes', () => {
+    const turn = Turn.create({});
+    turn.addEvent('context_compacted', {items_before: 50, items_after: 10});
+    turn.end();
+    const spans = getExporter().getFinishedSpans();
+    const ev = findSpan(spans, 'invoke_agent').events.find(
+      e => e.name === 'context_compacted'
+    );
+    expect(ev?.attributes).toMatchObject({items_before: 50, items_after: 10});
+  });
+
+  it('returns this for chaining', () => {
+    const turn = Turn.create({});
+    expect(turn.addEvent('e')).toBe(turn);
+    turn.end();
+    const spans = getExporter().getFinishedSpans();
+    expect(
+      findSpan(spans, 'invoke_agent').events.find(e => e.name === 'e')
+    ).toBeDefined();
+  });
+
+  it('is a no-op after end()', () => {
+    const turn = Turn.create({});
+    turn.end();
+    turn.addEvent('after.end');
+    const spans = getExporter().getFinishedSpans();
+    expect(
+      findSpan(spans, 'invoke_agent').events.find(e => e.name === 'after.end')
+    ).toBeUndefined();
+  });
+});

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -1,9 +1,12 @@
 import {
+  type AttributeValue,
+  type Attributes,
   type Context,
   ROOT_CONTEXT,
   type Span,
   SpanKind,
   SpanStatusCode,
+  type TimeInput,
   trace,
 } from '@opentelemetry/api';
 
@@ -122,6 +125,34 @@ export class Turn {
       parentContext: this.context,
       conversationId: this.conversationId,
     });
+  }
+
+  /**
+   * Set a single attribute on the Turn span. Useful for stamping running
+   * totals (e.g. cumulative cost, token usage) or other metadata that becomes
+   * known mid-turn. No-op after `end()`. Mirrors OTel `Span.setAttribute`.
+   *
+   * @example
+   * turn.setAttribute('gen_ai.usage.input_tokens', totalInputTokens);
+   */
+  setAttribute(key: string, value: AttributeValue): this {
+    if (this._ended) return this;
+    this.span.setAttribute(key, value);
+    return this;
+  }
+
+  /**
+   * Add a named event to the Turn span. Useful for marking non-span moments
+   * such as context compaction, tool-loop detection, or guardrail trips.
+   * No-op after `end()`. Mirrors OTel `Span.addEvent`.
+   *
+   * @example
+   * turn.addEvent('context_compacted', {removedMessages: 12});
+   */
+  addEvent(name: string, attributes?: Attributes, startTime?: TimeInput): this {
+    if (this._ended) return this;
+    this.span.addEvent(name, attributes, startTime);
+    return this;
   }
 
   /** Close the Turn span. Idempotent. Pass `error` to mark it as failed. */


### PR DESCRIPTION
## Summary

Adds two narrow methods to the genai `Turn` class:

- `setAttribute(key: string, value: AttributeValue): this`
- `addEvent(name: string, attributes?: Attributes, startTime?: TimeInput): this`

Both methods are 1:1 mirrors of the underlying OTel `Span` API, are post-`end()` no-ops, and return `this` for chaining. No exposure of the underlying span itself.

## Motivation

Plugins that need to stamp running attributes (e.g. cumulative cost, usage totals) or mark non-span events (e.g. context compaction, tool loop detection) on an `invoke_agent` Turn span had no canonical surface to do so without piercing encapsulation. The two new methods provide a minimal API surface for this. Required by the openclaw-plugin-weave.

## Test Plan

- [x] `Turn.setAttribute` writes to the underlying span (verified via in-memory exporter)
- [x] `Turn.setAttribute` returns `this`
- [x] `Turn.setAttribute` is a no-op after `end()`
- [x] `Turn.addEvent` writes a named event with attributes
- [x] `Turn.addEvent` returns `this`
- [x] `Turn.addEvent` is a no-op after `end()`
- [x] Full genai test suite (Turn/Session/LLM/Tool/SubAgent): 245/245 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)