### PR TITLE
chore(weave_ts): Update a couple js docs that break .mdx parsing in docs/

### DIFF
--- a/sdks/node/src/genai/context.ts
+++ b/sdks/node/src/genai/context.ts
@@ -77,10 +77,12 @@ export function _getGenaiState(): GenAIState {
  *
  * Use this to safely run parallel GenAI work:
  *
+ *   ```typescript
  *   await Promise.all([
  *     weave.runIsolated(async () => { ... }),
  *     weave.runIsolated(async () => { ... }),
  *   ]);
+ *  ```
  *
  * Sequential single-flight usage doesn't require this wrapper — the
  * process-wide default state handles it.

--- a/sdks/node/src/integrations/openai.agent.ts
+++ b/sdks/node/src/integrations/openai.agent.ts
@@ -678,7 +678,7 @@ export function createOpenAIAgentsTracingProcessor(): TracingProcessor {
  * and registers a TracingProcessor. If the package is not installed, it returns false without
  * throwing an error.
  *
- * @returns Promise<boolean> - true if registration succeeded, false if @openai/agents not available
+ * @returns `Promise<boolean>` - `true` if registration succeeded, `false` if `@openai/agents` not available
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## Description

* These pages currently 404 due to parsing errors:
  * https://wb-21fd5541-update-reference-docs-34.mintlify.app/weave/reference/typescript-sdk/functions/runisolated
  * https://wb-21fd5541-update-reference-docs-34.mintlify.app/weave/reference/typescript-sdk/functions/instrumentopenaiagents

* Escaping some of the code in the comments allows the mdx to parse as expected.

