### PR TITLE
feat(weave): optionally require time filter for heavy-field queries

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -20,7 +20,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     build_calls_stats_query,
 )
 from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH
-from weave.trace_server.errors import InvalidFieldError
+from weave.trace_server.errors import InvalidFieldError, InvalidRequest
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.project_version.types import ReadTable
 
@@ -5069,3 +5069,57 @@ def test_query_with_annotation_filter_still_uses_anyif() -> None:
             "pb_3": "project",
         },
     )
+
+
+def _heavy_contains_condition() -> "tsi_query.Operand":
+    return tsi_query.ContainsOperation.model_validate(
+        {
+            "$contains": {
+                "input": {"$getField": "inputs.message"},
+                "substr": {"$literal": "hello"},
+            }
+        }
+    )
+
+
+def _started_at_lower_bound() -> "tsi_query.Operand":
+    return tsi_query.GtOperation.model_validate(
+        {"$gt": [{"$getField": "started_at"}, {"$literal": 1700000000}]}
+    )
+
+
+@pytest.mark.parametrize(
+    ("enforce", "heavy", "time_filter", "should_raise"),
+    [
+        (True, True, False, True),  # heavy filter + no time -> rejected
+        (True, True, True, False),  # heavy filter + started_at bound -> allowed
+        (True, False, False, False),  # light-only filter -> allowed
+        (False, True, False, False),  # flag off -> allowed
+    ],
+)
+def test_heavy_field_requires_time_filter(
+    monkeypatch: pytest.MonkeyPatch,
+    enforce: bool,
+    heavy: bool,
+    time_filter: bool,
+    should_raise: bool,
+) -> None:
+    if enforce:
+        monkeypatch.setenv("WEAVE_ENFORCE_HEAVY_FIELD_TIME_FILTER", "true")
+    cq = CallsQuery(project_id="project")
+    cq.add_field("id")
+    cq.add_condition(
+        _heavy_contains_condition()
+        if heavy
+        else tsi_query.EqOperation.model_validate(
+            {"$eq": [{"$getField": "wb_user_id"}, {"$literal": "u1"}]}
+        )
+    )
+    if time_filter:
+        cq.add_condition(_started_at_lower_bound())
+
+    if should_raise:
+        with pytest.raises(InvalidRequest, match="started_at"):
+            cq.as_sql(ParamBuilder())
+    else:
+        assert cq.as_sql(ParamBuilder()).strip()

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -39,7 +39,7 @@ from weave.shared.trace_server_interface_util import (
     split_exact_and_wildcard_values,
     wildcard_version_value_to_ref_prefix,
 )
-from weave.trace_server import ch_sentinel_values
+from weave.trace_server import ch_sentinel_values, environment
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.calls_query_builder.cte import CTECollection
 from weave.trace_server.calls_query_builder.object_ref_query_builder import (
@@ -64,7 +64,7 @@ from weave.trace_server.calls_query_builder.utils import (
     trace_id_index_expr,
 )
 from weave.trace_server.common_interface import SortBy
-from weave.trace_server.errors import InvalidFieldError
+from weave.trace_server.errors import InvalidFieldError, InvalidRequest
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.interface.feedback_types import MULTI_VALUE_FEEDBACK_TYPES
 from weave.trace_server.interface.query import (
@@ -1066,6 +1066,30 @@ class CallsQuery(BaseModel):
         # No predicate pushdown possible
         return False
 
+    def _enforce_heavy_field_time_filter(self) -> None:
+        """Reject heavy-field filters that lack a `started_at` time bound.
+
+        A heavy-field filter (inputs, output, attributes) with no time bound
+        forces a full scan of the large dump columns; a `started_at` bound lets
+        the `sortable_datetime` minmax index prune parts. Gated by
+        `WEAVE_ENFORCE_HEAVY_FIELD_TIME_FILTER` (off by default).
+        """
+        if not environment.wf_enforce_heavy_field_time_filter():
+            return
+        table_name = get_calls_table_name(self.read_table)
+        consumed = [
+            field
+            for condition in self.query_conditions
+            for field in condition._get_consumed_fields(table_name)
+        ]
+        has_heavy = any(field.is_heavy() for field in consumed)
+        has_time = any(field.field == _STARTED_AT_FIELD for field in consumed)
+        if has_heavy and not has_time:
+            raise InvalidRequest(
+                "Querying heavy fields (inputs, output, attributes) requires a "
+                "started_at filter. Add a started_at bound to your query and retry."
+            )
+
     def as_sql(self, pb: ParamBuilder, table_alias: str | None = None) -> str:
         """This is the main entry point for building the query.
 
@@ -1140,6 +1164,8 @@ class CallsQuery(BaseModel):
         """
         if not self.select_fields:
             raise ValueError("Missing select columns")
+
+        self._enforce_heavy_field_time_filter()
 
         # Determine if we should use the two-step filtered_calls CTE pattern.
         # Only relevant for calls_merged (where GROUP BY makes the two-pass

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -66,6 +66,14 @@ def wf_enable_agent_scoring() -> bool:
     return os.environ.get("WEAVE_ENABLE_AGENT_SCORING", "false").lower() == "true"
 
 
+def wf_enforce_heavy_field_time_filter() -> bool:
+    """Whether to reject calls queries that filter on heavy fields without a started_at filter."""
+    return (
+        os.environ.get("WEAVE_ENFORCE_HEAVY_FIELD_TIME_FILTER", "false").lower()
+        == "true"
+    )
+
+
 def wf_scoring_worker_batch_size() -> int:
     """The batch size for the scoring worker."""
     return int(


### PR DESCRIPTION
## Summary
- Adds `WEAVE_ENFORCE_HEAVY_FIELD_TIME_FILTER` (off by default). When on, a calls query that filters a heavy field (inputs/output/attributes) without any `started_at` bound is rejected with `InvalidRequest`.
- Heavy-field filters with no time bound force a full scan of the dump columns (`inputs_dump` alone is ~17 TiB / no skip index), so a single content search reads tens to hundreds of GiB. Requiring a `started_at` bound lets the `sortable_datetime` minmax index prune parts (measured ~12x fewer rows on a busy project).
- Enforced in `CallsQuery.as_sql()`, the single chokepoint for both hydration and the general stats path. Reuses the existing `Condition.is_heavy()` machinery.

## Testing
unit test (parametrized: flag on/off x heavy/light x with/without time bound)