### PR TITLE
fix(weave): raise NotImplementedError from calls_score

### DIFF
--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -1158,6 +1158,9 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
     def rescore(self, req: tsi.RescoreReq) -> tsi.RescoreRes:
         raise NotImplementedError("rescore is not implemented")
 
+    def calls_score(self, req: tsi.CallsScoreReq) -> tsi.CallsScoreRes:
+        raise NotImplementedError("calls_score is not implemented")
+
     # === V2 APIs ===
 
     @validate_call

--- a/weave/trace_server_bindings/stainless_remote_http_trace_server.py
+++ b/weave/trace_server_bindings/stainless_remote_http_trace_server.py
@@ -1301,6 +1301,21 @@ class StainlessRemoteHTTPTraceServer(TraceServerClientInterface):
         """
         raise NotImplementedError("evaluation_status is not implemented")
 
+    @validate_call
+    def calls_score(self, req: tsi.CallsScoreReq) -> tsi.CallsScoreRes:
+        """Score calls.
+
+        Args:
+            req: Calls score request.
+
+        Returns:
+            Calls score response.
+
+        Raises:
+            NotImplementedError: Not implemented.
+        """
+        raise NotImplementedError("calls_score is not implemented")
+
     # === Object APIs ===
 
     @validate_call


### PR DESCRIPTION
this was confusing my claude

## Summary
- `calls_score` was the only `TraceServerInterface` method not overridden in the HTTP client bindings, so calling `client.server.calls_score(...)` hit the interface `...` stub and silently returned `None` (no request, no error), masking real failures.
- Make `RemoteHTTPTraceServer` and `StainlessRemoteHTTPTraceServer` raise `NotImplementedError`, matching the existing `evaluate_model` / `rescore` / `evaluation_status` stubs.

## Testing
non-functional parity with the sibling not-implemented stubs.