### PR TITLE
perf(weave): single-pass tree walk for base64 + refs extraction

### DIFF
--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -11,12 +12,14 @@ from weave.trace_server.base64_content_conversion import (
     is_base64,
     is_data_uri,
     process_call_req_to_content,
+    process_complete_call_to_content,
     replace_base64_with_content_objects,
     store_content_object,
 )
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallStartReq,
+    CompletedCallSchemaForInsert,
     EndedCallSchemaForInsert,
     FileCreateRes,
     StartedCallSchemaForInsert,
@@ -193,7 +196,7 @@ class TestBase64Replacement:
             start=StartedCallSchemaForInsert(
                 project_id="proj",
                 op_name="op",
-                started_at=__import__("datetime").datetime.utcnow(),
+                started_at=datetime.now(timezone.utc),
                 attributes={},
                 inputs={
                     "image": f"data:image/png;base64,{b64_data}",
@@ -213,7 +216,7 @@ class TestBase64Replacement:
             end=EndedCallSchemaForInsert(
                 project_id="proj",
                 id="call-id",
-                ended_at=__import__("datetime").datetime.utcnow(),
+                ended_at=datetime.now(timezone.utc),
                 summary={"usage": {}, "status_counts": {}},
                 output=long_b64,
             )
@@ -265,16 +268,7 @@ class TestBase64Replacement:
         assert result["image_ref"] == ref_b
 
     def test_process_complete_call_to_content_returns_refs_for_both_sides(self):
-        """`process_complete_call_to_content` returns (call, input_refs, output_refs)."""
-        from datetime import datetime, timezone
-
-        from weave.trace_server.base64_content_conversion import (
-            process_complete_call_to_content,
-        )
-        from weave.trace_server.trace_server_interface import (
-            CompletedCallSchemaForInsert,
-        )
-
+        """`process_complete_call_to_content` returns a ProcessedCompleteCall with both refs."""
         trace_server = MagicMock()
         input_ref = "weave-trace-internal:///proj/object/in:v1"
         output_ref = "weave-trace-internal:///proj/object/out:v1"
@@ -292,13 +286,11 @@ class TestBase64Replacement:
             output={"y": output_ref},
         )
 
-        processed, input_refs, output_refs = process_complete_call_to_content(
-            completed, trace_server
-        )
+        processed = process_complete_call_to_content(completed, trace_server)
 
-        assert processed is completed
-        assert input_refs == [input_ref]
-        assert output_refs == [output_ref]
+        assert processed["call"] is completed
+        assert processed["input_refs"] == [input_ref]
+        assert processed["output_refs"] == [output_ref]
 
 
 class TestStandaloneBase64Detection:
@@ -573,8 +565,6 @@ class TestThresholdAndStructuralIdentity:
         ``CallStartReq`` machinery in ``process_call_req_to_content`` just
         rebinds the field, which is fine.
         """
-        from datetime import datetime, timezone
-
         trace_server = MagicMock()
         inputs_before = {"text": "no binary content here"}
         start_req = CallStartReq(

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -119,7 +119,7 @@ class TestBase64Replacement:
             "nested": {"field3": f"data:image/png;base64,{b64_data}"},
         }
 
-        result = replace_base64_with_content_objects(
+        result, _refs = replace_base64_with_content_objects(
             input_data, "test_project", trace_server
         )
 
@@ -159,7 +159,7 @@ class TestBase64Replacement:
             {"nested": f"data:text/plain;base64,{b64_data}"},
         ]
 
-        result = replace_base64_with_content_objects(
+        result, _refs = replace_base64_with_content_objects(
             input_data, "test_project", trace_server
         )
 
@@ -202,7 +202,7 @@ class TestBase64Replacement:
             )
         )
 
-        processed_start = process_call_req_to_content(start_req, trace_server)
+        processed_start, _refs = process_call_req_to_content(start_req, trace_server)
         assert processed_start.start.inputs["text"] == "Some normal text"
         assert isinstance(processed_start.start.inputs["image"], dict)
         assert processed_start.start.inputs["image"]["_type"] == "CustomWeaveType"
@@ -219,8 +219,86 @@ class TestBase64Replacement:
             )
         )
 
-        processed_end = process_call_req_to_content(end_req, trace_server)
+        processed_end, _refs = process_call_req_to_content(end_req, trace_server)
         assert processed_end.end.output == long_b64
+
+    def test_fused_walk_extracts_refs_alongside_base64(self):
+        """Refs and base64 conversion both come out of a single traversal.
+
+        The fused walk replaces `replace_base64_with_content_objects` +
+        `extract_refs_from_values`, so refs must be returned alongside the
+        transformed tree (deduped, nested, co-located with base64).
+        """
+        trace_server = MagicMock()
+        trace_server.file_create = MagicMock(
+            side_effect=[
+                FileCreateRes(digest="content_digest"),
+                FileCreateRes(digest="metadata_digest"),
+            ]
+        )
+
+        ref_a = "weave-trace-internal:///proj/object/obj_a:abc123"
+        ref_b = "weave-trace-internal:///proj/object/obj_b:def456"
+        b64_data = base64.b64encode(b"x" * LARGE_TEST_DATA_SIZE).decode("ascii")
+        data_uri = f"data:image/png;base64,{b64_data}"
+
+        result, refs = replace_base64_with_content_objects(
+            {
+                "messages": [
+                    {"role": "user", "content": ref_a},
+                    {"role": "assistant", "content": data_uri},
+                    {"role": "system", "content": ref_a},  # dup
+                ],
+                "image_ref": ref_b,
+            },
+            "test_project",
+            trace_server,
+        )
+
+        # Base64 was replaced in-place
+        assert isinstance(result["messages"][1]["content"], dict)
+        assert result["messages"][1]["content"]["_type"] == "CustomWeaveType"
+        # Refs are deduped and nesting-agnostic
+        assert sorted(refs) == sorted([ref_a, ref_b])
+        # And refs are left untouched in the transformed tree
+        assert result["messages"][0]["content"] == ref_a
+        assert result["image_ref"] == ref_b
+
+    def test_process_complete_call_to_content_returns_refs_for_both_sides(self):
+        """`process_complete_call_to_content` returns (call, input_refs, output_refs)."""
+        from datetime import datetime, timezone
+
+        from weave.trace_server.base64_content_conversion import (
+            process_complete_call_to_content,
+        )
+        from weave.trace_server.trace_server_interface import (
+            CompletedCallSchemaForInsert,
+        )
+
+        trace_server = MagicMock()
+        input_ref = "weave-trace-internal:///proj/object/in:v1"
+        output_ref = "weave-trace-internal:///proj/object/out:v1"
+
+        completed = CompletedCallSchemaForInsert(
+            project_id="proj",
+            id="call-id",
+            trace_id="trace-id",
+            op_name="op",
+            started_at=datetime.now(timezone.utc),
+            ended_at=datetime.now(timezone.utc),
+            attributes={},
+            inputs={"x": input_ref},
+            summary={"usage": {}, "status_counts": {}},
+            output={"y": output_ref},
+        )
+
+        processed, input_refs, output_refs = process_complete_call_to_content(
+            completed, trace_server
+        )
+
+        assert processed is completed
+        assert input_refs == [input_ref]
+        assert output_refs == [output_ref]
 
 
 class TestStandaloneBase64Detection:
@@ -257,7 +335,7 @@ class TestStandaloneBase64Detection:
             assert is_base64(test_str), f"Expected {test_str} to match base64 pattern"
 
             input_data = {"field": test_str}
-            result = replace_base64_with_content_objects(
+            result, _refs = replace_base64_with_content_objects(
                 input_data, "test_project", trace_server
             )
 
@@ -326,7 +404,7 @@ class TestStandaloneBase64Detection:
             "other_field": "normal string",
         }
 
-        result = replace_base64_with_content_objects(
+        result, _refs = replace_base64_with_content_objects(
             input_data, "test_project", trace_server
         )
 
@@ -376,7 +454,7 @@ class TestThresholdAndStructuralIdentity:
         # successfully under the old threshold and gone through the regex
         # path. Now it must be returned untouched.
         below_threshold = "A" * 4096
-        result = replace_base64_with_content_objects(
+        result, _refs = replace_base64_with_content_objects(
             {"field": below_threshold}, "test_project", trace_server
         )
         assert result["field"] == below_threshold
@@ -398,7 +476,7 @@ class TestThresholdAndStructuralIdentity:
             ],
             "metadata": {"trace_id": "abc"},
         }
-        result = replace_base64_with_content_objects(
+        result, _refs = replace_base64_with_content_objects(
             original, "test_project", trace_server
         )
         # The outer dict, the messages list, every inner message dict, and
@@ -432,7 +510,7 @@ class TestThresholdAndStructuralIdentity:
             "model": "claude-sonnet-4-6",
         }
 
-        result = replace_base64_with_content_objects(
+        result, _refs = replace_base64_with_content_objects(
             original, "test_project", trace_server
         )
 
@@ -473,7 +551,7 @@ class TestThresholdAndStructuralIdentity:
         ]
         original = {"messages": original_messages, "model": "claude-sonnet-4-6"}
 
-        result = replace_base64_with_content_objects(
+        result, _refs = replace_base64_with_content_objects(
             original, "test_project", trace_server
         )
 
@@ -508,7 +586,7 @@ class TestThresholdAndStructuralIdentity:
                 inputs=inputs_before,
             )
         )
-        processed = process_call_req_to_content(start_req, trace_server)
+        processed, _refs = process_call_req_to_content(start_req, trace_server)
         # Pydantic shallow-copies inputs at model construction, so we compare
         # by value rather than identity here — content must round-trip
         # unchanged regardless of the SDK copy.

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -7,11 +7,12 @@ with content objects stored in bucket storage.
 import json
 import logging
 import re
-from typing import Any, TypeVar
+from typing import Any, TypedDict, TypeVar
 
 import ddtrace
 
 from weave.shared import refs_internal
+from weave.shared.refs_internal import InvalidInternalRef
 from weave.shared.trace_server_interface_util import valid_internal_schemes
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
@@ -22,6 +23,19 @@ from weave.trace_server.trace_server_interface import (
     TraceServerInterface,
 )
 from weave.type_wrappers.Content.content import Content
+
+
+class ProcessedCompleteCall(TypedDict):
+    """Result of `process_complete_call_to_content`.
+
+    Carrying input_refs and output_refs as named fields here (instead of a
+    3-tuple) keeps the call-site call_complete_to_ch_insertable mapping
+    positionally unambiguous.
+    """
+
+    call: CompletedCallSchemaForInsert
+    input_refs: list[str]
+    output_refs: list[str]
 
 logger = logging.getLogger(__name__)
 
@@ -175,7 +189,10 @@ def replace_base64_with_content_objects(
                     parsed = refs_internal.parse_internal_uri(val)
                     if parsed.uri == val:
                         seen_refs[val] = None
-                except Exception:
+                except InvalidInternalRef:
+                    # Malformed ref URI: stay silent (matches the legacy
+                    # `extract_refs_from_values` behaviour). Anything else
+                    # is a bug and must propagate.
                     pass
                 return val
             if len(val) > AUTO_CONVERSION_MIN_SIZE:
@@ -255,7 +272,7 @@ def process_call_req_to_content(
 def process_complete_call_to_content(
     complete_call: CompletedCallSchemaForInsert,
     trace_server: TraceServerInterface,
-) -> tuple[CompletedCallSchemaForInsert, list[str], list[str]]:
+) -> ProcessedCompleteCall:
     """Process a complete call to replace base64 content and extract refs.
 
     Args:
@@ -263,7 +280,8 @@ def process_complete_call_to_content(
         trace_server: Trace server instance for file storage.
 
     Returns:
-        Tuple of (complete_call, input_refs, output_refs).
+        A `ProcessedCompleteCall` carrying the mutated call plus refs for
+        each side as named fields.
     """
     complete_call.inputs, input_refs = replace_base64_with_content_objects(
         complete_call.inputs, complete_call.project_id, trace_server
@@ -271,4 +289,6 @@ def process_complete_call_to_content(
     complete_call.output, output_refs = replace_base64_with_content_objects(
         complete_call.output, complete_call.project_id, trace_server
     )
-    return complete_call, input_refs, output_refs
+    return ProcessedCompleteCall(
+        call=complete_call, input_refs=input_refs, output_refs=output_refs
+    )

--- a/weave/trace_server/base64_content_conversion.py
+++ b/weave/trace_server/base64_content_conversion.py
@@ -11,6 +11,8 @@ from typing import Any, TypeVar
 
 import ddtrace
 
+from weave.shared import refs_internal
+from weave.shared.trace_server_interface_util import valid_internal_schemes
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
     CallEndV2Req,
@@ -117,11 +119,13 @@ def replace_base64_with_content_objects(
     vals: T,
     project_id: str,
     trace_server: TraceServerInterface,
-) -> T:
-    """Recursively replace base64 content with Content objects.
+) -> tuple[T, list[str]]:
+    """Single-pass walk that replaces base64 content AND extracts internal refs.
 
-    Follows the same pattern as extract_refs_from_values, visiting all values
-    and replacing base64 content where found.
+    Fuses what was previously two separate traversals (this function plus
+    `extract_refs_from_values`) so each call insert touches the inputs/output
+    tree once instead of twice. Identity-preservation on no-binary subtrees is
+    unchanged: untouched subtrees still round-trip by `is`, not by value.
 
     Args:
         vals: Value to process (can be dict, list, or primitive)
@@ -129,8 +133,9 @@ def replace_base64_with_content_objects(
         trace_server: Trace server instance for file storage
 
     Returns:
-        Tuple of (processed_value, list_of_created_refs)
+        Tuple of (processed_value, list_of_refs).
     """
+    seen_refs: dict[str, None] = {}
 
     def _visit_children(items: Any, original: Any, cls: type) -> Any:
         # Walk one level of a collection's children. We allocate a shallow
@@ -159,48 +164,60 @@ def replace_base64_with_content_objects(
             return _visit_children(val.items(), val, dict)
         if isinstance(val, list):
             return _visit_children(enumerate(val), val, list)
-        if isinstance(val, str) and len(val) > AUTO_CONVERSION_MIN_SIZE:
-            # Check for data URI pattern first
-            if is_data_uri(val):
+        if isinstance(val, str):
+            # Refs are always far shorter than the base64 threshold; the cheap
+            # startswith check eliminates the vast majority of strings before
+            # we touch the length guard at all.
+            if any(
+                val.startswith(scheme + ":///") for scheme in valid_internal_schemes
+            ):
                 try:
-                    # Create proper Content object structure
-                    return store_content_object(
-                        Content.from_data_url(val),
-                        project_id,
-                        trace_server,
-                    )
-                except Exception as e:
-                    logger.warning(
-                        "Failed to create and store content from data URI with error %s",
-                        e,
-                    )
-
-            if is_base64(val):
-                try:
-                    # All we care about here is if this is an object that we can handle in some way.
-                    # 'aaaa' is valid base64 and will come out as text/plain
-                    # More complicated false positives or failed detections will show 'application/octet-stream'
-                    # The uncovered scenario is if a user has encoded a plaintext document as Base64
-                    # We don't handle text content objects in a special way on the clients, so this is acceptable.
-                    content: Content[Any] = Content.from_base64(val)
-                    if content.mimetype not in {
-                        "text/plain",
-                        "application/octet-stream",
-                    }:
+                    parsed = refs_internal.parse_internal_uri(val)
+                    if parsed.uri == val:
+                        seen_refs[val] = None
+                except Exception:
+                    pass
+                return val
+            if len(val) > AUTO_CONVERSION_MIN_SIZE:
+                # Check for data URI pattern first
+                if is_data_uri(val):
+                    try:
+                        # Create proper Content object structure
                         return store_content_object(
-                            content,
+                            Content.from_data_url(val),
                             project_id,
                             trace_server,
                         )
-                except Exception as e:
-                    logger.warning(
-                        "Failed to create content from standalone base64: %s", e
-                    )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to create and store content from data URI with error %s",
+                            e,
+                        )
 
-            return val
+                if is_base64(val):
+                    try:
+                        # All we care about here is if this is an object that we can handle in some way.
+                        # 'aaaa' is valid base64 and will come out as text/plain
+                        # More complicated false positives or failed detections will show 'application/octet-stream'
+                        # The uncovered scenario is if a user has encoded a plaintext document as Base64
+                        # We don't handle text content objects in a special way on the clients, so this is acceptable.
+                        content: Content[Any] = Content.from_base64(val)
+                        if content.mimetype not in {
+                            "text/plain",
+                            "application/octet-stream",
+                        }:
+                            return store_content_object(
+                                content,
+                                project_id,
+                                trace_server,
+                            )
+                    except Exception as e:
+                        logger.warning(
+                            "Failed to create content from standalone base64: %s", e
+                        )
         return val
 
-    return _visit(vals)
+    return _visit(vals), list(seen_refs)
 
 
 R = TypeVar("R", bound=CallStartReq | CallEndReq | CallEndV2Req)
@@ -209,8 +226,8 @@ R = TypeVar("R", bound=CallStartReq | CallEndReq | CallEndV2Req)
 def process_call_req_to_content(
     req: R,
     trace_server: TraceServerInterface,
-) -> R:
-    """Process call inputs/outputs to replace base64 content.
+) -> tuple[R, list[str]]:
+    """Process call inputs/outputs to replace base64 content and extract refs.
 
     This is the main entry point for processing trace data before insertion.
 
@@ -219,37 +236,39 @@ def process_call_req_to_content(
         trace_server: Trace server instance
 
     Returns:
-        Request with base64 content replaced by Content objects.
+        Tuple of (request, refs). `refs` is `input_refs` for `CallStartReq`,
+        `output_refs` for `CallEndReq`/`CallEndV2Req`, `[]` otherwise.
     """
     if isinstance(req, CallStartReq):
-        req.start.inputs = replace_base64_with_content_objects(
+        req.start.inputs, refs = replace_base64_with_content_objects(
             req.start.inputs, req.start.project_id, trace_server
         )
-    elif isinstance(req, (CallEndReq, CallEndV2Req)):
-        req.end.output = replace_base64_with_content_objects(
+        return req, refs
+    if isinstance(req, (CallEndReq, CallEndV2Req)):
+        req.end.output, refs = replace_base64_with_content_objects(
             req.end.output, req.end.project_id, trace_server
         )
-
-    return req
+        return req, refs
+    return req, []
 
 
 def process_complete_call_to_content(
     complete_call: CompletedCallSchemaForInsert,
     trace_server: TraceServerInterface,
-) -> CompletedCallSchemaForInsert:
-    """Process a complete call to replace base64 content in inputs and outputs.
+) -> tuple[CompletedCallSchemaForInsert, list[str], list[str]]:
+    """Process a complete call to replace base64 content and extract refs.
 
     Args:
         complete_call: Complete call schema with both inputs and outputs.
         trace_server: Trace server instance for file storage.
 
     Returns:
-        CompletedCallSchemaForInsert with base64 content replaced by Content objects.
+        Tuple of (complete_call, input_refs, output_refs).
     """
-    complete_call.inputs = replace_base64_with_content_objects(
+    complete_call.inputs, input_refs = replace_base64_with_content_objects(
         complete_call.inputs, complete_call.project_id, trace_server
     )
-    complete_call.output = replace_base64_with_content_objects(
+    complete_call.output, output_refs = replace_base64_with_content_objects(
         complete_call.output, complete_call.project_id, trace_server
     )
-    return complete_call
+    return complete_call, input_refs, output_refs

--- a/weave/trace_server/clickhouse/schema_converters.py
+++ b/weave/trace_server/clickhouse/schema_converters.py
@@ -126,14 +126,18 @@ def ch_call_to_row(ch_call: CallCHInsertable | CallCompleteCHInsertable) -> list
 def start_call_for_insert_to_ch_insertable(
     start_call: tsi.StartedCallSchemaForInsert,
     retention_days: int,
+    input_refs: list[str] | None = None,
 ) -> CallStartCHInsertable:
     # Note: it is technically possible for the user to mess up and provide the
     # wrong trace id (one that does not match the parent_id)!
     call_id = start_call.id or generate_id()
     trace_id = start_call.trace_id or generate_id()
-    # Process inputs for base64 content if trace_server is provided
     inputs = start_call.inputs
-    input_refs = extract_refs_from_values(inputs)
+    # `input_refs` may be pre-computed by the fused base64+refs walk in
+    # `process_call_req_to_content`. Fall back to walking the tree when callers
+    # don't run that pre-pass (OTel export, restore paths).
+    if input_refs is None:
+        input_refs = extract_refs_from_values(inputs)
 
     otel_dump_str = None
     if start_call.otel_dump is not None:
@@ -201,11 +205,14 @@ def start_call_insertable_to_complete_start(
 def end_call_for_insert_to_ch_insertable(
     end_call: tsi.EndedCallSchemaForInsert,
     retention_days: int,
+    output_refs: list[str] | None = None,
 ) -> CallEndCHInsertable:
     # Note: it is technically possible for the user to mess up and provide the
     # wrong trace id (one that does not match the parent_id)!
     output = end_call.output
-    output_refs = extract_refs_from_values(output)
+    # See `start_call_for_insert_to_ch_insertable` for the pre-computed refs path.
+    if output_refs is None:
+        output_refs = extract_refs_from_values(output)
 
     return CallEndCHInsertable(
         project_id=end_call.project_id,
@@ -291,21 +298,28 @@ def ch_complete_call_to_row(ch_call: CallCompleteCHInsertable) -> list[Any]:
 def complete_call_to_ch_insertable(
     complete_call: tsi.CompletedCallSchemaForInsert,
     retention_days: int,
+    input_refs: list[str] | None = None,
+    output_refs: list[str] | None = None,
 ) -> CallCompleteCHInsertable:
     """Convert a completed call schema to a ClickHouse insertable format.
 
     Args:
         complete_call: The completed call schema from the API.
         retention_days: The project's retention policy in days (0 = no TTL).
+        input_refs: Pre-extracted refs from `process_complete_call_to_content`.
+        output_refs: Pre-extracted refs from `process_complete_call_to_content`.
 
     Returns:
         CallCompleteCHInsertable: The ClickHouse insertable representation.
     """
     inputs = complete_call.inputs
-    input_refs = extract_refs_from_values(inputs)
+    # See `start_call_for_insert_to_ch_insertable` for the pre-computed refs path.
+    if input_refs is None:
+        input_refs = extract_refs_from_values(inputs)
 
     output = complete_call.output
-    output_refs = extract_refs_from_values(output)
+    if output_refs is None:
+        output_refs = extract_refs_from_values(output)
 
     otel_dump_str = None
     if complete_call.otel_dump is not None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -958,11 +958,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         with self.call_batch():
             for complete_call in req.batch:
-                (
-                    processed_complete_call,
-                    input_refs,
-                    output_refs,
-                ) = process_complete_call_to_content(complete_call, self)
+                processed = process_complete_call_to_content(complete_call, self)
+                processed_complete_call = processed["call"]
 
                 # Determine write target based on project, this should be the same for all
                 # calls in the batch, subsequent calls just hit the in-memory cache. This
@@ -979,8 +976,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 ch_call = complete_call_to_ch_insertable(
                     processed_complete_call,
                     retention_days,
-                    input_refs=input_refs,
-                    output_refs=output_refs,
+                    input_refs=processed["input_refs"],
+                    output_refs=processed["output_refs"],
                 )
                 if write_target == WriteTarget.CALLS_COMPLETE:
                     self._insert_call_complete(ch_call)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -867,11 +867,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # as enforcing business rules and defaults
         set_current_span_dd_tags({"weave_trace_server.insert_call_count": 1})
 
-        req = process_call_req_to_content(req, self)
+        req, input_refs = process_call_req_to_content(req, self)
         retention_days = get_project_retention_days(
             req.start.project_id, self.ch_client
         )
-        ch_call = start_call_for_insert_to_ch_insertable(req.start, retention_days)
+        ch_call = start_call_for_insert_to_ch_insertable(
+            req.start, retention_days, input_refs=input_refs
+        )
 
         # Check write target - v1 call_start cannot write to calls_complete
         write_target = self.table_routing_resolver.resolve_v1_write_target(
@@ -900,9 +902,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # Converts the user-provided call details into a clickhouse schema.
         # This does validation and conversion of the input data as well
         # as enforcing business rules and defaults
-        req = process_call_req_to_content(req, self)
+        req, output_refs = process_call_req_to_content(req, self)
         retention_days = get_project_retention_days(req.end.project_id, self.ch_client)
-        ch_call = end_call_for_insert_to_ch_insertable(req.end, retention_days)
+        ch_call = end_call_for_insert_to_ch_insertable(
+            req.end, retention_days, output_refs=output_refs
+        )
 
         # Check write target - v1 call_end cannot write to calls_complete
         write_target = self.table_routing_resolver.resolve_v1_write_target(
@@ -954,9 +958,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         with self.call_batch():
             for complete_call in req.batch:
-                processed_complete_call = process_complete_call_to_content(
-                    complete_call, self
-                )
+                (
+                    processed_complete_call,
+                    input_refs,
+                    output_refs,
+                ) = process_complete_call_to_content(complete_call, self)
 
                 # Determine write target based on project, this should be the same for all
                 # calls in the batch, subsequent calls just hit the in-memory cache. This
@@ -971,7 +977,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     processed_complete_call.project_id, self.ch_client
                 )
                 ch_call = complete_call_to_ch_insertable(
-                    processed_complete_call, retention_days
+                    processed_complete_call,
+                    retention_days,
+                    input_refs=input_refs,
+                    output_refs=output_refs,
                 )
                 if write_target == WriteTarget.CALLS_COMPLETE:
                     self._insert_call_complete(ch_call)
@@ -994,12 +1003,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         This is used for eager ops like Evaluation.evaluate that need
         their start to be visible immediately in the UI.
         """
-        start_req = process_call_req_to_content(tsi.CallStartReq(start=req.start), self)
+        start_req, input_refs = process_call_req_to_content(
+            tsi.CallStartReq(start=req.start), self
+        )
         retention_days = get_project_retention_days(
             start_req.start.project_id, self.ch_client
         )
         ch_start = start_call_for_insert_to_ch_insertable(
-            start_req.start, retention_days
+            start_req.start, retention_days, input_refs=input_refs
         )
 
         write_target = self.table_routing_resolver.resolve_v2_write_target(
@@ -1028,7 +1039,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         Returns:
             CallEndV2Res: Empty response on success.
         """
-        req = process_call_req_to_content(req, self)
+        req, output_refs = process_call_req_to_content(req, self)
 
         write_target = self.table_routing_resolver.resolve_v2_write_target(
             req.end.project_id,
@@ -1037,12 +1048,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # If writing to calls_complete, perform lightweight UPDATE
         if write_target == WriteTarget.CALLS_COMPLETE:
-            self._update_call_end_in_calls_complete(req.end)
+            self._update_call_end_in_calls_complete(req.end, output_refs=output_refs)
         elif write_target == WriteTarget.CALLS_MERGED:
             retention_days = get_project_retention_days(
                 req.end.project_id, self.ch_client
             )
-            ch_end = end_call_for_insert_to_ch_insertable(req.end, retention_days)
+            ch_end = end_call_for_insert_to_ch_insertable(
+                req.end, retention_days, output_refs=output_refs
+            )
             self._insert_call(ch_end)
             if self._flush_immediately:
                 self._flush_calls()
@@ -1061,7 +1074,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         name="clickhouse_trace_server_batched._update_call_end_in_calls_complete"
     )
     def _update_call_end_in_calls_complete(
-        self, end_call: tsi.EndedCallSchemaForInsert
+        self,
+        end_call: tsi.EndedCallSchemaForInsert,
+        output_refs: list[str] | None = None,
     ) -> None:
         """Update a call's end data in the calls_complete table using lightweight UPDATE.
 
@@ -1072,11 +1087,14 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             end_call: The end call data to update. If started_at is provided,
                 it enables more efficient queries by utilizing the ClickHouse
                 primary key (project_id, started_at, id).
+            output_refs: Pre-extracted refs from the fused base64+refs walk in
+                `process_call_req_to_content`. Computed locally if not provided.
         """
         table_name = self._get_calls_complete_table_name()
 
         output = end_call.output
-        output_refs = extract_refs_from_values(output)
+        if output_refs is None:
+            output_refs = extract_refs_from_values(output)
         output_dump = any_value_to_dump(output)
         summary_dump = dict_value_to_dump(dict(end_call.summary))
 


### PR DESCRIPTION
## Summary
- Fuses `replace_base64_with_content_objects` + `extract_refs_from_values` into a single Python walk on the SDK-ingest call insert paths (`call_start`, `call_end`, `call_start_v2`, `call_end_v2`, `calls_complete`). Those paths now walk the inputs/output tree once in Python + once in C (`json.dumps`) instead of twice in Python + once in C.
- OTel export and admin/restore paths still call schema converters without pre-extracted refs; they get the existing 2-Python-walk behavior via the converter's `None`-fallback to `extract_refs_from_values`.
- `replace_base64_with_content_objects` now returns `(value, refs)`. `process_call_req_to_content` returns `(req, refs)` (input_refs for start, output_refs for end). `process_complete_call_to_content` returns a `ProcessedCompleteCall` TypedDict (`call`, `input_refs`, `output_refs`) to avoid positional-confusion in the 3-value return.
- Schema converters (`start_call_for_insert_to_ch_insertable`, `end_call_for_insert_to_ch_insertable`, `complete_call_to_ch_insertable`) and `_update_call_end_in_calls_complete` accept optional pre-extracted refs; OTel/restore paths fall back to `extract_refs_from_values`.
- JSON dump intentionally left as the C-implemented 2nd walk: a Python-level json synthesizer would regress vs. `json.dumps`, and after the fused walk the tree it serializes is typically smaller (large base64 strings have been replaced with content-object dicts).

## Testing
added 2 focused tests for the fused-refs contract (refs alongside base64, dedup, nesting; `ProcessedCompleteCall` shape). updated 11 existing call sites for the new tuple/TypedDict returns.