### PR TITLE
fix(weave): distributed file chunks fix

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1244,6 +1244,8 @@ def test_file_content_read_retries_eventual_consistency():
         assert mock_read_once.call_count == 2
 
     # Real miss: after exhausting retries, the original NotFoundError still surfaces.
+    # `_file_content_read_with_retry` defaults to 5 attempts so chunked-file reads
+    # can absorb replication lag across multiple shards/replicas.
     with patch.object(
         server,
         "_file_content_read_once",
@@ -1255,7 +1257,7 @@ def test_file_content_read_retries_eventual_consistency():
         ):
             server.file_content_read(req)
 
-        assert mock_read_once.call_count == 2
+        assert mock_read_once.call_count == 5
 
 
 @pytest.mark.disable_logging_error_check

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1244,8 +1244,6 @@ def test_file_content_read_retries_eventual_consistency():
         assert mock_read_once.call_count == 2
 
     # Real miss: after exhausting retries, the original NotFoundError still surfaces.
-    # `_file_content_read_with_retry` defaults to 5 attempts so chunked-file reads
-    # can absorb replication lag across multiple shards/replicas.
     with patch.object(
         server,
         "_file_content_read_once",
@@ -1257,7 +1255,7 @@ def test_file_content_read_retries_eventual_consistency():
         ):
             server.file_content_read(req)
 
-        assert mock_read_once.call_count == 5
+        assert mock_read_once.call_count == 2
 
 
 @pytest.mark.disable_logging_error_check

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5603,9 +5603,15 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         name="clickhouse_trace_server_batched._file_content_read_with_retry"
     )
     def _file_content_read_with_retry(
-        self, req: tsi.FileContentReadReq, max_attempts: int = 2
+        self, req: tsi.FileContentReadReq, max_attempts: int = 5
     ) -> tsi.FileContentReadRes:
-        """Read file content with retry for ClickHouse eventual consistency."""
+        """Read file content with retry for ClickHouse eventual consistency.
+
+        Higher attempt count than `_obj_read_with_retry` because chunked-file
+        reads need all chunks visible across all shards/replicas: in
+        replicated/distributed mode each missing chunk on any replica trips
+        the retry, and lag can briefly exceed the 50ms-1s window.
+        """
         return self._read_with_retry(
             lambda: self._file_content_read_once(req), max_attempts=max_attempts
         )
@@ -6036,7 +6042,12 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         result_rows = list(query_result.result_rows)
 
         if len(result_rows) < n_chunks:
-            raise ValueError("Missing chunks")
+            # Treat as not-found so the tenacity retry in `_read_with_retry`
+            # picks it up. Replicated/distributed reads can transiently see
+            # fewer rows than `n_chunks` while replication catches up.
+            raise NotFoundError(
+                f"File with digest {req.digest} has {len(result_rows)}/{n_chunks} chunks visible"
+            )
         elif len(result_rows) > n_chunks:
             # The general case where this can occur is when there are multiple
             # writes of the same digest AND the effective `FILE_CHUNK_SIZE`

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5603,15 +5603,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         name="clickhouse_trace_server_batched._file_content_read_with_retry"
     )
     def _file_content_read_with_retry(
-        self, req: tsi.FileContentReadReq, max_attempts: int = 5
+        self, req: tsi.FileContentReadReq, max_attempts: int = 2
     ) -> tsi.FileContentReadRes:
-        """Read file content with retry for ClickHouse eventual consistency.
-
-        Higher attempt count than `_obj_read_with_retry` because chunked-file
-        reads need all chunks visible across all shards/replicas: in
-        replicated/distributed mode each missing chunk on any replica trips
-        the retry, and lag can briefly exceed the 50ms-1s window.
-        """
+        """Read file content with retry for ClickHouse eventual consistency."""
         return self._read_with_retry(
             lambda: self._file_content_read_once(req), max_attempts=max_attempts
         )

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -175,6 +175,12 @@ ID_SHARDED_TABLES: dict[str, str] = {
     # "versions for agent" queries have the same locality as the agent row.
     "agents": "project_id, agent_name",
     "agent_versions": "project_id, agent_name",
+    # Files are chunked: `_file_content_read_once` selects all rows for a
+    # (project_id, digest) and checks the count against `n_chunks`. With
+    # rand() sharding chunks land on different shards, so any per-shard
+    # replication lag manifests as "Missing chunks". Co-locate chunks of
+    # one file on one shard so the read sees an atomic set.
+    "files": "project_id, digest",
 }
 
 


### PR DESCRIPTION
[WB-34908](https://coreweave.atlassian.net/browse/WB-34908)

## Summary
- `_file_content_read_once` raised `ValueError("Missing chunks")` when `len(result_rows) < n_chunks`, but tenacity's retry only catches `NotFoundError`, so transient cross-shard replication lag bypassed the retry and failed the request. Now raises `NotFoundError` so the existing retry kicks in.
- Add `"files": "project_id, digest"` to `ID_SHARDED_TABLES` so all chunks of a single file co-locate on one shard. `rand()` sharding scattered chunks across shards, amplifying the lag window.

## Testing
existing `test_file_content_read_retries_eventual_consistency`; caught originally by `test_large_files` on 2s2r.

[WB-34908]: https://coreweave.atlassian.net/browse/WB-34908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ