### PR TITLE
chore(weave): add claude-fable-5 to model providers and costs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,11 @@ _Important:_ For OpenAI Codex agents (most likely you!), your environment does n
   - `weave/` - Python package implementation
   - `weave/trace_server` - Backend server implementation
 
+## Generated Files — Do Not Hand-Edit
+
+`weave/trace_server/model_providers/model_providers.json` and `weave/trace_server/costs/cost_checkpoint.json` are generated. Never edit them by hand — regenerate with `make update_model_providers` / `make update_costs` (see `weave/Makefile`).
+
+Note: the scripts read `modelsBegin.json`/`modelsFinal.json`, which are symlinks into wandb/core and only resolve when this repo is checked out as the submodule inside wandb/core (`services/weave-trace/weave-python/weave-public`).
 
 ## Python Testing Guidelines
 

--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -25977,6 +25977,16 @@
       "created_at": "2026-05-29 11:23:33"
     }
   ],
+  "claude-fable-5": [
+    {
+      "provider": "anthropic",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 1e-06,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-06-10 16:30:00"
+    }
+  ],
   "claude-opus-4-8": [
     {
       "provider": "anthropic",

--- a/weave/trace_server/costs/cost_checkpoint.json
+++ b/weave/trace_server/costs/cost_checkpoint.json
@@ -16637,6 +16637,14 @@
       "cache_read_input": 3.3e-07,
       "cache_creation_input": 4.125e-06,
       "created_at": "2026-04-01 13:02:37"
+    },
+    {
+      "provider": "bedrock",
+      "input": 3.6e-06,
+      "output": 1.8e-05,
+      "cache_read_input": 3.6e-07,
+      "cache_creation_input": 4.5e-06,
+      "created_at": "2026-06-10 16:22:38"
     }
   ],
   "bedrock/us-gov-west-1/claude-sonnet-4-5-20250929-v1:0": [
@@ -16653,6 +16661,14 @@
       "cache_read_input": 3.3e-07,
       "cache_creation_input": 4.125e-06,
       "created_at": "2026-04-01 13:02:37"
+    },
+    {
+      "provider": "bedrock",
+      "input": 3.6e-06,
+      "output": 1.8e-05,
+      "cache_read_input": 3.6e-07,
+      "cache_creation_input": 4.5e-06,
+      "created_at": "2026-06-10 16:22:38"
     }
   ],
   "cerebras/gpt-oss-120b": [
@@ -24727,6 +24743,14 @@
       "cache_read_input": 3.3e-07,
       "cache_creation_input": 4.125e-06,
       "created_at": "2026-04-16 12:32:59"
+    },
+    {
+      "provider": "bedrock",
+      "input": 3.6e-06,
+      "output": 1.8e-05,
+      "cache_read_input": 3.6e-07,
+      "cache_creation_input": 4.5e-06,
+      "created_at": "2026-06-10 16:22:38"
     }
   ],
   "bedrock/us-gov-west-1/anthropic.claude-sonnet-4-5-20250929-v1:0": [
@@ -24737,6 +24761,14 @@
       "cache_read_input": 3.3e-07,
       "cache_creation_input": 4.125e-06,
       "created_at": "2026-04-16 12:32:59"
+    },
+    {
+      "provider": "bedrock",
+      "input": 3.6e-06,
+      "output": 1.8e-05,
+      "cache_read_input": 3.6e-07,
+      "cache_creation_input": 4.5e-06,
+      "created_at": "2026-06-10 16:22:38"
     }
   ],
   "bedrock/us-west-2/minimax.minimax-m2.5": [
@@ -25147,6 +25179,14 @@
       "cache_read_input": 3.3e-07,
       "cache_creation_input": 4.125e-06,
       "created_at": "2026-04-16 12:32:59"
+    },
+    {
+      "provider": "bedrock_converse",
+      "input": 3.6e-06,
+      "output": 1.8e-05,
+      "cache_read_input": 3.6e-07,
+      "cache_creation_input": 4.5e-06,
+      "created_at": "2026-06-10 16:22:38"
     }
   ],
   "vertex_ai/claude-haiku-4-5": [
@@ -25977,16 +26017,6 @@
       "created_at": "2026-05-29 11:23:33"
     }
   ],
-  "claude-fable-5": [
-    {
-      "provider": "anthropic",
-      "input": 1e-05,
-      "output": 5e-05,
-      "cache_read_input": 1e-06,
-      "cache_creation_input": 1.25e-05,
-      "created_at": "2026-06-10 16:30:00"
-    }
-  ],
   "claude-opus-4-8": [
     {
       "provider": "anthropic",
@@ -26125,6 +26155,406 @@
       "cache_read_input": 5e-07,
       "cache_creation_input": 6.25e-06,
       "created_at": "2026-05-29 11:23:33"
+    }
+  ],
+  "coreweave/JetBrains/Mellum2-12B-A2.5B-Instruct": [
+    {
+      "provider": "coreweave",
+      "input": 5e-08,
+      "output": 1e-07,
+      "cache_read_input": 0,
+      "cache_creation_input": 0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "coreweave/nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": [
+    {
+      "provider": "coreweave",
+      "input": 7.5e-07,
+      "output": 2.75e-06,
+      "cache_read_input": 0,
+      "cache_creation_input": 0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "anthropic.claude-fable-5": [
+    {
+      "provider": "bedrock_converse",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 1e-06,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "global.anthropic.claude-fable-5": [
+    {
+      "provider": "bedrock_converse",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 1e-06,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "us.anthropic.claude-fable-5": [
+    {
+      "provider": "bedrock_converse",
+      "input": 1.1e-05,
+      "output": 5.5e-05,
+      "cache_read_input": 1.1e-06,
+      "cache_creation_input": 1.375e-05,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "eu.anthropic.claude-fable-5": [
+    {
+      "provider": "bedrock_converse",
+      "input": 1.1e-05,
+      "output": 5.5e-05,
+      "cache_read_input": 1.1e-06,
+      "cache_creation_input": 1.375e-05,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "jp.anthropic.claude-opus-4-7": [
+    {
+      "provider": "bedrock_converse",
+      "input": 5.5e-06,
+      "output": 2.75e-05,
+      "cache_read_input": 5.5e-07,
+      "cache_creation_input": 6.875e-06,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "azure_ai/claude-fable-5": [
+    {
+      "provider": "azure_ai",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 1e-06,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "azure_ai/kimi-k2.6": [
+    {
+      "provider": "azure_ai",
+      "input": 9.5e-07,
+      "output": 4e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "claude-fable-5": [
+    {
+      "provider": "anthropic",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 1e-06,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "inception/mercury-2": [
+    {
+      "provider": "inception",
+      "input": 2.5e-07,
+      "output": 7.5e-07,
+      "cache_read_input": 2.5e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "text-completion-inception/mercury-edit-2": [
+    {
+      "provider": "text-completion-inception",
+      "input": 2.5e-07,
+      "output": 7.5e-07,
+      "cache_read_input": 2.5e-08,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "minimax/MiniMax-M3": [
+    {
+      "provider": "minimax",
+      "input": 6e-07,
+      "output": 2.4e-06,
+      "cache_read_input": 1.2e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "mistral/ministral-8b-latest": [
+    {
+      "provider": "mistral",
+      "input": 1.5e-07,
+      "output": 1.5e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/claude-3-5-sonnet": [
+    {
+      "provider": "snowflake",
+      "input": 3e-06,
+      "output": 1.5e-05,
+      "cache_read_input": 3e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/deepseek-r1": [
+    {
+      "provider": "snowflake",
+      "input": 1.35e-06,
+      "output": 5.4e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/llama3.1-405b": [
+    {
+      "provider": "snowflake",
+      "input": 1.2e-06,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/llama3.1-70b": [
+    {
+      "provider": "snowflake",
+      "input": 7.2e-07,
+      "output": 7.2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/llama3.1-8b": [
+    {
+      "provider": "snowflake",
+      "input": 2.4e-07,
+      "output": 2.4e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/llama3.3-70b": [
+    {
+      "provider": "snowflake",
+      "input": 7.2e-07,
+      "output": 7.2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/mistral-large2": [
+    {
+      "provider": "snowflake",
+      "input": 2e-06,
+      "output": 6e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/snowflake-llama-3.3-70b": [
+    {
+      "provider": "snowflake",
+      "input": 7.2e-07,
+      "output": 7.2e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "vertex_ai/claude-fable-5": [
+    {
+      "provider": "vertex_ai-anthropic_models",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 1e-06,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "vertex_ai/claude-fable-5@default": [
+    {
+      "provider": "vertex_ai-anthropic_models",
+      "input": 1e-05,
+      "output": 5e-05,
+      "cache_read_input": 1e-06,
+      "cache_creation_input": 1.25e-05,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "vertex_ai/google/gemma-4-26b-a4b-it-maas": [
+    {
+      "provider": "vertex_ai-openai_models",
+      "input": 1.5e-07,
+      "output": 6e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "bedrock_mantle/openai.gpt-5.5": [
+    {
+      "provider": "bedrock_mantle",
+      "input": 5.5e-06,
+      "output": 3.3e-05,
+      "cache_read_input": 5.5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "bedrock_mantle/openai.gpt-5.4": [
+    {
+      "provider": "bedrock_mantle",
+      "input": 2.75e-06,
+      "output": 1.65e-05,
+      "cache_read_input": 2.75e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/claude-sonnet-4-5": [
+    {
+      "provider": "snowflake",
+      "input": 3e-06,
+      "output": 1.5e-05,
+      "cache_read_input": 3e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/claude-sonnet-4-6": [
+    {
+      "provider": "snowflake",
+      "input": 3e-06,
+      "output": 1.5e-05,
+      "cache_read_input": 3e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/claude-4-sonnet": [
+    {
+      "provider": "snowflake",
+      "input": 3e-06,
+      "output": 1.5e-05,
+      "cache_read_input": 3e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/claude-4-opus": [
+    {
+      "provider": "snowflake",
+      "input": 5e-06,
+      "output": 2.5e-05,
+      "cache_read_input": 5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/claude-haiku-4-5": [
+    {
+      "provider": "snowflake",
+      "input": 1e-06,
+      "output": 5e-06,
+      "cache_read_input": 1e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/claude-3-7-sonnet": [
+    {
+      "provider": "snowflake",
+      "input": 3e-06,
+      "output": 1.5e-05,
+      "cache_read_input": 3e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/openai-gpt-4.1": [
+    {
+      "provider": "snowflake",
+      "input": 2e-06,
+      "output": 8e-06,
+      "cache_read_input": 5e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/openai-gpt-5": [
+    {
+      "provider": "snowflake",
+      "input": 1.25e-06,
+      "output": 1e-05,
+      "cache_read_input": 1.25e-07,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/openai-gpt-5-mini": [
+    {
+      "provider": "snowflake",
+      "input": 3e-07,
+      "output": 1.2e-06,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/openai-gpt-5-nano": [
+    {
+      "provider": "snowflake",
+      "input": 1.5e-07,
+      "output": 6e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/llama4-maverick": [
+    {
+      "provider": "snowflake",
+      "input": 2.4e-07,
+      "output": 9.7e-07,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/snowflake-arctic-embed-l-v2.0": [
+    {
+      "provider": "snowflake",
+      "input": 7e-08,
+      "output": 0.0,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
+    }
+  ],
+  "snowflake/snowflake-arctic-embed-m-v2.0": [
+    {
+      "provider": "snowflake",
+      "input": 7e-08,
+      "output": 0.0,
+      "cache_read_input": 0.0,
+      "cache_creation_input": 0.0,
+      "created_at": "2026-06-10 16:22:38"
     }
   ]
 }

--- a/weave/trace_server/model_providers/model_providers.json
+++ b/weave/trace_server/model_providers/model_providers.json
@@ -2298,6 +2298,10 @@
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"
   },
+  "claude-fable-5": {
+    "litellm_provider": "anthropic",
+    "api_key_name": "ANTHROPIC_API_KEY"
+  },
   "claude-opus-4-20250514": {
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"

--- a/weave/trace_server/model_providers/model_providers.json
+++ b/weave/trace_server/model_providers/model_providers.json
@@ -15,6 +15,10 @@
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
+  "JetBrains/Mellum2-12B-A2.5B-Instruct": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
   "MiniMaxAI/MiniMax-M2.5": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
@@ -28,6 +32,10 @@
     "api_key_name": "WANDB_API_KEY"
   },
   "zai-org/GLM-4.5": {
+    "litellm_provider": "coreweave",
+    "api_key_name": "WANDB_API_KEY"
+  },
+  "nvidia/NVIDIA-Nemotron-3-Ultra-550B-A55B": {
     "litellm_provider": "coreweave",
     "api_key_name": "WANDB_API_KEY"
   },
@@ -419,6 +427,22 @@
     "litellm_provider": "bedrock_converse",
     "api_key_name": "BEDROCK_API_KEY"
   },
+  "anthropic.claude-fable-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "global.anthropic.claude-fable-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "us.anthropic.claude-fable-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "eu.anthropic.claude-fable-5": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
   "anthropic.claude-opus-4-8": {
     "litellm_provider": "bedrock_converse",
     "api_key_name": "BEDROCK_API_KEY"
@@ -436,6 +460,10 @@
     "api_key_name": "BEDROCK_API_KEY"
   },
   "au.anthropic.claude-opus-4-8": {
+    "litellm_provider": "bedrock_converse",
+    "api_key_name": "BEDROCK_API_KEY"
+  },
+  "jp.anthropic.claude-opus-4-7": {
     "litellm_provider": "bedrock_converse",
     "api_key_name": "BEDROCK_API_KEY"
   },
@@ -544,6 +572,10 @@
     "api_key_name": "AZURE_API_KEY"
   },
   "azure_ai/claude-opus-4-7": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
+  "azure_ai/claude-fable-5": {
     "litellm_provider": "azure_ai",
     "api_key_name": "AZURE_API_KEY"
   },
@@ -1599,6 +1631,10 @@
     "litellm_provider": "azure_ai",
     "api_key_name": "AZURE_API_KEY"
   },
+  "azure_ai/kimi-k2.6": {
+    "litellm_provider": "azure_ai",
+    "api_key_name": "AZURE_API_KEY"
+  },
   "azure_ai/ministral-3b": {
     "litellm_provider": "azure_ai",
     "api_key_name": "AZURE_API_KEY"
@@ -2298,10 +2334,6 @@
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"
   },
-  "claude-fable-5": {
-    "litellm_provider": "anthropic",
-    "api_key_name": "ANTHROPIC_API_KEY"
-  },
   "claude-opus-4-20250514": {
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"
@@ -2327,6 +2359,10 @@
     "api_key_name": "ANTHROPIC_API_KEY"
   },
   "claude-opus-4-7-20260416": {
+    "litellm_provider": "anthropic",
+    "api_key_name": "ANTHROPIC_API_KEY"
+  },
+  "claude-fable-5": {
     "litellm_provider": "anthropic",
     "api_key_name": "ANTHROPIC_API_KEY"
   },
@@ -4095,6 +4131,10 @@
     "api_key_name": "MISTRAL_API_KEY"
   },
   "mistral/ministral-8b-2512": {
+    "litellm_provider": "mistral",
+    "api_key_name": "MISTRAL_API_KEY"
+  },
+  "mistral/ministral-8b-latest": {
     "litellm_provider": "mistral",
     "api_key_name": "MISTRAL_API_KEY"
   },


### PR DESCRIPTION
## Description

Enables Anthropic's new Claude Fable 5 model (`claude-fable-5`, [announcement](https://www.anthropic.com/news/claude-fable-5-mythos-5)) in the trace server so it can be used from the model playground:

- `model_providers.json`: maps `claude-fable-5` → `anthropic` / `ANTHROPIC_API_KEY`
- `cost_checkpoint.json`: adds costs ($10/$50 per MTok input/output, cache read 10% of input, cache write 1.25x input, matching the pattern of other Anthropic entries)

Mirrors the prior model-add PR #7009 (opus 4.8). Frontend counterpart in wandb/core adds the model to the playground dropdown.

## Testing

Validated both JSON files parse; entries follow the same structure as existing Anthropic models.