### PR TITLE
fix(weave): mirror clickhouse CI image via ghcr 

### DIFF
--- a/.github/scripts/ch-image.sh
+++ b/.github/scripts/ch-image.sh
@@ -10,10 +10,11 @@ ghcr="ghcr.io/wandb/clickhouse-server:${tag}"
 hub="clickhouse/clickhouse-server:${tag}"
 
 if [ -n "${GITHUB_TOKEN:-}" ]; then
+  # best-effort: fork/dependabot PRs lack packages:write and fall back to the Hub path below.
   echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR:-wandb}" --password-stdin 1>&2 || true
 fi
 
-if docker pull "$ghcr" 1>&2 2>/dev/null; then
+if docker pull "$ghcr" 1>&2; then
   echo "$ghcr"
   exit 0
 fi

--- a/.github/scripts/ch-image.sh
+++ b/.github/scripts/ch-image.sh
@@ -4,7 +4,8 @@
 # the runnable image ref on stdout (everything else goes to stderr).
 set -uo pipefail
 
-tag="${1:?usage: ch-image.sh <tag>}"
+# Single source of truth for the ClickHouse image version used across CI.
+tag="${1:-25.11.2.24}"
 ghcr="ghcr.io/wandb/clickhouse-server:${tag}"
 hub="clickhouse/clickhouse-server:${tag}"
 

--- a/.github/scripts/ch-image.sh
+++ b/.github/scripts/ch-image.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Resolve a ClickHouse image via GHCR to dodge Docker Hub pull rate limits in CI.
+# Mirrors clickhouse/clickhouse-server:<tag> into GHCR on first use, then prints
+# the runnable image ref on stdout (everything else goes to stderr).
+set -uo pipefail
+
+tag="${1:?usage: ch-image.sh <tag>}"
+ghcr="ghcr.io/wandb/clickhouse-server:${tag}"
+hub="clickhouse/clickhouse-server:${tag}"
+
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  echo "${GITHUB_TOKEN}" | docker login ghcr.io -u "${GITHUB_ACTOR:-wandb}" --password-stdin 1>&2 || true
+fi
+
+if docker pull "$ghcr" 1>&2 2>/dev/null; then
+  echo "$ghcr"
+  exit 0
+fi
+
+echo "Mirroring ${hub} -> ${ghcr}" 1>&2
+docker pull "$hub" 1>&2
+docker tag "$hub" "$ghcr"
+if docker push "$ghcr" 1>&2; then
+  echo "$ghcr"
+else
+  echo "GHCR push skipped (no write access); running from Docker Hub image" 1>&2
+  echo "$hub"
+fi

--- a/.github/scripts/ch-image.sh
+++ b/.github/scripts/ch-image.sh
@@ -19,7 +19,10 @@ if docker pull "$ghcr" 1>&2 2>/dev/null; then
 fi
 
 echo "Mirroring ${hub} -> ${ghcr}" 1>&2
-docker pull "$hub" 1>&2
+if ! docker pull "$hub" 1>&2; then
+  echo "Failed to pull ${hub}" 1>&2
+  exit 1
+fi
 docker tag "$hub" "$ghcr"
 if docker push "$ghcr" 1>&2; then
   echo "$ghcr"

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -12,9 +12,6 @@ on:
         required: false
         default: ""
 
-env:
-  CLICKHOUSE_IMAGE_TAG: "25.11.2.24"
-
 jobs:
   nightly-tests:
     name: Nightly Tests
@@ -124,7 +121,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          image=$(.github/scripts/ch-image.sh "$CLICKHOUSE_IMAGE_TAG")
+          image=$(.github/scripts/ch-image.sh)
           docker run --detach --rm --name weave_clickhouse \
             --env CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
             --env CLICKHOUSE_USER=default \

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -12,6 +12,9 @@ on:
         required: false
         default: ""
 
+env:
+  CLICKHOUSE_IMAGE_TAG: "25.11.2.24"
+
 jobs:
   nightly-tests:
     name: Nightly Tests
@@ -19,6 +22,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     runs-on: ubuntu-latest
     env:
       MAX_ATTEMPTS: 3
@@ -67,17 +71,6 @@ jobs:
             python-version-minor: "10"
             shard: "verifiers_test"
       fail-fast: false
-    services:
-      weave_clickhouse:
-        image: clickhouse/clickhouse-server:25.10
-        env:
-          CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-          CLICKHOUSE_USER: default
-          CLICKHOUSE_PASSWORD: ""
-          CLICKHOUSE_DB: default
-        ports:
-          - "8123:8123"
-        options: --health-cmd "wget -nv -O- 'http://localhost:8123/ping' || exit 1" --health-interval=5s --health-timeout=3s
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -125,6 +118,29 @@ jobs:
           done
           docker logs wandbservice
           exit 1
+      - name: Start ClickHouse
+        if: steps.filter_shards.outputs.skip != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          image=$(.github/scripts/ch-image.sh "$CLICKHOUSE_IMAGE_TAG")
+          docker run --detach --rm --name weave_clickhouse \
+            --env CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
+            --env CLICKHOUSE_USER=default \
+            --env CLICKHOUSE_PASSWORD= \
+            --env CLICKHOUSE_DB=default \
+            --publish 8123:8123 \
+            "$image"
+          for _i in {1..30}; do
+            if wget -q -O- 'http://localhost:8123/ping' >/dev/null; then
+              echo "clickhouse is healthy"
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs weave_clickhouse
+          exit 1
       - name: Enable debug logging
         if: steps.filter_shards.outputs.skip != 'true'
         run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
@@ -161,7 +177,7 @@ jobs:
           CI: 1
           WEAVE_USE_MEMRAY: 1
           WB_SERVER_HOST: http://localhost
-          WF_CLICKHOUSE_HOST: weave_clickhouse
+          WF_CLICKHOUSE_HOST: localhost
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,9 +11,6 @@ name: test
 on:
   push:
 
-env:
-  CLICKHOUSE_IMAGE_TAG: "25.11.2.24"
-
 jobs:
   check-which-tests-to-run:
     uses: ./.github/workflows/check-which-tests-to-run.yaml
@@ -206,7 +203,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          image=$(.github/scripts/ch-image.sh "$CLICKHOUSE_IMAGE_TAG")
+          image=$(.github/scripts/ch-image.sh)
           docker run --detach --rm --name weave_clickhouse \
             --env CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
             --env CLICKHOUSE_USER=default \
@@ -298,7 +295,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          image=$(.github/scripts/ch-image.sh "$CLICKHOUSE_IMAGE_TAG")
+          image=$(.github/scripts/ch-image.sh)
           docker run -d --rm \
             -e CLICKHOUSE_DB=default \
             -e CLICKHOUSE_USER=default \

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,9 @@ name: test
 on:
   push:
 
+env:
+  CLICKHOUSE_IMAGE_TAG: "25.11.2.24"
+
 jobs:
   check-which-tests-to-run:
     uses: ./.github/workflows/check-which-tests-to-run.yaml
@@ -108,6 +111,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     # TODO: refactor to use matrix.include for runner selection
     # Use 8-core runners for trace and trace_calls_complete_only shards (resource-intensive)
     runs-on: ${{ (matrix.nox-shard == 'trace' || matrix.nox-shard == 'trace_calls_complete_only') && 'ubuntu-latest-8-cores' || 'ubuntu-latest' }}
@@ -166,17 +170,6 @@ jobs:
           - python-version-minor: "13"
             nox-shard: "verifiers_test"
       fail-fast: false
-    services:
-      weave_clickhouse:
-        image: clickhouse/clickhouse-server:25.11.2.24
-        env:
-          CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
-          CLICKHOUSE_USER: default
-          CLICKHOUSE_PASSWORD: ""
-          CLICKHOUSE_DB: default
-        ports:
-          - "8123:8123"
-        options: --health-cmd "wget -nv -O- 'http://localhost:8123/ping' || exit 1" --health-interval=5s --health-timeout=3s
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -208,6 +201,28 @@ jobs:
           done
           docker logs wandbservice
           exit 1
+      - name: Start ClickHouse
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          image=$(.github/scripts/ch-image.sh "$CLICKHOUSE_IMAGE_TAG")
+          docker run --detach --rm --name weave_clickhouse \
+            --env CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
+            --env CLICKHOUSE_USER=default \
+            --env CLICKHOUSE_PASSWORD= \
+            --env CLICKHOUSE_DB=default \
+            --publish 8123:8123 \
+            "$image"
+          for _i in {1..30}; do
+            if wget -q -O- 'http://localhost:8123/ping' >/dev/null; then
+              echo "clickhouse is healthy"
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs weave_clickhouse
+          exit 1
       - name: Enable debug logging
         run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
       - name: Install SQLite dev package
@@ -228,7 +243,7 @@ jobs:
           WEAVE_SENTRY_ENV: ci
           CI: 1
           WB_SERVER_HOST: http://localhost
-          WF_CLICKHOUSE_HOST: weave_clickhouse
+          WF_CLICKHOUSE_HOST: localhost
           WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
           # Use format-valid dummy API keys when secrets aren't available (e.g., Dependabot PRs)
           # Tests use VCR recordings so real keys aren't needed
@@ -267,6 +282,9 @@ jobs:
     name: Trace server migrator tests (1s1r)
     timeout-minutes: 10
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         python-version-major: ["3"]
@@ -276,7 +294,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
       - name: Start ClickHouse with embedded Keeper
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          set -euo pipefail
+          image=$(.github/scripts/ch-image.sh "$CLICKHOUSE_IMAGE_TAG")
           docker run -d --rm \
             -e CLICKHOUSE_DB=default \
             -e CLICKHOUSE_USER=default \
@@ -286,7 +308,7 @@ jobs:
             -v ${{ github.workspace }}/tests/trace_server/conftest_lib/clickhouse_keeper_config.xml:/etc/clickhouse-server/config.d/keeper.xml \
             --name weave-test-keeper \
             --ulimit nofile=262144:262144 \
-            clickhouse/clickhouse-server:25.11.2.24
+            "$image"
           # Wait for server to be healthy
           for i in $(seq 1 30); do
             wget -q -O- 'http://localhost:8130/ping' && break || sleep 1


### PR DESCRIPTION
## Summary
- The `weave_clickhouse` service container pulled from Docker Hub, which intermittently fails CI at image-pull time (`net/http: request canceled ... Client.Timeout`) due to the unauthenticated per-IP rate limit.
- Convert it to an in-step `docker run` that pulls from `ghcr.io/wandb/clickhouse-server`, mirroring from Docker Hub on first use (`.github/scripts/ch-image.sh`).
- Now CH version is single-sourced as the script's default tag (was pinned in 3 spots, incl. nightly's stale `25.10`).

## Performance
Per trace-tests job. The `Initialize containers` phase is gone (no service containers), so even the one-time seeding run beats the old Hub pull.

| stage | master (Hub service) | run #1 (seed) | run #2 (ghcr-hit) |
|---|---|---|---|
| Initialize containers | 21s | 0s | 0s |
| Start ClickHouse step | n/a | ~16s | ~12-13s |

## Testing
first run seeds ghcr (one hub pull); subsequent runs pull from ghcr, no hub access. 161/161 jobs green. make the ghcr package public so fork/dependabot PRs skip hub too.