### PR TITLE
chore(weave): extract shared op call lifecycle (CallFinisher)

### DIFF
--- a/tests/trace/test_op_lifecycle.py
+++ b/tests/trace/test_op_lifecycle.py
@@ -1,0 +1,83 @@
+"""Unit tests for the shared op call lifecycle (``weave.trace.op_lifecycle``).
+
+Before the lifecycle was extracted, the "finish this call exactly once" logic
+lived as a closure duplicated across the four ``op.py`` execution paths and
+could only be exercised by driving a full op execution. ``CallFinisher`` makes
+that behavior directly constructable, so these tests assert its contract
+(finish-once idempotency, the ``require_explicit_finish`` opt-out, and finish
+post-processing) through the real client at the ``finish_call`` seam.
+"""
+
+from __future__ import annotations
+
+import weave
+from weave.trace.op_lifecycle import CallFinisher
+
+
+def test_call_finisher_finishes_call_once(client) -> None:
+    @weave.op
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    call = client.create_call(add, {"a": 1, "b": 2})
+    finisher = CallFinisher(add, call, client)
+
+    finisher(output=3)
+
+    assert finisher.has_finished is True
+    assert call.ended_at is not None
+    ended_at_first = call.ended_at
+
+    # A second invocation is a no-op: the call must not be finished twice.
+    finisher(output=999)
+    assert call.ended_at == ended_at_first
+
+
+def test_call_finisher_respects_require_explicit_finish(client) -> None:
+    @weave.op
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    call = client.create_call(add, {"a": 1, "b": 2})
+    finisher = CallFinisher(add, call, client, require_explicit_finish=True)
+
+    # With require_explicit_finish, calling the finisher does nothing; the
+    # caller (e.g. the imperative eval logger) finishes the call itself.
+    finisher(output=3)
+    assert finisher.has_finished is False
+    assert call.ended_at is None
+
+    # Clean up so the call doesn't dangle on the context stack.
+    client.finish_call(call, 3)
+
+
+def test_call_finisher_applies_finish_post_processor(client) -> None:
+    @weave.op
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    # _on_finish_post_processor is the hook integrations install (e.g. via
+    # _add_accumulator) to transform the final output before it is logged.
+    add._on_finish_post_processor = lambda output: {"wrapped": output}
+
+    call = client.create_call(add, {"a": 1, "b": 2})
+    finisher = CallFinisher(add, call, client)
+
+    finisher(output=3)
+    assert call.output == {"wrapped": 3}
+
+
+def test_call_finisher_records_exception(client) -> None:
+    @weave.op
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    call = client.create_call(add, {"a": 1, "b": 2})
+    finisher = CallFinisher(add, call, client)
+
+    err = ValueError("boom")
+    finisher(exception=err)
+
+    assert finisher.has_finished is True
+    assert call.ended_at is not None
+    assert call.exception is not None

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -53,6 +53,12 @@ from weave.trace.op_accumulator import (
 from weave.trace.op_accumulator import (
     _build_iterator_from_accumulator_for_op as _build_iterator_from_accumulator_for_op_impl,
 )
+from weave.trace.op_lifecycle import (
+    ASYNC_CALL_CREATE_MSG,
+    CALL_CREATE_MSG,
+    ON_OUTPUT_MSG,
+    CallFinisher,
+)
 from weave.trace.op_protocol import (
     CallDisplayNameFunc,
     FinishCallbackType,
@@ -81,9 +87,8 @@ R = TypeVar("R")
 logger = logging.getLogger(__name__)
 
 
-CALL_CREATE_MSG = "Error creating call:\n{}"
-ASYNC_CALL_CREATE_MSG = "Error creating async call:\n{}"
-ON_OUTPUT_MSG = "Error capturing call output:\n{}"
+# CALL_CREATE_MSG, ASYNC_CALL_CREATE_MSG, and ON_OUTPUT_MSG now live in
+# weave.trace.op_lifecycle (imported above) so CallFinisher can share them.
 UNINITIALIZED_MSG = "Warning: Traces will not be logged. Call weave.init to log your traces to a project.\n"
 
 # Sentinel for the annotation cache. Decoration writes this when signature
@@ -451,6 +456,43 @@ def _set_python_function_type_on_weave_dict(
     weave_dict["type"] = type_str
 
 
+def _try_create_call(
+    op: Op,
+    args: tuple[Any, ...],
+    kwargs: dict[str, Any],
+    *,
+    weave_kwargs: WeaveKwargs | None,
+    use_stack: bool,
+    create_msg: str,
+) -> Call | None:
+    """Create a call, returning ``None`` when creation fails recoverably.
+
+    Snapshots the call stack, then attempts ``_create_call``:
+
+    - ``OpCallError`` always propagates — it signals a user-facing
+      argument-binding problem, not an internal tracing failure.
+    - Any other exception is treated as an internal tracing failure: the call
+      stack is restored to its pre-attempt snapshot and ``None`` is returned so
+      the caller can run the op untraced.
+
+    This is the shared body of the create-call-with-fallback block that each of
+    the four execution paths used to inline verbatim.
+    """
+    call_stack_snapshot = call_context.get_call_stack().copy()
+    try:
+        return _create_call(
+            op, *args, __weave=weave_kwargs, use_stack=use_stack, **kwargs
+        )
+    except OpCallError:
+        raise
+    except Exception:
+        _restore_call_stack(call_stack_snapshot)
+        if get_raise_on_captured_errors():
+            raise
+        log_once(logger.error, create_msg.format(traceback.format_exc()))
+        return None
+
+
 def _call_sync_func(
     op: Op,
     *args: Any,
@@ -483,56 +525,25 @@ def _call_sync_func(
     # Proceed with tracing. Note that we don't check the sample rate here.
     # Only root calls get sampling applied.
     # If the parent was traced (sampled in), the child will be too.
-    call_stack_snapshot = call_context.get_call_stack().copy()
-    try:
-        call = _create_call(op, *args, __weave=__weave, **kwargs)
-    except OpCallError as e:
-        raise
-    except Exception as e:
-        _restore_call_stack(call_stack_snapshot)
-        if get_raise_on_captured_errors():
-            raise
-        log_once(
-            logger.error,
-            CALL_CREATE_MSG.format(traceback.format_exc()),
-        )
+    created_call = _try_create_call(
+        op,
+        args,
+        kwargs,
+        weave_kwargs=__weave,
+        use_stack=True,
+        create_msg=CALL_CREATE_MSG,
+    )
+    if created_call is None:
+        # Tracing failed during call creation; run the op untraced.
         res = func(*args, **kwargs)
         return res, call
+    call = created_call
 
     # Execute the op and process the result
     client = weave_client_context.require_weave_client()
-    has_finished = False
-
-    def finish(output: Any = None, exception: BaseException | None = None) -> None:
-        if __require_explicit_finish:
-            return
-
-        nonlocal has_finished
-        if has_finished:
-            return
-        has_finished = True
-
-        try:
-            # Apply any post-processing to the accumulated state if needed
-            try:
-                if processor := getattr(op, "_on_finish_post_processor", None):
-                    output = processor(output)
-            except Exception as e:
-                if get_raise_on_captured_errors():
-                    raise
-                log_once(logger.error, ON_OUTPUT_MSG.format(traceback.format_exc()))
-
-            client.finish_call(
-                call,
-                output,
-                exception,
-                op=op,
-            )
-        finally:
-            # Only pop the call context if we're the current call
-            current_call = call_context.get_current_call()
-            if current_call and current_call.id == call.id:
-                call_context.pop_call(call.id)
+    finish = CallFinisher(
+        op, call, client, require_explicit_finish=__require_explicit_finish
+    )
 
     def on_output(output: Any) -> Any:
         if handler := getattr(op, "_on_output_handler", None):
@@ -612,56 +623,25 @@ async def _call_async_func(
     _set_python_function_type_on_weave_dict(__weave, "async_function")
 
     # Proceed with tracing
-    call_stack_snapshot = call_context.get_call_stack().copy()
-    try:
-        call = _create_call(op, *args, __weave=__weave, **kwargs)
-    except OpCallError as e:
-        raise
-    except Exception as e:
-        _restore_call_stack(call_stack_snapshot)
-        if get_raise_on_captured_errors():
-            raise
-        log_once(
-            logger.error,
-            ASYNC_CALL_CREATE_MSG.format(traceback.format_exc()),
-        )
+    created_call = _try_create_call(
+        op,
+        args,
+        kwargs,
+        weave_kwargs=__weave,
+        use_stack=True,
+        create_msg=ASYNC_CALL_CREATE_MSG,
+    )
+    if created_call is None:
+        # Tracing failed during call creation; run the op untraced.
         res = await func(*args, **kwargs)
         return res, call
+    call = created_call
 
     # Execute the op and process the result
     client = weave_client_context.require_weave_client()
-    has_finished = False
-
-    def finish(output: Any = None, exception: BaseException | None = None) -> None:
-        if __require_explicit_finish:
-            return
-
-        nonlocal has_finished
-        if has_finished:
-            return
-        has_finished = True
-
-        try:
-            # Apply any post-processing to the accumulated state if needed
-            try:
-                if processor := getattr(op, "_on_finish_post_processor", None):
-                    output = processor(output)
-            except Exception as e:
-                if get_raise_on_captured_errors():
-                    raise
-                log_once(logger.error, ON_OUTPUT_MSG.format(traceback.format_exc()))
-
-            client.finish_call(
-                call,
-                output,
-                exception,
-                op=op,
-            )
-        finally:
-            # Only pop the call context if we're the current call
-            current_call = call_context.get_current_call()
-            if current_call and current_call.id == call.id:
-                call_context.pop_call(call.id)
+    finish = CallFinisher(
+        op, call, client, require_explicit_finish=__require_explicit_finish
+    )
 
     def on_output(output: Any) -> Any:
         if handler := getattr(op, "_on_output_handler", None):
@@ -746,66 +726,34 @@ def _call_sync_gen(
     _set_python_function_type_on_weave_dict(__weave, "generator")
 
     # Proceed with tracing
-    call_stack_snapshot = call_context.get_call_stack().copy()
-    try:
-        # For generators, use_stack=False because we push when iteration starts,
-        # not when the call is created. This avoids double-pushing.
-        call = _create_call(op, *args, __weave=__weave, use_stack=False, **kwargs)
-    except OpCallError:
-        raise
-    except Exception:
-        _restore_call_stack(call_stack_snapshot)
-        if get_raise_on_captured_errors():
-            raise
-        log_once(
-            logger.error,
-            CALL_CREATE_MSG.format(traceback.format_exc()),
-        )
+    # For generators, use_stack=False because we push when iteration starts,
+    # not when the call is created. This avoids double-pushing.
+    created_call = _try_create_call(
+        op,
+        args,
+        kwargs,
+        weave_kwargs=__weave,
+        use_stack=False,
+        create_msg=CALL_CREATE_MSG,
+    )
+    if created_call is None:
         gen = func(*args, **kwargs)
         return gen, call
+    call = created_call
 
     # Execute the op and get the generator
     client = weave_client_context.require_weave_client()
-    has_finished = False
+    finish = CallFinisher(
+        op, call, client, require_explicit_finish=__require_explicit_finish
+    )
     accumulated_state = None
     acc = op._accumulator
-
-    def finish(output: Any = None, exception: BaseException | None = None) -> None:
-        if __require_explicit_finish:
-            return
-
-        nonlocal has_finished
-        if has_finished:
-            return
-        has_finished = True
-
-        try:
-            # Apply any post-processing to the accumulated state if needed
-            try:
-                if processor := getattr(op, "_on_finish_post_processor", None):
-                    output = processor(output)
-            except Exception as e:
-                if get_raise_on_captured_errors():
-                    raise
-                log_once(logger.error, ON_OUTPUT_MSG.format(traceback.format_exc()))
-
-            client.finish_call(
-                call,
-                output,
-                exception,
-                op=op,
-            )
-        finally:
-            # Only pop the call context if we're the current call
-            current_call = call_context.get_current_call()
-            if current_call and current_call.id == call.id:
-                call_context.pop_call(call.id)
 
     # Create the generator wrapper
     try:
         # Define the wrapper generator that will handle the call context properly
         def wrapped_generator() -> Generator[Any]:
-            nonlocal accumulated_state, has_finished
+            nonlocal accumulated_state
 
             # Set the call context before creating the original generator
             # This ensures all calls made during generator initialization are properly nested
@@ -830,7 +778,7 @@ def _call_sync_gen(
                                     yield value
                             except Exception as e:
                                 # Make sure to mark the call as finished with the exception
-                                if not has_finished:
+                                if not finish.has_finished:
                                     finish(accumulated_state, e)
                                 # Re-raise the exception to preserve user code behavior
                                 raise
@@ -895,7 +843,7 @@ def _call_sync_gen(
                         call_context.push_call(call)
                 except Exception as e:
                     # Make sure to mark the call as finished with the exception
-                    if not has_finished:
+                    if not finish.has_finished:
                         finish(accumulated_state, e)
                     # Re-raise the exception to preserve user code behavior
                     raise
@@ -904,7 +852,7 @@ def _call_sync_gen(
                 finish(accumulated_state)
             except Exception as e:
                 # Handle exceptions from the generator
-                if not has_finished:
+                if not finish.has_finished:
                     finish(accumulated_state, e)
                 raise
 
@@ -924,7 +872,7 @@ def _call_sync_gen(
         def empty_sync_gen() -> Generator[Any]:
             # Re-raise the original exception if __should_raise is False
             # but we're evaluating the generator, to maintain expected behavior
-            if not has_finished:
+            if not finish.has_finished:
                 nonlocal e
                 raise e  # noqa: TRY201 - bare raise invalid outside exception handler
             # This will never actually yield anything but is needed for typing
@@ -968,66 +916,34 @@ def _call_async_gen(
     _set_python_function_type_on_weave_dict(__weave, "async_generator")
 
     # Proceed with tracing
-    call_stack_snapshot = call_context.get_call_stack().copy()
-    try:
-        # For generators, use_stack=False because we push when iteration starts,
-        # not when the call is created. This avoids double-pushing.
-        call = _create_call(op, *args, __weave=__weave, use_stack=False, **kwargs)
-    except OpCallError:
-        raise
-    except Exception:
-        _restore_call_stack(call_stack_snapshot)
-        if get_raise_on_captured_errors():
-            raise
-        log_once(
-            logger.error,
-            ASYNC_CALL_CREATE_MSG.format(traceback.format_exc()),
-        )
+    # For generators, use_stack=False because we push when iteration starts,
+    # not when the call is created. This avoids double-pushing.
+    created_call = _try_create_call(
+        op,
+        args,
+        kwargs,
+        weave_kwargs=__weave,
+        use_stack=False,
+        create_msg=ASYNC_CALL_CREATE_MSG,
+    )
+    if created_call is None:
         gen = func(*args, **kwargs)
         return gen, call
+    call = created_call
 
     # Execute the op and get the generator
     client = weave_client_context.require_weave_client()
-    has_finished = False
+    finish = CallFinisher(
+        op, call, client, require_explicit_finish=__require_explicit_finish
+    )
     accumulated_state = None
     acc = op._accumulator
-
-    def finish(output: Any = None, exception: BaseException | None = None) -> None:
-        if __require_explicit_finish:
-            return
-
-        nonlocal has_finished
-        if has_finished:
-            return
-        has_finished = True
-
-        try:
-            # Apply any post-processing to the accumulated state if needed
-            try:
-                if processor := getattr(op, "_on_finish_post_processor", None):
-                    output = processor(output)
-            except Exception as e:
-                if get_raise_on_captured_errors():
-                    raise
-                log_once(logger.error, ON_OUTPUT_MSG.format(traceback.format_exc()))
-
-            client.finish_call(
-                call,
-                output,
-                exception,
-                op=op,
-            )
-        finally:
-            # Only pop the call context if we're the current call
-            current_call = call_context.get_current_call()
-            if current_call and current_call.id == call.id:
-                call_context.pop_call(call.id)
 
     # Create the generator wrapper
     try:
         # Define the wrapper generator that will handle the call context properly
         async def wrapped_generator() -> AsyncIterator:
-            nonlocal accumulated_state, has_finished
+            nonlocal accumulated_state
 
             # Set the call context before creating the original generator
             # This ensures all calls made during generator initialization are properly nested
@@ -1052,7 +968,7 @@ def _call_async_gen(
                                     yield value
                             except Exception as e:
                                 # Make sure to mark the call as finished with the exception
-                                if not has_finished:
+                                if not finish.has_finished:
                                     finish(accumulated_state, e)
                                 # Re-raise the exception to preserve user code behavior
                                 raise
@@ -1122,7 +1038,7 @@ def _call_async_gen(
                         call_context.push_call(call)
                 except Exception as e:
                     # Make sure to mark the call as finished with the exception
-                    if not has_finished:
+                    if not finish.has_finished:
                         finish(accumulated_state, e)
                     # Re-raise the exception to preserve user code behavior
                     raise
@@ -1131,7 +1047,7 @@ def _call_async_gen(
                 finish(accumulated_state)
             except Exception as e:
                 # Handle exceptions from the generator
-                if not has_finished:
+                if not finish.has_finished:
                     finish(accumulated_state, e)
                 raise
 
@@ -1151,7 +1067,7 @@ def _call_async_gen(
         async def empty_async_gen() -> AsyncIterator[Any]:  # noqa: RUF029 — must be async to produce AsyncIterator
             # Re-raise the original exception if __should_raise is False
             # but we're evaluating the generator, to maintain expected behavior
-            if not has_finished:
+            if not finish.has_finished:
                 nonlocal e
                 raise e  # noqa: TRY201 - bare raise invalid outside exception handler
             # This will never actually yield anything but is needed for typing

--- a/weave/trace/op_lifecycle.py
+++ b/weave/trace/op_lifecycle.py
@@ -1,0 +1,105 @@
+"""Shared per-call lifecycle logic for the ``@op`` execution paths.
+
+Historically, the four execution variants in ``op.py`` — sync function, async
+function, sync generator, and async generator — each defined their own
+byte-identical ``finish()`` closure to run ``client.finish_call`` exactly once,
+apply the op's finish post-processor, and pop the call off the context stack.
+That duplication meant any change to finish semantics had to be made in four
+places and could not be unit-tested without driving a full op execution.
+
+This module extracts that logic into :class:`CallFinisher`, a small object that
+owns the finish-once semantics for a single call and can be tested in isolation.
+The error-message templates used on the call-creation/finish paths live here too,
+since they are part of the same lifecycle concern.
+"""
+
+from __future__ import annotations
+
+import logging
+import traceback
+from typing import TYPE_CHECKING, Any
+
+from weave.trace.context import call_context
+from weave.trace.context.tests_context import get_raise_on_captured_errors
+from weave.trace.util import log_once
+
+if TYPE_CHECKING:
+    from weave.trace.call import Call
+    from weave.trace.op_protocol import Op
+    from weave.trace.weave_client import WeaveClient
+
+logger = logging.getLogger(__name__)
+
+# Error-message templates for the op call lifecycle. Kept here (rather than in
+# op.py) so CallFinisher can reference ON_OUTPUT_MSG without a circular import;
+# re-exported from op.py for backwards compatibility.
+CALL_CREATE_MSG = "Error creating call:\n{}"
+ASYNC_CALL_CREATE_MSG = "Error creating async call:\n{}"
+ON_OUTPUT_MSG = "Error capturing call output:\n{}"
+
+
+class CallFinisher:
+    """Owns the finish-once semantics for a single op call.
+
+    A single call may have ``finish`` invoked from several places (normal return,
+    an exception handler, ``GeneratorExit``, or an accumulator signalling end), so
+    this object guarantees the underlying ``client.finish_call`` runs at most once.
+    On the first call it applies the op's finish post-processor, forwards to
+    ``client.finish_call``, and — regardless of outcome — pops the call from the
+    context stack if it is still current.
+
+    Instances are callable with the same ``(output, exception)`` signature as the
+    closures they replace, so they can be passed anywhere a finish callback is
+    expected (e.g. accumulator iterators, on-output handlers).
+    """
+
+    def __init__(
+        self,
+        op: Op,
+        call: Call,
+        client: WeaveClient,
+        *,
+        require_explicit_finish: bool = False,
+    ) -> None:
+        self._op = op
+        self._call = call
+        self._client = client
+        self._require_explicit_finish = require_explicit_finish
+        # Public so the generator paths can decide whether they still need to
+        # finish on an error path (mirrors the old ``nonlocal has_finished``).
+        self.has_finished = False
+
+    def __call__(
+        self, output: Any = None, exception: BaseException | None = None
+    ) -> None:
+        if self._require_explicit_finish:
+            return
+
+        if self.has_finished:
+            return
+        self.has_finished = True
+
+        try:
+            # Apply any post-processing to the accumulated state if needed.
+            try:
+                # getattr-with-default preserves the original defensive access;
+                # the op decorator always sets this attribute, but tightening it
+                # is deferred so this stays a pure structural refactor.
+                if processor := getattr(self._op, "_on_finish_post_processor", None):
+                    output = processor(output)
+            except Exception:
+                if get_raise_on_captured_errors():
+                    raise
+                log_once(logger.error, ON_OUTPUT_MSG.format(traceback.format_exc()))
+
+            self._client.finish_call(
+                self._call,
+                output,
+                exception,
+                op=self._op,
+            )
+        finally:
+            # Only pop the call context if we're the current call.
+            current_call = call_context.get_current_call()
+            if current_call and current_call.id == self._call.id:
+                call_context.pop_call(self._call.id)


### PR DESCRIPTION
> 📚 **Stacked PR (1 of 2).** #7056 (the LLM-provider integration framework) is stacked on top of this one.

## Summary

Part 1 of a 2-PR stack from a separation-of-concerns audit of the op system. The integration-framework PR is stacked on top of this one.

The four `@op` execution paths in `op.py` — sync function, async function, sync generator, async generator — each defined a **byte-identical ~30-line `finish()` closure** plus an inline call-creation-with-fallback block. Any change to finish semantics had to be made in four places, and none of it was unit-testable without driving a full op execution.

## What changed

- New `weave/trace/op_lifecycle.py` owns **`CallFinisher`**, a small callable that encapsulates the finish-once semantics for a single call (apply finish post-processor → `client.finish_call` → pop the call if current). It's constructable and testable in isolation. The `CALL_CREATE_MSG` / `ASYNC_CALL_CREATE_MSG` / `ON_OUTPUT_MSG` templates move here too (re-exported from `op.py` for back-compat).
- `op.py` gains **`_try_create_call()`**, the shared create-call-with-fallback helper: `OpCallError` propagates; any other error restores the call stack and returns `None` so the op runs untraced.
- All four execution paths now use `_try_create_call` + `CallFinisher`. Net **−84 lines** in `op.py`.

## Behavior

Pure structural refactor — no behavior change. The `getattr`-based `_on_finish_post_processor` access and the per-path skip/sample/`on_output` logic are unchanged. The generator paths read `finish.has_finished` where they previously used a `nonlocal` flag.

## Testing

- **125** op tests pass — 121 existing (`test_op_coroutines/generators/call_method/return_forms/decorator_behaviour/accumulator/argument_forms`) + 4 new `CallFinisher` tests in `tests/trace/test_op_lifecycle.py` (finish-once idempotency, `require_explicit_finish` opt-out, finish post-processing, exception recording — none directly testable before).
- `test_client_trace.py` + `test_evaluation_imperative.py`: 147 passed. The 5 failures are **pre-existing on master** (`test_evaluation_invalid_model_name_*` call `require_weave_client()` during `__init__` before model-name validation, unrelated to this change — verified by re-running them on a clean checkout).
- `ruff check` + `ruff format` clean.

## Follow-ups (not in this PR)

The larger `OpState` dataclass consolidation (the 25 attributes monkey-patched onto the op wrapper) is deferred — 39+ files read `op.*` attributes directly, so it warrants its own PR.
