### PR TITLE
perf(weave): add attributes_dump ngram index + env-gated candidate CTE

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1601,6 +1601,70 @@ def test_trace_call_filter(client):
         )
 
 
+def test_attributes_dump_heavy_index_filter_parity(client, monkeypatch):
+    """Flag-on path returns the SAME calls as flag-off against real ClickHouse.
+
+    Proves the candidate-CTE + OR-IS-NULL arm is correct over real (unmerged)
+    rows, which the query-builder shape tests cannot. ClickHouse-only.
+    """
+    if client_is_sqlite(client):
+        pytest.skip("heavy-field index path is ClickHouse-only")
+
+    @weave.op
+    def attr_op(x: int) -> int:
+        return x
+
+    for i, model in enumerate(["gpt-4o", "gpt-4o-mini", "claude-3-opus"]):
+        with weave.attributes({"model": model, "nested": {"k": model}}):
+            attr_op(i)
+
+    project_id = get_client_project_id(client)
+    server = get_client_trace_server(client)
+    queries = [
+        # contains "gpt-4" matches gpt-4o and gpt-4o-mini
+        (
+            2,
+            {
+                "$contains": {
+                    "input": {"$getField": "attributes.model"},
+                    "substr": {"$literal": "gpt-4"},
+                }
+            },
+        ),
+        # eq matches exactly one
+        (
+            1,
+            {"$eq": [{"$getField": "attributes.model"}, {"$literal": "gpt-4o"}]},
+        ),
+        # nested attributes field still routes through the dump index
+        (
+            1,
+            {
+                "$contains": {
+                    "input": {"$getField": "attributes.nested.k"},
+                    "substr": {"$literal": "claude"},
+                }
+            },
+        ),
+    ]
+
+    def ids_for(query: dict) -> list[str]:
+        res = server.calls_query(
+            tsi.CallsQueryReq.model_validate(
+                {"project_id": project_id, "query": {"$expr": query}}
+            )
+        )
+        return sorted(c.id for c in res.calls)
+
+    for expected, query in queries:
+        monkeypatch.delenv("WF_CALLS_MERGED_HEAVY_INDEXES", raising=False)
+        off_ids = ids_for(query)
+        monkeypatch.setenv("WF_CALLS_MERGED_HEAVY_INDEXES", "true")
+        on_ids = ids_for(query)
+        assert off_ids == on_ids, f"flag changed results for {query}"
+        assert len(on_ids) == expected, f"{query}: expected {expected}, got {on_ids}"
+
+
 def test_ops_with_default_params(client):
     @weave.op
     def op_with_default(a: int, b: int = 10) -> int:

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2897,6 +2897,168 @@ def test_trace_id_filter_calls_complete_no_candidate_cte() -> None:
     )
 
 
+def test_attributes_dump_ngram_index_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """On-path shape + scoping: attributes candidate CTE, trace_id unification,
+    inputs_dump untouched (not indexed), calls_complete untouched (merged-only).
+    The off-path is pinned by every other heavy-field test (flag unset default).
+    """
+    monkeypatch.setenv("WF_CALLS_MERGED_HEAVY_INDEXES", "true")
+
+    contains_cq = CallsQuery(project_id="project")
+    contains_cq.add_field("id")
+    contains_cq.add_field("attributes")
+    contains_cq.add_condition(
+        tsi_query.ContainsOperation.model_validate(
+            {
+                "$contains": {
+                    "input": {"$getField": "attributes.model"},
+                    "substr": {"$literal": "gpt-4"},
+                }
+            }
+        )
+    )
+    assert_sql(
+        contains_cq,
+        """
+        WITH filter_candidate_ids AS (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_1:String}
+            WHERE (ifNull(calls_merged.attributes_dump, '') LIKE {pb_0:String}))
+        SELECT
+            calls_merged.id AS id,
+            any(calls_merged.attributes_dump) AS attributes_dump
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_1:String}
+        WHERE (calls_merged.id IN filter_candidate_ids)
+            AND ((ifNull(calls_merged.attributes_dump, '') LIKE {pb_0:String}
+                OR calls_merged.attributes_dump IS NULL))
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING ((position(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_2:String}), 'null'), ''), {pb_3:String}) > 0)
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {
+            "pb_0": '%"%gpt-4%"%',
+            "pb_1": "project",
+            "pb_2": '$."model"',
+            "pb_3": "gpt-4",
+        },
+    )
+
+    # trace_id + attributes_dump: both bloom pushdowns share one candidate CTE.
+    unified_cq = CallsQuery(project_id="project")
+    unified_cq.add_field("id")
+    unified_cq.hardcoded_filter = HardCodedFilter(filter={"trace_ids": ["t1"]})
+    unified_cq.add_condition(
+        tsi_query.ContainsOperation.model_validate(
+            {
+                "$contains": {
+                    "input": {"$getField": "attributes.model"},
+                    "substr": {"$literal": "gpt-4"},
+                }
+            }
+        )
+    )
+    assert_sql(
+        unified_cq,
+        """
+        WITH filter_candidate_ids AS (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_2:String}
+            WHERE (ifNull(calls_merged.trace_id, '') = {pb_0:String})
+                AND (ifNull(calls_merged.attributes_dump, '') LIKE {pb_1:String})),
+        filtered_calls AS (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_2:String}
+            WHERE (calls_merged.id IN filter_candidate_ids)
+                AND (ifNull(calls_merged.trace_id, '') = {pb_0:String}
+                    OR calls_merged.trace_id IS NULL)
+                AND ((ifNull(calls_merged.attributes_dump, '') LIKE {pb_1:String}
+                    OR calls_merged.attributes_dump IS NULL))
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING ((position(coalesce(nullIf(JSON_VALUE(any(calls_merged.attributes_dump), {pb_3:String}), 'null'), ''), {pb_4:String}) > 0)
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))))
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_2:String}
+        WHERE (calls_merged.id IN filtered_calls)
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        """,
+        {
+            "pb_0": "t1",
+            "pb_1": '%"%gpt-4%"%',
+            "pb_2": "project",
+            "pb_3": '$."model"',
+            "pb_4": "gpt-4",
+        },
+    )
+
+    # inputs_dump (not indexed): no wrap, no candidate CTE even with the flag on.
+    inputs_cq = CallsQuery(project_id="project")
+    inputs_cq.add_field("id")
+    inputs_cq.add_condition(
+        tsi_query.ContainsOperation.model_validate(
+            {
+                "$contains": {
+                    "input": {"$getField": "inputs.x"},
+                    "substr": {"$literal": "yy"},
+                }
+            }
+        )
+    )
+    assert_sql(
+        inputs_cq,
+        """
+        SELECT calls_merged.id AS id
+        FROM calls_merged
+        PREWHERE calls_merged.project_id = {pb_3:String}
+        WHERE ((calls_merged.inputs_dump LIKE {pb_2:String}
+                OR calls_merged.inputs_dump IS NULL))
+        GROUP BY (calls_merged.project_id, calls_merged.id)
+        HAVING ((position(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
+            AND ((any(calls_merged.deleted_at) IS NULL))
+            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {"pb_0": '$."x"', "pb_1": "yy", "pb_2": '%"%yy%"%', "pb_3": "project"},
+    )
+
+    # calls_complete: index is calls_merged-only, so no wrap and no candidate CTE.
+    complete_cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
+    complete_cq.add_field("id")
+    complete_cq.add_condition(
+        tsi_query.ContainsOperation.model_validate(
+            {
+                "$contains": {
+                    "input": {"$getField": "attributes.model"},
+                    "substr": {"$literal": "gpt-4"},
+                }
+            }
+        )
+    )
+    assert_sql(
+        complete_cq,
+        """
+        SELECT calls_complete.id AS id
+        FROM calls_complete
+        PREWHERE calls_complete.project_id = {pb_4:String}
+        WHERE (calls_complete.attributes_dump LIKE {pb_3:String})
+            AND ((position(coalesce(nullIf(JSON_VALUE(calls_complete.attributes_dump, {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
+                AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
+        """,
+        {
+            "pb_0": '$."model"',
+            "pb_1": "gpt-4",
+            "pb_2": SENTINEL_EPOCH,
+            "pb_3": '%"%gpt-4%"%',
+            "pb_4": "project",
+        },
+    )
+
+
 def test_wb_run_id_filter_eq():
     cq = CallsQuery(project_id="project")
     cq.add_field("id")

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -40,6 +40,7 @@ from weave.shared.trace_server_interface_util import (
     wildcard_version_value_to_ref_prefix,
 )
 from weave.trace_server import ch_sentinel_values
+from weave.trace_server import environment as wf_env
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.calls_query_builder.cte import CTECollection
 from weave.trace_server.calls_query_builder.object_ref_query_builder import (
@@ -592,6 +593,19 @@ class WhereFilters(BaseModel):
             self.object_refs,
         ]
         return "\n        ".join(f for f in filters if f)
+
+    def to_where_clause(self) -> str:
+        """Render filters as a standalone `WHERE ...` clause, or empty string.
+
+        Strips the leading `AND` that `to_sql()` emits for PREWHERE callers; the
+        assert pins the every-filter-starts-with-AND invariant.
+        """
+        body = self.to_sql()
+        if not body:
+            return ""
+        assert re.match(r"^\s*AND\s+", body), f"filter must start with AND: {body!r}"
+        stripped = re.sub(r"^\s*AND\s+", "", body)
+        return f"WHERE {stripped}"
 
 
 class QueryJoins(BaseModel):
@@ -1195,21 +1209,19 @@ class CallsQuery(BaseModel):
             pb, self.project_id, object_ref_conditions
         )
 
-        # Pre-narrow rows via the `idx_trace_id_bloom` skip-index when the
-        # query has a hardcoded trace_ids filter on calls_merged. The CTE
-        # uses the strict (no OR-IS-NULL) form so the bloom filter can prune
-        # granules; the outer query keeps the OR-IS-NULL form for unmerged-
-        # call-part correctness and restricts to `id IN filter_candidate_ids`.
+        # Pre-narrow rows via calls_merged bloom skip-indexes (trace_id from
+        # migration 032, attributes_dump ngram from migration 033) into a
+        # single `filter_candidate_ids` CTE. The CTE uses the strict (no
+        # OR-IS-NULL) form so the bloom filters can prune granules; the outer
+        # query keeps the OR-IS-NULL form for unmerged-call-part correctness
+        # and restricts to `id IN filter_candidate_ids`.
         #
         # Always-on: independent of `should_use_filter_cte`, because the bloom
         # prune pays for itself even on the trivial single-pass path and the
         # CTE itself is cheap (one extra SELECT, no replicated ordering).
-        # TODO(WB-34494): as_sql is getting long. Follow-up to hoist the
-        # early-return predicate into a named local and extract the
-        # single-pass / two-pass branches into helpers.
         candidate_cte_name: str | None = None
         candidate_cte_sql = self._build_filter_candidate_ids_cte_sql(
-            pb, table_alias_resolved
+            pb, table_alias_resolved, self.expand_columns
         )
         if candidate_cte_sql is not None:
             ctes.add_cte(CTE_FILTER_CANDIDATE_IDS, candidate_cte_sql)
@@ -1341,6 +1353,8 @@ class CallsQuery(BaseModel):
         table_alias: str,
         expand_columns: list[str] | None,
         id_subquery_name: str | None = None,
+        use_strict_heavy_filter: bool = False,
+        use_strict_trace_id_filter: bool = False,
     ) -> WhereFilters:
         """Build all WHERE clause optimization filters.
 
@@ -1352,6 +1366,14 @@ class CallsQuery(BaseModel):
             table_alias: The table alias to use in SQL
             expand_columns: List of columns that should be expanded for object refs
             id_subquery_name: Optional name of a CTE containing filtered IDs
+            use_strict_heavy_filter: When True, use the strict (no OR-IS-NULL,
+                bloom-indexed-only) heavy-field filter. The candidate-id CTE
+                sets this so the ngram bloom filter index can prune granules;
+                the outer query keeps the OR-IS-NULL form for correctness over
+                unmerged calls_merged parts.
+            use_strict_trace_id_filter: Same idea for the trace_id bloom-filter
+                index (migration 032). Set inside the candidate-id CTE so both
+                pushdowns prune; leave False outside it.
 
         Returns:
             WhereFilters object containing all filter SQL strings
@@ -1364,9 +1386,15 @@ class CallsQuery(BaseModel):
         # signal (start-only) because started_at now rides on call_end rows too.
 
         op_name = process_op_name_filter_to_sql(self.hardcoded_filter, pb, table_alias)
-        trace_id = process_trace_id_filter_to_sql(
-            self.hardcoded_filter, pb, table_alias, self.read_table
-        )
+        if use_strict_trace_id_filter:
+            trace_id_strict_cond = process_trace_id_filter_to_sql_strict(
+                self.hardcoded_filter, pb, table_alias
+            )
+            trace_id = f" AND ({trace_id_strict_cond})" if trace_id_strict_cond else ""
+        else:
+            trace_id = process_trace_id_filter_to_sql(
+                self.hardcoded_filter, pb, table_alias, self.read_table
+            )
         thread_id = process_thread_id_filter_to_sql(
             self.hardcoded_filter, pb, table_alias, self.read_table
         )
@@ -1402,7 +1430,10 @@ class CallsQuery(BaseModel):
             non_object_ref_conditions, pb, table_alias, self.read_table
         )
         sortable_datetime = optimization_conditions.sortable_datetime_filters_sql or ""
-        heavy_filter = optimization_conditions.heavy_filter_opt_sql or ""
+        if use_strict_heavy_filter:
+            heavy_filter = optimization_conditions.heavy_filter_opt_strict_sql or ""
+        else:
+            heavy_filter = optimization_conditions.heavy_filter_opt_sql or ""
 
         object_refs = process_object_refs_filter_to_opt_sql(
             pb, table_alias, object_ref_fields_consumed, self.read_table
@@ -1742,14 +1773,10 @@ class CallsQuery(BaseModel):
         if self.read_table == ReadTable.CALLS_MERGED:
             group_by_sql = f"GROUP BY ({table_alias}.project_id, {table_alias}.id)"
 
-        # Use PREWHERE for project_id to filter data before reading from disk
-        # This is a ClickHouse optimization for high-selectivity filters
-        where_filters_sql = where_filters.to_sql()
-        # Strip leading "AND " from where_filters since PREWHERE handles the first condition
-        where_filters_stripped = re.sub(r"^\s*AND\s+", "", where_filters_sql)
-        where_clause = (
-            f"WHERE {where_filters_stripped}" if where_filters_stripped else ""
-        )
+        # Use PREWHERE for project_id to filter data before reading from disk.
+        # `to_where_clause` strips the leading `AND ` since PREWHERE supplies
+        # the first predicate.
+        where_clause = where_filters.to_where_clause()
 
         # Fix where_clause when empty but we have filter_sql
         # For calls_complete, filter_sql starts with "AND "
@@ -1779,34 +1806,94 @@ class CallsQuery(BaseModel):
         self,
         pb: ParamBuilder,
         table_alias: str,
+        expand_columns: list[str] | None,
     ) -> str | None:
         """Build the `filter_candidate_ids` CTE body, or None if not applicable.
 
-        The CTE pre-narrows rows by trace_id using the strict
-        `ifNull(trace_id, '')` form so the `idx_trace_id_bloom` skip-index
-        from migration 031 can prune granules. The outer query then keeps the
-        OR-IS-NULL form for unmerged-call-part correctness and restricts to
-        `id IN filter_candidate_ids` to inherit the pruning.
+        Unifies two bloom pushdowns into one strict (no OR-IS-NULL) id superset
+        so the outer query can `id IN filter_candidate_ids` and inherit both
+        prunes: trace_id (migration 032, when hardcoded_filter has trace_ids)
+        and attributes_dump LIKE (migration 033, gated on the env flag). The
+        outer query keeps OR-IS-NULL for unmerged-part correctness, which would
+        defeat the indexes. Safe because the strict heavy form only covers
+        attributes_dump, a start-only field (see the START_ONLY assert).
 
-        Returns None when the optimization does not apply: non-calls_merged
-        read tables, or no hardcoded trace_ids filter to push down.
+        TODO(WB-34494): extending bloom pushdown to end-only fields
+        (output/summary) needs per-field candidate sub-CTEs intersected by id -
+        a single start+end conjunction matches no un-merged row. A
+        filter-contributor model (each filter declares outer SQL, optional
+        prunable SQL, index, and row-locality) would also dissolve the two
+        strict-vs-outer booleans this currently rides on.
         """
         if self.read_table != ReadTable.CALLS_MERGED:
             return None
-        if self.hardcoded_filter is None or not self.hardcoded_filter.filter.trace_ids:
-            return None
 
-        trace_id_strict = process_trace_id_filter_to_sql_strict(
-            self.hardcoded_filter, pb, table_alias
+        has_trace_ids = bool(
+            self.hardcoded_filter and self.hardcoded_filter.filter.trace_ids
         )
-        if not trace_id_strict:
+        heavy_has_strict_filter = self._peek_strict_heavy_filter_sql(
+            table_alias, expand_columns
+        )
+
+        if not has_trace_ids and not heavy_has_strict_filter:
             return None
 
-        project_param = pb.add_param(self.project_id)
-        return f"""SELECT {table_alias}.id AS id
+        # trace_id-only: emit the minimal `WHERE trace_id = ?` CTE.
+        if not heavy_has_strict_filter:
+            trace_id_strict = process_trace_id_filter_to_sql_strict(
+                self.hardcoded_filter, pb, table_alias
+            )
+            if not trace_id_strict:
+                return None
+            project_param = pb.add_param(self.project_id)
+            return f"""SELECT {table_alias}.id AS id
         FROM {table_alias}
         PREWHERE {table_alias}.project_id = {param_slot(project_param, "String")}
         WHERE {trace_id_strict}"""
+
+        # attributes_dump heavy-LIKE eligible. Build the full strict WHERE
+        # (heavy LIKE plus trace_id/op_name/etc. in their strict/non-bloom
+        # form) for real on the live param builder.
+        where_filters = self._build_where_clause_optimizations(
+            pb,
+            table_alias,
+            expand_columns=expand_columns,
+            id_subquery_name=None,
+            use_strict_heavy_filter=True,
+            use_strict_trace_id_filter=True,
+        )
+        if not where_filters.heavy_filter:
+            return None
+
+        project_param = pb.add_param(self.project_id)
+        raw_sql = f"""
+        SELECT {table_alias}.id AS id
+        FROM {table_alias}
+        PREWHERE {table_alias}.project_id = {param_slot(project_param, "String")}
+        {where_filters.to_where_clause()}
+        """
+        return safely_format_sql(raw_sql, logger)
+
+    def _peek_strict_heavy_filter_sql(
+        self, table_alias: str, expand_columns: list[str] | None
+    ) -> str | None:
+        """Whether a strict (bloom-indexed) heavy-LIKE filter exists, or None.
+
+        Computed on a throwaway ParamBuilder so queries without a heavy-LIKE
+        optimization don't shift the public param numbering or pay for
+        duplicate hardcoded-filter params when the candidate CTE ends up unused.
+        """
+        if not wf_env.wf_calls_merged_heavy_indexes_enabled():
+            return None
+        non_object_ref_conditions = [
+            c
+            for c in self.query_conditions
+            if not (expand_columns and is_object_ref_operand(c.operand, expand_columns))
+        ]
+        peek = process_query_to_optimization_sql(
+            non_object_ref_conditions, ParamBuilder(), table_alias, self.read_table
+        )
+        return peek.heavy_filter_opt_strict_sql
 
     def _as_sql_base_format(
         self,

--- a/weave/trace_server/calls_query_builder/optimization_builder.py
+++ b/weave/trace_server/calls_query_builder/optimization_builder.py
@@ -13,10 +13,12 @@ improving performance for complex conditions.
 """
 
 from abc import ABC, abstractmethod
+from enum import Enum, auto
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
+from weave.trace_server import environment as wf_env
 from weave.trace_server.calls_query_builder.utils import (
     NotContext,
     param_slot,
@@ -34,7 +36,29 @@ if TYPE_CHECKING:
 START_ONLY_CALL_FIELDS = {"started_at", "inputs_dump", "attributes_dump"}
 END_ONLY_CALL_FIELDS = {"ended_at", "output_dump", "summary_dump"}
 HEAVY_FIELDS_TO_OPTIMIZE = {"inputs_dump", "output_dump", "attributes_dump"}
+# Heavy fields backed by an ngram bloom filter index on `ifNull(<dump>, '')`
+# (migration 033). Only these get the `ifNull()` wrap and the strict
+# candidate-CTE pushdown; other heavy fields keep the pre-index query shape.
+BLOOM_INDEXED_HEAVY_FIELDS = {"attributes_dump"}
+# Must stay start-only: the candidate CTE matches one un-merged row, so a
+# start+end conjunction would match nothing and silently drop ids (see
+# _build_filter_candidate_ids_cte_sql for the end-only path).
+assert BLOOM_INDEXED_HEAVY_FIELDS <= START_ONLY_CALL_FIELDS, (
+    "bloom-indexed heavy fields must be start-only for the candidate CTE to be correct"
+)
 DATETIME_FIELDS_TO_OPTIMIZE = {"started_at"}
+
+
+class BloomPath(Enum):
+    """How a heavy-field LIKE relates to the calls_merged ngram index."""
+
+    # raw column: calls_complete, or the flag off (pre-index shape).
+    OFF = auto()
+    # ifNull-wrapped on indexed fields, all heavy fields kept (outer query).
+    OUTER = auto()
+    # strict candidate CTE: ifNull wrap, bloom-indexed fields only, no lower().
+    CANDIDATE = auto()
+
 
 DATETIME_BUFFER_TIME_SECONDS = 60 * 5  # 5 minutes
 
@@ -52,6 +76,16 @@ def _field_requires_null_check(field: str) -> bool:
 def _can_optimize_heavy_field(field: str) -> bool:
     """Returns whether a field can be optimized for heavy field search."""
     return field in HEAVY_FIELDS_TO_OPTIMIZE
+
+
+def _excluded_from_bloom_candidate(field: str, bloom_path: BloomPath) -> bool:
+    """Whether to drop a heavy field from the strict bloom candidate CTE.
+
+    The candidate CTE only narrows by fields with a backing ngram index, so a
+    non-indexed heavy field would scan rather than prune. Dropping it keeps the
+    CTE a valid id superset; the outer query still applies the full filter.
+    """
+    return bloom_path == BloomPath.CANDIDATE and field not in BLOOM_INDEXED_HEAVY_FIELDS
 
 
 def _can_optimize_datetime_field(field: str) -> bool:
@@ -221,10 +255,15 @@ class HeavyFieldOptimizationProcessor(QueryOptimizationProcessor):
     """
 
     def __init__(
-        self, pb: "ParamBuilder", table_alias: str, use_null_check: bool = True
+        self,
+        pb: "ParamBuilder",
+        table_alias: str,
+        use_null_check: bool = True,
+        bloom_path: BloomPath = BloomPath.OFF,
     ) -> None:
         super().__init__(pb, table_alias)
         self.use_null_check = use_null_check
+        self.bloom_path = bloom_path
 
     def process_eq(self, operation: tsi_query.EqOperation) -> str | None:
         """Process equality operation on heavy fields.
@@ -232,7 +271,11 @@ class HeavyFieldOptimizationProcessor(QueryOptimizationProcessor):
         Creates SQL condition using LIKE patterns for values in JSON fields.
         """
         return _create_like_optimized_eq_condition(
-            operation, self.pb, self.table_alias, self.use_null_check
+            operation,
+            self.pb,
+            self.table_alias,
+            self.use_null_check,
+            self.bloom_path,
         )
 
     def process_contains(self, operation: tsi_query.ContainsOperation) -> str | None:
@@ -241,7 +284,11 @@ class HeavyFieldOptimizationProcessor(QueryOptimizationProcessor):
         Creates SQL condition using LIKE patterns for substrings in JSON fields.
         """
         return _create_like_optimized_contains_condition(
-            operation, self.pb, self.table_alias, self.use_null_check
+            operation,
+            self.pb,
+            self.table_alias,
+            self.use_null_check,
+            self.bloom_path,
         )
 
     def process_in(self, operation: tsi_query.InOperation) -> str | None:
@@ -250,7 +297,11 @@ class HeavyFieldOptimizationProcessor(QueryOptimizationProcessor):
         Creates SQL conditions using LIKE patterns for multiple values.
         """
         return _create_like_optimized_in_condition(
-            operation, self.pb, self.table_alias, self.use_null_check
+            operation,
+            self.pb,
+            self.table_alias,
+            self.use_null_check,
+            self.bloom_path,
         )
 
     def process_gt(self, operation: tsi_query.GtOperation) -> str | None:
@@ -358,6 +409,13 @@ def apply_processor(
 
 class OptimizationConditions(BaseModel):
     heavy_filter_opt_sql: str | None = None
+    # Strict variant of heavy_filter_opt_sql restricted to bloom-indexed heavy
+    # fields with no `OR <field> IS NULL` clauses. The OR-IS-NULL form is
+    # correct over unmerged calls_merged parts but defeats the ngram bloom
+    # filter index on `ifNull(attributes_dump, '')`. Use the strict form in a
+    # candidate-id CTE that pre-narrows rows via the index, then keep the
+    # OR-IS-NULL form in the outer query for correctness.
+    heavy_filter_opt_strict_sql: str | None = None
     sortable_datetime_filters_sql: str | None = None
 
 
@@ -393,11 +451,36 @@ def process_query_to_optimization_sql(
     # null checks are skipped since every row is a complete call.
     config = TableConfig.from_read_table(read_table)
     use_null_check = config.use_aggregation
+
+    # The ngram index lives only on calls_merged, so the bloom paths are gated
+    # on use_aggregation (calls_merged) as well as the env flag. calls_complete
+    # always keeps the raw pre-index query shape.
+    bloom_enabled = (
+        config.use_aggregation and wf_env.wf_calls_merged_heavy_indexes_enabled()
+    )
+    outer_bloom_path = BloomPath.OUTER if bloom_enabled else BloomPath.OFF
     heavy_field_processor = HeavyFieldOptimizationProcessor(
-        param_builder, table_alias, use_null_check=use_null_check
+        param_builder,
+        table_alias,
+        use_null_check=use_null_check,
+        bloom_path=outer_bloom_path,
     )
     heavy_field_result = apply_processor(heavy_field_processor, and_operation)
     heavy_field_result_sql = heavy_field_processor.finalize_sql(heavy_field_result)
+
+    # Strict (no OR-IS-NULL), bloom-indexed-only variant for the candidate CTE.
+    # Matches _build_filter_candidate_ids_cte_sql, which returns None for the
+    # heavy path when bloom is disabled.
+    strict_result_sql = None
+    if bloom_enabled:
+        strict_processor = HeavyFieldOptimizationProcessor(
+            param_builder,
+            table_alias,
+            use_null_check=False,
+            bloom_path=BloomPath.CANDIDATE,
+        )
+        strict_result = apply_processor(strict_processor, and_operation)
+        strict_result_sql = strict_processor.finalize_sql(strict_result)
 
     sortable_datetime_result_sql = None
     if config.use_aggregation:
@@ -416,6 +499,7 @@ def process_query_to_optimization_sql(
 
     return OptimizationConditions(
         heavy_filter_opt_sql=heavy_field_result_sql,
+        heavy_filter_opt_strict_sql=strict_result_sql,
         sortable_datetime_filters_sql=sortable_datetime_result_sql,
     )
 
@@ -449,9 +533,21 @@ def _create_like_condition(
     pb: "ParamBuilder",
     table_alias: str,
     case_insensitive: bool = False,
+    bloom_path: BloomPath = BloomPath.OFF,
 ) -> str:
-    """Creates a LIKE condition for a JSON field."""
-    field_name = f"{table_alias}.{field}"
+    """Creates a LIKE condition for a JSON field.
+
+    On the bloom paths (calls_merged with the index enabled), a bloom-indexed
+    field (see `BLOOM_INDEXED_HEAVY_FIELDS`) is wrapped in `ifNull(..., '')` so
+    the expression matches the `idx_<dump>_ngram` index expression on
+    calls_merged (migration 033) and so LIKE never returns NULL over the
+    Nullable(String) column. Otherwise the raw column reference is emitted,
+    matching the pre-index query shape exactly.
+    """
+    if bloom_path != BloomPath.OFF and field in BLOOM_INDEXED_HEAVY_FIELDS:
+        field_name = f"ifNull({table_alias}.{field}, '')"
+    else:
+        field_name = f"{table_alias}.{field}"
 
     if case_insensitive:
         param_name = pb.add_param(like_pattern.lower())
@@ -507,6 +603,7 @@ def _create_like_optimized_eq_condition(
     pb: "ParamBuilder",
     table_alias: str,
     use_null_check: bool = True,
+    bloom_path: BloomPath = BloomPath.OFF,
 ) -> str | None:
     """Creates a LIKE-optimized condition for equality operations.
 
@@ -517,6 +614,7 @@ def _create_like_optimized_eq_condition(
         use_null_check: Whether to add OR IS NULL for start/end fields.
             True for calls_merged (unmerged parts may have NULL fields).
             False for calls_complete (every row is a complete call).
+        bloom_path: How this condition relates to the calls_merged ngram index.
     """
     field_operand, literal_operand = _extract_field_and_literal(operation)
     if field_operand is None or literal_operand is None:
@@ -536,13 +634,17 @@ def _create_like_optimized_eq_condition(
     if not _can_optimize_heavy_field(field):
         return None
 
+    if _excluded_from_bloom_candidate(field, bloom_path):
+        return None
+
     if literal_value is None or (isinstance(literal_value, str) and not literal_value):
         # Empty/None values are not valid for LIKE optimization
         return None
 
     like_patterns = _create_like_patterns_for_value(literal_value)
     per_pattern = [
-        _create_like_condition(field, p, pb, table_alias) for p in like_patterns
+        _create_like_condition(field, p, pb, table_alias, bloom_path=bloom_path)
+        for p in like_patterns
     ]
     like_condition = (
         per_pattern[0]
@@ -557,6 +659,7 @@ def _create_like_optimized_contains_condition(
     pb: "ParamBuilder",
     table_alias: str,
     use_null_check: bool = True,
+    bloom_path: BloomPath = BloomPath.OFF,
 ) -> str | None:
     """Creates a LIKE-optimized condition for contains operations.
 
@@ -567,6 +670,10 @@ def _create_like_optimized_contains_condition(
         use_null_check: Whether to add OR IS NULL for start/end fields.
             True for calls_merged (unmerged parts may have NULL fields).
             False for calls_complete (every row is a complete call).
+        bloom_path: How this condition relates to the calls_merged ngram index.
+            On the CANDIDATE path, case-insensitive contains is dropped:
+            `lower(<dump>)` cannot hit the index (built on `ifNull(<dump>, '')`),
+            so it prunes nothing; the outer query still applies the lower() LIKE.
     """
     # Check if the input is a GetField operation on a JSON field
     if not isinstance(operation.contains_.input, tsi_query.GetFieldOperator):
@@ -590,11 +697,16 @@ def _create_like_optimized_contains_condition(
     if not _can_optimize_heavy_field(field):
         return None
 
+    if _excluded_from_bloom_candidate(field, bloom_path):
+        return None
+
     case_insensitive = operation.contains_.case_insensitive or False
+    if bloom_path == BloomPath.CANDIDATE and case_insensitive:
+        return None
     like_pattern = f'%"%{substr_value}%"%'
 
     like_condition = _create_like_condition(
-        field, like_pattern, pb, table_alias, case_insensitive
+        field, like_pattern, pb, table_alias, case_insensitive, bloom_path=bloom_path
     )
     return _maybe_use_null_check(like_condition, field, table_alias, use_null_check)
 
@@ -604,6 +716,7 @@ def _create_like_optimized_in_condition(
     pb: "ParamBuilder",
     table_alias: str,
     use_null_check: bool = True,
+    bloom_path: BloomPath = BloomPath.OFF,
 ) -> str | None:
     """Creates a LIKE-optimized condition for in operations.
 
@@ -614,6 +727,7 @@ def _create_like_optimized_in_condition(
         use_null_check: Whether to add OR IS NULL for start/end fields.
             True for calls_merged (unmerged parts may have NULL fields).
             False for calls_complete (every row is a complete call).
+        bloom_path: How this condition relates to the calls_merged ngram index.
     """
     # Check if the left side is a GetField operation on a JSON field
     if not isinstance(operation.in_[0], tsi_query.GetFieldOperator):
@@ -634,6 +748,9 @@ def _create_like_optimized_in_condition(
     if not _can_optimize_heavy_field(field):
         return None
 
+    if _excluded_from_bloom_candidate(field, bloom_path):
+        return None
+
     # Create OR conditions for each value
     like_conditions: list[str] = []
 
@@ -649,7 +766,7 @@ def _create_like_optimized_in_condition(
 
         for like_pattern in _create_like_patterns_for_value(value_operand.literal_):
             like_condition = _create_like_condition(
-                field, like_pattern, pb, table_alias
+                field, like_pattern, pb, table_alias, bloom_path=bloom_path
             )
             like_conditions.append(like_condition)
 

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -66,6 +66,15 @@ def wf_enable_agent_scoring() -> bool:
     return os.environ.get("WEAVE_ENABLE_AGENT_SCORING", "false").lower() == "true"
 
 
+def wf_calls_merged_heavy_indexes_enabled() -> bool:
+    """Gate the attributes_dump ngram-index candidate-CTE path on calls_merged.
+
+    Off by default and independent of migration 033; operators flip it per
+    cluster once the index has materialized on enough parts to be useful.
+    """
+    return os.environ.get("WF_CALLS_MERGED_HEAVY_INDEXES", "false").lower() == "true"
+
+
 def wf_scoring_worker_batch_size() -> int:
     """The batch size for the scoring worker."""
     return int(

--- a/weave/trace_server/migrations/033_add_attributes_dump_ngram_index.down.sql
+++ b/weave/trace_server/migrations/033_add_attributes_dump_ngram_index.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE calls_merged DROP INDEX IF EXISTS idx_attributes_dump_ngram;

--- a/weave/trace_server/migrations/033_add_attributes_dump_ngram_index.up.sql
+++ b/weave/trace_server/migrations/033_add_attributes_dump_ngram_index.up.sql
@@ -1,0 +1,16 @@
+-- Migration 033: ngram bloom filter index on ifNull(attributes_dump, '') so
+-- attributes substring filters on calls_merged prune granules instead of
+-- scanning the column. The query layer (gated by WF_CALLS_MERGED_HEAVY_INDEXES)
+-- emits the matching ifNull(...) LIKE inside the candidate-id CTE.
+--
+-- ngrambf_v1(5, 65536, 3, 0): n=5 halves the token space vs n=4 over large
+-- JSON blobs while staying usable for short quoted values, GRANULARITY 8 keeps
+-- the index small enough to stay hot in RAM.
+--
+-- Lazy backfill: no MATERIALIZE INDEX, which would block the migration on a
+-- full-table reindex. New parts get the index immediately and existing parts
+-- gain it as they re-merge. Run MATERIALIZE INDEX idx_attributes_dump_ngram
+-- out-of-band for immediate coverage.
+ALTER TABLE calls_merged
+    ADD INDEX IF NOT EXISTS idx_attributes_dump_ngram
+        ifNull(attributes_dump, '') TYPE ngrambf_v1(5, 65536, 3, 0) GRANULARITY 8;


### PR DESCRIPTION
https://coreweave.atlassian.net/browse/WB-35212

## Summary
- Migration 033 adds `idx_attributes_dump_ngram` on `ifNull(attributes_dump, '')` (`ngrambf_v1(5, 65536, 3, 0) GRANULARITY 8`, lazy backfill, no MATERIALIZE).
- Behind `WF_CALLS_MERGED_HEAVY_INDEXES`, attributes_dump eq/contains/in filters push a strict `ifNull(...) LIKE` into the `filter_candidate_ids` CTE so the skip-index prunes granules; the outer query keeps OR-IS-NULL for unmerged-part correctness. Unifies with the existing `trace_id` bloom pushdown into one CTE.
- Scoped to `attributes_dump` only (via `BloomPath` + a start-only assert) and to `calls_merged` only (gated on `use_aggregation`). Flag off is byte-identical to master.


## Architecture
```mermaid
flowchart TD
    Q[CallsQuery.as_sql] --> CTE["_build_filter_candidate_ids_cte_sql"]
    GATE{"WF_CALLS_MERGED_HEAVY_INDEXES<br/>AND use_aggregation (calls_merged)"} -. gates .-> CTE
    CTE -->|"strict, no OR-IS-NULL"| FCI[("filter_candidate_ids")]
    FCI -->|"ifNull(trace_id)=?  AND  ifNull(attributes_dump) LIKE ?"| IDX[["idx_trace_id_bloom + idx_attributes_dump_ngram prune granules"]]
    Q -->|"id IN filter_candidate_ids  +  OR-IS-NULL arm"| OUT[outer calls_merged GROUP BY query]
```
Blast radius: new env var (default off, inert), one lazy CH index, and a shared `to_where_clause` seam. No SDK/route/signature change; `calls_complete` and other heavy fields keep the pre-index shape.

## Testing
query-builder shape tests pin the on-path + all four scoping cases; a new `client`-fixture test asserts flag-on == flag-off result sets against real ClickHouse (the candidate-CTE/unmerged-part correctness the shape tests can't prove).
