### PR TITLE
feat(weave): add set_attributes and add_event to Tool/LLM/SubAgent/Turn

### DIFF
--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -93,11 +93,16 @@ def test_add_event_no_op_after_end(
     assert len(finished_span.events) == 0
 
 
-def test_returns_self_for_chaining() -> None:
-    """Both methods return ``self`` — checked on Tool (mixin, same on all)."""
-    tool = Tool(name="test-tool")
-    assert tool.set_attribute("key", "value") is tool
-    assert tool.add_event("event-name") is tool
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "_span_name"), CASES, ids=CLASS_LABELS
+)
+def test_returns_self_for_chaining(
+    otel_spans: InMemorySpanExporter, _class_label, factory, _span_name
+) -> None:
+    """Both methods return ``self`` for fluent chaining on a live span."""
+    with Session(session_id="test-session"), factory() as span_obj:
+        assert span_obj.set_attribute("key", "value") is span_obj
+        assert span_obj.add_event("event-name") is span_obj
 
 
 def test_set_attribute_accepts_sequence_value(
@@ -110,11 +115,12 @@ def test_set_attribute_accepts_sequence_value(
     assert tuple(chat_span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
 
 
-def test_no_op_on_unentered_span() -> None:
-    """No OTel span ever created (caller never entered the context manager)."""
+def test_no_op_on_unentered_span(otel_spans: InMemorySpanExporter) -> None:
+    """Unentered span doesn't crash and emits no OTel output."""
     tool = Tool(name="test-tool")
-    assert tool.set_attribute("key", "value") is tool
-    assert tool.add_event("event-name") is tool
+    tool.set_attribute("key", "value")
+    tool.add_event("event-name")
+    assert len(otel_spans.get_finished_spans()) == 0
 
 
 def test_warns_when_span_not_started(caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -1,0 +1,224 @@
+"""Tests for ``set_attribute`` and ``add_event`` on session span classes.
+
+These two methods are escape hatches that delegate to the underlying OTel
+span: ``set_attribute`` lands arbitrary keys not covered by the declared
+GenAI semconv fields, and ``add_event`` records OTel span events.
+
+Both live on ``_SpanBase`` so all four span classes (Tool, LLM, SubAgent,
+Turn) get the same behavior. This file exercises each class independently
+to lock in that uniformity.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from weave.session.session import (
+    LLM,
+    Session,
+    SubAgent,
+    Tool,
+    Turn,
+)
+
+
+def _find(spans: list, name_prefix: str):
+    """Return the single finished span whose name starts with ``name_prefix``."""
+    matches = [sp for sp in spans if sp.name.startswith(name_prefix)]
+    assert len(matches) == 1, (
+        f"expected 1 span with prefix {name_prefix!r}, got {[s.name for s in matches]}"
+    )
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# set_attribute
+# ---------------------------------------------------------------------------
+
+
+class TestSetAttributeTool:
+    def test_lands_on_finished_span(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot"), Tool(name="f") as t:
+            t.set_attribute("weave.display_name", "f: Tokyo")
+        span = _find(otel_spans.get_finished_spans(), "execute_tool")
+        assert span.attributes["weave.display_name"] == "f: Tokyo"
+
+    def test_returns_self_for_chaining(self) -> None:
+        t = Tool(name="f")
+        assert t.set_attribute("k", "v") is t
+
+    def test_no_op_after_end(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot"):
+            t = Tool(name="f")
+            with t:
+                pass
+            t.set_attribute("weave.too_late", "x")
+        span = _find(otel_spans.get_finished_spans(), "execute_tool")
+        assert "weave.too_late" not in (span.attributes or {})
+
+
+class TestSetAttributeLLM:
+    def test_lands_on_finished_span(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot"), LLM(model="gpt-4o") as c:
+            c.set_attribute("gen_ai.response.id", "resp-abc")
+        span = _find(otel_spans.get_finished_spans(), "chat")
+        assert span.attributes["gen_ai.response.id"] == "resp-abc"
+
+    def test_accepts_sequence_values(self, otel_spans: InMemorySpanExporter) -> None:
+        """OTel accepts ``Sequence[str]`` / numeric sequences as attribute values."""
+        with Session(session_id="s"), Turn(agent_name="bot"), LLM(model="gpt-4o") as c:
+            c.set_attribute("gen_ai.response.finish_reasons", ["stop"])
+        span = _find(otel_spans.get_finished_spans(), "chat")
+        assert tuple(span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
+
+    def test_no_op_after_end(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot"):
+            c = LLM(model="gpt-4o")
+            with c:
+                pass
+            c.set_attribute("weave.too_late", "x")
+        span = _find(otel_spans.get_finished_spans(), "chat")
+        assert "weave.too_late" not in (span.attributes or {})
+
+
+class TestSetAttributeSubAgent:
+    def test_lands_on_finished_span(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot") as turn:
+            with turn.subagent(name="researcher") as sa:
+                sa.set_attribute("weave.display_name", "Agent: research-bot")
+        # Two invoke_agent spans (Turn + SubAgent); pick the SubAgent by name.
+        spans = otel_spans.get_finished_spans()
+        sa_spans = [
+            sp
+            for sp in spans
+            if sp.name.startswith("invoke_agent")
+            and sp.attributes.get("gen_ai.agent.name") == "researcher"
+        ]
+        assert len(sa_spans) == 1
+        assert sa_spans[0].attributes["weave.display_name"] == "Agent: research-bot"
+
+
+class TestSetAttributeTurn:
+    def test_lands_on_finished_span(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot") as t:
+            t.set_attribute("weave.custom_tag", "v1")
+        span = _find(otel_spans.get_finished_spans(), "invoke_agent")
+        assert span.attributes["weave.custom_tag"] == "v1"
+
+
+# ---------------------------------------------------------------------------
+# add_event
+# ---------------------------------------------------------------------------
+
+
+class TestAddEventTool:
+    def test_records_event_with_attributes(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        with Session(session_id="s"), Turn(agent_name="bot"), Tool(name="f") as t:
+            t.add_event(
+                "weave.permission_request",
+                {"weave.permission.suggestions": "[]"},
+                timestamp=ts,
+            )
+        span = _find(otel_spans.get_finished_spans(), "execute_tool")
+        assert len(span.events) == 1
+        event = span.events[0]
+        assert event.name == "weave.permission_request"
+        assert event.attributes["weave.permission.suggestions"] == "[]"
+        expected_ns = int(ts.timestamp() * 1_000_000_000)
+        assert event.timestamp == expected_ns
+
+    def test_default_timestamp_is_now(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot"), Tool(name="f") as t:
+            t.add_event("weave.marker")
+        span = _find(otel_spans.get_finished_spans(), "execute_tool")
+        assert len(span.events) == 1
+        assert span.events[0].name == "weave.marker"
+
+    def test_returns_self_for_chaining(self) -> None:
+        t = Tool(name="f")
+        assert t.add_event("e") is t
+
+    def test_no_op_after_end(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot"):
+            t = Tool(name="f")
+            with t:
+                pass
+            t.add_event("weave.too_late")
+        span = _find(otel_spans.get_finished_spans(), "execute_tool")
+        assert len(span.events) == 0
+
+
+class TestAddEventLLM:
+    def test_records_event(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot"), LLM(model="gpt-4o") as c:
+            c.add_event("weave.lifecycle", {"state": "streaming"})
+        span = _find(otel_spans.get_finished_spans(), "chat")
+        assert len(span.events) == 1
+        assert span.events[0].name == "weave.lifecycle"
+        assert span.events[0].attributes["state"] == "streaming"
+
+
+class TestAddEventSubAgent:
+    def test_records_event(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot") as turn:
+            with turn.subagent(name="researcher") as sa:
+                sa.add_event("weave.lifecycle", {"state": "spawned"})
+        spans = otel_spans.get_finished_spans()
+        sa_span = next(
+            sp
+            for sp in spans
+            if sp.name.startswith("invoke_agent")
+            and sp.attributes.get("gen_ai.agent.name") == "researcher"
+        )
+        assert len(sa_span.events) == 1
+        assert sa_span.events[0].name == "weave.lifecycle"
+
+
+class TestAddEventTurn:
+    def test_records_event(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot") as t:
+            t.add_event("weave.lifecycle", {"state": "received"})
+        span = _find(otel_spans.get_finished_spans(), "invoke_agent")
+        assert len(span.events) == 1
+        assert span.events[0].name == "weave.lifecycle"
+
+
+# ---------------------------------------------------------------------------
+# No-OTel safety
+# ---------------------------------------------------------------------------
+
+
+class TestNoOtelInstalled:
+    """When the span never got an OTel span (e.g. constructed without entering
+    a context manager, or OTel disabled), both methods quietly no-op.
+    """
+
+    def test_set_attribute_on_unentered_tool(self) -> None:
+        t = Tool(name="f")
+        # No otel_spans fixture — _otel_span stays None. Must not raise.
+        assert t.set_attribute("k", "v") is t
+
+    def test_add_event_on_unentered_tool(self) -> None:
+        t = Tool(name="f")
+        assert t.add_event("e", {"k": "v"}) is t
+
+
+# ---------------------------------------------------------------------------
+# Sanity: methods exist on all four classes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cls", [Tool, LLM, SubAgent, Turn])
+def test_set_attribute_defined_on_class(cls: type) -> None:
+    assert callable(getattr(cls, "set_attribute", None))
+
+
+@pytest.mark.parametrize("cls", [Tool, LLM, SubAgent, Turn])
+def test_add_event_defined_on_class(cls: type) -> None:
+    assert callable(getattr(cls, "add_event", None))

--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -14,90 +14,103 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 
 from weave.session.session import LLM, Session, SubAgent, Tool, Turn
 
-# (label, factory, otel span name) — name is full not prefix so SubAgent and
-# Turn (both "invoke_agent") don't collide.
+# (class_label, factory, otel_span_name) — span_name is the full emitted name
+# (not a prefix) so SubAgent and Turn (both "invoke_agent") don't collide.
 CASES = [
-    ("Tool", lambda: Tool(name="f"), "execute_tool f"),
+    ("Tool", lambda: Tool(name="test-tool"), "execute_tool test-tool"),
     ("LLM", lambda: LLM(model="gpt-4o"), "chat gpt-4o"),
-    ("SubAgent", lambda: SubAgent(name="sa"), "invoke_agent sa"),
-    ("Turn", lambda: Turn(agent_name="t"), "invoke_agent t"),
+    ("SubAgent", lambda: SubAgent(name="researcher"), "invoke_agent researcher"),
+    ("Turn", lambda: Turn(agent_name="weather-bot"), "invoke_agent weather-bot"),
 ]
-IDS = [c[0] for c in CASES]
+CLASS_LABELS = [case[0] for case in CASES]
 
 
-def _only(spans: list, name: str):
-    matches = [sp for sp in spans if sp.name == name]
-    assert len(matches) == 1, [s.name for s in matches]
+def _only_span(spans: list, span_name: str):
+    matches = [span for span in spans if span.name == span_name]
+    assert len(matches) == 1, [span.name for span in matches]
     return matches[0]
 
 
-@pytest.mark.parametrize(("_label", "factory", "span_name"), CASES, ids=IDS)
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
 def test_set_attribute_lands_on_span(
-    otel_spans: InMemorySpanExporter, _label, factory, span_name
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
 ) -> None:
-    with Session(session_id="s"), factory() as x:
-        x.set_attribute("weave.tag", "v")
-    assert (
-        _only(otel_spans.get_finished_spans(), span_name).attributes["weave.tag"] == "v"
-    )
+    with Session(session_id="test-session"), factory() as span_obj:
+        span_obj.set_attribute("weave.tag", "value")
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert finished_span.attributes["weave.tag"] == "value"
 
 
-@pytest.mark.parametrize(("_label", "factory", "span_name"), CASES, ids=IDS)
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
 def test_set_attribute_no_op_after_end(
-    otel_spans: InMemorySpanExporter, _label, factory, span_name
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
 ) -> None:
-    with Session(session_id="s"):
-        x = factory()
-        with x:
+    with Session(session_id="test-session"):
+        span_obj = factory()
+        with span_obj:
             pass
-        x.set_attribute("weave.late", "x")
-    assert "weave.late" not in (
-        _only(otel_spans.get_finished_spans(), span_name).attributes or {}
-    )
+        span_obj.set_attribute("weave.late", "value")
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert "weave.late" not in (finished_span.attributes or {})
 
 
-@pytest.mark.parametrize(("_label", "factory", "span_name"), CASES, ids=IDS)
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
 def test_add_event_records_on_span(
-    otel_spans: InMemorySpanExporter, _label, factory, span_name
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
 ) -> None:
-    ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    with Session(session_id="s"), factory() as x:
-        x.add_event("weave.evt", {"k": "v"}, timestamp=ts)
-    span = _only(otel_spans.get_finished_spans(), span_name)
-    assert len(span.events) == 1
-    assert (span.events[0].name, span.events[0].attributes["k"]) == ("weave.evt", "v")
-    assert span.events[0].timestamp == int(ts.timestamp() * 1_000_000_000)
+    timestamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    with Session(session_id="test-session"), factory() as span_obj:
+        span_obj.add_event(
+            "weave.evt", {"event_key": "event_value"}, timestamp=timestamp
+        )
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert len(finished_span.events) == 1
+    event = finished_span.events[0]
+    assert event.name == "weave.evt"
+    assert event.attributes["event_key"] == "event_value"
+    assert event.timestamp == int(timestamp.timestamp() * 1_000_000_000)
 
 
-@pytest.mark.parametrize(("_label", "factory", "span_name"), CASES, ids=IDS)
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
 def test_add_event_no_op_after_end(
-    otel_spans: InMemorySpanExporter, _label, factory, span_name
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
 ) -> None:
-    with Session(session_id="s"):
-        x = factory()
-        with x:
+    with Session(session_id="test-session"):
+        span_obj = factory()
+        with span_obj:
             pass
-        x.add_event("weave.late")
-    assert len(_only(otel_spans.get_finished_spans(), span_name).events) == 0
+        span_obj.add_event("weave.late")
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert len(finished_span.events) == 0
 
 
 def test_returns_self_for_chaining() -> None:
     """Both methods return ``self`` — checked on Tool (mixin, same on all)."""
-    t = Tool(name="f")
-    assert t.set_attribute("k", "v") is t
-    assert t.add_event("e") is t
+    tool = Tool(name="test-tool")
+    assert tool.set_attribute("key", "value") is tool
+    assert tool.add_event("event-name") is tool
 
 
-def test_set_attribute_accepts_sequence_value(otel_spans: InMemorySpanExporter) -> None:
+def test_set_attribute_accepts_sequence_value(
+    otel_spans: InMemorySpanExporter,
+) -> None:
     """OTel accepts ``Sequence[str]`` — used for e.g. ``gen_ai.response.finish_reasons``."""
-    with Session(session_id="s"), LLM(model="gpt-4o") as c:
-        c.set_attribute("gen_ai.response.finish_reasons", ["stop"])
-    span = _only(otel_spans.get_finished_spans(), "chat gpt-4o")
-    assert tuple(span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
+    with Session(session_id="test-session"), LLM(model="gpt-4o") as llm:
+        llm.set_attribute("gen_ai.response.finish_reasons", ["stop"])
+    chat_span = _only_span(otel_spans.get_finished_spans(), "chat gpt-4o")
+    assert tuple(chat_span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
 
 
 def test_no_op_on_unentered_span() -> None:
     """No OTel span ever created (caller never entered the context manager)."""
-    t = Tool(name="f")
-    assert t.set_attribute("k", "v") is t
-    assert t.add_event("e") is t
+    tool = Tool(name="test-tool")
+    assert tool.set_attribute("key", "value") is tool
+    assert tool.add_event("event-name") is tool

--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -1,12 +1,8 @@
 """Tests for ``set_attribute`` and ``add_event`` on session span classes.
 
-These two methods are escape hatches that delegate to the underlying OTel
-span: ``set_attribute`` lands arbitrary keys not covered by the declared
-GenAI semconv fields, and ``add_event`` records OTel span events.
-
-Both live on ``_SpanBase`` so all four span classes (Tool, LLM, SubAgent,
-Turn) get the same behavior. This file exercises each class independently
-to lock in that uniformity.
+Both methods live on ``_SpanBase`` so all four span classes (Tool, LLM,
+SubAgent, Turn) get identical behavior. Parametrized across the four
+classes to lock in uniformity.
 """
 
 from __future__ import annotations
@@ -16,209 +12,92 @@ from datetime import datetime, timezone
 import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from weave.session.session import (
-    LLM,
-    Session,
-    SubAgent,
-    Tool,
-    Turn,
-)
+from weave.session.session import LLM, Session, SubAgent, Tool, Turn
+
+# (label, factory, otel span name) — name is full not prefix so SubAgent and
+# Turn (both "invoke_agent") don't collide.
+CASES = [
+    ("Tool", lambda: Tool(name="f"), "execute_tool f"),
+    ("LLM", lambda: LLM(model="gpt-4o"), "chat gpt-4o"),
+    ("SubAgent", lambda: SubAgent(name="sa"), "invoke_agent sa"),
+    ("Turn", lambda: Turn(agent_name="t"), "invoke_agent t"),
+]
+IDS = [c[0] for c in CASES]
 
 
-def _find(spans: list, name_prefix: str):
-    """Return the single finished span whose name starts with ``name_prefix``."""
-    matches = [sp for sp in spans if sp.name.startswith(name_prefix)]
-    assert len(matches) == 1, (
-        f"expected 1 span with prefix {name_prefix!r}, got {[s.name for s in matches]}"
-    )
+def _only(spans: list, name: str):
+    matches = [sp for sp in spans if sp.name == name]
+    assert len(matches) == 1, [s.name for s in matches]
     return matches[0]
 
 
-# ---------------------------------------------------------------------------
-# set_attribute
-# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(("_label", "factory", "span_name"), CASES, ids=IDS)
+def test_set_attribute_lands_on_span(
+    otel_spans: InMemorySpanExporter, _label, factory, span_name
+) -> None:
+    with Session(session_id="s"), factory() as x:
+        x.set_attribute("weave.tag", "v")
+    assert (
+        _only(otel_spans.get_finished_spans(), span_name).attributes["weave.tag"] == "v"
+    )
 
 
-class TestSetAttributeTool:
-    def test_lands_on_finished_span(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot"), Tool(name="f") as t:
-            t.set_attribute("weave.display_name", "f: Tokyo")
-        span = _find(otel_spans.get_finished_spans(), "execute_tool")
-        assert span.attributes["weave.display_name"] == "f: Tokyo"
-
-    def test_returns_self_for_chaining(self) -> None:
-        t = Tool(name="f")
-        assert t.set_attribute("k", "v") is t
-
-    def test_no_op_after_end(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot"):
-            t = Tool(name="f")
-            with t:
-                pass
-            t.set_attribute("weave.too_late", "x")
-        span = _find(otel_spans.get_finished_spans(), "execute_tool")
-        assert "weave.too_late" not in (span.attributes or {})
+@pytest.mark.parametrize(("_label", "factory", "span_name"), CASES, ids=IDS)
+def test_set_attribute_no_op_after_end(
+    otel_spans: InMemorySpanExporter, _label, factory, span_name
+) -> None:
+    with Session(session_id="s"):
+        x = factory()
+        with x:
+            pass
+        x.set_attribute("weave.late", "x")
+    assert "weave.late" not in (
+        _only(otel_spans.get_finished_spans(), span_name).attributes or {}
+    )
 
 
-class TestSetAttributeLLM:
-    def test_lands_on_finished_span(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot"), LLM(model="gpt-4o") as c:
-            c.set_attribute("gen_ai.response.id", "resp-abc")
-        span = _find(otel_spans.get_finished_spans(), "chat")
-        assert span.attributes["gen_ai.response.id"] == "resp-abc"
-
-    def test_accepts_sequence_values(self, otel_spans: InMemorySpanExporter) -> None:
-        """OTel accepts ``Sequence[str]`` / numeric sequences as attribute values."""
-        with Session(session_id="s"), Turn(agent_name="bot"), LLM(model="gpt-4o") as c:
-            c.set_attribute("gen_ai.response.finish_reasons", ["stop"])
-        span = _find(otel_spans.get_finished_spans(), "chat")
-        assert tuple(span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
-
-    def test_no_op_after_end(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot"):
-            c = LLM(model="gpt-4o")
-            with c:
-                pass
-            c.set_attribute("weave.too_late", "x")
-        span = _find(otel_spans.get_finished_spans(), "chat")
-        assert "weave.too_late" not in (span.attributes or {})
+@pytest.mark.parametrize(("_label", "factory", "span_name"), CASES, ids=IDS)
+def test_add_event_records_on_span(
+    otel_spans: InMemorySpanExporter, _label, factory, span_name
+) -> None:
+    ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    with Session(session_id="s"), factory() as x:
+        x.add_event("weave.evt", {"k": "v"}, timestamp=ts)
+    span = _only(otel_spans.get_finished_spans(), span_name)
+    assert len(span.events) == 1
+    assert (span.events[0].name, span.events[0].attributes["k"]) == ("weave.evt", "v")
+    assert span.events[0].timestamp == int(ts.timestamp() * 1_000_000_000)
 
 
-class TestSetAttributeSubAgent:
-    def test_lands_on_finished_span(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot") as turn:
-            with turn.subagent(name="researcher") as sa:
-                sa.set_attribute("weave.display_name", "Agent: research-bot")
-        # Two invoke_agent spans (Turn + SubAgent); pick the SubAgent by name.
-        spans = otel_spans.get_finished_spans()
-        sa_spans = [
-            sp
-            for sp in spans
-            if sp.name.startswith("invoke_agent")
-            and sp.attributes.get("gen_ai.agent.name") == "researcher"
-        ]
-        assert len(sa_spans) == 1
-        assert sa_spans[0].attributes["weave.display_name"] == "Agent: research-bot"
+@pytest.mark.parametrize(("_label", "factory", "span_name"), CASES, ids=IDS)
+def test_add_event_no_op_after_end(
+    otel_spans: InMemorySpanExporter, _label, factory, span_name
+) -> None:
+    with Session(session_id="s"):
+        x = factory()
+        with x:
+            pass
+        x.add_event("weave.late")
+    assert len(_only(otel_spans.get_finished_spans(), span_name).events) == 0
 
 
-class TestSetAttributeTurn:
-    def test_lands_on_finished_span(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot") as t:
-            t.set_attribute("weave.custom_tag", "v1")
-        span = _find(otel_spans.get_finished_spans(), "invoke_agent")
-        assert span.attributes["weave.custom_tag"] == "v1"
+def test_returns_self_for_chaining() -> None:
+    """Both methods return ``self`` — checked on Tool (mixin, same on all)."""
+    t = Tool(name="f")
+    assert t.set_attribute("k", "v") is t
+    assert t.add_event("e") is t
 
 
-# ---------------------------------------------------------------------------
-# add_event
-# ---------------------------------------------------------------------------
+def test_set_attribute_accepts_sequence_value(otel_spans: InMemorySpanExporter) -> None:
+    """OTel accepts ``Sequence[str]`` — used for e.g. ``gen_ai.response.finish_reasons``."""
+    with Session(session_id="s"), LLM(model="gpt-4o") as c:
+        c.set_attribute("gen_ai.response.finish_reasons", ["stop"])
+    span = _only(otel_spans.get_finished_spans(), "chat gpt-4o")
+    assert tuple(span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
 
 
-class TestAddEventTool:
-    def test_records_event_with_attributes(
-        self, otel_spans: InMemorySpanExporter
-    ) -> None:
-        ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        with Session(session_id="s"), Turn(agent_name="bot"), Tool(name="f") as t:
-            t.add_event(
-                "weave.permission_request",
-                {"weave.permission.suggestions": "[]"},
-                timestamp=ts,
-            )
-        span = _find(otel_spans.get_finished_spans(), "execute_tool")
-        assert len(span.events) == 1
-        event = span.events[0]
-        assert event.name == "weave.permission_request"
-        assert event.attributes["weave.permission.suggestions"] == "[]"
-        expected_ns = int(ts.timestamp() * 1_000_000_000)
-        assert event.timestamp == expected_ns
-
-    def test_default_timestamp_is_now(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot"), Tool(name="f") as t:
-            t.add_event("weave.marker")
-        span = _find(otel_spans.get_finished_spans(), "execute_tool")
-        assert len(span.events) == 1
-        assert span.events[0].name == "weave.marker"
-
-    def test_returns_self_for_chaining(self) -> None:
-        t = Tool(name="f")
-        assert t.add_event("e") is t
-
-    def test_no_op_after_end(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot"):
-            t = Tool(name="f")
-            with t:
-                pass
-            t.add_event("weave.too_late")
-        span = _find(otel_spans.get_finished_spans(), "execute_tool")
-        assert len(span.events) == 0
-
-
-class TestAddEventLLM:
-    def test_records_event(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot"), LLM(model="gpt-4o") as c:
-            c.add_event("weave.lifecycle", {"state": "streaming"})
-        span = _find(otel_spans.get_finished_spans(), "chat")
-        assert len(span.events) == 1
-        assert span.events[0].name == "weave.lifecycle"
-        assert span.events[0].attributes["state"] == "streaming"
-
-
-class TestAddEventSubAgent:
-    def test_records_event(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot") as turn:
-            with turn.subagent(name="researcher") as sa:
-                sa.add_event("weave.lifecycle", {"state": "spawned"})
-        spans = otel_spans.get_finished_spans()
-        sa_span = next(
-            sp
-            for sp in spans
-            if sp.name.startswith("invoke_agent")
-            and sp.attributes.get("gen_ai.agent.name") == "researcher"
-        )
-        assert len(sa_span.events) == 1
-        assert sa_span.events[0].name == "weave.lifecycle"
-
-
-class TestAddEventTurn:
-    def test_records_event(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot") as t:
-            t.add_event("weave.lifecycle", {"state": "received"})
-        span = _find(otel_spans.get_finished_spans(), "invoke_agent")
-        assert len(span.events) == 1
-        assert span.events[0].name == "weave.lifecycle"
-
-
-# ---------------------------------------------------------------------------
-# No-OTel safety
-# ---------------------------------------------------------------------------
-
-
-class TestNoOtelInstalled:
-    """When the span never got an OTel span (e.g. constructed without entering
-    a context manager, or OTel disabled), both methods quietly no-op.
-    """
-
-    def test_set_attribute_on_unentered_tool(self) -> None:
-        t = Tool(name="f")
-        # No otel_spans fixture — _otel_span stays None. Must not raise.
-        assert t.set_attribute("k", "v") is t
-
-    def test_add_event_on_unentered_tool(self) -> None:
-        t = Tool(name="f")
-        assert t.add_event("e", {"k": "v"}) is t
-
-
-# ---------------------------------------------------------------------------
-# Sanity: methods exist on all four classes
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize("cls", [Tool, LLM, SubAgent, Turn])
-def test_set_attribute_defined_on_class(cls: type) -> None:
-    assert callable(getattr(cls, "set_attribute", None))
-
-
-@pytest.mark.parametrize("cls", [Tool, LLM, SubAgent, Turn])
-def test_add_event_defined_on_class(cls: type) -> None:
-    assert callable(getattr(cls, "add_event", None))
+def test_no_op_on_unentered_span() -> None:
+    """No OTel span ever created (caller never entered the context manager)."""
+    t = Tool(name="f")
+    assert t.set_attribute("k", "v") is t
+    assert t.add_event("e") is t

--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -7,6 +7,7 @@ classes to lock in uniformity.
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 
 import pytest
@@ -114,3 +115,39 @@ def test_no_op_on_unentered_span() -> None:
     tool = Tool(name="test-tool")
     assert tool.set_attribute("key", "value") is tool
     assert tool.add_event("event-name") is tool
+
+
+def test_warns_when_span_not_started(caplog: pytest.LogCaptureFixture) -> None:
+    """Calling set_attribute / add_event on an unentered span warns the user."""
+    caplog.set_level(logging.WARNING, logger="weave.session.session")
+    tool = Tool(name="test-tool")
+    tool.set_attribute("weave.tag", "value")
+    tool.add_event("weave.evt")
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "set_attribute" in message and "span not started" in message
+        for message in messages
+    )
+    assert any(
+        "add_event" in message and "span not started" in message for message in messages
+    )
+
+
+def test_warns_when_span_already_ended(caplog: pytest.LogCaptureFixture) -> None:
+    """Calling set_attribute / add_event after end() warns the user."""
+    caplog.set_level(logging.WARNING, logger="weave.session.session")
+    with Session(session_id="test-session"):
+        tool = Tool(name="test-tool")
+        with tool:
+            pass
+        tool.set_attribute("weave.tag", "value")
+        tool.add_event("weave.evt")
+    messages = [record.message for record in caplog.records]
+    assert any(
+        "set_attribute" in message and "span already ended" in message
+        for message in messages
+    )
+    assert any(
+        "add_event" in message and "span already ended" in message
+        for message in messages
+    )

--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -1,14 +1,13 @@
-"""Tests for ``set_attribute`` and ``add_event`` on session span classes.
+"""Tests for ``set_attribute``, ``set_attributes``, and ``add_event``.
 
-Both methods live on ``_SpanBase`` so all four span classes (Tool, LLM,
-SubAgent, Turn) get identical behavior. Parametrized across the four
-classes to lock in uniformity.
+All three live on ``_SpanBase`` so every span class (Tool, LLM, SubAgent,
+Turn) gets identical behavior. Tests cross-parametrize over the (span
+class x mutator method) cross product to lock in that uniformity.
 """
 
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
 
 import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -26,6 +25,36 @@ CASES = [
 CLASS_LABELS = [case[0] for case in CASES]
 
 
+# (op_name, invoke_on_span, assert_landed_on_finished_span)
+# The three mutators have different signatures; capture each call shape
+# alongside the matching "did it land?" check so cross-parametrize stays clean.
+MUTATORS = [
+    (
+        "set_attribute",
+        lambda span: span.set_attribute("weave.tag", "value"),
+        lambda finished: finished.attributes.get("weave.tag") == "value",
+    ),
+    (
+        "set_attributes",
+        lambda span: span.set_attributes({"weave.first": "one", "weave.second": "two"}),
+        lambda finished: (
+            finished.attributes.get("weave.first") == "one"
+            and finished.attributes.get("weave.second") == "two"
+        ),
+    ),
+    (
+        "add_event",
+        lambda span: span.add_event("weave.evt", {"event_key": "event_value"}),
+        lambda finished: (
+            len(finished.events) == 1
+            and finished.events[0].name == "weave.evt"
+            and finished.events[0].attributes["event_key"] == "event_value"
+        ),
+    ),
+]
+MUTATOR_LABELS = [mutator[0] for mutator in MUTATORS]
+
+
 def _only_span(spans: list, span_name: str):
     matches = [span for span in spans if span.name == span_name]
     assert len(matches) == 1, [span.name for span in matches]
@@ -35,89 +64,97 @@ def _only_span(spans: list, span_name: str):
 @pytest.mark.parametrize(
     ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
 )
-def test_set_attribute_lands_on_span(
-    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
+@pytest.mark.parametrize(
+    ("_op", "invoke", "assert_landed"), MUTATORS, ids=MUTATOR_LABELS
+)
+def test_mutator_lands_on_live_span(
+    otel_spans: InMemorySpanExporter,
+    _class_label,
+    factory,
+    span_name,
+    _op,
+    invoke,
+    assert_landed,
 ) -> None:
+    """Each mutator writes through to the OTel span when called inside ``with``."""
     with Session(session_id="test-session"), factory() as span_obj:
-        span_obj.set_attribute("weave.tag", "value")
-    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
-    assert finished_span.attributes["weave.tag"] == "value"
+        invoke(span_obj)
+    assert assert_landed(_only_span(otel_spans.get_finished_spans(), span_name))
 
 
 @pytest.mark.parametrize(
     ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
 )
-def test_set_attribute_no_op_after_end(
-    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
+@pytest.mark.parametrize(
+    ("_op", "invoke", "assert_landed"), MUTATORS, ids=MUTATOR_LABELS
+)
+def test_mutator_no_op_after_end(
+    otel_spans: InMemorySpanExporter,
+    _class_label,
+    factory,
+    span_name,
+    _op,
+    invoke,
+    assert_landed,
 ) -> None:
+    """Each mutator is a no-op when called after the span has ended."""
     with Session(session_id="test-session"):
         span_obj = factory()
         with span_obj:
             pass
-        span_obj.set_attribute("weave.late", "value")
-    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
-    assert "weave.late" not in (finished_span.attributes or {})
-
-
-@pytest.mark.parametrize(
-    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
-)
-def test_add_event_records_on_span(
-    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
-) -> None:
-    timestamp = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    with Session(session_id="test-session"), factory() as span_obj:
-        span_obj.add_event(
-            "weave.evt", {"event_key": "event_value"}, timestamp=timestamp
-        )
-    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
-    assert len(finished_span.events) == 1
-    event = finished_span.events[0]
-    assert event.name == "weave.evt"
-    assert event.attributes["event_key"] == "event_value"
-    assert event.timestamp == int(timestamp.timestamp() * 1_000_000_000)
-
-
-@pytest.mark.parametrize(
-    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
-)
-def test_add_event_no_op_after_end(
-    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
-) -> None:
-    with Session(session_id="test-session"):
-        span_obj = factory()
-        with span_obj:
-            pass
-        span_obj.add_event("weave.late")
-    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
-    assert len(finished_span.events) == 0
-
-
-@pytest.mark.parametrize(
-    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
-)
-def test_set_attributes_lands_on_span(
-    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
-) -> None:
-    """Bulk ``set_attributes`` lands every key on the OTel span."""
-    with Session(session_id="test-session"), factory() as span_obj:
-        span_obj.set_attributes({"weave.first": "one", "weave.second": "two"})
-    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
-    assert finished_span.attributes["weave.first"] == "one"
-    assert finished_span.attributes["weave.second"] == "two"
+        invoke(span_obj)
+    assert not assert_landed(_only_span(otel_spans.get_finished_spans(), span_name))
 
 
 @pytest.mark.parametrize(
     ("_class_label", "factory", "_span_name"), CASES, ids=CLASS_LABELS
 )
-def test_returns_self_for_chaining(
+def test_mutators_return_self_for_chaining(
     otel_spans: InMemorySpanExporter, _class_label, factory, _span_name
 ) -> None:
-    """All three mutators return ``self`` for fluent chaining on a live span."""
+    """All mutators return ``self`` for fluent chaining."""
     with Session(session_id="test-session"), factory() as span_obj:
-        assert span_obj.set_attribute("key", "value") is span_obj
-        assert span_obj.set_attributes({"key": "value"}) is span_obj
-        assert span_obj.add_event("event-name") is span_obj
+        for _op, invoke, _assert_landed in MUTATORS:
+            assert invoke(span_obj) is span_obj
+
+
+@pytest.mark.parametrize(
+    ("op", "invoke", "_assert_landed"), MUTATORS, ids=MUTATOR_LABELS
+)
+def test_warns_when_span_not_started(
+    caplog: pytest.LogCaptureFixture,
+    otel_spans: InMemorySpanExporter,
+    op,
+    invoke,
+    _assert_landed,
+) -> None:
+    """Each mutator warns and emits no span when called before ``with``."""
+    caplog.set_level(logging.WARNING, logger="weave.session.session")
+    invoke(Tool(name="test-tool"))
+    assert any(
+        op in record.message and "span not started" in record.message
+        for record in caplog.records
+    )
+    assert len(otel_spans.get_finished_spans()) == 0
+
+
+@pytest.mark.parametrize(
+    ("op", "invoke", "_assert_landed"), MUTATORS, ids=MUTATOR_LABELS
+)
+def test_warns_when_span_already_ended(
+    caplog: pytest.LogCaptureFixture, op, invoke, _assert_landed
+) -> None:
+    """Each mutator warns when called after ``end()``."""
+    caplog.set_level(logging.WARNING, logger="weave.session.session")
+    with Session(session_id="test-session"):
+        tool = Tool(name="test-tool")
+        with tool:
+            pass
+        invoke(tool)
+    assert any(
+        op in record.message and "span already ended" in record.message
+        for record in caplog.records
+    )
 
 
 def test_set_attribute_accepts_sequence_value(
@@ -128,47 +165,3 @@ def test_set_attribute_accepts_sequence_value(
         llm.set_attribute("gen_ai.response.finish_reasons", ["stop"])
     chat_span = _only_span(otel_spans.get_finished_spans(), "chat gpt-4o")
     assert tuple(chat_span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
-
-
-def test_no_op_on_unentered_span(otel_spans: InMemorySpanExporter) -> None:
-    """Unentered span doesn't crash and emits no OTel output."""
-    tool = Tool(name="test-tool")
-    tool.set_attribute("key", "value")
-    tool.add_event("event-name")
-    assert len(otel_spans.get_finished_spans()) == 0
-
-
-def test_warns_when_span_not_started(caplog: pytest.LogCaptureFixture) -> None:
-    """Calling set_attribute / add_event on an unentered span warns the user."""
-    caplog.set_level(logging.WARNING, logger="weave.session.session")
-    tool = Tool(name="test-tool")
-    tool.set_attribute("weave.tag", "value")
-    tool.add_event("weave.evt")
-    messages = [record.message for record in caplog.records]
-    assert any(
-        "set_attribute" in message and "span not started" in message
-        for message in messages
-    )
-    assert any(
-        "add_event" in message and "span not started" in message for message in messages
-    )
-
-
-def test_warns_when_span_already_ended(caplog: pytest.LogCaptureFixture) -> None:
-    """Calling set_attribute / add_event after end() warns the user."""
-    caplog.set_level(logging.WARNING, logger="weave.session.session")
-    with Session(session_id="test-session"):
-        tool = Tool(name="test-tool")
-        with tool:
-            pass
-        tool.set_attribute("weave.tag", "value")
-        tool.add_event("weave.evt")
-    messages = [record.message for record in caplog.records]
-    assert any(
-        "set_attribute" in message and "span already ended" in message
-        for message in messages
-    )
-    assert any(
-        "add_event" in message and "span already ended" in message
-        for message in messages
-    )

--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -1,8 +1,9 @@
 """Tests for ``set_attribute``, ``set_attributes``, and ``add_event``.
 
 All three live on ``_SpanBase`` so every span class (Tool, LLM, SubAgent,
-Turn) gets identical behavior. Tests cross-parametrize over the (span
-class x mutator method) cross product to lock in that uniformity.
+Turn) gets identical behavior. Tests are parametrized across the four
+span classes; the three methods get one test each so each test reads
+top-to-bottom without indirection.
 """
 
 from __future__ import annotations
@@ -25,136 +26,42 @@ CASES = [
 CLASS_LABELS = [case[0] for case in CASES]
 
 
-# (op_name, invoke_on_span, assert_landed_on_finished_span)
-# The three mutators have different signatures; capture each call shape
-# alongside the matching "did it land?" check so cross-parametrize stays clean.
-MUTATORS = [
-    (
-        "set_attribute",
-        lambda span: span.set_attribute("weave.tag", "value"),
-        lambda finished: finished.attributes.get("weave.tag") == "value",
-    ),
-    (
-        "set_attributes",
-        lambda span: span.set_attributes({"weave.first": "one", "weave.second": "two"}),
-        lambda finished: (
-            finished.attributes.get("weave.first") == "one"
-            and finished.attributes.get("weave.second") == "two"
-        ),
-    ),
-    (
-        "add_event",
-        lambda span: span.add_event("weave.evt", {"event_key": "event_value"}),
-        lambda finished: (
-            len(finished.events) == 1
-            and finished.events[0].name == "weave.evt"
-            and finished.events[0].attributes["event_key"] == "event_value"
-        ),
-    ),
-]
-MUTATOR_LABELS = [mutator[0] for mutator in MUTATORS]
-
-
 def _only_span(spans: list, span_name: str):
     matches = [span for span in spans if span.name == span_name]
     assert len(matches) == 1, [span.name for span in matches]
     return matches[0]
 
 
+# ---------------------------------------------------------------------------
+# set_attribute
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.parametrize(
     ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
 )
-@pytest.mark.parametrize(
-    ("_op", "invoke", "assert_landed"), MUTATORS, ids=MUTATOR_LABELS
-)
-def test_mutator_lands_on_live_span(
-    otel_spans: InMemorySpanExporter,
-    _class_label,
-    factory,
-    span_name,
-    _op,
-    invoke,
-    assert_landed,
+def test_set_attribute_lands_on_span(
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
 ) -> None:
-    """Each mutator writes through to the OTel span when called inside ``with``."""
     with Session(session_id="test-session"), factory() as span_obj:
-        invoke(span_obj)
-    assert assert_landed(_only_span(otel_spans.get_finished_spans(), span_name))
+        span_obj.set_attribute("weave.tag", "value")
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert finished_span.attributes["weave.tag"] == "value"
 
 
 @pytest.mark.parametrize(
     ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
 )
-@pytest.mark.parametrize(
-    ("_op", "invoke", "assert_landed"), MUTATORS, ids=MUTATOR_LABELS
-)
-def test_mutator_no_op_after_end(
-    otel_spans: InMemorySpanExporter,
-    _class_label,
-    factory,
-    span_name,
-    _op,
-    invoke,
-    assert_landed,
+def test_set_attribute_no_op_after_end(
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
 ) -> None:
-    """Each mutator is a no-op when called after the span has ended."""
     with Session(session_id="test-session"):
         span_obj = factory()
         with span_obj:
             pass
-        invoke(span_obj)
-    assert not assert_landed(_only_span(otel_spans.get_finished_spans(), span_name))
-
-
-@pytest.mark.parametrize(
-    ("_class_label", "factory", "_span_name"), CASES, ids=CLASS_LABELS
-)
-def test_mutators_return_self_for_chaining(
-    otel_spans: InMemorySpanExporter, _class_label, factory, _span_name
-) -> None:
-    """All mutators return ``self`` for fluent chaining."""
-    with Session(session_id="test-session"), factory() as span_obj:
-        for _op, invoke, _assert_landed in MUTATORS:
-            assert invoke(span_obj) is span_obj
-
-
-@pytest.mark.parametrize(
-    ("op", "invoke", "_assert_landed"), MUTATORS, ids=MUTATOR_LABELS
-)
-def test_warns_when_span_not_started(
-    caplog: pytest.LogCaptureFixture,
-    otel_spans: InMemorySpanExporter,
-    op,
-    invoke,
-    _assert_landed,
-) -> None:
-    """Each mutator warns and emits no span when called before ``with``."""
-    caplog.set_level(logging.WARNING, logger="weave.session.session")
-    invoke(Tool(name="test-tool"))
-    assert any(
-        op in record.message and "span not started" in record.message
-        for record in caplog.records
-    )
-    assert len(otel_spans.get_finished_spans()) == 0
-
-
-@pytest.mark.parametrize(
-    ("op", "invoke", "_assert_landed"), MUTATORS, ids=MUTATOR_LABELS
-)
-def test_warns_when_span_already_ended(
-    caplog: pytest.LogCaptureFixture, op, invoke, _assert_landed
-) -> None:
-    """Each mutator warns when called after ``end()``."""
-    caplog.set_level(logging.WARNING, logger="weave.session.session")
-    with Session(session_id="test-session"):
-        tool = Tool(name="test-tool")
-        with tool:
-            pass
-        invoke(tool)
-    assert any(
-        op in record.message and "span already ended" in record.message
-        for record in caplog.records
-    )
+        span_obj.set_attribute("weave.late", "value")
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert "weave.late" not in (finished_span.attributes or {})
 
 
 def test_set_attribute_accepts_sequence_value(
@@ -165,3 +72,122 @@ def test_set_attribute_accepts_sequence_value(
         llm.set_attribute("gen_ai.response.finish_reasons", ["stop"])
     chat_span = _only_span(otel_spans.get_finished_spans(), "chat gpt-4o")
     assert tuple(chat_span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
+
+
+# ---------------------------------------------------------------------------
+# set_attributes (bulk)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
+def test_set_attributes_lands_on_span(
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
+) -> None:
+    with Session(session_id="test-session"), factory() as span_obj:
+        span_obj.set_attributes({"weave.first": "one", "weave.second": "two"})
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert finished_span.attributes["weave.first"] == "one"
+    assert finished_span.attributes["weave.second"] == "two"
+
+
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
+def test_set_attributes_no_op_after_end(
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
+) -> None:
+    with Session(session_id="test-session"):
+        span_obj = factory()
+        with span_obj:
+            pass
+        span_obj.set_attributes({"weave.late_a": "a", "weave.late_b": "b"})
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert "weave.late_a" not in (finished_span.attributes or {})
+    assert "weave.late_b" not in (finished_span.attributes or {})
+
+
+# ---------------------------------------------------------------------------
+# add_event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
+def test_add_event_records_on_span(
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
+) -> None:
+    with Session(session_id="test-session"), factory() as span_obj:
+        span_obj.add_event("weave.evt", {"event_key": "event_value"})
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert len(finished_span.events) == 1
+    assert finished_span.events[0].name == "weave.evt"
+    assert finished_span.events[0].attributes["event_key"] == "event_value"
+
+
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
+def test_add_event_no_op_after_end(
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
+) -> None:
+    with Session(session_id="test-session"):
+        span_obj = factory()
+        with span_obj:
+            pass
+        span_obj.add_event("weave.late")
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert len(finished_span.events) == 0
+
+
+# ---------------------------------------------------------------------------
+# Cross-method: chaining + warning behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "_span_name"), CASES, ids=CLASS_LABELS
+)
+def test_returns_self_for_chaining(
+    otel_spans: InMemorySpanExporter, _class_label, factory, _span_name
+) -> None:
+    """All three mutators return ``self`` for fluent chaining on a live span."""
+    with Session(session_id="test-session"), factory() as span_obj:
+        assert span_obj.set_attribute("key", "value") is span_obj
+        assert span_obj.set_attributes({"key": "value"}) is span_obj
+        assert span_obj.add_event("event-name") is span_obj
+
+
+def test_warns_when_span_not_started(
+    caplog: pytest.LogCaptureFixture, otel_spans: InMemorySpanExporter
+) -> None:
+    """All three mutators warn and emit no span when called before ``with``."""
+    caplog.set_level(logging.WARNING, logger="weave.session.session")
+    tool = Tool(name="test-tool")
+    tool.set_attribute("weave.tag", "value")
+    tool.set_attributes({"weave.first": "one"})
+    tool.add_event("weave.evt")
+    messages = [record.message for record in caplog.records]
+    # The trailing "(" disambiguates set_attribute from set_attributes.
+    assert any("set_attribute(" in m and "span not started" in m for m in messages)
+    assert any("set_attributes(" in m and "span not started" in m for m in messages)
+    assert any("add_event(" in m and "span not started" in m for m in messages)
+    assert len(otel_spans.get_finished_spans()) == 0
+
+
+def test_warns_when_span_already_ended(caplog: pytest.LogCaptureFixture) -> None:
+    """All three mutators warn when called after ``end()``."""
+    caplog.set_level(logging.WARNING, logger="weave.session.session")
+    with Session(session_id="test-session"):
+        tool = Tool(name="test-tool")
+        with tool:
+            pass
+        tool.set_attribute("weave.tag", "value")
+        tool.set_attributes({"weave.first": "one"})
+        tool.add_event("weave.evt")
+    messages = [record.message for record in caplog.records]
+    assert any("set_attribute(" in m and "span already ended" in m for m in messages)
+    assert any("set_attributes(" in m and "span already ended" in m for m in messages)
+    assert any("add_event(" in m and "span already ended" in m for m in messages)

--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -94,14 +94,29 @@ def test_add_event_no_op_after_end(
 
 
 @pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
+def test_set_attributes_lands_on_span(
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
+) -> None:
+    """Bulk ``set_attributes`` lands every key on the OTel span."""
+    with Session(session_id="test-session"), factory() as span_obj:
+        span_obj.set_attributes({"weave.first": "one", "weave.second": "two"})
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert finished_span.attributes["weave.first"] == "one"
+    assert finished_span.attributes["weave.second"] == "two"
+
+
+@pytest.mark.parametrize(
     ("_class_label", "factory", "_span_name"), CASES, ids=CLASS_LABELS
 )
 def test_returns_self_for_chaining(
     otel_spans: InMemorySpanExporter, _class_label, factory, _span_name
 ) -> None:
-    """Both methods return ``self`` for fluent chaining on a live span."""
+    """All three mutators return ``self`` for fluent chaining on a live span."""
     with Session(session_id="test-session"), factory() as span_obj:
         assert span_obj.set_attribute("key", "value") is span_obj
+        assert span_obj.set_attributes({"key": "value"}) is span_obj
         assert span_obj.add_event("event-name") is span_obj
 
 

--- a/tests/session/test_span_attributes.py
+++ b/tests/session/test_span_attributes.py
@@ -1,8 +1,8 @@
-"""Tests for ``set_attribute``, ``set_attributes``, and ``add_event``.
+"""Tests for ``set_attributes`` and ``add_event``.
 
-All three live on ``_SpanBase`` so every span class (Tool, LLM, SubAgent,
-Turn) gets identical behavior. Tests are parametrized across the four
-span classes; the three methods get one test each so each test reads
+Both live on ``_SpanBase`` so every span class (Tool, LLM, SubAgent, Turn)
+gets identical behavior. Tests are parametrized across the four span
+classes; the two methods get one test each so each test reads
 top-to-bottom without indirection.
 """
 
@@ -33,49 +33,7 @@ def _only_span(spans: list, span_name: str):
 
 
 # ---------------------------------------------------------------------------
-# set_attribute
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.parametrize(
-    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
-)
-def test_set_attribute_lands_on_span(
-    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
-) -> None:
-    with Session(session_id="test-session"), factory() as span_obj:
-        span_obj.set_attribute("weave.tag", "value")
-    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
-    assert finished_span.attributes["weave.tag"] == "value"
-
-
-@pytest.mark.parametrize(
-    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
-)
-def test_set_attribute_no_op_after_end(
-    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
-) -> None:
-    with Session(session_id="test-session"):
-        span_obj = factory()
-        with span_obj:
-            pass
-        span_obj.set_attribute("weave.late", "value")
-    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
-    assert "weave.late" not in (finished_span.attributes or {})
-
-
-def test_set_attribute_accepts_sequence_value(
-    otel_spans: InMemorySpanExporter,
-) -> None:
-    """OTel accepts ``Sequence[str]`` — used for e.g. ``gen_ai.response.finish_reasons``."""
-    with Session(session_id="test-session"), LLM(model="gpt-4o") as llm:
-        llm.set_attribute("gen_ai.response.finish_reasons", ["stop"])
-    chat_span = _only_span(otel_spans.get_finished_spans(), "chat gpt-4o")
-    assert tuple(chat_span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
-
-
-# ---------------------------------------------------------------------------
-# set_attributes (bulk)
+# set_attributes
 # ---------------------------------------------------------------------------
 
 
@@ -106,6 +64,16 @@ def test_set_attributes_no_op_after_end(
     finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
     assert "weave.late_a" not in (finished_span.attributes or {})
     assert "weave.late_b" not in (finished_span.attributes or {})
+
+
+def test_set_attributes_accepts_sequence_value(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    """OTel accepts ``Sequence[str]`` — used for e.g. ``gen_ai.response.finish_reasons``."""
+    with Session(session_id="test-session"), LLM(model="gpt-4o") as llm:
+        llm.set_attributes({"gen_ai.response.finish_reasons": ["stop"]})
+    chat_span = _only_span(otel_spans.get_finished_spans(), "chat gpt-4o")
+    assert tuple(chat_span.attributes["gen_ai.response.finish_reasons"]) == ("stop",)
 
 
 # ---------------------------------------------------------------------------
@@ -153,9 +121,8 @@ def test_add_event_no_op_after_end(
 def test_returns_self_for_chaining(
     otel_spans: InMemorySpanExporter, _class_label, factory, _span_name
 ) -> None:
-    """All three mutators return ``self`` for fluent chaining on a live span."""
+    """Both mutators return ``self`` for fluent chaining on a live span."""
     with Session(session_id="test-session"), factory() as span_obj:
-        assert span_obj.set_attribute("key", "value") is span_obj
         assert span_obj.set_attributes({"key": "value"}) is span_obj
         assert span_obj.add_event("event-name") is span_obj
 
@@ -163,31 +130,26 @@ def test_returns_self_for_chaining(
 def test_warns_when_span_not_started(
     caplog: pytest.LogCaptureFixture, otel_spans: InMemorySpanExporter
 ) -> None:
-    """All three mutators warn and emit no span when called before ``with``."""
+    """Both mutators warn and emit no span when called before ``with``."""
     caplog.set_level(logging.WARNING, logger="weave.session.session")
     tool = Tool(name="test-tool")
-    tool.set_attribute("weave.tag", "value")
     tool.set_attributes({"weave.first": "one"})
     tool.add_event("weave.evt")
     messages = [record.message for record in caplog.records]
-    # The trailing "(" disambiguates set_attribute from set_attributes.
-    assert any("set_attribute(" in m and "span not started" in m for m in messages)
-    assert any("set_attributes(" in m and "span not started" in m for m in messages)
-    assert any("add_event(" in m and "span not started" in m for m in messages)
+    assert any("set_attributes" in m and "span not started" in m for m in messages)
+    assert any("add_event" in m and "span not started" in m for m in messages)
     assert len(otel_spans.get_finished_spans()) == 0
 
 
 def test_warns_when_span_already_ended(caplog: pytest.LogCaptureFixture) -> None:
-    """All three mutators warn when called after ``end()``."""
+    """Both mutators warn when called after ``end()``."""
     caplog.set_level(logging.WARNING, logger="weave.session.session")
     with Session(session_id="test-session"):
         tool = Tool(name="test-tool")
         with tool:
             pass
-        tool.set_attribute("weave.tag", "value")
         tool.set_attributes({"weave.first": "one"})
         tool.add_event("weave.evt")
     messages = [record.message for record in caplog.records]
-    assert any("set_attribute(" in m and "span already ended" in m for m in messages)
-    assert any("set_attributes(" in m and "span already ended" in m for m in messages)
-    assert any("add_event(" in m and "span already ended" in m for m in messages)
+    assert any("set_attributes" in m and "span already ended" in m for m in messages)
+    assert any("add_event" in m and "span already ended" in m for m in messages)

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -201,8 +201,12 @@ class _SpanBase(BaseModel):
     ) -> Self:
         """Record an OTel span event. No-op after ``end()``."""
         if self._otel_span is not None and self._otel_span.is_recording():
-            ts_ns = int(timestamp.timestamp() * 1_000_000_000) if timestamp else None
-            self._otel_span.add_event(name, attributes=attributes, timestamp=ts_ns)
+            timestamp_ns = (
+                int(timestamp.timestamp() * 1_000_000_000) if timestamp else None
+            )
+            self._otel_span.add_event(
+                name, attributes=attributes, timestamp=timestamp_ns
+            )
         return self
 
 

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -197,9 +197,8 @@ class _SpanBase(BaseModel):
             return False
         if self._otel_span is None:
             logger.warning(
-                "%s(%r) ignored: span not started. Use `with` to start a "
-                "streaming span, or pass the populated object to log_turn() "
-                "for batch ingest.",
+                "%s(%r) ignored: span not started. Use `with` for live "
+                "tracing, or log_turn() for batch ingest.",
                 operation,
                 key,
             )

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -188,15 +188,8 @@ class _SpanBase(BaseModel):
         self._otel_span.record_exception(exc_val)
 
     def set_attribute(self, key: str, value: Any) -> Self:
-        """Set an arbitrary attribute on this span's OTel span.
-
-        Escape hatch for values not covered by the declared GenAI semconv
-        fields (e.g. ``weave.display_name`` for Claude Code, enterprise tags).
-        No-op after :meth:`end`.
-        """
-        if not _OTEL_AVAILABLE or self._otel_span is None:
-            return self
-        if self._otel_span.is_recording():
+        """Stamp an arbitrary OTel attribute. No-op after ``end()``."""
+        if self._otel_span is not None and self._otel_span.is_recording():
             self._otel_span.set_attribute(key, value)
         return self
 
@@ -206,20 +199,9 @@ class _SpanBase(BaseModel):
         attributes: dict[str, Any] | None = None,
         timestamp: datetime | None = None,
     ) -> Self:
-        """Add an OTel span event with optional attributes and timestamp.
-
-        Used for marker events (e.g. ``weave.permission_request``,
-        lifecycle transitions). ``timestamp`` is a ``datetime``; if omitted,
-        OTel stamps the event with the current time. No-op after :meth:`end`.
-        """
-        if not _OTEL_AVAILABLE or self._otel_span is None:
-            return self
-        if self._otel_span.is_recording():
-            ts_ns = (
-                int(timestamp.timestamp() * 1_000_000_000)
-                if timestamp is not None
-                else None
-            )
+        """Record an OTel span event. No-op after ``end()``."""
+        if self._otel_span is not None and self._otel_span.is_recording():
+            ts_ns = int(timestamp.timestamp() * 1_000_000_000) if timestamp else None
             self._otel_span.add_event(name, attributes=attributes, timestamp=ts_ns)
         return self
 

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -233,10 +233,10 @@ class _SpanBase(BaseModel):
     def set_attributes(self, attributes: dict[str, Any]) -> Self:
         """Bulk-stamp OTel attributes. Mirrors OTel's ``Span.set_attributes``.
 
-        Convenience over repeated :meth:`set_attribute` when the caller has
-        a pre-built dict (e.g. forwarding attributes from an upstream span
+        Convenience over repeated ``set_attribute`` when the caller has a
+        pre-built dict (e.g. forwarding attributes from an upstream span
         or a transcript replay). Same no-op + warning semantics as
-        :meth:`set_attribute`.
+        ``set_attribute``.
         """
         if self._check_recording("set_attributes", list(attributes)):
             self._otel_span.set_attributes(attributes)
@@ -250,14 +250,12 @@ class _SpanBase(BaseModel):
     ) -> Self:
         """Record an OTel span event at a point in time within this span.
 
-        Examples:
-            - ``weave.permission_request`` — record that a permission
-              prompt was shown; attributes carry the suggested options
-            - Lifecycle markers — ``spawned`` / ``streaming`` / ``finished``
-              to time sub-operations inside the span
-            - Custom milestones — anything that happens at a point in time
-              within the span's lifetime (vs an attribute, which is a
-              property of the span as a whole)
+        Use for marker / lifecycle data — permission prompts (e.g.
+        ``weave.permission_request``), lifecycle transitions (e.g.
+        ``spawned`` / ``streaming`` / ``finished``), or any custom
+        milestone that happens at a point in time within the span's
+        lifetime (vs an attribute, which is a property of the span as a
+        whole).
 
         Must be called between span start and span end (inside ``with``).
         Outside that window the call is a no-op and logs a warning.

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -220,25 +220,17 @@ class _SpanBase(BaseModel):
             return None
         return self._otel_span
 
-    def set_attribute(self, key: str, value: Any) -> Self:
-        """Stamp an arbitrary OTel attribute on this span.
+    def set_attributes(self, attributes: dict[str, Any]) -> Self:
+        """Stamp arbitrary OTel attributes on this span.
+
+        Pass a dict whether you have one key or many — single-key callers
+        use ``span.set_attributes({"weave.tag": "value"})``. Mirrors OTel's
+        ``Span.set_attributes``.
 
         Must be called between span start and span end — i.e. inside a
         ``with`` block. Outside that window the call is a no-op and logs
         a warning. For batch ingest, populate the object's declared fields
         directly and pass it to ``log_turn`` / ``log_session``.
-        """
-        if span := self._recording_span("set_attribute", key):
-            span.set_attribute(key, value)
-        return self
-
-    def set_attributes(self, attributes: dict[str, Any]) -> Self:
-        """Bulk-stamp OTel attributes. Mirrors OTel's ``Span.set_attributes``.
-
-        Convenience over repeated ``set_attribute`` when the caller has a
-        pre-built dict (e.g. forwarding attributes from an upstream span
-        or a transcript replay). Same no-op + warning semantics as
-        ``set_attribute``.
         """
         if span := self._recording_span("set_attributes", list(attributes)):
             span.set_attributes(attributes)

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -195,20 +195,25 @@ class _SpanBase(BaseModel):
         """
         if not _OTEL_AVAILABLE or should_disable_weave():
             return False
+        key_repr = (
+            "{" + ", ".join(map(repr, key)) + "}"
+            if isinstance(key, list)
+            else repr(key)
+        )
         if self._otel_span is None:
             logger.warning(
-                "%s(%r) ignored: span not started. Use `with` for live "
+                "%s(%s) ignored: span not started. Use `with` for live "
                 "tracing, or log_turn() for batch ingest.",
                 operation,
-                key,
+                key_repr,
             )
             return False
         if not self._otel_span.is_recording():
             logger.warning(
-                "%s(%r) ignored: span already ended. Set attributes before "
+                "%s(%s) ignored: span already ended. Set attributes before "
                 "exiting `with` or calling .end().",
                 operation,
-                key,
+                key_repr,
             )
             return False
         return True

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -187,6 +187,42 @@ class _SpanBase(BaseModel):
         self._otel_span.set_status(StatusCode.ERROR, str(exc_val))
         self._otel_span.record_exception(exc_val)
 
+    def set_attribute(self, key: str, value: Any) -> Self:
+        """Set an arbitrary attribute on this span's OTel span.
+
+        Escape hatch for values not covered by the declared GenAI semconv
+        fields (e.g. ``weave.display_name`` for Claude Code, enterprise tags).
+        No-op after :meth:`end`.
+        """
+        if not _OTEL_AVAILABLE or self._otel_span is None:
+            return self
+        if self._otel_span.is_recording():
+            self._otel_span.set_attribute(key, value)
+        return self
+
+    def add_event(
+        self,
+        name: str,
+        attributes: dict[str, Any] | None = None,
+        timestamp: datetime | None = None,
+    ) -> Self:
+        """Add an OTel span event with optional attributes and timestamp.
+
+        Used for marker events (e.g. ``weave.permission_request``,
+        lifecycle transitions). ``timestamp`` is a ``datetime``; if omitted,
+        OTel stamps the event with the current time. No-op after :meth:`end`.
+        """
+        if not _OTEL_AVAILABLE or self._otel_span is None:
+            return self
+        if self._otel_span.is_recording():
+            ts_ns = (
+                int(timestamp.timestamp() * 1_000_000_000)
+                if timestamp is not None
+                else None
+            )
+            self._otel_span.add_event(name, attributes=attributes, timestamp=ts_ns)
+        return self
+
 
 def _publish_media_content(
     *,

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -187,7 +187,7 @@ class _SpanBase(BaseModel):
         self._otel_span.set_status(StatusCode.ERROR, str(exc_val))
         self._otel_span.record_exception(exc_val)
 
-    def _check_recording(self, operation: str, key: str) -> bool:
+    def _check_recording(self, operation: str, key: str | list[str]) -> bool:
         """Return True if the OTel span is recording.
 
         Else log a warning naming the caller-facing fix. Silent when OTel
@@ -223,6 +223,18 @@ class _SpanBase(BaseModel):
         """
         if self._check_recording("set_attribute", key):
             self._otel_span.set_attribute(key, value)
+        return self
+
+    def set_attributes(self, attributes: dict[str, Any]) -> Self:
+        """Bulk-stamp OTel attributes. Mirrors OTel's ``Span.set_attributes``.
+
+        Convenience over repeated :meth:`set_attribute` when the caller has
+        a pre-built dict (e.g. forwarding attributes from an upstream span
+        or a transcript replay). Same no-op + warning semantics as
+        :meth:`set_attribute`.
+        """
+        if self._check_recording("set_attributes", list(attributes)):
+            self._otel_span.set_attributes(attributes)
         return self
 
     def add_event(

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -187,9 +187,42 @@ class _SpanBase(BaseModel):
         self._otel_span.set_status(StatusCode.ERROR, str(exc_val))
         self._otel_span.record_exception(exc_val)
 
+    def _check_recording(self, operation: str, key: str) -> bool:
+        """Return True if the OTel span is recording.
+
+        Else log a warning naming the caller-facing fix. Silent when OTel
+        isn't installed or Weave is disabled — both are intentional configs.
+        """
+        if not _OTEL_AVAILABLE or should_disable_weave():
+            return False
+        if self._otel_span is None:
+            logger.warning(
+                "%s(%r) ignored: span not started. Use `with` to start a "
+                "streaming span, or pass the populated object to log_turn() "
+                "for batch ingest.",
+                operation,
+                key,
+            )
+            return False
+        if not self._otel_span.is_recording():
+            logger.warning(
+                "%s(%r) ignored: span already ended. Set attributes before "
+                "exiting `with` or calling .end().",
+                operation,
+                key,
+            )
+            return False
+        return True
+
     def set_attribute(self, key: str, value: Any) -> Self:
-        """Stamp an arbitrary OTel attribute. No-op after ``end()``."""
-        if self._otel_span is not None and self._otel_span.is_recording():
+        """Stamp an arbitrary OTel attribute on this span.
+
+        Must be called between span start and span end — i.e. inside a
+        ``with`` block. Outside that window the call is a no-op and logs
+        a warning. For batch ingest, populate the object's declared fields
+        directly and pass it to ``log_turn`` / ``log_session``.
+        """
+        if self._check_recording("set_attribute", key):
             self._otel_span.set_attribute(key, value)
         return self
 
@@ -199,8 +232,21 @@ class _SpanBase(BaseModel):
         attributes: dict[str, Any] | None = None,
         timestamp: datetime | None = None,
     ) -> Self:
-        """Record an OTel span event. No-op after ``end()``."""
-        if self._otel_span is not None and self._otel_span.is_recording():
+        """Record an OTel span event at a point in time within this span.
+
+        Examples:
+            - ``weave.permission_request`` — record that a permission
+              prompt was shown; attributes carry the suggested options
+            - Lifecycle markers — ``spawned`` / ``streaming`` / ``finished``
+              to time sub-operations inside the span
+            - Custom milestones — anything that happens at a point in time
+              within the span's lifetime (vs an attribute, which is a
+              property of the span as a whole)
+
+        Must be called between span start and span end (inside ``with``).
+        Outside that window the call is a no-op and logs a warning.
+        """
+        if self._check_recording("add_event", name):
             timestamp_ns = (
                 int(timestamp.timestamp() * 1_000_000_000) if timestamp else None
             )

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -261,11 +261,8 @@ class _SpanBase(BaseModel):
         Outside that window the call is a no-op and logs a warning.
         """
         if self._check_recording("add_event", name):
-            timestamp_ns = (
-                int(timestamp.timestamp() * 1_000_000_000) if timestamp else None
-            )
             self._otel_span.add_event(
-                name, attributes=attributes, timestamp=timestamp_ns
+                name, attributes=attributes, timestamp=_to_ns(timestamp)
             )
         return self
 

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -187,14 +187,16 @@ class _SpanBase(BaseModel):
         self._otel_span.set_status(StatusCode.ERROR, str(exc_val))
         self._otel_span.record_exception(exc_val)
 
-    def _check_recording(self, operation: str, key: str | list[str]) -> bool:
-        """Return True if the OTel span is recording.
+    def _recording_span(self, operation: str, key: str | list[str]) -> _OTelSpan | None:
+        """Return the OTel span if it's recording, else ``None``.
 
-        Else log a warning naming the caller-facing fix. Silent when OTel
-        isn't installed or Weave is disabled — both are intentional configs.
+        Logs a warning naming the caller-facing fix when not recording.
+        Silent when OTel isn't installed or Weave is disabled — both are
+        intentional configs. Returning the span (instead of a bool) lets
+        mypy narrow it through the caller's ``if`` guard.
         """
         if not _OTEL_AVAILABLE or should_disable_weave():
-            return False
+            return None
         key_repr = (
             "{" + ", ".join(map(repr, key)) + "}"
             if isinstance(key, list)
@@ -207,7 +209,7 @@ class _SpanBase(BaseModel):
                 operation,
                 key_repr,
             )
-            return False
+            return None
         if not self._otel_span.is_recording():
             logger.warning(
                 "%s(%s) ignored: span already ended. Set attributes before "
@@ -215,8 +217,8 @@ class _SpanBase(BaseModel):
                 operation,
                 key_repr,
             )
-            return False
-        return True
+            return None
+        return self._otel_span
 
     def set_attribute(self, key: str, value: Any) -> Self:
         """Stamp an arbitrary OTel attribute on this span.
@@ -226,8 +228,8 @@ class _SpanBase(BaseModel):
         a warning. For batch ingest, populate the object's declared fields
         directly and pass it to ``log_turn`` / ``log_session``.
         """
-        if self._check_recording("set_attribute", key):
-            self._otel_span.set_attribute(key, value)
+        if span := self._recording_span("set_attribute", key):
+            span.set_attribute(key, value)
         return self
 
     def set_attributes(self, attributes: dict[str, Any]) -> Self:
@@ -238,8 +240,8 @@ class _SpanBase(BaseModel):
         or a transcript replay). Same no-op + warning semantics as
         ``set_attribute``.
         """
-        if self._check_recording("set_attributes", list(attributes)):
-            self._otel_span.set_attributes(attributes)
+        if span := self._recording_span("set_attributes", list(attributes)):
+            span.set_attributes(attributes)
         return self
 
     def add_event(
@@ -260,10 +262,8 @@ class _SpanBase(BaseModel):
         Must be called between span start and span end (inside ``with``).
         Outside that window the call is a no-op and logs a warning.
         """
-        if self._check_recording("add_event", name):
-            self._otel_span.add_event(
-                name, attributes=attributes, timestamp=_to_ns(timestamp)
-            )
+        if span := self._recording_span("add_event", name):
+            span.add_event(name, attributes=attributes, timestamp=_to_ns(timestamp))
         return self
 
 


### PR DESCRIPTION
## Summary

Two escape hatches on the `_SpanBase` mixin — inherited by `Tool`, `LLM`, `SubAgent`, `Turn`:

- `set_attributes(attributes: dict)` — stamp arbitrary OTel attributes (e.g. `weave.display_name` for Claude Code, enterprise tags). Mirrors OTel's `Span.set_attributes`. Callers pass a dict whether they have one key or many.
- `add_event(name, attributes=None, timestamp=None)` — record OTel span events (e.g. `weave.permission_request`)

Both warn (via `logger.warning`) when called on a span that hasn't been started or has already ended — silent only when OTel isn't installed or Weave is disabled. Naming/fix hint is included in the warning, e.g. `set_attributes({'weave.tag'}) ignored: span not started. Use \`with\` for live tracing, or log_turn() for batch ingest.`

Mirrors the TypeScript SDK's `setAttribute`/`addEvent` surface from wandb/weave#7076, wandb/weave#7077, wandb/weave#7078, lifted onto the shared mixin so the implementation covers all four classes uniformly.

## Test plan

- [x] 23 tests in `tests/session/test_span_attributes.py` — parametrized across `(Tool, LLM, SubAgent, Turn)` for: lands-on-span, no-op-after-end, returns-self, plus mixin-level checks for sequence-value support and warning behavior (unstarted + already-ended)
- [x] Existing session tests still pass
- [x] `uvx ruff check` + `uvx ruff format --check` clean
- [x] `mypy weave/session/session.py` clean (no errors introduced)