### PR TITLE
chore(weave): stop verifiers test from hitting live OpenAI

### DIFF
--- a/tests/integrations/langchain/langchain_test.py
+++ b/tests/integrations/langchain/langchain_test.py
@@ -759,6 +759,8 @@ def test_langchain_google_vertexai_usage(client: WeaveClient) -> None:
             max_retries=2,
             api_transport="rest",
             credentials=AnonymousCredentials(),
+            # pin project to match cassette; don't inherit GOOGLE_CLOUD_PROJECT from CI
+            project="wandb-qa",
         )
 
         messages = [

--- a/tests/integrations/verifiers/cassettes/verifiers_test/test_verifiers_environment_evaluate_with_mock_env.yaml
+++ b/tests/integrations/verifiers/cassettes/verifiers_test/test_verifiers_environment_evaluate_with_mock_env.yaml
@@ -1,0 +1,31 @@
+interactions:
+- request:
+    body: '{"messages": [{"role": "user", "content": "What is 1+1?"}], "model": "gpt-4.1-mini",
+      "n": 1}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: '{"id": "chatcmpl-verifiers-mock", "object": "chat.completion", "created":
+        1748462400, "model": "gpt-4.1-mini-2025-04-14", "choices": [{"index": 0, "message":
+        {"role": "assistant", "content": "<think>1 plus 1 equals 2.</think>\n2"},
+        "logprobs": null, "finish_reason": "stop"}], "usage": {"prompt_tokens": 12,
+        "completion_tokens": 9, "total_tokens": 21}, "system_fingerprint": "fp_verifiers_mock"}'
+    headers:
+      Content-Type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/integrations/verifiers/verifiers_test.py
+++ b/tests/integrations/verifiers/verifiers_test.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from typing import Any
 
 import pytest
@@ -29,11 +28,17 @@ def patch_verifiers() -> None:
 
 
 @pytest.mark.skip_clickhouse_client
+@pytest.mark.vcr(
+    filter_headers=["authorization"],
+    allowed_hosts=["api.wandb.ai", "localhost"],
+    allow_playback_repeats=True,
+)
 def test_verifiers_environment_evaluate_with_mock_env(client: WeaveClient) -> None:
     """Run verifiers evaluation with a mocked environment and assert patched ops.
 
-    This test avoids external dependencies and focuses purely on the Weave
-    patching applied in `weave.integrations.verifiers.verifiers`.
+    The model call is replayed from a VCR cassette so the test never hits a live
+    provider; it focuses purely on the Weave patching applied in
+    `weave.integrations.verifiers.verifiers`.
     """
 
     class MockEnv(vf.MultiTurnEnv):
@@ -95,7 +100,7 @@ def test_verifiers_environment_evaluate_with_mock_env(client: WeaveClient) -> No
 
     env = MockEnv()
 
-    openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY", "DUMMY_API_KEY"))
+    openai_client = OpenAI(api_key="DUMMY_API_KEY")
     results = env.evaluate(
         openai_client,
         "gpt-4.1-mini",


### PR DESCRIPTION
[WB-34922](https://coreweave.atlassian.net/browse/WB-34922)
[WB-34974](https://coreweave.atlassian.net/browse/WB-34974)

## Summary
- `test_verifiers_environment_evaluate_with_mock_env` only mocked the verifiers `Environment` loop, not the model call, so `env.evaluate(...)` made a **live** OpenAI request. In CI this 401s (`not_authorized_invalid_key_type` -> the org rejects user keys), and even locally it depended on a real key.
- Add a `@pytest.mark.vcr` marker + committed cassette so the single `chat.completions.create` call is replayed, matching the rest of `tests/integrations/`. VCR intercepts at the httpx layer so the 43-call trace structure is unchanged.
- `allow_playback_repeats=True` + a dummy api key keep it hermetic regardless of how many completion calls the rollout makes.
- Also pin `project="wandb-qa"` in `test_langchain_google_vertexai_usage`: `ChatVertexAI` resolves project from `GOOGLE_CLOUD_PROJECT` (the runner sets `wandb-production`) before the patched `google.auth.default`, so VCR couldn't match the `wandb-qa` cassette path.

## Testing
ran locally against `verifiers==0.1.3.post0` (CIs pinned version) on the sqlite trace server: passes in 4s, cassette replays the model call, no network (dummy key). vertexai test reproduced the CI failure with `GOOGLE_CLOUD_PROJECT=wandb-production` and passes with the project pin.


[WB-34922]: https://coreweave.atlassian.net/browse/WB-34922?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[WB-34974]: https://coreweave.atlassian.net/browse/WB-34974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ