### PR TITLE
feat(weave): add agent_set_visibility write path + endpoint plumbing

### DIFF
--- a/tests/trace_server/test_genai_agent_visibility.py
+++ b/tests/trace_server/test_genai_agent_visibility.py
@@ -1,0 +1,52 @@
+"""Tests for the agent visibility (hide/unhide) feature.
+
+Requires ClickHouse (auto-skips on SQLite via the `ch_server` fixture).
+"""
+
+from tests.trace_server.helpers import make_project_id as _make_project_id
+from weave.trace_server.agents.types import AgentVisibilityReq
+
+
+def _current_hidden(ch_client, project_id: str, agent_name: str):
+    """Resolve current is_hidden via the argMax read pattern.
+
+    Mirrors how the read filter resolves state from the `hidden_agents`
+    ReplacingMergeTree without `FINAL`: the latest row by `updated_at` wins.
+    Returns None if the agent has no visibility row.
+    """
+    rows = ch_client.query(
+        "SELECT argMax(is_hidden, updated_at) "
+        "FROM hidden_agents "
+        "WHERE project_id = {pid:String} AND agent_name = {an:String} "
+        "GROUP BY agent_name",
+        parameters={"pid": project_id, "an": agent_name},
+    ).result_rows
+    return rows[0][0] if rows else None
+
+
+def test_set_visibility_persists_state(ch_server) -> None:
+    """agent_set_visibility writes is_hidden and echoes the applied state."""
+    project_id = _make_project_id("vis-write")
+
+    res = ch_server.agent_set_visibility(
+        AgentVisibilityReq(project_id=project_id, agent_name="a", hidden=True)
+    )
+    assert res.hidden is True
+
+    # Correct column mapping: hidden -> is_hidden=true.
+    assert _current_hidden(ch_server.ch_client, project_id, "a") is True
+
+
+def test_set_visibility_toggle_latest_write_wins(ch_server) -> None:
+    """Unhiding after hiding wins via updated_at (ReplacingMergeTree semantics)."""
+    project_id = _make_project_id("vis-write-toggle")
+
+    ch_server.agent_set_visibility(
+        AgentVisibilityReq(project_id=project_id, agent_name="a", hidden=True)
+    )
+    res = ch_server.agent_set_visibility(
+        AgentVisibilityReq(project_id=project_id, agent_name="a", hidden=False)
+    )
+    assert res.hidden is False
+
+    assert _current_hidden(ch_server.ch_client, project_id, "a") is False

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -66,6 +66,7 @@ from weave.trace_server.agents.types import (
     AgentVersionSchema,
     AgentVersionsQueryReq,
     AgentVersionsQueryRes,
+    AgentVisibilityReq,
     GenAIOTelExportReq,
     GenAIOTelExportRes,
     group_by_ref_alias,
@@ -723,6 +724,33 @@ class AgentWriteHandler:
             column_names=ALL_SPAN_INSERT_COLUMNS,
         )
         record_db_insert(table="spans", count=1)
+
+    def set_agent_visibility(self, req: AgentVisibilityReq) -> None:
+        """Hide or unhide an agent project-wide.
+
+        Writes a single row into the `hidden_agents` ReplacingMergeTree
+        (migration 033). The latest row by `updated_at` wins, so the same path
+        toggles both directions. Counts on the agents AMT are untouched.
+        """
+        insert_with_empty_query_retry(
+            self._ch_client,
+            "hidden_agents",
+            data=[
+                [
+                    req.project_id,
+                    req.agent_name,
+                    req.hidden,
+                    datetime.datetime.now(datetime.timezone.utc),
+                ]
+            ],
+            column_names=[
+                "project_id",
+                "agent_name",
+                "is_hidden",
+                "updated_at",
+            ],
+        )
+        record_db_insert(table="hidden_agents", count=1)
 
 
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -1052,6 +1052,20 @@ class AgentsQueryRes(BaseModel):
     total_count: int = 0
 
 
+class AgentVisibilityReq(BaseModel):
+    """Hide or unhide an agent for an entire project."""
+
+    project_id: str
+    agent_name: str
+    hidden: bool
+
+
+class AgentVisibilityRes(BaseModel):
+    """Echoes the visibility state that was applied."""
+
+    hidden: bool
+
+
 # ---------------------------------------------------------------------------
 # Agent versions (from agent_versions MV)
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -77,6 +77,8 @@ from weave.trace_server.agents.types import (
     AgentTraceChatRes,
     AgentVersionsQueryReq,
     AgentVersionsQueryRes,
+    AgentVisibilityReq,
+    AgentVisibilityRes,
     GenAIOTelExportReq,
     GenAIOTelExportRes,
 )
@@ -6844,6 +6846,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     def agent_agents_query(self, req: AgentsQueryReq) -> AgentsQueryRes:
         return AgentQueryHandler(self._query, self.feedback_query).agents_query(req)
+
+    def agent_set_visibility(self, req: AgentVisibilityReq) -> AgentVisibilityRes:
+        AgentWriteHandler(self.ch_client).set_agent_visibility(req)
+        return AgentVisibilityRes(hidden=req.hidden)
 
     def agent_versions_query(self, req: AgentVersionsQueryReq) -> AgentVersionsQueryRes:
         return AgentQueryHandler(self._query, self.feedback_query).agent_versions_query(

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1333,6 +1333,13 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             agent.project_id = original_project_id
         return res
 
+    def agent_set_visibility(
+        self, req: tsi.agent_types.AgentVisibilityReq
+    ) -> tsi.agent_types.AgentVisibilityRes:
+        req = req.model_copy(deep=True)
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._internal_trace_server.agent_set_visibility(req)
+
     def agent_versions_query(
         self, req: tsi.agent_types.AgentVersionsQueryReq
     ) -> tsi.agent_types.AgentVersionsQueryRes:

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3076,6 +3076,9 @@ class TraceServerInterface(Protocol):
     def agent_agents_query(
         self, req: agent_types.AgentsQueryReq
     ) -> agent_types.AgentsQueryRes: ...
+    def agent_set_visibility(
+        self, req: agent_types.AgentVisibilityReq
+    ) -> agent_types.AgentVisibilityRes: ...
     def agent_versions_query(
         self, req: agent_types.AgentVersionsQueryReq
     ) -> agent_types.AgentVersionsQueryRes: ...


### PR DESCRIPTION
## Summary
This adds the ability to hide or unhide an agent. Each call records the agent's new visibility state, and the same code path handles both hiding and unhiding.

## Testing
- [x] Unit tests
- [ ] QA
- [ ] Manual testing
