### PR TITLE
fix(weave): surface raw bytes truncation instead of dropping it silently

### DIFF
--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 
 from pydantic import BaseModel
@@ -6,6 +7,7 @@ import weave
 from weave.trace.object_record import pydantic_object_record
 from weave.trace.serialization.op_type import _replace_memory_address
 from weave.trace.serialization.serialize import (
+    TRUNCATED_BYTES_PREFIX,
     dictify,
     is_pydantic_model_class,
     stringify,
@@ -152,6 +154,44 @@ def test_stringify_returns_repr() -> None:
 
     pt = Point(1, 2)
     assert stringify(pt) == repr(pt)
+
+
+def test_stringify_bytes_truncation() -> None:
+    """Large/binary bytes become a visible marker; small bytes keep their repr."""
+    # Below the limit: behavior unchanged (regression guard).
+    assert stringify(b"hello") == "b'hello'"
+    assert stringify(bytearray(b"hi")) == repr(bytearray(b"hi"))
+
+    big = os.urandom(4096)
+    marker = stringify(big)
+    assert marker.startswith(TRUNCATED_BYTES_PREFIX)
+    assert "4096 bytes" in marker
+
+    # Short buffer whose repr expands past the limit still gets the marker.
+    assert stringify(b"\xff" * 400).startswith(TRUNCATED_BYTES_PREFIX)
+
+    # Reached via dictify's maxdepth path, not only the top-level to_json ladder.
+    assert dictify({"a": big}, maxdepth=1)["a"].startswith(TRUNCATED_BYTES_PREFIX)
+
+
+def test_op_raw_bytes_truncation_marker(client) -> None:
+    """Raw bytes logged through an op surface as a marker on read-back, not silent truncation."""
+    payload = os.urandom(4096)
+
+    @weave.op
+    def echo(b: bytes) -> bytes:
+        return b
+
+    echo(payload)
+
+    calls = list(client.get_calls())
+    assert len(calls) == 1
+    stored_input = calls[0].inputs["b"]
+    stored_output = calls[0].output
+    assert isinstance(stored_input, str)
+    assert stored_input.startswith(TRUNCATED_BYTES_PREFIX)
+    assert "4096 bytes" in stored_input
+    assert stored_output.startswith(TRUNCATED_BYTES_PREFIX)
 
 
 def test_dictify_sanitizes() -> None:

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -12,14 +12,21 @@ from weave.trace.object_record import ObjectRecord
 from weave.trace.refs import ObjectRef, Ref, TableRef
 from weave.trace.serialization import custom_objs
 from weave.trace.serialization.dictifiable import try_to_dict
+from weave.trace.util import log_once
 from weave.trace_server.trace_server_interface import (
     FileCreateReq,
     TraceServerInterface,
+)
+from weave.type_wrappers.Content.utils import (
+    MIME_DETECTION_BUFFER_SIZE,
+    get_mime_and_extension,
 )
 from weave.utils.sanitize import REDACTED_VALUE, should_redact
 
 if TYPE_CHECKING:
     from weave.trace.weave_client import WeaveClient
+
+logger = logging.getLogger(__name__)
 
 
 def is_pydantic_model_class(obj: Any) -> bool:
@@ -278,9 +285,28 @@ def _build_result_from_encoded(
 
 MAX_STR_LEN = 1000
 
+# Stable, parseable prefix for the placeholder substituted for oversized raw bytes.
+# Kept stable so exports/parsers can recognize these values.
+TRUNCATED_BYTES_PREFIX = "<weave-truncated-bytes:"
+
+_DEFAULT_MIMETYPE = "application/octet-stream"
+
+_RAW_BYTES_TRUNCATION_MSG = (
+    "weave does not store raw bytes inline, so a large bytes value was replaced "
+    "with a placeholder and is not recoverable. Wrap it in weave.Content "
+    "(e.g. weave.Content.from_bytes(value)) to store and export it losslessly."
+)
+
 
 def stringify(obj: Any, limit: int = MAX_STR_LEN) -> str:
     """This is a fallback for objects that we don't have a better way to serialize."""
+    if isinstance(obj, (bytes, bytearray)):
+        # repr(bytes) is at least len(obj) + 3 chars, so oversized buffers are
+        # rejected without materializing the (potentially huge) repr.
+        if len(obj) + 3 > limit:
+            return _truncated_bytes_marker(obj)
+        encoded = repr(obj)
+        return encoded if len(encoded) <= limit else _truncated_bytes_marker(obj)
     rep = None
     try:
         rep = repr(obj)
@@ -292,6 +318,28 @@ def stringify(obj: Any, limit: int = MAX_STR_LEN) -> str:
     if isinstance(rep, str) and len(rep) > limit:
         rep = rep[: limit - 3] + "..."
     return rep
+
+
+def _truncated_bytes_marker(obj: bytes | bytearray) -> str:
+    """Visible placeholder for raw bytes too large to store inline."""
+    log_once(logger.warning, _RAW_BYTES_TRUNCATION_MSG)
+    mimetype = _sniff_mimetype(bytes(obj[:MIME_DETECTION_BUFFER_SIZE]))
+    return (
+        f"{TRUNCATED_BYTES_PREFIX} {len(obj)} bytes, {mimetype}; "
+        "wrap in weave.Content to store losslessly>"
+    )
+
+
+def _sniff_mimetype(buffer: bytes) -> str:
+    """Best-effort content-type sniff; never raises (magic backend is optional)."""
+    try:
+        mimetype, _ = get_mime_and_extension(
+            mimetype=None, extension=None, filename=None, buffer=buffer
+        )
+    except Exception:
+        # Detection must never fail the user's op; fall back to the generic type.
+        return _DEFAULT_MIMETYPE
+    return mimetype
 
 
 def is_primitive(obj: Any) -> bool:


### PR DESCRIPTION
## Summary
- Raw `bytes`/`bytearray` logged through an op match no serializer and fall to `stringify`, which `repr`s then hard-clips at 1000 chars, so the payload was silently unrecoverable on `get_calls`/export.
- Now handled in `stringify` itself (covers the `dictify` deep path too): oversized bytes become a stable, visible marker naming the size + sniffed mimetype, plus a one-time warning pointing at `weave.Content`. `weave.Content` stays the lossless opt-in path.

Closes #4119

## Testing
unit + functional round-trip via `get_calls` (sqlite + clickhouse).