### PR TITLE
chore(weave): normalize wav mimetypes

### DIFF
--- a/tests/trace/type_handlers/Content/test_content_resolvers.py
+++ b/tests/trace/type_handlers/Content/test_content_resolvers.py
@@ -215,7 +215,8 @@ def extensionless_png_file(tmp_path_factory, png_bytes) -> Path:
 BUFFER_CASES = [
     ("png_bytes", "image/png"),
     ("jpeg_bytes", "image/jpeg"),
-    ("wav_bytes", "audio/x-wav"),
+    # libmagic detects audio/x-wav; normalized to canonical audio/wav.
+    ("wav_bytes", "audio/wav"),
     ("pdf_bytes", "application/pdf"),
     ("gif_bytes", "image/gif"),
 ]
@@ -269,7 +270,8 @@ class TestResolverDetectFromBuffer:
 FILE_CASES = [
     ("png_file", "image/png", ".png"),
     ("jpeg_file", "image/jpeg", ".jpg"),
-    ("wav_file", "audio/x-wav", ".wav"),
+    # libmagic detects audio/x-wav; normalized to canonical audio/wav.
+    ("wav_file", "audio/wav", ".wav"),
     ("pdf_file", "application/pdf", ".pdf"),
 ]
 
@@ -400,7 +402,7 @@ class TestGetMimeAndExtension:
             mimetype=None,
             extension=None,
             filename="music.mp3",  # mimetypes says audio/mpeg
-            buffer=wav_bytes,  # buffer says audio/x-wav
+            buffer=wav_bytes,  # buffer would detect audio/wav
         )
         # Filename-based detection should win
         assert mime == "audio/mpeg"
@@ -410,7 +412,7 @@ class TestGetMimeAndExtension:
         [
             ("png_bytes", "image/png"),
             ("pdf_bytes", "application/pdf"),
-            ("wav_bytes", "audio/x-wav"),
+            ("wav_bytes", "audio/wav"),
             ("jpeg_bytes", "image/jpeg"),
         ],
     )
@@ -563,7 +565,8 @@ class TestContentIntegration:
 
     def test_from_path_wav(self, resolver_backend, wav_file):
         c = Content.from_path(wav_file)
-        assert c.mimetype in {"audio/x-wav", "audio/wav"}
+        # Detected audio/x-wav is normalized to canonical audio/wav.
+        assert c.mimetype == "audio/wav"
         assert c.extension == ".wav"
 
     def test_from_bytes_with_extension(self, resolver_backend, png_bytes):
@@ -577,6 +580,7 @@ class TestContentIntegration:
         assert c.mimetype == "application/pdf"
 
     def test_from_bytes_mimetype_only(self, resolver_backend, wav_bytes):
+        # Explicit caller mimetype is preserved; only detected types are normalized.
         c = Content.from_bytes(wav_bytes, mimetype="audio/x-wav")
         assert c.mimetype == "audio/x-wav"
         assert c.extension is not None  # should be resolved from mimetype

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -347,10 +347,10 @@ class TestStandaloneBase64Detection:
         # Verify file_create was called twice (content + metadata)
         assert trace_server.file_create.call_count == 2
 
-        # Verify the content mimetype is audio/wav (not text/plain or application/octet-stream)
+        # Detected audio/x-wav is normalized to canonical audio/wav.
         metadata_call = trace_server.file_create.call_args_list[1][0][0]
         metadata = json.loads(metadata_call.content)
-        assert metadata["mimetype"] in {"audio/wav", "audio/x-wav", "audio/wave"}
+        assert metadata["mimetype"] == "audio/wav"
 
 
 class TestThresholdAndStructuralIdentity:

--- a/weave/type_wrappers/Content/utils.py
+++ b/weave/type_wrappers/Content/utils.py
@@ -90,10 +90,6 @@ _DETECTED_MIMETYPE_ALIASES = {
 }
 
 
-def _normalize_detected_mimetype(mimetype: str | None) -> str | None:
-    return _DETECTED_MIMETYPE_ALIASES.get(mimetype, mimetype)
-
-
 def _detect_from_resolver(
     *, filename: str | None, buffer: bytes | None
 ) -> tuple[str | None, str | None]:
@@ -105,7 +101,9 @@ def _detect_from_resolver(
     resolver = _get_resolver()
     if resolver is not None:
         mimetype, extension = resolver.detect(filename=filename, buffer=buffer)
-        return _normalize_detected_mimetype(mimetype), extension
+        if mimetype is not None:
+            mimetype = _DETECTED_MIMETYPE_ALIASES.get(mimetype, mimetype)
+        return mimetype, extension
 
     if buffer is not None:
         logger.warning(
@@ -196,7 +194,9 @@ def guess_from_buffer(buffer: bytes) -> str | None:
         return None
 
     mimetype, _ = resolver.detect(filename=None, buffer=buffer)
-    return _normalize_detected_mimetype(mimetype)
+    if mimetype is not None:
+        mimetype = _DETECTED_MIMETYPE_ALIASES.get(mimetype, mimetype)
+    return mimetype
 
 
 def guess_from_filename(filename: str) -> str | None:

--- a/weave/type_wrappers/Content/utils.py
+++ b/weave/type_wrappers/Content/utils.py
@@ -82,6 +82,18 @@ def _get_resolver() -> Any:
     return None
 
 
+# libmagic reports WAV as audio/x-wav; normalize detected types to the canonical
+# audio/wav so buffer- and filename-based detection agree. Caller-supplied
+# mimetypes don't pass through here and are preserved as-is.
+_DETECTED_MIMETYPE_ALIASES = {
+    "audio/x-wav": "audio/wav",
+}
+
+
+def _normalize_detected_mimetype(mimetype: str | None) -> str | None:
+    return _DETECTED_MIMETYPE_ALIASES.get(mimetype, mimetype)
+
+
 def _detect_from_resolver(
     *, filename: str | None, buffer: bytes | None
 ) -> tuple[str | None, str | None]:
@@ -92,7 +104,8 @@ def _detect_from_resolver(
     """
     resolver = _get_resolver()
     if resolver is not None:
-        return resolver.detect(filename=filename, buffer=buffer)
+        mimetype, extension = resolver.detect(filename=filename, buffer=buffer)
+        return _normalize_detected_mimetype(mimetype), extension
 
     if buffer is not None:
         logger.warning(
@@ -183,7 +196,7 @@ def guess_from_buffer(buffer: bytes) -> str | None:
         return None
 
     mimetype, _ = resolver.detect(filename=None, buffer=buffer)
-    return mimetype
+    return _normalize_detected_mimetype(mimetype)
 
 
 def guess_from_filename(filename: str) -> str | None:


### PR DESCRIPTION
## Purpose

`libmagic` reports WAV files as `audio/x-wav`, while filename/extension-based detection (via the `mimetypes` module) yields `audio/wav`. This inconsistency meant the same WAV file could end up with different mimetypes depending on whether it was detected from a buffer or a filename.

This PR normalizes WAV mimetypes to the canonical `audio/wav` so buffer- and filename-based detection agree.

## Changes

- Add `_DETECTED_MIMETYPE_ALIASES` mapping (`audio/x-wav` → `audio/wav`) and a 
- Apply normalization in `_detect_from_resolver` and `guess_from_buffer`.
- Caller-supplied mimetypes are preserved as-is

## Testing

Updated existing tests to assert the canonical `audio/wav` value instead of accepting a set of variants:

