### PR TITLE
feat(weave): declarative framework for LLM-provider integrations

### DIFF
--- a/tests/integrations/test_llm_provider.py
+++ b/tests/integrations/test_llm_provider.py
@@ -1,0 +1,112 @@
+"""Unit tests for the declarative LLM-provider integration framework.
+
+These exercise ``weave.integrations._llm_provider`` directly — no vendor SDK, no
+VCR cassette, and no live weave client. That is the point: the structural logic
+every provider integration used to inline (enabled/NoOp gate, singleton caching,
+per-endpoint op-name derivation, the async passthrough) is now verifiable in
+isolation, which was not possible when it lived as copy-pasted boilerplate behind
+each provider's recorded HTTP tests.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+from weave.integrations._llm_provider import (
+    Endpoint,
+    LLMProviderPatcher,
+    _build_endpoint_wrapper,
+    derive_endpoint_settings,
+    make_async_passthrough,
+)
+from weave.integrations.patcher import MultiPatcher, NoOpPatcher
+from weave.trace.autopatch import IntegrationSettings, OpSettings
+
+
+def _endpoint(**overrides: object) -> Endpoint:
+    kwargs: dict[str, object] = {
+        "module": "some.sdk.module",
+        "symbol": "SomeResource.create",
+        "op_name": "provider.chat.completions.create",
+    }
+    kwargs.update(overrides)
+    return Endpoint(**kwargs)  # type: ignore[arg-type]
+
+
+def test_make_async_passthrough_is_coroutine_function() -> None:
+    def sync_fn() -> None: ...
+
+    assert not inspect.iscoroutinefunction(sync_fn)
+    assert inspect.iscoroutinefunction(make_async_passthrough(sync_fn))
+
+
+def test_disabled_settings_returns_noop_patcher() -> None:
+    provider = LLMProviderPatcher([_endpoint()])
+    assert isinstance(provider.get(IntegrationSettings(enabled=False)), NoOpPatcher)
+
+
+def test_enabled_returns_multipatcher_caches_and_resets() -> None:
+    provider = LLMProviderPatcher(
+        [_endpoint(), _endpoint(symbol="SomeResource.acreate")]
+    )
+
+    first = provider.get(IntegrationSettings())
+    assert isinstance(first, MultiPatcher)
+    assert len(first.patchers) == 2  # one SymbolPatcher per endpoint
+
+    # The real patcher is built once and reused.
+    assert provider.get(IntegrationSettings()) is first
+
+    # reset() gives a coordinated way to rebuild (the old module-global
+    # singletons had no such hook).
+    provider.reset()
+    assert provider.get(IntegrationSettings()) is not first
+
+
+def test_endpoint_op_name_is_used_when_settings_do_not_override() -> None:
+    derived = derive_endpoint_settings(
+        OpSettings(), _endpoint(op_name="myprovider.chat.create")
+    )
+    assert derived.name == "myprovider.chat.create"
+    assert derived.kind == "llm"  # default kind applied
+
+
+def test_explicit_settings_name_overrides_endpoint_op_name() -> None:
+    derived = derive_endpoint_settings(
+        OpSettings(name="custom.op.name", kind="tool"),
+        _endpoint(op_name="myprovider.chat.create"),
+    )
+    # Explicit base settings win over the endpoint's fallbacks.
+    assert derived.name == "custom.op.name"
+    assert derived.kind == "tool"
+
+
+def test_endpoint_wrapper_uses_resolved_settings_name() -> None:
+    # The wrapper consumes already-resolved settings; it should produce an op
+    # carrying that resolved name.
+    wrapper = _build_endpoint_wrapper(_endpoint(), OpSettings(name="resolved.name"))
+
+    def some_sdk_method(a: int, b: int) -> int:
+        return a + b
+
+    op = wrapper(some_sdk_method)
+    assert op.name == "resolved.name"
+
+
+def test_async_passthrough_endpoint_produces_coroutine_op() -> None:
+    wrapper = _build_endpoint_wrapper(_endpoint(async_passthrough=True), OpSettings())
+
+    def sync_sdk_method() -> None: ...
+
+    op = wrapper(sync_sdk_method)
+    # The op must look async so weave.op routes it through the async path.
+    assert inspect.iscoroutinefunction(op.resolve_fn)
+
+
+def test_non_passthrough_endpoint_preserves_sync_function() -> None:
+    wrapper = _build_endpoint_wrapper(_endpoint(), OpSettings())
+
+    def sync_sdk_method() -> None: ...
+
+    op = wrapper(sync_sdk_method)
+    assert not inspect.iscoroutinefunction(op.resolve_fn)

--- a/weave/integrations/_llm_provider.py
+++ b/weave/integrations/_llm_provider.py
@@ -1,0 +1,194 @@
+"""Declarative framework for LLM-provider (patching-style) integrations.
+
+Most provider integrations (openai, anthropic, groq, cerebras, mistral, cohere,
+...) repeat the same ~80-line skeleton: a module-level singleton patcher, an
+``IntegrationSettings`` enabled-gate, one ``OpSettings.model_copy`` per endpoint,
+a sync/async ``weave.op`` wrapper, and a ``MultiPatcher`` of hand-written
+``SymbolPatcher`` entries. The only genuinely per-provider parts are the list of
+endpoints to patch, the streaming accumulator (if any), and whether the async
+endpoint needs the ``iscoroutinefunction`` passthrough.
+
+This module captures the repeated structure once. An integration declares its
+endpoints with :class:`Endpoint` and exposes a one-line getter backed by
+:class:`LLMProviderPatcher`; the framework owns settings defaulting, the
+enabled/NoOp gate, singleton caching, per-endpoint ``OpSettings`` derivation, the
+sync/async wrapper, and ``MultiPatcher`` assembly.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable
+from dataclasses import dataclass
+from functools import wraps
+from typing import Any
+
+import weave
+from weave.integrations.integration_utilities import should_use_accumulator
+from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
+from weave.trace.autopatch import IntegrationSettings, OpSettings
+from weave.trace.op import _add_accumulator
+
+# (inputs_dict) -> accumulator_fn(acc_state, value) -> new_acc_state
+AccumulatorFactory = Callable[[dict], Callable[[Any, Any], Any]]
+
+# Default op "kind" for LLM-provider endpoints, matching the historical
+# per-integration ``base.kind or "llm"`` default.
+DEFAULT_OP_KIND = "llm"
+
+
+def make_async_passthrough(fn: Callable) -> Callable:
+    """Wrap ``fn`` in a real ``async def`` so ``iscoroutinefunction`` is True.
+
+    Several vendor SDKs (Stainless-generated: openai, anthropic, cerebras, ...)
+    expose async client methods that do not themselves pass
+    ``inspect.iscoroutinefunction``. ``weave.op`` relies on that check to pick the
+    async execution path, so those endpoints must be wrapped. This is opt-in per
+    endpoint because some providers' async methods (e.g. groq) already pass the
+    check and must NOT be double-wrapped.
+    """
+
+    @wraps(fn)
+    async def _async_wrapper(*args: Any, **kwargs: Any) -> Any:
+        return await fn(*args, **kwargs)
+
+    return _async_wrapper
+
+
+@dataclass(frozen=True)
+class Endpoint:
+    """Declarative description of one method to patch on a provider SDK."""
+
+    module: str
+    """Importable module holding the symbol, e.g. ``"groq.resources.chat.completions"``."""
+
+    symbol: str
+    """Dotted attribute on ``module`` to patch, e.g. ``"Completions.create"``."""
+
+    op_name: str
+    """Default op name when the integration's settings don't override it."""
+
+    async_passthrough: bool = False
+    """Whether to wrap the target in :func:`make_async_passthrough` (see its docs)."""
+
+    accumulator: AccumulatorFactory | None = None
+    """Optional streaming-accumulator factory; ``None`` for non-streaming endpoints."""
+
+    should_accumulate: Callable[[dict], bool] | None = None
+    """Predicate deciding whether to accumulate for a given call. Defaults to
+    :func:`should_use_accumulator` when an accumulator is set."""
+
+    on_finish_post_processor: Callable[[Any], Any] | None = None
+    """Optional transform applied to the accumulated output before logging."""
+
+
+def _build_endpoint_wrapper(
+    endpoint: Endpoint, op_settings: OpSettings
+) -> Callable[[Callable], Callable]:
+    """Return the ``SymbolPatcher`` value factory for one endpoint.
+
+    The returned callable takes the original SDK function and returns the
+    ``weave.op``-wrapped replacement (plus an accumulator, if the endpoint
+    declares one).
+    """
+    op_kwargs = op_settings.model_dump()
+
+    def wrapper(fn: Callable) -> Callable:
+        target = make_async_passthrough(fn) if endpoint.async_passthrough else fn
+        op = weave.op(target, **op_kwargs)
+        if endpoint.accumulator is None:
+            return op
+        return _add_accumulator(
+            op,  # type: ignore[arg-type]
+            make_accumulator=endpoint.accumulator,
+            should_accumulate=endpoint.should_accumulate or should_use_accumulator,
+            on_finish_post_processor=endpoint.on_finish_post_processor,
+        )
+
+    return wrapper
+
+
+def derive_endpoint_settings(
+    op_settings: OpSettings, endpoint: Endpoint, *, kind: str = DEFAULT_OP_KIND
+) -> OpSettings:
+    """Derive the per-endpoint ``OpSettings`` from an integration's base settings.
+
+    The endpoint's ``op_name``/``kind`` are used only as fallbacks — explicit
+    values on ``op_settings`` win. This is the single home for the name/kind
+    resolution rule that each integration used to inline as a ``base.model_copy``
+    block (and which historically drifted between integrations).
+    """
+    return op_settings.model_copy(
+        update={
+            "name": op_settings.name or endpoint.op_name,
+            "kind": op_settings.kind or kind,
+        }
+    )
+
+
+def build_llm_provider_patcher(
+    op_settings: OpSettings,
+    endpoints: list[Endpoint],
+    *,
+    kind: str = DEFAULT_OP_KIND,
+) -> MultiPatcher:
+    """Build a :class:`MultiPatcher` from a declarative list of endpoints.
+
+    Each endpoint gets its own ``OpSettings`` via :func:`derive_endpoint_settings`,
+    mirroring the per-integration ``base.model_copy`` blocks this replaces. This
+    function assumes the integration is enabled; the enabled/NoOp/caching gate
+    lives in :class:`LLMProviderPatcher`.
+    """
+    patchers: list[SymbolPatcher] = []
+    for endpoint in endpoints:
+        endpoint_settings = derive_endpoint_settings(op_settings, endpoint, kind=kind)
+        patchers.append(
+            SymbolPatcher(
+                # default-arg binds the module string per-iteration (avoids the
+                # classic late-binding closure bug where every patcher would
+                # import the last endpoint's module).
+                lambda module=endpoint.module: importlib.import_module(module),
+                endpoint.symbol,
+                _build_endpoint_wrapper(endpoint, endpoint_settings),
+            )
+        )
+    return MultiPatcher(patchers)
+
+
+class LLMProviderPatcher:
+    """Holds an integration's endpoints and its singleton patcher.
+
+    Replaces the per-module ``_<name>_patcher`` global plus the boilerplate
+    ``get_<name>_patcher`` body. Caching matches the historical behavior exactly:
+    a disabled integration returns a fresh :class:`NoOpPatcher` (never cached), and
+    the real :class:`MultiPatcher` is built once and reused.
+    """
+
+    def __init__(
+        self, endpoints: list[Endpoint], *, kind: str = DEFAULT_OP_KIND
+    ) -> None:
+        self._endpoints = endpoints
+        self._kind = kind
+        self._patcher: MultiPatcher | None = None
+
+    def get(
+        self, settings: IntegrationSettings | None = None
+    ) -> MultiPatcher | NoOpPatcher:
+        if settings is None:
+            settings = IntegrationSettings()
+        if not settings.enabled:
+            return NoOpPatcher()
+        if self._patcher is not None:
+            return self._patcher
+        self._patcher = build_llm_provider_patcher(
+            settings.op_settings, self._endpoints, kind=self._kind
+        )
+        return self._patcher
+
+    def reset(self) -> None:
+        """Drop the cached patcher so the next ``get`` rebuilds it.
+
+        Gives integrations a coordinated reset hook for tests — the per-module
+        ``_<name>_patcher`` globals this replaces had no such affordance.
+        """
+        self._patcher = None

--- a/weave/integrations/cerebras/cerebras_sdk.py
+++ b/weave/integrations/cerebras/cerebras_sdk.py
@@ -1,77 +1,29 @@
 from __future__ import annotations
 
-import importlib
-from collections.abc import Callable
-from functools import wraps
-from typing import Any
+from weave.integrations._llm_provider import Endpoint, LLMProviderPatcher
+from weave.integrations.patcher import MultiPatcher, NoOpPatcher
+from weave.trace.autopatch import IntegrationSettings
 
-import weave
-from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
-from weave.trace.autopatch import IntegrationSettings, OpSettings
+# Cerebras' async client method does not pass ``inspect.iscoroutinefunction``,
+# so the async endpoint needs the async passthrough wrapper (async_passthrough).
+_CEREBRAS_ENDPOINTS = [
+    Endpoint(
+        module="cerebras.cloud.sdk.resources.chat",
+        symbol="CompletionsResource.create",
+        op_name="cerebras.chat.completions.create",
+    ),
+    Endpoint(
+        module="cerebras.cloud.sdk.resources.chat",
+        symbol="AsyncCompletionsResource.create",
+        op_name="cerebras.chat.completions.create",
+        async_passthrough=True,
+    ),
+]
 
-_cerebras_patcher: MultiPatcher | None = None
-
-
-def create_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
-    def wrapper(fn: Callable) -> Callable:
-        op_kwargs = settings.model_dump()
-        op = weave.op(fn, **op_kwargs)
-        return op
-
-    return wrapper
-
-
-def create_wrapper_async(settings: OpSettings) -> Callable[[Callable], Callable]:
-    def wrapper(fn: Callable) -> Callable:
-        def _fn_wrapper(fn: Callable) -> Callable:
-            @wraps(fn)
-            async def _async_wrapper(*args: Any, **kwargs: Any) -> Any:
-                return await fn(*args, **kwargs)
-
-            return _async_wrapper
-
-        op_kwargs = settings.model_dump()
-        op = weave.op(_fn_wrapper(fn), **op_kwargs)
-        return op
-
-    return wrapper
+_cerebras_provider = LLMProviderPatcher(_CEREBRAS_ENDPOINTS)
 
 
 def get_cerebras_patcher(
     settings: IntegrationSettings | None = None,
 ) -> MultiPatcher | NoOpPatcher:
-    if settings is None:
-        settings = IntegrationSettings()
-
-    if not settings.enabled:
-        return NoOpPatcher()
-
-    global _cerebras_patcher  # noqa: PLW0603
-    if _cerebras_patcher is not None:
-        return _cerebras_patcher
-
-    base = settings.op_settings
-
-    create_settings = base.model_copy(
-        update={
-            "name": base.name or "cerebras.chat.completions.create",
-            "kind": base.kind or "llm",
-        }
-    )
-
-    _cerebras_patcher = MultiPatcher(
-        [
-            SymbolPatcher(
-                lambda: importlib.import_module("cerebras.cloud.sdk.resources.chat"),
-                "CompletionsResource.create",
-                create_wrapper_sync(create_settings),
-            ),
-            SymbolPatcher(
-                lambda: importlib.import_module("cerebras.cloud.sdk.resources.chat"),
-                "AsyncCompletionsResource.create",
-                create_wrapper_async(create_settings),
-            ),
-        ]
-    )
-
-    return _cerebras_patcher
+    return _cerebras_provider.get(settings)

--- a/weave/integrations/groq/groq_sdk.py
+++ b/weave/integrations/groq/groq_sdk.py
@@ -1,25 +1,13 @@
 from __future__ import annotations
 
-import importlib
-from collections.abc import Callable
-from typing import TYPE_CHECKING
-
 from groq.types.chat import ChatCompletion, ChatCompletionChunk, ChatCompletionMessage
 from groq.types.chat.chat_completion import Choice
 from groq.types.chat.chat_completion_chunk import Choice as ChoiceChunk
 from groq.types.completion_usage import CompletionUsage
 
-import weave
-from weave.integrations.integration_utilities import should_use_accumulator
-from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
-from weave.trace.autopatch import IntegrationSettings, OpSettings
-from weave.trace.op import _add_accumulator
-
-if TYPE_CHECKING:
-    pass
-
-
-_groq_patcher: MultiPatcher | None = None
+from weave.integrations._llm_provider import Endpoint, LLMProviderPatcher
+from weave.integrations.patcher import MultiPatcher, NoOpPatcher
+from weave.trace.autopatch import IntegrationSettings
 
 
 def groq_accumulator(
@@ -87,60 +75,27 @@ def groq_accumulator(
     return acc
 
 
-def groq_wrapper(settings: OpSettings) -> Callable[[Callable], Callable]:
-    def wrapper(fn: Callable) -> Callable:
-        op_kwargs = settings.model_dump()
-        op = weave.op(fn, **op_kwargs)
-        return _add_accumulator(
-            op,  # type: ignore
-            make_accumulator=lambda inputs: groq_accumulator,
-            should_accumulate=should_use_accumulator,
-        )
+# NOTE: groq's async endpoint historically did NOT use the async passthrough
+# wrapper (unlike cerebras), so async_passthrough is left at its default (False).
+_GROQ_ENDPOINTS = [
+    Endpoint(
+        module="groq.resources.chat.completions",
+        symbol="Completions.create",
+        op_name="groq.chat.completions.create",
+        accumulator=lambda inputs: groq_accumulator,
+    ),
+    Endpoint(
+        module="groq.resources.chat.completions",
+        symbol="AsyncCompletions.create",
+        op_name="groq.async.chat.completions.create",
+        accumulator=lambda inputs: groq_accumulator,
+    ),
+]
 
-    return wrapper
+_groq_provider = LLMProviderPatcher(_GROQ_ENDPOINTS)
 
 
 def get_groq_patcher(
     settings: IntegrationSettings | None = None,
 ) -> MultiPatcher | NoOpPatcher:
-    if settings is None:
-        settings = IntegrationSettings()
-
-    if not settings.enabled:
-        return NoOpPatcher()
-
-    global _groq_patcher  # noqa: PLW0603
-    if _groq_patcher is not None:
-        return _groq_patcher
-
-    base = settings.op_settings
-
-    chat_completions_settings = base.model_copy(
-        update={
-            "name": base.name or "groq.chat.completions.create",
-            "kind": base.kind or "llm",
-        }
-    )
-    async_chat_completions_settings = base.model_copy(
-        update={
-            "name": base.name or "groq.async.chat.completions.create",
-            "kind": base.kind or "llm",
-        }
-    )
-
-    _groq_patcher = MultiPatcher(
-        [
-            SymbolPatcher(
-                lambda: importlib.import_module("groq.resources.chat.completions"),
-                "Completions.create",
-                groq_wrapper(chat_completions_settings),
-            ),
-            SymbolPatcher(
-                lambda: importlib.import_module("groq.resources.chat.completions"),
-                "AsyncCompletions.create",
-                groq_wrapper(async_chat_completions_settings),
-            ),
-        ]
-    )
-
-    return _groq_patcher
+    return _groq_provider.get(settings)


### PR DESCRIPTION
> 📚 **Stacked PR — depends on #7055** (op call lifecycle). Merge #7055 first; this PR's diff is only the integration framework.

## Summary

Part 2 of a 2-PR stack from a separation-of-concerns audit. **Stacked on `andrew/op-call-lifecycle` — review/merge that first.**

Most provider integrations repeat the same ~80-line skeleton: a module-level singleton patcher, an `IntegrationSettings` enabled-gate, one `OpSettings.model_copy` per endpoint, a sync/async `weave.op` wrapper (including the verbatim-duplicated `iscoroutinefunction` async-passthrough trick), and a `MultiPatcher` of hand-written `SymbolPatcher`s. The audit counted **122** duplicated `base.name or …` endpoint blocks and **26** singleton patchers across the tree.

## What changed

New `weave/integrations/_llm_provider.py` captures the structure once:

- **`Endpoint`** — a frozen dataclass declaring one method to patch (`module`, `symbol`, `op_name`, `async_passthrough`, `accumulator`, `should_accumulate`, `on_finish_post_processor`).
- **`make_async_passthrough`** — the shared `iscoroutinefunction` workaround (was copied verbatim across 6+ integrations), now opt-in per endpoint.
- **`derive_endpoint_settings`** — the single home for the name/kind resolution rule that each integration inlined as a `model_copy` block (and that drifted between providers).
- **`build_llm_provider_patcher` / `LLMProviderPatcher`** — own settings defaulting, the enabled/NoOp gate, singleton caching (plus a `reset()` hook for tests), and `MultiPatcher` assembly.

Two integrations migrated to prove the pattern; the rest are unchanged and keep working:

- **cerebras**: 77 → 29 lines (async endpoint uses `async_passthrough=True`).
- **groq**: 146 → 101 lines (boilerplate removed; the vendor `groq_accumulator` and its async-endpoint-without-passthrough behavior are preserved exactly).

## Behavior

`get_<provider>_patcher` names/signatures are unchanged (`patch.py` resolves them by string; tests import them directly). The NoOp/singleton caching semantics match the originals (disabled → fresh `NoOpPatcher`, never cached; enabled → built once and reused).

## Testing

- **8** new framework unit tests (`tests/integrations/test_llm_provider.py`) — **no vendor SDK, no VCR cassette, no live client**. This is the key testability win: the structural logic was previously reachable only through each provider's recorded-HTTP tests.
- Existing VCR suites pass against the migrated code: **7/7** in `tests/integrations/cerebras` + `tests/integrations/groq` (sync, async, streaming accumulator, tool calls).
- `ruff check` + `ruff format` clean.

## Follow-ups (not in this PR)

Migrating the remaining ~24 providers is mechanical follow-up. The OTel-style integrations (langchain, llamaindex, openai_agents) are a different shape (they need a callback adapter) and are out of scope for this framework.
