### PR TITLE
perf(weave): query cache for stats/count reads

### DIFF
--- a/tests/trace_server/test_clickhouse_trace_server_settings.py
+++ b/tests/trace_server/test_clickhouse_trace_server_settings.py
@@ -7,6 +7,7 @@ from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 ENV_KEYS = [
     "WF_CLICKHOUSE_MAX_EXECUTION_TIME",
     "WF_CLICKHOUSE_DISABLE_QUERY_FAILURE_PREDICTION",
+    "WF_CLICKHOUSE_STATS_QUERY_CACHE_TTL",
 ]
 
 
@@ -75,3 +76,34 @@ def test_command_settings_skip_prediction_guards(monkeypatch, reload_settings):
     assert "max_estimated_execution_time" not in command_settings
     assert "timeout_before_checking_execution_speed" not in command_settings
     assert "timeout_overflow_mode" not in command_settings
+
+
+def test_stats_query_cache_gating(monkeypatch, reload_settings):
+    # Off by default (TTL unset == 0): empty settings, and the merge helper is a
+    # no-op that preserves caller-provided settings untouched.
+    settings_module = reload_settings()
+    assert settings_module.CLICKHOUSE_STATS_QUERY_CACHE_SETTINGS == {}
+    assert settings_module.update_settings_for_stats_query_cache(
+        {"optimize_aggregation_in_order": 1}
+    ) == {"optimize_aggregation_in_order": 1}
+    assert settings_module.update_settings_for_stats_query_cache() == {}
+
+    # A 0 TTL also disables it.
+    monkeypatch.setenv("WF_CLICKHOUSE_STATS_QUERY_CACHE_TTL", "0")
+    assert reload_settings().CLICKHOUSE_STATS_QUERY_CACHE_SETTINGS == {}
+
+    # A positive TTL enables the read-side cache with that TTL and the pollution
+    # guards, merged on top of (without dropping) the caller's settings.
+    monkeypatch.setenv("WF_CLICKHOUSE_STATS_QUERY_CACHE_TTL", "30")
+    settings_module = reload_settings()
+    merged = settings_module.update_settings_for_stats_query_cache(
+        {"optimize_aggregation_in_order": 1}
+    )
+    assert merged == {
+        "optimize_aggregation_in_order": 1,
+        "use_query_cache": 1,
+        "query_cache_ttl": 30,
+        "query_cache_min_query_duration": 200,
+        "query_cache_min_query_runs": 2,
+        "query_cache_share_between_users": 0,
+    }

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1214,6 +1214,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         )
         pb = ParamBuilder()
         query, columns, settings = build_calls_stats_query(req, pb, read_table)
+        settings = ch_settings.update_settings_for_stats_query_cache(settings)
         raw_res = self._query(query, pb.get_params(), settings=settings or None)
 
         res_dict = (
@@ -2821,7 +2822,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             include_files_storage_size=_default_true(req.include_file_storage_size),
             read_table=read_table,
         )
-        query_result = self.ch_client.query(query, parameters=pb.get_params())
+        settings = ch_settings.update_settings_for_stats_query_cache()
+        query_result = self._query(query, pb.get_params(), settings=settings or None)
 
         if len(query_result.result_rows) != 1:
             raise RuntimeError("Unexpected number of results", query_result)

--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -199,3 +199,41 @@ def update_settings_for_calls_complete_read(
     settings: dict[str, int | str] | None = None,
 ) -> dict[str, int | str]:
     return {**(settings or {}), **CLICKHOUSE_CALLS_COMPLETE_READ_SETTINGS}
+
+
+# Query cache for repeated stats/count reads. The ClickHouse query cache is a
+# read-side, in-memory result cache: no write/insert-time cost and a handful of
+# bytes per scalar count result. Opted into only for stats/count endpoints, never
+# for large result sets. Gated by WF_CLICKHOUSE_STATS_QUERY_CACHE_TTL: 0 (the
+# default) disables it, a positive value enables it with that TTL (seconds).
+# Overview: https://clickhouse.com/docs/operations/query-cache
+MIN_CACHED_QUERY_DURATION_MS = 200
+MIN_CACHED_QUERY_RUNS = 2
+_stats_query_cache_ttl = wf_env.wf_clickhouse_stats_query_cache_ttl()
+CLICKHOUSE_STATS_QUERY_CACHE_SETTINGS: dict[str, int | str] = (
+    {}
+    if _stats_query_cache_ttl <= 0
+    else {
+        # opt this query into reading/writing the cache
+        # https://clickhouse.com/docs/operations/settings/settings#use_query_cache
+        "use_query_cache": 1,
+        # entry lifetime; bounds staleness since the cache is not invalidated on insert
+        # https://clickhouse.com/docs/operations/settings/settings#query_cache_ttl
+        "query_cache_ttl": _stats_query_cache_ttl,
+        # only cache queries that actually took this long (skip the cheap fast-path counts)
+        # https://clickhouse.com/docs/operations/settings/settings#query_cache_min_query_duration
+        "query_cache_min_query_duration": MIN_CACHED_QUERY_DURATION_MS,
+        # only cache after the query has repeated, so one-off requests don't pollute it
+        # https://clickhouse.com/docs/operations/settings/settings#query_cache_min_query_runs
+        "query_cache_min_query_runs": MIN_CACHED_QUERY_RUNS,
+        # never share entries across users (project_id is in the query text already)
+        # https://clickhouse.com/docs/operations/settings/settings#query_cache_share_between_users
+        "query_cache_share_between_users": 0,
+    }
+)
+
+
+def update_settings_for_stats_query_cache(
+    settings: dict[str, int | str] | None = None,
+) -> dict[str, int | str]:
+    return {**(settings or {}), **CLICKHOUSE_STATS_QUERY_CACHE_SETTINGS}

--- a/weave/trace_server/environment.py
+++ b/weave/trace_server/environment.py
@@ -364,6 +364,25 @@ def wf_clickhouse_disable_lightweight_update() -> bool:
     )
 
 
+def wf_clickhouse_stats_query_cache_ttl() -> int:
+    """TTL in seconds for cached stats/count query results.
+
+    Doubles as the on/off switch for the stats query cache: 0 (the default when
+    unset) disables it, any positive value enables it with that TTL. The TTL bounds
+    staleness, since query cache entries are not invalidated on insert.
+    """
+    ttl = os.environ.get("WF_CLICKHOUSE_STATS_QUERY_CACHE_TTL")
+    if ttl is None:
+        return 0
+    try:
+        return int(ttl)
+    except ValueError:
+        logger.exception(
+            "WF_CLICKHOUSE_STATS_QUERY_CACHE_TTL value '%s' is not valid", ttl
+        )
+        return 0
+
+
 def wf_clickhouse_async_insert_busy_timeout_max_ms() -> int:
     """The maximum async insert busy timeout in milliseconds for ClickHouse.
 


### PR DESCRIPTION
## Summary
- Opt the `calls_query_stats` and `project_stats` read paths into the ClickHouse query cache (read-side, in-memory result cache; no write/insert-time cost, ~256 B per scalar count result).
- Single knob `WF_CLICKHOUSE_STATS_QUERY_CACHE_TTL` (seconds): `0`/unset disables it (default), a positive value enables it with that TTL. The TTL bounds staleness, since entries are not invalidated on insert.
- `query_cache_min_query_duration`/`min_query_runs` keep cheap and one-off queries out of the cache; `share_between_users=0` scopes entries per user (project_id is already in the query text). `project_stats` now routes through `_query`, so it also picks up the standard memory/timeout guards.
- Off-by-default is a no-op: the settings dict is empty and the merge helper passes existing settings through unchanged.

## Performance
Local CH 25.11, 20M-call hot project: repeated stats queries (175 ms - 2.6 s cold) return in ~0 ms on a warm cache hit.

## Testing
unit test for the env gating + merge helper.