### PR TITLE
chore(weave): 0.81.x server release patch 2

### DIFF
--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -247,6 +247,12 @@ export interface CallsQueryStatsReq {
 export interface CallsQueryStatsRes {
   /** Count */
   count: number;
+  /**
+   * Has More
+   * True when count saturated the request's limit (caller-supplied or the server's defense-in-depth ceiling). Clients should render the count as e.g. '10,000+'.
+   * @default false
+   */
+  has_more?: boolean;
 }
 
 /** ContainsOperation */

--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -1290,7 +1290,15 @@
         "title": "CallsQueryStatsReq"
       },
       "CallsQueryStatsRes": {
-        "properties": {"count": {"type": "integer", "title": "Count"}},
+        "properties": {
+          "count": {"type": "integer", "title": "Count"},
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More",
+            "default": false,
+            "description": "True when count saturated the request's limit (caller-supplied or the server's defense-in-depth ceiling). Clients should render the count as e.g. '10,000+'."
+          }
+        },
         "type": "object",
         "required": ["count"],
         "title": "CallsQueryStatsRes"

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -4899,6 +4899,74 @@ def test_calls_query_stats_with_limit(client):
     assert result.total_storage_size_bytes is not None
 
 
+def test_calls_query_stats_started_at_window_excludes_deletes(client):
+    """A started_at lower-bound count must match across backends and exclude
+    soft-deleted calls and orphaned call-ends. On ClickHouse this exercises the
+    windowed distinct-id fast path; on SQLite it exercises the reference
+    implementation, so equal results pin the optimization to the GROUP BY
+    semantics.
+    """
+
+    @weave.op
+    def stats_window_op() -> int:
+        return 1
+
+    for _ in range(3):
+        stats_window_op()
+
+    project_id = get_client_project_id(client)
+    all_calls = client.get_calls()
+    assert len(all_calls) == 3
+
+    def count(literal_seconds: int) -> int:
+        query = tsi.Query(
+            **{
+                "$expr": {
+                    "$gt": [{"$getField": "started_at"}, {"$literal": literal_seconds}]
+                }
+            }
+        )
+        return client.server.calls_query_stats(
+            tsi.CallsQueryStatsReq(project_id=project_id, query=query)
+        ).count
+
+    def unfiltered_count() -> int:
+        # No query -> exercises the flat distinct-id fast path (Pattern 3).
+        return client.server.calls_query_stats(
+            tsi.CallsQueryStatsReq(project_id=project_id)
+        ).count
+
+    # Lower bound in the distant past counts every (non-deleted) call.
+    assert count(1) == 3
+    assert unfiltered_count() == 3
+    # Lower bound in the far future counts nothing.
+    assert count(99999999999) == 0
+
+    # Deleting a call removes it from both counts (delete exclusion).
+    client.server.calls_delete(
+        tsi.CallsDeleteReq(project_id=project_id, call_ids=[all_calls[0].id])
+    )
+    assert count(1) == 2
+    assert unfiltered_count() == 2
+
+    # An orphaned call-end (end row, no start) carries started_at since #6933 but
+    # has no op_name; the op_name guard must keep it out of both fast-path counts.
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    client.server.call_end(
+        tsi.CallEndReq(
+            end=tsi.EndedCallSchemaForInsert(
+                project_id=project_id,
+                id=generate_id(),
+                started_at=now,
+                ended_at=now,
+                summary={},
+            )
+        )
+    )
+    assert count(1) == 2
+    assert unfiltered_count() == 2
+
+
 @pytest.mark.parametrize(
     "thread_ids",
     [

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -16,6 +16,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     build_calls_complete_delete_query,
     build_calls_complete_update_end_query,
     build_calls_complete_update_query,
+    build_calls_stats_query,
 )
 from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH
 from weave.trace_server.errors import InvalidFieldError
@@ -3824,7 +3825,7 @@ def test_stats_query_calls_complete_flat_count() -> None:
     assert_stats_sql(
         req,
         """
-        SELECT count() AS count
+        SELECT count() AS count, toUInt8(0) AS has_more
         FROM calls_complete
         PREWHERE calls_complete.project_id = {pb_1:String}
         WHERE 1
@@ -3847,7 +3848,7 @@ def test_stats_query_calls_complete_flat_count_with_filter() -> None:
     assert_stats_sql(
         req,
         """
-        SELECT count() AS count
+        SELECT count() AS count, toUInt8(0) AS has_more
         FROM calls_complete
         PREWHERE calls_complete.project_id = {pb_2:String}
         WHERE ((calls_complete.op_name IN {pb_1:Array(String)})
@@ -3873,6 +3874,7 @@ def test_stats_query_calls_complete_flat_with_total_storage_size() -> None:
         req,
         """
         SELECT count() AS count,
+               toUInt8(0) AS has_more,
                sum(coalesce(CASE
                    WHEN calls_complete.parent_id = {pb_2:String}
                         THEN rolled_up_cms.total_storage_size_bytes
@@ -3924,7 +3926,7 @@ def test_stats_query_calls_complete_with_feedback_filter_uses_count_distinct() -
     assert_stats_sql(
         req,
         """
-        SELECT count(DISTINCT calls_complete.id) AS count
+        SELECT count(DISTINCT calls_complete.id) AS count, toUInt8(0) AS has_more
         FROM calls_complete
         LEFT JOIN (
             SELECT * FROM feedback WHERE feedback.project_id = {pb_4:String}
@@ -3951,13 +3953,21 @@ def test_stats_query_calls_complete_with_feedback_filter_uses_count_distinct() -
     )
 
 
-def test_stats_query_calls_merged_uses_subquery() -> None:
-    """Stats query on calls_merged should use subquery wrapping (GROUP BY requires it)."""
+def test_stats_query_calls_merged_no_caller_limit_skips_cap() -> None:
+    """No caller-supplied limit -> no server cap, no setting, has_more=0.
+
+    When the cap deferred behind `DEFAULT_STATS_MAX_LIMIT` is re-enabled, this
+    test should assert the streaming-aggregate setting + inner `LIMIT 1000000`
+    + `has_more = toUInt8(count() >= 1000000)`.
+    """
     req = tsi.CallsQueryStatsReq(project_id="project")
+    pb = ParamBuilder("pb")
+    query, _columns, settings = build_calls_stats_query(req, pb, ReadTable.CALLS_MERGED)
+    assert settings == {}
     assert_stats_sql(
         req,
         """
-        SELECT count()
+        SELECT count() AS count, toUInt8(0) AS has_more
         FROM (
             SELECT calls_merged.id AS id
             FROM calls_merged
@@ -3973,6 +3983,50 @@ def test_stats_query_calls_merged_uses_subquery() -> None:
         {"pb_0": "project"},
         read_table=ReadTable.CALLS_MERGED,
     )
+
+
+def test_stats_query_calls_merged_caller_limit_keeps_setting() -> None:
+    """Caller-supplied limit also triggers the streaming-aggregate setting and
+    `has_more` reflects saturation against the caller's limit.
+    """
+    req = tsi.CallsQueryStatsReq(project_id="project", limit=5)
+    pb = ParamBuilder("pb")
+    query, _columns, settings = build_calls_stats_query(req, pb, ReadTable.CALLS_MERGED)
+    assert settings == {"optimize_aggregation_in_order": 1}
+    assert_stats_sql(
+        req,
+        """
+        SELECT count() AS count, toUInt8(count() >= 5) AS has_more
+        FROM (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_0:String}
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((any(calls_merged.deleted_at) IS NULL))
+                AND
+                ((NOT ((any(calls_merged.started_at) IS NULL))))
+            )
+            LIMIT 5
+        )
+        """,
+        {"pb_0": "project"},
+        read_table=ReadTable.CALLS_MERGED,
+    )
+
+
+def test_stats_query_calls_merged_no_cap_when_summing_storage() -> None:
+    """include_total_storage_size needs every row, so no cap and no setting."""
+    req = tsi.CallsQueryStatsReq(
+        project_id="project",
+        include_total_storage_size=True,
+    )
+    query, _columns, settings = build_calls_stats_query(
+        req, ParamBuilder("pb"), ReadTable.CALLS_MERGED
+    )
+    assert settings == {}
+    assert "LIMIT" not in query
+    assert "toUInt8(0) AS has_more" in query
 
 
 # ---------------------------------------------------------------------------

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -3953,17 +3953,146 @@ def test_stats_query_calls_complete_with_feedback_filter_uses_count_distinct() -
     )
 
 
-def test_stats_query_calls_merged_no_caller_limit_skips_cap() -> None:
-    """No caller-supplied limit -> no server cap, no setting, has_more=0.
+def test_stats_query_calls_merged_unfiltered_limit_1_stays_with_pattern_1() -> None:
+    """limit=1 with no filter is the project-existence check (Pattern 1),
+    which uses `LIMIT 1` and is strictly cheaper than starting a uniqUpTo
+    aggregator. Pinning this boundary so Pattern 3 never intercepts.
+    """
+    req = tsi.CallsQueryStatsReq(project_id="project", limit=1)
+    assert_stats_sql(
+        req,
+        """
+        SELECT toUInt8(count()) AS has_any
+        FROM (
+            SELECT 1
+            FROM calls_merged
+            WHERE project_id = {pb_0:String}
+            LIMIT 1
+        )
+        """,
+        {"pb_0": "project"},
+        read_table=ReadTable.CALLS_MERGED,
+    )
 
-    When the cap deferred behind `DEFAULT_STATS_MAX_LIMIT` is re-enabled, this
-    test should assert the streaming-aggregate setting + inner `LIMIT 1000000`
-    + `has_more = toUInt8(count() >= 1000000)`.
+
+def test_stats_query_calls_merged_unfiltered_no_limit_uses_flat_distinct() -> None:
+    """Unfiltered calls_merged stats with no limit takes the flat distinct-id path.
+
+    Two parallel aggregators on one scan dedupe ids and subtract those with any
+    soft-delete row. Matches the GROUP BY path's exclusion semantics exactly.
     """
     req = tsi.CallsQueryStatsReq(project_id="project")
     pb = ParamBuilder("pb")
-    query, _columns, settings = build_calls_stats_query(req, pb, ReadTable.CALLS_MERGED)
+    _query, _columns, settings = build_calls_stats_query(
+        req, pb, ReadTable.CALLS_MERGED
+    )
     assert settings == {}
+    assert_stats_sql(
+        req,
+        """
+        SELECT raw_count AS count,
+               toUInt8(0) AS has_more
+        FROM (
+            SELECT uniqExact(calls_merged.id) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
+            FROM calls_merged
+            WHERE calls_merged.project_id = {pb_0:String})
+        """,
+        {"pb_0": "project"},
+        read_table=ReadTable.CALLS_MERGED,
+    )
+
+
+def test_stats_query_calls_merged_unfiltered_with_limit_caps_in_outer_select() -> None:
+    """Caller-supplied limit caps `count` via least() and flips `has_more`
+    when the raw distinct count exceeds the cap. Inner aggregator is unchanged.
+    """
+    req = tsi.CallsQueryStatsReq(project_id="project", limit=5)
+    pb = ParamBuilder("pb")
+    _query, _columns, settings = build_calls_stats_query(
+        req, pb, ReadTable.CALLS_MERGED
+    )
+    assert settings == {}
+    assert_stats_sql(
+        req,
+        """
+        SELECT least(raw_count, 5) AS count,
+               toUInt8(raw_count > 5) AS has_more
+        FROM (
+            SELECT uniqExact(calls_merged.id) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
+            FROM calls_merged
+            WHERE calls_merged.project_id = {pb_0:String})
+        """,
+        {"pb_0": "project"},
+        read_table=ReadTable.CALLS_MERGED,
+    )
+
+
+def test_stats_query_calls_merged_with_filter_falls_back_to_group_by() -> None:
+    """Hardcoded filter forces the GROUP BY rollup -- filters need per-id state."""
+    req = tsi.CallsQueryStatsReq(
+        project_id="project",
+        filter=tsi.CallsFilter(op_names=["my_op"]),
+    )
+    assert_stats_sql(
+        req,
+        """
+        SELECT count() AS count, toUInt8(0) AS has_more
+        FROM (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_1:String}
+            WHERE ((calls_merged.op_name IN {pb_0:Array(String)})
+                   OR (calls_merged.op_name IS NULL))
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((any(calls_merged.deleted_at) IS NULL))
+                AND
+                ((NOT ((any(calls_merged.started_at) IS NULL))))
+            )
+        )
+        """,
+        {"pb_0": ["my_op"], "pb_1": "project"},
+        read_table=ReadTable.CALLS_MERGED,
+    )
+
+
+def test_stats_query_calls_merged_with_query_falls_back_to_group_by() -> None:
+    """A `query` argument forces the GROUP BY rollup -- predicates live in HAVING."""
+    req = tsi.CallsQueryStatsReq(
+        project_id="project",
+        query=tsi.Query.model_validate(
+            {"$expr": {"$eq": [{"$getField": "id"}, {"$literal": "x"}]}}
+        ),
+    )
+    assert_stats_sql(
+        req,
+        """
+        SELECT count() AS count, toUInt8(0) AS has_more
+        FROM (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_1:String}
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((calls_merged.id = {pb_0:String}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.started_at) IS NULL))))
+            )
+        )
+        """,
+        {"pb_0": "x", "pb_1": "project"},
+        read_table=ReadTable.CALLS_MERGED,
+    )
+
+
+def test_stats_query_calls_merged_with_expand_columns_falls_back_to_group_by() -> None:
+    """expand_columns disables the flat path even when no filter/query references
+    the expansion -- treat any caller-supplied expansion as opting into rollup.
+    """
+    req = tsi.CallsQueryStatsReq(
+        project_id="project",
+        expand_columns=["inputs.model"],
+    )
     assert_stats_sql(
         req,
         """
@@ -3978,36 +4107,6 @@ def test_stats_query_calls_merged_no_caller_limit_skips_cap() -> None:
                 AND
                 ((NOT ((any(calls_merged.started_at) IS NULL))))
             )
-        )
-        """,
-        {"pb_0": "project"},
-        read_table=ReadTable.CALLS_MERGED,
-    )
-
-
-def test_stats_query_calls_merged_caller_limit_keeps_setting() -> None:
-    """Caller-supplied limit also triggers the streaming-aggregate setting and
-    `has_more` reflects saturation against the caller's limit.
-    """
-    req = tsi.CallsQueryStatsReq(project_id="project", limit=5)
-    pb = ParamBuilder("pb")
-    query, _columns, settings = build_calls_stats_query(req, pb, ReadTable.CALLS_MERGED)
-    assert settings == {"optimize_aggregation_in_order": 1}
-    assert_stats_sql(
-        req,
-        """
-        SELECT count() AS count, toUInt8(count() >= 5) AS has_more
-        FROM (
-            SELECT calls_merged.id AS id
-            FROM calls_merged
-            PREWHERE calls_merged.project_id = {pb_0:String}
-            GROUP BY (calls_merged.project_id, calls_merged.id)
-            HAVING (
-                ((any(calls_merged.deleted_at) IS NULL))
-                AND
-                ((NOT ((any(calls_merged.started_at) IS NULL))))
-            )
-            LIMIT 5
         )
         """,
         {"pb_0": "project"},

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -3978,8 +3978,9 @@ def test_stats_query_calls_merged_unfiltered_limit_1_stays_with_pattern_1() -> N
 def test_stats_query_calls_merged_unfiltered_no_limit_uses_flat_distinct() -> None:
     """Unfiltered calls_merged stats with no limit takes the flat distinct-id path.
 
-    Two parallel aggregators on one scan dedupe ids and subtract those with any
-    soft-delete row. Matches the GROUP BY path's exclusion semantics exactly.
+    Inclusion-exclusion on one scan: count(started or deleted) - count(deleted)
+    = distinct non-deleted started ids. op_name (start-only) drops orphaned
+    call-ends, matching the GROUP BY path's exclusion semantics exactly.
     """
     req = tsi.CallsQueryStatsReq(project_id="project")
     pb = ParamBuilder("pb")
@@ -3993,7 +3994,7 @@ def test_stats_query_calls_merged_unfiltered_no_limit_uses_flat_distinct() -> No
         SELECT raw_count AS count,
                toUInt8(0) AS has_more
         FROM (
-            SELECT uniqExact(calls_merged.id) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
+            SELECT uniqExactIf(calls_merged.id, isNotNull(calls_merged.op_name) OR isNotNull(calls_merged.deleted_at)) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_0:String})
         """,
@@ -4018,7 +4019,7 @@ def test_stats_query_calls_merged_unfiltered_with_limit_caps_in_outer_select() -
         SELECT least(raw_count, 5) AS count,
                toUInt8(raw_count > 5) AS has_more
         FROM (
-            SELECT uniqExact(calls_merged.id) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
+            SELECT uniqExactIf(calls_merged.id, isNotNull(calls_merged.op_name) OR isNotNull(calls_merged.deleted_at)) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS raw_count
             FROM calls_merged
             WHERE calls_merged.project_id = {pb_0:String})
         """,
@@ -4081,6 +4082,145 @@ def test_stats_query_calls_merged_with_query_falls_back_to_group_by() -> None:
         )
         """,
         {"pb_0": "x", "pb_1": "project"},
+        read_table=ReadTable.CALLS_MERGED,
+    )
+
+
+def _started_at_query(expr: dict) -> tsi.Query:
+    return tsi.Query.model_validate({"$expr": expr})
+
+
+def test_stats_query_calls_merged_started_at_window_uses_distinct_anti_set() -> None:
+    """A started_at-only window takes the distinct-id fast path (Pattern 4).
+
+    uniqExact counts start rows in the window -- the exact `started_at`
+    predicates match the GROUP BY path's `any(started_at) <op> T` HAVING (and
+    drop the prefilter buffer slop), and `op_name IS NOT NULL` reproduces its
+    orphaned-call-end exclusion (since #6933 end rows carry started_at too).
+    Soft-deleted ids are removed with an anti-set. Both bounds prefilter the
+    outer scan, but only the lower bound windows the anti-set: deletes can land
+    after the upper bound, never before the lower one. Limit capping reuses the
+    shared count/has_more wrapper.
+    """
+    req = tsi.CallsQueryStatsReq(
+        project_id="project",
+        limit=5,
+        query=_started_at_query(
+            {
+                "$and": [
+                    {"$gt": [{"$getField": "started_at"}, {"$literal": 1709251200}]},
+                    {"$lt": [{"$getField": "started_at"}, {"$literal": 1709337600}]},
+                ]
+            }
+        ),
+    )
+    assert_stats_sql(
+        req,
+        """
+        SELECT least(raw_count, 5) AS count,
+               toUInt8(raw_count > 5) AS has_more
+        FROM (
+            SELECT uniqExact(calls_merged.id) AS raw_count
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_0:String}
+            WHERE calls_merged.sortable_datetime > {pb_2:String}
+              AND calls_merged.sortable_datetime < {pb_4:String}
+              AND calls_merged.started_at > {pb_1:String}
+              AND calls_merged.started_at < {pb_3:String}
+              AND isNotNull(calls_merged.op_name)
+              AND calls_merged.id NOT IN (
+                  SELECT calls_merged.id
+                  FROM calls_merged
+                  PREWHERE calls_merged.project_id = {pb_0:String}
+                  WHERE calls_merged.sortable_datetime > {pb_2:String}
+                    AND isNotNull(calls_merged.deleted_at)))
+        """,
+        {
+            "pb_0": "project",
+            "pb_1": "2024-03-01 00:00:00.000000",
+            "pb_2": "2024-02-29 23:55:00.000000",
+            "pb_3": "2024-03-02 00:00:00.000000",
+            "pb_4": "2024-03-02 00:05:00.000000",
+        },
+        read_table=ReadTable.CALLS_MERGED,
+    )
+
+
+def test_stats_query_calls_merged_started_at_fast_path_gates() -> None:
+    """The fast path fires only when a lower-bounded started_at is the sole
+    filter. An upper-bound-only window (cannot window the delete anti-set) and a
+    started_at bound mixed with any other predicate both fall back to GROUP BY.
+    """
+    # Upper bound only -> no lower bound to window the anti-set -> fall back.
+    assert_stats_sql(
+        tsi.CallsQueryStatsReq(
+            project_id="project",
+            query=_started_at_query(
+                {"$lt": [{"$getField": "started_at"}, {"$literal": 1709251200}]}
+            ),
+        ),
+        """
+        SELECT count() AS count, toUInt8(0) AS has_more
+        FROM (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_2:String}
+            WHERE (calls_merged.sortable_datetime < {pb_1:String})
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((any(calls_merged.started_at) < {pb_0:String}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+            )
+        )
+        """,
+        {
+            "pb_0": "2024-03-01 00:00:00.000000",
+            "pb_1": "2024-03-01 00:05:00.000000",
+            "pb_2": "project",
+        },
+        read_table=ReadTable.CALLS_MERGED,
+    )
+    # started_at lower bound + a non-time predicate -> not time-only -> fall back.
+    assert_stats_sql(
+        tsi.CallsQueryStatsReq(
+            project_id="project",
+            query=_started_at_query(
+                {
+                    "$and": [
+                        {
+                            "$gt": [
+                                {"$getField": "started_at"},
+                                {"$literal": 1709251200},
+                            ]
+                        },
+                        {"$eq": [{"$getField": "op_name"}, {"$literal": "x"}]},
+                    ]
+                }
+            ),
+        ),
+        """
+        SELECT count() AS count, toUInt8(0) AS has_more
+        FROM (
+            SELECT calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_3:String}
+            WHERE (calls_merged.sortable_datetime > {pb_2:String})
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((any(calls_merged.started_at) > {pb_0:String}))
+                AND ((any(calls_merged.op_name) = {pb_1:String}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+            )
+        )
+        """,
+        {
+            "pb_0": "2024-03-01 00:00:00.000000",
+            "pb_1": "x",
+            "pb_2": "2024-02-29 23:55:00.000000",
+            "pb_3": "project",
+        },
         read_table=ReadTable.CALLS_MERGED,
     )
 

--- a/tests/trace_server/query_builder/utils.py
+++ b/tests/trace_server/query_builder/utils.py
@@ -169,7 +169,7 @@ def assert_stats_sql(
         read_table: Which table to query (calls_merged or calls_complete)
     """
     pb = ParamBuilder("pb")
-    query, _columns = build_calls_stats_query(req, pb, read_table)
+    query, _columns, _settings = build_calls_stats_query(req, pb, read_table)
     params = pb.get_params()
 
     exp_formatted = sqlparse.format(exp_query, reindent=True).strip()

--- a/tests/trace_server/test_sqlite_trace_server.py
+++ b/tests/trace_server/test_sqlite_trace_server.py
@@ -115,6 +115,60 @@ def _make_server_with_call(
     return server, call_id
 
 
+def test_sqlite_calls_query_stats_sets_has_more_when_limit_saturates():
+    """Backend-equivalence with the CH path: has_more must be True when
+    count==limit (caller's count is truncated) and False otherwise. Sqlite
+    previously returned the Pydantic default (False) regardless, which makes
+    a dev frontend hitting sqlite silently disagree with prod on the "X+" cap.
+    """
+    server = slts.SqliteTraceServer(":memory:")
+    server.drop_tables()
+    server.setup_tables()
+    try:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        for i in range(3):
+            server.call_start(
+                tsi.CallStartReq(
+                    start=tsi.StartedCallSchemaForInsert(
+                        project_id="test_project",
+                        id=f"call_{i}",
+                        trace_id=f"trace_{i}",
+                        op_name="op",
+                        started_at=now,
+                        attributes={},
+                        inputs={},
+                    )
+                )
+            )
+            server.call_end(
+                tsi.CallEndReq(
+                    end=tsi.EndedCallSchemaForInsert(
+                        project_id="test_project",
+                        id=f"call_{i}",
+                        ended_at=now,
+                        output=None,
+                        summary={},
+                    )
+                )
+            )
+
+        # 3 calls, limit=2 -> count==2, has_more=True (truncated).
+        truncated = server.calls_query_stats(
+            tsi.CallsQueryStatsReq(project_id="test_project", limit=2)
+        )
+        assert truncated.count == 2
+        assert truncated.has_more is True
+
+        # 3 calls, limit=10 -> count==3, has_more=False (room to spare).
+        exact = server.calls_query_stats(
+            tsi.CallsQueryStatsReq(project_id="test_project", limit=10)
+        )
+        assert exact.count == 3
+        assert exact.has_more is False
+    finally:
+        server.close()
+
+
 def test_sqlite_storage_size_bytes_populated_on_call_end():
     """storage_size_bytes column is populated when a call is started then ended."""
     server, call_id = _make_server_with_call(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -53,6 +53,7 @@ from weave.trace_server.calls_query_builder.object_ref_query_builder import (
     process_query_for_object_refs,
 )
 from weave.trace_server.calls_query_builder.optimization_builder import (
+    DATETIME_BUFFER_TIME_SECONDS,
     process_query_to_optimization_sql,
 )
 from weave.trace_server.calls_query_builder.utils import (
@@ -2892,6 +2893,27 @@ def _try_optimized_stats_query(
             req.project_id, req.limit, param_builder
         )
 
+    # Pattern 4: Time-windowed distinct-call count on calls_merged.
+    #
+    # Generalizes Pattern 3 to a count whose only narrowing is a started_at
+    # time bound: count windowed start rows with uniqExact (started_at lives
+    # only on the start row, so the per-row filter equals the GROUP BY path's
+    # `any(started_at) <op> T` HAVING), and exclude soft-deleted ids via an
+    # anti-set instead of a parallel aggregator (deleted_at lives on a separate
+    # delete row, so it cannot be correlated to started_at in one scan). A lower
+    # bound is required so the anti-set can be windowed too: a call's deleted_at
+    # is always >= its started_at, so deletes of in-window calls land in-window.
+    if (
+        read_table == ReadTable.CALLS_MERGED
+        and req.query is not None
+        and _is_time_filtered_stats_req(req)
+    ):
+        bounds = _extract_started_at_only_bounds(req.query.expr_)
+        if bounds is not None and any(op in {">", ">="} for op, _ in bounds):
+            return _optimized_time_filtered_calls_merged_count_query(
+                req.project_id, req.limit, bounds, param_builder
+            )
+
     return None
 
 
@@ -2955,21 +2977,104 @@ def _optimized_unfiltered_calls_merged_count_query(
 ) -> str:
     """Flat distinct-id count for unfiltered calls_merged stats.
 
-    Two parallel aggregators in one scan: total distinct ids minus distinct ids
-    that have any row with deleted_at set. Matches the GROUP BY path's
-    `argMax(deleted_at) IS NULL` exclusion exactly.
+    Counts distinct non-deleted started ids in one scan via inclusion-exclusion:
+    count(started not deleted) = count(started or deleted) - count(deleted).
+    op_name is start-only and deleted_at is delete-row-only (never on the same
+    row), so this matches the GROUP BY path's `op_name IS NOT NULL AND
+    deleted_at IS NULL` HAVING -- dropping orphaned call-ends -- without the
+    second scan an anti-set needs.
     """
     table_name = get_calls_table_name(ReadTable.CALLS_MERGED)
     project_id_slot = param_slot(param_builder.add_param(project_id), "String")
+    started = f"isNotNull({table_name}.op_name)"  # op_name is start-only
+    deleted = f"isNotNull({table_name}.deleted_at)"
     raw_count_expr = (
-        f"uniqExact({table_name}.id) "
-        f"- uniqExactIf({table_name}.id, isNotNull({table_name}.deleted_at))"
+        f"uniqExactIf({table_name}.id, {started} OR {deleted}) "
+        f"- uniqExactIf({table_name}.id, {deleted})"
     )
     inner = (
         f"SELECT {raw_count_expr} AS raw_count "
         f"FROM {table_name} "
         f"WHERE {table_name}.project_id = {project_id_slot}"
     )
+    return _wrap_raw_count_with_limit(inner, limit)
+
+
+def _optimized_time_filtered_calls_merged_count_query(
+    project_id: str,
+    limit: int | None,
+    bounds: list[tuple[str, float]],
+    param_builder: ParamBuilder,
+) -> str:
+    """Distinct-call count for a calls_merged stats request filtered only by time.
+
+    Counts windowed start rows with uniqExact. started_at gates the window;
+    since #6933 call-end rows carry started_at too, we also require op_name
+    (start-only) to be non-null -- that selects the start row and reproduces the
+    GROUP BY path's orphaned-call-end exclusion. Soft-deleted ids are removed
+    with an anti-set rather than a parallel aggregator, because deleted_at lives
+    on a separate delete row and cannot be correlated to started_at in one scan.
+
+    The loose `sortable_datetime` prefilter is kept for granule pruning via the
+    migration-012 minmax index; the exact `started_at` predicate removes its
+    buffer slop. The anti-set is windowed by the lower bound only: a call's
+    deleted_at is always >= its started_at, so every delete of an in-window call
+    also lands in-window and none is missed.
+    """
+    table_name = get_calls_table_name(ReadTable.CALLS_MERGED)
+    project_id_slot = param_slot(param_builder.add_param(project_id), "String")
+
+    # op_name is start-only, so its non-null-ness selects the start row and
+    # drops orphaned call-ends -- matching the GROUP BY path's HAVING. Required
+    # because since #6933 the end row carries started_at too.
+    started = f"isNotNull({table_name}.op_name)"
+
+    exact_conditions: list[str] = []
+    prefilter_conditions: list[str] = []
+    lower_prefilter_conditions: list[str] = []
+    for op_str, timestamp in bounds:
+        exact_slot = param_slot(
+            param_builder.add_param(timestamp_to_datetime_str(timestamp)), "String"
+        )
+        exact_conditions.append(f"{table_name}.started_at {op_str} {exact_slot}")
+
+        # Loosen toward the past for lower bounds (and toward the future for
+        # upper bounds) so the prefilter is a superset of the exact predicate.
+        is_lower = op_str in {">", ">="}
+        buffer = (
+            -DATETIME_BUFFER_TIME_SECONDS if is_lower else DATETIME_BUFFER_TIME_SECONDS
+        )
+        prefilter_slot = param_slot(
+            param_builder.add_param(timestamp_to_datetime_str(int(timestamp) + buffer)),
+            "String",
+        )
+        prefilter = f"{table_name}.sortable_datetime {op_str} {prefilter_slot}"
+        prefilter_conditions.append(prefilter)
+        if is_lower:
+            lower_prefilter_conditions.append(prefilter)
+
+    outer_prefilter = " AND ".join(prefilter_conditions)
+    lower_prefilter = " AND ".join(lower_prefilter_conditions)
+
+    deleted_ids = (
+        f"SELECT {table_name}.id FROM {table_name} "
+        f"PREWHERE {table_name}.project_id = {project_id_slot} "
+        f"WHERE {lower_prefilter} AND isNotNull({table_name}.deleted_at)"
+    )
+    inner = (
+        f"SELECT uniqExact({table_name}.id) AS raw_count "
+        f"FROM {table_name} "
+        f"PREWHERE {table_name}.project_id = {project_id_slot} "
+        f"WHERE {outer_prefilter} "
+        f"AND {' AND '.join(exact_conditions)} "
+        f"AND {started} "
+        f"AND {table_name}.id NOT IN ({deleted_ids})"
+    )
+    return _wrap_raw_count_with_limit(inner, limit)
+
+
+def _wrap_raw_count_with_limit(inner: str, limit: int | None) -> str:
+    """Wrap a `SELECT ... AS raw_count` inner query in the stats count/has_more shape."""
     if limit is None:
         return f"SELECT raw_count AS count, toUInt8(0) AS has_more FROM ({inner})"
     return (
@@ -2991,6 +3096,98 @@ def _is_unfiltered_stats_req(req: tsi.CallsQueryStatsReq) -> bool:
         and not req.expand_columns
         and _is_minimal_filter(req.filter)
     )
+
+
+def _is_time_filtered_stats_req(req: tsi.CallsQueryStatsReq) -> bool:
+    """True iff the request is a project-scope count narrowed only by a query.
+
+    Gates Pattern 4. The query is further validated to be started_at-only by
+    `_extract_started_at_only_bounds`; here we require a present query, no
+    storage-size rollup, no column expansion, a minimal hardcoded filter, and a
+    non-existence-check limit (limit=1 stays with Patterns 1/2).
+    """
+    return (
+        (req.limit is None or req.limit > 1)
+        and req.query is not None
+        and not req.include_total_storage_size
+        and not req.expand_columns
+        and _is_minimal_filter(req.filter)
+    )
+
+
+_STARTED_AT_FIELD = "started_at"
+_STARTED_AT_BOUND_OPS: dict[type[tsi_query.Operation], str] = {
+    tsi_query.GtOperation: ">",
+    tsi_query.GteOperation: ">=",
+    tsi_query.LtOperation: "<",
+    tsi_query.LteOperation: "<=",
+}
+
+
+def _extract_started_at_only_bounds(
+    operand: tsi_query.Operand,
+) -> list[tuple[str, float]] | None:
+    """Return the started_at bounds iff `operand` filters on nothing else.
+
+    Accepts a single gt/gte/lt/lte comparison of `started_at` against a numeric
+    literal (field on the left), or an AND tree of such comparisons. Returns
+    None for any other shape (other fields, OR/NOT, non-numeric literal, field
+    on the right, ...) so the caller falls back to the GROUP BY path.
+    """
+    if isinstance(operand, tsi_query.AndOperation):
+        bounds: list[tuple[str, float]] = []
+        for sub in operand.and_:
+            sub_bounds = _extract_started_at_only_bounds(sub)
+            if sub_bounds is None:
+                return None
+            bounds.extend(sub_bounds)
+        return bounds or None
+
+    if not isinstance(
+        operand,
+        (
+            tsi_query.GtOperation,
+            tsi_query.GteOperation,
+            tsi_query.LtOperation,
+            tsi_query.LteOperation,
+        ),
+    ):
+        return None
+    bound = _started_at_bound_from_comparison(
+        operand, _STARTED_AT_BOUND_OPS[type(operand)]
+    )
+    return [bound] if bound is not None else None
+
+
+def _started_at_bound_from_comparison(
+    operand: tsi_query.GtOperation
+    | tsi_query.GteOperation
+    | tsi_query.LtOperation
+    | tsi_query.LteOperation,
+    op_str: str,
+) -> tuple[str, float] | None:
+    """Return (op_str, unix_seconds) iff `operand` is `started_at <op> <number>`."""
+    if isinstance(operand, tsi_query.GtOperation):
+        left, right = operand.gt_
+    elif isinstance(operand, tsi_query.GteOperation):
+        left, right = operand.gte_
+    elif isinstance(operand, tsi_query.LtOperation):
+        left, right = operand.lt_
+    else:
+        left, right = operand.lte_
+
+    if (
+        not isinstance(left, tsi_query.GetFieldOperator)
+        or left.get_field_ != _STARTED_AT_FIELD
+    ):
+        return None
+    if not isinstance(right, tsi_query.LiteralOperation):
+        return None
+    literal = right.literal_
+    # bool is a subclass of int -- exclude it explicitly.
+    if isinstance(literal, bool) or not isinstance(literal, (int, float)):
+        return None
+    return (op_str, float(literal))
 
 
 def _is_minimal_filter(filter: tsi.CallsFilter | None) -> bool:

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -83,6 +83,12 @@ logger = logging.getLogger(__name__)
 CTE_FILTERED_CALLS = "filtered_calls"
 CTE_ALL_CALLS = "all_calls"
 
+# Deferred: server-side defense-in-depth cap for unfiltered calls_merged stats.
+# Wired up in `build_calls_stats_query` but currently commented out; callers
+# without a `limit` still get an exact count. Flip this on when we see real
+# >>1M-count requests in the wild.
+DEFAULT_STATS_MAX_LIMIT = 1_000_000
+
 
 @dataclass(frozen=True, slots=True)
 class FilterConditionsResult:
@@ -2697,11 +2703,10 @@ def build_calls_stats_query(
     req: tsi.CallsQueryStatsReq,
     param_builder: ParamBuilder,
     read_table: ReadTable = ReadTable.CALLS_MERGED,
-) -> tuple[str, KeysView[str]]:
+) -> tuple[str, KeysView[str], dict[str, int | str]]:
     """Build a stats query for calls, automatically using optimized queries when possible.
 
     This function handles both optimized special-case queries and the general case.
-    Returns a tuple of (query_sql, column_names).
 
     Args:
         req: The stats query request
@@ -2709,13 +2714,17 @@ def build_calls_stats_query(
         read_table: Which calls table to read from
 
     Returns:
-        Tuple of (SQL query string, column names in the result)
+        Tuple of (SQL query string, column names in the result, ClickHouse
+        query settings to apply at execution time).
     """
-    aggregated_columns = {"count": "count()"}
+    aggregated_columns: dict[str, str] = {
+        "count": "count()",
+        "has_more": "toUInt8(0)",
+    }
+    settings: dict[str, int | str] = {}
 
-    # Try optimized special case queries first
     if opt_query := _try_optimized_stats_query(req, param_builder, read_table):
-        return (opt_query, aggregated_columns.keys())
+        return (opt_query, aggregated_columns.keys(), settings)
 
     if req.include_total_storage_size:
         aggregated_columns["total_storage_size_bytes"] = (
@@ -2729,14 +2738,21 @@ def build_calls_stats_query(
         query = _build_calls_complete_stats_query(
             req, param_builder, aggregated_columns
         )
-        return (query, aggregated_columns.keys())
+        return (query, aggregated_columns.keys(), settings)
 
-    # For calls_merged, use subquery wrapping (GROUP BY requires materialization)
+    # Deferred (see DEFAULT_STATS_MAX_LIMIT): uncomment to apply the server-side
+    # cap when the caller didn't pass a limit.
+    # if req.limit is None and not req.include_total_storage_size:
+    #     req = req.model_copy(update={"limit": DEFAULT_STATS_MAX_LIMIT})
+    if req.limit is not None:
+        aggregated_columns["has_more"] = f"toUInt8(count() >= {req.limit})"
+        settings["optimize_aggregation_in_order"] = 1
+
     cq = _build_stats_calls_query(req, read_table)
     inner_query = cq.as_sql(param_builder)
-    calls_query_sql = f"SELECT {', '.join(aggregated_columns[k] for k in aggregated_columns)} FROM ({inner_query})"
+    calls_query_sql = f"SELECT {', '.join(aggregated_columns[k] + ' AS ' + k for k in aggregated_columns)} FROM ({inner_query})"
 
-    return (calls_query_sql, aggregated_columns.keys())
+    return (calls_query_sql, aggregated_columns.keys(), settings)
 
 
 def _build_stats_calls_query(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -2881,6 +2881,17 @@ def _try_optimized_stats_query(
             req.project_id, param_builder, read_table
         )
 
+    # Pattern 3: Unfiltered distinct-call count on calls_merged.
+    #
+    # Replace the GROUP BY + argMax rollup with two parallel aggregators on one
+    # scan: uniqExact(id) - uniqExactIf(id, isNotNull(deleted_at)). Exact match
+    # to the GROUP BY path's deleted-call exclusion. calls_complete has its own
+    # flat path; limit=1 stays with Pattern 1.
+    if read_table == ReadTable.CALLS_MERGED and _is_unfiltered_stats_req(req):
+        return _optimized_unfiltered_calls_merged_count_query(
+            req.project_id, req.limit, param_builder
+        )
+
     return None
 
 
@@ -2935,6 +2946,51 @@ def _optimized_wb_run_id_not_null_query(
             LIMIT 1
         )
     """
+
+
+def _optimized_unfiltered_calls_merged_count_query(
+    project_id: str,
+    limit: int | None,
+    param_builder: ParamBuilder,
+) -> str:
+    """Flat distinct-id count for unfiltered calls_merged stats.
+
+    Two parallel aggregators in one scan: total distinct ids minus distinct ids
+    that have any row with deleted_at set. Matches the GROUP BY path's
+    `argMax(deleted_at) IS NULL` exclusion exactly.
+    """
+    table_name = get_calls_table_name(ReadTable.CALLS_MERGED)
+    project_id_slot = param_slot(param_builder.add_param(project_id), "String")
+    raw_count_expr = (
+        f"uniqExact({table_name}.id) "
+        f"- uniqExactIf({table_name}.id, isNotNull({table_name}.deleted_at))"
+    )
+    inner = (
+        f"SELECT {raw_count_expr} AS raw_count "
+        f"FROM {table_name} "
+        f"WHERE {table_name}.project_id = {project_id_slot}"
+    )
+    if limit is None:
+        return f"SELECT raw_count AS count, toUInt8(0) AS has_more FROM ({inner})"
+    return (
+        f"SELECT least(raw_count, {limit}) AS count, "
+        f"toUInt8(raw_count > {limit}) AS has_more "
+        f"FROM ({inner})"
+    )
+
+
+def _is_unfiltered_stats_req(req: tsi.CallsQueryStatsReq) -> bool:
+    """True iff the request is a pure project-scope count with no narrowing.
+
+    Gates Pattern 3 (flat distinct-id count). limit=1 stays with Pattern 1.
+    """
+    return (
+        (req.limit is None or req.limit > 1)
+        and req.query is None
+        and not req.include_total_storage_size
+        and not req.expand_columns
+        and _is_minimal_filter(req.filter)
+    )
 
 
 def _is_minimal_filter(filter: tsi.CallsFilter | None) -> bool:

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1119,8 +1119,8 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             req.project_id, self.ch_client
         )
         pb = ParamBuilder()
-        query, columns = build_calls_stats_query(req, pb, read_table)
-        raw_res = self._query(query, pb.get_params())
+        query, columns, settings = build_calls_stats_query(req, pb, read_table)
+        raw_res = self._query(query, pb.get_params(), settings=settings or None)
 
         res_dict = (
             dict(zip(columns, raw_res.result_rows[0], strict=False))
@@ -1130,6 +1130,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
         return tsi.CallsQueryStatsRes(
             count=res_dict.get("count", 0),
+            has_more=bool(res_dict.get("has_more", 0)),
             total_storage_size_bytes=res_dict.get("total_storage_size_bytes"),
         )
 

--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -1527,8 +1527,10 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                 include_total_storage_size=req.include_total_storage_size,
             )
         ).calls
+        count = len(calls)
         return tsi.CallsQueryStatsRes(
-            count=len(calls),
+            count=count,
+            has_more=req.limit is not None and count >= req.limit,
             total_storage_size_bytes=sum(
                 call.total_storage_size_bytes
                 for call in calls

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -660,6 +660,8 @@ class CallsQueryStatsReq(BaseModelStrict):
 
 class CallsQueryStatsRes(BaseModel):
     count: int
+    # True when count saturated the request's limit; clients render as "<count>+".
+    has_more: bool = False
     total_storage_size_bytes: int | None = None
 
 


### PR DESCRIPTION
## Summary
Cherry-picks for image build `wandb/weave-trace:0.81.3-<id>`. Not intended to merge.

Cherry-picked onto the 0.81.3 RC weave pin (b7773bee4f):
- #6879 allow limited calls_query_stats (prereq)
- #6949 distinct-id stats path for unfiltered calls_merged
- #7021 extend calls_query_stats fast path w/ time-window

Branched off griffin/0.81.x-weave-patch-base.

## Testing
non-functional change.