### PR TITLE
fix(weave): annotation_queue mutations take table_name from caller

### DIFF
--- a/tests/trace_server/query_builder/test_on_cluster_query_builder.py
+++ b/tests/trace_server/query_builder/test_on_cluster_query_builder.py
@@ -82,13 +82,22 @@ def test_on_cluster_mutations_never_inject_local_suffix() -> None:
     # --- annotation queues ---
     pb = ParamBuilder()
     q_delete = make_queue_delete_query(
-        project_id="proj", queue_id="q", pb=pb, cluster_name=CLUSTER
+        project_id="proj",
+        queue_id="q",
+        pb=pb,
+        table_name="annotation_queues",
+        cluster_name=CLUSTER,
     )
     assert f"annotation_queues ON CLUSTER {CLUSTER}" in q_delete
 
     pb = ParamBuilder()
     q_update = make_queue_update_query(
-        project_id="proj", queue_id="q", pb=pb, cluster_name=CLUSTER, name="n"
+        project_id="proj",
+        queue_id="q",
+        pb=pb,
+        table_name="annotation_queues",
+        cluster_name=CLUSTER,
+        name="n",
     )
     assert f"annotation_queues ON CLUSTER {CLUSTER}" in q_update
 
@@ -99,6 +108,7 @@ def test_on_cluster_mutations_never_inject_local_suffix() -> None:
         annotator_id="a",
         annotation_state="done",
         pb=pb,
+        table_name="annotator_queue_items_progress",
         cluster_name=CLUSTER,
     )
     assert f"annotator_queue_items_progress ON CLUSTER {CLUSTER}" in progress

--- a/tests/trace_server/query_builder/test_on_cluster_query_builder.py
+++ b/tests/trace_server/query_builder/test_on_cluster_query_builder.py
@@ -104,6 +104,44 @@ def test_on_cluster_mutations_never_inject_local_suffix() -> None:
     assert f"annotator_queue_items_progress ON CLUSTER {CLUSTER}" in progress
 
 
+def test_annotation_queue_mutations_use_caller_provided_local_name() -> None:
+    """In distributed mode the caller passes `<table>_local`; the builder must
+    use that name verbatim (lightweight UPDATE isn't supported on Distributed).
+    """
+    pb = ParamBuilder()
+    q_delete = make_queue_delete_query(
+        project_id="proj",
+        queue_id="q",
+        pb=pb,
+        cluster_name=CLUSTER,
+        table_name="annotation_queues_local",
+    )
+    assert f"annotation_queues_local ON CLUSTER {CLUSTER}" in q_delete
+
+    pb = ParamBuilder()
+    q_update = make_queue_update_query(
+        project_id="proj",
+        queue_id="q",
+        pb=pb,
+        cluster_name=CLUSTER,
+        table_name="annotation_queues_local",
+        name="n",
+    )
+    assert f"annotation_queues_local ON CLUSTER {CLUSTER}" in q_update
+
+    pb = ParamBuilder()
+    progress = make_annotator_progress_update_query(
+        project_id="proj",
+        queue_item_id="qi",
+        annotator_id="a",
+        annotation_state="done",
+        pb=pb,
+        cluster_name=CLUSTER,
+        table_name="annotator_queue_items_progress_local",
+    )
+    assert f"annotator_queue_items_progress_local ON CLUSTER {CLUSTER}" in progress
+
+
 @pytest.mark.parametrize(
     ("use_distributed", "cluster_name", "expected_table", "expected_on_cluster"),
     [

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -553,9 +553,18 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         Returns:
             str: Table name to use for UPDATE statements.
         """
+        return self._mutation_table_name("calls_complete")
+
+    def _mutation_table_name(self, table: str) -> str:
+        """Resolve the concrete mutation target for `table`.
+
+        Lightweight UPDATE/DELETE don't run on Distributed engines, so
+        distributed mode targets `{table}_local` and lets `ON CLUSTER`
+        fan the mutation across shards via Keeper.
+        """
         if self.use_distributed_mode:
-            return f"calls_complete{ch_settings.LOCAL_TABLE_SUFFIX}"
-        return "calls_complete"
+            return f"{table}{ch_settings.LOCAL_TABLE_SUFFIX}"
+        return table
 
     def _get_existing_ops_from_spans(
         self, seen_ids: set[str], project_id: str, limit: int | None = None
@@ -3065,6 +3074,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             queue_id=req.queue_id,
             pb=pb,
             cluster_name=self.clickhouse_cluster_name,
+            table_name=self._mutation_table_name("annotation_queues"),
             name=req.name,
             description=req.description,
             scorer_refs=req.scorer_refs,
@@ -3130,6 +3140,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             queue_id=req.queue_id,
             pb=pb,
             cluster_name=self.clickhouse_cluster_name,
+            table_name=self._mutation_table_name("annotation_queues"),
         )
 
         self._command(
@@ -3473,6 +3484,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 annotation_state=req.annotation_state,
                 pb=update_pb,
                 cluster_name=self.clickhouse_cluster_name,
+                table_name=self._mutation_table_name("annotator_queue_items_progress"),
             )
             self._command(
                 update_query,

--- a/weave/trace_server/query_builder/annotation_queues_query_builder.py
+++ b/weave/trace_server/query_builder/annotation_queues_query_builder.py
@@ -237,6 +237,7 @@ def make_queue_delete_query(
     queue_id: str,
     pb: ParamBuilder,
     cluster_name: str | None = None,
+    table_name: str = "annotation_queues",
 ) -> str:
     """Generate an UPDATE query to soft-delete an annotation queue.
 
@@ -247,6 +248,9 @@ def make_queue_delete_query(
         queue_id: The queue ID (UUID as string)
         pb: Parameter builder for safe SQL parameter injection
         cluster_name: Optional ClickHouse cluster name for distributed mutations
+        table_name: Concrete table to mutate. Callers in distributed mode pass
+            `annotation_queues_local` because lightweight UPDATE/DELETE are
+            unsupported on the Distributed engine.
 
     Returns:
         SQL query string for soft-deleting a queue
@@ -254,8 +258,7 @@ def make_queue_delete_query(
     project_id_param = pb.add_param(project_id)
     queue_id_param = pb.add_param(queue_id)
 
-    # Format table name with ON CLUSTER if cluster_name is provided
-    formatted_table = _format_table_name_with_cluster("annotation_queues", cluster_name)
+    formatted_table = _format_table_name_with_cluster(table_name, cluster_name)
 
     query = f"""
     UPDATE {formatted_table} SET
@@ -274,6 +277,7 @@ def make_queue_update_query(
     queue_id: str,
     pb: ParamBuilder,
     cluster_name: str | None = None,
+    table_name: str = "annotation_queues",
     *,
     name: str | None = None,
     description: str | None = None,
@@ -319,8 +323,7 @@ def make_queue_update_query(
 
     set_clause = ",\n            ".join(set_clauses)
 
-    # Format table name with ON CLUSTER if cluster_name is provided
-    formatted_table = _format_table_name_with_cluster("annotation_queues", cluster_name)
+    formatted_table = _format_table_name_with_cluster(table_name, cluster_name)
 
     query = f"""
         UPDATE {formatted_table}
@@ -652,6 +655,7 @@ def make_annotator_progress_update_query(
     annotation_state: str,
     pb: ParamBuilder,
     cluster_name: str | None = None,
+    table_name: str = "annotator_queue_items_progress",
 ) -> str:
     """Generate an UPDATE query to update annotator progress for a queue item.
 
@@ -662,6 +666,9 @@ def make_annotator_progress_update_query(
         annotation_state: The new annotation state
         pb: Parameter builder for safe SQL parameter injection
         cluster_name: Optional ClickHouse cluster name for distributed mutations
+        table_name: Concrete table to mutate. Callers in distributed mode pass
+            `annotator_queue_items_progress_local` because lightweight UPDATE
+            is unsupported on the Distributed engine.
 
     Returns:
         SQL query string for updating annotator progress
@@ -671,10 +678,7 @@ def make_annotator_progress_update_query(
     annotator_id_param = pb.add_param(annotator_id)
     annotation_state_param = pb.add_param(annotation_state)
 
-    # Format table name with ON CLUSTER if cluster_name is provided
-    formatted_table = _format_table_name_with_cluster(
-        "annotator_queue_items_progress", cluster_name
-    )
+    formatted_table = _format_table_name_with_cluster(table_name, cluster_name)
 
     query = f"""
     UPDATE {formatted_table}

--- a/weave/trace_server/query_builder/annotation_queues_query_builder.py
+++ b/weave/trace_server/query_builder/annotation_queues_query_builder.py
@@ -236,8 +236,8 @@ def make_queue_delete_query(
     project_id: str,
     queue_id: str,
     pb: ParamBuilder,
+    table_name: str,
     cluster_name: str | None = None,
-    table_name: str = "annotation_queues",
 ) -> str:
     """Generate an UPDATE query to soft-delete an annotation queue.
 
@@ -247,10 +247,10 @@ def make_queue_delete_query(
         project_id: The project ID
         queue_id: The queue ID (UUID as string)
         pb: Parameter builder for safe SQL parameter injection
-        cluster_name: Optional ClickHouse cluster name for distributed mutations
         table_name: Concrete table to mutate. Callers in distributed mode pass
             `annotation_queues_local` because lightweight UPDATE/DELETE are
             unsupported on the Distributed engine.
+        cluster_name: Optional ClickHouse cluster name for distributed mutations
 
     Returns:
         SQL query string for soft-deleting a queue
@@ -276,8 +276,8 @@ def make_queue_update_query(
     project_id: str,
     queue_id: str,
     pb: ParamBuilder,
+    table_name: str,
     cluster_name: str | None = None,
-    table_name: str = "annotation_queues",
     *,
     name: str | None = None,
     description: str | None = None,
@@ -292,6 +292,9 @@ def make_queue_update_query(
         project_id: The project ID
         queue_id: The queue ID (UUID as string)
         pb: Parameter builder for safe SQL parameter injection
+        table_name: Concrete table to mutate. Callers in distributed mode pass
+            `annotation_queues_local` because lightweight UPDATE/DELETE are
+            unsupported on the Distributed engine.
         cluster_name: Optional ClickHouse cluster name for distributed mutations
         name: Optional new queue name
         description: Optional new queue description
@@ -654,8 +657,8 @@ def make_annotator_progress_update_query(
     annotator_id: str,
     annotation_state: str,
     pb: ParamBuilder,
+    table_name: str,
     cluster_name: str | None = None,
-    table_name: str = "annotator_queue_items_progress",
 ) -> str:
     """Generate an UPDATE query to update annotator progress for a queue item.
 
@@ -665,10 +668,10 @@ def make_annotator_progress_update_query(
         annotator_id: The annotator's wb_user_id
         annotation_state: The new annotation state
         pb: Parameter builder for safe SQL parameter injection
-        cluster_name: Optional ClickHouse cluster name for distributed mutations
         table_name: Concrete table to mutate. Callers in distributed mode pass
             `annotator_queue_items_progress_local` because lightweight UPDATE
             is unsupported on the Distributed engine.
+        cluster_name: Optional ClickHouse cluster name for distributed mutations
 
     Returns:
         SQL query string for updating annotator progress


### PR DESCRIPTION
[WB-34907](https://coreweave.atlassian.net/browse/WB-34907)

## Summary
- Lightweight UPDATE/DELETE only run on MergeTree-family engines, never the Distributed engine, so `annotation_queue_update`/`delete`/`annotator_progress_update` failed in distributed mode. This is architectural, not a CH version bug; no upgrade fixes it.
- Adopt the caller-resolves-table pattern (mirrors `_get_calls_complete_table_name`): batched server resolves `<table>_local` in distributed mode and passes it to the query builder, which fans the mutation across shards via `ON CLUSTER`. Builders use the name verbatim, never inject `_local`.

## Testing
new `test_annotation_queue_mutations_use_caller_provided_local_name` in `test_on_cluster_query_builder.py`; existing `test_on_cluster_mutations_never_inject_local_suffix` still enforces the no-injection rule.

[WB-34907]: https://coreweave.atlassian.net/browse/WB-34907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
