### PR TITLE
chore(weave_ts): Use forthcoming OTel-emitting `TracingProcessor` for the OpenAI Agents SDK when `WEAVE_USE_OTEL_V2` is set

### DIFF
--- a/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
+++ b/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
@@ -1,0 +1,36 @@
+import type {Span, Trace, TracingProcessor} from '../openai.agent.types';
+
+/**
+ * OTel-emitting TracingProcessor for the OpenAI Agents SDK.
+ *
+ * Emits one OpenTelemetry span per OpenAI Agents span using GenAI semantic
+ * conventions where they apply:
+ *
+ * - (TODO) `invoke_agent {gen_ai.agent.name}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-agent-spans/#invoke-agent-client-span)
+ * - (TODO) `execute_tool {gen_ai.tool.name}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#execute-tool-span)
+ * - (TODO) `chat {gen_ai.request.model}` (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/#inference)
+ *
+ * Span types without a clean semantic mapping emit with a descriptive operation name
+ * and `weave.openai_agents.*` attributes:
+ *
+ * - (TODO) `handoff {from} -> {to}`
+ * - (TODO) `guardrail {name}`
+ * - (TODO) `transcription`
+ * - (TODO) `speech`
+ * - (TODO) `speech_group`
+ * - (TODO) `mcp_list_tools`
+ * - (TODO) `{custom}`
+ */
+export class WeaveOtelTracingProcessor implements TracingProcessor {
+  async onTraceStart(_trace: Trace) {}
+
+  async onTraceEnd(_trace: Trace) {}
+
+  async onSpanStart(_span: Span) {}
+
+  async onSpanEnd(_span: Span) {}
+
+  async shutdown(_timeout: number) {}
+
+  async forceFlush() {}
+}

--- a/sdks/node/src/integrations/openai.agent.ts
+++ b/sdks/node/src/integrations/openai.agent.ts
@@ -23,6 +23,8 @@ import type {
   TracingProcessor,
   CustomSpanData,
 } from './openai.agent.types';
+import {shouldUseOtelV2} from '../settings';
+import {WeaveOtelTracingProcessor} from './openai-agents/weave-otel-tracing-processor';
 
 // ============================================================================
 // Helper Functions
@@ -660,6 +662,10 @@ export class WeaveTracingProcessor implements TracingProcessor {
  * ```
  */
 export function createOpenAIAgentsTracingProcessor(): TracingProcessor {
+  if (shouldUseOtelV2()) {
+    return new WeaveOtelTracingProcessor();
+  }
+
   return new WeaveTracingProcessor();
 }
 
@@ -747,7 +753,7 @@ const _agentsInstrumentedHolder = globalSingleton<{value: boolean}>(
   () => ({value: false})
 );
 
-export function instrumentOpenAIAgentsCommon(exports: any): boolean {
+function instrumentOpenAIAgentsCommon(exports: any): boolean {
   // Always capture context functions when available — even if already instrumented,
   // because a later module load may provide fresh references after a processor reset.
   registerAgentContextProvider(exports);

--- a/sdks/node/src/settings.ts
+++ b/sdks/node/src/settings.ts
@@ -57,7 +57,7 @@ export function shouldUseOtelV2(): boolean {
 }
 
 function parseEnvVar(val: string | undefined): boolean | undefined {
-  switch (val) {
+  switch (val?.toLowerCase()) {
     case 'true':
       return true;
 

--- a/sdks/node/src/settings.ts
+++ b/sdks/node/src/settings.ts
@@ -33,14 +33,7 @@ export class Settings {
   ) {}
 
   get shouldPrintCallLink(): boolean {
-    if (process.env.WEAVE_PRINT_CALL_LINK === 'true') {
-      return true;
-    }
-    if (process.env.WEAVE_PRINT_CALL_LINK === 'false') {
-      return false;
-    }
-
-    return this.printCallLink;
+    return parseEnvVar(process.env.WEAVE_PRINT_CALL_LINK) ?? this.printCallLink;
   }
 
   get attributes(): Record<string, any> {
@@ -57,4 +50,21 @@ export function makeSettings(settings?: SettingsInit): Settings {
     settings.globalAttributes ?? {},
     settings.genai ?? {}
   );
+}
+
+export function shouldUseOtelV2(): boolean {
+  return parseEnvVar(process.env.WEAVE_USE_OTEL_V2) ?? false;
+}
+
+function parseEnvVar(val: string | undefined): boolean | undefined {
+  switch (val) {
+    case 'true':
+      return true;
+
+    case 'false':
+      return false;
+
+    default:
+      return undefined;
+  }
 }


### PR DESCRIPTION
## Description

* Just introducing some plumbing to support swapping out the tracing processor for  the `@open-ai/agents` integration based on the environment variable introduced in https://github.com/wandb/weave/issues/6917. Implementation detailed across this stack.

* Note: we will be adding reference to this env variable here (https://docs.wandb.ai/weave/guides/core-types/env-vars#configure-weave-environment-variables), as well as document its corresponding in-code setting. (At the moment, the TS SDK doesn't support this, nor many of the other settings the Python SDK supports -- we'll be documenting that as well).


