### PR TITLE
feat(weave): bulk export module (tier 1)

### DIFF
--- a/tests/trace_server/export/README.md
+++ b/tests/trace_server/export/README.md
@@ -1,0 +1,69 @@
+# Export module tests
+
+Two layers of tests live here:
+
+| File | What it covers | Needs Docker? |
+|---|---|---|
+| `test_engine.py`, `test_sql_builders.py`, `test_escaping.py`, `test_state.py`, `test_table_registry.py`, `test_sweeper.py`, `test_costs_sql.py` | Orchestration logic against a fake CH client (`_FakeClient`) | No |
+| `test_export_integration.py` | End-to-end through a real ClickHouse + MinIO stack | Yes |
+
+## Running the end-to-end test locally
+
+The integration test is skipped unless `EXPORT_E2E=1` is set. It expects a
+ClickHouse + MinIO docker-compose stack to be running. Ports are offset
+from the `.tilt/*` dev compose files so you can run this alongside Tilt
+without conflicts.
+
+```bash
+# 1. Bring up the e2e stack (CH on localhost:8224, MinIO on localhost:9200)
+docker compose -f services/weave-python/weave-public/tests/trace_server/export/docker-compose.export-e2e.yml up -d
+
+# 2. Install pyarrow (required for Parquet schema validation)
+cd services/weave-python/weave-public
+uv pip install pyarrow
+
+# 3. Run the test
+EXPORT_E2E=1 uv run --group test python -m pytest \
+    tests/trace_server/export/test_export_integration.py -v
+
+# 4. Tear down when done
+docker compose -f services/weave-python/weave-public/tests/trace_server/export/docker-compose.export-e2e.yml down -v
+```
+
+### What it actually exercises
+
+- `POST /export/start` submits a detached `INSERT INTO FUNCTION s3(...)` against
+  MinIO via a temporary `CREATE NAMED COLLECTION` carrying STS credentials.
+- The fixture mints **real** temporary credentials via MinIO's STS
+  `AssumeRole` (MinIO rejects requests with a `session_token` that doesn't
+  match a live STS session, so a dummy token won't fly).
+- `GET /export/{job_id}` polls `system.query_log` until the query terminates,
+  then mints a presigned URL via `PresignedUrlMinter` targeted at the local
+  MinIO (the fixture exports `AWS_ENDPOINT_URL_S3` so boto3 picks it up).
+- The test downloads the presigned URL, cross-checks the bytes against a
+  direct MinIO `head_object`, and (via `pyarrow.parquet`) validates the
+  Parquet row count and column shape.
+- A second test confirms the `source_project_id` defense-in-depth check
+  rejects a request whose project_id does not match the resolver's target.
+
+### Important config caveats
+
+- **CH version pinned to 25.12**, not the 26.2 that the rest of the repo
+  runs against. CH 26.2 changed `named_collection_control` behavior in a
+  way that blocks the engine's `CREATE NAMED COLLECTION` even with
+  `access_management=1`. Once the upstream change is reproducible in
+  production the pin can move; until then, 25.12 is the version this test
+  has been validated against.
+- The `zz-access.xml` config filename is deliberate. The CH entrypoint
+  generates `default-user.xml` with `<default remove="remove">` which
+  wipes the existing default user, then recreates it without
+  `named_collection_control`. XML user-config files are merged in
+  alphabetical order, so the override needs a name that sorts AFTER
+  `default-user.xml` for its settings to survive.
+
+### Why this doesn't depend on the migration PR
+
+The `exports` audit table is created inline by the test fixture (matching
+the migration in `weave/trace_server/migrations/`). This keeps the
+integration test independent of merge order between the module branch and
+the migration branch.

--- a/tests/trace_server/export/clickhouse-config/users.d/zz-access.xml
+++ b/tests/trace_server/export/clickhouse-config/users.d/zz-access.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<!--
+  E2E test config. Grants the `default` user the full set of NAMED
+  COLLECTION + s3() function permissions the bulk-export engine needs at
+  runtime. Mirrors what the production trace-server CH role is granted.
+-->
+<clickhouse>
+    <users>
+        <default>
+            <access_management>1</access_management>
+            <named_collection_control>1</named_collection_control>
+            <show_named_collections>1</show_named_collections>
+            <show_named_collections_secrets>1</show_named_collections_secrets>
+        </default>
+    </users>
+</clickhouse>

--- a/tests/trace_server/export/docker-compose.export-e2e.yml
+++ b/tests/trace_server/export/docker-compose.export-e2e.yml
@@ -1,0 +1,71 @@
+# End-to-end stack for the bulk-export integration test.
+#
+# Ports are deliberately offset from the .tilt/* dev compose files so this
+# stack can run alongside Tilt without colliding. The test connects via the
+# `localhost:<host-port>` mappings below; ClickHouse reaches MinIO over the
+# internal docker network at `minio:9000`.
+#
+# Bring up:
+#   docker compose -f services/weave-python/weave-public/tests/trace_server/export/docker-compose.export-e2e.yml up -d
+#
+# Tear down:
+#   docker compose -f services/weave-python/weave-public/tests/trace_server/export/docker-compose.export-e2e.yml down -v
+
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server:25.12
+    container_name: weave-export-e2e-ch
+    ports:
+      - "8224:8123"  # HTTP
+      - "9224:9000"  # native TCP
+    volumes:
+      # `:ro` would block the entrypoint's default-user.xml writeback; the
+      # mount is read/write but the file we ship is never edited.
+      # Filename must sort AFTER `default-user.xml` (entrypoint-generated)
+      # so its merge wins and `named_collection_control` survives the
+      # entrypoint's `<default remove="remove">` reset.
+      - ./clickhouse-config/users.d/zz-access.xml:/etc/clickhouse-server/users.d/zz-access.xml
+    environment:
+      - CLICKHOUSE_DB=default
+      - CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    networks:
+      - export-e2e
+
+  minio:
+    image: minio/minio
+    container_name: weave-export-e2e-minio
+    ports:
+      - "9200:9000"  # S3 API
+      - "9201:9001"  # console
+    environment:
+      - MINIO_ROOT_USER=weave-e2e
+      - MINIO_ROOT_PASSWORD=weave-e2e-secret
+    command: server /data --console-address ":9001"
+    networks:
+      - export-e2e
+
+  minio-init:
+    image: minio/mc
+    depends_on:
+      - minio
+    environment:
+      - MINIO_ROOT_USER=weave-e2e
+      - MINIO_ROOT_PASSWORD=weave-e2e-secret
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        until mc alias set local http://minio:9000 weave-e2e weave-e2e-secret; do
+          echo "waiting for minio..."; sleep 1;
+        done
+        mc mb -p local/weave-export-e2e || true
+        echo "bucket weave-export-e2e ready"
+    networks:
+      - export-e2e
+
+networks:
+  export-e2e:

--- a/tests/trace_server/export/test_engine.py
+++ b/tests/trace_server/export/test_engine.py
@@ -1,0 +1,266 @@
+"""Engine-level behavior.
+
+Uses a fake CH client driven by a script (one stub return per CH call) so
+the tests are deterministic and don't require a live ClickHouse. Real-CH
+integration coverage lives in `tests/trace_server_migrator/` and (when
+spun up) the export integration shard.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+from uuid import UUID
+
+import pytest
+from pydantic import SecretStr
+
+from weave.trace_server.byob.resolver import (
+    BYOBResolver,
+    ExportStorageCredentials,
+    ResolvedExportTarget,
+    StorageResolutionError,
+)
+from weave.trace_server.export import constants
+from weave.trace_server.export.engine import (
+    ConcurrentExportLimitError,
+    ExportEngine,
+    ExportTooLargeError,
+    RequestTooLargeError,
+)
+from weave.trace_server.export.schemas import ExportStartReq
+
+PROJECT = "UHJvajEyMw=="
+
+
+def _make_target(project_id: str = PROJECT) -> ResolvedExportTarget:
+    return ResolvedExportTarget(
+        bucket_uri="s3://team-bucket",
+        bucket_name="team-bucket",
+        region="us-west-2",
+        credentials=ExportStorageCredentials(
+            access_key_id="AKIAIOSFODNN7EXAMPLE",
+            secret_access_key=SecretStr("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+            session_token=SecretStr("FQoGZXIvYXdzEPL"),
+        ),
+        source_project_id=project_id,
+    )
+
+
+class _FakeResolver(BYOBResolver):
+    """Engine-only fake: only `resolve_export_target` is exercised here.
+
+    The file-storage methods (`resolve_write`, `resolve_read`) are
+    irrelevant to the export path; they raise to make accidental use
+    visible.
+    """
+
+    def __init__(self, target: ResolvedExportTarget | None = None) -> None:
+        self._target = target
+        self.calls: list[str] = []
+
+    def resolve_write(self, project_id, default_client):  # pragma: no cover
+        raise AssertionError("export engine must not call resolve_write")
+
+    def resolve_read(self, project_id, stored_uri, default_client):  # pragma: no cover
+        raise AssertionError("export engine must not call resolve_read")
+
+    def resolve_export_target(self, project_id: str) -> ResolvedExportTarget:
+        self.calls.append(project_id)
+        if self._target is None:
+            raise StorageResolutionError("no bucket configured")
+        return self._target
+
+
+@dataclass
+class _QueryResult:
+    """Mirrors the slice of clickhouse_connect.QueryResult the engine uses."""
+
+    result_rows: list[tuple[Any, ...]]
+
+
+class _FakeClient:
+    """Drives `query`/`command` from a per-test script.
+
+    Each `query()` call pops one row-set from `query_returns`; each
+    `command()` and `insert()` call appends to `commands` / `inserts` for
+    later assertions.
+    """
+
+    def __init__(self) -> None:
+        self.query_returns: list[list[tuple[Any, ...]]] = []
+        self.commands: list[tuple[str, dict[str, Any] | None]] = []
+        self.inserts: list[tuple[str, list[tuple[object, ...]], list[str]]] = []
+
+    def query(self, sql: str, parameters: dict[str, Any] | None = None) -> _QueryResult:
+        rows = self.query_returns.pop(0)
+        return _QueryResult(result_rows=rows)
+
+    def command(self, cmd: str, *, parameters=None, settings=None) -> None:
+        self.commands.append((cmd, settings))
+
+    def insert(
+        self, table: str, rows: list[tuple[object, ...]], *, column_names: list[str]
+    ) -> None:
+        self.inserts.append((table, rows, column_names))
+
+
+@pytest.fixture
+def fake_now(monkeypatch: pytest.MonkeyPatch) -> datetime:
+    now = datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc)
+    return now
+
+
+def _build_engine(client: _FakeClient, resolver: BYOBResolver) -> ExportEngine:
+    return ExportEngine(client, resolver, env="test")
+
+
+def test_start_happy_path_submits_create_then_insert_and_audits() -> None:
+    client = _FakeClient()
+    # concurrent count -> 0; preflight count -> 100.
+    client.query_returns = [[(0,)], [(100,)]]
+    resolver = _FakeResolver(_make_target())
+
+    e = _build_engine(client, resolver)
+    res = e.start(
+        ExportStartReq(project_id=PROJECT, table="calls_complete"),
+        requested_by="user-a",
+    )
+
+    assert isinstance(res.job_id, UUID)
+    # commands fired: DROP -> CREATE -> INSERT
+    cmd_texts = [c[0] for c in client.commands]
+    assert any("DROP NAMED COLLECTION" in c for c in cmd_texts)
+    assert any("CREATE NAMED COLLECTION" in c for c in cmd_texts)
+    assert any("INSERT INTO FUNCTION s3" in c for c in cmd_texts)
+    # CREATE+DROP suppressed from query_log via settings
+    for cmd, settings in client.commands:
+        if "NAMED COLLECTION" in cmd:
+            assert settings == {"log_queries": "0"}
+        if cmd.startswith("INSERT"):
+            assert settings is not None
+            assert settings["query_id"] == str(res.job_id)
+            assert settings["wait_end_of_query"] == "0"
+    # one audit row written
+    assert len(client.inserts) == 1
+    table_name, rows, cols = client.inserts[0]
+    assert table_name == "exports"
+    assert "action" in cols
+    inserted_action = rows[0][cols.index("action")]
+    assert inserted_action == "EXPORT_START"
+
+
+def test_no_storage_target_propagates_resolution_error() -> None:
+    client = _FakeClient()
+    client.query_returns = [[(0,)], [(100,)]]
+    resolver = _FakeResolver(target=None)
+
+    e = _build_engine(client, resolver)
+    with pytest.raises(StorageResolutionError):
+        e.start(
+            ExportStartReq(project_id=PROJECT, table="calls_complete"),
+            requested_by="user-a",
+        )
+    # no NC was created, no audit row written
+    assert client.commands == []
+    assert client.inserts == []
+
+
+def test_too_large_raises_before_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(constants, "PHASE_2_PARTITION_ROW_THRESHOLD", 10)
+    client = _FakeClient()
+    client.query_returns = [[(0,)], [(11,)]]
+    resolver = _FakeResolver(_make_target())
+
+    e = _build_engine(client, resolver)
+    with pytest.raises(ExportTooLargeError) as exc_info:
+        e.start(
+            ExportStartReq(project_id=PROJECT, table="calls_complete"),
+            requested_by="user-a",
+        )
+    assert exc_info.value.row_count == 11
+    assert resolver.calls == []  # never reached the resolver
+    assert client.inserts == []
+
+
+def test_concurrent_cap_enforced(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(constants, "MAX_CONCURRENT_EXPORTS_PER_PROJECT", 1)
+    client = _FakeClient()
+    client.query_returns = [[(1,)]]  # in-flight count already at the cap
+    resolver = _FakeResolver(_make_target())
+
+    e = _build_engine(client, resolver)
+    with pytest.raises(ConcurrentExportLimitError):
+        e.start(
+            ExportStartReq(project_id=PROJECT, table="calls_complete"),
+            requested_by="user-a",
+        )
+    assert client.commands == []
+    assert client.inserts == []
+
+
+def test_oversized_request_json_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(constants, "MAX_REQUEST_JSON_BYTES", 4)
+    client = _FakeClient()
+    resolver = _FakeResolver(_make_target())
+
+    e = _build_engine(client, resolver)
+    with pytest.raises(RequestTooLargeError):
+        e.start(
+            ExportStartReq(project_id=PROJECT, table="calls_complete"),
+            requested_by="user-a",
+        )
+    # request size guard fires before any CH interaction
+    assert client.commands == []
+    assert client.inserts == []
+    assert client.query_returns == []
+
+
+class _RaisingOnInsertClient(_FakeClient):
+    """Fake CH client whose first INSERT raises mid-submission."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._first_insert = True
+
+    def command(self, cmd: str, *, parameters=None, settings=None) -> None:
+        if cmd.startswith("INSERT") and self._first_insert:
+            self._first_insert = False
+            super().command(cmd, parameters=parameters, settings=settings)
+            raise RuntimeError("ch unavailable")
+        super().command(cmd, parameters=parameters, settings=settings)
+
+
+def test_insert_failure_drops_named_collection_on_failure() -> None:
+    """Submit failure must DROP the NC so plaintext STS creds don't linger."""
+    client = _RaisingOnInsertClient()
+    client.query_returns = [[(0,)], [(50,)]]
+    resolver = _FakeResolver(_make_target())
+
+    e = _build_engine(client, resolver)
+    with pytest.raises(RuntimeError, match="ch unavailable"):
+        e.start(
+            ExportStartReq(project_id=PROJECT, table="calls_complete"),
+            requested_by="user-a",
+        )
+
+    drops = [c for c, _ in client.commands if c.startswith("DROP NAMED COLLECTION")]
+    assert len(drops) == 2, drops  # DROP at start + DROP in cleanup
+
+
+@pytest.mark.disable_logging_error_check
+def test_resolver_target_mismatch_refuses_to_proceed() -> None:
+    """Defense-in-depth: target.source_project_id must match request."""
+    client = _FakeClient()
+    client.query_returns = [[(0,)], [(50,)]]
+    # Resolver returns a target keyed to a DIFFERENT project_id.
+    resolver = _FakeResolver(_make_target(project_id="OTHER_PROJECT"))
+
+    e = _build_engine(client, resolver)
+    with pytest.raises(StorageResolutionError, match="does not match"):
+        e.start(
+            ExportStartReq(project_id=PROJECT, table="calls_complete"),
+            requested_by="user-a",
+        )
+    # No NC created, no audit row written.
+    assert client.commands == []
+    assert client.inserts == []

--- a/tests/trace_server/export/test_escaping.py
+++ b/tests/trace_server/export/test_escaping.py
@@ -1,0 +1,130 @@
+"""The escaping helper is the only place credentials touch a string literal.
+
+Every adversarial input the spec calls out (single-quote injection,
+backslash, semicolon, ANSI control char, percent-encoded forms) must
+raise; a passing test should NEVER emit a CREATE NAMED COLLECTION body
+that round-trips the bad input.
+"""
+
+import uuid
+
+import pytest
+
+from weave.trace_server.export.escaping import (
+    InvalidCredentialCharError,
+    build_create_named_collection_sql,
+    build_drop_named_collection_sql,
+    named_collection_name,
+)
+
+VALID_AKID = "AKIAIOSFODNN7EXAMPLE"
+VALID_SAK = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+VALID_STOK = "FQoGZXIvYXdzEPL//////////wEaDM=="
+VALID_URL = "s3://team-bucket/prod/exports/UHJvajEyMw==/abc123/data.parquet"
+
+
+def _new_job() -> uuid.UUID:
+    return uuid.UUID("11111111-2222-3333-4444-555555555555")
+
+
+class TestValid:
+    def test_collection_name_uses_uuid_hex(self) -> None:
+        nc = named_collection_name(_new_job())
+        assert nc.startswith("export_")
+        assert "-" not in nc
+        assert len(nc) == len("export_") + 32
+
+    def test_create_body_round_trips_valid_inputs(self) -> None:
+        sql = build_create_named_collection_sql(
+            job_id=_new_job(),
+            access_key_id=VALID_AKID,
+            secret_access_key=VALID_SAK,
+            session_token=VALID_STOK,
+            dest_url=VALID_URL,
+        )
+        assert sql.startswith("CREATE NAMED COLLECTION export_")
+        assert f"access_key_id = '{VALID_AKID}'" in sql
+        assert f"secret_access_key = '{VALID_SAK}'" in sql
+        assert f"session_token = '{VALID_STOK}'" in sql
+        assert f"url = '{VALID_URL}'" in sql
+
+    def test_drop_body_references_same_collection(self) -> None:
+        job = _new_job()
+        create = build_create_named_collection_sql(
+            job_id=job,
+            access_key_id=VALID_AKID,
+            secret_access_key=VALID_SAK,
+            session_token=VALID_STOK,
+            dest_url=VALID_URL,
+        )
+        drop = build_drop_named_collection_sql(job)
+        assert named_collection_name(job) in create
+        assert named_collection_name(job) in drop
+
+
+class TestRejection:
+    @pytest.mark.parametrize(
+        ("field", "bad_value"),
+        [
+            ("access_key_id", "AKIA'or'1=1"),
+            ("access_key_id", "AKIA\\nDROP"),
+            ("access_key_id", "AKIA OR 1=1"),
+            ("access_key_id", "AKIA;DROP"),
+            ("access_key_id", "AKIA\x00"),
+            ("access_key_id", ""),
+            ("secret_access_key", "key'--"),
+            ("secret_access_key", "key extra"),  # non-breaking space
+            ("session_token", "tok\nnew"),
+            ("session_token", "tok\rnew"),
+            ("session_token", "tok\t"),
+            ("session_token", "tok#"),
+        ],
+    )
+    def test_credential_chars(self, field: str, bad_value: str) -> None:
+        kwargs = {
+            "access_key_id": VALID_AKID,
+            "secret_access_key": VALID_SAK,
+            "session_token": VALID_STOK,
+        }
+        kwargs[field] = bad_value
+        with pytest.raises(InvalidCredentialCharError):
+            build_create_named_collection_sql(
+                job_id=_new_job(),
+                dest_url=VALID_URL,
+                **kwargs,
+            )
+
+    @pytest.mark.parametrize(
+        "bad_url",
+        [
+            "",
+            "s3://bucket/with'quote",
+            "s3://bucket/with space",
+            "s3://bucket/with\nnewline",
+            "s3://bucket/with;semi",
+            "s3://bucket/with#hash",
+            "s3://bucket/with\\backslash",
+        ],
+    )
+    def test_dest_url(self, bad_url: str) -> None:
+        with pytest.raises(InvalidCredentialCharError):
+            build_create_named_collection_sql(
+                job_id=_new_job(),
+                access_key_id=VALID_AKID,
+                secret_access_key=VALID_SAK,
+                session_token=VALID_STOK,
+                dest_url=bad_url,
+            )
+
+
+def test_quote_injection_never_emits_bad_sql() -> None:
+    """End-to-end: any rejected input MUST raise; never silently emit bad SQL."""
+    payload = "AKIA' OR '1'='1"
+    with pytest.raises(InvalidCredentialCharError):
+        build_create_named_collection_sql(
+            job_id=_new_job(),
+            access_key_id=payload,
+            secret_access_key=VALID_SAK,
+            session_token=VALID_STOK,
+            dest_url=VALID_URL,
+        )

--- a/tests/trace_server/export/test_export_integration.py
+++ b/tests/trace_server/export/test_export_integration.py
@@ -1,0 +1,382 @@
+"""End-to-end integration test for the bulk-export flow.
+
+Runs against a real ClickHouse + MinIO stack brought up by the sibling
+`docker-compose.export-e2e.yml`. Exercises the full path: `POST /export/start`
+submits a detached `INSERT INTO FUNCTION s3()` against MinIO, `GET
+/export/{job_id}` derives state from `system.query_log`, mints a presigned
+URL, and the test downloads the file and validates the Parquet content.
+
+Skipped by default. To run:
+
+    docker compose -f tests/trace_server/export/docker-compose.export-e2e.yml up -d
+    EXPORT_E2E=1 uv run --group test python -m pytest \
+        tests/trace_server/export/test_export_integration.py -v
+
+`AWS_ENDPOINT_URL_S3` is set automatically by the fixture so boto3's
+presigned-URL minter (`PresignedUrlMinter`) targets the local MinIO instead
+of real AWS S3. ClickHouse reaches MinIO via the in-network hostname
+`minio:9000`; the test reaches it via `localhost:9100`.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import time
+import uuid
+from collections.abc import Iterator
+from datetime import datetime, timezone
+
+import boto3
+import clickhouse_connect
+import httpx
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from weave.trace_server.byob.resolver import (
+    BYOBResolver,
+    ExportStorageCredentials,
+    ResolvedExportTarget,
+    StorageResolutionError,
+)
+from weave.trace_server.export import (
+    ExportEngine,
+    lookup_export_start,
+    register_export_routes,
+)
+
+# Skip the module entirely when not asked to run e2e. Importing pytest's
+# skip at module scope means the test is collected but never executed.
+if os.environ.get("EXPORT_E2E") != "1":
+    pytest.skip(
+        "EXPORT_E2E=1 not set; skipping end-to-end export tests "
+        "(see tests/trace_server/export/README.md to run them).",
+        allow_module_level=True,
+    )
+
+CH_HTTP_HOST = "localhost"
+CH_HTTP_PORT = 8224
+MINIO_HOST = "localhost"
+MINIO_PORT = 9200
+MINIO_INTERNAL_URL = "http://minio:9000"
+MINIO_ACCESS_KEY = "weave-e2e"
+MINIO_SECRET_KEY = "weave-e2e-secret"
+MINIO_REGION = "us-east-1"
+BUCKET_NAME = "weave-export-e2e"
+PROJECT_ID = "UHJvajEyMw=="
+TEST_DB = "weave_export_e2e"
+POLL_TIMEOUT_SECONDS = 60
+POLL_INTERVAL_SECONDS = 1
+
+
+class _StaticResolver(BYOBResolver):
+    """Returns the same MinIO-backed target for every project_id.
+
+    File-storage methods raise so accidental use shows up as a test failure
+    rather than silently routing somewhere unexpected.
+    """
+
+    def __init__(self, target: ResolvedExportTarget) -> None:
+        self._target = target
+
+    def resolve_write(self, project_id, default_client):  # pragma: no cover
+        raise AssertionError("export engine must not call resolve_write")
+
+    def resolve_read(self, project_id, stored_uri, default_client):  # pragma: no cover
+        raise AssertionError("export engine must not call resolve_read")
+
+    def resolve_export_target(self, project_id: str) -> ResolvedExportTarget:
+        if project_id != self._target.source_project_id:
+            raise StorageResolutionError(
+                f"no target for project_id={project_id}; "
+                f"resolver only knows {self._target.source_project_id}"
+            )
+        return self._target
+
+
+def _mint_minio_sts_creds() -> tuple[str, str, str]:
+    """Call MinIO's STS AssumeRole to get real temporary credentials.
+
+    MinIO validates `session_token` for every authenticated request; passing
+    a dummy token alongside the root credentials fails with `InvalidTokenId`.
+    Minting real STS creds mirrors what the production BYOB resolver does
+    via AWS STS.
+    """
+    sts = boto3.client(
+        "sts",
+        endpoint_url=f"http://{MINIO_HOST}:{MINIO_PORT}",
+        aws_access_key_id=MINIO_ACCESS_KEY,
+        aws_secret_access_key=MINIO_SECRET_KEY,
+        region_name=MINIO_REGION,
+    )
+    response = sts.assume_role(
+        RoleArn="arn:minio:bf:::role/weave-e2e",
+        RoleSessionName="weave-e2e-session",
+        DurationSeconds=3600,
+    )
+    creds = response["Credentials"]
+    return creds["AccessKeyId"], creds["SecretAccessKey"], creds["SessionToken"]
+
+
+def _make_target(project_id: str) -> ResolvedExportTarget:
+    access_key, secret_key, session_token = _mint_minio_sts_creds()
+    return ResolvedExportTarget(
+        bucket_uri=f"{MINIO_INTERNAL_URL}/{BUCKET_NAME}",
+        bucket_name=BUCKET_NAME,
+        region=MINIO_REGION,
+        credentials=ExportStorageCredentials(
+            access_key_id=access_key,
+            secret_access_key=SecretStr(secret_key),
+            session_token=SecretStr(session_token),
+        ),
+        source_project_id=project_id,
+    )
+
+
+@pytest.fixture(scope="module")
+def ch_client():
+    """ClickHouse client against the e2e container; creates a fresh DB."""
+    client = clickhouse_connect.get_client(
+        host=CH_HTTP_HOST,
+        port=CH_HTTP_PORT,
+        username="default",
+        password="",
+    )
+    try:
+        client.ping()
+    except Exception as exc:
+        pytest.skip(
+            f"ClickHouse e2e container is not reachable at "
+            f"{CH_HTTP_HOST}:{CH_HTTP_PORT} ({exc}). "
+            "Bring it up with `docker compose -f docker-compose.export-e2e.yml up -d`."
+        )
+    client.command(f"DROP DATABASE IF EXISTS {TEST_DB}")
+    client.command(f"CREATE DATABASE {TEST_DB}")
+    client.database = TEST_DB
+    _create_exports_table(client)
+    _create_calls_complete_table(client)
+    yield client
+    try:
+        client.command(f"DROP DATABASE IF EXISTS {TEST_DB}")
+    finally:
+        client.close()
+
+
+def _create_exports_table(client) -> None:
+    """Inline copy of the `exports` audit-table migration so this test does
+    not depend on the migration PR landing first.
+    """
+    client.command(
+        """
+        CREATE TABLE IF NOT EXISTS exports (
+            request_id    UUID,
+            action        LowCardinality(String),
+            project_id    String,
+            job_id        UUID,
+            requested_by  String,
+            minted_by     String DEFAULT '',
+            table_name    LowCardinality(String),
+            request_json  String DEFAULT '',
+            output_uri    String DEFAULT '',
+            ts            DateTime64(3)
+        )
+        ENGINE = MergeTree
+        PARTITION BY toYYYYMM(ts)
+        ORDER BY (project_id, job_id, action, ts)
+        """
+    )
+
+
+def _create_calls_complete_table(client) -> None:
+    """Minimal `calls_complete`-shaped table sufficient for the export
+    `SELECT *` path. The real production table has many more columns; the
+    export module only requires `project_id`, `started_at`, and any other
+    columns present on the row to flow through to Parquet.
+    """
+    client.command(
+        """
+        CREATE TABLE IF NOT EXISTS calls_complete (
+            project_id    String,
+            id            String,
+            trace_id      String,
+            started_at    DateTime64(3),
+            ended_at      DateTime64(3),
+            op_name       String,
+            summary_dump  String DEFAULT '{}'
+        )
+        ENGINE = MergeTree
+        ORDER BY (project_id, started_at)
+        """
+    )
+
+
+@pytest.fixture(scope="module")
+def s3_client(ch_client):
+    """boto3 S3 client targeted at the local MinIO; ensures bucket exists."""
+    client = boto3.client(
+        "s3",
+        endpoint_url=f"http://{MINIO_HOST}:{MINIO_PORT}",
+        aws_access_key_id=MINIO_ACCESS_KEY,
+        aws_secret_access_key=MINIO_SECRET_KEY,
+        region_name=MINIO_REGION,
+    )
+    try:
+        client.head_bucket(Bucket=BUCKET_NAME)
+    except Exception:
+        client.create_bucket(Bucket=BUCKET_NAME)
+    return client
+
+
+@pytest.fixture(scope="module")
+def app(ch_client) -> Iterator[FastAPI]:
+    """FastAPI app wired with the export routes and a static MinIO resolver.
+
+    `AWS_ENDPOINT_URL_S3` is exported here so `PresignedUrlMinter`'s boto3
+    client picks up the MinIO endpoint without needing a PresignedUrlMinter
+    code change.
+    """
+    target = _make_target(PROJECT_ID)
+    resolver = _StaticResolver(target)
+    engine = ExportEngine(ch_client, resolver, env="dev")
+
+    previous = os.environ.get("AWS_ENDPOINT_URL_S3")
+    os.environ["AWS_ENDPOINT_URL_S3"] = f"http://{MINIO_HOST}:{MINIO_PORT}"
+
+    router = APIRouter()
+
+    register_export_routes(
+        router,
+        get_engine=lambda auth: engine,
+        get_auth_params=lambda req: None,
+        require_project_read=lambda project_id, auth: None,
+        require_export_flag=lambda project_id, auth: None,
+        get_requester=lambda auth: "e2e-tester",
+        lookup_job_row=lambda job_id: lookup_export_start(ch_client, job_id),
+    )
+    application = FastAPI()
+    application.include_router(router)
+    try:
+        yield application
+    finally:
+        if previous is None:
+            os.environ.pop("AWS_ENDPOINT_URL_S3", None)
+        else:
+            os.environ["AWS_ENDPOINT_URL_S3"] = previous
+
+
+@pytest.fixture
+def seeded_calls(ch_client):
+    """Inserts 5 known `calls_complete` rows for `PROJECT_ID` and clears
+    them after the test.
+    """
+    now = datetime.now(timezone.utc)
+    rows = [
+        (
+            PROJECT_ID,
+            f"call-{i}",
+            f"trace-{i}",
+            now,
+            now,
+            f"op-{i}",
+            '{"usage": {}}',
+        )
+        for i in range(5)
+    ]
+    ch_client.insert(
+        "calls_complete",
+        rows,
+        column_names=[
+            "project_id",
+            "id",
+            "trace_id",
+            "started_at",
+            "ended_at",
+            "op_name",
+            "summary_dump",
+        ],
+    )
+    yield 5
+    ch_client.command(
+        "ALTER TABLE calls_complete DELETE WHERE project_id = {p:String}",
+        parameters={"p": PROJECT_ID},
+    )
+
+
+def _poll_until_terminal(client: TestClient, job_id: str) -> dict:
+    """Poll `GET /export/{job_id}` until the state leaves PENDING/RUNNING."""
+    deadline = time.time() + POLL_TIMEOUT_SECONDS
+    last_body: dict = {}
+    while time.time() < deadline:
+        response = client.get(f"/export/{job_id}")
+        assert response.status_code == 200, response.text
+        last_body = response.json()
+        if last_body["state"] not in {"pending", "running"}:
+            return last_body
+        time.sleep(POLL_INTERVAL_SECONDS)
+    pytest.fail(
+        f"export job {job_id} did not leave PENDING/RUNNING within "
+        f"{POLL_TIMEOUT_SECONDS}s; last body: {last_body}"
+    )
+
+
+def test_tier_1_export_writes_parquet_and_mints_signed_url(
+    app: FastAPI, s3_client, seeded_calls: int
+) -> None:
+    """Full happy-path: submit, poll, download, validate.
+
+    Asserts that:
+      1. POST /export/start returns 200 with a job_id.
+      2. The detached CH INSERT actually writes a Parquet object to MinIO
+         under the expected key layout.
+      3. GET /export/{job_id} eventually reaches SUCCEEDED and includes a
+         signed URL that downloads the same bytes MinIO stored.
+      4. (If pyarrow is installed) the Parquet row count matches the seed.
+    """
+    client = TestClient(app)
+    start_response = client.post(
+        "/export/start",
+        json={"project_id": PROJECT_ID, "table": "calls_complete"},
+    )
+    assert start_response.status_code == 200, start_response.text
+    job_id = start_response.json()["job_id"]
+
+    final = _poll_until_terminal(client, job_id)
+    assert final["state"] == "succeeded", final
+
+    signed_url = final["signed_url"]
+    assert signed_url, final
+    # boto3 presigns against AWS_ENDPOINT_URL_S3 (set in the fixture), so
+    # the URL host is localhost. Fetch and validate.
+    download = httpx.get(signed_url, timeout=10.0)
+    assert download.status_code == 200, download.text
+    body = download.content
+
+    # Direct MinIO read for a redundant sanity check that the object key
+    # the engine wrote matches what the minter signed.
+    expected_key = f"dev/exports/{PROJECT_ID}/{uuid.UUID(job_id).hex}/data.parquet"
+    head = s3_client.head_object(Bucket=BUCKET_NAME, Key=expected_key)
+    assert head["ContentLength"] == len(body)
+
+    # Optional schema validation when pyarrow is available. Skip silently
+    # if not installed; the structural checks above are the load-bearing
+    # part of the test.
+    pa_parquet = pytest.importorskip("pyarrow.parquet")
+    table = pa_parquet.read_table(io.BytesIO(body))
+    assert table.num_rows == seeded_calls
+    assert "project_id" in table.column_names
+    assert "started_at" in table.column_names
+
+
+def test_resolver_mismatch_refuses_to_proceed(app: FastAPI) -> None:
+    """Defense-in-depth: requesting a project the resolver does not own
+    must fail-closed with a 412 (no NC created, no audit row).
+    """
+    client = TestClient(app)
+    response = client.post(
+        "/export/start",
+        json={"project_id": "some-other-project", "table": "calls_complete"},
+    )
+    assert response.status_code == 412, response.text
+    assert response.json()["detail"]["code"] == "no_storage_target"

--- a/tests/trace_server/export/test_sql_builders.py
+++ b/tests/trace_server/export/test_sql_builders.py
@@ -1,0 +1,105 @@
+"""SQL builders: parameter shape, identifier safety, settings inlining."""
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from weave.trace_server.export import sql
+from weave.trace_server.export.constants import (
+    MAX_EXPORT_QUERY_SECONDS,
+    PARQUET_COMPRESSION,
+)
+
+JOB = uuid.UUID("11111111-2222-3333-4444-555555555555")
+
+
+class TestInsertSql:
+    def test_includes_project_id_param_only(self) -> None:
+        prepared = sql.build_export_insert_sql(
+            job_id=JOB, table="calls_complete", project_id="UHJvajEyMw=="
+        )
+        assert "{project_id:String}" in prepared.sql
+        assert prepared.params == {"project_id": "UHJvajEyMw=="}
+
+    def test_adds_time_predicates_when_range_present(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 2, 1, tzinfo=timezone.utc)
+        prepared = sql.build_export_insert_sql(
+            job_id=JOB,
+            table="calls_complete",
+            project_id="proj",
+            time_start=start,
+            time_end=end,
+        )
+        assert "{start_ts:DateTime64(3)}" in prepared.sql
+        assert "{end_ts:DateTime64(3)}" in prepared.sql
+        assert prepared.params["start_ts"] == start
+        assert prepared.params["end_ts"] == end
+
+    def test_uses_registry_identifiers_not_user_input(self) -> None:
+        # Identifier-injection attempt: user supplies a table name with a
+        # semicolon-suffix. The Literal[...] type constraint should already
+        # have rejected this upstream, but the builder must not pass it
+        # through either.
+        with pytest.raises(KeyError):
+            sql.build_export_insert_sql(
+                job_id=JOB,
+                table="calls_complete; DROP TABLE calls_complete; --",  # type: ignore[arg-type]
+                project_id="proj",
+            )
+
+    def test_settings_clause_inlines_constants(self) -> None:
+        prepared = sql.build_export_insert_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        assert f"max_execution_time = {MAX_EXPORT_QUERY_SECONDS}" in prepared.sql
+        assert (
+            f"output_format_parquet_compression_method = '{PARQUET_COMPRESSION}'"
+            in prepared.sql
+        )
+        assert "s3_truncate_on_insert = 1" in prepared.sql
+
+    def test_references_nc_by_name_not_credentials(self) -> None:
+        prepared = sql.build_export_insert_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        assert "access_key_id" not in prepared.sql
+        assert "secret_access_key" not in prepared.sql
+        assert "session_token" not in prepared.sql
+        assert JOB.hex in prepared.sql
+
+    @pytest.mark.parametrize("table", ["calls_complete", "calls_merged"])
+    def test_tier_1_tables_both_supported(self, table: str) -> None:
+        prepared = sql.build_export_insert_sql(
+            job_id=JOB,
+            table=table,
+            project_id="proj",  # type: ignore[arg-type]
+        )
+        assert f"FROM {table}" in prepared.sql
+
+
+class TestPreflightCountSql:
+    def test_count_returns_only_one_aggregation(self) -> None:
+        prepared = sql.build_preflight_count_sql(
+            table="calls_complete", project_id="proj"
+        )
+        assert "count()" in prepared.sql
+        assert "FROM calls_complete" in prepared.sql
+        assert prepared.params == {"project_id": "proj"}
+
+
+class TestQueryLogLookup:
+    def test_orders_by_event_time_descending(self) -> None:
+        prepared = sql.build_query_log_lookup_sql()
+        assert "ORDER BY event_time_microseconds DESC" in prepared.sql
+        assert "LIMIT 1" in prepared.sql
+        assert "{query_id:String}" in prepared.sql
+
+
+class TestOrphanNcScan:
+    def test_filters_to_export_prefix(self) -> None:
+        prepared = sql.build_orphan_nc_scan_sql()
+        assert "system.named_collections" in prepared.sql
+        assert "'export\\_%'" in prepared.sql
+        assert prepared.params == {}

--- a/tests/trace_server/export/test_state.py
+++ b/tests/trace_server/export/test_state.py
@@ -1,0 +1,164 @@
+"""Every `system.query_log.type` value the export module recognizes must
+map exactly once. Unknown values raise so CH version drift surfaces loudly
+instead of silently bucketing.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from weave.trace_server.export.constants import PENDING_GRACE_PERIOD
+from weave.trace_server.export.schemas import ExportErrorCode, ExportState
+from weave.trace_server.export.state import (
+    UnknownQueryLogTypeError,
+    derive_state_from_log,
+)
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 26, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _submitted_recently() -> datetime:
+    return _now() - timedelta(seconds=5)
+
+
+def _submitted_long_ago() -> datetime:
+    return _now() - PENDING_GRACE_PERIOD - timedelta(seconds=1)
+
+
+class TestKnownTypes:
+    def test_query_start_is_running(self) -> None:
+        state, err = derive_state_from_log(
+            log_type="QueryStart",
+            exception_code=0,
+            exception_text="",
+            submitted_at=_submitted_recently(),
+            now=_now(),
+        )
+        assert state is ExportState.RUNNING
+        assert err is None
+
+    def test_query_finish_zero_exception_is_succeeded(self) -> None:
+        state, err = derive_state_from_log(
+            log_type="QueryFinish",
+            exception_code=0,
+            exception_text="",
+            submitted_at=_submitted_recently(),
+            now=_now(),
+        )
+        assert state is ExportState.SUCCEEDED
+        assert err is None
+
+    @pytest.mark.parametrize("ch_code", [159, 160, 161])
+    def test_timeout_codes_map_to_timeout(self, ch_code: int) -> None:
+        state, err = derive_state_from_log(
+            log_type="QueryFinish",
+            exception_code=ch_code,
+            exception_text="Timeout exceeded",
+            submitted_at=_submitted_recently(),
+            now=_now(),
+        )
+        assert state is ExportState.FAILED
+        assert err is not None
+        assert err.code is ExportErrorCode.TIMEOUT
+
+    @pytest.mark.parametrize(
+        "exc_text",
+        [
+            "S3 error: AccessDenied",
+            "ExpiredToken",
+            "InvalidAccessKeyId",
+            "SignatureDoesNotMatch was found",
+        ],
+    )
+    def test_s3_auth_code_with_auth_substring_is_auth_revoked(
+        self, exc_text: str
+    ) -> None:
+        state, err = derive_state_from_log(
+            log_type="QueryFinish",
+            exception_code=499,
+            exception_text=exc_text,
+            submitted_at=_submitted_recently(),
+            now=_now(),
+        )
+        assert state is ExportState.FAILED
+        assert err is not None
+        assert err.code is ExportErrorCode.AUTH_REVOKED
+
+    def test_s3_error_unrelated_to_auth_falls_back_to_ch_exception(self) -> None:
+        state, err = derive_state_from_log(
+            log_type="QueryFinish",
+            exception_code=499,
+            exception_text="S3 error: SlowDown",
+            submitted_at=_submitted_recently(),
+            now=_now(),
+        )
+        assert state is ExportState.FAILED
+        assert err is not None
+        assert err.code is ExportErrorCode.CH_EXCEPTION
+
+    @pytest.mark.parametrize(
+        "log_type",
+        ["ExceptionBeforeStart", "ExceptionWhileProcessing"],
+    )
+    def test_terminal_failure_types_are_failed(self, log_type: str) -> None:
+        state, err = derive_state_from_log(
+            log_type=log_type,
+            exception_code=42,
+            exception_text="random",
+            submitted_at=_submitted_recently(),
+            now=_now(),
+        )
+        assert state is ExportState.FAILED
+        assert err is not None
+        assert err.code is ExportErrorCode.CH_EXCEPTION
+
+    def test_user_facing_error_never_echoes_raw_text(self) -> None:
+        secret_leak = "internal-host.cluster.local replica-3 row-data-here"
+        _state, err = derive_state_from_log(
+            log_type="ExceptionWhileProcessing",
+            exception_code=999,
+            exception_text=secret_leak,
+            submitted_at=_submitted_recently(),
+            now=_now(),
+        )
+        assert err is not None
+        assert secret_leak not in err.message
+
+
+class TestMissingRow:
+    def test_within_grace_window_is_pending(self) -> None:
+        state, err = derive_state_from_log(
+            log_type=None,
+            exception_code=0,
+            exception_text="",
+            submitted_at=_submitted_recently(),
+            now=_now(),
+        )
+        assert state is ExportState.PENDING
+        assert err is None
+
+    def test_past_grace_window_is_failed(self) -> None:
+        state, err = derive_state_from_log(
+            log_type=None,
+            exception_code=0,
+            exception_text="",
+            submitted_at=_submitted_long_ago(),
+            now=_now(),
+        )
+        assert state is ExportState.FAILED
+        assert err is not None
+        assert err.code is ExportErrorCode.CH_EXCEPTION
+
+
+class TestUnknown:
+    def test_unknown_type_raises(self) -> None:
+        with pytest.raises(UnknownQueryLogTypeError):
+            derive_state_from_log(
+                log_type="QueryRetried",  # not in the closed set
+                exception_code=0,
+                exception_text="",
+                submitted_at=_submitted_recently(),
+                now=_now(),
+            )

--- a/tests/trace_server/export/test_sweeper.py
+++ b/tests/trace_server/export/test_sweeper.py
@@ -1,0 +1,117 @@
+"""Sweeper drop-decision behavior.
+
+Drives `_should_drop` with a fake CH client whose query/command results are
+scripted per call. Covers the three branches: query_log row present and
+terminal, query_log missing but audit row past budget, audit row also
+missing entirely.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from uuid import UUID, uuid4
+
+from weave.trace_server.export import sweeper
+from weave.trace_server.export.constants import MAX_EXPORT_QUERY_SECONDS
+
+
+@dataclass
+class _QueryResult:
+    result_rows: list[tuple[Any, ...]]
+
+
+class _FakeClient:
+    """Scripts replies for `_should_drop` and `sweep_orphan_named_collections`.
+
+    `query_returns` queue is consumed in FIFO order across both the
+    `system.query_log` lookup AND the audit `exports` lookup that follows
+    when query_log returns no row.
+    """
+
+    def __init__(self) -> None:
+        self.query_returns: list[list[tuple[Any, ...]]] = []
+        self.commands: list[tuple[str, dict[str, Any] | None]] = []
+
+    def query(self, sql: str, parameters: dict[str, Any] | None = None) -> _QueryResult:
+        return _QueryResult(result_rows=self.query_returns.pop(0))
+
+    def command(self, cmd: str, *, parameters=None, settings=None) -> None:
+        self.commands.append((cmd, settings))
+
+
+def _job() -> UUID:
+    return uuid4()
+
+
+def test_should_drop_when_query_log_reports_terminal() -> None:
+    client = _FakeClient()
+    client.query_returns = [
+        [("QueryFinish", 0, "", 1000, 50_000)],  # query_log terminal-success row
+    ]
+    assert sweeper._should_drop(client, _job()) is True
+
+
+def test_should_not_drop_when_query_log_reports_running() -> None:
+    client = _FakeClient()
+    client.query_returns = [
+        [("QueryStart", 0, "", 0, 0)],  # still running
+    ]
+    assert sweeper._should_drop(client, _job()) is False
+
+
+def test_should_drop_when_audit_row_past_budget_and_query_log_missing() -> None:
+    """No query_log row, audit row older than MAX_EXPORT_QUERY_SECONDS + grace."""
+    client = _FakeClient()
+    submitted = datetime.now(timezone.utc) - timedelta(
+        seconds=MAX_EXPORT_QUERY_SECONDS + 600
+    )
+    client.query_returns = [
+        [],  # query_log: no row
+        [("p1", "user-a", "calls_complete", submitted)],  # audit lookup
+    ]
+    assert sweeper._should_drop(client, _job()) is True
+
+
+def test_should_not_drop_when_audit_row_inside_budget_and_query_log_missing() -> None:
+    """Recent audit submission, query_log not flushed yet: leave NC alone."""
+    client = _FakeClient()
+    submitted = datetime.now(timezone.utc) - timedelta(seconds=30)
+    client.query_returns = [
+        [],  # query_log: no row
+        [("p1", "user-a", "calls_complete", submitted)],
+    ]
+    assert sweeper._should_drop(client, _job()) is False
+
+
+def test_should_drop_when_query_log_and_audit_both_missing() -> None:
+    """Engine crashed between CREATE NC and audit write -> orphan NC."""
+    client = _FakeClient()
+    client.query_returns = [
+        [],  # query_log: no row
+        [],  # audit: no row
+    ]
+    assert sweeper._should_drop(client, _job()) is True
+
+
+def test_sweep_drops_terminal_nc_and_skips_unparseable_name() -> None:
+    """End-to-end sweep over a list of NCs from system.named_collections."""
+    client = _FakeClient()
+    nc_terminal = "export_" + uuid4().hex
+    nc_garbage = "export_not-a-uuid"
+    client.query_returns = [
+        [(nc_terminal,), (nc_garbage,)],  # scan result
+        [("QueryFinish", 0, "", 1000, 50_000)],  # terminal NC's query_log row
+    ]
+    dropped = sweeper.sweep_orphan_named_collections(client)
+    assert dropped == 1
+    drop_cmds = [c for c, _ in client.commands if c.startswith("DROP NAMED COLLECTION")]
+    assert len(drop_cmds) == 1
+    assert nc_terminal.split("_", 1)[1] in drop_cmds[0]
+
+
+def test_job_id_from_nc_name_rejects_bad_input() -> None:
+    assert sweeper._job_id_from_nc_name("not_prefixed") is None
+    assert sweeper._job_id_from_nc_name("export_") is None
+    assert sweeper._job_id_from_nc_name("export_not-a-uuid") is None
+    valid = uuid4()
+    assert sweeper._job_id_from_nc_name(f"export_{valid.hex}") == valid

--- a/tests/trace_server/export/test_table_registry.py
+++ b/tests/trace_server/export/test_table_registry.py
@@ -1,0 +1,34 @@
+"""Every `ExportTable` literal must have a registry row.
+
+Adding a new literal without a registry row should fail at import time,
+not return a 500 mid-request.
+"""
+
+from typing import get_args
+
+from weave.trace_server.export.schemas import ExportTable
+from weave.trace_server.export.table_registry import (
+    TABLE_REGISTRY,
+    assert_registry_covers_literal,
+)
+
+
+def test_registry_covers_every_literal() -> None:
+    assert set(TABLE_REGISTRY.keys()) == set(get_args(ExportTable))
+    # idempotent check passes
+    assert_registry_covers_literal()
+
+
+def test_calls_complete_uses_started_at() -> None:
+    spec = TABLE_REGISTRY["calls_complete"]
+    assert spec.ch_table == "calls_complete"
+    assert spec.time_column == "started_at"
+    assert spec.project_id_column == "project_id"
+
+
+def test_calls_merged_uses_started_at() -> None:
+    """`calls_merged` is supported at parity with `calls_complete` (spec §goal)."""
+    spec = TABLE_REGISTRY["calls_merged"]
+    assert spec.ch_table == "calls_merged"
+    assert spec.time_column == "started_at"
+    assert spec.project_id_column == "project_id"

--- a/weave/trace_server/export/__init__.py
+++ b/weave/trace_server/export/__init__.py
@@ -1,0 +1,39 @@
+"""Bulk-export module.
+
+`POST /export/start` submits a detached `INSERT INTO FUNCTION s3(...) SELECT ...`
+against the target CH cluster; `GET /export/{job_id}` derives state from
+`system.query_log` and mints a short-lived signed URL against the BYOB bucket
+the gorilla resolver returned for the project.
+"""
+
+from weave.trace_server.export.audit import lookup_export_start
+from weave.trace_server.export.engine import ExportEngine
+from weave.trace_server.export.routes import register_export_routes
+from weave.trace_server.export.schemas import (
+    ExportAuditRow,
+    ExportError,
+    ExportErrorCode,
+    ExportFormat,
+    ExportStartReq,
+    ExportStartRes,
+    ExportState,
+    ExportStatusRes,
+    ExportTable,
+)
+from weave.trace_server.export.sweeper import sweep_orphan_named_collections
+
+__all__ = [
+    "ExportAuditRow",
+    "ExportEngine",
+    "ExportError",
+    "ExportErrorCode",
+    "ExportFormat",
+    "ExportStartReq",
+    "ExportStartRes",
+    "ExportState",
+    "ExportStatusRes",
+    "ExportTable",
+    "lookup_export_start",
+    "register_export_routes",
+    "sweep_orphan_named_collections",
+]

--- a/weave/trace_server/export/audit.py
+++ b/weave/trace_server/export/audit.py
@@ -1,0 +1,125 @@
+"""Append-only writer for the `exports` audit table.
+
+Fail-closed: if the INSERT raises, the user-facing handler propagates a 500.
+A handler that cannot record what it did does not act.
+"""
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from weave.trace_server.export.schemas import ExportAuditRow, ExportStartReq
+
+if TYPE_CHECKING:
+    from clickhouse_connect.driver.client import Client as CHClient
+
+
+logger = logging.getLogger(__name__)
+
+
+_EXPORT_START = "EXPORT_START"
+_EXPORT_MINT = "EXPORT_MINT"
+
+_COLUMNS = (
+    "request_id",
+    "action",
+    "project_id",
+    "job_id",
+    "requested_by",
+    "minted_by",
+    "table_name",
+    "request_json",
+    "output_uri",
+    "ts",
+)
+
+
+def write_export_start(
+    ch_client: "CHClient",
+    *,
+    request_id: UUID,
+    job_id: UUID,
+    project_id: str,
+    requested_by: str,
+    request: ExportStartReq,
+    output_uri: str,
+) -> None:
+    """One row per `POST /export/start` accepted by CH.
+
+    `request_json` is the serialized request capped upstream at
+    `MAX_REQUEST_JSON_BYTES`; over-cap requests must be rejected before
+    reaching this writer.
+    """
+    row = (
+        request_id,
+        _EXPORT_START,
+        project_id,
+        job_id,
+        requested_by,
+        "",
+        request.table,
+        request.model_dump_json(),
+        output_uri,
+        datetime.now(timezone.utc),
+    )
+    _insert_row(ch_client, row)
+
+
+def write_export_mint(
+    ch_client: "CHClient",
+    *,
+    request_id: UUID,
+    job_id: UUID,
+    project_id: str,
+    requested_by: str,
+    minted_by: str,
+    table_name: str,
+) -> None:
+    """One row per successful signed-URL mint."""
+    row = (
+        request_id,
+        _EXPORT_MINT,
+        project_id,
+        job_id,
+        requested_by,
+        minted_by,
+        table_name,
+        "",
+        "",
+        datetime.now(timezone.utc),
+    )
+    _insert_row(ch_client, row)
+
+
+def _insert_row(ch_client: "CHClient", row: tuple[object, ...]) -> None:
+    ch_client.insert("exports", [row], column_names=list(_COLUMNS))
+
+
+def lookup_export_start(ch_client: "CHClient", job_id: UUID) -> ExportAuditRow | None:
+    """Read the `EXPORT_START` audit row for a job. Returns `None` if missing.
+
+    The GET handler needs `project_id` to re-auth, `requested_by` for the
+    audit trail, `table_name` for the mint row, and `submitted_at` for the
+    PENDING grace window.
+    """
+    result = ch_client.query(
+        "SELECT project_id, requested_by, table_name, ts "
+        "FROM exports "
+        "WHERE action = 'EXPORT_START' "
+        "  AND job_id = {job_id:UUID} "
+        "ORDER BY ts ASC "
+        "LIMIT 1",
+        parameters={"job_id": str(job_id)},
+    )
+    if not result.result_rows:
+        return None
+    project_id, requested_by, table_name, ts = result.result_rows[0]
+    if isinstance(ts, datetime) and ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ExportAuditRow(
+        project_id=str(project_id),
+        requested_by=str(requested_by),
+        table_name=str(table_name),
+        submitted_at=ts,
+    )

--- a/weave/trace_server/export/constants.py
+++ b/weave/trace_server/export/constants.py
@@ -1,0 +1,51 @@
+"""Magic values for the export module.
+
+Operator-tunable values (bucket, region, role ARN, cluster) live in helm
+values and reach the pod as env vars, not here.
+"""
+
+import re
+from datetime import timedelta
+
+MAX_EXPORT_QUERY_SECONDS = 1800
+
+SIGNED_URL_TTL = timedelta(minutes=15)
+
+EXPORT_OBJECT_LIFETIME = timedelta(days=7)
+
+EXPORTS_ROW_TTL = timedelta(days=365 * 7)
+
+STS_SESSION_DURATION = timedelta(hours=12)
+
+MAX_CONCURRENT_EXPORTS_PER_PROJECT = 1
+
+NAMED_COLLECTION_SWEEPER_INTERVAL = timedelta(minutes=5)
+
+CREDENTIAL_VALUE_REGEX = re.compile(r"^[A-Za-z0-9/+=._\-]+$")
+
+# Charset for the destination URL (`s3://bucket/env/exports/<project>/<job>/file.parquet`).
+# Permits `:` and the credential charset; explicitly rejects single quote, backslash,
+# whitespace, and anything CH could use to break out of a single-quoted literal.
+URL_VALUE_REGEX = re.compile(r"^[A-Za-z0-9/+=._:\-]+$")
+
+PHASE_2_PARTITION_ROW_THRESHOLD = 10_000_000
+
+MAX_REQUEST_JSON_BYTES = 64 * 1024
+
+# Grace window before a missing `system.query_log` row flips PENDING -> FAILED.
+# Covers query submission latency + initial parse delay.
+PENDING_GRACE_PERIOD = timedelta(seconds=30)
+
+# Object-storage layout. <bucket-uri>/<env>/exports/<project_id>/<job_id>/
+EXPORT_PREFIX = "exports"
+
+EXPORT_OBJECT_NAME = "data.parquet"
+EXPORT_MANIFEST_NAME = "manifest.json"
+
+# Compression for the Parquet output. Column-level (output_format_parquet_compression_method),
+# NOT the s3() function's positional outer-file compression arg.
+PARQUET_COMPRESSION = "zstd"
+
+# Named-collection name prefix. Sweeper scans `system.named_collections` for
+# names beginning with this string.
+NAMED_COLLECTION_PREFIX = "export_"

--- a/weave/trace_server/export/engine.py
+++ b/weave/trace_server/export/engine.py
@@ -1,0 +1,327 @@
+"""Bulk-export orchestrator.
+
+trace_server is a thin orchestrator. CH does the work via `INSERT INTO
+FUNCTION s3()` detached. No Kafka, no worker pod, no in-house state machine.
+"""
+
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from weave.trace_server.byob.resolver import (
+    BYOBResolver,
+    ResolvedExportTarget,
+    StorageResolutionError,
+)
+from weave.trace_server.export import audit, constants, sql
+from weave.trace_server.export.escaping import (
+    build_create_named_collection_sql,
+    build_drop_named_collection_sql,
+    named_collection_name,
+)
+from weave.trace_server.export.schemas import (
+    ExportError,
+    ExportErrorCode,
+    ExportStartReq,
+    ExportStartRes,
+    ExportState,
+    ExportStatusRes,
+)
+from weave.trace_server.export.state import (
+    UnknownQueryLogTypeError,
+    derive_state_from_log,
+)
+from weave.trace_server.export.storage import (
+    PresignedUrlMinter,
+    build_dest_url,
+)
+
+if TYPE_CHECKING:
+    from clickhouse_connect.driver.client import Client as CHClient
+
+
+logger = logging.getLogger(__name__)
+
+
+class ExportTooLargeError(Exception):
+    """Pre-flight count exceeded `PHASE_2_PARTITION_ROW_THRESHOLD`. -> 409."""
+
+    def __init__(self, row_count: int) -> None:
+        super().__init__(f"row_count={row_count} exceeds single-file threshold")
+        self.row_count = row_count
+
+
+class ConcurrentExportLimitError(Exception):
+    """Project already has an in-flight export. -> 409."""
+
+
+class RequestTooLargeError(Exception):
+    """Serialized request exceeded `MAX_REQUEST_JSON_BYTES`. -> 400."""
+
+
+@dataclass
+class _Submission:
+    job_id: UUID
+    nc_name: str
+    dest_url: str
+
+
+class ExportEngine:
+    """Orchestrates: resolve target -> count -> CREATE NC -> submit INSERT -> audit.
+
+    The engine itself is stateless across requests. Per-export liveness lives
+    in CH (`system.query_log` + the `exports` audit table); pod restarts do
+    not lose track of running queries.
+    """
+
+    def __init__(
+        self,
+        ch_client: "CHClient",
+        resolver: BYOBResolver,
+        *,
+        env: str,
+    ) -> None:
+        self._ch = ch_client
+        self._resolver = resolver
+        self._env = env
+
+    def start(
+        self,
+        req: ExportStartReq,
+        *,
+        requested_by: str,
+    ) -> ExportStartRes:
+        """Submit the detached `INSERT INTO FUNCTION s3()` and write the audit row."""
+        serialized = req.model_dump_json()
+        if len(serialized.encode("utf-8")) > constants.MAX_REQUEST_JSON_BYTES:
+            raise RequestTooLargeError("request_json exceeds MAX_REQUEST_JSON_BYTES")
+
+        self._enforce_concurrent_cap(req.project_id)
+        row_count = self._preflight_count(req)
+        if row_count > constants.PHASE_2_PARTITION_ROW_THRESHOLD:
+            raise ExportTooLargeError(row_count)
+
+        target = self._resolve_target(req.project_id)
+        job_id = uuid.uuid4()
+        submission = self._build_submission(target, req.project_id, job_id)
+
+        self._submit_insert(submission, target, req)
+
+        request_id = uuid.uuid4()
+        audit.write_export_start(
+            self._ch,
+            request_id=request_id,
+            job_id=job_id,
+            project_id=req.project_id,
+            requested_by=requested_by,
+            request=req,
+            output_uri=submission.dest_url,
+        )
+        return ExportStartRes(job_id=job_id)
+
+    def status(
+        self,
+        job_id: UUID,
+        *,
+        project_id: str,
+        requested_by: str,
+        minted_by: str,
+        table_name: str,
+        submitted_at: datetime,
+    ) -> ExportStatusRes:
+        """Derive state from `system.query_log` and (if SUCCEEDED) mint a URL."""
+        prepared = sql.build_query_log_lookup_sql()
+        result = self._ch.query(
+            prepared.sql, parameters={**prepared.params, "query_id": str(job_id)}
+        )
+        rows = result.result_rows
+        if rows:
+            log_type, exception_code, exception_text, written_rows, written_bytes = (
+                rows[0][0],
+                int(rows[0][1]),
+                str(rows[0][2]),
+                int(rows[0][3]),
+                int(rows[0][4]),
+            )
+        else:
+            log_type = None
+            exception_code = 0
+            exception_text = ""
+            written_rows = 0
+            written_bytes = 0
+
+        try:
+            state, error = derive_state_from_log(
+                log_type=log_type,
+                exception_code=exception_code,
+                exception_text=exception_text,
+                submitted_at=submitted_at,
+            )
+        except UnknownQueryLogTypeError:
+            logger.exception("unknown query_log.type for job %s", job_id)
+            return ExportStatusRes(
+                state=ExportState.FAILED,
+                error=ExportError(
+                    code=ExportErrorCode.INTERNAL,
+                    message="Unrecognized ClickHouse query state.",
+                ),
+            )
+
+        if state != ExportState.SUCCEEDED:
+            return ExportStatusRes(state=state, error=error)
+
+        target = self._resolve_target(project_id)
+        minter = PresignedUrlMinter(target, env=self._env)
+        signed_url, expires_at = minter.mint_download_url(
+            project_id, job_id, ttl=constants.SIGNED_URL_TTL
+        )
+
+        audit.write_export_mint(
+            self._ch,
+            request_id=uuid.uuid4(),
+            job_id=job_id,
+            project_id=project_id,
+            requested_by=requested_by,
+            minted_by=minted_by,
+            table_name=table_name,
+        )
+
+        return ExportStatusRes(
+            state=ExportState.SUCCEEDED,
+            signed_url=signed_url,
+            expires_at=expires_at,
+            row_count=written_rows,
+            bytes=written_bytes,
+        )
+
+    def _enforce_concurrent_cap(self, project_id: str) -> None:
+        prepared = sql.build_concurrent_export_count_sql()
+        result = self._ch.query(
+            prepared.sql,
+            parameters={
+                **prepared.params,
+                "project_id": project_id,
+                "window_seconds": int(_concurrent_window_seconds()),
+            },
+        )
+        in_flight = int(result.result_rows[0][0])
+        if in_flight >= _max_concurrent():
+            raise ConcurrentExportLimitError(
+                f"project_id={project_id} already has {in_flight} in-flight export(s)"
+            )
+
+    def _preflight_count(self, req: ExportStartReq) -> int:
+        prepared = sql.build_preflight_count_sql(
+            table=req.table,
+            project_id=req.project_id,
+            time_start=req.time_range.start if req.time_range else None,
+            time_end=req.time_range.end if req.time_range else None,
+        )
+        result = self._ch.query(prepared.sql, parameters=prepared.params)
+        return int(result.result_rows[0][0])
+
+    def _resolve_target(self, project_id: str) -> ResolvedExportTarget:
+        try:
+            target = self._resolver.resolve_export_target(project_id)
+        except StorageResolutionError as exc:
+            logger.warning(
+                "storage resolver could not produce a target for project %s: %s",
+                project_id,
+                exc,
+            )
+            raise
+        if target.source_project_id != project_id:
+            # Defense-in-depth: resolver bug or stale cache must not route an
+            # export to a different team's bucket.
+            logger.error(
+                "resolver returned target with source_project_id=%s for "
+                "requested project_id=%s; refusing to proceed",
+                target.source_project_id,
+                project_id,
+            )
+            raise StorageResolutionError(
+                "resolved target does not match requested project"
+            )
+        return target
+
+    def _build_submission(
+        self,
+        target: ResolvedExportTarget,
+        project_id: str,
+        job_id: UUID,
+    ) -> _Submission:
+        return _Submission(
+            job_id=job_id,
+            nc_name=named_collection_name(job_id),
+            dest_url=build_dest_url(
+                target, env=self._env, project_id=project_id, job_id=job_id
+            ),
+        )
+
+    def _submit_insert(
+        self,
+        submission: _Submission,
+        target: ResolvedExportTarget,
+        req: ExportStartReq,
+    ) -> None:
+        creds = target.credentials
+        create_sql = build_create_named_collection_sql(
+            job_id=submission.job_id,
+            access_key_id=creds.access_key_id,
+            secret_access_key=creds.secret_access_key.get_secret_value(),
+            session_token=creds.session_token.get_secret_value(),
+            dest_url=submission.dest_url,
+        )
+        drop_sql = build_drop_named_collection_sql(submission.job_id)
+
+        self._ch.command(drop_sql, settings={"log_queries": "0"})
+        self._ch.command(create_sql, settings={"log_queries": "0"})
+        submitted = False
+        try:
+            insert = sql.build_export_insert_sql(
+                job_id=submission.job_id,
+                table=req.table,
+                project_id=req.project_id,
+                time_start=req.time_range.start if req.time_range else None,
+                time_end=req.time_range.end if req.time_range else None,
+            )
+            self._ch.command(
+                insert.sql,
+                parameters=insert.params,
+                settings={
+                    "query_id": str(submission.job_id),
+                    "wait_end_of_query": "0",
+                },
+            )
+            submitted = True
+        finally:
+            if not submitted:
+                # Drop the NC so plaintext STS creds don't linger if submission
+                # blew up. Swallow cleanup failures so the original exception
+                # is what surfaces to the caller. `BaseException` (Ctrl-C,
+                # cancellation) triggers this finally path too.
+                try:
+                    self._ch.command(drop_sql, settings={"log_queries": "0"})
+                except Exception:
+                    logger.exception(
+                        "failed to drop named collection after submit failure "
+                        "for job %s",
+                        submission.job_id,
+                    )
+
+
+def _max_concurrent() -> int:
+    """Indirected so tests can monkeypatch the constants module."""
+    return constants.MAX_CONCURRENT_EXPORTS_PER_PROJECT
+
+
+def _concurrent_window_seconds() -> int:
+    """How far back to scan `exports` rows when counting in-flight starts.
+
+    Matches the per-query CH budget so any export older than this is
+    guaranteed terminal (CH would have aborted via max_execution_time).
+    """
+    return constants.MAX_EXPORT_QUERY_SECONDS + 60

--- a/weave/trace_server/export/escaping.py
+++ b/weave/trace_server/export/escaping.py
@@ -1,0 +1,80 @@
+"""The single escaping helper for `CREATE NAMED COLLECTION` bodies.
+
+CH does not accept `{name:T}` substitution inside `CREATE NAMED COLLECTION`,
+so credential values land via Python string formatting. Every interpolated
+value is validated against `CREDENTIAL_VALUE_REGEX` first; anything outside
+that charset raises before any SQL is built.
+
+Lint rule: `f"...CREATE NAMED COLLECTION..."` must not appear outside this
+module.
+"""
+
+from uuid import UUID
+
+from weave.trace_server.export.constants import (
+    CREDENTIAL_VALUE_REGEX,
+    NAMED_COLLECTION_PREFIX,
+    URL_VALUE_REGEX,
+)
+
+
+class InvalidCredentialCharError(ValueError):
+    """A credential value contained a char outside `CREDENTIAL_VALUE_REGEX`."""
+
+
+def _validate_credential_value(name: str, value: str) -> None:
+    if not value:
+        raise InvalidCredentialCharError(f"empty credential value: {name}")
+    if not CREDENTIAL_VALUE_REGEX.fullmatch(value):
+        raise InvalidCredentialCharError(
+            f"credential value for {name!r} contains characters outside the "
+            f"allowed charset"
+        )
+
+
+def _validate_url_value(value: str) -> None:
+    if not value:
+        raise InvalidCredentialCharError("empty dest_url")
+    if not URL_VALUE_REGEX.fullmatch(value):
+        raise InvalidCredentialCharError(
+            "dest_url contains characters outside the allowed URL charset"
+        )
+
+
+def named_collection_name(job_id: UUID) -> str:
+    """Stable per-export NC identifier. UUID hex; no hyphens."""
+    return f"{NAMED_COLLECTION_PREFIX}{job_id.hex}"
+
+
+def build_create_named_collection_sql(
+    *,
+    job_id: UUID,
+    access_key_id: str,
+    secret_access_key: str,
+    session_token: str,
+    dest_url: str,
+) -> str:
+    """Return the CREATE NAMED COLLECTION SQL body.
+
+    Every credential value is charset-validated; `dest_url` is too, so the
+    URL parser upstream must already have rejected anything weirder than
+    `[A-Za-z0-9/+=._-]`. The job_id is rendered as bare hex (UUID.hex), so
+    there is no quote-escape surface in the identifier either.
+    """
+    _validate_credential_value("access_key_id", access_key_id)
+    _validate_credential_value("secret_access_key", secret_access_key)
+    _validate_credential_value("session_token", session_token)
+    _validate_url_value(dest_url)
+
+    name = named_collection_name(job_id)
+    return (
+        f"CREATE NAMED COLLECTION {name} AS "
+        f"access_key_id = '{access_key_id}', "
+        f"secret_access_key = '{secret_access_key}', "
+        f"session_token = '{session_token}', "
+        f"url = '{dest_url}'"
+    )
+
+
+def build_drop_named_collection_sql(job_id: UUID) -> str:
+    return f"DROP NAMED COLLECTION IF EXISTS {named_collection_name(job_id)}"

--- a/weave/trace_server/export/routes.py
+++ b/weave/trace_server/export/routes.py
@@ -1,0 +1,114 @@
+"""FastAPI route registration for the export endpoints.
+
+Decoupled from the host service via callables (engine factory, auth callable,
+feature-flag callable, identity callable). The host wires these from its own
+authorization module so this module pulls no host-service imports.
+"""
+
+import logging
+from collections.abc import Callable
+from typing import Protocol
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Request, status
+
+from weave.trace_server.byob.resolver import StorageResolutionError
+from weave.trace_server.export.engine import (
+    ConcurrentExportLimitError,
+    ExportEngine,
+    ExportTooLargeError,
+    RequestTooLargeError,
+)
+from weave.trace_server.export.schemas import (
+    ExportAuditRow,
+    ExportStartReq,
+    ExportStartRes,
+    ExportStatusRes,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _AuthContext(Protocol):
+    """Whatever the host's auth handler returns; opaque to this module."""
+
+
+GetEngine = Callable[[_AuthContext], ExportEngine]
+RequireProjectRead = Callable[[str, _AuthContext], None]
+RequireExportFlag = Callable[[str, _AuthContext], None]
+GetRequester = Callable[[_AuthContext], str]
+LookupJobRow = Callable[[UUID], ExportAuditRow | None]
+
+
+def register_export_routes(
+    router: APIRouter,
+    *,
+    get_engine: GetEngine,
+    get_auth_params: Callable[[Request], _AuthContext],
+    require_project_read: RequireProjectRead,
+    require_export_flag: RequireExportFlag,
+    get_requester: GetRequester,
+    lookup_job_row: LookupJobRow,
+    tag: str = "exports",
+) -> None:
+    """Attach `POST /export/start` and `GET /export/{job_id}` to `router`."""
+
+    @router.post("/export/start", tags=[tag])
+    def export_start(req: ExportStartReq, request: Request) -> ExportStartRes:
+        auth = get_auth_params(request)
+        require_project_read(req.project_id, auth)
+        require_export_flag(req.project_id, auth)
+        engine = get_engine(auth)
+        try:
+            return engine.start(req, requested_by=get_requester(auth))
+        except RequestTooLargeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+            ) from exc
+        except ExportTooLargeError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={
+                    "code": "too_large",
+                    "row_count": exc.row_count,
+                    "message": (
+                        "Export size exceeds the v1 single-file threshold. "
+                        "Narrow the time_range or wait for Phase 2 multi-part."
+                    ),
+                },
+            ) from exc
+        except ConcurrentExportLimitError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail={"code": "concurrent_limit", "message": str(exc)},
+            ) from exc
+        except StorageResolutionError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail={
+                    "code": "no_storage_target",
+                    "message": (
+                        "No storage target is configured for this project. "
+                        "Configure a BYOB bucket in team settings."
+                    ),
+                },
+            ) from exc
+
+    @router.get("/export/{job_id}", tags=[tag])
+    def export_status(job_id: UUID, request: Request) -> ExportStatusRes:
+        auth = get_auth_params(request)
+        row = lookup_job_row(job_id)
+        if row is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="job not found"
+            )
+        require_project_read(row.project_id, auth)
+        engine = get_engine(auth)
+        return engine.status(
+            job_id,
+            project_id=row.project_id,
+            requested_by=row.requested_by,
+            minted_by=get_requester(auth),
+            table_name=row.table_name,
+            submitted_at=row.submitted_at,
+        )

--- a/weave/trace_server/export/schemas.py
+++ b/weave/trace_server/export/schemas.py
@@ -1,0 +1,79 @@
+"""Wire types for the export endpoints.
+
+All fields are concrete; constrained values are `Literal[...]`. Raw CH
+exception text never leaks to the response (it can carry table names,
+replica hostnames, or row data); error messages map to the closed-set
+`ExportErrorCode` and the raw text goes to internal logs only.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, Field, HttpUrl
+
+ExportTable = Literal["calls_complete", "calls_merged"]
+ExportFormat = Literal["parquet"]
+Compression = Literal["zstd"]
+
+
+class TimeRange(BaseModel):
+    """Half-open range `[start, end)` against the table's order-key time column."""
+
+    start: datetime
+    end: datetime
+
+
+class ExportStartReq(BaseModel):
+    project_id: str
+    table: ExportTable
+    time_range: TimeRange | None = None
+    format: ExportFormat = "parquet"
+    compression: Compression = "zstd"
+
+
+class ExportStartRes(BaseModel):
+    job_id: UUID = Field(description="ClickHouse query_id of the export query.")
+
+
+class ExportState(str, Enum):
+    PENDING = "pending"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+class ExportErrorCode(str, Enum):
+    TIMEOUT = "timeout"
+    AUTH_REVOKED = "auth_revoked"
+    CH_EXCEPTION = "ch_exception"
+    TOO_LARGE = "too_large"
+    NO_STORAGE_TARGET = "no_storage_target"
+    INTERNAL = "internal"
+
+
+class ExportError(BaseModel):
+    code: ExportErrorCode
+    message: str
+
+
+class ExportStatusRes(BaseModel):
+    state: ExportState
+    signed_url: HttpUrl | None = None
+    expires_at: datetime | None = None
+    row_count: int | None = None
+    bytes: int | None = None
+    error: ExportError | None = None
+
+
+class ExportAuditRow(BaseModel):
+    """Minimal slice of `exports.action='EXPORT_START'` the GET handler needs.
+
+    Internal type; never serialized over the wire.
+    """
+
+    project_id: str
+    requested_by: str
+    table_name: str
+    submitted_at: datetime

--- a/weave/trace_server/export/sql.py
+++ b/weave/trace_server/export/sql.py
@@ -1,0 +1,137 @@
+"""SQL builders for the export engine.
+
+Only credentialed identifiers (job_id -> NC name) and registry-resolved
+table/column names appear as bare identifiers; everything else flows
+through CH `{name:T}` parameter substitution.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from weave.trace_server.export.constants import (
+    MAX_EXPORT_QUERY_SECONDS,
+    PARQUET_COMPRESSION,
+)
+from weave.trace_server.export.escaping import named_collection_name
+from weave.trace_server.export.schemas import ExportTable
+from weave.trace_server.export.table_registry import TABLE_REGISTRY
+
+
+@dataclass
+class PreparedSql:
+    sql: str
+    params: dict[str, Any]
+
+
+def build_export_insert_sql(
+    *,
+    job_id: UUID,
+    table: ExportTable,
+    project_id: str,
+    time_start: datetime | None = None,
+    time_end: datetime | None = None,
+) -> PreparedSql:
+    """`INSERT INTO FUNCTION s3(<nc>, format='Parquet') SELECT * FROM <table> WHERE ...`.
+
+    `<table>` is a closed-set identifier from `TABLE_REGISTRY`.
+    `project_id`, `start_ts`, and `end_ts` go through `{name:T}` substitution.
+    SETTINGS values are inlined constants (CH does not accept `{name:T}`
+    inside SETTINGS).
+    """
+    spec = TABLE_REGISTRY[table]
+    nc_name = named_collection_name(job_id)
+
+    params: dict[str, Any] = {"project_id": project_id}
+    predicates = [f"{spec.project_id_column} = {{project_id:String}}"]
+
+    if time_start is not None:
+        params["start_ts"] = time_start
+        predicates.append(f"{spec.time_column} >= {{start_ts:DateTime64(3)}}")
+    if time_end is not None:
+        params["end_ts"] = time_end
+        predicates.append(f"{spec.time_column} < {{end_ts:DateTime64(3)}}")
+
+    where_clause = " AND ".join(predicates)
+
+    sql = (
+        f"INSERT INTO FUNCTION s3({nc_name}, format = 'Parquet') "
+        f"SELECT * FROM {spec.ch_table} "
+        f"WHERE {where_clause} "
+        f"SETTINGS "
+        f"s3_truncate_on_insert = 1, "
+        f"max_execution_time = {MAX_EXPORT_QUERY_SECONDS}, "
+        f"output_format_parquet_compression_method = '{PARQUET_COMPRESSION}'"
+    )
+    return PreparedSql(sql=sql, params=params)
+
+
+def build_preflight_count_sql(
+    *,
+    table: ExportTable,
+    project_id: str,
+    time_start: datetime | None = None,
+    time_end: datetime | None = None,
+) -> PreparedSql:
+    """`SELECT count() FROM <table> WHERE ...`. Run before submit to enforce
+    `PHASE_2_PARTITION_ROW_THRESHOLD`.
+    """
+    spec = TABLE_REGISTRY[table]
+    params: dict[str, Any] = {"project_id": project_id}
+    predicates = [f"{spec.project_id_column} = {{project_id:String}}"]
+
+    if time_start is not None:
+        params["start_ts"] = time_start
+        predicates.append(f"{spec.time_column} >= {{start_ts:DateTime64(3)}}")
+    if time_end is not None:
+        params["end_ts"] = time_end
+        predicates.append(f"{spec.time_column} < {{end_ts:DateTime64(3)}}")
+
+    sql = f"SELECT count() FROM {spec.ch_table} WHERE {' AND '.join(predicates)}"
+    return PreparedSql(sql=sql, params=params)
+
+
+def build_query_log_lookup_sql() -> PreparedSql:
+    """Fetch the latest `system.query_log` row for one query_id.
+
+    `type` is an Enum8 in CH; cast to String for stable Python decode.
+    """
+    sql = (
+        "SELECT toString(type) AS type, exception_code, exception, "
+        "       written_rows, written_bytes "
+        "FROM system.query_log "
+        "WHERE query_id = {query_id:String} "
+        "ORDER BY event_time_microseconds DESC "
+        "LIMIT 1"
+    )
+    return PreparedSql(sql=sql, params={})
+
+
+def build_concurrent_export_count_sql() -> PreparedSql:
+    """`SELECT count() FROM exports` filtered to in-flight EXPORT_START rows
+    for one project. Used to enforce `MAX_CONCURRENT_EXPORTS_PER_PROJECT`.
+    """
+    sql = (
+        "SELECT count() FROM exports "
+        "WHERE action = 'EXPORT_START' "
+        "  AND project_id = {project_id:String} "
+        "  AND ts > now() - INTERVAL {window_seconds:UInt32} SECOND "
+        "  AND job_id NOT IN ("
+        "    SELECT query_id FROM system.query_log "
+        "    WHERE toString(type) IN ('QueryFinish','ExceptionBeforeStart','ExceptionWhileProcessing')"
+        "  )"
+    )
+    return PreparedSql(sql=sql, params={})
+
+
+def build_orphan_nc_scan_sql() -> PreparedSql:
+    """Pull every export-prefixed named collection so the sweeper can DROP
+    the ones whose query_id is past terminal (or whose log row is missing
+    past the grace window).
+    """
+    sql = (
+        "SELECT name FROM system.named_collections "
+        "WHERE name LIKE 'export\\_%' ESCAPE '\\'"
+    )
+    return PreparedSql(sql=sql, params={})

--- a/weave/trace_server/export/state.py
+++ b/weave/trace_server/export/state.py
@@ -1,0 +1,106 @@
+"""Closed-set mapping from `system.query_log.type` -> `ExportState`.
+
+Unknown values raise: silently bucketing them would hide CH version drift.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from weave.trace_server.export.constants import PENDING_GRACE_PERIOD
+from weave.trace_server.export.schemas import (
+    ExportError,
+    ExportErrorCode,
+    ExportState,
+)
+
+
+class UnknownQueryLogTypeError(RuntimeError):
+    """`system.query_log.type` returned a value not in the closed set.
+
+    Caller maps to 500 with `INTERNAL`; never silently bucketed.
+    """
+
+
+_TERMINAL_FAILURE_TYPES = {"ExceptionBeforeStart", "ExceptionWhileProcessing"}
+_QUERY_FINISH = "QueryFinish"
+_QUERY_START = "QueryStart"
+
+
+def derive_state_from_log(
+    *,
+    log_type: str | None,
+    exception_code: int,
+    exception_text: str,
+    submitted_at: datetime,
+    now: datetime | None = None,
+    grace: timedelta = PENDING_GRACE_PERIOD,
+) -> tuple[ExportState, ExportError | None]:
+    """Map one CH log row to (state, optional error).
+
+    No row yet AND submission is within the grace window -> PENDING.
+    No row yet AND grace elapsed -> FAILED (CH never accepted the submit).
+    """
+    now = now or datetime.now(timezone.utc)
+
+    if log_type is None:
+        if now - submitted_at < grace:
+            return ExportState.PENDING, None
+        return (
+            ExportState.FAILED,
+            ExportError(
+                code=ExportErrorCode.CH_EXCEPTION,
+                message="ClickHouse did not record a query_log row for this job.",
+            ),
+        )
+
+    if log_type == _QUERY_START:
+        return ExportState.RUNNING, None
+
+    if log_type == _QUERY_FINISH:
+        if exception_code == 0:
+            return ExportState.SUCCEEDED, None
+        return ExportState.FAILED, _classify_failure(exception_code, exception_text)
+
+    if log_type in _TERMINAL_FAILURE_TYPES:
+        return ExportState.FAILED, _classify_failure(exception_code, exception_text)
+
+    raise UnknownQueryLogTypeError(f"unknown system.query_log.type value: {log_type!r}")
+
+
+# CH error codes we recognize and surface as a closed enum value. Sources:
+# https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp
+_CH_TIMEOUT_CODES = {
+    159,  # TIMEOUT_EXCEEDED
+    160,  # TOO_SLOW
+    161,  # TOO_MANY_ROWS
+}
+
+
+def _classify_failure(exception_code: int, exception_text: str) -> ExportError:
+    if exception_code in _CH_TIMEOUT_CODES:
+        return ExportError(
+            code=ExportErrorCode.TIMEOUT,
+            message="Export query exceeded its per-query time budget.",
+        )
+    if exception_code == 499 and _looks_like_auth_failure(exception_text):
+        return ExportError(
+            code=ExportErrorCode.AUTH_REVOKED,
+            message="Object-storage credentials were rejected during the export.",
+        )
+    return ExportError(
+        code=ExportErrorCode.CH_EXCEPTION,
+        message="ClickHouse reported a query exception. See server logs for details.",
+    )
+
+
+def _looks_like_auth_failure(text: str) -> bool:
+    """Cheap substring check; we never echo `text` to users."""
+    lowered = text.lower()
+    return any(
+        token in lowered
+        for token in (
+            "accessdenied",
+            "invalidaccesskeyid",
+            "expiredtoken",
+            "signaturedoesnotmatch",
+        )
+    )

--- a/weave/trace_server/export/storage.py
+++ b/weave/trace_server/export/storage.py
@@ -1,0 +1,85 @@
+"""Object-key layout + presigned-URL minter for the export bucket.
+
+Distinct from `weave.trace_server.file_storage`: that module handles
+trace `files` blobs; this one is scoped to bulk-export artifacts whose
+credentials come from the gorilla resolver per export.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+import boto3
+from botocore.client import Config
+
+from weave.trace_server.byob.resolver import ResolvedExportTarget
+from weave.trace_server.export.constants import (
+    EXPORT_OBJECT_NAME,
+    EXPORT_PREFIX,
+    SIGNED_URL_TTL,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def build_object_key(env: str, project_id: str, job_id: UUID) -> str:
+    """`<env>/exports/<project_id>/<job_id>/data.parquet`."""
+    return f"{env}/{EXPORT_PREFIX}/{project_id}/{job_id.hex}/{EXPORT_OBJECT_NAME}"
+
+
+def build_dest_url(
+    target: ResolvedExportTarget, env: str, project_id: str, job_id: UUID
+) -> str:
+    """Full `s3://bucket/<env>/exports/<project_id>/<job_id>/data.parquet`.
+
+    Used as the `url = '<...>'` value inside the CREATE NAMED COLLECTION body;
+    must validate against `URL_VALUE_REGEX` upstream of interpolation.
+    """
+    base = target.bucket_uri.rstrip("/")
+    key = build_object_key(env, project_id, job_id)
+    return f"{base}/{key}"
+
+
+class PresignedUrlMinter:
+    """Per-export presigned-URL minter.
+
+    Constructed fresh per GET request: the credentials change per resolve,
+    and there is no value in pooling boto3 clients here in v1 (the GET path
+    is single-call). Phase 2 multi-part can revisit if mint volume warrants.
+    """
+
+    def __init__(self, target: ResolvedExportTarget, env: str) -> None:
+        self._env = env
+        self._target = target
+        creds = target.credentials
+        config = Config(signature_version="s3v4", retries={"max_attempts": 0})
+        self._client = boto3.client(
+            "s3",
+            aws_access_key_id=creds.access_key_id,
+            aws_secret_access_key=creds.secret_access_key.get_secret_value(),
+            aws_session_token=creds.session_token.get_secret_value(),
+            region_name=target.region,
+            config=config,
+        )
+
+    def mint_download_url(
+        self,
+        project_id: str,
+        job_id: UUID,
+        ttl: timedelta = SIGNED_URL_TTL,
+    ) -> tuple[str, datetime]:
+        """Return (`signed_url`, `expires_at`).
+
+        The URL is scoped to the full object key; the signer identity has
+        no `s3:ListBucket` permission, so mutating the key path
+        invalidates the signature.
+        """
+        key = build_object_key(self._env, project_id, job_id)
+        url = self._client.generate_presigned_url(
+            ClientMethod="get_object",
+            Params={"Bucket": self._target.bucket_name, "Key": key},
+            ExpiresIn=int(ttl.total_seconds()),
+            HttpMethod="GET",
+        )
+        expires_at = datetime.now(timezone.utc) + ttl
+        return url, expires_at

--- a/weave/trace_server/export/sweeper.py
+++ b/weave/trace_server/export/sweeper.py
@@ -1,0 +1,115 @@
+"""Orphan named-collection sweeper.
+
+DROPs `export_<uuid>` collections whose query is past terminal, whose audit
+row indicates the query budget has elapsed, or whose audit row is missing
+entirely (engine crash between CREATE NC and the audit write). Gives the
+on-disk plaintext NC file a bounded lifetime even when the engine's
+finally block did not run AND `system.query_log` has rotated.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from weave.trace_server.export import sql
+from weave.trace_server.export.audit import lookup_export_start
+from weave.trace_server.export.constants import (
+    MAX_EXPORT_QUERY_SECONDS,
+    NAMED_COLLECTION_PREFIX,
+)
+from weave.trace_server.export.escaping import build_drop_named_collection_sql
+from weave.trace_server.export.schemas import ExportState
+from weave.trace_server.export.state import (
+    UnknownQueryLogTypeError,
+    derive_state_from_log,
+)
+
+if TYPE_CHECKING:
+    from clickhouse_connect.driver.client import Client as CHClient
+
+
+logger = logging.getLogger(__name__)
+
+# Slack on top of MAX_EXPORT_QUERY_SECONDS before we declare an export
+# whose query_log row is gone to be guaranteed-terminal-by-budget.
+QUERY_BUDGET_GRACE = timedelta(seconds=60)
+
+
+def sweep_orphan_named_collections(ch_client: "CHClient") -> int:
+    """Drop terminal-or-orphan `export_*` NCs. Returns count dropped."""
+    scan = sql.build_orphan_nc_scan_sql()
+    result = ch_client.query(scan.sql)
+    dropped = 0
+    for (name,) in result.result_rows:
+        job_id = _job_id_from_nc_name(name)
+        if job_id is None:
+            continue
+        if _should_drop(ch_client, job_id):
+            ch_client.command(
+                build_drop_named_collection_sql(job_id),
+                settings={"log_queries": "0"},
+            )
+            dropped += 1
+    return dropped
+
+
+def _job_id_from_nc_name(name: str) -> UUID | None:
+    if not name.startswith(NAMED_COLLECTION_PREFIX):
+        return None
+    suffix = name[len(NAMED_COLLECTION_PREFIX) :]
+    try:
+        return UUID(suffix)
+    except ValueError:
+        return None
+
+
+def _should_drop(ch_client: "CHClient", job_id: UUID) -> bool:
+    """True when the NC's underlying export is guaranteed past terminal.
+
+    Priority of evidence:
+      1. `system.query_log` row exists -> derive state -> drop on terminal.
+      2. No `query_log` row but audit `submitted_at` older than the per-query
+         CH budget plus grace -> CH would have aborted via max_execution_time.
+      3. No `query_log` row AND no audit row -> engine crashed between
+         CREATE NC and audit write; NC is orphaned with no other owner.
+    """
+    prepared = sql.build_query_log_lookup_sql()
+    result = ch_client.query(
+        prepared.sql, parameters={**prepared.params, "query_id": str(job_id)}
+    )
+    rows = result.result_rows
+    if rows:
+        log_type, exception_code, exception_text = (
+            rows[0][0],
+            int(rows[0][1]),
+            str(rows[0][2]),
+        )
+        try:
+            state, _ = derive_state_from_log(
+                log_type=log_type,
+                exception_code=exception_code,
+                exception_text=exception_text,
+                submitted_at=datetime.now(timezone.utc),
+            )
+        except UnknownQueryLogTypeError:
+            logger.exception("unknown query_log.type for NC sweeper job %s", job_id)
+            return False
+        return state in {ExportState.SUCCEEDED, ExportState.FAILED}
+
+    audit_row = lookup_export_start(ch_client, job_id)
+    budget = timedelta(seconds=MAX_EXPORT_QUERY_SECONDS) + QUERY_BUDGET_GRACE
+    if audit_row is not None:
+        if datetime.now(timezone.utc) - audit_row.submitted_at >= budget:
+            logger.warning(
+                "NC %s past query budget with no query_log row; dropping",
+                job_id,
+            )
+            return True
+        return False
+
+    logger.warning(
+        "NC %s has neither query_log nor audit row; dropping as orphan",
+        job_id,
+    )
+    return True

--- a/weave/trace_server/export/table_registry.py
+++ b/weave/trace_server/export/table_registry.py
@@ -1,0 +1,53 @@
+"""Closed-set mapping from the user-facing export table name to the concrete
+CH table identifier and time column.
+
+Identifiers in this registry are NEVER user-controlled; the SQL builder
+inlines them as bare identifiers. Anything else has to come through CH
+`{name:T}` parameter substitution.
+"""
+
+from dataclasses import dataclass
+from typing import get_args
+
+from weave.trace_server.export.schemas import ExportTable
+
+
+@dataclass(frozen=True)
+class TableSpec:
+    """One row of the registry.
+
+    Attributes:
+        ch_table: bare identifier of the source table in CH.
+        time_column: column name used for `time_range` filtering, or `None`
+            if the table has no time order key (filter is silently dropped
+            in that case; v1 only registers tables with a time column).
+        project_id_column: column carrying the project id; always
+            `project_id` today but kept explicit so future tables that use
+            a different name (e.g. join views) slot in.
+    """
+
+    ch_table: str
+    time_column: str
+    project_id_column: str = "project_id"
+
+
+TABLE_REGISTRY: dict[ExportTable, TableSpec] = {
+    "calls_complete": TableSpec(ch_table="calls_complete", time_column="started_at"),
+    "calls_merged": TableSpec(ch_table="calls_merged", time_column="started_at"),
+}
+
+
+def assert_registry_covers_literal() -> None:
+    """Static check: every `ExportTable` literal must have a TABLE_REGISTRY row.
+
+    Called at module import time so a literal added without a registry row
+    fails loudly at startup instead of returning a 500 mid-request.
+    """
+    missing = set(get_args(ExportTable)) - set(TABLE_REGISTRY.keys())
+    if missing:
+        raise RuntimeError(
+            f"ExportTable literals without TABLE_REGISTRY rows: {sorted(missing)}"
+        )
+
+
+assert_registry_covers_literal()


### PR DESCRIPTION
## Summary
- Adds `weave/trace_server/export/` (engine, escaping, sql, state mapper, storage, audit, sweeper, routes, BYOB protocol).
- trace_server stays thin: CH does the work via `INSERT INTO FUNCTION s3()` detached. trace_server resolves credentials, submits, polls `system.query_log` on GET, mints presigned URLs.
- Credentials only interpolate through the single escaping helper. Strict charset validation (`CREDENTIAL_VALUE_REGEX`); CREATE/DROP submitted with `log_queries=0`; DROP in finally + sweeper.
- Closed-set `TABLE_REGISTRY` (calls_complete, calls_merged); identifiers never user-controlled. All other inputs flow through CH `{name:T}` params.
- Stacks on #6959.
- Spec: `~/Desktop/specs/weave-bulk-export.md`. Depends on BYOB (`team-level-byob-weave-trace-mtsaas.md`).

## Testing
72 unit tests (escaping w/ adversarial inputs, state mapping for every `system.query_log.type`, sql builders, table registry, engine happy + every failure mode incl. drop-in-finally and concurrent cap).