### PR TITLE
fix(weave): treat all-zero OTel parent_span_id as root

### DIFF
--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -405,6 +405,27 @@ class TestPythonSpans:
         assert array_value[0] == "value1"
         assert array_value[1] == "value2"
 
+    def test_span_from_proto_parent_id_normalization(self):
+        """Test that empty and all-zero parent_span_id values normalize to None."""
+        # All-zero parent_span_id is the OTel invalid-id sentinel; must mean no parent.
+        pb_span = create_test_span()
+        pb_span.parent_span_id = b"\x00" * 8
+        assert PySpan.from_proto(pb_span).parent_id is None, (
+            "all-zero parent_span_id should yield parent_id=None"
+        )
+
+        pb_span = create_test_span()
+        pb_span.parent_span_id = b""
+        assert PySpan.from_proto(pb_span).parent_id is None, (
+            "empty parent_span_id should yield parent_id=None"
+        )
+
+        pb_span = create_test_span()
+        pb_span.parent_span_id = bytes.fromhex("0123456789abcdef")
+        assert PySpan.from_proto(pb_span).parent_id == "0123456789abcdef", (
+            "real parent_span_id should hex-encode to parent_id"
+        )
+
     def test_span_to_call(self):
         """Test converting a Python Span to Weave Calls."""
         pb_span = create_test_span()

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -48,6 +48,10 @@ from weave.trace_server.opentelemetry.helpers import (
     unflatten_key_values,
 )
 
+# OpenTelemetry's all-zero span id is the "invalid id" sentinel. Some exporters
+# serialize a root span's parent as this instead of omitting it, meaning no parent.
+OTEL_INVALID_SPAN_ID = b"\x00" * 8
+
 
 class SpanKind(Enum):
     """Enum representing the span's kind."""
@@ -235,8 +239,10 @@ class Span:
     def from_proto(cls, proto_span: PbSpan, resource: Resource | None = None) -> Self:
         """Create a Span from a protobuf Span."""
         parent_id = None
-        # An all-zero parent_span_id is the OTel invalid-id sentinel for a root span.
-        if any(proto_span.parent_span_id):
+        if (
+            proto_span.parent_span_id
+            and proto_span.parent_span_id != OTEL_INVALID_SPAN_ID
+        ):
             parent_id = hexlify(proto_span.parent_span_id).decode("ascii")
 
         return cls(

--- a/weave/trace_server/opentelemetry/python_spans.py
+++ b/weave/trace_server/opentelemetry/python_spans.py
@@ -235,7 +235,8 @@ class Span:
     def from_proto(cls, proto_span: PbSpan, resource: Resource | None = None) -> Self:
         """Create a Span from a protobuf Span."""
         parent_id = None
-        if proto_span.parent_span_id:
+        # An all-zero parent_span_id is the OTel invalid-id sentinel for a root span.
+        if any(proto_span.parent_span_id):
             parent_id = hexlify(proto_span.parent_span_id).decode("ascii")
 
         return cls(


### PR DESCRIPTION
## Summary
- OTel root spans whose exporter sends `parent_span_id` as the all-zero invalid-id sentinel were stored with `parent_id="0000000000000000"` instead of `None`, so they were not trace roots: the default "All Ops" / Trace Analytics view (`trace_roots_only` -> `parent_id IS NULL`) showed nothing, while op-filtered views still showed the traces.
- Fix: gate on `any(parent_span_id)` so all-zero and empty ids both mean "no parent".
- Zendesk 119023 (Canva `canva-design-generation/canva-ai-eval`, OTLP via `/otel/v1/traces`).
- Jira: [WB-35512](https://coreweave.atlassian.net/browse/WB-35512)

## Testing
unit test; reproduced against prod `trace.wandb.ai`: a span sent with `parent_span_id=b"\x00"*8` lands with `parent_id="0000000000000000"` and is excluded from `trace_roots_only=True`, while `b""` lands with `parent_id=None` and s included.

manually validated at the db level as well:
<img width="1237" height="176" alt="image" src="https://github.com/user-attachments/assets/fe8ed950-6dca-4742-b670-faf453f73ad4" />


[WB-35512]: https://coreweave.atlassian.net/browse/WB-35512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ