### PR TITLE
fix(weave): detect WAV from in-memory buffer when libmagic returns octet-stream

### DIFF
--- a/tests/session/test_session.py
+++ b/tests/session/test_session.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import threading
+from unittest.mock import patch
+
 import pytest
 
 from weave.session.session import (
@@ -25,6 +28,25 @@ from weave.session.session import (
     start_tool,
     start_turn,
 )
+
+_fake_ref_counter = iter(range(1, 10_000))
+
+
+def _fake_publish_media_content(**kwargs: object) -> str:
+    return f"weave:///test/project/object/content:{next(_fake_ref_counter)}"
+
+
+@pytest.fixture(autouse=True)
+def _reset_contextvars():
+    """Reset contextvar state after each test to prevent leakage."""
+    yield
+    if (llm := get_current_llm()) is not None:
+        llm.end()
+    if (turn := get_current_turn()) is not None:
+        turn.end()
+    if (session := get_current_session()) is not None:
+        session.end()
+
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -134,8 +156,13 @@ class TestLLM:
         assert c.reasoning.content == "Let me consider..."
 
     def test_attach_media_returns_self(self) -> None:
-        c = LLM(model="gpt-4o")
-        assert c.attach_media(content=b"png_bytes", mime_type="image/png") is c
+        with patch(
+            "weave.session.session._publish_media_content",
+            side_effect=_fake_publish_media_content,
+        ):
+            c = LLM(model="gpt-4o")
+            assert c.attach_media(content=b"png_bytes", mime_type="image/png") is c
+            c._await_uploads()
 
     def test_context_manager_sets_timestamps(self) -> None:
         with LLM(model="gpt-4o") as c:
@@ -149,16 +176,24 @@ class TestLLM:
 
 
 class TestAttachMedia:
+    @pytest.fixture(autouse=True)
+    def _mock_publish(self) -> None:
+        with patch(
+            "weave.session.session._publish_media_content",
+            side_effect=_fake_publish_media_content,
+        ):
+            yield  # type: ignore[misc]
+
     def test_attach_inline_image(self) -> None:
         llm = LLM(model="gpt-4o")
         result = llm.attach_media(content=b"png_bytes", mime_type="image/png")
         assert result is llm
         assert len(llm.media_attachments) == 1
+        llm._await_uploads()
         att = llm.media_attachments[0]
-        assert att.kind == "blob"
+        assert att.ref.startswith("weave:///")
         assert att.modality == "image"
         assert att.mime_type == "image/png"
-        assert att.content == b"png_bytes"
 
     def test_attach_uri(self) -> None:
         llm = LLM(model="gpt-4o")
@@ -168,21 +203,21 @@ class TestAttachMedia:
             mime_type="image/jpeg",
         )
         assert len(llm.media_attachments) == 1
+        llm._await_uploads()
         att = llm.media_attachments[0]
-        assert att.kind == "uri"
+        assert att.ref.startswith("weave:///")
         assert att.modality == "image"
         assert att.mime_type == "image/jpeg"
-        assert att.uri == "https://example.com/photo.jpg"
 
     def test_attach_file_id(self) -> None:
         llm = LLM(model="gpt-4o")
         llm.attach_media(file_id="file-abc123", mime_type="audio/wav")
         assert len(llm.media_attachments) == 1
+        llm._await_uploads()
         att = llm.media_attachments[0]
-        assert att.kind == "file"
+        assert att.ref.startswith("weave:///")
         assert att.modality == "audio"
         assert att.mime_type == "audio/wav"
-        assert att.file_id == "file-abc123"
 
     def test_modality_inferred_from_mime_type(self) -> None:
         llm = LLM(model="gpt-4o")
@@ -190,6 +225,7 @@ class TestAttachMedia:
         assert llm.media_attachments[0].modality == "audio"
         llm.attach_media(content=b"data", mime_type="video/mp4")
         assert llm.media_attachments[1].modality == "video"
+        llm._await_uploads()
 
     def test_rejects_zero_sources(self) -> None:
         llm = LLM(model="gpt-4o")
@@ -200,6 +236,86 @@ class TestAttachMedia:
         llm = LLM(model="gpt-4o")
         with pytest.raises(ValueError, match="Exactly one of"):
             llm.attach_media(content=b"x", uri="http://x")
+
+
+class TestAttachMediaAsync:
+    """attach_media uploads off-thread, in parallel, joined before the span."""
+
+    def test_attach_media_does_not_block(self) -> None:
+        """The call returns before the (slow) upload finishes."""
+        release = threading.Event()
+
+        def slow_publish(**kwargs: object) -> str:
+            release.wait(timeout=5)
+            return "weave:///e/p/object/content:done"
+
+        with patch(
+            "weave.session.session._publish_media_content",
+            side_effect=slow_publish,
+        ):
+            llm = LLM(model="gpt-4o")
+            llm.attach_media(content=b"x", mime_type="image/png")
+            # Upload still in flight: the placeholder exists but its ref is
+            # not yet populated, even though the call already returned.
+            assert llm.media_attachments[0].ref == ""
+            release.set()
+            llm._await_uploads()
+            assert llm.media_attachments[0].ref == "weave:///e/p/object/content:done"
+
+    def test_uploads_run_in_parallel(self) -> None:
+        """Each attach_media gets its own thread; uploads overlap."""
+        n = 4
+        # A barrier of size n only releases once all n workers reach it, so
+        # it can never fill if uploads ran serially on one thread.
+        barrier = threading.Barrier(n, timeout=5)
+        worker_threads: list[int] = []
+
+        def publish(**kwargs: object) -> str:
+            worker_threads.append(threading.get_ident())
+            barrier.wait()
+            return "weave:///e/p/object/content:v1"
+
+        with patch(
+            "weave.session.session._publish_media_content",
+            side_effect=publish,
+        ):
+            llm = LLM(model="gpt-4o")
+            for _ in range(n):
+                llm.attach_media(content=b"x", mime_type="image/png")
+            llm._await_uploads()
+
+        assert len(llm.media_attachments) == n
+        main_ident = threading.get_ident()
+        assert all(ident != main_ident for ident in worker_threads)
+        assert len(set(worker_threads)) == n  # one distinct thread per upload
+
+    @pytest.mark.disable_logging_error_check
+    def test_failed_upload_is_dropped(self) -> None:
+        """An upload that raises is logged and its attachment removed."""
+
+        def boom(**kwargs: object) -> str:
+            raise RuntimeError("upload failed")
+
+        with patch(
+            "weave.session.session._publish_media_content",
+            side_effect=boom,
+        ):
+            llm = LLM(model="gpt-4o")
+            llm.attach_media(content=b"x", mime_type="image/png")
+            llm._await_uploads()
+
+        assert llm.media_attachments == []
+
+    def test_end_awaits_uploads(self) -> None:
+        """Refs are populated by the time the span is built at end()."""
+        with patch(
+            "weave.session.session._publish_media_content",
+            side_effect=_fake_publish_media_content,
+        ):
+            llm = LLM(model="gpt-4o")
+            llm.attach_media(content=b"x", mime_type="image/png")
+            llm.end()
+            assert llm.media_attachments[0].ref.startswith("weave:///")
 
 
 class TestSubAgent:

--- a/tests/session/test_session_otel.py
+++ b/tests/session/test_session_otel.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-import base64
 import json
 import time
 from datetime import datetime, timedelta, timezone
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from opentelemetry import trace as otel_trace
@@ -390,17 +390,13 @@ class TestLLMAttributes:
         assert "finish_reason" not in raw[0]
         assert raw[1]["finish_reason"] == "length"
 
-    def test_attach_media_blob_serialized_as_blob_part(self) -> None:
+    def test_attach_media_serialized_as_uri_part(self) -> None:
+        ref = "weave:///test/project/object/img:v1"
         attrs = llm_attributes(
             model="gpt-4o",
             input_messages=[Message(role="user", content="what is this?")],
             media_attachments=[
-                MediaAttachment(
-                    kind="blob",
-                    modality="image",
-                    mime_type="image/png",
-                    content=b"\x89PNG",
-                )
+                MediaAttachment(ref=ref, modality="image", mime_type="image/png")
             ],
         )
         raw = json.loads(attrs["gen_ai.input.messages"])
@@ -410,59 +406,29 @@ class TestLLMAttributes:
                 "parts": [
                     {"type": "text", "content": "what is this?"},
                     {
-                        "type": "blob",
+                        "type": "uri",
                         "mime_type": "image/png",
                         "modality": "image",
-                        "content": base64.b64encode(b"\x89PNG").decode("ascii"),
+                        "uri": ref,
                     },
                 ],
             }
         ]
 
-    def test_attach_media_uri_serialized_as_uri_part(self) -> None:
+    def test_content_refs_emitted(self) -> None:
+        ref = "weave:///test/project/object/img:v1"
         attrs = llm_attributes(
             model="gpt-4o",
             input_messages=[Message(role="user", content="describe")],
             media_attachments=[
-                MediaAttachment(
-                    kind="uri",
-                    modality="image",
-                    mime_type="image/jpeg",
-                    uri="https://example.com/photo.jpg",
-                )
+                MediaAttachment(ref=ref, modality="image", mime_type="image/jpeg")
             ],
         )
-        raw = json.loads(attrs["gen_ai.input.messages"])
-        assert raw[0]["parts"][1] == {
-            "type": "uri",
-            "mime_type": "image/jpeg",
-            "modality": "image",
-            "uri": "https://example.com/photo.jpg",
-        }
-
-    def test_attach_media_file_serialized_as_file_part(self) -> None:
-        attrs = llm_attributes(
-            model="gpt-4o",
-            input_messages=[Message(role="user", content="transcribe")],
-            media_attachments=[
-                MediaAttachment(
-                    kind="file",
-                    modality="audio",
-                    mime_type="audio/wav",
-                    file_id="file-abc",
-                )
-            ],
-        )
-        raw = json.loads(attrs["gen_ai.input.messages"])
-        assert raw[0]["parts"][1] == {
-            "type": "file",
-            "mime_type": "audio/wav",
-            "modality": "audio",
-            "file_id": "file-abc",
-        }
+        assert attrs["weave.content_refs"] == [ref]
 
     def test_media_attached_to_last_user_message(self) -> None:
         """When multiple user messages exist, media goes on the most recent one."""
+        ref = "weave:///test/project/object/img:v1"
         attrs = llm_attributes(
             model="gpt-4o",
             input_messages=[
@@ -471,9 +437,7 @@ class TestLLMAttributes:
                 Message(role="user", content="last"),
             ],
             media_attachments=[
-                MediaAttachment(
-                    kind="uri", modality="image", mime_type="image/png", uri="u"
-                )
+                MediaAttachment(ref=ref, modality="image", mime_type="image/png")
             ],
         )
         raw = json.loads(attrs["gen_ai.input.messages"])
@@ -491,33 +455,32 @@ class TestLLMAttributes:
         SDK's contract is that media decorates a user message, and a
         media-only LLM call is degenerate.
         """
+        ref = "weave:///test/project/object/img:v1"
         attrs = llm_attributes(
             model="gpt-4o",
             media_attachments=[
-                MediaAttachment(
-                    kind="uri", modality="image", mime_type="image/png", uri="u"
-                )
+                MediaAttachment(ref=ref, modality="image", mime_type="image/png")
             ],
         )
         assert "gen_ai.input.messages" not in attrs
+        assert attrs["weave.content_refs"] == [ref]
 
     def test_multiple_media_all_on_last_user_message(self) -> None:
+        ref1 = "weave:///test/project/object/img1:v1"
+        ref2 = "weave:///test/project/object/img2:v1"
         attrs = llm_attributes(
             model="gpt-4o",
             input_messages=[Message(role="user", content="hi")],
             media_attachments=[
-                MediaAttachment(
-                    kind="uri", modality="image", mime_type="image/png", uri="u1"
-                ),
-                MediaAttachment(
-                    kind="uri", modality="image", mime_type="image/png", uri="u2"
-                ),
+                MediaAttachment(ref=ref1, modality="image", mime_type="image/png"),
+                MediaAttachment(ref=ref2, modality="image", mime_type="image/png"),
             ],
         )
         raw = json.loads(attrs["gen_ai.input.messages"])
         assert len(raw[0]["parts"]) == 3  # text + 2 media
-        assert raw[0]["parts"][1]["uri"] == "u1"
-        assert raw[0]["parts"][2]["uri"] == "u2"
+        assert raw[0]["parts"][1]["uri"] == ref1
+        assert raw[0]["parts"][2]["uri"] == ref2
+        assert attrs["weave.content_refs"] == [ref1, ref2]
 
     def test_system_instructions_serialized_as_text_parts(self) -> None:
         attrs = llm_attributes(
@@ -843,15 +806,9 @@ class TestExplicitMessageParts:
 
     def test_media_attachments_appended_to_explicit_parts(self) -> None:
         """media_attachments still extend the last user message even with explicit parts."""
+        ref = "weave:///test/project/object/img:v1"
         msg = Message(role="user", parts=[TextPart(content="see this")])
-        media = [
-            MediaAttachment(
-                kind="uri",
-                modality="image",
-                mime_type="image/png",
-                uri="https://example.com/x.png",
-            )
-        ]
+        media = [MediaAttachment(ref=ref, modality="image", mime_type="image/png")]
         attrs = llm_attributes(
             model="gpt-4o", input_messages=[msg], media_attachments=media
         )
@@ -1784,47 +1741,36 @@ class TestMessageBuilders:
 class TestAttachMediaUrl:
     """LLM.attach_media_url handles data: and plain URLs uniformly."""
 
+    _FAKE_REF = "weave:///e/p/object/c:v1"
+
+    @pytest.fixture(autouse=True)
+    def _mock_publish(self) -> None:
+        with patch(
+            "weave.session.session._publish_media_content",
+            return_value=self._FAKE_REF,
+        ):
+            yield  # type: ignore[misc]
+
     @pytest.mark.parametrize(
-        (
-            "url",
-            "expected_kind",
-            "expected_mime",
-            "expected_payload_field",
-            "expected_payload",
-        ),
+        ("url", "expected_mime"),
         [
-            (
-                "data:image/png;base64,iVBORw0KGgo=",
-                "blob",
-                "image/png",
-                "content",
-                "iVBORw0KGgo=",
-            ),
-            (
-                "https://example.com/cat.png",
-                "uri",
-                "",
-                "uri",
-                "https://example.com/cat.png",
-            ),
+            ("data:image/png;base64,iVBORw0KGgo=", "image/png"),
+            ("https://example.com/cat.png", ""),
         ],
-        ids=["data_url_blob", "plain_url_uri"],
+        ids=["data_url", "plain_url"],
     )
-    def test_url_dispatches_to_blob_or_uri(
+    def test_url_produces_weave_ref(
         self,
         url: str,
-        expected_kind: str,
         expected_mime: str,
-        expected_payload_field: str,
-        expected_payload: str,
     ) -> None:
         llm = LLM()
         llm.attach_media_url(url, modality="image")
+        llm._await_uploads()
         (att,) = llm.media_attachments
-        assert att.kind == expected_kind
+        assert att.ref.startswith("weave:///")
         assert att.mime_type == expected_mime
         assert att.modality == "image"
-        assert getattr(att, expected_payload_field) == expected_payload
 
     def test_data_url_modality_inferred_from_mime(self) -> None:
         """Modality auto-fills from mime_type when not provided."""
@@ -1833,6 +1779,7 @@ class TestAttachMediaUrl:
         att = llm.media_attachments[0]
         assert att.modality == "image"
         assert att.mime_type == "image/jpeg"
+        llm._await_uploads()
 
     def test_empty_url_ignored(self) -> None:
         llm = LLM()
@@ -1844,6 +1791,7 @@ class TestAttachMediaUrl:
         llm = LLM()
         result = llm.attach_media_url("https://e.com/a.png", modality="image")
         assert result is llm
+        llm._await_uploads()
 
 
 class TestLLMRecord:
@@ -2133,64 +2081,53 @@ class TestMessageFromOpenAIResponsesInput:
         assert [m["role"] for m in out] == ["user"]
 
     @pytest.mark.parametrize(
-        ("block", "expected_part"),
+        "block",
         [
-            (
-                {
-                    "type": "input_image",
-                    "image_url": "data:image/png;base64,iVBORw0KGgo=",
-                },
-                {
-                    "type": "blob",
-                    "mime_type": "image/png",
-                    "modality": "image",
-                    "content": "iVBORw0KGgo=",
-                },
-            ),
-            (
-                {"type": "image_url", "image_url": {"url": "https://e.com/cat.png"}},
-                {
-                    "type": "uri",
-                    "mime_type": "",
-                    "modality": "image",
-                    "uri": "https://e.com/cat.png",
-                },
-            ),
+            {"type": "input_image", "image_url": "data:image/png;base64,iVBORw0KGgo="},
+            {"type": "image_url", "image_url": {"url": "https://e.com/cat.png"}},
         ],
-        ids=["data_url_blob", "plain_url_uri"],
+        ids=["data_url", "plain_url"],
     )
     def test_image_only_user_message_attaches_media(
         self,
         otel_spans: InMemorySpanExporter,
         block: dict,
-        expected_part: dict,
     ) -> None:
         """Image-only user messages must keep a Message slot so the
         attachment binds to the right user turn on the wire.
         """
-        out = self._input_messages_attr(
-            otel_spans, [{"role": "user", "content": [block]}]
-        )
+        with patch(
+            "weave.session.adapters.openai._publish_media_content",
+            return_value="weave:///e/p/object/img:v1",
+        ):
+            out = self._input_messages_attr(
+                otel_spans, [{"role": "user", "content": [block]}]
+            )
         assert len(out) == 1
         assert out[0]["role"] == "user"
-        # No text part (empty content), just the media part.
-        assert out[0]["parts"] == [expected_part]
+        part = out[0]["parts"][0]
+        assert part["type"] == "uri"
+        assert part["uri"].startswith("weave:///")
 
     def test_duplicate_image_urls_deduplicated(
         self, otel_spans: InMemorySpanExporter
     ) -> None:
-        out = self._input_messages_attr(
-            otel_spans,
-            [
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "input_image", "image_url": "https://e.com/a.png"},
-                        {"type": "input_image", "image_url": "https://e.com/a.png"},
-                    ],
-                }
-            ],
-        )
+        with patch(
+            "weave.session.adapters.openai._publish_media_content",
+            return_value="weave:///e/p/object/img:v1",
+        ):
+            out = self._input_messages_attr(
+                otel_spans,
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "input_image", "image_url": "https://e.com/a.png"},
+                            {"type": "input_image", "image_url": "https://e.com/a.png"},
+                        ],
+                    }
+                ],
+            )
         assert out == [
             {
                 "role": "user",
@@ -2199,7 +2136,7 @@ class TestMessageFromOpenAIResponsesInput:
                         "type": "uri",
                         "mime_type": "",
                         "modality": "image",
-                        "uri": "https://e.com/a.png",
+                        "uri": "weave:///e/p/object/img:v1",
                     }
                 ],
             }

--- a/tests/trace/data_serialization/test_cases/media_cases.py
+++ b/tests/trace/data_serialization/test_cases/media_cases.py
@@ -300,9 +300,7 @@ media_cases = [
             "weave_type": {"type": "weave.type_wrappers.Content.content.Content"},
             "files": {
                 "content": "xfOhnNfgQxRzgWZ6DC1QEGt9vrJWcathymKPPZQmmIw",
-                "metadata.json": "v5gYkptifYVGd0JYbW3U0jYQPSKkLzEI3eamc0cnCG8"
-                if sys.platform == "win32"
-                else "0tY4LYkQE9BXzCQDItzaUoFLd3lesQ0RkuHNMuXQJIk",
+                "metadata.json": "v5gYkptifYVGd0JYbW3U0jYQPSKkLzEI3eamc0cnCG8",
             },
             "load_op": "weave:///shawn/test-project/op/load_weave.type_wrappers.Content.content.Content:SuzOIS69NdH6zLs4fsVxbYFkcYpXPPb7G8Y0VmdkISw",
         },
@@ -319,12 +317,8 @@ media_cases = [
         ],
         exp_files=[
             {
-                "digest": "v5gYkptifYVGd0JYbW3U0jYQPSKkLzEI3eamc0cnCG8"
-                if sys.platform == "win32"
-                else "0tY4LYkQE9BXzCQDItzaUoFLd3lesQ0RkuHNMuXQJIk",
-                "exp_content": b'{"size": 88244, "mimetype": "audio/wav", "digest": "c5f3a19cd7e043147381667a0c2d50106b7dbeb25671ab61ca628f3d9426988c", "filename": "audio.wav", "content_type": "file", "input_type": "str", "encoding": "utf-8", "metadata": null, "extension": ".wav"}'
-                if sys.platform == "win32"
-                else b'{"size": 88244, "mimetype": "audio/x-wav", "digest": "c5f3a19cd7e043147381667a0c2d50106b7dbeb25671ab61ca628f3d9426988c", "filename": "audio.wav", "content_type": "file", "input_type": "str", "encoding": "utf-8", "metadata": null, "extension": ".wav"}',
+                "digest": "v5gYkptifYVGd0JYbW3U0jYQPSKkLzEI3eamc0cnCG8",
+                "exp_content": b'{"size": 88244, "mimetype": "audio/wav", "digest": "c5f3a19cd7e043147381667a0c2d50106b7dbeb25671ab61ca628f3d9426988c", "filename": "audio.wav", "content_type": "file", "input_type": "str", "encoding": "utf-8", "metadata": null, "extension": ".wav"}',
             },
             {
                 "digest": "xfOhnNfgQxRzgWZ6DC1QEGt9vrJWcathymKPPZQmmIw",
@@ -523,9 +517,7 @@ media_cases = [
             "weave_type": {"type": "weave.type_wrappers.Content.content.Content"},
             "files": {
                 "content": "xfOhnNfgQxRzgWZ6DC1QEGt9vrJWcathymKPPZQmmIw",
-                "metadata.json": "v5gYkptifYVGd0JYbW3U0jYQPSKkLzEI3eamc0cnCG8"
-                if sys.platform == "win32"
-                else "0tY4LYkQE9BXzCQDItzaUoFLd3lesQ0RkuHNMuXQJIk",
+                "metadata.json": "v5gYkptifYVGd0JYbW3U0jYQPSKkLzEI3eamc0cnCG8",
             },
             "load_op": "weave:///shawn/test-project/op/load_weave.type_wrappers.Content.content.Content:jKs5CuwiyYGA4BenXYBijazlvmH04EyzP3JxskFLvUk",
         },
@@ -542,12 +534,8 @@ media_cases = [
         ],
         exp_files=[
             {
-                "digest": "v5gYkptifYVGd0JYbW3U0jYQPSKkLzEI3eamc0cnCG8"
-                if sys.platform == "win32"
-                else "0tY4LYkQE9BXzCQDItzaUoFLd3lesQ0RkuHNMuXQJIk",
-                "exp_content": b'{"size": 88244, "mimetype": "audio/wav", "digest": "c5f3a19cd7e043147381667a0c2d50106b7dbeb25671ab61ca628f3d9426988c", "filename": "audio.wav", "content_type": "file", "input_type": "str", "encoding": "utf-8", "metadata": null, "extension": ".wav"}'
-                if sys.platform == "win32"
-                else b'{"size": 88244, "mimetype": "audio/x-wav", "digest": "c5f3a19cd7e043147381667a0c2d50106b7dbeb25671ab61ca628f3d9426988c", "filename": "audio.wav", "content_type": "file", "input_type": "str", "encoding": "utf-8", "metadata": null, "extension": ".wav"}',
+                "digest": "v5gYkptifYVGd0JYbW3U0jYQPSKkLzEI3eamc0cnCG8",
+                "exp_content": b'{"size": 88244, "mimetype": "audio/wav", "digest": "c5f3a19cd7e043147381667a0c2d50106b7dbeb25671ab61ca628f3d9426988c", "filename": "audio.wav", "content_type": "file", "input_type": "str", "encoding": "utf-8", "metadata": null, "extension": ".wav"}',
             },
             {
                 "digest": "xfOhnNfgQxRzgWZ6DC1QEGt9vrJWcathymKPPZQmmIw",

--- a/tests/trace/type_handlers/Content/test_content.py
+++ b/tests/trace/type_handlers/Content/test_content.py
@@ -1,5 +1,4 @@
 import base64
-import sys
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -53,10 +52,9 @@ def audio_file(tmp_path_factory) -> Path:
 
 
 # New parameterization list using fixture names
-# Note: Windows uses "audio/wav" while Unix uses "audio/x-wav"
 MEDIA_TEST_PARAMS = [
     ("image_file", ".png", "image/png"),
-    ("audio_file", ".wav", "audio/wav" if sys.platform == "win32" else "audio/x-wav"),
+    ("audio_file", ".wav", "audio/wav"),
     ("video_file", ".mp4", "video/mp4"),
     ("pdf_file", ".pdf", "application/pdf"),
 ]

--- a/tests/trace/type_handlers/Content/test_content_resolvers.py
+++ b/tests/trace/type_handlers/Content/test_content_resolvers.py
@@ -215,7 +215,8 @@ def extensionless_png_file(tmp_path_factory, png_bytes) -> Path:
 BUFFER_CASES = [
     ("png_bytes", "image/png"),
     ("jpeg_bytes", "image/jpeg"),
-    ("wav_bytes", "audio/x-wav"),
+    # libmagic detects audio/x-wav; normalized to canonical audio/wav.
+    ("wav_bytes", "audio/wav"),
     ("pdf_bytes", "application/pdf"),
     ("gif_bytes", "image/gif"),
 ]
@@ -269,7 +270,8 @@ class TestResolverDetectFromBuffer:
 FILE_CASES = [
     ("png_file", "image/png", ".png"),
     ("jpeg_file", "image/jpeg", ".jpg"),
-    ("wav_file", "audio/x-wav", ".wav"),
+    # libmagic detects audio/x-wav; normalized to canonical audio/wav.
+    ("wav_file", "audio/wav", ".wav"),
     ("pdf_file", "application/pdf", ".pdf"),
 ]
 
@@ -400,7 +402,7 @@ class TestGetMimeAndExtension:
             mimetype=None,
             extension=None,
             filename="music.mp3",  # mimetypes says audio/mpeg
-            buffer=wav_bytes,  # buffer says audio/x-wav
+            buffer=wav_bytes,  # buffer would detect audio/wav
         )
         # Filename-based detection should win
         assert mime == "audio/mpeg"
@@ -410,7 +412,7 @@ class TestGetMimeAndExtension:
         [
             ("png_bytes", "image/png"),
             ("pdf_bytes", "application/pdf"),
-            ("wav_bytes", "audio/x-wav"),
+            ("wav_bytes", "audio/wav"),
             ("jpeg_bytes", "image/jpeg"),
         ],
     )
@@ -563,7 +565,8 @@ class TestContentIntegration:
 
     def test_from_path_wav(self, resolver_backend, wav_file):
         c = Content.from_path(wav_file)
-        assert c.mimetype in {"audio/x-wav", "audio/wav"}
+        # Detected audio/x-wav is normalized to canonical audio/wav.
+        assert c.mimetype == "audio/wav"
         assert c.extension == ".wav"
 
     def test_from_bytes_with_extension(self, resolver_backend, png_bytes):
@@ -577,6 +580,7 @@ class TestContentIntegration:
         assert c.mimetype == "application/pdf"
 
     def test_from_bytes_mimetype_only(self, resolver_backend, wav_bytes):
+        # Explicit caller mimetype is preserved; only detected types are normalized.
         c = Content.from_bytes(wav_bytes, mimetype="audio/x-wav")
         assert c.mimetype == "audio/x-wav"
         assert c.extension is not None  # should be resolved from mimetype

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -347,10 +347,10 @@ class TestStandaloneBase64Detection:
         # Verify file_create was called twice (content + metadata)
         assert trace_server.file_create.call_count == 2
 
-        # Verify the content mimetype is audio/wav (not text/plain or application/octet-stream)
+        # Detected audio/x-wav is normalized to canonical audio/wav.
         metadata_call = trace_server.file_create.call_args_list[1][0][0]
         metadata = json.loads(metadata_call.content)
-        assert metadata["mimetype"] in {"audio/wav", "audio/x-wav", "audio/wave"}
+        assert metadata["mimetype"] == "audio/wav"
 
 
 class TestThresholdAndStructuralIdentity:

--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -8,6 +8,7 @@ test since that's a separate code path (Status object vs attributes).
 """
 
 import datetime
+import json
 from typing import Any
 
 from weave.trace_server.agents import semconv
@@ -142,8 +143,12 @@ def test_extract_genai_span_comprehensive() -> None:
     assert len(result.input_messages) == 2
     assert result.input_messages[0].role == "system"
     assert result.input_messages[1].role == "user"
-    # parts concatenate into content; finish_reason passes through
-    assert result.output_messages[0].content == "Let me think...\nDone."
+    # structured parts are JSON-serialized into content
+    parts = json.loads(result.output_messages[0].content)
+    assert parts == [
+        {"type": "reasoning", "content": "Let me think..."},
+        {"type": "text", "content": "Done."},
+    ]
     assert result.output_messages[0].finish_reason == "stop"
 
     # Reasoning content extracted from output message parts

--- a/weave/session/adapters/openai.py
+++ b/weave/session/adapters/openai.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from weave.session.session import _publish_media_content
 from weave.session.types import (
     MediaAttachment,
     Message,
@@ -220,15 +221,9 @@ def _collect_image_attachments(
 def _url_to_attachment(url: str) -> MediaAttachment:
     if url.startswith("data:"):
         mime_type, payload = _parse_data_url(url)
-        return MediaAttachment(
-            kind="blob",
-            modality="image",
-            mime_type=mime_type,
-            content=payload,
+        ref_uri = _publish_media_content(
+            content=payload, uri="", file_id="", mime_type=mime_type
         )
-    return MediaAttachment(
-        kind="uri",
-        modality="image",
-        mime_type="",
-        uri=url,
-    )
+        return MediaAttachment(ref=ref_uri, modality="image", mime_type=mime_type)
+    ref_uri = _publish_media_content(content="", uri=url, file_id="", mime_type="")
+    return MediaAttachment(ref=ref_uri, modality="image", mime_type="")

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -10,6 +10,7 @@ attributes when used as context managers.
 
 from __future__ import annotations
 
+import logging
 import types
 import uuid
 from contextvars import ContextVar, Token
@@ -42,6 +43,7 @@ from weave.session.types import (
     _parse_data_url,
 )
 from weave.trace.settings import should_disable_weave, should_redact_pii
+from weave.trace.util import Thread
 from weave.utils import pii_redaction
 from weave.utils.capture_info import get_capture_info
 
@@ -108,6 +110,8 @@ __all__ = [
 
 # OTel tracer name — identifies the Session SDK as the source of these spans.
 _TRACER_NAME = "weave.session"
+
+logger = logging.getLogger(__name__)
 
 
 def _capture_info_attrs() -> dict[str, str]:
@@ -182,6 +186,45 @@ class _SpanBase(BaseModel):
             return
         self._otel_span.set_status(StatusCode.ERROR, str(exc_val))
         self._otel_span.record_exception(exc_val)
+
+
+def _publish_media_content(
+    *,
+    content: bytes | str,
+    uri: str,
+    file_id: str,
+    mime_type: str,
+) -> str:
+    """Create a Content object from raw media data and publish it.
+
+    Returns the ``weave://`` ref URI string.
+    """
+    from weave.trace.api import publish
+    from weave.type_wrappers.Content.content import Content
+
+    content_obj: Content
+    if content:
+        if isinstance(content, str):
+            content_obj = Content.from_base64(content, mimetype=mime_type or None)
+        else:
+            content_obj = Content.from_bytes(content, mimetype=mime_type or None)
+    elif uri:
+        if uri.startswith("data:"):
+            content_obj = Content.from_data_url(uri)
+        else:
+            content_obj = Content.from_url(uri)
+    elif file_id:
+        raise ValueError(
+            f"Cannot publish file_id {file_id!r} as Content; "
+            "fetch the content from the provider first or use a URI"
+        )
+    else:
+        raise ValueError("_publish_media_content requires content or uri")
+
+    ref = publish(content_obj)
+    # Coerce to a plain ``str``: ``ref.uri`` may be a ``_CallableStr`` subclass
+    # that OTel attribute validation rejects.
+    return str(getattr(ref, "uri", ref))
 
 
 class Tool(_SpanBase):
@@ -302,6 +345,7 @@ class LLM(_SpanBase):
 
     _ended: bool = PrivateAttr(default=False)
     _token: Token[LLM | None] | None = PrivateAttr(default=None)
+    _upload_threads: list[Thread] = PrivateAttr(default_factory=list)
 
     def model_post_init(self, context: Any, /) -> None:
         if self.started_at is None:
@@ -328,8 +372,18 @@ class LLM(_SpanBase):
     ) -> LLM:
         """Attach media to this LLM call.
 
-        Exactly one of content, uri, or file_id must be provided.
-        Modality is inferred from mime_type when not set explicitly.
+        Creates a ``Content`` object from the provided data, publishes it
+        to get a ``weave://`` ref, and stores only that ref.  Exactly one
+        of ``content``, ``uri``, or ``file_id`` must be provided.
+
+        The publish (which uploads the media) runs on a dedicated
+        background thread so the call returns immediately without blocking
+        the caller; one thread is dispatched per attachment so multiple
+        uploads proceed in parallel. The placeholder ``MediaAttachment`` is
+        appended synchronously and its ``ref`` is filled in once the upload
+        completes. Refs are guaranteed populated before the span is emitted
+        (the build path waits on the in-flight uploads via
+        ``_await_uploads``).
         """
         sources = sum(bool(s) for s in (content, uri, file_id))
         if sources != 1:
@@ -340,33 +394,73 @@ class LLM(_SpanBase):
             if prefix in {"image", "audio", "video"}:
                 modality = prefix
 
-        if content:
-            kind: Literal["blob", "uri", "file"] = "blob"
-        elif uri:
-            kind = "uri"
-        else:
-            kind = "file"
-
-        self.media_attachments.append(
-            MediaAttachment(
-                kind=kind,
-                modality=modality or "unknown",
-                mime_type=mime_type,
-                content=content,
-                uri=uri,
-                file_id=file_id,
-            )
+        attachment = MediaAttachment(
+            ref="",
+            modality=modality or "unknown",
+            mime_type=mime_type,
         )
+        self.media_attachments.append(attachment)
+        thread = Thread(
+            target=self._upload_media,
+            kwargs={
+                "attachment": attachment,
+                "content": content,
+                "uri": uri,
+                "file_id": file_id,
+                "mime_type": mime_type,
+            },
+            name="weave-session-media-upload",
+            daemon=True,
+        )
+        thread.start()
+        self._upload_threads.append(thread)
         return self
+
+    def _upload_media(
+        self,
+        *,
+        attachment: MediaAttachment,
+        content: bytes | str,
+        uri: str,
+        file_id: str,
+        mime_type: str,
+    ) -> None:
+        """Publish one media attachment and record its ref.
+
+        Runs on a background thread dispatched by ``attach_media``. On
+        success the ``weave://`` ref is written back onto ``attachment``.
+        Failures are logged and leave the ref empty; ``_await_uploads``
+        drops empty-ref attachments so a failed upload never emits a
+        broken URI part.
+        """
+        try:
+            attachment.ref = _publish_media_content(
+                content=content, uri=uri, file_id=file_id, mime_type=mime_type
+            )
+        except Exception:
+            logger.exception("Failed to publish media attachment for chat span")
+
+    def _await_uploads(self) -> None:
+        """Block until all in-flight media uploads finish.
+
+        Called before building span attributes so every attachment has its
+        ``weave://`` ref populated. Attachments whose upload failed (empty
+        ref) are dropped so the emitted span never carries a broken URI.
+        """
+        if not self._upload_threads:
+            return
+        for thread in self._upload_threads:
+            thread.join()
+        self._upload_threads.clear()
+        self.media_attachments = [m for m in self.media_attachments if m.ref]
 
     def attach_media_url(self, url: str, *, modality: str = "") -> LLM:
         """Attach a media URL to this LLM call.
 
         Convenience over ``attach_media`` for the common case where the
-        caller has a URL string from an upstream message and doesn't want
-        to inspect it. ``data:`` URLs are parsed into ``mime_type`` +
-        inline content (kind=blob); plain URIs become ``kind=uri``. Empty
-        URLs are ignored. Returns ``self`` for chaining.
+        caller has a URL string from an upstream message. ``data:`` URLs
+        are parsed into bytes and published; plain URIs are fetched and
+        published. Empty URLs are ignored. Returns ``self`` for chaining.
         """
         if not url:
             return self
@@ -436,6 +530,10 @@ class LLM(_SpanBase):
         ``reasoning``, which previously bypassed the gate and leaked
         into ``gen_ai.output.messages``.
         """
+        # Block on any background media uploads so every attachment's
+        # weave:// ref is populated before it is serialized into attrs.
+        self._await_uploads()
+
         input_messages: list[Message] | None
         output_messages: list[Message] | None
         system_instructions: list[str] | None

--- a/weave/session/session_otel.py
+++ b/weave/session/session_otel.py
@@ -34,7 +34,6 @@ flat format, so the dual-mode opt-in flag isn't needed.
 
 from __future__ import annotations
 
-import base64
 import json
 from typing import Any
 
@@ -42,36 +41,12 @@ from weave.session.types import MediaAttachment, Message, Reasoning, Usage
 
 
 def _media_to_part(media: MediaAttachment) -> dict[str, Any]:
-    """Build a BlobPart, UriPart, or FilePart per GenAI semconv.
-
-    Bytes content is base64-encoded; str content is assumed to already be
-    base64-encoded by the caller (matches the semconv field which is a
-    string of base64 data).
-    """
-    if media.kind == "blob":
-        encoded = (
-            base64.b64encode(media.content).decode("ascii")
-            if isinstance(media.content, bytes)
-            else media.content
-        )
-        return {
-            "type": "blob",
-            "mime_type": media.mime_type,
-            "modality": media.modality,
-            "content": encoded,
-        }
-    if media.kind == "uri":
-        return {
-            "type": "uri",
-            "mime_type": media.mime_type,
-            "modality": media.modality,
-            "uri": media.uri,
-        }
+    """Build a UriPart pointing to the published weave:// content ref."""
     return {
-        "type": "file",
+        "type": "uri",
         "mime_type": media.mime_type,
         "modality": media.modality,
-        "file_id": media.file_id,
+        "uri": media.ref,
     }
 
 
@@ -322,6 +297,11 @@ def llm_attributes(
     )
     if serialized_out is not None:
         attrs["gen_ai.output.messages"] = serialized_out
+
+    if media_attachments:
+        # Coerce to plain ``str``: OTel attribute validation does an exact-type
+        # check and rejects ``str`` subclasses (e.g. ``_CallableStr`` refs).
+        attrs["weave.content_refs"] = [str(m.ref) for m in media_attachments]
 
     return attrs
 

--- a/weave/session/types.py
+++ b/weave/session/types.py
@@ -241,14 +241,16 @@ class Reasoning(BaseModel):
 
 
 class MediaAttachment(BaseModel):
-    """A media attachment on an LLM call."""
+    """A media attachment on an LLM call.
 
-    kind: Literal["blob", "uri", "file"]
+    Always holds a ``weave://`` content ref URI.  Raw bytes, data-URLs,
+    and plain HTTP URIs are converted to a published ``Content`` object
+    by ``LLM.attach_media`` before being stored here.
+    """
+
+    ref: str
     modality: str = ""
     mime_type: str = ""
-    content: bytes | str = ""
-    uri: str = ""
-    file_id: str = ""
 
 
 class LogResult(BaseModel):

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -14,6 +14,7 @@ message wins and the parent invoke output is suppressed.
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -388,6 +389,30 @@ def _select_root_span(spans: list[AgentSpanSchema]) -> AgentSpanSchema:
     return max(spans, key=_root_sort_key)
 
 
+def _display_text(content: str) -> str:
+    """Extract human-readable text from a message content field.
+
+    Content is either plain text (legacy) or a JSON-serialized parts array
+    (multimodal messages).  For parts arrays, concatenate text and reasoning
+    parts; for plain text, return as-is.
+    """
+    if not content or not content.startswith("["):
+        return content
+    try:
+        parts = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return content
+    if not isinstance(parts, list):
+        return content
+    texts: list[str] = []
+    for p in parts:
+        if isinstance(p, dict) and isinstance(p.get("content"), str):
+            texts.append(p["content"])
+        elif isinstance(p, str):
+            texts.append(p)
+    return "\n".join(texts)
+
+
 def _filter_message_texts(
     messages: list[NormalizedMessage],
     *,
@@ -398,14 +423,14 @@ def _filter_message_texts(
     texts: list[str] = []
     for message in messages:
         role = message.role
-        content = message.content
-        if not content:
+        text = _display_text(message.content)
+        if not text:
             continue
         if include_roles is not None and role not in include_roles:
             continue
         if exclude_roles is not None and role in exclude_roles:
             continue
-        texts.append(content)
+        texts.append(text)
     return texts
 
 

--- a/weave/trace_server/agents/helpers.py
+++ b/weave/trace_server/agents/helpers.py
@@ -100,9 +100,7 @@ def normalize_span_row(d: dict[str, Any]) -> dict[str, Any]:
         for m in msgs:
             if isinstance(m, tuple):
                 if len(m) != 3:
-                    raise ValueError(
-                        f"{key} tuple must have 3 values (role, content, finish_reason), got {len(m)}"
-                    )
+                    raise ValueError(f"{key} tuple must have 3 values, got {len(m)}")
                 normalized.append(
                     {"role": m[0], "content": m[1], "finish_reason": m[2]}
                 )

--- a/weave/trace_server/agents/schema.py
+++ b/weave/trace_server/agents/schema.py
@@ -33,13 +33,12 @@ OutputTypeLiteral = Literal["", "text", "json", "image", "speech"]
 class NormalizedMessage(BaseModel):
     """A single message normalized from any provider format.
 
-    Maps to ClickHouse `Tuple(role String, content String, finish_reason String)`.
+    Maps to ClickHouse ``Tuple(role String, content String, finish_reason String)``.
 
     - role: message role (user, assistant, tool, system)
-    - content: concatenated text for search/display
+    - content: plain text for simple messages, or JSON-serialized parts
+      array for multimodal/structured messages
     - finish_reason: per-message finish reason (output messages only)
-
-    Lossless original data is preserved in `raw_span_dump` on the span.
     """
 
     role: str = ""

--- a/weave/trace_server/opentelemetry/genai_extraction.py
+++ b/weave/trace_server/opentelemetry/genai_extraction.py
@@ -248,13 +248,19 @@ def _text_from_parts(parts: list[Any]) -> str:
 def _normalize_single_message(
     msg: dict[str, Any], *, default_role: str = ""
 ) -> NormalizedMessage:
-    """Normalize a single message dict into a NormalizedMessage."""
+    """Normalize a single message dict into a NormalizedMessage.
+
+    When the message carries structured ``parts``, they are JSON-serialized
+    into ``content`` so the full multimodal payload survives the 3-field
+    ClickHouse tuple without a schema migration.  Plain-text messages store
+    the text directly.
+    """
     role = str(msg.get("role") or default_role)
 
     content = ""
     raw_parts = msg.get("parts")
     if isinstance(raw_parts, list):
-        content = _text_from_parts(raw_parts)
+        content = _json_str(raw_parts)
     elif isinstance(msg.get("content"), str):
         content = msg["content"]
     elif isinstance(msg.get("content"), list):

--- a/weave/type_wrappers/Content/python_magic_resolver.py
+++ b/weave/type_wrappers/Content/python_magic_resolver.py
@@ -139,9 +139,7 @@ def _is_wav_buffer(buffer: bytes) -> bool:
     never move regardless of the audio payload, so a 12-byte prefix suffices.
     """
     return (
-        len(buffer) >= 12
-        and buffer[:4] == _RIFF_MARKER
-        and buffer[8:12] == _WAVE_FORM
+        len(buffer) >= 12 and buffer[:4] == _RIFF_MARKER and buffer[8:12] == _WAVE_FORM
     )
 
 

--- a/weave/type_wrappers/Content/python_magic_resolver.py
+++ b/weave/type_wrappers/Content/python_magic_resolver.py
@@ -109,6 +109,42 @@ def is_available() -> bool:
     return available
 
 
+# Leading magic bytes of a WAV file. WAV is a RIFF container, so the bytes we
+# match live at fixed, little-endian offsets defined by the RIFF spec.
+_RIFF_MARKER = b"RIFF"  # offset 0: generic RIFF container marker (ChunkID)
+_WAVE_FORM = b"WAVE"  # offset 8: form type that marks this RIFF as WAVE audio
+
+
+def _is_wav_buffer(buffer: bytes) -> bool:
+    """Return True if the buffer's magic bytes identify it as a WAV file.
+
+    This works around a libmagic limitation: some builds only recognise the
+    generic RIFF container when classifying a WAV from an in-memory buffer
+    (``magic.from_buffer`` returns ``application/octet-stream``), even though
+    ``magic.from_file`` on the identical bytes correctly returns
+    ``audio/x-wav``. Content frequently detects from buffers (e.g. base64
+    payloads decoded in memory), so without this check WAV audio silently fails
+    to be recognised on the affected builds.
+
+    RIFF/WAVE header layout (fixed by the spec, little-endian)::
+
+        offset 0   4 bytes   "RIFF"   ChunkID   -- generic container marker
+        offset 4   4 bytes   <size>   ChunkSize
+        offset 8   4 bytes   "WAVE"   Format    -- the *form type*
+
+    The form type at offset 8 is what distinguishes WAV from every other RIFF
+    container ("AVI " video, "WEBP" image, "ANI " cursor, ...), so we require
+    BOTH the "RIFF" marker at offset 0 and the "WAVE" form at offset 8;
+    matching on "RIFF" alone would misclassify those as audio. These offsets
+    never move regardless of the audio payload, so a 12-byte prefix suffices.
+    """
+    return (
+        len(buffer) >= 12
+        and buffer[:4] == _RIFF_MARKER
+        and buffer[8:12] == _WAVE_FORM
+    )
+
+
 def detect(
     *, filename: str | None, buffer: bytes | None
 ) -> tuple[str | None, str | None]:
@@ -144,6 +180,15 @@ def detect(
     if buffer is not None:
         try:
             mimetype = mime_magic.from_buffer(buffer)
+            # Some libmagic builds cannot identify WAV from an in-memory buffer
+            # and report the generic octet-stream type (see _is_wav_buffer).
+            # Sniff the RIFF/WAVE signature and override so buffer-based
+            # detection matches what from_file would return. This is a no-op on
+            # builds that already classify WAV correctly.
+            if mimetype in {None, "application/octet-stream"} and _is_wav_buffer(
+                buffer
+            ):
+                return "audio/x-wav", ".wav"
             if mimetype:
                 raw_ext = ext_magic.from_buffer(buffer) if ext_magic else None
                 return mimetype, _resolve_extension(raw_ext, mimetype)

--- a/weave/type_wrappers/Content/utils.py
+++ b/weave/type_wrappers/Content/utils.py
@@ -49,8 +49,8 @@ def _get_mimetypes_module() -> ModuleType:
     if _mimetypes_module is None:
         import mimetypes as _m
 
-        # Mimetypes is missing text/markdown, add it on first use.
         _m.add_type("text/markdown", ".md")
+        _m.add_type("audio/wav", ".wav")
         _mimetypes_module = _m
     return _mimetypes_module
 

--- a/weave/type_wrappers/Content/utils.py
+++ b/weave/type_wrappers/Content/utils.py
@@ -82,6 +82,14 @@ def _get_resolver() -> Any:
     return None
 
 
+# libmagic reports WAV as audio/x-wav; normalize detected types to the canonical
+# audio/wav so buffer- and filename-based detection agree. Caller-supplied
+# mimetypes don't pass through here and are preserved as-is.
+_DETECTED_MIMETYPE_ALIASES = {
+    "audio/x-wav": "audio/wav",
+}
+
+
 def _detect_from_resolver(
     *, filename: str | None, buffer: bytes | None
 ) -> tuple[str | None, str | None]:
@@ -92,7 +100,10 @@ def _detect_from_resolver(
     """
     resolver = _get_resolver()
     if resolver is not None:
-        return resolver.detect(filename=filename, buffer=buffer)
+        mimetype, extension = resolver.detect(filename=filename, buffer=buffer)
+        if mimetype is not None:
+            mimetype = _DETECTED_MIMETYPE_ALIASES.get(mimetype, mimetype)
+        return mimetype, extension
 
     if buffer is not None:
         logger.warning(
@@ -183,6 +194,8 @@ def guess_from_buffer(buffer: bytes) -> str | None:
         return None
 
     mimetype, _ = resolver.detect(filename=None, buffer=buffer)
+    if mimetype is not None:
+        mimetype = _DETECTED_MIMETYPE_ALIASES.get(mimetype, mimetype)
     return mimetype
 
 


### PR DESCRIPTION
## Description

 - Fixes: WB-35004

 - Some `libmagic` builds cannot identify a WAV file when classifying it from an in-memory buffer
 - Returns `application/octet-stream`, even though `magic.from_file` on the identical bytes correctly returns `audio/x-wav`.
 - Because `Content` frequently detects from buffers, WAV (and Content by extension) detection behaves inconsistently 

PR fixes inconsistency by checking the RIFF & WAVE magic bytes directly when `from_buffer` returns nothing or the generic octet-stream type

## Testing

Made sure existing tests pass, this fixes failing tests in other branches