### PR TITLE
feat(weave): support match any and all filtering options on evals

### DIFF
--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -293,8 +293,7 @@ def test_cte_chain_sort_and_multi_eval_filters() -> None:
                 GROUP BY row_digest
                 HAVING 1=1
                     AND countDistinct(eval_call_id) >= {pb_7:UInt64}
-                    AND (toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_6:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '')) ELSE NULL END)) >= {pb_8:Float64})
-                    AND (toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_9:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '')) ELSE NULL END)) <= {pb_10:Float64})
+                    AND (((toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_6:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '')) ELSE NULL END)) >= {pb_8:Float64})) OR ((toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_9:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_5:String}), 'null'), '')) ELSE NULL END)) <= {pb_10:Float64})))
             ),
 
             ranked_digest_count AS (
@@ -429,7 +428,7 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                 FROM predict_and_score_calls_resolved
                 GROUP BY row_digest
                 HAVING 1=1
-                    AND (toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_5:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_4:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_4:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_4:String}), 'null'), '')) ELSE NULL END)) >= {pb_6:Float64})
+                    AND (((toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_5:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_4:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_4:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_4:String}), 'null'), '')) ELSE NULL END)) >= {pb_6:Float64})))
             ),
 
             ranked_digest_count AS (
@@ -609,11 +608,11 @@ def test_full_query_calls_merged() -> None:
     )
 
 
-def test_filter_logic_operator_defaults_to_and() -> None:
-    """Verify that omitting filter_logic_operator produces same SQL as explicit 'and'.
+def test_filter_logic_operator_defaults_to_or() -> None:
+    """Verify that omitting filter_logic_operator produces same SQL as explicit 'or'.
 
-    This ensures backward compatibility: frontends that don't send the new
-    parameter get Match All behavior.
+    The default is Match Any: frontends that don't send the new parameter get
+    'or' (a row matches if it satisfies the filters in ANY eval).
     """
     # Build with default (no filter_logic_operator specified)
     pb_default = ParamBuilder("pb")
@@ -649,10 +648,10 @@ def test_filter_logic_operator_defaults_to_and() -> None:
         offset=0,
         pb=pb_default,
         read_table="calls_complete",
-        # filter_logic_operator not specified - should default to "and"
+        # filter_logic_operator not specified - should default to "or"
     )
 
-    # Build with explicit "and"
+    # Build with explicit "or"
     pb_explicit = ParamBuilder("pb")
     cte_explicit = build_eval_results_cte_chain(
         project_id="proj-1",
@@ -664,7 +663,7 @@ def test_filter_logic_operator_defaults_to_and() -> None:
         offset=0,
         pb=pb_explicit,
         read_table="calls_complete",
-        filter_logic_operator="and",
+        filter_logic_operator="or",
     )
 
     # Both should produce identical SQL
@@ -752,6 +751,137 @@ def test_filter_logic_operator_or_produces_match_any() -> None:
                 HAVING 1=1
                     AND countDistinct(eval_call_id) >= {pb_5:UInt64}
                     AND (((toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_7:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '')) ELSE NULL END)) >= {pb_8:Float64})) OR ((toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_9:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '')) ELSE NULL END)) <= {pb_10:Float64})))
+            ),
+
+            ranked_digest_count AS (
+                SELECT count(*) AS total_rows FROM ranked_digests
+            ),
+
+            page_digests AS (
+                SELECT row_digest, row_order
+                FROM ranked_digests
+                ORDER BY row_order
+                LIMIT 10
+                OFFSET 0
+            ),
+
+            page_resolved_inputs AS (
+                SELECT digest, any(val_dump) AS val_dump
+                FROM table_rows
+                PREWHERE project_id = {pb_0:String}
+                WHERE digest IN (SELECT row_digest FROM page_digests)
+                GROUP BY digest
+            ),
+
+            page_rows AS (
+                SELECT predict_and_score_calls_resolved.call_id AS call_id,
+                    predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
+                    predict_and_score_calls_resolved.row_digest AS row_digest,
+                    page_digests.row_order AS row_order,
+                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                FROM predict_and_score_calls_resolved
+                INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
+                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
+            )
+            """,
+        pb.get_params(),
+        {
+            "pb_0": "proj-1",
+            "pb_1": ["eval-1", "eval-2"],
+            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
+            "pb_4": SENTINEL_EPOCH,
+            "pb_5": 2,
+            "pb_6": '$."scores"."accuracy"',
+            "pb_7": "eval-1",
+            "pb_8": 0.5,
+            "pb_9": "eval-2",
+            "pb_10": 0.9,
+        },
+    )
+
+
+def test_filter_logic_operator_and_produces_match_all() -> None:
+    """Filter logic 'and' (Match All) flat-ANDs every per-eval condition.
+
+    With two filters scoped to different evals (eval-1: accuracy >= 0.5,
+    eval-2: accuracy <= 0.9), the HAVING clause should be:
+        (eval1_condition) AND (eval2_condition)
+    instead of the default Match Any:
+        ((eval1_condition)) OR ((eval2_condition))
+    """
+    pb = ParamBuilder("pb")
+    filters = [
+        tsi.EvalResultsFilter(
+            evaluation_call_id="eval-1",
+            query=Query.model_validate(
+                {
+                    "$expr": {
+                        "$gte": [{"$getField": "scores.accuracy"}, {"$literal": 0.5}]
+                    }
+                }
+            ),
+        ),
+        tsi.EvalResultsFilter(
+            evaluation_call_id="eval-2",
+            query=Query.model_validate(
+                {
+                    "$expr": {
+                        "$lte": [{"$getField": "scores.accuracy"}, {"$literal": 0.9}]
+                    }
+                }
+            ),
+        ),
+    ]
+    cte = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1", "eval-2"],
+        sort_by=None,
+        filters=filters,
+        require_intersection=True,
+        limit=10,
+        offset=0,
+        pb=pb,
+        read_table="calls_complete",
+        filter_logic_operator="and",
+    )
+    # With AND logic, each per-eval condition is flat-AND'd in the HAVING clause
+    # (no OR grouping, no extra wrapping parens)
+    assert_raw_sql(
+        cte,
+        """
+            predict_and_score_calls AS (
+                SELECT calls_complete.id AS call_id,
+                    calls_complete.parent_id AS eval_call_id,
+                    calls_complete.inputs_dump,
+                    calls_complete.output_dump,
+                    CASE
+                        WHEN position(JSON_VALUE(calls_complete.inputs_dump, '$.example'), '/attr/rows/id/') > 0
+                            THEN regexpExtract(JSON_VALUE(calls_complete.inputs_dump, '$.example'), '/attr/rows/id/([^/]+)$', 1)
+                        ELSE hex(SHA256(JSONExtractRaw(calls_complete.inputs_dump, 'example')))
+                    END AS row_digest
+                FROM calls_complete
+                PREWHERE calls_complete.project_id = {pb_0:String}
+                WHERE calls_complete.parent_id IN {pb_1:Array(String)}
+                    AND calls_complete.id NOT IN {pb_1:Array(String)}
+                    AND (position(calls_complete.op_name, {pb_2:String}) > 0
+                        OR position(calls_complete.op_name, {pb_3:String}) > 0)
+                    AND calls_complete.deleted_at = {pb_4:DateTime64(3)}
+            ),
+
+            predict_and_score_calls_resolved AS (
+                SELECT * FROM predict_and_score_calls
+            ),
+
+            ranked_digests AS (
+                SELECT row_digest,
+                    ROW_NUMBER() OVER(ORDER BY row_digest ASC) AS row_order
+                FROM predict_and_score_calls_resolved
+                GROUP BY row_digest
+                HAVING 1=1
+                    AND countDistinct(eval_call_id) >= {pb_5:UInt64}
+                    AND (toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_7:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '')) ELSE NULL END)) >= {pb_8:Float64})
+                    AND (toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_9:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '')) ELSE NULL END)) <= {pb_10:Float64})
             ),
 
             ranked_digest_count AS (

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -621,13 +621,21 @@ def test_filter_logic_operator_defaults_to_and() -> None:
         tsi.EvalResultsFilter(
             evaluation_call_id="eval-1",
             query=Query.model_validate(
-                {"$expr": {"$gte": [{"$getField": "scores.accuracy"}, {"$literal": 0.5}]}}
+                {
+                    "$expr": {
+                        "$gte": [{"$getField": "scores.accuracy"}, {"$literal": 0.5}]
+                    }
+                }
             ),
         ),
         tsi.EvalResultsFilter(
             evaluation_call_id="eval-2",
             query=Query.model_validate(
-                {"$expr": {"$lte": [{"$getField": "scores.accuracy"}, {"$literal": 0.9}]}}
+                {
+                    "$expr": {
+                        "$lte": [{"$getField": "scores.accuracy"}, {"$literal": 0.9}]
+                    }
+                }
             ),
         ),
     ]
@@ -678,13 +686,21 @@ def test_filter_logic_operator_or_produces_match_any() -> None:
         tsi.EvalResultsFilter(
             evaluation_call_id="eval-1",
             query=Query.model_validate(
-                {"$expr": {"$gte": [{"$getField": "scores.accuracy"}, {"$literal": 0.5}]}}
+                {
+                    "$expr": {
+                        "$gte": [{"$getField": "scores.accuracy"}, {"$literal": 0.5}]
+                    }
+                }
             ),
         ),
         tsi.EvalResultsFilter(
             evaluation_call_id="eval-2",
             query=Query.model_validate(
-                {"$expr": {"$lte": [{"$getField": "scores.accuracy"}, {"$literal": 0.9}]}}
+                {
+                    "$expr": {
+                        "$lte": [{"$getField": "scores.accuracy"}, {"$literal": 0.9}]
+                    }
+                }
             ),
         ),
     ]
@@ -798,13 +814,21 @@ def test_filter_logic_operator_or_same_eval_multiple_conditions() -> None:
         tsi.EvalResultsFilter(
             evaluation_call_id="eval-1",
             query=Query.model_validate(
-                {"$expr": {"$gte": [{"$getField": "scores.accuracy"}, {"$literal": 0.5}]}}
+                {
+                    "$expr": {
+                        "$gte": [{"$getField": "scores.accuracy"}, {"$literal": 0.5}]
+                    }
+                }
             ),
         ),
         tsi.EvalResultsFilter(
             evaluation_call_id="eval-1",
             query=Query.model_validate(
-                {"$expr": {"$lte": [{"$getField": "scores.accuracy"}, {"$literal": 0.9}]}}
+                {
+                    "$expr": {
+                        "$lte": [{"$getField": "scores.accuracy"}, {"$literal": 0.9}]
+                    }
+                }
             ),
         ),
     ]
@@ -824,7 +848,9 @@ def test_filter_logic_operator_or_same_eval_multiple_conditions() -> None:
     # The HAVING should contain: ((condition1 AND condition2)) - wrapped in parens
     assert " AND " in cte
     # With only one eval group, the OR doesn't appear
-    assert " OR " not in cte or "OR position" in cte  # "OR position" is from op_name matching
+    assert (
+        " OR " not in cte or "OR position" in cte
+    )  # "OR position" is from op_name matching
 
 
 def test_full_query_calls_complete() -> None:

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -609,6 +609,224 @@ def test_full_query_calls_merged() -> None:
     )
 
 
+def test_filter_logic_operator_defaults_to_and() -> None:
+    """Verify that omitting filter_logic_operator produces same SQL as explicit 'and'.
+
+    This ensures backward compatibility: frontends that don't send the new
+    parameter get Match All behavior.
+    """
+    # Build with default (no filter_logic_operator specified)
+    pb_default = ParamBuilder("pb")
+    filters = [
+        tsi.EvalResultsFilter(
+            evaluation_call_id="eval-1",
+            query=Query.model_validate(
+                {"$expr": {"$gte": [{"$getField": "scores.accuracy"}, {"$literal": 0.5}]}}
+            ),
+        ),
+        tsi.EvalResultsFilter(
+            evaluation_call_id="eval-2",
+            query=Query.model_validate(
+                {"$expr": {"$lte": [{"$getField": "scores.accuracy"}, {"$literal": 0.9}]}}
+            ),
+        ),
+    ]
+    cte_default = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1", "eval-2"],
+        sort_by=None,
+        filters=filters,
+        require_intersection=True,
+        limit=10,
+        offset=0,
+        pb=pb_default,
+        read_table="calls_complete",
+        # filter_logic_operator not specified - should default to "and"
+    )
+
+    # Build with explicit "and"
+    pb_explicit = ParamBuilder("pb")
+    cte_explicit = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1", "eval-2"],
+        sort_by=None,
+        filters=filters,
+        require_intersection=True,
+        limit=10,
+        offset=0,
+        pb=pb_explicit,
+        read_table="calls_complete",
+        filter_logic_operator="and",
+    )
+
+    # Both should produce identical SQL
+    assert cte_default == cte_explicit
+    assert pb_default.get_params() == pb_explicit.get_params()
+
+
+def test_filter_logic_operator_or_produces_match_any() -> None:
+    """Filter logic 'or' groups conditions by eval and ORs between groups.
+
+    With two filters scoped to different evals (eval-1: accuracy >= 0.5,
+    eval-2: accuracy <= 0.9), the HAVING clause should be:
+        ((eval1_condition)) OR ((eval2_condition))
+    instead of the default:
+        (eval1_condition) AND (eval2_condition)
+    """
+    pb = ParamBuilder("pb")
+    filters = [
+        tsi.EvalResultsFilter(
+            evaluation_call_id="eval-1",
+            query=Query.model_validate(
+                {"$expr": {"$gte": [{"$getField": "scores.accuracy"}, {"$literal": 0.5}]}}
+            ),
+        ),
+        tsi.EvalResultsFilter(
+            evaluation_call_id="eval-2",
+            query=Query.model_validate(
+                {"$expr": {"$lte": [{"$getField": "scores.accuracy"}, {"$literal": 0.9}]}}
+            ),
+        ),
+    ]
+    cte = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1", "eval-2"],
+        sort_by=None,
+        filters=filters,
+        require_intersection=True,
+        limit=10,
+        offset=0,
+        pb=pb,
+        read_table="calls_complete",
+        filter_logic_operator="or",
+    )
+    # With OR logic, the HAVING clause should contain " OR " between the two filter groups
+    # and each group should be wrapped in parentheses
+    assert_raw_sql(
+        cte,
+        """
+            predict_and_score_calls AS (
+                SELECT calls_complete.id AS call_id,
+                    calls_complete.parent_id AS eval_call_id,
+                    calls_complete.inputs_dump,
+                    calls_complete.output_dump,
+                    CASE
+                        WHEN position(JSON_VALUE(calls_complete.inputs_dump, '$.example'), '/attr/rows/id/') > 0
+                            THEN regexpExtract(JSON_VALUE(calls_complete.inputs_dump, '$.example'), '/attr/rows/id/([^/]+)$', 1)
+                        ELSE hex(SHA256(JSONExtractRaw(calls_complete.inputs_dump, 'example')))
+                    END AS row_digest
+                FROM calls_complete
+                PREWHERE calls_complete.project_id = {pb_0:String}
+                WHERE calls_complete.parent_id IN {pb_1:Array(String)}
+                    AND calls_complete.id NOT IN {pb_1:Array(String)}
+                    AND (position(calls_complete.op_name, {pb_2:String}) > 0
+                        OR position(calls_complete.op_name, {pb_3:String}) > 0)
+                    AND calls_complete.deleted_at = {pb_4:DateTime64(3)}
+            ),
+
+            predict_and_score_calls_resolved AS (
+                SELECT * FROM predict_and_score_calls
+            ),
+
+            ranked_digests AS (
+                SELECT row_digest,
+                    ROW_NUMBER() OVER(ORDER BY row_digest ASC) AS row_order
+                FROM predict_and_score_calls_resolved
+                GROUP BY row_digest
+                HAVING 1=1
+                    AND countDistinct(eval_call_id) >= {pb_5:UInt64}
+                    AND (((toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_7:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '')) ELSE NULL END)) >= {pb_8:Float64})) OR ((toFloat64OrNull(any(CASE WHEN eval_call_id = {pb_9:String} THEN multiIf(coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'true', '1', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '') = 'false', '0', coalesce(nullIf(JSON_VALUE(output_dump, {pb_6:String}), 'null'), '')) ELSE NULL END)) <= {pb_10:Float64})))
+            ),
+
+            ranked_digest_count AS (
+                SELECT count(*) AS total_rows FROM ranked_digests
+            ),
+
+            page_digests AS (
+                SELECT row_digest, row_order
+                FROM ranked_digests
+                ORDER BY row_order
+                LIMIT 10
+                OFFSET 0
+            ),
+
+            page_resolved_inputs AS (
+                SELECT digest, any(val_dump) AS val_dump
+                FROM table_rows
+                PREWHERE project_id = {pb_0:String}
+                WHERE digest IN (SELECT row_digest FROM page_digests)
+                GROUP BY digest
+            ),
+
+            page_rows AS (
+                SELECT predict_and_score_calls_resolved.call_id AS call_id,
+                    predict_and_score_calls_resolved.eval_call_id AS eval_call_id,
+                    predict_and_score_calls_resolved.row_digest AS row_digest,
+                    page_digests.row_order AS row_order,
+                    COALESCE(nullIf(page_resolved_inputs.val_dump, ''), JSONExtractRaw(predict_and_score_calls_resolved.inputs_dump, 'example')) AS resolved_inputs
+                FROM predict_and_score_calls_resolved
+                INNER JOIN page_digests ON predict_and_score_calls_resolved.row_digest = page_digests.row_digest
+                LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
+            )
+            """,
+        pb.get_params(),
+        {
+            "pb_0": "proj-1",
+            "pb_1": ["eval-1", "eval-2"],
+            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
+            "pb_4": SENTINEL_EPOCH,
+            "pb_5": 2,
+            "pb_6": '$."scores"."accuracy"',
+            "pb_7": "eval-1",
+            "pb_8": 0.5,
+            "pb_9": "eval-2",
+            "pb_10": 0.9,
+        },
+    )
+
+
+def test_filter_logic_operator_or_same_eval_multiple_conditions() -> None:
+    """Multiple filters on the same eval stay AND'd within that eval's group.
+
+    With two filters both scoped to eval-1 (accuracy >= 0.5 AND accuracy <= 0.9),
+    and filter_logic_operator="or", the conditions should stay AND'd together
+    since they're in the same eval group.
+    """
+    pb = ParamBuilder("pb")
+    filters = [
+        tsi.EvalResultsFilter(
+            evaluation_call_id="eval-1",
+            query=Query.model_validate(
+                {"$expr": {"$gte": [{"$getField": "scores.accuracy"}, {"$literal": 0.5}]}}
+            ),
+        ),
+        tsi.EvalResultsFilter(
+            evaluation_call_id="eval-1",
+            query=Query.model_validate(
+                {"$expr": {"$lte": [{"$getField": "scores.accuracy"}, {"$literal": 0.9}]}}
+            ),
+        ),
+    ]
+    cte = build_eval_results_cte_chain(
+        project_id="proj-1",
+        eval_root_ids=["eval-1"],
+        sort_by=None,
+        filters=filters,
+        require_intersection=False,
+        limit=10,
+        offset=0,
+        pb=pb,
+        read_table="calls_complete",
+        filter_logic_operator="or",
+    )
+    # Even with OR logic, same-eval conditions should be AND'd together within the group
+    # The HAVING should contain: ((condition1 AND condition2)) - wrapped in parens
+    assert " AND " in cte
+    # With only one eval group, the OR doesn't appear
+    assert " OR " not in cte or "OR position" in cte  # "OR position" is from op_name matching
+
+
 def test_full_query_calls_complete() -> None:
     """Full SQL: lean CTEs + page_calls hydration on calls_complete (no GROUP BY)."""
     pb = ParamBuilder("pb")

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5551,6 +5551,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             ch_offset,
             pb,
             read_table,
+            req.filter_logic_operator,
         )
 
         result = self._query(page_query, pb.get_params())

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -325,14 +325,14 @@ def _build_having_clause(
     filters: list[tsi.EvalResultsFilter] | None,
     require_intersection: bool,
     pb: ParamBuilder,
-    filter_logic_operator: str = "and",
+    filter_logic_operator: str = "or",
 ) -> str:
     """Build the HAVING clause for ranked_digests.
 
     Args:
-        filter_logic_operator: 'and' (Match All) or 'or' (Match Any).
-            - 'and': Row must match filters in ALL evals (default, backward compat)
-            - 'or': Row must match filters in ANY eval
+        filter_logic_operator: 'and' (Match All) or 'or' (Match Any, default).
+            - 'and': Row must match filters in ALL evals
+            - 'or': Row must match filters in ANY eval (default)
     """
     having_parts: list[str] = ["1=1"]
 
@@ -378,7 +378,7 @@ def build_ranked_digests_cte(
     limit: int | None,
     offset: int,
     pb: ParamBuilder,
-    filter_logic_operator: str = "and",
+    filter_logic_operator: str = "or",
 ) -> str:
     """Build ranked_digests, ranked_digest_count, and page_digests CTEs.
 
@@ -497,7 +497,7 @@ def build_eval_results_query(
     offset: int,
     pb: ParamBuilder,
     read_table: str,
-    filter_logic_operator: str = "and",
+    filter_logic_operator: str = "or",
 ) -> str:
     """Build the complete eval_results SQL query.
 
@@ -554,7 +554,7 @@ def build_eval_results_cte_chain(
     offset: int,
     pb: ParamBuilder,
     read_table: str,
-    filter_logic_operator: str = "and",
+    filter_logic_operator: str = "or",
 ) -> str:
     """Build the CTE chain body (without WITH keyword).
 

--- a/weave/trace_server/query_builder/eval_results_query_builder.py
+++ b/weave/trace_server/query_builder/eval_results_query_builder.py
@@ -325,8 +325,15 @@ def _build_having_clause(
     filters: list[tsi.EvalResultsFilter] | None,
     require_intersection: bool,
     pb: ParamBuilder,
+    filter_logic_operator: str = "and",
 ) -> str:
-    """Build the HAVING clause for ranked_digests."""
+    """Build the HAVING clause for ranked_digests.
+
+    Args:
+        filter_logic_operator: 'and' (Match All) or 'or' (Match Any).
+            - 'and': Row must match filters in ALL evals (default, backward compat)
+            - 'or': Row must match filters in ANY eval
+    """
     having_parts: list[str] = ["1=1"]
 
     if require_intersection and len(eval_root_ids) > 1:
@@ -334,12 +341,31 @@ def _build_having_clause(
         having_parts.append(f"countDistinct(eval_call_id) >= {num_param}")
 
     if filters:
-        for f in filters:
-            resolver = _make_field_resolver(f.evaluation_call_id)
-            conditions, _ = _process_query_to_conditions(
-                f.query, param_builder=pb, field_resolver=resolver
-            )
-            having_parts.extend(conditions)
+        if filter_logic_operator == "or":
+            # Match Any: group conditions by eval, OR between groups
+            eval_groups: dict[str | None, list[str]] = {}
+            for f in filters:
+                resolver = _make_field_resolver(f.evaluation_call_id)
+                conditions, _ = _process_query_to_conditions(
+                    f.query, param_builder=pb, field_resolver=resolver
+                )
+                eval_groups.setdefault(f.evaluation_call_id, []).extend(conditions)
+
+            # Each eval's conditions are AND'd, then OR'd between evals
+            group_clauses = []
+            for conds in eval_groups.values():
+                if conds:
+                    group_clauses.append(f"({' AND '.join(conds)})")
+            if group_clauses:
+                having_parts.append(f"({' OR '.join(group_clauses)})")
+        else:
+            # Match All (default): flat AND of all conditions
+            for f in filters:
+                resolver = _make_field_resolver(f.evaluation_call_id)
+                conditions, _ = _process_query_to_conditions(
+                    f.query, param_builder=pb, field_resolver=resolver
+                )
+                having_parts.extend(conditions)
 
     return "\n                    AND ".join(having_parts)
 
@@ -352,6 +378,7 @@ def build_ranked_digests_cte(
     limit: int | None,
     offset: int,
     pb: ParamBuilder,
+    filter_logic_operator: str = "and",
 ) -> str:
     """Build ranked_digests, ranked_digest_count, and page_digests CTEs.
 
@@ -361,7 +388,7 @@ def build_ranked_digests_cte(
     """
     sort_expr = build_sort_expression(sort_by, eval_root_ids, pb)
     having_clause = _build_having_clause(
-        eval_root_ids, filters, require_intersection, pb
+        eval_root_ids, filters, require_intersection, pb, filter_logic_operator
     )
 
     pagination = ""
@@ -470,6 +497,7 @@ def build_eval_results_query(
     offset: int,
     pb: ParamBuilder,
     read_table: str,
+    filter_logic_operator: str = "and",
 ) -> str:
     """Build the complete eval_results SQL query.
 
@@ -487,6 +515,7 @@ def build_eval_results_query(
         offset,
         pb,
         read_table,
+        filter_logic_operator,
     )
     project_id_param = param_slot(pb.add_param(project_id), "String")
     page_calls_cte = _build_page_calls_cte(project_id_param, read_table)
@@ -525,6 +554,7 @@ def build_eval_results_cte_chain(
     offset: int,
     pb: ParamBuilder,
     read_table: str,
+    filter_logic_operator: str = "and",
 ) -> str:
     """Build the CTE chain body (without WITH keyword).
 
@@ -572,6 +602,7 @@ def build_eval_results_cte_chain(
         limit,
         offset,
         pb,
+        filter_logic_operator,
     )
     page_resolved_cte = build_page_resolved_inputs_cte(project_id_param)
     page_rows_cte = build_page_rows_cte()

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3136,10 +3136,11 @@ class EvalResultsQueryBody(BaseModelStrict):
         description="Filters applied to grouped rows. Multiple filters are AND'd together.",
     )
     filter_logic_operator: Literal["and", "or"] = Field(
-        default="and",
+        default="or",
         description=(
             "How to combine filters across evaluations: 'and' (Match All - row must "
-            "match in ALL evals) or 'or' (Match Any - row must match in ANY eval)."
+            "match in ALL evals) or 'or' (Match Any - row must match in ANY eval). "
+            "Defaults to 'or' (Match Any)."
         ),
     )
     limit: int | None = Field(

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3135,6 +3135,13 @@ class EvalResultsQueryBody(BaseModelStrict):
         default=None,
         description="Filters applied to grouped rows. Multiple filters are AND'd together.",
     )
+    filter_logic_operator: Literal["and", "or"] = Field(
+        default="and",
+        description=(
+            "How to combine filters across evaluations: 'and' (Match All - row must "
+            "match in ALL evals) or 'or' (Match Any - row must match in ANY eval)."
+        ),
+    )
     limit: int | None = Field(
         default=None,
         description="Optional row-level page size applied after grouping and intersection.",


### PR DESCRIPTION
## Description

- https://coreweave.atlassian.net/browse/WB-32712?search_id=0286ab65-71da-41e6-8461-bca714305538

This PR enables "match any" filtering logic to be used in evals by adding a `filter_logic_operator` param to `/eval_results` endpoint to support "match any" vs "match all" filter behavior. New default behavior for multiple evals is `match any`

**Background**
Notion doc for more context: [Supporting filtering on multiple evals](https://www.notion.so/wandbai/Supporting-Filtering-on-Multiple-Evals-367e2f5c7ef380078b87f9ddb7483964?source=copy_link#367e2f5c7ef3802d88cec5c4b1440051)

Frontend PRs that will use this new functionality:
1. https://github.com/wandb/core/pull/44731
2. https://github.com/wandb/core/pull/44732
3. https://github.com/wandb/core/pull/44734
4. https://github.com/wandb/core/pull/44735
5. https://github.com/wandb/core/pull/44794

**Behavior**

- `filter_logic_operator: "or"` (default) — **Match Any**: a row is included if it
  satisfies the filters in *any* compared eval.
- `filter_logic_operator: "and"` — **Match All**: a row must satisfy
  the filters in *every* compared eval.

**Implementation**

- `trace_server_interface.py` — adds the `filter_logic_operator: Literal["and",
  "or"]` field to the eval results request (defaults to `"or"`).
- `clickhouse_trace_server_batched.py` — passes `req.filter_logic_operator`
  through to the query builder.
- `eval_results_query_builder.py` — `_build_having_clause` now branches on the
  operator. For `"or"` it groups the per-eval filter conditions by
  `evaluation_call_id`, ANDs the conditions within each eval, then ORs the
  groups together; `"and"` keeps the existing flat-AND behavior. The frontend
  continues to send one filter per eval; only the combination logic changes.


## Testing

- [x] Tested against dev
- [x] Unit tests added covering both `and` / `or`
