### PR TITLE
chore(weave_ts): Use types provided by @openai/agents

### DIFF
--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -1,6 +1,6 @@
 import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
 import {createOpenAIAgentsTracingProcessor} from '../../integrations/openai.agent';
-import type { Trace, Span } from '../../integrations/openai.agent.types';
+import type {Trace, Span} from '../../integrations/openai.agent.types';
 import {initWithCustomTraceServer} from '../clientMock';
 
 describe('OpenAI Agents Integration', () => {

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -1,5 +1,6 @@
 import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
 import {createOpenAIAgentsTracingProcessor} from '../../integrations/openai.agent';
+import type { Trace, Span } from '../../integrations/openai.agent.types';
 import {initWithCustomTraceServer} from '../clientMock';
 
 describe('OpenAI Agents Integration', () => {
@@ -14,12 +15,12 @@ describe('OpenAI Agents Integration', () => {
   test('trace lifecycle creates and finishes call', async () => {
     const processor = createOpenAIAgentsTracingProcessor();
     const trace = {
-      type: 'trace' as const,
+      type: 'trace',
       traceId: 'test-trace-123',
       name: 'Agent Workflow',
       groupId: null,
       metadata: {},
-    };
+    } as Trace;
 
     await processor.onTraceStart(trace);
     await processor.onTraceEnd(trace);
@@ -43,7 +44,7 @@ describe('OpenAI Agents Integration', () => {
       traceId: 'test-trace',
       name: 'Test',
       groupId: null,
-    });
+    } as Trace);
 
     // Test key span types
     const spans = [
@@ -62,7 +63,7 @@ describe('OpenAI Agents Integration', () => {
         startedAt: null,
         endedAt: null,
         error: null,
-      });
+      } as Span);
     }
 
     const calls = await inMemoryTraceServer.getCalls(testProjectName);
@@ -81,7 +82,7 @@ describe('OpenAI Agents Integration', () => {
       traceId: 'trace-123',
       name: 'Workflow',
       groupId: null,
-    });
+    } as Trace);
 
     await processor.onSpanStart({
       type: 'trace.span',
@@ -92,7 +93,7 @@ describe('OpenAI Agents Integration', () => {
       startedAt: null,
       endedAt: null,
       error: null,
-    });
+    } as Span);
 
     const calls = await inMemoryTraceServer.getCalls(testProjectName);
     expect(calls).toHaveLength(2);

--- a/sdks/node/src/integrations/openai.agent.ts
+++ b/sdks/node/src/integrations/openai.agent.ts
@@ -1,9 +1,6 @@
 /**
  * Weave integration for OpenAI Agents SDK
  *
- * This module provides tracing integration for the OpenAI Agents SDK using duck typing
- * to avoid direct dependencies on @openai/agents types.
- *
  * Usage:
  * ```typescript
  * import { addTraceProcessor } from '@openai/agents';

--- a/sdks/node/src/integrations/openai.agent.types.ts
+++ b/sdks/node/src/integrations/openai.agent.types.ts
@@ -1,96 +1,26 @@
 /**
  * Type definitions for OpenAI Agents integration
  *
- * These types are duck-typed to match @openai/agents without importing from that package.
- * This allows users to use the integration without forcing a dependency on @openai/agents.
  */
 
 // ============================================================================
 // Span Data Types
 // ============================================================================
 
-/**
- * Base span data structure
- */
-type SpanDataBase = {
-  type: string;
-};
+import type {
+  AgentSpanData,
+  CustomSpanData,
+  FunctionSpanData,
+  GenerationSpanData,
+  GuardrailSpanData,
+  HandoffSpanData,
+  ResponseSpanData,
+  Span as OpenAIAgentsSpan,
+} from '@openai/agents';
 
-/**
- * Agent execution span data
- */
-type AgentSpanData = SpanDataBase & {
-  type: 'agent';
-  name: string;
-  handoffs?: string[];
-  tools?: string[];
-  output_type?: string;
-};
+export type {CustomSpanData, Trace, TracingProcessor} from '@openai/agents';
 
-/**
- * Function/tool execution span data
- */
-type FunctionSpanData = SpanDataBase & {
-  type: 'function';
-  name: string;
-  input: string;
-  output: string;
-  mcp_data?: string;
-};
-
-/**
- * LLM generation span data
- */
-type GenerationSpanData = SpanDataBase & {
-  type: 'generation';
-  input?: Array<Record<string, any>>;
-  output?: Array<Record<string, any>>;
-  model?: string;
-  model_config?: Record<string, any>;
-  usage?: {
-    input_tokens?: number;
-    output_tokens?: number;
-    details?: Record<string, unknown> | null;
-    [key: string]: unknown;
-  };
-};
-
-/**
- * Response span data
- */
-type ResponseSpanData = SpanDataBase & {
-  type: 'response';
-  response_id?: string;
-  _input?: string | Record<string, any>[];
-  _response?: Record<string, any>;
-};
-
-/**
- * Agent handoff span data
- */
-type HandoffSpanData = SpanDataBase & {
-  type: 'handoff';
-  from_agent?: string;
-  to_agent?: string;
-};
-
-/**
- * Custom span data
- */
-export type CustomSpanData = SpanDataBase & {
-  type: 'custom';
-  name: string;
-  data: Record<string, any>;
-};
-
-/**
- * Guardrail span data
- */
-type GuardrailSpanData = SpanDataBase & {
-  type: 'guardrail';
-  name: string;
-  triggered: boolean;
-};
+export type Span<TData extends SpanData = SpanData> = OpenAIAgentsSpan<TData>;
 
 /**
  * Union of all span data types
@@ -103,79 +33,3 @@ export type SpanData =
   | HandoffSpanData
   | CustomSpanData
   | GuardrailSpanData;
-
-/**
- * Span error structure
- */
-export type SpanError = {
-  message: string;
-  data?: Record<string, any>;
-};
-
-/**
- * Span structure (duck typed to match @openai/agents Span class)
- */
-export type Span<TData extends SpanData = SpanData> = {
-  readonly type: 'trace.span';
-  readonly traceId: string;
-  readonly spanId: string;
-  readonly parentId: string | null;
-  readonly spanData: TData;
-  readonly traceMetadata?: Record<string, any>;
-  readonly startedAt: string | null;
-  readonly endedAt: string | null;
-  readonly error: SpanError | null;
-  readonly tracingApiKey?: string;
-};
-
-/**
- * Trace structure (duck typed to match @openai/agents Trace class)
- */
-export type Trace = {
-  readonly type: 'trace';
-  traceId: string;
-  name: string;
-  groupId: string | null;
-  metadata?: Record<string, any>;
-  tracingApiKey?: string;
-};
-
-/**
- * TracingProcessor interface (duck typed to match @openai/agents)
- */
-export interface TracingProcessor {
-  /**
-   * Optional start method for processors that need initialization
-   */
-  start?(): void;
-
-  /**
-   * Called when a trace starts
-   */
-  onTraceStart(trace: Trace): Promise<void>;
-
-  /**
-   * Called when a trace ends
-   */
-  onTraceEnd(trace: Trace): Promise<void>;
-
-  /**
-   * Called when a span starts
-   */
-  onSpanStart(span: Span): Promise<void>;
-
-  /**
-   * Called when a span ends
-   */
-  onSpanEnd(span: Span): Promise<void>;
-
-  /**
-   * Called when the processor should shut down
-   */
-  shutdown(timeout?: number): Promise<void>;
-
-  /**
-   * Called to force flush any pending traces
-   */
-  forceFlush(): Promise<void>;
-}


### PR DESCRIPTION
## Description

* We manually maintain some duplicated types for 3rd party libraries. This can mask type issues / bugs that can be caught by pointing to the library-provided types via `devDependencies`.

* This change removes some of the duplicated `@openai/agents` types.
