### PR TITLE
fix(weave): azure file_storage must not overwrite existing blobs

### DIFF
--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -379,9 +379,7 @@ class TestAzureStorage:
         assert blob_client.download_blob().readall() == TEST_CONTENT
 
     @pytest.mark.usefixtures("azure_storage_env")
-    def test_azure_storage_does_not_overwrite_existing_blob(
-        self, client: WeaveClient
-    ):
+    def test_azure_storage_does_not_overwrite_existing_blob(self, client: WeaveClient):
         """Azure store must not clobber an existing content-addressable blob.
 
         Mirrors `test_gcp_storage_skips_duplicate_write`. Content-addressable
@@ -398,9 +396,7 @@ class TestAzureStorage:
         mock_service_client = mock.MagicMock()
         mock_container_client = mock.MagicMock()
         mock_blob_client = mock.MagicMock()
-        mock_service_client.get_container_client.return_value = (
-            mock_container_client
-        )
+        mock_service_client.get_container_client.return_value = mock_container_client
 
         def mock_get_blob_client(name):
             mock_blob_client.blob_name = name
@@ -449,17 +445,15 @@ class TestAzureStorage:
 
             assert res1.digest == res2.digest
             assert upload_calls, "upload_blob was never invoked"
-            assert all(
-                call["overwrite"] is False for call in upload_calls
-            ), f"upload_blob called with overwrite=True: {upload_calls}"
+            assert all(call["overwrite"] is False for call in upload_calls), (
+                f"upload_blob called with overwrite=True: {upload_calls}"
+            )
 
             stored = blob_data[next(iter(blob_data))]
             assert stored == original
 
             file = client.server.file_content_read(
-                FileContentReadReq(
-                    project_id=client.project_id, digest=res1.digest
-                )
+                FileContentReadReq(project_id=client.project_id, digest=res1.digest)
             )
             assert file.content == original
 

--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -11,6 +11,7 @@ from unittest import mock
 
 import boto3
 import pytest
+from azure.core.exceptions import ResourceExistsError
 from google.api_core import exceptions
 from google.auth.credentials import AnonymousCredentials
 from moto import mock_aws
@@ -376,6 +377,91 @@ class TestAzureStorage:
             f"weave/projects/{project}/files/{res.digest}"
         )
         assert blob_client.download_blob().readall() == TEST_CONTENT
+
+    @pytest.mark.usefixtures("azure_storage_env")
+    def test_azure_storage_does_not_overwrite_existing_blob(
+        self, client: WeaveClient
+    ):
+        """Azure store must not clobber an existing content-addressable blob.
+
+        Mirrors `test_gcp_storage_skips_duplicate_write`. Content-addressable
+        storage is a write-once contract: re-uploading at a known digest must
+        be a no-op, not an overwrite. Otherwise any project with write scope
+        can substitute content at a known URI.
+        """
+        if client_is_sqlite(client):
+            pytest.skip("Not implemented in SQLite")
+
+        blob_data: dict[str, bytes] = {}
+        upload_calls: list[dict] = []
+
+        mock_service_client = mock.MagicMock()
+        mock_container_client = mock.MagicMock()
+        mock_blob_client = mock.MagicMock()
+        mock_service_client.get_container_client.return_value = (
+            mock_container_client
+        )
+
+        def mock_get_blob_client(name):
+            mock_blob_client.blob_name = name
+            return mock_blob_client
+
+        def mock_upload_blob(data, overwrite=False, **kwargs):
+            blob_name = mock_blob_client.blob_name
+            upload_calls.append({"name": blob_name, "overwrite": overwrite})
+            # Azure semantics: overwrite=False on an existing blob raises.
+            if blob_name in blob_data and not overwrite:
+                raise ResourceExistsError("blob already exists")
+            blob_data[blob_name] = data
+
+        def mock_download_blob(**kwargs):
+            blob_name = mock_blob_client.blob_name
+            download = mock.MagicMock()
+            download.readall.return_value = blob_data.get(blob_name, b"")
+            return download
+
+        mock_container_client.get_blob_client.side_effect = mock_get_blob_client
+        mock_blob_client.upload_blob.side_effect = mock_upload_blob
+        mock_blob_client.download_blob.side_effect = mock_download_blob
+
+        original = b"original-content"
+
+        with mock.patch(
+            "weave.trace_server.file_storage.BlobServiceClient",
+            return_value=mock_service_client,
+        ) as mock_cls:
+            mock_cls.from_connection_string.return_value = mock_service_client
+
+            res1 = client.server.file_create(
+                FileCreateReq(
+                    project_id=client.project_id,
+                    name="test.txt",
+                    content=original,
+                )
+            )
+            res2 = client.server.file_create(
+                FileCreateReq(
+                    project_id=client.project_id,
+                    name="test.txt",
+                    content=original,
+                )
+            )
+
+            assert res1.digest == res2.digest
+            assert upload_calls, "upload_blob was never invoked"
+            assert all(
+                call["overwrite"] is False for call in upload_calls
+            ), f"upload_blob called with overwrite=True: {upload_calls}"
+
+            stored = blob_data[next(iter(blob_data))]
+            assert stored == original
+
+            file = client.server.file_content_read(
+                FileContentReadReq(
+                    project_id=client.project_id, digest=res1.digest
+                )
+            )
+            assert file.content == original
 
 
 def test_support_for_variable_length_chunks(client: WeaveClient):

--- a/weave/trace_server/file_storage.py
+++ b/weave/trace_server/file_storage.py
@@ -46,7 +46,7 @@ from collections.abc import Callable
 from typing import TypeVar, cast
 
 import boto3
-from azure.core.exceptions import HttpResponseError
+from azure.core.exceptions import HttpResponseError, ResourceExistsError
 from azure.storage.blob import BlobServiceClient
 from botocore.config import Config
 from botocore.exceptions import ClientError
@@ -369,13 +369,21 @@ class AzureStorageClient(FileStorageClient):
 
     @create_retry_decorator("azure_storage")
     def store(self, uri: FileStorageURI, data: bytes) -> None:
-        """Store data in Azure container with automatic retries on failure."""
+        """Store data in Azure container with automatic retries on failure.
+
+        Uses `overwrite=False` so content-addressable blobs are write-once:
+        a second writer at the same digest no-ops instead of clobbering.
+        Mirrors GCS's `if_generation_match=0` path.
+        """
         assert isinstance(uri, AzureFileStorageURI)
         assert uri.to_uri_str().startswith(self.base_uri.to_uri_str())
         client = self._get_client(uri.account)
         container_client = client.get_container_client(uri.container)
         blob_client = container_client.get_blob_client(uri.path)
-        blob_client.upload_blob(data, overwrite=True)
+        try:
+            blob_client.upload_blob(data, overwrite=False)
+        except ResourceExistsError:
+            logger.debug("Object already exists at %s, skipping write", uri)
 
     @create_retry_decorator("azure_read")
     def read(self, uri: FileStorageURI) -> bytes:


### PR DESCRIPTION
## Summary

- `AzureStorageClient.store` was calling `upload_blob(data, overwrite=True)`, which violates the write-once invariant the other backends enforce for content-addressable storage. GCS uses `if_generation_match=0`, so a second writer at a known digest no-ops; Azure was happy to clobber.
- Risk: a project (or attacker with project write scope) can re-upload at a known digest. If `file_create` ever skips re-verifying the client-supplied `expected_digest` against the actual content hash, content gets substituted silently. Any future cross-project dedup at the storage layer becomes a content-substitution risk on Azure specifically.
- Fix mirrors the GCS path: `overwrite=False` + catch `ResourceExistsError` and log-skip.

Jira: [WB-34786](https://coreweave.atlassian.net/browse/WB-34786)

## Testing

new test `test_azure_storage_does_not_overwrite_existing_blob` asserts every `upload_blob` call uses `overwrite=False` and that duplicate creates at the same digest don't replace stored bytes. red against `master` (`AssertionError: upload_blob called with overwrite=True`), green with the fix. existing S3/GCS/Azure tests in the module still pass.

[WB-34786]: https://coreweave.atlassian.net/browse/WB-34786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ