### PR TITLE
feat(weave): add exports audit table migration

### DIFF
--- a/weave/trace_server/migrations/032_add_exports.down.sql
+++ b/weave/trace_server/migrations/032_add_exports.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS exports;

--- a/weave/trace_server/migrations/032_add_exports.up.sql
+++ b/weave/trace_server/migrations/032_add_exports.up.sql
@@ -1,0 +1,20 @@
+-- Bulk export audit log. Append-only. One EXPORT_START row per
+-- POST /export/start and one EXPORT_MINT row per successful
+-- GET /export/{job_id} URL mint. In-flight query state lives in
+-- system.query_log and is never duplicated here.
+CREATE TABLE IF NOT EXISTS exports (
+    request_id      UUID,
+    action          LowCardinality(String),
+    project_id      String,
+    job_id          UUID,
+    requested_by    String,
+    minted_by       String DEFAULT '',
+    table_name      LowCardinality(String),
+    request_json    String DEFAULT '',
+    output_uri      String DEFAULT '',
+    ts              DateTime64(3)
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(ts)
+ORDER BY (project_id, job_id, action, ts)
+TTL toDateTime(ts) + INTERVAL 7 YEAR;


### PR DESCRIPTION
## Summary
- Adds `exports` append-only MergeTree (request_id, action, project_id, job_id, requested_by, minted_by, table_name, request_json, output_uri, ts), 7-year TTL.
- One `EXPORT_START` row per `POST /export/start`; one `EXPORT_MINT` row per successful `GET`. Mid-flight query state stays in `system.query_log`, not here.
- Spec: `~/Desktop/specs/weave-bulk-export.md` "Control plane".

## Testing
covered by existing `test_all_production_migrations_*` / `test_all_production_down_migrations_*` (auto-discovers latest migration).