### PR TITLE
fix(weave): force alter_sync on migration 032 ADD INDEX

### DIFF
--- a/weave/trace_server/migrations/032_add_bloom_filter_trace_id_index.up.sql
+++ b/weave/trace_server/migrations/032_add_bloom_filter_trace_id_index.up.sql
@@ -13,9 +13,13 @@
 -- `ifNull(trace_id, '')` (and matching the predicate in the query layer
 -- character-for-character) makes the comparison non-nullable on both
 -- sides so the index actually fires.
+-- alter_sync = 1 forces the metadata change to land on the local replica
+-- before the next statement runs, so the MATERIALIZE below is guaranteed
+-- to see the new index (matches the convention in migrations 012 and 028).
 ALTER TABLE calls_merged
     ADD INDEX IF NOT EXISTS idx_trace_id_bloom
-        ifNull(trace_id, '') TYPE bloom_filter(0.01) GRANULARITY 1;
+        ifNull(trace_id, '') TYPE bloom_filter(0.01) GRANULARITY 1
+    SETTINGS alter_sync = 1;
 
 -- Kick off background materialization for existing parts. mutations_sync
 -- defaults to 0, so this returns immediately and ClickHouse runs the


### PR DESCRIPTION
## Summary
- Migration 032 added `idx_trace_id_bloom` then immediately ran `MATERIALIZE INDEX` without `SETTINGS alter_sync = 1` on the ADD. On replicated tables the metadata DDL is async by default, so the MATERIALIZE could in principle race the index visibility on the local replica.
- Migrations [012](https://github.com/wandb/weave/blob/master/weave/trace_server/migrations/012_add_sortable_timestamp.up.sql) and [028](https://github.com/wandb/weave/blob/master/weave/trace_server/migrations/028_add_bloom_filter_id_index.up.sql) both use `SETTINGS alter_sync = 1` on ADD INDEX; this brings 032 in line.
- MATERIALIZE INDEX intentionally stays async (`mutations_sync = 0`) so the migrator does not block on a full-table reindex of `calls_merged`.

Fast follow to #6764.

## Testing
non-functional change.