### PR TITLE
chore(weave): add manual bulk-export operator script (interim BYOB bridge)

### DIFF
--- a/scripts/manual_export/README.md
+++ b/scripts/manual_export/README.md
@@ -1,0 +1,92 @@
+# Manual bulk export (interim, operator-run)
+
+A one-off, operator-run bulk export of a Weave project's data to a **W&B-owned**
+bucket, handed to the customer as short-TTL presigned download URLs. This is the
+bridge while team-level BYOB is in security/design review.
+
+It is deliberately the [bulk-export spec](../../../../specs/weave-bulk-export.md)
+**minus the BYOB target**: ClickHouse writes Parquet directly to a bucket we own
+(real platform creds, native multipart), then we presign GETs. Because we hold
+the bucket creds, there is no presigned-*write* problem (ClickHouse cannot write
+to a presigned URL; it SigV4-signs its own writes).
+
+## When to use / NOT use
+
+- **Use** for customers whose ask is "get my data out."
+- **Do NOT use** for a customer who requested BYOB on **data-residency** grounds.
+  This lands their data in our tenancy, the opposite of what they need, and may
+  breach a residency/DPA commitment. Those customers wait for BYOB.
+
+## Procedure
+
+1. **Preflight + plan** — `count()` + `sum(byteSize(*))` in one scan; estimate
+   compressed size (`/ 4.0` zstd) and split into ~256 MB files.
+2. **Audit** — write an `EXPORT_START` row to `exports`.
+3. **Write** — `INSERT INTO FUNCTION s3(<our-bucket>, <creds>, Parquet) SELECT *
+   FROM <table> WHERE project_id=…`. One file, or many via
+   `PARTITION BY cityHash64(id) % n` into `data_{_partition_id}.parquet`.
+4. **Mint** — presigned GET per part (15 min TTL); write `EXPORT_MINT`.
+5. **Deliver** — emit a manifest of `{key, bytes, url}` parts.
+
+## File-size / chunking rationale (measured)
+
+- Target **~256 MB compressed** per Parquet file (industry-consensus sweet spot).
+- Size by **bytes, not rows**: measured **58-6,324 bytes/row** across row shapes
+  (skinny calls vs fat multimodal), a 109x spread, so a fixed rows-per-file is
+  wrong. `n = ceil(rows * avg_row_bytes / zstd_ratio / 256MB)`.
+- `cityHash64(id) % n` distributes uniformly (measured CV 0.5%).
+- Encode time is **not** the constraint (~100M rows in minutes, under the 1800s
+  query budget); we chunk for download UX and consumer-tool compatibility.
+
+## Security posture (baked into the script)
+
+- **Dedicated export bucket**, never the shared trace-file bucket; SSE-KMS, not
+  public, no anonymous access.
+- **Short object lifetime** (hours, via bucket lifecycle) — we hold a full copy
+  only transiently.
+- **Each presigned URL is a bearer token to one file.** TTL 15 min, HTTPS,
+  full-object-key-scoped (tampering the key or expiry invalidates the signature),
+  and the signer identity must have **no `s3:ListBucket`** (can't enumerate
+  sibling keys).
+- **One audit row per start and per mint** — the record of "we materialized
+  customer X's data at T and user Y downloaded it."
+- Creds are passed as `s3()` args; in prod the cluster's `query_masking_rules`
+  redact them from every log surface (same as BYOB).
+
+## Run it (prod)
+
+Credentials come from the environment (never argv, so they don't leak via
+`ps`/shell history). The identity must be scoped to the export prefix with
+**no `s3:ListBucket`**.
+
+```bash
+export EXPORT_AKID=... EXPORT_SECRET=...   # EXPORT_SESSION_TOKEN if STS; CH_PASSWORD if set
+python manual_export.py \
+  --project-id ENTITY/PROJECT --table calls_complete \
+  --dest-endpoint https://s3.us-east-1.amazonaws.com \
+  --bucket wandb-weave-exports --region us-east-1 --env prod
+```
+
+`--time-start/--time-end` narrow the range; `--target-file-mb` overrides the
+256 MB default. `calls_merged` is read with **FINAL** so customers get merged
+rows, not raw start/end fragments (affordable for a one-off; the no-FINAL
+optimization is only for the automated hot-path export).
+
+## Verify locally
+
+`run_local_test.py` runs the full flow (single + chunked + >100 partitions)
+against MinIO and asserts: all rows exported, no cross-project leak, presigned
+URL bound to one key + expiry, full start/mint/complete audit trail.
+
+```bash
+docker network create bexp
+docker run -d --name bexp-minio --network bexp -p 9400:9000 \
+  -e MINIO_ROOT_USER=root -e MINIO_ROOT_PASSWORD=rootroot123 minio/minio server /data
+docker run -d --name bexp-ch --network bexp -p 8133:8123 -m 6g \
+  -e CLICKHOUSE_PASSWORD=stress clickhouse/clickhouse-server:26.3
+docker run --rm --network bexp --entrypoint sh minio/mc -c \
+  "until mc alias set m http://bexp-minio:9000 root rootroot123; do sleep 1; done; mc mb -p m/exports"
+
+uv run --group test python scripts/manual_export/run_local_test.py
+# teardown: docker rm -f bexp-ch bexp-minio && docker network rm bexp
+```

--- a/scripts/manual_export/manual_export.py
+++ b/scripts/manual_export/manual_export.py
@@ -1,0 +1,439 @@
+"""One-off bulk export to a W&B-owned bucket + presigned download URL(s).
+
+Interim path while team-level BYOB is in security/design review. ClickHouse
+writes the project's Parquet directly to a bucket WE own (real platform
+creds, native multipart, any size), then we mint short-TTL presigned GETs for
+the customer. No gorilla, no BYOB resolver, no presigned-write (which CH
+can't do anyway). This is the bulk-export spec minus the BYOB target.
+
+Security posture baked in (see weave/trace_server/export, spec
+`weave-bulk-export.md`):
+  - dedicated export bucket, never the shared trace-file bucket
+  - short URL TTL (default 15m); each URL is a bearer token to one file
+  - signer identity must have no s3:ListBucket (can't enumerate sibling keys)
+  - one audit row per start/mint/terminal; refuses to run without the table
+  - do NOT run this for a customer who asked for BYOB on residency grounds:
+    it lands their data in our tenancy, the opposite of what they want.
+
+Credentials come from the environment (EXPORT_AKID / EXPORT_SECRET /
+EXPORT_SESSION_TOKEN / CH_PASSWORD), never argv, so they don't leak via `ps`
+or shell history.
+
+Chunking: estimates compressed size from a byte-size preflight and splits
+into ~256MB Parquet files via `PARTITION BY cityHash64(id) % n`. Sizing is by
+bytes, not rows (measured 58-6,324 bytes/row across row shapes). The exact
+set of non-empty partitions is read back from CH so the manifest reflects
+what was actually written rather than a guess.
+"""
+
+import argparse
+import datetime
+import json
+import math
+import os
+import re
+import sys
+import uuid
+from dataclasses import dataclass
+
+import boto3
+import clickhouse_connect
+from botocore.client import Config
+from clickhouse_connect.driver.client import Client
+
+
+@dataclass(frozen=True)
+class TableSpec:
+    time_column: str
+    id_column: str
+    final: bool  # AggregatingMergeTree (calls_merged) MUST merge or rows are fragments
+
+
+TABLES = {
+    "calls_complete": TableSpec("started_at", "id", final=False),
+    "spans": TableSpec("started_at", "span_id", final=False),
+    "calls_merged": TableSpec("started_at", "id", final=True),
+}
+
+DEFAULT_TTL_MINUTES = 15
+MAX_EXPORT_QUERY_SECONDS = 1800
+TARGET_FILE_BYTES = 256 * 1024 * 1024
+# Conservative vs the measured 4.2-5.2x so the estimate slightly OVER-counts
+# size -> more, smaller files. Safe direction for download UX.
+ZSTD_RATIO = 4.0
+
+# Exactly entity/project, each segment from a safe charset; `..` rejected
+# separately since it would escape the key prefix.
+PROJECT_ID_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+TIMESTAMP_RE = re.compile(r"^[0-9 :.T+-]+$")
+# STS-issued AWS creds live in this charset; reject anything that could break
+# out of the single-quoted s3() literal.
+CREDENTIAL_RE = re.compile(r"^[A-Za-z0-9/+=._-]+$")
+# Operator-supplied bucket / endpoint / env also land in the s3() URL literal.
+DEST_VALUE_RE = re.compile(r"^[A-Za-z0-9._:/-]+$")
+
+
+def plan_export(
+    ch: Client, *, table: str, where: str, target_bytes: int = TARGET_FILE_BYTES
+) -> tuple[int, int, float]:
+    """Return (rows, n_files, est_compressed_bytes). One scan: count + avg row bytes."""
+    spec = TABLES[table]
+    row = ch.query(
+        f"SELECT count(), sum(byteSize(*)) FROM {table}{_final(spec)} WHERE {where}"
+    ).result_rows[0]
+    rows, uncompressed = int(row[0]), int(row[1] or 0)
+    est_compressed = uncompressed / ZSTD_RATIO
+    n_files = max(1, math.ceil(est_compressed / target_bytes)) if rows else 0
+    return rows, n_files, est_compressed
+
+
+def partition_row_counts(
+    ch: Client, *, table: str, where: str, n_files: int
+) -> dict[int, int]:
+    """Read back the exact non-empty `cityHash64(id) % n` partitions + row counts,
+    so the manifest reflects what was written rather than an assumption.
+    """
+    spec = TABLES[table]
+    rows = ch.query(
+        f"SELECT cityHash64({spec.id_column}) % {n_files} AS p, count() "
+        f"FROM {table}{_final(spec)} WHERE {where} GROUP BY p ORDER BY p"
+    ).result_rows
+    return {int(p): int(c) for p, c in rows}
+
+
+def export_project(
+    ch: Client,
+    *,
+    table: str,
+    where: str,
+    dest_base: str,
+    n_files: int,
+    parts: dict[int, int],
+    akid: str,
+    secret: str,
+    session_token: str | None,
+    job_id: uuid.UUID,
+) -> list[str]:
+    """Write the project's Parquet (single `data.parquet` or `PARTITION BY` parts) and return key suffixes."""
+    for value in (akid, secret, session_token):
+        if value is not None and not CREDENTIAL_RE.match(value):
+            sys.exit("credential contains characters outside the allowed charset")
+    cred_args = f"'{akid}', '{secret}'" + (
+        f", '{session_token}'" if session_token else ""
+    )
+    spec = TABLES[table]
+    settings = (
+        f"s3_truncate_on_insert = 1, max_execution_time = {MAX_EXPORT_QUERY_SECONDS}, "
+        f"output_format_parquet_compression_method = 'zstd'"
+    )
+    if n_files == 1:
+        ch.command(
+            f"INSERT INTO FUNCTION s3('{dest_base}/data.parquet', {cred_args}, format = 'Parquet') "
+            f"SELECT * FROM {table}{_final(spec)} WHERE {where} SETTINGS {settings}",
+            settings={"query_id": str(job_id)},
+        )
+        return ["data.parquet"]
+
+    ch.command(
+        # `{_partition_id}` is CH's filename token (sent literally, not a query param);
+        # max_partitions_per_insert_block defaults to 100, so raise it to cover n_files.
+        f"INSERT INTO FUNCTION s3('{dest_base}/data_{{_partition_id}}.parquet', {cred_args}, "
+        f"format = 'Parquet') PARTITION BY (cityHash64({spec.id_column}) % {n_files}) "
+        f"SELECT * FROM {table}{_final(spec)} WHERE {where} "
+        f"SETTINGS {settings}, max_partitions_per_insert_block = {n_files}",
+        settings={"query_id": str(job_id)},
+    )
+    return [f"data_{p}.parquet" for p in sorted(parts)]
+
+
+def mint_download_urls(
+    s3, *, bucket: str, prefix: str, suffixes: list[str], ttl_minutes: int
+) -> tuple[list[dict], datetime.datetime]:
+    """Mint a presigned GET per expected part; every HEAD must succeed.
+
+    A failure (incl. the no-ListBucket 403 on a missing key) is real, never skipped.
+    """
+    expires_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+        minutes=ttl_minutes
+    )
+    parts: list[dict] = []
+    for suffix in suffixes:
+        key = f"{prefix}/{suffix}"
+        size = s3.head_object(Bucket=bucket, Key=key)["ContentLength"]
+        url = s3.generate_presigned_url(
+            "get_object",
+            Params={"Bucket": bucket, "Key": key},
+            ExpiresIn=ttl_minutes * 60,
+            HttpMethod="GET",
+        )
+        parts.append({"key": key, "bytes": size, "url": url})
+    return parts, expires_at
+
+
+def write_audit(
+    ch: Client,
+    *,
+    action: str,
+    project_id: str,
+    job_id: uuid.UUID,
+    requested_by: str,
+    table: str,
+    output_uri: str,
+    request_json: str = "",
+    minted_by: str = "",
+    allow_missing: bool = False,
+) -> None:
+    """Append one `exports` audit row; refuse to run if the table is missing (override via --allow-no-audit)."""
+    if not ch.query(
+        "SELECT count() FROM system.tables WHERE database = currentDatabase() AND name = 'exports'"
+    ).result_rows[0][0]:
+        if allow_missing:
+            print(
+                "WARN: --allow-no-audit set; proceeding without an audit trail",
+                file=sys.stderr,
+            )
+            return
+        sys.exit(
+            "no `exports` audit table in this database; refusing to export "
+            "without an audit trail (pass --allow-no-audit to override)"
+        )
+    ch.insert(
+        "exports",
+        [
+            [
+                uuid.uuid4(),
+                action,
+                project_id,
+                job_id,
+                requested_by,
+                minted_by,
+                table,
+                request_json,
+                output_uri,
+                datetime.datetime.now(datetime.timezone.utc),
+            ]
+        ],
+        column_names=[
+            "request_id",
+            "action",
+            "project_id",
+            "job_id",
+            "requested_by",
+            "minted_by",
+            "table_name",
+            "request_json",
+            "output_uri",
+            "ts",
+        ],
+    )
+
+
+def build_where(
+    table: str, project_id: str, time_start: str | None, time_end: str | None
+) -> str:
+    """Validated, inlined WHERE (no param binding: it would collide with CH's
+    `{_partition_id}` filename token).
+    """
+    if not PROJECT_ID_RE.match(project_id) or ".." in project_id:
+        sys.exit(f"invalid project_id (want entity/project): {project_id!r}")
+    preds = [f"project_id = '{project_id}'"]
+    for bound, op in ((time_start, ">="), (time_end, "<")):
+        if bound:
+            if not TIMESTAMP_RE.match(bound):
+                sys.exit(f"invalid timestamp: {bound!r}")
+            preds.append(f"{TABLES[table].time_column} {op} '{bound}'")
+    return " AND ".join(preds)
+
+
+def make_s3(
+    endpoint: str | None, region: str, akid: str, secret: str, token: str | None
+):
+    return boto3.client(
+        "s3",
+        endpoint_url=endpoint,
+        aws_access_key_id=akid,
+        aws_secret_access_key=secret,
+        aws_session_token=token,
+        region_name=region,
+        config=Config(signature_version="s3v4", s3={"addressing_style": "path"}),
+    )
+
+
+def _final(spec: TableSpec) -> str:
+    return " FINAL" if spec.final else ""
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--project-id", required=True, help="entity/project")
+    p.add_argument("--table", default="calls_complete", choices=sorted(TABLES))
+    p.add_argument("--time-start")
+    p.add_argument("--time-end")
+    p.add_argument("--env", default="prod")
+    p.add_argument("--ttl-minutes", type=int, default=DEFAULT_TTL_MINUTES)
+    p.add_argument(
+        "--target-file-mb", type=int, default=TARGET_FILE_BYTES // 1024 // 1024
+    )
+    p.add_argument("--requested-by", default="oneoff-operator")
+    p.add_argument("--allow-no-audit", action="store_true")
+    p.add_argument("--ch-host", default="localhost")
+    p.add_argument("--ch-port", type=int, default=8123)
+    p.add_argument("--ch-database", default="default")
+    p.add_argument("--bucket", required=True)
+    p.add_argument("--region", default="us-east-1")
+    p.add_argument("--dest-endpoint", required=True, help="endpoint CH writes to")
+    p.add_argument(
+        "--presign-endpoint", help="download endpoint (defaults to --dest-endpoint)"
+    )
+    args = p.parse_args()
+
+    akid, secret = os.environ.get("EXPORT_AKID"), os.environ.get("EXPORT_SECRET")
+    if not akid or not secret:
+        sys.exit("set EXPORT_AKID and EXPORT_SECRET in the environment")
+    session_token = os.environ.get("EXPORT_SESSION_TOKEN")
+
+    ch = clickhouse_connect.get_client(
+        host=args.ch_host,
+        port=args.ch_port,
+        database=args.ch_database,
+        password=os.environ.get("CH_PASSWORD", ""),
+        send_receive_timeout=MAX_EXPORT_QUERY_SECONDS,
+    )
+    for label, value in (
+        ("bucket", args.bucket),
+        ("dest-endpoint", args.dest_endpoint),
+        ("presign-endpoint", args.presign_endpoint),
+        ("env", args.env),
+    ):
+        if value and not DEST_VALUE_RE.match(value):
+            sys.exit(f"--{label} contains characters outside the allowed charset")
+
+    job_id = uuid.uuid4()
+    where = build_where(args.table, args.project_id, args.time_start, args.time_end)
+    prefix = f"{args.env}/exports/{args.project_id}/{job_id.hex}"
+    slice_json = json.dumps(
+        {
+            "table": args.table,
+            "time_start": args.time_start,
+            "time_end": args.time_end,
+            "where": where,
+        }
+    )
+
+    rows, n_files, est = plan_export(
+        ch,
+        table=args.table,
+        where=where,
+        target_bytes=args.target_file_mb * 1024 * 1024,
+    )
+    print(
+        f"preflight: {rows:,} rows, est {est / 1024 / 1024:.0f} MB compressed -> {n_files} file(s)"
+    )
+    if rows == 0:
+        sys.exit("nothing to export (0 rows)")
+
+    write_audit(
+        ch,
+        action="EXPORT_START",
+        project_id=args.project_id,
+        job_id=job_id,
+        requested_by=args.requested_by,
+        table=args.table,
+        output_uri=prefix,
+        request_json=slice_json,
+        allow_missing=args.allow_no_audit,
+    )
+    try:
+        parts_counts = (
+            partition_row_counts(ch, table=args.table, where=where, n_files=n_files)
+            if n_files > 1
+            else {0: rows}
+        )
+        if sum(parts_counts.values()) != rows:
+            sys.exit(
+                f"partition counts {sum(parts_counts.values())} != preflight {rows}"
+            )
+
+        suffixes = export_project(
+            ch,
+            table=args.table,
+            where=where,
+            dest_base=f"{args.dest_endpoint.rstrip('/')}/{args.bucket}/{prefix}",
+            n_files=n_files,
+            parts=parts_counts,
+            akid=akid,
+            secret=secret,
+            session_token=session_token,
+            job_id=job_id,
+        )
+        s3 = make_s3(
+            args.presign_endpoint or args.dest_endpoint,
+            args.region,
+            akid,
+            secret,
+            session_token,
+        )
+        urls, expires_at = mint_download_urls(
+            s3,
+            bucket=args.bucket,
+            prefix=prefix,
+            suffixes=suffixes,
+            ttl_minutes=args.ttl_minutes,
+        )
+    except BaseException:
+        write_audit(
+            ch,
+            action="EXPORT_FAILED",
+            project_id=args.project_id,
+            job_id=job_id,
+            requested_by=args.requested_by,
+            table=args.table,
+            output_uri=prefix,
+            allow_missing=True,
+        )
+        raise
+
+    write_audit(
+        ch,
+        action="EXPORT_MINT",
+        project_id=args.project_id,
+        job_id=job_id,
+        requested_by=args.requested_by,
+        table=args.table,
+        output_uri=prefix,
+        minted_by=args.requested_by,
+        allow_missing=args.allow_no_audit,
+    )
+    write_audit(
+        ch,
+        action="EXPORT_COMPLETE",
+        project_id=args.project_id,
+        job_id=job_id,
+        requested_by=args.requested_by,
+        table=args.table,
+        output_uri=prefix,
+        allow_missing=args.allow_no_audit,
+    )
+
+    manifest = {
+        "job_id": job_id.hex,
+        "project_id": args.project_id,
+        "table": args.table,
+        "rows": rows,
+        "n_files": len(urls),
+        "expires_at": expires_at.isoformat(),
+        "parts": [
+            {"key": u["key"], "bytes": u["bytes"], "url": u["url"]} for u in urls
+        ],
+    }
+    print(json.dumps(manifest, indent=2))
+    total_mb = sum(u["bytes"] for u in urls) / 1024 / 1024
+    # NOTE: with STS session creds, the URLs also die when the SESSION expires,
+    # regardless of ttl-minutes; fine at 15m, watch it for short-lived creds.
+    print(
+        f"\n{len(urls)} file(s), {total_mb:.1f} MB total, URLs expire {expires_at.isoformat()}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/manual_export/run_local_test.py
+++ b/scripts/manual_export/run_local_test.py
@@ -1,0 +1,226 @@
+"""Local end-to-end test of the one-off export against MinIO (= our bucket).
+
+Exercises the single-file, chunked (PARTITION BY), and >100-partition paths,
+plus the security properties: no cross-project leak, presigned URL bound to
+one key + expiry, audit trail (start/mint/complete) written.
+
+Assumes a CH + MinIO stack on the `bexp` docker network:
+  CH at localhost:8133 (password 'stress'); reaches MinIO at bexp-minio:9000
+  MinIO S3 API at localhost:9400 (root / rootroot123), bucket 'exports'
+"""
+
+import io
+import json
+import urllib.error
+import urllib.request
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import clickhouse_connect
+import manual_export as ox
+import pyarrow.parquet as pq
+
+CH = {"host": "localhost", "port": 8133, "password": "stress"}
+INTERNAL_ENDPOINT = "http://bexp-minio:9000"
+HOST_ENDPOINT = "http://localhost:9400"
+BUCKET = "exports"
+PROJECT = "acme/prod"
+OTHER_PROJECT = "other/proj"
+ROOT_KEY, ROOT_SECRET = "root", "rootroot123"
+SEED_ROWS = 40_000
+
+
+def seed(client) -> None:
+    client.command("DROP TABLE IF EXISTS calls_complete")
+    client.command("DROP TABLE IF EXISTS exports")
+    client.command(
+        """
+        CREATE TABLE calls_complete (
+            id String, project_id String, created_at DateTime64(3) DEFAULT now64(3),
+            trace_id String, op_name String, started_at DateTime64(6),
+            inputs_dump String, output_dump String, summary_dump String, attributes_dump String
+        ) ENGINE = ReplacingMergeTree(created_at)
+        PARTITION BY toYYYYMM(started_at) ORDER BY (project_id, started_at, id)
+        """
+    )
+    client.command(
+        """
+        CREATE TABLE IF NOT EXISTS exports (
+            request_id UUID, action LowCardinality(String), project_id String, job_id UUID,
+            requested_by String, minted_by String DEFAULT '', table_name LowCardinality(String),
+            request_json String DEFAULT '', output_uri String DEFAULT '', ts DateTime64(3)
+        ) ENGINE = MergeTree PARTITION BY toYYYYMM(ts) ORDER BY (project_id, job_id, action, ts)
+        """
+    )
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    cols = [
+        "id",
+        "project_id",
+        "trace_id",
+        "op_name",
+        "started_at",
+        "inputs_dump",
+        "output_dump",
+        "summary_dump",
+        "attributes_dump",
+    ]
+
+    def rows_for(project: str, n: int) -> list:
+        return [
+            [
+                uuid.uuid4().hex,
+                project,
+                uuid.uuid4().hex,
+                "op/chat",
+                base + timedelta(seconds=i),
+                json.dumps(
+                    {"messages": [{"role": "user", "content": f"hello {i} " * 8}]}
+                ),
+                json.dumps({"choices": [{"message": {"content": f"hi {i} " * 8}}]}),
+                json.dumps({"usage": {"total_tokens": i % 500}}),
+                json.dumps({"env": "prod"}),
+            ]
+            for i in range(n)
+        ]
+
+    client.insert("calls_complete", rows_for(PROJECT, SEED_ROWS), column_names=cols)
+    client.insert("calls_complete", rows_for(OTHER_PROJECT, 5_000), column_names=cols)
+
+
+def run_case(
+    client, s3, *, label: str, target_mb: int | None = None, force_n: int | None = None
+) -> list[dict]:
+    job_id = uuid.uuid4()
+    where = ox.build_where("calls_complete", PROJECT, None, None)
+    rows, n_files, est = ox.plan_export(
+        client,
+        table="calls_complete",
+        where=where,
+        target_bytes=(target_mb or 256) * 1024 * 1024,
+    )
+    if force_n is not None:
+        n_files = force_n
+    prefix = f"test/exports/{PROJECT}/{job_id.hex}"
+
+    ox.write_audit(
+        client,
+        action="EXPORT_START",
+        project_id=PROJECT,
+        job_id=job_id,
+        requested_by="tester",
+        table="calls_complete",
+        output_uri=prefix,
+    )
+    parts_counts = (
+        ox.partition_row_counts(
+            client, table="calls_complete", where=where, n_files=n_files
+        )
+        if n_files > 1
+        else {0: rows}
+    )
+    assert sum(parts_counts.values()) == rows, "partition counts != preflight"
+
+    suffixes = ox.export_project(
+        client,
+        table="calls_complete",
+        where=where,
+        dest_base=f"{INTERNAL_ENDPOINT}/{BUCKET}/{prefix}",
+        n_files=n_files,
+        parts=parts_counts,
+        akid=ROOT_KEY,
+        secret=ROOT_SECRET,
+        session_token=None,
+        job_id=job_id,
+    )
+    parts, _ = ox.mint_download_urls(
+        s3, bucket=BUCKET, prefix=prefix, suffixes=suffixes, ttl_minutes=15
+    )
+    ox.write_audit(
+        client,
+        action="EXPORT_MINT",
+        project_id=PROJECT,
+        job_id=job_id,
+        requested_by="tester",
+        table="calls_complete",
+        output_uri=prefix,
+        minted_by="tester",
+    )
+    ox.write_audit(
+        client,
+        action="EXPORT_COMPLETE",
+        project_id=PROJECT,
+        job_id=job_id,
+        requested_by="tester",
+        table="calls_complete",
+        output_uri=prefix,
+    )
+
+    total_rows, projects, sizes = 0, set(), []
+    for part in parts:
+        with urllib.request.urlopen(part["url"]) as resp:
+            body = resp.read()
+        tbl = pq.read_table(io.BytesIO(body))
+        total_rows += tbl.num_rows
+        projects |= set(tbl.column("project_id").to_pylist())
+        sizes.append(part["bytes"])
+
+    print(
+        f"[{label}] {n_files} planned, {len(parts)} written; rows {total_rows:,}; "
+        f"max part {max(sizes) / 1024 / 1024:.2f}MB; projects {projects}"
+    )
+    assert total_rows == SEED_ROWS, f"row total {total_rows} != {SEED_ROWS}"
+    assert projects == {PROJECT}, f"LEAK: {projects}"
+    assert len(parts) == len(suffixes), "missing part(s) in manifest"
+    return parts
+
+
+def assert_url_scoped(parts: list[dict]) -> None:
+    """A presigned GET is bound to one key + expiry: tampering either -> 403."""
+
+    def code(u: str) -> int:
+        try:
+            urllib.request.urlopen(u)
+        except urllib.error.HTTPError as e:
+            return e.code
+        else:
+            return 200
+
+    url = parts[0]["url"]
+    assert code(url) == 200, "valid URL should download"
+    assert code(url.replace("acme/prod", "victim/prod")) == 403, (
+        "tampered key should 403"
+    )
+    assert code(url.replace("X-Amz-Expires=900", "X-Amz-Expires=99999")) == 403, (
+        "tampered TTL should 403"
+    )
+
+
+def main() -> None:
+    client = clickhouse_connect.get_client(**CH, send_receive_timeout=120)
+    client.command("CREATE DATABASE IF NOT EXISTS oneoff")
+    client.database = "oneoff"
+    seed(client)
+    s3 = ox.make_s3(HOST_ENDPOINT, "us-east-1", ROOT_KEY, ROOT_SECRET, None)
+
+    print("=== one-off export local test ===")
+    single = run_case(client, s3, label="single", target_mb=256)
+    run_case(client, s3, label="chunked", target_mb=1)
+    run_case(client, s3, label=">100 parts", force_n=120)
+    assert_url_scoped(single)
+
+    audit = client.query(
+        "SELECT action, count() FROM exports WHERE project_id={p:String} GROUP BY action ORDER BY action",
+        parameters={"p": PROJECT},
+    ).result_rows
+    print(f"audit rows: {audit}")
+    assert dict(audit) == {"EXPORT_START": 3, "EXPORT_MINT": 3, "EXPORT_COMPLETE": 3}, (
+        "audit mismatch"
+    )
+    print(
+        "\nPASS: single + chunked + >100-part export all rows, no leak, "
+        "URL key/TTL-scoped, full audit trail"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Interim, operator-run bulk export to a **WandB-owned** bucket + short-TTL presigned download URLs, while team-level BYOB is in security/design review. The bulk-export spec minus the BYOB target.
- CH writes Parquet directly with our own creds (no presigned-*write*, which CH can't do); byte-based chunking to ~256MB files via `PARTITION BY cityHash64(id) % n`.

## Flow
```mermaid
flowchart TD
    OP["operator runs manual_export.py<br/>project_id, table, time range"]
    OP --> PF["preflight: count + byteSize<br/>-> n files at ~256MB each"]
    PF --> START[("exports: EXPORT_START")]
    PF --> SW{n files}
    SW -->|one| SINGLE["CH INSERT INTO FUNCTION s3()<br/>-> data.parquet"]
    SW -->|many| MULTI["CH INSERT ... PARTITION BY<br/>cityHash64 id % n -> data_N.parquet"]
    SINGLE --> BUCKET[("WandB-owned bucket<br/>env/exports/entity/project/job/")]
    MULTI --> BUCKET
    BUCKET --> MINT["read back parts, mint presigned GET<br/>15m TTL, signer has no ListBucket"]
    MINT --> DONE[("exports: EXPORT_MINT + EXPORT_COMPLETE")]
    MINT --> MAN["manifest: parts of key, bytes, url"]
    MAN --> CUST["customer downloads directly"]
```

## Files
- `manual_export.py` - operator script: preflight -> CH write -> presign -> manifest, with audit rows + charset validation
- `run_local_test.py` - MinIO+CH e2e (single / chunked / >100 parts / URL tamper)
- `README.md` - procedure, security posture, residency-customer gate

## Testing
local e2e against MinIO+CH: single + chunked + 120-part export, no cross-project leak, presigned URL key/TTL-scoped, full audit trail.
