### PR TITLE
chore(weave): retry flaky genai agent query tests

### DIFF
--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -185,6 +185,7 @@ def test_group_by_trace_id(ch_server):
 # ---------------------------------------------------------------------------
 
 
+# flaky: CI ClickHouse occasionally doesn't surface the just-inserted spans to the immediate read.
 @pytest.mark.flaky(reruns=3)
 def test_group_by_conversation_id(ch_server):
     """Grouping spans by conversation_id returns per-conversation aggregates."""
@@ -748,6 +749,7 @@ def test_spans_query_filters_sorts_and_projects_custom_attrs(ch_server):
 # ---------------------------------------------------------------------------
 
 
+# flaky: CI ClickHouse occasionally doesn't surface the just-inserted spans to the immediate read.
 @pytest.mark.flaky(reruns=3)
 def test_agent_span_stats_ungrouped_metrics(ch_server):
     """Stats API returns requested token, duration, error, and invocation metrics."""

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -185,6 +185,7 @@ def test_group_by_trace_id(ch_server):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.flaky(reruns=3)
 def test_group_by_conversation_id(ch_server):
     """Grouping spans by conversation_id returns per-conversation aggregates."""
     project_id = _make_project_id("convs")
@@ -747,6 +748,7 @@ def test_spans_query_filters_sorts_and_projects_custom_attrs(ch_server):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.flaky(reruns=3)
 def test_agent_span_stats_ungrouped_metrics(ch_server):
     """Stats API returns requested token, duration, error, and invocation metrics."""
     project_id = _make_project_id("stats")


### PR DESCRIPTION
WB-35048

## Summary.
- Spans inserted via `ch_client.insert("spans", ...)` are occasionally not visible to the immediately-following read under CI ClickHouse. No production retry gap: production ingests via OTel (same insert call) then queries from the UI later, never reading its own write within ms. Same class as #6852.

TODO:
- build into the test suite a read after write handler to fix all of these.

Original failures ([3,10](https://github.com/wandb/weave/actions/runs/26788728287/job/78970293659), [3,11](https://github.com/wandb/weave/actions/runs/26788728287/job/78970293767)):
```
test_group_by_conversation_id - AssertionError: assert "conv-29be9732" in {}
test_agent_span_stats_ungrouped_metrics - assert 0.0 == 300
```

## Testing
test only change.