### PR TITLE
feat(weave): add hidden_agents table (migration 033)

### DIFF
--- a/weave/trace_server/migrations/033_add_hidden_agents.down.sql
+++ b/weave/trace_server/migrations/033_add_hidden_agents.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS hidden_agents;

--- a/weave/trace_server/migrations/033_add_hidden_agents.up.sql
+++ b/weave/trace_server/migrations/033_add_hidden_agents.up.sql
@@ -1,0 +1,20 @@
+-- Per-(project, agent) visibility toggle for the Agents tab.
+--
+-- An "agent" is not a stored entity. It is a derived aggregation over `spans`
+-- (see migration 030). There is no row to flip a flag on, so hide/unhide is
+-- tracked in this small side table instead.
+--
+-- ReplacingMergeTree keyed by (project_id, agent_name): the latest row by
+-- `updated_at` wins, so hide and unhide are both plain INSERTs and the toggle
+-- is fully reversible. Read-side queries resolve current state without FINAL
+-- via `GROUP BY agent_name HAVING argMax(is_hidden, updated_at) = true`.
+--
+-- Visibility is project-wide: a hide applies to everyone
+-- in the project.
+CREATE TABLE IF NOT EXISTS hidden_agents (
+    project_id String,
+    agent_name String,
+    is_hidden  Bool DEFAULT true,                -- true = hidden, false = visible
+    updated_at DateTime64(3) DEFAULT now64(3)    -- ReplacingMergeTree version
+) ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (project_id, agent_name);


### PR DESCRIPTION
## Summary
This adds a new table, `hidden_agents`, that keeps track of which agents have been hidden from the Agents tab. It's a ReplacingMergeTree, which means hiding or unhiding an agent is a single insert and can always be reversed.

## Testing
- [x] Unit tests (migration splitter test passes)
- [ ] QA
- [ ] Manual testing
