### PR TITLE
chore(weave_ts): Un-skip `live/` test suites

### DIFF
--- a/sdks/node/package.json
+++ b/sdks/node/package.json
@@ -200,6 +200,7 @@
     "typedoc-plugin-markdown": "^4.2.9",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.61.0",
+    "vcr-test": "^1.4.0",
     "zod": "^4.4.3"
   },
   "packageManager": "pnpm@10.8.1+sha512.c50088ba998c67b8ca8c99df8a5e02fd2ae2e2b29aaf238feaa9e124248d3f48f9fb6db2424949ff901cffbb5e0f0cc1ad6aedb602cd29450751d11c35023677"

--- a/sdks/node/pnpm-lock.yaml
+++ b/sdks/node/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       typescript-eslint:
         specifier: ^8.61.0
         version: 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@5.9.3)
+      vcr-test:
+        specifier: ^1.4.0
+        version: 1.4.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -769,6 +772,10 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@mswjs/interceptors@0.23.0':
+    resolution: {integrity: sha512-JytvDa7pBbxXvCTXBYQs+0eE6MqxpqH/H4peRNY6zVAlvJ6d/hAWLHAef1D9lWN4zuIigN0VkakGOAUrX7FWLg==}
+    engines: {node: '>=18'}
+
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
     peerDependencies:
@@ -786,6 +793,15 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@openai/agents-core@0.11.4':
     resolution: {integrity: sha512-K529uAX9oZV8LUnsv0b+c+nWflIJc+LAJeEfZLN74q0J9UYvyt4pddt30e7OsGS1kPVK/lbChnPCOkPhnd1cpg==}
@@ -1985,6 +2001,9 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  headers-polyfill@3.3.0:
+    resolution: {integrity: sha512-5e57etwBpNcDc0b6KCVWEh/Ro063OxPvzVimUdM0/tsYM/T7Hfy3kknIGj78SFTOhNd8AZY41U8mOHoO4LzmIQ==}
+
   hono@4.12.21:
     resolution: {integrity: sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==}
     engines: {node: '>=16.9.0'}
@@ -2068,6 +2087,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -2566,6 +2588,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   p-all@3.0.0:
     resolution: {integrity: sha512-qUZbvbBFVXm6uJ7U/WDiO0fv6waBMbjlCm4E66oZdRR+egswICarIdHyVSZZHudH8T5SF8x/JG0q0duFzPnlBw==}
     engines: {node: '>=10'}
@@ -2896,6 +2921,9 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
     engines: {node: '>=10'}
@@ -3170,6 +3198,9 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vcr-test@1.4.0:
+    resolution: {integrity: sha512-KkK20bfSdt6BV2FRxoWM19LXArIElSKyKsL5OTQT0K8Rr+1W03VxptsOQftI5bXp3MIUskvP19fRHPg2lUD4Pw==}
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
@@ -4141,6 +4172,15 @@ snapshots:
       - supports-color
     optional: true
 
+  '@mswjs/interceptors@0.23.0':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      headers-polyfill: 3.3.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@emnapi/core': 1.10.0
@@ -4159,6 +4199,15 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@openai/agents-core@0.11.4(ws@8.20.1)(zod@4.4.3)':
     dependencies:
@@ -5492,6 +5541,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  headers-polyfill@3.3.0: {}
+
   hono@4.12.21:
     optional: true
 
@@ -5561,6 +5612,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
 
@@ -6269,6 +6322,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  outvariant@1.4.3: {}
+
   p-all@3.0.0:
     dependencies:
       p-map: 4.0.0
@@ -6626,6 +6681,8 @@ snapshots:
   statuses@2.0.2:
     optional: true
 
+  strict-event-emitter@0.5.1: {}
+
   string-length@4.0.2:
     dependencies:
       char-regex: 1.0.2
@@ -6943,6 +7000,11 @@ snapshots:
 
   vary@1.1.2:
     optional: true
+
+  vcr-test@1.4.0:
+    dependencies:
+      '@mswjs/interceptors': 0.23.0
+      yaml: 2.8.0
 
   walker@1.0.8:
     dependencies:

--- a/sdks/node/src/__tests__/__cassettes__/dataset_should_save_a_dataset.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/dataset_should_save_a_dataset.yaml
@@ -1,0 +1,84 @@
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Tue, 09 Jun 2026 20:38:21 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/table/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"table":{"project_id":"drtangible-mocha/test-project","rows":[{"id":1,"value":2},{"id":2,"value":3},{"id":3,"value":4}]}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "231"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:21 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"03b86e8588d298a1814945664597d94281cb0dbca3b4ff8b0fcff30a6305d33e","row_digests":["mriP98RC2VPGkzk0QeZZ2hq4pUA8fQnhNlsivPxyYYA","DT31YGNzrm7UClL9NXjXYHGXBhYZJsh4Ct9jjBWY74s","1dMFHVoxulzjLOSTzDQMrTQ5ckPCI3aF2487OjvmxJI"]}'
+- request:
+    url: https://trace.wandb.ai/table/query
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"project_id":"drtangible-mocha/test-project","digest":"03b86e8588d298a1814945664597d94281cb0dbca3b4ff8b0fcff30a6305d33e"}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "313"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:22 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"rows":[{"digest":"mriP98RC2VPGkzk0QeZZ2hq4pUA8fQnhNlsivPxyYYA","val":{"id":1,"value":2},"original_index":0},{"digest":"DT31YGNzrm7UClL9NXjXYHGXBhYZJsh4Ct9jjBWY74s","val":{"id":2,"value":3},"original_index":1},{"digest":"1dMFHVoxulzjLOSTzDQMrTQ5ckPCI3aF2487OjvmxJI","val":{"id":3,"value":4},"original_index":2}]}'
+- request:
+    url: https://trace.wandb.ai/obj/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"obj":{"project_id":"drtangible-mocha/test-project","object_id":"Dataset","val":{"_type":"Dataset","_class_name":"Dataset","_bases":["Object","BaseModel"],"rows":"weave:///drtangible-mocha/test-project/table/03b86e8588d298a1814945664597d94281cb0dbca3b4ff8b0fcff30a6305d33e"}}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "78"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:22 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"Q87oPETHV3ZzCsBj9NY1vmb3I6tfYlyH3IfXKHNkaLI","object_id":"Dataset"}'

--- a/sdks/node/src/__tests__/__cassettes__/publishing_various_data_types_publish_various_data_types.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/publishing_various_data_types_publish_various_data_types.yaml
@@ -1,0 +1,856 @@
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Tue, 09 Jun 2026 20:38:21 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/file/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: multipart/form-data; boundary=----formdata-undici-017773695720
+      user-agent: W&B Weave JS Client unknown
+    body: "------formdata-undici-017773695720\r
+
+      Content-Disposition: form-data; name=\"project_id\"\r
+
+      \r
+
+      drtangible-mocha/test-project\r
+
+      ------formdata-undici-017773695720\r
+
+      Content-Disposition: form-data; name=\"file\"; filename=\"blob\"\r
+
+      Content-Type: application/octet-stream\r
+
+      \r
+
+      async function primitive(input) {
+
+      \        return `Hi ${input}!`;
+
+      \    }\r
+
+      ------formdata-undici-017773695720--\r\n"
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "56"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:21 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"6Moqwj0Ocp0Jx7FfEN8VcmmDDcu4l2K53xleNntSB34"}'
+- request:
+    url: https://trace.wandb.ai/obj/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"obj":{"project_id":"drtangible-mocha/test-project","object_id":"primitive","val":{"_type":"CustomWeaveType","weave_type":{"type":"Op"},"files":{"obj.py":"6Moqwj0Ocp0Jx7FfEN8VcmmDDcu4l2K53xleNntSB34"},"load_op":"NO_LOAD_OP"}}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "80"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:22 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"uPPlRCCga9tsuTZwve2Z2gswUYhhX15gb2XS8il0z4s","object_id":"primitive"}'
+- request:
+    url: https://trace.wandb.ai/file/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: multipart/form-data; boundary=----formdata-undici-099944069085
+      user-agent: W&B Weave JS Client unknown
+    body: "------formdata-undici-099944069085\r
+
+      Content-Disposition: form-data; name=\"project_id\"\r
+
+      \r
+
+      drtangible-mocha/test-project\r
+
+      ------formdata-undici-099944069085\r
+
+      Content-Disposition: form-data; name=\"file\"; filename=\"blob\"\r
+
+      Content-Type: application/octet-stream\r
+
+      \r
+
+      async function json(name, age) {
+
+      \        return { name, age };
+
+      \    }\r
+
+      ------formdata-undici-099944069085--\r\n"
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "56"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:22 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"8mDwaUAcA5C6TEdTHf5mjX2kAz6gAXKCmQnDiITXBHY"}'
+- request:
+    url: https://trace.wandb.ai/obj/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"obj":{"project_id":"drtangible-mocha/test-project","object_id":"json","val":{"_type":"CustomWeaveType","weave_type":{"type":"Op"},"files":{"obj.py":"8mDwaUAcA5C6TEdTHf5mjX2kAz6gAXKCmQnDiITXBHY"},"load_op":"NO_LOAD_OP"}}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "75"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:22 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"0NsakCX9GJYyeu65LdlWVO8azws33f39CeKNpidMc50","object_id":"json"}'
+- request:
+    url: https://trace.wandb.ai/call/upsert_batch
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"batch":[{"mode":"start","req":{"start":{"project_id":"drtangible-mocha/test-project","id":"019eae1b-8d23-7a49-9f3b-0ca26737be0a","op_name":"weave:///drtangible-mocha/test-project/op/primitive:uPPlRCCga9tsuTZwve2Z2gswUYhhX15gb2XS8il0z4s","trace_id":"019eae1b-8d23-7a49-9f3b-0ca31d2e406d","started_at":"2026-06-09T20:38:21.731Z","attributes":{"weave":{"client_version":"0.15.1","source":"js-sdk"}},"inputs":{"arg0":"world"}}}},{"mode":"end","req":{"end":{"project_id":"drtangible-mocha/test-project","id":"019eae1b-8d23-7a49-9f3b-0ca26737be0a","ended_at":"2026-06-09T20:38:21.732Z","output":"Hi
+      world!","summary":{}}}}]}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "108"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:22 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"res":[{"id":"019eae1b-8d23-7a49-9f3b-0ca26737be0a","trace_id":"019eae1b-8d23-7a49-9f3b-0ca31d2e406d"},{}]}'
+- request:
+    url: https://trace.wandb.ai/file/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: multipart/form-data; boundary=----formdata-undici-030139909131
+      user-agent: W&B Weave JS Client unknown
+    body: "------formdata-undici-030139909131\r
+
+      Content-Disposition: form-data; name=\"project_id\"\r
+
+      \r
+
+      drtangible-mocha/test-project\r
+
+      ------formdata-undici-030139909131\r
+
+      Content-Disposition: form-data; name=\"file\"; filename=\"blob\"\r
+
+      Content-Type: application/octet-stream\r
+
+      \r
+
+      async function image() {
+
+      \        const width = 16;
+
+      \        const height = 16;
+
+      \        const buffer = Buffer.alloc(width * height * 4); // 4 bytes per
+      pixel (RGBA)
+
+      \        // Deterministic pattern so VCR cassette replays match across
+      runs.
+
+      \        for (let i = 0; i < buffer.length; i++) {
+
+      \            buffer[i] = i % 256;
+
+      \        }
+
+      \        return (0, index_1.weaveImage)({
+
+      \            data: buffer,
+
+      \            imageType: 'png',
+
+      \        });
+
+      \    }\r
+
+      ------formdata-undici-030139909131--\r\n"
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "56"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:22 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"DsZ569GIUUuzvv3fnSnJprV5HvnpMGQtHuluMlNu2dc"}'
+- request:
+    url: https://trace.wandb.ai/call/upsert_batch
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"batch":[{"mode":"start","req":{"start":{"project_id":"drtangible-mocha/test-project","id":"019eae1b-9082-7763-a9fc-81f5c50d955e","op_name":"weave:///drtangible-mocha/test-project/op/json:0NsakCX9GJYyeu65LdlWVO8azws33f39CeKNpidMc50","trace_id":"019eae1b-9082-7763-a9fc-81f6e378a1b6","started_at":"2026-06-09T20:38:22.594Z","attributes":{"weave":{"client_version":"0.15.1","source":"js-sdk"}},"inputs":{"arg0":"Alice","arg1":10}}}},{"mode":"end","req":{"end":{"project_id":"drtangible-mocha/test-project","id":"019eae1b-9082-7763-a9fc-81f5c50d955e","ended_at":"2026-06-09T20:38:22.594Z","output":{"name":"Alice","age":10},"summary":{}}}}]}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "108"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:23 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"res":[{"id":"019eae1b-9082-7763-a9fc-81f5c50d955e","trace_id":"019eae1b-9082-7763-a9fc-81f6e378a1b6"},{}]}'
+- request:
+    url: https://trace.wandb.ai/obj/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"obj":{"project_id":"drtangible-mocha/test-project","object_id":"image","val":{"_type":"CustomWeaveType","weave_type":{"type":"Op"},"files":{"obj.py":"DsZ569GIUUuzvv3fnSnJprV5HvnpMGQtHuluMlNu2dc"},"load_op":"NO_LOAD_OP"}}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "76"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:23 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"JlZ8e9uewWsbOiMpUSopvdzZnZZTadb46dsjw3ZeIXc","object_id":"image"}'
+- request:
+    url: https://trace.wandb.ai/file/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: multipart/form-data; boundary=----formdata-undici-077152610145
+      user-agent: W&B Weave JS Client unknown
+    body: "------formdata-undici-077152610145\r
+
+      Content-Disposition: form-data; name=\"project_id\"\r
+
+      \r
+
+      drtangible-mocha/test-project\r
+
+      ------formdata-undici-077152610145\r
+
+      Content-Disposition: form-data; name=\"file\"; filename=\"blob\"\r
+
+      Content-Type: image/png\r
+
+      \r
+
+      \0\x01\x02\x03\x04\x05\x06\a\b\t
+
+      \v\f\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\e\x1c\x1d\x1e\
+      \x1f
+      !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefg\
+      hijklmnopqrstuvwxyz{|}~�������������������������������������������������\
+      �������������������������������������������������������������������������\
+      ������\0\x01\x02\x03\x04\x05\x06\a\b\t
+
+      \v\f\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\e\x1c\x1d\x1e\
+      \x1f
+      !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefg\
+      hijklmnopqrstuvwxyz{|}~�������������������������������������������������\
+      �������������������������������������������������������������������������\
+      ������\0\x01\x02\x03\x04\x05\x06\a\b\t
+
+      \v\f\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\e\x1c\x1d\x1e\
+      \x1f
+      !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefg\
+      hijklmnopqrstuvwxyz{|}~�������������������������������������������������\
+      �������������������������������������������������������������������������\
+      ������\0\x01\x02\x03\x04\x05\x06\a\b\t
+
+      \v\f\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\e\x1c\x1d\x1e\
+      \x1f
+      !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefg\
+      hijklmnopqrstuvwxyz{|}~�������������������������������������������������\
+      �������������������������������������������������������������������������\
+      ������\r
+
+      ------formdata-undici-077152610145--\r\n"
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "56"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:24 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"eFsHUfwsU9wUpM49gA5p75zhAJ6zJ8z0WKYgnCQsJsk"}'
+- request:
+    url: https://trace.wandb.ai/call/upsert_batch
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"batch":[{"mode":"start","req":{"start":{"project_id":"drtangible-mocha/test-project","id":"019eae1b-9479-7571-9dcb-e476a68c8439","op_name":"weave:///drtangible-mocha/test-project/op/image:JlZ8e9uewWsbOiMpUSopvdzZnZZTadb46dsjw3ZeIXc","trace_id":"019eae1b-9479-7571-9dcb-e4771f8dd1ec","started_at":"2026-06-09T20:38:23.609Z","attributes":{"weave":{"client_version":"0.15.1","source":"js-sdk"}},"inputs":{}}}}]}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "105"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:24 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"res":[{"id":"019eae1b-9479-7571-9dcb-e476a68c8439","trace_id":"019eae1b-9479-7571-9dcb-e4771f8dd1ec"}]}'
+- request:
+    url: https://trace.wandb.ai/file/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: multipart/form-data; boundary=----formdata-undici-062550160634
+      user-agent: W&B Weave JS Client unknown
+    body: "------formdata-undici-062550160634\r
+
+      Content-Disposition: form-data; name=\"project_id\"\r
+
+      \r
+
+      drtangible-mocha/test-project\r
+
+      ------formdata-undici-062550160634\r
+
+      Content-Disposition: form-data; name=\"file\"; filename=\"blob\"\r
+
+      Content-Type: application/octet-stream\r
+
+      \r
+
+      async function audio() {
+
+      \        const sampleRate = 44100; // Standard CD quality
+
+      \        const duration = 0.1; // 100ms
+
+      \        const numSamples = Math.floor(sampleRate * duration);
+
+      \        const buffer = Buffer.alloc(numSamples * 2); // 2 bytes per
+      sample for 16-bit audio
+
+      \        // Deterministic sawtooth so VCR cassette replays match across
+      runs.
+
+      \        for (let i = 0; i < buffer.length; i += 2) {
+
+      \            const sample = ((i / 2) % 65536) - 32768;
+
+      \            buffer.writeInt16LE(sample, i);
+
+      \        }
+
+      \        return (0, index_1.weaveAudio)({
+
+      \            data: buffer,
+
+      \            audioType: 'wav',
+
+      \        });
+
+      \    }\r
+
+      ------formdata-undici-062550160634--\r\n"
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "56"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:24 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"gdu5XikPEiCf2puYTg9i29aLBKMs6TehPZCknNYktkY"}'
+- request:
+    url: https://trace.wandb.ai/obj/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"obj":{"project_id":"drtangible-mocha/test-project","object_id":"audio","val":{"_type":"CustomWeaveType","weave_type":{"type":"Op"},"files":{"obj.py":"gdu5XikPEiCf2puYTg9i29aLBKMs6TehPZCknNYktkY"},"load_op":"NO_LOAD_OP"}}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "76"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:24 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"IG9eXWbmObjYbKa2lC0s3mSBsQnu9BynXYieZ8DQdJ8","object_id":"audio"}'
+- request:
+    url: https://trace.wandb.ai/call/upsert_batch
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"batch":[{"mode":"end","req":{"end":{"project_id":"drtangible-mocha/test-project","id":"019eae1b-9479-7571-9dcb-e476a68c8439","ended_at":"2026-06-09T20:38:23.609Z","output":{"_type":"CustomWeaveType","weave_type":{"type":"PIL.Image.Image"},"files":{"image.png":"eFsHUfwsU9wUpM49gA5p75zhAJ6zJ8z0WKYgnCQsJsk"},"load_op":"NO_LOAD_OP"},"summary":{}}}}]}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "12"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:24 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"res":[{}]}'
+- request:
+    url: https://trace.wandb.ai/file/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: multipart/form-data; boundary=----formdata-undici-010028348208
+      user-agent: W&B Weave JS Client unknown
+    body: "------formdata-undici-010028348208\r
+
+      Content-Disposition: form-data; name=\"project_id\"\r
+
+      \r
+
+      drtangible-mocha/test-project\r
+
+      ------formdata-undici-010028348208\r
+
+      Content-Disposition: form-data; name=\"file\"; filename=\"blob\"\r
+
+      Content-Type: audio/wav\r
+
+      \r
+
+      \0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÀĀŀƀǀȀɀʀˀ̀̀΀πЀрҀӀԀՀր׀؀ـڀۀ܀݀ހ߀����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÁāŁƁǁȁɁʁˁ́́΁ρЁсҁӁԁՁցׁ؁فځہ܁݁ށ߁����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÂĂłƂǂȂɂʂ˂̂͂΂ςЂт҂ӂԂՂւׂ؂قڂۂ܂݂ނ߂����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÃăŃƃǃȃɃʃ˃̃̓΃σЃу҃ӃԃՃփ׃؃كڃۃ܃݃ރ߃����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÄĄńƄǄȄɄʄ˄̄̈́΄τЄф҄ӄԄՄքׄ؄لڄۄ܄݄ބ߄����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÅąŅƅǅȅɅʅ˅̅ͅ΅υЅх҅ӅԅՅօׅ؅مڅۅ܅݅ޅ߅����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÆĆņƆǆȆɆʆˆ̆͆ΆφІц҆ӆԆՆֆ׆؆نچۆ܆݆ކ߆����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÇćŇƇǇȇɇʇˇ͇̇·χЇч҇ӇԇՇևׇ؇هڇۇ܇݇އ߇����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÈĈňƈǈȈɈʈˈ͈̈ΈψЈш҈ӈԈՈֈ׈؈وڈۈ܈݈ވ߈����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÉĉŉƉǉȉɉʉˉ͉̉ΉωЉщ҉ӉԉՉ։׉؉ىډۉ܉݉މ߉����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÊĊŊƊǊȊɊʊˊ̊͊ΊϊЊъҊӊԊՊ֊׊؊يڊۊ܊݊ފߊ����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ËċŋƋǋȋɋʋˋ̋͋΋ϋЋыҋӋԋՋ֋׋؋ًڋۋ܋݋ދߋ����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÌČŌƌǌȌɌʌˌ̌͌ΌόЌьҌӌԌՌ֌׌،ٌڌی܌݌ތߌ����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÍčōƍǍȍɍʍˍ͍̍΍ύЍэҍӍԍՍ֍׍؍ٍڍۍ܍ݍލߍ����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÎĎŎƎǎȎɎʎˎ͎̎ΎώЎюҎӎԎՎ֎׎؎َڎێ܎ݎގߎ����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÏďŏƏǏȏɏʏˏ̏͏ΏϏЏяҏӏԏՏ֏׏؏ُڏۏ܏ݏޏߏ����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�:�;�<�=�>�?�@�A�B�C�D\
+      �E�F�G�H�I�J�K�L�M�N�O�P�Q�R�S�T�U�V�W�X�Y�Z�[�\\�]�^�_�`�a�b�c�d�e�f�g�h\
+      �i�j�k�l�m�n�o�p�q�r�s�t�u�v�w�x�y�z�{�|�}�~����������������������������\
+      �������������������������������������������������������������������������\
+      ���������������������������������ÐĐŐƐǐȐɐʐː̐͐ΐϐАѐҐӐԐՐ֐אِؐڐېܐݐސߐ����������\
+      �����������������������������������\0�\x01�\x02�\x03�\x04�\x05�\x06�\a�\b�\
+      \t�
+
+      �\v�\f�\r�\x0e�\x0f�\x10�\x11�\x12�\x13�\x14�\x15�\x16�\x17�\x18�\x19�\
+      \x1a�\e�\x1c�\x1d�\x1e�\x1f�
+      �!�\"�#�$�%�&�'�(�)�*�+�,�-�.�/�0�1�2�3�4�5�6�7�8�9�\r
+
+      ------formdata-undici-010028348208--\r\n"
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "56"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:25 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"Vo1nyi1S6gru0QMG9l2pZU2VoPFDDv0nDeYcb34oATI"}'
+- request:
+    url: https://trace.wandb.ai/file/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: multipart/form-data; boundary=----formdata-undici-031012413932
+      user-agent: W&B Weave JS Client unknown
+    body: "------formdata-undici-031012413932\r
+
+      Content-Disposition: form-data; name=\"project_id\"\r
+
+      \r
+
+      drtangible-mocha/test-project\r
+
+      ------formdata-undici-031012413932\r
+
+      Content-Disposition: form-data; name=\"file\"; filename=\"blob\"\r
+
+      Content-Type: application/octet-stream\r
+
+      \r
+
+      async function dataset() {
+
+      \        return new index_1.Dataset({
+
+      \            name: 'my-dataset',
+
+      \            rows: [
+
+      \                { name: 'Alice', age: 10 },
+
+      \                { name: 'Bob', age: 20 },
+
+      \                { name: 'Charlie', age: 30 },
+
+      \            ],
+
+      \        });
+
+      \    }\r
+
+      ------formdata-undici-031012413932--\r\n"
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "56"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:26 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"2jp04xe7NEIAwPRPB3o92wung4iUf8JHjASelxMRrQM"}'
+- request:
+    url: https://trace.wandb.ai/call/upsert_batch
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"batch":[{"mode":"start","req":{"start":{"project_id":"drtangible-mocha/test-project","id":"019eae1b-9916-769c-8bc2-c662375f522a","op_name":"weave:///drtangible-mocha/test-project/op/audio:IG9eXWbmObjYbKa2lC0s3mSBsQnu9BynXYieZ8DQdJ8","trace_id":"019eae1b-9916-769c-8bc2-c6633a9877b8","started_at":"2026-06-09T20:38:24.790Z","attributes":{"weave":{"client_version":"0.15.1","source":"js-sdk"}},"inputs":{}}}}]}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-length: "105"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:25 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"res":[{"id":"019eae1b-9916-769c-8bc2-c662375f522a","trace_id":"019eae1b-9916-769c-8bc2-c6633a9877b8"}]}'
+- request:
+    url: https://trace.wandb.ai/obj/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"obj":{"project_id":"drtangible-mocha/test-project","object_id":"dataset","val":{"_type":"CustomWeaveType","weave_type":{"type":"Op"},"files":{"obj.py":"2jp04xe7NEIAwPRPB3o92wung4iUf8JHjASelxMRrQM"},"load_op":"NO_LOAD_OP"}}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "78"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:25 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"zTkOm7AxQhch95UlLWYnYyibbIbWl2UlPF551Woh9LE","object_id":"dataset"}'
+- request:
+    url: https://trace.wandb.ai/table/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"table":{"project_id":"drtangible-mocha/test-project","rows":[{"name":"Alice","age":10},{"name":"Bob","age":20},{"name":"Charlie","age":30}]}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "231"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:26 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"03649e929ba12f08d67e1a76de37177f4eced4190078c92cb6653fb56dcd3825","row_digests":["aMkVu8hYRa5Wvwor5RJfZYTXNa1nYwfn4P7MhSgtKUs","K8wEDqYPFXiHcBAZ4j6YEcYg434Xn7hdsaSvnbQakG0","NQ8XBhd5m0rukJ7rKgqf7IvXU3KdQF2anCFbFqS8WFE"]}'
+- request:
+    url: https://trace.wandb.ai/call/upsert_batch
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"batch":[{"mode":"end","req":{"end":{"project_id":"drtangible-mocha/test-project","id":"019eae1b-9916-769c-8bc2-c662375f522a","ended_at":"2026-06-09T20:38:24.790Z","output":{"_type":"CustomWeaveType","weave_type":{"type":"wave.Wave_read"},"files":{"audio.wav":"Vo1nyi1S6gru0QMG9l2pZU2VoPFDDv0nDeYcb34oATI"},"load_op":"NO_LOAD_OP"},"summary":{}}}}]}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "12"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:26 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"res":[{}]}'
+- request:
+    url: https://trace.wandb.ai/table/query
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"project_id":"drtangible-mocha/test-project","digest":"03649e929ba12f08d67e1a76de37177f4eced4190078c92cb6653fb56dcd3825"}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "334"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:26 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"rows":[{"digest":"aMkVu8hYRa5Wvwor5RJfZYTXNa1nYwfn4P7MhSgtKUs","val":{"name":"Alice","age":10},"original_index":0},{"digest":"K8wEDqYPFXiHcBAZ4j6YEcYg434Xn7hdsaSvnbQakG0","val":{"name":"Bob","age":20},"original_index":1},{"digest":"NQ8XBhd5m0rukJ7rKgqf7IvXU3KdQF2anCFbFqS8WFE","val":{"name":"Charlie","age":30},"original_index":2}]}'
+- request:
+    url: https://trace.wandb.ai/obj/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"obj":{"project_id":"drtangible-mocha/test-project","object_id":"my-dataset","val":{"_type":"Dataset","_class_name":"Dataset","_bases":["Object","BaseModel"],"name":"my-dataset","rows":"weave:///drtangible-mocha/test-project/table/03649e929ba12f08d67e1a76de37177f4eced4190078c92cb6653fb56dcd3825"}}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "81"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:26 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"dpw7LBwphpZwuNG5Xxl6Y7D7x0LlxBdlj87GNifayO4","object_id":"my-dataset"}'
+- request:
+    url: https://trace.wandb.ai/call/upsert_batch
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"batch":[{"mode":"start","req":{"start":{"project_id":"drtangible-mocha/test-project","id":"019eae1b-9e41-7ccb-b4df-507fd0bf5f7c","op_name":"weave:///drtangible-mocha/test-project/op/dataset:zTkOm7AxQhch95UlLWYnYyibbIbWl2UlPF551Woh9LE","trace_id":"019eae1b-9e41-7ccb-b4df-508083e77e36","started_at":"2026-06-09T20:38:26.113Z","attributes":{"weave":{"client_version":"0.15.1","source":"js-sdk"}},"inputs":{}}}}]}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "105"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:26 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"res":[{"id":"019eae1b-9e41-7ccb-b4df-507fd0bf5f7c","trace_id":"019eae1b-9e41-7ccb-b4df-508083e77e36"}]}'

--- a/sdks/node/src/__tests__/__cassettes__/table_example.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/table_example.yaml
@@ -1,0 +1,65 @@
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Tue, 09 Jun 2026 20:38:21 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/table/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"table":{"project_id":"drtangible-mocha/test-project","rows":[{"a":1,"b":2},{"a":3,"b":4},{"a":5,"b":6}]}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "231"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:21 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"d2e5de0d792d9f5636b67ab5c8baf8a7749b4703e89c625303b32405e0b17e77","row_digests":["2El9nYJ3CnBykmEJWqmPfvUVTXr0mfgDe2yiUClnhaY","sPyqicZSNerizfVt6DyxLHL8qEmPTfTyiXbx9OhVhDM","XfhC9dNA5D4taMvhKT4MKN2uce7F56Krsyv4Q6mvVMA"]}'
+- request:
+    url: https://trace.wandb.ai/table/query
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"project_id":"drtangible-mocha/test-project","digest":"d2e5de0d792d9f5636b67ab5c8baf8a7749b4703e89c625303b32405e0b17e77"}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "298"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:22 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"rows":[{"digest":"2El9nYJ3CnBykmEJWqmPfvUVTXr0mfgDe2yiUClnhaY","val":{"a":1,"b":2},"original_index":0},{"digest":"sPyqicZSNerizfVt6DyxLHL8qEmPTfTyiXbx9OhVhDM","val":{"a":3,"b":4},"original_index":1},{"digest":"XfhC9dNA5D4taMvhKT4MKN2uce7F56Krsyv4Q6mvVMA","val":{"a":5,"b":6},"original_index":2}]}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveobject_class_example.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveobject_class_example.yaml
@@ -1,0 +1,106 @@
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Tue, 09 Jun 2026 20:38:21 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/file/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: multipart/form-data; boundary=----formdata-undici-044877044187
+      user-agent: W&B Weave JS Client unknown
+    body: "------formdata-undici-044877044187\r
+
+      Content-Disposition: form-data; name=\"project_id\"\r
+
+      \r
+
+      drtangible-mocha/test-project\r
+
+      ------formdata-undici-044877044187\r
+
+      Content-Disposition: form-data; name=\"file\"; filename=\"blob\"\r
+
+      Content-Type: application/octet-stream\r
+
+      \r
+
+      async method() {
+
+      \        return this.key + '!';
+
+      \    }\r
+
+      ------formdata-undici-044877044187--\r\n"
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "56"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:21 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"5LPCsCuFWEk8TsCrQXF6eeF6hHLA8VzB2BeGgFbl5ng"}'
+- request:
+    url: https://trace.wandb.ai/obj/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"obj":{"project_id":"drtangible-mocha/test-project","object_id":"method","val":{"_type":"CustomWeaveType","weave_type":{"type":"Op"},"files":{"obj.py":"5LPCsCuFWEk8TsCrQXF6eeF6hHLA8VzB2BeGgFbl5ng"},"load_op":"NO_LOAD_OP"}}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "77"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:21 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"NLqQGA8CJAScye11A2W8syN2OOEFFuXgUUzPcNNPR2E","object_id":"method"}'
+- request:
+    url: https://trace.wandb.ai/obj/create
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"obj":{"project_id":"drtangible-mocha/test-project","object_id":"ExampleObject","val":{"_type":"ExampleObject","_class_name":"ExampleObject","_bases":["Object","BaseModel"],"key":"test","value":1,"method":"weave:///drtangible-mocha/test-project/op/method:NLqQGA8CJAScye11A2W8syN2OOEFFuXgUUzPcNNPR2E"}}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "84"
+      content-type: application/json
+      date: Tue, 09 Jun 2026 20:38:21 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"digest":"ZIa9k7irE40Hon8TY88M9F3GjEvvA4BgptYAXkMFYFM","object_id":"ExampleObject"}'

--- a/sdks/node/src/__tests__/helpers/vcrTest.ts
+++ b/sdks/node/src/__tests__/helpers/vcrTest.ts
@@ -1,0 +1,9 @@
+import {withCassette} from './withCassette';
+
+export function vcrTest(
+  name: string,
+  fn: () => Promise<void>,
+  timeout?: number
+) {
+  test(name, () => withCassette(fn), timeout);
+}

--- a/sdks/node/src/__tests__/helpers/withCassette.ts
+++ b/sdks/node/src/__tests__/helpers/withCassette.ts
@@ -1,0 +1,85 @@
+import {join} from 'node:path';
+import {DefaultRequestMatcher, FileStorage, VCR} from 'vcr-test';
+import type {HttpRequest} from 'vcr-test';
+
+const vcr = new VCR(new FileStorage(join(__dirname, '..', '__cassettes__')));
+
+vcr.requestMasker = req => {
+  req.headers['authorization'] = 'masked';
+};
+
+const UUID_V7 =
+  /[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}/g;
+
+const ISO8601 = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/g;
+
+/**
+ * Replace per-run volatile fields (UUIDv7s, ISO timestamps, SDK
+ * `client_version`) in a JSON-ish body with stable placeholders, so cassette
+ * matching survives across runs.
+ */
+function normalizeVolatileBodyFields(req: HttpRequest): HttpRequest {
+  const body = req.body
+    .replace(UUID_V7, '<UUID>')
+    .replace(ISO8601, '<TS>')
+    .replace(/"client_version":"[^"]+"/g, '"client_version":"<VERSION>"');
+
+  return {...req, body: body};
+}
+
+/**
+ * Replace per-request multipart boundary with a stable placeholder
+ * in both the `content-type` header and the body, so cassette matching works
+ * across runs. Non-multipart requests pass through untouched.
+ */
+function normalizeMultipartBoundary(req: HttpRequest): HttpRequest {
+  const contentType = req.headers['content-type'];
+  if (!contentType?.startsWith('multipart/form-data')) {
+    return req;
+  }
+  const match = contentType.match(/boundary=(.+)$/);
+  if (!match) {
+    return req;
+  }
+  const boundary = match[1];
+
+  return {
+    ...req,
+    headers: {...req.headers, 'content-type': 'multipart/form-data'},
+    body: req.body?.split(boundary).join('<BOUNDARY>'),
+  };
+}
+
+function normalizeRequest(req: HttpRequest): HttpRequest {
+  return [normalizeMultipartBoundary, normalizeVolatileBodyFields].reduce(
+    (req, normalizer) => normalizer(req),
+    req
+  );
+}
+
+class Matcher extends DefaultRequestMatcher {
+  override bodiesEqual(recorded: HttpRequest, request: HttpRequest): boolean {
+    return super.bodiesEqual(
+      normalizeRequest(recorded),
+      normalizeRequest(request)
+    );
+  }
+  override headersEqual(recorded: HttpRequest, request: HttpRequest): boolean {
+    return super.headersEqual(
+      normalizeRequest(recorded),
+      normalizeRequest(request)
+    );
+  }
+}
+
+vcr.matcher = new Matcher();
+
+export function withCassette(fn: () => Promise<void>) {
+  const testName = expect.getState().currentTestName!;
+  const cassetteName = testName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '');
+
+  return vcr.useCassette(cassetteName, fn);
+}

--- a/sdks/node/src/__tests__/live/dataset.test.ts
+++ b/sdks/node/src/__tests__/live/dataset.test.ts
@@ -1,13 +1,17 @@
 import {init, login} from '../../clientApi';
 import {Dataset} from '../../dataset';
+import {getWandbConfigs} from '../../wandb/settings';
+import {vcrTest} from '../helpers/vcrTest';
 
-describe.skip('Dataset', () => {
+describe('Dataset', () => {
   beforeEach(async () => {
-    await login(process.env.WANDB_API_KEY ?? '');
+    const {apiKey} = getWandbConfigs();
+    await login(apiKey ?? '');
   });
 
-  test('should save a dataset', async () => {
-    const client = await init('test-project');
+  vcrTest('should save a dataset', async () => {
+    await init('test-project');
+
     const data = [
       {id: 1, value: 2},
       {id: 2, value: 3},
@@ -17,7 +21,7 @@ describe.skip('Dataset', () => {
     const dataset = new Dataset({rows: data});
     const ref = await dataset.save();
 
-    const [entity, project] = ref.projectId.split('/') ?? [];
+    const [_entity, project] = ref.projectId.split('/') ?? [];
     expect(project).toBe('test-project');
 
     // Dataset has same rows as the original data

--- a/sdks/node/src/__tests__/live/publish.test.ts
+++ b/sdks/node/src/__tests__/live/publish.test.ts
@@ -1,9 +1,12 @@
 import {init, login} from '../../clientApi';
 import {Dataset, op, weaveAudio, weaveImage} from '../../index';
+import {getWandbConfigs} from '../../wandb/settings';
+import {vcrTest} from '../helpers/vcrTest';
 
-describe.skip('Publishing Various Data Types', () => {
+describe('Publishing Various Data Types', () => {
   beforeEach(async () => {
-    await login(process.env.WANDB_API_KEY ?? '');
+    const {apiKey} = getWandbConfigs();
+    await login(apiKey ?? '');
   });
 
   const primitiveOp = op(async function primitive(input: string) {
@@ -19,8 +22,9 @@ describe.skip('Publishing Various Data Types', () => {
     const height = 16;
     const buffer = Buffer.alloc(width * height * 4); // 4 bytes per pixel (RGBA)
 
+    // Deterministic pattern so VCR cassette replays match across runs.
     for (let i = 0; i < buffer.length; i++) {
-      buffer[i] = Math.floor(Math.random() * 256);
+      buffer[i] = i % 256;
     }
 
     return weaveImage({
@@ -30,15 +34,14 @@ describe.skip('Publishing Various Data Types', () => {
   });
 
   const audioOp = op(async function audio() {
-    // Create a small audio buffer with random samples
     const sampleRate = 44100; // Standard CD quality
     const duration = 0.1; // 100ms
     const numSamples = Math.floor(sampleRate * duration);
     const buffer = Buffer.alloc(numSamples * 2); // 2 bytes per sample for 16-bit audio
 
+    // Deterministic sawtooth so VCR cassette replays match across runs.
     for (let i = 0; i < buffer.length; i += 2) {
-      // Generate random 16-bit sample between -32768 and 32767
-      const sample = Math.floor(Math.random() * 65536 - 32768);
+      const sample = ((i / 2) % 65536) - 32768;
       buffer.writeInt16LE(sample, i);
     }
 
@@ -59,25 +62,29 @@ describe.skip('Publishing Various Data Types', () => {
     });
   });
 
-  test('publish various data types', async () => {
-    const client = await init('test-project');
+  vcrTest(
+    'publish various data types',
+    async () => {
+      const _client = await init('test-project');
 
-    const primitiveResult = await primitiveOp('world');
-    expect(primitiveResult).toBe('Hi world!');
+      const primitiveResult = await primitiveOp('world');
+      expect(primitiveResult).toBe('Hi world!');
 
-    const jsonResult = await jsonOp('Alice', 10);
-    expect(jsonResult).toEqual({name: 'Alice', age: 10});
+      const jsonResult = await jsonOp('Alice', 10);
+      expect(jsonResult).toEqual({name: 'Alice', age: 10});
 
-    const imageResult = await imageOp();
-    expect(imageResult).toHaveProperty('data');
-    expect(imageResult).toHaveProperty('imageType', 'png');
+      const imageResult = await imageOp();
+      expect(imageResult).toHaveProperty('data');
+      expect(imageResult).toHaveProperty('imageType', 'png');
 
-    const audioResult = await audioOp();
-    expect(audioResult).toHaveProperty('data');
-    expect(audioResult).toHaveProperty('audioType', 'wav');
+      const audioResult = await audioOp();
+      expect(audioResult).toHaveProperty('data');
+      expect(audioResult).toHaveProperty('audioType', 'wav');
 
-    const datasetResult = await datasetOp();
-    expect(datasetResult).toBeInstanceOf(Dataset);
-    expect(datasetResult.rows).toHaveLength(3);
-  }, 20000); // Adding explicit timeout here, though I'm not sure why it's needed
+      const datasetResult = await datasetOp();
+      expect(datasetResult).toBeInstanceOf(Dataset);
+      expect(datasetResult.rows).toHaveLength(3);
+    },
+    20000
+  ); // Adding explicit timeout here, though I'm not sure why it's needed
 });

--- a/sdks/node/src/__tests__/live/table.test.ts
+++ b/sdks/node/src/__tests__/live/table.test.ts
@@ -1,12 +1,15 @@
 import {init, login} from '../../clientApi';
 import {Table} from '../../table';
+import {getWandbConfigs} from '../../wandb/settings';
+import {vcrTest} from '../helpers/vcrTest';
 
-describe.skip('Table', () => {
+describe('Table', () => {
   beforeEach(async () => {
-    await login(process.env.WANDB_API_KEY ?? '');
+    const {apiKey} = getWandbConfigs();
+    await login(apiKey ?? '');
   });
 
-  test('example', async () => {
+  vcrTest('example', async () => {
     // Table behaves like a container of rows
     const rows = [
       {a: 1, b: 2},

--- a/sdks/node/src/__tests__/live/weaveObject.test.ts
+++ b/sdks/node/src/__tests__/live/weaveObject.test.ts
@@ -1,6 +1,8 @@
 import {init, login} from '../../clientApi';
 import {op} from '../../op';
 import {WeaveObject} from '../../weaveObject';
+import {getWandbConfigs} from '../../wandb/settings';
+import {vcrTest} from '../helpers/vcrTest';
 
 class ExampleObject extends WeaveObject {
   constructor(
@@ -17,9 +19,10 @@ class ExampleObject extends WeaveObject {
   }
 }
 
-describe.skip('WeaveObject', () => {
+describe('WeaveObject', () => {
   beforeEach(async () => {
-    await login(process.env.WANDB_API_KEY ?? '');
+    const {apiKey} = getWandbConfigs();
+    await login(apiKey ?? '');
   });
 
   test('basic-example', async () => {
@@ -31,7 +34,7 @@ describe.skip('WeaveObject', () => {
     // console.log(ref);
   });
 
-  test('class-example', async () => {
+  vcrTest('class-example', async () => {
     const client = await init('test-project');
     const obj = new ExampleObject('test', 1);
 
@@ -39,7 +42,7 @@ describe.skip('WeaveObject', () => {
     client.publish(obj);
 
     const ref = await obj.__savedRef;
-    const [entity, project] = ref?.projectId.split('/') ?? [];
+    const [_entity, project] = ref?.projectId.split('/') ?? [];
     expect(project).toBe('test-project');
     console.log(ref);
 


### PR DESCRIPTION
## Description

* Update: rather than removing these tests that haven't been running for ~16months, introducing some mocking that should allow us to un-`skip` them.

* The tests in `live/` act as integration tests, but are currently skipped. If we record their interaction with the network and replay it in tests, they should be less flaky.

* Similarly, a lot of our tests around our integrations with 3rd-party APIs would benefit from less manual mocking -- if we can record against an actual contract, we'll be less likely to introduce errors.

* Python side already uses https://vcrpy.readthedocs.io/en/latest/, this change introduces `vcr-test` for similar network recording / playback on the javascript side.

* Cassettes live in `/__tests__/cassettes/`, and are automatically recorded when not present.

* This library is a small wrapper on top of https://mswjs.io/, which has some other cool stuff we could potentially leverage, such as auto-mocking based on an OpenAPI spec.

* This change unskips the tests in `/live/`, and introduces a couple test helpers:
  * `withCassette()` for specifying that a fn should mock network requests w/a recorded cassette
  * `vcrTest` for automatically wrapping a test case `withCassette`.

