### PR TITLE
feat(weave_ts): Emit `execute_tool` spans for OpenAI Agents SDK.

### DIFF
--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -244,7 +244,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     expect(await inMemoryTraceServer.getCalls(testProjectName)).toHaveLength(0);
   });
 
-  test('emits `invoke_agent` span', async () => {
+  test('emits `invoke_agent` and `execute_tool` spans', async () => {
     await withTrace('Test', async () => {
       await withAgentSpan(async () => {}, {
         spanId: 'span-agent',
@@ -257,7 +257,11 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       });
       await withFunctionSpan(async () => {}, {
         spanId: 'span-function',
-        data: {name: 'test-function', input: '', output: ''},
+        data: {
+          name: 'test-function',
+          input: '{"city":"Tokyo"}',
+          output: 'sunny, 22C',
+        },
       });
       await withGuardrailSpan(async () => {}, {
         spanId: 'span-guardrail',
@@ -277,6 +281,17 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'weave.openai_agents.agent.handoffs': ['h1'],
       'weave.openai_agents.agent.output_type': 'text',
       'weave.openai_agents.span_id': 'span-agent',
+    });
+
+    const executeToolSpan = spans.find(
+      s => s.name === 'execute_tool test-function'
+    )!;
+    expect(executeToolSpan.attributes).toMatchObject({
+      'gen_ai.operation.name': 'execute_tool',
+      'gen_ai.tool.name': 'test-function',
+      'gen_ai.tool.call.arguments': '{"city":"Tokyo"}',
+      'gen_ai.tool.call.result': 'sunny, 22C',
+      'weave.openai_agents.span_id': 'span-function',
     });
   });
 
@@ -345,6 +360,24 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.provider.name': 'openai',
       'weave.openai_agents.agent.tools': ['get_weather'],
     });
+
+    const executeToolSpan = spans.find(
+      s => s.name === 'execute_tool get_weather'
+    )!;
+    expect(executeToolSpan).toBeDefined();
+    expect(executeToolSpan.attributes).toMatchObject({
+      'gen_ai.operation.name': 'execute_tool',
+      'gen_ai.tool.name': 'get_weather',
+      // The Agents SDK serializes the tool's JSON args/result as strings
+      // on the FunctionSpanData, which we lift straight to semconv.
+      'gen_ai.tool.call.arguments': '{"city":"Tokyo"}',
+      'gen_ai.tool.call.result': 'Tokyo: Sunny, 22°C',
+    });
+    // Span is a child of the agent span.
+    expect(executeToolSpan.parentSpanId).toBe(agentSpan!.spanContext().spanId);
+    expect(executeToolSpan.spanContext().traceId).toBe(
+      agentSpan!.spanContext().traceId
+    );
   });
 
   async function emittedSpans(): Promise<ReadableSpan[]> {

--- a/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
+++ b/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
@@ -13,9 +13,13 @@ import {
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_OPERATION_NAME,
   ATTR_GEN_AI_PROVIDER_NAME,
+  ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
+  ATTR_GEN_AI_TOOL_CALL_RESULT,
+  ATTR_GEN_AI_TOOL_NAME,
 } from '../../genai/semconv';
 import type {
   AgentSpanData,
+  FunctionSpanData,
   Span,
   Trace,
   TracingProcessor,
@@ -36,10 +40,12 @@ function otelSpanName(span: Span): string {
     case 'agent':
       return `invoke_agent ${span.spanData.name}`;
 
-    default: {
+    case 'function':
+      return `execute_tool ${span.spanData.name}`;
+
+    default:
       const name = (span.spanData as {name?: string}).name ?? '';
       return name ? `${span.spanData.type} ${name}` : span.spanData.type;
-    }
   }
 }
 
@@ -78,11 +84,34 @@ function attrsForSpan(span: Span, conversationId: string): Attributes {
     case 'agent':
       return invokeAgentAttrs(span.spanData, conversationId);
 
+    case 'function':
+      return executeToolAttrs(span.spanData, conversationId);
+
     default:
       // Remaining span types still emit OTel spans with the openai
       // trace_id/span_id attributes set in onSpanStart, but no semconv
       // attributes yet — per-type mappings land in later increments.
       return {};
+  }
+
+  function executeToolAttrs(
+    spanData: FunctionSpanData,
+    conversationId: string
+  ): Attributes {
+    const attrs: Attributes = {
+      [ATTR_GEN_AI_OPERATION_NAME]: 'execute_tool',
+      [ATTR_GEN_AI_TOOL_NAME]: spanData.name ?? '',
+    };
+    if (conversationId) {
+      attrs[ATTR_GEN_AI_CONVERSATION_ID] = conversationId;
+    }
+    if (spanData.input) {
+      attrs[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] = spanData.input;
+    }
+    if (spanData.output) {
+      attrs[ATTR_GEN_AI_TOOL_CALL_RESULT] = spanData.output;
+    }
+    return attrs;
   }
 }
 
@@ -93,7 +122,7 @@ function attrsForSpan(span: Span, conversationId: string): Attributes {
  * conventions where they apply:
  *
  * - `invoke_agent {gen_ai.agent.name}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/#invoke-agent-client-span)
- * - (TODO) `execute_tool {gen_ai.tool.name}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span)
+ * - `execute_tool {gen_ai.tool.name}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span)
  * - (TODO) `chat {gen_ai.request.model}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#inference)
  *
  * Span types without a clean semantic mapping emit with a descriptive operation name

--- a/sdks/node/src/integrations/openai.agent.types.ts
+++ b/sdks/node/src/integrations/openai.agent.types.ts
@@ -21,6 +21,7 @@ import type {
 export type {
   AgentSpanData,
   CustomSpanData,
+  FunctionSpanData,
   Trace,
   TracingProcessor,
 } from '@openai/agents';


### PR DESCRIPTION
## Description

* Emit `execute_tool` spans via `WeaveOtelTracingProcessor`.
* See #6917 for reference on the Python SDK side.