### PR TITLE
fix(weave): populate structured scorer feedback for runnable scores

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -410,6 +410,117 @@ def test_runnable_feedback(client: WeaveClient) -> None:
     assert typed_row["scorer_rating_confidences"] == {"_rating_": 0.88}
 
 
+def test_runnable_feedback_derives_scorer_columns_from_score_output(
+    client: WeaveClient,
+) -> None:
+    """Runnable score outputs in the structured shape backfill typed scorer columns."""
+    project_id = client.project_id
+    runnable_name = "signal_monitor"
+    feedback_type = f"wandb.runnable.{runnable_name}"
+    runnable_ref = f"weave:///{project_id}/op/{runnable_name}:op_id_123"
+    call_ref = f"weave:///{project_id}/call/call_id_123"
+
+    def read_feedback(feedback_id: str) -> dict:
+        query_res = client.server.feedback_query(
+            tsi.FeedbackQueryReq(
+                project_id=project_id,
+                query=Query(
+                    **{
+                        "$expr": {
+                            "$eq": [
+                                {"$getField": "id"},
+                                {"$literal": feedback_id},
+                            ]
+                        }
+                    }
+                ),
+            )
+        )
+        assert len(query_res.result) == 1
+        return query_res.result[0]
+
+    test_cases = [
+        (
+            "single_tag",
+            {
+                "output": {
+                    "value": "unsafe",
+                    "reason": "contains disallowed content",
+                    "confidence": "0.91",
+                }
+            },
+            {
+                "scorer_tags": ["unsafe"],
+                "scorer_tag_reasons": {"unsafe": "contains disallowed content"},
+                "scorer_tag_confidences": {"unsafe": 0.91},
+                "scorer_ratings": {},
+                "scorer_rating_reasons": {},
+                "scorer_rating_confidences": {},
+            },
+        ),
+        (
+            "list_mixed",
+            {
+                "output": [
+                    {
+                        "value": "bug",
+                        "reason": "runtime error",
+                        "confidence": 0.8,
+                    },
+                    {
+                        "value": 0.2,
+                        "reason": "low quality response",
+                        "confidence": "0.88",
+                    },
+                ]
+            },
+            {
+                "scorer_tags": ["bug"],
+                "scorer_tag_reasons": {"bug": "runtime error"},
+                "scorer_tag_confidences": {"bug": 0.8},
+                "scorer_ratings": {"_rating_": 0.2},
+                "scorer_rating_reasons": {"_rating_": "low quality response"},
+                "scorer_rating_confidences": {"_rating_": 0.88},
+            },
+        ),
+        (
+            "nested_scores",
+            {
+                "output": {
+                    "scores": [
+                        {"value": "PII", "reason": None, "confidence": None},
+                        {"value": 0.7},
+                    ]
+                }
+            },
+            {
+                "scorer_tags": ["PII"],
+                "scorer_tag_reasons": {},
+                "scorer_tag_confidences": {},
+                "scorer_ratings": {"_rating_": 0.7},
+                "scorer_rating_reasons": {},
+                "scorer_rating_confidences": {},
+            },
+        ),
+    ]
+
+    for suffix, payload, expected in test_cases:
+        create_res = client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=f"weave:///{project_id}/call/call_id_{suffix}",
+                feedback_type=feedback_type,
+                payload=payload,
+                runnable_ref=runnable_ref,
+                call_ref=call_ref,
+            )
+        )
+        row = read_feedback(create_res.id)
+        assert row["payload"] == payload
+        for key, value in expected.items():
+            assert row[key] == value
+
+
 def test_agent_monitor_feedback(client: WeaveClient) -> None:
     """End-to-end create/query for wandb.agent_monitor feedback with typed scorer columns."""
     project_id = client.project_id

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -494,7 +494,7 @@ def test_runnable_feedback_derives_scorer_columns_from_score_output(
                 }
             },
             {
-                "scorer_tags": ["PII"],
+                "scorer_tags": ["pii"],
                 "scorer_tag_reasons": {},
                 "scorer_tag_confidences": {},
                 "scorer_ratings": {"_rating_": 0.7},
@@ -519,6 +519,58 @@ def test_runnable_feedback_derives_scorer_columns_from_score_output(
         assert row["payload"] == payload
         for key, value in expected.items():
             assert row[key] == value
+
+
+def test_scorer_output_derivation_handles_invalid_shapes_by_feedback_type(
+    client: WeaveClient,
+) -> None:
+    project_id = client.project_id
+    runnable_name = "signal_monitor"
+    runnable_ref = f"weave:///{project_id}/op/{runnable_name}:op_id_123"
+    call_ref = f"weave:///{project_id}/call/call_id_123"
+
+    create_res = client.server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=f"weave:///{project_id}/call/call_id_runnable",
+            feedback_type=f"wandb.runnable.{runnable_name}",
+            payload={"output": {"passed": False}},
+            runnable_ref=runnable_ref,
+            call_ref=call_ref,
+        )
+    )
+    query_res = client.server.feedback_query(
+        tsi.FeedbackQueryReq(
+            project_id=project_id,
+            query=Query(
+                **{
+                    "$expr": {
+                        "$eq": [
+                            {"$getField": "id"},
+                            {"$literal": create_res.id},
+                        ]
+                    }
+                }
+            ),
+        )
+    )
+    assert query_res.result[0]["scorer_tags"] == []
+    assert query_res.result[0]["scorer_ratings"] == {}
+
+    with pytest.raises(InvalidRequest, match="Invalid scorer output"):
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=f"weave:///{project_id}/call/call_id_agent_monitor",
+                feedback_type="wandb.agent_monitor",
+                payload={"output": {"passed": False}},
+                runnable_ref=f"weave:///{project_id}/object/{runnable_name}:obj_id_123",
+                call_ref=call_ref,
+                trigger_ref=(
+                    f"weave:///{project_id}/object/{runnable_name}:trigger_id_123"
+                ),
+            )
+        )
 
 
 def test_agent_monitor_feedback(client: WeaveClient) -> None:

--- a/tests/trace_server/test_scorer_feedback.py
+++ b/tests/trace_server/test_scorer_feedback.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from weave.trace_server.scorer_feedback import (
+    _SCORER_RATING_MAP_KEY,
+    ScorerColumns,
+    ScorerLlmOutputGroup,
+    ScorerLlmOutputSchema,
+)
+
+
+@pytest.mark.parametrize(
+    ("raw", "exc"),
+    [
+        # Happy path: a tag, a rating, with optional reason/confidence.
+        ({"value": "good"}, None),
+        ({"value": 0.5}, None),
+        ({"value": "good", "reason": "ok", "confidence": 0.9}, None),
+        # `value` is required.
+        ({}, ValidationError),
+        # Multi-tag/rating is a list of separate outputs, not a list value.
+        ({"value": ["a", "b"]}, ValidationError),
+        # Length caps (tag <= 36 chars, reason <= 256 chars).
+        ({"value": "a" * 37}, ValidationError),
+        ({"value": "ok", "reason": "x" * 257}, ValidationError),
+        # Rating must be in [0, 1].
+        ({"value": 1.5}, ValidationError),
+        # Booleans should not be coerced into numeric ratings/confidences.
+        ({"value": True}, ValidationError),
+        ({"value": "ok", "confidence": False}, ValidationError),
+        # JSON int coerces to float and is routed as a rating.
+        ({"value": 1}, None),
+        # Stringified number stays a string and is routed as a tag.
+        ({"value": "0.5"}, None),
+    ],
+)
+def test_scorer_llm_output_schema_validation(
+    raw: dict, exc: type[Exception] | None
+) -> None:
+    if exc is None:
+        out = ScorerLlmOutputSchema.model_validate(raw)
+        for field, value in raw.items():
+            assert getattr(out, field) == value
+    else:
+        with pytest.raises(exc):
+            ScorerLlmOutputSchema.model_validate(raw)
+
+
+def test_union_discrimination_routes_to_correct_column() -> None:
+    int_group = ScorerLlmOutputGroup.from_raw_output({"value": 1})
+    int_cols = ScorerColumns.from_scorer_llm_output_group(int_group)
+    assert int_cols.tags == []
+    assert int_cols.ratings == {_SCORER_RATING_MAP_KEY: 1.0}
+
+    str_group = ScorerLlmOutputGroup.from_raw_output({"value": "0.5"})
+    str_cols = ScorerColumns.from_scorer_llm_output_group(str_group)
+    assert str_cols.tags == ["0.5"]
+    assert str_cols.ratings == {}
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected_scores"),
+    [
+        ({"value": "ok"}, [{"value": "ok"}]),
+        ([{"value": "ok"}, {"value": 0.5}], [{"value": "ok"}, {"value": 0.5}]),
+        (
+            {"scores": [{"value": 0.9}, {"value": "tag"}]},
+            [{"value": 0.9}, {"value": "tag"}],
+        ),
+        ([], []),
+    ],
+)
+def test_group_from_raw_output_formats(
+    raw: object, expected_scores: list[dict]
+) -> None:
+    group = ScorerLlmOutputGroup.from_raw_output(raw)
+    assert len(group.scores) == len(expected_scores)
+    for got, want in zip(group.scores, expected_scores, strict=True):
+        for field, value in want.items():
+            assert getattr(got, field) == value
+
+
+@pytest.mark.parametrize(
+    ("raw", "exc"),
+    [
+        ("not a payload", TypeError),
+        (42, TypeError),
+        (None, TypeError),
+        ({"scores": "not a list"}, ValidationError),
+        ([{"value": "ok"}, {"value": 1.5}], ValidationError),
+    ],
+)
+def test_group_from_raw_output_rejects(raw: object, exc: type[Exception]) -> None:
+    with pytest.raises(exc):
+        ScorerLlmOutputGroup.from_raw_output(raw)
+
+
+@pytest.mark.parametrize(
+    ("outputs", "expected", "exc"),
+    [
+        ([{"value": "High Quality"}], {"tags": ["high-quality"]}, None),
+        (
+            [{"value": "good", "reason": "nice", "confidence": 0.7}],
+            {
+                "tags": ["good"],
+                "tag_reasons": {"good": "nice"},
+                "tag_confidences": {"good": 0.7},
+            },
+            None,
+        ),
+        (
+            [{"value": 1.0, "reason": "perfect", "confidence": 0.8}],
+            {
+                "ratings": {_SCORER_RATING_MAP_KEY: 1.0},
+                "rating_reasons": {_SCORER_RATING_MAP_KEY: "perfect"},
+                "rating_confidences": {_SCORER_RATING_MAP_KEY: 0.8},
+            },
+            None,
+        ),
+        ([{"value": "a"}, {"value": "b"}], {"tags": ["a", "b"]}, None),
+        ([{"value": 0.2}, {"value": 0.4}], None, ValueError),
+        ([], {"tags": [], "ratings": {}}, None),
+    ],
+)
+def test_columns_from_scorer_llm_output_group(
+    outputs: list[dict], expected: dict | None, exc: type[Exception] | None
+) -> None:
+    group = ScorerLlmOutputGroup.from_raw_output(outputs)
+    if exc is None:
+        cols = ScorerColumns.from_scorer_llm_output_group(group)
+        assert expected is not None
+        for field, value in expected.items():
+            assert getattr(cols, field) == value
+    else:
+        with pytest.raises(exc):
+            ScorerColumns.from_scorer_llm_output_group(group)
+
+
+def test_columns_to_feedback_fields() -> None:
+    cols = ScorerColumns.from_raw_output(
+        [{"value": "Safety Risk", "reason": "blocked", "confidence": 0.7}]
+    )
+
+    assert cols.to_feedback_fields() == {
+        "scorer_tags": ["safety-risk"],
+        "scorer_tag_reasons": {"safety-risk": "blocked"},
+        "scorer_tag_confidences": {"safety-risk": 0.7},
+        "scorer_ratings": {},
+        "scorer_rating_reasons": {},
+        "scorer_rating_confidences": {},
+    }

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -28,6 +28,7 @@ from weave.trace_server.interface.feedback_types import (
 )
 from weave.trace_server.orm import Column, Row, Table
 from weave.trace_server.refs_internal_server_util import ensure_ref_is_valid
+from weave.trace_server.scorer_feedback import ScorerColumns, ScorerFeedbackFields
 from weave.trace_server.validation import (
     validate_purge_req_multiple,
     validate_purge_req_one,
@@ -96,97 +97,31 @@ def process_feedback_payload(
     return processed_payload
 
 
-def _optional_float(value: Any) -> float | None:
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, (int, float)):
-        return float(value)
-    if isinstance(value, str):
-        try:
-            return float(value)
-        except ValueError:
-            return None
-    return None
-
-
-def _optional_reason(value: Any) -> str | None:
-    if isinstance(value, str) and value:
-        return value
-    return None
-
-
-def _output_to_score_items(output: Any) -> list[dict[str, Any]]:
-    if isinstance(output, list):
-        return [item for item in output if isinstance(item, dict)]
-
-    if not isinstance(output, dict):
-        return []
-
-    scores = output.get("scores")
-    if isinstance(scores, list):
-        return [item for item in scores if isinstance(item, dict)]
-
-    if "value" in output:
-        return [output]
-
-    return []
+_MISSING_OUTPUT = object()
 
 
 def _derive_scorer_fields_from_payload(
     feedback_req: tsi.FeedbackCreateReq,
     processed_payload: dict[str, Any],
-) -> dict[str, Any]:
+) -> ScorerFeedbackFields:
     if not (
         feedback_type_is_runnable(feedback_req.feedback_type)
         or feedback_type_is_agent_monitor(feedback_req.feedback_type)
     ):
         return {}
 
-    output = processed_payload.get("output")
-    scorer_tags = []
-    scorer_tag_reasons = {}
-    scorer_tag_confidences = {}
-    scorer_ratings = {}
-    scorer_rating_reasons = {}
-    scorer_rating_confidences = {}
-    has_score_item = False
-
-    for score_item in _output_to_score_items(output):
-        value = score_item.get("value")
-        reason = _optional_reason(score_item.get("reason"))
-        confidence = _optional_float(score_item.get("confidence"))
-
-        if isinstance(value, str) and value:
-            has_score_item = True
-            scorer_tags.append(value)
-            if reason is not None:
-                scorer_tag_reasons[value] = reason
-            if confidence is not None:
-                scorer_tag_confidences[value] = confidence
-            continue
-
-        rating = _optional_float(value)
-        if rating is None:
-            continue
-
-        has_score_item = True
-        rating_name = "_rating_"
-        scorer_ratings[rating_name] = rating
-        if reason is not None:
-            scorer_rating_reasons[rating_name] = reason
-        if confidence is not None:
-            scorer_rating_confidences[rating_name] = confidence
-
-    if not has_score_item:
+    output = processed_payload.get("output", _MISSING_OUTPUT)
+    if output is _MISSING_OUTPUT:
         return {}
-    return {
-        "scorer_tags": scorer_tags,
-        "scorer_tag_reasons": scorer_tag_reasons,
-        "scorer_tag_confidences": scorer_tag_confidences,
-        "scorer_ratings": scorer_ratings,
-        "scorer_rating_reasons": scorer_rating_reasons,
-        "scorer_rating_confidences": scorer_rating_confidences,
-    }
+
+    try:
+        return ScorerColumns.from_raw_output(output).to_feedback_fields()
+    except (TypeError, ValueError, ValidationError) as e:
+        if feedback_type_is_agent_monitor(feedback_req.feedback_type):
+            raise InvalidRequest(
+                f"Invalid scorer output for feedback_type {feedback_req.feedback_type}: {e}"
+            ) from e
+        return {}
 
 
 def validate_feedback_create_req(
@@ -374,7 +309,7 @@ def format_feedback_to_row(
     feedback_id = feedback_req.id or generate_id()
     created_at = datetime.datetime.now(ZoneInfo("UTC"))
 
-    request_scorer_fields = {
+    request_scorer_fields: ScorerFeedbackFields = {
         "scorer_tags": feedback_req.scorer_tags,
         "scorer_tag_reasons": feedback_req.scorer_tag_reasons,
         "scorer_tag_confidences": feedback_req.scorer_tag_confidences,
@@ -383,7 +318,7 @@ def format_feedback_to_row(
         "scorer_rating_confidences": feedback_req.scorer_rating_confidences,
     }
 
-    scorer_fields = None
+    scorer_fields: ScorerFeedbackFields
 
     # If typed fields (scorer_*) exist on the feedback req object,
     # use those values. Otherwise, try to derive them from the output

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -96,6 +96,99 @@ def process_feedback_payload(
     return processed_payload
 
 
+def _optional_float(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _optional_reason(value: Any) -> str | None:
+    if isinstance(value, str) and value:
+        return value
+    return None
+
+
+def _output_to_score_items(output: Any) -> list[dict[str, Any]]:
+    if isinstance(output, list):
+        return [item for item in output if isinstance(item, dict)]
+
+    if not isinstance(output, dict):
+        return []
+
+    scores = output.get("scores")
+    if isinstance(scores, list):
+        return [item for item in scores if isinstance(item, dict)]
+
+    if "value" in output:
+        return [output]
+
+    return []
+
+
+def _derive_scorer_fields_from_payload(
+    feedback_req: tsi.FeedbackCreateReq,
+    processed_payload: dict[str, Any],
+) -> dict[str, Any]:
+    if not (
+        feedback_type_is_runnable(feedback_req.feedback_type)
+        or feedback_type_is_agent_monitor(feedback_req.feedback_type)
+    ):
+        return {}
+
+    output = processed_payload.get("output")
+    scorer_tags = []
+    scorer_tag_reasons = {}
+    scorer_tag_confidences = {}
+    scorer_ratings = {}
+    scorer_rating_reasons = {}
+    scorer_rating_confidences = {}
+    has_score_item = False
+
+    for score_item in _output_to_score_items(output):
+        value = score_item.get("value")
+        reason = _optional_reason(score_item.get("reason"))
+        confidence = _optional_float(score_item.get("confidence"))
+
+        if isinstance(value, str) and value:
+            has_score_item = True
+            scorer_tags.append(value)
+            if reason is not None:
+                scorer_tag_reasons[value] = reason
+            if confidence is not None:
+                scorer_tag_confidences[value] = confidence
+            continue
+
+        rating = _optional_float(value)
+        if rating is None:
+            continue
+
+        has_score_item = True
+        rating_name = "_rating_"
+        scorer_ratings[rating_name] = rating
+        if reason is not None:
+            scorer_rating_reasons[rating_name] = reason
+        if confidence is not None:
+            scorer_rating_confidences[rating_name] = confidence
+
+    if not has_score_item:
+        return {}
+    return {
+        "scorer_tags": scorer_tags,
+        "scorer_tag_reasons": scorer_tag_reasons,
+        "scorer_tag_confidences": scorer_tag_confidences,
+        "scorer_ratings": scorer_ratings,
+        "scorer_rating_reasons": scorer_rating_reasons,
+        "scorer_rating_confidences": scorer_rating_confidences,
+    }
+
+
 def validate_feedback_create_req(
     req: tsi.FeedbackCreateReq, trace_server: tsi.TraceServerInterface
 ) -> None:
@@ -281,6 +374,27 @@ def format_feedback_to_row(
     feedback_id = feedback_req.id or generate_id()
     created_at = datetime.datetime.now(ZoneInfo("UTC"))
 
+    request_scorer_fields = {
+        "scorer_tags": feedback_req.scorer_tags,
+        "scorer_tag_reasons": feedback_req.scorer_tag_reasons,
+        "scorer_tag_confidences": feedback_req.scorer_tag_confidences,
+        "scorer_ratings": feedback_req.scorer_ratings,
+        "scorer_rating_reasons": feedback_req.scorer_rating_reasons,
+        "scorer_rating_confidences": feedback_req.scorer_rating_confidences,
+    }
+
+    scorer_fields = None
+
+    # If typed fields (scorer_*) exist on the feedback req object,
+    # use those values. Otherwise, try to derive them from the output
+    if any(request_scorer_fields.values()):
+        scorer_fields = request_scorer_fields
+    else:
+        scorer_fields = _derive_scorer_fields_from_payload(
+            feedback_req,
+            processed_payload,
+        )
+
     return {
         "id": feedback_id,
         "project_id": feedback_req.project_id,
@@ -295,12 +409,12 @@ def format_feedback_to_row(
         "call_ref": feedback_req.call_ref,
         "trigger_ref": feedback_req.trigger_ref,
         "queue_id": feedback_req.queue_id,
-        "scorer_tags": feedback_req.scorer_tags,
-        "scorer_tag_reasons": feedback_req.scorer_tag_reasons,
-        "scorer_tag_confidences": feedback_req.scorer_tag_confidences,
-        "scorer_ratings": feedback_req.scorer_ratings,
-        "scorer_rating_reasons": feedback_req.scorer_rating_reasons,
-        "scorer_rating_confidences": feedback_req.scorer_rating_confidences,
+        "scorer_tags": scorer_fields.get("scorer_tags", []),
+        "scorer_tag_reasons": scorer_fields.get("scorer_tag_reasons", {}),
+        "scorer_tag_confidences": scorer_fields.get("scorer_tag_confidences", {}),
+        "scorer_ratings": scorer_fields.get("scorer_ratings", {}),
+        "scorer_rating_reasons": scorer_fields.get("scorer_rating_reasons", {}),
+        "scorer_rating_confidences": scorer_fields.get("scorer_rating_confidences", {}),
     }
 
 

--- a/weave/trace_server/scorer_feedback.py
+++ b/weave/trace_server/scorer_feedback.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Annotated, Any, TypeAlias
+
+from pydantic import BaseModel, Field, field_validator
+
+logger = logging.getLogger("weave.trace_server.scorer_feedback")
+
+ScorerFeedbackFieldValue: TypeAlias = list[str] | dict[str, Any]
+ScorerFeedbackFields: TypeAlias = dict[str, ScorerFeedbackFieldValue]
+
+_MAX_TAGS_PER_ROW = 10
+_MAX_TAG_LENGTH = 36
+_MAX_REASON_LENGTH = 256
+
+# Currently we allow scorers to emit a single numeric rating, which always uses this key.
+# If we choose to allow multiple ratings in the future we can remove this constant.
+_SCORER_RATING_MAP_KEY = "_rating_"
+
+# A scorer LLM might give a reason for *not* tagging, which we assign to this sentinel.
+_SCORER_EMPTY_TAG_KEY = "_empty_"
+
+# Regex for chars allowed in tags and reasons. Whitespace will be removed from tags separately.
+_SCORER_METADATA_CHARS_RE = re.compile(r"[^0-9a-zA-Z \.,;\-&!@#$%?]")
+
+_TagType = Annotated[str, Field(max_length=_MAX_TAG_LENGTH)]
+_RatingType = Annotated[float, Field(ge=0.0, le=1.0)]
+
+
+class ScorerLlmOutputSchema(BaseModel):
+    """Schema for a single scorer tag or rating. Extra keys are ignored."""
+
+    value: _TagType | _RatingType
+    reason: str | None = Field(default=None, max_length=_MAX_REASON_LENGTH)
+    confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+
+    @field_validator("value", "confidence", mode="before")
+    @classmethod
+    def reject_bool_as_number(cls, v: Any) -> Any:
+        if isinstance(v, bool):
+            raise ValueError("boolean values are not valid scorer numbers")  # noqa: TRY004
+        return v
+
+
+class ScorerLlmOutputGroup(BaseModel):
+    """Schema for a list of scorer tag or rating outputs."""
+
+    scores: list[ScorerLlmOutputSchema]
+
+    @staticmethod
+    def from_raw_output(obj: Any) -> ScorerLlmOutputGroup:
+        """Parse and validate scorer output in any of 3 formats:
+        - A single score payload:  `{"value": "ok"}`
+        - A list of scores:        `[{"value": "ok"}, {"value": 0.5}]`
+        - A nested list of scores: `{"scores": [{"value": 0.9}]}`
+        """
+        if isinstance(obj, list):
+            return ScorerLlmOutputGroup.model_validate({"scores": obj})
+        if not isinstance(obj, dict):
+            raise TypeError(f"Invalid scorer output type: {type(obj).__name__}")
+        if isinstance(obj.get("scores"), list):
+            return ScorerLlmOutputGroup.model_validate(obj)
+        return ScorerLlmOutputGroup(scores=[ScorerLlmOutputSchema.model_validate(obj)])
+
+    @staticmethod
+    def from_agent_scorer_output(obj: Any) -> ScorerLlmOutputGroup:
+        """Backward-compatible alias for the agent scoring worker."""
+        return ScorerLlmOutputGroup.from_raw_output(obj)
+
+
+class ScorerColumns(BaseModel):
+    """Represents a row of `feedback.score_*` columns in the DB.
+    Includes helper methods for normalizing raw scorer output.
+    """
+
+    tags: list[str] = Field(default_factory=list)
+    ratings: dict[str, float] = Field(default_factory=dict)
+    tag_reasons: dict[str, str] = Field(default_factory=dict)
+    tag_confidences: dict[str, float] = Field(default_factory=dict)
+    rating_reasons: dict[str, str] = Field(default_factory=dict)
+    rating_confidences: dict[str, float] = Field(default_factory=dict)
+
+    @classmethod
+    def from_raw_output(cls, output: Any) -> ScorerColumns:
+        """Return normalized `feedback.score_*` columns from raw scorer output."""
+        group = ScorerLlmOutputGroup.from_raw_output(output)
+        return cls.from_scorer_llm_output_group(group)
+
+    @classmethod
+    def from_scorer_llm_output_group(cls, group: ScorerLlmOutputGroup) -> ScorerColumns:
+        """Return normalized `feedback.score_*` columns from LLM output."""
+        cols = ScorerColumns()
+
+        for output in group.scores:
+            if isinstance(output.value, str):
+                cols._add_tag(output.value, output.reason, output.confidence)
+            elif isinstance(output.value, float):
+                cols._add_rating(output.value, output.reason, output.confidence)
+            else:
+                raise TypeError(
+                    f'Invalid output value: {type(output.value)} "{output.value}"'
+                )
+        return cols
+
+    def to_feedback_fields(self) -> ScorerFeedbackFields:
+        """Return the column names/values expected by FeedbackCreateReq and feedback rows."""
+        return {
+            "scorer_tags": self.tags,
+            "scorer_tag_reasons": self.tag_reasons,
+            "scorer_tag_confidences": self.tag_confidences,
+            "scorer_ratings": self.ratings,
+            "scorer_rating_reasons": self.rating_reasons,
+            "scorer_rating_confidences": self.rating_confidences,
+        }
+
+    def _add_tag(self, tag: str, reason: str | None, confidence: float | None) -> None:
+        """Add a tag to the `feedback.scorer_tags` column array."""
+        if len(self.tags) >= _MAX_TAGS_PER_ROW:
+            logger.warning(
+                'Exceeded max %d tags per scorer, skipping "%s"',
+                _MAX_TAGS_PER_ROW,
+                tag,
+            )
+            return
+        if tag := self._sanitize_tag(tag):
+            if tag in self.tags:
+                logger.warning("Skipping duplicate tag '%s'", tag)
+                return
+            self.tags.append(tag)
+            self.tags.sort()
+        else:
+            tag = _SCORER_EMPTY_TAG_KEY
+        if reason := self._sanitize_reason(reason):
+            self.tag_reasons[tag] = reason
+        if isinstance(confidence, float):
+            self.tag_confidences[tag] = confidence
+
+    def _add_rating(
+        self, rating: float, reason: str | None, confidence: float | None
+    ) -> None:
+        """Add a rating to the `feedback.scorer_ratings` column map."""
+        if self.ratings:
+            raise ValueError("Multiple ratings per scorer are not supported")
+        self.ratings[_SCORER_RATING_MAP_KEY] = rating
+        if reason := self._sanitize_reason(reason):
+            self.rating_reasons[_SCORER_RATING_MAP_KEY] = reason
+        if isinstance(confidence, float):
+            self.rating_confidences[_SCORER_RATING_MAP_KEY] = confidence
+
+    @staticmethod
+    def _sanitize_tag(tag: str | None) -> str:
+        """Strip forbidden chars, replace whitespace with dashes and coerce to lowercase."""
+        if not tag:
+            return ""
+        tag = _SCORER_METADATA_CHARS_RE.sub("", tag)
+        return re.sub(r"\s+", "-", tag.strip().lower())
+
+    @staticmethod
+    def _sanitize_reason(reason: str | None) -> str:
+        """Strip forbidden chars."""
+        if not reason:
+            return ""
+        reason = _SCORER_METADATA_CHARS_RE.sub("", reason).strip()
+        return reason[:_MAX_REASON_LENGTH]

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1188,7 +1188,7 @@ class FeedbackCreateReq(BaseModelStrict):
         examples=["018f1f2a-9c2b-7d3e-b5a1-8c9d2e4f6a7b"],
     )
 
-    # typed scorer outputs; populated by agent-monitor scorers
+    # typed scorer outputs; populated by scorer-generated feedback
     scorer_tags: list[str] = Field(
         default_factory=list,
         description="Tags applied to the ref by a scorer",


### PR DESCRIPTION
## Description

For older runnable call scorers using llm-as-judge, if the llm output matches what we expect for the typed outputs (scorer_* columns), populate them in the to-be-inserted feedback row.

This should allow the runnable scorers to start adopting the new typed columns while remaining backwards compatible for the ones that exist.

I ported the code from core (pydantic models / validations) over here so we can reuse it. Will need to follow up after merge with an update to core to 🔪  the duplication and import from weave.

## Testing

Unit tests
