### PR TITLE
chore(weave_ts): Add GH Action for adding npm dist-tag to published version.

### DIFF
--- a/.github/workflows/promote_ts_sdk_dist_tag.yml
+++ b/.github/workflows/promote_ts_sdk_dist_tag.yml
@@ -18,7 +18,7 @@ on:
 jobs:
   promote-typescript-sdk:
     name: Add TypeScript SDK dist-tag on npm
-    runs-on: ubuntu-8core
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     environment:
       name: release

--- a/.github/workflows/promote_ts_sdk_dist_tag.yml
+++ b/.github/workflows/promote_ts_sdk_dist_tag.yml
@@ -1,0 +1,54 @@
+name: promote-typescript-sdk-npm
+
+# This workflow promotes an already-published Weave TypeScript SDK version
+# to a dist-tag (e.g. next → latest).
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: "dist-tag to apply to version"
+        required: true
+        type: choice
+        options:
+          - latest
+          - next
+        default: latest
+
+jobs:
+  promote-typescript-sdk:
+    name: Add TypeScript SDK dist-tag on npm
+    runs-on: ubuntu-8core
+    timeout-minutes: 5
+    environment:
+      name: release
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.8.1
+          run_install: false
+
+      - id: package_meta
+        run: |
+          PACKAGE_NAME=$(node -p "require('./sdks/node/package.json').name")
+          PACKAGE_VERSION=$(node -p "require('./sdks/node/package.json').version")
+          echo "package_name=${PACKAGE_NAME}" >> "$GITHUB_OUTPUT"
+          echo "package_version=${PACKAGE_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Add dist-tag
+        env:
+          PACKAGE_NAME: ${{ steps.package_meta.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.package_meta.outputs.package_version }}
+        working-directory: sdks/node
+        run: npm dist-tag add "${PACKAGE_NAME}@${PACKAGE_VERSION}" "${{ inputs.dist_tag }}"


### PR DESCRIPTION
## Description

* We have a GH Action workflow that allows publishing to the either the `next` or `latest` dist-tag on npm. (https://github.com/wandb/weave/actions/workflows/publish_ts_sdk_npm.yaml)

* After publishing to `next`, we may want to test & then promote to `latest` when we're ready.

* This change adds another GH Action workflow that allows applying the either the `lastest` or `next` dist-tag to an already published version, to accommodate that flow.