### PR TITLE
chore(weave_ts): add Google ADK example and agent docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,6 +206,32 @@ npm i
 npm run test
 ```
 
+### TypeScript SDK integration patterns (sdks/node)
+
+- Integrations live in `sdks/node/src/integrations/`. Auto-instrumentation is
+  registered in `integrations/hooks.ts` via `addCJSInstrumentation` (keyed on
+  `<package>@<resolved subpath>`, e.g. `@google/adk@dist/cjs/index.js`) and
+  `addESMInstrumentation` (keyed on the bare module name, applied by the
+  `--import=weave/instrument` loader).
+- Agent-framework integrations write calls directly with
+  `client.saveCallStart` / `saveCallEnd` (see `openai-agents/weave-tracing-processor.ts`
+  and `googleAdk.ts`) rather than wrapping functions in `op()`.
+- Framework types are duck-typed locally (e.g. `googleAdk.types.ts`) so the
+  SDK has no runtime dependency on the framework package. Keep these types
+  free of index signatures or the real framework types stop being assignable.
+- Jest replaces Node's module system, so the CJS require hook never fires
+  inside jest tests — call the patch hook (e.g. `commonPatchGoogleADK`)
+  directly, and use the `hostApps` jest project for real loader testing.
+- `@google/adk`'s CJS dist `require()`s the ESM-only `lodash-es` (legal under
+  Node >= 22 `require(esm)`, fatal under jest); the default jest project maps
+  `^lodash-es$` → `lodash`.
+- Google ADK gotchas: ADK 1.2.0 never dispatches plugin agent callbacks
+  (`runBefore/AfterAgentCallback` have no call sites), so `WeaveAdkPlugin`
+  synthesizes agent calls from `agentName` + the agent tree. ADK-internal
+  `GoogleGenAI` clients are detected by the `google-adk/` marker in their
+  `x-goog-api-client` header and excluded from the genai wrapper to avoid
+  double-counted usage.
+
 ## Code Review & PR Guidelines
 
 ### PR Requirements

--- a/sdks/node/examples/googleAdkAgent.ts
+++ b/sdks/node/examples/googleAdkAgent.ts
@@ -1,0 +1,87 @@
+/**
+ * Example: Google ADK (Agent Development Kit) Integration with Weave
+ *
+ * Demonstrates a tool-using Gemini agent built with @google/adk, traced by
+ * Weave. The integration is automatic: importing weave installs module hooks
+ * that register a Weave plugin on every ADK Runner. For environments where
+ * the hooks cannot run (e.g. some bundlers), pass the plugin explicitly:
+ *
+ * ```typescript
+ * import {WeaveAdkPlugin} from 'weave';
+ * new InMemoryRunner({agent, appName, plugins: [new WeaveAdkPlugin()]});
+ * ```
+ *
+ * Requires GOOGLE_API_KEY (or Vertex AI env config) for the Gemini call.
+ */
+
+import * as weave from 'weave';
+import {FunctionTool, InMemoryRunner, LlmAgent} from '@google/adk';
+import {z} from 'zod';
+
+// Set your own entity/project name here
+const WANDB_PROJECT = process.env.WANDB_PROJECT || 'examples';
+
+const APP_NAME = 'weave-adk-example';
+const USER_ID = 'example-user';
+const MODEL = 'gemini-2.5-flash';
+
+// --- Tools ---
+
+const getWeatherTool = new FunctionTool({
+  name: 'get_weather',
+  description: 'Get the current weather for a given city.',
+  parameters: z.object({
+    city: z.string().describe('The name of the city'),
+  }),
+  execute: async ({city}) => {
+    // Simulated weather data
+    const weather: Record<string, {temp: number; condition: string}> = {
+      'San Francisco': {temp: 18, condition: 'Foggy'},
+      'New York': {temp: 22, condition: 'Sunny'},
+      London: {temp: 12, condition: 'Cloudy'},
+      Tokyo: {temp: 28, condition: 'Humid'},
+    };
+    const data = weather[city] ?? {temp: 20, condition: 'Clear'};
+    return {city, condition: data.condition, temperature_c: data.temp};
+  },
+});
+
+// --- Agent ---
+
+async function main() {
+  await weave.init(WANDB_PROJECT);
+
+  const agent = new LlmAgent({
+    name: 'weather_agent',
+    description: 'Answers questions about the weather.',
+    instruction:
+      'You answer weather questions. Always use the get_weather tool.',
+    model: MODEL,
+    tools: [getWeatherTool],
+  });
+
+  const runner = new InMemoryRunner({agent, appName: APP_NAME});
+  const session = await runner.sessionService.createSession({
+    appName: APP_NAME,
+    userId: USER_ID,
+  });
+
+  for await (const event of runner.runAsync({
+    userId: USER_ID,
+    sessionId: session.id,
+    newMessage: {
+      role: 'user',
+      parts: [{text: "What's the weather in Tokyo and London?"}],
+    },
+  })) {
+    const text = event.content?.parts
+      ?.map(part => part.text)
+      .filter(Boolean)
+      .join('');
+    if (text) {
+      console.log(`[${event.author}] ${text}`);
+    }
+  }
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Description

**Stack PR 4/4** (on #7137). Adds a runnable example and agent-facing docs for the Google ADK integration.

- `examples/googleAdkAgent.ts` — a tool-using Gemini agent built with `@google/adk` and traced by weave automatically, with the explicit `WeaveAdkPlugin` alternative documented for environments where module hooks cannot run (mirrors `examples/openaiAgents.ts`).
- `AGENTS.md` — records the TypeScript SDK integration patterns and ADK gotchas: hook registration/subpath keys, the `saveCallStart`/`saveCallEnd` transport for agent frameworks, duck-typing rules (no index signatures or real framework types stop being assignable), jest vs module hooks, the `lodash-es` → `lodash` test mapping, the ADK 1.2.0 agent-callback gap, and the `x-goog-api-client` exclusion marker.

## Testing

Example compiles under the examples tsconfig (the only `typecheck:examples` failure is the pre-existing `streamFunctionCalls.ts` openai-v6 type drift, untouched here); prettier clean.

## Breaking changes

None — docs and example only.