### PR TITLE
perf(weave): use orjson for ClickHouse trace JSON dumps/loads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,8 @@ rich = ["rich"]           # Optional dependency for enhanced console output
 # default dependencies as well.
 trace_server = [
   "ddtrace>=2.7.0",
+  # Fast JSON (de)serialization for ClickHouse trace inserts
+  "orjson>=3.9.0",
   # BYOB - S3
   "boto3>=1.34.0",
   # BYOB - Azure

--- a/tests/trace_server/test_clickhouse_utilities.py
+++ b/tests/trace_server/test_clickhouse_utilities.py
@@ -1,7 +1,17 @@
+import json
+import math
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from weave.trace_server import clickhouse_trace_server_batched as chts
-from weave.trace_server.clickhouse.utilities import sanitize_invalid_utf8_surrogates
+from weave.trace_server.clickhouse.utilities import (
+    any_dump_to_any,
+    any_value_to_dump,
+    dict_dump_to_dict,
+    dict_value_to_dump,
+    sanitize_invalid_utf8_surrogates,
+)
 
 
 def test_sanitize_invalid_utf8_surrogates_replaces_lone_surrogates() -> None:
@@ -72,3 +82,48 @@ def test_insert_sanitizes_invalid_utf8_surrogates_after_encode_error() -> None:
     inserted_data = retried_insert
     assert inserted_data == [["valid \U0001f600", "broken \ufffd"]]
     str(inserted_data).encode("utf-8")
+
+
+def test_dict_value_to_dump_round_trip() -> None:
+    value = {"a": 1, "b": [1, 2, {"c": "x"}], "d": None, "e": True}
+    assert dict_dump_to_dict(dict_value_to_dump(value)) == value
+
+
+def test_any_value_to_dump_round_trip() -> None:
+    for value in ({"a": 1}, [1, 2, 3], "hello", 42, 3.14, True, None):
+        assert any_dump_to_any(any_value_to_dump(value)) == value
+
+
+def test_dict_value_to_dump_rejects_non_dict() -> None:
+    with pytest.raises(TypeError):
+        dict_value_to_dump([1, 2, 3])  # type: ignore[arg-type]
+
+
+def test_dict_dump_to_dict_rejects_non_object_payload() -> None:
+    with pytest.raises(TypeError):
+        dict_dump_to_dict("[1, 2, 3]")
+
+
+def test_non_string_dict_keys_are_coerced() -> None:
+    # orjson with OPT_NON_STR_KEYS coerces int keys to str, matching stdlib json.dumps.
+    out = dict_value_to_dump({1: "x", 2: "y"})
+    assert json.loads(out) == {"1": "x", "2": "y"}
+
+
+def test_nan_and_inf_serialize_to_null() -> None:
+    # orjson emits null for NaN/Inf (strict JSON). This is a deliberate change from
+    # stdlib json's NaN/Infinity literals -> ClickHouse JSONExtract* now works on
+    # these columns.
+    assert any_value_to_dump(math.nan) == "null"
+    assert any_value_to_dump(math.inf) == "null"
+    assert any_value_to_dump(-math.inf) == "null"
+
+
+def test_legacy_nan_literal_payload_still_loads() -> None:
+    # Pre-orjson rows stored as `{"x": NaN}` must still round-trip through reads.
+    # Stdlib json.loads accepts these; orjson does not -> we fall back on
+    # JSONDecodeError.
+    legacy = json.dumps({"x": float("nan"), "y": float("inf")})
+    loaded = dict_dump_to_dict(legacy)
+    assert math.isnan(loaded["x"])
+    assert loaded["y"] == float("inf")

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -13,6 +13,7 @@ from collections.abc import Sequence
 from typing import Any, TypeVar, cast
 
 import ddtrace
+import orjson
 import sqlparse
 from clickhouse_connect.driver.exceptions import DatabaseError
 
@@ -106,29 +107,50 @@ def sanitize_invalid_utf8_surrogates(value: T) -> T:
     return value
 
 
+# orjson is 5-10x faster than stdlib json on the nested dicts trace data produces,
+# but it is stricter: it rejects NaN/Infinity and non-string dict keys that stdlib
+# tolerates. Fall back to stdlib on TypeError so callers see the same contract as
+# before, and so reads of historical rows containing NaN/Infinity literals still work.
+_ORJSON_DUMPS_OPTS = orjson.OPT_NON_STR_KEYS
+
+
+def _orjson_dumps(value: Any) -> str:
+    try:
+        return orjson.dumps(value, option=_ORJSON_DUMPS_OPTS).decode("utf-8")
+    except TypeError:
+        return json.dumps(value)
+
+
+def _orjson_loads(val: str) -> Any:
+    try:
+        return orjson.loads(val)
+    except orjson.JSONDecodeError:
+        return json.loads(val)
+
+
 def dict_value_to_dump(
     value: dict,
 ) -> str:
     if not isinstance(value, dict):
         raise TypeError(f"Value is not a dict: {value}")
-    return json.dumps(value)
+    return _orjson_dumps(value)
 
 
 def any_value_to_dump(
     value: Any,
 ) -> str:
-    return json.dumps(value)
+    return _orjson_dumps(value)
 
 
 def dict_dump_to_dict(val: str) -> dict[str, Any]:
-    res = json.loads(val)
+    res = _orjson_loads(val)
     if not isinstance(res, dict):
         raise TypeError(f"Value is not a dict: {val}")
     return res
 
 
 def any_dump_to_any(val: str) -> Any:
-    return json.loads(val)
+    return _orjson_loads(val)
 
 
 def nullable_any_dump_to_any(


### PR DESCRIPTION
## Summary
- Swap stdlib `json` for `orjson` in the four ClickHouse trace JSON helpers (`dict_value_to_dump`, `any_value_to_dump`, `dict_dump_to_dict`, `any_dump_to_any`). These run on every call_start / call_end (`attributes`, `inputs`, `output`, `summary`, `otel_dump`).
- Stdlib fallback on dump `TypeError` and load `orjson.JSONDecodeError` preserves the prior contract and keeps reads of legacy rows working.
- `orjson.OPT_NON_STR_KEYS` matches stdlib's coercion of int dict keys to str.
- One deliberate semantic change: `NaN`/`Infinity` floats now serialize as `null` (strict JSON, what ClickHouse `JSONExtract*` expects) instead of the non-standard `NaN`/`Infinity` literals stdlib emits. Legacy rows with the old literals still parse via the stdlib fallback.

## Performance

Measured locally on trace-shaped payloads (median of 5 batches, GC disabled per batch, warm cache, M-series Mac). `helper.*` is the helper with the stdlib fallback path enabled.

| size  | actual  | json.dumps | orjson.dumps | helper.dumps | dump x | json.loads | orjson.loads | helper.loads | load x |
|-------|---------|-----------:|-------------:|-------------:|-------:|-----------:|-------------:|-------------:|-------:|
| 500 B | 500 B   |  3.39 us   |  1.03 us     |  1.13 us     | 3.29x  |  2.84 us   |  1.19 us     |  1.22 us     | 2.39x  |
| 5 KB  | 3.9 KB  | 12.84 us   |  2.20 us     |  2.38 us     | 5.83x  |  7.11 us   |  2.78 us     |  2.83 us     | 2.55x  |
| 50 KB | 53 KB   | 182.5 us   | 27.93 us     | 31.07 us     | 6.53x  | 103.6 us   | 48.59 us     | 47.48 us     | 2.13x  |
| 500 KB| 502 KB  |  1.679 ms  | 244.7 us     | 264.86 us    | 6.86x  |  1.007 ms  | 481.0 us     | 495.42 us    | 2.09x  |
| 5 MB  | 5.0 MB  | 17.83 ms   |  3.88 ms     |  4.49 ms     | 4.59x  | 11.44 ms   |  5.97 ms     |  6.04 ms     | 1.92x  |

- dumps: ~3.3x at 500B, peaks ~6.9x around 50-500 KB, ~4.6x at 5 MB
- loads: ~1.9-2.6x across the range
- helper wrapper overhead vs raw orjson: ~5-15%, within noise below 5 MB

## Testing
new round-trip + edge-case tests in `test_clickhouse_utilities.py` (non-str keys coerced, NaN/Inf -> null on dump, legacy `NaN` literal payloads still load). full `tests/trace_server/` shard: 1120 passed, 1 unrelated pre-existing failure (`test_skip_clickhouse_client`, reproduces on master).