### PR TITLE
fix(weave): run INSERT on distributed tables during migration

### DIFF
--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -159,7 +159,10 @@ def _discover_truncatable_tables(ch_client, database: str) -> list[str]:
         "AND engine NOT IN ('View', 'MaterializedView', 'Distributed') "
         "ORDER BY name"
     )
-    return [row[0] for row in result.result_rows if row[0] not in SEED_DATA_TABLES]
+    seed_tables = SEED_DATA_TABLES | {
+        t + ch_settings.LOCAL_TABLE_SUFFIX for t in SEED_DATA_TABLES
+    }
+    return [row[0] for row in result.result_rows if row[0] not in seed_tables]
 
 
 def _truncate_all_tables(ch_client, database: str, tables: list[str]) -> None:

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -1351,13 +1351,18 @@ def test_skip_materialize_command_distributed(distributed_migrator):
     assert distributed_migrator.ch_client.database == "original_db"
 
 
-def test_skip_insert_command_distributed(distributed_migrator):
-    """Test that INSERT INTO commands are skipped in distributed mode."""
-    insert_command = "INSERT INTO calls_complete_new SELECT * FROM calls_complete"
-
-    distributed_migrator._execute_migration_command("test_db", insert_command)
-
+def test_insert_command_distributed(distributed_migrator):
+    """INSERT ... SELECT backfills are skipped; INSERT ... VALUES seeds run synchronously."""
+    backfill = "INSERT INTO calls_complete_new SELECT * FROM calls_complete"
+    distributed_migrator._execute_migration_command("test_db", backfill)
     assert distributed_migrator.ch_client.command.call_count == 0
+
+    seed = "INSERT INTO llm_token_prices (id, llm_id) VALUES ('a', 'gpt-4')"
+    distributed_migrator._execute_migration_command("test_db", seed)
+    assert distributed_migrator.ch_client.command.call_count == 1
+    args, kwargs = distributed_migrator.ch_client.command.call_args
+    assert args[0] == seed
+    assert kwargs == {"settings": {"distributed_foreground_insert": 1}}
     assert distributed_migrator.ch_client.database == "original_db"
 
 

--- a/weave/trace_server/clickhouse_trace_server_migrator.py
+++ b/weave/trace_server/clickhouse_trace_server_migrator.py
@@ -1069,12 +1069,16 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
                 )
                 return
 
-            # Skip INSERT commands (backfill not supported in distributed mode)
+            # Run INSERT ... VALUES seeds (the Distributed engine fans rows to
+            # shards); skip INSERT ... SELECT backfills, which need per-shard handling.
             if SQLPatterns.INSERT_STMT.search(command_for_match):
-                logger.warning(
-                    "Skipping INSERT command (not supported in distributed mode): %s...",
-                    command[:_COMMAND_PREVIEW_LENGTH],
-                )
+                if SQLPatterns.INSERT_SELECT_STMT.search(command_for_match):
+                    logger.warning(
+                        "Skipping INSERT ... SELECT backfill (not supported in distributed mode): %s...",
+                        command[:_COMMAND_PREVIEW_LENGTH],
+                    )
+                    return
+                self._run_distributed_insert(command)
                 return
 
             # Handle RENAME TABLE (local rename + drop/recreate distributed table)
@@ -1284,6 +1288,10 @@ class DistributedClickHouseTraceServerMigrator(ReplicatedClickHouseTraceServerMi
             local_command, target_db=self.ch_client.database
         )
         self._run_ddl_with_retry(local_command)
+
+    def _run_distributed_insert(self, command: str) -> None:
+        """Run an INSERT ... VALUES seed against the distributed table synchronously."""
+        self.ch_client.command(command, settings={"distributed_foreground_insert": 1})
 
     def _execute_distributed_rename(self, command: str) -> None:
         """Handle RENAME TABLE in distributed mode.
@@ -1629,6 +1637,9 @@ class SQLPatterns:
     MODIFY_QUERY: Pattern = re.compile(r"\bMODIFY\s+QUERY\b", re.IGNORECASE)
     MATERIALIZE: Pattern = re.compile(r"\bMATERIALIZE\b", re.IGNORECASE)
     INSERT_STMT: Pattern = re.compile(r"\bINSERT\s+INTO\b", re.IGNORECASE)
+    INSERT_SELECT_STMT: Pattern = re.compile(
+        r"\bINSERT\s+INTO\b.*\bSELECT\b", re.IGNORECASE | re.DOTALL
+    )
     LOCAL_ONLY_OPS: Pattern = re.compile(
         r"\b(ADD|DROP)\s+INDEX\b|\b(DELETE|UPDATE)\b|\b(MODIFY|REMOVE)\s+TTL\b",
         re.IGNORECASE,


### PR DESCRIPTION
## Summary
- On distributed (2s2r) clusters the migrator skipped every `INSERT INTO`, so migration 006's `llm_token_prices` cost seeds never landed. The cost query then ranked over only the checkpoint-seeded rows and returned a different price than single-node (e.g. gpt-4o), failing `test_summary_tokens_cost`.
- Run `INSERT ... VALUES` seeds synchronously against the Distributed table (the engine fans rows to shards); keep skipping `INSERT ... SELECT` backfills (per-shard). Also exclude the `_local` twins of seed tables from the per-test TRUNCATE so seeded prices survive between tests.

## Testing
`test_summary_tokens_cost` passes on a local 2s2r cluster and on single-node; migrator (104) + costs (10) unit suites green.