### PR TITLE
feat(weave): tier-2 cost-join export

### DIFF
--- a/tests/trace_server/export/test_costs_sql.py
+++ b/tests/trace_server/export/test_costs_sql.py
@@ -1,0 +1,150 @@
+"""Tier 2 cost-join SQL builder.
+
+The output is one Parquet row per `(call, model)`; the GROUP BY from
+`token_costs.py` is intentionally dropped. The ranking subquery must
+prefer project-level over default pricing, prefer prices effective at or
+before the call's started_at, and drop calls with no model key in
+`summary.usage` (no `weave_dummy_llm_id` pollution).
+"""
+
+import uuid
+from datetime import datetime, timezone
+from typing import cast
+
+import pytest
+
+from weave.trace_server.export.costs_sql import (
+    DUMMY_LLM_ID,
+    LLM_TOKEN_PRICES_TABLE,
+    build_cost_join_export_sql,
+)
+from weave.trace_server.export.schemas import ExportTable
+
+JOB = uuid.UUID("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+
+class TestCostJoinShape:
+    def test_select_passes_through_all_call_columns(self) -> None:
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        # `ranked.* EXCEPT (usage_raw, kv, rnk)` keeps every raw call column
+        # plus the derived per-model columns and the joined price columns.
+        assert "ranked.* EXCEPT (usage_raw, kv, rnk)" in prepared.sql
+
+    def test_join_attaches_price_columns(self) -> None:
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        for col in [
+            "prompt_token_cost",
+            "completion_token_cost",
+            "cache_read_input_token_cost",
+            "cache_creation_input_token_cost",
+            "prompt_token_cost_unit",
+            "completion_token_cost_unit",
+            "effective_date",
+            "pricing_level",
+        ]:
+            assert f"ltp.{col}" in prepared.sql
+
+    def test_join_left_keeps_calls_without_price_rows(self) -> None:
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        assert "LEFT JOIN" in prepared.sql
+
+    def test_no_group_by_in_export_path(self) -> None:
+        """v1 contract: one row per (call, model). GROUP BY is dropped."""
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        assert "GROUP BY" not in prepared.sql.upper()
+
+    def test_filters_dummy_llm_id(self) -> None:
+        """Calls with empty/malformed `summary.usage` must be dropped, not
+        emitted with the `weave_dummy_llm_id` sentinel.
+        """
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        assert f"ranked.llm_id != '{DUMMY_LLM_ID}'" in prepared.sql
+
+    def test_pricing_rank_prefers_project_over_default(self) -> None:
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        # Project override beats default beats nothing.
+        assert "pricing_level = 'project'" in prepared.sql
+        assert "pricing_level = 'default'" in prepared.sql
+        # `rnk = 1` selects the best-matching row.
+        assert "ranked.rnk = 1" in prepared.sql
+
+    def test_rank_respects_started_at_versus_effective_date(self) -> None:
+        """Mirror token_costs.py: prices live-at-call-time outrank later ones."""
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        assert "lu.started_at >= ltp.effective_date" in prepared.sql
+
+    def test_rank_partition_is_per_call_per_model(self) -> None:
+        """One row per (call, model) requires PARTITION BY (id, llm_id)."""
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        assert "PARTITION BY lu.id, lu.llm_id" in prepared.sql
+
+    def test_only_project_id_is_parameterized(self) -> None:
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="UHJvajEyMw=="
+        )
+        # `project_id` flows through CH parameter substitution.
+        assert "{project_id:String}" in prepared.sql
+        assert prepared.params["project_id"] == "UHJvajEyMw=="
+        # The literal project_id must not appear inlined anywhere.
+        assert "UHJvajEyMw==" not in prepared.sql
+
+    def test_time_range_pushed_into_inner_subquery(self) -> None:
+        start = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2026, 2, 1, tzinfo=timezone.utc)
+        prepared = build_cost_join_export_sql(
+            job_id=JOB,
+            table="calls_complete",
+            project_id="proj",
+            time_start=start,
+            time_end=end,
+        )
+        assert "{start_ts:DateTime64(3)}" in prepared.sql
+        assert "{end_ts:DateTime64(3)}" in prepared.sql
+        assert prepared.params["start_ts"] == start
+        assert prepared.params["end_ts"] == end
+
+
+class TestSecurity:
+    def test_no_credentials_in_sql(self) -> None:
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        for forbidden in ("access_key_id", "secret_access_key", "session_token"):
+            assert forbidden not in prepared.sql
+
+    def test_references_nc_by_name(self) -> None:
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        assert JOB.hex in prepared.sql  # NC name is built from job_id.hex
+
+    @pytest.mark.parametrize("table", ["calls_complete", "calls_merged"])
+    def test_tier_1_tables_supported(self, table: str) -> None:
+        prepared = build_cost_join_export_sql(
+            job_id=JOB,
+            table=cast(ExportTable, table),
+            project_id="proj",
+        )
+        assert f"FROM {table}" in prepared.sql
+
+    def test_references_canonical_prices_table(self) -> None:
+        prepared = build_cost_join_export_sql(
+            job_id=JOB, table="calls_complete", project_id="proj"
+        )
+        assert LLM_TOKEN_PRICES_TABLE in prepared.sql

--- a/tests/trace_server/export/test_engine.py
+++ b/tests/trace_server/export/test_engine.py
@@ -247,6 +247,38 @@ def test_insert_failure_drops_named_collection_on_failure() -> None:
     assert len(drops) == 2, drops  # DROP at start + DROP in cleanup
 
 
+def test_include_costs_routes_to_cost_join_sql() -> None:
+    """Tier 2: setting `include_costs=True` must submit the cost-join SQL.
+
+    The cost-join builder leaves a `LEFT JOIN llm_token_prices` and the dummy
+    filter behind that the tier-1 builder never emits; checking for both
+    pins the branch.
+    """
+    client = _FakeClient()
+    client.query_returns = [[(0,)], [(50,)]]
+    resolver = _FakeResolver(_make_target())
+
+    e = _build_engine(client, resolver)
+    e.start(
+        ExportStartReq(
+            project_id=PROJECT,
+            table="calls_complete",
+            include_costs=True,
+        ),
+        requested_by="user-a",
+    )
+
+    insert_cmd = next(
+        c
+        for c, _ in client.commands
+        if c.startswith("\nINSERT") or "INSERT INTO FUNCTION s3" in c
+    )
+    assert "LEFT JOIN" in insert_cmd
+    assert "llm_token_prices" in insert_cmd
+    assert "weave_dummy_llm_id" in insert_cmd
+    assert "ROW_NUMBER() OVER" in insert_cmd
+
+
 @pytest.mark.disable_logging_error_check
 def test_resolver_target_mismatch_refuses_to_proceed() -> None:
     """Defense-in-depth: target.source_project_id must match request."""

--- a/weave/trace_server/export/costs_sql.py
+++ b/weave/trace_server/export/costs_sql.py
@@ -1,0 +1,142 @@
+"""Tier 2 cost-join SQL builder.
+
+One Parquet row per `(call, model)`. The GROUP BY that `token_costs.py` uses
+to collapse joined rows back into one-row-per-call is intentionally dropped:
+the export's contract is flat per-model rows so consumers can filter / sum
+in whatever tool they pull the file into.
+
+Pricing-level ordering matches the calls UI:
+    1. project-override row whose `pricing_level_id == {project_id:String}`
+    2. default row whose `pricing_level_id IN ('default', '')`
+
+Prices effective at or before the call's `started_at` rank ahead of prices
+that took effect later, mirroring `token_costs.py`. Combined with the
+(call, model) partition this means the export reflects the price that was
+live when the call ran, not today's most-recent price. Calls with empty or
+malformed `summary.usage` are filtered out so the Parquet is not polluted
+with zero-cost rows.
+"""
+
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from weave.trace_server.export.constants import (
+    MAX_EXPORT_QUERY_SECONDS,
+    PARQUET_COMPRESSION,
+)
+from weave.trace_server.export.escaping import named_collection_name
+from weave.trace_server.export.schemas import ExportTable
+from weave.trace_server.export.sql import PreparedSql
+from weave.trace_server.export.table_registry import TABLE_REGISTRY
+
+DUMMY_LLM_ID = "weave_dummy_llm_id"
+LLM_TOKEN_PRICES_TABLE = "llm_token_prices"
+DEFAULT_PRICING_LEVEL_ID = "default"
+
+# Empty-string is the legacy "no level id" sentinel; the costs query filters
+# the JOIN to (project_id, default, '') just like `token_costs.py` does.
+PRICING_LEVEL_IDS = ("{project_id:String}", "'default'", "''")
+
+
+USAGE_KV = (
+    "arrayJoin(if(usage_raw != '' AND usage_raw != '{{}}', "
+    "JSONExtractKeysAndValuesRaw(usage_raw), "
+    f"[('{DUMMY_LLM_ID}', '{{}}')])) AS kv"
+)
+
+
+def build_cost_join_export_sql(
+    *,
+    job_id: UUID,
+    table: ExportTable,
+    project_id: str,
+    time_start: datetime | None = None,
+    time_end: datetime | None = None,
+) -> PreparedSql:
+    """`INSERT INTO FUNCTION s3(<nc>, format='Parquet') SELECT ... LEFT JOIN llm_token_prices ...`.
+
+    The inner subquery does `arrayJoin(JSONExtractKeysAndValuesRaw(summary.usage))`
+    so one input call expands to one output row per model key. The LEFT JOIN
+    attaches every candidate price; ROW_NUMBER picks the best one per
+    `(call_id, model)` partition. Calls with no model in `summary.usage` are
+    dropped via the dummy-llm filter.
+    """
+    spec = TABLE_REGISTRY[table]
+    nc_name = named_collection_name(job_id)
+    params: dict[str, Any] = {"project_id": project_id}
+
+    predicates = [f"{spec.project_id_column} = {{project_id:String}}"]
+    if time_start is not None:
+        params["start_ts"] = time_start
+        predicates.append(f"{spec.time_column} >= {{start_ts:DateTime64(3)}}")
+    if time_end is not None:
+        params["end_ts"] = time_end
+        predicates.append(f"{spec.time_column} < {{end_ts:DateTime64(3)}}")
+    where_clause = " AND ".join(predicates)
+
+    pricing_in_clause = ", ".join(PRICING_LEVEL_IDS)
+
+    # `lu.* EXCEPT (usage_raw, kv)` already projects every call column plus
+    # the derived per-model columns (llm_id, requests, prompt_tokens, ...).
+    # The outer SELECT only adds the `ltp.*` price columns to avoid the
+    # duplicate-column emission that earlier versions of this query had.
+    sql = f"""
+INSERT INTO FUNCTION s3({nc_name}, format = 'Parquet')
+SELECT
+    ranked.* EXCEPT (usage_raw, kv, rnk)
+FROM (
+    SELECT
+        lu.*,
+        ltp.prompt_token_cost AS prompt_token_cost,
+        ltp.completion_token_cost AS completion_token_cost,
+        ltp.cache_read_input_token_cost AS cache_read_input_token_cost,
+        ltp.cache_creation_input_token_cost AS cache_creation_input_token_cost,
+        ltp.prompt_token_cost_unit AS prompt_token_cost_unit,
+        ltp.completion_token_cost_unit AS completion_token_cost_unit,
+        ltp.effective_date AS effective_date,
+        ltp.pricing_level AS pricing_level,
+        ROW_NUMBER() OVER (
+            PARTITION BY lu.id, lu.llm_id
+            ORDER BY
+                CASE
+                    WHEN lu.started_at >= ltp.effective_date THEN 1
+                    ELSE 2
+                END,
+                CASE
+                    WHEN ltp.pricing_level = 'project' AND ltp.pricing_level_id = {{project_id:String}} THEN 1
+                    WHEN ltp.pricing_level = 'default' AND ltp.pricing_level_id = '{DEFAULT_PRICING_LEVEL_ID}' THEN 2
+                    ELSE 3
+                END,
+                ltp.effective_date DESC
+        ) AS rnk
+    FROM (
+        SELECT
+            *,
+            ifNull(JSONExtractRaw(summary_dump, 'usage'), '{{}}') AS usage_raw,
+            {USAGE_KV},
+            kv.1 AS llm_id,
+            JSONExtractInt(kv.2, 'requests') AS requests,
+            (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0)
+                + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0))
+                AS prompt_tokens,
+            (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0)
+                + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0))
+                AS completion_tokens,
+            JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+            JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+            JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
+        FROM {spec.ch_table}
+        WHERE {where_clause}
+    ) AS lu
+    LEFT JOIN {LLM_TOKEN_PRICES_TABLE} AS ltp
+        ON lu.llm_id = ltp.llm_id
+        AND ltp.pricing_level_id IN ({pricing_in_clause})
+) AS ranked
+WHERE ranked.rnk = 1 AND ranked.llm_id != '{DUMMY_LLM_ID}'
+SETTINGS
+    s3_truncate_on_insert = 1,
+    max_execution_time = {MAX_EXPORT_QUERY_SECONDS},
+    output_format_parquet_compression_method = '{PARQUET_COMPRESSION}'
+"""
+    return PreparedSql(sql=sql, params=params)

--- a/weave/trace_server/export/engine.py
+++ b/weave/trace_server/export/engine.py
@@ -16,7 +16,7 @@ from weave.trace_server.byob.resolver import (
     ResolvedExportTarget,
     StorageResolutionError,
 )
-from weave.trace_server.export import audit, constants, sql
+from weave.trace_server.export import audit, constants, costs_sql, sql
 from weave.trace_server.export.escaping import (
     build_create_named_collection_sql,
     build_drop_named_collection_sql,
@@ -281,7 +281,12 @@ class ExportEngine:
         self._ch.command(create_sql, settings={"log_queries": "0"})
         submitted = False
         try:
-            insert = sql.build_export_insert_sql(
+            build = (
+                costs_sql.build_cost_join_export_sql
+                if req.include_costs
+                else sql.build_export_insert_sql
+            )
+            insert = build(
                 job_id=submission.job_id,
                 table=req.table,
                 project_id=req.project_id,

--- a/weave/trace_server/export/schemas.py
+++ b/weave/trace_server/export/schemas.py
@@ -31,6 +31,14 @@ class ExportStartReq(BaseModel):
     time_range: TimeRange | None = None
     format: ExportFormat = "parquet"
     compression: Compression = "zstd"
+    include_costs: bool = False
+    """Tier 2: emit one row per (call, model) with cost columns inlined.
+
+    Row-count semantics differ from `include_costs=False` (tier 1): calls
+    with multiple models in `summary.usage` produce multiple Parquet rows.
+    Calls with no model (`summary.usage` empty or malformed) are dropped
+    rather than emitted with a sentinel `llm_id`.
+    """
 
 
 class ExportStartRes(BaseModel):


### PR DESCRIPTION
## Summary
- Adds `include_costs=true` on `ExportStartReq`. When set, the engine submits a cost-join `INSERT ... SELECT` instead of the tier-1 raw select.
- `arrayJoin(JSONExtractKeysAndValuesRaw(summary.usage))` expands one input call to one output row per model; LEFT JOIN `llm_token_prices` with the same `project > default` ranking `token_costs.py` uses today.
- Drops the GROUP BY so output is flat per-(call, model). Filters the `weave_dummy_llm_id` sentinel so calls without usage data don't pollute the Parquet.
- Stacks on #6960.
- Spec: `~/Desktop/specs/weave-bulk-export.md` Appendix "Tier 2: costs".

## Testing
14 new tests pin join shape, dummy filter, project-over-default ranking, params-only-on-project_id, time-range pushdown, no credentials in body, and engine routing on `include_costs=true`. Total 72 unit tests, all green.