### PR TITLE
fix(weave): route agent chat media to the user or assistant message by direction

### DIFF
--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -5,6 +5,7 @@ end-to-end against ClickHouse; these tests pin the pure projection rules.
 """
 
 import datetime
+import json
 
 import pytest
 
@@ -69,6 +70,24 @@ def _span(
         or datetime.datetime(2026, 1, 1, 0, 0, 1, tzinfo=datetime.timezone.utc),
         **kwargs,
     )
+
+
+def _parts(*parts: dict) -> str:
+    """Serialize message parts the way ingestion stores multimodal content.
+
+    `genai_extraction._normalize_single_message` JSON-dumps a message's parts
+    array into the `content` field, so a multimodal message arrives here as a
+    JSON string starting with "[".
+    """
+    return json.dumps(list(parts))
+
+
+def _text_part(text: str) -> dict:
+    return {"type": "text", "content": text}
+
+
+def _uri_part(uri: str, *, mime_type: str = "audio/wav", modality: str = "audio") -> dict:
+    return {"type": "uri", "mime_type": mime_type, "modality": modality, "uri": uri}
 
 
 def _user_payload(message: AgentChatMessage) -> AgentChatUserMessage:
@@ -505,6 +524,126 @@ def test_system_message_not_used_as_user_prompt_fallback() -> None:
     )
 
     assert [m.type for m in messages] == ["assistant_message"]
+
+
+def test_input_media_attaches_to_user_message_not_assistant() -> None:
+    """Regression: media supplied with the user prompt renders on the user
+    bubble, not the assistant.
+
+    Mirrors the session SDK shape — `attach_media` records media on the
+    LLM/chat span as a `uri` part on the user input message (external form)
+    and, separately, in the span-level `content_refs` (internal,
+    int<->ext-convertible form). The user text comes from the enclosing
+    invoke_agent span. The ref *value* surfaced is the internal `content_refs`
+    one (so the response's int->ext adapter can round-trip it); its *direction*
+    comes from the input part, matched by digest. So the audio lands on the
+    user message and the assistant stays clean.
+    """
+    audio_internal = "weave-trace-internal:///PID/object/Content:AUDIODIGEST"
+    audio_external = "weave:///e/p/object/Content:AUDIODIGEST"
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="audio-agent",
+            input_messages=[
+                {"role": "user", "content": _parts(_text_part("Describe the audio."))}
+            ],
+        ),
+        _span(
+            span_id="chat",
+            parent_span_id="agent",
+            operation_name="chat",
+            input_messages=[
+                {
+                    "role": "user",
+                    "content": _parts(
+                        _text_part("Describe the audio."), _uri_part(audio_external)
+                    ),
+                }
+            ],
+            output_messages=[
+                {"role": "assistant", "content": _parts(_text_part("Chiptune music."))}
+            ],
+            # Round-trippable internal-form ref; same object digest as the part.
+            content_refs=[audio_internal],
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+    user = next(m for m in messages if m.type == "user_message")
+    assistant = next(m for m in messages if m.type == "assistant_message")
+
+    # Value is the internal (convertible) ref; direction is from the input part.
+    assert _user_payload(user).content_refs == [audio_internal]
+    assert _assistant_payload(assistant).content_refs == []
+
+
+def test_output_media_attaches_to_assistant_message() -> None:
+    """Model-generated media is a part on the output message and renders on
+    the assistant bubble (mirror image of the input case)."""
+    image_internal = "weave-trace-internal:///PID/object/Content:GENIMG"
+    image_external = "weave:///e/p/object/Content:GENIMG"
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="image-gen",
+            input_messages=[
+                {"role": "user", "content": _parts(_text_part("Draw a cat."))}
+            ],
+        ),
+        _span(
+            span_id="chat",
+            parent_span_id="agent",
+            operation_name="chat",
+            input_messages=[
+                {"role": "user", "content": _parts(_text_part("Draw a cat."))}
+            ],
+            output_messages=[
+                {
+                    "role": "assistant",
+                    "content": _parts(
+                        _text_part("Here you go."),
+                        _uri_part(
+                            image_external, mime_type="image/png", modality="image"
+                        ),
+                    ),
+                }
+            ],
+            content_refs=[image_internal],
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+    user = next(m for m in messages if m.type == "user_message")
+    assistant = next(m for m in messages if m.type == "assistant_message")
+
+    assert _user_payload(user).content_refs == []
+    assert _assistant_payload(assistant).content_refs == [image_internal]
+
+
+def test_content_ref_without_inline_part_is_not_attached() -> None:
+    """A `content_refs` entry with no matching inline message part has no
+    direction signal, so it attaches to neither bubble — only refs anchored to
+    an input/output part are surfaced (documents the deliberate pre-GA break
+    away from the undirected flat list)."""
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="bot",
+            input_messages=[{"role": "user", "content": "hello"}],
+            output_messages=[{"role": "assistant", "content": "hi"}],
+            content_refs=["weave-trace-internal:///PID/object/Content:ORPHAN"],
+        ),
+    ]
+
+    messages = build_chat_messages(spans)
+    user = next(m for m in messages if m.type == "user_message")
+    assistant = next(m for m in messages if m.type == "assistant_message")
+    assert _user_payload(user).content_refs == []
+    assert _assistant_payload(assistant).content_refs == []
 
 
 def test_build_span_tree_sort_is_stable_on_equal_timestamps() -> None:

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -86,7 +86,9 @@ def _text_part(text: str) -> dict:
     return {"type": "text", "content": text}
 
 
-def _uri_part(uri: str, *, mime_type: str = "audio/wav", modality: str = "audio") -> dict:
+def _uri_part(
+    uri: str, *, mime_type: str = "audio/wav", modality: str = "audio"
+) -> dict:
     return {"type": "uri", "mime_type": mime_type, "modality": modality, "uri": uri}
 
 
@@ -581,7 +583,8 @@ def test_input_media_attaches_to_user_message_not_assistant() -> None:
 
 def test_output_media_attaches_to_assistant_message() -> None:
     """Model-generated media is a part on the output message and renders on
-    the assistant bubble (mirror image of the input case)."""
+    the assistant bubble (mirror image of the input case).
+    """
     image_internal = "weave-trace-internal:///PID/object/Content:GENIMG"
     image_external = "weave:///e/p/object/Content:GENIMG"
     spans = [
@@ -627,7 +630,8 @@ def test_content_ref_without_inline_part_is_not_attached() -> None:
     """A `content_refs` entry with no matching inline message part has no
     direction signal, so it attaches to neither bubble — only refs anchored to
     an input/output part are surfaced (documents the deliberate pre-GA break
-    away from the undirected flat list)."""
+    away from the undirected flat list).
+    """
     spans = [
         _span(
             span_id="agent",

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -500,6 +500,94 @@ def _content_refs(span: AgentSpanSchema) -> list[str]:
     return [str(r) for r in (span.content_refs or []) if r]
 
 
+# Content part types that reference uploaded media by ref rather than inlining
+# text. The session SDK emits attached media as ``uri`` parts (see
+# weave/session/session_otel.py::_media_to_part); ``blob``/``file`` are accepted
+# defensively in case other producers use a ref-bearing variant.
+_MEDIA_PART_TYPES = {"uri", "blob", "file"}
+
+
+def _parse_content_parts(content: str) -> list[dict]:
+    """Parse a message ``content`` field into its parts array.
+
+    Multimodal content is a JSON-serialized parts array (see
+    genai_extraction._normalize_single_message); plain-text/legacy content is
+    not a JSON list and yields nothing.
+    """
+    if not content or not content.startswith("["):
+        return []
+    try:
+        parsed = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(parsed, list):
+        return []
+    return [p for p in parsed if isinstance(p, dict)]
+
+
+def _ref_digest(ref: str) -> str:
+    """Return the trailing object digest of a content ref.
+
+    The same object is referenced in two forms sharing one digest: the inline
+    message ``uri`` part uses the external ``weave:///entity/project/...`` form,
+    while the span-level ``content_refs`` uses the internal
+    ``weave-trace-internal:///...`` form. Both end in ``...:<digest>``, so the
+    digest is the stable key for matching one to the other.
+    """
+    return ref.rsplit(":", 1)[-1] if ":" in ref else ref
+
+
+def _media_part_digests(messages: list[NormalizedMessage]) -> set[str]:
+    """Object digests of media (uri/blob/file) parts inlined in these messages.
+
+    Direction lives in the parts: a user-supplied audio/image is a ``uri`` part
+    on an input message; model-generated media is a part on an output message.
+    """
+    digests: set[str] = set()
+    for message in messages:
+        for part in _parse_content_parts(message.content):
+            if part.get("type") in _MEDIA_PART_TYPES:
+                uri = part.get("uri")
+                if isinstance(uri, str) and uri:
+                    digests.add(_ref_digest(uri))
+    return digests
+
+
+def _directional_content_refs(
+    span: AgentSpanSchema, part_digests: set[str]
+) -> list[str]:
+    """Span ``content_refs`` whose object digest matches an inline part.
+
+    The value comes from ``content_refs`` because it holds the ref in the
+    internal, int<->ext-convertible form the response pipeline requires — the
+    int->ext adapter raises on a bare external ref. The direction comes from
+    the message parts (external form). Match the two by digest so each ref is
+    surfaced on the correct side (input -> user, output -> assistant).
+    """
+    if not part_digests:
+        return []
+    return [r for r in _content_refs(span) if _ref_digest(r) in part_digests]
+
+
+def _input_content_refs(spans: list[AgentSpanSchema]) -> list[str]:
+    """Input-side media refs across a trace, de-duplicated, in internal form.
+
+    ``attach_media`` records media on the LLM/chat span, but the rendered user
+    prompt is synthesized from the enclosing invoke_agent span, so the media
+    lives on a different span than the user text. Gather input media across all
+    spans so it lands on the user message regardless of which span carries it.
+    """
+    refs: list[str] = []
+    seen: set[str] = set()
+    for span in spans:
+        in_digests = _media_part_digests(span.input_messages)
+        for ref in _directional_content_refs(span, in_digests):
+            if ref not in seen:
+                seen.add(ref)
+                refs.append(ref)
+    return refs
+
+
 def _sum_descendant_tokens(node: SpanNode) -> TokenTotals:
     """Sum input, output, and reasoning tokens across a subtree."""
     input_t = node.span.input_tokens or 0
@@ -522,7 +610,13 @@ def _find_user_message(spans: list[AgentSpanSchema]) -> AgentChatMessage | None:
     Priority order: invoke_agent spans first, then anything else, with
     started_at tiebreaking inside each group. Returns the first span whose
     `input_messages` yields user text, already shaped as an API message.
+
+    Media direction comes from the input message parts; the ref value comes
+    from `content_refs` (internal form) via `_input_content_refs`, gathered
+    across the trace since `attach_media` records on the LLM span while the
+    user text comes from the enclosing invoke_agent span.
     """
+    user_media_refs = _input_content_refs(spans)
     prioritized = sorted(
         spans,
         key=lambda s: (s.operation_name != OP_INVOKE_AGENT, _span_sort_key(s)),
@@ -539,7 +633,7 @@ def _find_user_message(spans: list[AgentSpanSchema]) -> AgentChatMessage | None:
                 started_at=s.started_at,
                 user_message=AgentChatUserMessage(
                     text=text,
-                    content_refs=_content_refs(s),
+                    content_refs=user_media_refs,
                 ),
             )
     return None
@@ -589,6 +683,8 @@ def _emit_assistant_message(
             output_tokens=totals.output_tokens or span.output_tokens,
             duration_ms=_compute_duration_ms(span.started_at, span.ended_at),
             status=span.status_code,
-            content_refs=_content_refs(span),
+            content_refs=_directional_content_refs(
+                span, _media_part_digests(span.output_messages)
+            ),
         ),
     )

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -534,7 +534,7 @@ def _ref_digest(ref: str) -> str:
     ``weave-trace-internal:///...`` form. Both end in ``...:<digest>``, so the
     digest is the stable key for matching one to the other.
     """
-    return ref.rsplit(":", 1)[-1] if ":" in ref else ref
+    return ref.rsplit(":", 1)[-1]
 
 
 def _media_part_digests(messages: list[NormalizedMessage]) -> set[str]:


### PR DESCRIPTION
- Media attached to an agent's LLM call was rendering on the assistant bubble instead of the user's
- chat view now routes each content ref to the user or assistant message based on whether it appears in the input or output message parts matched by object digest

Before:
<img width="1890" height="1474" alt="image" src="https://github.com/user-attachments/assets/c005f0bc-47b1-4a13-85e5-20adcbca2c05" />

After:
<img width="1890" height="1474" alt="image" src="https://github.com/user-attachments/assets/88a09ab8-3cba-41bd-8ea5-a7dc800d4f1e" />
