### PR TITLE
chore(weave_ts): Lint against importing types without 'type'

### DIFF
--- a/sdks/node/eslint.config.mjs
+++ b/sdks/node/eslint.config.mjs
@@ -11,6 +11,10 @@ export default defineConfig([
     extends: [js.configs.recommended, tseslint.configs.recommended],
     rules: {
       '@typescript-eslint/ban-ts-comment': 'off',
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        { prefer: 'type-imports', fixStyle: 'inline-type-imports' },
+      ],
       '@typescript-eslint/no-empty-object-type': 'off',
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-non-null-asserted-optional-chain': 'off',

--- a/sdks/node/src/__tests__/call.test.ts
+++ b/sdks/node/src/__tests__/call.test.ts
@@ -1,5 +1,5 @@
 import * as weave from 'weave';
-import {op, Op} from 'weave';
+import {op, type Op} from 'weave';
 
 const mockOpName = 'weave://test-project-id/op/test-op';
 const mockCallId = 'test-call-id';

--- a/sdks/node/src/__tests__/clientMock.ts
+++ b/sdks/node/src/__tests__/clientMock.ts
@@ -1,8 +1,8 @@
 import {setGlobalClient} from '../clientApi';
-import {Api as TraceServerApi} from '../generated/traceServerApi';
-import {InMemoryTraceServer} from './helpers/inMemoryTraceServer';
+import {type Api as TraceServerApi} from '../generated/traceServerApi';
+import {type InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {Settings} from '../settings';
-import {WandbServerApi} from '../wandb/wandbServerApi';
+import {type WandbServerApi} from '../wandb/wandbServerApi';
 import {WeaveClient} from '../weaveClient';
 
 export function initWithCustomTraceServer(

--- a/sdks/node/src/__tests__/evaluation.test.ts
+++ b/sdks/node/src/__tests__/evaluation.test.ts
@@ -1,6 +1,6 @@
 import {Dataset} from '../dataset';
 import {Evaluation} from '../evaluation';
-import {ColumnMapping} from '../fn';
+import {type ColumnMapping} from '../fn';
 import {op} from '../op';
 
 const createMockDataset = () =>

--- a/sdks/node/src/__tests__/genai/common.ts
+++ b/sdks/node/src/__tests__/genai/common.ts
@@ -5,9 +5,9 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 
 import {setGlobalClient} from '../../clientApi';
-import {Api as TraceServerApi} from '../../generated/traceServerApi';
+import {type Api as TraceServerApi} from '../../generated/traceServerApi';
 import {Settings, type SettingsInit} from '../../settings';
-import {WandbServerApi} from '../../wandb/wandbServerApi';
+import {type WandbServerApi} from '../../wandb/wandbServerApi';
 import {WeaveClient} from '../../weaveClient';
 import state from 'weave/state';
 

--- a/sdks/node/src/__tests__/integrations/openai2.test.ts
+++ b/sdks/node/src/__tests__/integrations/openai2.test.ts
@@ -1,11 +1,11 @@
-import {Api as TraceServerApi} from '../../generated/traceServerApi';
+import {type Api as TraceServerApi} from '../../generated/traceServerApi';
 import {
   makeOpenAIImagesGenerateOp,
   openAIStreamReducer,
   wrapOpenAI,
 } from '../../integrations/openai';
 import {isWeaveImage} from '../../media';
-import {WandbServerApi} from '../../wandb/wandbServerApi';
+import {type WandbServerApi} from '../../wandb/wandbServerApi';
 import {WeaveClient} from '../../weaveClient';
 import {makeAPIPromiseShim} from '../openaiMock';
 

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -29,7 +29,7 @@ import * as weave from '../..';
 import {clearWeaveTracerProvider} from '../../genai/provider';
 import {Settings} from '../../settings';
 import {initWithCustomTraceServer} from '../clientMock';
-import {InMemoryTraceServer, Call} from '../helpers/inMemoryTraceServer';
+import {InMemoryTraceServer, type Call} from '../helpers/inMemoryTraceServer';
 import {agentsInstrumentedHolder} from 'weave/integrations/openai.agent';
 import {wrapOpenAIChatCompletionsCreate} from '../../integrations/openai';
 import {makeAPIPromiseShim} from '../openaiMock';

--- a/sdks/node/src/__tests__/legacy/op.test.ts
+++ b/sdks/node/src/__tests__/legacy/op.test.ts
@@ -1,6 +1,6 @@
 import * as weave from 'weave';
 import {getGlobalClient} from 'weave/clientApi';
-import {Op} from 'weave/opType';
+import {type Op} from 'weave/opType';
 
 // Mock the client to capture callDisplayName
 let capturedDisplayName: string | undefined;

--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -1,8 +1,8 @@
 import {ReadableStream} from 'stream/web';
-import {Api as TraceServerApi} from '../generated/traceServerApi';
+import {type Api as TraceServerApi} from '../generated/traceServerApi';
 import {StringPrompt} from '../prompt';
 import * as registryLinkBindings from '../traceServerBindings/linkAssetToRegistry';
-import {WandbServerApi} from '../wandb/wandbServerApi';
+import {type WandbServerApi} from '../wandb/wandbServerApi';
 import {WeaveClient} from '../weaveClient';
 import {ObjectRef} from '../weaveObject';
 

--- a/sdks/node/src/call.ts
+++ b/sdks/node/src/call.ts
@@ -1,5 +1,5 @@
 import {getGlobalClient} from './clientApi';
-import {CallSchema} from './generated/traceServerApi';
+import {type CallSchema} from './generated/traceServerApi';
 
 const MAX_DISPLAY_NAME_LENGTH = 1000;
 

--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -1,13 +1,13 @@
 import {Api as TraceServerApi} from './generated/traceServerApi';
 import {registerEvalLinkSpanProcessor} from './evalLinkSpanProcessor';
-import {makeSettings, SettingsInit} from './settings';
+import {makeSettings, type SettingsInit} from './settings';
 import {defaultHost, getUrls, setGlobalDomain} from './urls';
 import {ConcurrencyLimiter} from './utils/concurrencyLimit';
 import {Netrc} from './utils/netrc';
 import {createFetchWithRetry} from './utils/retry';
 import {getWandbConfigs} from './wandb/settings';
 import {WandbServerApi} from './wandb/wandbServerApi';
-import {CallStackEntry, WeaveClient} from './weaveClient';
+import {type CallStackEntry, WeaveClient} from './weaveClient';
 import {globalSingleton} from './utils/globalSingleton';
 
 // Held behind a globalThis-backed container so that a dual-package-hazard load

--- a/sdks/node/src/dataset.ts
+++ b/sdks/node/src/dataset.ts
@@ -6,9 +6,8 @@ import {
   type WeaveObjectParameters,
 } from './weaveObject';
 
-interface DatasetParameters<
-  R extends DatasetRow,
-> extends WeaveObjectParameters {
+interface DatasetParameters<R extends DatasetRow>
+  extends WeaveObjectParameters {
   rows: R[];
 }
 

--- a/sdks/node/src/dataset.ts
+++ b/sdks/node/src/dataset.ts
@@ -1,9 +1,14 @@
 import {requireGlobalClient} from './clientApi';
 import {Table} from './table';
-import {ObjectRef, WeaveObject, WeaveObjectParameters} from './weaveObject';
+import {
+  type ObjectRef,
+  WeaveObject,
+  type WeaveObjectParameters,
+} from './weaveObject';
 
-interface DatasetParameters<R extends DatasetRow>
-  extends WeaveObjectParameters {
+interface DatasetParameters<
+  R extends DatasetRow,
+> extends WeaveObjectParameters {
   rows: R[];
 }
 

--- a/sdks/node/src/digest.ts
+++ b/sdks/node/src/digest.ts
@@ -1,4 +1,4 @@
-import {Buffer} from 'buffer';
+import type {Buffer} from 'buffer';
 import crypto from 'crypto';
 
 export function computeDigest(data: Buffer): string {

--- a/sdks/node/src/evaluation.ts
+++ b/sdks/node/src/evaluation.ts
@@ -9,11 +9,8 @@ import {WeaveObject, type WeaveObjectParameters} from './weaveObject';
 const PROGRESS_BAR = false;
 
 // Column mapping takes a dataset row of type R and maps it to a scorer's dataset row of type E
-interface EvaluationParameters<
-  R extends DatasetRow,
-  E extends DatasetRow,
-  M,
-> extends WeaveObjectParameters {
+interface EvaluationParameters<R extends DatasetRow, E extends DatasetRow, M>
+  extends WeaveObjectParameters {
   dataset: Dataset<R>;
   scorers: WeaveCallable<(...args: [{datasetRow: E; modelOutput: M}]) => any>[];
   maxConcurrency?: number;

--- a/sdks/node/src/evaluation.ts
+++ b/sdks/node/src/evaluation.ts
@@ -1,16 +1,19 @@
 import cliProgress from 'cli-progress';
-import {Dataset, DatasetRow} from './dataset';
-import {ColumnMapping, mapArgs} from './fn';
+import {type Dataset, type DatasetRow} from './dataset';
+import {type ColumnMapping, mapArgs} from './fn';
 import {isMedia} from './media';
 import {op} from './op';
-import {Op, getOpName} from './opType';
-import {WeaveObject, WeaveObjectParameters} from './weaveObject';
+import {type Op, getOpName} from './opType';
+import {WeaveObject, type WeaveObjectParameters} from './weaveObject';
 
 const PROGRESS_BAR = false;
 
 // Column mapping takes a dataset row of type R and maps it to a scorer's dataset row of type E
-interface EvaluationParameters<R extends DatasetRow, E extends DatasetRow, M>
-  extends WeaveObjectParameters {
+interface EvaluationParameters<
+  R extends DatasetRow,
+  E extends DatasetRow,
+  M,
+> extends WeaveObjectParameters {
   dataset: Dataset<R>;
   scorers: WeaveCallable<(...args: [{datasetRow: E; modelOutput: M}]) => any>[];
   maxConcurrency?: number;

--- a/sdks/node/src/evaluationLogger.ts
+++ b/sdks/node/src/evaluationLogger.ts
@@ -16,13 +16,13 @@
  * await ev.logSummary();
  */
 
-import {WeaveObject, WeaveObjectParameters} from './weaveObject';
-import {Dataset, DatasetRow} from './dataset';
+import {WeaveObject, type WeaveObjectParameters} from './weaveObject';
+import {type Dataset, type DatasetRow} from './dataset';
 import {op} from './op';
 import {requireGlobalClient} from './clientApi';
 import {InternalCall} from './call';
-import {CallStackEntry, WeaveClient} from './weaveClient';
-import {Op, OpRef, ParameterNamesOption} from './opType';
+import {type CallStackEntry, type WeaveClient} from './weaveClient';
+import {type Op, type OpRef, type ParameterNamesOption} from './opType';
 import {uuidv7} from 'uuidv7';
 
 // ============================================================================

--- a/sdks/node/src/genai/api.ts
+++ b/sdks/node/src/genai/api.ts
@@ -1,8 +1,8 @@
 import {_getGenaiState} from './context';
-import {LLM, type LLMInit} from './llm';
+import {type LLM, type LLMInit} from './llm';
 import {Session, type SessionInit} from './session';
-import {SubAgent, type SubAgentInit} from './subagent';
-import {Tool, type ToolInit} from './tool';
+import {type SubAgent, type SubAgentInit} from './subagent';
+import {type Tool, type ToolInit} from './tool';
 import {Turn, type TurnInit} from './turn';
 
 /**

--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -1090,8 +1090,10 @@ export interface ApiConfig<SecurityDataType = unknown> {
   customFetch?: typeof fetch;
 }
 
-export interface HttpResponse<D extends unknown, E extends unknown = unknown>
-  extends Response {
+export interface HttpResponse<
+  D extends unknown,
+  E extends unknown = unknown,
+> extends Response {
   data: D;
   error: E;
 }

--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -1090,10 +1090,8 @@ export interface ApiConfig<SecurityDataType = unknown> {
   customFetch?: typeof fetch;
 }
 
-export interface HttpResponse<
-  D extends unknown,
-  E extends unknown = unknown,
-> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown>
+  extends Response {
   data: D;
   error: E;
 }

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -59,7 +59,12 @@ export type {
   TurnInit,
   Usage,
 } from './genai';
-export {weaveAudio, weaveImage, type WeaveAudio, type WeaveImage} from './media';
+export {
+  weaveAudio,
+  weaveImage,
+  type WeaveAudio,
+  type WeaveImage,
+} from './media';
 export {op} from './op';
 export * from './types';
 export {WeaveObject, ObjectRef} from './weaveObject';

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -8,13 +8,13 @@ export {
 export {Dataset} from './dataset';
 export {Evaluation} from './evaluation';
 export {EvaluationLogger, ScoreLogger} from './evaluationLogger';
-export {
+export type {
   CallSchema,
   CallsFilter,
   Query,
   SortBy,
 } from './generated/traceServerApi';
-export {GetCallsOptions} from './weaveClient';
+export type {GetCallsOptions} from './weaveClient';
 export {
   wrapOpenAI,
   wrapGoogleGenAI,
@@ -59,7 +59,7 @@ export type {
   TurnInit,
   Usage,
 } from './genai';
-export {weaveAudio, weaveImage, WeaveAudio, WeaveImage} from './media';
+export {weaveAudio, weaveImage, type WeaveAudio, type WeaveImage} from './media';
 export {op} from './op';
 export * from './types';
 export {WeaveObject, ObjectRef} from './weaveObject';

--- a/sdks/node/src/integrations/anthropic.ts
+++ b/sdks/node/src/integrations/anthropic.ts
@@ -1,6 +1,6 @@
 import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
 import {op} from '../op';
-import {OpOptions, StreamReducer} from '../opType';
+import {type OpOptions, type StreamReducer} from '../opType';
 
 type Message = {
   id: string;

--- a/sdks/node/src/integrations/googleGenAI.ts
+++ b/sdks/node/src/integrations/googleGenAI.ts
@@ -1,5 +1,5 @@
 import {op} from '../op';
-import {OpOptions, StreamReducer} from '../opType';
+import {type OpOptions, type StreamReducer} from '../opType';
 import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
 
 const weaveGeminiModelHint = Symbol.for('_weave_gemini_model_hint');

--- a/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
+++ b/sdks/node/src/integrations/openai-agents/weave-otel-tracing-processor.ts
@@ -1,5 +1,5 @@
 import {
-  Attributes,
+  type Attributes,
   type Context as OtelContext,
   type Span as OtelSpan,
   SpanStatusCode,

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -1,10 +1,10 @@
 import {weaveImage} from '../media';
 import {op} from '../op';
-import {OpOptions} from '../opType';
+import {type OpOptions} from '../opType';
 import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
 import {getGlobalClient} from '../clientApi';
 import {InternalCall} from '../call';
-import {WeaveClient} from '../weaveClient';
+import {type WeaveClient} from '../weaveClient';
 import {warnOnce} from '../utils/warnOnce';
 import {
   getCallStackFromOpenAIAgents,
@@ -197,7 +197,7 @@ export function makeOpenAIImagesGenerateOp(originalGenerate: any) {
   };
 }
 
-import {StreamReducer} from '../opType';
+import {type StreamReducer} from '../opType';
 
 export type Response = {
   id: string;

--- a/sdks/node/src/op.ts
+++ b/sdks/node/src/op.ts
@@ -1,7 +1,7 @@
-import {Call, InternalCall} from './call';
+import {type Call, InternalCall} from './call';
 import {getGlobalClient} from './clientApi';
 import {TRACE_CALL_EMOJI} from './constants';
-import {Op, OpOptions, OpRef, CallMethod} from './opType';
+import {type Op, type OpOptions, type OpRef, type CallMethod} from './opType';
 import {getGlobalDomain} from './urls';
 import {warnOnce} from './utils/warnOnce';
 

--- a/sdks/node/src/opType.ts
+++ b/sdks/node/src/opType.ts
@@ -1,6 +1,6 @@
-import {Call} from './call';
+import {type Call} from './call';
 import {getGlobalDomain} from './urls';
-import {WeaveObject} from './weaveObject';
+import {type WeaveObject} from './weaveObject';
 
 export type ParameterNamesOption = 'useParam0Object' | string[] | undefined;
 

--- a/sdks/node/src/prompt.ts
+++ b/sdks/node/src/prompt.ts
@@ -1,5 +1,9 @@
-import {WeaveClient} from './weaveClient';
-import {ObjectRef, WeaveObject, WeaveObjectParameters} from './weaveObject';
+import {type WeaveClient} from './weaveClient';
+import {
+  ObjectRef,
+  WeaveObject,
+  type WeaveObjectParameters,
+} from './weaveObject';
 
 export class Prompt extends WeaveObject {
   constructor(parameters: WeaveObjectParameters) {

--- a/sdks/node/src/types.ts
+++ b/sdks/node/src/types.ts
@@ -1,2 +1,2 @@
-export {Op, OpDecorator} from './opType';
+export type {Op, OpDecorator} from './opType';
 export {WeaveClient} from './weaveClient';

--- a/sdks/node/src/utils/commonJSLoader.ts
+++ b/sdks/node/src/utils/commonJSLoader.ts
@@ -3,8 +3,8 @@ import path from 'path';
 import semifies from 'semifies';
 
 import instrumentations, {
-  CacheEntry,
-  CJSInstrumentation,
+  type CacheEntry,
+  type CJSInstrumentation,
 } from '../integrations/instrumentations';
 import {requirePackageJson} from './npmModuleUtils';
 

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -5,27 +5,27 @@ import {uuidv7} from 'uuidv7';
 import {MAX_OBJECT_NAME_LENGTH} from './constants';
 import {computeDigest} from './digest';
 import {
-  CallSchema,
-  CallsQueryReq,
-  CallsFilter,
-  EndedCallSchemaForInsert,
-  Query,
-  SortBy,
-  StartedCallSchemaForInsert,
-  Api as TraceServerApi,
+  type CallSchema,
+  type CallsQueryReq,
+  type CallsFilter,
+  type EndedCallSchemaForInsert,
+  type Query,
+  type SortBy,
+  type StartedCallSchemaForInsert,
+  type Api as TraceServerApi,
 } from './generated/traceServerApi';
 import {
-  AudioType,
+  type AudioType,
   DEFAULT_AUDIO_TYPE,
   DEFAULT_IMAGE_TYPE,
-  ImageType,
+  type ImageType,
   isWeaveAudio,
   isWeaveImage,
 } from './media';
 import {
-  Op,
+  type Op,
   OpRef,
-  ParameterNamesOption,
+  type ParameterNamesOption,
   getOpName,
   getOpWrappedFunction,
   isOp,
@@ -38,9 +38,9 @@ import type {
   LinkAssetToRegistryRes,
 } from './traceServerBindings/linkAssetToRegistry';
 import {packageVersion} from './utils/userAgent';
-import {WandbServerApi} from './wandb/wandbServerApi';
+import {type WandbServerApi} from './wandb/wandbServerApi';
 import {ObjectRef, WeaveObject, getClassChain} from './weaveObject';
-import {Call, CallState, InternalCall} from './call';
+import {type Call, CallState, InternalCall} from './call';
 import {CallRef} from './refs';
 import type {Prompt} from './prompt';
 


### PR DESCRIPTION
## Description

* Enables the `@typescript-eslint/consistent-type-imports` rule. This'll let us lint against type imports so that we don't accidentally introduce a runtime dependency on one of our `devDependencies`. (Add'l context: https://github.com/wandb/weave/pull/6970#discussion_r3350421403)

