### PR TITLE
fix(weave): retry_on_not_found when dereferencing nested refs

### DIFF
--- a/weave/trace/vals.py
+++ b/weave/trace/vals.py
@@ -33,6 +33,7 @@ from weave.trace_server.trace_server_interface import (
     TableRowFilter,
     TraceServerInterface,
 )
+from weave.trace_server_bindings.http_utils import retry_on_not_found
 from weave.utils.iterators import ThreadSafeLazyList
 from weave.utils.project_id import to_project_id
 
@@ -801,7 +802,10 @@ def make_trace_obj(
         extra = val.extra
         try:
             project_id = to_project_id(val.entity, val.project)
-            read_res = server.obj_read(
+            # Retry on a transient miss: dereferencing a nested ref right after
+            # publish races against server-side eventual consistency, same as
+            # the top-level reads in WeaveClient.get.
+            read_res = retry_on_not_found(server.obj_read)(
                 ObjReadReq(
                     project_id=project_id,
                     object_id=val.name,


### PR DESCRIPTION
## Description

`test_dict_mutation_saving_nested` was flaky in CI:

```
FAILED tests/trace/test_weave_client_mutations.py::test_dict_mutation_saving_nested
  - weave.trace_server.errors.NotFoundError: Obj dict:YQJ30NfRGucjeH0jIrYXuIfWkg6OHZO3uw36haHTXnc not found
```

The test publishes a dict, nests it inside another, republishes, then reads the outer dict and compares. The comparison dereferences the nested ref.

Nested ref dereferencing goes through `make_trace_obj` (`weave/trace/vals.py`), which called `server.obj_read` without retry. Every top-level read in `WeaveClient` (`get`, version/tags/aliases) is already wrapped in `retry_on_not_found` because the `publish(); read` pattern races against server-side eventual consistency (#6663). This nested-read site was missed, so a transient miss propagated as a hard `NotFoundError` instead of retrying. The race surfaces under parallel CI load (`-n8`).

This wraps the nested read with the same `retry_on_not_found` helper. `_is_retryable_not_found` already handles the local-backend `NotFoundError` raised here and skips authoritative deletes (`ObjectDeletedError`), so behavior on genuine misses is unchanged.

It also fixes the same race for any user dereferencing a freshly-published nested ref, not just the test.

## Testing

- `uvx ruff check weave/trace/vals.py` clean
- `tests/trace/test_weave_client_mutations.py` 16/16 pass (sqlite)
- Import check confirms no circular import

The flake is timing-based and does not reproduce deterministically locally; the fix targets the only unguarded read on the nested-deref path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)