### PR TITLE
chore(weave): retry-once proxy to mask clickhouse read-after-write lag in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,7 @@ from fastapi.testclient import TestClient
 import weave
 from tests.trace.util import DummyTestException
 from tests.trace_server.conftest import TEST_ENTITY, get_trace_server_flag
+from tests.trace_server.eventually_consistent import EventuallyConsistentServer
 from weave.trace import weave_client, weave_init
 from weave.trace.context import weave_client_context
 from weave.trace.context.call_context import set_call_stack
@@ -460,6 +461,11 @@ def create_client(
         server = RemoteHTTPTraceServer(trace_server_flag)
     else:
         server = trace_server
+
+    # On ClickHouse, retry reads once on empty/not-found below the cache to mask
+    # rare read-your-write lag (WB-35048). SQLite is synchronous, so skip it.
+    if trace_server_flag == "clickhouse":
+        server = EventuallyConsistentServer(server)
 
     # Removing this as it lead to passing tests that were not passing in prod!
     # Keeping off for now until it is the default behavior.

--- a/tests/trace/data_serialization/test_serialization_correctness.py
+++ b/tests/trace/data_serialization/test_serialization_correctness.py
@@ -51,7 +51,6 @@ def set_weave_logger_to_debug():
     cases,
     ids=lambda case: case.id,
 )
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
 def test_serialization_correctness(
     client, case: SerializationTestCase, set_weave_logger_to_debug
 ):

--- a/tests/trace/server_utils.py
+++ b/tests/trace/server_utils.py
@@ -11,7 +11,14 @@ T = TypeVar("T")
 TEST_ENTITY = "shawn"
 
 # Attribute names used by each middleware layer to reference the next server.
-_NEXT_SERVER_ATTRS = ("server", "_next_trace_server", "_internal_trace_server")
+# `_inner` (EventuallyConsistentServer) is checked first: its __getattr__ would
+# otherwise delegate `_internal_trace_server` to the layer below, skipping it.
+_NEXT_SERVER_ATTRS = (
+    "_inner",
+    "server",
+    "_next_trace_server",
+    "_internal_trace_server",
+)
 
 
 def find_server_layer(server: tsi.TraceServerInterface, layer_type: type[T]) -> T:

--- a/tests/trace/server_utils.py
+++ b/tests/trace/server_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TypeVar
 
+from tests.trace_server.eventually_consistent import EventuallyConsistentServer
 from weave.trace_server import trace_server_interface as tsi
 
 T = TypeVar("T")
@@ -11,14 +12,7 @@ T = TypeVar("T")
 TEST_ENTITY = "shawn"
 
 # Attribute names used by each middleware layer to reference the next server.
-# `_inner` (EventuallyConsistentServer) is checked first: its __getattr__ would
-# otherwise delegate `_internal_trace_server` to the layer below, skipping it.
-_NEXT_SERVER_ATTRS = (
-    "_inner",
-    "server",
-    "_next_trace_server",
-    "_internal_trace_server",
-)
+_NEXT_SERVER_ATTRS = ("server", "_next_trace_server", "_internal_trace_server")
 
 
 def find_server_layer(server: tsi.TraceServerInterface, layer_type: type[T]) -> T:
@@ -37,6 +31,12 @@ def find_server_layer(server: tsi.TraceServerInterface, layer_type: type[T]) -> 
         if obj_id in visited:
             break
         visited.add(obj_id)
+        # EventuallyConsistentServer is a transparent proxy: its __getattr__
+        # forwards `_internal_trace_server` to the layer below, which would skip
+        # that layer. Step into its real child explicitly instead.
+        if isinstance(current, EventuallyConsistentServer):
+            current = current._inner
+            continue
         next_layer = None
         for attr in _NEXT_SERVER_ATTRS:
             next_layer = getattr(current, attr, None)

--- a/tests/trace/test_base_object_classes.py
+++ b/tests/trace/test_base_object_classes.py
@@ -176,7 +176,6 @@ def test_pythonic_creation(client: WeaveClient):
     assert inherited_obj_result.val == expected_inherited_val
 
 
-@pytest.mark.flaky(reruns=3)
 def test_interface_creation(client):
     # Now we will do the equivant operation using low-level interface.
     nested_obj_id = "TestOnlyNestedBaseObject"

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -97,7 +97,6 @@ def get_client_project_id(client: weave_client.WeaveClient) -> str:
 ## End hacky interface compatibility helpers
 
 
-@pytest.mark.flaky(reruns=2, reruns_delay=0.2)
 def test_simple_op(client):
     @weave.op
     def my_op(a: int) -> int:
@@ -903,9 +902,6 @@ def test_trace_call_query_filter_trace_roots_only(client, no_autoflush):
         assert len(inner_res.calls) == exp_count
 
 
-# Flaky against ClickHouse in CI: read-after-write visibility lag means a
-# calls_query right after flush can miss just-written rows. Rerun to absorb it.
-@pytest.mark.flaky(reruns=2)
 def test_trace_call_query_filter_wb_run_ids(client, no_autoflush):
     full_wb_run_id_1 = f"{client.entity}/{client.project}/test-run-1"
     full_wb_run_id_2 = f"{client.entity}/{client.project}/test-run-2"
@@ -951,9 +947,6 @@ def test_trace_call_query_filter_wb_run_ids(client, no_autoflush):
         assert len(inner_res.calls) == exp_count
 
 
-# Flaky against ClickHouse in CI: read-after-write visibility lag means a
-# calls_query right after flush can miss just-written rows. Rerun to absorb it.
-@pytest.mark.flaky(reruns=2)
 def test_trace_call_query_filter_wb_user_ids(client, trace_server, no_autoflush):
     call_spec_1 = simple_line_call_bootstrap()
     client.flush()
@@ -1786,7 +1779,6 @@ def test_op_retrieval(weave_active):
     assert my_op2(1) == 2
 
 
-@pytest.mark.flaky(reruns=3)
 def test_bound_op_retrieval(weave_active):
     class CustomType(weave.Object):
         a: int
@@ -3256,7 +3248,6 @@ class BasicModel(weave.Model):
         return {"answer": "42"}
 
 
-@pytest.mark.flaky(reruns=3)
 def test_model_save(client):
     model = BasicModel()
     assert model.predict(1) == {"answer": "42"}
@@ -4751,7 +4742,6 @@ def test_get_object_from_uri(weave_active, obj):
     assert weave.get(uri) == obj
 
 
-@pytest.mark.flaky(reruns=3)
 def test_get_object_from_uri_non_registered_object(weave_active):
     class MyModel(weave.Model):
         a: int

--- a/tests/trace/test_objs_query.py
+++ b/tests/trace/test_objs_query.py
@@ -1,8 +1,6 @@
 import base64
 import time
 
-import pytest
-
 import weave
 from tests.trace.server_utils import TEST_ENTITY
 from weave.trace.weave_client import WeaveClient
@@ -190,7 +188,6 @@ def test_objs_query_wb_user_id(client: WeaveClient):
     assert all(obj.wb_user_id == correct_id for obj in res)
 
 
-@pytest.mark.flaky(reruns=3)
 def test_objs_query_deleted_interaction(client: WeaveClient):
     weave.publish({"i": 1}, name="obj_1")
     weave.publish({"i": 2}, name="obj_1")
@@ -249,7 +246,6 @@ def test_objs_query_deleted_interaction(client: WeaveClient):
     assert len(res.objs) == 0
 
 
-@pytest.mark.flaky(reruns=3)
 def test_objs_query_delete_and_recreate(client: WeaveClient):
     weave.publish({"i": 1}, name="obj_1")
     weave.publish({"i": 2}, name="obj_1")
@@ -306,7 +302,6 @@ def test_objs_query_delete_and_recreate(client: WeaveClient):
         assert res.objs[i].val["i"] == i + 1
 
 
-@pytest.mark.flaky(reruns=3)
 def test_objs_query_delete_and_add_new_versions(client: WeaveClient):
     weave.publish({"i": 1}, name="obj_1")
     weave.publish({"i": 2}, name="obj_1")

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -77,7 +77,6 @@ from weave.trace_server.trace_server_interface import (
 from weave.trace_server_bindings.http_utils import _ENDPOINT_CACHE
 
 
-@pytest.mark.flaky(reruns=3, reruns_delay=0.2)
 def test_table_create(client):
     res = client.server.table_create(
         TableCreateReq(
@@ -1115,7 +1114,6 @@ def test_save_model(client):
 
 
 @pytest.mark.skip(reason="TODO: Skip flake")
-@pytest.mark.flaky(reruns=5, reruns_delay=2)
 @pytest.mark.asyncio
 async def test_saved_nested_modellike(client):
     class A(weave.Object):
@@ -1559,7 +1557,6 @@ def row_gen(num_rows: int, approx_row_bytes: int = 1024):
 
 
 @pytest.mark.timeout(60)
-@pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.parametrize("use_parallel_table_upload", [False, True])
 def test_table_partitioning(network_proxy_client, use_parallel_table_upload):
     """This test is specifically testing the correctness

--- a/tests/trace/type_handlers/Image/image_test.py
+++ b/tests/trace/type_handlers/Image/image_test.py
@@ -85,7 +85,6 @@ def test_image_as_property(client: WeaveClient, test_img: Image.Image) -> None:
         gotten_img_wrapper.img.close()
 
 
-@pytest.mark.flaky(reruns=3)
 def test_image_as_dataset_cell(client: WeaveClient, test_img: Image.Image) -> None:
     client.project = "test_image_as_dataset_cell"
     dataset = weave.Dataset(rows=[{"img": test_img}])

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -13,6 +13,7 @@ from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     UserInjectingExternalTraceServer,
     externalize_trace_server,
 )
+from tests.trace_server.eventually_consistent import EventuallyConsistentAgentServer
 from tests.trace_server.workers.evaluate_model_test_worker import (
     EvaluateModelTestDispatcher,
 )
@@ -392,7 +393,7 @@ def ch_server(trace_server):
     server = trace_server._internal_trace_server
     if not isinstance(server, ClickHouseTraceServer):
         pytest.skip("ClickHouse-only test")
-    return server
+    return EventuallyConsistentAgentServer(server)
 
 
 @pytest.fixture

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -13,7 +13,6 @@ from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     UserInjectingExternalTraceServer,
     externalize_trace_server,
 )
-from tests.trace_server.eventually_consistent import EventuallyConsistentServer
 from tests.trace_server.workers.evaluate_model_test_worker import (
     EvaluateModelTestDispatcher,
 )
@@ -393,7 +392,7 @@ def ch_server(trace_server):
     server = trace_server._internal_trace_server
     if not isinstance(server, ClickHouseTraceServer):
         pytest.skip("ClickHouse-only test")
-    return EventuallyConsistentServer(server)
+    return server
 
 
 @pytest.fixture

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -13,7 +13,7 @@ from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     UserInjectingExternalTraceServer,
     externalize_trace_server,
 )
-from tests.trace_server.eventually_consistent import EventuallyConsistentAgentServer
+from tests.trace_server.eventually_consistent import EventuallyConsistentServer
 from tests.trace_server.workers.evaluate_model_test_worker import (
     EvaluateModelTestDispatcher,
 )
@@ -393,7 +393,7 @@ def ch_server(trace_server):
     server = trace_server._internal_trace_server
     if not isinstance(server, ClickHouseTraceServer):
         pytest.skip("ClickHouse-only test")
-    return EventuallyConsistentAgentServer(server)
+    return EventuallyConsistentServer(server)
 
 
 @pytest.fixture

--- a/tests/trace_server/eventually_consistent.py
+++ b/tests/trace_server/eventually_consistent.py
@@ -1,0 +1,112 @@
+"""Test-only proxy that retries an agent read once when it returns empty.
+
+Masks rare read-your-write visibility lag on CI ClickHouse (a just-inserted
+span not yet visible to the immediately-following query) so the genai agent
+query tests don't flake. One 200ms retry is sufficient; see WB-35048.
+"""
+
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+RETRY_DELAY_SECONDS = 0.2
+BUCKET_COUNT_KEY = "count"
+
+T = TypeVar("T")
+
+
+class EventuallyConsistentAgentServer:
+    """Wraps a ClickHouseTraceServer, retrying agent reads once on an empty result.
+
+    Non-agent attributes (e.g. `ch_client`) pass straight through to the inner
+    server, so tests insert exactly as before.
+    """
+
+    def __init__(self, inner: object) -> None:
+        self._inner = inner
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._inner, name)
+
+    def agent_spans_query(self, req: object) -> object:
+        return retry_until_found(
+            lambda: self._inner.agent_spans_query(req),
+            lambda res: res.total_count == 0,
+        )
+
+    def agent_spans_stats(self, req: object) -> object:
+        metric_keys = stats_metric_keys(req)
+        return retry_until_found(
+            lambda: self._inner.agent_spans_stats(req),
+            lambda res: stats_result_is_empty(res, metric_keys),
+        )
+
+    def agent_agents_query(self, req: object) -> object:
+        return retry_until_found(
+            lambda: self._inner.agent_agents_query(req),
+            lambda res: not res.agents,
+        )
+
+    def agent_versions_query(self, req: object) -> object:
+        return retry_until_found(
+            lambda: self._inner.agent_versions_query(req),
+            lambda res: not res.agent_versions,
+        )
+
+    def agent_search(self, req: object) -> object:
+        return retry_until_found(
+            lambda: self._inner.agent_search(req),
+            lambda res: not res.results,
+        )
+
+    def agent_conversation_chat(self, req: object) -> object:
+        return retry_until_found(
+            lambda: self._inner.agent_conversation_chat(req),
+            lambda res: res.total_turns == 0,
+        )
+
+    def agent_custom_attrs_schema(self, req: object) -> object:
+        return retry_until_found(
+            lambda: self._inner.agent_custom_attrs_schema(req),
+            lambda res: not res.attributes,
+        )
+
+
+def retry_until_found(call: Callable[[], T], is_empty: Callable[[T], bool]) -> T:
+    """Run `call`; if it returns empty, wait once and run it again."""
+    result = call()
+    if is_empty(result):
+        time.sleep(RETRY_DELAY_SECONDS)
+        result = call()
+    return result
+
+
+def stats_metric_keys(req: object) -> list[str]:
+    """Result-row keys the stats query produces for the requested metrics."""
+    keys: list[str] = []
+    for metric in req.metrics:
+        for aggregation in metric.aggregations:
+            keys.append(f"{aggregation}_{metric.alias}")
+        for percentile in metric.percentiles or []:
+            keys.append(f"p{percentile}_{metric.alias}")
+    return keys
+
+
+def stats_result_is_empty(res: object, metric_keys: list[str]) -> bool:
+    """Empty when no rows, or every judged column is zero/None in every row.
+
+    Judged columns are the requested metric aliases, or the bucket `count` column
+    for bucket queries that request no metrics. A populated grid whose values are
+    all zero is the visibility-lag signature. With no judgeable column, treat as
+    non-empty so we never retry a query we cannot reason about.
+    """
+    if not res.rows:
+        return True
+    keys = [
+        key
+        for key in (metric_keys or [BUCKET_COUNT_KEY])
+        if any(key in row for row in res.rows)
+    ]
+    if not keys:
+        return False
+    return all(not row.get(key) for row in res.rows for key in keys)

--- a/tests/trace_server/eventually_consistent.py
+++ b/tests/trace_server/eventually_consistent.py
@@ -11,6 +11,8 @@ import time
 from collections.abc import Callable
 from typing import TypeVar
 
+from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.agents import types as agent_types
 from weave.trace_server.errors import NotFoundError
 
 RETRY_DELAY_SECONDS = 0.2
@@ -28,69 +30,83 @@ class EventuallyConsistentServer:
     `find_server_layer` (see its `_NEXT_SERVER_ATTRS`).
     """
 
-    def __init__(self, inner: object) -> None:
+    def __init__(self, inner: tsi.TraceServerInterface) -> None:
         self._inner = inner
 
     def __getattr__(self, name: str) -> object:
         return getattr(self._inner, name)
 
     # --- objects / tables / files ---
-    def obj_read(self, req: object) -> object:
+    def obj_read(self, req: tsi.ObjReadReq) -> tsi.ObjReadRes:
         return retry_read(lambda: self._inner.obj_read(req))
 
-    def objs_query(self, req: object) -> object:
+    def objs_query(self, req: tsi.ObjQueryReq) -> tsi.ObjQueryRes:
         return retry_read(lambda: self._inner.objs_query(req), lambda res: not res.objs)
 
-    def table_query(self, req: object) -> object:
+    def table_query(self, req: tsi.TableQueryReq) -> tsi.TableQueryRes:
         return retry_read(
             lambda: self._inner.table_query(req), lambda res: not res.rows
         )
 
-    def refs_read_batch(self, req: object) -> object:
+    def refs_read_batch(self, req: tsi.RefsReadBatchReq) -> tsi.RefsReadBatchRes:
         return retry_read(
             lambda: self._inner.refs_read_batch(req), lambda res: not res.vals
         )
 
-    def file_content_read(self, req: object) -> object:
+    def file_content_read(self, req: tsi.FileContentReadReq) -> tsi.FileContentReadRes:
         return retry_read(lambda: self._inner.file_content_read(req))
 
     # --- agents ---
-    def agent_spans_query(self, req: object) -> object:
+    def agent_spans_query(
+        self, req: agent_types.AgentSpansQueryReq
+    ) -> agent_types.AgentSpansQueryRes:
         return retry_read(
             lambda: self._inner.agent_spans_query(req),
             lambda res: res.total_count == 0,
         )
 
-    def agent_spans_stats(self, req: object) -> object:
+    def agent_spans_stats(
+        self, req: agent_types.AgentSpanStatsReq
+    ) -> agent_types.AgentSpanStatsRes:
         metric_keys = stats_metric_keys(req)
         return retry_read(
             lambda: self._inner.agent_spans_stats(req),
             lambda res: stats_result_is_empty(res, metric_keys),
         )
 
-    def agent_agents_query(self, req: object) -> object:
+    def agent_agents_query(
+        self, req: agent_types.AgentsQueryReq
+    ) -> agent_types.AgentsQueryRes:
         return retry_read(
             lambda: self._inner.agent_agents_query(req), lambda res: not res.agents
         )
 
-    def agent_versions_query(self, req: object) -> object:
+    def agent_versions_query(
+        self, req: agent_types.AgentVersionsQueryReq
+    ) -> agent_types.AgentVersionsQueryRes:
         return retry_read(
             lambda: self._inner.agent_versions_query(req),
-            lambda res: not res.agent_versions,
+            lambda res: not res.versions,
         )
 
-    def agent_search(self, req: object) -> object:
+    def agent_search(
+        self, req: agent_types.AgentSearchReq
+    ) -> agent_types.AgentSearchRes:
         return retry_read(
             lambda: self._inner.agent_search(req), lambda res: not res.results
         )
 
-    def agent_conversation_chat(self, req: object) -> object:
+    def agent_conversation_chat(
+        self, req: agent_types.AgentConversationChatReq
+    ) -> agent_types.AgentConversationChatRes:
         return retry_read(
             lambda: self._inner.agent_conversation_chat(req),
             lambda res: res.total_turns == 0,
         )
 
-    def agent_custom_attrs_schema(self, req: object) -> object:
+    def agent_custom_attrs_schema(
+        self, req: agent_types.AgentCustomAttrsSchemaReq
+    ) -> agent_types.AgentCustomAttrsSchemaRes:
         return retry_read(
             lambda: self._inner.agent_custom_attrs_schema(req),
             lambda res: not res.attributes,
@@ -114,7 +130,7 @@ def retry_read(call: Callable[[], T], is_empty: Callable[[T], bool] | None = Non
     return result
 
 
-def stats_metric_keys(req: object) -> list[str]:
+def stats_metric_keys(req: agent_types.AgentSpanStatsReq) -> list[str]:
     """Result-row keys the stats query produces for the requested metrics."""
     keys: list[str] = []
     for metric in req.metrics:
@@ -125,7 +141,9 @@ def stats_metric_keys(req: object) -> list[str]:
     return keys
 
 
-def stats_result_is_empty(res: object, metric_keys: list[str]) -> bool:
+def stats_result_is_empty(
+    res: agent_types.AgentSpanStatsRes, metric_keys: list[str]
+) -> bool:
     """Empty when no rows, or every judged column is zero/None in every row.
 
     Judged columns are the requested metric aliases, or the bucket `count` column

--- a/tests/trace_server/eventually_consistent.py
+++ b/tests/trace_server/eventually_consistent.py
@@ -1,13 +1,17 @@
-"""Test-only proxy that retries an agent read once when it returns empty.
+"""Test-only proxy that retries a read once when it returns empty or not-found.
 
-Masks rare read-your-write visibility lag on CI ClickHouse (a just-inserted
-span not yet visible to the immediately-following query) so the genai agent
-query tests don't flake. One 200ms retry is sufficient; see WB-35048.
+Masks rare read-your-write lag on CI ClickHouse (a just-written row not yet
+visible to the immediately-following query) so trace_server tests don't flake.
+It wraps the raw server *below* the externalize/caching layers, so both direct
+`ch_server.*` calls and the `client` -> caching -> externalize -> server path
+are covered. One 200ms retry is sufficient; see WB-35048.
 """
 
 import time
 from collections.abc import Callable
 from typing import TypeVar
+
+from weave.trace_server.errors import NotFoundError
 
 RETRY_DELAY_SECONDS = 0.2
 BUCKET_COUNT_KEY = "count"
@@ -15,11 +19,13 @@ BUCKET_COUNT_KEY = "count"
 T = TypeVar("T")
 
 
-class EventuallyConsistentAgentServer:
-    """Wraps a ClickHouseTraceServer, retrying agent reads once on an empty result.
+class EventuallyConsistentServer:
+    """Wraps a ClickHouseTraceServer, retrying reads once on empty/not-found.
 
-    Non-agent attributes (e.g. `ch_client`) pass straight through to the inner
-    server, so tests insert exactly as before.
+    Only read methods whose miss signature is unambiguous are wrapped; every
+    other attribute (writes, `ch_client`, streams, internals) passes straight
+    through to the inner server. `_inner` is also discoverable by
+    `find_server_layer` (see its `_NEXT_SERVER_ATTRS`).
     """
 
     def __init__(self, inner: object) -> None:
@@ -28,56 +34,83 @@ class EventuallyConsistentAgentServer:
     def __getattr__(self, name: str) -> object:
         return getattr(self._inner, name)
 
+    # --- objects / tables / files ---
+    def obj_read(self, req: object) -> object:
+        return retry_read(lambda: self._inner.obj_read(req))
+
+    def objs_query(self, req: object) -> object:
+        return retry_read(lambda: self._inner.objs_query(req), lambda res: not res.objs)
+
+    def table_query(self, req: object) -> object:
+        return retry_read(
+            lambda: self._inner.table_query(req), lambda res: not res.rows
+        )
+
+    def refs_read_batch(self, req: object) -> object:
+        return retry_read(
+            lambda: self._inner.refs_read_batch(req), lambda res: not res.vals
+        )
+
+    def file_content_read(self, req: object) -> object:
+        return retry_read(lambda: self._inner.file_content_read(req))
+
+    # --- agents ---
     def agent_spans_query(self, req: object) -> object:
-        return retry_until_found(
+        return retry_read(
             lambda: self._inner.agent_spans_query(req),
             lambda res: res.total_count == 0,
         )
 
     def agent_spans_stats(self, req: object) -> object:
         metric_keys = stats_metric_keys(req)
-        return retry_until_found(
+        return retry_read(
             lambda: self._inner.agent_spans_stats(req),
             lambda res: stats_result_is_empty(res, metric_keys),
         )
 
     def agent_agents_query(self, req: object) -> object:
-        return retry_until_found(
-            lambda: self._inner.agent_agents_query(req),
-            lambda res: not res.agents,
+        return retry_read(
+            lambda: self._inner.agent_agents_query(req), lambda res: not res.agents
         )
 
     def agent_versions_query(self, req: object) -> object:
-        return retry_until_found(
+        return retry_read(
             lambda: self._inner.agent_versions_query(req),
             lambda res: not res.agent_versions,
         )
 
     def agent_search(self, req: object) -> object:
-        return retry_until_found(
-            lambda: self._inner.agent_search(req),
-            lambda res: not res.results,
+        return retry_read(
+            lambda: self._inner.agent_search(req), lambda res: not res.results
         )
 
     def agent_conversation_chat(self, req: object) -> object:
-        return retry_until_found(
+        return retry_read(
             lambda: self._inner.agent_conversation_chat(req),
             lambda res: res.total_turns == 0,
         )
 
     def agent_custom_attrs_schema(self, req: object) -> object:
-        return retry_until_found(
+        return retry_read(
             lambda: self._inner.agent_custom_attrs_schema(req),
             lambda res: not res.attributes,
         )
 
 
-def retry_until_found(call: Callable[[], T], is_empty: Callable[[T], bool]) -> T:
-    """Run `call`; if it returns empty, wait once and run it again."""
-    result = call()
-    if is_empty(result):
-        time.sleep(RETRY_DELAY_SECONDS)
+def retry_read(call: Callable[[], T], is_empty: Callable[[T], bool] | None = None) -> T:
+    """Call once; on NotFoundError or an empty result, wait 200ms and retry once.
+
+    A second NotFoundError (or empty result) propagates/returns as-is. The
+    retry only masks a transient read-your-write miss, never a real absence.
+    """
+    try:
         result = call()
+    except NotFoundError:
+        time.sleep(RETRY_DELAY_SECONDS)
+        return call()
+    if is_empty is not None and is_empty(result):
+        time.sleep(RETRY_DELAY_SECONDS)
+        return call()
     return result
 
 

--- a/tests/trace_server/eventually_consistent.py
+++ b/tests/trace_server/eventually_consistent.py
@@ -36,6 +36,12 @@ class EventuallyConsistentServer:
     def __getattr__(self, name: str) -> object:
         return getattr(self._inner, name)
 
+    # --- calls ---
+    def calls_query(self, req: tsi.CallsQueryReq) -> tsi.CallsQueryRes:
+        return retry_read(
+            lambda: self._inner.calls_query(req), lambda res: not res.calls
+        )
+
     # --- objects / tables / files ---
     def obj_read(self, req: tsi.ObjReadReq) -> tsi.ObjReadRes:
         return retry_read(lambda: self._inner.obj_read(req))

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -7,8 +7,6 @@ Migration 030 creates the genai tables automatically.
 import datetime
 import uuid
 
-import pytest
-
 from tests.trace_server.helpers import make_project_id as _make_project_id
 from weave.trace_server.agents.helpers import genai_span_to_row
 from weave.trace_server.agents.schema import (
@@ -186,7 +184,6 @@ def test_group_by_trace_id(ch_server):
 
 
 # flaky: CI ClickHouse occasionally doesn't surface the just-inserted spans to the immediate read.
-@pytest.mark.flaky(reruns=3)
 def test_group_by_conversation_id(ch_server):
     """Grouping spans by conversation_id returns per-conversation aggregates."""
     project_id = _make_project_id("convs")
@@ -822,7 +819,6 @@ def test_spans_query_filters_sorts_and_projects_custom_attrs(ch_server):
 
 
 # flaky: CI ClickHouse occasionally doesn't surface the just-inserted spans to the immediate read.
-@pytest.mark.flaky(reruns=3)
 def test_agent_span_stats_ungrouped_metrics(ch_server):
     """Stats API returns requested token, duration, error, and invocation metrics."""
     project_id = _make_project_id("stats")
@@ -957,7 +953,6 @@ def test_agent_span_stats_numeric_value_buckets(ch_server):
     assert res.rows[-1]["bucket_max"] == 30
 
 
-@pytest.mark.flaky(reruns=3)
 def test_agent_span_stats_conversation_numeric_value_buckets(ch_server):
     """Stats API can bucket grouped conversation aggregate values."""
     project_id = _make_project_id("stats_conv_hist")

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -7,6 +7,9 @@ Migration 030 creates the genai tables automatically.
 import datetime
 import uuid
 
+import pytest
+
+from tests.trace_server.eventually_consistent import EventuallyConsistentServer
 from tests.trace_server.helpers import make_project_id as _make_project_id
 from weave.trace_server.agents.helpers import genai_span_to_row
 from weave.trace_server.agents.schema import (
@@ -31,6 +34,17 @@ from weave.trace_server.agents.types import (
     AgentsQueryReq,
 )
 from weave.trace_server.interface.query import Query
+
+
+@pytest.fixture
+def ch_server(ch_server):
+    """Wrap the shared ch_server with one read-retry on empty/not-found.
+
+    These agent queries insert spans then immediately read them back; on CI
+    ClickHouse that read can miss the just-written row (read-your-write lag).
+    Scoped to this file so the shared fixture stays unwrapped (WB-35048).
+    """
+    return EventuallyConsistentServer(ch_server)
 
 
 def _make_span(project_id: str, **overrides: object) -> AgentSpanCHInsertable:

--- a/tests/trace_server/test_trace_server_conftest.py
+++ b/tests/trace_server/test_trace_server_conftest.py
@@ -59,12 +59,12 @@ def test_reset_server_state_covers_all_attrs(ch_server):
     Instrumentation attrs (ddtrace, coverage) are ignored — only attrs
     missing from KNOWN_SERVER_ATTRS trigger failure.
     """
+    # ch_server is wrapped in EventuallyConsistentServer; introspect the raw server.
+    raw = getattr(ch_server, "_inner", ch_server)
     # Only check underscore-prefixed attrs (real app state).
     # Instrumentation (ddtrace) injects public-name wrappers like
     # 'objs_query', 'file_create' etc. — ignore those.
-    actual = {
-        a for a in ch_server.__dict__ if a.startswith("_") and not a.startswith("__")
-    }
+    actual = {a for a in raw.__dict__ if a.startswith("_") and not a.startswith("__")}
     unknown = actual - KNOWN_SERVER_ATTRS
     assert not unknown, (
         f"ClickHouseTraceServer has new attributes: {unknown}. "


### PR DESCRIPTION
## Summary
Test-only mitigation for ClickHouse read-after-write lag that flakes trace tests (WB-35048), replacing the scattered `@pytest.mark.flaky(reruns=3)` band-aids. `EventuallyConsistentServer` is a thin proxy that retries a read once (200ms) when it comes back empty or not-found, then returns whatever the second read sees. A genuinely-empty result stays empty after the retry, so this masks transient visibility lag without ever hiding a real failure.

Applied in two spots, ClickHouse only:
- client stack, below the cache (`tests/conftest.py`): calls/object/table/file reads (`calls_query`, `obj_read`, `objs_query`, `table_query`, `refs_read_batch`, `file_content_read`).
- the genai query suite's `ch_server` (`test_genai_agent_queries.py`): the agent read paths that originally flaked.

It wraps `calls_query` (the de-flaked `test_trace_call_query_filter_*` tests read through it), but does NOT wrap the shared `ch_server` fixture (kept raw so `patch.object(ch_server, ...)` tests still work).

## Why this is real, not a test smell
The test CH is a single non-replicated node, so this is async-insert/flush timing, not replication lag. ClickHouse async inserts do not guarantee a row is queryable the instant the INSERT returns.
- [Asynchronous inserts (CH docs)](https://clickhouse.com/docs/optimize/asynchronous-inserts)
- [Async data inserts in ClickHouse (blog)](https://clickhouse.com/blog/asynchronous-data-inserts-in-clickhouse)

## Performance
Rebased on master and re-ran the full matrix vs the master baseline: trace-shard wall-time +1.0% (+186s across 79 shards, mean +2.4s/shard, range -44s..+43s). Within CI noise: untouched SDK integration shards swing ±40s, and the six core CH `trace`/`trace_server` shards net ~+1s each, split evenly faster/slower. The 200ms retry-on-empty doesn't register at shard granularity.

## Testing
deterministic repro by flipping `wait_for_async_insert=0` on CH 26.3: the reads miss the just-written row without the wrapper and hit it with the wrapper. ran the `trace` + `trace_server` shards 3x in CI on the final commit: green (the only reds were a docker hub image-pull timeout and unrelated integration shards). genai 24/24, full `test_weave_client.py` + caching + objects/tables/files green locally.
