### PR TITLE
feat(weave): migration to add agent columns to feedback table

### DIFF
--- a/weave/trace_server/migrations/033_add_agent_columns_to_feedback.down.sql
+++ b/weave/trace_server/migrations/033_add_agent_columns_to_feedback.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE feedback
+    DROP INDEX IF EXISTS idx_span_agent_name,
+    DROP INDEX IF EXISTS idx_span_agent_version;
+
+ALTER TABLE feedback
+    DROP COLUMN IF EXISTS span_agent_name,
+    DROP COLUMN IF EXISTS span_agent_version,
+    DROP COLUMN IF EXISTS span_status_code;

--- a/weave/trace_server/migrations/033_add_agent_columns_to_feedback.up.sql
+++ b/weave/trace_server/migrations/033_add_agent_columns_to_feedback.up.sql
@@ -1,0 +1,23 @@
+/*
+Duplicate select genai metadata from the `spans` table into `feedback`.
+Denormalizing the data this ways allows for efficient queries on agent data.
+Includes only the data that we frequently want to filter/group on for scores.
+This is used only for visualizations and `spans` remains the source of truth.
+
+- `span_agent_name`: display name of the scored agent (from `spans.agent_name`).
+- `span_agent_version`: agent version string (from `spans.agent_version`).
+- `span_status_code`: status of the scored turn (from `spans.status_code`).
+*/
+ALTER TABLE feedback
+    ADD COLUMN IF NOT EXISTS span_agent_name    String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS span_agent_version String DEFAULT '',
+    ADD COLUMN IF NOT EXISTS span_status_code   Enum8('UNSET'=0, 'OK'=1, 'ERROR'=2) DEFAULT 'UNSET';
+
+/*
+Add data-skipping indexes on the columns we want to filter on.
+- `idx_span_agent_name`: skip granules with agents not in the query.
+- `idx_span_agent_version`: skip granules with versions not in the query.
+*/
+ALTER TABLE feedback
+    ADD INDEX IF NOT EXISTS idx_span_agent_name   span_agent_name    TYPE set(64)  GRANULARITY 1,
+    ADD INDEX IF NOT EXISTS idx_span_agent_version span_agent_version TYPE set(128) GRANULARITY 1;


### PR DESCRIPTION
First of several stacked PRs adding a pre-aggregated feedback API for the Agent Signals charts.

## Changes

Migration to add 3 new columns to the `feedback` table that are duplicated from the agent `spans` table: `span_agent_name`, `span_agent_version`, `span_status_code`. 

Denormalizing the data this ways allows for efficient queries on agent data. Includes only the data that we frequently want to filter/group on for scores. This will used only for visualizations and `spans` remains the source of truth.

## Stack

1. **#7042 (this PR)** — migration
2. #7043 — ORM plumbing + aggregate query builder + models
3. #7044 — feedback_aggregate endpoint impl + bindings

## Testing

- [x] Deploy to QA