### PR TITLE
fix(weave): make PaginatedIterator page cache per-instance

### DIFF
--- a/tests/utils/test_paginated_iterator.py
+++ b/tests/utils/test_paginated_iterator.py
@@ -1,3 +1,5 @@
+import gc
+import weakref
 from collections.abc import Iterator
 
 import pytest
@@ -36,3 +38,40 @@ def test_paginated_iterator_iter_remains_restartable() -> None:
     assert next(paginated) == 0
     assert list(paginated) == [0, 1, 2, 3, 4]
     assert list(paginated) == [0, 1, 2, 3, 4]
+
+
+def test_paginated_iterator_reuses_fetched_pages_within_instance() -> None:
+    fetch_offsets: list[int] = []
+
+    def fetch(offset: int, limit: int) -> list[int]:
+        fetch_offsets.append(offset)
+        return list(range(100))[offset : offset + limit]
+
+    paginated = PaginatedIterator(fetch, page_size=10)
+
+    # Two reads within the same page hit the source exactly once.
+    assert paginated[0] == 0
+    assert paginated[9] == 9
+    assert fetch_offsets == [0]
+
+    # A read in a different page triggers exactly one more fetch.
+    assert paginated[10] == 10
+    assert fetch_offsets == [0, 10]
+
+
+def test_paginated_iterator_released_when_unreferenced() -> None:
+    # Regression: a method-level functools.lru_cache keys on `self` and lives
+    # for the process lifetime, pinning every iterator (and its fetched pages)
+    # in memory. The per-instance cache must let the iterator be garbage
+    # collected once the caller drops it.
+    def fetch(offset: int, limit: int) -> list[int]:
+        return list(range(100))[offset : offset + limit]
+
+    paginated = PaginatedIterator(fetch, page_size=10)
+    assert paginated[0] == 0  # populate the page cache
+
+    ref = weakref.ref(paginated)
+    del paginated
+    gc.collect()
+
+    assert ref() is None

--- a/weave/utils/paginated_iterator.py
+++ b/weave/utils/paginated_iterator.py
@@ -15,6 +15,9 @@ T = TypeVar("T")
 R_co = TypeVar("R_co", covariant=True)
 
 DEFAULT_PAGE_SIZE = 1000
+# Max number of fetched pages retained per iterator. Bounds peak memory on
+# large iterations.
+DEFAULT_MAX_CACHED_PAGES = 128
 
 
 class FetchFunc(Protocol[T]):
@@ -46,15 +49,35 @@ class PaginatedIterator(Generic[T, R_co]):
         self.limit = limit
         self.offset = offset
         self._next_index = 0
+        self._fetch_page = self._make_page_fetcher(
+            fetch_func, page_size, DEFAULT_MAX_CACHED_PAGES
+        )
 
         if page_size <= 0:
             raise ValueError("page_size must be greater than 0")
         if limit is not None and limit <= 0:
             raise ValueError("limit must be greater than 0")
 
-    @lru_cache  # noqa: B019
-    def _fetch_page(self, index: int) -> list[T]:
-        return self.fetch_func(index * self.page_size, self.page_size)
+    @staticmethod
+    def _make_page_fetcher(
+        fetch_func: FetchFunc[T], page_size: int, max_cached_pages: int
+    ) -> Callable[[int], list[T]]:
+        """Build a bounded page cache for a single iterator.
+
+        The returned callable wraps a fresh ``functools.lru_cache`` that closes
+        over ``fetch_func`` and ``page_size`` only -- never the iterator. It is a
+        ``@staticmethod`` (no ``self``) precisely so the cache cannot capture the
+        instance; that is what lets the iterator and its cached pages be released
+        as soon as the caller drops it. A method-level ``@lru_cache`` would
+        instead key on ``self`` and live at class/function scope, pinning every
+        iterator for the life of the process (ruff B019).
+        """
+
+        @lru_cache(maxsize=max_cached_pages)
+        def fetch_page(index: int) -> list[T]:
+            return fetch_func(index * page_size, page_size)
+
+        return fetch_page
 
     @overload
     def _get_one(self: PaginatedIterator[T, T], index: int) -> T: ...


### PR DESCRIPTION
## Summary
Fixes a bug in the `PaginatedIterator` impl that could cause mem to bloat