### PR TITLE
chore(weave): route test OPTIMIZE to _local on distributed clusters

### DIFF
--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -32,6 +32,7 @@ from tests.trace.util import (
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     DummyIdConverter,
 )
+from tests.trace_server.helpers import force_optimize
 from weave import Thread, ThreadPoolExecutor
 from weave.shared.refs_internal import extra_value_quoter
 from weave.shared.trace_server_interface_util import (
@@ -4462,9 +4463,7 @@ def test_calls_query_with_storage_size_clickhouse(client, clickhouse_client):
     # due to some race condition/optimizations in clickhouse, there is a chance
     # that the calls_merged_stats table is not updated in time for the query below
     # to return the correct results.
-    clickhouse_client.command(
-        "OPTIMIZE TABLE calls_merged_stats FINAL",
-    )
+    force_optimize(clickhouse_client, "calls_merged_stats")
 
     # Query with storage size
     calls = list(
@@ -4503,9 +4502,7 @@ def test_calls_query_with_total_storage_size_clickhouse(client, clickhouse_clien
     # due to some race condition/optimizations in clickhouse, there is a chance
     # that the calls_merged_stats table is not updated in time for the query below
     # to return the correct results.
-    clickhouse_client.command(
-        "OPTIMIZE TABLE calls_merged_stats FINAL",
-    )
+    force_optimize(clickhouse_client, "calls_merged_stats")
 
     # Query with total storage size
     calls = list(
@@ -4558,9 +4555,7 @@ def test_calls_query_with_both_storage_sizes_clickhouse(client, clickhouse_clien
     # due to some race condition/optimizations in clickhouse, there is a chance
     # that the calls_merged_stats table is not updated in time for the query below
     # to return the correct results.
-    clickhouse_client.command(
-        "OPTIMIZE TABLE calls_merged_stats FINAL",
-    )
+    force_optimize(clickhouse_client, "calls_merged_stats")
 
     # Query with total storage size
     calls = list(
@@ -4706,12 +4701,8 @@ def test_call_query_stream_with_costs_and_storage_size(client, clickhouse_client
     # that the calls_merged_stats table is not updated in time for the query below
     # to return the correct results.
     if not client_is_sqlite(client):
-        clickhouse_client.command(
-            "OPTIMIZE TABLE calls_merged FINAL",
-        )
-        clickhouse_client.command(
-            "OPTIMIZE TABLE calls_merged_stats FINAL",
-        )
+        force_optimize(clickhouse_client, "calls_merged")
+        force_optimize(clickhouse_client, "calls_merged_stats")
 
     # Test that "include_costs" and "include_total_storage_size" can be used together
     calls = list(
@@ -5108,9 +5099,7 @@ def test_calls_query_stats_total_storage_size_clickhouse(client, clickhouse_clie
     # due to some race condition/optimizations in clickhouse, there is a chance
     # that the calls_merged_stats table is not updated in time for the query below
     # to return the correct results.
-    clickhouse_client.command(
-        "OPTIMIZE TABLE calls_merged_stats FINAL",
-    )
+    force_optimize(clickhouse_client, "calls_merged_stats")
 
     # Query with total storage size
     result = client.server.calls_query_stats(

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -27,6 +27,7 @@ from tests.trace.util import (
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     UserInjectingExternalTraceServer,
 )
+from tests.trace_server.helpers import force_optimize
 from weave import Evaluation
 from weave.integrations.integration_utilities import op_name_from_call
 from weave.prompt.prompt import MessagesPrompt
@@ -1868,7 +1869,7 @@ def test_get_calls_storage_size_values(client, clickhouse_client):
     # ClickHouse merges data asynchronously, so queries may see unmerged data.
     # OPTIMIZE TABLE ... FINAL forces an immediate merge to ensure consistency for tests.
     if clickhouse_client:
-        clickhouse_client.command("OPTIMIZE TABLE calls_merged_stats FINAL")
+        force_optimize(clickhouse_client, "calls_merged_stats")
 
     # Get calls via get_calls with storage size parameters
     client_calls = list(

--- a/tests/trace_server/helpers.py
+++ b/tests/trace_server/helpers.py
@@ -3,6 +3,8 @@
 import base64
 import uuid
 
+from clickhouse_connect.driver.client import Client as CHClient
+
 from weave.trace_server import environment as wf_env
 
 
@@ -12,16 +14,19 @@ def make_project_id(prefix: str) -> str:
     return base64.b64encode(raw.encode()).decode()
 
 
-def force_optimize_calls_merged(ch_client) -> None:
-    """OPTIMIZE `calls_merged` for test merge-consistency, distributed-mode aware.
+def force_optimize(ch_client: CHClient, table: str) -> None:
+    """OPTIMIZE `table` for test merge-consistency, distributed-mode aware.
 
     OPTIMIZE is not supported on Distributed engines; in distributed mode we
     target the underlying `_local` ReplicatedMergeTree on the cluster.
     """
     if wf_env.wf_clickhouse_use_distributed_tables():
         cluster = wf_env.wf_clickhouse_replicated_cluster()
-        ch_client.command(
-            f"OPTIMIZE TABLE calls_merged_local ON CLUSTER {cluster} FINAL"
-        )
+        ch_client.command(f"OPTIMIZE TABLE {table}_local ON CLUSTER {cluster} FINAL")
     else:
-        ch_client.command("OPTIMIZE TABLE calls_merged FINAL")
+        ch_client.command(f"OPTIMIZE TABLE {table} FINAL")
+
+
+def force_optimize_calls_merged(ch_client: CHClient) -> None:
+    """OPTIMIZE `calls_merged`, distributed-mode aware."""
+    force_optimize(ch_client, "calls_merged")


### PR DESCRIPTION
## Summary
- The replicated 2s2r nightly leg (`WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES=true`) failed ~12x with `Code 48 NOT_IMPLEMENTED: OPTIMIZE ... not supported by storage Distributed` ([CI run](https://github.com/wandb/weave/actions/runs/27110446368)), part of WB-35378.
- Tests issued `OPTIMIZE TABLE <t> FINAL` against the Distributed table; OPTIMIZE only works on the underlying `_local` ReplicatedMergeTree.
- Generalized `force_optimize_calls_merged` into `force_optimize(ch_client, table)`, routing to `{table}_local ON CLUSTER {cluster} FINAL` in distributed mode, and switched the storage-size/merge tests to it.

## Testing
test-infra only; ran the routed clickhouse storage-size tests locally in non-distributed mode (pass).