### PR TITLE
perf(weave): bounded conversation message previews for grouped spans query

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -41,6 +41,7 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_agents_list_query,
     make_conversation_chat_spans_query,
     make_conversation_chat_turns_count_query,
+    make_conversation_previews_query,
     make_custom_attrs_schema_query,
     make_message_search_query,
     make_span_group_categorical_distributions_query,
@@ -334,6 +335,38 @@ _GROUPED_AGG_TAIL = """count() AS span_count,
                groupUniqArray(s.conversation_name) AS conversation_names,
                min(s.started_at) AS first_seen,
                max(s.started_at) AS last_seen"""
+
+
+class TestMakeConversationPreviewsQuery:
+    def test_scoped_to_conversation_ids(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_conversation_previews_query(pb, "p1", ["conv-a", "conv-b"])
+        expected = """
+            SELECT s.conversation_id AS conversation_id,
+                   argMinIf(s.input_messages, s.started_at, length(s.input_messages) > 0) AS first_input_messages,
+                   argMaxIf(s.output_messages, s.ended_at, length(s.output_messages) > 0) AS last_output_messages
+            FROM spans s
+            WHERE s.project_id = {genai_0:String} AND s.conversation_id IN {genai_1:Array(String)}
+            GROUP BY conversation_id
+        """
+        assert_sql(
+            expected,
+            {"genai_0": "p1", "genai_1": ["conv-a", "conv-b"]},
+            query,
+            pb.get_params(),
+        )
+
+    def test_applies_time_range(self) -> None:
+        pb = ParamBuilder("genai")
+        start = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+        end = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+        query = make_conversation_previews_query(
+            pb, "p1", ["conv-a"], started_after=start, started_before=end
+        )
+        # Time bounds let ClickHouse prune partitions / primary-key ranges so the
+        # wide message columns are read for an even smaller slice.
+        assert "s.started_at >= {genai_2:DateTime64(6)}" in query
+        assert "s.started_at < {genai_3:DateTime64(6)}" in query
 
 
 class TestMakeGroupedSpansCountQuery:

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -255,6 +255,78 @@ def test_group_by_conversation_id(ch_server):
     assert "Beta Chat" in by_conv[conv_b].conversation_names
 
 
+def test_group_by_conversation_id_message_previews(ch_server):
+    """Grouped conversation rows carry first/last message previews computed via
+    argMin/argMax over the spans — no per-row hydration needed.
+
+    Validates the real ClickHouse aggregate semantics: the earliest span's user
+    prompt becomes `first_message`; the latest span's assistant output becomes
+    `last_message`. Spans with no renderable text are skipped by the -If guard.
+    """
+    project_id = _make_project_id("conv-previews")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    conv = f"conv-{uuid.uuid4().hex[:8]}"
+
+    spans = [
+        # Earliest span: opening turn. Carries system + user input. Its user
+        # text should win as the first-message preview.
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            operation_name="invoke_agent",
+            started_at=now,
+            ended_at=now + datetime.timedelta(seconds=1),
+            input_messages=[
+                NormalizedMessage(role="system", content="be terse"),
+                NormalizedMessage(role="user", content="hello first"),
+            ],
+            output_messages=[NormalizedMessage(role="assistant", content="reply one")],
+        ),
+        # A later tool span with no messages — must be skipped by the -If guard
+        # even though it is not the earliest/latest by timestamp checks below.
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            operation_name="execute_tool",
+            started_at=now + datetime.timedelta(seconds=2),
+            ended_at=now + datetime.timedelta(seconds=3),
+            input_messages=[],
+            output_messages=[],
+        ),
+        # Latest span by ended_at: its assistant output is the last-message preview.
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            operation_name="chat",
+            started_at=now + datetime.timedelta(seconds=4),
+            ended_at=now + datetime.timedelta(seconds=5),
+            input_messages=[NormalizedMessage(role="user", content="hello second")],
+            output_messages=[
+                NormalizedMessage(role="assistant", content="final reply")
+            ],
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(
+            project_id=project_id,
+            group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+        )
+    )
+    by_conv = {g.group_keys["conversation_id"]: g for g in res.groups}
+    assert conv in by_conv
+    row = by_conv[conv]
+
+    assert row.first_message is not None
+    assert row.first_message.role == "user_message"
+    assert row.first_message.text == "hello first"
+
+    assert row.last_message is not None
+    assert row.last_message.role == "assistant_message"
+    assert row.last_message.text == "final reply"
+
+
 def test_group_by_conversation_id_filters_numeric_aggregates(ch_server):
     """Grouped conversation queries support server-side aggregate range filters."""
     project_id = _make_project_id("convs_num")

--- a/tests/trace_server/test_genai_agent_query_handler.py
+++ b/tests/trace_server/test_genai_agent_query_handler.py
@@ -113,6 +113,15 @@ def test_group_distributions_are_hydrated_with_batched_queries() -> None:
                 ("conv-a", "cached_distribution", "true", 1, 1),
             ],
         ),
+        # Conversation grouping also triggers the bounded message-preview query.
+        _FakeQueryResult(
+            column_names=[
+                "conversation_id",
+                "first_input_messages",
+                "last_output_messages",
+            ],
+            result_rows=[("conv-a", [], [])],
+        ),
     ]
     calls: list[tuple[str, dict[str, Any]]] = []
 
@@ -124,7 +133,7 @@ def test_group_distributions_are_hydrated_with_batched_queries() -> None:
 
     res = handler.spans_query(req)
 
-    assert len(calls) == 5
+    assert len(calls) == 6
     assert not results
 
     numeric_params = calls[3][1]
@@ -146,3 +155,88 @@ def test_group_distributions_are_hydrated_with_batched_queries() -> None:
     assert [
         (v.value, v.count) for v in group.distributions["cached_distribution"].values
     ] == [("true", 1)]
+
+
+def test_grouped_rows_hydrate_message_previews() -> None:
+    """Conversation groupings get first/last message previews from a second,
+    bounded query (scoped to the page's conversation_ids) — the main grouped
+    query never reads the wide message columns.
+    """
+    req = AgentSpansQueryReq(
+        project_id="p1",
+        group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+    )
+    grouped_row_columns = [
+        "conversation_id",
+        "span_count",
+        "invocation_count",
+        "conversation_count",
+        "total_input_tokens",
+        "total_output_tokens",
+        "total_duration_ms",
+        "error_count",
+        "agent_names",
+        "agent_versions",
+        "provider_names",
+        "request_models",
+        "conversation_names",
+        "first_seen",
+        "last_seen",
+    ]
+    results = [
+        # count query
+        _FakeQueryResult(column_names=[], result_rows=[(2,)]),
+        # grouped list query — note: no message columns
+        _FakeQueryResult(
+            column_names=grouped_row_columns,
+            result_rows=[
+                ("conv-a", 3, 0, 1, 0, 0, 0, 0, [], [], [], [], [], None, None),
+                ("conv-empty", 1, 0, 1, 0, 0, 0, 0, [], [], [], [], [], None, None),
+            ],
+        ),
+        # bounded preview query, keyed by conversation_id. ClickHouse returns
+        # Array(Tuple(role, content, finish_reason)); first span carries a
+        # system + user prompt and the user text wins.
+        _FakeQueryResult(
+            column_names=[
+                "conversation_id",
+                "first_input_messages",
+                "last_output_messages",
+            ],
+            result_rows=[
+                (
+                    "conv-a",
+                    [("system", "be helpful", ""), ("user", "what is 2+2?", "")],
+                    [("assistant", "It is 4.", "stop")],
+                ),
+                ("conv-empty", [], []),
+            ],
+        ),
+    ]
+    calls: list[str] = []
+
+    def query(sql: str, params: dict[str, Any]) -> _FakeQueryResult:
+        calls.append(sql)
+        return results.pop(0)
+
+    handler = AgentQueryHandler(query, lambda req: FeedbackQueryRes(result=[]))
+    res = handler.spans_query(req)
+
+    # 3 queries: count, grouped list, bounded preview.
+    assert len(calls) == 3
+    assert "conversation_id IN" in calls[2]
+    # The main grouped list query must NOT touch the wide message columns.
+    assert "input_messages" not in calls[1]
+    assert "output_messages" not in calls[1]
+
+    first, empty = res.groups
+    assert first.first_message is not None
+    assert first.first_message.role == "user_message"
+    assert first.first_message.text == "what is 2+2?"
+    assert first.last_message is not None
+    assert first.last_message.role == "assistant_message"
+    assert first.last_message.text == "It is 4."
+
+    # No renderable text → no preview, so the UI falls back to the conversation id.
+    assert empty.first_message is None
+    assert empty.last_message is None

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -434,6 +434,21 @@ def _extract_user_text(
     return "\n\n".join(texts)
 
 
+def first_user_preview_text(messages: list[NormalizedMessage]) -> str:
+    """Public: opening user-prompt text from a span's `input_messages`.
+
+    Used to build the conversation table's "first message" preview directly
+    from the grouped spans query, applying the same role resolution as the
+    full chat view so previews match the opened conversation.
+    """
+    return _extract_user_text(messages, last_only=True)
+
+
+def last_assistant_preview_text(messages: list[NormalizedMessage]) -> str:
+    """Public: final assistant/output text from a span's `output_messages`."""
+    return _extract_non_user_output_text(messages)
+
+
 def _extract_non_user_output_text(messages: list[NormalizedMessage]) -> str:
     """Extract renderable output text from normalized output_messages.
 

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -14,27 +14,36 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NamedTuple, TypeAlias, TypeVar, cast
 
 from weave.shared import refs_internal as ri
-from weave.trace_server.agents.chat_view import build_trace_chat
+from weave.trace_server.agents.chat_view import (
+    build_trace_chat,
+    first_user_preview_text,
+    last_assistant_preview_text,
+)
 from weave.trace_server.agents.constants import (
+    CONVERSATION_PREVIEW_CHARS,
     MAX_INGEST_ERRORS_REPORTED,
     NO_CONVERSATION_LABEL,
 )
 from weave.trace_server.agents.helpers import (
     genai_span_to_row,
+    messages_from_ch_value,
     normalize_span_row,
     unpack_string_array,
 )
 from weave.trace_server.agents.schema import (
     ALL_SPAN_INSERT_COLUMNS,
     AgentSpanCHInsertable,
+    NormalizedMessage,
 )
 from weave.trace_server.agents.types import (
     AGENT_CUSTOM_ATTR_SOURCE_VALUE_TYPES,
     AgentConversationChatReq,
     AgentConversationChatRes,
+    AgentConversationMessagePreview,
     AgentCustomAttrSchemaItem,
     AgentCustomAttrsSchemaReq,
     AgentCustomAttrsSchemaRes,
+    AgentGroupByRef,
     AgentSchema,
     AgentSearchConversationResult,
     AgentSearchMatchedMessage,
@@ -73,6 +82,7 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_agents_list_query,
     make_conversation_chat_spans_query,
     make_conversation_chat_turns_count_query,
+    make_conversation_previews_query,
     make_custom_attrs_schema_query,
     make_message_search_query,
     make_span_group_categorical_distributions_query,
@@ -169,7 +179,53 @@ class AgentQueryHandler:
         groups = [_hydrate_group_row(r, aliases, measure_aliases) for r in rows]
         if req.group_distributions:
             self._hydrate_group_distributions(req, groups, aliases[0])
+        if _is_conversation_grouping(req.group_by):
+            self._hydrate_conversation_previews(req, groups, aliases[0])
         return AgentSpansQueryRes(groups=groups, total_count=total)
+
+    def _hydrate_conversation_previews(
+        self,
+        req: AgentSpansQueryReq,
+        groups: list[AgentSpanGroupRow],
+        group_alias: str,
+    ) -> None:
+        """Attach first/last message previews to conversation rows.
+
+        Runs a second, bounded query scoped to exactly the conversation_ids on
+        this page so the wide message columns are read only for the displayed
+        conversations — not for every span matching the list filters. Failures
+        are swallowed: previews are best-effort display data and must not fail
+        the list query.
+        """
+        conversation_ids: set[str] = set()
+        for g in groups:
+            cid = g.group_keys.get(group_alias)
+            if isinstance(cid, str) and cid:
+                conversation_ids.add(cid)
+        if not conversation_ids:
+            return
+        pb = ParamBuilder(PARAM_NAMESPACE)
+        sql = make_conversation_previews_query(
+            pb,
+            req.project_id,
+            conversation_ids,
+            started_after=req.started_after,
+            started_before=req.started_before,
+        )
+        try:
+            rows = _rows_as_dicts(self._query(sql, pb.get_params()))
+        except Exception:
+            logger.exception("failed to hydrate conversation message previews")
+            return
+        previews_by_conv = {
+            safe_str(row.get("conversation_id")): _conversation_preview(row)
+            for row in rows
+        }
+        for g in groups:
+            cid = g.group_keys.get(group_alias)
+            preview = previews_by_conv.get(cid) if isinstance(cid, str) else None
+            if preview is not None:
+                g.first_message, g.last_message = preview
 
     def spans_stats(self, req: AgentSpanStatsReq) -> AgentSpanStatsRes:
         """Return chart-ready aggregations over spans."""
@@ -782,8 +838,61 @@ def _hydrate_group_row(
         conversation_names=unpack_string_array(row.get("conversation_names")),
         first_seen=_datetime_or_none(row.get("first_seen")),
         last_seen=_datetime_or_none(row.get("last_seen")),
+        # first_message / last_message are hydrated separately for conversation
+        # groupings via _hydrate_conversation_previews; left None here.
         metrics=metrics,
     )
+
+
+def _is_conversation_grouping(group_by: list[AgentGroupByRef]) -> bool:
+    """Whether this is a single group-by on the conversation_id column.
+
+    Message previews are a per-conversation concept, so we only pay for the
+    second query when the page is grouped by conversation_id alone.
+    """
+    return (
+        len(group_by) == 1
+        and group_by[0].source == "column"
+        and group_by[0].key == "conversation_id"
+    )
+
+
+def _conversation_preview(
+    row: ClickHouseRow,
+) -> tuple[
+    AgentConversationMessagePreview | None, AgentConversationMessagePreview | None
+]:
+    """Return (first_message, last_message) previews from a preview-query row."""
+    return (
+        _message_preview(
+            row.get("first_input_messages"), "user_message", first_user_preview_text
+        ),
+        _message_preview(
+            row.get("last_output_messages"),
+            "assistant_message",
+            last_assistant_preview_text,
+        ),
+    )
+
+
+def _message_preview(
+    raw_messages: object,
+    role: str,
+    extract_text: Callable[[list[NormalizedMessage]], str],
+) -> AgentConversationMessagePreview | None:
+    """Build a truncated message preview from a raw ClickHouse message array.
+
+    `extract_text` applies the same role resolution as the full chat view so
+    previews match what the opened conversation shows. Returns None when no
+    renderable text is present so callers can fall back to the conversation id.
+    """
+    messages = messages_from_ch_value(raw_messages)
+    text = extract_text(messages).strip()
+    if not text:
+        return None
+    if len(text) > CONVERSATION_PREVIEW_CHARS:
+        text = text[:CONVERSATION_PREVIEW_CHARS].rstrip() + "…"
+    return AgentConversationMessagePreview(role=role, text=text)
 
 
 def _datetime_or_none(val: object) -> datetime.datetime | None:

--- a/weave/trace_server/agents/constants.py
+++ b/weave/trace_server/agents/constants.py
@@ -95,6 +95,10 @@ SPAN_GROUP_RESULT_COLS: frozenset[str] = SPAN_GROUP_AGGREGATE_COLS.union(
     )
 )
 
+# Max characters retained for a conversation message preview snippet. Keeps the
+# grouped list response lean — the table only renders a truncated line.
+CONVERSATION_PREVIEW_CHARS = 280
+
 # ---------------------------------------------------------------------------
 # Ingest
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/agents/helpers.py
+++ b/weave/trace_server/agents/helpers.py
@@ -12,6 +12,7 @@ from typing import Any, NamedTuple
 from weave.trace_server.agents.schema import (
     ALL_SPAN_INSERT_COLUMNS,
     AgentSpanCHInsertable,
+    NormalizedMessage,
 )
 
 # ---------------------------------------------------------------------------
@@ -54,6 +55,35 @@ def unpack_string_array(val: Any) -> list[str]:
     if not val:
         return []
     return [str(x) for x in list(val) if x]
+
+
+def messages_from_ch_value(val: Any) -> list[NormalizedMessage]:
+    """Coerce a ClickHouse Array(Tuple(role, content, finish_reason)) into
+    NormalizedMessage objects.
+
+    The driver returns each message as a 3-tuple; tolerate dicts too so the
+    same helper works on already-normalized rows. Anything malformed is
+    skipped rather than raised — previews are best-effort display data.
+    """
+    if not val or not isinstance(val, (list, tuple)):
+        return []
+    messages: list[NormalizedMessage] = []
+    for m in val:
+        if isinstance(m, (tuple, list)) and len(m) == 3:
+            messages.append(
+                NormalizedMessage(
+                    role=str(m[0]), content=str(m[1]), finish_reason=str(m[2])
+                )
+            )
+        elif isinstance(m, dict):
+            messages.append(
+                NormalizedMessage(
+                    role=str(m.get("role", "")),
+                    content=str(m.get("content", "")),
+                    finish_reason=str(m.get("finish_reason", "")),
+                )
+            )
+    return messages
 
 
 def normalize_span_row(d: dict[str, Any]) -> dict[str, Any]:

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -590,6 +590,18 @@ class AgentSpanGroupDistributionItem(BaseModel):
     values: list[AgentSpanGroupDistributionValue] = Field(default_factory=list)
 
 
+class AgentConversationMessagePreview(BaseModel):
+    """A truncated first/last message snippet for a grouped conversation row.
+
+    `role` is the chat-timeline message type (e.g. "user_message",
+    "assistant_message") so clients can style it consistently with the full
+    chat view; `text` is the trimmed, length-capped preview content.
+    """
+
+    role: str = ""
+    text: str = ""
+
+
 class AgentSpanGroupRow(BaseModel):
     """A single row in a grouped spans query response.
 
@@ -615,6 +627,11 @@ class AgentSpanGroupRow(BaseModel):
     conversation_names: list[str] = Field(default_factory=list)
     first_seen: datetime.datetime | None = None
     last_seen: datetime.datetime | None = None
+    # First/last message previews, populated when grouping by conversation_id so
+    # the conversations table needs no per-row hydration. None when the earliest/
+    # latest span carried no renderable message text.
+    first_message: AgentConversationMessagePreview | None = None
+    last_message: AgentConversationMessagePreview | None = None
     metrics: dict[str, AgentSpanStatsCell] = Field(default_factory=dict)
     distributions: dict[str, AgentSpanGroupDistributionItem] = Field(
         default_factory=dict

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import datetime
 import re
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Collection, Sequence
 from dataclasses import dataclass
 from typing import Any, NamedTuple, TypeAlias
 
@@ -1014,6 +1014,50 @@ def make_spans_list_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:
         {having_sql}
         ORDER BY {order_by}
         LIMIT {limit_slot} OFFSET {offset_slot}
+    """
+
+
+def make_conversation_previews_query(
+    pb: ParamBuilder,
+    project_id: str,
+    conversation_ids: Collection[str],
+    *,
+    started_after: datetime.datetime | None = None,
+    started_before: datetime.datetime | None = None,
+) -> str:
+    """First/last message previews for an explicit set of conversations.
+
+    Deliberately scoped to ``conversation_id IN (...)`` — the page's already
+    computed conversation_ids — so the wide ``input_messages`` / ``output_messages``
+    columns are only read for the conversations actually shown, not for every
+    span matching the list filters. (A grouped ``argMin``/``argMax`` folded into
+    the main list query would read those columns for the entire filter match
+    before LIMIT.) The bloom-filter skip index on ``conversation_id`` plus the
+    optional time range bound the scan further.
+
+    ``argMinIf``/``argMaxIf`` pick the earliest input and latest output span that
+    actually carries messages; the handler turns the arrays into preview text.
+    """
+    pid_slot = pb.add(project_id, param_type="String")
+    ids_slot = pb.add(list(conversation_ids), param_type="Array(String)")
+    where_conditions = [
+        _project_filter_sql("s.project_id", pid_slot),
+        f"s.conversation_id IN {ids_slot}",
+    ]
+    add_time_filters(
+        where_conditions,
+        pb,
+        started_after=started_after,
+        started_before=started_before,
+    )
+    where = " AND ".join(where_conditions)
+    return f"""
+        SELECT s.conversation_id AS conversation_id,
+               argMinIf(s.input_messages, s.started_at, length(s.input_messages) > 0) AS first_input_messages,
+               argMaxIf(s.output_messages, s.ended_at, length(s.output_messages) > 0) AS last_output_messages
+        FROM spans s
+        WHERE {where}
+        GROUP BY conversation_id
     """
 
 


### PR DESCRIPTION
## Problem

The Agents conversations table shows a first-message and last-message preview per row. Each row was hydrated separately via `useConversationPagePreviews` (frontend), firing up to **two `agentConversationChat` requests per conversation** through a 6-worker pool — ~100 round trips per page, re-run on every sort/page change. This is a 1-2 order or magnitude speedup for loading the messages in the conversations table if the table is showing many rows with many and long messages.

## Why not just fold argMin/argMax into the grouped query

The obvious fix — adding `argMinIf(input_messages, …)` / `argMaxIf(output_messages, …)` to the grouped list query — has a nasty cost: ClickHouse aggregates **all** groups before applying `LIMIT`, and those aggregates need their argument columns for every qualifying row. So it would read the wide `input_messages` / `output_messages` array columns for **every span matching the list filters** (potentially the whole project / time window), then throw away all but the displayed page. `spans` is `ORDER BY (project_id, started_at, span_id)` with only a bloom-filter skip index on `conversation_id`, so that's an expensive scan on busy projects.

## Change — bounded second query

Compute previews server-side, but in a **second query scoped to the page's already-computed conversation_ids**:

- `make_conversation_previews_query` (`agent_query_builder.py`): `argMinIf`/`argMaxIf` over `spans`, `WHERE project_id = ? AND conversation_id IN (<page ids>)` plus the optional time range. The wide message columns are read **only for the conversations actually shown**; the bloom-filter index + time bounds prune the scan further.
- `AgentQueryHandler.spans_query` runs it **only when grouping by `conversation_id`** (other group-bys pay nothing), then attaches `first_message` / `last_message` to each row.
- Previews use the chat view's exact role resolution (`first_user_preview_text` / `last_assistant_preview_text`) so they match the opened conversation, truncated to `CONVERSATION_PREVIEW_CHARS = 280`.
- New `AgentConversationMessagePreview` + `first_message`/`last_message` on `AgentSpanGroupRow` (`types.py`).

One extra round trip to ClickHouse, vs ~N requests to the browser. The matching frontend change is a separate PR in `wandb/core` (#44907).

## Validation

- ClickHouse-backed integration test `test_group_by_conversation_id_message_previews` inserts a multi-turn conversation (opening user prompt, an empty tool span, final assistant turn) and runs the **real** two-query path — confirms `first_message → "hello first"`, `last_message → "final reply"`, empty tool span skipped by the `-If` guard.
- Handler unit test asserts 3 queries (count, grouped list, bounded preview), that the grouped list query does **not** reference message columns, and that the preview query is scoped with `conversation_id IN`.
- Query-builder tests for the new SQL (scoping + time range).
- Full suites green: 25 CH integration + 83 query/handler/helper/chat-view tests.

## Notes / follow-ups

- The page currently requests up to 1000 conversations; the preview query hydrates exactly that returned set. If a project's displayed set approaches its total conversation count, the bounded query's savings shrink (still never worse than folding in). A natural follow-up is to hydrate only the visible page.
- Previews derive from the earliest/latest *span* rather than the oldest/newest *turn*; in practice these coincide and the role resolution is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
