### PR TITLE
refactor(weave): remove bare type:ignore / cast(Any) in trace server

### DIFF
--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -117,6 +117,13 @@ _ALLOWED_AGGS_BY_TYPE: dict[AgentSpanStatsValueType, set[AgentSpanStatsAggregati
 }
 
 
+def _derived_value_type(key: str) -> AgentSpanStatsValueType:
+    for metric, value_type in AGENT_SPAN_STATS_DERIVED_VALUE_TYPES.items():
+        if metric == key:
+            return value_type
+    raise ValueError(f"unknown derived span value: {key!r}")
+
+
 def _as_utc(dt: datetime.datetime) -> datetime.datetime:
     if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
         return dt.replace(tzinfo=datetime.timezone.utc)
@@ -154,9 +161,7 @@ class AgentSpanMeasureSpec(BaseModel):
             raise ValueError("only count measures may omit value")
 
         if self.value is not None and self.value.source == "derived":
-            expected_type = AGENT_SPAN_STATS_DERIVED_VALUE_TYPES[
-                self.value.key  # type: ignore[index]
-            ]
+            expected_type = _derived_value_type(self.value.key)
             if self.value_type is not None and self.value_type != expected_type:
                 raise ValueError(
                     f"derived value {self.value.key!r} has value_type "
@@ -189,9 +194,7 @@ class AgentSpanStatsMetricSpec(BaseModel):
     @model_validator(mode="after")
     def validate_metric_spec(self) -> AgentSpanStatsMetricSpec:
         if self.value.source == "derived":
-            expected_type = AGENT_SPAN_STATS_DERIVED_VALUE_TYPES[
-                self.value.key  # type: ignore[index]
-            ]
+            expected_type = _derived_value_type(self.value.key)
             if self.value_type != expected_type:
                 raise ValueError(
                     f"derived metric {self.value.key!r} has value_type "
@@ -295,9 +298,7 @@ class AgentSpanStatsNumericBucketSpec(BaseModel):
 
         if self.value is not None:
             if self.value.source == "derived":
-                expected_type = AGENT_SPAN_STATS_DERIVED_VALUE_TYPES[
-                    self.value.key  # type: ignore[index]
-                ]
+                expected_type = _derived_value_type(self.value.key)
                 if expected_type != "number":
                     raise ValueError(
                         f"derived bucket value {self.value.key!r} has value_type "

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -2308,7 +2308,7 @@ def process_query_to_conditions(
     def process_operand(operand: "tsi_query.Operand") -> str:
         if isinstance(operand, tsi_query.LiteralOperation):
             return param_slot(
-                param_builder.add_param(operand.literal_),  # type: ignore
+                param_builder.add_param(operand.literal_),
                 python_value_to_ch_type(operand.literal_),
             )
         elif isinstance(operand, tsi_query.GetFieldOperator):

--- a/weave/trace_server/clickhouse/schema_converters.py
+++ b/weave/trace_server/clickhouse/schema_converters.py
@@ -6,7 +6,7 @@ interface (API) representations and their ClickHouse storage formats.
 
 import json
 from collections.abc import Sequence
-from typing import Any, cast
+from typing import Any
 
 from weave.shared.trace_server_interface_util import extract_refs_from_values
 from weave.trace_server import ch_sentinel_values
@@ -392,7 +392,7 @@ def ch_table_stats_to_table_stats_schema(
     # Unpack the row with a default for the third value if it doesn't exist
     row_tuple = tuple(ch_table_stats_row)
     digest, count = row_tuple[:2]
-    storage_size_bytes = row_tuple[2] if len(row_tuple) > 2 else cast(Any, None)
+    storage_size_bytes = row_tuple[2] if len(row_tuple) > 2 else None
 
     return tsi.TableStatsRow(
         count=count,

--- a/weave/trace_server/interface/builtin_object_classes/annotation_spec.py
+++ b/weave/trace_server/interface/builtin_object_classes/annotation_spec.py
@@ -83,7 +83,9 @@ class AnnotationSpec(base_object_def.BaseObject):
 
         # Handle Pydantic model
         if isinstance(field_schema, type) and issubclass(field_schema, BaseModel):
-            data["field_schema"] = field_schema.model_json_schema()
+            # Read back through `data` (typed `Any`): pydantic is invisible to
+            # the type-check env, so `issubclass` cannot narrow off bare `type`.
+            data["field_schema"] = data["field_schema"].model_json_schema()
             return data
 
         return data

--- a/weave/trace_server/interface/builtin_object_classes/annotation_spec.py
+++ b/weave/trace_server/interface/builtin_object_classes/annotation_spec.py
@@ -83,7 +83,7 @@ class AnnotationSpec(base_object_def.BaseObject):
 
         # Handle Pydantic model
         if isinstance(field_schema, type) and issubclass(field_schema, BaseModel):
-            data["field_schema"] = field_schema.model_json_schema()  # type: ignore
+            data["field_schema"] = field_schema.model_json_schema()
             return data
 
         return data

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -9,6 +9,7 @@ from pydantic import (
     Field,
     field_serializer,
     model_validator,
+    with_config,
 )
 from typing_extensions import TypedDict
 
@@ -42,12 +43,10 @@ DEFAULT_FEEDBACK_SAMPLE_LIMIT = 2000
 MAX_FEEDBACK_SAMPLE_LIMIT = 5000
 
 
+# https://docs.pydantic.dev/2.8/concepts/strict_mode/#dataclasses-and-typeddict
+@with_config(ConfigDict(extra="allow"))
 class ExtraKeysTypedDict(TypedDict):
     pass
-
-
-# https://docs.pydantic.dev/2.8/concepts/strict_mode/#dataclasses-and-typeddict
-ExtraKeysTypedDict.__pydantic_config__ = ConfigDict(extra="allow")  # type: ignore
 
 
 class LLMUsageSchema(TypedDict, total=False):


### PR DESCRIPTION
## Summary
- `trace_server_interface.py`: replace `__pydantic_config__ = ...  # type: ignore` with the `@with_config(ConfigDict(extra="allow"))` decorator on `ExtraKeysTypedDict`
- `annotation_spec.py`: drop the stale ignore on `model_json_schema()`
- `schema_converters.py`: use `None` directly instead of `cast(Any, None)` for `storage_size_bytes`; drop the now-unused `cast` import
- `agents/types.py`: replace 3x `# type: ignore[index]` with a typed `_derived_value_type()` lookup that narrows the str key
- `calls_query_builder.py`: drop the stale bare ignore on `add_param(operand.literal_)`

## Testing
type-only change; pyright + ty + ruff clean on touched files, agent/calls/table query-builder unit tests pass