### PR TITLE
fix(weave): honor skip_clickhouse_client marker so VCR tests use sqlite

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -93,6 +93,11 @@ def pytest_collection_modifyitems(config, items):
 
 
 def get_trace_server_flag(request):
+    # Tests marked `skip_clickhouse_client` run on sqlite: they patch HTTP via VCR,
+    # and a real clickhouse client would emit unmatched localhost traffic.
+    node = getattr(request, "node", None)
+    if node is not None and node.get_closest_marker("skip_clickhouse_client"):
+        return "sqlite"
     if request.config.getoption("--clickhouse"):
         return "clickhouse"
     if request.config.getoption("--sqlite"):


### PR DESCRIPTION
## Summary
- `verifiers_test` and other VCR integration tests fail nightly with `CannotOverwriteExistingCassetteException`: they run on the default clickhouse backend, so VCR intercepts the clickhouse HTTP flush, which the cassette has no match for. The `skip_clickhouse_client` marker was meant to prevent exactly this but was dead, `get_trace_server_flag` never honored it (and `test_skip_clickhouse_client` already asserts it should).
- Honor the marker at the single backend chokepoint, routing marked tests to sqlite.

## Testing
exercised by the nightly verifiers/integration shards.
