### PR TITLE
chore(weave): pin uv version in setup-uv

### DIFF
--- a/.github/workflows/publish_ts_sdk_npm.yaml
+++ b/.github/workflows/publish_ts_sdk_npm.yaml
@@ -67,6 +67,8 @@ jobs:
       # toolchain itself.
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.19"
 
       - name: Run tests
         working-directory: sdks/node

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -516,6 +516,7 @@ jobs:
       - name: Set up uv (cached)
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.11.19"
           enable-cache: true
           cache-local-path: ${{ runner.temp }}\uv-cache
           cache-dependency-glob: "**/pyproject.toml"
@@ -603,6 +604,7 @@ jobs:
       - name: Set up uv (cached)
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.11.19"
           enable-cache: true
           cache-local-path: ${{ runner.temp }}\uv-cache
           cache-dependency-glob: "**/pyproject.toml"

--- a/.github/workflows/weave-node-tests.yaml
+++ b/.github/workflows/weave-node-tests.yaml
@@ -31,6 +31,8 @@ jobs:
       # toolchain itself.
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.11.19"
       - name: Run tests
         run: pnpm test
         working-directory: sdks/node


### PR DESCRIPTION
pin `uv` to `0.11.19` across all `astral-sh/setup-uv@v7` steps. unpinned, the action resolves "latest" by fetching `raw.githubusercontent.com/astral-sh/versions/.../uv.ndjson`, which flakes and fails the step (seen on Windows trace nox jobs).

## Testing
ci only change.