### PR TITLE
feat(weave): Support scorer_* fields for wandb.runnable scorers

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -362,6 +362,53 @@ def test_runnable_feedback(client: WeaveClient) -> None:
         "scorer_rating_confidences": {},
     }
 
+    # Runnable scorer feedback may also populate typed scorer columns while
+    # keeping the raw scorer output in payload for backwards compatibility.
+    typed_weave_ref = f"weave:///{project_id}/call/call_id_456"
+    typed_create_res = client.server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=typed_weave_ref,
+            feedback_type=feedback_type,
+            payload={"output": {"passed": False}},
+            runnable_ref=runnable_ref,
+            call_ref=call_ref,
+            trigger_ref=trigger_ref,
+            scorer_tags=["unsafe"],
+            scorer_tag_reasons={"unsafe": "contains disallowed content"},
+            scorer_tag_confidences={"unsafe": 0.91},
+            scorer_ratings={"_rating_": 0.2},
+            scorer_rating_reasons={"_rating_": "low quality response"},
+            scorer_rating_confidences={"_rating_": 0.88},
+        )
+    )
+
+    typed_query_res = client.server.feedback_query(
+        tsi.FeedbackQueryReq(
+            project_id=project_id,
+            query=Query(
+                **{
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "id"},
+                            {"$literal": typed_create_res.id},
+                        ]
+                    }
+                }
+            ),
+        )
+    )
+    assert len(typed_query_res.result) == 1
+    typed_row = typed_query_res.result[0]
+    assert typed_row["feedback_type"] == feedback_type
+    assert typed_row["payload"] == {"output": {"passed": False}}
+    assert typed_row["scorer_tags"] == ["unsafe"]
+    assert typed_row["scorer_tag_reasons"] == {"unsafe": "contains disallowed content"}
+    assert typed_row["scorer_tag_confidences"] == {"unsafe": 0.91}
+    assert typed_row["scorer_ratings"] == {"_rating_": 0.2}
+    assert typed_row["scorer_rating_reasons"] == {"_rating_": "low quality response"}
+    assert typed_row["scorer_rating_confidences"] == {"_rating_": 0.88}
+
 
 def test_agent_monitor_feedback(client: WeaveClient) -> None:
     """End-to-end create/query for wandb.agent_monitor feedback with typed scorer columns."""
@@ -411,8 +458,8 @@ def test_agent_monitor_feedback(client: WeaveClient) -> None:
             )
         )
 
-    # Case 4: scorer_* fields rejected on non-agent-monitor feedback types
-    # (non-empty value).
+    # Case 4: scorer_* fields rejected on feedback that is neither agent-monitor
+    # nor runnable (non-empty value).
     with pytest.raises(InvalidRequest):
         client.server.feedback_create(
             tsi.FeedbackCreateReq(

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -169,7 +169,7 @@ def validate_feedback_create_req(
     elif req.trigger_ref:
         raise InvalidRequest("trigger_ref is not allowed for non-runnable feedback")
 
-    # Typed scorer columns are reserved for agent monitor feedback.
+    # Typed scorer columns are reserved for scorer-generated feedback.
     scorer_fields_set = any(
         getattr(req, name)
         for name in (
@@ -181,11 +181,16 @@ def validate_feedback_create_req(
             "scorer_rating_confidences",
         )
     )
-    if scorer_fields_set and not feedback_type_is_agent_monitor(req.feedback_type):
+
+    is_runnable = feedback_type_is_runnable(req.feedback_type)
+    is_agent_monitor = feedback_type_is_agent_monitor(req.feedback_type)
+    scorer_fields_allowed = is_runnable or is_agent_monitor
+
+    if scorer_fields_set and not scorer_fields_allowed:
         raise InvalidRequest(
             "scorer_tags, scorer_tag_reasons, scorer_tag_confidences, "
             "scorer_ratings, scorer_rating_reasons, and scorer_rating_confidences "
-            "are only allowed on wandb.agent_monitor feedback"
+            "are only allowed on wandb.agent_monitor or wandb.runnable feedback"
         )
 
     # Validate the ref formats (we could even query the DB to ensure they exist and are valid)


### PR DESCRIPTION
## Description

Piggy backing off of @nikumar1206's work, starting to support the new structured feedback columns (scorer_*) for wandb.runnable scorers.

## Testing

Unit tests.
