### PR TITLE
feat(weave): upload attach_media content on background threads

### DIFF
--- a/tests/session/test_session.py
+++ b/tests/session/test_session.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from unittest.mock import patch
 
 import pytest
@@ -161,6 +162,7 @@ class TestLLM:
         ):
             c = LLM(model="gpt-4o")
             assert c.attach_media(content=b"png_bytes", mime_type="image/png") is c
+            c._await_uploads()
 
     def test_context_manager_sets_timestamps(self) -> None:
         with LLM(model="gpt-4o") as c:
@@ -187,6 +189,7 @@ class TestAttachMedia:
         result = llm.attach_media(content=b"png_bytes", mime_type="image/png")
         assert result is llm
         assert len(llm.media_attachments) == 1
+        llm._await_uploads()
         att = llm.media_attachments[0]
         assert att.ref.startswith("weave:///")
         assert att.modality == "image"
@@ -200,6 +203,7 @@ class TestAttachMedia:
             mime_type="image/jpeg",
         )
         assert len(llm.media_attachments) == 1
+        llm._await_uploads()
         att = llm.media_attachments[0]
         assert att.ref.startswith("weave:///")
         assert att.modality == "image"
@@ -209,6 +213,7 @@ class TestAttachMedia:
         llm = LLM(model="gpt-4o")
         llm.attach_media(file_id="file-abc123", mime_type="audio/wav")
         assert len(llm.media_attachments) == 1
+        llm._await_uploads()
         att = llm.media_attachments[0]
         assert att.ref.startswith("weave:///")
         assert att.modality == "audio"
@@ -220,6 +225,7 @@ class TestAttachMedia:
         assert llm.media_attachments[0].modality == "audio"
         llm.attach_media(content=b"data", mime_type="video/mp4")
         assert llm.media_attachments[1].modality == "video"
+        llm._await_uploads()
 
     def test_rejects_zero_sources(self) -> None:
         llm = LLM(model="gpt-4o")
@@ -230,6 +236,86 @@ class TestAttachMedia:
         llm = LLM(model="gpt-4o")
         with pytest.raises(ValueError, match="Exactly one of"):
             llm.attach_media(content=b"x", uri="http://x")
+
+
+class TestAttachMediaAsync:
+    """attach_media uploads off-thread, in parallel, joined before the span."""
+
+    def test_attach_media_does_not_block(self) -> None:
+        """The call returns before the (slow) upload finishes."""
+        release = threading.Event()
+
+        def slow_publish(**kwargs: object) -> str:
+            release.wait(timeout=5)
+            return "weave:///e/p/object/content:done"
+
+        with patch(
+            "weave.session.session._publish_media_content",
+            side_effect=slow_publish,
+        ):
+            llm = LLM(model="gpt-4o")
+            llm.attach_media(content=b"x", mime_type="image/png")
+            # Upload still in flight: the placeholder exists but its ref is
+            # not yet populated, even though the call already returned.
+            assert llm.media_attachments[0].ref == ""
+            release.set()
+            llm._await_uploads()
+            assert llm.media_attachments[0].ref == "weave:///e/p/object/content:done"
+
+    def test_uploads_run_in_parallel(self) -> None:
+        """Each attach_media gets its own thread; uploads overlap."""
+        n = 4
+        # A barrier of size n only releases once all n workers reach it, so
+        # it can never fill if uploads ran serially on one thread.
+        barrier = threading.Barrier(n, timeout=5)
+        worker_threads: list[int] = []
+
+        def publish(**kwargs: object) -> str:
+            worker_threads.append(threading.get_ident())
+            barrier.wait()
+            return "weave:///e/p/object/content:v1"
+
+        with patch(
+            "weave.session.session._publish_media_content",
+            side_effect=publish,
+        ):
+            llm = LLM(model="gpt-4o")
+            for _ in range(n):
+                llm.attach_media(content=b"x", mime_type="image/png")
+            llm._await_uploads()
+
+        assert len(llm.media_attachments) == n
+        main_ident = threading.get_ident()
+        assert all(ident != main_ident for ident in worker_threads)
+        assert len(set(worker_threads)) == n  # one distinct thread per upload
+
+    @pytest.mark.disable_logging_error_check
+    def test_failed_upload_is_dropped(self) -> None:
+        """An upload that raises is logged and its attachment removed."""
+
+        def boom(**kwargs: object) -> str:
+            raise RuntimeError("upload failed")
+
+        with patch(
+            "weave.session.session._publish_media_content",
+            side_effect=boom,
+        ):
+            llm = LLM(model="gpt-4o")
+            llm.attach_media(content=b"x", mime_type="image/png")
+            llm._await_uploads()
+
+        assert llm.media_attachments == []
+
+    def test_end_awaits_uploads(self) -> None:
+        """Refs are populated by the time the span is built at end()."""
+        with patch(
+            "weave.session.session._publish_media_content",
+            side_effect=_fake_publish_media_content,
+        ):
+            llm = LLM(model="gpt-4o")
+            llm.attach_media(content=b"x", mime_type="image/png")
+            llm.end()
+            assert llm.media_attachments[0].ref.startswith("weave:///")
 
 
 class TestSubAgent:

--- a/tests/session/test_session_otel.py
+++ b/tests/session/test_session_otel.py
@@ -1766,6 +1766,7 @@ class TestAttachMediaUrl:
     ) -> None:
         llm = LLM()
         llm.attach_media_url(url, modality="image")
+        llm._await_uploads()
         (att,) = llm.media_attachments
         assert att.ref.startswith("weave:///")
         assert att.mime_type == expected_mime
@@ -1778,6 +1779,7 @@ class TestAttachMediaUrl:
         att = llm.media_attachments[0]
         assert att.modality == "image"
         assert att.mime_type == "image/jpeg"
+        llm._await_uploads()
 
     def test_empty_url_ignored(self) -> None:
         llm = LLM()
@@ -1789,6 +1791,7 @@ class TestAttachMediaUrl:
         llm = LLM()
         result = llm.attach_media_url("https://e.com/a.png", modality="image")
         assert result is llm
+        llm._await_uploads()
 
 
 class TestLLMRecord:

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -10,6 +10,7 @@ attributes when used as context managers.
 
 from __future__ import annotations
 
+import logging
 import types
 import uuid
 from contextvars import ContextVar, Token
@@ -42,6 +43,7 @@ from weave.session.types import (
     _parse_data_url,
 )
 from weave.trace.settings import should_disable_weave, should_redact_pii
+from weave.trace.util import Thread
 from weave.utils import pii_redaction
 from weave.utils.capture_info import get_capture_info
 
@@ -108,6 +110,8 @@ __all__ = [
 
 # OTel tracer name — identifies the Session SDK as the source of these spans.
 _TRACER_NAME = "weave.session"
+
+logger = logging.getLogger(__name__)
 
 
 def _capture_info_attrs() -> dict[str, str]:
@@ -339,6 +343,7 @@ class LLM(_SpanBase):
 
     _ended: bool = PrivateAttr(default=False)
     _token: Token[LLM | None] | None = PrivateAttr(default=None)
+    _upload_threads: list[Thread] = PrivateAttr(default_factory=list)
 
     def model_post_init(self, context: Any, /) -> None:
         if self.started_at is None:
@@ -368,6 +373,15 @@ class LLM(_SpanBase):
         Creates a ``Content`` object from the provided data, publishes it
         to get a ``weave://`` ref, and stores only that ref.  Exactly one
         of ``content``, ``uri``, or ``file_id`` must be provided.
+
+        The publish (which uploads the media) runs on a dedicated
+        background thread so the call returns immediately without blocking
+        the caller; one thread is dispatched per attachment so multiple
+        uploads proceed in parallel. The placeholder ``MediaAttachment`` is
+        appended synchronously and its ``ref`` is filled in once the upload
+        completes. Refs are guaranteed populated before the span is emitted
+        (the build path waits on the in-flight uploads via
+        ``_await_uploads``).
         """
         sources = sum(bool(s) for s in (content, uri, file_id))
         if sources != 1:
@@ -378,17 +392,65 @@ class LLM(_SpanBase):
             if prefix in {"image", "audio", "video"}:
                 modality = prefix
 
-        ref_uri = _publish_media_content(
-            content=content, uri=uri, file_id=file_id, mime_type=mime_type
+        attachment = MediaAttachment(
+            ref="",
+            modality=modality or "unknown",
+            mime_type=mime_type,
         )
-        self.media_attachments.append(
-            MediaAttachment(
-                ref=ref_uri,
-                modality=modality or "unknown",
-                mime_type=mime_type,
-            )
+        self.media_attachments.append(attachment)
+        thread = Thread(
+            target=self._upload_media,
+            kwargs={
+                "attachment": attachment,
+                "content": content,
+                "uri": uri,
+                "file_id": file_id,
+                "mime_type": mime_type,
+            },
+            name="weave-session-media-upload",
+            daemon=True,
         )
+        thread.start()
+        self._upload_threads.append(thread)
         return self
+
+    def _upload_media(
+        self,
+        *,
+        attachment: MediaAttachment,
+        content: bytes | str,
+        uri: str,
+        file_id: str,
+        mime_type: str,
+    ) -> None:
+        """Publish one media attachment and record its ref.
+
+        Runs on a background thread dispatched by ``attach_media``. On
+        success the ``weave://`` ref is written back onto ``attachment``.
+        Failures are logged and leave the ref empty; ``_await_uploads``
+        drops empty-ref attachments so a failed upload never emits a
+        broken URI part.
+        """
+        try:
+            attachment.ref = _publish_media_content(
+                content=content, uri=uri, file_id=file_id, mime_type=mime_type
+            )
+        except Exception:
+            logger.exception("Failed to publish media attachment for chat span")
+
+    def _await_uploads(self) -> None:
+        """Block until all in-flight media uploads finish.
+
+        Called before building span attributes so every attachment has its
+        ``weave://`` ref populated. Attachments whose upload failed (empty
+        ref) are dropped so the emitted span never carries a broken URI.
+        """
+        if not self._upload_threads:
+            return
+        for thread in self._upload_threads:
+            thread.join()
+        self._upload_threads.clear()
+        self.media_attachments = [m for m in self.media_attachments if m.ref]
 
     def attach_media_url(self, url: str, *, modality: str = "") -> LLM:
         """Attach a media URL to this LLM call.
@@ -466,6 +528,10 @@ class LLM(_SpanBase):
         ``reasoning``, which previously bypassed the gate and leaked
         into ``gen_ai.output.messages``.
         """
+        # Block on any background media uploads so every attachment's
+        # weave:// ref is populated before it is serialized into attrs.
+        self._await_uploads()
+
         input_messages: list[Message] | None
         output_messages: list[Message] | None
         system_instructions: list[str] | None

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -222,7 +222,9 @@ def _publish_media_content(
         raise ValueError("_publish_media_content requires content or uri")
 
     ref = publish(content_obj)
-    return str(ref)
+    # Coerce to a plain ``str``: ``ref.uri`` may be a ``_CallableStr`` subclass
+    # that OTel attribute validation rejects.
+    return str(getattr(ref, "uri", ref))
 
 
 class Tool(_SpanBase):

--- a/weave/session/session_otel.py
+++ b/weave/session/session_otel.py
@@ -299,7 +299,9 @@ def llm_attributes(
         attrs["gen_ai.output.messages"] = serialized_out
 
     if media_attachments:
-        attrs["weave.content_refs"] = [m.ref for m in media_attachments]
+        # Coerce to plain ``str``: OTel attribute validation does an exact-type
+        # check and rejects ``str`` subclasses (e.g. ``_CallableStr`` refs).
+        attrs["weave.content_refs"] = [str(m.ref) for m in media_attachments]
 
     return attrs
 


### PR DESCRIPTION
Prevents `LLM.attach_media` from blocking user code.

## What changed

- `attach_media` now appends a placeholder and dispatches a daemon that runs `_publish_media_content` and writes the resolved `weave://` ref back onto the attachment. Threads run concurrently — the call returns immediately.
- `_await_uploads()` joins all in-flight upload threads refs are guaranteed populated before the span is emitted
- Failed uploads are logged (not raised, so a failed upload can't crash the caller) and their empty-ref attachments are dropped so the span never emits a broken URI part.

## Testing
- Added new tests and ensured existing pass
