### PR TITLE
chore(weave): add claude-fable-5 to model providers and costs

### DIFF
--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -25977,6 +25977,16 @@
       "created_at": "2026-05-29 11:23:33"
     }
   ],
+  "claude-fable-5": [
+    {
+      "provider": "anthropic",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 1e-06,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-06-10 16:30:00"
+    }
+  ],
   "claude-opus-4-8": [
     {
       "provider": "anthropic",

--- a/weave/trace_server/model_providers/model_providers.json
+++ b/weave/trace_server/model_providers/model_providers.json
@@ -2298,6 +2298,10 @@
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"
   },
+  "claude-fable-5": {
+    "litellm_provider": "anthropic",
+    "api_key_name": "ANTHROPIC_API_KEY"
+  },
   "claude-opus-4-20250514": {
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"


### PR DESCRIPTION
## Description

Enables Anthropic's new Claude Fable 5 model (`claude-fable-5`, [announcement](https://www.anthropic.com/news/claude-fable-5-mythos-5)) in the trace server so it can be used from the model playground:

- `model_providers.json`: maps `claude-fable-5` → `anthropic` / `ANTHROPIC_API_KEY`
- `cost_checkpoint.json`: adds costs ($10/$50 per MTok input/output, cache read 10% of input, cache write 1.25x input, matching the pattern of other Anthropic entries)

Mirrors the prior model-add PR #7009 (opus 4.8). Frontend counterpart in wandb/core adds the model to the playground dropdown.

## Testing

Validated both JSON files parse; entries follow the same structure as existing Anthropic models.

Link to Devin session: https://app.devin.ai/sessions/403b1e40916d4e54b9aa1a2c3065a660
Requested by: @nichochar