### PR TITLE
fix(weave_ts): Don't duplicate traces when in '@openai/agents' context

### DIFF
--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -31,6 +31,8 @@ import {Settings} from '../../settings';
 import {initWithCustomTraceServer} from '../clientMock';
 import {InMemoryTraceServer, Call} from '../helpers/inMemoryTraceServer';
 import {agentsInstrumentedHolder} from 'weave/integrations/openai.agent';
+import {wrapOpenAIChatCompletionsCreate} from '../../integrations/openai';
+import {makeAPIPromiseShim} from '../openaiMock';
 
 describe('OpenAI Agents Integration', () => {
   withOpenAITracingEnabled();
@@ -599,6 +601,42 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     expect(executeToolSpan.spanContext().traceId).toBe(
       agentSpan!.spanContext().traceId
     );
+  });
+
+  test('OpenAI SDK calls inside an agent context are not double-traced', async () => {
+    // Under OTel V2 the agents OTel processor already emits a `chat` span
+    // for every model call (with messages + usage). The OpenAI integration's
+    // own Weave call would duplicate that record, so it should bypass when
+    // an agents trace is active.
+    const mockResponse = {
+      id: 'resp-1',
+      object: 'chat.completion',
+      model: 'gpt-4o-mini',
+      choices: [{index: 0, message: {role: 'assistant', content: 'hi'}}],
+      usage: {prompt_tokens: 1, completion_tokens: 1, total_tokens: 2},
+    };
+    const mockCreate = jest.fn(() => makeAPIPromiseShim(mockResponse));
+    const wrapped = wrapOpenAIChatCompletionsCreate(
+      mockCreate as any,
+      'openai.chat.completions.create'
+    );
+
+    await withTrace('Workflow', async () => {
+      await wrapped({
+        model: 'gpt-4o-mini',
+        messages: [{role: 'user', content: 'hi'}],
+      });
+    });
+
+    expect(mockCreate).toHaveBeenCalledTimes(1);
+
+    // Wait for any fire-and-forget finishCall — if suppression failed and
+    // a call WAS created, we want to see it.
+    await new Promise(resolve => setTimeout(resolve, 300));
+    const calls = await inMemoryTraceServer.getCalls(testProjectName);
+    expect(
+      calls.find(c => c.op_name === 'openai.chat.completions.create')
+    ).toBeUndefined();
   });
 
   async function emittedSpans(): Promise<ReadableSpan[]> {

--- a/sdks/node/src/integrations/openai-agents/weave-tracing-processor.ts
+++ b/sdks/node/src/integrations/openai-agents/weave-tracing-processor.ts
@@ -16,6 +16,12 @@ import {
 } from '../openai.agent';
 import {CallStack} from '../../weaveClient';
 
+type OpenAIAgentsContext = {
+  spanId: string | null;
+  spanParentId: string | null;
+  traceId: string | null;
+};
+
 // ============================================================================
 // Helper Functions
 // ============================================================================
@@ -500,17 +506,7 @@ export class WeaveTracingProcessor implements TracingProcessor {
   }
 }
 
-/**
- * Attempts to recover the Weave call stack from the current OpenAI Agents trace/span context.
- * Returns a CallStack with the current agent call as parent, or null if not in an agent context.
- *
- * This handles the AsyncLocalStorage isolation issue where OpenAI Agents' ALSO.run() creates
- * a new context that doesn't share Weave's stack. We work around this by looking up the
- * parent call from a global registry keyed by the OpenAI Agents trace/span ID.
- *
- * @returns CallStack with parent set to the current agent call, or null if not available
- */
-export function getCallStackFromOpenAIAgents(): any | null {
+function getCurrentOpenAIAgentsContext(): OpenAIAgentsContext | null {
   const currentTrace = getCurrentTrace();
   const currentSpan = getCurrentSpan();
 
@@ -541,6 +537,32 @@ export function getCallStackFromOpenAIAgents(): any | null {
     return null;
   }
 
+  return {
+    spanId,
+    spanParentId,
+    traceId,
+  };
+}
+
+/**
+ * Attempts to recover the Weave call stack from the current OpenAI Agents trace/span context.
+ * Returns a CallStack with the current agent call as parent, or null if not in an agent context.
+ *
+ * This handles the AsyncLocalStorage isolation issue where OpenAI Agents' ALSO.run() creates
+ * a new context that doesn't share Weave's stack. We work around this by looking up the
+ * parent call from a global registry keyed by the OpenAI Agents trace/span ID.
+ *
+ * @returns CallStack with parent set to the current agent call, or null if not available
+ */
+export function getCallStackFromOpenAIAgents(): any | null {
+  const ctx = getCurrentOpenAIAgentsContext();
+
+  if (!ctx) {
+    return null;
+  }
+
+  const {spanId, spanParentId, traceId} = ctx;
+
   // Look up Weave call data with fallback chain:
   // 1. Try current span ID first (most specific)
   // 2. Fall back to parent span ID (if current span not tracked not tracking is delayed)
@@ -562,4 +584,9 @@ export function getCallStackFromOpenAIAgents(): any | null {
   }
 
   return null;
+}
+
+export function isInOpenAIAgentsContext(): boolean {
+  const ctx = getCurrentOpenAIAgentsContext();
+  return !!ctx;
 }

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -6,7 +6,11 @@ import {getGlobalClient} from '../clientApi';
 import {InternalCall} from '../call';
 import {WeaveClient} from '../weaveClient';
 import {warnOnce} from '../utils/warnOnce';
-import {getCallStackFromOpenAIAgents} from './openai-agents/weave-tracing-processor';
+import {
+  getCallStackFromOpenAIAgents,
+  isInOpenAIAgentsContext,
+} from './openai-agents/weave-tracing-processor';
+import {shouldUseOtelV2} from '../settings';
 
 /**
  * Wraps a function to run with OpenAI Agents call stack if available.
@@ -24,6 +28,10 @@ function runWithOpenAIAgentsContext<T>(fn: () => T): T {
     }
   }
   return fn();
+}
+
+function shouldSkipTracingInAgentContext(): boolean {
+  return shouldUseOtelV2() && isInOpenAIAgentsContext();
 }
 
 // exported just for testing
@@ -112,6 +120,9 @@ export function wrapOpenAIChatCompletionsCreate(
   ) {
     const client = getGlobalClient();
     if (!client) return originalCreate(...args);
+    if (shouldSkipTracingInAgentContext()) {
+      return originalCreate(...args);
+    }
 
     const [originalParams]: any[] = args;
     // Streaming needs include_usage so the reducer sees token counts.
@@ -179,6 +190,9 @@ export function makeOpenAIImagesGenerateOp(originalGenerate: any) {
 
   // Wrap with OpenAI Agents context if available
   return function wrappedWithAgents(...args: Parameters<typeof wrapped>) {
+    if (shouldSkipTracingInAgentContext()) {
+      return originalGenerate(...args);
+    }
     return runWithOpenAIAgentsContext(() => weaveOp(...args));
   };
 }
@@ -473,6 +487,9 @@ function wrapOpenAIResponsesCreate(originalCreate: any) {
   ) {
     const client = getGlobalClient();
     if (!client) return originalCreate(...args);
+    if (shouldSkipTracingInAgentContext()) {
+      return originalCreate.apply(this, args);
+    }
 
     return runWithOpenAIAgentsContext(() =>
       traceOpenAICall({


### PR DESCRIPTION
## Description

* The existing `openai` integration has a dependency on the `@openai/agents` integration when registered. It uses a globally-exposed `getCallStackFromOpenAIAgents` to attempts to recover the Weave call stack from the current `@openai/agents` trace/span context.

* This change bypasses this behavior when `WEAVE_USE_OTEL_V2=true`, where the OTel processor is responsible for emitting necessary spans for the Agents SDK.

