### PR TITLE
fix(weave): call_end_v2 UPDATE on primary key, fix no-op

### DIFF
--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -12,7 +12,11 @@ from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
 from weave.trace_server.calls_query_builder.utils import param_slot
-from weave.trace_server.errors import CallsCompleteModeRequired, RequestTooLarge
+from weave.trace_server.errors import (
+    CallsCompleteModeRequired,
+    NotFoundError,
+    RequestTooLarge,
+)
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.project_version.project_version import (
     reset_project_residence_cache,
@@ -956,6 +960,77 @@ def test_call_end_v2_without_started_at(trace_server, clickhouse_trace_server):
     calls = _fetch_calls_stream(trace_server, project_id)
     assert len(calls) == 1
     assert calls[0].ended_at is not None
+
+
+def test_call_end_v2_mismatched_started_at_still_finishes(
+    trace_server, clickhouse_trace_server
+):
+    """call_end_v2 finishes on a mismatched started_at and errors on an unknown id."""
+    project_id = f"{TEST_ENTITY}/calls_complete_v2_mismatched_started_at"
+    internal_project_id = b64(project_id)
+
+    started_at = datetime.datetime.now(datetime.timezone.utc)
+    call_id = str(uuid.uuid4())
+    trace_id = str(uuid.uuid4())
+    trace_server.call_start_v2(
+        tsi.CallStartV2Req(
+            start=tsi.StartedCallSchemaForInsert(
+                project_id=project_id,
+                id=call_id,
+                trace_id=trace_id,
+                op_name="test_op",
+                started_at=started_at,
+                attributes={},
+                inputs={},
+            )
+        )
+    )
+
+    # End with a started_at that does NOT match the stored start.
+    ended_at = started_at + datetime.timedelta(seconds=5)
+    mismatched_started_at = started_at + datetime.timedelta(hours=1)
+    trace_server.call_end_v2(
+        tsi.CallEndV2Req(
+            end=tsi.EndedCallSchemaForInsertWithStartedAt(
+                project_id=project_id,
+                id=call_id,
+                started_at=mismatched_started_at,
+                ended_at=ended_at,
+                summary={"usage": {}, "status_counts": {}},
+            )
+        )
+    )
+
+    assert (
+        _count_project_rows(
+            clickhouse_trace_server.ch_client, "calls_complete", internal_project_id
+        )
+        == 1
+    )
+    updated_ended_at = _fetch_call_ended_at(
+        clickhouse_trace_server.ch_client,
+        "calls_complete",
+        internal_project_id,
+        call_id,
+    )
+    assert updated_ended_at == ended_at.replace(tzinfo=None)
+
+    calls = _fetch_calls_stream(trace_server, project_id)
+    assert len(calls) == 1
+    assert calls[0].ended_at == ended_at
+
+    # Ending an unknown id has no start row to find, so it must signal not-found.
+    with pytest.raises(NotFoundError):
+        trace_server.call_end_v2(
+            tsi.CallEndV2Req(
+                end=tsi.EndedCallSchemaForInsertWithStartedAt(
+                    project_id=project_id,
+                    id=str(uuid.uuid4()),
+                    ended_at=ended_at,
+                    summary={"usage": {}, "status_counts": {}},
+                )
+            )
+        )
 
 
 def test_call_start_and_end_require_calls_complete_mode(

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -1286,10 +1286,17 @@ def server_with_mock_kafka():
     mock_ch_client.command.return_value = None
     mock_ch_client.insert.return_value = MagicMock()
 
-    # Mock query to return empty project (resolves to CALLS_MERGED write target)
-    mock_query_result = MagicMock()
-    mock_query_result.result_rows = [(None, None)]
-    mock_ch_client.query.return_value = mock_query_result
+    # Empty residence (resolves v2 writes to calls_complete); the calls_complete
+    # end path then reads the stored started_at, so return one for that query.
+    def _query_side_effect(query, *args, **kwargs):
+        result = MagicMock()
+        if "started_at" in query:
+            result.result_rows = [(dt.datetime.now(dt.timezone.utc),)]
+        else:
+            result.result_rows = [(None, None)]
+        return result
+
+    mock_ch_client.query.side_effect = _query_side_effect
 
     mock_producer = MagicMock()
 

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -3473,6 +3473,26 @@ def build_calls_complete_delete_query(
     return safely_format_sql(raw_sql, logger)
 
 
+def build_calls_complete_started_at_select_query(
+    table_name: str,
+    project_id_param: str,
+    id_param: str,
+    started_at_param: str | None = None,
+) -> str:
+    """Build a query that reads a call's stored started_at.
+
+    When started_at_param is given, the WHERE clause uses the full primary key
+    (project_id, started_at, id) for a point lookup. Otherwise it falls back to
+    (project_id, id), which scans the project's granules.
+    """
+    where = f"project_id = {{{project_id_param}:String}}"
+    if started_at_param is not None:
+        where += f" AND started_at = fromUnixTimestamp64Micro({{{started_at_param}:Int64}}, 'UTC')"
+    where += f" AND id = {{{id_param}:String}}"
+    raw_sql = f"SELECT started_at FROM {table_name} WHERE {where} LIMIT 1"
+    return safely_format_sql(raw_sql, logger)
+
+
 def build_calls_complete_update_query(
     table_name: str,
     project_id_param: str,

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -100,6 +100,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     QueryBuilderDynamicField,
     QueryBuilderField,
     build_calls_complete_delete_query,
+    build_calls_complete_started_at_select_query,
     build_calls_complete_update_end_query,
     build_calls_complete_update_query,
     build_calls_stats_query,
@@ -1123,11 +1124,28 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         and the end arrives separately via call_end_v2.
 
         Args:
-            end_call: The end call data to update. If started_at is provided,
-                it enables more efficient queries by utilizing the ClickHouse
-                primary key (project_id, started_at, id).
+            end_call: The end call data to update. The UPDATE is keyed on the
+                full primary key (project_id, started_at, id).
+
+        Raises:
+            NotFoundError: If no start row exists for (project_id, id).
         """
         table_name = self._get_calls_complete_table_name()
+
+        # Confirm the row exists before the UPDATE (full PK fast path, then a
+        # (project_id, id) fallback) so a wrong started_at can't silently no-op.
+        started_at = end_call.started_at
+        if started_at is None or not self._calls_complete_call_exists(
+            table_name, end_call.project_id, end_call.id, started_at
+        ):
+            started_at = self._read_calls_complete_started_at(
+                table_name, end_call.project_id, end_call.id
+            )
+            if started_at is None:
+                raise NotFoundError(
+                    f"Cannot end call {end_call.id}: no start found in project "
+                    f"{end_call.project_id}"
+                )
 
         output = end_call.output
         output_refs = extract_refs_from_values(output)
@@ -1139,6 +1157,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         # but DateTime64(6) requires microsecond precision for exact matching. This is a
         # hack, not sure why inserting a json dump and passing an explicit param differ
         ended_at_us = datetime_to_microseconds(end_call.ended_at)
+        started_at_us = datetime_to_microseconds(started_at)
 
         pb = ParamBuilder()
         project_id_param = pb.add_param(end_call.project_id)
@@ -1153,12 +1172,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         wb_run_step_end_param = pb.add_param(
             ch_sentinel_values.to_ch_value("wb_run_step_end", end_call.wb_run_step_end)
         )
-
-        # Add started_at param if provided for more efficient primary key usage
-        started_at_param: str | None = None
-        if end_call.started_at is not None:
-            started_at_us = datetime_to_microseconds(end_call.started_at)
-            started_at_param = pb.add_param(started_at_us)
+        started_at_param = pb.add_param(started_at_us)
 
         query = build_calls_complete_update_end_query(
             table_name=table_name,
@@ -1179,6 +1193,44 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             parameters=pb.get_params(),
             settings=ch_settings.CLICKHOUSE_LIGHTWEIGHT_UPDATE_SETTINGS,
         )
+
+    def _calls_complete_call_exists(
+        self,
+        table_name: str,
+        project_id: str,
+        call_id: str,
+        started_at: datetime.datetime,
+    ) -> bool:
+        """Point-lookup a call on the full primary key (project_id, started_at, id)."""
+        pb = ParamBuilder()
+        project_id_param = pb.add_param(project_id)
+        id_param = pb.add_param(call_id)
+        started_at_param = pb.add_param(datetime_to_microseconds(started_at))
+        query = build_calls_complete_started_at_select_query(
+            table_name=table_name,
+            project_id_param=project_id_param,
+            id_param=id_param,
+            started_at_param=started_at_param,
+        )
+        res = self._query(query, parameters=pb.get_params())
+        return bool(res.result_rows)
+
+    def _read_calls_complete_started_at(
+        self, table_name: str, project_id: str, call_id: str
+    ) -> datetime.datetime | None:
+        """Read a call's stored started_at by (project_id, id), or None if absent."""
+        pb = ParamBuilder()
+        project_id_param = pb.add_param(project_id)
+        id_param = pb.add_param(call_id)
+        query = build_calls_complete_started_at_select_query(
+            table_name=table_name,
+            project_id_param=project_id_param,
+            id_param=id_param,
+        )
+        res = self._query(query, parameters=pb.get_params())
+        if not res.result_rows:
+            return None
+        return res.result_rows[0][0]
 
     def call_read(self, req: tsi.CallReadReq) -> tsi.CallReadRes:
         res = self.calls_query_stream(


### PR DESCRIPTION
Jira: https://coreweave.atlassian.net/browse/WB-35267

## Summary
- `call_end_v2` on a calls_complete project runs a lightweight UPDATE keyed on the client `started_at`; a wrong/omitted value matched 0 rows, leaving the call permanently unfinished while the endpoint returned 200.
- Fast path keys an existence check + UPDATE on the full PK `(project_id, started_at, id)`; fallback recovers the real `started_at` by `(project_id, id)` and raises `NotFoundError` (404) if the start is truly absent.

## Performance
The extra read only runs on the eager `call/end` -> calls_complete path (`_update_call_end_in_calls_complete`). Last 7d in prod: that path fired 2,486 times vs ~135k v2 `calls/complete` writes -> ~1.8% of (calls/complete + call/end) hits, ~0.04% of all ~6.9M call ends. Added cost is one PK point lookup before the existing UPDATE. Local benchmark (1M-row single-project calls_complete clone, CH 26.3):

| op | p50 | p95 |
|----|-----|-----|
| added full-PK existence SELECT | 3.4ms | 5.8ms |
| existing lightweight UPDATE | 5.3ms | 7.5ms |
| added latency (+ms) | +3.4ms | +5.8ms |
| added latency (+%) | +64% | +78% |

## Testing
clickhouse-backed regression test: mismatched started_at still finishes, unknown id raises NotFoundError.