### PR TITLE
fix(weave): real VCR passthrough for integration tests via vcr_config

### DIFF
--- a/tests/integrations/anthropic/anthropic_test.py
+++ b/tests/integrations/anthropic/anthropic_test.py
@@ -26,7 +26,6 @@ def patch_anthropic() -> Generator[None, None, None]:
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_anthropic(
     client: weave.trace.weave_client.WeaveClient,
@@ -64,7 +63,6 @@ def test_anthropic(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_anthropic_stream(
     client: weave.trace.weave_client.WeaveClient,
@@ -111,7 +109,6 @@ def test_anthropic_stream(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_async_anthropic(
@@ -153,7 +150,6 @@ async def test_async_anthropic(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_async_anthropic_stream(
@@ -204,7 +200,6 @@ async def test_async_anthropic_stream(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_tools_calling(
     client: weave.trace.weave_client.WeaveClient,
@@ -264,7 +259,6 @@ def test_tools_calling(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_anthropic_messages_stream_ctx_manager(
     client: weave.trace.weave_client.WeaveClient,
@@ -311,7 +305,6 @@ def test_anthropic_messages_stream_ctx_manager(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_async_anthropic_messages_stream_ctx_manager(
@@ -361,7 +354,6 @@ async def test_async_anthropic_messages_stream_ctx_manager(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_anthropic_messages_stream_get_final_message(
     client: weave.trace.weave_client.WeaveClient,
@@ -404,7 +396,6 @@ def test_anthropic_messages_stream_get_final_message(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_async_anthropic_messages_stream_get_final_message(
@@ -450,7 +441,6 @@ async def test_async_anthropic_messages_stream_get_final_message(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_anthropic_messages_stream_ctx_manager_text(
     client: weave.trace.weave_client.WeaveClient,
@@ -496,7 +486,6 @@ def test_anthropic_messages_stream_ctx_manager_text(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_async_anthropic_messages_stream_ctx_manager_text(
@@ -545,7 +534,6 @@ async def test_async_anthropic_messages_stream_ctx_manager_text(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_beta_anthropic(
     client: weave.trace.weave_client.WeaveClient,
@@ -583,7 +571,6 @@ def test_beta_anthropic(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_beta_anthropic_parse(
     client: weave.trace.weave_client.WeaveClient,
@@ -629,7 +616,6 @@ def test_beta_anthropic_parse(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_beta_anthropic_stream(
     client: weave.trace.weave_client.WeaveClient,
@@ -676,7 +662,6 @@ def test_beta_anthropic_stream(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_beta_async_anthropic(
@@ -718,7 +703,6 @@ async def test_beta_async_anthropic(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_beta_async_anthropic_stream(

--- a/tests/integrations/autogen/autogen_test.py
+++ b/tests/integrations/autogen/autogen_test.py
@@ -26,7 +26,6 @@ def patch_autogen() -> Generator[None, None, None]:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_simple_client_create(
@@ -63,7 +62,6 @@ async def test_simple_client_create(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check(reason="This test is expected to fail")
@@ -108,7 +106,6 @@ async def test_simple_client_create_with_exception(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_simple_client_create_stream(
@@ -148,7 +145,6 @@ async def test_simple_client_create_stream(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_simple_cached_client_create(
@@ -205,7 +201,6 @@ async def test_simple_cached_client_create(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_simple_cached_client_create_stream(
@@ -257,7 +252,6 @@ async def test_simple_cached_client_create_stream(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_agentchat_run_with_tool(
@@ -340,7 +334,6 @@ async def test_agentchat_run_with_tool(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_agentchat_run_stream_with_tool(
@@ -414,7 +407,6 @@ async def test_agentchat_run_stream_with_tool(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_agentchat_group_chat(
@@ -693,7 +685,6 @@ async def test_agentchat_group_chat(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_agent_with_memory(
@@ -814,7 +805,6 @@ async def test_agent_with_memory(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_workflows_singlethreaded_runtime(

--- a/tests/integrations/cerebras/cerebras_test.py
+++ b/tests/integrations/cerebras/cerebras_test.py
@@ -20,9 +20,7 @@ def patch_cerebras() -> Generator[None, None, None]:
 
 
 @pytest.mark.skip_clickhouse_client
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_cerebras_sync(client: weave.trace.weave_client.WeaveClient) -> None:
     api_key = os.environ.get("CEREBRAS_API_KEY", "DUMMY_API_KEY")
     cerebras_client = Cerebras(api_key=api_key)
@@ -56,9 +54,7 @@ def test_cerebras_sync(client: weave.trace.weave_client.WeaveClient) -> None:
 
 
 @pytest.mark.skip_clickhouse_client
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_cerebras_async(client: weave.trace.weave_client.WeaveClient) -> None:
     api_key = os.environ.get("CEREBRAS_API_KEY", "DUMMY_API_KEY")

--- a/tests/integrations/cohere/cohere_test.py
+++ b/tests/integrations/cohere/cohere_test.py
@@ -23,7 +23,6 @@ def patch_cohere() -> Generator[None, None, None]:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_cohere(
     client: weave.trace.weave_client.WeaveClient,
@@ -77,7 +76,6 @@ def test_cohere(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_cohere_stream(
     client: weave.trace.weave_client.WeaveClient,
@@ -137,7 +135,6 @@ def test_cohere_stream(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 async def test_cohere_async(
     client: weave.trace.weave_client.WeaveClient,
@@ -192,7 +189,6 @@ async def test_cohere_async(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 async def test_cohere_async_stream(
     client: weave.trace.weave_client.WeaveClient,
@@ -250,7 +246,6 @@ async def test_cohere_async_stream(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_cohere_v2(
     client: weave.trace.weave_client.WeaveClient,
@@ -298,7 +293,6 @@ def test_cohere_v2(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 async def test_cohere_async_v2(
     client: weave.trace.weave_client.WeaveClient,
@@ -345,7 +339,6 @@ async def test_cohere_async_v2(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_cohere_stream_v2(
     client: weave.trace.weave_client.WeaveClient,
@@ -396,7 +389,6 @@ def test_cohere_stream_v2(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 async def test_cohere_async_stream_v2(
     client: weave.trace.weave_client.WeaveClient,

--- a/tests/integrations/conftest.py
+++ b/tests/integrations/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture
+def vcr_config() -> dict[str, object]:
+    """VCR passthrough for infra: clickhouse (localhost) and the wandb API bypass cassettes; only provider calls replay."""
+    return {"ignore_localhost": True, "ignore_hosts": ["api.wandb.ai"]}

--- a/tests/integrations/crewai/crewai_test.py
+++ b/tests/integrations/crewai/crewai_test.py
@@ -132,7 +132,6 @@ def get_flow_with_router_or():
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_crewai_simple_crew(client: WeaveClient) -> None:
     crew = get_crew()
@@ -265,7 +264,6 @@ def test_crewai_simple_crew(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_crewai_simple_crew_kickoff_for_each(client: WeaveClient) -> None:
     crew = get_crew()
@@ -309,7 +307,6 @@ def test_crewai_simple_crew_kickoff_for_each(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 async def test_crewai_simple_crew_kickoff_async(client: WeaveClient) -> None:
     crew = get_crew()
@@ -342,7 +339,6 @@ async def test_crewai_simple_crew_kickoff_async(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 async def test_crewai_simple_crew_kickoff_for_each_async(client: WeaveClient) -> None:
     crew = get_crew()
@@ -390,10 +386,6 @@ async def test_crewai_simple_crew_kickoff_for_each_async(client: WeaveClient) ->
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=[
-        "api.wandb.ai",
-        "localhost",
-    ],
 )
 def test_simple_flow(client: WeaveClient) -> None:
     flow = get_flow_with_router_or()

--- a/tests/integrations/dspy/dspy_test.py
+++ b/tests/integrations/dspy/dspy_test.py
@@ -95,7 +95,6 @@ def accuracy_metric(answer, model_output, trace=None):
         "x-request-id",
         "x-rate-limit",
     ],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_dspy_language_models(client: WeaveClient) -> None:
     lm = dspy.LM("openai/gpt-4o-mini", cache=False)
@@ -139,7 +138,6 @@ def test_dspy_language_models(client: WeaveClient) -> None:
         "x-request-id",
         "x-rate-limit",
     ],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_dspy_predict_module(client: WeaveClient) -> None:
     dspy.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=False))
@@ -188,7 +186,6 @@ def test_dspy_predict_module(client: WeaveClient) -> None:
         "x-request-id",
         "x-rate-limit",
     ],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_dspy_cot(client: WeaveClient) -> None:
     dspy.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=False))
@@ -245,7 +242,6 @@ def test_dspy_cot(client: WeaveClient) -> None:
         "x-request-id",
         "x-rate-limit",
     ],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_dspy_custom_module(client: WeaveClient) -> None:
     dspy.configure(lm=dspy.LM("openai/gpt-4o-mini", cache=False))
@@ -307,7 +303,6 @@ def test_dspy_custom_module(client: WeaveClient) -> None:
         "x-request-id",
         "x-rate-limit",
     ],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skipif(
     sys.platform == "win32",
@@ -378,7 +373,6 @@ def test_dspy_evaluate(client: WeaveClient) -> None:
         "x-request-id",
         "x-rate-limit",
     ],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skipif(
     sys.platform == "win32",
@@ -438,7 +432,6 @@ def test_dspy_evaluate_with_pydantic_prediction(client: WeaveClient) -> None:
         "x-request-id",
         "x-rate-limit",
     ],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skipif(
     sys.platform == "win32",
@@ -477,7 +470,6 @@ def test_dspy_optimizer_labeled_fewshot(client: WeaveClient) -> None:
         "x-request-id",
         "x-rate-limit",
     ],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skipif(
     sys.platform == "win32",
@@ -516,7 +508,6 @@ def test_dspy_optimizer_bootstrap_fewshot(client: WeaveClient) -> None:
         "x-request-id",
         "x-rate-limit",
     ],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skipif(
     sys.platform == "win32",

--- a/tests/integrations/fastmcp/fastmcp_test.py
+++ b/tests/integrations/fastmcp/fastmcp_test.py
@@ -119,7 +119,6 @@ def main():
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_fastmcp_client(client: WeaveClient) -> None:
     main()
@@ -169,7 +168,6 @@ def test_fastmcp_client(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skipif(
     sys.platform == "win32",

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -36,7 +36,6 @@ class Recipe(BaseModel):
 
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 def test_content_generation_sync(client):
@@ -65,7 +64,6 @@ def test_content_generation_sync(client):
 @pytest.mark.asyncio
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 async def test_content_generation_async(client):
@@ -91,7 +89,6 @@ async def test_content_generation_async(client):
 
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 def test_content_generation_sync_stream(client):
@@ -127,7 +124,6 @@ def test_content_generation_sync_stream(client):
 @pytest.mark.asyncio
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 async def test_content_generation_async_stream(client):
@@ -161,7 +157,6 @@ async def test_content_generation_async_stream(client):
 
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 def test_chat_session_sync(client):
@@ -199,7 +194,6 @@ You are able to generate high-quality code in the Python programming language.""
 @pytest.mark.asyncio
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 async def test_chat_session_async(client):
@@ -232,7 +226,6 @@ You are able to generate high-quality code in the Python programming language.""
 
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 def test_function_calling(client):
@@ -287,7 +280,6 @@ def test_function_calling(client):
 
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 def test_system_instruction_extracted_from_config(client):
@@ -323,7 +315,6 @@ def test_system_instruction_extracted_from_config(client):
 
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 def test_image_generation_sync(client):
@@ -345,7 +336,6 @@ def test_image_generation_sync(client):
 
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.asyncio
@@ -954,7 +944,6 @@ def test_postprocess_inputs_leaves_text_only_contents_unchanged():
 
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.skip_clickhouse_client
 def test_content_generation_with_image_bytes(client):

--- a/tests/integrations/groq/groq_test.py
+++ b/tests/integrations/groq/groq_test.py
@@ -24,7 +24,6 @@ def patch_groq() -> Generator[None, None, None]:
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_groq_quickstart(
     client: weave.trace.weave_client.WeaveClient,
@@ -73,7 +72,6 @@ def test_groq_quickstart(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_groq_async_chat_completion(
@@ -135,7 +133,6 @@ Remember, as your psychiatrist, my goal is to help you understand what's going o
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_groq_streaming_chat_completion(
     client: weave.trace.weave_client.WeaveClient,
@@ -214,7 +211,6 @@ In summary, fast language models have revolutionized the field of NLP, enabling 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_groq_async_streaming_chat_completion(
@@ -285,7 +281,6 @@ Remember, as your psychiatrist, my goal is to help you understand what's going o
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_groq_tool_call(
     client: weave.trace.weave_client.WeaveClient,

--- a/tests/integrations/huggingface/test_huggingface_inference_client.py
+++ b/tests/integrations/huggingface/test_huggingface_inference_client.py
@@ -9,7 +9,6 @@ from weave.integrations.integration_utilities import op_name_from_ref
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_huggingface_chat_completion(client):
     from huggingface_hub import InferenceClient
@@ -47,7 +46,6 @@ def test_huggingface_chat_completion(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_huggingface_chat_completion_stream(client):
     from huggingface_hub import InferenceClient
@@ -86,7 +84,6 @@ def test_huggingface_chat_completion_stream(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_huggingface_chat_completion_async(client):
@@ -124,7 +121,6 @@ async def test_huggingface_chat_completion_async(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_huggingface_document_question_answering(client):
     from huggingface_hub import InferenceClient
@@ -155,7 +151,6 @@ def test_huggingface_document_question_answering(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_huggingface_document_question_answering_async(client):
@@ -187,7 +182,6 @@ async def test_huggingface_document_question_answering_async(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_huggingface_fill_mask(client):
     from huggingface_hub import InferenceClient
@@ -211,7 +205,6 @@ def test_huggingface_fill_mask(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_huggingface_fill_mask_async(client):
@@ -239,7 +232,6 @@ async def test_huggingface_fill_mask_async(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_huggingface_question_answering(client):
     from huggingface_hub import InferenceClient
@@ -267,7 +259,6 @@ def test_huggingface_question_answering(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_huggingface_question_answering_async(client):
@@ -297,7 +288,6 @@ async def test_huggingface_question_answering_async(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_huggingface_table_question_answering(client):
     from huggingface_hub import InferenceClient
@@ -328,7 +318,6 @@ def test_huggingface_table_question_answering(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_huggingface_table_question_answering_async(client):
@@ -360,7 +349,6 @@ async def test_huggingface_table_question_answering_async(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_huggingface_text_classification(client):
     from huggingface_hub import InferenceClient
@@ -387,7 +375,6 @@ def test_huggingface_text_classification(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_huggingface_text_classification_async(client):
@@ -415,7 +402,6 @@ async def test_huggingface_text_classification_async(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_huggingface_token_classification(client):
     from huggingface_hub import InferenceClient
@@ -444,7 +430,6 @@ def test_huggingface_token_classification(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_huggingface_token_classification_async(client):
@@ -474,7 +459,6 @@ async def test_huggingface_token_classification_async(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_huggingface_translation(client):
     from huggingface_hub import InferenceClient
@@ -501,7 +485,6 @@ def test_huggingface_translation(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_huggingface_translation_async(client):
@@ -531,7 +514,6 @@ async def test_huggingface_translation_async(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_huggingface_text_to_image(client):
     from huggingface_hub import InferenceClient
@@ -561,7 +543,6 @@ def test_huggingface_text_to_image(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_huggingface_text_to_image_async(client):

--- a/tests/integrations/instructor/instructor_test.py
+++ b/tests/integrations/instructor/instructor_test.py
@@ -48,7 +48,6 @@ def patch_instructor() -> Generator[None, None, None]:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_instructor_openai(
     client: weave.trace.weave_client.WeaveClient,
@@ -90,7 +89,6 @@ def test_instructor_openai(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_instructor_openai_with_completion(
     client: weave.trace.weave_client.WeaveClient,
@@ -129,7 +127,6 @@ def test_instructor_openai_with_completion(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_instructor_openai_async(
@@ -175,7 +172,6 @@ async def test_instructor_openai_async(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_instructor_iterable(
     client: weave.trace.weave_client.WeaveClient,
@@ -233,7 +229,6 @@ def test_instructor_iterable(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_instructor_iterable_sync_stream(
     client: weave.trace.weave_client.WeaveClient,
@@ -282,7 +277,6 @@ def test_instructor_iterable_sync_stream(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_instructor_iterable_async_stream(
@@ -338,7 +332,6 @@ async def test_instructor_iterable_async_stream(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 def test_instructor_partial_stream(
     client: weave.trace.weave_client.WeaveClient,
@@ -408,7 +401,6 @@ list of speakers.
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
 )
 @pytest.mark.asyncio
 async def test_instructor_partial_stream_async(

--- a/tests/integrations/langchain/langchain_test.py
+++ b/tests/integrations/langchain/langchain_test.py
@@ -69,7 +69,6 @@ def assert_correct_calls_for_chain_invoke(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_simple_chain_invoke(
@@ -106,7 +105,6 @@ def test_simple_chain_invoke(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_simple_chain_invoke_no_client(client) -> None:
@@ -135,7 +133,6 @@ def test_simple_chain_invoke_no_client(client) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 @pytest.mark.asyncio
@@ -160,7 +157,6 @@ async def test_simple_chain_ainvoke(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_simple_chain_stream(
@@ -185,7 +181,6 @@ def test_simple_chain_stream(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 @pytest.mark.asyncio
@@ -232,7 +227,6 @@ def assert_correct_calls_for_chain_batch(calls: list[Call]) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 @pytest.mark.skipif(
@@ -258,7 +252,6 @@ def test_simple_chain_batch(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 @pytest.mark.asyncio
@@ -305,7 +298,6 @@ def assert_correct_calls_for_chain_batch_from_op(calls: list[Call]) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 @pytest.mark.skipif(
@@ -423,7 +415,6 @@ def fix_chroma_ci() -> Generator[None, None, None]:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_simple_rag_chain(client: WeaveClient, fix_chroma_ci: None) -> None:
@@ -504,7 +495,6 @@ def assert_correct_calls_for_agent_with_tool(calls: list[Call]) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_agent_run_with_tools(
@@ -620,7 +610,6 @@ def assert_correct_calls_for_agent_with_function_call(calls: list[Call]) -> None
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_agent_run_with_function_call(
@@ -713,7 +702,6 @@ def test_agent_run_with_function_call(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_weave_attributes_in_call(client: WeaveClient) -> None:
@@ -741,7 +729,6 @@ def test_weave_attributes_in_call(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key", "x-goog-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai", "*.googleapis.com"],
     before_record_request=filter_body,
     match_on=["method", "scheme", "path", "query"],
 )
@@ -785,7 +772,6 @@ def test_langchain_google_vertexai_usage(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
     match_on=["method", "scheme", "path", "query"],
 )
@@ -817,7 +803,6 @@ def test_langchain_google_genai_usage(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
     match_on=["method", "scheme", "path", "query"],
 )
@@ -849,7 +834,6 @@ def test_langchain_google_chat_genai_usage(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_langchain_anthropic_usage(client: WeaveClient) -> None:
@@ -885,7 +869,6 @@ def test_langchain_anthropic_usage(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_langchain_cohere_usage(client: WeaveClient) -> None:
@@ -921,7 +904,6 @@ def test_langchain_cohere_usage(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_langchain_litellm_usage(client: WeaveClient) -> None:

--- a/tests/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints_test.py
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints_test.py
@@ -13,7 +13,6 @@ model = "meta/llama-3.1-8b-instruct"
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_chatnvidia_quickstart(client: weave.trace.weave_client.WeaveClient) -> None:
     api_key = os.environ.get("NVIDIA_API_KEY", "DUMMY_API_KEY")
@@ -56,9 +55,7 @@ def test_chatnvidia_quickstart(client: weave.trace.weave_client.WeaveClient) -> 
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_chatnvidia_async_quickstart(
     client: weave.trace.weave_client.WeaveClient,
@@ -105,7 +102,6 @@ async def test_chatnvidia_async_quickstart(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_chatnvidia_stream_quickstart(
     client: weave.trace.weave_client.WeaveClient,
@@ -155,9 +151,7 @@ def test_chatnvidia_stream_quickstart(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_chatnvidia_async_stream_quickstart(
     client: weave.trace.weave_client.WeaveClient,
@@ -206,9 +200,7 @@ async def test_chatnvidia_async_stream_quickstart(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_chatnvidia_tool_call(client: weave.trace.weave_client.WeaveClient) -> None:
     api_key = os.environ.get("NVIDIA_API_KEY", "DUMMY_API_KEY")
 
@@ -290,9 +282,7 @@ def test_chatnvidia_tool_call(client: weave.trace.weave_client.WeaveClient) -> N
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_chatnvidia_tool_call_async(
     client: weave.trace.weave_client.WeaveClient,
@@ -377,9 +367,7 @@ async def test_chatnvidia_tool_call_async(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_chatnvidia_tool_call_stream(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
@@ -468,9 +456,7 @@ def test_chatnvidia_tool_call_stream(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_chatnvidia_tool_call_async_stream(
     client: weave.trace.weave_client.WeaveClient,

--- a/tests/integrations/litellm/litellm_test.py
+++ b/tests/integrations/litellm/litellm_test.py
@@ -53,9 +53,7 @@ def patch_litellm(request: Any) -> Generator[None, None, None]:
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_litellm_quickstart(
     client: weave.trace.weave_client.WeaveClient, patch_litellm: None
 ) -> None:
@@ -94,9 +92,7 @@ def test_litellm_quickstart(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_litellm_quickstart_async(
     client: weave.trace.weave_client.WeaveClient, patch_litellm: None
@@ -137,9 +133,7 @@ async def test_litellm_quickstart_async(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_litellm_quickstart_stream(
     client: weave.trace.weave_client.WeaveClient, patch_litellm: None
 ) -> None:
@@ -186,9 +180,7 @@ def test_litellm_quickstart_stream(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_litellm_quickstart_stream_async(
     client: weave.trace.weave_client.WeaveClient, patch_litellm: None
@@ -237,7 +229,6 @@ async def test_litellm_quickstart_stream_async(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_model_predict(weave_active, patch_litellm: None) -> None:
     class TranslatorModel(weave.Model):

--- a/tests/integrations/llamaindex/llamaindex_test.py
+++ b/tests/integrations/llamaindex/llamaindex_test.py
@@ -52,7 +52,6 @@ def patch_llamaindex() -> Generator[None, None, None]:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_llamaindex_llm_complete_sync(client: WeaveClient) -> None:
@@ -121,7 +120,6 @@ def test_llamaindex_llm_complete_sync(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 @pytest.mark.asyncio
@@ -186,7 +184,6 @@ async def test_llamaindex_llm_complete_async(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_llamaindex_llm_stream_complete_sync(client: WeaveClient) -> None:
@@ -265,7 +262,6 @@ def test_llamaindex_llm_stream_complete_sync(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 @pytest.mark.asyncio
@@ -338,7 +334,6 @@ async def test_llamaindex_llm_stream_complete_async(client: WeaveClient) -> None
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_llamaindex_llm_chat_sync(client: WeaveClient) -> None:
@@ -421,7 +416,6 @@ def test_llamaindex_llm_chat_sync(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 @pytest.mark.asyncio
@@ -505,7 +499,6 @@ async def test_llamaindex_llm_chat_async(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_llamaindex_llm_stream_chat_sync(client: WeaveClient) -> None:
@@ -614,7 +607,6 @@ def test_llamaindex_llm_stream_chat_sync(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 @pytest.mark.asyncio
@@ -725,7 +717,6 @@ async def test_llamaindex_llm_stream_chat_async(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_llamaindex_tool_calling_sync(client: WeaveClient) -> None:
@@ -797,7 +788,6 @@ def test_llamaindex_tool_calling_sync(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 @pytest.mark.asyncio
@@ -843,7 +833,6 @@ async def test_llamaindex_workflow(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     # before_record_request=filter_body,
 )
 @pytest.mark.asyncio

--- a/tests/integrations/mistral/mistral_test.py
+++ b/tests/integrations/mistral/mistral_test.py
@@ -18,9 +18,7 @@ def patch_mistral() -> Generator[None, None, None]:
 
 
 @pytest.mark.skip_clickhouse_client
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_mistral_quickstart(client: weave.trace.weave_client.WeaveClient) -> None:
     # This is taken directly from https://docs.mistral.ai/getting-started/quickstart/
 
@@ -82,9 +80,7 @@ Each of these cheeses has its unique characteristics, so the "best" one depends 
 
 
 @pytest.mark.skip_clickhouse_client
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_mistral_quickstart_async(
     client: weave.trace.weave_client.WeaveClient,
@@ -141,9 +137,7 @@ Each of these cheeses offers a unique taste and texture, so the "best" one is a 
 
 
 @pytest.mark.skip_clickhouse_client
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_mistral_quickstart_with_stream(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
@@ -201,9 +195,7 @@ Each of these cheeses offers a unique taste and texture, so the "best" one depen
 
 
 @pytest.mark.skip_clickhouse_client
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_mistral_quickstart_with_stream_async(
     client: weave.trace.weave_client.WeaveClient,

--- a/tests/integrations/openai/openai_test.py
+++ b/tests/integrations/openai/openai_test.py
@@ -101,9 +101,7 @@ def test_maybe_unwrap_api_response_returns_value_when_parse_fails(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_openai_async_quickstart(
     client: weave.trace.weave_client.WeaveClient,
@@ -149,9 +147,7 @@ async def test_openai_async_quickstart(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_openai_stream_quickstart(client: weave.trace.weave_client.WeaveClient) -> None:
     api_key = os.environ.get("OPENAI_API_KEY", "DUMMY_API_KEY")
 
@@ -204,9 +200,7 @@ def test_openai_stream_quickstart(client: weave.trace.weave_client.WeaveClient) 
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_openai_async_stream_quickstart(
     client: weave.trace.weave_client.WeaveClient,
@@ -258,9 +252,7 @@ async def test_openai_async_stream_quickstart(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_openai_stream_usage_quickstart(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
@@ -298,9 +290,7 @@ def test_openai_stream_usage_quickstart(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_openai_function_call(client: weave.trace.weave_client.WeaveClient) -> None:
     api_key = os.environ.get("OPENAI_API_KEY", "DUMMY_API_KEY")
 
@@ -382,9 +372,7 @@ def test_openai_function_call(client: weave.trace.weave_client.WeaveClient) -> N
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_openai_function_call_async(
     client: weave.trace.weave_client.WeaveClient,
@@ -468,9 +456,7 @@ async def test_openai_function_call_async(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_openai_function_call_async_stream(
     client: weave.trace.weave_client.WeaveClient,
@@ -558,9 +544,7 @@ async def test_openai_function_call_async_stream(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_openai_tool_call(client: weave.trace.weave_client.WeaveClient) -> None:
     api_key = os.environ.get("OPENAI_API_KEY", "DUMMY_API_KEY")
 
@@ -644,9 +628,7 @@ def test_openai_tool_call(client: weave.trace.weave_client.WeaveClient) -> None:
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_openai_tool_call_async(
     client: weave.trace.weave_client.WeaveClient,
@@ -731,9 +713,7 @@ async def test_openai_tool_call_async(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_openai_tool_call_async_stream(
     client: weave.trace.weave_client.WeaveClient,
@@ -834,9 +814,7 @@ async def test_openai_tool_call_async_stream(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 def test_openai_as_context_manager(
     client: weave.trace.weave_client.WeaveClient,
 ) -> None:
@@ -886,9 +864,7 @@ def test_openai_as_context_manager(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_openai_as_context_manager_async(
     client: weave.trace.weave_client.WeaveClient,
@@ -943,7 +919,6 @@ async def test_openai_as_context_manager_async(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_openai_moderation_patching(
     client: weave.trace.weave_client.WeaveClient,
@@ -977,9 +952,7 @@ def test_openai_moderation_patching(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_openai_async_moderation_patching(
     client: weave.trace.weave_client.WeaveClient,
@@ -1015,7 +988,6 @@ async def test_openai_async_moderation_patching(
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_openai_embeddings_patching(
     client: weave.trace.weave_client.WeaveClient,
@@ -1049,9 +1021,7 @@ def test_openai_embeddings_patching(
 
 
 @pytest.mark.skip_clickhouse_client  # TODO:VCR recording does not seem to allow us to make requests to the clickhouse db in non-recording mode
-@pytest.mark.vcr(
-    filter_headers=["authorization"], allowed_hosts=["api.wandb.ai", "localhost"]
-)
+@pytest.mark.vcr(filter_headers=["authorization"])
 @pytest.mark.asyncio
 async def test_openai_async_embeddings_patching(
     client: weave.trace.weave_client.WeaveClient,
@@ -1090,7 +1060,6 @@ async def test_openai_async_embeddings_patching(
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_openai_responses_quickstart(client: WeaveClient) -> None:
     oai = OpenAI()
@@ -1133,7 +1102,6 @@ def test_openai_responses_quickstart(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_openai_responses_quickstart_stream(client: WeaveClient) -> None:
     oai = OpenAI()
@@ -1178,7 +1146,6 @@ def test_openai_responses_quickstart_stream(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_openai_responses_quickstart_async(client: WeaveClient) -> None:
@@ -1222,7 +1189,6 @@ async def test_openai_responses_quickstart_async(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_openai_responses_quickstart_async_stream(client: WeaveClient) -> None:
@@ -1269,7 +1235,6 @@ async def test_openai_responses_quickstart_async_stream(client: WeaveClient) -> 
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_openai_responses_tool_calling(client: WeaveClient) -> None:
     oai = OpenAI()
@@ -1324,7 +1289,6 @@ def test_openai_responses_tool_calling(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_openai_responses_tool_calling_stream(client: WeaveClient) -> None:
     oai = OpenAI()
@@ -1381,7 +1345,6 @@ def test_openai_responses_tool_calling_stream(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_openai_responses_tool_calling_async(client: WeaveClient) -> None:
@@ -1438,7 +1401,6 @@ async def test_openai_responses_tool_calling_async(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_openai_responses_tool_calling_async_stream(client: WeaveClient) -> None:

--- a/tests/integrations/openai_agents/openai_agents_otel_test.py
+++ b/tests/integrations/openai_agents/openai_agents_otel_test.py
@@ -131,7 +131,6 @@ def _by_name(spans: list[Any], prefix: str) -> list[Any]:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_openai_agents_quickstart_otel(
     client: WeaveClient, setup_tests, otel_spans: InMemorySpanExporter

--- a/tests/integrations/openai_agents/openai_agents_test.py
+++ b/tests/integrations/openai_agents/openai_agents_test.py
@@ -39,7 +39,6 @@ def setup_tests():
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 def test_openai_agents_quickstart(client: WeaveClient, setup_tests) -> None:
     agent = Agent(name="Assistant", instructions="You are a helpful assistant")
@@ -103,7 +102,6 @@ def test_openai_agents_quickstart(client: WeaveClient, setup_tests) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
 )
 @pytest.mark.asyncio
 async def test_openai_agents_quickstart_homework(

--- a/tests/integrations/smolagents/test_smolagents.py
+++ b/tests/integrations/smolagents/test_smolagents.py
@@ -44,7 +44,6 @@ def patch_smolagents() -> Generator[None, None, None]:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai", "huggingface.co"],
     match_on=["method", "scheme", "host", "port", "path", "query"],
 )
 def test_hf_api_model(client):
@@ -81,7 +80,6 @@ def test_hf_api_model(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai", "huggingface.co"],
     match_on=["method", "scheme", "host", "port", "path"],
 )
 def test_openai_server_model(client):
@@ -114,7 +112,6 @@ def test_openai_server_model(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai", "huggingface.co"],
     match_on=["method", "scheme", "host", "port", "path"],
 )
 def test_tool_calling_agent_search(client):
@@ -143,7 +140,6 @@ def test_tool_calling_agent_search(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai", "huggingface.co"],
     match_on=["method", "scheme", "host", "port", "path"],
 )
 def test_tool_calling_agent_weather(client):
@@ -181,7 +177,6 @@ def test_tool_calling_agent_weather(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai", "huggingface.co"],
     match_on=["method", "scheme", "host", "port", "path"],
 )
 def test_code_agent_search(client):
@@ -211,7 +206,6 @@ def test_code_agent_search(client):
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai", "huggingface.co"],
     match_on=["method", "scheme", "host", "port", "path"],
 )
 def test_code_agent_weather(client):

--- a/tests/integrations/verdict/verdict_test.py
+++ b/tests/integrations/verdict/verdict_test.py
@@ -20,7 +20,6 @@ def assert_ends_and_errors(calls: list[tuple[Call, int]]) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_simple_verdict_pipeline(client: WeaveClient) -> None:
@@ -69,7 +68,6 @@ def test_simple_verdict_pipeline(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_verdict_layer_tracing(client: WeaveClient) -> None:
@@ -119,7 +117,6 @@ def test_verdict_layer_tracing(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_verdict_custom_unit_tracing(client: WeaveClient) -> None:
@@ -170,7 +167,6 @@ def test_verdict_custom_unit_tracing(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_verdict_block_tracing(client: WeaveClient) -> None:
@@ -220,7 +216,6 @@ def test_verdict_block_tracing(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_verdict_dataset_execution_tracing(client: WeaveClient) -> None:
@@ -269,7 +264,6 @@ def test_verdict_dataset_execution_tracing(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_verdict_layer_configurations_tracing(client: WeaveClient) -> None:
@@ -317,7 +311,6 @@ def test_verdict_layer_configurations_tracing(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_verdict_complex_pipeline_tracing(client: WeaveClient) -> None:
@@ -370,7 +363,6 @@ def test_verdict_complex_pipeline_tracing(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_verdict_error_handling_tracing(client: WeaveClient) -> None:
@@ -424,7 +416,6 @@ def test_verdict_error_handling_tracing(client: WeaveClient) -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization", "x-api-key"],
-    allowed_hosts=["api.wandb.ai", "localhost", "trace.wandb.ai"],
     before_record_request=filter_body,
 )
 def test_verdict_tracer_inheritance(client: WeaveClient) -> None:

--- a/tests/integrations/verifiers/verifiers_test.py
+++ b/tests/integrations/verifiers/verifiers_test.py
@@ -30,7 +30,6 @@ def patch_verifiers() -> None:
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(
     filter_headers=["authorization"],
-    allowed_hosts=["api.wandb.ai", "localhost"],
     allow_playback_repeats=True,
 )
 def test_verifiers_environment_evaluate_with_mock_env(client: WeaveClient) -> None:


### PR DESCRIPTION
[WB-35389](https://coreweave.atlassian.net/browse/WB-35389)

## Summary
- `allowed_hosts=[...]` on `@pytest.mark.vcr(...)` is a no-op: pytest-recording only reads it for its `block_network` feature, never for cassette matching, so it's passed to `vcr.use_cassette()` and ignored. ClickHouse/wandb traffic was never actually passed through.
- It bit `verifiers_test` (9/9 fail on the nightly CH leg with `CannotOverwriteExistingCassetteException` on the `localhost:8123` clickhouse-connect request) and was latent in 21 other integration suites.
- Add a shared `vcr_config` fixture (`tests/integrations/conftest.py`) with the real passthrough (`ignore_localhost=True`, `ignore_hosts=["api.wandb.ai"]`) and remove the dead `allowed_hosts` from all 22 files. No cassette records a localhost/wandb request, so no replayed interaction changes.

## Testing
verified on a real clickhouse backend locally: `verifiers_test` `1 error` -> `1 passed`, and the full `openai` shard `27 passed` (no regression).


[WB-35389]: https://coreweave.atlassian.net/browse/WB-35389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ