### PR TITLE
perf(weave): extend calls_query_stats fast path w/ time-window

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -4901,9 +4901,10 @@ def test_calls_query_stats_with_limit(client):
 
 def test_calls_query_stats_started_at_window_excludes_deletes(client):
     """A started_at lower-bound count must match across backends and exclude
-    soft-deleted calls. On ClickHouse this exercises the windowed distinct-id
-    fast path; on SQLite it exercises the reference implementation, so equal
-    results pin the optimization to the GROUP BY semantics.
+    soft-deleted calls and orphaned call-ends. On ClickHouse this exercises the
+    windowed distinct-id fast path; on SQLite it exercises the reference
+    implementation, so equal results pin the optimization to the GROUP BY
+    semantics.
     """
 
     @weave.op
@@ -4937,6 +4938,22 @@ def test_calls_query_stats_started_at_window_excludes_deletes(client):
     # Deleting a call removes it from the windowed count (anti-set exclusion).
     client.server.calls_delete(
         tsi.CallsDeleteReq(project_id=project_id, call_ids=[all_calls[0].id])
+    )
+    assert count(1) == 2
+
+    # An orphaned call-end (end row, no start) carries started_at since #6933 but
+    # has no op_name; the op_name guard must keep it out of the windowed count.
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    client.server.call_end(
+        tsi.CallEndReq(
+            end=tsi.EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=generate_id(),
+                started_at=now,
+                ended_at=now,
+                summary={},
+            )
+        )
     )
     assert count(1) == 2
 

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -4899,6 +4899,48 @@ def test_calls_query_stats_with_limit(client):
     assert result.total_storage_size_bytes is not None
 
 
+def test_calls_query_stats_started_at_window_excludes_deletes(client):
+    """A started_at lower-bound count must match across backends and exclude
+    soft-deleted calls. On ClickHouse this exercises the windowed distinct-id
+    fast path; on SQLite it exercises the reference implementation, so equal
+    results pin the optimization to the GROUP BY semantics.
+    """
+
+    @weave.op
+    def stats_window_op() -> int:
+        return 1
+
+    for _ in range(3):
+        stats_window_op()
+
+    project_id = get_client_project_id(client)
+    all_calls = client.get_calls()
+    assert len(all_calls) == 3
+
+    def count(literal_seconds: int) -> int:
+        query = tsi.Query(
+            **{
+                "$expr": {
+                    "$gt": [{"$getField": "started_at"}, {"$literal": literal_seconds}]
+                }
+            }
+        )
+        return client.server.calls_query_stats(
+            tsi.CallsQueryStatsReq(project_id=project_id, query=query)
+        ).count
+
+    # Lower bound in the distant past counts every (non-deleted) call.
+    assert count(1) == 3
+    # Lower bound in the far future counts nothing.
+    assert count(99999999999) == 0
+
+    # Deleting a call removes it from the windowed count (anti-set exclusion).
+    client.server.calls_delete(
+        tsi.CallsDeleteReq(project_id=project_id, call_ids=[all_calls[0].id])
+    )
+    assert count(1) == 2
+
+
 @pytest.mark.parametrize(
     "thread_ids",
     [

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -4930,19 +4930,27 @@ def test_calls_query_stats_started_at_window_excludes_deletes(client):
             tsi.CallsQueryStatsReq(project_id=project_id, query=query)
         ).count
 
+    def unfiltered_count() -> int:
+        # No query -> exercises the flat distinct-id fast path (Pattern 3).
+        return client.server.calls_query_stats(
+            tsi.CallsQueryStatsReq(project_id=project_id)
+        ).count
+
     # Lower bound in the distant past counts every (non-deleted) call.
     assert count(1) == 3
+    assert unfiltered_count() == 3
     # Lower bound in the far future counts nothing.
     assert count(99999999999) == 0
 
-    # Deleting a call removes it from the windowed count (anti-set exclusion).
+    # Deleting a call removes it from both counts (delete exclusion).
     client.server.calls_delete(
         tsi.CallsDeleteReq(project_id=project_id, call_ids=[all_calls[0].id])
     )
     assert count(1) == 2
+    assert unfiltered_count() == 2
 
     # An orphaned call-end (end row, no start) carries started_at since #6933 but
-    # has no op_name; the op_name guard must keep it out of the windowed count.
+    # has no op_name; the op_name guard must keep it out of both fast-path counts.
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     client.server.call_end(
         tsi.CallEndReq(
@@ -4956,6 +4964,7 @@ def test_calls_query_stats_started_at_window_excludes_deletes(client):
         )
     )
     assert count(1) == 2
+    assert unfiltered_count() == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4388,10 +4388,12 @@ def test_stats_query_calls_merged_started_at_window_uses_distinct_anti_set() -> 
 
     uniqExact counts start rows in the window -- the exact `started_at`
     predicates match the GROUP BY path's `any(started_at) <op> T` HAVING (and
-    drop the prefilter buffer slop) -- and soft-deleted ids are removed with an
-    anti-set. Both bounds prefilter the outer scan, but only the lower bound
-    windows the anti-set: deletes can land after the upper bound, never before
-    the lower one. Limit capping reuses the shared count/has_more wrapper.
+    drop the prefilter buffer slop), and `op_name IS NOT NULL` reproduces its
+    orphaned-call-end exclusion (since #6933 end rows carry started_at too).
+    Soft-deleted ids are removed with an anti-set. Both bounds prefilter the
+    outer scan, but only the lower bound windows the anti-set: deletes can land
+    after the upper bound, never before the lower one. Limit capping reuses the
+    shared count/has_more wrapper.
     """
     req = tsi.CallsQueryStatsReq(
         project_id="project",
@@ -4418,6 +4420,7 @@ def test_stats_query_calls_merged_started_at_window_uses_distinct_anti_set() -> 
               AND calls_merged.sortable_datetime < {pb_4:String}
               AND calls_merged.started_at > {pb_1:String}
               AND calls_merged.started_at < {pb_3:String}
+              AND calls_merged.op_name IS NOT NULL
               AND calls_merged.id NOT IN (
                   SELECT calls_merged.id
                   FROM calls_merged

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4379,6 +4379,137 @@ def test_stats_query_calls_merged_with_query_falls_back_to_group_by() -> None:
     )
 
 
+def _started_at_query(expr: dict) -> tsi.Query:
+    return tsi.Query.model_validate({"$expr": expr})
+
+
+def test_stats_query_calls_merged_started_at_window_uses_distinct_anti_set() -> None:
+    """A started_at-only window takes the distinct-id fast path (Pattern 4).
+
+    uniqExact counts start rows in the window -- the exact `started_at`
+    predicates match the GROUP BY path's `any(started_at) <op> T` HAVING (and
+    drop the prefilter buffer slop) -- and soft-deleted ids are removed with an
+    anti-set. Both bounds prefilter the outer scan, but only the lower bound
+    windows the anti-set: deletes can land after the upper bound, never before
+    the lower one. Limit capping reuses the shared count/has_more wrapper.
+    """
+    req = tsi.CallsQueryStatsReq(
+        project_id="project",
+        limit=5,
+        query=_started_at_query(
+            {
+                "$and": [
+                    {"$gt": [{"$getField": "started_at"}, {"$literal": 1709251200}]},
+                    {"$lt": [{"$getField": "started_at"}, {"$literal": 1709337600}]},
+                ]
+            }
+        ),
+    )
+    assert_stats_sql(
+        req,
+        """
+        SELECT least(raw_count, 5) AS count,
+               toUInt8(raw_count > 5) AS has_more
+        FROM (
+            SELECT uniqExact(calls_merged.id) AS raw_count
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_0:String}
+            WHERE calls_merged.sortable_datetime > {pb_2:String}
+              AND calls_merged.sortable_datetime < {pb_4:String}
+              AND calls_merged.started_at > {pb_1:String}
+              AND calls_merged.started_at < {pb_3:String}
+              AND calls_merged.id NOT IN (
+                  SELECT calls_merged.id
+                  FROM calls_merged
+                  PREWHERE calls_merged.project_id = {pb_0:String}
+                  WHERE calls_merged.sortable_datetime > {pb_2:String}
+                    AND isNotNull(calls_merged.deleted_at)))
+        """,
+        {
+            "pb_0": "project",
+            "pb_1": "2024-03-01 00:00:00.000000",
+            "pb_2": "2024-02-29 23:55:00.000000",
+            "pb_3": "2024-03-02 00:00:00.000000",
+            "pb_4": "2024-03-02 00:05:00.000000",
+        },
+        read_table=ReadTable.CALLS_MERGED,
+    )
+
+
+def test_stats_query_calls_merged_started_at_fast_path_gates() -> None:
+    """The fast path fires only when a lower-bounded started_at is the sole
+    filter. An upper-bound-only window (cannot window the delete anti-set) and a
+    started_at bound mixed with any other predicate both fall back to GROUP BY.
+    """
+    # Upper bound only -> no lower bound to window the anti-set -> fall back.
+    assert_stats_sql(
+        tsi.CallsQueryStatsReq(
+            project_id="project",
+            query=_started_at_query(
+                {"$lt": [{"$getField": "started_at"}, {"$literal": 1709251200}]}
+            ),
+        ),
+        """
+        SELECT count() AS count, toUInt8(0) AS has_more
+        FROM (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_2:String}
+            WHERE (calls_merged.sortable_datetime < {pb_1:String})
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((any(calls_merged.started_at) < {pb_0:String}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+            )
+        )
+        """,
+        {
+            "pb_0": "2024-03-01 00:00:00.000000",
+            "pb_1": "2024-03-01 00:05:00.000000",
+            "pb_2": "project",
+        },
+        read_table=ReadTable.CALLS_MERGED,
+    )
+    # started_at lower bound + a non-time predicate -> not time-only -> fall back.
+    assert_stats_sql(
+        tsi.CallsQueryStatsReq(
+            project_id="project",
+            query=_started_at_query(
+                {
+                    "$and": [
+                        {"$gt": [{"$getField": "started_at"}, {"$literal": 1709251200}]},
+                        {"$eq": [{"$getField": "op_name"}, {"$literal": "x"}]},
+                    ]
+                }
+            ),
+        ),
+        """
+        SELECT count() AS count, toUInt8(0) AS has_more
+        FROM (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_3:String}
+            WHERE (calls_merged.sortable_datetime > {pb_2:String})
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((any(calls_merged.started_at) > {pb_0:String}))
+                AND ((any(calls_merged.op_name) = {pb_1:String}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+            )
+        )
+        """,
+        {
+            "pb_0": "2024-03-01 00:00:00.000000",
+            "pb_1": "x",
+            "pb_2": "2024-02-29 23:55:00.000000",
+            "pb_3": "project",
+        },
+        read_table=ReadTable.CALLS_MERGED,
+    )
+
+
 def test_stats_query_calls_merged_with_expand_columns_falls_back_to_group_by() -> None:
     """expand_columns disables the flat path even when no filter/query references
     the expansion -- treat any caller-supplied expansion as opting into rollup.

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4288,7 +4288,7 @@ def test_stats_query_calls_merged_unfiltered_no_limit_uses_flat_distinct() -> No
         SELECT raw_count AS count,
                toUInt8(0) AS has_more
         FROM (
-            SELECT uniqExactIf(calls_merged.id, calls_merged.op_name IS NOT NULL OR isNotNull(calls_merged.deleted_at)) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
+            SELECT uniqExactIf(calls_merged.id, isNotNull(calls_merged.op_name) OR isNotNull(calls_merged.deleted_at)) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_0:String})
         """,
@@ -4313,7 +4313,7 @@ def test_stats_query_calls_merged_unfiltered_with_limit_caps_in_outer_select() -
         SELECT least(raw_count, 5) AS count,
                toUInt8(raw_count > 5) AS has_more
         FROM (
-            SELECT uniqExactIf(calls_merged.id, calls_merged.op_name IS NOT NULL OR isNotNull(calls_merged.deleted_at)) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
+            SELECT uniqExactIf(calls_merged.id, isNotNull(calls_merged.op_name) OR isNotNull(calls_merged.deleted_at)) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_0:String})
         """,
@@ -4421,7 +4421,7 @@ def test_stats_query_calls_merged_started_at_window_uses_distinct_anti_set() -> 
               AND calls_merged.sortable_datetime < {pb_4:String}
               AND calls_merged.started_at > {pb_1:String}
               AND calls_merged.started_at < {pb_3:String}
-              AND calls_merged.op_name IS NOT NULL
+              AND isNotNull(calls_merged.op_name)
               AND calls_merged.id NOT IN (
                   SELECT calls_merged.id
                   FROM calls_merged

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4272,8 +4272,9 @@ def test_stats_query_calls_merged_unfiltered_limit_1_stays_with_pattern_1() -> N
 def test_stats_query_calls_merged_unfiltered_no_limit_uses_flat_distinct() -> None:
     """Unfiltered calls_merged stats with no limit takes the flat distinct-id path.
 
-    Two parallel aggregators on one scan dedupe ids and subtract those with any
-    soft-delete row. Matches the GROUP BY path's exclusion semantics exactly.
+    Inclusion-exclusion on one scan: count(started or deleted) - count(deleted)
+    = distinct non-deleted started ids. op_name (start-only) drops orphaned
+    call-ends, matching the GROUP BY path's exclusion semantics exactly.
     """
     req = tsi.CallsQueryStatsReq(project_id="project")
     pb = ParamBuilder("pb")
@@ -4287,7 +4288,7 @@ def test_stats_query_calls_merged_unfiltered_no_limit_uses_flat_distinct() -> No
         SELECT raw_count AS count,
                toUInt8(0) AS has_more
         FROM (
-            SELECT uniqExact(calls_merged.id) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
+            SELECT uniqExactIf(calls_merged.id, calls_merged.op_name IS NOT NULL OR isNotNull(calls_merged.deleted_at)) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_0:String})
         """,
@@ -4312,7 +4313,7 @@ def test_stats_query_calls_merged_unfiltered_with_limit_caps_in_outer_select() -
         SELECT least(raw_count, 5) AS count,
                toUInt8(raw_count > 5) AS has_more
         FROM (
-            SELECT uniqExact(calls_merged.id) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
+            SELECT uniqExactIf(calls_merged.id, calls_merged.op_name IS NOT NULL OR isNotNull(calls_merged.deleted_at)) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_0:String})
         """,

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -4478,7 +4478,12 @@ def test_stats_query_calls_merged_started_at_fast_path_gates() -> None:
             query=_started_at_query(
                 {
                     "$and": [
-                        {"$gt": [{"$getField": "started_at"}, {"$literal": 1709251200}]},
+                        {
+                            "$gt": [
+                                {"$getField": "started_at"},
+                                {"$literal": 1709251200},
+                            ]
+                        },
                         {"$eq": [{"$getField": "op_name"}, {"$literal": "x"}]},
                     ]
                 }

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -3163,15 +3163,22 @@ def _optimized_unfiltered_calls_merged_count_query(
 ) -> str:
     """Flat distinct-id count for unfiltered calls_merged stats.
 
-    Two parallel aggregators in one scan: total distinct ids minus distinct ids
-    that have any row with deleted_at set. Matches the GROUP BY path's
-    `argMax(deleted_at) IS NULL` exclusion exactly.
+    Counts distinct non-deleted started ids in one scan via inclusion-exclusion:
+    count(started not deleted) = count(started or deleted) - count(deleted).
+    op_name is start-only and deleted_at is delete-row-only (never on the same
+    row), so this matches the GROUP BY path's `op_name IS NOT NULL AND
+    deleted_at IS NULL` HAVING -- dropping orphaned call-ends -- without the
+    second scan an anti-set needs.
     """
     table_name = get_calls_table_name(ReadTable.CALLS_MERGED)
     project_id_slot = param_slot(param_builder.add_param(project_id), "String")
+    op_name_not_null = get_field_by_name("op_name").null_check_sql(
+        param_builder, table_name, ReadTable.CALLS_MERGED, use_agg_fn=False, negate=True
+    )
+    deleted = f"isNotNull({table_name}.deleted_at)"
     raw_count_expr = (
-        f"uniqExact({table_name}.id) "
-        f"- uniqExactIf({table_name}.id, isNotNull({table_name}.deleted_at))"
+        f"uniqExactIf({table_name}.id, {op_name_not_null} OR {deleted}) "
+        f"- uniqExactIf({table_name}.id, {deleted})"
     )
     inner = (
         f"SELECT {raw_count_expr} AS raw_count "

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -3189,12 +3189,12 @@ def _optimized_time_filtered_calls_merged_count_query(
 ) -> str:
     """Distinct-call count for a calls_merged stats request filtered only by time.
 
-    Counts windowed start rows directly with uniqExact -- started_at lives only
-    on the start row, so the per-row predicate equals the GROUP BY path's
-    `any(started_at) <op> T` HAVING (and implies its `op_name IS NOT NULL`).
-    Soft-deleted ids are removed with an anti-set rather than a parallel
-    aggregator, because deleted_at lives on a separate delete row and cannot be
-    correlated to started_at in a single scan.
+    Counts windowed start rows with uniqExact. started_at gates the window;
+    since #6933 call-end rows carry started_at too, we also require op_name
+    (start-only) to be non-null -- that selects the start row and reproduces the
+    GROUP BY path's orphaned-call-end exclusion. Soft-deleted ids are removed
+    with an anti-set rather than a parallel aggregator, because deleted_at lives
+    on a separate delete row and cannot be correlated to started_at in one scan.
 
     The loose `sortable_datetime` prefilter is kept for granule pruning via the
     migration-012 minmax index; the exact `started_at` predicate removes its
@@ -3205,8 +3205,16 @@ def _optimized_time_filtered_calls_merged_count_query(
     table_name = get_calls_table_name(ReadTable.CALLS_MERGED)
     project_id_slot = param_slot(param_builder.add_param(project_id), "String")
 
+    # op_name is start-only, so its non-null-ness selects the start row and
+    # drops orphaned call-ends -- matching the GROUP BY path's HAVING. Required
+    # because since #6933 the end row carries started_at too.
+    op_name_not_null = get_field_by_name("op_name").null_check_sql(
+        param_builder, table_name, ReadTable.CALLS_MERGED, use_agg_fn=False, negate=True
+    )
+
     exact_conditions: list[str] = []
-    prefilter_by_bound: dict[tuple[str, float], str] = {}
+    prefilter_conditions: list[str] = []
+    lower_prefilter_conditions: list[str] = []
     for op_str, timestamp in bounds:
         exact_slot = param_slot(
             param_builder.add_param(timestamp_to_datetime_str(timestamp)), "String"
@@ -3215,23 +3223,21 @@ def _optimized_time_filtered_calls_merged_count_query(
 
         # Loosen toward the past for lower bounds (and toward the future for
         # upper bounds) so the prefilter is a superset of the exact predicate.
+        is_lower = op_str in {">", ">="}
         buffer = (
-            DATETIME_BUFFER_TIME_SECONDS
-            if op_str in {"<", "<="}
-            else -DATETIME_BUFFER_TIME_SECONDS
+            -DATETIME_BUFFER_TIME_SECONDS if is_lower else DATETIME_BUFFER_TIME_SECONDS
         )
         prefilter_slot = param_slot(
             param_builder.add_param(timestamp_to_datetime_str(int(timestamp) + buffer)),
             "String",
         )
-        prefilter_by_bound[op_str, timestamp] = (
-            f"{table_name}.sortable_datetime {op_str} {prefilter_slot}"
-        )
+        prefilter = f"{table_name}.sortable_datetime {op_str} {prefilter_slot}"
+        prefilter_conditions.append(prefilter)
+        if is_lower:
+            lower_prefilter_conditions.append(prefilter)
 
-    outer_prefilter = " AND ".join(prefilter_by_bound[b] for b in bounds)
-    lower_prefilter = " AND ".join(
-        prefilter_by_bound[b] for b in bounds if b[0] in {">", ">="}
-    )
+    outer_prefilter = " AND ".join(prefilter_conditions)
+    lower_prefilter = " AND ".join(lower_prefilter_conditions)
 
     deleted_ids = (
         f"SELECT {table_name}.id FROM {table_name} "
@@ -3244,6 +3250,7 @@ def _optimized_time_filtered_calls_merged_count_query(
         f"PREWHERE {table_name}.project_id = {project_id_slot} "
         f"WHERE {outer_prefilter} "
         f"AND {' AND '.join(exact_conditions)} "
+        f"AND {op_name_not_null} "
         f"AND {table_name}.id NOT IN ({deleted_ids})"
     )
     return _wrap_raw_count_with_limit(inner, limit)
@@ -3292,7 +3299,7 @@ def _is_time_filtered_stats_req(req: tsi.CallsQueryStatsReq) -> bool:
 
 
 _STARTED_AT_FIELD = "started_at"
-_STARTED_AT_BOUND_OPS: dict[type, str] = {
+_STARTED_AT_BOUND_OPS: dict[type[tsi_query.Operation], str] = {
     tsi_query.GtOperation: ">",
     tsi_query.GteOperation: ">=",
     tsi_query.LtOperation: "<",

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -3172,12 +3172,10 @@ def _optimized_unfiltered_calls_merged_count_query(
     """
     table_name = get_calls_table_name(ReadTable.CALLS_MERGED)
     project_id_slot = param_slot(param_builder.add_param(project_id), "String")
-    op_name_not_null = get_field_by_name("op_name").null_check_sql(
-        param_builder, table_name, ReadTable.CALLS_MERGED, use_agg_fn=False, negate=True
-    )
+    started = f"isNotNull({table_name}.op_name)"  # op_name is start-only
     deleted = f"isNotNull({table_name}.deleted_at)"
     raw_count_expr = (
-        f"uniqExactIf({table_name}.id, {op_name_not_null} OR {deleted}) "
+        f"uniqExactIf({table_name}.id, {started} OR {deleted}) "
         f"- uniqExactIf({table_name}.id, {deleted})"
     )
     inner = (
@@ -3215,9 +3213,7 @@ def _optimized_time_filtered_calls_merged_count_query(
     # op_name is start-only, so its non-null-ness selects the start row and
     # drops orphaned call-ends -- matching the GROUP BY path's HAVING. Required
     # because since #6933 the end row carries started_at too.
-    op_name_not_null = get_field_by_name("op_name").null_check_sql(
-        param_builder, table_name, ReadTable.CALLS_MERGED, use_agg_fn=False, negate=True
-    )
+    started = f"isNotNull({table_name}.op_name)"
 
     exact_conditions: list[str] = []
     prefilter_conditions: list[str] = []
@@ -3257,7 +3253,7 @@ def _optimized_time_filtered_calls_merged_count_query(
         f"PREWHERE {table_name}.project_id = {project_id_slot} "
         f"WHERE {outer_prefilter} "
         f"AND {' AND '.join(exact_conditions)} "
-        f"AND {op_name_not_null} "
+        f"AND {started} "
         f"AND {table_name}.id NOT IN ({deleted_ids})"
     )
     return _wrap_raw_count_with_limit(inner, limit)

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -53,6 +53,7 @@ from weave.trace_server.calls_query_builder.object_ref_query_builder import (
     process_query_for_object_refs,
 )
 from weave.trace_server.calls_query_builder.optimization_builder import (
+    DATETIME_BUFFER_TIME_SECONDS,
     process_query_to_optimization_sql,
 )
 from weave.trace_server.calls_query_builder.utils import (
@@ -3078,6 +3079,27 @@ def _try_optimized_stats_query(
             req.project_id, req.limit, param_builder
         )
 
+    # Pattern 4: Time-windowed distinct-call count on calls_merged.
+    #
+    # Generalizes Pattern 3 to a count whose only narrowing is a started_at
+    # time bound: count windowed start rows with uniqExact (started_at lives
+    # only on the start row, so the per-row filter equals the GROUP BY path's
+    # `any(started_at) <op> T` HAVING), and exclude soft-deleted ids via an
+    # anti-set instead of a parallel aggregator (deleted_at lives on a separate
+    # delete row, so it cannot be correlated to started_at in one scan). A lower
+    # bound is required so the anti-set can be windowed too: a call's deleted_at
+    # is always >= its started_at, so deletes of in-window calls land in-window.
+    if (
+        read_table == ReadTable.CALLS_MERGED
+        and req.query is not None
+        and _is_time_filtered_stats_req(req)
+    ):
+        bounds = _extract_started_at_only_bounds(req.query.expr_)
+        if bounds is not None and any(op in {">", ">="} for op, _ in bounds):
+            return _optimized_time_filtered_calls_merged_count_query(
+                req.project_id, req.limit, bounds, param_builder
+            )
+
     return None
 
 
@@ -3156,6 +3178,79 @@ def _optimized_unfiltered_calls_merged_count_query(
         f"FROM {table_name} "
         f"WHERE {table_name}.project_id = {project_id_slot}"
     )
+    return _wrap_raw_count_with_limit(inner, limit)
+
+
+def _optimized_time_filtered_calls_merged_count_query(
+    project_id: str,
+    limit: int | None,
+    bounds: list[tuple[str, float]],
+    param_builder: ParamBuilder,
+) -> str:
+    """Distinct-call count for a calls_merged stats request filtered only by time.
+
+    Counts windowed start rows directly with uniqExact -- started_at lives only
+    on the start row, so the per-row predicate equals the GROUP BY path's
+    `any(started_at) <op> T` HAVING (and implies its `op_name IS NOT NULL`).
+    Soft-deleted ids are removed with an anti-set rather than a parallel
+    aggregator, because deleted_at lives on a separate delete row and cannot be
+    correlated to started_at in a single scan.
+
+    The loose `sortable_datetime` prefilter is kept for granule pruning via the
+    migration-012 minmax index; the exact `started_at` predicate removes its
+    buffer slop. The anti-set is windowed by the lower bound only: a call's
+    deleted_at is always >= its started_at, so every delete of an in-window call
+    also lands in-window and none is missed.
+    """
+    table_name = get_calls_table_name(ReadTable.CALLS_MERGED)
+    project_id_slot = param_slot(param_builder.add_param(project_id), "String")
+
+    exact_conditions: list[str] = []
+    prefilter_by_bound: dict[tuple[str, float], str] = {}
+    for op_str, timestamp in bounds:
+        exact_slot = param_slot(
+            param_builder.add_param(timestamp_to_datetime_str(timestamp)), "String"
+        )
+        exact_conditions.append(f"{table_name}.started_at {op_str} {exact_slot}")
+
+        # Loosen toward the past for lower bounds (and toward the future for
+        # upper bounds) so the prefilter is a superset of the exact predicate.
+        buffer = (
+            DATETIME_BUFFER_TIME_SECONDS
+            if op_str in {"<", "<="}
+            else -DATETIME_BUFFER_TIME_SECONDS
+        )
+        prefilter_slot = param_slot(
+            param_builder.add_param(timestamp_to_datetime_str(int(timestamp) + buffer)),
+            "String",
+        )
+        prefilter_by_bound[op_str, timestamp] = (
+            f"{table_name}.sortable_datetime {op_str} {prefilter_slot}"
+        )
+
+    outer_prefilter = " AND ".join(prefilter_by_bound[b] for b in bounds)
+    lower_prefilter = " AND ".join(
+        prefilter_by_bound[b] for b in bounds if b[0] in {">", ">="}
+    )
+
+    deleted_ids = (
+        f"SELECT {table_name}.id FROM {table_name} "
+        f"PREWHERE {table_name}.project_id = {project_id_slot} "
+        f"WHERE {lower_prefilter} AND isNotNull({table_name}.deleted_at)"
+    )
+    inner = (
+        f"SELECT uniqExact({table_name}.id) AS raw_count "
+        f"FROM {table_name} "
+        f"PREWHERE {table_name}.project_id = {project_id_slot} "
+        f"WHERE {outer_prefilter} "
+        f"AND {' AND '.join(exact_conditions)} "
+        f"AND {table_name}.id NOT IN ({deleted_ids})"
+    )
+    return _wrap_raw_count_with_limit(inner, limit)
+
+
+def _wrap_raw_count_with_limit(inner: str, limit: int | None) -> str:
+    """Wrap a `SELECT ... AS raw_count` inner query in the stats count/has_more shape."""
     if limit is None:
         return f"SELECT raw_count AS count, toUInt8(0) AS has_more FROM ({inner})"
     return (
@@ -3177,6 +3272,98 @@ def _is_unfiltered_stats_req(req: tsi.CallsQueryStatsReq) -> bool:
         and not req.expand_columns
         and _is_minimal_filter(req.filter)
     )
+
+
+def _is_time_filtered_stats_req(req: tsi.CallsQueryStatsReq) -> bool:
+    """True iff the request is a project-scope count narrowed only by a query.
+
+    Gates Pattern 4. The query is further validated to be started_at-only by
+    `_extract_started_at_only_bounds`; here we require a present query, no
+    storage-size rollup, no column expansion, a minimal hardcoded filter, and a
+    non-existence-check limit (limit=1 stays with Patterns 1/2).
+    """
+    return (
+        (req.limit is None or req.limit > 1)
+        and req.query is not None
+        and not req.include_total_storage_size
+        and not req.expand_columns
+        and _is_minimal_filter(req.filter)
+    )
+
+
+_STARTED_AT_FIELD = "started_at"
+_STARTED_AT_BOUND_OPS: dict[type, str] = {
+    tsi_query.GtOperation: ">",
+    tsi_query.GteOperation: ">=",
+    tsi_query.LtOperation: "<",
+    tsi_query.LteOperation: "<=",
+}
+
+
+def _extract_started_at_only_bounds(
+    operand: tsi_query.Operand,
+) -> list[tuple[str, float]] | None:
+    """Return the started_at bounds iff `operand` filters on nothing else.
+
+    Accepts a single gt/gte/lt/lte comparison of `started_at` against a numeric
+    literal (field on the left), or an AND tree of such comparisons. Returns
+    None for any other shape (other fields, OR/NOT, non-numeric literal, field
+    on the right, ...) so the caller falls back to the GROUP BY path.
+    """
+    if isinstance(operand, tsi_query.AndOperation):
+        bounds: list[tuple[str, float]] = []
+        for sub in operand.and_:
+            sub_bounds = _extract_started_at_only_bounds(sub)
+            if sub_bounds is None:
+                return None
+            bounds.extend(sub_bounds)
+        return bounds or None
+
+    if not isinstance(
+        operand,
+        (
+            tsi_query.GtOperation,
+            tsi_query.GteOperation,
+            tsi_query.LtOperation,
+            tsi_query.LteOperation,
+        ),
+    ):
+        return None
+    bound = _started_at_bound_from_comparison(
+        operand, _STARTED_AT_BOUND_OPS[type(operand)]
+    )
+    return [bound] if bound is not None else None
+
+
+def _started_at_bound_from_comparison(
+    operand: tsi_query.GtOperation
+    | tsi_query.GteOperation
+    | tsi_query.LtOperation
+    | tsi_query.LteOperation,
+    op_str: str,
+) -> tuple[str, float] | None:
+    """Return (op_str, unix_seconds) iff `operand` is `started_at <op> <number>`."""
+    if isinstance(operand, tsi_query.GtOperation):
+        left, right = operand.gt_
+    elif isinstance(operand, tsi_query.GteOperation):
+        left, right = operand.gte_
+    elif isinstance(operand, tsi_query.LtOperation):
+        left, right = operand.lt_
+    else:
+        left, right = operand.lte_
+
+    if (
+        not isinstance(left, tsi_query.GetFieldOperator)
+        or left.get_field_ != _STARTED_AT_FIELD
+    ):
+        return None
+    if not isinstance(right, tsi_query.LiteralOperation):
+        return None
+    literal = right.literal_
+    # bool is a subclass of int -- exclude it explicitly.
+    if isinstance(literal, bool) or not isinstance(literal, (int, float)):
+        return None
+    return (op_str, float(literal))
 
 
 def _is_minimal_filter(filter: tsi.CallsFilter | None) -> bool:


### PR DESCRIPTION
## Summary
- Extends #6949's distinct-count fast path to stats counts whose only filter is a `started_at` time window: swaps the GROUP BY + argMax rollup for `uniqExact` over the windowed start rows, excluding soft-deleted ids with an anti-set (deleted_at lives on a separate delete row, so it can't be correlated to started_at in one scan).
- Requires a lower bound so the anti-set is windowed too (a call's `deleted_at` is always >= its `started_at`); upper-bound-only or mixed-field queries fall back to GROUP BY.

## Query shape (unfiltered count, Pattern 3)
Orphaned call-ends have an `id` but no `op_name`. The current prod path excludes them with a GROUP BY + HAVING; the fast path must reproduce that. The old fast path dropped the `op_name` guard and slightly overcounted; the new one restores it in the same single scan via `count(started or deleted) - count(deleted)`:

```sql
-- current prod (GROUP BY rollup; correct but reads/aggregates every row)
SELECT count() FROM (
    SELECT id FROM calls_merged
    PREWHERE project_id = {project}
    GROUP BY (project_id, id)
    HAVING any(deleted_at) IS NULL
       AND any(op_name) IS NOT NULL      -- excludes orphaned call-ends
)

-- old fast path (one scan, but slightly overcounts un-merged orphaned call-ends)
SELECT uniqExact(id)
     - uniqExactIf(id, isNotNull(deleted_at)) AS raw_count
FROM calls_merged WHERE project_id = {project}

-- new fast path (one scan, correct: distinct non-deleted *started* ids)
SELECT uniqExactIf(id, isNotNull(op_name) OR isNotNull(deleted_at))
     - uniqExactIf(id, isNotNull(deleted_at)) AS raw_count
FROM calls_merged WHERE project_id = {project}
```

## Performance
~48.5M-call project, ~30d window, `enable_filesystem_cache=0`; count identical to master.

| | Peak memory | Elapsed | Data read |
|---|---|---|---|
| master (GROUP BY rollup) | 30 GB | 5.15s | 12.64 GB |
| this PR (uniqExact + anti-set) | 2.99 GB | 2.00s | 10.15 GB |
| change | -90% | -61% | -20% |

The orphan-end guard is measured ~free: on a 6M-row local CH table the windowed path is +2% bytes / no wall-clock delta, and the single-scan Pattern 3 fix is +4% bytes (vs +22% time, 2x read for an anti-set form).

## Production impact
Over a recent ~5-day window on a large instance, `calls_query_stats` logged ~918 count-query failures: 598 `TOO_SLOW` timeouts (code 160) + 319 `MEMORY_LIMIT_EXCEEDED` (code 241, 32 GB cap) + 1 timeout. ~724 of those match the exact shapes this PR fast-paths (401 time-windowed with a lower bound + 323 unfiltered Pattern 3) and would no longer hit the GROUP BY rollup; the remaining 194 carry extra filters and still fall back. The -90% memory addresses the 241s and the -61% elapsed/scan addresses most of the 160s.

## Testing
sql-shape unit tests for both fast paths + the two fallback gates; cross-backend integration test asserts the optimized count matches the sqlite reference and excludes soft-deletes and orphaned call-ends (verified on clickhouse: both assertions fail without the op_name guard).
