### PR TITLE
fix(weave): return count=0 from table_query_stats for missing digest

### DIFF
--- a/tests/trace/test_table_query.py
+++ b/tests/trace/test_table_query.py
@@ -307,6 +307,19 @@ def test_table_query_stats_missing(client: WeaveClient):
     assert len(stats_res.tables) == 0
 
 
+def test_table_query_stats_legacy_missing(client: WeaveClient):
+    # The legacy single-digest endpoint must not IndexError when the digest
+    # doesn't exist; it should report count=0.
+    stats_res = client.server.table_query_stats(
+        tsi.TableQueryStatsReq(
+            project_id=client.project_id,
+            digest="missing",
+        )
+    )
+
+    assert stats_res.count == 0
+
+
 def generate_duplication_simple_table_data(
     client: WeaveClient, n_rows: int, copy_count: int
 ):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2688,8 +2688,6 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         res = self.table_query_stats_batch(batch_req)
 
-        # A missing/deleted/mismatched digest returns no rows, so the batch
-        # result is empty. Treat that as a not-found (count=0) rather than 500ing.
         if len(res.tables) != 1:
             logger.warning(
                 "Unexpected number of table_query_stats results: %d", len(res.tables)

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2688,10 +2688,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         res = self.table_query_stats_batch(batch_req)
 
-        if len(res.tables) != 1:
-            logger.warning(
-                "Unexpected number of table_query_stats results: %d", len(res.tables)
-            )
+        if len(res.tables) == 0:
+            logger.warning("No table_query_stats results for digest %s", req.digest)
             return tsi.TableQueryStatsRes(count=0)
 
         count = res.tables[0].count

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -2688,8 +2688,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         res = self.table_query_stats_batch(batch_req)
 
+        # A missing/deleted/mismatched digest returns no rows, so the batch
+        # result is empty. Treat that as a not-found (count=0) rather than 500ing.
         if len(res.tables) != 1:
-            logger.exception(RuntimeError("Unexpected number of results", res))
+            logger.warning(
+                "Unexpected number of table_query_stats results: %d", len(res.tables)
+            )
+            return tsi.TableQueryStatsRes(count=0)
 
         count = res.tables[0].count
         return tsi.TableQueryStatsRes(count=count)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -2547,8 +2547,6 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
 
         res = self.table_query_stats_batch(batch_req)
 
-        # A missing/deleted/mismatched digest returns no rows, so the batch
-        # result is empty. Treat that as a not-found (count=0) rather than erroring.
         if len(res.tables) != 1:
             logger.warning(
                 "Unexpected number of table_query_stats results: %d", len(res.tables)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -2547,8 +2547,13 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
 
         res = self.table_query_stats_batch(batch_req)
 
+        # A missing/deleted/mismatched digest returns no rows, so the batch
+        # result is empty. Treat that as a not-found (count=0) rather than erroring.
         if len(res.tables) != 1:
-            raise RuntimeError("Unexpected number of results", res)
+            logger.warning(
+                "Unexpected number of table_query_stats results: %d", len(res.tables)
+            )
+            return tsi.TableQueryStatsRes(count=0)
 
         count = res.tables[0].count
         return tsi.TableQueryStatsRes(count=count)

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -2547,10 +2547,8 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
 
         res = self.table_query_stats_batch(batch_req)
 
-        if len(res.tables) != 1:
-            logger.warning(
-                "Unexpected number of table_query_stats results: %d", len(res.tables)
-            )
+        if len(res.tables) == 0:
+            logger.warning("No table_query_stats results for digest %s", req.digest)
             return tsi.TableQueryStatsRes(count=0)
 
         count = res.tables[0].count


### PR DESCRIPTION
## Summary
- Legacy `table_query_stats` indexed `res.tables[0]` even when the batch result was empty, 500ing for a nonexistent/deleted/mismatched digest (`IndexError` on CH, `RuntimeError` on sqlite). Now logs and returns `count=0`.
- [WB-35053](https://coreweave.atlassian.net/browse/WB-35053)

## Testing
adds `test_table_query_stats_legacy_missing`, passes on sqlite + clickhouse

[WB-35053]: https://coreweave.atlassian.net/browse/WB-35053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ