### PR TITLE
chore(weave_ts): Don't include `inMemoryTraceServer` in `dist/`

### DIFF
--- a/sdks/node/src/__tests__/attributes.test.ts
+++ b/sdks/node/src/__tests__/attributes.test.ts
@@ -1,7 +1,7 @@
 import {withAttributes, op} from 'weave';
 
 import {initWithCustomTraceServer} from './clientMock';
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
+import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {Settings} from '../settings';
 
 describe('attributes context', () => {

--- a/sdks/node/src/__tests__/clientMock.ts
+++ b/sdks/node/src/__tests__/clientMock.ts
@@ -1,6 +1,6 @@
 import {setGlobalClient} from '../clientApi';
 import {Api as TraceServerApi} from '../generated/traceServerApi';
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
+import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {Settings} from '../settings';
 import {WandbServerApi} from '../wandb/wandbServerApi';
 import {WeaveClient} from '../weaveClient';

--- a/sdks/node/src/__tests__/dataset.test.ts
+++ b/sdks/node/src/__tests__/dataset.test.ts
@@ -4,7 +4,7 @@
 
 import {Dataset} from '../dataset';
 import {ObjectRef} from '../weaveObject';
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
+import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {initWithCustomTraceServer} from './clientMock';
 import {requireGlobalClient} from '../clientApi';
 

--- a/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
+++ b/sdks/node/src/__tests__/evalLinkSpanProcessor.test.ts
@@ -8,7 +8,7 @@ import {
   EvalLinkSpanProcessor,
   registerEvalLinkSpanProcessor,
 } from '../evalLinkSpanProcessor';
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
+import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {op} from '../op';
 import {CallStack, type CallStackEntry} from '../weaveClient';
 import {initWithCustomTraceServer} from './clientMock';

--- a/sdks/node/src/__tests__/evaluationLogger.test.ts
+++ b/sdks/node/src/__tests__/evaluationLogger.test.ts
@@ -5,7 +5,7 @@
 import {EvaluationLogger} from '../evaluationLogger';
 import {WeaveObject} from '../weaveObject';
 import {initWithCustomTraceServer} from './clientMock';
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
+import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 
 // Helper function to get calls from trace server
 async function getCalls(traceServer: InMemoryTraceServer, projectId: string) {

--- a/sdks/node/src/__tests__/helpers/inMemoryTraceServer.ts
+++ b/sdks/node/src/__tests__/helpers/inMemoryTraceServer.ts
@@ -1,6 +1,5 @@
 import {uuidv7} from 'uuidv7';
 
-// This is mostly used for testing
 // TODO: Maybe move the interfaces to something like trace_server_interface.py
 
 interface Call {

--- a/sdks/node/src/__tests__/integrations/anthropic.test.ts
+++ b/sdks/node/src/__tests__/integrations/anthropic.test.ts
@@ -1,4 +1,4 @@
-import {InMemoryTraceServer} from '../../inMemoryTraceServer';
+import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
 import {commonPatchAnthropic} from '../../integrations/anthropic';
 import {initWithCustomTraceServer} from '../clientMock';
 

--- a/sdks/node/src/__tests__/integrations/googleGenAI.test.ts
+++ b/sdks/node/src/__tests__/integrations/googleGenAI.test.ts
@@ -1,4 +1,4 @@
-import {InMemoryTraceServer} from '../../inMemoryTraceServer';
+import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
 import {commonPatchGoogleGenAI} from '../../integrations/googleGenAI';
 import {initWithCustomTraceServer} from '../clientMock';
 

--- a/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
+++ b/sdks/node/src/__tests__/integrations/integrationOpenAI.test.ts
@@ -1,4 +1,4 @@
-import {InMemoryTraceServer} from '../../inMemoryTraceServer';
+import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
 import {wrapOpenAI} from '../../integrations/openai';
 import {initWithCustomTraceServer} from '../clientMock';
 import {makeAPIPromiseShim, makeMockOpenAIChat} from '../openaiMock';

--- a/sdks/node/src/__tests__/integrations/openaiAgent.realtime.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.realtime.test.ts
@@ -1,6 +1,6 @@
 import {EventEmitter} from 'events';
 import {WeaveRealtimeTracingAdapter} from '../../integrations/openai.realtime.agent';
-import {InMemoryTraceServer} from '../../inMemoryTraceServer';
+import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
 import {initWithCustomTraceServer} from '../clientMock';
 
 function makeMockSession() {

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -1,4 +1,4 @@
-import {InMemoryTraceServer} from '../../inMemoryTraceServer';
+import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
 import {createOpenAIAgentsTracingProcessor} from '../../integrations/openai.agent';
 import {initWithCustomTraceServer} from '../clientMock';
 

--- a/sdks/node/src/__tests__/opFlow.test.ts
+++ b/sdks/node/src/__tests__/opFlow.test.ts
@@ -1,4 +1,4 @@
-import {InMemoryTraceServer} from '../inMemoryTraceServer';
+import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {wrapOpenAIChatCompletionsCreate} from '../integrations/openai';
 import {op} from '../op';
 import {initWithCustomTraceServer} from './clientMock';


### PR DESCRIPTION
## Description

* This module is included in our built `dist/`, but only needed for tests.

```
➜  some-project ls -al node_modules/weave/dist/inMemoryTraceServer.*
-rw-r--r--  node_modules/weave/dist/inMemoryTraceServer.d.ts
-rw-r--r--  node_modules/weave/dist/inMemoryTraceServer.d.ts.map
-rw-r--r--  node_modules/weave/dist/inMemoryTraceServer.js
-rw-r--r--  node_modules/weave/dist/inMemoryTraceServer.js.map
-rw-r--r--  node_modules/weave/dist/inMemoryTraceServer.mjs
-rw-r--r--  node_modules/weave/dist/inMemoryTraceServer.mjs.map
```

