### PR TITLE
fix(weave): nest Claude Agent SDK subagent calls under their Task call

### DIFF
--- a/tests/integrations/claude_agent_sdk/cassettes/subagent_response.json
+++ b/tests/integrations/claude_agent_sdk/cassettes/subagent_response.json
@@ -1,0 +1,97 @@
+[
+  {
+    "type": "system",
+    "subtype": "init",
+    "session_id": "s-sub789"
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "content": [
+        {
+          "type": "text",
+          "text": "I'll delegate this to a subagent."
+        },
+        {
+          "type": "tool_use",
+          "id": "toolu_lead_task",
+          "name": "Agent",
+          "input": {
+            "description": "investigate files",
+            "prompt": "List the files"
+          }
+        }
+      ],
+      "model": "claude-sonnet-4-6"
+    }
+  },
+  {
+    "type": "assistant",
+    "parent_tool_use_id": "toolu_lead_task",
+    "message": {
+      "content": [
+        {
+          "type": "tool_use",
+          "id": "toolu_sub_bash",
+          "name": "Bash",
+          "input": {
+            "command": "ls -la"
+          }
+        }
+      ],
+      "model": "claude-haiku-4-5"
+    }
+  },
+  {
+    "type": "user",
+    "parent_tool_use_id": "toolu_lead_task",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_sub_bash",
+          "content": "file1.py\nfile2.py"
+        }
+      ]
+    }
+  },
+  {
+    "type": "user",
+    "message": {
+      "content": [
+        {
+          "type": "tool_result",
+          "tool_use_id": "toolu_lead_task",
+          "content": "The subagent found file1.py and file2.py."
+        }
+      ]
+    }
+  },
+  {
+    "type": "assistant",
+    "message": {
+      "content": [
+        {
+          "type": "text",
+          "text": "The subagent found 2 files: file1.py and file2.py."
+        }
+      ],
+      "model": "claude-sonnet-4-6"
+    }
+  },
+  {
+    "type": "result",
+    "subtype": "result",
+    "duration_ms": 4200,
+    "duration_api_ms": 3600,
+    "is_error": false,
+    "num_turns": 2,
+    "session_id": "s-sub789",
+    "total_cost_usd": 0.012,
+    "usage": {
+      "input_tokens": 200,
+      "output_tokens": 90
+    },
+    "result": "The subagent found 2 files: file1.py and file2.py."
+  }
+]

--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_test.py
@@ -183,6 +183,54 @@ async def test_multi_tool_query(
 
 
 # =====================================================================
+# query() — subagent tool calls nest under the spawning Task/Agent call
+# =====================================================================
+
+
+@pytest.mark.skip_clickhouse_client
+@pytest.mark.asyncio
+async def test_subagent_nesting(
+    client: weave.trace.weave_client.WeaveClient,
+) -> None:
+    """A subagent's tool calls should nest under the lead agent's Task/Agent
+    call (via parent_tool_use_id), not flatten under the root query."""
+    cassette = load_cassette("subagent_response")
+    transport = ReplayTransport(cassette)
+
+    async for _ in query(
+        prompt="Delegate listing files to a subagent",
+        options=ClaudeAgentOptions(),
+        transport=transport,
+    ):
+        pass
+
+    calls = list(client.get_calls())
+
+    root_call = next(
+        c for c in calls if op_name_from_call(c) == "claude_agent_sdk.query"
+    )
+    agent_call = next(
+        c for c in calls if op_name_from_call(c) == "claude_agent_sdk.tool_use.Agent"
+    )
+    sub_bash_call = next(
+        c for c in calls if op_name_from_call(c) == "claude_agent_sdk.tool_use.Bash"
+    )
+
+    # The lead agent's Agent tool call hangs off the root query.
+    assert agent_call.parent_id == root_call.id
+
+    # The subagent's Bash call nests under the Agent call — NOT the root.
+    assert sub_bash_call.parent_id == agent_call.id
+    assert sub_bash_call.parent_id != root_call.id
+
+    # The lead agent's own text still hangs off the root.
+    text_call = next(
+        c for c in calls if op_name_from_call(c) == "claude_agent_sdk.text"
+    )
+    assert text_call.parent_id == root_call.id
+
+
+# =====================================================================
 # query() — thinking blocks
 # =====================================================================
 

--- a/weave/integrations/claude_agent_sdk/claude_agent_sdk_integration.py
+++ b/weave/integrations/claude_agent_sdk/claude_agent_sdk_integration.py
@@ -79,6 +79,15 @@ def _process_message_inline(
     open_tool_calls = state["open_tool_calls"]
     accumulated = state["accumulated_messages"]
 
+    def _parent_for(message: Any) -> Any:
+        """Nest under the spawning tool call when this message comes from a
+        subagent. A subagent's messages carry ``parent_tool_use_id`` equal to
+        the id of the lead agent's Task/Agent tool-use block, whose Call is
+        still open in ``open_tool_calls`` while the subagent runs. Falls back
+        to ``root_call`` for the lead agent (parent_tool_use_id is None)."""
+        ptid = getattr(message, "parent_tool_use_id", None)
+        return open_tool_calls.get(ptid, root_call) if ptid else root_call
+
     def _is_thinking_only(m: Any) -> bool:
         return isinstance(m, AssistantMessage) and all(
             isinstance(b, ThinkingBlock) for b in m.content
@@ -107,6 +116,10 @@ def _process_message_inline(
         history = list(accumulated)
         accumulated.append(serialized)
 
+        # Subagent messages nest under the Task/Agent call that spawned them;
+        # lead-agent messages nest under the root.
+        parent_call = _parent_for(msg)
+
         # Create child calls for thinking blocks
         thinking_blocks = [b for b in msg.content if isinstance(b, ThinkingBlock)]
         if thinking_blocks:
@@ -115,7 +128,7 @@ def _process_message_inline(
                 op="claude_agent_sdk.thinking",
                 inputs={},
                 display_name=thinking_display_name(thinking_text),
-                parent=root_call,
+                parent=parent_call,
                 attributes={"kind": "llm"},
                 use_stack=False,
             )
@@ -129,7 +142,7 @@ def _process_message_inline(
                 op="claude_agent_sdk.text",
                 inputs={},
                 display_name=text_display_name(text_content),
-                parent=root_call,
+                parent=parent_call,
                 attributes={"kind": "llm"},
                 use_stack=False,
             )
@@ -143,7 +156,7 @@ def _process_message_inline(
                 op=f"claude_agent_sdk.tool_use.{tool_block.name}",
                 inputs={"message": serialized},
                 display_name=tool_use_display_name(tool_block.name, tool_block.input),
-                parent=root_call,
+                parent=parent_call,
                 attributes={"kind": "tool"},
                 use_stack=False,
             )


### PR DESCRIPTION
## What

The `claude_agent_sdk` integration creates every `tool_use` / `text` / `thinking` child call with `parent=root_call`. When the lead agent spawns subagents (Anthropic **dynamic workflows** / the `Task`/`Agent` tool), all of the subagents' tool calls get flattened directly under the root `claude_agent_sdk.query` call instead of nesting under the `Task` call that spawned them — so a multi-agent run looks flat in Weave and you can't tell which agent did what.

## Why this needs no SDK change

Every streamed message already carries `parent_tool_use_id`. For a subagent's messages that value is the id of the lead agent's `Task`/`Agent` tool-use block, whose Weave `Call` is *still open* in `open_tool_calls` while the subagent runs (its tool result only arrives once the subagent finishes). So we can rebuild the true hierarchy purely in the integration.

## Change

`_process_message_inline` now resolves the parent from `parent_tool_use_id` (falling back to `root_call` for the lead agent, whose `parent_tool_use_id` is `None`) and uses it for thinking/text/tool_use child calls. Deeply nested sub-subagents chain correctly for the same reason.

```
Before                          After
query                           query
├─ tool_use.Agent               ├─ tool_use.Agent
├─ tool_use.Bash   (subagent)   │  └─ tool_use.Bash   (subagent)
├─ tool_use.Read   (subagent)   │  └─ tool_use.Read   (subagent)
└─ text                         └─ text
```

## Tests

Adds `cassettes/subagent_response.json` (a lead `Agent` tool-use spawning a subagent that runs `Bash`, via `parent_tool_use_id`) and `test_subagent_nesting`, asserting the subagent's `Bash` call nests under the `Agent` call and not the root.

Verified end-to-end against a real dynamic-workflow run (lead Opus + Haiku subagents): subagent tool calls now parent to their `Agent` call. The new test passes locally (`--trace-server=sqlite`); the other integration tests' exact-call-count assertions fail identically on clean `master` under sqlite (they rely on per-test project isolation in the ClickHouse CI harness), so this change introduces no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)