### PR TITLE
feat(weave): in-memory trace server ClickHouse dynamic-field evaluation

### DIFF
--- a/tests/trace/test_call_object.py
+++ b/tests/trace/test_call_object.py
@@ -1,10 +1,6 @@
-import pytest
-
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_to_dict(weave_active):
     @weave.op
     def greet(name: str, age: int) -> str:

--- a/tests/trace/test_client_server_caching.py
+++ b/tests/trace/test_client_server_caching.py
@@ -13,7 +13,6 @@ import pytest
 import weave
 from tests.conftest import CachingMiddlewareTraceServer
 from tests.trace.server_utils import find_server_layer
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace import weave_client
 from weave.trace_server.service_interface import EnsureProjectExistsRes
 from weave.trace_server.trace_server_interface import (
@@ -90,7 +89,6 @@ def test_weave_client_init_with_caching_middleware():
     mock_server.ensure_project_exists.assert_called_once_with("entity", "project")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_caching(client):
     os.environ["WEAVE_USE_SERVER_CACHE"] = "true"
     caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
@@ -244,7 +242,6 @@ def test_server_cache_latency():
         assert added_latency < 0.003
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_file_create_caching(client):
     caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
     file_bytes = b"hello"

--- a/tests/trace/test_client_side_digests.py
+++ b/tests/trace/test_client_side_digests.py
@@ -12,7 +12,6 @@ from PIL import Image
 
 import weave
 from tests.trace.server_utils import find_server_layer
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.shared.digest import (
     compute_file_digest,
     compute_object_digest,
@@ -76,7 +75,6 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_dataset(self, client: WeaveClient):
         rows = [{"x": i, "y": str(i)} for i in range(10)]
 
@@ -105,7 +103,6 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_op(self, client: WeaveClient):
         @weave.op
         def my_test_op(x: int) -> int:
@@ -144,7 +141,6 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_large_dataset(self, client: WeaveClient):
         rows = [
             {"idx": i, "val": f"row_{i}", "data": list(range(i % 10))}
@@ -180,7 +176,6 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_custom_weave_type(self, client: WeaveClient):
         """CustomWeaveType (PIL Image) produces the same digest on both paths."""
         img_client = Image.new("RGB", (16, 16), color=(0, 128, 255))
@@ -195,7 +190,6 @@ class TestClientServerDigestConsistency:
 
         assert digest_client == digest_server
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_table_row_digests(self, client: WeaveClient):
         """Client-computed row and table digests match the server's."""
         rows = [{"x": i, "y": str(i)} for i in range(5)]
@@ -228,7 +222,6 @@ class TestDataCorrectness:
         assert got["number"] == 42
         assert got["list"] == [1, 2, 3]
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_dataset(self, client: WeaveClient, fast_path: None):
         rows = [{"a": i, "b": i * 2} for i in range(5)]
         ds = weave.Dataset(name="round_trip_ds", rows=rows)
@@ -254,7 +247,6 @@ class TestDataCorrectness:
         assert got["config"]["a"] == 1
         assert got["metadata"]["nested"]["deep"] is True
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_op(self, client: WeaveClient, fast_path: None):
         @weave.op
         def my_rt_op(x: int) -> int:
@@ -280,7 +272,6 @@ class TestDataCorrectness:
         assert got["emoji"] == "\U0001f680"
         assert got["cjk"] == "\u4f60\u597d"
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_custom_weave_type(self, client: WeaveClient, fast_path: None):
         img = Image.new("RGB", (32, 32), color=(255, 0, 0))
         ref = weave.publish(img, name="fast_path_image")
@@ -330,7 +321,6 @@ class TestServerDigestValidation:
             with pytest.raises(DigestMismatchError):
                 client.server.obj_create(req)
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
     def test_table(self, client: WeaveClient, correct: bool):
         rows = [{"a": 1}, {"a": 2}, {"a": 3}]
@@ -355,7 +345,6 @@ class TestServerDigestValidation:
             with pytest.raises(DigestMismatchError):
                 client.server.table_create(req)
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
     def test_file(self, client: WeaveClient, correct: bool):
         content = b"hello world"
@@ -491,7 +480,6 @@ class TestDigestMismatchAutoDisable:
 
         assert seen_digests == [None]
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     @pytest.mark.disable_logging_error_check
     def test_table_mismatch_retries_and_disables(
         self, client: WeaveClient, fast_path: None, monkeypatch

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -1805,7 +1805,6 @@ def test_dataclass_support(client):
     }
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_retrieval(weave_active):
     @weave.op
     def my_op(a: int) -> int:
@@ -1817,7 +1816,6 @@ def test_op_retrieval(weave_active):
     assert my_op2(1) == 2
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_bound_op_retrieval(weave_active):
     class CustomType(weave.Object):
@@ -1862,7 +1860,6 @@ def test_bound_op_retrieval_no_self(weave_active):
         my_op2 = my_op_ref.get()
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_row_ref(weave_active):
     d = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
     ref = weave.publish(d)
@@ -1876,7 +1873,6 @@ def test_dataset_row_ref(weave_active):
     assert gotten == 5
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_empty_sort_field_validation(client):
     """Test that empty or invalid sort fields in table queries are properly validated."""
     # Create a dataset with table data
@@ -1978,7 +1974,6 @@ def test_namedtuple_support(client):
     assert res.calls[0].output == [{"x": 1, "y": 2}, 3]
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_named_reuse(client):
     d = weave.Dataset(rows=[{"x": 1}, {"x": 2}])
@@ -3183,7 +3178,6 @@ def test_in_operation(client):
         assert res[i].id == call_ids[i]
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_call_has_client_version(weave_active):
     @weave.op
     def test():
@@ -3194,7 +3188,6 @@ def test_call_has_client_version(weave_active):
     assert "client_version" in c.attributes["weave"]
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_user_cannot_modify_call_weave_dict(weave_active):
     @weave.op
     def test():
@@ -3311,7 +3304,6 @@ class BasicModel(weave.Model):
         return {"answer": "42"}
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_model_save(client):
     model = BasicModel()
@@ -3549,7 +3541,6 @@ def test_object_with_char_over_limit(client):
 chars = "+_(){}|\"'<>!@$^&*#:,.[]-=;~`"
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_objects_and_keys_with_special_characters(client):
     # make sure to include ":", "/" which are URI-related
 
@@ -4676,7 +4667,6 @@ def test_calls_hydrated(client):
     assert calls[2].inputs["input_ref"]["hi"]["there"]["foo"] == "bar"
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_obj_query_with_storage_size_clickhouse(client):
     """Test querying objects with storage size information."""
     # Create a test object with some data to ensure it has size
@@ -4800,7 +4790,6 @@ def test_call_query_stream_with_invalid_filter_field(client):
         )
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize(
     "obj",
     [
@@ -4815,7 +4804,6 @@ def test_get_object_from_uri(weave_active, obj):
     assert weave.get(uri) == obj
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3)
 def test_get_object_from_uri_non_registered_object(weave_active):
     class MyModel(weave.Model):
@@ -5666,7 +5654,6 @@ def test_get_calls_filter_by_thread_ids_only(client):
     assert all(call.thread_id == f"thread_a_{unique}" for call in calls_thread_a)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_thread_context_error_handling(weave_active):
     """Test that ThreadContext is properly managed even when exceptions occur."""
     import weave

--- a/tests/trace/test_custom_objs.py
+++ b/tests/trace/test_custom_objs.py
@@ -28,7 +28,6 @@ def test_encode_custom_obj_unknown_type():
     assert encode_custom_obj(unknown) is None
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_decode_custom_obj_known_type(client):
     img = Image.new("RGB", (100, 100))
     encoded = encode_custom_obj(img)
@@ -40,7 +39,6 @@ def test_decode_custom_obj_known_type(client):
     assert decoded.tobytes() == img.tobytes()
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_inline_custom_obj(client):
     dt = datetime(2025, 3, 7, 0, 0, 0)
     encoded = encode_custom_obj(dt)
@@ -103,7 +101,6 @@ def test_no_extra_calls_created(client):
     assert len(calls) == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_safe_type_decodes_when_unsafe_decode_disabled(client):
     # Data-only types must still decode on a worker client that forbids unsafe decode:
     # they reconstruct via the in-process serializer and run no user code. Breaking
@@ -145,7 +142,6 @@ def test_unsafe_decode_disabled_refuses_code_bearing(client, encoded):
         decode_custom_obj(encoded)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_setting_disables_unsafe_decode_globally(client):
     # `WEAVE_ALLOW_UNSAFE_CUSTOM_OBJ_DECODE=false` (here via override_settings) closes
     # the gate even on a normal client whose own flag still allows unsafe decode, so a
@@ -168,7 +164,6 @@ def test_setting_disables_unsafe_decode_globally(client):
         assert decoded.tobytes() == img.tobytes()
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_encode_custom_obj_save_exception_returns_none(client, failing_serializer):
     """Requirement: Type handler save exceptions should not crash user code
     Interface: encode_custom_obj function
@@ -185,7 +180,6 @@ def test_encode_custom_obj_save_exception_returns_none(client, failing_serialize
     assert result is None
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_encode_custom_obj_save_exception_does_not_propagate(
     client, failing_serializer
 ):

--- a/tests/trace/test_dataset.py
+++ b/tests/trace/test_dataset.py
@@ -6,7 +6,6 @@ from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.context.tests_context import raise_on_captured_errors
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_basic_dataset_lifecycle(weave_active):
     for _i in range(2):
         dataset = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
@@ -73,7 +72,6 @@ def test_dataset_laziness(client):
         assert _top_level_logs(log) == []
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_published_dataset_laziness(client):
     """The intention of this test is to show that publishing a dataset,
     then iterating through the "gotten" version of the dataset has
@@ -145,7 +143,6 @@ def test_dataset_from_calls(client):
     assert rows[1]["output"] == "Hello Bob, you are 25!"
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_caching(weave_active):
     ds = weave.Dataset(rows=[{"a": i} for i in range(200)])
     ref = weave.publish(ds)
@@ -215,7 +212,6 @@ def test_dataset_select(weave_active):
         ds.select([-1])
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_add_rows(weave_active):
     ds = weave.Dataset(name="test", rows=[{"a": i} for i in range(10)])
     ref = weave.publish(ds)

--- a/tests/trace/test_deepcopy.py
+++ b/tests/trace/test_deepcopy.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 import pytest
 
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.box import (
     BoxedDatetime,
     BoxedFloat,
@@ -111,7 +110,6 @@ def test_deepcopy_boxed(boxed_val):
     assert id(res) != id(boxed_val)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_deepcopy_boxed_model_e2e(weave_active):
     class Model(weave.Model):
         system_prompt: str = "You are a helpful assistant."  # this will get boxed

--- a/tests/trace/test_dirty_model_op_retrieval.py
+++ b/tests/trace/test_dirty_model_op_retrieval.py
@@ -1,10 +1,6 @@
-import pytest
-
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dirty_model_op_retrieval(client):
     class MyModel(weave.Model):
         client: str

--- a/tests/trace/test_eval_otel_linking.py
+++ b/tests/trace/test_eval_otel_linking.py
@@ -135,7 +135,6 @@ async def test_multiple_genai_span_refs_attached_to_eval_call(client, otel_setup
     }
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_eval_metadata_injected_onto_spans(client, otel_setup):
     """Eval context attributes should be injected onto all spans created

--- a/tests/trace/test_evaluation_ref_get.py
+++ b/tests/trace/test_evaluation_ref_get.py
@@ -1,7 +1,4 @@
-import pytest
-
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.scorers import LLMAsAJudgeScorer
 from weave.trace_server.interface.builtin_object_classes.builtin_object_registry import (
     LLMStructuredCompletionModel,
@@ -11,7 +8,6 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 )
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_and_load_evaluation(weave_active):
     """This test just verifies the round trip for the evaluation.
 

--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -637,7 +637,6 @@ def make_test_eval():
     return evaluation
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_eval_supports_model_as_op(weave_active):
     @weave.op
@@ -660,7 +659,6 @@ class MyTestModel(Model):
         return ""
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_eval_supports_model_class(weave_active):
     evaluation = make_test_eval()
@@ -674,7 +672,6 @@ async def test_eval_supports_model_class(weave_active):
     assert res is not None
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_eval_supports_non_op_funcs(weave_active):
     def function_model(sentence: str) -> dict:

--- a/tests/trace/test_llm_as_a_judge_scorer.py
+++ b/tests/trace/test_llm_as_a_judge_scorer.py
@@ -1,9 +1,6 @@
 from unittest.mock import patch
 
-import pytest
-
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.flow.scorer import Scorer
 from weave.prompt.prompt import MessagesPrompt
 from weave.scorers import LLMAsAJudgeScorer
@@ -18,7 +15,6 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 )
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_and_load_scorer_with_prompt_ref(weave_active):
     """Test that LLMAsAJudgeScorer with a MessagesPrompt ref can be published and loaded.
 

--- a/tests/trace/test_llm_as_a_judge_scorer.py
+++ b/tests/trace/test_llm_as_a_judge_scorer.py
@@ -1,6 +1,9 @@
 from unittest.mock import patch
 
+import pytest
+
 import weave
+from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.flow.scorer import Scorer
 from weave.prompt.prompt import MessagesPrompt
 from weave.scorers import LLMAsAJudgeScorer
@@ -15,6 +18,7 @@ from weave.trace_server.interface.builtin_object_classes.llm_structured_model im
 )
 
 
+@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_and_load_scorer_with_prompt_ref(weave_active):
     """Test that LLMAsAJudgeScorer with a MessagesPrompt ref can be published and loaded.
 

--- a/tests/trace/test_llm_structured_completion_model.py
+++ b/tests/trace/test_llm_structured_completion_model.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from pydantic import ValidationError
 
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave import publish
 from weave.prompt.prompt import MessagesPrompt
 from weave.trace import object_record, vals
@@ -656,7 +655,6 @@ def test_cast_to_message():
         cast_to_message(123)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
@@ -734,7 +732,6 @@ def test_llm_structured_completion_model_predict_with_prompt(
     assert call_args.inputs.messages == expected_messages
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )

--- a/tests/trace/test_obj_delete.py
+++ b/tests/trace/test_obj_delete.py
@@ -1,7 +1,6 @@
 import pytest
 
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
@@ -216,7 +215,6 @@ def test_republish_after_deleting_all_versions(
     assert latest[0].val == republish_val
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_read_deleted_object(client: WeaveClient):
     weave.publish({"i": 1}, name="obj_1")
     weave.publish({"i": 2}, name="obj_1")
@@ -243,7 +241,6 @@ def test_read_deleted_object(client: WeaveClient):
     assert ref_res.vals[0] is None
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versions(client: WeaveClient):
     @weave.op
     def my_op(x: int) -> int:
@@ -273,7 +270,6 @@ def test_op_versions(client: WeaveClient):
     assert len(objs3) == 0
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_read_deleted_op(client: WeaveClient):
     @weave.op
     def my_op(x: int) -> int:
@@ -323,7 +319,6 @@ def test_delete_all_object_versions_api(client: WeaveClient):
         client.delete_all_object_versions("obj_test_all")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_delete_all_op_versions_api(client: WeaveClient):
     """Test the public API for deleting all versions of an op."""
 
@@ -404,7 +399,6 @@ def _datasets_query(client: WeaveClient, latest_only: bool) -> list[tsi.ObjSchem
     return objs.objs
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_republish_dataset_after_deleting_all_versions(client: WeaveClient):
     # Repro for #6298: the Datasets tab queries by base_object_class +
     # latest_only. After deleting every version and re-publishing the

--- a/tests/trace/test_objs_query.py
+++ b/tests/trace/test_objs_query.py
@@ -5,7 +5,6 @@ import pytest
 
 import weave
 from tests.trace.server_utils import TEST_ENTITY
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
@@ -345,7 +344,6 @@ def test_objs_query_delete_and_add_new_versions(client: WeaveClient):
     assert all(obj.val["i"] in {4, 5, 6} for obj in res.objs)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_model_query_no_ref(client: WeaveClient):
     class MyModel(weave.Model):
         @weave.op

--- a/tests/trace/test_op_accumulator.py
+++ b/tests/trace/test_op_accumulator.py
@@ -8,7 +8,7 @@ import weakref
 import pytest
 
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED, DummyTestException
+from tests.trace.util import DummyTestException
 from weave.trace.context import call_context
 from weave.trace.context.tests_context import raise_on_captured_errors
 from weave.trace.op import (
@@ -154,7 +154,6 @@ def test_process_exit_closes_unfinished_iterator_wrapper(tmp_path):
     assert marker_path.read_text(encoding="utf-8") == "closed"
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_collector):
     def do_test():
@@ -186,7 +185,6 @@ def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_col
     assert logs[0].msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_make_accumulator_errors_async(
@@ -223,7 +221,6 @@ async def test_resilience_to_accumulator_make_accumulator_errors_async(
     assert logs[0].msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collector):
     def do_test():
@@ -259,7 +256,6 @@ def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collect
     )
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_accumulation_errors_async(
@@ -300,7 +296,6 @@ async def test_resilience_to_accumulator_accumulation_errors_async(
     )
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_should_accumulate_errors(
     weave_active, log_collector
@@ -343,7 +338,6 @@ def test_resilience_to_accumulator_should_accumulate_errors(
     assert logs[0].msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_should_accumulate_errors_async(
@@ -394,7 +388,6 @@ async def test_resilience_to_accumulator_should_accumulate_errors_async(
 # and that is expected and tested for. It happens to be at the deletion moment
 # so pytest is complaining that the exception is not being raised in the
 # expected manner.
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_on_finish_post_processor_errors(
@@ -440,7 +433,6 @@ def test_resilience_to_accumulator_on_finish_post_processor_errors(
         assert log.msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
@@ -488,7 +480,6 @@ async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
         assert log.msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_resilience_to_accumulator_internal_errors(weave_active):
     def do_test():
         @weave.op(accumulator=lambda *args, **kwargs: {})
@@ -510,7 +501,6 @@ def test_resilience_to_accumulator_internal_errors(weave_active):
     assert_no_current_call()
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_resilience_to_accumulator_internal_errors_async(weave_active):
     async def do_test():

--- a/tests/trace/test_op_call_method.py
+++ b/tests/trace/test_op_call_method.py
@@ -1,11 +1,7 @@
-import pytest
-
 import weave
 import weave.trace.call
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_call_method(weave_active):
     @weave.op
     def add(a, b):

--- a/tests/trace/test_op_coroutines.py
+++ b/tests/trace/test_op_coroutines.py
@@ -4,11 +4,9 @@ from collections.abc import Coroutine
 import pytest
 
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.call import Call
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_val(weave_active):
     @weave.op
     def sync_val():
@@ -21,7 +19,6 @@ def test_sync_val(weave_active):
     assert res == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_val_method(weave_active):
     class TestClass:
         @weave.op
@@ -36,7 +33,6 @@ def test_sync_val_method(weave_active):
     assert res == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_sync_coro(weave_active):
     @weave.op
@@ -52,7 +48,6 @@ async def test_sync_coro(weave_active):
     assert await res == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_sync_coro_method(weave_active):
     class TestClass:
@@ -70,7 +65,6 @@ async def test_sync_coro_method(weave_active):
     assert await res == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_coro(weave_active):
     @weave.op
@@ -88,7 +82,6 @@ async def test_async_coro(weave_active):
     assert await res == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_coro_method(weave_active):
     class TestClass:
@@ -109,7 +102,6 @@ async def test_async_coro_method(weave_active):
     assert await res == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_awaited_coro(weave_active):
     @weave.op
@@ -124,7 +116,6 @@ async def test_async_awaited_coro(weave_active):
     assert res == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_awaited_coro_method(weave_active):
     class TestClass:
@@ -141,7 +132,6 @@ async def test_async_awaited_coro_method(weave_active):
     assert res == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_val(weave_active):
     @weave.op
@@ -156,7 +146,6 @@ async def test_async_val(weave_active):
     assert res == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_val_method(weave_active):
     class TestClass:
@@ -173,7 +162,6 @@ async def test_async_val_method(weave_active):
     assert res == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_with_exception(weave_active):
     @weave.op
     def sync_with_exception():
@@ -187,7 +175,6 @@ def test_sync_with_exception(weave_active):
     assert res is None
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_with_exception_method(weave_active):
     class TestClass:
         @weave.op
@@ -203,7 +190,6 @@ def test_sync_with_exception_method(weave_active):
     assert res is None
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_with_exception(weave_active):
     @weave.op
@@ -218,7 +204,6 @@ async def test_async_with_exception(weave_active):
     assert res is None
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_with_exception_method(weave_active):
     class TestClass:

--- a/tests/trace/test_op_decorator_behaviour.py
+++ b/tests/trace/test_op_decorator_behaviour.py
@@ -63,7 +63,6 @@ def py_obj():
     return B()
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_func(weave_active, func):
     assert func(1) == 2
 
@@ -73,7 +72,6 @@ def test_sync_func(weave_active, func):
     assert func2(1) == 2
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_func_call(weave_active, func):
     res, call = func.call(1)
     assert isinstance(call, Call)
@@ -91,7 +89,6 @@ def test_sync_func_call(weave_active, func):
     assert res2 == 2
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_func(weave_active, afunc):
     assert await afunc(1) == 2
@@ -102,7 +99,6 @@ async def test_async_func(weave_active, afunc):
     assert await afunc2(1) == 2
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_func_call(weave_active, afunc):
     res, call = await afunc.call(1)
@@ -121,7 +117,6 @@ async def test_async_func_call(weave_active, afunc):
     assert res2 == 2
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_method(weave_active, weave_obj, py_obj):
     assert weave_obj.method(1) == 2
     assert py_obj.method(1) == 2
@@ -131,7 +126,6 @@ def test_sync_method(weave_active, weave_obj, py_obj):
         weave_obj_method2 = weave_obj_method_ref.get()
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_sync_method_call(weave_active, weave_obj, py_obj):
     res, call = weave_obj.method.call(weave_obj, 1)
     assert isinstance(call, Call)
@@ -156,7 +150,6 @@ def test_sync_method_call(weave_active, weave_obj, py_obj):
         res2, call2 = py_obj.method.call(1)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_method(weave_active, weave_obj, py_obj):
     assert await weave_obj.amethod(1) == 2
@@ -167,7 +160,6 @@ async def test_async_method(weave_active, weave_obj, py_obj):
         weave_obj_amethod2 = weave_obj_amethod_ref.get()
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_async_method_call(weave_active, weave_obj, py_obj):
     res, call = await weave_obj.amethod.call(weave_obj, 1)
@@ -250,7 +242,6 @@ async def test_async_method_calls(weave_active, weave_obj):
     assert len(calls) == 6
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_gotten_object_method_is_callable(weave_active, weave_obj):
     ref = weave.publish(weave_obj)
@@ -260,7 +251,6 @@ async def test_gotten_object_method_is_callable(weave_active, weave_obj):
     assert await weave_obj.amethod(1) == await weave_obj2.amethod(1) == 2
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_gotten_object_method_is_callable_with_call_func(weave_active, weave_obj):
     ref = weave.publish(weave_obj)

--- a/tests/trace/test_op_return_forms.py
+++ b/tests/trace/test_op_return_forms.py
@@ -250,7 +250,6 @@ def test_op_return_sync_generator_never_iter(client):
     assert res.calls[0].output is None
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_generator_never_iter(client):
     @weave.op(accumulator=simple_list_accumulator)
@@ -369,7 +368,6 @@ def test_op_return_sync_generator_partial(client):
     assert res.calls[0].output == list(range(9, 4, -1))
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_op_return_async_generator_partial(client):
     @weave.op(accumulator=simple_list_accumulator)

--- a/tests/trace/test_op_versioning.py
+++ b/tests/trace/test_op_versioning.py
@@ -7,7 +7,6 @@ import pytest
 
 import weave
 import weave as wv
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.op import as_op
 from weave.trace.serialization.mem_artifact import MemTraceFilesArtifact
 from weave.trace.serialization.op_type import save_instance
@@ -42,7 +41,6 @@ def solo_versioned_op(a: int) -> float:
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_solo_op_versioning(client):
     from tests.trace import op_versioning_solo
 
@@ -66,7 +64,6 @@ def versioned_op(self, a: int) -> float:
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_object_op_versioning(client):
     from tests.trace import op_versioning_obj
 
@@ -91,7 +88,6 @@ def versioned_op_importfrom(a: int) -> float:
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versioning_importfrom(client):
     from tests.trace import op_versioning_importfrom
 
@@ -137,7 +133,6 @@ def versioned_op_closure_constant(a: int) -> float:
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versioning_closure_constant(client):
     x = 10
 
@@ -167,7 +162,6 @@ def versioned_op_closure_constant(a: int) -> float:
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versioning_closure_dict_simple(client):
     x = {"a": 5, "b": 10}
 
@@ -338,7 +332,6 @@ def test_op_versioning_exception():
         return x
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_versioning_2ops(client):
     @weave.op
     def dog():
@@ -369,7 +362,6 @@ def some_d(v: int) -> SomeDict:
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_typeddict_annotation(
     client,
 ):
@@ -409,7 +401,6 @@ def some_d(v: int):
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_return_return_custom_class(
     client,
 ):
@@ -446,7 +437,6 @@ def some_d(v: int):
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_nested_function(
     client,
 ):
@@ -470,7 +460,6 @@ def test_op_nested_function(
     assert weave.ref(ref.uri).get()(2) == 5
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_basic_execution(weave_active):
     @weave.op
     def adder(v: int) -> int:
@@ -511,7 +500,6 @@ def some_d(v):
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_no_repeats(client):
     @weave.op
     def some_d(v):
@@ -540,7 +528,6 @@ def t(text: str):
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_instance(client):
     class MyClass:
         _version: str
@@ -582,7 +569,6 @@ def func(data: dict) -> str:
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_import_as(client):
     import json as js
 
@@ -610,7 +596,6 @@ def func(data: dict) -> str:
 """
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_import_from_as(client):
     from json import dumps as ds
 

--- a/tests/trace/test_publish_round_trip.py
+++ b/tests/trace/test_publish_round_trip.py
@@ -1,14 +1,11 @@
-import pytest
 from pydantic import BaseModel
 
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.objectify import register_object
 from weave.trace_server.interface.query import Query
 from weave.trace_server.trace_server_interface import RefsReadBatchReq
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_publish_round_trip_query_object(client) -> None:
     query_raw = {
         "$expr": {

--- a/tests/trace/test_redaction.py
+++ b/tests/trace/test_redaction.py
@@ -1,14 +1,10 @@
 import dataclasses
 
-import pytest
-
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import redact_sensitive_keys
 from weave.utils import sanitize
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_code_capture_redacts_sensitive_values(weave_active):
     api_key = "123"
 

--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -316,7 +316,6 @@ def test_to_json_pydantic_class(client) -> None:
     }
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_to_json_object_excludes_ref(client) -> None:
     class MyObj(weave.Object):
         @weave.op

--- a/tests/trace/test_serialize_encoders.py
+++ b/tests/trace/test_serialize_encoders.py
@@ -19,7 +19,6 @@ from typing import Any, NamedTuple
 import pytest
 from pydantic import BaseModel
 
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.flow.scorer import WeaveScorerResult
 from weave.trace.object_record import ObjectRecord
 from weave.trace.refs import ObjectRef, TableRef
@@ -260,7 +259,6 @@ def test_encode_weave_scorer_result_non_scorer_returns_miss(value: Any) -> None:
 # ---------- _encode_custom_obj ----------
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_encode_custom_obj_registered_type(client: Any) -> None:
     # datetime has a built-in registered serializer; encoding produces a
     # CustomWeaveType payload with the inline value format.
@@ -438,7 +436,6 @@ def test_to_json_weave_scorer_result_emits_plain_dict() -> None:
     assert encoded == {"passed": True, "metadata": {"score": 1.0}}
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_to_json_custom_obj_datetime_roundtrips_via_registry(client: Any) -> None:
     dt = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
     encoded = to_json(dt, client.project_id, client)

--- a/tests/trace/test_server_object_creation_utils.py
+++ b/tests/trace/test_server_object_creation_utils.py
@@ -5,10 +5,7 @@ as the SDK.  Ideally they would be placed next to the trace_server tests, but
 the client serialization requires a client object to serialize.
 """
 
-import pytest
-
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.evaluation.eval import Evaluation
 from weave.flow.scorer import Scorer
 from weave.trace.object_record import pydantic_object_record
@@ -17,7 +14,6 @@ from weave.trace.weave_client import WeaveClient, map_to_refs
 from weave.trace_server import object_creation_utils
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_helper_serializes_op_same_way_as_sdk(client: WeaveClient) -> None:
     """Test that helpers serialize an Op the same way as SDK."""
 
@@ -33,7 +29,6 @@ def test_helper_serializes_op_same_way_as_sdk(client: WeaveClient) -> None:
     assert helper_val == sdk_val
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_helper_serializes_dataset_same_way_as_sdk(client: WeaveClient) -> None:
     """Test that helpers serialize a Dataset the same way as SDK."""
     # Create a test dataset
@@ -76,7 +71,6 @@ def test_helper_serializes_dataset_same_way_as_sdk(client: WeaveClient) -> None:
     assert helper_val == sdk_val
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_helper_serializes_scorer_same_way_as_sdk(client: WeaveClient) -> None:
     """Test that helpers serialize a Scorer with the correct structure.
 
@@ -127,7 +121,6 @@ def test_helper_serializes_scorer_same_way_as_sdk(client: WeaveClient) -> None:
     assert helper_val == sdk_val
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_helper_serializes_evaluation_same_way_as_sdk(client: WeaveClient) -> None:
     """Test that helpers serialize an Evaluation with the correct structure.
     Note: The helper creates base Evaluation objects (not custom subclasses),

--- a/tests/trace/test_table_query.py
+++ b/tests/trace/test_table_query.py
@@ -1,9 +1,6 @@
 import random
 from collections.abc import Iterator
 
-import pytest
-
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
@@ -43,7 +40,6 @@ def generate_table_data(client: WeaveClient, n_rows: int, n_cols: int):
     return digest, row_digests, data
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
 
@@ -63,7 +59,6 @@ def test_table_query(client: WeaveClient):
     assert result_indices == list(range(len(data)))
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stream(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
 
@@ -88,7 +83,6 @@ def test_table_query_stream(client: WeaveClient):
     assert result_indices == list(range(len(data)))
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_invalid_digest(client: WeaveClient):
     res = client.server.table_query(
         tsi.TableQueryReq(
@@ -100,7 +94,6 @@ def test_table_query_invalid_digest(client: WeaveClient):
     assert res.rows == []
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_filter_by_row_digests(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 5)
 
@@ -121,7 +114,6 @@ def test_table_query_filter_by_row_digests(client: WeaveClient):
     assert result_indices == [2, 3, 4]
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_invalid_row_digest(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
     res = client.server.table_query(
@@ -135,7 +127,6 @@ def test_table_query_invalid_row_digest(client: WeaveClient):
     assert res.rows == []
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_limit(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 5)
 
@@ -154,7 +145,6 @@ def test_table_query_limit(client: WeaveClient):
     assert result_indices == list(range(limit))
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_offset(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 5)
 
@@ -173,7 +163,6 @@ def test_table_query_offset(client: WeaveClient):
     assert result_indices == list(range(offset, len(data)))
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_sort_by_column(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 5)
 
@@ -200,7 +189,6 @@ def test_table_query_sort_by_column(client: WeaveClient):
     assert result_indices == expected_indices
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_sort_by_nested_column(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 5)
 
@@ -223,7 +211,6 @@ def test_table_query_sort_by_nested_column(client: WeaveClient):
     assert result_indices == expected_indices
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_combined(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 20, 5)
 
@@ -252,7 +239,6 @@ def test_table_query_combined(client: WeaveClient):
     assert result_indices == expected_indices
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_multiple_sort_criteria(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 20, 5)
 
@@ -277,7 +263,6 @@ def test_table_query_multiple_sort_criteria(client: WeaveClient):
     assert result_indices == expected_indices
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stats(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
 
@@ -291,7 +276,6 @@ def test_table_query_stats(client: WeaveClient):
     assert stats_res.tables[0].count == len(data)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stats_empty(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 0, 0)
 
@@ -305,7 +289,6 @@ def test_table_query_stats_empty(client: WeaveClient):
     assert stats_res.tables[0].count == len(data)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stats_missing(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
 
@@ -319,7 +302,6 @@ def test_table_query_stats_missing(client: WeaveClient):
     assert len(stats_res.tables) == 0
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stats_legacy_missing(client: WeaveClient):
     # The legacy single-digest endpoint must not IndexError when the digest
     # doesn't exist; it should report count=0.
@@ -353,7 +335,6 @@ def generate_duplication_simple_table_data(
     return {"digest": digest, "row_digests": row_digests, "data": data}
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_with_duplicate_row_digests(client: WeaveClient):
     res1 = generate_duplication_simple_table_data(client, 10, 1)
     res2 = generate_duplication_simple_table_data(client, 10, 2)
@@ -441,7 +422,6 @@ def test_table_query_with_duplicate_row_digests(client: WeaveClient):
     assert [r.original_index for r in res.rows] == [0, 1, 2]
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_duplicate_table_with_identical_rows(client: WeaveClient):
     data = [{"val": i} for i in range(10)]
 
@@ -482,7 +462,6 @@ def test_duplicate_table_with_identical_rows(client: WeaveClient):
     assert [r.original_index for r in res.rows] == list(range(10))
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_query_stats_with_storage_size(client: WeaveClient):
     digest, row_digests, data = generate_table_data(client, 10, 10)
 

--- a/tests/trace/test_trace_server.py
+++ b/tests/trace/test_trace_server.py
@@ -27,7 +27,6 @@ def test_save_object(client):
     assert read_res.obj.val == {"a": 1}
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_robust_to_url_sensitive_chars(client):
     project_id = client.project_id
     object_id = "mali_cious-obj.ect"

--- a/tests/trace/test_tracing_resilience.py
+++ b/tests/trace/test_tracing_resilience.py
@@ -32,7 +32,6 @@ def reset_call_context():
     call_context._call_stack.reset(token)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_resilience_to_user_code_errors(weave_active):
     def do_test():
         @weave.op
@@ -191,7 +190,6 @@ async def test_resilience_to_output_handler_errors_async(weave_active, log_colle
     assert logs[0].msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_collector):
     def do_test():
@@ -223,7 +221,6 @@ def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_col
     assert logs[0].msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_make_accumulator_errors_async(
@@ -260,7 +257,6 @@ async def test_resilience_to_accumulator_make_accumulator_errors_async(
     assert logs[0].msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collector):
     def do_test():
@@ -296,7 +292,6 @@ def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collect
     )
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_accumulation_errors_async(
@@ -337,7 +332,6 @@ async def test_resilience_to_accumulator_accumulation_errors_async(
     )
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_should_accumulate_errors(
     weave_active, log_collector
@@ -380,7 +374,6 @@ def test_resilience_to_accumulator_should_accumulate_errors(
     assert logs[0].msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_should_accumulate_errors_async(
@@ -431,7 +424,6 @@ async def test_resilience_to_accumulator_should_accumulate_errors_async(
 # and that is expected and tested for. It happens to be at the deletion moment
 # so pytest is complaining that the exception is not being raised in the
 # expected manner.
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 @pytest.mark.disable_logging_error_check
 def test_resilience_to_accumulator_on_finish_post_processor_errors(
@@ -477,7 +469,6 @@ def test_resilience_to_accumulator_on_finish_post_processor_errors(
         assert log.msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
 async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
@@ -525,7 +516,6 @@ async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
         assert log.msg.startswith("Error capturing call output")
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_resilience_to_accumulator_internal_errors(weave_active):
     def do_test():
         @weave.op(accumulator=lambda *args, **kwargs: {})
@@ -547,7 +537,6 @@ def test_resilience_to_accumulator_internal_errors(weave_active):
     assert_no_current_call()
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_resilience_to_accumulator_internal_errors_async(weave_active):
     async def do_test():

--- a/tests/trace/test_vals.py
+++ b/tests/trace/test_vals.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pytest
 
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.shared.refs_internal import (
     DICT_KEY_EDGE_NAME,
     LIST_INDEX_EDGE_NAME,
@@ -71,7 +70,6 @@ def test_list_iter(client):
     assert isinstance(l[1].ref, ObjectRef)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_row_ref_inside_dict(client):
     """Test the case where a Weave object has a value that is a ref to a row within a Dataset.
 

--- a/tests/trace/test_wal_client_writes.py
+++ b/tests/trace/test_wal_client_writes.py
@@ -329,7 +329,6 @@ class TestWALDisabled:
         ref = weave.publish({"key": "value"}, name="no_wal_obj")
         assert ref is not None
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_dataset_publish_works_without_wal(self, weave_active):
         """Dataset publish should succeed when WAL is disabled."""
         ds = weave.Dataset(name="no_wal_ds", rows=[{"x": 1}])

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -75,7 +75,6 @@ from weave.trace_server.trace_server_interface import (
 from weave.trace_server_bindings.http_utils import _ENDPOINT_CACHE
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.flaky(reruns=3, reruns_delay=0.2)
 def test_table_create(client):
     res = client.server.table_create(
@@ -98,7 +97,6 @@ def test_table_create(client):
     assert result.rows[2].val["val"] == 3
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_update(client):
     data = [
         {"val": 1},
@@ -207,7 +205,6 @@ def test_save_load(client):
     assert val_table[2] == 3
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_refs(client):
     ref = client.save(weave.Dataset(rows=[{"v": 1}, {"v": 2}]), "my-dataset")
     new_table_rows = []
@@ -252,7 +249,6 @@ def test_dataset_refs(client):
     )
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_obj_with_table(client):
     class ObjWithTable(weave.Object):
         table: weave_client.Table
@@ -1172,7 +1168,6 @@ async def test_saved_nested_modellike(client):
     assert await call_model(c, 5) == 4
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_dataset_rows_ref(client):
     dataset = weave.Dataset(rows=[{"a": 1}, {"a": 2}, {"a": 3}])
     saved = client.save(dataset, "my-dataset")
@@ -1296,7 +1291,6 @@ async def test_evaluate(weave_active):
     assert example1_obj.ref.extra[3] != example0_obj.ref.extra[3]
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_nested_ref_is_inner(client):
     dataset_rows = [{"input": "1 + 2", "target": 3}, {"input": "2**4", "target": 15}]
 
@@ -1325,7 +1319,6 @@ def test_obj_dedupe(client):
     assert res[1].version_index == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_query(client):
     @weave.op
     def myop(x):
@@ -1337,7 +1330,6 @@ def test_op_query(client):
     assert len(res) == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_noextra(client):
     ref = client._save_object([1, 2, 3], "my-list")
     ref2 = client._save_object({"a": [3, 4, 5]}, "my-obj")
@@ -1347,7 +1339,6 @@ def test_refs_read_batch_noextra(client):
     assert res.vals[1] == {"a": [3, 4, 5]}
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_with_extra(client):
     saved = client.save([{"a": 5}, {"a": 6}], "my-list")
     ref1 = saved[0]["a"].ref
@@ -1358,7 +1349,6 @@ def test_refs_read_batch_with_extra(client):
     assert res.vals[1] == {"a": 6}
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_dataset_rows(client):
     saved = client.save(weave.Dataset(rows=[{"a": 5}, {"a": 6}]), "my-dataset")
     ref1 = saved.rows[0]["a"].ref
@@ -1369,7 +1359,6 @@ def test_refs_read_batch_dataset_rows(client):
     assert res.vals[1] == 6
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_multi_project(client):
     client.project = "test111"
     ref = client._save_object([1, 2, 3], "my-list")
@@ -1388,7 +1377,6 @@ def test_refs_read_batch_multi_project(client):
     assert res.vals[2] == {"ab": [3, 4, 5]}
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_refs_read_batch_call_ref(client):
     call_ref = refs.CallRef(entity="shawn", project="test-project", id="my-call")
     with pytest.raises(ValueError, match="Call refs not supported"):
@@ -1418,7 +1406,6 @@ def test_large_files(client):
     assert len(res.a) == 10000005
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_server_file(client):
     f_bytes = b"0" * 10000005
     res = client.server.file_create(
@@ -1588,7 +1575,6 @@ def row_gen(num_rows: int, approx_row_bytes: int = 1024):
         yield {"a": i, "b": "x" * approx_row_bytes}
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.timeout(60)
 @pytest.mark.flaky(reruns=3, reruns_delay=2)
 @pytest.mark.parametrize("use_parallel_table_upload", [False, True])
@@ -2310,7 +2296,6 @@ def test_client_attributes_with_call_attributes(client_creator):
         assert call.attributes["env"] == "override"
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_flush_progress_bar(client):
     client.set_autoflush(False)
 
@@ -2328,7 +2313,6 @@ def test_flush_progress_bar(client):
     assert client._has_pending_jobs() == False
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_flush_callback(client):
     client.set_autoflush(False)
 
@@ -4123,7 +4107,6 @@ def test_filter_calls_by_ref_wildcard_versions(client):
     assert sorted(call.inputs["ref"]["a"] for call in calls) == [1, 2]
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_files_stats(client):
 
     f_bytes = b"0" * 10000005
@@ -4250,7 +4233,6 @@ def test_feedback_batching(network_proxy_client):
         assert feedback.payload["note"] == f"Test feedback {i}"
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 @pytest.mark.parametrize("use_parallel_table_upload", [False, True])
 def test_parallel_table_uploads_digest_consistency(
@@ -4412,7 +4394,6 @@ def test_parallel_table_uploads_digest_consistency(
     assert saved_table5.table_ref is not None
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_create_from_digests(network_proxy_client):
     """Test that table_create_from_digests works correctly to merge existing row digests."""
     basic_client, remote_client, records = network_proxy_client

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -1359,6 +1359,17 @@ def test_refs_read_batch_dataset_rows(client):
     assert res.vals[1] == 6
 
 
+def test_refs_read_batch_dataset_rows_multi_project_same_digest(client):
+    client.project = f"table-row-a-{uuid.uuid4().hex}"
+    ref1 = client.save(weave.Dataset(rows=[{"a": 5}]), "my-dataset").rows[0]["a"].ref
+
+    client.project = f"table-row-b-{uuid.uuid4().hex}"
+    ref2 = client.save(weave.Dataset(rows=[{"a": 5}]), "my-dataset").rows[0]["a"].ref
+
+    res = client.server.refs_read_batch(RefsReadBatchReq(refs=[ref1.uri, ref2.uri]))
+    assert res.vals == [5, 5]
+
+
 def test_refs_read_batch_multi_project(client):
     client.project = "test111"
     ref = client._save_object([1, 2, 3], "my-list")

--- a/tests/trace/test_weave_client_threaded.py
+++ b/tests/trace/test_weave_client_threaded.py
@@ -43,7 +43,6 @@ def test_flask_server(flask_server):
     assert response.text == "FkWFKCRcl9wsGp3yclN7v1IIAICTPenpZYrWo0otI4Y"
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_weave_client_global_accessible_in_thread(weave_active):
     def thread_func(q: queue.Queue):
         try:

--- a/tests/trace/test_weave_object_vals.py
+++ b/tests/trace/test_weave_object_vals.py
@@ -1,7 +1,4 @@
-import pytest
-
 import weave
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace.context.weave_client_context import set_weave_client_global
 from weave.trace.vals import WeaveObject
 
@@ -16,7 +13,6 @@ def test_weaveobject_properties():
     assert to.x == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_weaveobject_access_after_init_termination(weave_active):
     my_obj = None
 

--- a/tests/trace/type_handlers/Content/test_content.py
+++ b/tests/trace/type_handlers/Content/test_content.py
@@ -419,7 +419,6 @@ class TestWeaveContent:
             original_data = original_files[row["name"]]
             assert row["content"].data == original_data
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_content_postprocessing(self, weave_active):
         """Test that Content postprocessing works correctly in ops."""
 

--- a/tests/trace/type_handlers/Image/image_test.py
+++ b/tests/trace/type_handlers/Image/image_test.py
@@ -163,7 +163,6 @@ def test_image_as_call_io_refs(client: WeaveClient, test_img: Image.Image) -> No
         image_as_input_and_output_part_call.output["out_img"].close()
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_image_as_file(client: WeaveClient) -> None:
     client.project = "test_image_as_file"
     file_path = Path(__file__).parent.resolve() / "example.jpg"

--- a/tests/trace/type_handlers/Video/video_test.py
+++ b/tests/trace/type_handlers/Video/video_test.py
@@ -294,7 +294,6 @@ def test_video_as_call_io_refs(client: WeaveClient, test_video: VideoClip) -> No
             video_as_input_and_output_part_call.output["out_video"].close()
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_video_as_file(client: WeaveClient, tmp_path: Path) -> None:
     client.project = "test_video_as_file"
 

--- a/tests/trace/type_handlers/test_type_handler_safety.py
+++ b/tests/trace/type_handlers/test_type_handler_safety.py
@@ -14,7 +14,6 @@ from tests.trace.test_utils import FailingSaveType
 from tests.trace.util import FAKE_NOT_IMPLEMENTED
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_output_with_failing_serializer_does_not_raise(
     weave_active, failing_serializer
 ):
@@ -37,7 +36,6 @@ def test_op_output_with_failing_serializer_does_not_raise(
     assert result.value == "hello"
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_op_input_with_failing_serializer_does_not_raise(
     weave_active, failing_serializer
 ):

--- a/tests/trace_server/isolated_client_executor/test_isolated_client_executor.py
+++ b/tests/trace_server/isolated_client_executor/test_isolated_client_executor.py
@@ -154,7 +154,6 @@ def do_task(args: dict):
     return get_keys(args)
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.asyncio
 async def test_executor_basic_lifecycle(client):
     """Happy-path lifecycle on a single runner: execute + pid isolation, reuse,

--- a/tests/trace_server/test_clickhouse_batching.py
+++ b/tests/trace_server/test_clickhouse_batching.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tests.trace.util import FAKE_NOT_IMPLEMENTED, NOT_CLICKHOUSE_BACKEND
+from tests.trace.util import NOT_CLICKHOUSE_BACKEND
 from weave.shared.digest import str_digest
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
@@ -438,7 +438,6 @@ def test_obj_batch_different_key_order_deduplicates(trace_server, client):
     assert len(res.objs) == 1
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 def test_table_create_different_key_order_same_digest(trace_server):
     """Rows with different key ordering produce the same digest in table_create."""
     server = trace_server._internal_trace_server

--- a/tests/trace_server/test_digest_validation.py
+++ b/tests/trace_server/test_digest_validation.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import pytest
 
-from tests.trace.util import FAKE_NOT_IMPLEMENTED
 from weave.trace_server.digest_validation import validate_expected_digest
 from weave.trace_server.errors import DigestMismatchError
 from weave.trace_server.trace_server_interface import (
@@ -38,7 +37,6 @@ def test_validate_expected_digest_mismatch_raises() -> None:
 
 @pytest.mark.trace_server
 class TestFileCreateExpectedDigest:
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_no_expected_digest(self, client) -> None:
         """file_create without expected_digest succeeds (fallback path)."""
         req = FileCreateReq(
@@ -49,7 +47,6 @@ class TestFileCreateExpectedDigest:
         res = client.server.file_create(req)
         assert res.digest is not None
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_correct_expected_digest(self, client) -> None:
         """file_create with correct expected_digest succeeds."""
         from weave.shared.digest import compute_file_digest
@@ -65,7 +62,6 @@ class TestFileCreateExpectedDigest:
         res = client.server.file_create(req)
         assert res.digest == digest
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_wrong_expected_digest(self, client) -> None:
         """file_create with wrong expected_digest raises DigestMismatchError."""
         req = FileCreateReq(
@@ -108,7 +104,6 @@ class TestObjCreateExpectedDigest:
 
 @pytest.mark.trace_server
 class TestTableCreateExpectedDigest:
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_no_expected_digest(self, client) -> None:
         """table_create without expected_digest succeeds (fallback path)."""
         req = TableCreateReq(
@@ -120,7 +115,6 @@ class TestTableCreateExpectedDigest:
         res = client.server.table_create(req)
         assert res.digest is not None
 
-    @pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
     def test_wrong_expected_digest(self, client) -> None:
         """table_create with wrong expected_digest raises DigestMismatchError."""
         req = TableCreateReq(

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -388,7 +388,6 @@ def test_evaluate_model(client: WeaveClient, direct_script_execution):
 
 # The guard raises inside the lazy row-decode threadpool, which logs the failure
 # at ERROR before it propagates out of asyncio.run; that log is the expected path.
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.disable_logging_error_check
 def test_evaluate_model_rejects_unsafe_dataset_row(client):
     """An Op node in a dataset row must be refused at decode time, not loaded and
@@ -474,7 +473,6 @@ def test_evaluate_model_rejects_unsafe_dataset_row(client):
         )
 
 
-@pytest.mark.skipif(FAKE_NOT_IMPLEMENTED, reason="fake: not implemented yet")
 @pytest.mark.parametrize("op_arg", ["evaluation_ref", "model_ref"])
 def test_evaluate_model_rejects_op_ref_as_eval_or_model_ref(client, op_arg):
     """An op ref passed directly as the evaluation_ref/model_ref must be refused at

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -18,9 +18,12 @@ import copy
 import datetime
 import json
 import logging
+import math
+import re
 import threading
 from collections.abc import Iterator
 from dataclasses import dataclass, field
+from operator import attrgetter
 from typing import Any, cast
 
 from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans
@@ -48,6 +51,7 @@ from weave.trace_server.clickhouse_trace_server_settings import (
 from weave.trace_server.common_interface import SortBy
 from weave.trace_server.digest_validation import validate_expected_digest
 from weave.trace_server.errors import (
+    InvalidFieldError,
     InvalidRequest,
     NotFoundError,
     ObjectDeletedError,
@@ -56,6 +60,7 @@ from weave.trace_server.errors import (
 )
 from weave.trace_server.opentelemetry.helpers import AttributePathConflictError
 from weave.trace_server.opentelemetry.python_spans import Resource, Span
+from weave.trace_server.orm import split_escaped_field_path
 from weave.trace_server.trace_server_common import (
     apply_tags_and_synth_latest_in_place,
     digest_is_content_hash,
@@ -75,6 +80,50 @@ logger = logging.getLogger(__name__)
 
 MAX_REFS_BATCH_SIZE = 1000
 MAX_OTEL_ERROR_MESSAGES = 20
+
+# Top-level calls columns (mirrors ALLOWED_CALL_FIELDS in the ClickHouse
+# query builder, with the *_dump suffixes normalized away).
+_CALLS_PLAIN_COLUMNS = frozenset(
+    {
+        "id",
+        "project_id",
+        "trace_id",
+        "parent_id",
+        "thread_id",
+        "turn_id",
+        "op_name",
+        "display_name",
+        "started_at",
+        "ended_at",
+        "exception",
+        "wb_user_id",
+        "wb_run_id",
+        "wb_run_step",
+        "wb_run_step_end",
+        "deleted_at",
+        "expire_at",
+        "input_refs",
+        "output_refs",
+    }
+)
+
+# Mirrors DISALLOWED_FILTERING_FIELDS / DATETIME_COLUMN_FIELDS in the
+# ClickHouse calls query builder.
+_DISALLOWED_FILTERING_FIELDS = frozenset(
+    {"storage_size_bytes", "total_storage_size_bytes"}
+)
+# Summary fields with computed handlers (anything else under summary.weave.
+# raises InvalidFieldError, mirroring SUMMARY_FIELD_HANDLERS).
+_SUMMARY_FIELD_HANDLERS = frozenset({"status", "latency_ms", "trace_name"})
+
+
+def _compile_call_column(column: str) -> Any:
+    """Per-record getter for a plain calls column; unknown columns raise
+    InvalidFieldError like the ClickHouse query builder.
+    """
+    if column not in _CALLS_PLAIN_COLUMNS:
+        raise InvalidFieldError(f"Field {column} is not allowed")
+    return attrgetter(column)
 
 
 def _ensure_tz(dt: datetime.datetime) -> datetime.datetime:
@@ -137,6 +186,124 @@ def _json_extract(parsed: Any, path_parts: list[str] | None) -> tuple[Any, str |
     # Unknown python type (shouldn't happen for JSON-derived data); treat as
     # its text rendering.
     return (str(val), "text")
+
+
+def _ch_json_value(parsed: Any, path_parts: list[str] | None) -> str:
+    """Mirror the ClickHouse dynamic-field read:
+    coalesce(nullIf(JSON_VALUE(dump, path), 'null'), '').
+
+    The trace server enables function_json_value_return_type_allow_complex,
+    so objects/arrays render as minified JSON text. Missing paths and JSON
+    nulls read as ''. Numbers are normalized (5.0 -> '5', 1e3 -> '1000'),
+    booleans render as 'true'/'false', strings are unquoted.
+    """
+    val = parsed
+    for part in path_parts or []:
+        if isinstance(val, dict):
+            if part not in val:
+                return ""
+            val = val[part]
+        elif isinstance(val, list):
+            try:
+                idx = int(part)
+            except ValueError:
+                return ""
+            if idx < 0 or idx >= len(val):
+                return ""
+            val = val[idx]
+        else:
+            return ""
+    if val is None:
+        return ""
+    if isinstance(val, bool):
+        return "true" if val else "false"
+    if isinstance(val, str):
+        return val
+    if isinstance(val, (dict, list)):
+        return _minify_json(val)
+    if isinstance(val, float) and val.is_integer() and not math.isinf(val):
+        return str(int(val))
+    return str(val)
+
+
+def _ch_json_exists(parsed: Any, path_parts: list[str] | None) -> bool:
+    """Mirror the builder's exists cast:
+    NOT (JSONType(...) = 'Null' OR JSONType(...) IS NULL) — i.e. the path
+    exists AND its value is not JSON null.
+    """
+    val = parsed
+    for part in path_parts or []:
+        if isinstance(val, dict):
+            if part not in val:
+                return False
+            val = val[part]
+        elif isinstance(val, list):
+            try:
+                idx = int(part)
+            except ValueError:
+                return False
+            if idx < 0 or idx >= len(val):
+                return False
+            val = val[idx]
+        else:
+            return False
+    return val is not None
+
+
+_CH_INT64_RE = re.compile(r"^[+-]?\d+$")
+
+
+def _to_int64_or_null(value: Any) -> int | None:
+    """ClickHouse toInt64OrNull over a string expression."""
+    if value is None:
+        return None
+    text = value if isinstance(value, str) else str(value)
+    text = text.strip()
+    if not _CH_INT64_RE.match(text):
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
+
+
+def _to_float64_or_null(value: Any) -> float | None:
+    """ClickHouse toFloat64OrNull over a string expression."""
+    if value is None:
+        return None
+    text = value if isinstance(value, str) else str(value)
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def _to_uint8_or_null(value: Any) -> int | None:
+    """ClickHouse toUInt8OrNull over a string expression."""
+    parsed = _to_int64_or_null(value)
+    if parsed is None or parsed < 0 or parsed > 255:
+        return None
+    return parsed
+
+
+def _ch_cast_json_value(value: str | None, cast_to: str | None) -> Any:
+    """Mirror clickhouse_cast_json_value applied to a JSON_VALUE string."""
+    if cast_to is None or cast_to == "string":
+        return value
+    if cast_to == "int":
+        return _to_int64_or_null(value)
+    if cast_to in {"double", "float"}:
+        return _to_float64_or_null(value)
+    if cast_to == "bool":
+        if value == "true":
+            return 1
+        if value == "false":
+            return 0
+        return _to_uint8_or_null(value)
+    raise ValueError(f"Unknown cast: {cast_to}")
 
 
 def _value_rank(value: Any) -> int:
@@ -595,6 +762,185 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
                     + len(summary_json)
                 )
         return tsi.CallEndRes()
+
+    def _feedback_rows_for_call(
+        self, project_id: str, call_id: str, feedback_type: str | None
+    ) -> list[dict[str, Any]]:
+        """Feedback rows attached to a call ref, in insertion (rowid) order."""
+        call_ref = ri.InternalCallRef(project_id=project_id, id=call_id).uri
+        with self.lock:
+            rows = [row for row in self._feedback if row["weave_ref"] == call_ref]
+        if feedback_type is not None:
+            rows = [row for row in rows if row["feedback_type"] == feedback_type]
+        return rows
+
+    def _compile_feedback_field(self, field_path: str) -> Any:
+        """Compile a `feedback.[type].…` field into a per-record evaluator,
+        mirroring CallsMergedFeedbackPayloadField in the ClickHouse builder:
+        anyIf over the call's feedback rows, then JSON_VALUE extraction —
+        a String expression where "no feedback" reads as ''.
+        """
+        path = field_path[len("feedback.") :]
+        match = re.match(r"^\[(.+?)\]\.(.+)$", path)
+        if not match:
+            raise InvalidFieldError(f"Invalid feedback field path: {field_path}")
+        feedback_type, rest = match.groups()
+
+        parts = rest.split(".")
+        if parts[0] == "payload":
+            db_column = "payload"
+            extra_parts = parts[1:]
+        elif parts[0] in {"runnable_ref", "trigger_ref"}:
+            db_column = parts[0]
+            extra_parts = []
+        else:
+            raise InvalidFieldError(f"Invalid feedback field path: {field_path}")
+
+        def extract(row: dict[str, Any]) -> str:
+            raw = row.get(db_column)
+            if db_column == "payload":
+                if extra_parts:
+                    return _ch_json_value(raw, extra_parts)
+                return "" if raw is None else _minify_json(raw)
+            return raw if isinstance(raw, str) else ""
+
+        if feedback_type == "*":
+
+            def evaluate_any(rec: _CallRec) -> str:
+                # anyIf(extracted, extracted != ''): first non-empty value
+                # across all feedback rows; '' when none.
+                for row in self._feedback_rows_for_call(rec.project_id, rec.id, None):
+                    value = extract(row)
+                    if value != "":
+                        return value
+                return ""
+
+            return evaluate_any
+
+        def evaluate(rec: _CallRec) -> str:
+            rows = self._feedback_rows_for_call(rec.project_id, rec.id, feedback_type)
+            if not rows:
+                return ""
+            return extract(rows[0])
+
+        return evaluate
+
+    def _feedback_values_array(self, rec: _CallRec, field_path: str) -> list[str]:
+        """Mirror as_array_sql: groupArrayIf of extracted values for a
+        multi-value feedback type (non-empty extracted values only when an
+        extra path is present).
+        """
+        path = field_path[len("feedback.") :]
+        match = re.match(r"^\[(.+?)\]\.(.+)$", path)
+        if not match:
+            raise InvalidFieldError(f"Invalid feedback field path: {field_path}")
+        feedback_type, rest = match.groups()
+        parts = rest.split(".")
+        extra_parts = parts[1:] if parts[0] == "payload" else []
+        rows = self._feedback_rows_for_call(rec.project_id, rec.id, feedback_type)
+        values: list[str] = []
+        for row in rows:
+            payload = row.get("payload")
+            if extra_parts:
+                value = _ch_json_value(payload, extra_parts)
+                if value != "":
+                    values.append(value)
+            else:
+                values.append("" if payload is None else _minify_json(payload))
+        return values
+
+    def _compile_calls_field(self, field_path: str, cast_to: str | None = None) -> Any:
+        """Compile a calls field reference into a per-record evaluator,
+        mirroring get_field_by_name + the field classes' as_sql in the
+        ClickHouse calls query builder.
+        """
+        if field_path.startswith("summary.weave."):
+            summary_field = field_path[len("summary.weave.") :]
+            if summary_field not in _SUMMARY_FIELD_HANDLERS:
+                supported = ", ".join(sorted(_SUMMARY_FIELD_HANDLERS))
+                raise InvalidFieldError(
+                    f"Summary field '{summary_field}' is not allowed. "
+                    f"Supported fields are: {supported}"
+                )
+            if summary_field == "status":
+                return self._status_case
+            if summary_field == "latency_ms":
+                return self._latency_ms
+            return self._trace_name_case
+        for col_name in ("inputs", "output", "attributes", "summary"):
+            if field_path == col_name or field_path.startswith(col_name + "."):
+                json_path = (
+                    split_escaped_field_path(field_path[len(col_name) + 1 :])
+                    if field_path != col_name
+                    else []
+                )
+                if cast_to == "exists":
+
+                    def evaluate_exists(
+                        rec: _CallRec,
+                        _col_name: str = col_name,
+                        _json_path: list[str] = json_path,
+                    ) -> bool:
+                        return _ch_json_exists(getattr(rec, _col_name), _json_path)
+
+                    return evaluate_exists
+
+                def evaluate(
+                    rec: _CallRec,
+                    _col_name: str = col_name,
+                    _json_path: list[str] = json_path,
+                    _cast_to: str | None = cast_to,
+                ) -> Any:
+                    value = _ch_json_value(getattr(rec, _col_name), _json_path)
+                    return _ch_cast_json_value(value, _cast_to)
+
+                return evaluate
+
+        # Plain column access. Casts are not applied to static columns in
+        # filters (mirroring process_operand); storage-size fields are
+        # filterable nowhere.
+        if field_path in _DISALLOWED_FILTERING_FIELDS:
+            raise InvalidFieldError(f"Field {field_path} is not allowed")
+        return _compile_call_column(field_path)
+
+    def _latency_ms(self, rec: _CallRec) -> int | None:
+        # CH: toUnixTimestamp64Milli(ended) - toUnixTimestamp64Milli(started);
+        # NULL while the call is still running.
+        if rec.ended_at is None or rec.started_at is None:
+            return None
+        started_ms = int(rec.started_at.timestamp() * 1000)
+        ended_ms = int(rec.ended_at.timestamp() * 1000)
+        return ended_ms - started_ms
+
+    def _status_case(self, rec: _CallRec) -> str:
+        # ClickHouse handler order: error, then descendant_error, then
+        # running, then success.
+        if rec.exception is not None:
+            return "error"
+        error_count = _ch_cast_json_value(
+            _ch_json_value(rec.summary, ["status_counts", "error"]), "int"
+        )
+        if (error_count or 0) > 0:
+            return "descendant_error"
+        if rec.ended_at is None:
+            return "running"
+        return "success"
+
+    def _trace_name_case(self, rec: _CallRec) -> Any:
+        if rec.display_name is not None and rec.display_name != "":
+            return rec.display_name
+        op_name = rec.op_name
+        if op_name is not None and op_name.startswith(
+            ri.WEAVE_INTERNAL_SCHEME + ":///"
+        ):
+            last_segment = op_name.rsplit("/", 1)[-1]
+            colon_idx = last_segment.find(":")
+            if colon_idx == -1:
+                # The SQL substring expression yields an empty string when no
+                # colon is present.
+                return ""
+            return last_segment[:colon_idx]
+        return op_name
 
     def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
         assert_non_null_wb_user_id(req)

--- a/weave/trace_server/in_memory_trace_server.py
+++ b/weave/trace_server/in_memory_trace_server.py
@@ -17,7 +17,9 @@
 import copy
 import datetime
 import json
+import logging
 import threading
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Any, cast
 
@@ -25,7 +27,10 @@ from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans
 
 from weave.shared import refs_internal as ri
 from weave.shared.digest import (
+    compute_file_digest,
     compute_object_digest_result,
+    compute_row_digest,
+    compute_table_digest,
 )
 from weave.shared.trace_server_interface_util import (
     assert_non_null_wb_user_id,
@@ -66,6 +71,9 @@ from weave.trace_server.workers.evaluate_model_worker.evaluate_model_worker impo
     EvaluateModelDispatcher,
 )
 
+logger = logging.getLogger(__name__)
+
+MAX_REFS_BATCH_SIZE = 1000
 MAX_OTEL_ERROR_MESSAGES = 20
 
 
@@ -74,6 +82,61 @@ def _ensure_tz(dt: datetime.datetime) -> datetime.datetime:
     if dt.tzinfo is None:
         return dt.replace(tzinfo=datetime.timezone.utc)
     return dt.astimezone(datetime.timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Generic JSON value helpers (dict-shaped doc traversal + stable ordering)
+# ---------------------------------------------------------------------------
+
+
+def _minify_json(val: Any) -> str:
+    """JSON text with minified separators, as the backends store dumps."""
+    return json.dumps(val, separators=(",", ":"))
+
+
+def _json_extract(parsed: Any, path_parts: list[str] | None) -> tuple[Any, str | None]:
+    """Dot-path traversal over a parsed JSON doc, with a type tag.
+
+    Returns (value, json_type) where json_type is one of:
+    'object', 'array', 'text', 'integer', 'real', 'true', 'false', 'null',
+    or None when the path does not exist. Scalars convert to their stored
+    renderings: true/false -> 1/0, objects/arrays -> minified JSON text.
+    Used by the generic doc sorts (table rows) and ref expansion.
+    """
+    val = parsed
+    for part in path_parts or []:
+        if isinstance(val, dict):
+            if part not in val:
+                return (None, None)
+            val = val[part]
+        elif isinstance(val, list):
+            try:
+                idx = int(part)
+            except ValueError:
+                return (None, None)
+            if idx < 0 or idx >= len(val):
+                return (None, None)
+            val = val[idx]
+        else:
+            return (None, None)
+
+    if val is None:
+        return (None, "null")
+    if isinstance(val, bool):
+        return (1, "true") if val else (0, "false")
+    if isinstance(val, int):
+        return (val, "integer")
+    if isinstance(val, float):
+        return (val, "real")
+    if isinstance(val, str):
+        return (val, "text")
+    if isinstance(val, dict):
+        return (_minify_json(val), "object")
+    if isinstance(val, list):
+        return (_minify_json(val), "array")
+    # Unknown python type (shouldn't happen for JSON-derived data); treat as
+    # its text rendering.
+    return (str(val), "text")
 
 
 def _value_rank(value: Any) -> int:
@@ -228,9 +291,9 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         self._objs: dict[tuple[str, str, str, str], _ObjRec] = {}
         # Tables keyed by (project_id, digest) -> ordered row digests.
         self._tables: dict[tuple[str, str], list[str]] = {}
-        # Table rows keyed by digest (content-addressed, first-writer-wins:
-        # first writer wins, reads filter on project_id).
-        self._table_rows: dict[str, _TableRowRec] = {}
+        # Table rows keyed by (project_id, digest), matching ClickHouse's
+        # project-scoped table_rows primary key.
+        self._table_rows: dict[tuple[str, str], _TableRowRec] = {}
         # Files keyed by (project_id, digest).
         self._files: dict[tuple[str, str], bytes] = {}
         # Tags keyed by (project_id, object_id, digest) -> set of tags.
@@ -1088,6 +1151,331 @@ class InMemoryTraceServer(tsi.FullTraceServerInterface):
         tags_map = self._get_tags_for_objects(project_id, object_ids)
         aliases_map = self._get_aliases_for_objects(project_id, object_ids)
         apply_tags_and_synth_latest_in_place(objs, tags_map, aliases_map)
+
+    # ------------------------------------------------------------------
+    # Tables
+    # ------------------------------------------------------------------
+
+    def table_create(self, req: tsi.TableCreateReq) -> tsi.TableCreateRes:
+        insert_rows = []
+        for r in req.table.rows:
+            if not isinstance(r, dict):
+                raise TypeError("All rows must be dictionaries")
+            row_json = json.dumps(r)
+            row_digest = compute_row_digest(r)
+            insert_rows.append((req.table.project_id, row_digest, row_json))
+
+        row_digests = [r[1] for r in insert_rows]
+        digest = compute_table_digest(row_digests)
+        validate_expected_digest(
+            expected=req.table.expected_digest,
+            actual=digest,
+            label=f"table ({len(row_digests)} rows)",
+        )
+
+        with self.lock:
+            for project_id, row_digest, row_json in insert_rows:
+                row_key = (project_id, row_digest)
+                if row_key not in self._table_rows:
+                    self._table_rows[row_key] = _TableRowRec(
+                        project_id=project_id,
+                        val=json.loads(row_json),
+                        val_dump_len=len(row_json),
+                    )
+            self._tables.setdefault((req.table.project_id, digest), list(row_digests))
+
+        return tsi.TableCreateRes(digest=digest, row_digests=row_digests)
+
+    def table_create_from_digests(
+        self, req: tsi.TableCreateFromDigestsReq
+    ) -> tsi.TableCreateFromDigestsRes:
+        digest = compute_table_digest(req.row_digests)
+        validate_expected_digest(
+            expected=req.expected_digest,
+            actual=digest,
+            label=f"table ({len(req.row_digests)} rows)",
+        )
+
+        with self.lock:
+            self._tables.setdefault((req.project_id, digest), list(req.row_digests))
+
+        return tsi.TableCreateFromDigestsRes(digest=digest)
+
+    def table_update(self, req: tsi.TableUpdateReq) -> tsi.TableUpdateRes:
+        with self.lock:
+            base = self._tables.get((req.project_id, req.base_digest))
+            if base is None:
+                raise IndexError("list index out of range")
+            final_row_digests: list[str] = list(base)
+        new_rows_needed_to_insert: list[tuple[str, str, str]] = []
+        known_digests = set(final_row_digests)
+
+        def add_new_row_needed_to_insert(row_data: Any) -> str:
+            if not isinstance(row_data, dict):
+                raise TypeError("All rows must be dictionaries")
+            row_json = json.dumps(row_data)
+            row_digest = compute_row_digest(row_data)
+            if row_digest not in known_digests:
+                new_rows_needed_to_insert.append((req.project_id, row_digest, row_json))
+                known_digests.add(row_digest)
+            return row_digest
+
+        updated_digests = []
+        for update in req.updates:
+            if isinstance(update, tsi.TableAppendSpec):
+                new_digest = add_new_row_needed_to_insert(update.append.row)
+                final_row_digests.append(new_digest)
+                updated_digests.append(new_digest)
+            elif isinstance(update, tsi.TablePopSpec):
+                if update.pop.index >= len(final_row_digests) or update.pop.index < 0:
+                    raise ValueError("Index out of range")
+                popped_digest = final_row_digests.pop(update.pop.index)
+                updated_digests.append(popped_digest)
+            elif isinstance(update, tsi.TableInsertSpec):
+                if (
+                    update.insert.index > len(final_row_digests)
+                    or update.insert.index < 0
+                ):
+                    raise ValueError("Index out of range")
+                new_digest = add_new_row_needed_to_insert(update.insert.row)
+                final_row_digests.insert(update.insert.index, new_digest)
+                updated_digests.append(new_digest)
+            else:
+                raise TypeError("Unrecognized update", update)
+
+        with self.lock:
+            for project_id, row_digest, row_json in new_rows_needed_to_insert:
+                row_key = (project_id, row_digest)
+                if row_key not in self._table_rows:
+                    self._table_rows[row_key] = _TableRowRec(
+                        project_id=project_id,
+                        val=json.loads(row_json),
+                        val_dump_len=len(row_json),
+                    )
+
+            digest = compute_table_digest(final_row_digests)
+            self._tables.setdefault((req.project_id, digest), final_row_digests)
+
+        return tsi.TableUpdateRes(digest=digest, updated_row_digests=updated_digests)
+
+    def table_query(self, req: tsi.TableQueryReq) -> tsi.TableQueryRes:
+        with self.lock:
+            row_digests = self._tables.get((req.project_id, req.digest)) or []
+            # (original_index, digest, val) tuples; rows are materialized as
+            # schema objects (with copied vals) only for the returned slice.
+            entries: list[tuple[int, str, Any]] = []
+            for original_index, row_digest in enumerate(row_digests):
+                row_rec = self._table_rows.get((req.project_id, row_digest))
+                if row_rec is None:
+                    continue
+                if (
+                    req.filter
+                    and req.filter.row_digests
+                    and row_digest not in req.filter.row_digests
+                ):
+                    continue
+                entries.append((original_index, row_digest, row_rec.val))
+
+        if req.sort_by:
+            sort_terms: list[tuple[str, str]] = []
+            for sort in req.sort_by:
+                field_name = sort.field
+                if not field_name or not field_name.strip():
+                    raise InvalidRequest("Sort field cannot be empty")
+                if (
+                    field_name.startswith(".")
+                    or field_name.endswith(".")
+                    or ".." in field_name
+                ):
+                    raise InvalidRequest(
+                        f"Invalid sort field '{field_name}': field names cannot start/end with dots or contain consecutive dots"
+                    )
+                if "." in field_name:
+                    parts = field_name.split(".")
+                    if any(not component.strip() for component in parts):
+                        raise InvalidRequest(
+                            f"Invalid sort field '{field_name}': field path components cannot be empty"
+                        )
+                sort_terms.append((field_name, sort.direction.upper()))
+
+            def sort_value(entry: tuple[int, str, Any], term: str) -> Any:
+                value, _ = _json_extract(entry[2], term.split("."))
+                return value
+
+            entries = _sorted_by_terms(entries, sort_terms, sort_value)
+
+        if req.offset is not None and req.offset > 0:
+            entries = entries[req.offset :]
+        if req.limit is not None and req.limit >= 0:
+            entries = entries[: req.limit]
+
+        return tsi.TableQueryRes(
+            rows=[
+                tsi.TableRowSchema(
+                    digest=row_digest,
+                    val=copy.deepcopy(val),
+                    original_index=original_index,
+                )
+                for original_index, row_digest, val in entries
+            ]
+        )
+
+    def table_query_stream(
+        self, req: tsi.TableQueryReq
+    ) -> Iterator[tsi.TableRowSchema]:
+        results = self.table_query(req)
+        yield from results.rows
+
+    def table_query_stats(self, req: tsi.TableQueryStatsReq) -> tsi.TableQueryStatsRes:
+        batch_req = tsi.TableQueryStatsBatchReq(
+            project_id=req.project_id, digests=[req.digest]
+        )
+
+        res = self.table_query_stats_batch(batch_req)
+
+        if len(res.tables) == 0:
+            logger.warning("No table_query_stats results for digest %s", req.digest)
+            return tsi.TableQueryStatsRes(count=0)
+
+        count = res.tables[0].count
+        return tsi.TableQueryStatsRes(count=count)
+
+    def table_query_stats_batch(
+        self, req: tsi.TableQueryStatsBatchReq
+    ) -> tsi.TableQueryStatsBatchRes:
+        tables = []
+        with self.lock:
+            for digest in req.digests or []:
+                row_digests = self._tables.get((req.project_id, digest))
+                if row_digests is None:
+                    continue
+                storage_size: int | None = None
+                if req.include_storage_size:
+                    storage_size = sum(
+                        rec.val_dump_len
+                        for row_digest in row_digests
+                        if (rec := self._table_rows.get((req.project_id, row_digest)))
+                        is not None
+                    )
+                tables.append(
+                    tsi.TableStatsRow(
+                        count=len(row_digests),
+                        digest=digest,
+                        storage_size_bytes=storage_size,
+                    )
+                )
+        return tsi.TableQueryStatsBatchRes(tables=tables)
+
+    def _table_rows_read_batch(
+        self, project_id: str, digests: list[str]
+    ) -> dict[str, Any]:
+        """Batch read table_rows by digest. Returns {digest: parsed_val}."""
+        if not digests:
+            return {}
+        with self.lock:
+            result = {}
+            for digest in digests:
+                rec = self._table_rows.get((project_id, digest))
+                if rec is not None and rec.project_id == project_id:
+                    result[digest] = copy.deepcopy(rec.val)
+            return result
+
+    def _table_row_read(self, project_id: str, row_digest: str) -> tsi.TableRowSchema:
+        with self.lock:
+            rec = self._table_rows.get((project_id, row_digest))
+            if rec is None or rec.project_id != project_id:
+                raise NotFoundError(f"Row {row_digest} not found")
+            return tsi.TableRowSchema(digest=row_digest, val=copy.deepcopy(rec.val))
+
+    # ------------------------------------------------------------------
+    # Refs
+    # ------------------------------------------------------------------
+
+    def refs_read_batch(self, req: tsi.RefsReadBatchReq) -> tsi.RefsReadBatchRes:
+        if len(req.refs) > MAX_REFS_BATCH_SIZE:
+            raise ValueError("Too many refs")
+
+        parsed_refs = [ri.parse_internal_uri(r) for r in req.refs]
+        if any(isinstance(r, ri.InternalTableRef) for r in parsed_refs):
+            raise ValueError("Table refs not supported")
+        if any(isinstance(r, ri.InternalCallRef) for r in parsed_refs):
+            raise ValueError("Call refs not supported")
+        parsed_obj_refs = cast(list[ri.InternalObjectRef], parsed_refs)
+
+        return tsi.RefsReadBatchRes(
+            vals=[self._read_internal_obj_ref(r) for r in parsed_obj_refs]
+        )
+
+    def _read_internal_obj_ref(self, r: ri.InternalObjectRef) -> Any:
+        objs = self._select_objs(
+            r.project_id,
+            predicate=lambda rec: rec.object_id == r.name and rec.digest == r.version,
+            include_deleted=True,
+        )
+        if len(objs) == 0:
+            raise NotFoundError(f"Obj {r.name}:{r.version} not found")
+        obj = objs[0]
+        if obj.deleted_at is not None:
+            return None
+        val = obj.val
+        extra = r.extra
+        for extra_index in range(0, len(extra), 2):
+            op, arg = extra[extra_index], extra[extra_index + 1]
+            if op == ri.DICT_KEY_EDGE_NAME:
+                val = val[arg]
+            elif op == ri.OBJECT_ATTR_EDGE_NAME:
+                val = val[arg]
+            elif op == ri.LIST_INDEX_EDGE_NAME:
+                val = val[int(arg)]
+            elif op == ri.TABLE_ROW_ID_EDGE_NAME:
+                weave_internal_prefix = ri.WEAVE_INTERNAL_SCHEME + ":///"
+                if isinstance(val, str) and val.startswith(weave_internal_prefix):
+                    table_ref = ri.parse_internal_uri(val)
+                    if not isinstance(table_ref, ri.InternalTableRef):
+                        raise ValueError(
+                            "invalid data layout encountered, expected TableRef when resolving id"
+                        )
+                    row = self._table_row_read(
+                        project_id=table_ref.project_id,
+                        row_digest=arg,
+                    )
+                    val = row.val
+                else:
+                    raise ValueError(
+                        "invalid data layout encountered, expected TableRef when resolving id"
+                    )
+            else:
+                raise ValueError(f"Unknown ref type: {extra[extra_index]}")
+        return val
+
+    # ------------------------------------------------------------------
+    # Files
+    # ------------------------------------------------------------------
+
+    def file_create(self, req: tsi.FileCreateReq) -> tsi.FileCreateRes:
+        digest = compute_file_digest(req.content)
+        validate_expected_digest(
+            expected=req.expected_digest, actual=digest, label="file"
+        )
+        with self.lock:
+            self._files.setdefault((req.project_id, digest), req.content)
+        return tsi.FileCreateRes(digest=digest)
+
+    def file_content_read(self, req: tsi.FileContentReadReq) -> tsi.FileContentReadRes:
+        with self.lock:
+            content = self._files.get((req.project_id, req.digest))
+        if content is None:
+            raise NotFoundError(f"File {req.digest} not found")
+        return tsi.FileContentReadRes(content=content)
+
+    def files_stats(self, req: tsi.FilesStatsReq) -> tsi.FilesStatsRes:
+        with self.lock:
+            total = sum(
+                len(content)
+                for (project_id, _digest), content in self._files.items()
+                if project_id == req.project_id
+            )
+        return tsi.FilesStatsRes(total_size_bytes=total)
 
     # ------------------------------------------------------------------
     # OTel export


### PR DESCRIPTION
## Description

Part 5/17. The value layer of the calls query engine — the most
semantics-dense slice:
- Dynamic JSON fields evaluate with ClickHouse JSON_VALUE complex-allowed
  semantics (the server sets
  `function_json_value_return_type_allow_complex=1`): '' for missing keys
  and JSON nulls, minified JSON for objects/arrays, normalized number
  rendering ('5.0' → '5'), 'true'/'false' bools.
- Casts map to toInt64OrNull / toFloat64OrNull / the multiIf bool chain;
  comparisons propagate NULL like SQL.
- Computed summary fields use the ClickHouse expressions: status CASE
  order error → descendant_error → running → success, latency_ms NULL
  while running, trace_name via regexpExtract.
- Feedback fields evaluate with anyIf semantics ('*' = first non-empty).

This stage deliberately precedes the feedback APIs so the ClickHouse value
machinery lands here, with the calls engine that motivates it.

## Testing

Per-PR validation: each stage of the module is ruff-clean and importable.
The full suites run against the fake at the top of the stack (the fake is
selectable from this stack's first PR, but its API surface completes at
the top): tests/trace_server — fake 1203 passed / 0 failed vs ClickHouse
1317 / 0 on the same tree; tests/trace — fake 1664 / 1 failed vs ClickHouse
1681 / 1 (the same pre-existing `test_flask_server` env failure). Per-shard
totals match exactly: every test either passes on the fake or carries an
explicit ClickHouse-internals `skipif`.