### PR TITLE
fix(weave): preserve caller-set started_at/ended_at in streaming end()

### DIFF
--- a/tests/session/test_post_hoc_times.py
+++ b/tests/session/test_post_hoc_times.py
@@ -1,238 +1,146 @@
-"""Tests that streaming end() honors caller-supplied ``started_at`` / ``ended_at``.
+"""Tests that streaming end() honors caller-supplied started_at / ended_at.
 
-Before this PR:
-- ``LLM.end()`` / ``SubAgent.end()`` / ``Turn.end()`` unconditionally clobbered
-  ``self.ended_at = now()``, so a caller-set value was lost.
-- All four span classes' ``_end_otel_span()`` calls omitted ``end_time_ns``,
-  so the emitted OTel span carried ``now()`` as its end time regardless of
-  what was on the SDK object.
-- ``SubAgent.__enter__`` ignored ``self.started_at`` entirely — both clobbered
-  the field with ``now()`` and never passed ``start_time_ns`` to OTel.
+Pre-fix: LLM / SubAgent / Turn end() clobbered self.ended_at = now(), and
+all four span classes' _end_otel_span calls omitted end_time_ns — so the
+emitted OTel span carried now() regardless of what the SDK object held.
+SubAgent.__enter__ did the same for started_at.
 
-The batch path (``log_turn`` / ``log_session``) already honored timestamps
-via ``_emit_span_now``. After this PR the streaming and batch paths emit
-byte-identical spans for the same inputs.
+Post-fix: streaming end() emits OTel spans byte-identical to the batch
+path (log_turn / log_session) for the same inputs.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
 
+import pytest
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
-from weave.session.session import (
-    LLM,
-    Session,
-    SubAgent,
-    Tool,
-    Turn,
-    log_turn,
-)
+from weave.session.session import LLM, Session, SubAgent, Tool, Turn, log_turn
 
 
-def _ts(seconds_offset: int) -> datetime:
-    """A deterministic datetime far enough in the past that ``now()`` can't equal it."""
+def _at(seconds_offset: int) -> datetime:
+    """Deterministic datetime, distinct from now()."""
     return datetime(2020, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=seconds_offset)
 
 
-def _ns(dt: datetime) -> int:
-    return int(dt.timestamp() * 1_000_000_000)
+def _to_ns(timestamp: datetime) -> int:
+    return int(timestamp.timestamp() * 1_000_000_000)
 
 
-def _find(spans: list, name_prefix: str):
-    matches = [sp for sp in spans if sp.name.startswith(name_prefix)]
-    assert len(matches) == 1, (
-        f"expected 1 span with prefix {name_prefix!r}, got {[s.name for s in matches]}"
-    )
+# (class_label, factory, otel_span_name) — factory accepts **kwargs so tests
+# can pass started_at / ended_at or omit them.
+CASES = [
+    (
+        "Tool",
+        lambda **kwargs: Tool(name="test-tool", **kwargs),
+        "execute_tool test-tool",
+    ),
+    (
+        "LLM",
+        lambda **kwargs: LLM(model="gpt-4o", **kwargs),
+        "chat gpt-4o",
+    ),
+    (
+        "SubAgent",
+        lambda **kwargs: SubAgent(name="researcher", **kwargs),
+        "invoke_agent researcher",
+    ),
+    (
+        "Turn",
+        lambda **kwargs: Turn(agent_name="weather-bot", **kwargs),
+        "invoke_agent weather-bot",
+    ),
+]
+CLASS_LABELS = [case[0] for case in CASES]
+
+
+def _only_span(spans: list, span_name: str):
+    matches = [span for span in spans if span.name == span_name]
+    assert len(matches) == 1, [span.name for span in matches]
     return matches[0]
 
 
-# ---------------------------------------------------------------------------
-# Streaming end() preserves caller-supplied ended_at
-# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "_span_name"), CASES, ids=CLASS_LABELS
+)
+def test_end_preserves_caller_ended_at(_class_label, factory, _span_name) -> None:
+    """``ended_at`` set by the caller survives ``end()``."""
+    ended_at = _at(5)
+    span_obj = factory(ended_at=ended_at)
+    span_obj.end()
+    assert span_obj.ended_at == ended_at
 
 
-class TestEndedAtPreservedOnSdkObject:
-    """Pydantic field round-trip: ``ended_at`` set by the caller survives ``end()``."""
-
-    def test_tool(self) -> None:
-        t = Tool(name="f", ended_at=_ts(5))
-        t.end()
-        assert t.ended_at == _ts(5)
-
-    def test_llm(self) -> None:
-        c = LLM(model="gpt-4o", ended_at=_ts(5))
-        c.end()
-        assert c.ended_at == _ts(5)
-
-    def test_subagent(self) -> None:
-        sa = SubAgent(name="x", ended_at=_ts(5))
-        sa.end()
-        assert sa.ended_at == _ts(5)
-
-    def test_turn(self) -> None:
-        t = Turn(agent_name="bot", ended_at=_ts(5))
-        t.end()
-        assert t.ended_at == _ts(5)
-
-
-# ---------------------------------------------------------------------------
-# Streaming OTel span carries the caller-supplied end_time
-# ---------------------------------------------------------------------------
-
-
-class TestOtelEndTimeMatchesEndedAt:
-    """The emitted OTel span's ``end_time`` matches ``self.ended_at``, not ``now()``."""
-
-    def test_tool(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot"):
-            t = Tool(name="f", started_at=_ts(0), ended_at=_ts(3))
-            with t:
-                pass
-        span = _find(otel_spans.get_finished_spans(), "execute_tool")
-        assert span.start_time == _ns(_ts(0))
-        assert span.end_time == _ns(_ts(3))
-
-    def test_llm(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot"):
-            c = LLM(model="gpt-4o", started_at=_ts(0), ended_at=_ts(3))
-            with c:
-                pass
-        span = _find(otel_spans.get_finished_spans(), "chat")
-        assert span.start_time == _ns(_ts(0))
-        assert span.end_time == _ns(_ts(3))
-
-    def test_subagent(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot") as turn:
-            sa = SubAgent(name="x", started_at=_ts(0), ended_at=_ts(3))
-            with sa:
-                pass
-            _ = turn  # silence "unused"
-        spans = otel_spans.get_finished_spans()
-        sa_span = next(
-            sp
-            for sp in spans
-            if sp.name == "invoke_agent x"
-            and sp.attributes.get("gen_ai.agent.name") == "x"
-        )
-        assert sa_span.start_time == _ns(_ts(0))
-        assert sa_span.end_time == _ns(_ts(3))
-
-    def test_turn(self, otel_spans: InMemorySpanExporter) -> None:
-        with Session(session_id="s"):
-            t = Turn(agent_name="bot", started_at=_ts(0), ended_at=_ts(3))
-            with t:
-                pass
-        span = _find(otel_spans.get_finished_spans(), "invoke_agent")
-        assert span.start_time == _ns(_ts(0))
-        assert span.end_time == _ns(_ts(3))
-
-
-# ---------------------------------------------------------------------------
-# Default (no caller-supplied timestamps) still works
-# ---------------------------------------------------------------------------
-
-
-class TestDefaultTimestampsStillWork:
-    """When the caller doesn't supply ``ended_at``, ``end()`` fills in ``now()``."""
-
-    def test_llm_ended_at_set_on_end(self) -> None:
-        c = LLM(model="gpt-4o")
-        c.end()
-        assert c.ended_at is not None
-
-    def test_subagent_ended_at_set_on_end(self) -> None:
-        sa = SubAgent(name="x")
-        sa.end()
-        assert sa.ended_at is not None
-
-    def test_turn_ended_at_set_on_end(self) -> None:
-        t = Turn(agent_name="bot")
-        t.end()
-        assert t.ended_at is not None
-
-
-# ---------------------------------------------------------------------------
-# SubAgent.__enter__ now honors started_at (previously the odd one out)
-# ---------------------------------------------------------------------------
-
-
-class TestSubAgentEnterHonorsStartedAt:
-    def test_preserves_existing_started_at(self) -> None:
-        sa = SubAgent(name="x", started_at=_ts(0))
-        with sa:
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "span_name"), CASES, ids=CLASS_LABELS
+)
+def test_otel_span_times_match_caller_values(
+    otel_spans: InMemorySpanExporter, _class_label, factory, span_name
+) -> None:
+    """Emitted OTel span's ``start_time`` and ``end_time`` match caller values."""
+    started_at, ended_at = _at(0), _at(3)
+    with Session(session_id="test-session"):
+        span_obj = factory(started_at=started_at, ended_at=ended_at)
+        with span_obj:
             pass
-        assert sa.started_at == _ts(0)
-
-    def test_sets_started_at_when_none(self) -> None:
-        sa = SubAgent(name="x")
-        with sa:
-            pass
-        assert sa.started_at is not None
-
-    def test_otel_start_time_matches_started_at(
-        self, otel_spans: InMemorySpanExporter
-    ) -> None:
-        with Session(session_id="s"), Turn(agent_name="bot"):
-            sa = SubAgent(name="x", started_at=_ts(0), ended_at=_ts(2))
-            with sa:
-                pass
-        spans = otel_spans.get_finished_spans()
-        sa_span = next(sp for sp in spans if sp.name == "invoke_agent x")
-        assert sa_span.start_time == _ns(_ts(0))
+    finished_span = _only_span(otel_spans.get_finished_spans(), span_name)
+    assert finished_span.start_time == _to_ns(started_at)
+    assert finished_span.end_time == _to_ns(ended_at)
 
 
-# ---------------------------------------------------------------------------
-# Streaming == batch parity (the headline contract this PR establishes)
-# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("_class_label", "factory", "_span_name"), CASES, ids=CLASS_LABELS
+)
+def test_end_defaults_ended_at_to_now(_class_label, factory, _span_name) -> None:
+    """No caller-supplied ``ended_at`` → ``end()`` fills in ``now()``."""
+    span_obj = factory()
+    span_obj.end()
+    assert span_obj.ended_at is not None
 
 
-class TestStreamingMatchesBatch:
-    """Same inputs through streaming vs ``log_turn`` produce identical spans.
+def test_streaming_matches_batch_for_llm(otel_spans: InMemorySpanExporter) -> None:
+    """Streaming and ``log_turn`` produce byte-identical OTel chat spans.
 
-    This is the regression test for the divergence that motivated the PR:
-    pre-fix, streaming emitted ``now()`` end_times while batch honored
-    ``ended_at``. The two paths now agree.
+    Pre-fix divergence: streaming emitted ``now()`` end_times while batch
+    honored ``ended_at``. This pins both paths together.
     """
+    started_at, ended_at = _at(0), _at(5)
 
-    def test_llm_streaming_matches_log_turn(
-        self, otel_spans: InMemorySpanExporter
-    ) -> None:
-        started, ended = _ts(0), _ts(5)
-
-        otel_spans.clear()
-        with (
-            Session(session_id="s"),
-            Turn(agent_name="bot", started_at=started, ended_at=ended),
+    otel_spans.clear()
+    with (
+        Session(session_id="test-session"),
+        Turn(agent_name="weather-bot", started_at=started_at, ended_at=ended_at),
+    ):
+        with LLM(
+            model="gpt-4o",
+            provider_name="openai",
+            started_at=started_at,
+            ended_at=ended_at,
         ):
-            llm = LLM(
+            pass
+    streaming_chat_span = _only_span(otel_spans.get_finished_spans(), "chat gpt-4o")
+
+    otel_spans.clear()
+    log_turn(
+        session_id="test-session",
+        agent_name="weather-bot",
+        started_at=started_at,
+        ended_at=ended_at,
+        spans=[
+            LLM(
                 model="gpt-4o",
                 provider_name="openai",
-                started_at=started,
-                ended_at=ended,
+                started_at=started_at,
+                ended_at=ended_at,
             )
-            with llm:
-                pass
-        streaming_chat = _find(otel_spans.get_finished_spans(), "chat")
-        streaming = (streaming_chat.start_time, streaming_chat.end_time)
+        ],
+    )
+    batch_chat_span = _only_span(otel_spans.get_finished_spans(), "chat gpt-4o")
 
-        otel_spans.clear()
-        log_turn(
-            session_id="s",
-            agent_name="bot",
-            started_at=started,
-            ended_at=ended,
-            spans=[
-                LLM(
-                    model="gpt-4o",
-                    provider_name="openai",
-                    started_at=started,
-                    ended_at=ended,
-                )
-            ],
-        )
-        batch_chat = _find(otel_spans.get_finished_spans(), "chat")
-        batch = (batch_chat.start_time, batch_chat.end_time)
-
-        assert streaming == batch
-        assert streaming == (_ns(started), _ns(ended))
+    assert (streaming_chat_span.start_time, streaming_chat_span.end_time) == (
+        batch_chat_span.start_time,
+        batch_chat_span.end_time,
+    )
+    assert streaming_chat_span.start_time == _to_ns(started_at)
+    assert streaming_chat_span.end_time == _to_ns(ended_at)

--- a/tests/session/test_post_hoc_times.py
+++ b/tests/session/test_post_hoc_times.py
@@ -1,0 +1,238 @@
+"""Tests that streaming end() honors caller-supplied ``started_at`` / ``ended_at``.
+
+Before this PR:
+- ``LLM.end()`` / ``SubAgent.end()`` / ``Turn.end()`` unconditionally clobbered
+  ``self.ended_at = now()``, so a caller-set value was lost.
+- All four span classes' ``_end_otel_span()`` calls omitted ``end_time_ns``,
+  so the emitted OTel span carried ``now()`` as its end time regardless of
+  what was on the SDK object.
+- ``SubAgent.__enter__`` ignored ``self.started_at`` entirely — both clobbered
+  the field with ``now()`` and never passed ``start_time_ns`` to OTel.
+
+The batch path (``log_turn`` / ``log_session``) already honored timestamps
+via ``_emit_span_now``. After this PR the streaming and batch paths emit
+byte-identical spans for the same inputs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from weave.session.session import (
+    LLM,
+    Session,
+    SubAgent,
+    Tool,
+    Turn,
+    log_turn,
+)
+
+
+def _ts(seconds_offset: int) -> datetime:
+    """A deterministic datetime far enough in the past that ``now()`` can't equal it."""
+    return datetime(2020, 1, 1, tzinfo=timezone.utc) + timedelta(seconds=seconds_offset)
+
+
+def _ns(dt: datetime) -> int:
+    return int(dt.timestamp() * 1_000_000_000)
+
+
+def _find(spans: list, name_prefix: str):
+    matches = [sp for sp in spans if sp.name.startswith(name_prefix)]
+    assert len(matches) == 1, (
+        f"expected 1 span with prefix {name_prefix!r}, got {[s.name for s in matches]}"
+    )
+    return matches[0]
+
+
+# ---------------------------------------------------------------------------
+# Streaming end() preserves caller-supplied ended_at
+# ---------------------------------------------------------------------------
+
+
+class TestEndedAtPreservedOnSdkObject:
+    """Pydantic field round-trip: ``ended_at`` set by the caller survives ``end()``."""
+
+    def test_tool(self) -> None:
+        t = Tool(name="f", ended_at=_ts(5))
+        t.end()
+        assert t.ended_at == _ts(5)
+
+    def test_llm(self) -> None:
+        c = LLM(model="gpt-4o", ended_at=_ts(5))
+        c.end()
+        assert c.ended_at == _ts(5)
+
+    def test_subagent(self) -> None:
+        sa = SubAgent(name="x", ended_at=_ts(5))
+        sa.end()
+        assert sa.ended_at == _ts(5)
+
+    def test_turn(self) -> None:
+        t = Turn(agent_name="bot", ended_at=_ts(5))
+        t.end()
+        assert t.ended_at == _ts(5)
+
+
+# ---------------------------------------------------------------------------
+# Streaming OTel span carries the caller-supplied end_time
+# ---------------------------------------------------------------------------
+
+
+class TestOtelEndTimeMatchesEndedAt:
+    """The emitted OTel span's ``end_time`` matches ``self.ended_at``, not ``now()``."""
+
+    def test_tool(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot"):
+            t = Tool(name="f", started_at=_ts(0), ended_at=_ts(3))
+            with t:
+                pass
+        span = _find(otel_spans.get_finished_spans(), "execute_tool")
+        assert span.start_time == _ns(_ts(0))
+        assert span.end_time == _ns(_ts(3))
+
+    def test_llm(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot"):
+            c = LLM(model="gpt-4o", started_at=_ts(0), ended_at=_ts(3))
+            with c:
+                pass
+        span = _find(otel_spans.get_finished_spans(), "chat")
+        assert span.start_time == _ns(_ts(0))
+        assert span.end_time == _ns(_ts(3))
+
+    def test_subagent(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot") as turn:
+            sa = SubAgent(name="x", started_at=_ts(0), ended_at=_ts(3))
+            with sa:
+                pass
+            _ = turn  # silence "unused"
+        spans = otel_spans.get_finished_spans()
+        sa_span = next(
+            sp
+            for sp in spans
+            if sp.name == "invoke_agent x"
+            and sp.attributes.get("gen_ai.agent.name") == "x"
+        )
+        assert sa_span.start_time == _ns(_ts(0))
+        assert sa_span.end_time == _ns(_ts(3))
+
+    def test_turn(self, otel_spans: InMemorySpanExporter) -> None:
+        with Session(session_id="s"):
+            t = Turn(agent_name="bot", started_at=_ts(0), ended_at=_ts(3))
+            with t:
+                pass
+        span = _find(otel_spans.get_finished_spans(), "invoke_agent")
+        assert span.start_time == _ns(_ts(0))
+        assert span.end_time == _ns(_ts(3))
+
+
+# ---------------------------------------------------------------------------
+# Default (no caller-supplied timestamps) still works
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultTimestampsStillWork:
+    """When the caller doesn't supply ``ended_at``, ``end()`` fills in ``now()``."""
+
+    def test_llm_ended_at_set_on_end(self) -> None:
+        c = LLM(model="gpt-4o")
+        c.end()
+        assert c.ended_at is not None
+
+    def test_subagent_ended_at_set_on_end(self) -> None:
+        sa = SubAgent(name="x")
+        sa.end()
+        assert sa.ended_at is not None
+
+    def test_turn_ended_at_set_on_end(self) -> None:
+        t = Turn(agent_name="bot")
+        t.end()
+        assert t.ended_at is not None
+
+
+# ---------------------------------------------------------------------------
+# SubAgent.__enter__ now honors started_at (previously the odd one out)
+# ---------------------------------------------------------------------------
+
+
+class TestSubAgentEnterHonorsStartedAt:
+    def test_preserves_existing_started_at(self) -> None:
+        sa = SubAgent(name="x", started_at=_ts(0))
+        with sa:
+            pass
+        assert sa.started_at == _ts(0)
+
+    def test_sets_started_at_when_none(self) -> None:
+        sa = SubAgent(name="x")
+        with sa:
+            pass
+        assert sa.started_at is not None
+
+    def test_otel_start_time_matches_started_at(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        with Session(session_id="s"), Turn(agent_name="bot"):
+            sa = SubAgent(name="x", started_at=_ts(0), ended_at=_ts(2))
+            with sa:
+                pass
+        spans = otel_spans.get_finished_spans()
+        sa_span = next(sp for sp in spans if sp.name == "invoke_agent x")
+        assert sa_span.start_time == _ns(_ts(0))
+
+
+# ---------------------------------------------------------------------------
+# Streaming == batch parity (the headline contract this PR establishes)
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingMatchesBatch:
+    """Same inputs through streaming vs ``log_turn`` produce identical spans.
+
+    This is the regression test for the divergence that motivated the PR:
+    pre-fix, streaming emitted ``now()`` end_times while batch honored
+    ``ended_at``. The two paths now agree.
+    """
+
+    def test_llm_streaming_matches_log_turn(
+        self, otel_spans: InMemorySpanExporter
+    ) -> None:
+        started, ended = _ts(0), _ts(5)
+
+        otel_spans.clear()
+        with (
+            Session(session_id="s"),
+            Turn(agent_name="bot", started_at=started, ended_at=ended),
+        ):
+            llm = LLM(
+                model="gpt-4o",
+                provider_name="openai",
+                started_at=started,
+                ended_at=ended,
+            )
+            with llm:
+                pass
+        streaming_chat = _find(otel_spans.get_finished_spans(), "chat")
+        streaming = (streaming_chat.start_time, streaming_chat.end_time)
+
+        otel_spans.clear()
+        log_turn(
+            session_id="s",
+            agent_name="bot",
+            started_at=started,
+            ended_at=ended,
+            spans=[
+                LLM(
+                    model="gpt-4o",
+                    provider_name="openai",
+                    started_at=started,
+                    ended_at=ended,
+                )
+            ],
+        )
+        batch_chat = _find(otel_spans.get_finished_spans(), "chat")
+        batch = (batch_chat.start_time, batch_chat.end_time)
+
+        assert streaming == batch
+        assert streaming == (_ns(started), _ns(ended))

--- a/weave/session/session.py
+++ b/weave/session/session.py
@@ -296,7 +296,7 @@ class Tool(_SpanBase):
             session_id=session.session_id if session else "",
             include_content=session.include_content if session else True,
         )
-        self._end_otel_span(attrs)
+        self._end_otel_span(attrs, end_time_ns=_to_ns(self.ended_at))
 
     def __enter__(self) -> Self:
         if self.started_at is None:
@@ -591,7 +591,8 @@ class LLM(_SpanBase):
         if self._ended:
             return
         self._ended = True
-        self.ended_at = datetime.now(timezone.utc)
+        if self.ended_at is None:
+            self.ended_at = datetime.now(timezone.utc)
 
         session = get_current_session()
         attrs = self._build_attrs(
@@ -603,7 +604,7 @@ class LLM(_SpanBase):
             _current_llm.reset(self._token)
             self._token = None
 
-        self._end_otel_span(attrs)
+        self._end_otel_span(attrs, end_time_ns=_to_ns(self.ended_at))
 
     def __enter__(self) -> Self:
         if self._token is None:
@@ -691,18 +692,21 @@ class SubAgent(_SpanBase):
         if self._ended:
             return
         self._ended = True
-        self.ended_at = datetime.now(timezone.utc)
+        if self.ended_at is None:
+            self.ended_at = datetime.now(timezone.utc)
 
         session = get_current_session()
         attrs = self._build_attrs(
             session_id=session.session_id if session else "",
             session_name=session.session_name if session else "",
         )
-        self._end_otel_span(attrs)
+        self._end_otel_span(attrs, end_time_ns=_to_ns(self.ended_at))
 
     def __enter__(self) -> Self:
-        self.started_at = datetime.now(timezone.utc)
-        self._start_otel_span(f"invoke_agent {self.name}")
+        if self.started_at is None:
+            self.started_at = datetime.now(timezone.utc)
+        start_ns = int(self.started_at.timestamp() * 1_000_000_000)
+        self._start_otel_span(f"invoke_agent {self.name}", start_time_ns=start_ns)
         return self
 
     def __exit__(
@@ -816,7 +820,8 @@ class Turn(_SpanBase):
         if self._ended:
             return
         self._ended = True
-        self.ended_at = datetime.now(timezone.utc)
+        if self.ended_at is None:
+            self.ended_at = datetime.now(timezone.utc)
 
         session = get_current_session()
         attrs = self._build_attrs(
@@ -829,7 +834,7 @@ class Turn(_SpanBase):
             _current_turn.reset(self._token)
             self._token = None
 
-        self._end_otel_span(attrs)
+        self._end_otel_span(attrs, end_time_ns=_to_ns(self.ended_at))
 
     def __enter__(self) -> Self:
         if self._token is None:


### PR DESCRIPTION
## Summary

Streaming `end()` on `LLM` / `SubAgent` / `Turn` overwrote caller-supplied `ended_at` with `now()`, and all four span classes' `_end_otel_span` calls dropped the value before reaching OTel. `SubAgent.__enter__` did the same for `started_at`. Net: caller-set timestamps on the SDK object never reached the emitted OTel span.

Batch path (`log_turn` / `log_session`) already worked. After this PR, streaming and batch produce identical spans for the same inputs.

## Changes

- `LLM.end()` / `SubAgent.end()` / `Turn.end()`: preserve existing `ended_at` (matching `Tool.end()`'s pre-existing pattern)
- All four `end()`s: pass `end_time_ns=_to_ns(self.ended_at)` to `_end_otel_span`
- `SubAgent.__enter__`: preserve existing `started_at` and pass `start_time_ns` (the only `__enter__` that ignored it)

## Why

Reconstructing chat spans from upstream transcripts (replay, queue worker, callback) needs to backdate the OTel span_time to when the LLM call actually happened, not when the SDK called `end()`.

## Test plan

- [x] 13 tests in `tests/session/test_post_hoc_times.py` — 4×3 parametrized across `(Tool, LLM, SubAgent, Turn)` covering `ended_at` round-trip, OTel span times match caller values, default `now()` fallback; plus a streaming-vs-batch regression on `chat` spans
- [x] 241 existing session tests still pass
- [x] `uvx ruff check` + `uvx ruff format --check` clean