### PR TITLE
fix(weave): tag feedback.created_at as UTC on read

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -1809,3 +1809,30 @@ def test_feedback_stats_empty_metrics(client: WeaveClient) -> None:
 
     assert res.buckets == []
     assert res.granularity == 3600
+
+
+def test_feedback_query_returns_tz_aware_created_at(client: WeaveClient) -> None:
+    """Ensure `feedback_query` returns tz-aware `created_at`."""
+    if client_is_sqlite(client):
+        pytest.skip("created_at is a string on sqlite; tz semantics only apply to CH")
+
+    project_id = client.project_id
+    client.server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref="weave:///entity/project/object/test:digest",
+            feedback_type="custom",
+            payload={"k": "v"},
+            wb_user_id="",
+        )
+    )
+    res = client.server.feedback_query(tsi.FeedbackQueryReq(project_id=project_id))
+    assert len(res.result) == 1
+    created_at = res.result[0]["created_at"]
+    assert isinstance(created_at, datetime.datetime)
+    assert created_at.tzinfo is not None, (
+        "feedback_query returned a naive datetime; browsers will misinterpret it"
+    )
+    assert created_at.utcoffset() == datetime.timedelta(0), (
+        "feedback created_at must be tz-aware UTC"
+    )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6242,7 +6242,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         # Make `created_at` tz-aware (otherwise the client will assume local time)
         for row in result:
-            if "created_at" in row:
+            if "created_at" in row and isinstance(row["created_at"], datetime.datetime):
                 row["created_at"] = ensure_datetimes_have_tz(row["created_at"])
         return tsi.FeedbackQueryRes(result=result)
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6240,6 +6240,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         result = TABLE_FEEDBACK.tuples_to_rows(
             query_result.result_rows, prepared.fields, database_type="clickhouse"
         )
+        # Make `created_at` tz-aware (otherwise the client will assume local time)
+        for row in result:
+            if "created_at" in row:
+                row["created_at"] = ensure_datetimes_have_tz(row["created_at"])
         return tsi.FeedbackQueryRes(result=result)
 
     def feedback_purge(self, req: tsi.FeedbackPurgeReq) -> tsi.FeedbackPurgeRes:


### PR DESCRIPTION
## Summary

\`feedback_query\` was returning \`created_at\` as a naive Python datetime. The feedback table stores \`created_at\` as \`DateTime64(3)\` with no timezone parameter, and clickhouse-connect returns those values without tzinfo even though the digits are UTC. Pydantic then serializes the value as a naive ISO string with no \`Z\` / offset, and browsers parse the digits as local time — producing a wall-clock skew equal to the user's UTC delta (+7h for PDT users).

The fix re-attaches \`tzinfo=UTC\` to each row's \`created_at\` inside \`feedback_query\`, mirroring what every other read path in \`clickhouse_trace_server_batched\` already does for its datetime columns via \`ensure_datetimes_have_tz\`.

Read-side only — values stored in CH have always been UTC.

## Test plan

- [x] Added \`test_feedback_query_returns_tz_aware_created_at\` in \`tests/trace/test_feedback.py\` asserting tz-aware UTC. Verified it fails on \`master\` and passes with the fix.
- [x] Full \`tests/trace/test_feedback.py\` suite passes on ClickHouse (26 / 26).
- [ ] SQLite path unaffected (skipped explicitly — SQLite returns \`created_at\` as a string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)