### PR TITLE
feat(weave): AgentStats types + agent stats query builder

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -25,6 +25,7 @@ from weave.trace_server.agents.types import (
     AgentSpanValueRef,
     AgentsQueryFilters,
     AgentsQueryReq,
+    AgentStatsReq,
     AgentVersionsQueryReq,
 )
 from weave.trace_server.interface import query as tsi_query
@@ -35,6 +36,7 @@ from weave.trace_server.query_builder.agent_query_builder import (
     SPAN_SORTABLE_COLS,
     SPANS_LIST_COLS,
     build_order_by,
+    make_agent_stats_query,
     make_agent_versions_count_query,
     make_agent_versions_list_query,
     make_agents_count_query,
@@ -65,6 +67,51 @@ def assert_sql(
     assert expected_params == params, (
         f"\nExpected params: {expected_params}\n\nGot params: {params}"
     )
+
+
+class TestMakeAgentStatsQuery:
+    def test_basic(self) -> None:
+        pb = ParamBuilder("genai")
+        query = make_agent_stats_query(pb, AgentStatsReq(project_id="p1"))
+
+        expected = """
+            SELECT count() AS span_count,
+                   uniq(s.conversation_id) AS conversation_count,
+                   uniq(s.agent_name) AS agent_count
+            FROM spans s WHERE s.project_id = {genai_0:String}
+        """
+        assert_sql(expected, {"genai_0": "p1"}, query, pb.get_params())
+
+    def test_with_time_window(self) -> None:
+        pb = ParamBuilder("genai")
+        start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        end = datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc)
+        query = make_agent_stats_query(
+            pb,
+            AgentStatsReq(
+                project_id="p1",
+                started_after=start,
+                started_before=end,
+            ),
+        )
+
+        expected = """
+            SELECT count() AS span_count,
+                   uniq(s.conversation_id) AS conversation_count,
+                   uniq(s.agent_name) AS agent_count
+            FROM spans s
+            WHERE s.project_id = {genai_0:String}
+              AND s.started_at >= {genai_1:DateTime64(6)}
+              AND s.started_at < {genai_2:DateTime64(6)}
+        """
+        expected_params = {"genai_0": "p1", "genai_1": start, "genai_2": end}
+        assert_sql(expected, expected_params, query, pb.get_params())
+
+    def test_rejects_inverted_window(self) -> None:
+        start = datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc)
+        end = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        with pytest.raises(ValidationError, match="started_before must be after"):
+            AgentStatsReq(project_id="p1", started_after=start, started_before=end)
 
 
 # ============================================================================

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AwareDatetime, BaseModel, Field, model_validator
 
 from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import (
@@ -1051,6 +1051,41 @@ class AgentsQueryRes(BaseModel):
 
     agents: list[AgentSchema]
     total_count: int = 0
+
+
+class AgentStatsReq(BaseModel):
+    """Request a fast, approximate rollup of agent activity for a project.
+
+    Returns a total span count plus approximate distinct agent and
+    conversation counts, optionally scoped to a time window. When both
+    bounds are omitted the rollup is unbounded.
+    """
+
+    project_id: str
+    started_after: AwareDatetime | None = None
+    started_before: AwareDatetime | None = None
+
+    @model_validator(mode="after")
+    def validate_stats_request(self) -> AgentStatsReq:
+        if self.started_after is not None:
+            self.started_after = _as_utc(self.started_after)
+        if self.started_before is not None:
+            self.started_before = _as_utc(self.started_before)
+        if (
+            self.started_after is not None
+            and self.started_before is not None
+            and self.started_before < self.started_after
+        ):
+            raise ValueError("AgentStatsReq started_before must be after started_after")
+        return self
+
+
+class AgentStatsRes(BaseModel):
+    """Approximate project-level rollup of agent activity."""
+
+    agent_count: int = 0
+    conversation_count: int = 0
+    span_count: int = 0
 
 
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -42,6 +42,7 @@ from weave.trace_server.agents.types import (
     AgentSpanStatsValueType,
     AgentSpanValueRef,
     AgentsQueryReq,
+    AgentStatsReq,
     AgentVersionsQueryReq,
     group_by_ref_alias,
 )
@@ -923,6 +924,30 @@ _GROUPED_SPAN_AGGREGATES: str = """count() AS span_count,
                groupUniqArray(s.conversation_name) AS conversation_names,
                min(s.started_at) AS first_seen,
                max(s.started_at) AS last_seen"""
+
+
+def make_agent_stats_query(pb: ParamBuilder, req: AgentStatsReq) -> str:
+    """Build a fast, approximate project-level agent activity rollup.
+
+    A single pass over `spans` returning the total span count plus
+    approximate distinct agent and conversation counts, optionally scoped to
+    a time window. Distinct counts trade exactness for latency by design.
+    """
+    pid_slot = pb.add(req.project_id, param_type="String")
+    where_conditions = [_project_filter_sql("s.project_id", pid_slot)]
+    add_time_filters(
+        where_conditions,
+        pb,
+        started_after=req.started_after,
+        started_before=req.started_before,
+    )
+    where = " AND ".join(where_conditions)
+    return (
+        "SELECT count() AS span_count, "
+        "uniq(s.conversation_id) AS conversation_count, "
+        "uniq(s.agent_name) AS agent_count "
+        f"FROM spans s WHERE {where}"
+    )
 
 
 def make_spans_count_query(pb: ParamBuilder, req: AgentSpansQueryReq) -> str:


### PR DESCRIPTION
## Summary
Adds the request/response models and SQL builder for a fast, approximate project-level rollup of agent activity. First of a two-PR stack that exposes an `agent_stats` operation on the trace server; the handler + wiring land in #7122.

The rollup returns, optionally scoped to a time window:
- `span_count` — total agent spans
- `agent_count` — approximate distinct agents
- `conversation_count` — approximate distinct conversations

## Design
- `make_agent_stats_query` is a single pass over the `spans` table. The distinct agent/conversation counts are approximate by design — this endpoint prioritizes latency over exactness.
- Optionally scoped to a `started_after` / `started_before` time window; unbounded when omitted.

## Testing
- [x] Manual tests
- [x] Unit tests
- [x] QA tests

## Stack
1. **#7121 (this PR)** — types + query builder
2. #7122 — handler + interface/adapter/dispatch wiring
