### PR TITLE
feat(weave): formalize integration-tracking call attributes

### DIFF
--- a/tests/integrations/anthropic/anthropic_test.py
+++ b/tests/integrations/anthropic/anthropic_test.py
@@ -46,6 +46,11 @@ def test_anthropic(
     call = calls[0]
     assert call.exception is None
     assert call.ended_at is not None
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "anthropic"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "anthropic"
     output = call.output
     assert output.id == message.id
     assert output.model == message.model

--- a/tests/integrations/autogen/autogen_test.py
+++ b/tests/integrations/autogen/autogen_test.py
@@ -40,6 +40,15 @@ async def test_simple_client_create(
         [UserMessage(content="Hello, how are you?", source="user")]
     )
     calls = list(client.get_calls())
+    # Integration-tracking metadata is stamped on the integration's patched calls.
+    # AutoGen also drives openai sub-calls, which carry their own metadata, so
+    # filter to the autogen-stamped calls before asserting their shape.
+    stamped = [
+        c.attributes["integration"] for c in calls if "integration" in c.attributes
+    ]
+    autogen_meta = [i for i in stamped if i["name"] == "autogen"]
+    assert autogen_meta, "expected >=1 call to carry autogen metadata"
+    assert all(i["meta"]["package_name"] == "autogen-agentchat" for i in autogen_meta)
     assert len(calls) == 2
     flattened = flatten_calls(calls)
     assert len(flattened) == 3

--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -326,6 +326,12 @@ def test_bedrock_converse(
     assert call.exception is None
     assert call.ended_at is not None
 
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "bedrock"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "boto3"
+
     # Inspect the captured output if desired
     output = call.output
 

--- a/tests/integrations/cerebras/cerebras_test.py
+++ b/tests/integrations/cerebras/cerebras_test.py
@@ -39,6 +39,11 @@ def test_cerebras_sync(client: weave.trace.weave_client.WeaveClient) -> None:
 
     assert call.exception is None
     assert call.ended_at is not None
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "cerebras"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "cerebras-cloud-sdk"
     output = call.output
     assert output.choices[0].message.content.strip() == exp
     assert output.choices[0].finish_reason == "stop"

--- a/tests/integrations/cohere/cohere_test.py
+++ b/tests/integrations/cohere/cohere_test.py
@@ -46,6 +46,11 @@ def test_cohere(
     assert call.exception is None
     assert call.ended_at is not None
     assert call.started_at < call.ended_at
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "cohere"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "cohere"
     assert op_name_from_ref(call.op_name) == "cohere.Client.chat"
     output = call.output
     assert output.text == exp

--- a/tests/integrations/crewai/crewai_test.py
+++ b/tests/integrations/crewai/crewai_test.py
@@ -140,6 +140,18 @@ def test_crewai_simple_crew(client: WeaveClient) -> None:
     calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
     flattened_calls = flatten_calls(calls)
 
+    # Integration-tracking metadata is stamped on the integration's patched calls.
+    # The crew also drives litellm/openai sub-calls, which carry their own metadata,
+    # so filter to the crewai-stamped calls before asserting their shape.
+    stamped = [
+        c.attributes["integration"]
+        for c, _ in flattened_calls
+        if "integration" in c.attributes
+    ]
+    crewai_meta = [i for i in stamped if i["name"] == "crewai"]
+    assert crewai_meta, "expected >=1 call to carry crewai metadata"
+    assert all(i["meta"]["package_name"] == "crewai" for i in crewai_meta)
+
     assert len(flattened_calls) == 6
 
     assert flattened_calls_to_names(flattened_calls) == [

--- a/tests/integrations/dspy/dspy_test.py
+++ b/tests/integrations/dspy/dspy_test.py
@@ -105,6 +105,16 @@ def test_dspy_language_models(client: WeaveClient) -> None:
     calls = list(client.get_calls())
     assert len(calls) == 4
 
+    # Integration-tracking metadata is stamped on the integration's patched calls.
+    # dspy also drives litellm/openai sub-calls, which carry their own metadata,
+    # so filter to the dspy-stamped calls before asserting their shape.
+    stamped = [
+        c.attributes["integration"] for c in calls if "integration" in c.attributes
+    ]
+    dspy_meta = [i for i in stamped if i["name"] == "dspy"]
+    assert dspy_meta, "expected >=1 call to carry dspy metadata"
+    assert all(i["meta"]["package_name"] == "dspy" for i in dspy_meta)
+
     call = calls[0]
     assert call.started_at < call.ended_at
     assert op_name_from_ref(call.op_name) == "dspy.LM"

--- a/tests/integrations/fastmcp/fastmcp_test.py
+++ b/tests/integrations/fastmcp/fastmcp_test.py
@@ -124,6 +124,13 @@ def test_fastmcp_client(client: WeaveClient) -> None:
     main()
 
     calls = list(client.get_calls(filter=CallsFilter(trace_roots_only=True)))
+    # Integration-tracking metadata is stamped on the integration's patched calls.
+    stamped = [
+        c.attributes["integration"] for c in calls if "integration" in c.attributes
+    ]
+    fastmcp_meta = [i for i in stamped if i["name"] == "fastmcp"]
+    assert fastmcp_meta, "expected >=1 call to carry fastmcp metadata"
+    assert all(i["meta"]["package_name"] == "fastmcp" for i in fastmcp_meta)
     assert len(calls) == 3
 
     flattened_calls = flatten_calls(calls)

--- a/tests/integrations/gepa/gepa_test.py
+++ b/tests/integrations/gepa/gepa_test.py
@@ -223,6 +223,13 @@ def test_gepa_optimize_does_not_double_inject_callback(client: WeaveClient) -> N
     )
     # Still emits traces even with a user-supplied callback.
     calls = list(client.get_calls())
+    # Integration-tracking metadata is stamped on the integration's patched calls.
+    stamped = [
+        c.attributes["integration"] for c in calls if "integration" in c.attributes
+    ]
+    gepa_meta = [i for i in stamped if i["name"] == "gepa"]
+    assert gepa_meta, "expected >=1 call to carry gepa metadata"
+    assert all(i["meta"]["package_name"] == "gepa" for i in gepa_meta)
     assert calls, "expected at least the top-level gepa.optimize call"
 
 

--- a/tests/integrations/google_genai/test_google_genai.py
+++ b/tests/integrations/google_genai/test_google_genai.py
@@ -49,6 +49,11 @@ def test_content_generation_sync(client):
 
     call = next(iter(client.get_calls()))
     assert call.started_at < call.ended_at
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "google_genai"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "google-genai"
     trace_name = op_name_from_ref(call.op_name)
     assert trace_name == "google.genai.models.Models.generate_content"
     assert call.output is not None

--- a/tests/integrations/groq/groq_test.py
+++ b/tests/integrations/groq/groq_test.py
@@ -59,6 +59,11 @@ def test_groq_quickstart(
     call = calls[0]
     assert call.exception is None
     assert call.ended_at is not None
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "groq"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "groq"
     output = call.output
     assert output.id == chat_completion.id
     assert output.model == chat_completion.model

--- a/tests/integrations/huggingface/test_huggingface_inference_client.py
+++ b/tests/integrations/huggingface/test_huggingface_inference_client.py
@@ -29,6 +29,11 @@ def test_huggingface_chat_completion(client):
 
     call = calls[0]
     assert call.started_at < call.ended_at
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "huggingface"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "huggingface-hub"
     assert (
         op_name_from_ref(call.op_name)
         == "huggingface_hub.InferenceClient.chat_completion"
@@ -69,6 +74,11 @@ def test_huggingface_chat_completion_stream(client):
 
     call = calls[0]
     assert call.started_at < call.ended_at
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "huggingface"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "huggingface-hub"
     assert (
         op_name_from_ref(call.op_name)
         == "huggingface_hub.InferenceClient.chat_completion"

--- a/tests/integrations/instructor/instructor_test.py
+++ b/tests/integrations/instructor/instructor_test.py
@@ -69,6 +69,11 @@ def test_instructor_openai(
     call = calls[0]
     assert call.started_at < call.ended_at
     assert op_name_from_ref(call.op_name) == "Instructor.create"
+    # Integration-tracking metadata is stamped on the integration's patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "instructor"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "instructor"
     output = call.output
     assert output.person_name == "John"
     assert output.age == 20

--- a/tests/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints_test.py
+++ b/tests/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints_test.py
@@ -28,6 +28,18 @@ def test_chatnvidia_quickstart(client: weave.trace.weave_client.WeaveClient) -> 
     assert len(calls) == 2
     call = calls[1]
 
+    # Integration-tracking metadata is stamped on the integration's patched calls.
+    # The langchain integration also logs a call, which carries its own metadata,
+    # so filter to the nvidia-stamped calls before asserting their shape.
+    stamped = [
+        c.attributes["integration"] for c in calls if "integration" in c.attributes
+    ]
+    nvidia = [i for i in stamped if i["name"] == "langchain_nvidia_ai_endpoints"]
+    assert nvidia, "expected >=1 call to carry langchain_nvidia_ai_endpoints metadata"
+    assert all(
+        i["meta"]["package_name"] == "langchain-nvidia-ai-endpoints" for i in nvidia
+    )
+
     assert response.content is not None
 
     assert (

--- a/tests/integrations/litellm/litellm_test.py
+++ b/tests/integrations/litellm/litellm_test.py
@@ -73,6 +73,11 @@ def test_litellm_quickstart(
     call = calls[0]
     assert call.exception is None
     assert call.ended_at is not None
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "litellm"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "litellm"
     output = call.output
     assert output["choices"][0]["message"]["content"] == exp
     assert output["choices"][0]["finish_reason"] == "stop"
@@ -113,6 +118,11 @@ async def test_litellm_quickstart_async(
     call = calls[0]
     assert call.exception is None
     assert call.ended_at is not None
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "litellm"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "litellm"
     output = call.output
     assert output["choices"][0]["message"]["content"] == exp
     assert output["choices"][0]["finish_reason"] == "stop"

--- a/tests/integrations/mistral/mistral_test.py
+++ b/tests/integrations/mistral/mistral_test.py
@@ -62,6 +62,11 @@ Each of these cheeses has its unique characteristics, so the "best" one depends 
     call = calls[0]
 
     assert call.exception is None
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "mistral"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "mistralai"
     assert call.ended_at is not None
     output = call.output
     assert output.choices[0].message.content == exp

--- a/tests/integrations/notdiamond/custom_router_test.py
+++ b/tests/integrations/notdiamond/custom_router_test.py
@@ -65,6 +65,15 @@ def preference_id():
         return None
 
 
+def test_custom_router_ops_carry_integration_metadata() -> None:
+    """The module-level train/evaluate ops expose integration provenance on `.attributes`."""
+    for fn in (train_router, evaluate_router):
+        integration = fn.attributes["integration"]
+        assert integration["name"] == "notdiamond"
+        assert integration["version"]  # weave SDK version
+        assert integration["meta"]["package_name"] == "notdiamond"
+
+
 @pytest.mark.skip_clickhouse_client
 @pytest.mark.vcr(filter_headers=["authorization"], decode_compressed_response=True)
 @pytest.mark.skipif(

--- a/tests/integrations/notdiamond/tracing_test.py
+++ b/tests/integrations/notdiamond/tracing_test.py
@@ -42,6 +42,13 @@ def test_notdiamond_quickstart(
         hash_content=False,
     )
     calls = list(client.get_calls(filter=tsi.CallsFilter(trace_roots_only=True)))
+    # Integration-tracking metadata is stamped on the integration's patched calls.
+    stamped = [
+        c.attributes["integration"] for c in calls if "integration" in c.attributes
+    ]
+    notdiamond_meta = [i for i in stamped if i["name"] == "notdiamond"]
+    assert notdiamond_meta, "expected >=1 call to carry notdiamond metadata"
+    assert all(i["meta"]["package_name"] == "notdiamond" for i in notdiamond_meta)
     flattened_calls = flattened_calls_to_names(flatten_calls(calls))
     assert len([call for call in flattened_calls if "select_model" in call[0]]) == 1
 

--- a/tests/integrations/openai/openai_test.py
+++ b/tests/integrations/openai/openai_test.py
@@ -128,6 +128,12 @@ async def test_openai_async_quickstart(
     assert call.started_at is not None
     assert call.started_at < call.ended_at  # type: ignore
 
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "openai"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "openai"
+
     output = call.output
     assert output["model"] == "gpt-4o-2024-05-13"
     assert output["object"] == "chat.completion"

--- a/tests/integrations/smolagents/test_smolagents.py
+++ b/tests/integrations/smolagents/test_smolagents.py
@@ -60,8 +60,21 @@ def test_hf_api_model(client):
     response = engine(messages, stop_sequences=["END"])
     assert "paris" in response.content.lower()
 
-    calls = client.get_calls()
+    # Materialize the lazy CallsIter up front: iterating it for the metadata
+    # check below otherwise changes how calls[0].output later deserializes
+    # (object -> WeaveDict), which breaks the `.content` assertion.
+    calls = list(client.get_calls())
     assert len(calls) == 2
+
+    # Integration-tracking metadata is stamped on the integration's patched calls.
+    # The model also drives a huggingface_hub sub-call, which carries its own
+    # metadata, so filter to the smolagents-stamped calls before asserting shape.
+    stamped = [
+        c.attributes["integration"] for c in calls if "integration" in c.attributes
+    ]
+    smolagents_meta = [i for i in stamped if i["name"] == "smolagents"]
+    assert smolagents_meta, "expected >=1 call to carry smolagents metadata"
+    assert all(i["meta"]["package_name"] == "smolagents" for i in smolagents_meta)
 
     call = calls[0]
     assert call.started_at < call.ended_at

--- a/tests/integrations/verifiers/verifiers_test.py
+++ b/tests/integrations/verifiers/verifiers_test.py
@@ -113,6 +113,13 @@ def test_verifiers_environment_evaluate_with_mock_env(client: WeaveClient) -> No
 
     # Validate that the expected weave ops were traced
     calls = list(client.get_calls())
+    # Integration-tracking metadata is stamped on the integration's patched calls.
+    stamped = [
+        c.attributes["integration"] for c in calls if "integration" in c.attributes
+    ]
+    verifiers_meta = [i for i in stamped if i["name"] == "verifiers"]
+    assert verifiers_meta, "expected >=1 call to carry verifiers metadata"
+    assert all(i["meta"]["package_name"] == "verifiers" for i in verifiers_meta)
     flattened = flatten_calls(calls)
     assert len(flattened) == 43
 

--- a/tests/integrations/vertexai/vertexai_test.py
+++ b/tests/integrations/vertexai/vertexai_test.py
@@ -21,6 +21,11 @@ def test_content_generation(client):
 
     call = calls[0]
     assert call.started_at < call.ended_at
+    # Integration-tracking metadata is stamped on every patched call.
+    integration = call.attributes["integration"]
+    assert integration["name"] == "vertexai"
+    assert integration["version"]  # weave SDK version
+    assert integration["meta"]["package_name"] == "google-cloud-aiplatform"
 
     trace_name = op_name_from_ref(call.op_name)
     assert trace_name == "vertexai.GenerativeModel.generate_content"

--- a/tests/trace/test_integration_metadata.py
+++ b/tests/trace/test_integration_metadata.py
@@ -1,0 +1,252 @@
+"""Tests for op-level default attributes and formalized integration metadata.
+
+The mechanism: `op(attributes=...)` (and `OpSettings.attributes`) stamps default
+attributes onto every call an op creates, at the lowest precedence. Integrations
+use `IntegrationMetadata` to render an `attributes["integration"]` provenance
+block and `with_integration_metadata` to thread it through `OpSettings`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import weave
+from weave.integrations.integration_metadata import (
+    INTEGRATION_ATTRIBUTE_KEY,
+    IntegrationMetadata,
+    apply_integration_metadata,
+    library_integration,
+    resolve_package_version,
+    with_integration_metadata,
+)
+from weave.trace.autopatch import OpSettings
+from weave.version import VERSION as WEAVE_VERSION
+
+
+def _only_call(client):
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    return calls[0]
+
+
+# --- IntegrationMetadata model -------------------------------------------------
+
+
+def test_as_attributes_shape():
+    meta = IntegrationMetadata(name="openai", version="1.2.3", meta={"k": "v"})
+    assert meta.as_attributes() == {
+        "integration": {"name": "openai", "version": "1.2.3", "meta": {"k": "v"}}
+    }
+
+
+def test_version_defaults_to_weave_sdk_version():
+    assert IntegrationMetadata(name="openai").version == WEAVE_VERSION
+
+
+def test_as_otel_attributes_flattens_to_dotted_keys():
+    meta = IntegrationMetadata(
+        name="openai_agents",
+        version="1.2.3",
+        meta={"package_name": "openai-agents", "package_version": "0.1.0"},
+    )
+    assert meta.as_otel_attributes() == {
+        "integration.name": "openai_agents",
+        "integration.version": "1.2.3",
+        "integration.meta.package_name": "openai-agents",
+        "integration.meta.package_version": "0.1.0",
+    }
+
+
+def test_as_otel_attributes_stringifies_non_scalar_meta():
+    meta = IntegrationMetadata(name="demo", version="1", meta={"opts": {"a": 1}})
+    otel = meta.as_otel_attributes()
+    # Nested values are not OTel-legal scalars, so they are stringified.
+    assert otel["integration.meta.opts"] == "{'a': 1}"
+
+
+def test_as_attributes_returns_fresh_copies():
+    meta = IntegrationMetadata(name="openai", meta={"k": "v"})
+    first = meta.as_attributes()
+    first["integration"]["meta"]["k"] = "mutated"
+    # Mutating the returned dict must not leak back into the instance.
+    assert meta.as_attributes()["integration"]["meta"] == {"k": "v"}
+
+
+def test_library_integration_records_package_version():
+    # `weave` is always installed in the test environment. Note the resolved
+    # package version is PEP 440-normalized (e.g. "0.52.43.dev0"), which may
+    # differ in punctuation from the declared VERSION ("0.52.43-dev0").
+    meta = library_integration("weave-self-test", distribution_name="weave")
+    assert meta.name == "weave-self-test"
+    assert meta.version == WEAVE_VERSION
+    assert meta.meta["package_name"] == "weave"
+    assert isinstance(meta.meta["package_version"], str)
+    assert meta.meta["package_version"]
+
+
+def test_library_integration_missing_package_omits_version():
+    meta = library_integration(
+        "ghost", distribution_name="definitely-not-installed-xyz"
+    )
+    assert meta.meta == {"package_name": "definitely-not-installed-xyz"}
+
+
+def test_library_integration_extra_meta():
+    meta = library_integration(
+        "weave-self-test", distribution_name="weave", flavor="async"
+    )
+    assert meta.meta["flavor"] == "async"
+
+
+def test_resolve_package_version_unknown_returns_none():
+    assert resolve_package_version("definitely-not-installed-xyz") is None
+
+
+def test_with_integration_metadata_is_nonmutating_and_preserved_through_copy():
+    base = OpSettings(name="base")
+    out = with_integration_metadata(base, IntegrationMetadata(name="openai"))
+
+    # Original settings untouched.
+    assert base.attributes is None
+    # Returned settings carry the integration block.
+    assert out.attributes[INTEGRATION_ATTRIBUTE_KEY]["name"] == "openai"
+
+    # Derived settings (the real-world pattern) keep the integration block.
+    derived = out.model_copy(update={"name": "derived", "kind": "llm"})
+    assert derived.attributes[INTEGRATION_ATTRIBUTE_KEY]["name"] == "openai"
+
+
+def test_with_integration_metadata_preserves_existing_attributes():
+    base = OpSettings(name="base", attributes={"team": "search"})
+    out = with_integration_metadata(base, IntegrationMetadata(name="openai"))
+    assert out.attributes["team"] == "search"
+    assert out.attributes[INTEGRATION_ATTRIBUTE_KEY]["name"] == "openai"
+
+
+# --- op-level default attributes (end to end) ---------------------------------
+
+
+def test_op_level_attributes_land_on_call(client):
+    @weave.op(attributes={"integration": {"name": "demo"}})
+    def func():
+        return 1
+
+    func()
+    call = _only_call(client)
+    assert call.attributes["integration"] == {"name": "demo"}
+
+
+def test_op_level_attributes_coexist_with_context(client):
+    @weave.op(attributes={"integration": {"name": "demo"}})
+    def func():
+        return 1
+
+    with weave.attributes({"env": "prod"}):
+        func()
+
+    call = _only_call(client)
+    assert call.attributes["integration"] == {"name": "demo"}
+    assert call.attributes["env"] == "prod"
+
+
+def test_context_attributes_override_op_level_on_collision(client):
+    @weave.op(attributes={"integration": {"name": "demo"}})
+    def func():
+        return 1
+
+    with weave.attributes({"integration": "user-override"}):
+        func()
+
+    # Op-level defaults are the lowest precedence: the user context wins.
+    call = _only_call(client)
+    assert call.attributes["integration"] == "user-override"
+
+
+def test_op_level_attributes_do_not_clobber_weave_subdict(client):
+    @weave.op(kind="llm", attributes={"integration": {"name": "demo"}})
+    def func():
+        return 1
+
+    func()
+    call = _only_call(client)
+    assert call.attributes["integration"] == {"name": "demo"}
+    # The reserved weave subdict (kind) must survive alongside op attributes.
+    assert call.attributes["weave"]["kind"] == "llm"
+
+
+def test_op_rejects_reserved_weave_key():
+    with pytest.raises(ValueError, match="reserved 'weave' key"):
+
+        @weave.op(attributes={"weave": {"kind": "llm"}})
+        def func():
+            return 1
+
+
+def test_op_without_attributes_has_no_integration_key(client):
+    @weave.op
+    def func():
+        return 1
+
+    func()
+    call = _only_call(client)
+    assert "integration" not in call.attributes
+
+
+@pytest.mark.asyncio
+async def test_op_level_attributes_on_async_call(client):
+    @weave.op(attributes={"integration": {"name": "demo"}})
+    async def afunc():
+        return 1
+
+    await afunc()
+    call = _only_call(client)
+    assert call.attributes["integration"] == {"name": "demo"}
+
+
+def test_op_level_attributes_on_sync_generator(client):
+    @weave.op(attributes={"integration": {"name": "demo"}})
+    def gen():
+        yield 1
+        yield 2
+
+    list(gen())
+    call = _only_call(client)
+    assert call.attributes["integration"] == {"name": "demo"}
+
+
+@pytest.mark.asyncio
+async def test_op_level_attributes_on_async_generator(client):
+    @weave.op(attributes={"integration": {"name": "demo"}})
+    async def agen():
+        yield 1
+        yield 2
+
+    [x async for x in agen()]
+    call = _only_call(client)
+    assert call.attributes["integration"] == {"name": "demo"}
+
+
+# --- callback/tracer path (Family B: direct create_call) ----------------------
+
+
+def test_create_call_carries_integration_attributes(client):
+    """Integrations that build attributes directly still land integration data."""
+    attrs = {"trace_id": "t1"}
+    apply_integration_metadata(
+        attrs, library_integration("demo", distribution_name="weave")
+    )
+
+    call = client.create_call("demo.op", inputs={}, attributes=attrs)
+    client.finish_call(call)
+
+    fetched = _only_call(client)
+    assert fetched.attributes["integration"]["name"] == "demo"
+    assert fetched.attributes["integration"]["meta"]["package_name"] == "weave"
+    assert fetched.attributes["trace_id"] == "t1"
+
+
+def test_apply_integration_metadata_preserves_existing_integration():
+    attrs = {"integration": "user-set"}
+    apply_integration_metadata(attrs, IntegrationMetadata(name="demo"))
+    # setdefault semantics: an existing integration value is not overwritten.
+    assert attrs["integration"] == "user-set"

--- a/weave/integrations/README.md
+++ b/weave/integrations/README.md
@@ -159,10 +159,19 @@ When developing a new integration, it will automatically work with both implicit
    import importlib
 
    import weave
+   from weave.integrations.integration_metadata import (
+       library_integration,
+       with_integration_metadata,
+   )
    from weave.integrations.patcher import SymbolPatcher, MultiPatcher, NoOpPatcher
    from weave.trace.autopatch import IntegrationSettings
 
    _<vendor>_patcher: MultiPatcher | None = None
+
+   # Integration-tracking provenance stamped onto every call this integration
+   # produces, under `attributes["integration"]`. Pass `distribution_name=` when
+   # the PyPI package name differs from the integration name.
+   <VENDOR>_INTEGRATION = library_integration("<vendor>")
 
    def get_<vendor>_patcher(
        settings: IntegrationSettings | None = None,
@@ -177,7 +186,9 @@ When developing a new integration, it will automatically work with both implicit
        if _<vendor>_patcher is not None:
            return _<vendor>_patcher
 
-       base = settings.op_settings
+       # Thread integration metadata through the base op settings; every op
+       # derived from `base` via `model_copy` inherits it automatically.
+       base = with_integration_metadata(settings.op_settings, <VENDOR>_INTEGRATION)
        # Configure settings for the operation
        op_settings = base.model_copy(
            update={"name": base.name or "<vendor>.operation_name"}

--- a/weave/integrations/anthropic/anthropic_sdk.py
+++ b/weave/integrations/anthropic/anthropic_sdk.py
@@ -22,6 +22,10 @@ from anthropic.types.beta import (
 )
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.integration_utilities import should_use_accumulator
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
@@ -31,6 +35,8 @@ if TYPE_CHECKING:
     from anthropic.lib.streaming import MessageStream
 
 _anthropic_patcher: MultiPatcher | None = None
+
+ANTHROPIC_INTEGRATION = library_integration("anthropic")
 
 
 def anthropic_accumulator(
@@ -233,7 +239,7 @@ def get_anthropic_patcher(
     if _anthropic_patcher is not None:
         return _anthropic_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, ANTHROPIC_INTEGRATION)
 
     messages_create_settings = base.model_copy(
         update={

--- a/weave/integrations/autogen/autogen_sdk.py
+++ b/weave/integrations/autogen/autogen_sdk.py
@@ -11,6 +11,10 @@ from typing import Any, TypeVar
 
 import weave
 from weave.integrations.autogen.config import get_module_patch_configs
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import (
     MultiPatcher,
     NoOpPatcher,
@@ -24,6 +28,9 @@ from weave.trace.op_protocol import Op, OpKind, ProcessedInputs
 logger = logging.getLogger(__name__)
 
 _autogen_patcher: MultiPatcher | None = None
+AUTOGEN_INTEGRATION = library_integration(
+    "autogen", distribution_name="autogen-agentchat"
+)
 
 
 T = TypeVar("T")
@@ -596,7 +603,9 @@ def get_autogen_patcher(
         # Preload autogen-ext modules to ensure subclasses are properly discovered
         _preload_autogen_extensions()
 
-        base_settings = settings.op_settings
+        base_settings = with_integration_metadata(
+            settings.op_settings, AUTOGEN_INTEGRATION
+        )
         op_patch_settings = base_settings.model_copy(
             update={"name": base_settings.name or "autogen.component"}
         )

--- a/weave/integrations/bedrock/bedrock_sdk.py
+++ b/weave/integrations/bedrock/bedrock_sdk.py
@@ -9,11 +9,15 @@ from typing import TYPE_CHECKING, Any
 import boto3
 
 import weave
+from weave.integrations.integration_metadata import library_integration
 from weave.trace.call import Call
 from weave.trace.op import _add_accumulator, _IteratorWrapper
 
 if TYPE_CHECKING:
     from botocore.client import BaseClient
+
+# Bedrock is accessed through the AWS SDK (boto3); track its version in meta.
+BEDROCK_INTEGRATION = library_integration("bedrock", distribution_name="boto3")
 
 
 def bedrock_on_finish_converse(
@@ -298,6 +302,7 @@ def _patch_converse(bedrock_client: "BaseClient") -> None:
         name="BedrockRuntime.converse",
         postprocess_inputs=postprocess_inputs_converse,
         kind="llm",
+        attributes=BEDROCK_INTEGRATION.as_attributes(),
     )
     op._set_on_finish_handler(bedrock_on_finish_converse)
     bedrock_client.converse = op
@@ -310,6 +315,7 @@ def _patch_invoke(bedrock_client: "BaseClient") -> None:
         postprocess_inputs=postprocess_inputs_invoke,
         postprocess_output=postprocess_output_invoke,
         kind="llm",
+        attributes=BEDROCK_INTEGRATION.as_attributes(),
     )
     op._set_on_finish_handler(bedrock_on_finish_invoke)
     bedrock_client.invoke_model = op
@@ -320,6 +326,7 @@ def _patch_apply_guardrail(bedrock_client: "BaseClient") -> None:
         bedrock_client.apply_guardrail,
         name="BedrockRuntime.apply_guardrail",
         postprocess_inputs=postprocess_inputs_apply_guardrail,
+        attributes=BEDROCK_INTEGRATION.as_attributes(),
     )
     bedrock_client.apply_guardrail = op
 
@@ -331,6 +338,7 @@ def _patch_invoke_agent(bedrock_agent_client: "BaseClient") -> None:
         name="BedrockAgentRuntime.invoke_agent",
         postprocess_inputs=postprocess_inputs_invoke_agent,
         postprocess_output=postprocess_output_invoke_agent,
+        attributes=BEDROCK_INTEGRATION.as_attributes(),
     )
     op._set_on_finish_handler(bedrock_agent_on_finish_invoke_agent)
     bedrock_agent_client.invoke_agent = op
@@ -383,7 +391,11 @@ def create_stream_wrapper(
     name: str,
 ) -> Callable[[Callable], Callable]:
     def wrapper(fn: Callable) -> Callable:
-        op = weave.op(postprocess_inputs=postprocess_inputs_converse, kind="llm")(fn)
+        op = weave.op(
+            postprocess_inputs=postprocess_inputs_converse,
+            kind="llm",
+            attributes=BEDROCK_INTEGRATION.as_attributes(),
+        )(fn)
         op.name = name  # type: ignore
         op._set_on_finish_handler(bedrock_on_finish_converse)
 

--- a/weave/integrations/cerebras/cerebras_sdk.py
+++ b/weave/integrations/cerebras/cerebras_sdk.py
@@ -6,10 +6,17 @@ from functools import wraps
 from typing import Any
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 
 _cerebras_patcher: MultiPatcher | None = None
+CEREBRAS_INTEGRATION = library_integration(
+    "cerebras", distribution_name="cerebras-cloud-sdk"
+)
 
 
 def create_wrapper_sync(settings: OpSettings) -> Callable[[Callable], Callable]:
@@ -50,7 +57,7 @@ def get_cerebras_patcher(
     if _cerebras_patcher is not None:
         return _cerebras_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, CEREBRAS_INTEGRATION)
 
     create_settings = base.model_copy(
         update={

--- a/weave/integrations/cohere/cohere_sdk.py
+++ b/weave/integrations/cohere/cohere_sdk.py
@@ -14,6 +14,10 @@ from cohere.types.usage import Usage
 from cohere.v2.types.v2chat_response import V2ChatResponse
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import _add_accumulator
@@ -23,6 +27,8 @@ if TYPE_CHECKING:
 
 
 _cohere_patcher: MultiPatcher | None = None
+
+COHERE_INTEGRATION = library_integration("cohere")
 
 
 def cohere_accumulator(acc: dict | None, value: Any) -> NonStreamedChatResponse:
@@ -209,7 +215,7 @@ def get_cohere_patcher(
     if _cohere_patcher is not None:
         return _cohere_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, COHERE_INTEGRATION)
 
     chat_settings = base.model_copy(
         update={

--- a/weave/integrations/crewai/crewai_sdk.py
+++ b/weave/integrations/crewai/crewai_sdk.py
@@ -24,11 +24,16 @@ from weave.integrations.crewai.crewai_utils import (
     default_call_display_name_execute_sync,
     default_call_display_name_execute_task,
 )
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.serialization.serialize import dictify
 
 _crewai_patcher: MultiPatcher | None = None
+CREWAI_INTEGRATION = library_integration("crewai")
 
 
 def crewai_wrapper(settings: OpSettings) -> Callable:
@@ -86,7 +91,7 @@ def get_crewai_patcher(
     if _crewai_patcher is not None:
         return _crewai_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, CREWAI_INTEGRATION)
 
     # Create settings for different Crew methods
     crew_methods = [

--- a/weave/integrations/dspy/dspy_sdk.py
+++ b/weave/integrations/dspy/dspy_sdk.py
@@ -10,6 +10,10 @@ from pydantic import BaseModel
 
 from weave.evaluation.eval_imperative import EvaluationLogger
 from weave.integrations.dspy.dspy_utils import dictify, get_symbol_patcher
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, Patcher
 from weave.trace.autopatch import IntegrationSettings
 from weave.trace.context import call_context
@@ -17,6 +21,7 @@ from weave.trace.context import call_context
 logger = logging.getLogger(__name__)
 
 _dspy_patcher: MultiPatcher | None = None
+DSPY_INTEGRATION = library_integration("dspy")
 _evaluate_patched = False
 
 
@@ -240,7 +245,7 @@ def get_dspy_patcher(
     if _dspy_patcher is not None:
         return _dspy_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, DSPY_INTEGRATION)
 
     _dspy_patcher = DSPyPatcher(
         [

--- a/weave/integrations/fastmcp/fastmcp_client.py
+++ b/weave/integrations/fastmcp/fastmcp_client.py
@@ -8,10 +8,15 @@ from typing import Any
 from pydantic import AnyUrl
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 
 _fastmcp_client_patcher: MultiPatcher | None = None
+FASTMCP_INTEGRATION = library_integration("fastmcp")
 
 
 def fastmcp_client_wrapper(settings: OpSettings) -> Callable:
@@ -131,7 +136,7 @@ def get_fastmcp_client_patcher(
     if _fastmcp_client_patcher is not None:
         return _fastmcp_client_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, FASTMCP_INTEGRATION)
 
     # Settings for core client methods
     call_tool_settings = base.model_copy(

--- a/weave/integrations/fastmcp/fastmcp_server.py
+++ b/weave/integrations/fastmcp/fastmcp_server.py
@@ -6,10 +6,15 @@ from collections.abc import Callable
 from typing import Any
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 
 _fastmcp_server_patcher: MultiPatcher | None = None
+FASTMCP_INTEGRATION = library_integration("fastmcp")
 
 
 def fastmcp_server_wrapper(settings: OpSettings) -> Callable:
@@ -73,7 +78,7 @@ def get_fastmcp_server_patcher(
     if _fastmcp_server_patcher is not None:
         return _fastmcp_server_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, FASTMCP_INTEGRATION)
 
     # Settings for core methods
     call_tool_settings = base.model_copy(

--- a/weave/integrations/gepa/gepa_sdk.py
+++ b/weave/integrations/gepa/gepa_sdk.py
@@ -8,10 +8,15 @@ from typing import Any
 
 import weave
 from weave.integrations.gepa.gepa_callback import WeaveGEPACallback
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 
 _gepa_patcher: MultiPatcher | None = None
+GEPA_INTEGRATION = library_integration("gepa")
 
 
 def _fn_accepts_callbacks(fn: Callable) -> bool:
@@ -133,7 +138,7 @@ def get_gepa_patcher(
     if _gepa_patcher is not None:
         return _gepa_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, GEPA_INTEGRATION)
     optimize_settings = base.model_copy(update={"name": base.name or "gepa.optimize"})
     optimize_anything_settings = base.model_copy(
         update={"name": base.name or "gepa.optimize_anything"}

--- a/weave/integrations/google_genai/google_genai_sdk.py
+++ b/weave/integrations/google_genai/google_genai_sdk.py
@@ -9,8 +9,16 @@ from weave.integrations.google_genai.imagen_utils import (
     google_genai_imagen_wrapper_async,
     google_genai_imagen_wrapper_sync,
 )
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
+
+GOOGLE_GENAI_INTEGRATION = library_integration(
+    "google_genai", distribution_name="google-genai"
+)
 
 
 def get_google_genai_symbol_patcher(
@@ -45,7 +53,7 @@ def get_google_genai_patcher(
     if not settings.enabled:
         return NoOpPatcher()
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, GOOGLE_GENAI_INTEGRATION)
 
     google_genai_patcher = MultiPatcher(
         [

--- a/weave/integrations/groq/groq_sdk.py
+++ b/weave/integrations/groq/groq_sdk.py
@@ -10,6 +10,10 @@ from groq.types.chat.chat_completion_chunk import Choice as ChoiceChunk
 from groq.types.completion_usage import CompletionUsage
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.integration_utilities import should_use_accumulator
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
@@ -20,6 +24,8 @@ if TYPE_CHECKING:
 
 
 _groq_patcher: MultiPatcher | None = None
+
+GROQ_INTEGRATION = library_integration("groq")
 
 
 def groq_accumulator(
@@ -113,7 +119,7 @@ def get_groq_patcher(
     if _groq_patcher is not None:
         return _groq_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, GROQ_INTEGRATION)
 
     chat_completions_settings = base.model_copy(
         update={

--- a/weave/integrations/huggingface/huggingface_inference_client_sdk.py
+++ b/weave/integrations/huggingface/huggingface_inference_client_sdk.py
@@ -4,6 +4,10 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import _add_accumulator
@@ -16,6 +20,9 @@ if TYPE_CHECKING:
     )
 
 _huggingface_patcher: MultiPatcher | None = None
+HUGGINGFACE_INTEGRATION = library_integration(
+    "huggingface", distribution_name="huggingface-hub"
+)
 
 
 def huggingface_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
@@ -129,7 +136,7 @@ def get_huggingface_patcher(
     if _huggingface_patcher is not None:
         return _huggingface_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, HUGGINGFACE_INTEGRATION)
     patchers = []
 
     chat_completion_settings = base.model_copy(

--- a/weave/integrations/instructor/instructor_sdk.py
+++ b/weave/integrations/instructor/instructor_sdk.py
@@ -9,10 +9,15 @@ from weave.integrations.instructor.instructor_iterable_utils import (
 from weave.integrations.instructor.instructor_partial_utils import (
     instructor_wrapper_partial,
 )
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings
 
 _instructor_patcher: MultiPatcher | None = None
+INSTRUCTOR_INTEGRATION = library_integration("instructor")
 
 
 def get_instructor_patcher(
@@ -28,7 +33,7 @@ def get_instructor_patcher(
     if _instructor_patcher is not None:
         return _instructor_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, INSTRUCTOR_INTEGRATION)
 
     create_settings = base.model_copy(
         update={

--- a/weave/integrations/integration_metadata.py
+++ b/weave/integrations/integration_metadata.py
@@ -1,0 +1,181 @@
+"""Formalized integration-tracking metadata for Weave calls.
+
+:class:`IntegrationMetadata` is the typed builder for a call's
+``attributes[INTEGRATION_ATTRIBUTE_KEY]`` provenance; :class:`IntegrationAttributes`
+and :class:`IntegrationInfo` below define its shape. Op-wrapping integrations
+attach it via :func:`with_integration_metadata` (which threads it through
+:class:`~weave.trace.autopatch.OpSettings`); callback/tracer integrations merge
+:meth:`IntegrationMetadata.as_attributes` into the attribute dict they already
+build.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _distribution_version
+from typing import Any, TypedDict, cast
+
+from weave.trace.autopatch import OpSettings
+from weave.version import VERSION as WEAVE_VERSION
+
+logger = logging.getLogger(__name__)
+
+# Top-level attribute key under which integration provenance is stored.
+INTEGRATION_ATTRIBUTE_KEY = "integration"
+
+# OpenTelemetry span attributes must be scalars (or scalar sequences); values
+# outside this set are stringified when flattened onto a span.
+# See opentelemetry.util.types.AttributeValue.
+_OTEL_SCALAR_TYPES = (str, bool, int, float)
+
+
+class IntegrationInfo(TypedDict):
+    """The provenance block stored at ``attributes["integration"]``."""
+
+    name: str
+    version: str
+    meta: dict[str, Any]
+
+
+class IntegrationAttributes(TypedDict):
+    """The attribute fragment an integration merges into a call's attributes.
+
+    The single ``integration`` key mirrors :data:`INTEGRATION_ATTRIBUTE_KEY`.
+    """
+
+    integration: IntegrationInfo
+
+
+@dataclass(slots=True, frozen=True)
+class IntegrationMetadata:
+    """Typed builder for a call's ``attributes["integration"]`` provenance.
+
+    Attributes:
+        name: The integration identifier (e.g. ``"openai"``, ``"langchain"``).
+        version: The version of the *integrating code*. For Weave's built-in
+            integrations this is the Weave SDK version; an external integration
+            (e.g. a Claude Code plugin) would pass its own version.
+        meta: Integration-specific detail. For library integrations this carries
+            the patched library's distribution name and installed version.
+    """
+
+    name: str
+    version: str = WEAVE_VERSION
+    meta: dict[str, Any] = field(default_factory=dict)
+
+    def as_attributes(self) -> dict[str, Any]:
+        """Render the attribute fragment to merge into a call's attributes.
+
+        Returns a fresh dict every call so callers can mutate or merge it freely
+        without aliasing this instance's ``meta``. Typed as ``dict[str, Any]``
+        because every caller folds it into a call's ``attributes`` dict (the
+        ``op``/``create_call`` attributes are ``dict[str, Any]``) or stamps extra
+        keys onto it; :class:`IntegrationAttributes` still documents and
+        type-checks the shape at construction below.
+        """
+        # Build via the TypedDict for field/key safety, then hand it out as a
+        # plain attributes dict. `cast` is a runtime no-op, so this avoids the
+        # extra copy a `{**...}` spread at each call site would incur.
+        return cast(
+            dict[str, Any],
+            IntegrationAttributes(
+                integration=IntegrationInfo(
+                    name=self.name,
+                    version=self.version,
+                    meta=dict(self.meta),
+                )
+            ),
+        )
+
+    def as_otel_attributes(self) -> dict[str, Any]:
+        """Render the metadata as flattened OpenTelemetry span attributes.
+
+        OTel span attributes must be scalars, so the nested shape from
+        :meth:`as_attributes` is flattened to dotted keys (``integration.name``,
+        ``integration.version``, ``integration.meta.<key>``). The trace server
+        reconstructs the nested dict from these keys on ingest. Used by the
+        agent OTel processors that emit spans instead of calling ``create_call``.
+        """
+        attributes: dict[str, Any] = {
+            f"{INTEGRATION_ATTRIBUTE_KEY}.name": self.name,
+            f"{INTEGRATION_ATTRIBUTE_KEY}.version": self.version,
+        }
+        for key, value in self.meta.items():
+            attributes[f"{INTEGRATION_ATTRIBUTE_KEY}.meta.{key}"] = (
+                value if isinstance(value, _OTEL_SCALAR_TYPES) else str(value)
+            )
+        return attributes
+
+
+def resolve_package_version(distribution_name: str) -> str | None:
+    """Return the installed version of ``distribution_name``, or None if unknown.
+
+    Never raises: a missing package or metadata lookup failure resolves to None
+    so integration patching is never blocked by version discovery.
+    """
+    try:
+        return _distribution_version(distribution_name)
+    except PackageNotFoundError:
+        return None
+    except Exception:
+        logger.debug(
+            "Failed to resolve version for distribution %r",
+            distribution_name,
+            exc_info=True,
+        )
+        return None
+
+
+def library_integration(
+    name: str,
+    *,
+    distribution_name: str | None = None,
+    **meta: Any,
+) -> IntegrationMetadata:
+    """Build :class:`IntegrationMetadata` for a patched third-party library.
+
+    Fills ``meta`` with the library's distribution name and (when resolvable)
+    installed version, plus any extra ``meta`` keyword pairs supplied.
+
+    Args:
+        name: The integration identifier (e.g. ``"openai"``).
+        distribution_name: PyPI distribution name to resolve the version from,
+            when it differs from ``name`` (e.g. ``"google-genai"``). Defaults to
+            ``name``.
+        **meta: Additional integration-specific metadata to record.
+    """
+    package_name = distribution_name or name
+    resolved_meta: dict[str, Any] = {"package_name": package_name}
+    if (resolved_version := resolve_package_version(package_name)) is not None:
+        resolved_meta["package_version"] = resolved_version
+    resolved_meta.update(meta)
+    return IntegrationMetadata(name=name, meta=resolved_meta)
+
+
+def apply_integration_metadata(
+    attributes: dict[str, Any],
+    metadata: IntegrationMetadata,
+) -> None:
+    """Merge ``metadata`` into ``attributes`` in place without overriding keys.
+
+    For callback/tracer integrations that build the call's attribute dict
+    directly (rather than going through ``OpSettings``). Existing keys win, so a
+    user-supplied ``attributes["integration"]`` is preserved.
+    """
+    for key, value in metadata.as_attributes().items():
+        attributes.setdefault(key, value)
+
+
+def with_integration_metadata(
+    op_settings: OpSettings,
+    metadata: IntegrationMetadata,
+) -> OpSettings:
+    """Return a copy of ``op_settings`` carrying ``metadata`` as op attributes.
+
+    Non-mutating: allocates a fresh attributes dict so the returned settings (and
+    every op derived from them via ``model_copy``) do not alias the input.
+    """
+    merged_attributes = {**(op_settings.attributes or {}), **metadata.as_attributes()}
+    return op_settings.model_copy(update={"attributes": merged_attributes})

--- a/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
+++ b/weave/integrations/langchain_nvidia_ai_endpoints/langchain_nv_ai_endpoints.py
@@ -13,6 +13,10 @@ except ImportError:
     import_failed = True
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.integration_utilities import should_use_accumulator
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
@@ -20,6 +24,9 @@ from weave.trace.op import _add_accumulator
 from weave.trace.op_protocol import Op, ProcessedInputs
 
 _lc_nvidia_patcher: MultiPatcher | None = None
+LANGCHAIN_NVIDIA_INTEGRATION = library_integration(
+    "langchain_nvidia_ai_endpoints", distribution_name="langchain-nvidia-ai-endpoints"
+)
 
 
 # NVIDIA-specific accumulator for parsing the objects of streaming interactions
@@ -181,7 +188,7 @@ def get_nvidia_ai_patcher(
     if _lc_nvidia_patcher is not None:
         return _lc_nvidia_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, LANGCHAIN_NVIDIA_INTEGRATION)
 
     generate_settings: OpSettings = base.model_copy(
         update={

--- a/weave/integrations/litellm/litellm.py
+++ b/weave/integrations/litellm/litellm.py
@@ -5,6 +5,10 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.integration_utilities import should_use_accumulator
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
@@ -14,6 +18,8 @@ if TYPE_CHECKING:
     from litellm.utils import ModelResponse
 
 _litellm_patcher: MultiPatcher | None = None
+
+LITELLM_INTEGRATION = library_integration("litellm")
 
 
 # This accumulator is nearly identical to the mistral accumulator, just with different types.
@@ -120,7 +126,7 @@ def get_litellm_patcher(
     if _litellm_patcher is not None:
         return _litellm_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, LITELLM_INTEGRATION)
 
     completion_settings = base.model_copy(
         update={

--- a/weave/integrations/mistral/mistral_sdk.py
+++ b/weave/integrations/mistral/mistral_sdk.py
@@ -13,6 +13,10 @@ from mistralai.models import (
 )
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import _add_accumulator
@@ -21,6 +25,8 @@ if TYPE_CHECKING:
     pass
 
 _mistral_patcher: MultiPatcher | None = None
+
+MISTRAL_INTEGRATION = library_integration("mistral", distribution_name="mistralai")
 
 
 def mistral_accumulator(
@@ -115,7 +121,7 @@ def get_mistral_patcher(
     if _mistral_patcher is not None:
         return _mistral_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, MISTRAL_INTEGRATION)
     chat_complete_settings = base.model_copy(
         update={
             "name": base.name or "mistralai.chat.complete",

--- a/weave/integrations/notdiamond/custom_router.py
+++ b/weave/integrations/notdiamond/custom_router.py
@@ -8,11 +8,16 @@ from notdiamond import NotDiamond
 
 import weave
 from weave.evaluation.eval import EvaluationResults
+from weave.integrations.integration_metadata import library_integration
 from weave.utils.iterators import first
+
+# Integration provenance stamped onto the calls these helper ops produce.
+NOTDIAMOND_INTEGRATION = library_integration("notdiamond")
 
 
 @weave.op(
     name="notdiamond.custom_router.train_router",
+    attributes=NOTDIAMOND_INTEGRATION.as_attributes(),
 )
 def train_router(
     model_evals: dict[weave.Model | str, EvaluationResults],
@@ -61,6 +66,7 @@ def train_router(
 
 @weave.op(
     name="notdiamond.custom_router.evaluate_router",
+    attributes=NOTDIAMOND_INTEGRATION.as_attributes(),
 )
 def evaluate_router(
     model_datasets: dict[weave.Model | str, weave.Dataset],

--- a/weave/integrations/notdiamond/tracing.py
+++ b/weave/integrations/notdiamond/tracing.py
@@ -5,10 +5,15 @@ from collections.abc import Callable
 from typing import Any
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 
 _notdiamond_patcher: MultiPatcher | None = None
+NOTDIAMOND_INTEGRATION = library_integration("notdiamond")
 
 
 def not_diamond_wrapper(settings: OpSettings) -> Callable[[Callable], Callable]:
@@ -74,7 +79,7 @@ def get_notdiamond_patcher(
     if _notdiamond_patcher is not None:
         return _notdiamond_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, NOTDIAMOND_INTEGRATION)
 
     model_select_settings = base.model_copy(
         update={

--- a/weave/integrations/openai/openai_sdk.py
+++ b/weave/integrations/openai/openai_sdk.py
@@ -26,6 +26,10 @@ from openai.types.chat.chat_completion_message_tool_call import (
 )
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op import (
@@ -45,6 +49,8 @@ if TYPE_CHECKING:
     from openai.types.responses import Response, ResponseStreamEvent
 
 _openai_patcher: MultiPatcher | None = None
+
+OPENAI_INTEGRATION = library_integration("openai")
 
 logger = logging.getLogger(__name__)
 
@@ -786,7 +792,7 @@ def get_openai_patcher(
     if _openai_patcher is not None:
         return _openai_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, OPENAI_INTEGRATION)
 
     completions_create_settings = base.model_copy(
         update={

--- a/weave/integrations/smolagents/smolagents_sdk.py
+++ b/weave/integrations/smolagents/smolagents_sdk.py
@@ -5,12 +5,17 @@ from collections.abc import Callable
 from typing import Any
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.op_protocol import OpKind
 from weave.trace.serialization.serialize import dictify
 
 _smolagents_patcher: MultiPatcher | None = None
+SMOLAGENTS_INTEGRATION = library_integration("smolagents")
 
 
 def smolagents_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
@@ -118,7 +123,7 @@ def get_smolagents_patcher(
     if _smolagents_patcher is not None:
         return _smolagents_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, SMOLAGENTS_INTEGRATION)
     patchers = [
         patcher
         for patcher in [

--- a/weave/integrations/verifiers/verifiers.py
+++ b/weave/integrations/verifiers/verifiers.py
@@ -11,12 +11,17 @@ from openai.types.completion import Completion
 from pydantic import BaseModel
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 
 ModelResponse = Completion | ChatCompletion
 
 _verifiers_patcher: MultiPatcher | None = None
+VERIFIERS_INTEGRATION = library_integration("verifiers")
 
 
 def _verifiers_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
@@ -201,7 +206,9 @@ def get_verifiers_patcher(
     if _verifiers_patcher is not None:
         return _verifiers_patcher
 
-    base: OpSettings = settings.op_settings
+    base: OpSettings = with_integration_metadata(
+        settings.op_settings, VERIFIERS_INTEGRATION
+    )
     get_model_response_settings = base.model_copy(
         update={"name": base.name or "verifiers.Environment.get_model_response"}
     )

--- a/weave/integrations/vertexai/vertexai_sdk.py
+++ b/weave/integrations/vertexai/vertexai_sdk.py
@@ -12,6 +12,10 @@ from google.cloud.aiplatform_v1beta1.types import (
 from vertexai.generative_models import GenerationResponse
 
 import weave
+from weave.integrations.integration_metadata import (
+    library_integration,
+    with_integration_metadata,
+)
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
 from weave.trace.autopatch import IntegrationSettings, OpSettings
 from weave.trace.call import Call
@@ -23,6 +27,9 @@ if TYPE_CHECKING:
 
 
 _vertexai_patcher: MultiPatcher | None = None
+VERTEXAI_INTEGRATION = library_integration(
+    "vertexai", distribution_name="google-cloud-aiplatform"
+)
 
 
 def vertexai_postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
@@ -160,7 +167,7 @@ def get_vertexai_patcher(
     if _vertexai_patcher is not None:
         return _vertexai_patcher
 
-    base = settings.op_settings
+    base = with_integration_metadata(settings.op_settings, VERTEXAI_INTEGRATION)
 
     generate_content_settings = base.model_copy(
         update={

--- a/weave/trace/autopatch.py
+++ b/weave/trace/autopatch.py
@@ -25,6 +25,9 @@ class OpSettings(BaseModel):
     postprocess_output: Callable[[Any], Any] | None = None
     kind: OpKind | None = None
     color: OpColor | None = None
+    # Default attributes applied to every call this op creates. Integrations set
+    # this (via `with_integration_metadata`) to stamp `attributes["integration"]`.
+    attributes: dict[str, Any] | None = None
 
 
 class IntegrationSettings(BaseModel):

--- a/weave/trace/op.py
+++ b/weave/trace/op.py
@@ -224,6 +224,7 @@ class OpKwargs(TypedDict, total=False):
     accumulator: Callable[[Any | None, Any], Any] | None
     kind: OpKind | None
     color: OpColor | None
+    attributes: dict[str, Any] | None
     eager_call_start: bool
 
 
@@ -386,6 +387,11 @@ def _create_call(
     from weave.trace.serialization.serialize import dictify
 
     attributes = dictify(call_attributes.get())
+
+    # Op-level default attributes are the lowest precedence: a `weave.attributes()`
+    # context and explicit per-call attributes both override them on key collision.
+    if func.attributes:
+        attributes = {**func.attributes, **attributes}
 
     if call_attrs is not None:
         attributes = {**attributes, **call_attrs}
@@ -1243,6 +1249,7 @@ def op(
     accumulator: Callable[[Any | None, Any], Any] | None = None,
     kind: OpKind | None = None,
     color: OpColor | None = None,
+    attributes: dict[str, Any] | None = None,
     eager_call_start: bool = False,
 ) -> Callable[[Callable[P, R]], Op[P, R]] | Op[P, R]:
     """A decorator to weave op-ify a function or method. Works for both sync and async.
@@ -1257,6 +1264,10 @@ def op(
         tracing_sample_rate: Fraction of calls to trace (0.0 to 1.0).
         enable_code_capture: Whether to capture source code for this op.
         accumulator: Function to accumulate results for streaming ops.
+        attributes: Default attributes merged into every call this op creates,
+            at the lowest precedence. A `weave.attributes()` context and explicit
+            per-call attributes override them on key collision. The reserved
+            "weave" key may not be set here.
         eager_call_start: If True, call starts are sent immediately rather than batched.
             Useful for long-running operations like evaluations that should
             be visible in the UI immediately.
@@ -1265,6 +1276,11 @@ def op(
         raise TypeError("tracing_sample_rate must be a float")
     if not 0 <= tracing_sample_rate <= 1:
         raise ValueError("tracing_sample_rate must be between 0 and 1")
+    if attributes is not None and "weave" in attributes:
+        raise ValueError(
+            "op `attributes` cannot set the reserved 'weave' key; "
+            "it is managed internally by Weave."
+        )
 
     def op_deco(func: Callable[P, R]) -> Op[P, R]:
         # Check function type
@@ -1367,6 +1383,7 @@ def op(
 
             wrapper.kind = kind  # type: ignore
             wrapper.color = color  # type: ignore
+            wrapper.attributes = attributes  # type: ignore
 
             # Set `__signature__` so future `inspect.signature(wrapper)` calls
             # short-circuit to this object instead of re-walking `func`.

--- a/weave/trace/op_protocol.py
+++ b/weave/trace/op_protocol.py
@@ -108,6 +108,12 @@ class Op(Protocol[P, R]):
     # The color for the kind icon in the UI. Overrides the default color for the kind.
     color: OpColor | None
 
+    # Default attributes merged into every call created by this op, at the lowest
+    # precedence (a `weave.attributes()` context or explicit per-call attributes
+    # override them). The reserved "weave" key may not be set here. Integrations
+    # use this to stamp `attributes["integration"]` provenance onto their calls.
+    attributes: dict[str, Any] | None
+
     # Whether this op's call start should be sent eagerly (immediately rather than batched).
     # Useful for long-running operations that need to be visible in the UI immediately,
     # like evaluation runs. Flipping this will incur a heavy cost at call-end time, only use


### PR DESCRIPTION
Formalizes how we're doing integration tracking via attributes.  This PR introduces some types and a mechanism for applying the metadata generally to integrations