### PR TITLE
fix(weave): qualify bare wb_run_ids in calls-query filters

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -950,9 +950,8 @@ def test_trace_call_query_filter_wb_run_ids(client, no_autoflush):
 
         assert len(inner_res.calls) == exp_count
 
-    # Bare run ids in the filter are qualified to the query's entity/project, so
-    # a bare id resolves to the same calls as its fully-qualified form (and can
-    # be mixed with already-qualified ids).
+    # Bare run ids are qualified to the query's entity/project, so they resolve
+    # to the same calls as their fully-qualified form (and can be mixed).
     for wb_run_ids, exp_count in [
         (["test-run-1"], call_spec_1.total_calls),
         ([full_wb_run_id_1], call_spec_1.total_calls),
@@ -963,6 +962,13 @@ def test_trace_call_query_filter_wb_run_ids(client, no_autoflush):
     ]:
         got = list(client.get_calls(filter=tsi.CallsFilter(wb_run_ids=wb_run_ids)))
         assert len(got) == exp_count
+        stats = get_client_trace_server(client).calls_query_stats(
+            tsi.CallsQueryStatsReq(
+                project_id=get_client_project_id(client),
+                filter=tsi.CallsFilter(wb_run_ids=wb_run_ids),
+            )
+        )
+        assert stats.count == exp_count
 
 
 # Flaky against ClickHouse in CI: read-after-write visibility lag means a

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -950,6 +950,20 @@ def test_trace_call_query_filter_wb_run_ids(client, no_autoflush):
 
         assert len(inner_res.calls) == exp_count
 
+    # Bare run ids in the filter are qualified to the query's entity/project, so
+    # a bare id resolves to the same calls as its fully-qualified form (and can
+    # be mixed with already-qualified ids).
+    for wb_run_ids, exp_count in [
+        (["test-run-1"], call_spec_1.total_calls),
+        ([full_wb_run_id_1], call_spec_1.total_calls),
+        (
+            ["test-run-1", full_wb_run_id_2],
+            call_spec_1.total_calls + call_spec_2.total_calls,
+        ),
+    ]:
+        got = list(client.get_calls(filter=tsi.CallsFilter(wb_run_ids=wb_run_ids)))
+        assert len(got) == exp_count
+
 
 # Flaky against ClickHouse in CI: read-after-write visibility lag means a
 # calls_query right after flush can miss just-written rows. Rerun to absorb it.

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -265,14 +265,13 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         return res
 
     def _ext_to_int_run_ids(self, run_ids: list[str], ext_project_id: str) -> list[str]:
-        # Queries are already scoped to a project, so qualify bare run ids
-        # (no "/") to the "entity/project/run" the converter requires.
-        return [
-            self._idc.ext_to_int_run_id(
-                run_id if "/" in run_id else f"{ext_project_id}/{run_id}"
-            )
-            for run_id in run_ids
-        ]
+        # Bare run ids (no "/") are qualified to the queried project, since the
+        # converter requires the full "entity/project/run" form.
+        int_run_ids = []
+        for run_id in run_ids:
+            qualified = run_id if "/" in run_id else f"{ext_project_id}/{run_id}"
+            int_run_ids.append(self._idc.ext_to_int_run_id(qualified))
+        return int_run_ids
 
     def calls_query(self, req: tsi.CallsQueryReq) -> tsi.CallsQueryRes:
         req = req.model_copy(deep=True)

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -264,12 +264,14 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             res.call.wb_user_id = self._idc.int_to_ext_user_id(res.call.wb_user_id)
         return res
 
-    def _ext_to_int_run_ids(self, run_ids: list[str], ext_project_id: str) -> list[str]:
-        # Bare run ids (no "/") are qualified to the queried project, since the
-        # converter requires the full "entity/project/run" form.
+    def _ext_to_int_run_ids(
+        self, run_ids: list[str], ext_entity_project_id: str
+    ) -> list[str]:
+        # A bare run id (no "/") is prefixed with the queried "entity/project"
+        # to form the "entity/project/run" that ext_to_int_run_id requires.
         int_run_ids = []
         for run_id in run_ids:
-            qualified = run_id if "/" in run_id else f"{ext_project_id}/{run_id}"
+            qualified = run_id if "/" in run_id else f"{ext_entity_project_id}/{run_id}"
             int_run_ids.append(self._idc.ext_to_int_run_id(qualified))
         return int_run_ids
 

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -264,16 +264,25 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             res.call.wb_user_id = self._idc.int_to_ext_user_id(res.call.wb_user_id)
         return res
 
+    def _ext_to_int_run_ids(self, run_ids: list[str], ext_project_id: str) -> list[str]:
+        # Queries are already scoped to a project, so qualify bare run ids
+        # (no "/") to the "entity/project/run" the converter requires.
+        return [
+            self._idc.ext_to_int_run_id(
+                run_id if "/" in run_id else f"{ext_project_id}/{run_id}"
+            )
+            for run_id in run_ids
+        ]
+
     def calls_query(self, req: tsi.CallsQueryReq) -> tsi.CallsQueryRes:
         req = req.model_copy(deep=True)
         original_project_id = req.project_id
         req.project_id = self._idc.ext_to_int_project_id(original_project_id)
         if req.filter is not None:
             if req.filter.wb_run_ids is not None:
-                req.filter.wb_run_ids = [
-                    self._idc.ext_to_int_run_id(run_id)
-                    for run_id in req.filter.wb_run_ids
-                ]
+                req.filter.wb_run_ids = self._ext_to_int_run_ids(
+                    req.filter.wb_run_ids, original_project_id
+                )
             # TODO: How do we correctly process run_id for the query filters?
             if req.filter.wb_user_ids is not None:
                 req.filter.wb_user_ids = [
@@ -309,10 +318,9 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         req.project_id = self._idc.ext_to_int_project_id(original_project_id)
         if req.filter is not None:
             if req.filter.wb_run_ids is not None:
-                req.filter.wb_run_ids = [
-                    self._idc.ext_to_int_run_id(run_id)
-                    for run_id in req.filter.wb_run_ids
-                ]
+                req.filter.wb_run_ids = self._ext_to_int_run_ids(
+                    req.filter.wb_run_ids, original_project_id
+                )
             # TODO: How do we correctly process the query filters?
             if req.filter.wb_user_ids is not None:
                 req.filter.wb_user_ids = [
@@ -355,13 +363,13 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
 
     def calls_query_stats(self, req: tsi.CallsQueryStatsReq) -> tsi.CallsQueryStatsRes:
         req = req.model_copy(deep=True)
-        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        original_project_id = req.project_id
+        req.project_id = self._idc.ext_to_int_project_id(original_project_id)
         if req.filter is not None:
             if req.filter.wb_run_ids is not None:
-                req.filter.wb_run_ids = [
-                    self._idc.ext_to_int_run_id(run_id)
-                    for run_id in req.filter.wb_run_ids
-                ]
+                req.filter.wb_run_ids = self._ext_to_int_run_ids(
+                    req.filter.wb_run_ids, original_project_id
+                )
             # TODO: How do we correctly process the query filters?
             if req.filter.wb_user_ids is not None:
                 req.filter.wb_user_ids = [

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -590,6 +590,7 @@ class CallsFilter(BaseModelStrict):
     turn_ids: list[str] | None = None
     trace_roots_only: bool | None = None
     wb_user_ids: list[str] | None = None
+    # "entity/project/run", or a bare run id (qualified to the queried project).
     wb_run_ids: list[str] | None = None
 
 


### PR DESCRIPTION
Jira: [WB-35246](https://coreweave.atlassian.net/browse/WB-35246)

## Summary
- Querying calls with a bare wandb run id (e.g. `nf18qjc6`) in `wb_run_ids` 400s with `InvalidIdFormat` (the converter expects `entity/project/run`), spiking prod errors on `/calls/stream_query` + `/calls/query_stats`.
- Fix in the external->internal adapter, where every read consumer converges (SDK `get_calls`, stainless, raw REST): the query is already project-scoped, so bare ids are qualified to the request's `entity/project` before conversion. Full `entity/project/run` ids pass through; malformed ids still raise.
- Documents the accepted formats on `CallsFilter.wb_run_ids` for SDK users.

## Testing
extends `test_trace_call_query_filter_wb_run_ids` (bare resolves same as qualified, mixed ids, both stream + query_stats paths); passes sqlite + clickhouse.

[WB-35246]: https://coreweave.atlassian.net/browse/WB-35246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ