### PR TITLE
fix(weave): break obj_delete latest tie by publish order, not digest

### DIFF
--- a/weave/trace_server/sqlite_trace_server.py
+++ b/weave/trace_server/sqlite_trace_server.py
@@ -2261,7 +2261,9 @@ class SqliteTraceServer(tsi.FullTraceServerInterface):
                     WHEN digest = (
                         SELECT digest FROM objects
                         WHERE project_id = ? AND object_id = ? AND deleted_at IS NULL
-                        ORDER BY created_at DESC, digest DESC
+                        -- tie-break on version_index (publish order), not digest,
+                        -- so a coarse-clock created_at tie still picks the latest.
+                        ORDER BY created_at DESC, version_index DESC
                         LIMIT 1
                     ) THEN 1
                     ELSE 0


### PR DESCRIPTION
## Summary
- `SqliteTraceServer.obj_delete` re-pointed `objects.is_latest` with `ORDER BY created_at DESC, digest DESC`. On coarse-clock platforms (Windows, ~15ms) rapid publishes share a `created_at`, so the `digest DESC` tiebreaker arbitrarily picked the lexically-largest digest instead of the most recently published survivor.
- Tie-break on `version_index` (monotonic publish order) instead.

Original failure ([CI job](https://github.com/wandb/weave/actions/runs/27245994702/job/80460039909?pr=7117)):
```
FAILED tests/trace/test_obj_tags_aliases.py::test_hybrid_latest_full_lifecycle - AssertionError: assert 'pk2QYGNnCT9d...' (v0) == 'NXxXwOGAERV5...' (v1)
```

## Testing
manually reproduced by pinning the server clock so three publishes tie on `created_at`: old `digest DESC` picks v0, fix picks v1.