### PR TITLE
feat(weave_ts): Emit `chat` spans for OpenAI Agents SDK.

### DIFF
--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -7,7 +7,9 @@ import {
   Usage,
   withAgentSpan,
   withFunctionSpan,
+  withGenerationSpan,
   withGuardrailSpan,
+  withResponseSpan,
   withTrace,
 } from '@openai/agents';
 import type {Model, ModelRequest, ModelResponse} from '@openai/agents';
@@ -244,7 +246,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     expect(await inMemoryTraceServer.getCalls(testProjectName)).toHaveLength(0);
   });
 
-  test('emits `invoke_agent` and `execute_tool` spans', async () => {
+  test('emits `invoke_agent`, `execute_tool` and `chat` spans', async () => {
     await withTrace('Test', async () => {
       await withAgentSpan(async () => {}, {
         spanId: 'span-agent',
@@ -263,6 +265,19 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
           output: 'sunny, 22C',
         },
       });
+      await withResponseSpan(async span => {
+        span.spanData._response = {
+          id: 'resp-abc',
+          model: 'gpt-4o-mini',
+          usage: {input_tokens: 12, output_tokens: 7},
+        };
+      });
+      await withGenerationSpan(async () => {}, {
+        data: {
+          model: 'gpt-3.5-turbo',
+          usage: {input_tokens: 9, output_tokens: 4},
+        },
+      });
       await withGuardrailSpan(async () => {}, {
         spanId: 'span-guardrail',
         data: {name: 'test-guardrail', triggered: false},
@@ -270,7 +285,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     });
 
     const spans = await emittedSpans();
-    expect(spans).toHaveLength(3);
+    expect(spans).toHaveLength(5);
 
     const agent = spans.find(s => s.name === 'invoke_agent test-agent')!;
     expect(agent.attributes).toMatchObject({
@@ -293,6 +308,30 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
       'gen_ai.tool.call.result': 'sunny, 22C',
       'weave.openai_agents.span_id': 'span-function',
     });
+
+    const resp = spans.find(s => s.name === 'chat gpt-4o-mini')!;
+    expect(resp.attributes).toMatchObject({
+      'gen_ai.operation.name': 'chat',
+      'gen_ai.provider.name': 'openai',
+      'gen_ai.output.type': 'text',
+      'gen_ai.request.model': 'gpt-4o-mini',
+      'gen_ai.response.model': 'gpt-4o-mini',
+      'gen_ai.response.id': 'resp-abc',
+      'gen_ai.usage.input_tokens': 12,
+      'gen_ai.usage.output_tokens': 7,
+    });
+
+    const gen = spans.find(s => s.name === 'chat gpt-3.5-turbo')!;
+    expect(gen.attributes).toMatchObject({
+      'gen_ai.operation.name': 'chat',
+      'gen_ai.provider.name': 'openai',
+      'gen_ai.output.type': 'text',
+      'gen_ai.request.model': 'gpt-3.5-turbo',
+      'gen_ai.usage.input_tokens': 9,
+      'gen_ai.usage.output_tokens': 4,
+    });
+    // No response.id on the legacy generation span.
+    expect(gen.attributes['gen_ai.response.id']).toBeUndefined();
   });
 
   test('preserves parent-child relationship', async () => {

--- a/sdks/node/src/genai/semconv.ts
+++ b/sdks/node/src/genai/semconv.ts
@@ -31,6 +31,7 @@ export const ATTR_GEN_AI_PROVIDER_NAME = 'gen_ai.provider.name';
 export const ATTR_GEN_AI_REQUEST_MODEL = 'gen_ai.request.model';
 export const ATTR_GEN_AI_RESPONSE_FINISH_REASONS =
   'gen_ai.response.finish_reasons';
+export const ATTR_GEN_AI_RESPONSE_ID = 'gen_ai.response.id';
 export const ATTR_GEN_AI_RESPONSE_MODEL = 'gen_ai.response.model';
 export const ATTR_GEN_AI_SYSTEM_INSTRUCTIONS = 'gen_ai.system_instructions';
 export const ATTR_GEN_AI_TOOL_CALL_ARGUMENTS = 'gen_ai.tool.call.arguments';

--- a/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
+++ b/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
@@ -12,14 +12,22 @@ import {
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_OPERATION_NAME,
+  ATTR_GEN_AI_OUTPUT_TYPE,
   ATTR_GEN_AI_PROVIDER_NAME,
+  ATTR_GEN_AI_REQUEST_MODEL,
+  ATTR_GEN_AI_RESPONSE_ID,
+  ATTR_GEN_AI_RESPONSE_MODEL,
   ATTR_GEN_AI_TOOL_CALL_ARGUMENTS,
   ATTR_GEN_AI_TOOL_CALL_RESULT,
   ATTR_GEN_AI_TOOL_NAME,
+  ATTR_GEN_AI_USAGE_INPUT_TOKENS,
+  ATTR_GEN_AI_USAGE_OUTPUT_TOKENS,
 } from '../../genai/semconv';
 import type {
   AgentSpanData,
   FunctionSpanData,
+  GenerationSpanData,
+  ResponseSpanData,
   Span,
   Trace,
   TracingProcessor,
@@ -28,6 +36,64 @@ import type {
 const TRACER_NAME = 'weave.openai_agents';
 const WEAVE_ATTR_PREFIX = 'weave.openai_agents';
 const PROVIDER_NAME = 'openai';
+const DEFAULT_CHAT_OUTPUT_TYPE = 'text';
+
+function hasModel(resp: Record<string, any>): resp is {model: string} {
+  return typeof resp.model === 'string';
+}
+
+function hasId(resp: Record<string, any>): resp is {id: string} {
+  return typeof resp.id === 'string';
+}
+
+function hasUsage(
+  resp: Record<string, any>
+): resp is {usage: ResponseSpanDataUsage} {
+  return (
+    typeof resp.usage !== 'undefined' &&
+    typeof resp.usage.input_tokens !== 'undefined'
+  );
+}
+
+/**
+ * Extract the model string from a ResponseSpanData. The Agents SDK exposes
+ * the raw openai response under `_response`.
+ */
+function modelFromResponseSpan(spanData: ResponseSpanData): string | undefined {
+  if (spanData._response && hasModel(spanData._response)) {
+    return spanData._response.model;
+  }
+}
+
+/**
+ * Extract the openai response id from a ResponseSpanData. Prefer the
+ * top-level `response_id` (which the Agents SDK populates directly) and
+ * fall back to `_response.id`.
+ */
+function responseIdFromResponseSpan(
+  spanData: ResponseSpanData
+): string | undefined {
+  if (spanData.response_id) {
+    return spanData.response_id;
+  }
+
+  if (spanData._response && hasId(spanData._response)) {
+    return spanData._response.id;
+  }
+}
+
+type ResponseSpanDataUsage = {
+  input_tokens?: number;
+  output_tokens?: number;
+};
+
+function usageFromResponseSpan(
+  spanData: ResponseSpanData
+): ResponseSpanDataUsage | undefined {
+  if (spanData._response && hasUsage(spanData._response)) {
+    return spanData._response.usage;
+  }
+}
 
 /**
  * Descriptive OTel span name. AgentSpan uses the conventional
@@ -42,6 +108,12 @@ function otelSpanName(span: Span): string {
 
     case 'function':
       return `execute_tool ${span.spanData.name}`;
+
+    case 'response':
+      return `chat ${modelFromResponseSpan(span.spanData) ?? ''}`.trimEnd();
+
+    case 'generation':
+      return `chat ${span.spanData.model ?? ''}`.trimEnd();
 
     default:
       const name = (span.spanData as {name?: string}).name ?? '';
@@ -79,6 +151,84 @@ function invokeAgentAttrs(
   return attrs;
 }
 
+function executeToolAttrs(
+  spanData: FunctionSpanData,
+  conversationId: string
+): Attributes {
+  const attrs: Attributes = {
+    [ATTR_GEN_AI_OPERATION_NAME]: 'execute_tool',
+    [ATTR_GEN_AI_TOOL_NAME]: spanData.name ?? '',
+  };
+  if (conversationId) {
+    attrs[ATTR_GEN_AI_CONVERSATION_ID] = conversationId;
+  }
+  if (spanData.input) {
+    attrs[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] = spanData.input;
+  }
+  if (spanData.output) {
+    attrs[ATTR_GEN_AI_TOOL_CALL_RESULT] = spanData.output;
+  }
+  return attrs;
+}
+
+/**
+ * `chat` attrs for a ResponseSpan. Pulls data from Agents-SDK populated `_response`
+ * attribute when present. Input/output message serialization is not yet implemented.
+ */
+function responseChatAttrs(
+  spanData: ResponseSpanData,
+  conversationId: string
+): Attributes {
+  const model = modelFromResponseSpan(spanData);
+  const attrs: Attributes = {
+    [ATTR_GEN_AI_OPERATION_NAME]: 'chat',
+    [ATTR_GEN_AI_PROVIDER_NAME]: PROVIDER_NAME,
+    [ATTR_GEN_AI_OUTPUT_TYPE]: DEFAULT_CHAT_OUTPUT_TYPE,
+  };
+  if (conversationId) {
+    attrs[ATTR_GEN_AI_CONVERSATION_ID] = conversationId;
+  }
+  if (model) {
+    attrs[ATTR_GEN_AI_REQUEST_MODEL] = model;
+    attrs[ATTR_GEN_AI_RESPONSE_MODEL] = model;
+  }
+  const respId = responseIdFromResponseSpan(spanData);
+  if (respId) {
+    attrs[ATTR_GEN_AI_RESPONSE_ID] = respId;
+  }
+  const usage = usageFromResponseSpan(spanData);
+  if (usage) {
+    attrs[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = usage.input_tokens;
+    attrs[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] = usage.output_tokens;
+  }
+  return attrs;
+}
+
+/**
+ * `chat` attrs for a GenerationSpan.
+ */
+function generationChatAttrs(
+  spanData: GenerationSpanData,
+  conversationId: string
+): Attributes {
+  const attrs: Attributes = {
+    [ATTR_GEN_AI_OPERATION_NAME]: 'chat',
+    [ATTR_GEN_AI_PROVIDER_NAME]: PROVIDER_NAME,
+    [ATTR_GEN_AI_OUTPUT_TYPE]: DEFAULT_CHAT_OUTPUT_TYPE,
+  };
+  if (conversationId) {
+    attrs[ATTR_GEN_AI_CONVERSATION_ID] = conversationId;
+  }
+  if (spanData.model) {
+    attrs[ATTR_GEN_AI_REQUEST_MODEL] = spanData.model;
+  }
+  if (spanData.usage) {
+    attrs[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = spanData.usage.input_tokens;
+    attrs[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] = spanData.usage.output_tokens;
+  }
+  return attrs;
+}
+
 function attrsForSpan(span: Span, conversationId: string): Attributes {
   switch (span.spanData.type) {
     case 'agent':
@@ -87,31 +237,17 @@ function attrsForSpan(span: Span, conversationId: string): Attributes {
     case 'function':
       return executeToolAttrs(span.spanData, conversationId);
 
+    case 'response':
+      return responseChatAttrs(span.spanData, conversationId);
+
+    case 'generation':
+      return generationChatAttrs(span.spanData, conversationId);
+
     default:
       // Remaining span types still emit OTel spans with the openai
       // trace_id/span_id attributes set in onSpanStart, but no semconv
       // attributes yet — per-type mappings land in later increments.
       return {};
-  }
-
-  function executeToolAttrs(
-    spanData: FunctionSpanData,
-    conversationId: string
-  ): Attributes {
-    const attrs: Attributes = {
-      [ATTR_GEN_AI_OPERATION_NAME]: 'execute_tool',
-      [ATTR_GEN_AI_TOOL_NAME]: spanData.name ?? '',
-    };
-    if (conversationId) {
-      attrs[ATTR_GEN_AI_CONVERSATION_ID] = conversationId;
-    }
-    if (spanData.input) {
-      attrs[ATTR_GEN_AI_TOOL_CALL_ARGUMENTS] = spanData.input;
-    }
-    if (spanData.output) {
-      attrs[ATTR_GEN_AI_TOOL_CALL_RESULT] = spanData.output;
-    }
-    return attrs;
   }
 }
 
@@ -123,7 +259,7 @@ function attrsForSpan(span: Span, conversationId: string): Attributes {
  *
  * - `invoke_agent {gen_ai.agent.name}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/#invoke-agent-client-span)
  * - `execute_tool {gen_ai.tool.name}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span)
- * - (TODO) `chat {gen_ai.request.model}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#inference)
+ * - `chat {gen_ai.request.model}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#inference)
  *
  * Span types without a clean semantic mapping emit with a descriptive operation name
  * and `weave.openai_agents.*` attributes:

--- a/sdks/node/src/integrations/openai.agent.types.ts
+++ b/sdks/node/src/integrations/openai.agent.types.ts
@@ -22,6 +22,8 @@ export type {
   AgentSpanData,
   CustomSpanData,
   FunctionSpanData,
+  GenerationSpanData,
+  ResponseSpanData,
   Trace,
   TracingProcessor,
 } from '@openai/agents';


### PR DESCRIPTION
## Description

* Emit `chat` spans via `WeaveOtelTracingProcessor`.
* Note: Much of the data present on these will be introduced further up the stack, after getting plumbing for the other supported types in place.
* See #6917 for reference on the Python SDK side.