### PR TITLE
chore(weave_ts): Remove unused getOpParameterNames fn

### DIFF
--- a/sdks/node/src/opType.ts
+++ b/sdks/node/src/opType.ts
@@ -99,10 +99,6 @@ export function getOpName(opValue: Op<any>): string {
   return opValue.__name;
 }
 
-export function getOpParameterNames(opValue: Op<any>): ParameterNamesOption {
-  return opValue.__parameterNames;
-}
-
 export class OpRef {
   constructor(
     public projectId: string,

--- a/sdks/node/src/weaveObject.ts
+++ b/sdks/node/src/weaveObject.ts
@@ -3,8 +3,6 @@ import {isOp} from './op';
 import {getGlobalDomain} from './urls';
 import {parseWeaveUri} from './uriParser';
 
-export interface Callable {}
-
 export interface WeaveObjectParameters {
   name?: string;
   description?: string;


### PR DESCRIPTION
## Description

* Removes an unused function `getOpParameterNames`.