### PR TITLE
chore(dev): add devin-ai-integration[bot] to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -27,4 +27,4 @@ jobs:
           # branch should not be protected
           branch: "cla"
           # cannot use teams due to: https://github.com/contributor-assistant/github-action/issues/100
-          allowlist: actions-user, altay, andrewtruong, bdytx5, dannygoldstein, davidwallacejackson, jamie-rasmussen, jlzhao27, jo-fang, jwlee64, laxels, morganmcg1, nickpenaranda, openhands@all-hands.dev, scottire, shawnlewis, staceysv, tssweeney, vanpelt, vwrj, wandbmachine, weave@wandb.com, dependabot[bot], fixit-agent[bot]
+          allowlist: actions-user, altay, andrewtruong, bdytx5, dannygoldstein, davidwallacejackson, jamie-rasmussen, jlzhao27, jo-fang, jwlee64, laxels, morganmcg1, nickpenaranda, openhands@all-hands.dev, scottire, shawnlewis, staceysv, tssweeney, vanpelt, vwrj, wandbmachine, weave@wandb.com, dependabot[bot], fixit-agent[bot], devin-ai-integration[bot]


### PR DESCRIPTION
## Description

Adds `devin-ai-integration[bot]` to the CLA Assistant allowlist in `.github/workflows/cla.yaml`, alongside the existing `dependabot[bot]` and `fixit-agent[bot]` entries.

The required CLAAssistant check is currently blocking bot-authored PRs (e.g. #7127): the bot cannot satisfy the signature flow (posting the signing comment + `recheck` doesn't flip the check), so it needs to be allowlisted like the other automation accounts.

Because the workflow runs on `pull_request_target` (from master), this change must land on master before it takes effect on open PRs.

## Testing

Config-only change; verified YAML matches the existing allowlist format. After merge, commenting `recheck` on #7127 should turn CLAAssistant green.

Link to Devin session: https://app.devin.ai/sessions/403b1e40916d4e54b9aa1a2c3065a660
Requested by: @nichochar