### PR TITLE
chore(weave): tune replicated nightly trace shard runner + memory caps

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -194,10 +194,21 @@ jobs:
 
   nightly-tests-replicated-1s3r:
     name: Nightly Tests (replicated 1s3r)
-    timeout-minutes: 90
-    runs-on: ubuntu-latest
+    # Successful 8-core trace leg ran in ~16 min; cap at 25 min so any hang
+    # fails fast and we can RCA from the captured CH logs + faulthandler dump.
+    timeout-minutes: 25
+    # `trace` shard is CH-heavy and was hitting ~2h on the 2-core default;
+    # mirror test.yaml's pattern and bump just that shard to 8-core. Other
+    # shards stay on free 2-core. 8-core is billed at $0.022/min, so a
+    # typical 30 min trace leg ~= $0.66.
+    runs-on: ${{ (matrix.shard == 'trace' || matrix.shard == 'trace_calls_complete_only') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     env:
-      MAX_ATTEMPTS: 3
+      # MAX_ATTEMPTS=1 (no retry). Retries on replicated topologies amplify
+      # failures: each attempt re-runs against the same docker-compose CH
+      # cluster, which accumulates data/parts and starts OOMing. In one
+      # RCA, test fixture setup grew 52s -> 297s between attempt 1 and 2.
+      # A single attempt + uploaded CH logs is more diagnostic.
+      MAX_ATTEMPTS: 1
     strategy:
       matrix:
         python-version-major: ["3"]
@@ -332,8 +343,14 @@ jobs:
           DD_TRACE_ENABLED: false
           OPENAI_API_KEY: sk-1234567890abcdef1234567890abcdef
         run: |
+          # --timeout=300: per-test cap so a single hung test fails with a
+          # thread-stack dump instead of stalling the whole job. Thread method
+          # works under pytest-xdist; signal method would be unreliable across
+          # workers. 300s is well above any clean-cluster setup (~50s observed)
+          # but tight enough that a wedged ClickHouse query fails fast.
           .github/scripts/retry.sh nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.shard }}')" -- \
-            -m "trace_server and not skip_clickhouse_client"
+            -m "trace_server and not skip_clickhouse_client" \
+            --timeout=300 --timeout-method=thread
       - name: Run nox (No marker filters for integration-only shards)
         if: steps.filter_shards.outputs.skip != 'true' && steps.check_trace_markers.outputs.needs_markers == 'false'
         env:
@@ -371,10 +388,16 @@ jobs:
 
   nightly-tests-replicated-2s2r:
     name: Nightly Tests (replicated 2s2r)
-    timeout-minutes: 120
-    runs-on: ubuntu-latest
+    # Successful 8-core trace leg ran in ~16 min; cap at 25 min so any hang
+    # fails fast and we can RCA from the captured CH logs + faulthandler dump.
+    timeout-minutes: 25
+    # See note on 1s3r above. 2s2r has the heaviest CH footprint (4 CH
+    # nodes + Keeper), so the bump matters even more here.
+    runs-on: ${{ (matrix.shard == 'trace' || matrix.shard == 'trace_calls_complete_only') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
     env:
-      MAX_ATTEMPTS: 3
+      # See 1s3r note above: retries against a shared docker-compose cluster
+      # amplify failures rather than smoothing them.
+      MAX_ATTEMPTS: 1
     strategy:
       matrix:
         python-version-major: ["3"]
@@ -510,8 +533,10 @@ jobs:
           DD_TRACE_ENABLED: false
           OPENAI_API_KEY: sk-1234567890abcdef1234567890abcdef
         run: |
+          # See 1s3r note: --timeout=300 gives us thread-stack dumps on hang.
           .github/scripts/retry.sh nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.shard }}')" -- \
-            -m "trace_server and not skip_clickhouse_client"
+            -m "trace_server and not skip_clickhouse_client" \
+            --timeout=300 --timeout-method=thread
       - name: Run nox (No marker filters for integration-only shards)
         if: steps.filter_shards.outputs.skip != 'true' && steps.check_trace_markers.outputs.needs_markers == 'false'
         env:

--- a/tests/trace_server/conftest_lib/topologies/1s3r.yaml
+++ b/tests/trace_server/conftest_lib/topologies/1s3r.yaml
@@ -17,10 +17,13 @@
 #   bugs we're trying to catch. Revisit only if an incident proves
 #   Keeper HA is part of our bug surface.
 #
-# Resource limits target the GH Actions ubuntu-latest runner (7 GB RAM,
-# 2 vCPU). Each CH node caps at 1.5 GB; total committed memory across
-# 3 CH nodes is 4.5 GB, leaving ~2.5 GB headroom for the test runner
-# and OS. Do not raise without verifying CI runner capacity.
+# Resource limits target the GH Actions ubuntu-latest-8-cores runner
+# (32 GB RAM, 8 vCPU) used by the `trace`/`trace_calls_complete_only`
+# shards. ch-s1-r1 hosts the embedded Keeper alongside CH, so it gets
+# a larger cap (4 GB) than the keeper-less replicas (3 GB). Total
+# committed memory: 4 + 3 + 3 = 10 GB, well under the runner's 32 GB.
+# Caps were doubled (from 2/1.5) after an 8-worker xdist test hit the
+# 1.04 GiB / 1.80 GiB OvercommitTracker ceiling on a JOIN query.
 #
 # Usage (local):
 #   docker compose -f 1s3r.yaml up -d --wait
@@ -42,7 +45,7 @@ x-ch-node: &ch-node
   deploy:
     resources:
       limits:
-        memory: 1536M
+        memory: 3072M
   healthcheck:
     test: ["CMD-SHELL", "wget -q -O- http://localhost:8123/ping || exit 1"]
     interval: 3s
@@ -55,6 +58,12 @@ services:
     <<: *ch-node
     container_name: weave-ci-ch-s1-r1
     hostname: ch-s1-r1
+    # Larger memory cap than the other replicas because this node also
+    # runs the embedded Keeper.
+    deploy:
+      resources:
+        limits:
+          memory: 4096M
     ports:
       # Host-side port 8130 matches the default expected by
       # tests/trace_server_migrator/conftest.py::_DEFAULT_PORT,

--- a/tests/trace_server/conftest_lib/topologies/2s2r.yaml
+++ b/tests/trace_server/conftest_lib/topologies/2s2r.yaml
@@ -26,11 +26,14 @@
 #   behavior. Revisit only if an incident proves Keeper HA is in our
 #   bug surface.
 #
-# Resource limits target the GH Actions ubuntu-latest runner (7 GB RAM,
-# 2 vCPU). Each CH node caps at 1.5 GB; total committed memory across
-# 4 CH nodes is 6 GB — tighter than 1s3r's 4.5 GB, but observed actual
-# usage is ~800 MB per node (~3.2 GB total) so real headroom is
-# comfortable. If CI OOMs, first lever is lowering per-node cap to 1 GB.
+# Resource limits target the GH Actions ubuntu-latest-8-cores runner
+# (32 GB RAM, 8 vCPU) used by the `trace`/`trace_calls_complete_only`
+# shards. ch-s1-r1 hosts the embedded Keeper alongside CH, so it gets
+# a larger cap (4 GB) than the keeper-less replicas (3 GB). Total
+# committed memory: 4 + 3 * 3 = 13 GB, well under the runner's 32 GB.
+# Caps were doubled (from 2/1.5) after an 8-worker xdist test hit the
+# 1.04 GiB / 1.80 GiB OvercommitTracker ceiling on a JOIN query
+# (test_eval_results_query_multiple_scorers).
 #
 # Host port 8131 is used (1s3r uses 8130) to avoid collision when both
 # topologies are up simultaneously for local dev. CI runs them in
@@ -57,7 +60,7 @@ x-ch-node: &ch-node
   deploy:
     resources:
       limits:
-        memory: 1536M
+        memory: 3072M
   healthcheck:
     test: ["CMD-SHELL", "wget -q -O- http://localhost:8123/ping || exit 1"]
     interval: 3s
@@ -70,8 +73,14 @@ services:
     <<: *ch-node
     container_name: weave-ci-ch-2s2r-s1-r1
     hostname: ch-s1-r1
+    # Larger memory cap than the other nodes because this one also
+    # runs the embedded Keeper.
+    deploy:
+      resources:
+        limits:
+          memory: 4096M
     ports:
-      # Host port 8131 → container 8123. 1s3r uses 8130.
+      # Host port 8131 -> container 8123. 1s3r uses 8130.
       - "8131:8123"
       - "9001:9000"
     volumes:


### PR DESCRIPTION
Follow-up to [WB-34904](https://coreweave.atlassian.net/browse/WB-34904).

## Summary
- Replicated trace shard was hitting ~2h on the 2-core default; bump to `ubuntu-latest-8-cores` brings it under 20 min.
- Double per-node CH memory caps (1.5/2 GiB -> 3/4 GiB) so the 8-worker xdist load doesn't trip the OvercommitTracker. Verified by `test_eval_results_query_multiple_scorers` which was OOMing on the JOIN.
- `MAX_ATTEMPTS=1` + `timeout-minutes: 25`: retries against a shared docker-compose cluster amplify failures because data/parts accumulate between attempts (test fixture setup grew 52s -> 297s in one RCA). One clean attempt is more diagnostic.
- `--timeout=300 --timeout-method=thread`: gives us per-test thread-stack dumps on hang instead of a silent suite stall.

## Testing
smoke 26596965141 - 2s2r 3.11 trace finishes in 19.08 min (was hanging at >1h before tuning).

[WB-34904]: https://coreweave.atlassian.net/browse/WB-34904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ