### PR TITLE
test(weave): unify nightly auth with test.yaml

### DIFF
--- a/.github/workflows/nightly-replicated-leg.yaml
+++ b/.github/workflows/nightly-replicated-leg.yaml
@@ -28,6 +28,11 @@ on:
 jobs:
   run:
     name: ${{ inputs.topology }} (3.${{ matrix.python-version-minor }}, ${{ matrix.shard }})
+    # id-token: write lets google-github-actions/auth mint an OIDC token for
+    # Workload Identity Federation (same keyless auth as test.yaml).
+    permissions:
+      contents: read
+      id-token: write
     # Successful 8-core trace leg ran in ~16 min; cap at 25 min so any hang
     # fails fast and we can RCA from the captured CH logs + faulthandler dump.
     timeout-minutes: 25
@@ -87,25 +92,6 @@ jobs:
             python-version-minor: "10"
             shard: "verifiers_test"
       fail-fast: false
-    services:
-      wandbservice:
-        image: us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
-        credentials:
-          username: _json_key
-          password: ${{ secrets.gcp_wb_sa_key }}
-        env:
-          CI: 1
-          WANDB_ENABLE_TEST_CONTAINER: true
-          LOGGING_ENABLED: true
-        ports:
-          - "8080:8080"
-          - "8083:8083"
-          - "9015:9015"
-        options: >-
-          --health-cmd "wget -q -O /dev/null http://localhost:8080/healthz || exit 1"
-          --health-interval=5s
-          --health-timeout=3s
-          --health-start-period=10s
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -123,6 +109,36 @@ jobs:
           fi
           echo "Running shard: ${{ matrix.shard }}"
           echo "skip=false" >> $GITHUB_OUTPUT
+      - id: auth
+        name: Authenticate to Google Cloud
+        if: steps.filter_shards.outputs.skip != 'true'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ secrets.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.WORKLOAD_IDENTITY_SERVICE_ACCOUNT }}
+          token_format: access_token
+      - name: Start wandb service
+        if: steps.filter_shards.outputs.skip != 'true'
+        run: |
+          set -euo pipefail
+          echo "${{ steps.auth.outputs.access_token }}" | docker login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev
+          docker run --detach --name wandbservice \
+            --env CI=1 \
+            --env WANDB_ENABLE_TEST_CONTAINER=true \
+            --env LOGGING_ENABLED=true \
+            --publish 8080:8080 \
+            --publish 8083:8083 \
+            --publish 9015:9015 \
+            us-central1-docker.pkg.dev/wandb-production/images/local-testcontainer:master
+          for _i in {1..30}; do
+            if curl --silent --fail --show-error http://localhost:8080/healthz >/dev/null; then
+              echo "wandb service is healthy"
+              exit 0
+            fi
+            sleep 5
+          done
+          docker logs wandbservice
+          exit 1
       - name: Enable debug logging
         if: steps.filter_shards.outputs.skip != 'true'
         run: echo "ACTIONS_STEP_DEBUG=true" >> $GITHUB_ENV
@@ -168,7 +184,7 @@ jobs:
           WEAVE_SENTRY_ENV: ci
           CI: 1
           WEAVE_USE_MEMRAY: 1
-          WB_SERVER_HOST: http://wandbservice
+          WB_SERVER_HOST: http://localhost
           WF_CLICKHOUSE_HOST: localhost
           WF_CLICKHOUSE_PORT: ${{ inputs.ch_port }}
           WF_CLICKHOUSE_REPLICATED: "true"
@@ -192,7 +208,7 @@ jobs:
           WEAVE_SENTRY_ENV: ci
           CI: 1
           WEAVE_USE_MEMRAY: 1
-          WB_SERVER_HOST: http://wandbservice
+          WB_SERVER_HOST: http://localhost
           WF_CLICKHOUSE_HOST: localhost
           WF_CLICKHOUSE_PORT: ${{ inputs.ch_port }}
           WF_CLICKHOUSE_REPLICATED: "true"

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -222,6 +222,11 @@ jobs:
 
   nightly-tests-replicated-1s3r:
     name: Nightly Tests (replicated 1s3r)
+    # id-token: write must be granted here too; a reusable workflow's
+    # effective permissions are the intersection of caller and callee.
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/nightly-replicated-leg.yaml
     with:
       topology: "1s3r"
@@ -232,6 +237,9 @@ jobs:
 
   nightly-tests-replicated-2s2r:
     name: Nightly Tests (replicated 2s2r)
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/nightly-replicated-leg.yaml
     with:
       topology: "2s2r"


### PR DESCRIPTION
## Summary
- Nightly replicated legs fail at `docker login us-central1-docker.pkg.dev` because the static `gcp_wb_sa_key` service-container credential expired ([example run](https://github.com/wandb/weave/actions/runs/26988999745/job/79644867340)).
- Swap to the keyless Workload Identity Federation flow `test.yaml` already uses: drop the `services:` block, start `wandbservice` via an explicit `docker run` after `google-github-actions/auth`. Nothing left to rotate.
- Grant `id-token: write` on both the leg and its two callers (reusable-workflow perms are the caller/callee intersection).

## Testing
manually dispatched on this branch (`shards=anthropic`): all replicated legs pass, incl. the 8 anthropic legs that exercise the new wandbservice WIF auth ([run 27030915977](https://github.com/wandb/weave/actions/runs/27030915977)). overall `failure` there is only the pre-existing Slack `account_inactive` step, unrelated.