### PR TITLE
fix(weave): send clickhouse settings to server instead of rejecting client-side

### DIFF
--- a/tests/trace_server/test_clickhouse_utilities.py
+++ b/tests/trace_server/test_clickhouse_utilities.py
@@ -1,7 +1,29 @@
 from unittest.mock import MagicMock, patch
 
+from clickhouse_connect import common as ch_common
+from clickhouse_connect.driver.httpclient import HttpClient
+
 from weave.trace_server import clickhouse_trace_server_batched as chts
+from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server.clickhouse.utilities import sanitize_invalid_utf8_surrogates
+
+
+def test_poisoned_client_settings_are_sent_not_rejected() -> None:
+    # A client minted during a CH degradation window caches an empty/readonly
+    # server_settings map; 'send' lets the rejected weave settings reach the server.
+    assert ch_common.get_setting("invalid_setting_action") == "send"
+
+    poisoned = HttpClient.__new__(HttpClient)
+    poisoned.server_settings = {}
+    poisoned.optional_transport_settings = set()
+
+    settings = {
+        **ch_settings.CLICKHOUSE_DEFAULT_QUERY_SETTINGS,
+        **ch_settings.CLICKHOUSE_ASYNC_INSERT_SETTINGS,
+    }
+    validated = poisoned._validate_settings(settings)
+
+    assert validated == settings
 
 
 def test_sanitize_invalid_utf8_surrogates_replaces_lone_surrogates() -> None:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -17,6 +17,7 @@ from zoneinfo import ZoneInfo
 import clickhouse_connect
 import ddtrace
 from cachetools import TTLCache
+from clickhouse_connect import common as ch_common
 from clickhouse_connect.driver.client import Client as CHClient
 from clickhouse_connect.driver.exceptions import DatabaseError
 from clickhouse_connect.driver.httputil import get_pool_manager
@@ -348,6 +349,10 @@ OBJ_READ_RETRY_ATTEMPTS = 3
 _CH_POOL_MANAGER = get_pool_manager(
     maxsize=CH_POOL_MAX_CONNECTIONS, num_pools=CH_POOL_COUNT
 )
+
+# Send query settings to the server instead of rejecting them against the client's
+# cached server_settings map, which is poisoned when minted during a CH degradation.
+ch_common.set_setting("invalid_setting_action", "send")
 
 
 # Precomputed list of (column_index, field_name) for every sentinel field that appears


### PR DESCRIPTION
## Summary
- A clickhouse-connect client minted during a CH Cloud degradation window caches an empty/readonly `server_settings` map, so client-side validation rejects every query setting (`Setting <x> is unknown or readonly`) for the client's lifetime, dropping inserts and failing reads in bursts.
- Fix: set `invalid_setting_action='send'` once at module load so settings go to the server (the real authority) instead of being validated against the poisoned cache. With a healthy cache it's a no-op; the warning only fires during the poison window.
- Supersedes the earlier re-mint/retry approach (was 4 files, 18 call-sites) with a 1-line change.
- WB-35057: https://coreweave.atlassian.net/browse/WB-35057

## Testing
unit: poisoned client (empty `server_settings`) now passes weave's query+async-insert settings through `_validate_settings` instead of raising. verified the pre-fix default raises the exact prod error.