### PR TITLE
chore(weave): migrate GCP image pulls to WIF

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -13,9 +13,26 @@ on:
         default: ""
 
 jobs:
+  gcp-auth:
+    name: Mint GCP access token (WIF)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      access_token: ${{ steps.auth.outputs.access_token }}
+    steps:
+      - id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+          token_format: access_token
+
   nightly-tests:
     name: Nightly Tests
     timeout-minutes: 30
+    needs: gcp-auth
     runs-on: ubuntu-latest
     env:
       MAX_ATTEMPTS: 3
@@ -68,8 +85,8 @@ jobs:
       wandbservice:
         image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
         credentials:
-          username: _json_key
-          password: ${{ secrets.gcp_wb_sa_key }}
+          username: oauth2accesstoken
+          password: ${{ needs.gcp-auth.outputs.access_token }}
         env:
           CI: 1
           WANDB_ENABLE_TEST_CONTAINER: true

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -13,26 +13,12 @@ on:
         default: ""
 
 jobs:
-  gcp-auth:
-    name: Mint GCP access token (WIF)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    outputs:
-      access_token: ${{ steps.auth.outputs.access_token }}
-    steps:
-      - id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
-          token_format: access_token
-
   nightly-tests:
     name: Nightly Tests
     timeout-minutes: 30
-    needs: gcp-auth
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-latest
     env:
       MAX_ATTEMPTS: 3
@@ -82,24 +68,6 @@ jobs:
             shard: "verifiers_test"
       fail-fast: false
     services:
-      wandbservice:
-        image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
-        credentials:
-          username: oauth2accesstoken
-          password: ${{ needs.gcp-auth.outputs.access_token }}
-        env:
-          CI: 1
-          WANDB_ENABLE_TEST_CONTAINER: true
-          LOGGING_ENABLED: true
-        ports:
-          - "8080:8080"
-          - "8083:8083"
-          - "9015:9015"
-        options: >-
-          --health-cmd "wget -q -O /dev/null http://localhost:8080/healthz || exit 1"
-          --health-interval=5s
-          --health-timeout=3s
-          --health-start-period=10s
       weave_clickhouse:
         image: clickhouse/clickhouse-server:25.10
         env:
@@ -127,6 +95,35 @@ jobs:
           fi
           echo "Running shard: ${{ matrix.shard }}"
           echo "skip=false" >> $GITHUB_OUTPUT
+      - id: auth
+        name: Authenticate to Google Cloud
+        if: steps.filter_shards.outputs.skip != 'true'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+          token_format: access_token
+      - name: Start wandb service
+        if: steps.filter_shards.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          echo "${{ steps.auth.outputs.access_token }}" | docker login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev
+          docker run --detach --name wandbservice \
+            --env CI=1 \
+            --env WANDB_ENABLE_TEST_CONTAINER=true \
+            --env LOGGING_ENABLED=true \
+            --publish 8080:8080 \
+            --publish 8083:8083 \
+            --publish 9015:9015 \
+            us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
+          for _i in {1..30}; do
+            if curl --silent --fail --show-error http://localhost:8080/healthz >/dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          docker logs wandbservice
+          exit 1
       - name: Enable debug logging
         if: steps.filter_shards.outputs.skip != 'true'
         run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
@@ -162,7 +159,7 @@ jobs:
           WEAVE_SENTRY_ENV: ci
           CI: 1
           WEAVE_USE_MEMRAY: 1
-          WB_SERVER_HOST: http://wandbservice
+          WB_SERVER_HOST: http://localhost
           WF_CLICKHOUSE_HOST: weave_clickhouse
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
@@ -182,7 +179,7 @@ jobs:
           WEAVE_SENTRY_ENV: ci
           CI: 1
           WEAVE_USE_MEMRAY: 1
-          WB_SERVER_HOST: http://wandbservice
+          WB_SERVER_HOST: http://localhost
           WF_CLICKHOUSE_HOST: localhost
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
           DD_TRACE_ENABLED: false
@@ -196,7 +193,7 @@ jobs:
           WEAVE_SENTRY_ENV: ci
           CI: 1
           WEAVE_USE_MEMRAY: 1
-          WB_SERVER_HOST: http://wandbservice
+          WB_SERVER_HOST: http://localhost
           WF_CLICKHOUSE_HOST: localhost
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -118,6 +118,7 @@ jobs:
             us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
           for _i in {1..30}; do
             if curl --silent --fail --show-error http://localhost:8080/healthz >/dev/null; then
+              echo "wandb service is healthy"
               exit 0
             fi
             sleep 5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -201,6 +201,7 @@ jobs:
             us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
           for _i in {1..30}; do
             if curl --silent --fail --show-error http://localhost:8080/healthz >/dev/null; then
+              echo "wandb service is healthy"
               exit 0
             fi
             sleep 5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,26 +102,12 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  gcp-auth:
-    name: Mint GCP access token (WIF)
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
-    outputs:
-      access_token: ${{ steps.auth.outputs.access_token }}
-    steps:
-      - id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
-        with:
-          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
-          token_format: access_token
-
   trace-tests:
     name: Trace nox tests
     timeout-minutes: 15
-    needs: gcp-auth
+    permissions:
+      contents: read
+      id-token: write
     # TODO: refactor to use matrix.include for runner selection
     # Use 8-core runners for trace and trace_calls_complete_only shards (resource-intensive)
     runs-on: ${{ (matrix.nox-shard == 'trace' || matrix.nox-shard == 'trace_calls_complete_only') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
@@ -181,24 +167,6 @@ jobs:
             nox-shard: "verifiers_test"
       fail-fast: false
     services:
-      wandbservice:
-        image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
-        credentials:
-          username: oauth2accesstoken
-          password: ${{ needs.gcp-auth.outputs.access_token }}
-        env:
-          CI: 1
-          WANDB_ENABLE_TEST_CONTAINER: true
-          LOGGING_ENABLED: true
-        ports:
-          - "8080:8080"
-          - "8083:8083"
-          - "9015:9015"
-        options: >-
-          --health-cmd "wget -q -O /dev/null http://localhost:8080/healthz || exit 1"
-          --health-interval=5s
-          --health-timeout=3s
-          --health-start-period=10s
       weave_clickhouse:
         image: clickhouse/clickhouse-server:25.11.2.24
         env:
@@ -212,6 +180,33 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+          token_format: access_token
+      - name: Start wandb service
+        run: |
+          set -euo pipefail
+          echo "${{ steps.auth.outputs.access_token }}" | docker login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev
+          docker run --detach --name wandbservice \
+            --env CI=1 \
+            --env WANDB_ENABLE_TEST_CONTAINER=true \
+            --env LOGGING_ENABLED=true \
+            --publish 8080:8080 \
+            --publish 8083:8083 \
+            --publish 9015:9015 \
+            us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
+          for _i in {1..30}; do
+            if curl --silent --fail --show-error http://localhost:8080/healthz >/dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          docker logs wandbservice
+          exit 1
       - name: Enable debug logging
         run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
       - name: Install SQLite dev package
@@ -231,7 +226,7 @@ jobs:
         env:
           WEAVE_SENTRY_ENV: ci
           CI: 1
-          WB_SERVER_HOST: http://wandbservice
+          WB_SERVER_HOST: http://localhost
           WF_CLICKHOUSE_HOST: weave_clickhouse
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
           # Use format-valid dummy API keys when secrets aren't available (e.g., Dependabot PRs)
@@ -251,7 +246,7 @@ jobs:
         env:
           WEAVE_SENTRY_ENV: ci
           CI: 1
-          WB_SERVER_HOST: http://wandbservice
+          WB_SERVER_HOST: http://localhost
           WF_CLICKHOUSE_HOST: localhost
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
           DD_TRACE_ENABLED: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -102,9 +102,26 @@ jobs:
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  gcp-auth:
+    name: Mint GCP access token (WIF)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      access_token: ${{ steps.auth.outputs.access_token }}
+    steps:
+      - id: auth
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+          token_format: access_token
+
   trace-tests:
     name: Trace nox tests
     timeout-minutes: 15
+    needs: gcp-auth
     # TODO: refactor to use matrix.include for runner selection
     # Use 8-core runners for trace and trace_calls_complete_only shards (resource-intensive)
     runs-on: ${{ (matrix.nox-shard == 'trace' || matrix.nox-shard == 'trace_calls_complete_only') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
@@ -167,8 +184,8 @@ jobs:
       wandbservice:
         image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
         credentials:
-          username: _json_key
-          password: ${{ secrets.gcp_wb_sa_key }}
+          username: oauth2accesstoken
+          password: ${{ needs.gcp-auth.outputs.access_token }}
         env:
           CI: 1
           WANDB_ENABLE_TEST_CONTAINER: true


### PR DESCRIPTION
## Summary
- Replace static `gcp_wb_sa_key` usage for `local-testcontainer` with per-job Workload Identity Federation auth.
- Authenticate inside the test jobs, docker-login to Artifact Registry with a WIF access token, and start `local-testcontainer` via `docker run` before tests.
- Point test envs at `WB_SERVER_HOST=http://localhost` for the manually-started container.
- Depends on wandb/core#44764 for `roles/artifactregistry.reader` on the WIF service account.

## Test plan
- `rg -i "gcp_wb_sa_key|GCP_WB_SA_KEY" /Users/jacob.pusateri/wandb/weave /Users/jacob.pusateri/wandb/core`
- `ReadLints` on changed workflow and Terraform files
- `git diff --check` in `wandb/weave` and `wandb/core`
- `terraform -chdir=/Users/jacob.pusateri/wandb/core/terraform/ci/global fmt -check`
- `ruby -ryaml -e 'ARGV.each { |p| YAML.load_file(p) }' .github/workflows/test.yaml .github/workflows/nightly-tests.yaml`