### PR TITLE
refactor(weave): extract is_publicly_routable_url helper

### DIFF
--- a/tests/trace_server/test_url_safety.py
+++ b/tests/trace_server/test_url_safety.py
@@ -1,0 +1,145 @@
+"""Tests for `weave.trace_server.url_safety.is_publicly_routable_url`."""
+
+from __future__ import annotations
+
+import pytest
+
+from weave.trace_server.url_safety import is_publicly_routable_url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://api.openai.com/v1",
+        "http://my-ollama-server.example.com:11434",
+        "https://cdn.openai.com/foo/bar.png",
+        "https://oaidalleapiprodscus.blob.core.windows.net/private/image.png",
+        "http://images.example.org/x.jpg",
+        "https://example.com:8443/path",
+        "https://example.com./trailing-dot",
+        "http://user:pass@example.com/",
+        "HTTPS://Example.Com/Path",
+        "https://evil.example.com/",
+    ],
+)
+def test_accepts_public_http_urls(url: str) -> None:
+    assert is_publicly_routable_url(url) is True
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://files.example.com",
+        "file:///etc/passwd",
+        "gopher://internal.svc/",
+        "ws://example.com/",
+        "wss://example.com/",
+        "javascript:alert(1)",
+        "data:text/plain,hello",
+    ],
+)
+def test_rejects_non_http_schemes(url: str) -> None:
+    assert is_publicly_routable_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "",
+        "not a url",
+        "http:///no-host",
+        "http://",
+        "https://",
+    ],
+)
+def test_rejects_malformed_or_hostless(url: str) -> None:
+    assert is_publicly_routable_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost/",
+        "http://localhost",
+        "http://LOCALHOST/path",
+        "http://localhost.localdomain/",
+        "http://ip6-localhost/",
+        "http://ip6-loopback/",
+        "http://foo.localhost/",
+        "http://a.b.localhost/",
+    ],
+)
+def test_rejects_localhost_variants(url: str) -> None:
+    assert is_publicly_routable_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://metadata.google.internal/",
+        "http://metadata.google.internal./",
+        "http://foo.metadata.google.internal/",
+        "http://metadata.goog/",
+        "http://metadata.internal/",
+        "http://metadata.azure.com/",
+        "http://METADATA.GOOGLE.INTERNAL/",
+    ],
+)
+def test_rejects_cloud_metadata_hostnames(url: str) -> None:
+    assert is_publicly_routable_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # loopback
+        "http://127.0.0.1/",
+        "http://127.0.0.1:6379/",
+        # private RFC1918
+        "http://10.0.0.1/",
+        "http://172.16.0.1/",
+        "http://192.168.1.1/",
+        # link-local (incl. IMDS)
+        "http://169.254.169.254/latest/meta-data/",
+        # unspecified / multicast / broadcast
+        "http://0.0.0.0/",
+        "http://224.0.0.1/",
+        "http://255.255.255.255/",
+    ],
+)
+def test_rejects_non_global_ipv4(url: str) -> None:
+    assert is_publicly_routable_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://[::1]/",
+        "http://[fe80::1]/",
+        "http://[fc00::1]/",
+        "http://[ff00::1]/",
+        "http://[::ffff:169.254.169.254]/",
+        "http://[::ffff:10.0.0.1]/",
+    ],
+)
+def test_rejects_non_global_ipv6(url: str) -> None:
+    assert is_publicly_routable_url(url) is False
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://0x7f000001/",  # hex 127.0.0.1
+        "http://0xa9fea9fe/",  # hex 169.254.169.254
+        "http://2130706433/",  # decimal 127.0.0.1
+        "http://2852039166/",  # decimal 169.254.169.254
+        "http://0/",  # decimal 0.0.0.0
+    ],
+)
+def test_rejects_alt_ipv4_encodings(url: str) -> None:
+    """Alternative IPv4 encodings (hex/decimal) must not bypass the IP check.
+
+    socket.inet_aton accepts these forms; a naive ipaddress.ip_address check
+    would let them through.
+    """
+    assert is_publicly_routable_url(url) is False

--- a/weave/trace_server/interface/builtin_object_classes/provider.py
+++ b/weave/trace_server/interface/builtin_object_classes/provider.py
@@ -1,12 +1,11 @@
-import ipaddress
 import re
-import socket
 from enum import Enum
 from urllib.parse import urlparse
 
 from pydantic import ConfigDict, Field, field_validator
 
 from weave.trace_server.interface.builtin_object_classes import base_object_def
+from weave.trace_server.url_safety import is_publicly_routable_url
 
 # Headers that must not appear in user-supplied extra_headers.
 # https://coreweave.atlassian.net/browse/VULNMGMT-770
@@ -14,18 +13,6 @@ BLOCKED_HEADER_RE = re.compile(
     r"^(?:metadata-flavor"
     r"|x-aws-ec2-metadata-token(?:-ttl-seconds)?"
     r")$",
-    re.IGNORECASE,
-)
-
-# Hostnames that must not appear in user-supplied base_url values.
-# https://coreweave.atlassian.net/browse/VULNMGMT-770
-BLOCKED_HOSTNAME_RE = re.compile(
-    r"(?:^|\.)"
-    r"(?:metadata\.google\.internal"
-    r"|metadata\.goog"
-    r"|metadata\.internal"
-    r"|metadata\.azure\.com"
-    r")\.?$",
     re.IGNORECASE,
 )
 
@@ -38,41 +25,17 @@ def _validate_provider_base_url(url: str) -> str:
 
     See https://coreweave.atlassian.net/browse/VULNMGMT-770
     """
+    # urlparse silently strips a bare trailing '?', so check the raw string too.
+    if "?" in url:
+        raise ValueError(INVALID_BASE_URL_MSG)
     try:
         parsed = urlparse(url)
-    except Exception as exc:
+    except ValueError as exc:
         raise ValueError(INVALID_BASE_URL_MSG) from exc
-
-    if parsed.scheme not in {"http", "https"}:
+    if parsed.fragment:
         raise ValueError(INVALID_BASE_URL_MSG)
-
-    # urlparse silently strips a bare trailing '?', so check the raw string too.
-    if "?" in url or parsed.fragment:
+    if not is_publicly_routable_url(url):
         raise ValueError(INVALID_BASE_URL_MSG)
-
-    host = (parsed.hostname or "").lower().rstrip(".")
-    if not host:
-        raise ValueError(INVALID_BASE_URL_MSG)
-
-    if BLOCKED_HOSTNAME_RE.search(host):
-        raise ValueError(INVALID_BASE_URL_MSG)
-
-    # Reject non-globally-routable IP addresses.  socket.inet_aton handles
-    # alternative IPv4 encodings that ipaddress.ip_address does not.
-    addr = None
-    try:
-        addr = ipaddress.ip_address(host)
-    except ValueError:
-        # Not a strict IP literal — try inet_aton for alternative IPv4 forms.
-        try:
-            packed = socket.inet_aton(host)
-            addr = ipaddress.ip_address(packed)
-        except OSError:
-            pass  # Not any form of IP — hostname checks above are sufficient.
-
-    if addr is not None and not addr.is_global:
-        raise ValueError(INVALID_BASE_URL_MSG)
-
     return url
 
 

--- a/weave/trace_server/url_safety.py
+++ b/weave/trace_server/url_safety.py
@@ -1,0 +1,93 @@
+"""Server-side URL safety helpers (defense in depth against SSRF).
+
+Used to gate any place where the trace server fetches a URL whose host
+could come from an untrusted source: provider base URLs, upstream image
+generation responses, etc. Primary SSRF mitigation belongs at the network
+layer (pod egress policy); this module is belt-and-suspenders.
+
+`is_publicly_routable_url` rejects:
+- non-http(s) schemes
+- empty / missing host
+- localhost variants and reserved cloud-metadata hostnames
+- IP literals that are not globally routable, including alternative IPv4
+  encodings (decimal, hex, octal) that bypass naive string checks
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import socket
+from urllib.parse import urlparse
+
+ALLOWED_SCHEMES = frozenset({"http", "https"})
+
+LOCALHOST_LITERALS = frozenset(
+    {"localhost", "localhost.localdomain", "ip6-localhost", "ip6-loopback"}
+)
+
+# Symbolic hostnames that resolve to cloud instance-metadata services.
+# Bare-IP IMDS (169.254.169.254) is covered by the is_global check below;
+# this regex catches the hostnames that resolve to it.
+BLOCKED_HOSTNAME_RE = re.compile(
+    r"(?:^|\.)"
+    r"(?:metadata\.google\.internal"
+    r"|metadata\.goog"
+    r"|metadata\.internal"
+    r"|metadata\.azure\.com"
+    r")\.?$",
+    re.IGNORECASE,
+)
+
+
+def is_publicly_routable_url(url: str) -> bool:
+    """Return True if `url` is safe to fetch from a server context.
+
+    A URL is considered safe when it parses cleanly, uses http or https,
+    has a host that is neither a localhost literal nor a known cloud-
+    metadata hostname, and (if the host is an IP literal in any common
+    encoding) resolves to a globally routable address.
+
+    Non-IP hostnames are accepted on the assumption that DNS resolution
+    and further egress filtering happen downstream. DNS-rebinding attacks
+    against hostnames are the egress policy's job, not this function's.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+
+    if parsed.scheme.lower() not in ALLOWED_SCHEMES:
+        return False
+
+    host = (parsed.hostname or "").lower().rstrip(".")
+    if not host:
+        return False
+
+    if host in LOCALHOST_LITERALS or host.endswith(".localhost"):
+        return False
+
+    if BLOCKED_HOSTNAME_RE.search(host):
+        return False
+
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address | None = None
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        try:
+            packed = socket.inet_aton(host)
+        except OSError:
+            return True
+        addr = ipaddress.ip_address(packed)
+
+    # `is_global` alone is too permissive: it returns True for IPv4/IPv6
+    # multicast (e.g. 224.0.0.1, ff00::/8). Enumerate the disallowed
+    # categories explicitly.
+    return not (
+        addr.is_loopback
+        or addr.is_link_local
+        or addr.is_private
+        or addr.is_reserved
+        or addr.is_multicast
+        or addr.is_unspecified
+    )


### PR DESCRIPTION
## Summary

Extract `is_publicly_routable_url` from `provider.py` into shared `weave/trace_server/url_safety.py`. We've now hand-rolled this check in 3+ places (provider base_url, remote scorer endpoint, #6972 image fetch). One helper means one place to harden, one place to test.

Tightens two gaps the original provider check had:
- IPv4/IPv6 multicast (`224.0.0.1`, `ff00::/8`) - `is_global` returned True
- `localhost`, `*.localhost`, `localhost.localdomain` - previously accepted as hostnames

Followup: #6972 should rebase to call `is_publicly_routable_url` and delete its local `_is_safe_external_url`. The hand-rolled version there misses alt IPv4 encodings (`http://0xa9fea9fe/`) and cloud-metadata hostnames.

Defense in depth - primary SSRF control is pod egress policy.

[VULNMGMT-770](https://coreweave.atlassian.net/browse/VULNMGMT-770).

## Testing

57 parametrized cases in new `test_url_safety.py`; existing `test_provider_base_url_validation` unchanged.

[VULNMGMT-770]: https://coreweave.atlassian.net/browse/VULNMGMT-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ