### PR TITLE
fix(weave): support eval_results filtering on inputs

### DIFF
--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -94,7 +94,7 @@ def test_cte_chain_calls_merged() -> None:
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
                     page_digests.row_order AS row_order,
-                    COALESCE(page_resolved_inputs.val_dump, JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
                 LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
@@ -184,7 +184,7 @@ def test_cte_chain_calls_complete() -> None:
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
                     page_digests.row_order AS row_order,
-                    COALESCE(page_resolved_inputs.val_dump, JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
                 LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
@@ -322,7 +322,7 @@ def test_cte_chain_sort_and_multi_eval_filters() -> None:
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
                     page_digests.row_order AS row_order,
-                    COALESCE(page_resolved_inputs.val_dump, JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
                 LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
@@ -457,7 +457,7 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
                     page_digests.row_order AS row_order,
-                    COALESCE(page_resolved_inputs.val_dump, JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
                 LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
@@ -556,7 +556,7 @@ def test_full_query_calls_merged() -> None:
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
                     page_digests.row_order AS row_order,
-                    COALESCE(page_resolved_inputs.val_dump, JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
                 LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
@@ -682,7 +682,7 @@ def test_full_query_calls_complete() -> None:
                     predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
                     predict_and_score_calls_resolved.row_digest AS row_digest,
                     page_digests.row_order AS row_order,
-                    COALESCE(page_resolved_inputs.val_dump, JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
                 FROM predict_and_score_calls_resolved
                 INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
                 LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -159,7 +159,7 @@ def build_predict_and_score_calls_resolved_cte(
     SELECT
         predict_and_score_calls.*,
         COALESCE(
-            tr.val_dump,
+            nullIf(tr.val_dump, ''),
             JSONExtractRaw(predict_and_score_calls.inputs_dump, 'example')
         ) AS resolved_inputs
     FROM predict_and_score_calls
@@ -412,7 +412,7 @@ def build_page_rows_cte() -> str:
         predict_and_score_calls_resolved.row_digest AS row_digest,
         page_digests.row_order AS row_order,
         COALESCE(
-            page_resolved_inputs.val_dump,
+            nullIf(page_resolved_inputs.val_dump, ''),
             JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')
         ) AS resolved_inputs
     FROM predict_and_score_calls_resolved


### PR DESCRIPTION
## Description

- https://coreweave.atlassian.net/browse/WB-32712

This PR fixes a few issues with filtering and sorting capabilities on imperatively logged evals because they don't have an actual dataset.

**Background**
Notion doc for more context: [Supporting filtering on multiple evals](https://www.notion.so/wandbai/Supporting-Filtering-on-Multiple-Evals-367e2f5c7ef380078b87f9ddb7483964?source=copy_link#367e2f5c7ef3802d88cec5c4b1440051)

Frontend PRs that will use this new functionality:
1. https://github.com/wandb/core/pull/44731
2. https://github.com/wandb/core/pull/44732
3. https://github.com/wandb/core/pull/44734

**Problem**

Filtering and sorting on `inputs.*` was returning empty results whose row_digest had no matching row in `table_rows`.
* The query builder builds`resolved_inputs` with `COALESCE(tr.val_dump, JSONExtractRaw(
inputs_dump, 'example'))`
  * `tr` is the result of a LEFT JOIN on the row digest.
  * If the row digest is null, like in the case of imperatively logged evals, then Clickhouse fills the result with the default value, `''`, because `val_dump` is a non nullable string.

COALESCE will always return the empty string, which makes sorting and filtering broken on inputs.

To fix this, the PR adds `nullIf` calls on the `val_dump` so that the COALESCE can actually fallthrough to the example.

## Testing

How was this PR tested?
* Against dev frontend
* unit tests updated