### PR TITLE
feat(weave): wire agent_stats through the trace server

### DIFF
--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -31,6 +31,7 @@ from weave.trace_server.agents.types import (
     AgentSpanStatsReq,
     AgentSpanValueRef,
     AgentsQueryReq,
+    AgentStatsReq,
 )
 from weave.trace_server.interface.query import Query
 
@@ -1712,3 +1713,53 @@ def test_query_dsl_typed_custom_attr_comparison(ch_server):
     )
     assert res.total_count == 1
     assert len(res.spans) == 1
+
+
+def test_agent_stats(ch_server):
+    """Rollup returns span count plus distinct agent/conversation counts."""
+    project_id = _make_project_id("agent-stats")
+
+    spans = [
+        _make_span(project_id, agent_name="agent-A", conversation_id="conv-1"),
+        _make_span(project_id, agent_name="agent-A", conversation_id="conv-1"),
+        _make_span(project_id, agent_name="agent-B", conversation_id="conv-2"),
+        _make_span(project_id, agent_name="agent-A", conversation_id="conv-3"),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_stats(AgentStatsReq(project_id=project_id))
+    assert res.span_count == 4
+    assert res.agent_count == 2  # agent-A, agent-B
+    assert res.conversation_count == 3  # conv-1, conv-2, conv-3
+
+
+def test_agent_stats_time_window(ch_server):
+    """started_after scopes the rollup to spans within the window."""
+    project_id = _make_project_id("agent-stats-window")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    old = now - datetime.timedelta(days=90)
+
+    spans = [
+        _make_span(project_id, agent_name="recent", started_at=now),
+        _make_span(project_id, agent_name="stale", started_at=old),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_stats(
+        AgentStatsReq(
+            project_id=project_id,
+            started_after=now - datetime.timedelta(days=1),
+        )
+    )
+    assert res.span_count == 1
+    assert res.agent_count == 1
+
+
+def test_agent_stats_empty_project(ch_server):
+    """A project with no agent spans rolls up to all zeros."""
+    project_id = _make_project_id("agent-stats-empty")
+
+    res = ch_server.agent_stats(AgentStatsReq(project_id=project_id))
+    assert res.span_count == 0
+    assert res.agent_count == 0
+    assert res.conversation_count == 0

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -61,6 +61,8 @@ from weave.trace_server.agents.types import (
     AgentSpanStatsRes,
     AgentsQueryReq,
     AgentsQueryRes,
+    AgentStatsReq,
+    AgentStatsRes,
     AgentTraceChatReq,
     AgentTraceChatRes,
     AgentVersionSchema,
@@ -77,6 +79,7 @@ from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
 from weave.trace_server.opentelemetry.python_spans import Resource, Span
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_query_builder import (
+    make_agent_stats_query,
     make_agent_versions_count_query,
     make_agent_versions_list_query,
     make_agents_count_query,
@@ -379,6 +382,22 @@ class AgentQueryHandler:
     # ------------------------------------------------------------------
     # AMT-backed agents queries
     # ------------------------------------------------------------------
+
+    def stats(self, req: AgentStatsReq) -> AgentStatsRes:
+        """Fast, approximate project-level rollup of agent activity.
+
+        Single pass over `spans` returning total span count plus approximate
+        distinct agent and conversation counts.
+        """
+        pb = ParamBuilder(PARAM_NAMESPACE)
+        sql = make_agent_stats_query(pb, req)
+        rows = _rows_as_dicts(self._query(sql, pb.get_params()))
+        row = rows[0] if rows else {}
+        return AgentStatsRes(
+            agent_count=safe_int(row.get("agent_count")),
+            conversation_count=safe_int(row.get("conversation_count")),
+            span_count=safe_int(row.get("span_count")),
+        )
 
     def agents_query(self, req: AgentsQueryReq) -> AgentsQueryRes:
         """Query agents AMT for agent list page."""

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -72,6 +72,8 @@ from weave.trace_server.agents.types import (
     AgentSpanStatsRes,
     AgentsQueryReq,
     AgentsQueryRes,
+    AgentStatsReq,
+    AgentStatsRes,
     AgentTraceChatReq,
     AgentTraceChatRes,
     AgentVersionsQueryReq,
@@ -6879,6 +6881,9 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
 
     def agent_agents_query(self, req: AgentsQueryReq) -> AgentsQueryRes:
         return AgentQueryHandler(self._query, self.feedback_query).agents_query(req)
+
+    def agent_stats(self, req: AgentStatsReq) -> AgentStatsRes:
+        return AgentQueryHandler(self._query, self.feedback_query).stats(req)
 
     def agent_versions_query(self, req: AgentVersionsQueryReq) -> AgentVersionsQueryRes:
         return AgentQueryHandler(self._query, self.feedback_query).agent_versions_query(

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1319,6 +1319,14 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             agent.project_id = original_project_id
         return res
 
+    def agent_stats(
+        self, req: tsi.agent_types.AgentStatsReq
+    ) -> tsi.agent_types.AgentStatsRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(
+            self._internal_trace_server.agent_stats, req, req.project_id
+        )
+
     def agent_versions_query(
         self, req: tsi.agent_types.AgentVersionsQueryReq
     ) -> tsi.agent_types.AgentVersionsQueryRes:

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3068,6 +3068,9 @@ class TraceServerInterface(Protocol):
     def agent_agents_query(
         self, req: agent_types.AgentsQueryReq
     ) -> agent_types.AgentsQueryRes: ...
+    def agent_stats(
+        self, req: agent_types.AgentStatsReq
+    ) -> agent_types.AgentStatsRes: ...
     def agent_versions_query(
         self, req: agent_types.AgentVersionsQueryReq
     ) -> agent_types.AgentVersionsQueryRes: ...


### PR DESCRIPTION
## Summary
Exposes the agent stats rollup (added in #7121) as an `agent_stats` operation across the trace server stack.

## Changes
- `AgentQueryHandler.stats()` runs `make_agent_stats_query` and hydrates the single result row into `AgentStatsRes`.
- `agent_stats` added to the `TraceServerInterface` protocol, the ClickHouse batched server dispatch, and the external→internal adapter (project_id remap).

## Testing
- [x] Manual tests
- [x] Unit tests
- [x] QA tests

## Notes
- Agent observability is ClickHouse-only; the SQLite trace server has no agent methods (consistent with existing agent operations). SDK bindings delegate via `__getattr__`, so no change is needed there.
- The HTTP route (`POST /agents/stats`) and the TS client live in `wandb/core` and will land as a separate stack after this merges.

## Stack
1. #7121 — types + query builder
2. **#7122 (this PR)** — handler + wiring
