### PR TITLE
fix(weave): emit GLOBAL IN for object-ref UNION subqueries on distributed clusters

### DIFF
--- a/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
@@ -53,10 +53,10 @@ def test_object_ref_filter_simple() -> None:
                   OR calls_merged.ended_at IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
-           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), '') IN
+           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), '') GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_0)
-                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_0)))
                    AND ((any(calls_merged.deleted_at) IS NULL))
@@ -124,10 +124,10 @@ def test_object_ref_filter_lt() -> None:
                   OR calls_merged.ended_at IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
-           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), '') IN
+           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), '') GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_0)
-                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_0)))
                    AND ((any(calls_merged.deleted_at) IS NULL))
@@ -198,7 +198,7 @@ def test_object_ref_filter_nested() -> None:
            FROM object_versions ov
            WHERE ov.project_id = {pb_0:String}
              AND length(refs) > 0
-             AND JSON_VALUE(ov.val_dump, {pb_3:String}) IN (SELECT ref FROM obj_filter_0)
+             AND JSON_VALUE(ov.val_dump, {pb_3:String}) GLOBAL IN (SELECT ref FROM obj_filter_0)
            GROUP BY ov.project_id,
                     ov.object_id,
                     ov.digest),
@@ -208,7 +208,7 @@ def test_object_ref_filter_nested() -> None:
            FROM object_versions ov
            WHERE ov.project_id = {pb_0:String}
              AND length(refs) > 0
-             AND JSON_VALUE(ov.val_dump, {pb_4:String}) IN (SELECT ref FROM obj_filter_1)
+             AND JSON_VALUE(ov.val_dump, {pb_4:String}) GLOBAL IN (SELECT ref FROM obj_filter_1)
            GROUP BY ov.project_id,
                     ov.object_id,
                     ov.digest),
@@ -221,10 +221,10 @@ def test_object_ref_filter_nested() -> None:
                   OR calls_merged.op_name IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
-           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_5:String}), 'null'), '') IN
+           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_5:String}), 'null'), '') GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_2)
-                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_5:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_5:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_2)))
                    AND ((any(calls_merged.deleted_at) IS NULL))
@@ -338,16 +338,16 @@ def test_multiple_object_ref_filters() -> None:
                   OR calls_merged.op_name IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
-           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), '') IN
+           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), '') GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_0)
-                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_0)))
-                   AND ((NOT ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), '') IN
+                   AND ((NOT ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), '') GLOBAL IN
                                (SELECT ref
                                 FROM obj_filter_1)
-                             OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                             OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                                (SELECT ref
                                 FROM obj_filter_1)))))
                    AND ((any(calls_merged.deleted_at) IS NULL))
@@ -518,34 +518,34 @@ def test_object_ref_filter_duplicates_and_similar() -> None:
                   OR calls_merged.op_name IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
-           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') IN
+           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') GLOBAL IN
               (SELECT ref
                FROM obj_filter_0)
-             OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) IN
+             OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
               (SELECT ref
                FROM obj_filter_0)))
-           AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') IN
+           AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') GLOBAL IN
                (SELECT ref
                 FROM obj_filter_0)
-             OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) IN
+             OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                (SELECT ref
                 FROM obj_filter_0)))
-           AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') IN
+           AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') GLOBAL IN
                (SELECT ref
                 FROM obj_filter_1)
-             OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) IN
+             OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                (SELECT ref
                 FROM obj_filter_1)))
-           AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') IN
+           AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') GLOBAL IN
                  (SELECT ref
                   FROM obj_filter_2)
-               OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) IN
+               OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                  (SELECT ref
                   FROM obj_filter_2)))
-           AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') IN
+           AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') GLOBAL IN
                (SELECT ref
                 FROM obj_filter_3)
-             OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) IN
+             OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                (SELECT ref
                 FROM obj_filter_3)))
            AND (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_8:String}), 'null'), ''), {pb_9:String}) > 0)
@@ -697,23 +697,23 @@ def test_object_ref_filter_complex_mixed_conditions() -> None:
                OR calls_merged.op_name IS NULL)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)
-        HAVING (((((((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') IN
+        HAVING (((((((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') GLOBAL IN
                        (SELECT ref
                         FROM obj_filter_0)
-                     OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                     OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                        (SELECT ref
                         FROM obj_filter_0)))
-                    AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') IN
+                    AND ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') GLOBAL IN
                            (SELECT ref
                             FROM obj_filter_1)
-                         OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                         OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                            (SELECT ref
                             FROM obj_filter_1)))))
                   OR ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_8:String}), 'null'), '') = {pb_9:String}))
-                  OR ((NOT ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') IN
+                  OR ((NOT ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), '') GLOBAL IN
                              (SELECT ref
                               FROM obj_filter_2)
-                           OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                           OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_7:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                              (SELECT ref
                               FROM obj_filter_2)))))))
                 AND ((any(calls_merged.deleted_at) IS NULL))
@@ -846,7 +846,7 @@ def test_object_ref_filter_heavily_nested_keys() -> None:
            FROM object_versions ov
            WHERE ov.project_id = {pb_0:String}
              AND length(refs) > 0
-             AND JSON_VALUE(ov.val_dump, {pb_3:String}) IN (SELECT ref FROM obj_filter_0)
+             AND JSON_VALUE(ov.val_dump, {pb_3:String}) GLOBAL IN (SELECT ref FROM obj_filter_0)
            GROUP BY ov.project_id,
                     ov.object_id,
                     ov.digest),
@@ -858,10 +858,10 @@ def test_object_ref_filter_heavily_nested_keys() -> None:
                   OR calls_merged.op_name IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
-           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), '') IN
+           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), '') GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_1)
-                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_1)))
                    AND ((any(calls_merged.deleted_at) IS NULL))
@@ -930,7 +930,7 @@ def test_object_ref_filter_complex_nested_path() -> None:
            FROM object_versions ov
            WHERE ov.project_id = {pb_0:String}
              AND length(refs) > 0
-             AND JSON_VALUE(ov.val_dump, {pb_3:String}) IN (SELECT ref FROM obj_filter_0)
+             AND JSON_VALUE(ov.val_dump, {pb_3:String}) GLOBAL IN (SELECT ref FROM obj_filter_0)
            GROUP BY ov.project_id,
                     ov.object_id,
                     ov.digest),
@@ -943,10 +943,10 @@ def test_object_ref_filter_complex_nested_path() -> None:
                   OR calls_merged.op_name IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
-           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), '') IN
+           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), '') GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_1)
-                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_4:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_1)))
                    AND ((any(calls_merged.deleted_at) IS NULL))
@@ -1018,10 +1018,10 @@ def test_object_ref_filter_calls_complete() -> None:
         FROM calls_complete PREWHERE calls_complete.project_id = {pb_0:String}
         WHERE (length(calls_complete.output_refs) > 0
                OR calls_complete.ended_at = {pb_5:DateTime64(6)})
-        AND (((coalesce(nullIf(JSON_VALUE(calls_complete.output_dump, {pb_3:String}), 'null'), '') IN
+        AND (((coalesce(nullIf(JSON_VALUE(calls_complete.output_dump, {pb_3:String}), 'null'), '') GLOBAL IN
                    (SELECT ref
                     FROM obj_filter_0)
-                OR regexpExtract(coalesce(nullIf(JSON_VALUE(calls_complete.output_dump, {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                OR regexpExtract(coalesce(nullIf(JSON_VALUE(calls_complete.output_dump, {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                    (SELECT ref
                     FROM obj_filter_0)))
                 AND ((calls_complete.deleted_at = {pb_4:DateTime64(3)})))
@@ -1101,10 +1101,10 @@ def test_object_ref_filter_calls_complete_mixed_conditions() -> None:
         FROM calls_complete PREWHERE calls_complete.project_id = {pb_0:String}
         WHERE (calls_complete.parent_id = {pb_7:String})
           AND (length(calls_complete.input_refs) > 0)
-          AND (((((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_3:String}), 'null'), '') IN
+          AND (((((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_3:String}), 'null'), '') GLOBAL IN
                      (SELECT ref
                       FROM obj_filter_0)
-                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) IN
+                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                      (SELECT ref
                       FROM obj_filter_0)))
                 OR ((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_4:String}), 'null'), '') = {pb_5:String}))))

--- a/weave/trace_server/calls_query_builder/object_ref_query_builder.py
+++ b/weave/trace_server/calls_query_builder/object_ref_query_builder.py
@@ -21,7 +21,7 @@ by the caller, in the expand_columns parameter.
 2. Process the leaf object reference condition, which filters on the value, or in the case
 of ordering extracts and returns the value, into a CTE. In this way we are starting from the
 bottom of the tree, working our way up to the root.
-3. Then we processe the intermediate object reference conditions, which find all objects
+3. Then we process the intermediate object reference conditions, which find all objects
 with a json path value that matches the intermediate object reference condition, into a CTE.
 4. Finally, the main query filters or orders on the result of the last CTE.
 
@@ -254,7 +254,7 @@ class ObjectRefCondition(BaseModel):
         Examples:
             >>> condition = ObjectRefFilterCondition(...)
             >>> condition.as_sql_condition(pb, "calls_merged", {"field_eq_value": "obj_filter_0"})
-            'JSON_VALUE(any(calls_merged.inputs_dump), $.model) IN (SELECT ref FROM obj_filter_0)'
+            'JSON_VALUE(any(calls_merged.inputs_dump), $.model) GLOBAL IN (SELECT ref FROM obj_filter_0)'
         """
         if self.unique_key not in field_to_object_join_alias_map:
             raise ValueError(
@@ -286,7 +286,9 @@ class ObjectRefCondition(BaseModel):
         # Table row refs have the format: weave-trace-internal:///<project_id>/object/<object_id>:<digest>/attr/rows/id/<row_digest>
         # We need to extract the row digest part for table_rows matching
         row_digest_extract = f"regexpExtract({json_extract_sql}, '/([^/]+)$', 1)"
-        return f"({json_extract_sql} IN (SELECT ref FROM {cte_alias}) OR {row_digest_extract} IN (SELECT ref FROM {cte_alias}))"
+        # GLOBAL IN: the referenced CTE reads Distributed object_versions and
+        # table_rows (UNION ALL), which the analyzer won't globalize via the setting.
+        return f"({json_extract_sql} GLOBAL IN (SELECT ref FROM {cte_alias}) OR {row_digest_extract} GLOBAL IN (SELECT ref FROM {cte_alias}))"
 
 
 class ObjectRefFilterCondition(ObjectRefCondition):
@@ -852,7 +854,7 @@ def _build_intermediate_cte_sql(
         {join_clause_for_ordering}
         WHERE ov.project_id = {param_slot(project_param, "String")}
             AND length(refs) > 0
-            AND JSON_VALUE(ov.val_dump, {param_slot(prop_json_path_param, "String")}) IN (
+            AND JSON_VALUE(ov.val_dump, {param_slot(prop_json_path_param, "String")}) GLOBAL IN (
                 SELECT ref FROM {current_cte_name}
             )
         GROUP BY ov.project_id, ov.object_id, ov.digest


### PR DESCRIPTION
## Summary
- The object-ref condition CTEs read Distributed `object_versions` + `table_rows` via `UNION ALL`. The CH analyzer won't globalize an `IN (SELECT ref FROM cte)` against that shape via `distributed_product_mode` (CH #99370), so the 2s2r nightly hit `Code 36` "Invalid local IN function name globalIn". Emit `GLOBAL IN` explicitly at those sites only.
- Scoped down from the original blanket rewrite: `distributed_product_mode='global'` still covers the other (non-UNION) IN/JOIN shapes, so calls-query / eval-results builders are untouched. The annotation Code 288 fix is split into #7118.

## Performance
Local benchmark, object-ref filter as `count()` over the full filtered scan, `IN` vs `GLOBAL IN`:

| cluster | plain `IN` | `GLOBAL IN` |
|---|---|---|
| single-node, 500k calls | ~195 ms | ~199 ms |
| 2s2r distributed, 50k calls | Code 36 (fails) | ~110 ms |

Single-node is neutral (delta flips sign run-to-run, within ~±5% noise, identical row counts). On distributed, `GLOBAL IN` is what lets the query run at all.

## Testing
object_ref query-builder unit tests updated to the GLOBAL IN SQL; full `query_builder` unit suite green. Functional + benchmark paths validated on a local single-node and 2s2r cluster.
