### PR TITLE
chore(weave): map ObjectNameTypeCollision to 400 not 500

### DIFF
--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -5,6 +5,7 @@ from gql.transport.exceptions import TransportServerError
 from weave.trace_server.errors import (
     InvalidFieldError,
     InvalidRequest,
+    ObjectNameTypeCollision,
     handle_clickhouse_query_error,
     handle_server_exception,
 )
@@ -51,3 +52,25 @@ def test_invalid_field_error_maps_to_422() -> None:
     """
     result = handle_server_exception(InvalidFieldError("Field 'foo' is not allowed"))
     assert result.status_code == 422
+
+
+def test_object_name_type_collision_maps_to_400() -> None:
+    """Name+type collision is a fixable user error -> 400 with an actionable reason,
+    not 500. The registry matches by exact type, so the InvalidRequest subclass must
+    be registered explicitly.
+    """
+    exc = ObjectNameTypeCollision(
+        object_id="my-object",
+        kind="object",
+        new_base_object_class="Prompt",
+        existing_base_object_classes=[None],
+    )
+    result = handle_server_exception(exc)
+    assert result.status_code == 400
+    assert result.message == {
+        "reason": (
+            "Cannot publish 'my-object' as a Prompt: that name is already used "
+            "by a generic (untyped) object in this project. Object versions "
+            "cannot share types, publish this object under a different name."
+        )
+    }

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -65,12 +65,14 @@ class ObjectNameTypeCollision(InvalidRequest):
         self.kind = kind
         self.new_base_object_class = new_base_object_class
         self.existing_base_object_classes = existing_base_object_classes
-        existing_str = ", ".join(repr(c) for c in existing_base_object_classes)
+        existing_labels = [
+            _describe_object_class(c) for c in existing_base_object_classes
+        ]
+        existing_desc = " or ".join(dict.fromkeys(existing_labels))
         super().__init__(
-            f"Cannot create {kind} {object_id!r} with "
-            f"base_object_class={new_base_object_class!r}: a {kind} with this "
-            f"name already exists with base_object_class in [{existing_str}]. "
-            f"Object names are bound to one type per project."
+            f"Cannot publish {object_id!r} as {_describe_object_class(new_base_object_class)}: "
+            f"that name is already used by {existing_desc} in this project. "
+            f"Object versions cannot share types, publish this object under a different name."
         )
 
 
@@ -304,6 +306,7 @@ class ErrorRegistry:
         # 400
         self.register(InvalidRequest, 400)
         self.register(CallsCompleteModeRequired, 400)
+        self.register(ObjectNameTypeCollision, 400)
         self.register(InvalidExternalRef, 400)
         self.register(DigestMismatchError, 409)
         self.register(QueryNoCommonTypeError, 400)
@@ -466,6 +469,13 @@ def handle_clickhouse_query_error(e: Exception) -> None:
 
     # Re-raise the original exception if no known pattern matches
     raise e
+
+
+def _describe_object_class(base_object_class: str | None) -> str:
+    """Human-readable label for a base_object_class (None = an untyped object)."""
+    if base_object_class is None:
+        return "a generic (untyped) object"
+    return f"a {base_object_class}"
 
 
 def _format_missing_llm_api_key(exc: Exception) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- `ObjectNameTypeCollision` is a fixable user error (object name already bound to another `base_object_class`) but was returning 500 in prod.
- The error registry matches by exact exception type, so the `InvalidRequest` subclass was never found and fell through to the default 500. Register it as 400 so the actionable message reaches the user.

## Testing
unit test 