### PR TITLE
chore(weave): import timestamp_to_datetime_str in calls_query_builder

### DIFF
--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -78,6 +78,7 @@ from weave.trace_server.orm import (
     maybe_convert_datetime_operands,
     python_value_to_ch_type,
     split_escaped_field_path,
+    timestamp_to_datetime_str,
 )
 from weave.trace_server.project_version.types import ReadTable, TableConfig
 from weave.trace_server.token_costs import build_cost_ctes, get_cost_final_select


### PR DESCRIPTION
## Summary
- master is red: `#7021` calls `timestamp_to_datetime_str` but the import was dropped when `#6991` moved that helper from `calls_query_builder.utils` to `orm.py`. Logical merge conflict (both mine).
- adds the symbol to the existing `weave.trace_server.orm` import.

## Testing
ruff F821 clears; one-line import fix