### PR TITLE
feat(weave): `feedback_agg_query_builder.py`

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -5,13 +5,21 @@ from clickhouse_connect.driver.exceptions import DatabaseError
 
 import weave
 from tests.trace.util import client_is_sqlite
+from tests.trace_server.conftest_lib.trace_server_external_adapter import (
+    DummyIdConverter,
+)
 from weave import AnnotationSpec
 from weave.trace.weave_client import WeaveClient, get_ref
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
 from weave.trace_server.errors import InvalidRequest
+from weave.trace_server.feedback_agg_query_builder import (
+    build_feedback_aggregate_query,
+)
 from weave.trace_server.interface.query import Query
+from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.trace_server_interface import (
+    FeedbackAggregateReq,
     FeedbackCreateReq,
     FeedbackQueryReq,
     FeedbackReplaceReq,
@@ -991,6 +999,79 @@ async def test_filter_by_feedback(client: WeaveClient, no_autoflush) -> None:
             f"Filtering by {model_output_field} $contains '{substr}' failed, "
             f"expected {expected_ids}, got {found_ids}"
         )
+
+
+def test_feedback_aggregate_filter_matching_functional(client: WeaveClient) -> None:
+    """Functional checks (ClickHouse-only) that the WHERE filters match precisely.
+
+    The aggregate endpoint lands separately, so this executes the built query
+    directly. Guards against over-broad matching that string assertions miss:
+    object-id filters match the id exactly (a trailing '*' opts into prefix), and
+    span_types matches the ref's span-type segment, not an arbitrary substring.
+    """
+    if client_is_sqlite(client):
+        pytest.skip("feedback_aggregate query is ClickHouse-only (sumMap/splitByChar)")
+
+    project_id = client.project_id
+    now_ms = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
+    after_ms = now_ms - 3_600_000
+    before_ms = now_ms + 3_600_000
+
+    def _monitor(suffix: str, monitor_id: str, weave_ref: str) -> None:
+        client.server.feedback_create(
+            tsi.FeedbackCreateReq(
+                project_id=project_id,
+                weave_ref=weave_ref,
+                feedback_type="wandb.agent_monitor",
+                payload={"value": []},
+                runnable_ref=f"weave:///{project_id}/object/scorer_{suffix}:obj_{suffix}",
+                call_ref=f"weave:///{project_id}/call/{suffix}",
+                trigger_ref=f"weave:///{project_id}/object/{monitor_id}:trig_{suffix}",
+            )
+        )
+
+    # Two monitors whose ids share a prefix ("mon" vs "monday"), one scoring an
+    # agent_turn ref and one an agent_conversation ref.
+    _monitor("t1", "mon", f"weave:///{project_id}/agent_turn/trace_t1")
+    _monitor("c1", "monday", f"weave:///{project_id}/agent_conversation/conv_c1")
+
+    # feedback_create (via the external adapter) stores the internal project_id and
+    # internalized refs; query against that internal id, not the external one.
+    internal_project_id = DummyIdConverter().ext_to_int_project_id(project_id)
+
+    def _total(**filters) -> int:
+        """Run the aggregate (global rollup) and return the total matched rows."""
+        pb = ParamBuilder()
+        built = build_feedback_aggregate_query(
+            FeedbackAggregateReq(
+                project_id=internal_project_id,
+                after_ms=after_ms,
+                before_ms=before_ms,
+                feedback_types=["wandb.agent_monitor"],
+                **filters,
+            ),
+            pb,
+        )
+        result = client.server._query(built.sql, built.parameters)
+        rows = [
+            dict(zip(built.columns, row, strict=True)) for row in result.result_rows
+        ]
+        return sum(int(r["total_count"]) for r in rows)
+
+    # Sanity: both rows are present absent any id/type filter.
+    assert _total() == 2
+
+    # monitor_ids: exact by default, so "mon" must NOT match "monday".
+    assert _total(monitor_ids=["mon"]) == 1
+    assert _total(monitor_ids=["monday"]) == 1
+    assert _total(monitor_ids=["mond"]) == 0  # no partial match without '*'
+    # A trailing '*' opts into prefix matching -> matches both ids.
+    assert _total(monitor_ids=["mon*"]) == 2
+
+    # span_types: matches the exact span-type segment of the ref, not a substring.
+    assert _total(span_types=["agent_turn"]) == 1
+    assert _total(span_types=["agent_conversation"]) == 1
+    assert _total(span_types=["agent_turn", "agent_conversation"]) == 2
 
 
 class MatchAnyDatetime:  # noqa: PLW1641

--- a/tests/trace_server/query_builder/test_feedback_aggregate.py
+++ b/tests/trace_server/query_builder/test_feedback_aggregate.py
@@ -1,0 +1,351 @@
+"""Tests for the feedback aggregate query builder."""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+from pydantic import ValidationError
+
+from weave.trace_server.feedback_agg_query_builder import (
+    _any_prefix_clause,
+    _build_where_sql,
+    _object_id_match_clause,
+    _ref_object_id_sql,
+    build_feedback_aggregate_query,
+)
+from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.trace_server_interface import (
+    DAY_IN_MS,
+    FEEDBACK_AGGREGATE_GROUP_BY_COLUMNS,
+    FeedbackAggregateReq,
+)
+
+# 2024-01-01 and 2024-01-02 UTC, in unix epoch ms (a 1-day window).
+_AFTER_MS = 1704067200000
+_BEFORE_MS = 1704153600000
+_BUCKET_SECONDS = 21600
+
+
+def _make_pb() -> ParamBuilder:
+    return ParamBuilder(prefix="pb")
+
+
+def _normalize_sql(sql: str) -> str:
+    return "\n".join(
+        line.rstrip() for line in textwrap.dedent(sql).strip().splitlines()
+    )
+
+
+def _make_req(**kwargs) -> FeedbackAggregateReq:
+    defaults: dict = {
+        "project_id": "entity/project",
+        "after_ms": _AFTER_MS,
+        "before_ms": _BEFORE_MS,
+        "time_bucket_seconds": _BUCKET_SECONDS,
+    }
+    defaults.update(kwargs)
+    return FeedbackAggregateReq(**defaults)
+
+
+def test_build_feedback_aggregate_query():
+    """Happy path: a grouped, tag-filtered request yields the expected SQL + params.
+
+    Edge: with no group_by the dimension drops out of SELECT/GROUP BY and columns.
+    """
+    pb = _make_pb()
+    result = build_feedback_aggregate_query(
+        _make_req(group_by=["runnable_ref"], tags=["nsfw"]), pb
+    )
+    assert _normalize_sql(result.sql) == _normalize_sql(
+        """
+        SELECT toStartOfInterval(created_at, toIntervalSecond({pb_3:Int64}), 'UTC') AS bucket,
+               runnable_ref,
+               sumMap(scorer_tags, arrayMap(x -> toUInt64(1), scorer_tags)) AS tag_counts,
+               sumMap(mapKeys(scorer_ratings), mapValues(scorer_ratings)) AS rating_sums,
+               sumMap(mapKeys(scorer_ratings), arrayMap(x -> toUInt64(1), mapValues(scorer_ratings))) AS rating_counts,
+               count() AS total_count,
+               countIf(notEmpty(scorer_tags)
+                       OR notEmpty(scorer_ratings)) AS scored_count
+        FROM feedback
+        WHERE project_id = {pb_0:String}
+          AND created_at >= fromUnixTimestamp64Milli({pb_1:Int64})
+          AND created_at < fromUnixTimestamp64Milli({pb_2:Int64})
+          AND hasAny(scorer_tags, {pb_4:Array(String)})
+        GROUP BY bucket,
+                 runnable_ref
+        ORDER BY bucket
+        """
+    )
+    assert pb.get_params() == {
+        "pb_0": "entity/project",
+        "pb_1": _AFTER_MS,
+        "pb_2": _BEFORE_MS,
+        "pb_3": _BUCKET_SECONDS,
+        "pb_4": ["nsfw"],
+    }
+
+    # Edge: with no group_by the dimension drops out of SELECT/GROUP BY/columns,
+    # leaving just the bucket + aggregates.
+    no_group = build_feedback_aggregate_query(_make_req(), _make_pb())
+    assert _normalize_sql(no_group.sql) == _normalize_sql(
+        """
+        SELECT toStartOfInterval(created_at, toIntervalSecond({pb_3:Int64}), 'UTC') AS bucket,
+               sumMap(scorer_tags, arrayMap(x -> toUInt64(1), scorer_tags)) AS tag_counts,
+               sumMap(mapKeys(scorer_ratings), mapValues(scorer_ratings)) AS rating_sums,
+               sumMap(mapKeys(scorer_ratings), arrayMap(x -> toUInt64(1), mapValues(scorer_ratings))) AS rating_counts,
+               count() AS total_count,
+               countIf(notEmpty(scorer_tags)
+                       OR notEmpty(scorer_ratings)) AS scored_count
+        FROM feedback
+        WHERE project_id = {pb_0:String}
+          AND created_at >= fromUnixTimestamp64Milli({pb_1:Int64})
+          AND created_at < fromUnixTimestamp64Milli({pb_2:Int64})
+        GROUP BY bucket
+        ORDER BY bucket
+        """
+    )
+    assert no_group.columns == [
+        "bucket",
+        "tag_counts",
+        "rating_sums",
+        "rating_counts",
+        "total_count",
+        "scored_count",
+    ]
+
+    # Edge: every allowlisted dimension lands in the SELECT, GROUP BY, and columns
+    # in the same shape — only the dimension name changes.
+    for col in sorted(FEEDBACK_AGGREGATE_GROUP_BY_COLUMNS):
+        grouped = build_feedback_aggregate_query(_make_req(group_by=[col]), _make_pb())
+        assert _normalize_sql(grouped.sql) == _normalize_sql(
+            "SELECT toStartOfInterval(created_at, toIntervalSecond({pb_3:Int64}), 'UTC') AS bucket,\n"
+            f"       {col},\n"
+            "       sumMap(scorer_tags, arrayMap(x -> toUInt64(1), scorer_tags)) AS tag_counts,\n"
+            "       sumMap(mapKeys(scorer_ratings), mapValues(scorer_ratings)) AS rating_sums,\n"
+            "       sumMap(mapKeys(scorer_ratings), arrayMap(x -> toUInt64(1), mapValues(scorer_ratings))) AS rating_counts,\n"
+            "       count() AS total_count,\n"
+            "       countIf(notEmpty(scorer_tags)\n"
+            "               OR notEmpty(scorer_ratings)) AS scored_count\n"
+            "FROM feedback\n"
+            "WHERE project_id = {pb_0:String}\n"
+            "  AND created_at >= fromUnixTimestamp64Milli({pb_1:Int64})\n"
+            "  AND created_at < fromUnixTimestamp64Milli({pb_2:Int64})\n"
+            "GROUP BY bucket,\n"
+            f"         {col}\n"
+            "ORDER BY bucket"
+        )
+        assert grouped.columns == [
+            "bucket",
+            col,
+            "tag_counts",
+            "rating_sums",
+            "rating_counts",
+            "total_count",
+            "scored_count",
+        ]
+
+    # Edge: time_bucket_seconds=None drops the bucket entirely; group/order by the
+    # dimensions instead.
+    unbucketed = build_feedback_aggregate_query(
+        _make_req(time_bucket_seconds=None, group_by=["runnable_ref"]), _make_pb()
+    )
+    assert _normalize_sql(unbucketed.sql) == _normalize_sql(
+        """
+        SELECT runnable_ref,
+               sumMap(scorer_tags, arrayMap(x -> toUInt64(1), scorer_tags)) AS tag_counts,
+               sumMap(mapKeys(scorer_ratings), mapValues(scorer_ratings)) AS rating_sums,
+               sumMap(mapKeys(scorer_ratings), arrayMap(x -> toUInt64(1), mapValues(scorer_ratings))) AS rating_counts,
+               count() AS total_count,
+               countIf(notEmpty(scorer_tags)
+                       OR notEmpty(scorer_ratings)) AS scored_count
+        FROM feedback
+        WHERE project_id = {pb_0:String}
+          AND created_at >= fromUnixTimestamp64Milli({pb_1:Int64})
+          AND created_at < fromUnixTimestamp64Milli({pb_2:Int64})
+        GROUP BY runnable_ref
+        ORDER BY runnable_ref
+        """
+    )
+    assert unbucketed.columns == [
+        "runnable_ref",
+        "tag_counts",
+        "rating_sums",
+        "rating_counts",
+        "total_count",
+        "scored_count",
+    ]
+
+    # Edge: no bucket and no group_by -> one global rollup, no GROUP BY / ORDER BY.
+    global_rollup = build_feedback_aggregate_query(
+        _make_req(time_bucket_seconds=None), _make_pb()
+    )
+    assert _normalize_sql(global_rollup.sql) == _normalize_sql(
+        """
+        SELECT sumMap(scorer_tags, arrayMap(x -> toUInt64(1), scorer_tags)) AS tag_counts,
+               sumMap(mapKeys(scorer_ratings), mapValues(scorer_ratings)) AS rating_sums,
+               sumMap(mapKeys(scorer_ratings), arrayMap(x -> toUInt64(1), mapValues(scorer_ratings))) AS rating_counts,
+               count() AS total_count,
+               countIf(notEmpty(scorer_tags)
+                       OR notEmpty(scorer_ratings)) AS scored_count
+        FROM feedback
+        WHERE project_id = {pb_0:String}
+          AND created_at >= fromUnixTimestamp64Milli({pb_1:Int64})
+          AND created_at < fromUnixTimestamp64Milli({pb_2:Int64})
+        """
+    )
+    assert global_rollup.columns == [
+        "tag_counts",
+        "rating_sums",
+        "rating_counts",
+        "total_count",
+        "scored_count",
+    ]
+
+
+def test_ref_object_id_sql():
+    """Extracts the object id: the last path segment's name, before any ':digest'."""
+    assert _ref_object_id_sql("trigger_ref") == (
+        "splitByChar(':', splitByChar('/', ifNull(trigger_ref, ''))[-1])[1]"
+    )
+    assert _ref_object_id_sql("runnable_ref") == (
+        "splitByChar(':', splitByChar('/', ifNull(runnable_ref, ''))[-1])[1]"
+    )
+
+
+def test_object_id_match_clause():
+    """Exact match by default; a trailing '*' opts into prefix match.
+
+    Both forms reuse the same object-id expression (digest stripped).
+    """
+    object_id = "splitByChar(':', splitByChar('/', ifNull(trigger_ref, ''))[-1])[1]"
+
+    pb = _make_pb()
+    exact = _object_id_match_clause("trigger_ref", ["mon"], pb)
+    assert exact == f"({object_id} = {{pb_0:String}})"
+    assert pb.get_params() == {"pb_0": "mon"}
+
+    pb = _make_pb()
+    prefix = _object_id_match_clause("trigger_ref", ["mon*"], pb)
+    assert prefix == f"(startsWith({object_id}, {{pb_0:String}}))"
+    assert pb.get_params() == {"pb_0": "mon"}  # '*' stripped before binding
+
+    # Multiple values OR together, mixing exact and prefix.
+    pb = _make_pb()
+    mixed = _object_id_match_clause("trigger_ref", ["a", "b*"], pb)
+    assert mixed == (
+        f"({object_id} = {{pb_0:String}} OR startsWith({object_id}, {{pb_1:String}}))"
+    )
+    assert pb.get_params() == {"pb_0": "a", "pb_1": "b"}
+
+
+def test_any_prefix_clause():
+    """Happy path: values are OR'd as startsWith checks.
+
+    Edge: a trailing '*' decoration is stripped from each value before binding.
+    """
+    pb = _make_pb()
+    clause = _any_prefix_clause("feedback_type", ["wandb.runnable.*", "custom"], pb)
+    assert clause == (
+        "(startsWith(feedback_type, {pb_0:String})"
+        " OR startsWith(feedback_type, {pb_1:String}))"
+    )
+    assert pb.get_params() == {"pb_0": "wandb.runnable.", "pb_1": "custom"}
+
+
+def test_build_where_sql():
+    """Happy path: each typed filter contributes a clause.
+
+    Edges: with no filters only project + time bounds remain; rating bounds emit a
+    guarded _rating_ lookup only when set (defaults are None).
+    """
+    pb = _make_pb()
+    project = pb.add_param("entity/project")
+    after = pb.add_param(_AFTER_MS)
+    before = pb.add_param(_BEFORE_MS)
+    where = _build_where_sql(
+        _make_req(
+            feedback_types=["wandb.agent_monitor"],
+            monitor_ids=["mon"],
+            scorer_ids=["sc"],
+            span_agent_names=["agent_a"],
+            span_types=["agent_turn"],
+            tags=["nsfw"],
+            rating_min=0.5,
+            rating_max=0.9,
+        ),
+        project,
+        after,
+        before,
+        pb,
+    )
+    assert where == (
+        "project_id = {pb_0:String}"
+        " AND created_at >= fromUnixTimestamp64Milli({pb_1:Int64})"
+        " AND created_at < fromUnixTimestamp64Milli({pb_2:Int64})"
+        " AND (startsWith(feedback_type, {pb_3:String}))"
+        " AND (splitByChar(':', splitByChar('/', ifNull(trigger_ref, ''))[-1])[1] = {pb_4:String})"
+        " AND (splitByChar(':', splitByChar('/', ifNull(runnable_ref, ''))[-1])[1] = {pb_5:String})"
+        " AND span_agent_name IN {pb_6:Array(String)}"
+        " AND (splitByChar('/', weave_ref)[-2] = {pb_7:String})"
+        " AND hasAny(scorer_tags, {pb_8:Array(String)})"
+        " AND mapContains(scorer_ratings, {pb_9:String})"
+        " AND scorer_ratings[{pb_9:String}] >= {pb_10:Float64}"
+        " AND scorer_ratings[{pb_9:String}] <= {pb_11:Float64}"
+    )
+    assert pb.get_params() == {
+        "pb_0": "entity/project",
+        "pb_1": _AFTER_MS,
+        "pb_2": _BEFORE_MS,
+        "pb_3": "wandb.agent_monitor",
+        "pb_4": "mon",
+        "pb_5": "sc",
+        "pb_6": ["agent_a"],
+        "pb_7": "agent_turn",
+        "pb_8": ["nsfw"],
+        "pb_9": "_rating_",
+        "pb_10": 0.5,
+        "pb_11": 0.9,
+    }
+
+    # Edge: no filters -> just the project + time-range bounds.
+    bare = _build_where_sql(_make_req(), project, after, before, _make_pb())
+    assert bare == (
+        f"project_id = {{{project}:String}}"
+        f" AND created_at >= fromUnixTimestamp64Milli({{{after}:Int64}})"
+        f" AND created_at < fromUnixTimestamp64Milli({{{before}:Int64}})"
+    )
+
+    # Edge: rating bounds default to None -> no rating clause emitted.
+    no_rating = _build_where_sql(_make_req(), project, after, before, _make_pb())
+    assert "scorer_ratings" not in no_rating
+
+
+def test_feedback_aggregate_req_validation():
+    """The request model validates the window, bucket count, and group_by allowlist."""
+    # Happy path: a sane request constructs cleanly.
+    assert _make_req().time_bucket_seconds == _BUCKET_SECONDS
+
+    # before_ms must be strictly after after_ms.
+    with pytest.raises(ValidationError):
+        _make_req(before_ms=_AFTER_MS)
+
+    # Range cannot exceed the 31-day cap.
+    with pytest.raises(ValidationError):
+        _make_req(after_ms=0, before_ms=DAY_IN_MS * 32, time_bucket_seconds=86_400)
+
+    # Bucket count is capped (1 day at 1s buckets = 86,400 buckets).
+    with pytest.raises(ValidationError):
+        _make_req(time_bucket_seconds=1)
+
+    # time_bucket_seconds is optional; None aggregates over the whole range and
+    # skips the bucket-count cap (which the 1s window above would otherwise trip).
+    assert _make_req(time_bucket_seconds=None).time_bucket_seconds is None
+
+    # A positive bucket is still required when present (gt=0).
+    with pytest.raises(ValidationError):
+        _make_req(time_bucket_seconds=0)
+
+    # group_by is an allowlist; unknown columns are rejected.
+    with pytest.raises(ValidationError):
+        _make_req(group_by=["payload_dump"])

--- a/weave/trace_server/feedback_agg_query_builder.py
+++ b/weave/trace_server/feedback_agg_query_builder.py
@@ -1,0 +1,194 @@
+"""Query builder for feedback aggregates over the typed scorer columns."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+from weave.trace_server.calls_query_builder.utils import param_slot, safely_format_sql
+from weave.trace_server.orm import ParamBuilder
+from weave.trace_server.trace_server_interface import FeedbackAggregateReq
+
+logger = logging.getLogger(__name__)
+
+# A value bound into the parameterized query: the scalar param types plus the
+# list params used for the IN / Array(String) filters (tags, span_agent_names).
+QueryParamValue: TypeAlias = str | int | float | bool | list[str] | None
+
+
+@dataclass
+class FeedbackAggregateQuery:
+    """A parameterized ClickHouse query plus the column order of its result rows."""
+
+    sql: str
+    columns: list[str]
+    parameters: dict[str, QueryParamValue] = field(default_factory=dict)
+
+
+# Agent-monitor scores land under this scorer_ratings key; the rating filter targets it.
+_RATING_KEY = "_rating_"
+
+# SQL to add up tags and ratings by name. Each returns Map(<key-name>, <count-or-sum>).
+# Sum and count are separate for ratings so the client can calculate averages across buckets.
+_TAG_COUNTS_SQL = "sumMap(scorer_tags, arrayMap(x -> toUInt64(1), scorer_tags))"
+_RATING_SUMS_SQL = "sumMap(mapKeys(scorer_ratings), mapValues(scorer_ratings))"
+_RATING_COUNTS_SQL = "sumMap(mapKeys(scorer_ratings), arrayMap(x -> toUInt64(1), mapValues(scorer_ratings)))"
+
+# Count a row if it produced at least one tag or rating. Used to show the total volume of scores.
+_SCORED_COUNT_SQL = "countIf(notEmpty(scorer_tags) OR notEmpty(scorer_ratings))"
+
+
+def build_feedback_aggregate_query(
+    req: FeedbackAggregateReq,
+    pb: ParamBuilder,
+) -> FeedbackAggregateQuery:
+    """Generate parameterized ClickHouse SQL for feedback aggregates.
+
+    Groups by a time bucket (optional) plus `req.group_by`, returning per-group total count,
+    per-tag counts, and per-rating sum/count. Empty time buckets are skipped.
+    """
+    project_param = pb.add_param(req.project_id)
+    after_param = pb.add_param(req.after_ms)
+    before_param = pb.add_param(req.before_ms)
+
+    # The time bucket is an optional leading group key. Without it we roll up the
+    # whole range into one row per group_by combination (or a single global row).
+    dimension_parts: list[str] = []
+    group_keys: list[str] = []
+    if req.time_bucket_seconds is not None:
+        bin_param = pb.add_param(req.time_bucket_seconds)
+        bucket_expr = f"toStartOfInterval(created_at, toIntervalSecond({param_slot(bin_param, 'Int64')}), 'UTC')"
+        dimension_parts.append(f"{bucket_expr} AS bucket")
+        group_keys.append("bucket")
+    dimension_parts.extend(req.group_by)
+    group_keys.extend(req.group_by)
+
+    select_parts = [
+        *dimension_parts,
+        f"{_TAG_COUNTS_SQL} AS tag_counts",
+        f"{_RATING_SUMS_SQL} AS rating_sums",
+        f"{_RATING_COUNTS_SQL} AS rating_counts",
+        "count() AS total_count",
+        f"{_SCORED_COUNT_SQL} AS scored_count",
+    ]
+    select_sql = ",\n      ".join(select_parts)
+    where_sql = _build_where_sql(req, project_param, after_param, before_param, pb)
+
+    raw_sql = f"SELECT {select_sql} FROM feedback WHERE {where_sql}"
+    if group_keys:
+        raw_sql += f" GROUP BY {', '.join(group_keys)}"
+        # Bucketed results read as a time series (order by bucket); otherwise order
+        # by the group_by dimensions for a deterministic row order.
+        order_keys = ["bucket"] if req.time_bucket_seconds is not None else req.group_by
+        raw_sql += f" ORDER BY {', '.join(order_keys)}"
+
+    columns = [
+        *group_keys,
+        "tag_counts",
+        "rating_sums",
+        "rating_counts",
+        "total_count",
+        "scored_count",
+    ]
+
+    return FeedbackAggregateQuery(
+        sql=safely_format_sql(raw_sql, logger),
+        columns=columns,
+        parameters=pb.get_params(),
+    )
+
+
+def _ref_object_id_sql(column: str) -> str:
+    """SQL for a ref's object id: the last path segment's name, before any ':digest'.
+
+    e.g. `weave:///proj/object/my_scorer:abc123` -> `my_scorer`. This is the
+    stable object identity; the digest is the (version-specific) tail.
+    """
+    last_segment = f"splitByChar('/', ifNull({column}, ''))[-1]"
+    return f"splitByChar(':', {last_segment})[1]"
+
+
+def _any_prefix_clause(column_expr: str, values: list[str], pb: ParamBuilder) -> str:
+    """Match if `column_expr` starts with ANY of `values` (OR'd together).
+
+    Used for namespace columns like feedback_type where prefix matching is the
+    point (e.g. `wandb.runnable.` matches every runnable scorer).
+    """
+    ors: list[str] = []
+    for value in values:
+        # Client may add a trailing '*' to signal this is a prefix match: strip it
+        param = pb.add_param(value.rstrip("*"))
+        ors.append(f"startsWith({column_expr}, {param_slot(param, 'String')})")
+    return f"({' OR '.join(ors)})"
+
+
+def _object_id_match_clause(column: str, values: list[str], pb: ParamBuilder) -> str:
+    """Match a ref's object id against ANY of `values` (OR'd together).
+
+    Exact match by default (so `mon` matches the monitor `mon`, not `monday`); a
+    trailing `*` opts into prefix matching (`mon*` matches both).
+    """
+    object_id = _ref_object_id_sql(column)
+    ors: list[str] = []
+    for value in values:
+        if value.endswith("*"):
+            param = pb.add_param(value.rstrip("*"))
+            ors.append(f"startsWith({object_id}, {param_slot(param, 'String')})")
+        else:
+            param = pb.add_param(value)
+            ors.append(f"{object_id} = {param_slot(param, 'String')}")
+    return f"({' OR '.join(ors)})"
+
+
+def _build_where_sql(
+    req: FeedbackAggregateReq,
+    project_param: str,
+    after_param: str,
+    before_param: str,
+    pb: ParamBuilder,
+) -> str:
+    """Assemble the WHERE clause: project + time range + the typed structured filters."""
+    clauses = [
+        f"project_id = {param_slot(project_param, 'String')}",
+        f"created_at >= fromUnixTimestamp64Milli({param_slot(after_param, 'Int64')})",
+        f"created_at < fromUnixTimestamp64Milli({param_slot(before_param, 'Int64')})",
+    ]
+    if req.feedback_types:
+        clauses.append(_any_prefix_clause("feedback_type", req.feedback_types, pb))
+    if req.monitor_ids:
+        # Monitors are always stored in the `trigger_ref` column
+        clauses.append(_object_id_match_clause("trigger_ref", req.monitor_ids, pb))
+    if req.scorer_ids:
+        # Scorers are always stored in the `runnable_ref` column
+        clauses.append(_object_id_match_clause("runnable_ref", req.scorer_ids, pb))
+    if req.span_agent_names:
+        names_param = pb.add_param(req.span_agent_names)
+        clauses.append(f"span_agent_name IN {param_slot(names_param, 'Array(String)')}")
+    if req.span_types:
+        # weave_ref looks like `<weave-scheme>:///<project_id>/<span_type>/<id>`, so the
+        # span type is the second-to-last path segment (robust whether project_id is one
+        # segment or `entity/project`). Match it exactly, not as a substring of the ref.
+        ors = [
+            f"splitByChar('/', weave_ref)[-2] = {param_slot(pb.add_param(span_type), 'String')}"
+            for span_type in req.span_types
+        ]
+        clauses.append(f"({' OR '.join(ors)})")
+    if req.tags:
+        tags_param = pb.add_param(req.tags)
+        clauses.append(
+            f"hasAny(scorer_tags, {param_slot(tags_param, 'Array(String)')})"
+        )
+    # Rating bounds default to the full [0, 1] range; only filter when narrowed. A row
+    # must actually carry a _rating_ (mapContains) so tag-only rows drop out.
+    if req.rating_min is not None or req.rating_max is not None:
+        key_param = pb.add_param(_RATING_KEY)
+        key_slot = param_slot(key_param, "String")
+        clauses.append(f"mapContains(scorer_ratings, {key_slot})")
+        if req.rating_min is not None:
+            gte_slot = param_slot(pb.add_param(req.rating_min), "Float64")
+            clauses.append(f"scorer_ratings[{key_slot}] >= {gte_slot}")
+        if req.rating_max is not None:
+            lte_slot = param_slot(pb.add_param(req.rating_max), "Float64")
+            clauses.append(f"scorer_ratings[{key_slot}] <= {lte_slot}")
+    return " AND ".join(clauses)

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -1,7 +1,7 @@
 import datetime
 from collections.abc import Iterator
 from enum import Enum
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Protocol, TypeAlias, get_args
 
 from pydantic import (
     BaseModel,
@@ -1458,6 +1458,152 @@ class FeedbackStatsRes(BaseModel):
             "(e.g. 'output_score'). Each value maps agg name to result."
         ),
     )
+
+
+# --- Feedback aggregate schema (for scores grouped by time bucket) ---
+
+FeedbackAggregateGroupByColumn: TypeAlias = Literal[
+    "runnable_ref", "span_agent_name", "span_agent_version", "span_status_code"
+]
+
+# Valid GROUP BY columns for aggregate feedback requests.
+FEEDBACK_AGGREGATE_GROUP_BY_COLUMNS: frozenset[FeedbackAggregateGroupByColumn] = (
+    frozenset(get_args(FeedbackAggregateGroupByColumn))
+)
+
+# Span types, matched on the feedback's weave_ref path segment
+FeedbackSpanType: TypeAlias = Literal["agent_turn", "agent_conversation"]
+
+# Limit aggregate feedback request time range and time bucket count
+MAX_FEEDBACK_AGG_TIME_RANGE_DAYS = 31
+MAX_FEEDBACK_AGG_TIME_BUCKETS = 256
+DAY_IN_MS = datetime.timedelta(days=1).total_seconds() * 1000
+
+
+class FeedbackAggregateReq(BaseModelStrict):
+    """Query for aggregate scores by time bucket and dimension."""
+
+    project_id: str = Field(examples=["entity/project"])
+    after_ms: int = Field(
+        description="Inclusive lower bound on created_at (milliseconds since epoch).",
+        ge=0,
+    )
+    before_ms: int = Field(
+        description="Exclusive upper bound on created_at (milliseconds since epoch).",
+        ge=0,
+    )
+    time_bucket_seconds: int | None = Field(
+        default=None,
+        description="Time bucket size in seconds, e.g. 3600 for 1h buckets",
+        gt=0,
+    )
+    feedback_types: list[str] = Field(
+        default_factory=list,
+        description="Filter on feedback_type by prefix",
+    )
+    tags: list[str] = Field(
+        default_factory=list,
+        description="Filter to feedback that includes any of the given tags",
+    )
+    rating_min: float | None = Field(
+        default=None,
+        description="Include only rows with a rating >= this value",
+        ge=0.0,
+        le=1.0,
+    )
+    rating_max: float | None = Field(
+        default=None,
+        description="Include only rows with a rating <= this value",
+        ge=0.0,
+        le=1.0,
+    )
+    monitor_ids: list[str] = Field(
+        default_factory=list,
+        description="Filter by the monitor's objectID:digest by prefix",
+    )
+    scorer_ids: list[str] = Field(
+        default_factory=list,
+        description="Filter by the scorer's objectID:digest by prefix",
+    )
+    span_agent_names: list[str] = Field(
+        default_factory=list,
+        description="Filter to feedback whose span_agent_name matches any of these (exact).",
+    )
+    span_types: list[FeedbackSpanType] = Field(
+        default_factory=list,
+        description="Filter by span type (turn vs conversation), matched on weave_ref.",
+    )
+    group_by: list[FeedbackAggregateGroupByColumn] = Field(
+        default_factory=list,
+        description=(f"Allowed: {sorted(FEEDBACK_AGGREGATE_GROUP_BY_COLUMNS)}."),
+    )
+
+    @model_validator(mode="after")
+    def _validate(self) -> "FeedbackAggregateReq":
+        time_range_ms = self.before_ms - self.after_ms
+        if time_range_ms <= 0:
+            raise ValueError("before_ms must be greater than after_ms")
+        if time_range_ms > MAX_FEEDBACK_AGG_TIME_RANGE_DAYS * DAY_IN_MS:
+            raise ValueError(
+                f"Feedback request range cannot exceed {MAX_FEEDBACK_AGG_TIME_RANGE_DAYS} days"
+            )
+        # Only cap the bucket count when bucketing; None means a single rollup row.
+        if self.time_bucket_seconds is not None:
+            n_buckets = (time_range_ms / 1000) / self.time_bucket_seconds
+            if n_buckets > MAX_FEEDBACK_AGG_TIME_BUCKETS:
+                raise ValueError(
+                    f"Feedback request range cannot exceed {MAX_FEEDBACK_AGG_TIME_BUCKETS} buckets"
+                )
+        return self
+
+
+class FeedbackAggregateBucket(BaseModel):
+    """One (time bucket, group) row of aggregated scorer feedback."""
+
+    time_bucket_start_ms: int | None = Field(
+        default=None,
+        description="Time bucket start, unix epoch ms (UTC). None when unbucketed.",
+    )
+    group: dict[str, str] = Field(
+        default_factory=dict,
+        description="Group-by dimension values for this row (e.g. {'runnable_ref': '...'}).",
+    )
+    total_count: int = Field(
+        description="Number of feedback rows in this bucket/group."
+    )
+    scored_count: int = Field(
+        description=(
+            "Rows that emitted a score (at least one tag or rating). Excludes "
+            "agent-monitor rows that scored nothing — use this for score volume."
+        ),
+    )
+    tag_counts: dict[str, int] = Field(
+        default_factory=dict, description="Count of each scorer tag."
+    )
+    rating_counts: dict[str, int] = Field(
+        default_factory=dict,
+        description="Number of rows carrying each rating key (e.g. '_rating_').",
+    )
+    rating_sums: dict[str, float] = Field(
+        default_factory=dict,
+        description="Sum of each rating key's values; client derives avg = sum/count.",
+    )
+
+
+class FeedbackAggregateRes(BaseModel):
+    """Sparse time-series of aggregated scorer feedback (empty buckets omitted)."""
+
+    time_bucket_seconds: int | None = Field(
+        default=None,
+        description="Time bucket size used (seconds). None when unbucketed.",
+    )
+    after_ms: int = Field(
+        description="Resolved inclusive lower bound, unix epoch ms (UTC)."
+    )
+    before_ms: int = Field(
+        description="Resolved exclusive upper bound, unix epoch ms (UTC)."
+    )
+    buckets: list[FeedbackAggregateBucket] = Field(default_factory=list)
 
 
 # --- Feedback payload schema (discovered paths for stats) ---
@@ -3164,6 +3310,7 @@ class TraceServerInterface(Protocol):
     def feedback_purge(self, req: FeedbackPurgeReq) -> FeedbackPurgeRes: ...
     def feedback_replace(self, req: FeedbackReplaceReq) -> FeedbackReplaceRes: ...
     def feedback_stats(self, req: FeedbackStatsReq) -> FeedbackStatsRes: ...
+    def feedback_aggregate(self, req: FeedbackAggregateReq) -> FeedbackAggregateRes: ...
     def feedback_payload_schema(
         self, req: FeedbackPayloadSchemaReq
     ) -> FeedbackPayloadSchemaRes: ...


### PR DESCRIPTION
Stacked on #7043.

## Summary

Adds `feedback_agg_query_builder.py` which will be the basis for a new endpoint to return aggregate scores from the feedback table (added in #7044). This isn't wired up to anything yet.

## Testing

- [x] Unit tests
- [x] Tested locally
