### PR TITLE
chore(weave): bump CI clickhouse to 26.4, disable query condition cache

### DIFF
--- a/.github/scripts/ch-image.sh
+++ b/.github/scripts/ch-image.sh
@@ -5,7 +5,7 @@
 set -uo pipefail
 
 # Single source of truth for the ClickHouse image version used across CI.
-tag="${1:-25.11.2.24}"
+tag="${1:-26.4}"
 ghcr="ghcr.io/wandb/clickhouse-server:${tag}"
 hub="clickhouse/clickhouse-server:${tag}"
 

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -128,6 +128,7 @@ jobs:
             --env CLICKHOUSE_PASSWORD= \
             --env CLICKHOUSE_DB=default \
             --publish 8123:8123 \
+            -v ${{ github.workspace }}/tests/trace_server/conftest_lib/test_overrides.xml:/etc/clickhouse-server/users.d/test_overrides.xml:ro \
             "$image"
           for _i in {1..30}; do
             if wget -q -O- 'http://localhost:8123/ping' >/dev/null; then

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -210,6 +210,7 @@ jobs:
             --env CLICKHOUSE_PASSWORD= \
             --env CLICKHOUSE_DB=default \
             --publish 8123:8123 \
+            -v ${{ github.workspace }}/tests/trace_server/conftest_lib/test_overrides.xml:/etc/clickhouse-server/users.d/test_overrides.xml:ro \
             "$image"
           for _i in {1..30}; do
             if wget -q -O- 'http://localhost:8123/ping' >/dev/null; then
@@ -303,6 +304,7 @@ jobs:
             -e CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT=1 \
             -p 8130:8123 \
             -v ${{ github.workspace }}/tests/trace_server/conftest_lib/clickhouse_keeper_config.xml:/etc/clickhouse-server/config.d/keeper.xml \
+            -v ${{ github.workspace }}/tests/trace_server/conftest_lib/test_overrides.xml:/etc/clickhouse-server/users.d/test_overrides.xml:ro \
             --name weave-test-keeper \
             --ulimit nofile=262144:262144 \
             "$image"

--- a/tests/trace_server/conftest_lib/test_overrides.xml
+++ b/tests/trace_server/conftest_lib/test_overrides.xml
@@ -1,6 +1,19 @@
 <!-- Server-side defaults applied only to test CH clusters. Mounted into
-     /etc/clickhouse-server/users.d/ by the topology compose files so every
-     connection from every test thread inherits these as profile defaults.
+     /etc/clickhouse-server/users.d/ by the topology compose files and the
+     single-node CI docker runs, so every connection from every test thread
+     inherits these as profile defaults.
+
+     async_insert=0: synchronous inserts in CI for read-after-write consistency.
+
+     use_query_condition_cache=0: CH 26.2-26.5 return wrong results when a query
+     combines PREWHERE on a pk-prefix column with WHERE non-pk IN/= on a
+     skip-indexed column (our calls_merged trace_id bloom-filter CTE): the query
+     condition cache is poisoned and later reads under-count / drop rows. See
+     https://github.com/ClickHouse/ClickHouse/issues/104781 (fixed by PR #105686,
+     backported to 26.3/26.4/26.5 but not yet in the pinned image). conftest
+     disables it per-query, but only on trace-server reads; setting it
+     server-side also covers the direct clickhouse-connect queries
+     (truncate/migrate/etc.) that would otherwise poison the shared cache.
 
      distributed_foreground_insert=1: by default ClickHouse buffers a
      Distributed INSERT locally and forwards async to the destination shard,
@@ -19,6 +32,8 @@
 <clickhouse>
     <profiles>
         <default>
+            <async_insert>0</async_insert>
+            <use_query_condition_cache>0</use_query_condition_cache>
             <distributed_foreground_insert>1</distributed_foreground_insert>
             <load_balancing>in_order</load_balancing>
         </default>

--- a/tests/trace_server/conftest_lib/topologies/1s3r.yaml
+++ b/tests/trace_server/conftest_lib/topologies/1s3r.yaml
@@ -32,7 +32,7 @@
 #   docker compose -f 1s3r.yaml down -v
 
 x-ch-node: &ch-node
-  image: clickhouse/clickhouse-server:25.11.2.24
+  image: clickhouse/clickhouse-server:26.4
   environment:
     CLICKHOUSE_DB: default
     CLICKHOUSE_USER: default
@@ -72,6 +72,7 @@ services:
       - "9000:9000"     # native TCP
     volumes:
       - ../keeper_1s3r.xml:/etc/clickhouse-server/config.d/cluster.xml:ro
+      - ../test_overrides.xml:/etc/clickhouse-server/users.d/test_overrides.xml:ro
       - ./macros_s1_r1.xml:/etc/clickhouse-server/config.d/macros.xml:ro
 
   ch-s1-r2:
@@ -80,6 +81,7 @@ services:
     hostname: ch-s1-r2
     volumes:
       - ../keeper_1s3r.xml:/etc/clickhouse-server/config.d/cluster.xml:ro
+      - ../test_overrides.xml:/etc/clickhouse-server/users.d/test_overrides.xml:ro
       - ./macros_s1_r2.xml:/etc/clickhouse-server/config.d/macros.xml:ro
     depends_on:
       ch-s1-r1:
@@ -91,6 +93,7 @@ services:
     hostname: ch-s1-r3
     volumes:
       - ../keeper_1s3r.xml:/etc/clickhouse-server/config.d/cluster.xml:ro
+      - ../test_overrides.xml:/etc/clickhouse-server/users.d/test_overrides.xml:ro
       - ./macros_s1_r3.xml:/etc/clickhouse-server/config.d/macros.xml:ro
     depends_on:
       ch-s1-r1:

--- a/tests/trace_server/conftest_lib/topologies/2s2r.yaml
+++ b/tests/trace_server/conftest_lib/topologies/2s2r.yaml
@@ -46,7 +46,7 @@
 #   docker compose -f 2s2r.yaml down -v
 
 x-ch-node: &ch-node
-  image: clickhouse/clickhouse-server:25.11.2.24
+  image: clickhouse/clickhouse-server:26.4
   environment:
     CLICKHOUSE_DB: default
     CLICKHOUSE_USER: default


### PR DESCRIPTION
## Summary
- Bumps CI ClickHouse to `26.4` and disables `use_query_condition_cache` in the test CH profile (`test_overrides.xml`).
- The 5 `test_trace_usage.py` failures are a ClickHouse query-condition-cache correctness bug (not async insert): CH 26.2-26.5 poison the cache on `calls_merged`'s `PREWHERE project_id` + `WHERE trace_id IN (...)` (bloom-skip-indexed) shape, so `calls_usage`/`trace_usage` drop the call_end row and read NULL `summary`/`ended_at`.
- Upstream: https://github.com/ClickHouse/ClickHouse/issues/104781, fixed by https://github.com/ClickHouse/ClickHouse/pull/105686 (backported to 26.3/26.4/26.5, not yet in the pinned image). Remove the setting once it lands.
- `_disable_query_condition_cache` in conftest only covers trace-server reads; the server-side profile setting also covers direct clickhouse-connect queries (truncate/migrate) that poison the shared cache.
- Stayed on `26.4` (not 26.5) - see "Why not 26.5?" below.

## Testing
full `trace_server` suite green on 26.4 with the profile setting (848 passed); the 5 `test_trace_usage.py` tests fail without it.

## Why not 26.5?
26.5 turns on a new sort+limit pushdown (`use_top_k_dynamic_filtering`, https://github.com/ClickHouse/ClickHouse/pull/99537) whose internal `__topKFilter` misbinds column positions under lazy materialization, crashing `ORDER BY <DateTime64> DESC, <String pk-key> ASC LIMIT n` reads (our annotation-queue pagination) with `Code: 53 TYPE_MISMATCH`. Unfixed upstream: https://github.com/ClickHouse/ClickHouse/issues/106294. No clean per-query fix (only `use_top_k_dynamic_filtering=0` / disabling lazy materialization), so we stay on 26.4 where the optimization is off by default.

Minimal repro (crashes on 26.5.1.882, clean on 26.4):
```sql
CREATE TABLE annotation_queues (id String, project_id String, created_at DateTime64(3), name String)
ENGINE = MergeTree ORDER BY (project_id, id);
SYSTEM STOP MERGES annotation_queues;
INSERT INTO annotation_queues SELECT generateUUIDv7(), 'p', now64(3), 'q0';
INSERT INTO annotation_queues SELECT generateUUIDv7(), 'p', now64(3), 'q1';
INSERT INTO annotation_queues SELECT generateUUIDv7(), 'p', now64(3), 'q2';
INSERT INTO annotation_queues SELECT generateUUIDv7(), 'p', now64(3), 'q3';
INSERT INTO annotation_queues SELECT generateUUIDv7(), 'p', now64(3), 'q4';
-- repeat ~20x; one throws: Cannot convert string '<uuid>' to DateTime64(3) in __topKFilter(created_at)
SELECT id, project_id, created_at, name FROM annotation_queues
WHERE project_id = 'p' ORDER BY created_at DESC, id ASC LIMIT 2 OFFSET 0;
```
