### PR TITLE
chore(weave): enrich call-end kafka payload with op_name/trace_id

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1383,6 +1383,38 @@ def test_call_end_flushes_kafka_immediately(server_with_mock_kafka):
     assert mock_producer.produce_call_end.call_args[0][1] is True
 
 
+def test_call_end_payload_op_identity_per_path(server_with_mock_kafka):
+    """calls_complete enriches the Kafka payload with op_name/trace_id; v1 leaves them None."""
+    server, mock_producer = server_with_mock_kafka
+    project_id = base64.b64encode(b"test_entity/test_project").decode("utf-8")
+    now = dt.datetime.now(dt.timezone.utc)
+
+    server.call_end(_make_call_end_req())
+    v1_payload = mock_producer.produce_call_end.call_args[0][0]
+    assert v1_payload.op_name is None
+    assert v1_payload.trace_id is None
+
+    complete = tsi.CompletedCallSchemaForInsert(
+        project_id=project_id,
+        id=str(uuid.uuid4()),
+        trace_id=str(uuid.uuid4()),
+        op_name="weave-trace-internal:///int-id-1/op/my_op:abc",
+        started_at=now,
+        ended_at=now,
+        attributes={},
+        inputs={},
+        output={},
+        summary={},
+    )
+    with patch.object(chts, "get_project_retention_days", return_value=30):
+        server.calls_complete(tsi.CallsUpsertCompleteReq(batch=[complete]))
+
+    complete_payload = mock_producer.produce_call_end.call_args[0][0]
+    assert complete_payload.op_name == complete.op_name
+    assert complete_payload.trace_id == complete.trace_id
+    assert complete_payload.id == complete.id
+
+
 def test_call_end_v2_flushes_kafka_immediately(server_with_mock_kafka):
     """Non-batch call_end_v2 should flush Kafka per-request."""
     server, mock_producer = server_with_mock_kafka

--- a/weave/trace_server/clickhouse/utilities.py
+++ b/weave/trace_server/clickhouse/utilities.py
@@ -322,6 +322,8 @@ def maybe_enqueue_minimal_call_end(
     id: str,
     ended_at: datetime.datetime,
     flush_immediately: bool = False,
+    op_name: str | None = None,
+    trace_id: str | None = None,
 ) -> None:
     """Enqueue a minimal call end event to Kafka if online eval is enabled.
 
@@ -334,6 +336,8 @@ def maybe_enqueue_minimal_call_end(
         id: The call ID.
         ended_at: The call end timestamp.
         flush_immediately: Whether to flush the producer immediately.
+        op_name: Op identity, when available at produce time (calls_complete/OTel).
+        trace_id: Trace identity, when available at produce time.
     """
     if kafka_producer is None:
         return
@@ -345,6 +349,8 @@ def maybe_enqueue_minimal_call_end(
         output=None,
         summary={},
         exception=None,
+        op_name=op_name,
+        trace_id=trace_id,
     )
     kafka_producer.produce_call_end(minimal_end, flush_immediately)
 

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -693,8 +693,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 end_call.id,
                 end_call.ended_at,
                 False,
+                start_call.op_name,
+                start_call.trace_id,
             )
-            for _, end_call in calls
+            for start_call, end_call in calls
         ]
 
         # Convert and insert based on write target. All calls in the batch
@@ -1020,6 +1022,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     processed_complete_call.project_id,
                     processed_complete_call.id,
                     processed_complete_call.ended_at,
+                    op_name=processed_complete_call.op_name,
+                    trace_id=processed_complete_call.trace_id,
                 )
 
         return tsi.CallsUpsertCompleteRes()

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -244,6 +244,11 @@ class EndedCallSchemaForInsert(BaseModel):
     # WB Metadata
     wb_run_step_end: int | None = None
 
+    # Op identity. Populated only on the calls_complete and OTel produce paths
+    # so downstream scoring can filter without hydrating. None on the v1 path.
+    op_name: str | None = None
+    trace_id: str | None = None
+
     @field_serializer("summary")
     def serialize_typed_dicts(self, v: dict[str, Any]) -> dict[str, Any]:
         return dict(v)


### PR DESCRIPTION
See spec: scoring-partition-bucketing (item #1).

## Summary
- add optional `op_name`/`trace_id` to the minimal call-end Kafka payload on the `calls_complete` and OTel produce paths (both already in scope); v1 `call_end` leaves them None
- lets the scoring worker fast-skip by op without hydrating from ClickHouse

## Testing
unit test asserts the enriched payload on the calls_complete path and None on v1