### PR TITLE
fix(weave): disable lazy materialization on calls_complete

### DIFF
--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -1941,3 +1941,47 @@ def test_feedback_filter_does_not_duplicate_calls_complete(
         f"Expected 1 call but got {len(results)} — feedback LEFT JOIN is duplicating rows"
     )
     assert results[0].id == call_id
+
+
+@pytest.mark.parametrize(
+    ("read_table", "expect_lazy_materialization_disabled"),
+    [
+        (ReadTable.CALLS_COMPLETE, True),
+        (ReadTable.CALLS_MERGED, False),
+    ],
+)
+def test_calls_query_stream_lazy_materialization_scoped_to_calls_complete(
+    monkeypatch,
+    clickhouse_trace_server,
+    read_table,
+    expect_lazy_materialization_disabled,
+):
+    """calls_complete reads inject query_plan_optimize_lazy_materialization=0 to dodge
+    the CH 25.11/25.12 patch-part `_block_number` crash; calls_merged reads do not.
+    """
+    captured: dict[str, Any] = {}
+
+    def _capture(query, parameters=None, settings=None, **kwargs):
+        captured["settings"] = dict(settings or {})
+        return iter([])
+
+    monkeypatch.setattr(
+        clickhouse_trace_server.table_routing_resolver,
+        "resolve_read_table",
+        lambda *args, **kwargs: read_table,
+    )
+    monkeypatch.setattr(clickhouse_trace_server, "_query_stream", _capture)
+
+    list(
+        clickhouse_trace_server.calls_query_stream(
+            tsi.CallsQueryReq(
+                project_id=f"{TEST_ENTITY}/lazy_mat", columns=["id"], limit=10
+            )
+        )
+    )
+
+    flag = "query_plan_optimize_lazy_materialization"
+    if expect_lazy_materialization_disabled:
+        assert captured["settings"][flag] == 0
+    else:
+        assert flag not in captured["settings"]

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -1961,16 +1961,17 @@ def test_calls_query_stream_lazy_materialization_scoped_to_calls_complete(
     """
     captured: dict[str, Any] = {}
 
-    def _capture(query, parameters=None, settings=None, **kwargs):
+    def _capture(self, query, parameters=None, settings=None, **kwargs):
         captured["settings"] = dict(settings or {})
         return iter([])
 
+    # Patch on the classes, not the shared instances: instance-level setattr would
+    # leak `_query_stream` into the server's __dict__ (see test_reset_server_state).
+    resolver = clickhouse_trace_server.table_routing_resolver
     monkeypatch.setattr(
-        clickhouse_trace_server.table_routing_resolver,
-        "resolve_read_table",
-        lambda *args, **kwargs: read_table,
+        type(resolver), "resolve_read_table", lambda self, *args, **kwargs: read_table
     )
-    monkeypatch.setattr(clickhouse_trace_server, "_query_stream", _capture)
+    monkeypatch.setattr(type(clickhouse_trace_server), "_query_stream", _capture)
 
     list(
         clickhouse_trace_server.calls_query_stream(

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1614,6 +1614,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         ):
             settings = ch_settings.update_settings_for_aggregation_in_order(settings)
 
+        # calls_complete reads can hit lightweight-update patch parts that crash under
+        # CH lazy materialization (see CLICKHOUSE_CALLS_COMPLETE_READ_SETTINGS).
+        if read_table == ReadTable.CALLS_COMPLETE:
+            settings = ch_settings.update_settings_for_calls_complete_read(settings)
+
         pb = ParamBuilder()
         raw_res = self._query_stream(cq.as_sql(pb), pb.get_params(), settings=settings)
 

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -180,3 +180,22 @@ def update_settings_for_aggregation_in_order(
     settings: dict[str, int | str] | None = None,
 ) -> dict[str, int | str]:
     return {**(settings or {}), **CLICKHOUSE_AGGREGATION_IN_ORDER_SETTINGS}
+
+
+# `calls_complete` is the only calls table with `enable_block_number_column=1`, so its
+# lightweight-update patch parts carry a `_block_number` virtual column. Since CH 25.11
+# allowed `optimize_read_in_order` + lazy materialization together, reads that hit Join-mode
+# patch parts under the InOrder pool feed an empty `read_sample_block` to the patch reader and
+# raise "Not found column `_block_number` in block" (NOT_FOUND_COLUMN_IN_BLOCK). Disabling lazy
+# materialization on this read path sidesteps it at no measurable cost (identical bytes_read,
+# equal-or-better latency in prod benchmarks). Fixed upstream by ClickHouse PR #99023, first
+# released in 26.3 and NOT backported to any 25.12.x. Remove once CH is >= 26.3.
+CLICKHOUSE_CALLS_COMPLETE_READ_SETTINGS: dict[str, int | str] = {
+    "query_plan_optimize_lazy_materialization": 0,
+}
+
+
+def update_settings_for_calls_complete_read(
+    settings: dict[str, int | str] | None = None,
+) -> dict[str, int | str]:
+    return {**(settings or {}), **CLICKHOUSE_CALLS_COMPLETE_READ_SETTINGS}


### PR DESCRIPTION
## Summary
- Jira: [WB-35195](https://coreweave.atlassian.net/browse/WB-35195)
- `calls_complete` reads on CH 25.11/25.12 crash with `NOT_FOUND_COLUMN_IN_BLOCK: Not found column _block_number in block` when a query hits lightweight-update patch parts under the InOrder read pool (prod 502s on `/calls/stream_query` and `/call/read`).
- Scoped fix: inject `query_plan_optimize_lazy_materialization=0` only for `ReadTable.CALLS_COMPLETE`, the sole calls table with `enable_block_number_column=1`. `calls_merged` is untouched.
- Upstream fix is ClickHouse PR #99023, first released in 26.3 and never backported to 25.12.x; inline comment says to remove once CH >= 26.3.

## Prod impact
231 errors in the last 7 days (Datadog): 122 on `/calls/stream_query`, 106 on `/call/read` 

## Performance
Benchmarked on prod (read-only replica, 25.12.1.1606), busiest calls_complete project, real stream_query shape. `bytes_read` identical with the flag on/off; latency equal-or-better with it off:

| query | lazy on | lazy off |
|-------|--------:|---------:|
| ORDER BY started_at DESC LIMIT 100 | ~50ms | ~42ms |
| LIMIT 1000 | ~240ms | ~198ms |

No measurable cost: lazy materialization gives no benefit here since the heavy dump columns are read per-granule regardless.

## Testing
parametrized test asserts the setting is threaded for calls_complete reads and absent for calls_merged.


[WB-35195]: https://coreweave.atlassian.net/browse/WB-35195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ