### PR TITLE
fix(weave): return 4xx for unsupported / unselectable trace_server fields

### DIFF
--- a/tests/trace/test_actions_lifecycle.py
+++ b/tests/trace/test_actions_lifecycle.py
@@ -3,6 +3,7 @@ import pytest
 import weave
 from tests.trace.util import client_is_sqlite
 from weave.trace.weave_client import WeaveClient
+from weave.trace_server.errors import InvalidRequest
 from weave.trace_server.interface.builtin_object_classes.actions import (
     ActionSpec,
 )
@@ -83,6 +84,27 @@ def test_action_lifecycle_word_count(client: WeaveClient):
     assert feedback.feedback_type == "wandb.runnable." + action_name
     assert feedback.runnable_ref == action_ref_uri
     assert feedback.payload == {"output": True}
+
+
+def test_actions_execute_batch_rejects_multiple_call_ids(client: WeaveClient):
+    """Submitting >1 call_id must raise InvalidRequest (HTTP 400), not
+    NotImplementedError (HTTP 500). Regression for WB-34836: batching is
+    unsupported but that's invalid input from the client's perspective, not
+    a server bug.
+    """
+    if client_is_sqlite(client):
+        return pytest.skip("skipping for sqlite")
+
+    with pytest.raises(InvalidRequest, match="Batching actions"):
+        client.server.actions_execute_batch(
+            ActionsExecuteBatchReq.model_validate(
+                {
+                    "project_id": client.project_id,
+                    "action_ref": "weave:///fake/fake/op/fake:v0",
+                    "call_ids": ["call_a", "call_b"],
+                }
+            )
+        )
 
 
 primitive_mock_response = {

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -11,6 +11,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     CallsQuery,
     HardCodedFilter,
     ParamBuilder,
+    QueryBuilderDynamicField,
     _is_minimal_filter,
     _maybe_convert_datetime_operands,
     build_calls_complete_delete_query,
@@ -2134,6 +2135,37 @@ def test_unsupported_summary_field_raises_invalid_field_error() -> None:
     )
     with pytest.raises(InvalidFieldError, match="duration_ms"):
         cq.as_sql(ParamBuilder())
+
+
+def test_unselectable_columns_raise_invalid_field_error() -> None:
+    """Selecting columns that the SQL builder can't materialize as a select expression
+    must surface as InvalidFieldError (403), not NotImplementedError (500). Regression
+    for WB-34836: dynamic, feedback, and annotation-queue-item paths all hit the same
+    "implement me!" raise.
+    """
+    # Nested dynamic field (e.g. inputs.foo) - routed through CallsMergedDynamicField
+    cq = CallsQuery(project_id="project")
+    cq.add_field("inputs.foo")
+    with pytest.raises(InvalidFieldError, match="cannot be selected directly"):
+        cq.as_sql(ParamBuilder())
+
+    # Feedback payload column - routed through CallsMergedFeedbackPayloadField
+    cq = CallsQuery(project_id="project")
+    cq.add_field("feedback.[wandb.note].payload.note")
+    with pytest.raises(InvalidFieldError, match="Feedback fields"):
+        cq.as_sql(ParamBuilder())
+
+    # Annotation queue item column - routed through CallsMergedQueueItemField
+    cq = CallsQuery(project_id="project")
+    cq.add_field("annotation_queue_items.queue_id")
+    with pytest.raises(InvalidFieldError, match="queue item fields"):
+        cq.as_sql(ParamBuilder())
+
+    # QueryBuilderDynamicField with extra_path (used by table_query, not CallsQuery,
+    # so we have to construct and select directly).
+    field = QueryBuilderDynamicField(field="val_dump", extra_path=["foo", "bar"])
+    with pytest.raises(InvalidFieldError, match="val_dump.foo.bar"):
+        field.as_select_sql(ParamBuilder(), "table")
 
 
 def test_build_calls_complete_update_end_query() -> None:

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2114,6 +2114,28 @@ def test_query_with_summary_weave_trace_name_filter() -> None:
     )
 
 
+def test_unsupported_summary_field_raises_invalid_field_error() -> None:
+    """Filtering by an unknown summary.weave.* field must surface as InvalidFieldError
+    (mapped to HTTP 403) rather than NotImplementedError (HTTP 500). Regression for
+    WB-34835: clients hitting /calls/query_stats with summary.weave.duration_ms were
+    getting 500s for what is actually invalid input.
+    """
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        tsi_query.GtOperation.model_validate(
+            {
+                "$gt": [
+                    {"$getField": "summary.weave.duration_ms"},
+                    {"$literal": 0},
+                ]
+            }
+        )
+    )
+    with pytest.raises(InvalidFieldError, match="duration_ms"):
+        cq.as_sql(ParamBuilder())
+
+
 def test_build_calls_complete_update_end_query() -> None:
     """Ensure the update-end helper builds the expected query."""
     query = build_calls_complete_update_end_query(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -285,8 +285,8 @@ class CallsMergedSummaryField(CallsMergedField):
             return clickhouse_cast(sql, cast)
         else:
             supported_fields = ", ".join(SUMMARY_FIELD_HANDLERS.keys())
-            raise NotImplementedError(
-                f"Summary field '{self.summary_field}' not implemented. "
+            raise InvalidFieldError(
+                f"Summary field '{self.summary_field}' is not allowed. "
                 f"Supported fields are: {supported_fields}"
             )
 

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -246,8 +246,9 @@ class CallsMergedDynamicField(CallsMergedAggField):
         self, pb: ParamBuilder, table_alias: str, use_agg_fn: bool = True, **kwargs: Any
     ) -> str:
         if self.extra_path:
-            raise NotImplementedError(
-                "Dynamic fields cannot be selected directly, yet - implement me!"
+            raise InvalidFieldError(
+                f"Field '{self.field}.{'.'.join(self.extra_path)}' cannot be selected directly; "
+                "select the parent column instead."
             )
         # Use the parent (CallsMergedAggField) as_sql to get the aggregate
         # expression without the JSON extraction that our own as_sql adds.
@@ -416,8 +417,9 @@ class CallsMergedFeedbackPayloadField(CallsMergedField):
     def as_select_sql(
         self, pb: ParamBuilder, table_alias: str, use_agg_fn: bool = True, **kwargs: Any
     ) -> str:
-        raise NotImplementedError(
-            "Feedback fields cannot be selected directly, yet - implement me!"
+        raise InvalidFieldError(
+            "Feedback fields cannot be selected directly. "
+            "Use the feedback endpoints to read feedback payloads."
         )
 
 
@@ -458,8 +460,9 @@ class CallsMergedQueueItemField(CallsMergedField):
     def as_select_sql(
         self, pb: ParamBuilder, table_alias: str, use_agg_fn: bool = True, **kwargs: Any
     ) -> str:
-        raise NotImplementedError(
-            "Queue item fields cannot be selected directly, yet - implement me!"
+        raise InvalidFieldError(
+            "Annotation queue item fields cannot be selected directly; "
+            "use the annotation queue endpoints instead."
         )
 
 
@@ -537,8 +540,9 @@ class QueryBuilderDynamicField(QueryBuilderField):
         self, pb: ParamBuilder, table_alias: str, use_agg_fn: bool = True, **kwargs: Any
     ) -> str:
         if self.extra_path:
-            raise NotImplementedError(
-                "Dynamic fields cannot be selected directly, yet - implement me!"
+            raise InvalidFieldError(
+                f"Field '{self.field}.{'.'.join(self.extra_path)}' cannot be selected directly; "
+                "select the parent column instead."
             )
         return super().as_select_sql(pb, table_alias, use_agg_fn=use_agg_fn)
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -6260,7 +6260,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             return tsi.ActionsExecuteBatchRes()
         if len(req.call_ids) > 1:
             # This is temporary until we setup our batching infrastructure
-            raise NotImplementedError("Batching actions is not yet supported")
+            raise InvalidRequest(
+                "Batching actions is not yet supported; submit one call_id at a time."
+            )
 
         # For now, we just execute in-process if it is a single action
         execute_batch(


### PR DESCRIPTION
## Summary
- Trace server was raising `NotImplementedError` for a handful of invalid-input paths, which FastAPI surfaces as **500**. Each is a 1-line swap to `InvalidFieldError` (403) or `InvalidRequest` (400), matching the convention used elsewhere in the file.
- Original report (datadog 500 on `summary.weave.duration_ms`): [WB-34835](https://coreweave.atlassian.net/browse/WB-34835)
- Audit roll-up (all the other sites in trace_server): [WB-34836](https://coreweave.atlassian.net/browse/WB-34836)

Sites fixed in this PR:
- `CallsMergedSummaryField.as_sql` -> `InvalidFieldError` for unknown `summary.weave.*` fields
- `CallsMergedDynamicField.as_select_sql` -> `InvalidFieldError` for nested dynamic columns
- `CallsMergedFeedbackPayloadField.as_select_sql` -> `InvalidFieldError`
- `CallsMergedQueueItemField.as_select_sql` -> `InvalidFieldError`
- `QueryBuilderDynamicField.as_select_sql` -> `InvalidFieldError` (table_query path)
- `actions_execute_batch` (len > 1) -> `InvalidRequest`

Original failure ([datadog trace](https://us5.datadoghq.com/apm/trace/6a1741e3000000002361024f82ac6f5f?spanID=6292556010059681545&timeHint=1779909091772)):
```
builtins.NotImplementedError: Summary field 'duration_ms' not implemented.
Supported fields are: status, latency_ms, trace_name
```

## Testing
- `test_unsupported_summary_field_raises_invalid_field_error` covers the original report.
- `test_unselectable_columns_raise_invalid_field_error` covers all four select-side sites in a single test.
- `test_actions_execute_batch_rejects_multiple_call_ids` covers the actions batching case (integration test, skipped on sqlite).

[WB-34835]: https://coreweave.atlassian.net/browse/WB-34835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-34836]: https://coreweave.atlassian.net/browse/WB-34836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ