### PR TITLE
fix(weave): verifiers test passes CH/wandb traffic through VCR

### DIFF
--- a/tests/integrations/verifiers/verifiers_test.py
+++ b/tests/integrations/verifiers/verifiers_test.py
@@ -30,7 +30,10 @@ def patch_verifiers() -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
+    # `allowed_hosts` is a no-op for vcr; use vcr's real passthrough so the
+    # clickhouse/wandb HTTP calls bypass the cassette and only the LLM call replays.
+    ignore_localhost=True,
+    ignore_hosts=["api.wandb.ai"],
     allow_playback_repeats=True,
 )
 def test_verifiers_environment_evaluate_with_mock_env(client: WeaveClient) -> None:


### PR DESCRIPTION
## Summary
- `verifiers_test` fails on the clickhouse backend (`CannotOverwriteExistingCassetteException`): the clickhouse-connect `POST localhost:8123` is matched against the OpenAI-only cassette and rejected. The decorator's `allowed_hosts` is a no-op for vcr (it only affects pytest-recording's `block_network`), so CH traffic was never passed through.
- Use vcr's real passthrough (`ignore_localhost=True` + `ignore_hosts=["api.wandb.ai"]`) so CH/wandb calls bypass the cassette and only the LLM call replays. Keeps the test on the CH backend like its siblings.

## Testing
reproduced the failure and verified the fix on a real clickhouse backend locally (`shard=verifiers_test --trace-server=clickhouse`): `1 error` -> `1 passed`.
