### PR TITLE
fix(weave): resolve ref-extracted output.scores in eval_results

### DIFF
--- a/tests/trace_server/test_eval_results_genai_span_ref.py
+++ b/tests/trace_server/test_eval_results_genai_span_ref.py
@@ -148,3 +148,26 @@ def test_extract_genai_span_refs_skips_invalid_items() -> None:
     assert eval_helpers.extract_genai_span_refs(call) == [
         tsi.GenAISpanRef.model_validate(_genai_span_ref("valid-trace"))
     ]
+
+
+def test_build_eval_rows_handles_ref_extracted_scores() -> None:
+    predict_and_score_call = _call(
+        call_id="pas-1",
+        inputs={"example": {"x": 1}, "model": "model://agent"},
+        output={
+            "output": "result",
+            "scores": "weave-trace-internal:///project-1/object/scores:abc123/key/scores",
+        },
+    )
+
+    rows = eval_helpers.build_eval_rows(
+        [predict_and_score_call],
+        ["eval-1"],
+        {"pas-1": "row-1"},
+        include_raw_data_rows=False,
+        include_predict_and_score_children=False,
+    )
+
+    trial = rows[0].evaluations[0].trials[0]
+    assert trial.scores == {}
+    assert trial.scorer_call_ids == {}

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 import os
+from typing import Any
 from unittest import mock
 from unittest.mock import patch
 
@@ -13,10 +14,13 @@ from tests.trace_server.completions_util import with_simple_mock_litellm_complet
 from weave.trace.refs import ObjectRef
 from weave.trace.serialization.custom_objs import UnsafeDeserializationError
 from weave.trace.weave_client import WeaveClient, generate_id
+from weave.trace_server import constants
+from weave.trace_server import eval_results_helpers as eval_helpers
 from weave.trace_server.errors import InvalidRequest
 from weave.trace_server.interface.query import Query
 from weave.trace_server.trace_server_interface import (
     CallEndReq,
+    CallSchema,
     CallsDeleteReq,
     CallsQueryReq,
     CallStartReq,
@@ -795,6 +799,62 @@ def test_eval_results_resolve_refs_only_for_paginated_rows(client):
     for call in refs_read_batch_calls:
         # only resolve refs for the paginated slice, not all rows
         assert len(call.refs) <= 2
+
+
+def _pas_call(call_id: str, project_id: str, scores: Any) -> CallSchema:
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    return CallSchema(
+        id=call_id,
+        project_id=project_id,
+        trace_id="trace-1",
+        parent_id="eval-1",
+        op_name=constants.EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+        started_at=now,
+        ended_at=now,
+        attributes={},
+        inputs={"example": {"x": 1}, "model": "model://agent"},
+        output={"output": "result", "scores": scores},
+        summary={},
+    )
+
+
+def test_resolve_eval_score_refs_internal_only(client):
+    """Only internal-scheme score refs are routed to resolution; external/inline are untouched.
+
+    A real internal ref cannot be resolved in this harness (refs_read_batch needs an
+    entity/project id, parse_internal_uri needs a slash-free one), so this asserts the
+    detection/guard contract end-to-end: an internal ref degrades to {} without crashing,
+    while external refs and inline dicts pass through unchanged.
+    """
+    internal_ref = "weave-trace-internal:///pid/object/Scores:abc123/key/scores"
+    external_ref = "weave:///entity/project/object/Scores:abc123/key/scores"
+    inline = {"already": {"true_fraction": 0.5}}
+    calls = [
+        _pas_call("c-int", client.project_id, internal_ref),
+        _pas_call("c-ext", client.project_id, external_ref),
+        _pas_call("c-inline", client.project_id, inline),
+    ]
+
+    warnings = eval_helpers.resolve_eval_score_refs(client.server, calls)
+
+    assert isinstance(
+        warnings, list
+    )  # internal ref unresolvable here -> graceful, no raise
+    assert calls[0].output["scores"] == internal_ref  # left in place
+    assert (
+        calls[1].output["scores"] == external_ref
+    )  # external never treated as resolvable
+    assert calls[2].output["scores"] == inline  # inline dict untouched
+
+    rows = eval_helpers.build_eval_rows(
+        calls,
+        ["eval-1"],
+        {"c-int": "r1", "c-ext": "r2", "c-inline": "r3"},
+        include_raw_data_rows=False,
+        include_predict_and_score_children=False,
+    )
+    trial_scores = {r.row_digest: r.evaluations[0].trials[0].scores for r in rows}
+    assert trial_scores == {"r1": {}, "r2": {}, "r3": inline}
 
 
 def test_eval_subtree_query_excludes_unrelated_top_level_calls(client, internal_server):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5577,6 +5577,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 )
                 page_calls.extend(self.calls_query_stream(child_req))
 
+        score_ref_warnings = eval_helpers.resolve_eval_score_refs(self, page_calls)
+
         all_rows = eval_helpers.build_eval_rows(
             page_calls,
             eval_root_ids,
@@ -5604,7 +5606,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         # apply pagination in python if include_summary is True; otherwise, we already applied pagination in the CH query
         rows: list[tsi.EvalResultsRow] = []
-        warnings: list[str] = []
+        warnings: list[str] = list(score_ref_warnings)
         if req.include_rows:
             if req.include_summary:
                 # all_rows has everything; apply pagination in Python

--- a/weave/trace_server/eval_results_helpers.py
+++ b/weave/trace_server/eval_results_helpers.py
@@ -335,7 +335,8 @@ def _build_trial(
         if isinstance(predict_and_score_call.output, dict)
         else {}
     )
-    scores = output.get("scores", {})
+    raw_scores = output.get("scores", {})
+    scores = raw_scores if isinstance(raw_scores, dict) else {}
     trial_children = child_by_parent.get(predict_and_score_call.id, [])
     model_ref = (
         predict_and_score_call.inputs.get("model")
@@ -542,6 +543,53 @@ def resolve_eval_row_refs(
     return []
 
 
+@ddtrace.tracer.wrap(name="eval_results_helpers.resolve_eval_score_refs")
+def resolve_eval_score_refs(
+    server: tsi.TraceServerInterface,
+    calls: list[tsi.CallSchema],
+) -> list[str]:
+    """Inline ref-extracted `output.scores` values in-place via refs_read_batch.
+
+    When the SDK ref-extracts the scores dict, the call output stores an internal
+    ref string for that key; resolve it so trials get a dict, not a ref.
+
+    Returns:
+        list[str]: Warnings if resolution failed (e.g. refs_read_batch error).
+    """
+    pending: list[tuple[dict[str, Any], str]] = []
+    for call in calls:
+        output = call.output
+        if not isinstance(output, dict):
+            continue
+        scores = output.get("scores")
+        if not isinstance(scores, str) or not scores.startswith(
+            f"{ri.WEAVE_INTERNAL_SCHEME}:///"
+        ):
+            continue
+        try:
+            parsed = ri.parse_internal_uri(scores)
+        except ri.InvalidInternalRef:
+            continue
+        if not isinstance(parsed, ri.InternalObjectRef):
+            continue
+        pending.append((output, scores))
+    if not pending:
+        return []
+    try:
+        refs_res = server.refs_read_batch(
+            tsi.RefsReadBatchReq(refs=[ref for _, ref in pending])
+        )
+    except Exception:
+        logger.warning("Failed to resolve eval score refs", exc_info=True)
+        return [
+            "Failed to resolve eval score refs; scores may be missing for some rows"
+        ]
+    for (output, _), val in zip(pending, refs_res.vals, strict=False):
+        if isinstance(val, dict):
+            output["scores"] = val
+    return []
+
+
 @ddtrace.tracer.wrap(name="eval_results_helpers.eval_results_grouped_rows")
 def eval_results_grouped_rows(
     req: tsi.EvalResultsQueryReq,
@@ -640,11 +688,11 @@ def eval_results_query(
         limit=None,
         offset=0,
     )
+    warnings: list[str] = resolve_eval_score_refs(server, all_calls)
     all_rows, _ = eval_results_grouped_rows(all_rows_req, eval_root_ids, all_calls)
 
     rows: list[tsi.EvalResultsRow] = []
     total_rows = 0
-    warnings: list[str] = []
     if req.include_rows:
         rows, total_rows = apply_row_selection(
             all_rows,
@@ -654,7 +702,7 @@ def eval_results_query(
             req.limit,
         )
         if req.include_raw_data_rows and req.resolve_row_refs:
-            warnings = resolve_eval_row_refs(server, rows, req.project_id)
+            warnings.extend(resolve_eval_row_refs(server, rows, req.project_id))
 
     summary: tsi.EvalResultsSummaryRes | None = None
     if req.include_summary:


### PR DESCRIPTION
## Summary
- eval_results 500'd building `EvalResultsTrial.scores` when `output.scores` was ref-extracted by the SDK (stored as a ref string, not a dict). Resolve those refs via `refs_read_batch` in both query paths, plus a non-dict guard in `_build_trial`.
- Jira: https://coreweave.atlassian.net/browse/WB-35058

## Testing
data-level guard test, plus a functional resolve test using the real `refs_read_batch`.
