### PR TITLE
fix(weave): route distributed annotation reads through the _query helper

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -3383,7 +3383,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             include_position=req.include_position,
         )
 
-        result = self.ch_client.query(query, parameters=pb.get_params())
+        result = self._query(query, pb.get_params())
 
         items = []
         for row in result.named_results():
@@ -3428,7 +3428,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             pb=pb,
         )
 
-        result = self.ch_client.query(query, parameters=pb.get_params())
+        result = self._query(query, pb.get_params())
 
         stats = []
         for row in result.result_rows:
@@ -3459,7 +3459,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             offset=None,
             include_position=False,
         )
-        fetch_result = self.ch_client.query(fetch_query, parameters=pb.get_params())
+        fetch_result = self._query(fetch_query, pb.get_params())
 
         for row in fetch_result.named_results():
             item = tsi.AnnotationQueueItemSchema(


### PR DESCRIPTION
## Summary
- On distributed (2s2r) clusters the annotation-queue reads (`annotation_queue_items_query`, `annotation_queues_stats`, the progress-update fetch) called `ch_client.query` directly, bypassing `_query`/`merge_default_query_settings`, so `distributed_product_mode='global'` never reached them and their `annotation_queue_items LEFT JOIN annotator_queue_items_progress` hit `Code 288` (double-distributed denied).
- Route those reads through `self._query` so they inherit session settings. Prod CH doesn't set dpm server-side, so it must travel in session settings.

## Testing
verified on a local 2s2r cluster: the `test_client_annotation_queues` suite passes (these were ~68 of the 2s2r nightly failures).