### PR TITLE
feat(weave): add in-memory fake trace server skeleton and test wiring

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -232,6 +232,46 @@ jobs:
           name: trace-tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}-${{ matrix.nox-shard }}
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+  fake-trace-tests:
+    name: Fake (in-memory) trace server tests
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    # The in-memory fake needs no ClickHouse/wandb services — it is a pure
+    # in-process backend. Tests it cannot satisfy yet are skipped via
+    # per-test @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, ...) decorators
+    # (see tests/trace/util.py); the rest must match ClickHouse.
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version-major: ["3"]
+        python-version-minor: ["13"]
+        nox-shard: ["trace", "trace_server"]
+      fail-fast: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install Libmagic dependency package
+        run: sudo apt update && sudo apt install -y libmagic1
+      - name: Set up Python ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install nox uv
+      - name: Run nox (Fake trace server)
+        env:
+          WEAVE_SENTRY_ENV: ci
+          CI: 1
+          WEAVE_SERVER_DISABLE_ECOSYSTEM: 1
+          DD_TRACE_ENABLED: false
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY || 'DUMMY_API_KEY' }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY || 'sk-1234567890abcdef1234567890abcdef' }}
+        run: |
+          nox -e "tests-${{ matrix.python-version-major }}.${{ matrix.python-version-minor }}(shard='${{ matrix.nox-shard }}')" -- \
+            -m "trace_server" --trace-server=fake
   trace-server-migrator-1s1r:
     name: Trace server migrator tests (1s1r)
     timeout-minutes: 10

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,32 @@ Examples:
 - ✅ CORRECT: `-- tests/trace/test_dataset.py::test_basic_dataset_lifecycle`
 - ❌ WRONG: `-- trace/test_dataset.py::test_basic_dataset_lifecycle`
 
-#### Backend
+#### Backend Selection
+
+The `--trace-server` flag selects the backend: `clickhouse` (default) or
+`fake` (in-memory).
+
+**Fake / in-memory (Fastest for Development):**
+
+```bash
+nox --no-install -e "tests-3.12(shard='trace')" -- tests/trace/test_client_trace.py::test_simple_op --trace-server=fake
+```
+
+The fake backend (`weave/trace_server/in_memory_trace_server.py`,
+`InMemoryTraceServer`) is a pure-Python, dict-backed drop-in replacement that
+lives parallel to the ClickHouse implementation. It replicates **ClickHouse**
+(the production backend) at the interface level: JSON_VALUE string typing for
+dynamic fields, `to*OrNull` cast rules, NULLS-LAST ordering, DateTime64
+comparisons, and computed summary fields. Tests that assert ClickHouse
+*internals* (SQL, table routing/residence, insert batching, bucket file
+storage) are gated with `client_is_clickhouse` and skip on the fake. No
+files, no SQL, no Docker.
+
+**ClickHouse (the real backend):**
+
+```bash
+nox --no-install -e "tests-3.12(shard='trace')" -- tests/trace/test_client_trace.py::test_simple_op
+```
 
 ClickHouse is the only trace-server backend (`--trace-server` defaults to
 `clickhouse`):
@@ -150,7 +175,8 @@ nox --no-install -e "tests-3.12(shard='trace')" -- tests/trace/test_client_trace
 
 **Note:** ClickHouse tests require Docker to be running (the fixtures start a
 container automatically), or a local `clickhouse-server` binary with
-`--clickhouse-process=true`.
+`--clickhouse-process=true`. When neither is available, use the in-memory
+fake with `--trace-server=fake`.
 
 #### Remote HTTP Trace Server Implementation Selection
 

--- a/tests/trace/data_serialization/test_serialization_correctness.py
+++ b/tests/trace/data_serialization/test_serialization_correctness.py
@@ -9,6 +9,7 @@ from spec import SerializationTestCase
 from test_cases import cases
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.refs import ObjectRef
 from weave.trace_server.trace_server_interface import (
     CallReadReq,
@@ -46,6 +47,7 @@ def set_weave_logger_to_debug():
         logger.setLevel(current_level)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize(
     "case",
     cases,

--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -2,11 +2,13 @@ import pytest
 from pydantic import BaseModel, Field
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave import AnnotationSpec
 from weave.trace_server.clickhouse_trace_server_batched import InvalidRequest
 from weave.trace_server.trace_server_interface import FeedbackCreateReq, ObjQueryReq
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_human_feedback_basic(client):
     # create a human feedback spec
 
@@ -89,6 +91,7 @@ def test_human_feedback_basic(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_field_schema_with_pydantic_model(client):
     # Test using a Pydantic model as field_schema
     class FeedbackModel(BaseModel):
@@ -181,6 +184,7 @@ def test_field_schema_with_pydantic_model(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_field_schema_with_pydantic_field(client):
     # Test various field types
     rating_field = Field(ge=1, le=5, description="Rating from 1 to 5")
@@ -458,6 +462,7 @@ def test_annotation_spec_validate_return_value():
     assert not enum_spec.value_is_valid(123)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_feedback_sdk(weave_active):
     number_spec = AnnotationSpec(
         name="Number Rating",

--- a/tests/trace/test_anonymous_ops.py
+++ b/tests/trace/test_anonymous_ops.py
@@ -1,8 +1,11 @@
+import pytest
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace import weave_client
 from weave.trace_server.trace_server_interface import CallsQueryReq
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_anonymous_op(client: weave_client.WeaveClient) -> str:
     call = client.create_call("anonymous_op", {"a": 1})
     client.finish_call(call, {"c": 3}, None)
@@ -25,6 +28,7 @@ def test_anonymous_op(client: weave_client.WeaveClient) -> str:
     assert call.exception is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_anonymous_op_with_config(client: weave_client.WeaveClient) -> str:
     call = client.create_call(
         weave_client._build_anonymous_op("anonymous_op", {"library_version": "0.42.0"}),

--- a/tests/trace/test_anonymous_ops.py
+++ b/tests/trace/test_anonymous_ops.py
@@ -1,3 +1,4 @@
+
 from weave.trace import weave_client
 from weave.trace_server.trace_server_interface import CallsQueryReq
 

--- a/tests/trace/test_base_object_classes.py
+++ b/tests/trace/test_base_object_classes.py
@@ -18,6 +18,7 @@ import pytest
 from pydantic import ValidationError
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace import base_objects
 from weave.trace.refs import ObjectRef
 from weave.trace.serialization.serialize import to_json
@@ -56,6 +57,7 @@ def with_base_object_class_annotations(
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_pythonic_creation(client: WeaveClient):
     # First, let's use the high-level pythonic creation API.
     nested_obj = base_objects.TestOnlyNestedBaseObject(b=3)
@@ -185,6 +187,7 @@ def test_pythonic_creation(client: WeaveClient):
     assert inherited_obj_result.val == expected_inherited_val
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_interface_creation(client):
     # Now we will do the equivant operation using low-level interface.
@@ -314,6 +317,7 @@ def test_interface_creation(client):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_digest_equality(client):
     # Next, let's make sure that the digests are all equivalent
     nested_obj = base_objects.TestOnlyNestedBaseObject(b=3)
@@ -377,6 +381,7 @@ def test_digest_equality(client):
     assert top_level_pythonic_digest == top_level_interface_style_digest
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_schema_validation(client):
     # Test that we can't create an object with the wrong schema
     with pytest.raises(ValidationError):
@@ -454,6 +459,7 @@ def test_schema_validation(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_leaf_object_class_from_builtin_object_class(client: WeaveClient):
     """Test that when builtin_object_class is set, leaf_object_class is correctly set on stored object."""
     # Create an object using builtin_object_class parameter
@@ -515,6 +521,7 @@ def test_leaf_object_class_from_builtin_object_class(client: WeaveClient):
     assert read_top_obj_res.obj.leaf_object_class == "TestOnlyExample"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_leaf_object_class_filtering_with_builtin_objects(client: WeaveClient):
     """Test that leaf_object_class filtering works correctly with builtin objects created via builtin_object_class."""
     # Create several objects with different builtin_object_classes
@@ -687,6 +694,7 @@ def test_leaf_object_class_filtering_with_builtin_objects(client: WeaveClient):
     assert len(empty_res.objs) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_base_and_leaf_object_class_combined_filtering_builtin_objects(
     client: WeaveClient,
 ):
@@ -759,6 +767,7 @@ def test_base_and_leaf_object_class_combined_filtering_builtin_objects(
     assert len(mismatched_res.objs) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_inherited_builtin_object_class_hierarchy(client: WeaveClient):
     """Test that inheritance between builtin objects works correctly with base_object_class and leaf_object_class."""
     # Create base object
@@ -927,6 +936,7 @@ def test_inherited_builtin_object_class_hierarchy(client: WeaveClient):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_exclude_base_object_classes(client: WeaveClient):
     """Test that exclude_base_object_classes filter correctly excludes objects by their base classes."""
     # Create several objects with different base classes
@@ -1008,6 +1018,7 @@ def test_exclude_base_object_classes(client: WeaveClient):
     assert len(exclude_nonexistent_res.objs) >= 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_exclude_base_object_classes_with_include_filter(client: WeaveClient):
     """Test that exclude_base_object_classes works correctly when combined with base_object_classes."""
     # Create objects with different base classes
@@ -1049,6 +1060,7 @@ def test_exclude_base_object_classes_with_include_filter(client: WeaveClient):
     assert len(combined_res.objs) >= 3  # nested_obj1, nested_obj2, inherited_obj
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_exclude_base_object_classes_with_inherited_objects(client: WeaveClient):
     """Test that exclude_base_object_classes correctly handles inherited objects."""
     # Create base and inherited objects
@@ -1083,6 +1095,7 @@ def test_exclude_base_object_classes_with_inherited_objects(client: WeaveClient)
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_obj_create_rejects_name_type_collision(client: WeaveClient):
     """WB-30574: object_id is bound to one base_object_class per project.
 
@@ -1180,6 +1193,7 @@ def _create_monitor(client: WeaveClient, name: str, query: dict | None):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_monitor_create_rejects_unknown_query_field(client: WeaveClient):
     """A Monitor query on an unknown field is rejected with the complete allowed-field list."""
     bad_query = {
@@ -1207,6 +1221,7 @@ def test_monitor_create_rejects_unknown_query_field(client: WeaveClient):
     assert objs_res.objs == []
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_monitor_create_accepts_valid_query_fields(client: WeaveClient):
     """Static, dynamic, and absent monitor queries all create successfully."""
     valid_query = {

--- a/tests/trace/test_call_behaviours.py
+++ b/tests/trace/test_call_behaviours.py
@@ -2,6 +2,7 @@ import pytest
 
 import weave
 from tests.trace.util import (
+    FAKE_NOT_IMPLEMENTED,
     capture_output,
     flush_and_wait_for_output,
     flush_output,
@@ -22,6 +23,7 @@ async def afunc():
     return 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_prints_link(client):
     with capture_output() as captured:
         func()
@@ -39,6 +41,7 @@ def test_call_doesnt_print_link_if_failed(client_with_throwing_server):
     assert captured.getvalue().count(TRACE_CALL_EMOJI) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_call_prints_link(client):
     with capture_output() as captured:
@@ -58,6 +61,7 @@ async def test_async_call_doesnt_print_link_if_failed(client_with_throwing_serve
     assert captured.getvalue().count(TRACE_CALL_EMOJI) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_nested_calls_print_single_link(client):
     @weave.op
     def inner(a, b):

--- a/tests/trace/test_call_object.py
+++ b/tests/trace/test_call_object.py
@@ -1,7 +1,10 @@
+import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_to_dict(weave_active):
     @weave.op
     def greet(name: str, age: int) -> str:

--- a/tests/trace/test_call_object.py
+++ b/tests/trace/test_call_object.py
@@ -1,3 +1,4 @@
+
 import weave
 
 

--- a/tests/trace/test_client_annotation_queue_sdk.py
+++ b/tests/trace/test_client_annotation_queue_sdk.py
@@ -4,6 +4,7 @@ import datetime
 
 import pytest
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.call import Call
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server.common_interface import AnnotationQueueItemsFilter, SortBy
@@ -203,6 +204,7 @@ def _create_finished_calls(client, count: int) -> list[Call]:
     return calls
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_sdk_lifecycle(client):
     scorer_refs = ["weave:///entity/project/scorer/sdk_test:abc123"]
 

--- a/tests/trace/test_client_annotation_queues.py
+++ b/tests/trace/test_client_annotation_queues.py
@@ -13,7 +13,7 @@ import pytest
 
 import weave
 from tests.trace.server_utils import TEST_ENTITY, find_server_layer
-from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, NOT_CLICKHOUSE_BACKEND
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.common_interface import AnnotationQueueItemsFilter, SortBy
@@ -143,6 +143,7 @@ def create_queue_with_calls(
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_create_and_read(client):
     """Test creating and reading an annotation queue."""
     # Create a queue
@@ -176,6 +177,7 @@ def test_annotation_queue_create_and_read(client):
     assert read_res.queue.deleted_at is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_multiple_scorer_refs(client):
     """Test creating a queue with multiple scorer refs."""
     req = tsi.AnnotationQueueCreateReq(
@@ -210,6 +212,7 @@ def test_annotation_queue_multiple_scorer_refs(client):
     assert "weave:///entity/project/scorer/safety:ghi789" in read_res.queue.scorer_refs
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_update_all_fields(client):
     """Test updating all fields of an annotation queue."""
     # Create a queue
@@ -259,6 +262,7 @@ def test_annotation_queue_update_all_fields(client):
     assert len(read_res.queue.scorer_refs) == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_update_partial(client):
     """Test updating only some fields (partial update)."""
     # Create a queue
@@ -291,6 +295,7 @@ def test_annotation_queue_update_partial(client):
     ]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_update_nonexistent(client):
     """Test updating a non-existent queue raises NotFoundError."""
     # Try to update a non-existent queue
@@ -305,6 +310,7 @@ def test_annotation_queue_update_nonexistent(client):
         client.server.annotation_queue_update(update_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_update_no_fields(client):
     """Test updating with no fields provided returns existing queue."""
     # Create a queue
@@ -338,6 +344,7 @@ def test_annotation_queue_update_no_fields(client):
     ]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queues_query_stream_all(client):
     """Test querying all annotation queues for a project."""
     # Create multiple queues
@@ -366,6 +373,7 @@ def test_annotation_queues_query_stream_all(client):
         assert queues[i].created_at >= queues[i + 1].created_at
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queues_query_stream_with_name_filter(client):
     """Test querying queues with name filter."""
     # Create queues with different names
@@ -400,6 +408,7 @@ def test_annotation_queues_query_stream_with_name_filter(client):
     assert not any(q.name == "Quality Check Queue" for q in queues)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queues_query_stream_with_pagination(client):
     """Test querying queues with limit and offset."""
     # Create 5 queues
@@ -436,6 +445,7 @@ def test_annotation_queues_query_stream_with_pagination(client):
     assert page1_ids.isdisjoint(page2_ids)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_add_calls(client):
     """Test adding calls to an annotation queue."""
 
@@ -478,6 +488,7 @@ def test_annotation_queue_add_calls(client):
     assert add_res.duplicates == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_add_calls_duplicate_prevention(client):
     """Test that adding duplicate calls is handled correctly."""
     project_id = client.project_id
@@ -527,6 +538,7 @@ def test_annotation_queue_add_calls_duplicate_prevention(client):
     assert add_res2.duplicates == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_add_calls_batch(client):
     """Test adding multiple calls in batch."""
 
@@ -566,6 +578,7 @@ def test_annotation_queue_add_calls_batch(client):
     assert add_res.duplicates == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_add_calls_partial_duplicates(client):
     """Test adding calls where some are duplicates and some are new."""
 
@@ -788,6 +801,7 @@ def test_annotation_queues_stats(client):
     assert stats_map[queue_ids[2]].completed_items == 4
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queues_stats_empty_queues(client):
     """Test getting stats for queues with no items."""
     # Create two empty queues
@@ -816,6 +830,7 @@ def test_annotation_queues_stats_empty_queues(client):
         assert stat.completed_items == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queues_stats_no_queue_ids(client):
     """Test getting stats with empty queue_ids list."""
     # Request stats with no queue IDs
@@ -829,6 +844,7 @@ def test_annotation_queues_stats_no_queue_ids(client):
     assert len(stats_res.stats) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_basic(client):
     """Test basic querying of annotation queue items."""
     # Create queue with 5 calls
@@ -856,6 +872,7 @@ def test_annotation_queue_items_query_basic(client):
         assert item.deleted_at is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_with_pagination(client):
     """Test querying queue items with limit and offset."""
     # Create queue with 10 calls
@@ -889,6 +906,7 @@ def test_annotation_queue_items_query_with_pagination(client):
     assert page1_ids.isdisjoint(page2_ids)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_with_sorting(client):
     """Test querying queue items with different sort orders."""
     # Create queue with 3 calls
@@ -925,6 +943,7 @@ def test_annotation_queue_items_query_with_sorting(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_empty_queue(client):
     """Test querying items from an empty queue."""
     # Create an empty queue
@@ -941,6 +960,7 @@ def test_annotation_queue_items_query_empty_queue(client):
     assert len(query_res.items) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_with_multiple_sort_fields(client):
     """Test querying with multiple sort fields."""
     # Create queue with 5 calls
@@ -963,6 +983,7 @@ def test_annotation_queue_items_query_with_multiple_sort_fields(client):
     assert len(query_res.items) == 5
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_filter_by_call_id(client):
     """Test filtering queue items by call_id."""
     # Create queue with 5 calls
@@ -986,6 +1007,7 @@ def test_annotation_queue_items_query_filter_by_call_id(client):
     assert query_res.items[0].call_id == target_call_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_filter_by_call_op_name(client):
     """Test filtering queue items by call_op_name."""
     # Create two different sets of calls with different op names
@@ -1020,6 +1042,7 @@ def test_annotation_queue_items_query_filter_by_call_op_name(client):
         assert item.call_op_name == target_op_name
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_filter_by_call_trace_id(client):
     """Test filtering queue items by call_trace_id."""
     # Create queue with 5 calls
@@ -1051,6 +1074,7 @@ def test_annotation_queue_items_query_filter_by_call_trace_id(client):
         assert item.call_trace_id == target_trace_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_filter_by_added_by(client):
     """Test filtering queue items by added_by."""
     # Create queue with 5 calls added by test_user
@@ -1083,6 +1107,7 @@ def test_annotation_queue_items_query_filter_by_added_by(client):
     assert len(query_res.items) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_filter_by_annotation_states(client):
     """Test filtering queue items by annotation_states.
 
@@ -1120,6 +1145,7 @@ def test_annotation_queue_items_query_filter_by_annotation_states(client):
     assert len(query_res.items) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_filter_combined(client):
     """Test filtering queue items with multiple filters combined."""
     # Create queue with 5 calls
@@ -1170,6 +1196,7 @@ def test_annotation_queue_items_query_filter_combined(client):
     assert len(query_res.items) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_filter_empty_results(client):
     """Test filtering queue items that returns no results."""
     # Create queue with 5 calls
@@ -1200,6 +1227,7 @@ def test_annotation_queue_items_query_filter_empty_results(client):
     assert len(query_res.items) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_filter_with_pagination(client):
     """Test filtering with pagination."""
     # Create queue with 10 calls
@@ -1237,6 +1265,7 @@ def test_annotation_queue_items_query_filter_with_pagination(client):
     assert page1_ids.isdisjoint(page2_ids)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_filter_with_sorting(client):
     """Test filtering with sorting."""
     # Create queue with 5 calls
@@ -1263,6 +1292,7 @@ def test_annotation_queue_items_query_filter_with_sorting(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_with_position_basic(client):
     """Test querying queue items with position tracking enabled."""
     # Create queue with 5 calls
@@ -1291,6 +1321,7 @@ def test_annotation_queue_items_query_with_position_basic(client):
     assert positions == {1, 2, 3, 4, 5}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_without_position(client):
     """Test that position_in_queue is None when include_position=False."""
     # Create queue with 3 calls
@@ -1311,6 +1342,7 @@ def test_annotation_queue_items_query_without_position(client):
         assert item.position_in_queue is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_position_with_sorting(client):
     """Test that position respects custom sort order."""
     # Create queue with 5 calls
@@ -1339,6 +1371,7 @@ def test_annotation_queue_items_query_position_with_sorting(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_items_query_position_with_filter_unstarted(client):
     """Test position calculation with annotation_states filter.
 
@@ -1372,6 +1405,7 @@ def test_annotation_queue_items_query_position_with_filter_unstarted(client):
 # ============================================================================
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_completed(client):
     """Test updating queue item state to 'completed'."""
     # Create queue with 1 call
@@ -1422,6 +1456,7 @@ def test_annotator_queue_items_progress_update_completed(client):
     assert query_res.items[0].annotator_user_id == expected_annotator_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_skipped(client):
     """Test updating queue item state to 'skipped'."""
     # Create queue with 1 call
@@ -1453,6 +1488,7 @@ def test_annotator_queue_items_progress_update_skipped(client):
     assert update_res.item.annotation_state == "skipped"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_invalid_state(client):
     """Test that updating to invalid state raises error."""
     # Create queue with 1 call
@@ -1482,6 +1518,7 @@ def test_annotator_queue_items_progress_update_invalid_state(client):
         client.server.annotator_queue_items_progress_update(update_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_nonexistent_item(client):
     """Test that updating nonexistent item raises error."""
     # Create an empty queue
@@ -1501,6 +1538,7 @@ def test_annotator_queue_items_progress_update_nonexistent_item(client):
         client.server.annotator_queue_items_progress_update(update_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_no_user_id(client):
     """Test that updating without user_id raises error."""
     # Create queue with 1 call
@@ -1530,6 +1568,7 @@ def test_annotator_queue_items_progress_update_no_user_id(client):
         client.server.annotator_queue_items_progress_update(update_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_transition_from_in_progress(client):
     """Test valid state transition from in_progress to completed."""
     # Create queue with 1 call
@@ -1579,6 +1618,7 @@ def test_annotator_queue_items_progress_update_transition_from_in_progress(clien
     assert update_res.item.annotation_state == "completed"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_invalid_transition_from_completed(
     client,
 ):
@@ -1620,6 +1660,7 @@ def test_annotator_queue_items_progress_update_invalid_transition_from_completed
         client.server.annotator_queue_items_progress_update(update_req2)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize("state", ["completed", "skipped"])
 def test_annotator_queue_items_progress_update_idempotent(client, state):
     """Test that setting the same state twice is idempotent (no error, no-op).
@@ -1667,6 +1708,7 @@ def test_annotator_queue_items_progress_update_idempotent(client, state):
     assert update_res2.item.annotation_state == state
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_stats_integration(client):
     """Test that progress updates correctly affect queue stats."""
     # Create queue with 5 calls
@@ -1724,6 +1766,7 @@ def test_annotator_queue_items_progress_update_stats_integration(client):
     assert stats_res.stats[0].completed_items == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_in_progress_new(client):
     """Test updating queue item state to 'in_progress' for a new record."""
     # Create queue with 1 call
@@ -1768,6 +1811,7 @@ def test_annotator_queue_items_progress_update_in_progress_new(client):
     assert query_res.items[0].annotation_state == "in_progress"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_in_progress_existing(client):
     """Test that in_progress -> in_progress is idempotent (no-op, succeeds)."""
     # Create queue with 1 call
@@ -1809,6 +1853,7 @@ def test_annotator_queue_items_progress_update_in_progress_existing(client):
     assert update_res2.item.annotation_state == "in_progress"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_in_progress_from_completed(client):
     """Test that completed -> in_progress fails (can't restart a finished item)."""
     # Create queue with 1 call
@@ -1851,6 +1896,7 @@ def test_annotator_queue_items_progress_update_in_progress_from_completed(client
         client.server.annotator_queue_items_progress_update(update_req2)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_in_progress_to_completed(client):
     """Test transitioning from 'in_progress' to 'completed'."""
     # Create queue with 1 call
@@ -1901,6 +1947,7 @@ def test_annotator_queue_items_progress_in_progress_to_completed(client):
     assert query_res.items[0].annotation_state == "completed"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_in_progress_workflow(client):
     """Test the full workflow: mark in_progress, then complete."""
     # Create queue with 3 calls
@@ -2005,6 +2052,7 @@ def test_annotator_queue_items_progress_in_progress_workflow(client):
     assert stats_res.stats[0].completed_items == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotator_queue_items_progress_update_returns_correct_item(client):
     """Test that progress update returns the specific item that was updated."""
     # Create queue with 3 items - we need multiple items to expose the bug
@@ -2178,6 +2226,7 @@ def test_annotation_queue_add_calls_with_calls_complete_table(trace_server):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_read_nonexistent(client):
     """Test that reading a non-existent annotation queue raises NotFoundError.
 
@@ -2203,6 +2252,7 @@ def test_annotation_queue_read_nonexistent(client):
 # ============================================================================
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_delete_basic(client):
     """Test complete deletion lifecycle: delete, verify response, verify cannot read/delete again."""
     # Create a queue
@@ -2262,6 +2312,7 @@ def test_annotation_queue_delete_basic(client):
         client.server.annotation_queue_delete(delete_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_delete_not_in_query(client):
     """Test that deleted queues don't appear in query results."""
     # Create two queues
@@ -2295,6 +2346,7 @@ def test_annotation_queue_delete_not_in_query(client):
     assert queue2_id in queue_ids
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_queue_delete_nonexistent(client):
     """Test that deleting a non-existent queue raises NotFoundError."""
     nonexistent_queue_id = "00000000-0000-0000-0000-000000000000"

--- a/tests/trace/test_client_annotation_queues.py
+++ b/tests/trace/test_client_annotation_queues.py
@@ -13,6 +13,7 @@ import pytest
 
 import weave
 from tests.trace.server_utils import TEST_ENTITY, find_server_layer
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.common_interface import AnnotationQueueItemsFilter, SortBy
@@ -614,6 +615,10 @@ def test_annotation_queue_add_calls_partial_duplicates(client):
     assert add_res2.duplicates == 3  # 3 were duplicates
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND,
+    reason="ClickHouse-only: direct annotator-progress table inserts",
+)
 def test_annotation_queues_stats(client):
     """Test getting stats for multiple annotation queues with partial completion."""
 
@@ -684,10 +689,7 @@ def test_annotation_queues_stats(client):
     # For Queue 2 (7 items): Mark 4 as skipped, 3 stay pending (no progress record)
 
     # We need to insert into the annotator_queue_items_progress table
-    try:
-        ch_server = find_server_layer(client.server, ClickHouseTraceServer)
-    except TypeError:
-        pytest.skip("Direct DB manipulation only works with ClickHouse server")
+    ch_server = find_server_layer(client.server, ClickHouseTraceServer)
     ch_client = ch_server.ch_client
 
     # Ensure writes are flushed
@@ -2041,6 +2043,9 @@ def test_annotator_queue_items_progress_update_returns_correct_item(client):
     assert update_res.item.annotation_state == "completed"
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: calls_complete table residence"
+)
 def test_annotation_queue_add_calls_with_calls_complete_table(trace_server):
     """Test adding calls to annotation queue when using calls_complete table.
 

--- a/tests/trace/test_client_cost.py
+++ b/tests/trace/test_client_cost.py
@@ -3,11 +3,13 @@ import uuid
 
 import pytest
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import InvalidRequest
 from weave.trace_server.interface.query import Query
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_cost_apis(client):
     project_id = client.project_id
 
@@ -137,6 +139,7 @@ def test_cost_apis(client):
     assert len(res) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_purge_only_ids(client):
     project_id = client.project_id
     costs = {
@@ -191,6 +194,7 @@ def test_purge_only_ids(client):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_costs_streamed_with_all_fields(client):
     """Costs returned by calls_query_stream include extra metadata fields
     (provider_id, effective_date, pricing_level, etc.) and must not fail

--- a/tests/trace/test_client_feedback.py
+++ b/tests/trace/test_client_feedback.py
@@ -1,10 +1,12 @@
 import pytest
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import InvalidRequest
 from weave.trace_server.interface.query import Query
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_apis(client):
     project_id = client.project_id
 
@@ -199,6 +201,7 @@ def test_feedback_apis(client):
         client.server.feedback_purge(req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_payload(client):
     project_id = client.project_id
 
@@ -225,6 +228,7 @@ def test_feedback_payload(client):
     assert payload["emoji"] == "🎱"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_create_too_large(client):
     project_id = client.project_id
 
@@ -240,6 +244,7 @@ def test_feedback_create_too_large(client):
         client.server.feedback_create(req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_query_created_at_filter(client):
     """created_at filters accept ISO-8601 strings (regression for WB-34897).
 

--- a/tests/trace/test_client_filter_calls_by_refs.py
+++ b/tests/trace/test_client_filter_calls_by_refs.py
@@ -1,10 +1,12 @@
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave import Evaluation
 from weave.trace_server.common_interface import SortBy
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_filter_calls_by_ref_properties(client, no_autoflush):
     """Test filtering calls by values within objects stored as refs in inputs/outputs."""
     nested1 = {"nested key with spaces": {"one": "1"}}
@@ -342,6 +344,7 @@ def test_filter_calls_by_ref_properties(client, no_autoflush):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_filter_calls_by_ref_properties_with_table_rows_simple(
     client, no_autoflush
@@ -493,6 +496,7 @@ async def test_filter_calls_by_ref_properties_with_table_rows_simple(
     # assert calls[4].inputs["example"]["object"]["a"] == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_mixed_objects_and_refs(client):
     """Test filtering calls by values within objects stored as refs in inputs/outputs."""
 

--- a/tests/trace/test_client_server_caching.py
+++ b/tests/trace/test_client_server_caching.py
@@ -13,6 +13,7 @@ import pytest
 import weave
 from tests.conftest import CachingMiddlewareTraceServer
 from tests.trace.server_utils import find_server_layer
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace import weave_client
 from weave.trace_server.service_interface import EnsureProjectExistsRes
 from weave.trace_server.trace_server_interface import (
@@ -89,6 +90,7 @@ def test_weave_client_init_with_caching_middleware():
     mock_server.ensure_project_exists.assert_called_once_with("entity", "project")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_caching(client):
     os.environ["WEAVE_USE_SERVER_CACHE"] = "true"
     caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
@@ -242,6 +244,7 @@ def test_server_cache_latency():
         assert added_latency < 0.003
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_file_create_caching(client):
     caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
     file_bytes = b"hello"
@@ -300,6 +303,7 @@ def test_file_create_caching(client):
     assert read_0.content == read_1.content == file_bytes
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_obj_create_caching(client):
     caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
     val = {"hello": "world"}
@@ -558,6 +562,7 @@ def test_cache_directory_creation(tmp_path):
     cache_server.close()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_cache_invalidation_on_add_tags(client):
     """obj_read cache should be invalidated when tags are added."""
     caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
@@ -605,6 +610,7 @@ def test_cache_invalidation_on_add_tags(client):
     assert res2.obj.tags == ["new-tag"]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_cache_invalidation_on_remove_tags(client):
     """obj_read cache should be invalidated when tags are removed."""
     caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
@@ -641,6 +647,7 @@ def test_cache_invalidation_on_remove_tags(client):
     assert res2.obj.tags == []
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_cache_invalidation_on_set_alias(client):
     """obj_read cache should be invalidated when an alias is set."""
     caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
@@ -676,6 +683,7 @@ def test_cache_invalidation_on_set_alias(client):
     assert "prod" in res2.obj.aliases
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_cache_invalidation_on_remove_aliases(client):
     """obj_read cache should be invalidated when aliases are removed."""
     caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)

--- a/tests/trace/test_client_side_digests.py
+++ b/tests/trace/test_client_side_digests.py
@@ -12,6 +12,7 @@ from PIL import Image
 
 import weave
 from tests.trace.server_utils import find_server_layer
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.shared.digest import (
     compute_file_digest,
     compute_object_digest,
@@ -67,6 +68,7 @@ def fast_path(client: WeaveClient):
 class TestClientServerDigestConsistency:
     """Client-side and server-side digests must agree for the same data."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_object(self, client: WeaveClient):
         obj = {"model": "gpt-4", "temperature": 0.7, "tags": ["a", "b"]}
 
@@ -75,6 +77,7 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_dataset(self, client: WeaveClient):
         rows = [{"x": i, "y": str(i)} for i in range(10)]
 
@@ -90,6 +93,7 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_nested_object(self, client: WeaveClient):
         obj = {
             "config": {"a": 1, "b": [2, 3]},
@@ -103,6 +107,7 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_op(self, client: WeaveClient):
         @weave.op
         def my_test_op(x: int) -> int:
@@ -117,6 +122,7 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_empty_dict(self, client: WeaveClient):
         obj: dict = {}
 
@@ -125,6 +131,7 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_unicode_content(self, client: WeaveClient):
         obj = {
             "emoji": "\U0001f680\U0001f30d",
@@ -141,6 +148,7 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_large_dataset(self, client: WeaveClient):
         rows = [
             {"idx": i, "val": f"row_{i}", "data": list(range(i % 10))}
@@ -159,6 +167,7 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_object_with_ref(self, client: WeaveClient):
         """Object containing a ref to another object."""
         inner = {"inner_key": "inner_value"}
@@ -176,6 +185,7 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_custom_weave_type(self, client: WeaveClient):
         """CustomWeaveType (PIL Image) produces the same digest on both paths."""
         img_client = Image.new("RGB", (16, 16), color=(0, 128, 255))
@@ -190,6 +200,7 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_table_row_digests(self, client: WeaveClient):
         """Client-computed row and table digests match the server's."""
         rows = [{"x": i, "y": str(i)} for i in range(5)]
@@ -212,6 +223,7 @@ class TestClientServerDigestConsistency:
 class TestDataCorrectness:
     """Publish (client-side and server-side), read back, verify data is intact."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_object(self, client: WeaveClient, fast_path: None):
         obj = {"key": "value", "number": 42, "list": [1, 2, 3]}
         ref = weave.publish(obj, name="round_trip_obj")
@@ -222,6 +234,7 @@ class TestDataCorrectness:
         assert got["number"] == 42
         assert got["list"] == [1, 2, 3]
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_dataset(self, client: WeaveClient, fast_path: None):
         rows = [{"a": i, "b": i * 2} for i in range(5)]
         ds = weave.Dataset(name="round_trip_ds", rows=rows)
@@ -235,6 +248,7 @@ class TestDataCorrectness:
             assert row["a"] == i
             assert row["b"] == i * 2
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_nested_object(self, client: WeaveClient, fast_path: None):
         obj = {
             "config": {"a": 1, "b": [2, 3]},
@@ -247,6 +261,7 @@ class TestDataCorrectness:
         assert got["config"]["a"] == 1
         assert got["metadata"]["nested"]["deep"] is True
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_op(self, client: WeaveClient, fast_path: None):
         @weave.op
         def my_rt_op(x: int) -> int:
@@ -258,11 +273,13 @@ class TestDataCorrectness:
         got = ref.get()
         assert got(3) == 4
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_empty_dict(self, client: WeaveClient, fast_path: None):
         ref = weave.publish({}, name="empty_rt")
         client._flush()
         assert ref.get() == {}
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_unicode_content(self, client: WeaveClient, fast_path: None):
         obj = {"emoji": "\U0001f680", "cjk": "\u4f60\u597d"}
         ref = weave.publish(obj, name="unicode_rt")
@@ -272,6 +289,7 @@ class TestDataCorrectness:
         assert got["emoji"] == "\U0001f680"
         assert got["cjk"] == "\u4f60\u597d"
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_custom_weave_type(self, client: WeaveClient, fast_path: None):
         img = Image.new("RGB", (32, 32), color=(255, 0, 0))
         ref = weave.publish(img, name="fast_path_image")
@@ -282,6 +300,7 @@ class TestDataCorrectness:
         assert got.size == (32, 32)
         assert got.getpixel((0, 0)) == (255, 0, 0)
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_get_without_explicit_flush(self, weave_active, fast_path: None):
         """ref.get() must work without an explicit _flush() call.
 
@@ -300,6 +319,7 @@ class TestDataCorrectness:
 class TestServerDigestValidation:
     """Server must reject wrong expected_digest and accept correct ones."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
     def test_object(self, client: WeaveClient, correct: bool):
         val = {"hello": "world"}
@@ -321,6 +341,7 @@ class TestServerDigestValidation:
             with pytest.raises(DigestMismatchError):
                 client.server.obj_create(req)
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
     def test_table(self, client: WeaveClient, correct: bool):
         rows = [{"a": 1}, {"a": 2}, {"a": 3}]
@@ -345,6 +366,7 @@ class TestServerDigestValidation:
             with pytest.raises(DigestMismatchError):
                 client.server.table_create(req)
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
     def test_file(self, client: WeaveClient, correct: bool):
         content = b"hello world"
@@ -400,6 +422,7 @@ class TestConvertRefsToInternal:
         with pytest.raises(CrossProjectRefError):
             client._convert_refs_to_internal(json_val)
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_cross_project_ref_skips_expected_digest(
         self, client: WeaveClient, fast_path: None, monkeypatch
     ) -> None:
@@ -443,6 +466,7 @@ class TestDigestMismatchAutoDisable:
     and disables client-side digests for the rest of the session.
     """
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.disable_logging_error_check
     def test_object_mismatch_retries_and_disables(
         self, client: WeaveClient, fast_path: None, monkeypatch
@@ -480,6 +504,7 @@ class TestDigestMismatchAutoDisable:
 
         assert seen_digests == [None]
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.disable_logging_error_check
     def test_table_mismatch_retries_and_disables(
         self, client: WeaveClient, fast_path: None, monkeypatch
@@ -509,6 +534,7 @@ class TestDigestMismatchAutoDisable:
         got_rows = list(got.rows)
         assert len(got_rows) == 2
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.disable_logging_error_check
     def test_file_mismatch_retries_and_disables(
         self, client: WeaveClient, fast_path: None, monkeypatch

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -22,6 +22,7 @@ import weave
 import weave.trace.call
 from tests.trace.server_utils import find_server_layer
 from tests.trace.util import (
+    FAKE_NOT_IMPLEMENTED,
     NOT_CLICKHOUSE_BACKEND,
     AnyIntMatcher,
     DatetimeMatcher,
@@ -98,6 +99,7 @@ def get_client_project_id(client: weave_client.WeaveClient) -> str:
 ## End hacky interface compatibility helpers
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=2, reruns_delay=0.2)
 def test_simple_op(client):
     @weave.op
@@ -157,6 +159,7 @@ def test_simple_op(client):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_server_call_start_and_end(client):
     call_id = generate_id()
     trace_id = generate_id()
@@ -270,6 +273,7 @@ def test_trace_server_call_start_and_end(client):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_read_not_found(client):
     call_id = generate_id()
     res = client.server.call_read(
@@ -281,6 +285,7 @@ def test_call_read_not_found(client):
     assert res.call is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_graph_call_ordering(client):
     @weave.op
     def my_op(a: int) -> int:
@@ -416,6 +421,7 @@ def ref_str(op):
     return weave_client.get_ref(op).uri
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_query_filter_op_version_refs(client, no_autoflush):
     call_spec = simple_line_call_bootstrap()
     client.flush()
@@ -498,6 +504,7 @@ def get_all_calls_asserting_finished(
     return res
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_query_filter_input_object_version_refs(client):
     call_spec = simple_line_call_bootstrap()
 
@@ -556,6 +563,7 @@ def test_trace_call_query_filter_input_object_version_refs(client):
         assert len(inner_res.calls) == exp_count
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_wb_run_step_query(client):
     from weave.trace import weave_client
     from weave.trace.wandb_run_context import WandbRunContext
@@ -656,6 +664,7 @@ def test_trace_call_wb_run_step_query(client):
     assert found_steps == exp_steps
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_wb_run_context_override(client):
     """Test that client.set_wandb_run_context() overrides wandb run info."""
     # Set the context with a specific run_id and step
@@ -734,6 +743,7 @@ def test_trace_call_wb_run_context_override(client):
     assert latest_call.wb_run_step is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_query_filter_output_object_version_refs(client):
     call_spec = simple_line_call_bootstrap()
 
@@ -792,6 +802,7 @@ def test_trace_call_query_filter_output_object_version_refs(client):
         assert len(inner_res.calls) == exp_count
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_query_filter_parent_ids(client):
     call_spec = simple_line_call_bootstrap()
 
@@ -828,6 +839,7 @@ def test_trace_call_query_filter_parent_ids(client):
         assert len(inner_res.calls) == exp_count
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_query_filter_trace_ids(client):
     call_spec = simple_line_call_bootstrap()
 
@@ -855,6 +867,7 @@ def test_trace_call_query_filter_trace_ids(client):
         assert len(inner_res.calls) == exp_count
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_query_filter_call_ids(client):
     call_spec = simple_line_call_bootstrap()
 
@@ -882,6 +895,7 @@ def test_trace_call_query_filter_call_ids(client):
         assert len(inner_res.calls) == exp_count
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_query_filter_trace_roots_only(client, no_autoflush):
     call_spec = simple_line_call_bootstrap()
     client.flush()
@@ -906,6 +920,7 @@ def test_trace_call_query_filter_trace_roots_only(client, no_autoflush):
 
 # Flaky against ClickHouse in CI: read-after-write visibility lag means a
 # calls_query right after flush can miss just-written rows. Rerun to absorb it.
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=2)
 def test_trace_call_query_filter_wb_run_ids(client, no_autoflush):
     full_wb_run_id_1 = f"{client.entity}/{client.project}/test-run-1"
@@ -974,6 +989,7 @@ def test_trace_call_query_filter_wb_run_ids(client, no_autoflush):
 
 # Flaky against ClickHouse in CI: read-after-write visibility lag means a
 # calls_query right after flush can miss just-written rows. Rerun to absorb it.
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=2)
 def test_trace_call_query_filter_wb_user_ids(client, trace_server, no_autoflush):
     call_spec_1 = simple_line_call_bootstrap()
@@ -1013,6 +1029,7 @@ def test_trace_call_query_filter_wb_user_ids(client, trace_server, no_autoflush)
         assert len(inner_res.calls) == exp_count
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_query_limit(client, no_autoflush):
     call_spec = simple_line_call_bootstrap()
     client.flush()
@@ -1035,6 +1052,7 @@ def test_trace_call_query_limit(client, no_autoflush):
         assert len(inner_res.calls) == exp_count
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_query_offset(client, no_autoflush):
     call_spec = simple_line_call_bootstrap()
     client.flush()
@@ -1057,6 +1075,7 @@ def test_trace_call_query_offset(client, no_autoflush):
         assert len(inner_res.calls) == exp_count
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_query_timings(client, no_autoflush):
     now = datetime.datetime(2025, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
     later = now + datetime.timedelta(seconds=1)
@@ -1135,6 +1154,7 @@ def test_trace_call_query_timings(client, no_autoflush):
         assert tids == ids
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_sort(client):
     @weave.op
     def basic_op(in_val: dict, delay) -> dict:
@@ -1166,6 +1186,7 @@ def test_trace_call_sort(client):
         assert inner_res.calls[2].inputs["in_val"]["prim"] == last
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_sort_with_mixed_types(client):
 
     @weave.op
@@ -1207,6 +1228,7 @@ def test_trace_call_sort_with_mixed_types(client):
             assert call.inputs["in_val"].get("prim") == seq[i]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_call_filter(client):
     @weave.op
     def basic_op(in_val: dict, delay) -> dict:
@@ -1601,6 +1623,7 @@ def test_trace_call_filter(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_ops_with_default_params(client):
     @weave.op
     def op_with_default(a: int, b: int = 10) -> int:
@@ -1628,6 +1651,7 @@ def test_ops_with_default_params(client):
     assert inner_res.calls[5].inputs == {"a": 1, "b": 5}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_root_type(client):
     class BaseTypeA(weave.Object):
         a: int
@@ -1675,6 +1699,7 @@ def test_root_type(client):
     assert len(inner_res.objs) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_attributes_on_ops(client):
     @weave.op
     def op_with_attrs(a: int, b: int) -> int:
@@ -1731,6 +1756,7 @@ def test_dataset_row_type(weave_active):
         d = weave.Dataset(rows=[{"a": 1}, {}])
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataclass_support(client):
     @dataclasses.dataclass
     class MyDataclass:
@@ -1780,6 +1806,7 @@ def test_dataclass_support(client):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_retrieval(weave_active):
     @weave.op
     def my_op(a: int) -> int:
@@ -1791,6 +1818,7 @@ def test_op_retrieval(weave_active):
     assert my_op2(1) == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_bound_op_retrieval(weave_active):
     class CustomType(weave.Object):
@@ -1835,6 +1863,7 @@ def test_bound_op_retrieval_no_self(weave_active):
         my_op2 = my_op_ref.get()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_row_ref(weave_active):
     d = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
     ref = weave.publish(d)
@@ -1848,6 +1877,7 @@ def test_dataset_row_ref(weave_active):
     assert gotten == 5
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_empty_sort_field_validation(client):
     """Test that empty or invalid sort fields in table queries are properly validated."""
     # Create a dataset with table data
@@ -1894,6 +1924,7 @@ def test_table_query_empty_sort_field_validation(client):
         assert "jsonpath" not in str(exc_info.value).lower()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_tuple_support(client):
     @weave.op
     def tuple_maker(a, b):
@@ -1923,6 +1954,7 @@ class Point(NamedTuple):
     y: Any
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_namedtuple_support(client):
     @weave.op
     def tuple_maker(a, b):
@@ -1947,6 +1979,7 @@ def test_namedtuple_support(client):
     assert res.calls[0].output == [{"x": 1, "y": 2}, 3]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_named_reuse(client):
     d = weave.Dataset(rows=[{"x": 1}, {"x": 2}])
@@ -1987,6 +2020,7 @@ async def test_named_reuse(client):
     assert len(res.objs) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_unknown_input_and_output_types(client):
     class MyUnknownClassA:
         a_val: float
@@ -2023,6 +2057,7 @@ def test_unknown_input_and_output_types(client):
     assert inner_res.calls[0].output == repr(res)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_unknown_attribute(weave_active):
     class MyUnknownClass:
         val: int
@@ -2074,6 +2109,7 @@ def _patched_default_initializer(trace_client: weave_client.WeaveClient):
         weave_init.init_weave_get_server = orig
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_single_primitive_output(client):
     @weave.op
     def single_int_output(a: int) -> int:
@@ -2165,6 +2201,7 @@ def map_with_copying_thread_executor(fn, vals):
 
 
 # TODO: Make an async version of this
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(retries=5)  # <-- Flakes in CI
 @pytest.mark.parametrize(
     "mapper",
@@ -2306,6 +2343,7 @@ def call_structure(calls):
     return found_structure
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stack_order_implicit_depth_first(client):
     # Note: There is a debate going on about if the client should
     # be responsible for enforcing the call stack order (vs having)
@@ -2350,6 +2388,7 @@ def test_call_stack_order_implicit_depth_first(client):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stack_order_explicit_depth_first(client):
     # Note: There is a debate going on about if the client should
     # be responsible for enforcing the call stack order (vs having)
@@ -2396,6 +2435,7 @@ def test_call_stack_order_explicit_depth_first(client):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stack_order_langchain_batch(client):
     # Note: There is a debate going on about if the client should
     # be responsible for enforcing the call stack order (vs having)
@@ -2448,6 +2488,7 @@ def test_call_stack_order_langchain_batch(client):
 POP_REORDERS_STACK = False
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stack_order_out_of_order_pop(client):
     # Note: There is a debate going on about if the client should
     # be responsible for enforcing the call stack order (vs having)
@@ -2520,6 +2561,7 @@ def test_call_stack_order_out_of_order_pop(client):
     assert call_structure(inner_res.calls) == exp
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stack_order_height_ordering(client):
     # Note: There is a debate going on about if the client should
     # be responsible for enforcing the call stack order (vs having)
@@ -2565,6 +2607,7 @@ def test_call_stack_order_height_ordering(client):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stack_order_mixed(client):
     # Note: There is a debate going on about if the client should
     # be responsible for enforcing the call stack order (vs having)
@@ -2608,6 +2651,7 @@ def test_call_stack_order_mixed(client):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_query_stream_equality(client):
     @weave.op
     def calculate(a: int, b: int) -> int:
@@ -2636,6 +2680,7 @@ def test_call_query_stream_equality(client):
     assert i == len(calls.calls)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_query_stream_columns(client):
     @weave.op
     def calculate(a: int, b: int) -> dict[str, Any]:
@@ -2696,6 +2741,7 @@ def test_call_query_stream_columns(client):
     assert calls2[0].output is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_query_stream_columns_with_costs(client):
     @weave.op
     def calculate(a: int, b: int) -> dict[str, Any]:
@@ -2789,6 +2835,7 @@ def test_call_query_stream_columns_with_costs(client):
     assert calls[0].summary.get("weave", {}).get("costs") is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_query_stream_trace_name_column_with_costs(client):
     @weave.op
     def my_traced_op(x: int) -> dict[str, Any]:
@@ -2843,6 +2890,7 @@ def test_call_query_stream_trace_name_column_with_costs(client):
     assert calls[0].summary.get("weave", {}).get("costs") is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_read_call_start_with_cost(client):
 
     project_id = client.project_id
@@ -2919,6 +2967,7 @@ def test_read_call_start_with_cost(client):
     client.purge_costs(price_id)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_read_with_unkown_llm(client):
     """Tests that if an op reports usage for an LLM ID that has no cost entry
     in the database, the cost calculation handles it gracefully (by not adding cost info).
@@ -3085,6 +3134,7 @@ def test_sort_and_filter_through_refs(client):
         assert inner_res.count == count
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_in_operation(client):
     @weave.op
     def test_op(label, val):
@@ -3135,6 +3185,7 @@ def test_in_operation(client):
         assert res[i].id == call_ids[i]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_has_client_version(weave_active):
     @weave.op
     def test():
@@ -3145,6 +3196,7 @@ def test_call_has_client_version(weave_active):
     assert "client_version" in c.attributes["weave"]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_user_cannot_modify_call_weave_dict(weave_active):
     @weave.op
     def test():
@@ -3176,6 +3228,7 @@ def test_user_cannot_modify_call_weave_dict(weave_active):
     # but at that point you're on your own :)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_iter_slice(weave_active):
     @weave.op
     def func(x):
@@ -3189,6 +3242,7 @@ def test_calls_iter_slice(weave_active):
     assert len(calls_subset) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_iter_cached(weave_active):
     @weave.op
     def func(x):
@@ -3216,6 +3270,7 @@ def test_calls_iter_cached(weave_active):
         assert elapsed_times[0] > elapsed_times[2] * 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_iter_different_value_same_page_cached(weave_active):
     @weave.op
     def func(x):
@@ -3258,6 +3313,7 @@ class BasicModel(weave.Model):
         return {"answer": "42"}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_model_save(client):
     model = BasicModel()
@@ -3284,6 +3340,7 @@ def test_model_save(client):
     assert expected_predict_op.startswith("weave:///")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_stream_column_expansion(client):
     # make an object, and a nested object
     # make an op that accepts the nested object, and returns it
@@ -3382,6 +3439,7 @@ def test_calls_stream_column_expansion(client):
 # Batch size is dynamically increased from 10 to MAX_CALLS_STREAM_BATCH_SIZE (500)
 # in clickhouse_trace_server_settings.py, this test verifies that the dynamic
 # increase works as expected
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize("batch_size", [1, 5, 6])
 def test_calls_stream_column_expansion_dynamic_batch_size(
     client, batch_size, monkeypatch
@@ -3419,6 +3477,7 @@ class Custom(weave.Object):
     val: dict
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_with_disallowed_keys(client):
     name = "thing % with / disallowed : keys"
     obj = Custom(name=name, val={"1": 1})
@@ -3444,6 +3503,7 @@ def test_object_with_disallowed_keys(client):
 CHAR_LIMIT = 128
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_with_char_limit(client):
     name = "l" * CHAR_LIMIT
     obj = Custom(name=name, val={"1": 1})
@@ -3468,6 +3528,7 @@ def test_object_with_char_limit(client):
     client.server.obj_create(create_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_with_char_over_limit(client):
     name = "l" * (CHAR_LIMIT + 1)
     obj = Custom(name=name, val={"1": 1})
@@ -3493,6 +3554,7 @@ def test_object_with_char_over_limit(client):
 chars = "+_(){}|\"'<>!@$^&*#:,.[]-=;~`"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_objects_and_keys_with_special_characters(client):
     # make sure to include ":", "/" which are URI-related
 
@@ -3544,6 +3606,7 @@ def test_objects_and_keys_with_special_characters(client):
     assert gotten_fn(obj) == "hello world"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_stream_feedback(client):
     batch_size = 10
     num_calls = batch_size + 1
@@ -3604,6 +3667,7 @@ def test_calls_stream_feedback(client):
     } in call2_payloads
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_filter_finds_minority_reaction(client):
     """Regression test-ish: filtering by emoji must check all reactions, not pick one arbitrarily.
 
@@ -3647,6 +3711,7 @@ def test_feedback_filter_finds_minority_reaction(client):
     assert results[0].id == calls[0].id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_inline_dataclass_generates_no_refs_in_function(client):
     @dataclasses.dataclass
     class A:
@@ -3675,6 +3740,7 @@ def test_inline_dataclass_generates_no_refs_in_function(client):
     assert len(output_object_version_refs) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_inline_dataclass_generates_no_refs_in_object(client):
     @dataclasses.dataclass
     class A:
@@ -3694,6 +3760,7 @@ def test_inline_dataclass_generates_no_refs_in_object(client):
     assert len(res.objs) == 1  # Just the weave object, and not the dataclass
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_inline_pydantic_basemodel_generates_no_refs_in_function(client):
     class A(BaseModel):
         b: int
@@ -3721,6 +3788,7 @@ def test_inline_pydantic_basemodel_generates_no_refs_in_function(client):
     assert len(output_object_version_refs) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_inline_pydantic_basemodel_generates_no_refs_in_object(client):
     class A(BaseModel):
         b: int
@@ -3887,6 +3955,7 @@ def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
     assert large_calls[0].inputs == json.loads(ENTITY_TOO_LARGE_PAYLOAD)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_weave_finish_unsets_client(client, monkeypatch):
     @weave.op
     def foo():
@@ -3917,6 +3986,7 @@ def test_weave_finish_unsets_client(client, monkeypatch):
     assert get_weave_client() is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_sampling(client):
     never_traced_calls = 0
     always_traced_calls = 0
@@ -3966,6 +4036,7 @@ def test_op_sampling(client):
     assert num_traces == 38
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_sampling_async(client):
     never_traced_calls = 0
@@ -4015,6 +4086,7 @@ async def test_op_sampling_async(client):
     assert num_traces == 38
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_sampling_inheritance(client):
     parent_calls = 0
     child_calls = 0
@@ -4052,6 +4124,7 @@ def test_op_sampling_inheritance(client):
     assert "call_start" in client.server.attribute_access_log  # Verify tracing occurred
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_sampling_inheritance_async(client):
     parent_calls = 0
@@ -4090,6 +4163,7 @@ async def test_op_sampling_inheritance_async(client):
     assert "call_start" in client.server.attribute_access_log  # Verify tracing occurred
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_sampling_inheritance_generator(client):
     parent_calls = 0
     child_calls = 0
@@ -4115,6 +4189,7 @@ def test_op_sampling_inheritance_generator(client):
     assert len(client.get_calls()) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_sampling_inheritance_async_generator(client):
     parent_calls = 0
@@ -4161,6 +4236,7 @@ def test_op_sampling_invalid_rates(weave_active):
             pass
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_sampling_child_follows_parent(weave_active):
     parent_calls = 0
     child_calls = 0
@@ -4191,6 +4267,7 @@ def test_op_sampling_child_follows_parent(weave_active):
     assert child_traces == num_runs  # Child was traced whenever parent was
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_len(client):
     @weave.op
     def test():
@@ -4203,6 +4280,7 @@ def test_calls_len(client):
     assert len(client.get_calls()) == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_multiple_dupe_select_columns(client):
     @weave.op
     def test():
@@ -4249,6 +4327,7 @@ def test_calls_query_dupe_select_columns_no_duplicate_sql(client, caplog):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_stream_heavy_condition_aggregation_parts(client):
     def _make_query(field: str, value: str) -> tsi.CallsQueryRes:
         query = {
@@ -4303,6 +4382,7 @@ def test_calls_stream_heavy_condition_aggregation_parts(client):
     assert res[0].output["d"] == 5
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stream_query_heavy_query_batch(client):
     # start 10 calls
     call_ids = []
@@ -4424,6 +4504,7 @@ def clickhouse_client(client):
     return ch_server.ch_client
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_with_storage_size_clickhouse(client):
     """Test querying calls with storage size information."""
 
@@ -4457,6 +4538,7 @@ def test_calls_query_with_storage_size_clickhouse(client):
     assert call.storage_size_bytes is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_with_total_storage_size_clickhouse(client):
     """Test querying calls with total storage size."""
 
@@ -4508,6 +4590,7 @@ def test_calls_query_with_total_storage_size_clickhouse(client):
     )  # Child should not have total size
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_with_both_storage_sizes_clickhouse(client):
     """Test querying calls with total storage size."""
 
@@ -4559,6 +4642,7 @@ def test_calls_query_with_both_storage_sizes_clickhouse(client):
     assert child_call.total_storage_size_bytes is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_hydrated(client):
     nested = {"hi": {"there": {"foo": "bar"}}}
     nested_ref = weave.publish(nested)
@@ -4599,6 +4683,7 @@ def test_calls_hydrated(client):
     assert calls[2].inputs["input_ref"]["hi"]["there"]["foo"] == "bar"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_obj_query_with_storage_size_clickhouse(client):
     """Test querying objects with storage size information."""
     # Create a test object with some data to ensure it has size
@@ -4648,6 +4733,7 @@ def test_obj_query_with_storage_size_clickhouse(client):
     assert queried_obj_without_size.size_bytes is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_query_stream_with_costs_and_storage_size(client):
     @weave.op
     def child_op(a: int, b: int) -> dict[str, Any]:
@@ -4700,6 +4786,7 @@ def test_call_query_stream_with_costs_and_storage_size(client):
     assert child_call.storage_size_bytes is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_query_stream_with_invalid_filter_field(client):
 
     with pytest.raises(InvalidFieldError):
@@ -4720,6 +4807,7 @@ def test_call_query_stream_with_invalid_filter_field(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize(
     "obj",
     [
@@ -4734,6 +4822,7 @@ def test_get_object_from_uri(weave_active, obj):
     assert weave.get(uri) == obj
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_get_object_from_uri_non_registered_object(weave_active):
     class MyModel(weave.Model):
@@ -4760,6 +4849,7 @@ def test_get_object_from_uri_non_registered_object(weave_active):
     assert res.predict(5) == 6
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dedupe_ref_in_calls_stream(client):
     nested_obj = {"nested": 123}
     nested_ref = weave.publish(nested_obj)
@@ -4838,6 +4928,7 @@ def test_dedupe_ref_in_calls_stream(client):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_stats_with_limit(client):
     def calls_stats(limit=None, filter=None, include_total_storage_size=False):
         return client.server.calls_query_stats(
@@ -4950,6 +5041,7 @@ def test_calls_query_stats_unfiltered_storage_counts_deleted_bytes(
     assert filtered.total_storage_size_bytes < storage_before
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_stats_started_at_window_excludes_deletes(client):
     """A started_at lower-bound count must exclude soft-deleted calls and
     orphaned call-ends. This exercises the windowed distinct-id fast path,
@@ -5016,6 +5108,7 @@ def test_calls_query_stats_started_at_window_excludes_deletes(client):
     assert unfiltered_count() == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize(
     "thread_ids",
     [
@@ -5073,6 +5166,7 @@ def test_calls_query_stats_thread_ids_filter_not_minimal(client, thread_ids):
     assert res.count == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_thread_ids_filter_returns_matching_thread(client):
     """Create 3 threads, request the second one, assert the returned call has the correct thread_id."""
     client.set_wandb_run_context(run_id="thread-filter-run", step=0)
@@ -5109,6 +5203,7 @@ def test_calls_query_thread_ids_filter_returns_matching_thread(client):
     assert res.calls[0].thread_id == thread_2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_stats_total_storage_size_clickhouse(client):
     """Test querying calls with total storage size."""
 
@@ -5214,6 +5309,7 @@ def test_project_stats_clickhouse(client, clickhouse_client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_with_descendant_error(client):
     class TestException(Exception):
         pass
@@ -5368,6 +5464,7 @@ def test_thread_context_with_weave_api(client):
     assert call_context.get_thread_id() is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_thread_id_in_calls(client):
     """Test that thread_id is properly captured in call records, including auto-generation."""
     import weave
@@ -5430,6 +5527,7 @@ def test_thread_id_in_calls(client):
     assert no_thread_call.thread_id is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_thread_id_inheritance(client):
     """Test that thread_id is inherited by child calls, demonstrated via ThreadContext."""
     import weave
@@ -5478,6 +5576,7 @@ def test_thread_id_inheritance(client):
     assert child_call.thread_id == "inherited_thread"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_thread_id_query_filtering(client):
     """Test that calls can be filtered by thread_id."""
     import weave
@@ -5543,6 +5642,7 @@ def test_thread_id_query_filtering(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_calls_filter_by_thread_ids_only(client):
     """Test that get_calls with only CallsFilter(thread_ids=[...]) returns just that thread's calls.
 
@@ -5573,6 +5673,7 @@ def test_get_calls_filter_by_thread_ids_only(client):
     assert all(call.thread_id == f"thread_a_{unique}" for call in calls_thread_a)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_thread_context_error_handling(weave_active):
     """Test that ThreadContext is properly managed even when exceptions occur."""
     import weave
@@ -5618,6 +5719,7 @@ def test_thread_context_error_handling(weave_active):
     assert call_context.get_thread_id() is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_threads_query_endpoint(client):
     """Test the threads_query endpoint (/threads/query) functionality."""
     import datetime
@@ -5864,6 +5966,7 @@ def test_threads_query_endpoint(client):
         assert thread.start_time <= thread.last_updated
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_threads_query_aggregation_fields(client):
     """Test the new aggregation fields in threads query: first_turn_id, last_turn_id, and duration percentiles."""
     import time
@@ -6020,6 +6123,7 @@ def test_threads_query_aggregation_fields(client):
     assert find_test_thread_in_results(sorted_by_p99) is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_turn_id_functionality(client):
     """Test that turn_id is properly assigned for turn calls and descendants."""
     import weave
@@ -6090,6 +6194,7 @@ def test_turn_id_functionality(client):
         assert child_call.turn_id == parent_turn_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_nested_thread_contexts_turn_lineage(client):
     """Test that nested thread contexts properly cut off turn lineage."""
     import weave
@@ -6178,6 +6283,7 @@ def test_nested_thread_contexts_turn_lineage(client):
         assert child_call.turn_id == parent_turn_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_thread_id_none_turn_id_none(client):
     """Test that when thread_id is None, turn_id is also None."""
     import weave
@@ -6238,6 +6344,7 @@ def test_thread_id_none_turn_id_none(client):
     assert outside_call.turn_id is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_nested_thread_disable_with_none(client):
     """Test that ThreadContext properly shows thread_id=None when threading is disabled."""
     import weave
@@ -6323,6 +6430,7 @@ def test_nested_thread_disable_with_none(client):
     assert turn_a_call.turn_id != turn_c_call.turn_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_thread_api_with_auto_generation(client):
     """Test the thread API with ThreadContext and auto-generation."""
     import weave
@@ -6388,6 +6496,7 @@ def test_thread_api_with_auto_generation(client):
     assert disabled_call.turn_id is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_filter_contains_in_message_array(client):
     @weave.op
     def op1(extra_message: str | None = None):
@@ -6464,6 +6573,7 @@ def test_calls_query_filter_contains_in_message_array(client):
     # assert len(calls) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_sort_by_deselected_heavy_field(client):
     @weave.op
     def op1(x: int) -> int:
@@ -6492,6 +6602,7 @@ def test_calls_query_sort_by_deselected_heavy_field(client):
     assert calls[1].id == call_ids[1]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_sort_by_nested_attributes_field_with_costs(client):
     """Test sorting by nested attributes field with cost query and minimal columns."""
 
@@ -6528,6 +6639,7 @@ def test_calls_query_sort_by_nested_attributes_field_with_costs(client):
     assert calls[1].id == call_ids[0]  # call1 has priority 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_calls_query_sort_by_feedback_field_with_costs(client):
     """Test sorting by feedback field with cost query and minimal columns."""
@@ -6580,6 +6692,7 @@ async def test_calls_query_sort_by_feedback_field_with_costs(client):
     assert calls[1].id == call_ids[1]  # call2 has score 8
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_sort_by_agg_field_with_costs(client):
     """Test sorting by an aggregate field (display_name) with costs enabled.
 
@@ -6630,6 +6743,7 @@ def test_calls_query_sort_by_agg_field_with_costs(client):
     assert calls[1].id == call_a.id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_sort_by_trace_name_with_costs(client):
     """Test sorting by summary.weave.trace_name with costs enabled.
 
@@ -6680,6 +6794,7 @@ def test_calls_query_sort_by_trace_name_with_costs(client):
     assert calls[1].id == call_a.id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_ordering_with_costs_comprehensive(client, no_autoflush):
     @weave.op
     def my_op(x: int) -> int:
@@ -6819,6 +6934,7 @@ def test_calls_query_ordering_with_costs_comprehensive(client, no_autoflush):
     assert len(calls) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sentinel_round_trip_none_values(client):
     """Verify that None values survive the full write→read pipeline without leaking sentinels.
 

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -22,6 +22,7 @@ import weave
 import weave.trace.call
 from tests.trace.server_utils import find_server_layer
 from tests.trace.util import (
+    NOT_CLICKHOUSE_BACKEND,
     AnyIntMatcher,
     DatetimeMatcher,
     FuzzyDateTimeMatcher,
@@ -31,7 +32,7 @@ from tests.trace.util import (
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     DummyIdConverter,
 )
-from tests.trace_server.helpers import force_optimize
+from tests.trace_server.helpers import force_optimize, force_optimize_if_clickhouse
 from weave import Thread, ThreadPoolExecutor
 from weave.shared.refs_internal import extra_value_quoter
 from weave.shared.trace_server_interface_util import (
@@ -3738,8 +3739,11 @@ def test_inline_pydantic_basemodel_generates_no_refs_in_object(client):
     assert len(res.objs) == 1  # Just the weave object, and not the pydantic model
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND,
+    reason="ClickHouse-only: stripping triggers via patched _insert_call_batch",
+)
 def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
-
     original_insert_call_batch = weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer._insert_call_batch
     max_size = 10 * 1024
 
@@ -4199,7 +4203,7 @@ def test_calls_len(client):
     assert len(client.get_calls()) == 2
 
 
-def test_calls_query_multiple_dupe_select_columns(client, capsys, caplog):
+def test_calls_query_multiple_dupe_select_columns(client):
     @weave.op
     def test():
         return {"a": {"b": {"c": {"d": 1}}}}
@@ -4224,7 +4228,21 @@ def test_calls_query_multiple_dupe_select_columns(client, capsys, caplog):
     assert calls[0].output["a"]["b"]["c"] == {"d": 1}
     assert calls[0].output["a"]["b"]["c"]["d"] == 1
 
-    # now make sure we don't make duplicate selects
+
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: asserts the emitted SQL"
+)
+def test_calls_query_dupe_select_columns_no_duplicate_sql(client, caplog):
+    @weave.op
+    def test():
+        return {"a": {"b": {"c": {"d": 1}}}}
+
+    test()
+
+    # Consume the (lazy) calls iterator so the SELECT actually executes.
+    calls = client.get_calls(columns=["output", "output.a", "output.a.b"])
+    assert len(list(calls)) == 1
+
     select_query = get_info_loglines(caplog, "clickhouse_stream_query", ["query"])[0]
     assert (
         select_query["query"].count("any(calls_merged.output_dump) AS output_dump") == 1
@@ -4406,7 +4424,7 @@ def clickhouse_client(client):
     return ch_server.ch_client
 
 
-def test_calls_query_with_storage_size_clickhouse(client, clickhouse_client):
+def test_calls_query_with_storage_size_clickhouse(client):
     """Test querying calls with storage size information."""
 
     @weave.op
@@ -4420,7 +4438,7 @@ def test_calls_query_with_storage_size_clickhouse(client, clickhouse_client):
     # due to some race condition/optimizations in clickhouse, there is a chance
     # that the calls_merged_stats table is not updated in time for the query below
     # to return the correct results.
-    force_optimize(clickhouse_client, "calls_merged_stats")
+    force_optimize_if_clickhouse(client, "calls_merged_stats")
 
     # Query with storage size
     calls = list(
@@ -4439,7 +4457,7 @@ def test_calls_query_with_storage_size_clickhouse(client, clickhouse_client):
     assert call.storage_size_bytes is not None
 
 
-def test_calls_query_with_total_storage_size_clickhouse(client, clickhouse_client):
+def test_calls_query_with_total_storage_size_clickhouse(client):
     """Test querying calls with total storage size."""
 
     @weave.op
@@ -4457,7 +4475,7 @@ def test_calls_query_with_total_storage_size_clickhouse(client, clickhouse_clien
     # due to some race condition/optimizations in clickhouse, there is a chance
     # that the calls_merged_stats table is not updated in time for the query below
     # to return the correct results.
-    force_optimize(clickhouse_client, "calls_merged_stats")
+    force_optimize_if_clickhouse(client, "calls_merged_stats")
 
     # Query with total storage size
     calls = list(
@@ -4490,7 +4508,7 @@ def test_calls_query_with_total_storage_size_clickhouse(client, clickhouse_clien
     )  # Child should not have total size
 
 
-def test_calls_query_with_both_storage_sizes_clickhouse(client, clickhouse_client):
+def test_calls_query_with_both_storage_sizes_clickhouse(client):
     """Test querying calls with total storage size."""
 
     @weave.op
@@ -4508,7 +4526,7 @@ def test_calls_query_with_both_storage_sizes_clickhouse(client, clickhouse_clien
     # due to some race condition/optimizations in clickhouse, there is a chance
     # that the calls_merged_stats table is not updated in time for the query below
     # to return the correct results.
-    force_optimize(clickhouse_client, "calls_merged_stats")
+    force_optimize_if_clickhouse(client, "calls_merged_stats")
 
     # Query with total storage size
     calls = list(
@@ -4630,7 +4648,7 @@ def test_obj_query_with_storage_size_clickhouse(client):
     assert queried_obj_without_size.size_bytes is None
 
 
-def test_call_query_stream_with_costs_and_storage_size(client, clickhouse_client):
+def test_call_query_stream_with_costs_and_storage_size(client):
     @weave.op
     def child_op(a: int, b: int) -> dict[str, Any]:
         return {
@@ -4650,8 +4668,8 @@ def test_call_query_stream_with_costs_and_storage_size(client, clickhouse_client
     # due to some race condition/optimizations in clickhouse, there is a chance
     # that the calls_merged_stats table is not updated in time for the query below
     # to return the correct results.
-    force_optimize(clickhouse_client, "calls_merged")
-    force_optimize(clickhouse_client, "calls_merged_stats")
+    force_optimize_if_clickhouse(client, "calls_merged")
+    force_optimize_if_clickhouse(client, "calls_merged_stats")
 
     # Test that "include_costs" and "include_total_storage_size" can be used together
     calls = list(
@@ -5091,7 +5109,7 @@ def test_calls_query_thread_ids_filter_returns_matching_thread(client):
     assert res.calls[0].thread_id == thread_2
 
 
-def test_calls_query_stats_total_storage_size_clickhouse(client, clickhouse_client):
+def test_calls_query_stats_total_storage_size_clickhouse(client):
     """Test querying calls with total storage size."""
 
     @weave.op
@@ -5109,7 +5127,7 @@ def test_calls_query_stats_total_storage_size_clickhouse(client, clickhouse_clie
     # due to some race condition/optimizations in clickhouse, there is a chance
     # that the calls_merged_stats table is not updated in time for the query below
     # to return the correct results.
-    force_optimize(clickhouse_client, "calls_merged_stats")
+    force_optimize_if_clickhouse(client, "calls_merged_stats")
 
     # Query with total storage size
     result = client.server.calls_query_stats(
@@ -5127,8 +5145,10 @@ def test_calls_query_stats_total_storage_size_clickhouse(client, clickhouse_clie
     assert result.total_storage_size_bytes is not None
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: requires raw stats-table inserts"
+)
 def test_project_stats_clickhouse(client, clickhouse_client):
-
     project_id = get_client_project_id(client)
     internal_project_id = DummyIdConverter().ext_to_int_project_id(project_id)
 

--- a/tests/trace/test_current_call.py
+++ b/tests/trace/test_current_call.py
@@ -1,12 +1,14 @@
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.context import call_context
 from weave.trace.serialization.serialize import to_json
 from weave.trace.weave_client import RESERVED_SUMMARY_STATUS_COUNTS_KEY
 from weave.trace_server import trace_server_interface as tsi
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_attributes_read_only(client):
     @weave.op
     def my_op():
@@ -21,6 +23,7 @@ def test_call_attributes_read_only(client):
     assert "new" not in calls[0].attributes
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_summary_editable(client):
     @weave.op
     def my_op():
@@ -38,6 +41,7 @@ def test_call_summary_editable(client):
     assert summary[RESERVED_SUMMARY_STATUS_COUNTS_KEY][tsi.TraceStatus.SUCCESS] == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_attributes_update_and_delete_forbidden(client):
     @weave.op
     def my_op():
@@ -57,6 +61,7 @@ def test_call_attributes_update_and_delete_forbidden(client):
     assert "extra" not in calls[0].attributes
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_summary_deep_merge(client):
     @weave.op
     def my_op():
@@ -72,6 +77,7 @@ def test_call_summary_deep_merge(client):
     assert summary[RESERVED_SUMMARY_STATUS_COUNTS_KEY][tsi.TraceStatus.SUCCESS] == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_set_view_inside_op(client):
     """Verify weave.set_view stores serialized content on op call summary."""
     markdown_view = weave.Content.from_text("# Report", mimetype="text/markdown")
@@ -114,6 +120,7 @@ def test_set_view_inside_op(client):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_set_view_string_content(client):
     """Verify weave.set_view accepts raw string content."""
 

--- a/tests/trace/test_custom_objs.py
+++ b/tests/trace/test_custom_objs.py
@@ -8,6 +8,7 @@ from PIL import Image
 
 import weave
 from tests.trace.test_utils import FailingSaveType
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.serialization.custom_objs import (
     KNOWN_TYPES,
     UnsafeDeserializationError,
@@ -27,6 +28,7 @@ def test_encode_custom_obj_unknown_type():
     assert encode_custom_obj(unknown) is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_decode_custom_obj_known_type(client):
     img = Image.new("RGB", (100, 100))
     encoded = encode_custom_obj(img)
@@ -38,6 +40,7 @@ def test_decode_custom_obj_known_type(client):
     assert decoded.tobytes() == img.tobytes()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_inline_custom_obj(client):
     dt = datetime(2025, 3, 7, 0, 0, 0)
     encoded = encode_custom_obj(dt)
@@ -53,6 +56,7 @@ def test_inline_custom_obj(client):
     assert decoded == dt_with_tz
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_inline_custom_obj_needs_load_op(client):
     """Test the condition that the current version of the SDK doesn't know how to load the object.
 
@@ -79,6 +83,7 @@ def test_inline_custom_obj_needs_load_op(client):
         KNOWN_TYPES.add("rich.markdown.Markdown")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_no_extra_calls_created(client):
     @weave.op
     def make_datetime():
@@ -98,6 +103,7 @@ def test_no_extra_calls_created(client):
     assert len(calls) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_safe_type_decodes_when_unsafe_decode_disabled(client):
     # Data-only types must still decode on a worker client that forbids unsafe decode:
     # they reconstruct via the in-process serializer and run no user code. Breaking
@@ -139,6 +145,7 @@ def test_unsafe_decode_disabled_refuses_code_bearing(client, encoded):
         decode_custom_obj(encoded)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_setting_disables_unsafe_decode_globally(client):
     # `WEAVE_ALLOW_UNSAFE_CUSTOM_OBJ_DECODE=false` (here via override_settings) closes
     # the gate even on a normal client whose own flag still allows unsafe decode, so a
@@ -161,6 +168,7 @@ def test_setting_disables_unsafe_decode_globally(client):
         assert decoded.tobytes() == img.tobytes()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_encode_custom_obj_save_exception_returns_none(client, failing_serializer):
     """Requirement: Type handler save exceptions should not crash user code
     Interface: encode_custom_obj function
@@ -177,6 +185,7 @@ def test_encode_custom_obj_save_exception_returns_none(client, failing_serialize
     assert result is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_encode_custom_obj_save_exception_does_not_propagate(
     client, failing_serializer
 ):

--- a/tests/trace/test_dataset.py
+++ b/tests/trace/test_dataset.py
@@ -2,9 +2,11 @@ import pytest
 
 import weave
 from tests.trace.test_evaluate import Dataset
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.context.tests_context import raise_on_captured_errors
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_basic_dataset_lifecycle(weave_active):
     for _i in range(2):
         dataset = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
@@ -71,6 +73,7 @@ def test_dataset_laziness(client):
         assert _top_level_logs(log) == []
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_published_dataset_laziness(client):
     """The intention of this test is to show that publishing a dataset,
     then iterating through the "gotten" version of the dataset has
@@ -120,6 +123,7 @@ def test_published_dataset_laziness(client):
         assert _top_level_logs(log) == ["table_query"] * ((i // 100) + 1)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_from_calls(client):
     @weave.op
     def greet(name: str, age: int) -> str:
@@ -141,6 +145,7 @@ def test_dataset_from_calls(client):
     assert rows[1]["output"] == "Hello Bob, you are 25!"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_caching(weave_active):
     ds = weave.Dataset(rows=[{"a": i} for i in range(200)])
     ref = weave.publish(ds)
@@ -210,6 +215,7 @@ def test_dataset_select(weave_active):
         ds.select([-1])
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_add_rows(weave_active):
     ds = weave.Dataset(name="test", rows=[{"a": i} for i in range(10)])
     ref = weave.publish(ds)

--- a/tests/trace/test_deepcopy.py
+++ b/tests/trace/test_deepcopy.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.box import (
     BoxedDatetime,
     BoxedFloat,
@@ -44,6 +45,7 @@ def test_deepcopy_weavelist(client):
     assert id(res) != id(lst)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_deepcopy_weavelist_e2e(weave_active):
     lst = [1, 2, 3]
     ref = weave.publish(lst)
@@ -60,6 +62,7 @@ def test_deepcopy_weavedict(client):
     assert id(res) != id(d)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_deepcopy_weavedict_e2e(weave_active):
     d = {"a": 1, "b": 2}
     ref = weave.publish(d)
@@ -83,6 +86,7 @@ def test_deepcopy_weaveobject(client, example_class):
     assert id(res) != id(o)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_deepcopy_weaveobject_e2e(weave_active, example_class):
     cls, expected_record = example_class
 
@@ -110,6 +114,7 @@ def test_deepcopy_boxed(boxed_val):
     assert id(res) != id(boxed_val)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_deepcopy_boxed_model_e2e(weave_active):
     class Model(weave.Model):
         system_prompt: str = "You are a helpful assistant."  # this will get boxed

--- a/tests/trace/test_dictifiable.py
+++ b/tests/trace/test_dictifiable.py
@@ -1,7 +1,10 @@
+import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dictifiable(weave_active):
     class NonDictifiable:  # noqa: B903
         attr: int

--- a/tests/trace/test_dictifiable.py
+++ b/tests/trace/test_dictifiable.py
@@ -1,3 +1,4 @@
+
 import weave
 
 

--- a/tests/trace/test_dirty_model_op_retrieval.py
+++ b/tests/trace/test_dirty_model_op_retrieval.py
@@ -1,7 +1,10 @@
+import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dirty_model_op_retrieval(client):
     class MyModel(weave.Model):
         client: str

--- a/tests/trace/test_dirty_model_op_retrieval.py
+++ b/tests/trace/test_dirty_model_op_retrieval.py
@@ -1,3 +1,4 @@
+
 import weave
 
 

--- a/tests/trace/test_eval_otel_linking.py
+++ b/tests/trace/test_eval_otel_linking.py
@@ -7,6 +7,7 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave import Evaluation
 from weave.evaluation.otel_eval_linker import EvalLinkSpanProcessor
 from weave.trace_server import constants
@@ -43,6 +44,7 @@ def _emit_genai_span(model: str = "gpt-4o") -> None:
     span.end()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_genai_span_ref_attached_to_eval_call(client, otel_setup):
     """A GenAI OTel span emitted during a prediction should produce a
@@ -90,6 +92,7 @@ async def test_genai_span_ref_attached_to_eval_call(client, otel_setup):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_multiple_genai_span_refs_attached_to_eval_call(client, otel_setup):
     """All GenAI OTel spans emitted during a prediction should be linked."""
@@ -132,6 +135,7 @@ async def test_multiple_genai_span_refs_attached_to_eval_call(client, otel_setup
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_eval_metadata_injected_onto_spans(client, otel_setup):
     """Eval context attributes should be injected onto all spans created
@@ -158,6 +162,7 @@ async def test_eval_metadata_injected_onto_spans(client, otel_setup):
     assert constants.EVAL_PROJECT_ID_SPAN_ATTR in span_attrs
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_non_genai_span_gets_eval_metadata_but_no_span_ref(client, otel_setup):
     """Non-GenAI spans during eval get eval metadata (on_start) but no

--- a/tests/trace/test_evaluate.py
+++ b/tests/trace/test_evaluate.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 import weave
 from tests.conftest import LATENCY_TOL
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave import Dataset, Evaluation, Model
 
 dataset_rows = [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
@@ -37,6 +38,7 @@ def example_to_model_input(example):
     return {"input": example["input"]}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluate_callable_as_model(weave_active):
     @weave.op
@@ -51,6 +53,7 @@ async def test_evaluate_callable_as_model(weave_active):
     assert result == expected_eval_result
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_predict_can_receive_other_params(weave_active):
     @weave.op
@@ -71,6 +74,7 @@ async def test_predict_can_receive_other_params(weave_active):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_can_preprocess_model_input(weave_active):
     @weave.op
@@ -90,6 +94,7 @@ async def test_can_preprocess_model_input(weave_active):
     assert result == expected_eval_result
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluate_rows_only(weave_active):
     evaluation = Evaluation(
@@ -117,6 +122,7 @@ async def test_evaluate_other_model_method_names():
     assert result == expected_eval_result
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_score_as_class(weave_active):
     class MyScorer(weave.Scorer):
@@ -139,6 +145,7 @@ async def test_score_as_class(weave_active):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_score_with_custom_summarize(weave_active):
     class MyScorer(weave.Scorer):
@@ -166,6 +173,7 @@ async def test_score_with_custom_summarize(weave_active):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("scorers", "expected_output_key"),
@@ -303,6 +311,7 @@ async def test_scorer_name_sanitization(scorer_name):
     assert result["my-scorer"] == {"true_count": 1, "true_fraction": 0.5}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_sync_eval_parallelism(weave_active):
     @weave.op
@@ -341,6 +350,7 @@ async def test_sync_eval_parallelism(weave_active):
     assert time.time() - now < (15 if sys.platform == "win32" else 8)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluation_from_weaveobject_missing_evaluation_name(weave_active):
     dataset_rows = [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
@@ -377,6 +387,7 @@ async def test_evaluation_from_weaveobject_missing_evaluation_name(weave_active)
     assert result == expected_eval_result
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluate_table_lazy_iter(client, monkeypatch):
     """The intention of this test is to show that an evaluation harness
@@ -446,6 +457,7 @@ async def test_evaluate_table_lazy_iter(client, monkeypatch):
     assert counts_split_by_table_query == [count, 28, 28, 14 + 5], log
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluate_table_order(weave_active):
     """Test that evaluation results maintain the original order of the dataset
@@ -506,6 +518,7 @@ async def test_evaluate_table_order(weave_active):
     assert len(scores) == 5
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluate_with_pydantic_summary(weave_active):
     class MyScorerSummary(BaseModel):

--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -2,6 +2,7 @@ import pytest
 
 import weave
 from tests.conftest import LATENCY_TOL
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave import Dataset, Evaluation, Model
 from weave.scorers import MultiTaskBinaryClassificationF1
 
@@ -37,6 +38,7 @@ def example_to_model_input(example):
     return {"input": example["input"]}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluate_callable_as_model(weave_active):
     @weave.op
@@ -51,6 +53,7 @@ async def test_evaluate_callable_as_model(weave_active):
     assert result == expected_eval_result
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_predict_can_receive_other_params(weave_active):
     @weave.op
@@ -71,6 +74,7 @@ async def test_predict_can_receive_other_params(weave_active):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_can_preprocess_model_input(weave_active):
     @weave.op
@@ -90,6 +94,7 @@ async def test_can_preprocess_model_input(weave_active):
     assert result == expected_eval_result
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluate_rows_only(weave_active):
     evaluation = Evaluation(
@@ -101,6 +106,7 @@ async def test_evaluate_rows_only(weave_active):
     assert result == expected_eval_result
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluate_both_styles(weave_active):
     evaluation = Evaluation(
@@ -133,6 +139,7 @@ async def test_evaluate_other_model_method_names():
     assert result == expected_eval_result
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_score_as_class(weave_active):
     class MyScorerOldstyle(weave.Scorer):
@@ -155,6 +162,7 @@ async def test_score_as_class(weave_active):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_score_with_custom_summarize(weave_active):
     class MyScorerOldstyle(weave.Scorer):
@@ -182,6 +190,7 @@ async def test_score_with_custom_summarize(weave_active):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_multiclass_f1_score(weave_active):
     evaluation = Evaluation(

--- a/tests/trace/test_evaluation_performance.py
+++ b/tests/trace/test_evaluation_performance.py
@@ -8,7 +8,7 @@ import PIL
 import pytest
 
 import weave
-from tests.trace.util import DummyTestException
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, DummyTestException
 from weave.trace.context.tests_context import raise_on_captured_errors
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
@@ -104,6 +104,7 @@ def build_evaluation():
     return evaluation, predict
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluation_performance(client: WeaveClient):
     client.project = "test_evaluation_performance"

--- a/tests/trace/test_evaluation_ref_get.py
+++ b/tests/trace/test_evaluation_ref_get.py
@@ -1,3 +1,4 @@
+
 import weave
 from weave.scorers import LLMAsAJudgeScorer
 from weave.trace_server.interface.builtin_object_classes.builtin_object_registry import (

--- a/tests/trace/test_evaluation_ref_get.py
+++ b/tests/trace/test_evaluation_ref_get.py
@@ -1,5 +1,7 @@
+import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.scorers import LLMAsAJudgeScorer
 from weave.trace_server.interface.builtin_object_classes.builtin_object_registry import (
     LLMStructuredCompletionModel,
@@ -9,6 +11,7 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_and_load_evaluation(weave_active):
     """This test just verifies the round trip for the evaluation.
 

--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -8,7 +8,7 @@ from PIL import Image
 
 import weave
 from tests.conftest import LATENCY_TOL
-from tests.trace.util import AnyIntMatcher, AnyStrMatcher
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, AnyIntMatcher, AnyStrMatcher
 from weave import Evaluation, Model
 from weave.trace.ref_util import get_ref
 from weave.trace.refs import CallRef
@@ -89,6 +89,7 @@ async def do_quickstart():
     return await evaluation.evaluate(model)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_basic_evaluation(client):
     res = await do_quickstart()
@@ -324,6 +325,7 @@ def with_empty_feedback(obj: Any) -> Any:
     return obj
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluation_data_topology(client):
     """We support a number of different types of scorers, and we want to ensure that
@@ -635,6 +637,7 @@ def make_test_eval():
     return evaluation
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_eval_supports_model_as_op(weave_active):
     @weave.op
@@ -657,6 +660,7 @@ class MyTestModel(Model):
         return ""
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_eval_supports_model_class(weave_active):
     evaluation = make_test_eval()
@@ -670,6 +674,7 @@ async def test_eval_supports_model_class(weave_active):
     assert res is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_eval_supports_non_op_funcs(weave_active):
     def function_model(sentence: str) -> dict:
@@ -701,6 +706,7 @@ async def test_eval_supports_non_op_funcs(weave_active):
     # assert shouldBeModelRef.startswith("weave:///")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_eval_is_robust_to_missing_values(weave_active):
     # At least 1 None
@@ -738,6 +744,7 @@ async def test_eval_is_robust_to_missing_values(weave_active):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_eval_with_complex_types(client):
     client.project = "test_eval_with_complex_types"
@@ -990,6 +997,7 @@ async def test_evaluation_with_multiple_column_maps():
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_feedback_is_correctly_linked(client):
     @weave.op
@@ -1030,6 +1038,7 @@ async def test_feedback_is_correctly_linked(client):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_feedback_is_correctly_linked_with_scorer_subclass(client):
     @weave.op
@@ -1092,6 +1101,7 @@ def test_scorers_with_output_and_model_output_raise_error():
         evaluation = weave.Evaluation(dataset=ds, scorers=[my_second_scorer])
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluation_with_custom_name(client):
     dataset = weave.Dataset(rows=[{"input": "hi", "output": "hello"}])
@@ -1110,6 +1120,7 @@ async def test_evaluation_with_custom_name(client):
     assert call.display_name == "wow-custom!"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_evaluate_calls(client, make_evals):
     ref, ref2 = make_evals
     ev = ref.get()
@@ -1129,6 +1140,7 @@ def test_get_evaluate_calls(client, make_evals):
     assert call2.inputs["model"].name == "ghi"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_score_calls(client, make_evals):
     ref, ref2 = make_evals
     ev = ref.get()
@@ -1150,6 +1162,7 @@ def test_get_score_calls(client, make_evals):
     assert score_calls2[3].output == 7878
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_scores(client, make_evals):
     ref, ref2 = make_evals
     ev = ref.get()

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -4,7 +4,7 @@ import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError
 
 import weave
-from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, NOT_CLICKHOUSE_BACKEND
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     DummyIdConverter,
 )
@@ -28,6 +28,7 @@ from weave.trace_server.trace_server_interface import (
 )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_client_feedback(client) -> None:
     feedbacks = client.get_feedback()
     assert len(feedbacks) == 0
@@ -64,6 +65,7 @@ def test_client_feedback(client) -> None:
     assert len(feedbacks) == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_custom_feedback(client) -> None:
     feedbacks = client.get_feedback()
     assert len(feedbacks) == 0
@@ -91,6 +93,7 @@ def test_custom_feedback(client) -> None:
         trace_object.feedback.add("wandb.trying_to_use_reserved_prefix", value=1)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_annotation_feedback(client: WeaveClient) -> None:
     project_id = client.project_id
     column_name = "column_name"
@@ -214,6 +217,7 @@ def test_annotation_feedback(client: WeaveClient) -> None:
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_runnable_feedback(client: WeaveClient) -> None:
     """Test feedback creation with runnable references."""
     project_id = client.project_id
@@ -416,6 +420,7 @@ def test_runnable_feedback(client: WeaveClient) -> None:
     assert typed_row["scorer_rating_confidences"] == {"_rating_": 0.88}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_agent_monitor_feedback(client: WeaveClient) -> None:
     """End-to-end create/query for wandb.agent_monitor feedback with typed scorer columns."""
     project_id = client.project_id
@@ -518,6 +523,7 @@ def test_agent_monitor_feedback(client: WeaveClient) -> None:
     assert row["span_status_code"] == "OK"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_agent_monitor_feedback_empty_defaults(client: WeaveClient) -> None:
     """A minimal agent_monitor row (no typed scorer fields) round-trips with empty defaults."""
     project_id = client.project_id
@@ -553,6 +559,7 @@ def test_agent_monitor_feedback_empty_defaults(client: WeaveClient) -> None:
     assert query_res.result[0]["span_status_code"] == "UNSET"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_agent_user_feedback(client: WeaveClient) -> None:
     """A human agent score's value is a tag in scorer_tags (e.g. an emoji
     glyph), carrying no scorer refs. Non-emoji tags are allowed too.
@@ -591,6 +598,7 @@ def test_agent_user_feedback(client: WeaveClient) -> None:
     assert row["span_status_code"] == "OK"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_agent_monitor_feedback_filters(client: WeaveClient) -> None:
     """Filter agent_monitor rows by typed scorer columns.
 
@@ -734,6 +742,7 @@ def test_agent_monitor_feedback_filters(client: WeaveClient) -> None:
     assert matches == []
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_aggregate(client: WeaveClient) -> None:
     """Aggregate scorer feedback, asserting the entire FeedbackAggregateRes shape.
 
@@ -1050,6 +1059,7 @@ def test_feedback_aggregate(client: WeaveClient) -> None:
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_agent_monitor_feedback_sort_by_map_column(client: WeaveClient) -> None:
     """Sorting by a map-column key (e.g. `scorer_ratings._rating_`) must work.
 
@@ -1155,6 +1165,7 @@ async def populate_feedback(client: WeaveClient) -> None:
     return ids, my_scorer, my_model
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_sort_by_feedback(client: WeaveClient, no_autoflush) -> None:
     """Test sorting by feedback."""
@@ -1216,6 +1227,7 @@ async def test_sort_by_feedback(client: WeaveClient, no_autoflush) -> None:
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_filter_by_feedback(client: WeaveClient, no_autoflush) -> None:
     """Test filtering by feedback."""
@@ -1426,6 +1438,7 @@ class MatchAnyDatetime:  # noqa: PLW1641
         return isinstance(other, datetime.datetime)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_filter_and_sort_by_feedback(client: WeaveClient, no_autoflush) -> None:
     """Test filtering and sorting by feedback."""
@@ -1459,6 +1472,7 @@ async def test_filter_and_sort_by_feedback(client: WeaveClient, no_autoflush) ->
     assert [c.id for c in calls] == [ids[2], ids[0]]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_filter_by_wildcard_feedback_with_multiple_items(
     client: WeaveClient,
@@ -1566,6 +1580,7 @@ async def test_filter_by_wildcard_feedback_with_multiple_items(
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_replace(client) -> None:
     # Create initial feedback
     create_req = FeedbackCreateReq(
@@ -1643,6 +1658,7 @@ def test_feedback_replace(client) -> None:
     assert new_feedback["payload"] == {"emoji": "👍"}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_replace_validates_before_purge(client) -> None:
     """Replace must reject invalid payloads BEFORE deleting the existing row."""
     project_id = client.project_id
@@ -1681,6 +1697,7 @@ def test_feedback_replace_validates_before_purge(client) -> None:
     assert [r["id"] for r in query_res.result] == [initial.id]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_feedback_with_dict_query(client) -> None:
     """Test that get_feedback works with dict queries as shown in the docstring example."""
     # Create some test feedback using the server API
@@ -1761,6 +1778,7 @@ def test_get_feedback_with_dict_query(client) -> None:
     assert len(list(no_results)) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_query_bad_json_path(client) -> None:
     """Test that querying for nonexistent JSON paths raises appropriate error."""
     # Create some test feedback
@@ -1794,6 +1812,7 @@ def test_feedback_query_bad_json_path(client) -> None:
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_query_contains_numeric_literal(client) -> None:
     """Test that $contains works with numeric literals on JSON fields.
 
@@ -1860,6 +1879,7 @@ def test_feedback_query_contains_numeric_literal(client) -> None:
     assert res.result[0]["payload"]["dataset_id_str"] == "94"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_query_typed_payload_filters(client: WeaveClient) -> None:
     """Regression for WB-33832: /feedback/query 500s on typed payload literals.
 
@@ -1928,6 +1948,7 @@ def test_feedback_query_typed_payload_filters(client: WeaveClient) -> None:
     assert rows[0]["payload"] == {"is_positive": False, "score": 0.1, "rank": 2}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_with_queue_id(client: WeaveClient) -> None:
     """Test feedback creation with queue_id field."""
     project_id = client.project_id
@@ -1979,6 +2000,7 @@ def test_feedback_with_queue_id(client: WeaveClient) -> None:
     assert no_queue_feedback["queue_id"] is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_with_invalid_queue_id(client: WeaveClient) -> None:
     """Test feedback creation with invalid queue_id."""
     project_id = client.project_id
@@ -1998,6 +2020,7 @@ def test_feedback_with_invalid_queue_id(client: WeaveClient) -> None:
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_with_queue_id_from_different_project(client: WeaveClient) -> None:
     """Test feedback creation with queue_id from a different project."""
     project_id = client.project_id
@@ -2028,6 +2051,7 @@ def test_feedback_with_queue_id_from_different_project(client: WeaveClient) -> N
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_query_by_queue_id(client: WeaveClient) -> None:
     """Test querying feedback filtered by queue_id."""
     project_id = client.project_id
@@ -2166,6 +2190,7 @@ def _seed_numeric_feedback(
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_stats(client: WeaveClient) -> None:
     """End-to-end: seed feedback, query aggregated stats, verify buckets and window_stats."""
     project_id = client.project_id
@@ -2214,6 +2239,7 @@ def test_feedback_stats(client: WeaveClient) -> None:
     assert ws["avg"] == pytest.approx(sum(scores) / len(scores), abs=1e-6)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_payload_schema(client: WeaveClient) -> None:
     """End-to-end: seed varied feedback, discover payload schema paths."""
     project_id = client.project_id
@@ -2258,6 +2284,7 @@ def test_feedback_payload_schema(client: WeaveClient) -> None:
     assert path_map["label"] == "categorical"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_stats_empty_metrics(client: WeaveClient) -> None:
     """Empty metrics list returns empty buckets without error."""
     project_id = client.project_id
@@ -2275,6 +2302,7 @@ def test_feedback_stats_empty_metrics(client: WeaveClient) -> None:
     assert res.granularity == 3600
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_query_returns_tz_aware_created_at(client: WeaveClient) -> None:
     """Ensure `feedback_query` returns tz-aware `created_at`."""
     project_id = client.project_id

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -4,6 +4,7 @@ import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError
 
 import weave
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     DummyIdConverter,
 )
@@ -1346,6 +1347,10 @@ async def test_filter_by_feedback(client: WeaveClient, no_autoflush) -> None:
         )
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND,
+    reason="ClickHouse-only: executes the built SQL directly via server._query",
+)
 def test_feedback_aggregate_filter_matching_functional(client: WeaveClient) -> None:
     """Functional checks (ClickHouse-only) that the WHERE filters match precisely.
 

--- a/tests/trace/test_integration_metadata.py
+++ b/tests/trace/test_integration_metadata.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.integrations.integration_metadata import (
     INTEGRATION_ATTRIBUTE_KEY,
     IntegrationMetadata,
@@ -126,6 +127,7 @@ def test_with_integration_metadata_preserves_existing_attributes():
 # --- op-level default attributes (end to end) ---------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_level_attributes_land_on_call(client):
     @weave.op(attributes={"integration": {"name": "demo"}})
     def func():
@@ -136,6 +138,7 @@ def test_op_level_attributes_land_on_call(client):
     assert call.attributes["integration"] == {"name": "demo"}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_level_attributes_coexist_with_context(client):
     @weave.op(attributes={"integration": {"name": "demo"}})
     def func():
@@ -149,6 +152,7 @@ def test_op_level_attributes_coexist_with_context(client):
     assert call.attributes["env"] == "prod"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_context_attributes_override_op_level_on_collision(client):
     @weave.op(attributes={"integration": {"name": "demo"}})
     def func():
@@ -162,6 +166,7 @@ def test_context_attributes_override_op_level_on_collision(client):
     assert call.attributes["integration"] == "user-override"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_level_attributes_do_not_clobber_weave_subdict(client):
     @weave.op(kind="llm", attributes={"integration": {"name": "demo"}})
     def func():
@@ -182,6 +187,7 @@ def test_op_rejects_reserved_weave_key():
             return 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_without_attributes_has_no_integration_key(client):
     @weave.op
     def func():
@@ -192,6 +198,7 @@ def test_op_without_attributes_has_no_integration_key(client):
     assert "integration" not in call.attributes
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_level_attributes_on_async_call(client):
     @weave.op(attributes={"integration": {"name": "demo"}})
@@ -203,6 +210,7 @@ async def test_op_level_attributes_on_async_call(client):
     assert call.attributes["integration"] == {"name": "demo"}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_level_attributes_on_sync_generator(client):
     @weave.op(attributes={"integration": {"name": "demo"}})
     def gen():
@@ -214,6 +222,7 @@ def test_op_level_attributes_on_sync_generator(client):
     assert call.attributes["integration"] == {"name": "demo"}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_level_attributes_on_async_generator(client):
     @weave.op(attributes={"integration": {"name": "demo"}})
@@ -229,6 +238,7 @@ async def test_op_level_attributes_on_async_generator(client):
 # --- callback/tracer path (Family B: direct create_call) ----------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_create_call_carries_integration_attributes(client):
     """Integrations that build attributes directly still land integration data."""
     attrs = {"trace_id": "t1"}

--- a/tests/trace/test_llm_as_a_judge_scorer.py
+++ b/tests/trace/test_llm_as_a_judge_scorer.py
@@ -1,6 +1,9 @@
 from unittest.mock import patch
 
+import pytest
+
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.flow.scorer import Scorer
 from weave.prompt.prompt import MessagesPrompt
 from weave.scorers import LLMAsAJudgeScorer
@@ -15,6 +18,7 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_and_load_scorer_with_prompt_ref(weave_active):
     """Test that LLMAsAJudgeScorer with a MessagesPrompt ref can be published and loaded.
 

--- a/tests/trace/test_llm_structured_completion_model.py
+++ b/tests/trace/test_llm_structured_completion_model.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from pydantic import ValidationError
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave import publish
 from weave.prompt.prompt import MessagesPrompt
 from weave.trace import object_record, vals
@@ -22,6 +23,7 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_llm_structured_completion_model_creation_and_class_assignment(
     client: WeaveClient,
 ):
@@ -114,6 +116,7 @@ def test_llm_structured_completion_model_creation_and_class_assignment(
     assert reconstructed_model.llm_model_id == "gpt-4"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_llm_structured_completion_model_filtering(client: WeaveClient):
     """Test querying LLMStructuredCompletionModel objects by leaf/base object classes."""
     # Create multiple models
@@ -655,6 +658,7 @@ def test_cast_to_message():
         cast_to_message(123)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
@@ -732,6 +736,7 @@ def test_llm_structured_completion_model_predict_with_prompt(
     assert call_args.inputs.messages == expected_messages
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
@@ -790,6 +795,7 @@ def test_llm_structured_completion_model_prompt_takes_precedence(
     assert call_args.inputs.messages == []
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_llm_structured_completion_model_schema_validation(client: WeaveClient):
     """Test schema validation for LLMStructuredCompletionModel."""
     # Test missing required field

--- a/tests/trace/test_log_call.py
+++ b/tests/trace/test_log_call.py
@@ -1,10 +1,13 @@
 """Tests for the log_call function."""
 
+import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import WeaveClient
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_basic(client: WeaveClient):
     """Test basic log_call functionality."""
     call = weave.log_call("test", {"a": 1}, 2)
@@ -17,6 +20,7 @@ def test_log_call_basic(client: WeaveClient):
     assert call.exception is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_with_display_name(client: WeaveClient):
     """Test log_call with a custom display name."""
     call = weave.log_call("test_op", {"x": 5}, 10, display_name="Custom Display Name")
@@ -26,6 +30,7 @@ def test_log_call_with_display_name(client: WeaveClient):
     assert fetched_call.display_name == "Custom Display Name"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_with_attributes(client: WeaveClient):
     """Test log_call with custom attributes."""
     attrs = {"version": "1.0", "env": "test", "user": "test_user"}
@@ -38,6 +43,7 @@ def test_log_call_with_attributes(client: WeaveClient):
         assert fetched_call.attributes[key] == value
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_with_exception(client: WeaveClient):
     """Test log_call with an exception."""
     exc = ValueError("Something went wrong")
@@ -50,6 +56,7 @@ def test_log_call_with_exception(client: WeaveClient):
     assert "Something went wrong" in fetched_call.exception
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_nested_with_parent(client: WeaveClient):
     """Test log_call with parent-child relationship."""
     parent_call = weave.log_call("parent_op", {"parent_input": 1}, {"parent_output": 2})
@@ -69,6 +76,7 @@ def test_log_call_nested_with_parent(client: WeaveClient):
     assert parent.parent_id is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_multiple_calls(client: WeaveClient):
     """Test multiple log_call invocations."""
     call1 = weave.log_call("op1", {"a": 1}, 2)
@@ -83,6 +91,7 @@ def test_log_call_multiple_calls(client: WeaveClient):
     assert len(ids) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_with_complex_inputs_outputs(client: WeaveClient):
     """Test log_call with complex nested data structures."""
     inputs = {
@@ -103,6 +112,7 @@ def test_log_call_with_complex_inputs_outputs(client: WeaveClient):
     assert fetched_call.output == output
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_with_empty_inputs(client: WeaveClient):
     """Test log_call with empty inputs dictionary."""
     call = weave.log_call("no_input_op", {}, "result")
@@ -113,6 +123,7 @@ def test_log_call_with_empty_inputs(client: WeaveClient):
     assert fetched_call.output == "result"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_with_none_output(client: WeaveClient):
     """Test log_call with None as output."""
     call = weave.log_call("none_output_op", {"x": 1}, None)
@@ -122,6 +133,7 @@ def test_log_call_with_none_output(client: WeaveClient):
     assert fetched_call.output is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_with_callable_display_name(client: WeaveClient):
     """Test log_call with a callable display name."""
 
@@ -141,6 +153,7 @@ def test_log_call_with_callable_display_name(client: WeaveClient):
     assert fetched_call.display_name == "Call-123"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_different_op_names(client: WeaveClient):
     """Test log_call with different operation names."""
     ops = ["op1", "op2", "my_custom_op", "process_data", "analyze"]
@@ -155,6 +168,7 @@ def test_log_call_different_op_names(client: WeaveClient):
     assert op_names == set(ops)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_with_combined_params(client: WeaveClient):
     """Test log_call with all parameters combined."""
     parent_call = weave.log_call("parent", {}, "parent_result")
@@ -181,6 +195,7 @@ def test_log_call_with_combined_params(client: WeaveClient):
     assert child.display_name == "Combined Test"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_preserves_call_data(client: WeaveClient):
     """Test that the returned call object matches fetched data."""
     returned_call = weave.log_call("test_op", {"input": "test"}, {"output": "result"})
@@ -195,6 +210,7 @@ def test_log_call_preserves_call_data(client: WeaveClient):
     assert returned_call.op_name == fetched_call.op_name
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_returns_finished_call(client: WeaveClient):
     """Test that log_call returns a finished call with timestamps."""
     call = weave.log_call("test_op", {"x": 1}, 2)
@@ -210,6 +226,7 @@ def test_log_call_returns_finished_call(client: WeaveClient):
     assert fetched_call.ended_at >= fetched_call.started_at
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_with_use_stack_false(client: WeaveClient):
     """Test log_call with use_stack=False doesn't add to call stack."""
     # Log a call without adding to stack
@@ -225,6 +242,7 @@ def test_log_call_with_use_stack_false(client: WeaveClient):
     assert current_call is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_with_use_stack_true(client: WeaveClient):
     """Test log_call with use_stack=True adds to and removes from call stack."""
 
@@ -252,6 +270,7 @@ def test_log_call_with_use_stack_true(client: WeaveClient):
     assert inner.parent_id == parent_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_call_use_stack_default_behavior(client: WeaveClient):
     """Test that use_stack defaults to True."""
 

--- a/tests/trace/test_log_call.py
+++ b/tests/trace/test_log_call.py
@@ -1,5 +1,6 @@
 """Tests for the log_call function."""
 
+
 import weave
 from weave.trace.weave_client import WeaveClient
 

--- a/tests/trace/test_obj_delete.py
+++ b/tests/trace/test_obj_delete.py
@@ -1,6 +1,7 @@
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
@@ -27,6 +28,7 @@ def _obj_delete(client: WeaveClient, object_id: str, digests: list[str]) -> int:
     ).num_deleted
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_object_versions(client: WeaveClient):
     v0 = weave.publish({"i": 1}, name="obj_1")
     v1 = weave.publish({"i": 2}, name="obj_1")
@@ -54,6 +56,7 @@ def test_delete_object_versions(client: WeaveClient):
     assert len(objs) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_all_object_versions(client: WeaveClient):
     weave.publish({"i": 1}, name="obj_1")
     weave.publish({"i": 2}, name="obj_1")
@@ -69,6 +72,7 @@ def test_delete_all_object_versions(client: WeaveClient):
         _obj_delete(client, "obj_1", None)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_version_correctness(client: WeaveClient):
     v0 = weave.publish({"i": 1}, name="obj_1")
     v1 = weave.publish({"i": 2}, name="obj_1")
@@ -108,6 +112,7 @@ def test_delete_version_correctness(client: WeaveClient):
     assert objs[1].version_index == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_object_max_limit(client: WeaveClient):
     # Create more than MAX_OBJECTS_TO_DELETE objects
     max_objs = 100
@@ -121,11 +126,13 @@ def test_delete_object_max_limit(client: WeaveClient):
         _obj_delete(client, "obj_1", digests)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_nonexistent_object_id(client: WeaveClient):
     with pytest.raises(weave.trace_server.errors.NotFoundError):
         _obj_delete(client, "nonexistent_obj", None)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_mixed_valid_invalid_digests(client: WeaveClient):
     v0 = weave.publish({"i": 1}, name="obj_1")
     v1 = weave.publish({"i": 2}, name="obj_1")
@@ -138,6 +145,7 @@ def test_delete_mixed_valid_invalid_digests(client: WeaveClient):
         _obj_delete(client, "obj_1", invalid_digests)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_duplicate_digests(client: WeaveClient):
     v0 = weave.publish({"i": 1}, name="obj_1")
 
@@ -145,6 +153,7 @@ def test_delete_duplicate_digests(client: WeaveClient):
     assert num_deleted == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_with_digest_aliases(client: WeaveClient):
     v0 = weave.publish({"i": 1}, name="obj_1")
     weave.publish({"i": 2}, name="obj_1")
@@ -164,6 +173,7 @@ def test_delete_with_digest_aliases(client: WeaveClient):
     assert len(objs) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_and_recreate_object(client: WeaveClient):
     # Create and delete initial object
     v0 = weave.publish({"i": 1}, name="obj_1")
@@ -188,6 +198,7 @@ def _latest_objs_query(client: WeaveClient, object_id: str) -> list[tsi.ObjSchem
     return objs.objs
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize("republish_val", [{"i": 1}, {"i": 99}])
 def test_republish_after_deleting_all_versions(
     client: WeaveClient, republish_val: dict[str, int]
@@ -215,6 +226,7 @@ def test_republish_after_deleting_all_versions(
     assert latest[0].val == republish_val
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_read_deleted_object(client: WeaveClient):
     weave.publish({"i": 1}, name="obj_1")
     weave.publish({"i": 2}, name="obj_1")
@@ -241,6 +253,7 @@ def test_read_deleted_object(client: WeaveClient):
     assert ref_res.vals[0] is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versions(client: WeaveClient):
     @weave.op
     def my_op(x: int) -> int:
@@ -270,6 +283,7 @@ def test_op_versions(client: WeaveClient):
     assert len(objs3) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_read_deleted_op(client: WeaveClient):
     @weave.op
     def my_op(x: int) -> int:
@@ -298,6 +312,7 @@ def test_read_deleted_op(client: WeaveClient):
     assert ref_res.vals[0] is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_all_object_versions_api(client: WeaveClient):
     """Test the public API for deleting all versions of an object."""
     v0 = weave.publish({"i": 1}, name="obj_test_all")
@@ -319,6 +334,7 @@ def test_delete_all_object_versions_api(client: WeaveClient):
         client.delete_all_object_versions("obj_test_all")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_all_op_versions_api(client: WeaveClient):
     """Test the public API for deleting all versions of an op."""
 
@@ -350,6 +366,7 @@ def test_delete_all_op_versions_api(client: WeaveClient):
         client.delete_all_op_versions("test_op")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_object_versions_api(client: WeaveClient):
     """Test the public API for deleting multiple specific versions of an object."""
     v0 = weave.publish({"i": 1}, name="obj_multi_delete")
@@ -399,6 +416,7 @@ def _datasets_query(client: WeaveClient, latest_only: bool) -> list[tsi.ObjSchem
     return objs.objs
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_republish_dataset_after_deleting_all_versions(client: WeaveClient):
     # Repro for #6298: the Datasets tab queries by base_object_class +
     # latest_only. After deleting every version and re-publishing the

--- a/tests/trace/test_obj_tags_aliases.py
+++ b/tests/trace/test_obj_tags_aliases.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.refs import ObjectRef
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
@@ -220,6 +221,7 @@ def test_digest_is_content_hash(digest: str, expected: bool):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_tag_crud(client: WeaveClient):
     """Full tag lifecycle via server API: add, remove, re-add, idempotent, remove nonexistent."""
     object_id, digest = _publish_obj(client, "srv_tag_crud")
@@ -339,6 +341,7 @@ def test_server_tag_crud(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_alias_crud(client: WeaveClient):
     """Full alias lifecycle via server API: set, reassign, remove, remove nonexistent."""
     object_id, digest = _publish_obj(client, "srv_alias_crud")
@@ -432,6 +435,7 @@ def test_server_alias_crud(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_tag_errors(client: WeaveClient):
     """Tags on nonexistent or deleted objects raise NotFoundError.
 
@@ -450,6 +454,7 @@ def test_server_tag_errors(client: WeaveClient):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_alias_errors(client: WeaveClient):
     """Aliases on nonexistent or deleted objects raise NotFoundError."""
     # Nonexistent object
@@ -464,6 +469,7 @@ def test_server_alias_errors(client: WeaveClient):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_tag_on_deleted_object(client: WeaveClient):
     """Tags on deleted objects raise NotFoundError."""
     oid, digest = _publish_obj(client, "srv_err_deleted")
@@ -485,6 +491,7 @@ def test_server_tag_on_deleted_object(client: WeaveClient):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_alias_on_deleted_object(client: WeaveClient):
     """Aliases on deleted objects raise NotFoundError."""
     oid, digest = _publish_obj(client, "srv_err_deleted2")
@@ -511,6 +518,7 @@ def test_server_alias_on_deleted_object(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_enrichment(client: WeaveClient):
     """Enrichment toggle: None when off, populated when on, empty lists for untagged objects."""
     oid, digest = _publish_obj(client, "srv_enrich")
@@ -630,6 +638,7 @@ def test_server_enrichment(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_obj_read_digest_types(client: WeaveClient):
     """obj_read with real digest, alias, 'latest', and nonexistent alias."""
     oid, digest = _publish_obj(client, "srv_read_digest")
@@ -724,6 +733,7 @@ def test_server_obj_read_digest_types(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_filter_by_tags(client: WeaveClient):
     """Filter by tags: single, multiple, nonexistent, empty list."""
     oid1, d1 = _publish_obj(client, "srv_ftag_a")
@@ -785,6 +795,7 @@ def test_server_filter_by_tags(client: WeaveClient):
     assert len(res.objs) >= 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_filter_by_aliases(client: WeaveClient):
     """Filter by aliases: custom alias, 'latest', nonexistent, specific version only."""
     oid, digest = _publish_obj(client, "srv_falias")
@@ -865,6 +876,7 @@ def test_server_filter_by_aliases(client: WeaveClient):
     assert len(res.objs) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_filter_combined_tags_and_aliases(client: WeaveClient):
     """Filtering with both tags and aliases simultaneously ANDs the conditions."""
     oid1, d1 = _publish_obj(client, "srv_combo1")
@@ -927,6 +939,7 @@ def test_server_filter_combined_tags_and_aliases(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_version_and_object_isolation(client: WeaveClient):
     """Tags scoped to version, aliases across versions, latest virtual, cross-object isolation."""
     # Tags scoped to version
@@ -1024,6 +1037,7 @@ def test_server_version_and_object_isolation(client: WeaveClient):
     assert "only-on-b" not in (objs_by_id[oid_a].aliases or [])
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_batch_enrichment(client: WeaveClient):
     """Enrichment of 3+ distinct objects in one objs_query call."""
     oid1, d1 = _publish_obj(client, "srv_batch_a")
@@ -1090,6 +1104,7 @@ def test_server_batch_enrichment(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_list_endpoints(client: WeaveClient):
     """List tags and aliases: empty project, distinct sorted, excludes removed."""
     # Empty project
@@ -1176,6 +1191,7 @@ def test_server_list_endpoints(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sdk_tag_lifecycle(client: WeaveClient):
     """SDK client tag operations: add, remove, get, idempotent, re-add, scoped, multiple, list."""
     ref = weave.publish({"data": "test"}, name="sdk_tags")
@@ -1235,6 +1251,7 @@ def test_sdk_tag_lifecycle(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sdk_alias_lifecycle(client: WeaveClient):
     """SDK client alias operations: set, remove, get, reassign, list, string/list variants."""
     ref = weave.publish({"data": "test"}, name="sdk_aliases")
@@ -1304,6 +1321,7 @@ def test_sdk_alias_lifecycle(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sdk_uri_strings(client: WeaveClient):
     """All SDK tag/alias methods accept weave:/// URI strings alongside ObjectRef."""
     ref = weave.publish({"data": "test"}, name="sdk_uri")
@@ -1341,6 +1359,7 @@ def test_sdk_uri_strings(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sdk_add_tags_error_nonexistent(client: WeaveClient):
     """SDK add_tags raises NotFoundError on fake ref."""
     fake_ref = ObjectRef(
@@ -1353,6 +1372,7 @@ def test_sdk_add_tags_error_nonexistent(client: WeaveClient):
         client.add_tags(fake_ref, ["tag"])
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sdk_set_aliases_error_nonexistent(client: WeaveClient):
     """SDK set_aliases raises NotFoundError on fake ref."""
     fake_ref = ObjectRef(
@@ -1370,6 +1390,7 @@ def test_sdk_set_aliases_error_nonexistent(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_weave_tag_functions(weave_active):
     """weave.add_tags, remove_tags, get_tags, list_tags — full lifecycle."""
     ref = weave.publish({"data": "test"}, name="tl_tags")
@@ -1440,6 +1461,7 @@ def test_weave_tag_functions(weave_active):
     assert all_tags.count("only-on-a") == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_weave_alias_functions(client: WeaveClient):
     """weave.set_aliases, remove_aliases, get_aliases, list_aliases — full lifecycle."""
     ref = weave.publish({"data": "test"}, name="tl_aliases")
@@ -1509,6 +1531,7 @@ def test_weave_alias_functions(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_alias_resolution(client: WeaveClient):
     """Resolve by alias: latest, custom, reassignment, publish-time, implicit, nonexistent, digest check."""
     # latest alias
@@ -1562,6 +1585,7 @@ def test_alias_resolution(client: WeaveClient):
         assert weave.ref(f"resolve_multi:{alias}").get()["v"] == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_aliases_list_contains_latest_after_publish(client: WeaveClient):
     """A fresh project's aliases_list must include 'latest' after a single publish.
 
@@ -1575,6 +1599,7 @@ def test_aliases_list_contains_latest_after_publish(client: WeaveClient):
     assert "latest" in res.aliases
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_republish_promotes_to_latest(client: WeaveClient, monkeypatch):
     """Re-publishing existing content (dedup hit) should move 'latest' to that digest.
 
@@ -1711,6 +1736,7 @@ def _resolve_latest_digest(client: WeaveClient, object_id: str) -> str | None:
     return digest
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_hybrid_latest_full_lifecycle(client: WeaveClient, monkeypatch):
     """Walk the full hybrid lifecycle: linear publish/delete, dedup-republish-
     then-delete, terminal delete-all, and self-heal on the next publish.
@@ -1771,6 +1797,7 @@ def test_hybrid_latest_full_lifecycle(client: WeaveClient, monkeypatch):
     assert _resolve_latest_digest(client, "hybrid_obj") == ref_d.digest
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_hybrid_latest_multi_object_query(client: WeaveClient, monkeypatch):
     """objs_query with latest_only=True and aliases=["latest"|"prod"] across
     multiple objects where one object uses the alias path and another uses
@@ -1846,6 +1873,7 @@ def test_hybrid_latest_multi_object_query(client: WeaveClient, monkeypatch):
     assert len(mixed_digests) == 4, f"unexpected rows: {sorted(mixed_digests)}"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_non_current_version_leaves_latest_unchanged(
     client: WeaveClient, monkeypatch
 ):
@@ -1906,6 +1934,7 @@ def test_delete_non_current_version_leaves_latest_unchanged(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_full_lifecycle(weave_active):
     """Comprehensive lifecycle: publish, tag, alias, resolve, reassign, remove, verify lists."""
     ref_v0 = weave.publish({"v": 0}, name="lifecycle_obj")
@@ -1945,6 +1974,7 @@ def test_full_lifecycle(weave_active):
     assert "reviewed" in all_tags
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_with_tags_and_aliases(weave_active):
     """Tags and aliases set at publish time work with resolution."""
     weave.publish({"v": 0}, name="pub_resolve")
@@ -1965,6 +1995,7 @@ def test_publish_with_tags_and_aliases(weave_active):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_cross_project_isolation(client: WeaveClient):
     """Tags, aliases, lists, and resolution are all scoped to their project."""
     server = client.server
@@ -2066,6 +2097,7 @@ def test_cross_project_isolation(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_deletion_cascades(client: WeaveClient):
     """Deleting versions cleans up tags/aliases; surviving versions keep theirs."""
     # Specific version cleanup — tags

--- a/tests/trace/test_objs_query.py
+++ b/tests/trace/test_objs_query.py
@@ -5,6 +5,7 @@ import pytest
 
 import weave
 from tests.trace.server_utils import TEST_ENTITY
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
@@ -16,6 +17,7 @@ def generate_objects(weave_client: WeaveClient, obj_count: int, version_count: i
             weave.publish({"i": i, "j": j}, name=f"obj_{i}")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_objs_query_all(client: WeaveClient):
     generate_objects(client, 10, 10)
 
@@ -27,6 +29,7 @@ def test_objs_query_all(client: WeaveClient):
     assert len(res.objs) == 100
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_objs_query_filter_object_ids(client: WeaveClient):
     generate_objects(client, 10, 10)
 
@@ -40,6 +43,7 @@ def test_objs_query_filter_object_ids(client: WeaveClient):
     assert all(obj.object_id in {"obj_0", "obj_1"} for obj in res.objs)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_objs_query_filter_is_op(client: WeaveClient):
     generate_objects(client, 10, 10)
 
@@ -57,6 +61,7 @@ def test_objs_query_filter_is_op(client: WeaveClient):
     assert len(res.objs) == 100
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_objs_query_filter_latest_only(client: WeaveClient):
     generate_objects(client, 10, 10)
 
@@ -71,6 +76,7 @@ def test_objs_query_filter_latest_only(client: WeaveClient):
     assert all(obj.val["j"] == 9 for obj in res.objs)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_objs_query_filter_limit_offset_sort_by_created_at(client: WeaveClient):
     generate_objects(client, 10, 10)
 
@@ -111,6 +117,7 @@ def test_objs_query_filter_limit_offset_sort_by_created_at(client: WeaveClient):
     assert res.objs[2].val["i"] == 7
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_objs_query_filter_limit_offset_sort_by_object_id(client: WeaveClient):
     generate_objects(client, 10, 10)
 
@@ -151,6 +158,7 @@ def test_objs_query_filter_limit_offset_sort_by_object_id(client: WeaveClient):
     assert res.objs[2].val["i"] == 7
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_objs_query_filter_metadata_only(client: WeaveClient):
     generate_objects(client, 10, 10)
 
@@ -178,6 +186,7 @@ def test_objs_query_filter_metadata_only(client: WeaveClient):
         assert obj.val
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_objs_query_wb_user_id(client: WeaveClient):
     weave.publish({"i": 1}, name="obj_1")
     weave.publish({"i": 2}, name="obj_1")
@@ -190,6 +199,7 @@ def test_objs_query_wb_user_id(client: WeaveClient):
     assert all(obj.wb_user_id == correct_id for obj in res)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_objs_query_deleted_interaction(client: WeaveClient):
     weave.publish({"i": 1}, name="obj_1")
@@ -249,6 +259,7 @@ def test_objs_query_deleted_interaction(client: WeaveClient):
     assert len(res.objs) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_objs_query_delete_and_recreate(client: WeaveClient):
     weave.publish({"i": 1}, name="obj_1")
@@ -306,6 +317,7 @@ def test_objs_query_delete_and_recreate(client: WeaveClient):
         assert res.objs[i].val["i"] == i + 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_objs_query_delete_and_add_new_versions(client: WeaveClient):
     weave.publish({"i": 1}, name="obj_1")
@@ -344,6 +356,7 @@ def test_objs_query_delete_and_add_new_versions(client: WeaveClient):
     assert all(obj.val["i"] in {4, 5, 6} for obj in res.objs)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_model_query_no_ref(client: WeaveClient):
     class MyModel(weave.Model):
         @weave.op

--- a/tests/trace/test_op_accumulator.py
+++ b/tests/trace/test_op_accumulator.py
@@ -8,7 +8,7 @@ import weakref
 import pytest
 
 import weave
-from tests.trace.util import DummyTestException
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, DummyTestException
 from weave.trace.context import call_context
 from weave.trace.context.tests_context import raise_on_captured_errors
 from weave.trace.op import (
@@ -154,6 +154,7 @@ def test_process_exit_closes_unfinished_iterator_wrapper(tmp_path):
     assert marker_path.read_text(encoding="utf-8") == "closed"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_collector):
     def do_test():
@@ -185,6 +186,7 @@ def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_col
     assert logs[0].msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_make_accumulator_errors_async(
@@ -221,6 +223,7 @@ async def test_resilience_to_accumulator_make_accumulator_errors_async(
     assert logs[0].msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collector):
     def do_test():
@@ -256,6 +259,7 @@ def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collect
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_accumulation_errors_async(
@@ -296,6 +300,7 @@ async def test_resilience_to_accumulator_accumulation_errors_async(
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_should_accumulate_errors(
     weave_active, log_collector
@@ -338,6 +343,7 @@ def test_resilience_to_accumulator_should_accumulate_errors(
     assert logs[0].msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_should_accumulate_errors_async(
@@ -388,6 +394,7 @@ async def test_resilience_to_accumulator_should_accumulate_errors_async(
 # and that is expected and tested for. It happens to be at the deletion moment
 # so pytest is complaining that the exception is not being raised in the
 # expected manner.
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_on_finish_post_processor_errors(
@@ -433,6 +440,7 @@ def test_resilience_to_accumulator_on_finish_post_processor_errors(
         assert log.msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
@@ -480,6 +488,7 @@ async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
         assert log.msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_resilience_to_accumulator_internal_errors(weave_active):
     def do_test():
         @weave.op(accumulator=lambda *args, **kwargs: {})
@@ -501,6 +510,7 @@ def test_resilience_to_accumulator_internal_errors(weave_active):
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_resilience_to_accumulator_internal_errors_async(weave_active):
     async def do_test():

--- a/tests/trace/test_op_argument_forms.py
+++ b/tests/trace/test_op_argument_forms.py
@@ -1,6 +1,7 @@
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace_server import trace_server_interface as tsi
 
 # This file tests the different argument variations that can be passed to an op.
@@ -52,6 +53,7 @@ from weave.trace_server import trace_server_interface as tsi
 # added or removed.
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize(
     ("fn", "arg_variations"),
     [
@@ -433,6 +435,7 @@ def test_general_arg_variations(client, fn, arg_variations):
 # a bit easier to read and understand (technically, the above test is more comprehensive and should be enough)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_no_args(client):
     @weave.op
     def my_op() -> int:
@@ -450,6 +453,7 @@ def test_no_args(client):
     assert res.calls[0].inputs == {}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_args_concrete(client):
     @weave.op
     def my_op(val):
@@ -468,6 +472,7 @@ def test_args_concrete(client):
     assert res.calls[0].output == [1]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_args_concrete_splat(client):
     @weave.op
     def my_op(val, *args):
@@ -490,6 +495,7 @@ def test_args_concrete_splat(client):
     assert res.calls[1].output == [1, [2, 3]]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_args_concrete_splats(client):
     @weave.op
     def my_op(val, *args, **kwargs):
@@ -520,6 +526,7 @@ def test_args_concrete_splats(client):
     assert res.calls[3].output == [1, [2, 3], {"a": 4, "b": 5}]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_args_concrete_splat_concrete(client):
     @weave.op
     def my_op(val, *args, a=0):
@@ -546,6 +553,7 @@ def test_args_concrete_splat_concrete(client):
     assert res.calls[2].output == [1, [2, 3], 4]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_args_concrete_splat_concrete_splat(client):
     @weave.op
     def my_op(val, *args, a=0, **kwargs):

--- a/tests/trace/test_op_call_method.py
+++ b/tests/trace/test_op_call_method.py
@@ -1,3 +1,4 @@
+
 import weave
 import weave.trace.call
 

--- a/tests/trace/test_op_call_method.py
+++ b/tests/trace/test_op_call_method.py
@@ -1,8 +1,11 @@
+import pytest
 
 import weave
 import weave.trace.call
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_call_method(weave_active):
     @weave.op
     def add(a, b):

--- a/tests/trace/test_op_coroutines.py
+++ b/tests/trace/test_op_coroutines.py
@@ -4,9 +4,11 @@ from collections.abc import Coroutine
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.call import Call
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_val(weave_active):
     @weave.op
     def sync_val():
@@ -19,6 +21,7 @@ def test_sync_val(weave_active):
     assert res == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_val_method(weave_active):
     class TestClass:
         @weave.op
@@ -33,6 +36,7 @@ def test_sync_val_method(weave_active):
     assert res == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_sync_coro(weave_active):
     @weave.op
@@ -48,6 +52,7 @@ async def test_sync_coro(weave_active):
     assert await res == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_sync_coro_method(weave_active):
     class TestClass:
@@ -65,6 +70,7 @@ async def test_sync_coro_method(weave_active):
     assert await res == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_coro(weave_active):
     @weave.op
@@ -82,6 +88,7 @@ async def test_async_coro(weave_active):
     assert await res == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_coro_method(weave_active):
     class TestClass:
@@ -102,6 +109,7 @@ async def test_async_coro_method(weave_active):
     assert await res == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_awaited_coro(weave_active):
     @weave.op
@@ -116,6 +124,7 @@ async def test_async_awaited_coro(weave_active):
     assert res == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_awaited_coro_method(weave_active):
     class TestClass:
@@ -132,6 +141,7 @@ async def test_async_awaited_coro_method(weave_active):
     assert res == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_val(weave_active):
     @weave.op
@@ -146,6 +156,7 @@ async def test_async_val(weave_active):
     assert res == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_val_method(weave_active):
     class TestClass:
@@ -162,6 +173,7 @@ async def test_async_val_method(weave_active):
     assert res == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_with_exception(weave_active):
     @weave.op
     def sync_with_exception():
@@ -175,6 +187,7 @@ def test_sync_with_exception(weave_active):
     assert res is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_with_exception_method(weave_active):
     class TestClass:
         @weave.op
@@ -190,6 +203,7 @@ def test_sync_with_exception_method(weave_active):
     assert res is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_with_exception(weave_active):
     @weave.op
@@ -204,6 +218,7 @@ async def test_async_with_exception(weave_active):
     assert res is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_with_exception_method(weave_active):
     class TestClass:

--- a/tests/trace/test_op_decorator_behaviour.py
+++ b/tests/trace/test_op_decorator_behaviour.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any, Literal, get_type_hints
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.call import Call
 from weave.trace.op import (
     OpCallError,
@@ -62,6 +63,7 @@ def py_obj():
     return B()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_func(weave_active, func):
     assert func(1) == 2
 
@@ -71,6 +73,7 @@ def test_sync_func(weave_active, func):
     assert func2(1) == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_func_call(weave_active, func):
     res, call = func.call(1)
     assert isinstance(call, Call)
@@ -88,6 +91,7 @@ def test_sync_func_call(weave_active, func):
     assert res2 == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_func(weave_active, afunc):
     assert await afunc(1) == 2
@@ -98,6 +102,7 @@ async def test_async_func(weave_active, afunc):
     assert await afunc2(1) == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_func_call(weave_active, afunc):
     res, call = await afunc.call(1)
@@ -116,6 +121,7 @@ async def test_async_func_call(weave_active, afunc):
     assert res2 == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_method(weave_active, weave_obj, py_obj):
     assert weave_obj.method(1) == 2
     assert py_obj.method(1) == 2
@@ -125,6 +131,7 @@ def test_sync_method(weave_active, weave_obj, py_obj):
         weave_obj_method2 = weave_obj_method_ref.get()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_method_call(weave_active, weave_obj, py_obj):
     res, call = weave_obj.method.call(weave_obj, 1)
     assert isinstance(call, Call)
@@ -149,6 +156,7 @@ def test_sync_method_call(weave_active, weave_obj, py_obj):
         res2, call2 = py_obj.method.call(1)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_method(weave_active, weave_obj, py_obj):
     assert await weave_obj.amethod(1) == 2
@@ -159,6 +167,7 @@ async def test_async_method(weave_active, weave_obj, py_obj):
         weave_obj_amethod2 = weave_obj_amethod_ref.get()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_method_call(weave_active, weave_obj, py_obj):
     res, call = await weave_obj.amethod.call(weave_obj, 1)
@@ -212,6 +221,7 @@ def test_async_method_patching_passes_inspection(weave_obj, py_obj):
     assert inspect.ismethod(py_obj.amethod)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_method_calls(weave_active, weave_obj):
     for x in range(3):
         weave_obj.method(x)
@@ -225,6 +235,7 @@ def test_sync_method_calls(weave_active, weave_obj):
     assert len(calls) == 6
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_method_calls(weave_active, weave_obj):
     for x in range(3):
@@ -239,6 +250,7 @@ async def test_async_method_calls(weave_active, weave_obj):
     assert len(calls) == 6
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_gotten_object_method_is_callable(weave_active, weave_obj):
     ref = weave.publish(weave_obj)
@@ -248,6 +260,7 @@ async def test_gotten_object_method_is_callable(weave_active, weave_obj):
     assert await weave_obj.amethod(1) == await weave_obj2.amethod(1) == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_gotten_object_method_is_callable_with_call_func(weave_active, weave_obj):
     ref = weave.publish(weave_obj)
@@ -266,6 +279,7 @@ async def test_gotten_object_method_is_callable_with_call_func(weave_active, wea
     assert call3.output == call4.output
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_postprocessing_funcs(client):
     def postprocess_inputs(inputs: dict[str, Any]) -> dict[str, Any]:
         d = {}
@@ -301,6 +315,7 @@ def test_postprocessing_funcs(client):
     assert call.output == {"postprocessed_b": 2}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_call_display_name_str(client):
     @op(call_display_name="example")
     def func():
@@ -322,6 +337,7 @@ def test_op_call_display_name_callable_invalid():
             return 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_call_display_name_callable_lambda(client):
     @op(call_display_name=lambda call: f"{call.project_id}-123")
     def func():
@@ -335,6 +351,7 @@ def test_op_call_display_name_callable_lambda(client):
     assert call.display_name == "shawn/test-project-123"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_call_display_name_callable_func(client):
     def custom_display_name_func(call) -> str:
         reversed_project = call.project_id[::-1]
@@ -353,6 +370,7 @@ def test_op_call_display_name_callable_func(client):
     assert call.display_name == "wow-1844-tcejorp-tset/nwahs"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_call_display_name_callable_other_attributes(client):
     def custom_attribute_name(call):
         model = call.attributes["model"]
@@ -388,6 +406,7 @@ def test_op_call_display_name_callable_other_attributes(client):
     assert calls[1].display_name == "finetuned-gpt-4o__v0.1.3__2024-08-02"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_call_display_name_modified_dynamically(client):
     def custom_display_name1(call):
         return "wow"
@@ -413,6 +432,7 @@ def test_op_call_display_name_modified_dynamically(client):
     assert calls[2].display_name == "amazing"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_name(client):
     @op(name="custom_name")
     def func():

--- a/tests/trace/test_op_generators.py
+++ b/tests/trace/test_op_generators.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncGenerator, Generator
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.context import call_context
 
 
@@ -52,6 +53,7 @@ async def deeply_nested_async_generator(x: int) -> AsyncGenerator[int, None]:
             yield j
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_basic_gen(client):
     res = basic_gen(3)
     assert list(res) == [0, 1, 2]
@@ -60,6 +62,7 @@ def test_basic_gen(client):
     assert len(calls) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_nested_generator(client):
     res = nested_generator(3)
     assert list(res) == [1, 2, 3]
@@ -74,6 +77,7 @@ def test_nested_generator(client):
         assert call.inputs["x"] == i
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_deeply_nested_generator(client):
     res = deeply_nested_generator(4)
     # basic_gen(0) -> nothing
@@ -94,6 +98,7 @@ def test_deeply_nested_generator(client):
             assert call2.inputs["x"] == j
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_basic_async_gen(client):
     lst = []
@@ -107,6 +112,7 @@ async def test_basic_async_gen(client):
     assert len(calls) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_nested_async_generator(client):
     lst = []
@@ -126,6 +132,7 @@ async def test_nested_async_generator(client):
         assert call.inputs["x"] == i
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_deeply_nested_async_generator(client):
     lst = []
@@ -163,6 +170,7 @@ def basic_gen_with_accumulator(x: int) -> Generator[int, None, None]:
     yield from range(x)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_generator_with_custom_accumulator(client):
     # Call the generator with the accumulator from the decorator
     res = basic_gen_with_accumulator(3)
@@ -189,6 +197,7 @@ async def basic_async_gen_with_accumulator(x: int) -> AsyncGenerator[int, None]:
         yield i
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_generator_with_custom_accumulator(client):
     # Call the generator with the accumulator from the decorator
@@ -203,6 +212,7 @@ async def test_async_generator_with_custom_accumulator(client):
     assert calls[0].output == [0, 1, 2]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_nested_generator_multiple_iterations(client):
     """Test that nested generators work correctly when called multiple times.
 
@@ -251,6 +261,7 @@ def test_nested_generator_multiple_iterations(client):
         assert "inner_gen" in children[0].op_name
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_nested_async_generator_multiple_iterations(client):
     """Test that nested async generators work correctly when called multiple times.

--- a/tests/trace/test_op_return_forms.py
+++ b/tests/trace/test_op_return_forms.py
@@ -1,10 +1,12 @@
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.ref_util import get_ref
 from weave.trace_server import trace_server_interface as tsi
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_sync_empty(client):
     @weave.op
     def fn():
@@ -25,6 +27,7 @@ def test_op_return_sync_empty(client):
     assert res.calls[0].output is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_empty(client):
     @weave.op
@@ -46,6 +49,7 @@ async def test_op_return_async_empty(client):
     assert res.calls[0].output is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_sync_obj(client):
     @weave.op
     def fn():
@@ -66,6 +70,7 @@ def test_op_return_sync_obj(client):
     assert res.calls[0].output == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_obj(client):
     @weave.op
@@ -101,6 +106,7 @@ def simple_list_accumulator(acc, value):
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_sync_generator(client):
     @weave.op(accumulator=simple_list_accumulator)
     def fn():
@@ -125,6 +131,7 @@ def test_op_return_sync_generator(client):
     assert res.calls[0].output == list(range(9, -1, -1))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_generator(client):
     @weave.op(accumulator=simple_list_accumulator)
@@ -150,6 +157,7 @@ async def test_op_return_async_generator(client):
     assert res.calls[0].output == list(range(9, -1, -1))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_sync_iterator(client):
     class MyIterator:
         size = 10
@@ -183,6 +191,7 @@ def test_op_return_sync_iterator(client):
     assert res.calls[0].output == list(range(9, -1, -1))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_iterator(client):
     class MyAsyncIterator:
@@ -217,6 +226,7 @@ async def test_op_return_async_iterator(client):
     assert res.calls[0].output == list(range(9, -1, -1))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_sync_generator_never_iter(client):
     @weave.op(accumulator=simple_list_accumulator)
     def fn():
@@ -240,6 +250,7 @@ def test_op_return_sync_generator_never_iter(client):
     assert res.calls[0].output is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_generator_never_iter(client):
     @weave.op(accumulator=simple_list_accumulator)
@@ -265,6 +276,7 @@ async def test_op_return_async_generator_never_iter(client):
     assert res.calls[0].output is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_sync_iterator_never_iter(client):
     class MyIterator:
         size = 10
@@ -297,6 +309,7 @@ def test_op_return_sync_iterator_never_iter(client):
     assert res.calls[0].output is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_iterator_never_iter(client):
     class MyAsyncIterator:
@@ -330,6 +343,7 @@ async def test_op_return_async_iterator_never_iter(client):
     assert res.calls[0].output is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_sync_generator_partial(client):
     @weave.op(accumulator=simple_list_accumulator)
     def fn():
@@ -355,6 +369,7 @@ def test_op_return_sync_generator_partial(client):
     assert res.calls[0].output == list(range(9, 4, -1))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_generator_partial(client):
     @weave.op(accumulator=simple_list_accumulator)
@@ -382,6 +397,7 @@ async def test_op_return_async_generator_partial(client):
     assert res.calls[0].output == list(range(9, 4, -1))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_sync_iterator_partial(client):
     class MyIterator:
         size = 10
@@ -416,6 +432,7 @@ def test_op_return_sync_iterator_partial(client):
     assert res.calls[0].output == list(range(9, 4, -1))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_iterator_partial(client):
     class MyAsyncIterator:
@@ -451,6 +468,7 @@ async def test_op_return_async_iterator_partial(client):
     assert res.calls[0].output == list(range(9, 4, -1))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_sync_generator_exception(client):
     @weave.op(accumulator=simple_list_accumulator)
     def fn():
@@ -481,6 +499,7 @@ def test_op_return_sync_generator_exception(client):
     assert res.calls[0].exception is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_generator_exception(client):
     @weave.op(accumulator=simple_list_accumulator)
@@ -512,6 +531,7 @@ async def test_op_return_async_generator_exception(client):
     assert res.calls[0].exception is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_sync_iterator_exception(client):
     class MyIterator:
         size = 10
@@ -551,6 +571,7 @@ def test_op_return_sync_iterator_exception(client):
     assert res.calls[0].exception is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_iterator_exception(client):
     class MyAsyncIterator:

--- a/tests/trace/test_op_versioning.py
+++ b/tests/trace/test_op_versioning.py
@@ -7,6 +7,7 @@ import pytest
 
 import weave
 import weave as wv
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.op import as_op
 from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact
 from weave.trace.serialization.op_type import save_instance
@@ -41,6 +42,7 @@ def solo_versioned_op(a: int) -> float:
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_solo_op_versioning(client):
     from tests.trace import op_versioning_solo
 
@@ -64,6 +66,7 @@ def versioned_op(self, a: int) -> float:
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_op_versioning(client):
     from tests.trace import op_versioning_obj
 
@@ -88,6 +91,7 @@ def versioned_op_importfrom(a: int) -> float:
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versioning_importfrom(client):
     from tests.trace import op_versioning_importfrom
 
@@ -133,6 +137,7 @@ def versioned_op_closure_constant(a: int) -> float:
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versioning_closure_constant(client):
     x = 10
 
@@ -162,6 +167,7 @@ def versioned_op_closure_constant(a: int) -> float:
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versioning_closure_dict_simple(client):
     x = {"a": 5, "b": 10}
 
@@ -332,6 +338,7 @@ def test_op_versioning_exception():
         return x
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versioning_2ops(client):
     @weave.op
     def dog():
@@ -362,6 +369,7 @@ def some_d(v: int) -> SomeDict:
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_typeddict_annotation(
     client,
 ):
@@ -401,6 +409,7 @@ def some_d(v: int):
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_return_custom_class(
     client,
 ):
@@ -437,6 +446,7 @@ def some_d(v: int):
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_nested_function(
     client,
 ):
@@ -460,6 +470,7 @@ def test_op_nested_function(
     assert weave.ref(ref.uri).get()(2) == 5
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_basic_execution(weave_active):
     @weave.op
     def adder(v: int) -> int:
@@ -500,6 +511,7 @@ def some_d(v):
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_no_repeats(client):
     @weave.op
     def some_d(v):
@@ -528,6 +540,7 @@ def t(text: str):
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_instance(client):
     class MyClass:
         _version: str
@@ -569,6 +582,7 @@ def func(data: dict) -> str:
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_import_as(client):
     import json as js
 
@@ -596,6 +610,7 @@ def func(data: dict) -> str:
 """
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_import_from_as(client):
     from json import dumps as ds
 

--- a/tests/trace/test_postprocessing.py
+++ b/tests/trace/test_postprocessing.py
@@ -1,6 +1,7 @@
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
 def redact_keys(d: dict) -> dict:
@@ -27,6 +28,7 @@ def apply_postprocessing(client):
     client.postprocess_output = original_postprocess_output
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_global_postprocessing(client, apply_postprocessing) -> None:
     @weave.op
     def func(api_key: str, secret_key: str, name: str, age: int) -> str:

--- a/tests/trace/test_publish_round_trip.py
+++ b/tests/trace/test_publish_round_trip.py
@@ -1,11 +1,14 @@
+import pytest
 from pydantic import BaseModel
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.objectify import register_object
 from weave.trace_server.interface.query import Query
 from weave.trace_server.trace_server_interface import RefsReadBatchReq
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_round_trip_query_object(client) -> None:
     query_raw = {
         "$expr": {
@@ -26,6 +29,7 @@ def test_publish_round_trip_query_object(client) -> None:
     assert query_2 == query
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_round_trip_register_object_nested(weave_active) -> None:
     class Inner(BaseModel):
         name: str
@@ -47,6 +51,7 @@ def test_publish_round_trip_register_object_nested(weave_active) -> None:
     assert outer == outer_gotten
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_round_trip_unwrap(weave_active) -> None:
     data = {
         "a": 1,

--- a/tests/trace/test_queue_filtering.py
+++ b/tests/trace/test_queue_filtering.py
@@ -12,11 +12,12 @@ import pytest
 
 import weave
 from tests.trace.server_utils import TEST_ENTITY
-from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, NOT_CLICKHOUSE_BACKEND
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ids import generate_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_filter_calls_by_queue_inner_join_behavior(client):
     """Test that INNER JOIN correctly filters calls by queue membership.
 
@@ -84,6 +85,7 @@ def test_filter_calls_by_queue_inner_join_behavior(client):
     assert returned_ids.isdisjoint(excluded_ids)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_filter_calls_by_multiple_distinct_queues(client):
     """Test that queue filtering correctly isolates calls by queue_id.
 
@@ -182,6 +184,7 @@ def test_filter_calls_by_multiple_distinct_queues(client):
     assert {call.id for call in res1.calls}.isdisjoint({call.id for call in res2.calls})
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_filter_calls_by_queue_combined_with_other_filters(client):
     """Test queue filter works correctly when combined with other query conditions.
 
@@ -263,6 +266,7 @@ def test_filter_calls_by_queue_combined_with_other_filters(client):
     assert {call.id for call in res.calls} == set(include_ids[:2])
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_filter_calls_by_nonexistent_queue(client):
     """Test that filtering by a non-existent queue returns empty results.
 

--- a/tests/trace/test_queue_filtering.py
+++ b/tests/trace/test_queue_filtering.py
@@ -8,8 +8,11 @@ These tests verify the queue filtering functionality added to calls_query_builde
 
 import datetime
 
+import pytest
+
 import weave
 from tests.trace.server_utils import TEST_ENTITY
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ids import generate_id
 
@@ -296,6 +299,9 @@ def test_filter_calls_by_nonexistent_queue(client):
     assert len(res.calls) == 0
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: calls_complete table residence"
+)
 def test_filter_calls_by_queue_with_calls_complete_table(trace_server):
     """Integration test: queue filtering works correctly with calls_complete table.
 

--- a/tests/trace/test_redaction.py
+++ b/tests/trace/test_redaction.py
@@ -1,10 +1,14 @@
 import dataclasses
 
+import pytest
+
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import redact_sensitive_keys
 from weave.utils import sanitize
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_code_capture_redacts_sensitive_values(weave_active):
     api_key = "123"
 

--- a/tests/trace/test_ref_trace.py
+++ b/tests/trace/test_ref_trace.py
@@ -3,6 +3,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.refs import (
     AgentConversationRef,
     AgentSpanRef,
@@ -87,6 +88,7 @@ def test_leaderboard_column_accepts_str_of_ref():
     assert col.evaluation_object_ref.startswith("weave:///")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_ref_hashable(weave_active):
     class Thing(weave.Object):
         val: int
@@ -106,6 +108,7 @@ def test_ref_hashable(weave_active):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_ref_immutable(weave_active):
     class Thing(weave.Object):
         val: int

--- a/tests/trace/test_saved_view.py
+++ b/tests/trace/test_saved_view.py
@@ -3,6 +3,7 @@ import datetime
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.flow.saved_view import (
     Filter,
     Filters,
@@ -240,12 +241,14 @@ def test_column_manipulation():
     assert view.base.definition.columns[0].path == ["inputs", "foo"]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_saved_view_create(weave_active):
     view = weave.SavedView("traces", "My saved view").hide_column("feedback").save()
     assert view.label == "My saved view"
     assert isinstance(view.ref, ObjectRef)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_saved_view_load(weave_active):
     saved_view = weave.SavedView("traces", "My saved view")
     saved_view.show_column("attributes.weave.client_version")
@@ -257,6 +260,7 @@ def test_saved_view_load(weave_active):
     assert loaded_view.base.definition.cols["attributes.weave.client_version"] is True
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_saved_view_expand_columns_round_trip(client):
     # A view that filters on `inputs.self.base_model_name` needs `inputs.self`
     # in `expand_columns` for the trace server to join through the ref at query
@@ -370,6 +374,7 @@ def make_calls():
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_saved_view_column_select(client):
     make_calls()
     view = weave.SavedView("traces", "My saved view")

--- a/tests/trace/test_scored_calls_query.py
+++ b/tests/trace/test_scored_calls_query.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave import Scorer
 from weave.trace.op_protocol import Op
 from weave.trace.weave_client import WeaveClient
@@ -184,6 +185,7 @@ async def perform_scorer_tests(
     assert len(calls_high_level) == len(calls_low_level) == count
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_scorer_query_op(client: WeaveClient):
     @weave.op
@@ -204,6 +206,7 @@ async def test_scorer_query_op(client: WeaveClient):
     await perform_scorer_tests(client, fn0_v0, fn0, fn1)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_scorer_query_obj(client: WeaveClient):
     class MyScorer0(weave.Scorer):

--- a/tests/trace/test_scores.py
+++ b/tests/trace/test_scores.py
@@ -1,10 +1,14 @@
 from concurrent.futures import Future
 
+import pytest
+
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.ref_util import get_ref
 from weave.trace_server import trace_server_interface as tsi
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_send_score_call(client):
     @weave.op
     def my_op(x: int) -> int:

--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass
 
+import pytest
 from pydantic import BaseModel
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.object_record import pydantic_object_record
 from weave.trace.serialization.op_type import _replace_memory_address
 from weave.trace.serialization.serialize import (
@@ -314,6 +316,7 @@ def test_to_json_pydantic_class(client) -> None:
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_to_json_object_excludes_ref(client) -> None:
     class MyObj(weave.Object):
         @weave.op
@@ -326,6 +329,7 @@ def test_to_json_object_excludes_ref(client) -> None:
     assert "ref" not in serialized
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_to_json_function_with_memory_address_in_op(weave_active) -> None:
     opaque = object()
 

--- a/tests/trace/test_serialize_encoders.py
+++ b/tests/trace/test_serialize_encoders.py
@@ -19,6 +19,7 @@ from typing import Any, NamedTuple
 import pytest
 from pydantic import BaseModel
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.flow.scorer import WeaveScorerResult
 from weave.trace.object_record import ObjectRecord
 from weave.trace.refs import ObjectRef, TableRef
@@ -259,6 +260,7 @@ def test_encode_weave_scorer_result_non_scorer_returns_miss(value: Any) -> None:
 # ---------- _encode_custom_obj ----------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_encode_custom_obj_registered_type(client: Any) -> None:
     # datetime has a built-in registered serializer; encoding produces a
     # CustomWeaveType payload with the inline value format.
@@ -436,6 +438,7 @@ def test_to_json_weave_scorer_result_emits_plain_dict() -> None:
     assert encoded == {"passed": True, "metadata": {"score": 1.0}}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_to_json_custom_obj_datetime_roundtrips_via_registry(client: Any) -> None:
     dt = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     encoded = to_json(dt, client.project_id, client)

--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -17,6 +17,7 @@ from google.auth import credentials as ga_credentials
 from google.cloud import storage
 from moto import mock_aws
 
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from weave.shared.digest import compute_file_digest
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import clickhouse_trace_server_settings, file_storage
@@ -84,6 +85,9 @@ class TestS3Storage:
             yield
 
     @pytest.mark.usefixtures("aws_storage_env")
+    @pytest.mark.skipif(
+        NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+    )
     def test_aws_storage(self, run_storage_test, s3):
         """Test file storage using AWS S3."""
         res = run_storage_test()
@@ -98,6 +102,9 @@ class TestS3Storage:
         obj_response = s3.get_object(Bucket=TEST_BUCKET, Key=obj["Key"])
         assert obj_response["Body"].read() == TEST_CONTENT
 
+    @pytest.mark.skipif(
+        NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+    )
     def test_large_file_migration(self, run_storage_test, s3, client: WeaveClient):
         # This test is critical in that it ensures that the system works correctly for large files. Both
         # before and after the migration to file storage, we should be able to read the file correctly.
@@ -156,6 +163,9 @@ class TestGCSStorage:
     """
 
     @pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
+    @pytest.mark.skipif(
+        NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+    )
     def test_gcp_storage(self, run_storage_test, gcs, client: WeaveClient):
         """Test file storage using Google Cloud Storage."""
         res = run_storage_test()
@@ -167,6 +177,9 @@ class TestGCSStorage:
         assert gcs.state.upload_count == 1
 
     @pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
+    @pytest.mark.skipif(
+        NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+    )
     def test_gcp_storage_skips_duplicate_write(self, client: WeaveClient):
         """Test that writing the same content twice skips the second write.
 
@@ -336,6 +349,9 @@ class TestAzureStorage:
             yield
 
     @pytest.mark.usefixtures("azure_storage_env")
+    @pytest.mark.skipif(
+        NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+    )
     def test_azure_storage(self, run_storage_test, azure_blob):
         """Test file storage using Azure Blob Storage."""
         res = run_storage_test()
@@ -350,6 +366,9 @@ class TestAzureStorage:
         assert blob_client.download_blob().readall() == TEST_CONTENT
 
     @pytest.mark.usefixtures("azure_storage_env")
+    @pytest.mark.skipif(
+        NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+    )
     def test_azure_storage_does_not_overwrite_existing_blob(self, client: WeaveClient):
         """Azure store must not clobber an existing content-addressable blob.
 
@@ -426,6 +445,9 @@ class TestAzureStorage:
             assert file.content == original
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+)
 def test_support_for_variable_length_chunks(client: WeaveClient):
     """Test that the system supports variable length chunks.
     We don't actually want to change this often, but we need to make sure it works.
@@ -470,6 +492,9 @@ def test_support_for_variable_length_chunks(client: WeaveClient):
 
 
 @pytest.mark.disable_logging_error_check
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+)
 def test_file_storage_retry_limit(client: WeaveClient):
     """Test that file storage operations retry exactly 3 times on storage failures."""
     attempt_count = 0
@@ -550,6 +575,9 @@ def _unique_payload(unique: str, size: int) -> bytes:
 
 @pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
 @pytest.mark.disable_logging_error_check
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
+)
 def test_call_batch_uploads_files_to_bucket_in_parallel(client: WeaveClient, gcs):
     """Multiple file_create calls inside one call_batch fan out to GCS in
     parallel: concurrent uploads happen, identical content within the batch
@@ -603,6 +631,9 @@ def test_call_batch_uploads_files_to_bucket_in_parallel(client: WeaveClient, gcs
         250_000,
     ],
     ids=["single-chunk-fallback", "multi-chunk-fallback"],
+)
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: bucket file storage machinery"
 )
 def test_call_batch_falls_back_to_clickhouse_on_per_file_bucket_failure(
     client: WeaveClient, gcs, fail_payload_size: int

--- a/tests/trace/test_server_object_creation_utils.py
+++ b/tests/trace/test_server_object_creation_utils.py
@@ -5,6 +5,7 @@ as the SDK.  Ideally they would be placed next to the trace_server tests, but
 the client serialization requires a client object to serialize.
 """
 
+
 import weave
 from weave.evaluation.eval import Evaluation
 from weave.flow.scorer import Scorer

--- a/tests/trace/test_server_object_creation_utils.py
+++ b/tests/trace/test_server_object_creation_utils.py
@@ -5,8 +5,10 @@ as the SDK.  Ideally they would be placed next to the trace_server tests, but
 the client serialization requires a client object to serialize.
 """
 
+import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.evaluation.eval import Evaluation
 from weave.flow.scorer import Scorer
 from weave.trace.object_record import pydantic_object_record
@@ -15,6 +17,7 @@ from weave.trace.weave_client import WeaveClient, map_to_refs
 from weave.trace_server import object_creation_utils
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_helper_serializes_op_same_way_as_sdk(client: WeaveClient) -> None:
     """Test that helpers serialize an Op the same way as SDK."""
 
@@ -30,6 +33,7 @@ def test_helper_serializes_op_same_way_as_sdk(client: WeaveClient) -> None:
     assert helper_val == sdk_val
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_helper_serializes_dataset_same_way_as_sdk(client: WeaveClient) -> None:
     """Test that helpers serialize a Dataset the same way as SDK."""
     # Create a test dataset
@@ -72,6 +76,7 @@ def test_helper_serializes_dataset_same_way_as_sdk(client: WeaveClient) -> None:
     assert helper_val == sdk_val
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_helper_serializes_scorer_same_way_as_sdk(client: WeaveClient) -> None:
     """Test that helpers serialize a Scorer with the correct structure.
 
@@ -122,6 +127,7 @@ def test_helper_serializes_scorer_same_way_as_sdk(client: WeaveClient) -> None:
     assert helper_val == sdk_val
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_helper_serializes_evaluation_same_way_as_sdk(client: WeaveClient) -> None:
     """Test that helpers serialize an Evaluation with the correct structure.
     Note: The helper creates base Evaluation objects (not custom subclasses),

--- a/tests/trace/test_table_query.py
+++ b/tests/trace/test_table_query.py
@@ -1,6 +1,9 @@
 import random
 from collections.abc import Iterator
 
+import pytest
+
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
@@ -40,6 +43,7 @@ def generate_table_data(client: WeaveClient, n_rows: int, n_cols: int):
     return digest, row_digests, data
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
 
@@ -59,6 +63,7 @@ def test_table_query(client: WeaveClient):
     assert result_indices == list(range(len(data)))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stream(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
 
@@ -83,6 +88,7 @@ def test_table_query_stream(client: WeaveClient):
     assert result_indices == list(range(len(data)))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_invalid_digest(client: WeaveClient):
     res = client.server.table_query(
         tsi.TableQueryReq(
@@ -94,6 +100,7 @@ def test_table_query_invalid_digest(client: WeaveClient):
     assert res.rows == []
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_filter_by_row_digests(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 5)
 
@@ -114,6 +121,7 @@ def test_table_query_filter_by_row_digests(client: WeaveClient):
     assert result_indices == [2, 3, 4]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_invalid_row_digest(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
     res = client.server.table_query(
@@ -127,6 +135,7 @@ def test_table_query_invalid_row_digest(client: WeaveClient):
     assert res.rows == []
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_limit(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 5)
 
@@ -145,6 +154,7 @@ def test_table_query_limit(client: WeaveClient):
     assert result_indices == list(range(limit))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_offset(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 5)
 
@@ -163,6 +173,7 @@ def test_table_query_offset(client: WeaveClient):
     assert result_indices == list(range(offset, len(data)))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_sort_by_column(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 5)
 
@@ -189,6 +200,7 @@ def test_table_query_sort_by_column(client: WeaveClient):
     assert result_indices == expected_indices
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_sort_by_nested_column(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 5)
 
@@ -211,6 +223,7 @@ def test_table_query_sort_by_nested_column(client: WeaveClient):
     assert result_indices == expected_indices
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_combined(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 20, 5)
 
@@ -239,6 +252,7 @@ def test_table_query_combined(client: WeaveClient):
     assert result_indices == expected_indices
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_multiple_sort_criteria(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 20, 5)
 
@@ -263,6 +277,7 @@ def test_table_query_multiple_sort_criteria(client: WeaveClient):
     assert result_indices == expected_indices
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stats(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
 
@@ -276,6 +291,7 @@ def test_table_query_stats(client: WeaveClient):
     assert stats_res.tables[0].count == len(data)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stats_empty(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 0, 0)
 
@@ -289,6 +305,7 @@ def test_table_query_stats_empty(client: WeaveClient):
     assert stats_res.tables[0].count == len(data)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stats_missing(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
 
@@ -302,6 +319,7 @@ def test_table_query_stats_missing(client: WeaveClient):
     assert len(stats_res.tables) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stats_legacy_missing(client: WeaveClient):
     # The legacy single-digest endpoint must not IndexError when the digest
     # doesn't exist; it should report count=0.
@@ -335,6 +353,7 @@ def generate_duplication_simple_table_data(
     return {"digest": digest, "row_digests": row_digests, "data": data}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_with_duplicate_row_digests(client: WeaveClient):
     res1 = generate_duplication_simple_table_data(client, 10, 1)
     res2 = generate_duplication_simple_table_data(client, 10, 2)
@@ -422,6 +441,7 @@ def test_table_query_with_duplicate_row_digests(client: WeaveClient):
     assert [r.original_index for r in res.rows] == [0, 1, 2]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_duplicate_table_with_identical_rows(client: WeaveClient):
     data = [{"val": i} for i in range(10)]
 
@@ -462,6 +482,7 @@ def test_duplicate_table_with_identical_rows(client: WeaveClient):
     assert [r.original_index for r in res.rows] == list(range(10))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stats_with_storage_size(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
 

--- a/tests/trace/test_trace_server.py
+++ b/tests/trace/test_trace_server.py
@@ -2,11 +2,13 @@ import urllib
 
 import pytest
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.shared.refs_internal import InvalidInternalRef
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import RefObjectsNotFoundError
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_save_object(client):
     create_res = client.server.obj_create(
         tsi.ObjCreateReq(
@@ -26,6 +28,7 @@ def test_save_object(client):
     assert read_res.obj.val == {"a": 1}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_robust_to_url_sensitive_chars(client):
     project_id = client.project_id
     object_id = "mali_cious-obj.ect"
@@ -84,6 +87,7 @@ def test_robust_to_url_sensitive_chars(client):
     assert read_res.vals[0] == bad_val[bad_key]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_missing_refs_reports_digests(client):
     project_id = client.project_id
     create_res = client.server.obj_create(

--- a/tests/trace/test_trace_server_v2_api.py
+++ b/tests/trace/test_trace_server_v2_api.py
@@ -18,6 +18,7 @@ import datetime
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.evaluation.eval_imperative import EvaluationLogger
 from weave.trace_server import constants
 from weave.trace_server import trace_server_interface as tsi
@@ -28,6 +29,7 @@ from weave.utils.project_id import from_project_id
 class TestOpsV2API:
     """Tests for Ops V2 API endpoints."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_op_create(self, client):
         """Test creating an op via V2 API."""
         project_id = client.project_id
@@ -45,6 +47,7 @@ class TestOpsV2API:
         assert res.digest is not None
         assert res.version_index == 0
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_op_read(self, client):
         """Test reading an op via V2 API."""
         project_id = client.project_id
@@ -73,6 +76,7 @@ class TestOpsV2API:
         assert read_res.code == source_code
         assert read_res.created_at is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_op_list(self, client):
         """Test listing ops via V2 API."""
         project_id = client.project_id
@@ -97,6 +101,7 @@ class TestOpsV2API:
         assert "list_test_op_1" in op_names
         assert "list_test_op_2" in op_names
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_op_list_with_limit(self, client):
         """Test listing ops with limit via V2 API."""
         project_id = client.project_id
@@ -117,6 +122,7 @@ class TestOpsV2API:
         # Verify limit is respected
         assert len(ops) == 2
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_op_delete(self, client):
         """Test deleting an op via V2 API."""
         project_id = client.project_id
@@ -140,6 +146,7 @@ class TestOpsV2API:
         # Verify deletion
         assert delete_res.num_deleted == 1
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_op_delete_all_versions(self, client):
         """Test deleting all versions of an op via V2 API."""
         project_id = client.project_id
@@ -170,6 +177,7 @@ class TestOpsV2API:
 class TestDatasetsV2API:
     """Tests for Datasets V2 API endpoints."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_dataset_create(self, client):
         """Test creating a dataset via V2 API."""
         project_id = client.project_id
@@ -192,6 +200,7 @@ class TestDatasetsV2API:
         assert res.digest is not None
         assert res.version_index == 0
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_dataset_read(self, client):
         """Test reading a dataset via V2 API."""
         project_id = client.project_id
@@ -226,6 +235,7 @@ class TestDatasetsV2API:
         assert read_res.rows is not None  # Field is 'rows', not 'rows_ref'
         assert read_res.created_at is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_dataset_list(self, client):
         """Test listing datasets via V2 API."""
         project_id = client.project_id
@@ -250,6 +260,7 @@ class TestDatasetsV2API:
         assert "list_dataset_1" in dataset_names
         assert "list_dataset_2" in dataset_names
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_dataset_delete(self, client):
         """Test deleting a dataset via V2 API."""
         project_id = client.project_id
@@ -277,6 +288,7 @@ class TestDatasetsV2API:
 class TestScorersV2API:
     """Tests for Scorers V2 API endpoints."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_scorer_create(self, client):
         """Test creating a scorer via V2 API."""
         project_id = client.project_id
@@ -296,6 +308,7 @@ class TestScorersV2API:
         assert res.digest is not None
         assert res.version_index == 0
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_scorer_read(self, client):
         """Test reading a scorer via V2 API."""
         project_id = client.project_id
@@ -329,6 +342,7 @@ class TestScorersV2API:
         assert read_res.score_op is not None  # ScorerReadRes has 'score_op', not 'code'
         assert read_res.created_at is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_scorer_list(self, client):
         """Test listing scorers via V2 API."""
         project_id = client.project_id
@@ -353,6 +367,7 @@ class TestScorersV2API:
         assert "list_scorer_1" in scorer_names
         assert "list_scorer_2" in scorer_names
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_scorer_delete(self, client):
         """Test deleting a scorer via V2 API."""
         project_id = client.project_id
@@ -380,6 +395,7 @@ class TestScorersV2API:
 class TestEvaluationsV2API:
     """Tests for Evaluations V2 API endpoints."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_evaluation_create(self, client):
         """Test creating an evaluation via V2 API."""
         project_id = client.project_id
@@ -413,6 +429,7 @@ class TestEvaluationsV2API:
         assert res.version_index == 0
         assert res.evaluation_ref is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_evaluation_read(self, client):
         """Test reading an evaluation via V2 API."""
         project_id = client.project_id
@@ -462,6 +479,7 @@ class TestEvaluationsV2API:
         assert read_res.summarize_op is not None
         assert read_res.created_at is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_evaluation_list(self, client):
         """Test listing evaluations via V2 API."""
         project_id = client.project_id
@@ -498,6 +516,7 @@ class TestEvaluationsV2API:
         assert "list_evaluation_1" in eval_names
         assert "list_evaluation_2" in eval_names
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_evaluation_delete(self, client):
         """Test deleting an evaluation via V2 API."""
         project_id = client.project_id
@@ -532,6 +551,7 @@ class TestEvaluationsV2API:
         # Verify deletion
         assert delete_res.num_deleted == 1
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_evaluation_with_scorers(self, client):
         """Test creating an evaluation with scorers."""
         project_id = client.project_id
@@ -590,6 +610,7 @@ class TestEvaluationsV2API:
 class TestV2APIIntegration:
     """Integration tests for V2 API endpoints."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_complete_evaluation_workflow(self, client):
         """Test a complete workflow: create dataset, scorers, and evaluation."""
         project_id = client.project_id
@@ -682,6 +703,7 @@ class TestV2APIIntegration:
         scorer2_read_res = client.server.scorer_read(scorer2_read_req)
         assert scorer2_read_res.name == "length_check"
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_versioning_workflow(self, client):
         """Test that versioning works correctly across V2 API."""
         project_id = client.project_id
@@ -722,6 +744,7 @@ class TestV2APIIntegration:
 class TestModelsV2API:
     """Tests for Models V2 API endpoints."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_model_create(self, client):
         """Test creating a model via V2 API."""
         project_id = client.project_id
@@ -750,6 +773,7 @@ class TestModel(weave.Model):
         assert res.version_index == 0
         assert res.model_ref is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_model_read(self, client):
         """Test reading a model via V2 API."""
         project_id = client.project_id
@@ -792,6 +816,7 @@ class MyTestModel(weave.Model):
         assert read_res.attributes.get("prompt") == "Hello"
         assert read_res.created_at is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_model_list(self, client):
         """Test listing models via V2 API."""
         project_id = client.project_id
@@ -822,6 +847,7 @@ class ListTestModel{i}(weave.Model):
         assert "ListTestModel1" in model_names
         assert "ListTestModel2" in model_names
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_model_delete(self, client):
         """Test deleting a model via V2 API."""
         project_id = client.project_id
@@ -851,6 +877,7 @@ class DeletableModel(weave.Model):
         # Verify deletion
         assert delete_res.num_deleted == 1
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_model_delete_all_versions(self, client):
         """Test deleting all versions of a model via V2 API."""
         project_id = client.project_id
@@ -889,6 +916,7 @@ class MultiVersionModel(weave.Model):
 class TestEvaluationRunsV2API:
     """Tests for Evaluation Runs V2 API endpoints."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_evaluation_run_create(self, client):
         """Test creating an evaluation run via V2 API."""
         project_id = client.project_id
@@ -937,6 +965,7 @@ class EvalRunModel(weave.Model):
         # Verify response
         assert run_res.evaluation_run_id is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_evaluation_run_read(self, client):
         """Test reading an evaluation run via V2 API."""
         project_id = client.project_id
@@ -992,6 +1021,7 @@ class ReadEvalRunModel(weave.Model):
         assert read_res.evaluation == eval_res.evaluation_ref
         assert read_res.model == model_res.model_ref
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_evaluation_run_list(self, client):
         """Test listing evaluation runs via V2 API."""
         project_id = client.project_id
@@ -1049,6 +1079,7 @@ class ListEvalRunModel{i}(weave.Model):
         for run_id in run_ids:
             assert run_id in returned_ids
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_evaluation_run_delete(self, client):
         """Test deleting evaluation runs via V2 API."""
         project_id = client.project_id
@@ -1104,6 +1135,7 @@ class DeleteEvalRunModel(weave.Model):
         # Verify deletion
         assert delete_res.num_deleted == 1
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_evaluation_run_finish(self, client):
         """Test finishing an evaluation run via V2 API."""
         project_id = client.project_id
@@ -1164,6 +1196,7 @@ class FinishEvalRunModel(weave.Model):
 class TestPredictionsV2API:
     """Tests for Predictions V2 API endpoints."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_prediction_create(self, client):
         """Test creating a prediction via V2 API."""
         project_id = client.project_id
@@ -1195,6 +1228,7 @@ class PredictionTestModel(weave.Model):
         # Verify response
         assert pred_res.prediction_id is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_prediction_read(self, client):
         """Test reading a prediction via V2 API."""
         project_id = client.project_id
@@ -1236,6 +1270,7 @@ class ReadPredictionModel(weave.Model):
         assert read_res.inputs == {"question": "What is 2+2?"}
         assert read_res.output == "4"
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_prediction_read_with_none_inputs(self, client):
         """Test reading a prediction where the underlying call has None inputs.
 
@@ -1287,6 +1322,7 @@ class ReadPredictionModel(weave.Model):
         assert read_res.inputs == {}
         assert read_res.output == "some output"
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_prediction_list(self, client):
         """Test listing predictions via V2 API."""
         project_id = client.project_id
@@ -1328,6 +1364,7 @@ class ListPredictionModel(weave.Model):
         for pred_id in pred_ids:
             assert pred_id in returned_ids
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_prediction_delete(self, client):
         """Test deleting predictions via V2 API."""
         project_id = client.project_id
@@ -1369,6 +1406,7 @@ class DeletePredictionModel(weave.Model):
         # Verify deletion
         assert delete_res.num_deleted == 2
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_prediction_with_evaluation_run(self, client):
         """Test creating a prediction linked to an evaluation run."""
         project_id = client.project_id
@@ -1472,6 +1510,7 @@ class PredEvalRunModel(weave.Model):
 class TestScoresV2API:
     """Tests for Scores V2 API endpoints."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_score_create(self, client):
         """Test creating a score via V2 API."""
         project_id = client.project_id
@@ -1521,6 +1560,7 @@ class ScoreTestModel(weave.Model):
         # Verify response
         assert score_res.score_id is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_score_read(self, client):
         """Test reading a score via V2 API."""
         project_id = client.project_id
@@ -1579,6 +1619,7 @@ class ReadScoreModel(weave.Model):
         assert read_res.scorer == scorer_ref
         assert read_res.value == 0.85
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_score_list(self, client):
         """Test listing scores via V2 API."""
         project_id = client.project_id
@@ -1637,6 +1678,7 @@ class ListScoreModel(weave.Model):
         for score_id in score_ids:
             assert score_id in returned_ids
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_score_delete(self, client):
         """Test deleting scores via V2 API."""
         project_id = client.project_id
@@ -1695,6 +1737,7 @@ class DeleteScoreModel(weave.Model):
         # Verify deletion
         assert delete_res.num_deleted == 2
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_score_with_evaluation_run(self, client):
         """Test creating a score linked to an evaluation run."""
         project_id = client.project_id
@@ -1782,6 +1825,7 @@ class ScoreEvalRunModel(weave.Model):
 class TestEvalResultsReadAPI:
     """Tests for the read-oriented eval results API."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_eval_results_query_intersection(self, client):
         """Keeps only rows shared by all requested evaluations."""
         project_id = client.project_id
@@ -1901,6 +1945,7 @@ class TestEvalResultsReadAPI:
             run_b.evaluation_run_id,
         }
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_eval_results_summary_pass_signal(self, client):
         """Aggregates pass-rate stats from scorer outputs with `passed` booleans."""
         project_id = client.project_id
@@ -2004,6 +2049,7 @@ class TestEvalResultsReadAPI:
         assert scorer_stats.pass_true_count == 1
         assert scorer_stats.pass_rate == 1.0
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_eval_results_summary_nested_passed_dimension(self, client):
         """Verify scorer_stats emits one entry per flattened leaf (e.g. token_distance.passed)."""
         project_id = client.project_id
@@ -2115,6 +2161,7 @@ class TestEvalResultsReadAPI:
         assert distance_stats.numeric_count == 1
         assert distance_stats.numeric_mean == 0.0
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.asyncio
     async def test_eval_results_from_high_level_evaluation(self, client):
         """Run a real weave.Evaluation then verify eval_results_query and summary."""
@@ -2198,6 +2245,7 @@ class TestEvalResultsReadAPI:
         assert match_stats.pass_true_count == 2
         assert match_stats.pass_rate == 1.0
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_eval_results_from_imperative_evaluation(self, client):
         """Run a real EvaluationLogger then verify eval_results_query and summary."""
         project_id = client.project_id
@@ -2269,6 +2317,7 @@ class TestEvalResultsReadAPI:
         assert conf.numeric_mean == pytest.approx((0.9 + 0.3 + 0.7) / 3)
         assert conf.pass_known_count == 0
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_eval_results_summary_numeric_mean(self, client):
         """Verify numeric aggregation in eval_results_summary."""
         project_id = client.project_id
@@ -2344,6 +2393,7 @@ class TestEvalResultsReadAPI:
         assert stats.pass_rate is None
         assert stats.pass_known_count == 0
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_eval_results_query_multiple_scorers(self, client):
         """Verify multiple scorers appear in query and summary results."""
         project_id = client.project_id
@@ -2478,6 +2528,7 @@ class TestEvalResultsReadAPI:
         assert beta.numeric_count == 2
         assert beta.numeric_mean == pytest.approx(0.15)
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_eval_results_query_combined_sections_match_separate_calls(self, client):
         """Combined eval_results/query sections should match separate query+summary."""
         project_id = client.project_id
@@ -2536,6 +2587,7 @@ class TestEvalResultsReadAPI:
         assert combined_query.summary is not None
         assert combined_query.summary.model_dump() == separate_summary.model_dump()
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_eval_results_summary_text_dimension_scalar(self, client):
         """A scorer that returns a plain string produces a 'text' scorer_stats entry."""
         project_id = client.project_id
@@ -2640,6 +2692,7 @@ class TestEvalResultsReadAPI:
         assert stats.pass_known_count == 0
         assert stats.pass_rate is None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_eval_results_summary_text_dimension_mixed_dict(self, client):
         """A scorer returning a dict with string and bool produces one 'text' and one 'binary' entry."""
         project_id = client.project_id

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -12,6 +12,7 @@ import tenacity
 
 import weave
 from tests.trace.util import (
+    FAKE_NOT_IMPLEMENTED,
     capture_output,
     flush_and_wait_for_output,
     flush_output,
@@ -43,6 +44,7 @@ def func():
     return 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_disabled_setting(client):
     replace_settings(UserSettings(disabled=True))
     disabled_time = timeit.timeit(func, number=10)
@@ -59,6 +61,7 @@ def test_disabled_setting(client):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_disabled_env(client):
     os.environ["WEAVE_DISABLED"] = "true"
     disabled_time = timeit.timeit(func, number=10)
@@ -144,6 +147,7 @@ def test_publish_when_disabled_ignores_tags_aliases(weave_active, monkeypatch):
     assert ref.digest == "DISABLED"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_print_call_link_setting(client_creator):
     with client_creator(settings=UserSettings(print_call_link=False)) as client:
         with capture_output() as captured:
@@ -158,6 +162,7 @@ def test_print_call_link_setting(client_creator):
     assert TRACE_CALL_EMOJI in captured.getvalue()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_print_call_link_env(client):
     os.environ["WEAVE_PRINT_CALL_LINK"] = "false"
     with capture_output() as captured:
@@ -177,6 +182,7 @@ def test_print_call_link_env(client):
     del os.environ["WEAVE_PRINT_CALL_LINK"]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_should_capture_code_setting(weave_active):
     replace_settings(UserSettings(capture_code=False))
 
@@ -203,6 +209,7 @@ def test_should_capture_code_setting(weave_active):
     assert "Code-capture was disabled" not in code3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_should_capture_code_env(weave_active):
     os.environ["WEAVE_CAPTURE_CODE"] = "false"
 
@@ -419,6 +426,7 @@ def test_retry_max_interval_env(caplog, monkeypatch) -> None:
     del os.environ["WEAVE_RETRY_MAX_INTERVAL"]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_level_setting(client_creator):
     """Test that log_level setting properly silences publish messages."""
 
@@ -443,6 +451,7 @@ def test_log_level_setting(client_creator):
     assert "Published to" in output
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_log_level_env(client_creator):
     """Test that WEAVE_LOG_LEVEL environment variable properly silences publish messages."""
 

--- a/tests/trace/test_tracing_resilience.py
+++ b/tests/trace/test_tracing_resilience.py
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 
 import weave
-from tests.trace.util import DummyTestException
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, DummyTestException
 from weave.trace import weave_client
 from weave.trace.context import call_context
 from weave.trace.context.tests_context import raise_on_captured_errors
@@ -32,6 +32,7 @@ def reset_call_context():
     call_context._call_stack.reset(token)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_resilience_to_user_code_errors(weave_active):
     def do_test():
         @weave.op
@@ -52,6 +53,7 @@ def test_resilience_to_user_code_errors(weave_active):
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_server_errors(client_with_throwing_server, log_collector):
     def do_test():
@@ -126,6 +128,7 @@ def test_resilience_to_obj_create_failure_does_not_pin_payload(
     assert obj_weak() is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_output_handler_errors(weave_active, log_collector):
     def do_test():
@@ -156,6 +159,7 @@ def test_resilience_to_output_handler_errors(weave_active, log_collector):
     assert logs[0].msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_output_handler_errors_async(weave_active, log_collector):
@@ -187,6 +191,7 @@ async def test_resilience_to_output_handler_errors_async(weave_active, log_colle
     assert logs[0].msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_collector):
     def do_test():
@@ -218,6 +223,7 @@ def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_col
     assert logs[0].msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_make_accumulator_errors_async(
@@ -254,6 +260,7 @@ async def test_resilience_to_accumulator_make_accumulator_errors_async(
     assert logs[0].msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collector):
     def do_test():
@@ -289,6 +296,7 @@ def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collect
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_accumulation_errors_async(
@@ -329,6 +337,7 @@ async def test_resilience_to_accumulator_accumulation_errors_async(
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_should_accumulate_errors(
     weave_active, log_collector
@@ -371,6 +380,7 @@ def test_resilience_to_accumulator_should_accumulate_errors(
     assert logs[0].msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_should_accumulate_errors_async(
@@ -421,6 +431,7 @@ async def test_resilience_to_accumulator_should_accumulate_errors_async(
 # and that is expected and tested for. It happens to be at the deletion moment
 # so pytest is complaining that the exception is not being raised in the
 # expected manner.
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_on_finish_post_processor_errors(
@@ -466,6 +477,7 @@ def test_resilience_to_accumulator_on_finish_post_processor_errors(
         assert log.msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
@@ -513,6 +525,7 @@ async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
         assert log.msg.startswith("Error capturing call output")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_resilience_to_accumulator_internal_errors(weave_active):
     def do_test():
         @weave.op(accumulator=lambda *args, **kwargs: {})
@@ -534,6 +547,7 @@ def test_resilience_to_accumulator_internal_errors(weave_active):
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_resilience_to_accumulator_internal_errors_async(weave_active):
     async def do_test():
@@ -579,6 +593,7 @@ def _bad_finish_handler(call, output, exception):
     raise DummyTestException("FAILURE in on_finish_handler!")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_postprocess_inputs_errors(weave_active, log_collector):
     """Test that errors in postprocess_inputs don't crash the user's program."""
@@ -596,6 +611,7 @@ def test_resilience_to_postprocess_inputs_errors(weave_active, log_collector):
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_postprocess_inputs_errors_async(
@@ -616,6 +632,7 @@ async def test_resilience_to_postprocess_inputs_errors_async(
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_postprocess_output_errors(weave_active, log_collector):
     """Test that errors in postprocess_output don't crash the user's program."""
@@ -633,6 +650,7 @@ def test_resilience_to_postprocess_output_errors(weave_active, log_collector):
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_postprocess_output_errors_async(
@@ -653,6 +671,7 @@ async def test_resilience_to_postprocess_output_errors_async(
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_call_display_name_errors(weave_active, log_collector):
     """Test that errors in call_display_name callable don't crash the user's program."""
@@ -670,6 +689,7 @@ def test_resilience_to_call_display_name_errors(weave_active, log_collector):
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_call_display_name_errors_async(
@@ -690,6 +710,7 @@ async def test_resilience_to_call_display_name_errors_async(
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_on_input_handler_errors(weave_active, log_collector):
     """Test that errors in _on_input_handler don't crash the user's program."""
@@ -709,6 +730,7 @@ def test_resilience_to_on_input_handler_errors(weave_active, log_collector):
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_on_input_handler_errors_async(weave_active, log_collector):
@@ -729,6 +751,7 @@ async def test_resilience_to_on_input_handler_errors_async(weave_active, log_col
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_on_finish_handler_errors(weave_active, log_collector):
     """Test that errors in _on_finish_handler don't crash the user's program."""
@@ -748,6 +771,7 @@ def test_resilience_to_on_finish_handler_errors(weave_active, log_collector):
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_on_finish_handler_errors_async(
@@ -865,6 +889,7 @@ async def test_create_call_leak_restores_call_stack_async_gen(
     assert_no_current_call()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_create_call_leak_preserves_parent_call(
     weave_active, monkeypatch, log_collector

--- a/tests/trace/test_vals.py
+++ b/tests/trace/test_vals.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.shared.refs_internal import (
     DICT_KEY_EDGE_NAME,
     LIST_INDEX_EDGE_NAME,
@@ -10,6 +11,7 @@ from weave.shared.refs_internal import (
 from weave.trace.refs import ObjectRef
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dict_refs(client):
     d = client.save({"a": 1, "b": 2}, name="d")
 
@@ -24,6 +26,7 @@ def test_dict_refs(client):
     assert d["b"].ref.extra == (DICT_KEY_EDGE_NAME, "b")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dict_iter(client):
     d_orig = client.save({"a": 1, "b": 2, "c": 3}, name="d")
     d = dict(d_orig)
@@ -41,6 +44,7 @@ def test_dict_iter(client):
     assert d["b"].ref.extra == (DICT_KEY_EDGE_NAME, "b")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_list_refs(client):
     l = client.save([1, 2], name="l")
 
@@ -55,6 +59,7 @@ def test_list_refs(client):
     assert l[1].ref.extra == (LIST_INDEX_EDGE_NAME, "1")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_list_iter(client):
     l_orig = client.save([1, 2], name="l")
     l = list(l_orig)
@@ -70,6 +75,7 @@ def test_list_iter(client):
     assert isinstance(l[1].ref, ObjectRef)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_row_ref_inside_dict(client):
     """Test the case where a Weave object has a value that is a ref to a row within a Dataset.
 

--- a/tests/trace/test_wal_client_writes.py
+++ b/tests/trace/test_wal_client_writes.py
@@ -18,6 +18,7 @@ import pytest
 from PIL import Image
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.durability.wal_client_id import compute_client_id
 from weave.durability.wal_consumer import JSONLWALConsumer
 from weave.durability.wal_directory_manager import FileWALDirectoryManager
@@ -103,6 +104,7 @@ def wal_client_with_sender(client_creator, tmp_path):
 class TestWALClientWrites:
     """Verify that client operations produce WAL records when enabled."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_obj_create(self, wal_client):
         weave.publish({"model": "gpt-4", "temp": 0.7}, name="my_obj")
         wal_client._flush()
@@ -143,6 +145,7 @@ class TestWALClientWrites:
             },
         }
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_file_create(self, wal_client):
         img = Image.new("RGB", (2, 2), color="red")
         weave.publish(img, name="my_image")
@@ -167,6 +170,7 @@ class TestWALClientWrites:
             "type": "PIL.Image.Image"
         }
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_call_start(self, wal_client):
         """Calling an op should produce a call_start WAL record with all fields."""
 
@@ -193,6 +197,7 @@ class TestWALClientWrites:
         assert isinstance(start["attributes"], dict)
         assert start["parent_id"] is None  # root call
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_call_end(self, wal_client):
         """Calling an op should produce a call_end WAL record with all fields."""
 
@@ -217,6 +222,7 @@ class TestWALClientWrites:
         assert end["exception"] is None
         assert isinstance(end["summary"], dict)
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_call_with_exception(self, wal_client):
         """A failing op should record the exception in call_end."""
 
@@ -234,6 +240,7 @@ class TestWALClientWrites:
         assert len(call_ends) == 1
         assert "boom" in call_ends[0]["req"]["end"]["exception"]
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_nested_calls(self, wal_client):
         """Nested op calls should produce parent-child call_start records."""
 
@@ -288,6 +295,7 @@ class TestWALClientWrites:
         assert inner_end["req"]["end"]["output"] == 10
         assert outer_end["req"]["end"]["output"] == 10
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_wal_records_are_json_serializable(self, wal_client):
         """Ensure WAL records round-trip through JSON without loss."""
         weave.publish({"nested": {"list": [1, 2, 3]}}, name="json_obj")
@@ -298,6 +306,7 @@ class TestWALClientWrites:
         roundtripped = json.loads(json.dumps(records[0]))
         assert roundtripped == records[0]
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_flush_fsyncs_wal(self, wal_client):
         """flush() should fsync the WAL so records survive a process crash."""
         weave.publish({"a": 1}, name="fsync_obj")
@@ -315,17 +324,20 @@ class TestWALDisabled:
         """Default client should have _wal=None."""
         assert client._wal is None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_publish_works_without_wal(self, weave_active):
         """publish() should succeed and return a ref when WAL is disabled."""
         ref = weave.publish({"key": "value"}, name="no_wal_obj")
         assert ref is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_dataset_publish_works_without_wal(self, weave_active):
         """Dataset publish should succeed when WAL is disabled."""
         ds = weave.Dataset(name="no_wal_ds", rows=[{"x": 1}])
         ref = weave.publish(ds, name="no_wal_ds")
         assert ref is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_flush_works_without_wal(self, client):
         """flush() should not raise when WAL is disabled."""
         weave.publish({"a": 1}, name="flush_obj")
@@ -335,6 +347,7 @@ class TestWALDisabled:
 class TestWALSender:
     """Verify that the in-process sender drains WAL records automatically."""
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_sender_drains_on_close(self, wal_client_with_sender):
         """After close(), the sender's final drain should consume all records."""
         weave.publish({"k": "v"}, name="sender_obj")
@@ -345,6 +358,7 @@ class TestWALSender:
         remaining = list(wal_dir.glob("*.jsonl"))
         assert len(remaining) == 0
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_sender_drains_table_create(self, wal_client_with_sender):
         """Table-create records should be drained and files cleaned up."""
         ds = weave.Dataset(name="sender_ds", rows=[{"x": 1}])

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -19,6 +19,7 @@ from tests.conftest import TestOnlyFlushingWeaveClient
 from tests.trace.server_utils import find_server_layer
 from tests.trace.testutil import ObjectRefStrMatcher
 from tests.trace.util import (
+    FAKE_NOT_IMPLEMENTED,
     AnyIntMatcher,
     DatetimeMatcher,
     RegexStringMatcher,
@@ -74,6 +75,7 @@ from weave.trace_server.trace_server_interface import (
 from weave.trace_server_bindings.http_utils import _ENDPOINT_CACHE
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3, reruns_delay=0.2)
 def test_table_create(client):
     res = client.server.table_create(
@@ -96,6 +98,7 @@ def test_table_create(client):
     assert result.rows[2].val["val"] == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_update(client):
     data = [
         {"val": 1},
@@ -195,6 +198,7 @@ def test_object(server):
     assert server._resolve_object("my-obj", "latest2") is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_save_load(client):
     saved_val = client.save({"a": [1, 2, 3]}, "my-obj")
     val = client.get(saved_val.ref)
@@ -204,6 +208,7 @@ def test_save_load(client):
     assert val_table[2] == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_refs(client):
     ref = client.save(weave.Dataset(rows=[{"v": 1}, {"v": 2}]), "my-dataset")
     new_table_rows = []
@@ -248,6 +253,7 @@ def test_dataset_refs(client):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_obj_with_table(client):
     class ObjWithTable(weave.Object):
         table: weave_client.Table
@@ -261,6 +267,7 @@ def test_obj_with_table(client):
     assert row_vals[2]["a"] == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_pydantic(client):
     class A(pydantic.BaseModel):
         a: int
@@ -355,6 +362,7 @@ def test_get_calls_forwards_include_usernames(client, monkeypatch):
     assert captured_kwargs["include_usernames"] is True
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_create(client):
     call = client.create_call("x", {"a": 5, "b": 10})
     client.finish_call(call, "hello")
@@ -398,6 +406,7 @@ def test_call_create(client):
     assert result == expected
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query(client):
     call0 = client.create_call("x", {"a": 5, "b": 10})
     call1 = client.create_call("x", {"a": 6, "b": 11})
@@ -463,6 +472,7 @@ def test_calls_query(client):
     client.finish_call(call0, None)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_calls_complete(client):
     obj = weave.Dataset(rows=[{"a": 1}, {"a": 2}, {"a": 3}])
     ref = client.save(obj, "my-dataset")
@@ -569,6 +579,7 @@ def test_get_calls_complete(client):
         assert call1.inputs["s"] == call2.inputs["s"]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_calls_len(client):
     for i in range(10):
         client.create_call("x", {"a": i})
@@ -599,6 +610,7 @@ def test_get_calls_len(client):
         client.get_calls(offset=-1)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_calls_limit_offset(client):
     for i in range(10):
         client.create_call("x", {"a": i})
@@ -641,6 +653,7 @@ def test_get_calls_limit_offset(client):
         assert call.inputs["a"] == 7 + i
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_calls_page_size_with_offset(client):
     for i in range(20):
         client.create_call("x", {"a": i})
@@ -678,6 +691,7 @@ def test_get_calls_page_size_with_offset(client):
     assert sorted(all_values) == list(range(20))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_delete(client):
     call0 = client.create_call("x", {"a": 5, "b": 10})
     call0_child1 = client.create_call("x", {"a": 5, "b": 11}, call0)
@@ -708,6 +722,7 @@ def test_calls_delete(client):
     assert len(result) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_calls_delete_cascade(client):
     # run an evaluation, then delete the evaluation and its children
@@ -742,6 +757,7 @@ async def test_calls_delete_cascade(client):
     assert len(result) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_calls(client):
     @weave.op
     def my_op(a: int) -> int:
@@ -782,6 +798,7 @@ def test_delete_calls(client):
     assert len(calls) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_display_name(client):
     call0 = client.create_call("x", {"a": 5, "b": 10})
 
@@ -825,6 +842,7 @@ def test_call_display_name(client):
     assert call0.display_name is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_set_display_name_does_not_block_caller(client, no_autoflush):
     """set_display_name must defer the server PATCH to future_executor.
 
@@ -881,6 +899,7 @@ def test_set_display_name_does_not_block_caller(client, no_autoflush):
         client.server = real_server
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_calls(client):
     rows = [{"doc": "xx", "label": "c"}, {"doc": "yy", "label": "d"}]
     op_name = ""
@@ -979,6 +998,7 @@ def test_stable_dataset_row_refs(client):
     assert len(list(x)) == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_opdef(client):
     @weave.op
     def add2(x, y):
@@ -990,6 +1010,7 @@ def test_opdef(client):
     assert len(list(client.get_calls())) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_mismatch_project_ref(client):
     client.project = "test-project"
 
@@ -1011,6 +1032,7 @@ def test_object_mismatch_project_ref(client):
     assert "weave:///shawn/test-project2/op" in str(calls[0].op_name)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_mismatch_project_ref_nested(client):
     client.project = "test-project"
 
@@ -1052,6 +1074,7 @@ def test_object_mismatch_project_ref_nested(client):
     assert obj.project_id == "shawn/test-project2"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_saveload_customtype(client):
     class MyCustomObj:
         a: int
@@ -1086,6 +1109,7 @@ def test_saveload_customtype(client):
     assert obj2.b == "x"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_save_unknown_type(client):
     class SomeUnknownThing:
         def __init__(self, a):
@@ -1097,6 +1121,7 @@ def test_save_unknown_type(client):
     assert obj2 == repr(obj)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_save_model(client):
     class MyModel(weave.Model):
         prompt: str
@@ -1150,6 +1175,7 @@ async def test_saved_nested_modellike(client):
     assert await call_model(c, 5) == 4
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_rows_ref(client):
     dataset = weave.Dataset(rows=[{"a": 1}, {"a": 2}, {"a": 3}])
     saved = client.save(dataset, "my-dataset")
@@ -1273,6 +1299,7 @@ async def test_evaluate(weave_active):
     assert example1_obj.ref.extra[3] != example0_obj.ref.extra[3]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_nested_ref_is_inner(client):
     dataset_rows = [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
 
@@ -1291,6 +1318,7 @@ def test_nested_ref_is_inner(client):
     assert saved.dataset.rows.ref.name == "Dataset"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_obj_dedupe(client):
     client._save_object({"a": 1}, "my-obj")
     client._save_object({"a": 1}, "my-obj")
@@ -1301,6 +1329,7 @@ def test_obj_dedupe(client):
     assert res[1].version_index == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_query(client):
     @weave.op
     def myop(x):
@@ -1312,6 +1341,7 @@ def test_op_query(client):
     assert len(res) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_noextra(client):
     ref = client._save_object([1, 2, 3], "my-list")
     ref2 = client._save_object({"a": [3, 4, 5]}, "my-obj")
@@ -1321,6 +1351,7 @@ def test_refs_read_batch_noextra(client):
     assert res.vals[1] == {"a": [3, 4, 5]}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_with_extra(client):
     saved = client.save([{"a": 5}, {"a": 6}], "my-list")
     ref1 = saved[0]["a"].ref
@@ -1331,6 +1362,7 @@ def test_refs_read_batch_with_extra(client):
     assert res.vals[1] == {"a": 6}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_dataset_rows(client):
     saved = client.save(weave.Dataset(rows=[{"a": 5}, {"a": 6}]), "my-dataset")
     ref1 = saved.rows[0]["a"].ref
@@ -1341,6 +1373,7 @@ def test_refs_read_batch_dataset_rows(client):
     assert res.vals[1] == 6
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_multi_project(client):
     client.project = "test111"
     ref = client._save_object([1, 2, 3], "my-list")
@@ -1359,12 +1392,14 @@ def test_refs_read_batch_multi_project(client):
     assert res.vals[2] == {"ab": [3, 4, 5]}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_call_ref(client):
     call_ref = refs.CallRef(entity="shawn", project="test-project", id="my-call")
     with pytest.raises(ValueError, match="Call refs not supported"):
         client.server.refs_read_batch(RefsReadBatchReq(refs=[call_ref.uri]))
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_large_files(client):
     class CoolCustomThing:
         a: str
@@ -1387,6 +1422,7 @@ def test_large_files(client):
     assert len(res.a) == 10000005
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_file(client):
     f_bytes = b"0" * 10000005
     res = client.server.file_create(
@@ -1399,6 +1435,7 @@ def test_server_file(client):
     assert f_bytes == read_res.content
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_isinstance_checks(client):
     class PydanticObjA(weave.Object):
         x: dict
@@ -1440,6 +1477,7 @@ def test_isinstance_checks(client):
     assert y3 is None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_summary_tokens(weave_active):
     @weave.op
     def model_a(text):
@@ -1555,6 +1593,7 @@ def row_gen(num_rows: int, approx_row_bytes: int = 1024):
         yield {"a": i, "b": "x" * approx_row_bytes}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.timeout(60)
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.parametrize("use_parallel_table_upload", [False, True])
@@ -1655,6 +1694,7 @@ def test_table_partitioning(network_proxy_client, use_parallel_table_upload):
         assert len(records) == 6, f"Expected 6 total records, got {len(records)}"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_summary_tokens_cost(client):
     @weave.op
     def gpt4(text):
@@ -1810,6 +1850,7 @@ def _setup_calls_for_storage_size_test(client):
     return [call0, call0_child1, call1]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_calls_storage_size_with_filter(client):
     """Test that storage size parameters can be combined with other get_calls parameters."""
     all_calls = _setup_calls_for_storage_size_test(client)
@@ -1828,6 +1869,7 @@ def test_get_calls_storage_size_with_filter(client):
     assert len(calls_filtered) == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_calls_storage_size_with_limit(client):
     """Test that storage size parameters can be combined with other get_calls parameters."""
     all_calls = _setup_calls_for_storage_size_test(client)
@@ -1853,6 +1895,7 @@ def clickhouse_client(client):
     return ch_server.ch_client
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_calls_storage_size_values(client, clickhouse_client):
     """Test that storage size values are correctly included when parameters are set."""
     _setup_calls_for_storage_size_test(client)
@@ -1916,6 +1959,7 @@ def test_get_calls_storage_size_values(client, clickhouse_client):
             )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_ref_in_dict(client):
     ref = client._save_object({"a": 5}, "d1")
 
@@ -1926,6 +1970,7 @@ def test_ref_in_dict(client):
     assert obj["b"] == {"a": 5}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_stream_table_ref_expansion(client):
     class ObjWithTable(weave.Object):
         table: weave_client.Table
@@ -1950,6 +1995,7 @@ def test_calls_stream_table_ref_expansion(client):
     assert calls[0].output["table"] == o.table.table_ref.uri
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_version_read(client):
     refs = []
     for i in range(10):
@@ -2069,6 +2115,7 @@ def test_object_version_read(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_calltime_display_name(weave_active):
     @weave.op
@@ -2091,6 +2138,7 @@ async def test_op_calltime_display_name(weave_active):
     assert call.display_name == "custom_display_name"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_long_display_names_are_elided(weave_active):
     @weave.op(call_display_name="a" * 2048)
     def func():
@@ -2114,6 +2162,7 @@ def test_long_display_names_are_elided(weave_active):
     assert len(call.display_name) <= MAX_DISPLAY_NAME_LENGTH
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_deletion(client):
     # Simple case, delete a single version of an object
     obj = {"a": 5}
@@ -2169,6 +2218,7 @@ def test_object_deletion(client):
     assert len(versions.objs) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_recursive_object_deletion(weave_active):
     # Create a bunch of objects that refer to each other
     obj1 = {"a": 5}
@@ -2199,6 +2249,7 @@ def test_recursive_object_deletion(weave_active):
     assert obj3_ref.get() == {"c": obj2}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_op_version(weave_active):
     @weave.op
     def my_op(a: int) -> int:
@@ -2227,6 +2278,7 @@ def test_delete_op_version(weave_active):
         op_ref.get()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_client_attributes(client_creator):
     @weave.op
     def my_op(a: int) -> int:
@@ -2243,6 +2295,7 @@ def test_client_attributes(client_creator):
         assert call.attributes["version"] == "1.0"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_client_attributes_with_call_attributes(client_creator):
     @weave.op
     def my_op(a: int) -> int:
@@ -2263,6 +2316,7 @@ def test_client_attributes_with_call_attributes(client_creator):
         assert call.attributes["env"] == "override"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_flush_progress_bar(client):
     client.set_autoflush(False)
 
@@ -2280,6 +2334,7 @@ def test_flush_progress_bar(client):
     assert client._has_pending_jobs() == False
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_flush_callback(client):
     client.set_autoflush(False)
 
@@ -2300,6 +2355,7 @@ def test_flush_callback(client):
     assert client._has_pending_jobs() == False
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_repeated_flushing(client):
     client.set_autoflush(False)
 
@@ -2328,6 +2384,7 @@ def test_repeated_flushing(client):
     assert client._has_pending_jobs() == False
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_filter_by_strings(client):
     """Test string filter optimization with nested queries."""
     test_id = str(uuid.uuid4())
@@ -2656,6 +2713,7 @@ def test_calls_query_filter_by_strings(client):
         assert call.inputs["value"] > 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_default_sort_secondary_id_asc(client):
     """Test that the default sort uses id ASC as a secondary tiebreaker.
 
@@ -2737,6 +2795,7 @@ def test_calls_default_sort_secondary_id_asc(client):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_sort_by_status(client):
     """Test that sort_by summary.weave.status works with get_calls."""
     # Use a unique test ID to identify these calls
@@ -2801,6 +2860,7 @@ def test_calls_query_sort_by_status(client):
     assert calls_desc[2].id == error_call.id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_sort_by_latency(client):
     """Test that sort_by summary.weave.latency_ms works with get_calls."""
     # Use a unique test ID to identify these calls
@@ -2876,6 +2936,7 @@ def test_calls_query_sort_by_latency(client):
     assert calls_desc[2].id == fast_call.id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_filter_by_status(client):
     """Test filtering calls by status using get_calls."""
     # Use a unique test ID to identify these calls
@@ -2936,6 +2997,7 @@ def test_calls_filter_by_status(client):
     assert running_calls[0].summary.get("weave", {}).get("status") == "running"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_filter_by_latency(client):
     """Test filtering calls by latency using get_calls."""
     # Use a unique test ID to identify these calls
@@ -3033,6 +3095,7 @@ def test_calls_filter_by_latency(client):
     assert len(latency_calls) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_sort_by_trace_name(client):
     """Test that sort_by and filter by summary.weave.trace_name works with get_calls."""
     # Use a unique test ID to identify these calls
@@ -3117,6 +3180,7 @@ def test_calls_query_sort_by_trace_name(client):
     assert plain_call_result[0].id == plain_call.id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_sort_by_display_name_prioritized(client):
     """Test that sorting by trace_name prioritizes display_name over op_name when op_names are identical."""
     import uuid
@@ -3180,6 +3244,7 @@ def test_calls_query_sort_by_display_name_prioritized(client):
     assert call_list[0].op_name == call_list[1].op_name == call_list[2].op_name
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_tracing_enabled_context(client):
     """Test that gc.create_call() and gc.finish_call() respect the _tracing_enabled context variable."""
     from weave.trace.call import Call
@@ -3209,6 +3274,7 @@ def test_tracing_enabled_context(client):
         client.finish_call(call)  # Should not raise any error
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_hardcoded_filter_length_validation(client):
     @weave.op
     def test():
@@ -3263,6 +3329,7 @@ def test_calls_query_hardcoded_filter_length_validation(client):
         calls = client.get_calls(filter={"trace_ids": ["11111"] * 1001})[0]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_datetime_optimization_with_gt_operation(client):
     """Test that datetime optimization works correctly with GT operations on started_at and ended_at fields."""
     # Use a unique test ID to identify these calls
@@ -3551,6 +3618,7 @@ def _make_call(client, _id):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_with_non_uuidv7_ids(client):
     """Test that calls query works with non-uuidv7 ids."""
     # Create a call with an 8 byte hex id
@@ -3744,6 +3812,7 @@ def test_calls_query_with_non_uuidv7_ids(client):
     assert call_ids[7] == uuidv7_calls[3].id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_filter_by_root_refs(client):
     @weave.op
     def root_op(x: int):
@@ -3950,6 +4019,7 @@ def test_calls_query_filter_by_root_refs(client):
     assert op_name_from_call(calls[1]) == "root_op"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_filter_calls_by_ref(client):
     obj = {"a": 1}
     ref = client.save(obj, "obj").ref
@@ -4017,6 +4087,7 @@ def test_filter_calls_by_ref(client):
     assert len(calls) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_filter_calls_by_ref_wildcard_versions(client):
     input_ref_v1 = client.save({"a": 1}, "my_input").ref
     input_ref_v2 = client.save({"a": 2}, "my_input").ref
@@ -4058,6 +4129,7 @@ def test_filter_calls_by_ref_wildcard_versions(client):
     assert sorted(call.inputs["ref"]["a"] for call in calls) == [1, 2]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_files_stats(client):
 
     f_bytes = b"0" * 10000005
@@ -4069,6 +4141,7 @@ def test_files_stats(client):
     assert read_res.total_size_bytes == 10000005
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_no_400_on_invalid_artifact_url(client):
     @weave.op
     def test() -> str:
@@ -4081,6 +4154,7 @@ def test_no_400_on_invalid_artifact_url(client):
     assert server_call.id == id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_no_400_on_invalid_refs(client):
     @weave.op
     def test() -> str:
@@ -4093,6 +4167,7 @@ def test_no_400_on_invalid_refs(client):
     assert server_call.id == id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_evaluation(client, make_evals):
     ref, _ = make_evals
     ev = client.get_evaluation(ref.uri)
@@ -4100,6 +4175,7 @@ def test_get_evaluation(client, make_evals):
     assert ev.ref.uri == ref.uri
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_evaluations(client, make_evals):
     ref, ref2 = make_evals
     evs = client.get_evaluations()
@@ -4114,6 +4190,7 @@ def test_get_evaluations(client, make_evals):
     assert evs[1].dataset.rows[0] == {"dataset_id": "jkl"}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_feedback_batching(network_proxy_client):
     """Test that feedback batching works correctly when enabled."""
     # Set up advanced client that uses the RemoteHttpTraceServer handler
@@ -4179,6 +4256,7 @@ def test_feedback_batching(network_proxy_client):
         assert feedback.payload["note"] == f"Test feedback {i}"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 @pytest.mark.parametrize("use_parallel_table_upload", [False, True])
 def test_parallel_table_uploads_digest_consistency(
@@ -4340,6 +4418,7 @@ def test_parallel_table_uploads_digest_consistency(
     assert saved_table5.table_ref is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_create_from_digests(network_proxy_client):
     """Test that table_create_from_digests works correctly to merge existing row digests."""
     basic_client, remote_client, records = network_proxy_client
@@ -4441,6 +4520,7 @@ def test_table_create_from_digests(network_proxy_client):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_with_wb_run_id_not_null(client, monkeypatch):
     """Test optimized stats query for wb_run_id not null."""
     mock_run_id = f"{client.project_id}/test_run_123"
@@ -4464,6 +4544,7 @@ def test_calls_query_with_wb_run_id_not_null(client, monkeypatch):
     assert calls[0].wb_run_id == mock_run_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_calls_columns_wb_run_id(client, monkeypatch):
     # Step 1: Mock wandb run context so a deterministic wb_run_id is attached to the call.
     mock_run_id = f"{client.project_id}/test_run_456"
@@ -4512,6 +4593,7 @@ def test_get_calls_columns_wb_run_id(client, monkeypatch):
     assert calls[0].wb_run_id == mock_run_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_get_calls_include_usernames(client, monkeypatch):
     external_server = find_server_layer(client.server, UserInjectingExternalTraceServer)
     internal_user_id = external_server._idc.ext_to_int_user_id(client.entity)
@@ -4550,6 +4632,7 @@ def test_get_calls_include_usernames(client, monkeypatch):
     assert calls_with_usernames[0].wb_username == "resolved-user"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_query_with_dotted_field_keys(client):
     """Test querying calls with nested field keys containing dots."""
     test_id = str(uuid.uuid4())
@@ -4708,6 +4791,7 @@ def test_calls_query_with_dotted_field_keys(client):
     assert any(o.get("triple.nested.dot") == "universe" for o in outputs)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_evaluate_with_llm_completion_model_and_prompt_template_vars(client):
     """Test that LLMStructuredCompletionModel correctly passes prompt and template_vars in evaluation context.
 

--- a/tests/trace/test_weave_client_mutations.py
+++ b/tests/trace/test_weave_client_mutations.py
@@ -2,8 +2,10 @@ import pytest
 from pydantic import Field
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_mutation_saving(weave_active):
     class Thing(weave.Object):
         a: str
@@ -29,6 +31,7 @@ def test_object_mutation_saving(weave_active):
     assert thing3.c == 4.2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_list_mutation_saving(weave_active):
     lst = [1, 2, 3]
     ref = weave.publish(lst)
@@ -46,6 +49,7 @@ def test_list_mutation_saving(weave_active):
     assert lst3 == [100, 2, 3, 4, 5, 6]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dict_mutation_saving(weave_active):
     # TODO: Today we assume all the keys must be str?
     d = {"a": 1, "b": 2}
@@ -62,6 +66,7 @@ def test_dict_mutation_saving(weave_active):
     assert d3 == {"a": 1, "b": "new_value", "new_key": 3}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_mutation_saving_nested(weave_active):
     class A(weave.Object):
         b: int = 1
@@ -89,6 +94,7 @@ def test_object_mutation_saving_nested(weave_active):
     assert d3.c.a.b == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_list_mutation_saving_nested(weave_active):
     lst = [1, 2, 3]
     ref = weave.publish(lst)
@@ -109,6 +115,7 @@ def test_list_mutation_saving_nested(weave_active):
     assert lst5 == [1, 2, 3, [4, 5, 6]]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dict_mutation_saving_nested(weave_active):
     d = {"a": 1, "b": 2}
     ref = weave.publish(d)
@@ -133,6 +140,7 @@ def test_dict_mutation_saving_nested(weave_active):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_mutation_saving_nested_lists_and_dicts(weave_active):
     class A(weave.Object):
         b: int
@@ -185,6 +193,7 @@ def test_object_mutation_saving_nested_lists_and_dicts(weave_active):
     assert g3.b.f == {"d": {"e": "f"}}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_list_mutation_saving_nested_objects(weave_active):
     class A(weave.Object):
         b: int
@@ -203,6 +212,7 @@ def test_list_mutation_saving_nested_objects(weave_active):
     assert lst3[2].b == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_list_mutation_saving_nested_dicts(weave_active):
     lst = [{"a": {"b": 1}}, {"a": {"b": 2}}]
     ref = weave.publish(lst)
@@ -218,6 +228,7 @@ def test_list_mutation_saving_nested_dicts(weave_active):
     assert lst3[2]["a"]["b"] == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dict_mutation_saving_nested_objects(weave_active):
     class A(weave.Object):
         b: int
@@ -235,6 +246,7 @@ def test_dict_mutation_saving_nested_objects(weave_active):
     assert d3["c"].b == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dict_mutation_saving_nested_lists(weave_active):
     d = {"a": [1, 2], "b": [3, 4]}
     ref = weave.publish(d)
@@ -249,6 +261,7 @@ def test_dict_mutation_saving_nested_lists(weave_active):
     assert d3["c"] == [5, 6]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_mutation_saving_append_rows(weave_active):
     t = weave.Table(rows=[{"a": 1, "b": 2}])
     t.append({"a": 3, "b": 4})
@@ -270,6 +283,7 @@ def test_table_mutation_saving_append_rows(weave_active):
     ]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_mutation_saving_pop_rows(weave_active):
     t = weave.Table(
         rows=[
@@ -293,6 +307,7 @@ def test_table_mutation_saving_pop_rows(weave_active):
     assert t3.rows == [{"a": 5, "b": 6}]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_mutation_saving_replace_rows(weave_active):
     t = weave.Table(
         rows=[
@@ -310,6 +325,7 @@ def test_table_mutation_saving_replace_rows(weave_active):
     assert t3.rows == [{"a": 5, "b": 6}]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_cant_append_bad_data(weave_active):
     t = weave.Table(rows=[{"a": 1, "b": 2}])
     with pytest.raises(TypeError):
@@ -325,6 +341,7 @@ def test_table_cant_append_bad_data(weave_active):
         t2.append([1, 2, 3])
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_cant_set_bad_data(weave_active):
     t = weave.Table(rows=[{"a": 1, "b": 2}])
     with pytest.raises(ValueError, match="must be (a list of )?dicts"):

--- a/tests/trace/test_weave_client_threaded.py
+++ b/tests/trace/test_weave_client_threaded.py
@@ -7,6 +7,7 @@ import pytest
 from flask import Flask
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
 @pytest.fixture
@@ -33,6 +34,7 @@ def flask_server(weave_active):
     return url
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_flask_server(flask_server):
     url = flask_server
     with httpx.Client() as client:
@@ -41,6 +43,7 @@ def test_flask_server(flask_server):
     assert response.text == "FkWFKCRcl9wsGp3yclN7v1IIAICTPenpZYrWo0otI4Y"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_weave_client_global_accessible_in_thread(weave_active):
     def thread_func(q: queue.Queue):
         try:

--- a/tests/trace/test_weave_object_vals.py
+++ b/tests/trace/test_weave_object_vals.py
@@ -1,3 +1,4 @@
+
 import weave
 from weave.trace.context.weave_client_context import set_weave_client_global
 from weave.trace.vals import WeaveObject

--- a/tests/trace/test_weave_object_vals.py
+++ b/tests/trace/test_weave_object_vals.py
@@ -1,5 +1,7 @@
+import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.context.weave_client_context import set_weave_client_global
 from weave.trace.vals import WeaveObject
 
@@ -14,6 +16,7 @@ def test_weaveobject_properties():
     assert to.x == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_weaveobject_access_after_init_termination(weave_active):
     my_obj = None
 

--- a/tests/trace/type_handlers/Audio/audio_test.py
+++ b/tests/trace/type_handlers/Audio/audio_test.py
@@ -5,6 +5,7 @@ import wave
 import pytest
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import WeaveClient, get_ref
 from weave.type_handlers.Audio.audio import Audio
 
@@ -15,6 +16,7 @@ TEST_MP3_FILE = os.path.join(TEST_AUDIO_DIR, "audio.mp3")
 
 
 class TestWaveRead:
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_audio_publish(self, client: WeaveClient) -> None:
         client.project = "test_audio_publish"
         audio = wave.open(TEST_WAV_FILE, "rb")
@@ -25,6 +27,7 @@ class TestWaveRead:
         gotten_audio = weave.ref(ref.uri).get()
         assert audio.readframes(10) == gotten_audio.readframes(10)
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_audio_as_dataset_cell(self, client: WeaveClient) -> None:
         client.project = "test_audio_as_dataset_cell"
         audio = wave.open(TEST_WAV_FILE, "rb")
@@ -37,6 +40,7 @@ class TestWaveRead:
         gotten_dataset = weave.ref(ref.uri).get()
         assert audio.readframes(10) == gotten_dataset.rows[0]["audio"].readframes(10)
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_audio_as_call_io(self, client: WeaveClient) -> None:
         @weave.op
         def audio_as_input_and_output_part(in_audio: wave.Wave_read) -> dict:
@@ -61,6 +65,7 @@ class TestWaveRead:
 
 
 class TestWeaveAudio:
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.parametrize("audio_file", [TEST_MP3_FILE, TEST_WAV_FILE])
     def test_publish_audio_from_path(
         self, client: WeaveClient, audio_file: str
@@ -75,6 +80,7 @@ class TestWeaveAudio:
         # Ensure at least the first 10 bytes are the same
         assert open(audio_file, "rb").read(10) == gotten_audio.data[:10]
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.parametrize(
         "audio_file_and_format", [(TEST_MP3_FILE, "mp3"), (TEST_WAV_FILE, "wav")]
     )
@@ -96,6 +102,7 @@ class TestWeaveAudio:
         # Ensure at least the first 10 bytes are the same
         assert open(audio_file, "rb").read(10) == gotten_audio.data[:10]
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.parametrize(
         "audio_file_and_format", [(TEST_MP3_FILE, "mp3"), (TEST_WAV_FILE, "wav")]
     )
@@ -125,6 +132,7 @@ class TestWeaveAudio:
         with pytest.raises(ValueError, match="data"):
             Audio.from_data(data=b"", format="mp3")
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.parametrize("audio_file", [TEST_MP3_FILE, TEST_WAV_FILE])
     def test_audio_as_dataset_cell(self, client: WeaveClient, audio_file: str) -> None:
         client.project = "test_audio_as_dataset_cell"
@@ -140,6 +148,7 @@ class TestWeaveAudio:
         gotten_dataset = ref.get()
         assert audio.data[:10] == gotten_dataset.rows[0]["audio"].data[:10]
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.parametrize("audio_file", [TEST_MP3_FILE, TEST_WAV_FILE])
     def test_audio_as_call_io(self, client: WeaveClient, audio_file: str) -> None:
         client.project = "test_audio_as_call_io"

--- a/tests/trace/type_handlers/Content/test_content.py
+++ b/tests/trace/type_handlers/Content/test_content.py
@@ -7,6 +7,7 @@ import pytest
 from util import generate_media
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave import Dataset
 from weave.trace.table import Table
 from weave.type_wrappers.Content.content import Content
@@ -366,6 +367,7 @@ class TestWeaveContent:
         content2 = Content.from_bytes(file_bytes, extension="txt", encoding="latin-1")
         assert content2.encoding == "latin-1"
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_content_save_and_retrieve(self, image_file, weave_active):
         """Test publishing and retrieving Content objects."""
         content = Content.from_path(image_file)
@@ -382,6 +384,7 @@ class TestWeaveContent:
         assert retrieved.mimetype == content.mimetype
         assert retrieved.size == content.size
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_content_in_dataset(
         self, image_file, audio_file, video_file, pdf_file, weave_active
     ):
@@ -416,6 +419,7 @@ class TestWeaveContent:
             original_data = original_files[row["name"]]
             assert row["content"].data == original_data
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_content_postprocessing(self, weave_active):
         """Test that Content postprocessing works correctly in ops."""
 

--- a/tests/trace/type_handlers/Image/image_test.py
+++ b/tests/trace/type_handlers/Image/image_test.py
@@ -7,6 +7,7 @@ import pytest
 from PIL import Image
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.context.weave_client_context import (
     get_weave_client,
     set_weave_client_global,
@@ -51,6 +52,7 @@ def test_img(request) -> Image.Image:
         img.close()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_image_publish(weave_active, test_img: Image.Image) -> None:
     weave.publish(test_img)
 
@@ -68,6 +70,7 @@ class ImageWrapper(weave.Object):
     img: Image.Image
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_image_as_property(client: WeaveClient, test_img: Image.Image) -> None:
     client.project = "test_image_as_property"
     img_wrapper = ImageWrapper(img=test_img)
@@ -85,6 +88,7 @@ def test_image_as_property(client: WeaveClient, test_img: Image.Image) -> None:
         gotten_img_wrapper.img.close()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_image_as_dataset_cell(client: WeaveClient, test_img: Image.Image) -> None:
     client.project = "test_image_as_dataset_cell"
@@ -132,6 +136,7 @@ def test_image_as_call_io(client: WeaveClient, test_img: Image.Image) -> None:
     assert image_as_input_and_output_part_call.output["out_img"].tobytes() == exp_bytes
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_image_as_call_io_refs(client: WeaveClient, test_img: Image.Image) -> None:
     client.project = "test_image_as_call_io_refs"
     non_published_img = image_as_solo_output(publish_first=True, img=test_img)
@@ -158,6 +163,7 @@ def test_image_as_call_io_refs(client: WeaveClient, test_img: Image.Image) -> No
         image_as_input_and_output_part_call.output["out_img"].close()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_image_as_file(client: WeaveClient) -> None:
     client.project = "test_image_as_file"
     file_path = Path(__file__).parent.resolve() / "example.jpg"
@@ -204,6 +210,7 @@ def dataset_ref(weave_active):
     return ref
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_images_in_dataset_for_evaluation(weave_active, dataset_ref):
     dataset = dataset_ref.get()
@@ -245,6 +252,7 @@ async def test_many_images_will_consistently_log():
     assert "Task failed" not in res.stderr
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_images_in_load_of_dataset(weave_active):
     n_rows = 5
     rows = [{"img": make_random_image()} for _ in range(n_rows)]
@@ -261,6 +269,7 @@ def test_images_in_load_of_dataset(weave_active):
             gotten_row["img"].close()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_images_in_dataset_without_client(weave_active):
     """Regression test for WB-21596: datasets with images should be iterable
     without an active global client (e.g. after ref.get() auto-init cleanup).

--- a/tests/trace/type_handlers/Video/video_test.py
+++ b/tests/trace/type_handlers/Video/video_test.py
@@ -8,6 +8,7 @@ import pytest
 from moviepy.editor import ColorClip, VideoClip, VideoFileClip
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import WeaveClient
 from weave.type_handlers.Video.video import VideoFormat, write_video
 
@@ -51,6 +52,7 @@ def test_save_invalid_clip(tmp_path: Path, test_video: VideoClip, filename: str)
         write_video(fp, test_video)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_video_with_no_ext_converted(
     weave_active, tmp_path: Path, test_video: VideoClip
 ):
@@ -95,6 +97,7 @@ def test_weave_op_video(tmp_path: Path, test_video: VideoClip):
     assert os.path.getsize(result) > 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_video_publish(weave_active, test_video: VideoClip) -> None:
     ref = weave.publish(test_video)
     assert ref is not None
@@ -124,6 +127,7 @@ class VideoWrapper(weave.Object):
     video: VideoClip
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_video_as_property(client: WeaveClient, test_video: VideoClip) -> None:
     client.project = "test_video_as_property"
 
@@ -153,6 +157,7 @@ def test_video_as_property(client: WeaveClient, test_video: VideoClip) -> None:
         gotten_video_wrapper.video.close()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_video_as_dataset_cell(client: WeaveClient, test_video: VideoClip) -> None:
     client.project = "test_video_as_dataset_cell"
 
@@ -194,6 +199,7 @@ def video_as_input_and_output_part(in_video: VideoClip) -> dict:
     return {"out_video": in_video}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_video_as_call_io(weave_active, test_video: VideoClip) -> None:
     non_published_video = video_as_solo_output(publish_first=False, video=test_video)
     video_dict = video_as_input_and_output_part(non_published_video)
@@ -241,6 +247,7 @@ def test_video_as_call_io(weave_active, test_video: VideoClip) -> None:
             video_as_input_and_output_part_call.output["out_video"].close()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_video_as_call_io_refs(client: WeaveClient, test_video: VideoClip) -> None:
     client.project = "test_video_as_call_io_refs"
 
@@ -287,6 +294,7 @@ def test_video_as_call_io_refs(client: WeaveClient, test_video: VideoClip) -> No
             video_as_input_and_output_part_call.output["out_video"].close()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_video_as_file(client: WeaveClient, tmp_path: Path) -> None:
     client.project = "test_video_as_file"
 
@@ -336,6 +344,7 @@ def dataset_ref(weave_active):
     return ref
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_videos_in_dataset_for_evaluation(weave_active, dataset_ref):
     dataset = dataset_ref.get()
@@ -359,6 +368,7 @@ async def test_videos_in_dataset_for_evaluation(weave_active, dataset_ref):
             row["video"].close()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_videos_in_load_of_dataset(weave_active):
     n_rows = 3
     # Create smaller duration videos to avoid encoding issues
@@ -413,6 +423,7 @@ def test_video_format_from_filename():
     assert get_format_from_filename("test.something.mp4") == VideoFormat.MP4
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.skipif(
     sys.platform == "win32",
     reason="moviepy library uses /dev/null on Windows which doesn't exist",

--- a/tests/trace/type_handlers/test_type_handler_safety.py
+++ b/tests/trace/type_handlers/test_type_handler_safety.py
@@ -7,10 +7,14 @@ affecting the user's program execution.
 
 from __future__ import annotations
 
+import pytest
+
 import weave
 from tests.trace.test_utils import FailingSaveType
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_output_with_failing_serializer_does_not_raise(
     weave_active, failing_serializer
 ):
@@ -33,6 +37,7 @@ def test_op_output_with_failing_serializer_does_not_raise(
     assert result.value == "hello"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_input_with_failing_serializer_does_not_raise(
     weave_active, failing_serializer
 ):
@@ -56,6 +61,7 @@ def test_op_input_with_failing_serializer_does_not_raise(
     assert result == "processed: test_input"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_with_multiple_args_one_failing_serializer_does_not_raise(
     client, failing_serializer
 ):
@@ -88,6 +94,7 @@ def test_op_with_multiple_args_one_failing_serializer_does_not_raise(
     assert call.inputs["normal_arg"] == "normal"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_with_failing_serializer_call_is_recorded(client, failing_serializer):
     """Requirement: Calls should still be recorded even when serialization fails (with stringified fallback)
     Interface: @weave.op decorated function and call record retrieval

--- a/tests/trace/util.py
+++ b/tests/trace/util.py
@@ -7,6 +7,44 @@ import re
 import time
 from contextlib import contextmanager
 
+from tests.trace.server_utils import find_server_layer
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+
+# Condition string for `pytest.mark.skipif`: True when the selected
+# trace-server backend is not a real ClickHouse server (e.g. the in-memory
+# fake). skipif conditions evaluate at collection time, where only `config`
+# is available — fixture-based predicates like `client_is_clickhouse` cannot
+# run there. Mirrors conftest's get_trace_server_flag precedence
+# (--clickhouse beats --trace-server).
+NOT_CLICKHOUSE_BACKEND = (
+    "not (config.getoption('--clickhouse') "
+    "or config.getoption('--trace-server') == 'clickhouse')"
+)
+
+# Condition string for `pytest.mark.skipif`: True on the in-memory fake
+# backend, marking tests whose capability the fake has not implemented yet.
+# Same backend check as NOT_CLICKHOUSE_BACKEND, but a DISTINCT name because
+# these gates are TEMPORARY: each PR up the fake stack deletes the
+# `skipif(FAKE_NOT_IMPLEMENTED, ...)` decorators for the capability it
+# implements, so CI then runs those tests on the fake and verifies they match
+# ClickHouse. (NOT_CLICKHOUSE_BACKEND, by contrast, is permanent CH-only.)
+FAKE_NOT_IMPLEMENTED = NOT_CLICKHOUSE_BACKEND
+
+
+def client_is_clickhouse(client):
+    """True only for a real ClickHouse backend (NOT the in-memory fake).
+
+    The in-memory fake replicates ClickHouse at the interface level, so
+    behavioral tests run on it unmodified. Use this predicate to gate tests
+    that assert ClickHouse *internals* (raw SQL, table routing, batching,
+    bucket file storage), which the fake does not reproduce.
+    """
+    try:
+        find_server_layer(client.server, ClickHouseTraceServer)
+    except TypeError:
+        return False
+    return True
+
 
 class AnyStrMatcher:  # noqa: PLW1641
     """Matches any string."""

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -22,6 +22,7 @@ from weave.trace_server import (
 )
 from weave.trace_server import environment as wf_env
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.in_memory_trace_server import InMemoryTraceServer
 from weave.trace_server.parallel_bucket_uploads import BucketUploadBatch
 from weave.trace_server.project_version import project_version
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
@@ -46,7 +47,7 @@ def pytest_addoption(parser):
             "--trace-server",
             action="store",
             default="clickhouse",
-            help="Specify the backend to use: clickhouse",
+            help="Specify the backend to use: clickhouse or fake (in-memory)",
         )
         parser.addoption(
             "--ch",
@@ -188,8 +189,8 @@ def _ch_session_server(
     `prod`/`http` escape hatches), so dependents can skip instead of
     spinning up a server that won't be used.
     """
-    trace_server_flag = request.config.getoption("--trace-server", default="clickhouse")
-    if trace_server_flag != "clickhouse":
+    backend = get_trace_server_flag(request)
+    if backend != "clickhouse":
         yield None
         return
 
@@ -317,6 +318,24 @@ def get_ch_trace_server(
     return ch_trace_server_inner
 
 
+@pytest.fixture
+def get_fake_trace_server(
+    request,
+) -> Callable[[], UserInjectingExternalTraceServer]:
+    def fake_trace_server_inner() -> UserInjectingExternalTraceServer:
+        id_converter = DummyIdConverter()
+        fake_server = InMemoryTraceServer(
+            evaluate_model_dispatcher=EvaluateModelTestDispatcher(
+                id_converter=id_converter
+            ),
+        )
+        return externalize_trace_server(
+            fake_server, TEST_ENTITY, id_converter=id_converter
+        )
+
+    return fake_trace_server_inner
+
+
 class LocalSecretFetcher:
     def fetch(self, secret_name: str) -> dict:
         return {"secrets": {secret_name: os.getenv(secret_name)}}
@@ -330,17 +349,21 @@ def local_secret_fetcher():
 
 @pytest.fixture
 def trace_server(
-    request, local_secret_fetcher, get_ch_trace_server
+    request, local_secret_fetcher, get_ch_trace_server, get_fake_trace_server
 ) -> UserInjectingExternalTraceServer:
-    trace_server_flag = get_trace_server_flag(request)
-    if trace_server_flag == "clickhouse":
+    backend = get_trace_server_flag(request)
+    if backend == "clickhouse":
         return get_ch_trace_server()
-    raise ValueError(f"Invalid trace server: {trace_server_flag}")
+    elif backend == "fake":
+        return get_fake_trace_server()
+    raise ValueError(f"Invalid trace server: {backend}")
 
 
 @pytest.fixture
-def ch_server(trace_server):
-    """Extract the ClickHouseTraceServer from the test fixture."""
+def ch_server(request, trace_server):
+    """Extract the ClickHouseTraceServer from the test fixture, or skip."""
+    if get_trace_server_flag(request) != "clickhouse":
+        pytest.skip("ClickHouse-only test")
     server = trace_server._internal_trace_server
     assert isinstance(server, ClickHouseTraceServer)
     return server
@@ -348,5 +371,13 @@ def ch_server(trace_server):
 
 @pytest.fixture
 def internal_server(client):
-    """Return the underlying ClickHouse server from the middleware chain."""
-    return find_server_layer(client.server, ClickHouseTraceServer)
+    """Return the underlying fake or ClickHouse server from the middleware chain."""
+    for layer_type in (InMemoryTraceServer, ClickHouseTraceServer):
+        try:
+            return find_server_layer(client.server, layer_type)
+        except TypeError:
+            continue
+    raise TypeError(
+        "No known internal trace server (InMemoryTraceServer or "
+        "ClickHouseTraceServer) found in the client's middleware chain"
+    )

--- a/tests/trace_server/helpers.py
+++ b/tests/trace_server/helpers.py
@@ -5,7 +5,10 @@ import uuid
 
 from clickhouse_connect.driver.client import Client as CHClient
 
+from tests.trace.server_utils import find_server_layer
+from weave.trace.weave_client import WeaveClient
 from weave.trace_server import environment as wf_env
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 
 
 def make_project_id(prefix: str) -> str:
@@ -30,3 +33,17 @@ def force_optimize(ch_client: CHClient, table: str) -> None:
 def force_optimize_calls_merged(ch_client: CHClient) -> None:
     """OPTIMIZE `calls_merged`, distributed-mode aware."""
     force_optimize(ch_client, "calls_merged")
+
+
+def force_optimize_if_clickhouse(client: WeaveClient, table: str) -> None:
+    """OPTIMIZE `table` when the client runs on ClickHouse; no-op otherwise.
+
+    Lets tests that exercise both backends force ClickHouse merge-consistency
+    without teaching `force_optimize` about non-ClickHouse servers. The
+    in-memory fake has no async merges to force.
+    """
+    try:
+        ch_server = find_server_layer(client.server, ClickHouseTraceServer)
+    except TypeError:
+        return
+    force_optimize(ch_server.ch_client, table)

--- a/tests/trace_server/isolated_client_executor/test_isolated_client_executor.py
+++ b/tests/trace_server/isolated_client_executor/test_isolated_client_executor.py
@@ -17,6 +17,7 @@ import pytest
 from pydantic import BaseModel
 
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from tests.trace_server.isolated_client_executor.cross_process_trace_server import (
     CrossProcessTraceServerReceiver,
 )
@@ -153,6 +154,7 @@ def do_task(args: dict):
     return get_keys(args)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_executor_basic_lifecycle(client):
     """Happy-path lifecycle on a single runner: execute + pid isolation, reuse,
@@ -379,6 +381,7 @@ def log_to_weave(req: SimpleRequest):
     return log_to_weave_op(req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_correct_isolation(client):
     """This test demonstrates successful isolation of function execution, but

--- a/tests/trace_server/test_call_lifecycle.py
+++ b/tests/trace_server/test_call_lifecycle.py
@@ -3,6 +3,7 @@ import uuid
 
 import pytest
 
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from tests.trace_server.helpers import force_optimize_calls_merged
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
@@ -81,6 +82,9 @@ def test_call_update_out_of_order(client: weave_client.WeaveClient):
 
 
 @pytest.mark.parametrize("end_arrives_first", [False, True])
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: calls_merged columns"
+)
 def test_call_end_started_at_anchors_sortable_datetime(
     client: weave_client.WeaveClient, end_arrives_first: bool
 ) -> None:

--- a/tests/trace_server/test_call_lifecycle.py
+++ b/tests/trace_server/test_call_lifecycle.py
@@ -3,13 +3,14 @@ import uuid
 
 import pytest
 
-from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, NOT_CLICKHOUSE_BACKEND
 from tests.trace_server.helpers import force_optimize_calls_merged
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.interface import query as tsi_query
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_update_out_of_order(client: weave_client.WeaveClient):
     # Here, we are going to do an out of order sequence:
     # 1. Name a call

--- a/tests/trace_server/test_call_stats.py
+++ b/tests/trace_server/test_call_stats.py
@@ -12,6 +12,7 @@ import uuid
 import pytest
 from pydantic import ValidationError
 
+from tests.trace.util import client_is_clickhouse
 from tests.trace_server.helpers import force_optimize_calls_merged
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
@@ -34,6 +35,9 @@ def force_merge_calls(client: weave_client.WeaveClient):
     ClickHouse merges ReplacingMergeTree rows asynchronously. In tests, we write
     and immediately query, so rows may not be merged yet. This forces a merge.
     """
+    if not client_is_clickhouse(client):
+        # Only a real ClickHouse backend has async merges to force.
+        return
     ch_client = client.server._next_trace_server.ch_client
     force_optimize_calls_merged(ch_client)
 

--- a/tests/trace_server/test_call_stats.py
+++ b/tests/trace_server/test_call_stats.py
@@ -12,7 +12,7 @@ import uuid
 import pytest
 from pydantic import ValidationError
 
-from tests.trace.util import client_is_clickhouse
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, client_is_clickhouse
 from tests.trace_server.helpers import force_optimize_calls_merged
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
@@ -88,6 +88,7 @@ def create_call_with_usage(
     return call_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stats_usage_sum_aggregation(client: weave_client.WeaveClient):
     """Test basic SUM aggregation across multiple calls with known usage data."""
     project_id = client.project_id
@@ -178,6 +179,7 @@ def test_call_stats_date_range_limit_validation():
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stats_multiple_models(client: weave_client.WeaveClient):
     """Test that different models are tracked and aggregated separately."""
     project_id = client.project_id
@@ -241,6 +243,7 @@ def test_call_stats_multiple_models(client: weave_client.WeaveClient):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stats_all_aggregation_types(client: weave_client.WeaveClient):
     """Test SUM, AVG, MIN, MAX, COUNT aggregations compute correctly."""
     project_id = client.project_id
@@ -339,6 +342,7 @@ def test_call_stats_all_aggregation_types(client: weave_client.WeaveClient):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stats_percentiles(client: weave_client.WeaveClient):
     """Test percentile calculations (p50, p95, p99) with varied data."""
     project_id = client.project_id
@@ -403,6 +407,7 @@ def test_call_stats_percentiles(client: weave_client.WeaveClient):
     assert 90 <= p99 <= 100, f"p99 should be around 99, got {p99}"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stats_time_buckets(client: weave_client.WeaveClient):
     """Test that calls are grouped into correct time buckets based on started_at."""
     project_id = client.project_id
@@ -470,6 +475,7 @@ def test_call_stats_time_buckets(client: weave_client.WeaveClient):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stats_op_names_filter(client: weave_client.WeaveClient):
     """Test op_names filter works correctly."""
     project_id = client.project_id
@@ -516,6 +522,7 @@ def test_call_stats_op_names_filter(client: weave_client.WeaveClient):
     assert total_sum == 100, f"Expected 100 (only op1), got {total_sum}"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stats_trace_roots_only_filter(client: weave_client.WeaveClient):
     """Test trace_roots_only filter excludes child calls."""
     project_id = client.project_id
@@ -606,6 +613,7 @@ def test_call_stats_trace_roots_only_filter(client: weave_client.WeaveClient):
     assert total_sum == 100, f"Expected 100 (root only), got {total_sum}"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stats_trace_ids_filter(client: weave_client.WeaveClient):
     """Test trace_ids filter limits to specific traces."""
     project_id = client.project_id
@@ -696,6 +704,7 @@ def test_call_stats_trace_ids_filter(client: weave_client.WeaveClient):
     assert total_sum == 100, f"Expected 100 (trace_1 only), got {total_sum}"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_stats_call_metrics(client: weave_client.WeaveClient):
     """Test call-level metrics (latency, call_count, error_count)."""
     project_id = client.project_id

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -6,12 +6,15 @@ from typing import Any
 
 import pytest
 
+from tests.trace.server_utils import find_server_layer
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from tests.trace_server.conftest import TEST_ENTITY
 from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
 from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
 from weave.trace_server.calls_query_builder.utils import param_slot
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.errors import (
     CallsCompleteModeRequired,
     NotFoundError,
@@ -28,6 +31,12 @@ from weave.trace_server.project_version.types import (
     WriteTarget,
 )
 
+# Every test in this file asserts calls_complete table residence and raw
+# ClickHouse reads.
+pytestmark = pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: calls_complete table residence"
+)
+
 
 @pytest.fixture
 def clickhouse_trace_server(trace_server):
@@ -42,7 +51,7 @@ def clickhouse_trace_server(trace_server):
     Examples:
         >>> internal = clickhouse_trace_server
     """
-    internal_server = trace_server._internal_trace_server
+    internal_server = find_server_layer(trace_server, ClickHouseTraceServer)
     internal_server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
     return internal_server
 

--- a/tests/trace_server/test_clickhouse_batching.py
+++ b/tests/trace_server/test_clickhouse_batching.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, NOT_CLICKHOUSE_BACKEND
 from weave.shared.digest import str_digest
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
@@ -438,6 +438,7 @@ def test_obj_batch_different_key_order_deduplicates(trace_server, client):
     assert len(res.objs) == 1
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_create_different_key_order_same_digest(trace_server):
     """Rows with different key ordering produce the same digest in table_create."""
     server = trace_server._internal_trace_server

--- a/tests/trace_server/test_clickhouse_batching.py
+++ b/tests/trace_server/test_clickhouse_batching.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from weave.shared.digest import str_digest
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
@@ -236,6 +237,7 @@ def _internal_wb_user_id() -> str:
     return base64.b64encode(b"test_user").decode()
 
 
+@pytest.mark.skipif(NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: insert batching")
 def test_obj_batch_same_object_id_different_hash(trace_server, client):
     """Two versions for same object_id with different digests."""
     server = trace_server._internal_trace_server
@@ -265,6 +267,7 @@ def test_obj_batch_same_object_id_different_hash(trace_server, client):
     assert sum(o.is_latest for o in res.objs) == 1
 
 
+@pytest.mark.skipif(NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: insert batching")
 def test_obj_batch_same_hash_different_object_ids(trace_server, client):
     """Same digest payload uploaded under different object_ids yields distinct objects."""
     server = trace_server._internal_trace_server
@@ -289,6 +292,7 @@ def test_obj_batch_same_hash_different_object_ids(trace_server, client):
     assert {o.object_id for o in res.objs} == {"obj_1", "obj_2"}
 
 
+@pytest.mark.skipif(NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: insert batching")
 def test_obj_batch_identical_same_id_same_hash_deduplicates(trace_server, client):
     """Duplicate rows (same object_id and digest) are represented once in metadata view."""
     server = trace_server._internal_trace_server
@@ -312,6 +316,7 @@ def test_obj_batch_identical_same_id_same_hash_deduplicates(trace_server, client
     assert res.objs[0].digest == str_digest(json.dumps(val))
 
 
+@pytest.mark.skipif(NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: insert batching")
 def test_obj_batch_four_versions_and_read_path(trace_server, client):
     """Batch upload 4 versions and verify reads over all and latest work."""
     server = trace_server._internal_trace_server
@@ -348,6 +353,7 @@ def test_obj_batch_four_versions_and_read_path(trace_server, client):
     assert latest.obj.is_latest == 1
 
 
+@pytest.mark.skipif(NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: insert batching")
 def test_obj_batch_delete_version_preserves_indices(trace_server, client):
     """Delete one version and ensure indices remain intact and deletion is reflected."""
     server = trace_server._internal_trace_server
@@ -404,6 +410,7 @@ def test_str_digest_is_key_order_independent():
     assert str_digest(json.dumps(val_a)) != str_digest(json.dumps(val_b))
 
 
+@pytest.mark.skipif(NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: insert batching")
 def test_obj_batch_different_key_order_deduplicates(trace_server, client):
     """Objects with identical values but different key ordering share the same digest."""
     server = trace_server._internal_trace_server
@@ -506,6 +513,7 @@ def test_call_start_batch_invalid_trace_id_returns_400():
             assert "Invalid UUID" in error_with_status.message["reason"]
 
 
+@pytest.mark.skipif(NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: insert batching")
 def test_obj_batch_mixed_projects_errors(trace_server, client):
     """Uploading objects to different projects in one batch should error."""
     server = trace_server._internal_trace_server

--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -4,8 +4,10 @@ import uuid
 from datetime import datetime
 from unittest.mock import patch
 
+import pytest
 from litellm.types.utils import ModelResponse
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.settings import override_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError
@@ -268,6 +270,7 @@ def test_custom_provider_model_classes():
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_custom_provider_completions_create(client):
     """Test the completions_create endpoint with a custom provider.
 
@@ -377,6 +380,7 @@ def test_custom_provider_completions_create(client):
             _secret_fetcher_context.reset(token)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_custom_provider_ollama_model(client):
     """Test handling of ollama models that need special prefixing."""
     # Create provider ID and model ID for testing
@@ -449,6 +453,7 @@ def test_custom_provider_ollama_model(client):
             _secret_fetcher_context.reset(token)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_custom_provider_trailing_slash_normalization(client):
     """Test that trailing slashes in base_url are stripped to prevent redirect issues.
 
@@ -564,6 +569,7 @@ def test_get_custom_provider_info():
         _secret_fetcher_context.reset(token)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_error_handling_custom_provider(client):
     """Test error handling for custom provider."""
     # Create provider ID and model ID for testing
@@ -605,6 +611,7 @@ def test_error_handling_custom_provider(client):
             _secret_fetcher_context.reset(token)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_custom_provider_invalid_model_format(client):
     """Test error handling for invalid model format."""
     # Use an invalid model format (no slash)

--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import uuid
 from datetime import datetime
@@ -171,6 +172,24 @@ def setup_test_environment(mock_secret_fetcher=None):
     return mock_secret_fetcher, token
 
 
+@contextlib.contextmanager
+def patch_server_obj_read(mock_obj_read):
+    """Patch obj_read on both backend classes so provider/model objects come
+    from the mock regardless of which trace server the client fixture uses.
+    """
+    with (
+        patch(
+            "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
+        ) as ch_read,
+        patch(
+            "weave.trace_server.in_memory_trace_server.InMemoryTraceServer.obj_read"
+        ) as mem_read,
+    ):
+        ch_read.side_effect = mock_obj_read
+        mem_read.side_effect = mock_obj_read
+        yield
+
+
 def create_mock_obj_read(
     provider_obj: tsi.ObjSchema, provider_model_obj: tsi.ObjSchema
 ):
@@ -303,10 +322,7 @@ def test_custom_provider_completions_create(client):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
+            with patch_server_obj_read(mock_obj_read):
                 with patch("litellm.completion") as mock_completion:
                     mock_completion.return_value = ModelResponse.model_validate(
                         mock_response
@@ -406,10 +422,7 @@ def test_custom_provider_ollama_model(client):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
+            with patch_server_obj_read(mock_obj_read):
                 with patch("litellm.completion") as mock_completion:
                     mock_completion.return_value = ModelResponse.model_validate(
                         mock_response
@@ -485,10 +498,7 @@ def test_custom_provider_trailing_slash_normalization(client):
     with override_settings(disabled=True):
         mock_secret_fetcher, token = setup_test_environment()
         try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
+            with patch_server_obj_read(mock_obj_read):
                 with patch("litellm.completion") as mock_completion:
                     mock_completion.return_value = ModelResponse.model_validate(
                         mock_response
@@ -575,10 +585,7 @@ def test_error_handling_custom_provider(client):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
+            with patch_server_obj_read(mock_obj_read):
                 res = client.server.completions_create(
                     tsi.CompletionsCreateReq.model_validate(
                         {

--- a/tests/trace_server/test_dataset_v2_api.py
+++ b/tests/trace_server/test_dataset_v2_api.py
@@ -5,11 +5,13 @@ Tests verify that the Dataset V2 API correctly creates, reads, lists, and delete
 
 import pytest
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from tests.trace_server.conftest import TEST_ENTITY
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_create_basic(trace_server):
     """Test creating a basic dataset object."""
     project_id = f"{TEST_ENTITY}/test_dataset_create_basic"
@@ -33,6 +35,7 @@ def test_dataset_create_basic(trace_server):
     assert create_res.version_index == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_create_without_description(trace_server):
     """Test creating a dataset without providing a description."""
     project_id = f"{TEST_ENTITY}/test_dataset_create_no_desc"
@@ -52,6 +55,7 @@ def test_dataset_create_without_description(trace_server):
     assert create_res.version_index == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_read_basic(trace_server):
     """Test reading a specific dataset object."""
     project_id = f"{TEST_ENTITY}/test_dataset_read_basic"
@@ -88,6 +92,7 @@ def test_dataset_read_basic(trace_server):
     assert read_res.rows.startswith("weave:///")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_read_not_found(trace_server):
     """Test reading a non-existent dataset raises NotFoundError."""
     project_id = f"{TEST_ENTITY}/test_dataset_read_not_found"
@@ -102,6 +107,7 @@ def test_dataset_read_not_found(trace_server):
         trace_server.dataset_read(read_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_list_basic(trace_server):
     """Test listing all datasets in a project."""
     project_id = f"{TEST_ENTITY}/test_dataset_list_basic"
@@ -132,6 +138,7 @@ def test_dataset_list_basic(trace_server):
         assert ds.created_at is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_list_with_limit(trace_server):
     """Test listing datasets with a limit."""
     project_id = f"{TEST_ENTITY}/test_dataset_list_limit"
@@ -153,6 +160,7 @@ def test_dataset_list_with_limit(trace_server):
     assert len(datasets) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_list_with_offset(trace_server):
     """Test listing datasets with an offset."""
     project_id = f"{TEST_ENTITY}/test_dataset_list_offset"
@@ -174,6 +182,7 @@ def test_dataset_list_with_offset(trace_server):
     assert len(datasets) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_list_with_limit_and_offset(trace_server):
     """Test listing datasets with both limit and offset for pagination."""
     project_id = f"{TEST_ENTITY}/test_dataset_list_pagination"
@@ -204,6 +213,7 @@ def test_dataset_list_with_limit_and_offset(trace_server):
     assert len(datasets1_names & datasets2_names) == 0  # No overlap
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_list_empty_project(trace_server):
     """Test listing datasets in a project with no datasets."""
     project_id = f"{TEST_ENTITY}/test_dataset_list_empty"
@@ -214,6 +224,7 @@ def test_dataset_list_empty_project(trace_server):
     assert len(datasets) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_delete_single_version(trace_server):
     """Test deleting a single version of a dataset."""
     project_id = f"{TEST_ENTITY}/test_dataset_delete_single"
@@ -247,6 +258,7 @@ def test_dataset_delete_single_version(trace_server):
         trace_server.dataset_read(read_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_delete_all_versions(trace_server):
     """Test deleting all versions of a dataset (no digests specified)."""
     project_id = f"{TEST_ENTITY}/test_dataset_delete_all"
@@ -274,6 +286,7 @@ def test_dataset_delete_all_versions(trace_server):
     assert delete_res.num_deleted == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_delete_multiple_versions(trace_server):
     """Test deleting multiple specific versions of a dataset."""
     project_id = f"{TEST_ENTITY}/test_dataset_delete_multiple"
@@ -321,6 +334,7 @@ def test_dataset_delete_multiple_versions(trace_server):
         assert read_res.digest == digest
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_delete_not_found(trace_server):
     """Test deleting a non-existent dataset raises NotFoundError."""
     project_id = f"{TEST_ENTITY}/test_dataset_delete_not_found"
@@ -335,6 +349,7 @@ def test_dataset_delete_not_found(trace_server):
         trace_server.dataset_delete(delete_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_versioning(trace_server):
     """Test that creating multiple versions of a dataset increments version_index."""
     project_id = f"{TEST_ENTITY}/test_dataset_versioning"
@@ -360,6 +375,7 @@ def test_dataset_versioning(trace_server):
     assert len({v.digest for v in versions}) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_with_special_characters(trace_server):
     """Test creating and reading a dataset with special characters in data."""
     project_id = f"{TEST_ENTITY}/test_dataset_special_chars"
@@ -393,6 +409,7 @@ def test_dataset_with_special_characters(trace_server):
     assert read_res.rows.startswith("weave:///")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_with_unicode(trace_server):
     """Test creating and reading a dataset with unicode characters."""
     project_id = f"{TEST_ENTITY}/test_dataset_unicode"
@@ -424,6 +441,7 @@ def test_dataset_with_unicode(trace_server):
     assert "🌍" in read_res.description
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_list_after_deletion(trace_server):
     """Test that deleted datasets don't appear in list results."""
     project_id = f"{TEST_ENTITY}/test_dataset_list_after_deletion"
@@ -458,6 +476,7 @@ def test_dataset_list_after_deletion(trace_server):
     assert "delete_me" not in dataset_names_returned
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_empty_rows(trace_server):
     """Test creating a dataset with empty rows."""
     project_id = f"{TEST_ENTITY}/test_dataset_empty_rows"
@@ -486,6 +505,7 @@ def test_dataset_empty_rows(trace_server):
     assert isinstance(read_res.rows, str)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_large_rows(trace_server):
     """Test creating a dataset with many rows."""
     project_id = f"{TEST_ENTITY}/test_dataset_large_rows"

--- a/tests/trace_server/test_digest_validation.py
+++ b/tests/trace_server/test_digest_validation.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import pytest
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace_server.digest_validation import validate_expected_digest
 from weave.trace_server.errors import DigestMismatchError
 from weave.trace_server.trace_server_interface import (
@@ -37,6 +38,7 @@ def test_validate_expected_digest_mismatch_raises() -> None:
 
 @pytest.mark.trace_server
 class TestFileCreateExpectedDigest:
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_no_expected_digest(self, client) -> None:
         """file_create without expected_digest succeeds (fallback path)."""
         req = FileCreateReq(
@@ -47,6 +49,7 @@ class TestFileCreateExpectedDigest:
         res = client.server.file_create(req)
         assert res.digest is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_correct_expected_digest(self, client) -> None:
         """file_create with correct expected_digest succeeds."""
         from weave.shared.digest import compute_file_digest
@@ -62,6 +65,7 @@ class TestFileCreateExpectedDigest:
         res = client.server.file_create(req)
         assert res.digest == digest
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_wrong_expected_digest(self, client) -> None:
         """file_create with wrong expected_digest raises DigestMismatchError."""
         req = FileCreateReq(
@@ -76,6 +80,7 @@ class TestFileCreateExpectedDigest:
 
 @pytest.mark.trace_server
 class TestObjCreateExpectedDigest:
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_no_expected_digest(self, client) -> None:
         """obj_create without expected_digest succeeds (fallback path)."""
         req = ObjCreateReq(
@@ -88,6 +93,7 @@ class TestObjCreateExpectedDigest:
         res = client.server.obj_create(req)
         assert res.digest is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_wrong_expected_digest(self, client) -> None:
         """obj_create with wrong expected_digest raises DigestMismatchError."""
         req = ObjCreateReq(
@@ -104,6 +110,7 @@ class TestObjCreateExpectedDigest:
 
 @pytest.mark.trace_server
 class TestTableCreateExpectedDigest:
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_no_expected_digest(self, client) -> None:
         """table_create without expected_digest succeeds (fallback path)."""
         req = TableCreateReq(
@@ -115,6 +122,7 @@ class TestTableCreateExpectedDigest:
         res = client.server.table_create(req)
         assert res.digest is not None
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_wrong_expected_digest(self, client) -> None:
         """table_create with wrong expected_digest raises DigestMismatchError."""
         req = TableCreateReq(

--- a/tests/trace_server/test_migration_lock.py
+++ b/tests/trace_server/test_migration_lock.py
@@ -5,6 +5,7 @@ import clickhouse_connect
 import pytest
 from clickhouse_connect.driver.exceptions import OperationalError
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace_server.migration_lock import (
     MigrationLockError,
     _active_owner,
@@ -342,6 +343,7 @@ def real_ch_lock(ensure_clickhouse_db):
     client.close()
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_lock_acquire_release_real_clickhouse(real_ch_lock):
     """Two holders race on a real ClickHouse — only one wins at a time."""
     client, mgmt_db = real_ch_lock

--- a/tests/trace_server/test_op_v2_api.py
+++ b/tests/trace_server/test_op_v2_api.py
@@ -5,11 +5,13 @@ Tests verify that the Op V2 API correctly creates, reads, lists, and deletes op 
 
 import pytest
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from tests.trace_server.conftest import TEST_ENTITY
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_create_basic(trace_server):
     """Test creating a basic op object."""
     project_id = f"{TEST_ENTITY}/test_op_create_basic"
@@ -28,6 +30,7 @@ def test_op_create_basic(trace_server):
     assert create_res.version_index == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_create_without_source_code(trace_server):
     """Test creating an op without providing source code (uses placeholder)."""
     project_id = f"{TEST_ENTITY}/test_op_create_no_source"
@@ -46,6 +49,7 @@ def test_op_create_without_source_code(trace_server):
     assert create_res.version_index == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_read_basic(trace_server):
     """Test reading a specific op object."""
     project_id = f"{TEST_ENTITY}/test_op_read_basic"
@@ -75,6 +79,7 @@ def test_op_read_basic(trace_server):
     assert read_res.created_at is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_read_not_found(trace_server):
     """Test reading a non-existent op raises NotFoundError."""
     project_id = f"{TEST_ENTITY}/test_op_read_not_found"
@@ -89,6 +94,7 @@ def test_op_read_not_found(trace_server):
         trace_server.op_read(read_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_list_basic(trace_server):
     """Test listing all ops in a project."""
     project_id = f"{TEST_ENTITY}/test_op_list_basic"
@@ -119,6 +125,7 @@ def test_op_list_basic(trace_server):
         assert op.created_at is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_list_with_limit(trace_server):
     """Test listing ops with a limit."""
     project_id = f"{TEST_ENTITY}/test_op_list_limit"
@@ -140,6 +147,7 @@ def test_op_list_with_limit(trace_server):
     assert len(ops) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_list_with_offset(trace_server):
     """Test listing ops with an offset."""
     project_id = f"{TEST_ENTITY}/test_op_list_offset"
@@ -161,6 +169,7 @@ def test_op_list_with_offset(trace_server):
     assert len(ops) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_list_with_limit_and_offset(trace_server):
     """Test listing ops with both limit and offset for pagination."""
     project_id = f"{TEST_ENTITY}/test_op_list_pagination"
@@ -191,6 +200,7 @@ def test_op_list_with_limit_and_offset(trace_server):
     assert len(ops1_ids & ops2_ids) == 0  # No overlap
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_list_empty_project(trace_server):
     """Test listing ops in a project with no ops."""
     project_id = f"{TEST_ENTITY}/test_op_list_empty"
@@ -201,6 +211,7 @@ def test_op_list_empty_project(trace_server):
     assert len(ops) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_delete_single_version(trace_server):
     """Test deleting a single version of an op."""
     project_id = f"{TEST_ENTITY}/test_op_delete_single"
@@ -234,6 +245,7 @@ def test_op_delete_single_version(trace_server):
         trace_server.op_read(read_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_delete_all_versions(trace_server):
     """Test deleting all versions of an op (no digests specified)."""
     project_id = f"{TEST_ENTITY}/test_op_delete_all"
@@ -261,6 +273,7 @@ def test_op_delete_all_versions(trace_server):
     assert delete_res.num_deleted == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_delete_multiple_versions(trace_server):
     """Test deleting multiple specific versions of an op."""
     project_id = f"{TEST_ENTITY}/test_op_delete_multiple"
@@ -308,6 +321,7 @@ def test_op_delete_multiple_versions(trace_server):
         assert read_res.digest == digest
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_delete_not_found(trace_server):
     """Test deleting a non-existent op raises NotFoundError."""
     project_id = f"{TEST_ENTITY}/test_op_delete_not_found"
@@ -322,6 +336,7 @@ def test_op_delete_not_found(trace_server):
         trace_server.op_delete(delete_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versioning(trace_server):
     """Test that creating multiple versions of an op increments version_index."""
     project_id = f"{TEST_ENTITY}/test_op_versioning"
@@ -347,6 +362,7 @@ def test_op_versioning(trace_server):
     assert len({v.digest for v in versions}) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_code_with_special_characters(trace_server):
     """Test creating and reading an op with special characters in source code."""
     project_id = f"{TEST_ENTITY}/test_op_special_chars"
@@ -375,6 +391,7 @@ def test_op_code_with_special_characters(trace_server):
     assert read_res.code == source_code
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_code_with_unicode(trace_server):
     """Test creating and reading an op with unicode characters in source code."""
     project_id = f"{TEST_ENTITY}/test_op_unicode"
@@ -406,6 +423,7 @@ def test_op_code_with_unicode(trace_server):
     assert "café" in read_res.code
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_list_after_deletion(trace_server):
     """Test that deleted ops don't appear in list results."""
     project_id = f"{TEST_ENTITY}/test_op_list_after_deletion"

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -20,6 +20,7 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
 )
 from opentelemetry.semconv_ai import SpanAttributes as OTSpanAttr
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.constants import MAX_OP_NAME_LENGTH
@@ -140,6 +141,7 @@ def create_test_export_request(project_id="test_project") -> tsi.OTelExportReq:
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_otel_export_clickhouse(client: weave_client.WeaveClient):
     """Test the otel_export method."""
     export_req = create_test_export_request()
@@ -202,6 +204,7 @@ def test_otel_export_clickhouse(client: weave_client.WeaveClient):
     assert len(res.calls) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_otel_export_multiple_processed_spans(client: weave_client.WeaveClient):
     """Test that exporting multiple ProcessedResourceSpans produces correct calls.
 
@@ -272,6 +275,7 @@ def test_otel_export_multiple_processed_spans(client: weave_client.WeaveClient):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_otel_export_with_turn_and_thread(client: weave_client.WeaveClient):
     """Test the otel_export method with turn and thread attributes."""
     # Create a test export request
@@ -326,6 +330,7 @@ def test_otel_export_with_turn_and_thread(client: weave_client.WeaveClient):
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_otel_export_with_turn_no_thread(client: weave_client.WeaveClient):
     """Test the otel_export method with is_turn=True but no thread_id."""
     # Create a test export request
@@ -1493,6 +1498,7 @@ class TestSemanticConventionParsing:
         extracted = get_wandb_attributes(attributes)
         assert extracted["thread_id"] == "conv-from-semconv"
 
+    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_opentelemetry_cost_calculation(self, client: weave_client.WeaveClient):
         """Test that costs are properly calculated for OTEL spans with usage at query time."""
         project_id = client.project_id
@@ -1802,6 +1808,7 @@ class TestSpanOverrides:
         assert overrides == {}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_otel_export_partial_success_on_attribute_conflict(
     client: weave_client.WeaveClient,
 ):
@@ -1880,6 +1887,7 @@ def test_otel_export_partial_success_on_attribute_conflict(
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_otel_span_wandb_attributes_and_data_routing(
     client: weave_client.WeaveClient,
 ):
@@ -2066,6 +2074,7 @@ def test_otel_span_wandb_attributes_and_data_routing(
     )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_otel_export_json_string_and_dotted_completion_keys(
     client: weave_client.WeaveClient,
 ):

--- a/tests/trace_server/test_otel_calls_complete.py
+++ b/tests/trace_server/test_otel_calls_complete.py
@@ -30,11 +30,13 @@ from opentelemetry.proto.trace.v1.trace_pb2 import (
     Span,
 )
 
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from tests.trace_server.conftest import TEST_ENTITY
 from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
 from weave.shared import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.calls_query_builder.utils import param_slot
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.errors import CallsCompleteModeRequired
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.project_version.types import CallsStorageServerMode
@@ -44,10 +46,18 @@ from weave.trace_server.project_version.types import CallsStorageServerMode
 # =============================================================================
 
 
+# Every test in this file asserts calls_complete table residence and raw
+# ClickHouse reads.
+pytestmark = pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: calls_complete table residence"
+)
+
+
 @pytest.fixture
 def clickhouse_trace_server(trace_server):
     """Get internal ClickHouse server with AUTO routing mode enabled."""
     internal_server = trace_server._internal_trace_server
+    assert isinstance(internal_server, ClickHouseTraceServer)
     internal_server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
     return internal_server
 

--- a/tests/trace_server/test_project_version.py
+++ b/tests/trace_server/test_project_version.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from weave.trace_server.project_version.clickhouse_project_version import (
     get_project_data_residence,
 )
@@ -90,6 +91,9 @@ def count_queries(ch_client):
     ],
 )
 @pytest.mark.parametrize("log_collector", ["warning"], indirect=True)
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: table routing/residence"
+)
 def test_version_resolution_by_table_contents(
     client,
     trace_server,
@@ -138,7 +142,11 @@ def test_version_resolution_by_table_contents(
         )
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: table routing/residence"
+)
 def test_caching_behavior(client, trace_server):
+
     ch_server = trace_server._internal_trace_server
     resolver = ch_server.table_routing_resolver
     resolver._mode = CallsStorageServerMode.AUTO
@@ -166,7 +174,11 @@ def test_caching_behavior(client, trace_server):
         assert get_count() == 2
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: table routing/residence"
+)
 def test_mode_off_and_force_legacy(client, trace_server):
+
     ch_server = trace_server._internal_trace_server
     resolver = ch_server.table_routing_resolver
 
@@ -191,7 +203,11 @@ def test_mode_off_and_force_legacy(client, trace_server):
     assert table == ReadTable.CALLS_COMPLETE
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: table routing/residence"
+)
 def test_clickhouse_provider_directly(client, trace_server):
+
     ch_server = trace_server._internal_trace_server
     project_id = make_project_id("provider_direct")
     insert_call(ch_server.ch_client, "calls_merged", project_id)
@@ -201,6 +217,9 @@ def test_clickhouse_provider_directly(client, trace_server):
     assert residence == ProjectDataResidence.MERGED_ONLY
 
 
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: table routing/residence"
+)
 def test_resolver_as_trace_server_member(client, trace_server):
     """Test that the resolver is properly integrated as a trace server member."""
     ch_server = trace_server._internal_trace_server

--- a/tests/trace_server/test_rescore_evaluation.py
+++ b/tests/trace_server/test_rescore_evaluation.py
@@ -13,6 +13,7 @@ import pytest
 
 from tests.trace.server_utils import find_server_layer
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.in_memory_trace_server import InMemoryTraceServer
 from weave.trace_server.trace_server_interface import (
     CallReadReq,
     EvaluationRunCreateReq,
@@ -95,7 +96,17 @@ def _setup_server_with_dispatcher(server):
     _evaluate_model_dispatcher, then swaps it for a MagicMock so rescore()
     can be tested without real worker invocation.
     """
-    target = find_server_layer(server, ClickHouseTraceServer)
+    target = None
+    last_err: TypeError | None = None
+    for server_type in (InMemoryTraceServer, ClickHouseTraceServer):
+        try:
+            target = find_server_layer(server, server_type)
+            break
+        except TypeError as err:
+            last_err = err
+    if target is None:
+        # No known concrete server found — re-raise the last lookup error
+        raise last_err from None
     mock_dispatcher = MagicMock()
     target._evaluate_model_dispatcher = mock_dispatcher
     return mock_dispatcher

--- a/tests/trace_server/test_rescore_evaluation.py
+++ b/tests/trace_server/test_rescore_evaluation.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from tests.trace.server_utils import find_server_layer
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.in_memory_trace_server import InMemoryTraceServer
 from weave.trace_server.trace_server_interface import (
@@ -31,6 +32,7 @@ from weave.utils.project_id import from_project_id
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_evaluation_run_create_stores_source_evaluation_run_id(client):
     """source_evaluation_run_id written at create time must survive a read."""
     project_id = client.project_id
@@ -64,6 +66,7 @@ def test_evaluation_run_create_stores_source_evaluation_run_id(client):
     assert read_res.source_evaluation_run_id == source_run.evaluation_run_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_evaluation_run_without_source_has_none(client):
     """evaluation_run_read returns source_evaluation_run_id=None for normal runs."""
     project_id = client.project_id
@@ -112,6 +115,7 @@ def _setup_server_with_dispatcher(server):
     return mock_dispatcher
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_rescore_allocates_new_id_and_dispatches_without_precreating_call(client):
     """rescore() must allocate a fresh evaluation_run_id and dispatch the
     worker, but must NOT pre-create the call row. Call ownership lives
@@ -170,6 +174,7 @@ def test_rescore_allocates_new_id_and_dispatches_without_precreating_call(client
     assert "abc123" in dispatched.scorer_refs[0]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_rescore_without_wb_user_id_raises(client):
     """rescore() must reject requests with wb_user_id=None at the server layer."""
     project_id = client.project_id
@@ -200,6 +205,7 @@ def test_rescore_without_wb_user_id_raises(client):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_prediction_list_filters_by_evaluation_run_id(client):
     """prediction_list(evaluation_run_id=X) must return only predictions for run X."""
     project_id = client.project_id
@@ -271,6 +277,7 @@ def test_prediction_list_filters_by_evaluation_run_id(client):
     assert preds_b[0].evaluation_run_id == run_b.evaluation_run_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_prediction_list_pagination(client):
     """prediction_list respects limit and offset."""
     project_id = client.project_id

--- a/tests/trace_server/test_scorer_v2_api.py
+++ b/tests/trace_server/test_scorer_v2_api.py
@@ -5,11 +5,13 @@ Tests verify that the Scorer V2 API correctly creates, reads, lists, and deletes
 
 import pytest
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from tests.trace_server.conftest import TEST_ENTITY
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_create_basic(trace_server):
     """Test creating a basic scorer object."""
     project_id = f"{TEST_ENTITY}/test_scorer_create_basic"
@@ -35,6 +37,7 @@ def score(output: str, target: str) -> dict:
     assert create_res.scorer.startswith("weave:///")
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_create_without_description(trace_server):
     """Test creating a scorer without providing a description."""
     project_id = f"{TEST_ENTITY}/test_scorer_create_no_desc"
@@ -58,6 +61,7 @@ def score(output: str) -> dict:
     assert isinstance(create_res.scorer, str)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_read_basic(trace_server):
     """Test reading a specific scorer object."""
     project_id = f"{TEST_ENTITY}/test_scorer_read_basic"
@@ -94,6 +98,7 @@ def score(output: str, target: str) -> dict:
     assert read_res.score_op.startswith("weave:///") or len(read_res.score_op) > 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_read_not_found(trace_server):
     """Test reading a non-existent scorer raises NotFoundError."""
     project_id = f"{TEST_ENTITY}/test_scorer_read_not_found"
@@ -108,6 +113,7 @@ def test_scorer_read_not_found(trace_server):
         trace_server.scorer_read(read_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_list_basic(trace_server):
     """Test listing all scorers in a project."""
     project_id = f"{TEST_ENTITY}/test_scorer_list_basic"
@@ -137,6 +143,7 @@ def test_scorer_list_basic(trace_server):
         assert scorer.created_at is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_list_with_limit(trace_server):
     """Test listing scorers with a limit."""
     project_id = f"{TEST_ENTITY}/test_scorer_list_limit"
@@ -158,6 +165,7 @@ def test_scorer_list_with_limit(trace_server):
     assert len(scorers) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_list_with_offset(trace_server):
     """Test listing scorers with an offset."""
     project_id = f"{TEST_ENTITY}/test_scorer_list_offset"
@@ -179,6 +187,7 @@ def test_scorer_list_with_offset(trace_server):
     assert len(scorers) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_list_with_limit_and_offset(trace_server):
     """Test listing scorers with both limit and offset for pagination."""
     project_id = f"{TEST_ENTITY}/test_scorer_list_pagination"
@@ -209,6 +218,7 @@ def test_scorer_list_with_limit_and_offset(trace_server):
     assert len(scorers1_names & scorers2_names) == 0  # No overlap
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_list_empty_project(trace_server):
     """Test listing scorers in a project with no scorers."""
     project_id = f"{TEST_ENTITY}/test_scorer_list_empty"
@@ -219,6 +229,7 @@ def test_scorer_list_empty_project(trace_server):
     assert len(scorers) == 0
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_delete_single_version(trace_server):
     """Test deleting a single version of a scorer."""
     project_id = f"{TEST_ENTITY}/test_scorer_delete_single"
@@ -252,6 +263,7 @@ def test_scorer_delete_single_version(trace_server):
         trace_server.scorer_read(read_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_delete_all_versions(trace_server):
     """Test deleting all versions of a scorer (no digests specified)."""
     project_id = f"{TEST_ENTITY}/test_scorer_delete_all"
@@ -279,6 +291,7 @@ def test_scorer_delete_all_versions(trace_server):
     assert delete_res.num_deleted == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_delete_multiple_versions(trace_server):
     """Test deleting multiple specific versions of a scorer."""
     project_id = f"{TEST_ENTITY}/test_scorer_delete_multiple"
@@ -326,6 +339,7 @@ def test_scorer_delete_multiple_versions(trace_server):
         assert read_res.digest == digest
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_delete_not_found(trace_server):
     """Test deleting a non-existent scorer raises NotFoundError."""
     project_id = f"{TEST_ENTITY}/test_scorer_delete_not_found"
@@ -340,6 +354,7 @@ def test_scorer_delete_not_found(trace_server):
         trace_server.scorer_delete(delete_req)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_versioning(trace_server):
     """Test that creating multiple versions of a scorer increments version_index."""
     project_id = f"{TEST_ENTITY}/test_scorer_versioning"
@@ -365,6 +380,7 @@ def test_scorer_versioning(trace_server):
     assert len({v.digest for v in versions}) == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_with_special_characters(trace_server):
     """Test creating and reading a scorer with special characters in code."""
     project_id = f"{TEST_ENTITY}/test_scorer_special_chars"
@@ -396,6 +412,7 @@ def score(output: str) -> dict:
     assert read_res.score_op  # Should have a reference
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_with_unicode(trace_server):
     """Test creating and reading a scorer with unicode characters."""
     project_id = f"{TEST_ENTITY}/test_scorer_unicode"
@@ -427,6 +444,7 @@ def score(output: str) -> dict:
     assert "🌍" in read_res.description
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_list_after_deletion(trace_server):
     """Test that deleted scorers don't appear in list results."""
     project_id = f"{TEST_ENTITY}/test_scorer_list_after_deletion"
@@ -461,6 +479,7 @@ def test_scorer_list_after_deletion(trace_server):
     assert "delete_me" not in scorer_names_returned
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_complex_source_code(trace_server):
     """Test creating a scorer with complex multi-line source code."""
     project_id = f"{TEST_ENTITY}/test_scorer_complex_code"
@@ -520,6 +539,7 @@ def score(output: str, target: str) -> dict:
     assert read_res.description == "Complex JSON similarity scorer"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_scorer_list_with_missing_name_in_val(trace_server):
     """Regression test: scorer_list should not crash when val has no 'name' key.
 

--- a/tests/trace_server/test_trace_server_conftest.py
+++ b/tests/trace_server/test_trace_server_conftest.py
@@ -1,12 +1,22 @@
+from tests.trace_server.conftest import get_trace_server_flag
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     UserInjectingExternalTraceServer,
 )
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.in_memory_trace_server import InMemoryTraceServer
 
 
-def test_trace_server_fixture(trace_server: UserInjectingExternalTraceServer):
+def test_trace_server_fixture(request, trace_server: UserInjectingExternalTraceServer):
     assert isinstance(trace_server, UserInjectingExternalTraceServer)
-    assert isinstance(trace_server._internal_trace_server, ClickHouseTraceServer)
+    flag = get_trace_server_flag(request)
+    expected_internal_types = {
+        "fake": InMemoryTraceServer,
+        "clickhouse": ClickHouseTraceServer,
+    }
+    # KeyError on an unrecognized backend — fail loudly rather than guess.
+    assert isinstance(
+        trace_server._internal_trace_server, expected_internal_types[flag]
+    )
 
 
 # All instance attributes set in ClickHouseTraceServer.__init__.

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -8,6 +8,7 @@ import pytest
 
 import weave
 from tests.conftest import LATENCY_TOL
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from tests.trace_server.completions_util import with_simple_mock_litellm_completion
 from weave.trace.refs import ObjectRef
 from weave.trace.serialization.custom_objs import UnsafeDeserializationError
@@ -46,6 +47,7 @@ from weave.trace_server.workers.evaluate_model_worker import evaluate_model_work
 from weave.utils.project_id import from_project_id, to_project_id
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_evaluation_status(client):
     eval_call_id = generate_id()
@@ -276,6 +278,7 @@ def setup_test_objects(server: TraceServerInterface, entity: str, project: str):
     return model_ref_uri, evaluation_ref_uri
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize("direct_script_execution", [True, False])
 def test_evaluate_model(client: WeaveClient, direct_script_execution):
     """Test the evaluate_model API endpoint with isolated execution.
@@ -385,6 +388,7 @@ def test_evaluate_model(client: WeaveClient, direct_script_execution):
 
 # The guard raises inside the lazy row-decode threadpool, which logs the failure
 # at ERROR before it propagates out of asyncio.run; that log is the expected path.
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_evaluate_model_rejects_unsafe_dataset_row(client):
     """An Op node in a dataset row must be refused at decode time, not loaded and
@@ -470,6 +474,7 @@ def test_evaluate_model_rejects_unsafe_dataset_row(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize("op_arg", ["evaluation_ref", "model_ref"])
 def test_evaluate_model_rejects_op_ref_as_eval_or_model_ref(client, op_arg):
     """An op ref passed directly as the evaluation_ref/model_ref must be refused at
@@ -543,6 +548,7 @@ def test_evaluate_model_rejects_op_ref_as_eval_or_model_ref(client, op_arg):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_query_basic(client):
     project_id = client.project_id
     entity, project = from_project_id(project_id)
@@ -604,6 +610,7 @@ def test_eval_results_query_basic(client):
     assert trial.scores["basic_scorer"] == 0.9
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_query_returns_genai_span_ref_without_children(client):
     project_id = client.project_id
     genai_span_ref = GenAISpanRef(
@@ -649,6 +656,7 @@ def test_eval_results_query_returns_genai_span_ref_without_children(client):
     assert trial.genai_span_ref == [genai_span_ref]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_query_nonexistent_eval_root(client):
     project_id = client.project_id
 
@@ -663,6 +671,7 @@ def test_eval_results_query_nonexistent_eval_root(client):
     assert res.rows == []
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_query_multiple_evals(client):
     project_id = client.project_id
 
@@ -713,6 +722,7 @@ def test_eval_results_query_multiple_evals(client):
     }
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_resolve_refs_only_for_paginated_rows(client):
     """Verify that resolve_row_refs only resolves refs for the paginated slice"""
     project_id = client.project_id
@@ -771,6 +781,7 @@ def test_eval_results_resolve_refs_only_for_paginated_rows(client):
         assert len(call.refs) <= 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_include_predict_and_score_children(client):
     """Verify include_predict_and_score_children controls child call data."""
     project_id = client.project_id
@@ -846,6 +857,7 @@ def test_eval_results_include_predict_and_score_children(client):
     assert trial_without.scores["children_test_scorer"] == 0.8
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_resolved_inputs_inline(client):
     """Inline inputs should be available as dicts in raw_data_row."""
     project_id = client.project_id
@@ -888,6 +900,7 @@ def test_eval_results_resolved_inputs_inline(client):
     assert row.raw_data_row["question"] == "What is 2+2?"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize(
     "predict_and_score_op_name",
     [
@@ -1012,6 +1025,7 @@ def _create_eval_with_scores(client, scores_per_row, eval_name="eval"):
     return run.evaluation_run_id, predict_and_score_ids
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_row_order_is_stable(client):
     """Row order should be stable across repeated requests (default sort by row_digest)."""
     eval_id, _ = _create_eval_with_scores(
@@ -1034,6 +1048,7 @@ def test_eval_results_row_order_is_stable(client):
             assert digests == digests_first, "Row order changed between requests"
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_excludes_deleted_calls(client):
     """Deleted PAS calls should not appear in eval results."""
     eval_id, predict_and_score_ids = _create_eval_with_scores(
@@ -1066,6 +1081,7 @@ def test_eval_results_excludes_deleted_calls(client):
     assert res.total_rows == 2
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_sort_by_score_desc(client):
     """Sort by scores.accuracy DESC should return highest-scoring row first."""
     eval_id, _ = _create_eval_with_scores(
@@ -1086,6 +1102,7 @@ def test_eval_results_sort_by_score_desc(client):
     assert accuracies == [0.9, 0.6, 0.3]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_sort_by_score_asc(client):
     """Sort by scores.accuracy ASC should return lowest-scoring row first."""
     eval_id, _ = _create_eval_with_scores(
@@ -1105,6 +1122,7 @@ def test_eval_results_sort_by_score_asc(client):
     assert accuracies == [0.3, 0.6, 0.9]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_filter_score_gte(client):
     """Filter scores.accuracy >= 0.5 should exclude rows below threshold."""
     eval_id, _ = _create_eval_with_scores(
@@ -1145,6 +1163,7 @@ def test_eval_results_filter_score_gte(client):
     assert accuracies == [0.6, 0.9]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_sort_and_filter_combined(client):
     """Sort + filter together: filter first, then sort the remaining rows."""
     eval_id, _ = _create_eval_with_scores(
@@ -1184,6 +1203,7 @@ def test_eval_results_sort_and_filter_combined(client):
     assert accuracies == [0.9, 0.7, 0.5]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_filter_with_evaluation_call_id_scope(client):
     """Filter scoped to evaluation_call_id only tests that eval's scores."""
     eval_id, _ = _create_eval_with_scores(
@@ -1234,6 +1254,7 @@ def test_eval_results_filter_with_evaluation_call_id_scope(client):
     assert accuracies == [0.7, 0.9]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_sort_unsupported_field_returns_invalid_request(client):
     """Sorting on an unsupported field prefix returns InvalidRequest."""
     eval_id, _ = _create_eval_with_scores(
@@ -1249,6 +1270,7 @@ def test_eval_results_sort_unsupported_field_returns_invalid_request(client):
         )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_sort_by_output(client):
     """Sort by output.label orders rows by nested model output field."""
     project_id = client.project_id
@@ -1309,6 +1331,7 @@ def test_eval_results_sort_by_output(client):
     assert sorted_labels == ["apple", "banana", "cherry"]
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_eval_results_summary_with_filter(client):
     """Summary reflects filtered rows, not all rows."""
     eval_id, _ = _create_eval_with_scores(

--- a/tests/trace_server/test_trace_usage.py
+++ b/tests/trace_server/test_trace_usage.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server import usage_utils
@@ -442,6 +443,7 @@ def test_aggregate_usage_handles_missing_summaries(
     assert_usage(leaf_id, expected_leaf)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_usage_rolls_up_descendants(client: weave_client.WeaveClient) -> None:
     project_id = client.project_id
     trace_id = str(uuid.uuid4())
@@ -494,6 +496,7 @@ def test_trace_usage_rolls_up_descendants(client: weave_client.WeaveClient) -> N
     assert child_usage.total_tokens == 7
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_usage_include_costs_flag(client: weave_client.WeaveClient) -> None:
     project_id = client.project_id
     trace_id = str(uuid.uuid4())
@@ -532,6 +535,7 @@ def test_trace_usage_include_costs_flag(client: weave_client.WeaveClient) -> Non
     assert usage_with_costs.completion_tokens_total_cost is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_trace_usage_returns_unfinished_call_ids(
     client: weave_client.WeaveClient,
 ) -> None:
@@ -568,6 +572,7 @@ def test_trace_usage_returns_unfinished_call_ids(
     assert set(res.unfinished_call_ids) == {unfinished_child_id}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_usage_rolls_up_descendants(client: weave_client.WeaveClient) -> None:
     project_id = client.project_id
     trace_id = str(uuid.uuid4())
@@ -630,6 +635,7 @@ def test_calls_usage_rolls_up_descendants(client: weave_client.WeaveClient) -> N
     assert root_two_usage.total_tokens == 3
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_usage_include_costs_flag(client: weave_client.WeaveClient) -> None:
     project_id = client.project_id
     trace_id = str(uuid.uuid4())
@@ -668,6 +674,7 @@ def test_calls_usage_include_costs_flag(client: weave_client.WeaveClient) -> Non
     assert usage_with_costs.completion_tokens_total_cost is not None
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_calls_usage_returns_unfinished_call_ids(
     client: weave_client.WeaveClient,
 ) -> None:
@@ -714,6 +721,7 @@ def test_calls_usage_returns_unfinished_call_ids(
     assert set(res.unfinished_call_ids) == {unfinished_child_id}
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize(
     ("root_usage", "middle_usage", "leaf_usage"),
     [

--- a/tests/trace_server/test_ttl_insert_paths.py
+++ b/tests/trace_server/test_ttl_insert_paths.py
@@ -17,6 +17,7 @@ import uuid
 
 import pytest
 
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER
@@ -127,6 +128,9 @@ def _now_utc() -> datetime.datetime:
 
 
 @pytest.mark.parametrize(("retention_days", "expected_delta"), RETENTION_CASES)
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: raw expire_at table reads"
+)
 def test_ttl_call_start_end_sets_expire_at(
     trace_server, internal_server, retention_days, expected_delta
 ):
@@ -177,6 +181,9 @@ def test_ttl_call_start_end_sets_expire_at(
 
 
 @pytest.mark.parametrize(("retention_days", "expected_delta"), RETENTION_CASES)
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: raw expire_at table reads"
+)
 def test_ttl_call_start_batch_sets_expire_at(
     trace_server, internal_server, retention_days, expected_delta
 ):
@@ -233,6 +240,9 @@ def test_ttl_call_start_batch_sets_expire_at(
 
 
 @pytest.mark.parametrize(("retention_days", "expected_delta"), RETENTION_CASES)
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: raw expire_at table reads"
+)
 def test_ttl_calls_complete_sets_expire_at(
     trace_server, internal_server, retention_days, expected_delta
 ):
@@ -272,6 +282,9 @@ def test_ttl_calls_complete_sets_expire_at(
 
 
 @pytest.mark.parametrize(("retention_days", "expected_delta"), RETENTION_CASES)
+@pytest.mark.skipif(
+    NOT_CLICKHOUSE_BACKEND, reason="ClickHouse-only: raw expire_at table reads"
+)
 def test_ttl_call_start_v2_end_v2_sets_expire_at(
     trace_server, internal_server, retention_days, expected_delta
 ):

--- a/tests/trace_server/test_ttl_insert_paths.py
+++ b/tests/trace_server/test_ttl_insert_paths.py
@@ -17,7 +17,7 @@ import uuid
 
 import pytest
 
-from tests.trace.util import NOT_CLICKHOUSE_BACKEND
+from tests.trace.util import FAKE_NOT_IMPLEMENTED, NOT_CLICKHOUSE_BACKEND
 from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ch_sentinel_values import EXPIRE_AT_NEVER
@@ -330,6 +330,7 @@ def test_ttl_call_start_v2_end_v2_sets_expire_at(
     _assert_expire_at_matches(values, started_at, retention_days, expected_delta)
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_project_ttl_settings_endpoints_round_trip(trace_server):
     """project_ttl_settings_read/update: default -> set -> clear, plus validation.
 

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -1,0 +1,157 @@
+# In-Memory ("fake") Trace Server
+#
+# A pure-Python, dict/list-backed implementation of the full trace server
+# interface, intended as a fast drop-in replacement for the ClickHouse trace
+# server in tests. It lives parallel to `clickhouse_trace_server_batched.py`.
+#
+# Behavioral contract: this server replicates the *ClickHouse* trace server
+# (the production backend) at the interface level, so tests written against
+# ClickHouse behavior pass unmodified. That includes ClickHouse's observable
+# semantics: JSON_VALUE string typing for dynamic fields ('' for missing keys,
+# JSON nulls, and non-scalars), to*OrNull cast rules, NULLS-LAST ordering with
+# existence-first sorting for dynamic fields, DateTime64 column comparisons,
+# and the computed summary fields (status/latency_ms/trace_name).
+# ClickHouse *internals* (SQL, table routing/residence, batching, bucket file
+# storage) are out of scope; tests asserting those are ClickHouse-gated.
+
+import datetime
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+from weave.trace_server import trace_server_interface as tsi
+
+# Completion request preparation (prompt resolution, provider/secret setup) is
+# backend-agnostic business logic that currently lives in the ClickHouse
+# module; import it rather than fork it.
+from weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker import (
+    EvaluateModelDispatcher,
+)
+
+
+@dataclass(slots=True)
+class _CallRec:
+    project_id: str
+    id: str
+    trace_id: str | None
+    parent_id: str | None
+    thread_id: str | None
+    turn_id: str | None
+    op_name: str | None
+    display_name: str | None
+    started_at: datetime.datetime | None
+    attributes: Any
+    inputs: Any
+    input_refs: list[str]
+    wb_user_id: str | None
+    wb_run_id: str | None
+    wb_run_step: int | None
+    otel_dump: Any
+    expire_at: datetime.datetime
+    attributes_len: int | None = None
+    inputs_len: int | None = None
+    output_len: int | None = None
+    summary_len: int | None = None
+    otel_dump_len: int | None = None
+    ended_at: datetime.datetime | None = None
+    exception: str | None = None
+    output: Any = None
+    output_refs: list[str] = field(default_factory=list)
+    summary: Any = None
+    wb_run_step_end: int | None = None
+    deleted_at: datetime.datetime | None = None
+    storage_size_bytes: int | None = None
+
+
+@dataclass(slots=True)
+class _ObjRec:
+    project_id: str
+    object_id: str
+    created_at: datetime.datetime
+    kind: str
+    base_object_class: str | None
+    leaf_object_class: str | None
+    val: Any
+    digest: str
+    version_index: int
+    is_latest: int
+    wb_user_id: str | None
+    val_dump_len: int = 0
+    deleted_at: datetime.datetime | None = None
+
+
+@dataclass(slots=True)
+class _TableRowRec:
+    project_id: str
+    val: Any
+    val_dump_len: int = 0
+
+
+@dataclass(slots=True)
+class _AliasRec:
+    digest: str
+    created_at: datetime.datetime
+
+
+@dataclass(slots=True)
+class _TtlRec:
+    project_id: str
+    retention_days: int
+    updated_at: datetime.datetime
+    updated_by: str
+
+
+class InMemoryTraceServer(tsi.FullTraceServerInterface):
+    """Pure in-memory trace server for tests, replicating ClickHouse semantics."""
+
+    def __init__(
+        self,
+        evaluate_model_dispatcher: EvaluateModelDispatcher | None = None,
+    ):
+        self.lock = threading.RLock()
+        self._evaluate_model_dispatcher = evaluate_model_dispatcher
+        self._init_storage()
+
+    def _init_storage(self) -> None:
+        # Calls keyed by (project_id, id), mirroring ClickHouse's scoping
+        # of calls by project.
+        self._calls: dict[tuple[str, str], _CallRec] = {}
+        # Objects keyed by (project_id, kind, object_id, digest), insertion
+        # ordered (rowid order matters for version_index and tie-breaks).
+        self._objs: dict[tuple[str, str, str, str], _ObjRec] = {}
+        # Tables keyed by (project_id, digest) -> ordered row digests.
+        self._tables: dict[tuple[str, str], list[str]] = {}
+        # Table rows keyed by digest (content-addressed, first-writer-wins:
+        # first writer wins, reads filter on project_id).
+        self._table_rows: dict[str, _TableRowRec] = {}
+        # Files keyed by (project_id, digest).
+        self._files: dict[tuple[str, str], bytes] = {}
+        # Tags keyed by (project_id, object_id, digest) -> set of tags.
+        self._tags: dict[tuple[str, str, str], set[str]] = {}
+        # Aliases keyed by (project_id, object_id, alias) -> digest record.
+        self._aliases: dict[tuple[str, str, str], _AliasRec] = {}
+        # Feedback rows: stored in the post-insert read shape (see
+        # _feedback_row_for_storage), insertion ordered.
+        self._feedback: list[dict[str, Any]] = []
+        # LLM token price rows (plain dicts mirroring the table columns).
+        self._llm_token_prices: list[dict[str, Any]] = []
+        # Project TTL settings, append-only audit rows.
+        self._ttl_settings: list[_TtlRec] = []
+        # Annotation queues / items / per-annotator progress (one mutable
+        # record per id, soft-deleted via deleted_at — mirrors the ClickHouse
+        # lightweight-update model).
+        self._annotation_queues: dict[str, dict[str, Any]] = {}
+        self._annotation_queue_items: dict[str, dict[str, Any]] = {}
+        self._annotation_progress: dict[str, dict[str, Any]] = {}
+        # Agent spans keyed by span_id (ReplacingMergeTree semantics: a
+        # re-insert with the same span_id replaces the row).
+        self._agent_spans: dict[str, Any] = {}
+
+    def close(self) -> None:
+        pass
+
+    def drop_tables(self) -> None:
+        self._init_storage()
+
+    def setup_tables(self) -> None:
+        pass


### PR DESCRIPTION
This PR has two commits:
1. The first commit introduces the skeleton of the fake trace server implementation, including new wiring to run the impl.  Initially, this impl is a no-op to start.
2. The second commit (most of the changes in this PR) are mechanical additions telling pytest to skip tests against the fake impl.  As we implement the fake in subsequent PRs, we'll remove the skips.

At the end of this process, we should have a fully featured fake impl and no skips.

---

All subsequent PRs in this stack share these properties:
1. The first commit removes the skip from relevant tests whose impl will be implemented; then
3. The second commit actually implements the fake, allowing the tests to pass.