### PR TITLE
chore(weave): cache uv on windows test runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -493,7 +493,7 @@ jobs:
   # ==== Windows Jobs ====
   windows_trace_no_server:
     name: Windows Trace non-trace server tests
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: windows-latest
     strategy:
       matrix:
@@ -513,10 +513,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+      - name: Set up uv (cached)
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-local-path: ${{ runner.temp }}\uv-cache
+          cache-dependency-glob: "**/pyproject.toml"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nox uv
+          pip install nox
       - name: Run nox (Non Trace Server)
         env:
           DD_TRACE_ENABLED: "false"
@@ -533,7 +539,7 @@ jobs:
 
   windows_trace_tests:
     name: Windows Trace nox tests
-    timeout-minutes: 15
+    timeout-minutes: 25
     runs-on: windows-latest
     strategy:
       matrix:
@@ -594,10 +600,16 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+      - name: Set up uv (cached)
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-local-path: ${{ runner.temp }}\uv-cache
+          cache-dependency-glob: "**/pyproject.toml"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install nox uv
+          pip install nox
       - name: Run nox (Sqlite Trace Server)
         env:
           WEAVE_SENTRY_ENV: ci


### PR DESCRIPTION
## Summary
- Windows trace jobs full-copy ~237 packages into the `.nox` venv every run (uv cache on `C:`, venv on `D:` -> hardlink always falls back to copy).
- Relocate the uv cache to `D:` (`runner.temp`) via `setup-uv` so packages materialize via hardlink instead of copy. Bump timeouts (15->25, 10->15) for slow-runner headroom.
- [WB-35115](https://coreweave.atlassian.net/browse/WB-35115)

## Performance
`3.13 openai` shard, healthy runners:

| run | nox step (install + tests) | total job |
| --- | --- | --- |
| master | 104s | 146s |
| this branch | 78s | 123s |

## Testing
ci only change.

[WB-35115]: https://coreweave.atlassian.net/browse/WB-35115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ