### PR TITLE
feat(weave_ts): Emit `handoff`, `guardrail`, `transcription`, `speech`, `speech_group`, `mcp_list_tools`, and custom spans for OpenAI Agents SDK.

### DIFF
--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -6,11 +6,17 @@ import {
   tool,
   Usage,
   withAgentSpan,
+  withCustomSpan,
   withFunctionSpan,
   withGenerationSpan,
   withGuardrailSpan,
+  withHandoffSpan,
+  withMCPListToolsSpan,
   withResponseSpan,
+  withSpeechGroupSpan,
+  withSpeechSpan,
   withTrace,
+  withTranscriptionSpan,
 } from '@openai/agents';
 import type {Model, ModelRequest, ModelResponse} from '@openai/agents';
 import {
@@ -246,7 +252,7 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     expect(await inMemoryTraceServer.getCalls(testProjectName)).toHaveLength(0);
   });
 
-  test('emits `invoke_agent`, `execute_tool` and `chat` spans', async () => {
+  test('emits `invoke_agent`, `execute_tool`, `chat`, `handoff`, `guardrail`, `transcription`, `speech`, `speech_group`, `mcp_list_tools` and custom spans', async () => {
     await withTrace('Test', async () => {
       await withAgentSpan(async () => {}, {
         spanId: 'span-agent',
@@ -282,10 +288,47 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
         spanId: 'span-guardrail',
         data: {name: 'test-guardrail', triggered: false},
       });
+      await withHandoffSpan(async () => {}, {
+        spanId: 'span-handoff',
+        data: {from_agent: 'Triage', to_agent: 'Specialist'},
+      });
+      await withTranscriptionSpan(async () => {}, {
+        spanId: 'span-transcription',
+        data: {
+          input: {data: 'base64audio', format: 'pcm'},
+          output: 'hello world',
+          model: 'whisper-1',
+        },
+      });
+      await withSpeechSpan(async () => {}, {
+        spanId: 'span-speech',
+        data: {
+          input: 'say hello',
+          output: {data: 'base64audio', format: 'pcm'},
+          model: 'tts-1',
+        },
+      });
+      await withSpeechGroupSpan(async () => {}, {
+        spanId: 'span-speech-group',
+        data: {input: 'narration script'},
+      });
+      await withMCPListToolsSpan(async () => {}, {
+        spanId: 'span-mcp',
+        data: {server: 'http://localhost:9000', result: ['search', 'fetch']},
+      });
+      await withCustomSpan(async () => {}, {
+        spanId: 'span-custom',
+        data: {
+          name: 'my_step',
+          // Each non-null key in `data` becomes its own
+          // weave.openai_agents.custom.<key> attribute; null is dropped.
+          data: {kind: 'cache_lookup', hits: 3, miss: null},
+        },
+      });
     });
 
     const spans = await emittedSpans();
-    expect(spans).toHaveLength(5);
+    expect(spans).toHaveLength(11);
 
     const agent = spans.find(s => s.name === 'invoke_agent test-agent')!;
     expect(agent.attributes).toMatchObject({
@@ -332,6 +375,70 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     });
     // No response.id on the legacy generation span.
     expect(gen.attributes['gen_ai.response.id']).toBeUndefined();
+
+    const handoff = spans.find(s => s.name === 'handoff Triage -> Specialist')!;
+    expect(handoff.attributes).toMatchObject({
+      'weave.openai_agents.handoff.from_agent': 'Triage',
+      'weave.openai_agents.handoff.to_agent': 'Specialist',
+      'weave.openai_agents.span_id': 'span-handoff',
+    });
+    expect(handoff.attributes['gen_ai.operation.name']).toBeUndefined();
+
+    const guard = spans.find(s => s.name === 'guardrail test-guardrail')!;
+    expect(guard.attributes).toMatchObject({
+      'weave.openai_agents.guardrail.name': 'test-guardrail',
+      'weave.openai_agents.guardrail.triggered': false,
+      'weave.openai_agents.span_id': 'span-guardrail',
+    });
+    expect(guard.attributes['gen_ai.operation.name']).toBeUndefined();
+
+    const transcription = spans.find(s => s.name === 'transcription')!;
+    expect(transcription.attributes).toMatchObject({
+      'weave.openai_agents.transcription.model': 'whisper-1',
+      'weave.openai_agents.transcription.input': 'base64audio',
+      'weave.openai_agents.transcription.input_format': 'pcm',
+      'weave.openai_agents.transcription.output': 'hello world',
+      'weave.openai_agents.span_id': 'span-transcription',
+    });
+    expect(transcription.attributes['gen_ai.operation.name']).toBeUndefined();
+
+    const speech = spans.find(s => s.name === 'speech')!;
+    expect(speech.attributes).toMatchObject({
+      'weave.openai_agents.speech.model': 'tts-1',
+      'weave.openai_agents.speech.input': 'say hello',
+      'weave.openai_agents.speech.output': 'base64audio',
+      'weave.openai_agents.speech.output_format': 'pcm',
+      'weave.openai_agents.span_id': 'span-speech',
+    });
+    expect(speech.attributes['gen_ai.operation.name']).toBeUndefined();
+
+    const speechGroup = spans.find(s => s.name === 'speech_group')!;
+    expect(speechGroup.attributes).toMatchObject({
+      'weave.openai_agents.speech_group.input': 'narration script',
+      'weave.openai_agents.span_id': 'span-speech-group',
+    });
+    expect(speechGroup.attributes['gen_ai.operation.name']).toBeUndefined();
+
+    const mcp = spans.find(s => s.name === 'mcp_list_tools')!;
+    expect(mcp.attributes).toMatchObject({
+      'weave.openai_agents.mcp.server': 'http://localhost:9000',
+      'weave.openai_agents.mcp.result': ['search', 'fetch'],
+      'weave.openai_agents.span_id': 'span-mcp',
+    });
+    expect(mcp.attributes['gen_ai.operation.name']).toBeUndefined();
+
+    // CustomSpan uses the user-supplied name with no prefix.
+    const custom = spans.find(s => s.name === 'my_step')!;
+    expect(custom.attributes).toMatchObject({
+      'weave.openai_agents.custom.kind': 'cache_lookup',
+      'weave.openai_agents.custom.hits': 3,
+      'weave.openai_agents.span_id': 'span-custom',
+    });
+    // Null values dropped — `miss: null` doesn't produce an attribute.
+    expect(
+      custom.attributes['weave.openai_agents.custom.miss']
+    ).toBeUndefined();
+    expect(custom.attributes['gen_ai.operation.name']).toBeUndefined();
   });
 
   test('preserves parent-child relationship', async () => {

--- a/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
+++ b/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
@@ -25,12 +25,19 @@ import {
 } from '../../genai/semconv';
 import type {
   AgentSpanData,
+  CustomSpanData,
   FunctionSpanData,
   GenerationSpanData,
+  GuardrailSpanData,
+  HandoffSpanData,
+  MCPListToolsSpanData,
   ResponseSpanData,
   Span,
+  SpeechGroupSpanData,
+  SpeechSpanData,
   Trace,
   TracingProcessor,
+  TranscriptionSpanData,
 } from '../openai.agent.types';
 
 const TRACER_NAME = 'weave.openai_agents';
@@ -115,9 +122,35 @@ function otelSpanName(span: Span): string {
     case 'generation':
       return `chat ${span.spanData.model ?? ''}`.trimEnd();
 
+    case 'handoff':
+      const from = span.spanData.from_agent || '?';
+      const to = span.spanData.to_agent || '?';
+      return `handoff ${from} -> ${to}`;
+
+    case 'guardrail':
+      return `guardrail ${span.spanData.name}`.trimEnd();
+
+    case 'transcription':
+      return 'transcription';
+
+    case 'speech':
+      return 'speech';
+
+    case 'speech_group':
+      return 'speech_group';
+
+    case 'mcp_tools':
+      return 'mcp_list_tools';
+
+    case 'custom':
+      const name = span.spanData.name ?? '';
+      return name || 'custom';
+
     default:
-      const name = (span.spanData as {name?: string}).name ?? '';
-      return name ? `${span.spanData.type} ${name}` : span.spanData.type;
+      const spanData = span.spanData as {type: string; name?: string};
+      return spanData.name
+        ? `${spanData.type} ${spanData.name}`
+        : spanData.type;
   }
 }
 
@@ -201,6 +234,7 @@ function responseChatAttrs(
     attrs[ATTR_GEN_AI_USAGE_INPUT_TOKENS] = usage.input_tokens;
     attrs[ATTR_GEN_AI_USAGE_OUTPUT_TOKENS] = usage.output_tokens;
   }
+
   return attrs;
 }
 
@@ -229,6 +263,68 @@ function generationChatAttrs(
   return attrs;
 }
 
+function handoffAttrs(spanData: HandoffSpanData): Attributes {
+  return {
+    [`${WEAVE_ATTR_PREFIX}.handoff.from_agent`]: spanData.from_agent ?? '',
+    [`${WEAVE_ATTR_PREFIX}.handoff.to_agent`]: spanData.to_agent ?? '',
+  };
+}
+
+function transcriptionAttrs(spanData: TranscriptionSpanData): Attributes {
+  return {
+    [`${WEAVE_ATTR_PREFIX}.transcription.model`]: spanData.model ?? '',
+    [`${WEAVE_ATTR_PREFIX}.transcription.input`]: spanData.input?.data ?? '',
+    [`${WEAVE_ATTR_PREFIX}.transcription.input_format`]:
+      spanData.input?.format ?? '',
+    [`${WEAVE_ATTR_PREFIX}.transcription.output`]: spanData.output ?? '',
+  };
+}
+
+function guardrailAttrs(spanData: GuardrailSpanData): Attributes {
+  return {
+    [`${WEAVE_ATTR_PREFIX}.guardrail.name`]: spanData.name ?? '',
+    [`${WEAVE_ATTR_PREFIX}.guardrail.triggered`]: Boolean(spanData.triggered),
+  };
+}
+
+function speechAttrs(spanData: SpeechSpanData): Attributes {
+  return {
+    [`${WEAVE_ATTR_PREFIX}.speech.model`]: spanData.model ?? '',
+    [`${WEAVE_ATTR_PREFIX}.speech.input`]: spanData.input ?? '',
+    [`${WEAVE_ATTR_PREFIX}.speech.output`]: spanData.output?.data ?? '',
+    [`${WEAVE_ATTR_PREFIX}.speech.output_format`]:
+      spanData.output?.format ?? '',
+  };
+}
+
+function speechGroupAttrs(spanData: SpeechGroupSpanData): Attributes {
+  return {
+    [`${WEAVE_ATTR_PREFIX}.speech_group.input`]: spanData.input ?? '',
+  };
+}
+
+function mcpListToolsAttrs(spanData: MCPListToolsSpanData): Attributes {
+  return {
+    [`${WEAVE_ATTR_PREFIX}.mcp.server`]: spanData.server ?? '',
+    [`${WEAVE_ATTR_PREFIX}.mcp.result`]: spanData.result ?? [],
+  };
+}
+
+/**
+ * Surface CustomSpan data under `weave.openai_agents.custom.*`. Each
+ * non-null key in `spanData.data` becomes its own attribute so users can
+ * filter / aggregate on individual fields. Null/undefined values are
+ * dropped to keep the wire format clean.
+ */
+function customAttrs(spanData: CustomSpanData): Attributes {
+  const out: Attributes = {};
+  for (const [key, value] of Object.entries(spanData.data ?? {})) {
+    if (value === null || value === undefined) continue;
+    out[`${WEAVE_ATTR_PREFIX}.custom.${key}`] = value;
+  }
+  return out;
+}
+
 function attrsForSpan(span: Span, conversationId: string): Attributes {
   switch (span.spanData.type) {
     case 'agent':
@@ -243,10 +339,32 @@ function attrsForSpan(span: Span, conversationId: string): Attributes {
     case 'generation':
       return generationChatAttrs(span.spanData, conversationId);
 
+    case 'handoff':
+      return handoffAttrs(span.spanData);
+
+    case 'guardrail':
+      return guardrailAttrs(span.spanData);
+
+    case 'transcription':
+      return transcriptionAttrs(span.spanData);
+
+    case 'speech':
+      return speechAttrs(span.spanData);
+
+    case 'speech_group':
+      return speechGroupAttrs(span.spanData);
+
+    case 'mcp_tools':
+      return mcpListToolsAttrs(span.spanData);
+
+    case 'custom':
+      return customAttrs(span.spanData);
+
     default:
-      // Remaining span types still emit OTel spans with the openai
-      // trace_id/span_id attributes set in onSpanStart, but no semconv
-      // attributes yet — per-type mappings land in later increments.
+      // Unknown span type — still emits an OTel span with the openai
+      // trace_id/span_id attrs from onSpanStart, but no per-type semconv.
+      // Most likely cause: a new SpanData subtype was added to the SDK that
+      // this processor doesn't yet handle.
       return {};
   }
 }
@@ -264,13 +382,13 @@ function attrsForSpan(span: Span, conversationId: string): Attributes {
  * Span types without a clean semantic mapping emit with a descriptive operation name
  * and `weave.openai_agents.*` attributes:
  *
- * - (TODO) `handoff {from} -> {to}`
- * - (TODO) `guardrail {name}`
- * - (TODO) `transcription`
- * - (TODO) `speech`
- * - (TODO) `speech_group`
- * - (TODO) `mcp_list_tools`
- * - (TODO) `{custom}`
+ * - `handoff {from} -> {to}`
+ * - `guardrail {name}`
+ * - `transcription`
+ * - `speech`
+ * - `speech_group`
+ * - `mcp_list_tools`
+ * - `{custom}`
  */
 export class WeaveOtelTracingProcessor implements TracingProcessor {
   private spansById = new Map<string, OtelSpan>();

--- a/sdks/node/src/integrations/openai.agent.types.ts
+++ b/sdks/node/src/integrations/openai.agent.types.ts
@@ -14,8 +14,12 @@ import type {
   GenerationSpanData,
   GuardrailSpanData,
   HandoffSpanData,
+  MCPListToolsSpanData,
   ResponseSpanData,
   Span as OpenAIAgentsSpan,
+  SpeechGroupSpanData,
+  SpeechSpanData,
+  TranscriptionSpanData,
 } from '@openai/agents';
 
 export type {
@@ -23,9 +27,15 @@ export type {
   CustomSpanData,
   FunctionSpanData,
   GenerationSpanData,
+  GuardrailSpanData,
+  HandoffSpanData,
+  MCPListToolsSpanData,
   ResponseSpanData,
+  SpeechGroupSpanData,
+  SpeechSpanData,
   Trace,
   TracingProcessor,
+  TranscriptionSpanData,
 } from '@openai/agents';
 
 export type Span<TData extends SpanData = SpanData> = OpenAIAgentsSpan<TData>;
@@ -40,4 +50,8 @@ export type SpanData =
   | ResponseSpanData
   | HandoffSpanData
   | CustomSpanData
-  | GuardrailSpanData;
+  | GuardrailSpanData
+  | TranscriptionSpanData
+  | SpeechSpanData
+  | SpeechGroupSpanData
+  | MCPListToolsSpanData;


### PR DESCRIPTION
## Description

* Emit remaining span types support by Python SDK via `WeaveOtelTracingProcessor`.
* See #6917 for reference on the Python SDK side.