### PR TITLE
feat(weave): filter hidden agents from agents list/count queries

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -67,6 +67,20 @@ def assert_sql(
     )
 
 
+def _hidden_not_in(slot: str) -> str:
+    """The NOT IN subquery the agents queries use to exclude hidden agents.
+
+    ``slot`` is the param placeholder name carrying the project id, e.g.
+    ``"genai_1"``. Built by concatenation so the literal ``{slot:String}``
+    braces survive (str.format would read ``:String`` as a format spec).
+    """
+    return (
+        "agent_name NOT IN ("
+        "SELECT agent_name FROM hidden_agents WHERE project_id = {" + slot + ":String} "
+        "GROUP BY agent_name HAVING argMax(is_hidden, updated_at) = true)"
+    )
+
+
 # ============================================================================
 # make_spans_count_query (ungrouped)
 # ============================================================================
@@ -1060,6 +1074,26 @@ class TestMakeAgentsQueries:
         pb = ParamBuilder("genai")
         query = make_agents_count_query(pb, AgentsQueryReq(project_id="p1"))
 
+        exclusion = _hidden_not_in("genai_1")
+        expected = f"""
+            SELECT count() FROM (
+                SELECT agent_name FROM agents
+                WHERE project_id = {{genai_0:String}}
+                AND {exclusion}
+                GROUP BY agent_name
+            )
+        """
+        assert_sql(expected, {"genai_0": "p1", "genai_1": "p1"}, query, pb.get_params())
+
+    def test_count_include_hidden(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_agents_count_query(
+            pb,
+            AgentsQueryReq(
+                project_id="p1", filters=AgentsQueryFilters(include_hidden=True)
+            ),
+        )
+
         expected = """
             SELECT count() FROM (
                 SELECT agent_name FROM agents
@@ -1073,7 +1107,8 @@ class TestMakeAgentsQueries:
         pb = ParamBuilder("genai")
         query = make_agents_list_query(pb, AgentsQueryReq(project_id="p1"))
 
-        expected = """
+        exclusion = _hidden_not_in("genai_1")
+        expected = f"""
             SELECT agent_name,
                    sum(invocation_count) AS invocation_count,
                    sum(span_count) AS span_count,
@@ -1084,12 +1119,57 @@ class TestMakeAgentsQueries:
                    min(first_seen) AS first_seen,
                    max(last_seen) AS last_seen
             FROM agents
-            WHERE project_id = {genai_0:String}
+            WHERE project_id = {{genai_0:String}}
+            AND {exclusion}
             GROUP BY agent_name
             ORDER BY last_seen DESC, agent_name
-            LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
+            LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
         """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": "p1",
+            "genai_2": 100,
+            "genai_3": 0,
+        }
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_list_include_hidden_projects_flag(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_agents_list_query(
+            pb,
+            AgentsQueryReq(
+                project_id="p1", filters=AgentsQueryFilters(include_hidden=True)
+            ),
+        )
+
+        membership = (
+            "agent_name IN ("
+            "SELECT agent_name FROM hidden_agents WHERE project_id = {genai_1:String} "
+            "GROUP BY agent_name HAVING argMax(is_hidden, updated_at) = true)"
+        )
+        expected = f"""
+            SELECT agent_name,
+                   sum(invocation_count) AS invocation_count,
+                   sum(span_count) AS span_count,
+                   sum(total_input_tokens) AS total_input_tokens,
+                   sum(total_output_tokens) AS total_output_tokens,
+                   sum(total_duration_ms) AS total_duration_ms,
+                   sum(error_count) AS error_count,
+                   min(first_seen) AS first_seen,
+                   max(last_seen) AS last_seen,
+                   {membership} AS hidden
+            FROM agents
+            WHERE project_id = {{genai_0:String}}
+            GROUP BY agent_name
+            ORDER BY last_seen DESC, agent_name
+            LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
+        """
+        expected_params = {
+            "genai_0": "p1",
+            "genai_1": "p1",
+            "genai_2": 100,
+            "genai_3": 0,
+        }
         assert_sql(expected, expected_params, query, pb.get_params())
 
     def test_list_with_filter(self) -> None:
@@ -1102,7 +1182,8 @@ class TestMakeAgentsQueries:
             ),
         )
 
-        expected = """
+        exclusion = _hidden_not_in("genai_2")
+        expected = f"""
             SELECT agent_name,
                    sum(invocation_count) AS invocation_count,
                    sum(span_count) AS span_count,
@@ -1113,17 +1194,19 @@ class TestMakeAgentsQueries:
                    min(first_seen) AS first_seen,
                    max(last_seen) AS last_seen
             FROM agents
-            WHERE project_id = {genai_0:String}
-            AND agent_name = {genai_1:String}
+            WHERE project_id = {{genai_0:String}}
+            AND agent_name = {{genai_1:String}}
+            AND {exclusion}
             GROUP BY agent_name
             ORDER BY last_seen DESC, agent_name
-            LIMIT {genai_2:UInt64} OFFSET {genai_3:UInt64}
+            LIMIT {{genai_3:UInt64}} OFFSET {{genai_4:UInt64}}
         """
         expected_params = {
             "genai_0": "p1",
             "genai_1": "my-agent",
-            "genai_2": 100,
-            "genai_3": 0,
+            "genai_2": "p1",
+            "genai_3": 100,
+            "genai_4": 0,
         }
         assert_sql(expected, expected_params, query, pb.get_params())
 

--- a/tests/trace_server/test_genai_agent_visibility.py
+++ b/tests/trace_server/test_genai_agent_visibility.py
@@ -3,8 +3,20 @@
 Requires ClickHouse (auto-skips on SQLite via the `ch_server` fixture).
 """
 
+import datetime
+import uuid
+
 from tests.trace_server.helpers import make_project_id as _make_project_id
-from weave.trace_server.agents.types import AgentVisibilityReq
+from weave.trace_server.agents.helpers import genai_span_to_row
+from weave.trace_server.agents.schema import (
+    ALL_SPAN_INSERT_COLUMNS,
+    AgentSpanCHInsertable,
+)
+from weave.trace_server.agents.types import (
+    AgentsQueryFilters,
+    AgentsQueryReq,
+    AgentVisibilityReq,
+)
 
 
 def _current_hidden(ch_client, project_id: str, agent_name: str):
@@ -50,3 +62,142 @@ def test_set_visibility_toggle_latest_write_wins(ch_server) -> None:
     assert res.hidden is False
 
     assert _current_hidden(ch_server.ch_client, project_id, "a") is False
+
+
+# ---------------------------------------------------------------------------
+# Read-filter behaviour (end-to-end: write path + agent_agents_query)
+# ---------------------------------------------------------------------------
+
+
+def _make_span(project_id: str, **overrides: object) -> AgentSpanCHInsertable:
+    """Build a span with sensible defaults; override any field via kwargs."""
+    defaults: dict[str, object] = {
+        "project_id": project_id,
+        "trace_id": uuid.uuid4().hex,
+        "span_id": uuid.uuid4().hex,
+        "span_name": "test-span",
+        "started_at": datetime.datetime.now(tz=datetime.timezone.utc),
+        "ended_at": datetime.datetime.now(tz=datetime.timezone.utc),
+        "status_code": "OK",
+        "operation_name": "chat",
+        "agent_name": "test-agent",
+        "input_tokens": 100,
+        "output_tokens": 50,
+    }
+    defaults.update(overrides)
+    return AgentSpanCHInsertable(**defaults)
+
+
+def _insert_spans(ch_client, spans: list[AgentSpanCHInsertable]) -> None:
+    ch_client.insert(
+        "spans",
+        data=[genai_span_to_row(s) for s in spans],
+        column_names=ALL_SPAN_INSERT_COLUMNS,
+    )
+
+
+def test_hidden_agent_excluded_by_default(ch_server) -> None:
+    """A hidden agent drops out of the default list and the total_count."""
+    project_id = _make_project_id("vis-excl")
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(project_id, agent_name="visible"),
+            _make_span(project_id, agent_name="secret"),
+        ],
+    )
+
+    res = ch_server.agent_agents_query(AgentsQueryReq(project_id=project_id))
+    assert {a.agent_name for a in res.agents} == {"visible", "secret"}
+    assert res.total_count == 2
+
+    ch_server.agent_set_visibility(
+        AgentVisibilityReq(project_id=project_id, agent_name="secret", hidden=True)
+    )
+
+    res = ch_server.agent_agents_query(AgentsQueryReq(project_id=project_id))
+    assert [a.agent_name for a in res.agents] == ["visible"]
+    assert res.total_count == 1
+    assert res.agents[0].hidden is False
+
+
+def test_include_hidden_returns_with_flag_and_unchanged_counts(ch_server) -> None:
+    """include_hidden surfaces hidden agents with hidden=True; counts are intact.
+
+    The hidden_agents tombstone never touches the agents AMT, so aggregated
+    counts for a hidden agent are exactly what they were before hiding.
+    """
+    project_id = _make_project_id("vis-incl")
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                project_id,
+                agent_name="secret",
+                operation_name="invoke_agent",
+                input_tokens=100,
+                output_tokens=50,
+            ),
+            _make_span(
+                project_id,
+                agent_name="secret",
+                operation_name="chat",
+                input_tokens=10,
+                output_tokens=5,
+            ),
+        ],
+    )
+    ch_server.agent_set_visibility(
+        AgentVisibilityReq(project_id=project_id, agent_name="secret", hidden=True)
+    )
+
+    res = ch_server.agent_agents_query(
+        AgentsQueryReq(
+            project_id=project_id,
+            filters=AgentsQueryFilters(include_hidden=True),
+        )
+    )
+    by_name = {a.agent_name: a for a in res.agents}
+    assert by_name["secret"].hidden is True
+    assert by_name["secret"].span_count == 2
+    assert by_name["secret"].total_input_tokens == 110
+    assert by_name["secret"].invocation_count == 1
+
+
+def test_hide_unhide_round_trip(ch_server) -> None:
+    """Unhiding restores the agent to the default list (reversible toggle)."""
+    project_id = _make_project_id("vis-rt")
+    _insert_spans(ch_server.ch_client, [_make_span(project_id, agent_name="a")])
+
+    ch_server.agent_set_visibility(
+        AgentVisibilityReq(project_id=project_id, agent_name="a", hidden=True)
+    )
+    assert (
+        ch_server.agent_agents_query(AgentsQueryReq(project_id=project_id)).agents == []
+    )
+
+    ch_server.agent_set_visibility(
+        AgentVisibilityReq(project_id=project_id, agent_name="a", hidden=False)
+    )
+    res = ch_server.agent_agents_query(AgentsQueryReq(project_id=project_id))
+    assert [a.agent_name for a in res.agents] == ["a"]
+    assert res.agents[0].hidden is False
+
+
+def test_hiding_one_agent_leaves_others_visible(ch_server) -> None:
+    """Visibility is per (project, agent): hiding one does not affect another."""
+    project_id = _make_project_id("vis-iso")
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(project_id, agent_name="a"),
+            _make_span(project_id, agent_name="b"),
+        ],
+    )
+
+    ch_server.agent_set_visibility(
+        AgentVisibilityReq(project_id=project_id, agent_name="a", hidden=True)
+    )
+
+    res = ch_server.agent_agents_query(AgentsQueryReq(project_id=project_id))
+    assert {a.agent_name for a in res.agents} == {"b"}

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -390,6 +390,7 @@ class AgentQueryHandler:
             AgentSchema(
                 project_id=req.project_id,
                 agent_name=safe_str(r.get("agent_name")),
+                hidden=bool(r.get("hidden", False)),
                 **_agent_aggregate_fields(r),
             )
             for r in rows

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -1025,12 +1025,21 @@ class AgentSchema(BaseModel):
     error_count: int
     first_seen: datetime.datetime | None
     last_seen: datetime.datetime | None
+    hidden: bool = False
 
 
 class AgentsQueryFilters(BaseModel):
     """Optional filters for querying agents."""
 
     agent_name: str | None = None
+    include_hidden: bool = Field(
+        default=False,
+        description=(
+            "When False (default), agents hidden via `hidden_agents` are "
+            "excluded. When True, hidden agents are returned with `hidden=True` "
+            "on the schema."
+        ),
+    )
 
 
 class AgentsQueryReq(BaseModel):

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -839,11 +839,32 @@ def _spans_filter_sql(
     return _FilterSQL(where=" AND ".join(where_conditions))
 
 
+def _hidden_agents_subquery(pb: ParamBuilder, project_id: str) -> str:
+    """SQL selecting agent names currently hidden in a project.
+
+    Resolves current state from the `hidden_agents` ReplacingMergeTree without
+    FINAL: the latest toggle per agent wins via `argMax` on `updated_at`,
+    so a row with `is_hidden = true` only counts if it is the most recent write.
+    """
+    pid_slot = pb.add(project_id, param_type="String")
+    return (
+        f"SELECT agent_name FROM hidden_agents "
+        f"WHERE project_id = {pid_slot} "
+        f"GROUP BY agent_name HAVING argMax(is_hidden, updated_at) = true"
+    )
+
+
 def _agents_where(pb: ParamBuilder, req: AgentsQueryReq) -> str:
     conditions: list[str] = []
     if req.filters and req.filters.agent_name:
         aname_slot = pb.add(req.filters.agent_name, param_type="String")
         conditions.append(f"agent_name = {aname_slot}")
+    # Exclude hidden agents unless the caller explicitly opts in. When opted in,
+    # the list query instead projects a `hidden` flag (see make_agents_list_query).
+    if not (req.filters and req.filters.include_hidden):
+        conditions.append(
+            f"agent_name NOT IN ({_hidden_agents_subquery(pb, req.project_id)})"
+        )
     return " AND ".join(conditions)
 
 
@@ -1431,6 +1452,15 @@ def make_agents_list_query(pb: ParamBuilder, req: AgentsQueryReq) -> str:
     order_by = build_order_by(
         req.sort_by, AGENT_SORTABLE_COLS, "last_seen DESC, agent_name"
     )
+    # When hidden agents are included they are not excluded by _agents_where, so
+    # surface their state as a `hidden` flag. agent_name is the GROUP BY key, so
+    # membership in the (uncorrelated) hidden set is valid in the SELECT list.
+    hidden_select = ""
+    if req.filters and req.filters.include_hidden:
+        hidden_select = (
+            f",\n               agent_name IN "
+            f"({_hidden_agents_subquery(pb, req.project_id)}) AS hidden"
+        )
     limit_slot, offset_slot = _pagination_slots(pb, req.limit, req.offset)
     return f"""
         SELECT agent_name,
@@ -1441,7 +1471,7 @@ def make_agents_list_query(pb: ParamBuilder, req: AgentsQueryReq) -> str:
                sum(total_duration_ms) AS total_duration_ms,
                sum(error_count) AS error_count,
                min(first_seen) AS first_seen,
-               max(last_seen) AS last_seen
+               max(last_seen) AS last_seen{hidden_select}
         FROM agents
         {where_sql}
         GROUP BY agent_name


### PR DESCRIPTION
## Summary
This makes hiding take effect. The Agents list and its count now leave out hidden agents by default. If a caller passes `include_hidden`, the hidden agents are returned as well, each marked so the UI can tell them apart. Hiding an agent does not change any of its stats.

## Testing
- [x] Unit tests
- [ ] QA
- [ ] Manual testing
