### PR TITLE
feat(weave_ts): exclude ADK-internal GoogleGenAI clients from genai wrapping

### DIFF
--- a/sdks/node/src/integrations/googleGenAI.ts
+++ b/sdks/node/src/integrations/googleGenAI.ts
@@ -5,6 +5,14 @@ import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
 const weaveGeminiModelHint = Symbol.for('_weave_gemini_model_hint');
 const weaveGeminiModelsWrapped = Symbol.for('_weave_gemini_models_wrapped');
 
+// Marker found in the `x-goog-api-client` header of GoogleGenAI clients that
+// the Google ADK (`@google/adk`) constructs internally (its `trackingHeaders`).
+// Those clients are excluded from wrapping: the ADK integration (WeaveAdkPlugin)
+// already records each model call as `google.adk.call_llm` with usage, so
+// wrapping here would double-count tokens and emit orphan root traces.
+const ADK_INTERNAL_CLIENT_HEADER = 'x-goog-api-client';
+const ADK_INTERNAL_CLIENT_MARKER = 'google-adk/';
+
 type GeminiUsageMetadata = {
   promptTokenCount?: number;
   candidatesTokenCount?: number;
@@ -237,12 +245,33 @@ export function wrapGoogleGenAI<T extends GoogleGenAIAPI>(googleGenAI: T): T {
   return googleGenAI;
 }
 
+/** True for clients constructed by `@google/adk` internally (see marker above). */
+function isAdkInternalClientOptions(options: any): boolean {
+  const headers = options?.httpOptions?.headers;
+  if (headers == null || typeof headers !== 'object') {
+    return false;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (
+      key.toLowerCase() === ADK_INTERNAL_CLIENT_HEADER &&
+      typeof value === 'string' &&
+      value.includes(ADK_INTERNAL_CLIENT_MARKER)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function commonProxy(exports: any) {
   const OriginalGoogleGenAIClass = exports.GoogleGenAI;
 
   return new Proxy(OriginalGoogleGenAIClass, {
     construct(target, args, newTarget) {
       const instance = Reflect.construct(target, args, newTarget);
+      if (isAdkInternalClientOptions(args[0])) {
+        return instance;
+      }
       return wrapGoogleGenAI(instance);
     },
   });


### PR DESCRIPTION
## Description

**Stack PR 2/4** (on #7135). Excludes ADK-internal `GoogleGenAI` clients from `@google/genai` wrapping.

The Google ADK constructs `@google/genai` `GoogleGenAI` clients internally for its Gemini calls. With the genai integration active, those clients would be wrapped too, producing a second record of every ADK model call: orphan root-level `google.genai.models.generateContent` traces (weave's call stack is empty inside ADK's async flow, so they cannot parent correctly) and double-counted token usage on top of the `google.adk.call_llm` calls emitted by `WeaveAdkPlugin`.

ADK marks its internal clients via `BaseLlm.trackingHeaders`: the `x-goog-api-client` header always contains `google-adk/<version>`. The `GoogleGenAI` constructor proxy now skips wrapping when that marker is present in the construction options, leaving the ADK plugin as the single source of truth for ADK model calls. User-constructed `GoogleGenAI` clients in the same process carry no such marker and keep being wrapped as before.

## Testing

- Covered by the integration test added in #7137 (an ADK-marked construction stays unwrapped; a plain construction is wrapped); existing googleGenAI tests unaffected.
- Verified end to end against prod Weave: an ADK run produces no orphan `google.genai.*` traces.

## Breaking changes

None. Behavior change only for `GoogleGenAI` clients constructed with ADK's tracking header.