### PR TITLE
feat(weave): wire in-memory fake trace server into the test suite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,7 +139,32 @@ Examples:
 - ✅ CORRECT: `-- tests/trace/test_dataset.py::test_basic_dataset_lifecycle`
 - ❌ WRONG: `-- trace/test_dataset.py::test_basic_dataset_lifecycle`
 
-#### Backend
+#### Backend Selection
+
+The `--trace-server` flag selects the backend: `clickhouse` (default) or
+`fake` (in-memory).
+
+**Fake / in-memory (Fastest for Development):**
+
+```bash
+nox --no-install -e "tests-3.12(shard='trace')" -- tests/trace/test_client_trace.py::test_simple_op --trace-server=fake
+```
+
+The fake backend (`weave/trace_server/in_memory_trace_server.py`,
+`InMemoryTraceServer`) is a pure-Python, dict-backed drop-in replacement that
+lives parallel to the ClickHouse implementation. It replicates **ClickHouse**
+(the production backend) at the interface level: JSON_VALUE string typing for
+dynamic fields, `to*OrNull` cast rules, NULLS-LAST ordering, DateTime64
+comparisons, and computed summary fields. Tests that assert ClickHouse
+*internals* (SQL, table routing/residence, insert batching, bucket file
+storage) are gated with `client_is_clickhouse` and skip on the fake. No
+files, no SQL, no Docker. Shorthand: `--fk` / `--fake`.
+
+**ClickHouse (the real backend):**
+
+```bash
+nox --no-install -e "tests-3.12(shard='trace')" -- tests/trace/test_client_trace.py::test_simple_op
+```
 
 ClickHouse is the only trace-server backend (`--trace-server` defaults to
 `clickhouse`):
@@ -150,7 +175,8 @@ nox --no-install -e "tests-3.12(shard='trace')" -- tests/trace/test_client_trace
 
 **Note:** ClickHouse tests require Docker to be running (the fixtures start a
 container automatically), or a local `clickhouse-server` binary with
-`--clickhouse-process=true`.
+`--clickhouse-process=true`. When neither is available, use the in-memory
+fake with `--trace-server=fake`.
 
 #### Remote HTTP Trace Server Implementation Selection
 

--- a/tests/trace/test_client_annotation_queues.py
+++ b/tests/trace/test_client_annotation_queues.py
@@ -18,6 +18,7 @@ from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceSe
 from weave.trace_server.common_interface import AnnotationQueueItemsFilter, SortBy
 from weave.trace_server.errors import NotFoundError
 from weave.trace_server.ids import generate_id
+from weave.trace_server.in_memory_trace_server import InMemoryTraceServer
 
 
 class CallsFixture(NamedTuple):
@@ -2055,6 +2056,12 @@ def test_annotation_queue_add_calls_with_calls_complete_table(trace_server):
     4. Verify items are correctly added with proper display_data
     5. Query items back to confirm correct data population
     """
+    try:
+        find_server_layer(trace_server, InMemoryTraceServer)
+    except TypeError:
+        pass
+    else:
+        pytest.skip("ClickHouse-only test")
     project_id = f"{TEST_ENTITY}/test_queue_add_calls_complete"
 
     # Step 1: Seed project with calls_complete data

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -26,6 +26,7 @@ from tests.trace.util import (
     DatetimeMatcher,
     FuzzyDateTimeMatcher,
     MaybeStringMatcher,
+    client_is_clickhouse,
     get_info_loglines,
 )
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
@@ -3739,6 +3740,10 @@ def test_inline_pydantic_basemodel_generates_no_refs_in_object(client):
 
 
 def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
+    if not client_is_clickhouse(client):
+        # Stripping is triggered by patching ClickHouse's _insert_call_batch
+        # to raise InsertTooLarge; only meaningful on a real ClickHouse server.
+        return
 
     original_insert_call_batch = weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer._insert_call_batch
     max_size = 10 * 1024
@@ -4224,11 +4229,16 @@ def test_calls_query_multiple_dupe_select_columns(client, capsys, caplog):
     assert calls[0].output["a"]["b"]["c"] == {"d": 1}
     assert calls[0].output["a"]["b"]["c"]["d"] == 1
 
-    # now make sure we don't make duplicate selects
-    select_query = get_info_loglines(caplog, "clickhouse_stream_query", ["query"])[0]
-    assert (
-        select_query["query"].count("any(calls_merged.output_dump) AS output_dump") == 1
-    )
+    # now make sure we don't make duplicate selects (the in-memory fake
+    # builds no SQL, so there is no query log to inspect there)
+    if client_is_clickhouse(client):
+        select_query = get_info_loglines(caplog, "clickhouse_stream_query", ["query"])[
+            0
+        ]
+        assert (
+            select_query["query"].count("any(calls_merged.output_dump) AS output_dump")
+            == 1
+        )
 
 
 def test_calls_stream_heavy_condition_aggregation_parts(client):
@@ -5060,6 +5070,8 @@ def test_calls_query_stats_total_storage_size_clickhouse(client, clickhouse_clie
 
 
 def test_project_stats_clickhouse(client, clickhouse_client):
+    if not client_is_clickhouse(client):
+        pytest.skip("Requires raw ClickHouse stats-table inserts")
 
     project_id = get_client_project_id(client)
     internal_project_id = DummyIdConverter().ext_to_int_project_id(project_id)

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -4,6 +4,7 @@ import pytest
 from clickhouse_connect.driver.exceptions import DatabaseError
 
 import weave
+from tests.trace.util import client_is_clickhouse
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     DummyIdConverter,
 )
@@ -1316,6 +1317,10 @@ def test_feedback_aggregate_filter_matching_functional(client: WeaveClient) -> N
     object-id filters match the id exactly (a trailing '*' opts into prefix), and
     span_types matches the ref's span-type segment, not an arbitrary substring.
     """
+    if not client_is_clickhouse(client):
+        pytest.skip(
+            "ClickHouse-only: executes the built SQL directly via server._query"
+        )
     project_id = client.project_id
     now_ms = int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
     after_ms = now_ms - 3_600_000

--- a/tests/trace/test_queue_filtering.py
+++ b/tests/trace/test_queue_filtering.py
@@ -8,10 +8,13 @@ These tests verify the queue filtering functionality added to calls_query_builde
 
 import datetime
 
+import pytest
+
 import weave
-from tests.trace.server_utils import TEST_ENTITY
+from tests.trace.server_utils import TEST_ENTITY, find_server_layer
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ids import generate_id
+from weave.trace_server.in_memory_trace_server import InMemoryTraceServer
 
 
 def test_filter_calls_by_queue_inner_join_behavior(client):
@@ -309,6 +312,12 @@ def test_filter_calls_by_queue_with_calls_complete_table(trace_server):
     4. Query by queue_id - should automatically use calls_complete table
     5. Verify INNER JOIN correctly filters results
     """
+    try:
+        find_server_layer(trace_server, InMemoryTraceServer)
+    except TypeError:
+        pass
+    else:
+        pytest.skip("ClickHouse-only test")
     project_id = f"{TEST_ENTITY}/test_queue_calls_complete"
 
     # Step 1: Seed project with calls_complete data to establish residence

--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -15,6 +15,7 @@ from azure.core.exceptions import ResourceExistsError
 from google.api_core import exceptions
 from moto import mock_aws
 
+from tests.trace.util import client_is_clickhouse
 from weave.shared.digest import compute_file_digest
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import clickhouse_trace_server_settings
@@ -48,6 +49,8 @@ def run_storage_test(client: WeaveClient):
         assert file.content == TEST_CONTENT
         return res
 
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: bucket file storage machinery")
     return _run_test
 
 
@@ -142,6 +145,9 @@ class TestS3Storage:
             d3 = _run_single_test()
             assert d1 == d2 == d3
 
+        if not client_is_clickhouse(client):
+            pytest.skip("ClickHouse-only: bucket file storage machinery")
+
         _run_test()
 
 
@@ -171,6 +177,9 @@ class TestGCSStorage:
         This verifies the if_generation_match=0 conditional write works correctly
         to prevent GCS rate limiting when multiple pods write the same object.
         """
+        if not client_is_clickhouse(client):
+            pytest.skip("ClickHouse-only: bucket file storage machinery")
+
         upload_count = 0
         blob_data = {}
 
@@ -312,6 +321,9 @@ class TestAzureStorage:
         be a no-op, not an overwrite. Otherwise any project with write scope
         can substitute content at a known URI.
         """
+        if not client_is_clickhouse(client):
+            pytest.skip("ClickHouse-only: bucket file storage machinery")
+
         blob_data: dict[str, bytes] = {}
         upload_calls: list[dict] = []
 
@@ -384,6 +396,8 @@ def test_support_for_variable_length_chunks(client: WeaveClient):
     """Test that the system supports variable length chunks.
     We don't actually want to change this often, but we need to make sure it works.
     """
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: bucket file storage machinery")
 
     def create_and_read_file(content: bytes):
         res = client.server.file_create(
@@ -426,6 +440,9 @@ def test_support_for_variable_length_chunks(client: WeaveClient):
 @pytest.mark.disable_logging_error_check
 def test_file_storage_retry_limit(client: WeaveClient):
     """Test that file storage operations retry exactly 3 times on storage failures."""
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: bucket file storage machinery")
+
     attempt_count = 0
 
     def mock_upload_fail(*args, **kwargs):
@@ -510,6 +527,9 @@ def test_call_batch_uploads_files_to_bucket_in_parallel(client: WeaveClient, gcs
     collapses to one upload, and every stored object lands under the
     expected project prefix.
     """
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: bucket file storage machinery")
+
     gcs.state.delay = 0.1
     # 4 unique blobs + 2 duplicates of the first => 4 GCS uploads after dedup.
     payload_size = 50_000
@@ -568,6 +588,9 @@ def test_call_batch_falls_back_to_clickhouse_on_per_file_bucket_failure(
     server's read path -- it must reassemble bit-for-bit from CH chunks for
     both single-chunk and multi-chunk payloads.
     """
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: bucket file storage machinery")
+
     server = client.server
     project_b64 = base64.b64encode(client.project_id.encode()).decode()
 

--- a/tests/trace/util.py
+++ b/tests/trace/util.py
@@ -7,6 +7,24 @@ import re
 import time
 from contextlib import contextmanager
 
+from tests.trace.server_utils import find_server_layer
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+
+
+def client_is_clickhouse(client):
+    """True only for a real ClickHouse backend (NOT the in-memory fake).
+
+    The in-memory fake replicates ClickHouse at the interface level, so
+    behavioral tests run on it unmodified. Use this predicate to gate tests
+    that assert ClickHouse *internals* (raw SQL, table routing, batching,
+    bucket file storage), which the fake does not reproduce.
+    """
+    try:
+        find_server_layer(client.server, ClickHouseTraceServer)
+    except TypeError:
+        return False
+    return True
+
 
 class AnyStrMatcher:  # noqa: PLW1641
     """Matches any string."""

--- a/tests/trace_server/conftest.py
+++ b/tests/trace_server/conftest.py
@@ -22,6 +22,7 @@ from weave.trace_server import (
 )
 from weave.trace_server import environment as wf_env
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.in_memory_trace_server import InMemoryTraceServer
 from weave.trace_server.parallel_bucket_uploads import BucketUploadBatch
 from weave.trace_server.project_version import project_version
 from weave.trace_server.secret_fetcher_context import secret_fetcher_context
@@ -46,13 +47,19 @@ def pytest_addoption(parser):
             "--trace-server",
             action="store",
             default="clickhouse",
-            help="Specify the backend to use: clickhouse",
+            help="Specify the backend to use: clickhouse or fake (in-memory)",
         )
         parser.addoption(
             "--ch",
             "--clickhouse",
             action="store_true",
             help="Use clickhouse server (shorthand for --trace-server=clickhouse)",
+        )
+        parser.addoption(
+            "--fk",
+            "--fake",
+            action="store_true",
+            help="Use the in-memory fake server (shorthand for --trace-server=fake)",
         )
         parser.addoption(
             "--clickhouse-process",
@@ -87,6 +94,8 @@ def pytest_collection_modifyitems(config, items):
 def get_trace_server_flag(request):
     if request.config.getoption("--clickhouse"):
         return "clickhouse"
+    if request.config.getoption("--fake"):
+        return "fake"
     return request.config.getoption("--trace-server")
 
 
@@ -185,7 +194,7 @@ def _ch_session_server(
     `prod`/`http` escape hatches), so dependents can skip instead of
     spinning up a server that won't be used.
     """
-    trace_server_flag = request.config.getoption("--trace-server", default="clickhouse")
+    trace_server_flag = get_trace_server_flag(request)
     if trace_server_flag != "clickhouse":
         yield None
         return
@@ -314,6 +323,24 @@ def get_ch_trace_server(
     return ch_trace_server_inner
 
 
+@pytest.fixture
+def get_fake_trace_server(
+    request,
+) -> Callable[[], UserInjectingExternalTraceServer]:
+    def fake_trace_server_inner() -> UserInjectingExternalTraceServer:
+        id_converter = DummyIdConverter()
+        fake_server = InMemoryTraceServer(
+            evaluate_model_dispatcher=EvaluateModelTestDispatcher(
+                id_converter=id_converter
+            ),
+        )
+        return externalize_trace_server(
+            fake_server, TEST_ENTITY, id_converter=id_converter
+        )
+
+    return fake_trace_server_inner
+
+
 class LocalSecretFetcher:
     def fetch(self, secret_name: str) -> dict:
         return {"secrets": {secret_name: os.getenv(secret_name)}}
@@ -327,23 +354,30 @@ def local_secret_fetcher():
 
 @pytest.fixture
 def trace_server(
-    request, local_secret_fetcher, get_ch_trace_server
+    request, local_secret_fetcher, get_ch_trace_server, get_fake_trace_server
 ) -> UserInjectingExternalTraceServer:
     trace_server_flag = get_trace_server_flag(request)
     if trace_server_flag == "clickhouse":
         return get_ch_trace_server()
+    elif trace_server_flag == "fake":
+        return get_fake_trace_server()
     raise ValueError(f"Invalid trace server: {trace_server_flag}")
 
 
 @pytest.fixture
 def ch_server(trace_server):
-    """Extract the ClickHouseTraceServer from the test fixture."""
+    """Extract the ClickHouseTraceServer from the test fixture, or skip."""
     server = trace_server._internal_trace_server
-    assert isinstance(server, ClickHouseTraceServer)
+    if not isinstance(server, ClickHouseTraceServer):
+        pytest.skip("ClickHouse-only test")
     return server
 
 
 @pytest.fixture
 def internal_server(client):
-    """Return the underlying ClickHouse server from the middleware chain."""
+    """Return the underlying fake or ClickHouse server from the middleware chain."""
+    try:
+        return find_server_layer(client.server, InMemoryTraceServer)
+    except TypeError:
+        pass
     return find_server_layer(client.server, ClickHouseTraceServer)

--- a/tests/trace_server/helpers.py
+++ b/tests/trace_server/helpers.py
@@ -14,12 +14,16 @@ def make_project_id(prefix: str) -> str:
     return base64.b64encode(raw.encode()).decode()
 
 
-def force_optimize(ch_client: CHClient, table: str) -> None:
+def force_optimize(ch_client: CHClient | None, table: str) -> None:
     """OPTIMIZE `table` for test merge-consistency, distributed-mode aware.
 
     OPTIMIZE is not supported on Distributed engines; in distributed mode we
     target the underlying `_local` ReplicatedMergeTree on the cluster.
+    No-op when there is no ClickHouse client (e.g. the in-memory fake
+    backend, which has no merge consistency to force).
     """
+    if ch_client is None:
+        return
     if wf_env.wf_clickhouse_use_distributed_tables():
         cluster = wf_env.wf_clickhouse_replicated_cluster()
         ch_client.command(f"OPTIMIZE TABLE {table}_local ON CLUSTER {cluster} FINAL")

--- a/tests/trace_server/test_call_lifecycle.py
+++ b/tests/trace_server/test_call_lifecycle.py
@@ -3,6 +3,7 @@ import uuid
 
 import pytest
 
+from tests.trace.util import client_is_clickhouse
 from tests.trace_server.helpers import force_optimize_calls_merged
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
@@ -94,6 +95,9 @@ def test_call_end_started_at_anchors_sortable_datetime(
     cannot drop a long-running call merely because `any()` picked the end-row
     contribution -- the buggy path repro'd in #6932.
     """
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: calls_merged columns")
+
     ch_client = client.server._next_trace_server.ch_client
     project_id = client.project_id
     call_id = str(uuid.uuid4())

--- a/tests/trace_server/test_call_stats.py
+++ b/tests/trace_server/test_call_stats.py
@@ -12,6 +12,7 @@ import uuid
 import pytest
 from pydantic import ValidationError
 
+from tests.trace.util import client_is_clickhouse
 from tests.trace_server.helpers import force_optimize_calls_merged
 from weave.trace import weave_client
 from weave.trace_server import trace_server_interface as tsi
@@ -34,6 +35,9 @@ def force_merge_calls(client: weave_client.WeaveClient):
     ClickHouse merges ReplacingMergeTree rows asynchronously. In tests, we write
     and immediately query, so rows may not be merged yet. This forces a merge.
     """
+    if not client_is_clickhouse(client):
+        # Only a real ClickHouse backend has async merges to force.
+        return
     ch_client = client.server._next_trace_server.ch_client
     force_optimize_calls_merged(ch_client)
 

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -12,6 +12,7 @@ from weave.trace_server import clickhouse_trace_server_settings as ch_settings
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
 from weave.trace_server.calls_query_builder.utils import param_slot
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.errors import (
     CallsCompleteModeRequired,
     NotFoundError,
@@ -43,6 +44,8 @@ def clickhouse_trace_server(trace_server):
         >>> internal = clickhouse_trace_server
     """
     internal_server = trace_server._internal_trace_server
+    if not isinstance(internal_server, ClickHouseTraceServer):
+        pytest.skip("ClickHouse-only test")
     internal_server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
     return internal_server
 

--- a/tests/trace_server/test_clickhouse_batching.py
+++ b/tests/trace_server/test_clickhouse_batching.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tests.trace.util import client_is_clickhouse
 from weave.shared.digest import str_digest
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.base64_content_conversion import AUTO_CONVERSION_MIN_SIZE
@@ -238,6 +239,8 @@ def _internal_wb_user_id() -> str:
 
 def test_obj_batch_same_object_id_different_hash(trace_server, client):
     """Two versions for same object_id with different digests."""
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: insert batching")
     server = trace_server._internal_trace_server
     pid = _internal_pid()
     wb_user_id = _internal_wb_user_id()
@@ -267,6 +270,8 @@ def test_obj_batch_same_object_id_different_hash(trace_server, client):
 
 def test_obj_batch_same_hash_different_object_ids(trace_server, client):
     """Same digest payload uploaded under different object_ids yields distinct objects."""
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: insert batching")
     server = trace_server._internal_trace_server
     pid = _internal_pid()
     wb_user_id = _internal_wb_user_id()
@@ -292,6 +297,8 @@ def test_obj_batch_same_hash_different_object_ids(trace_server, client):
 def test_obj_batch_identical_same_id_same_hash_deduplicates(trace_server, client):
     """Duplicate rows (same object_id and digest) are represented once in metadata view."""
     server = trace_server._internal_trace_server
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: insert batching")
     pid = _internal_pid()
     wb_user_id = _internal_wb_user_id()
     obj_id = "dup_obj"
@@ -314,6 +321,8 @@ def test_obj_batch_identical_same_id_same_hash_deduplicates(trace_server, client
 
 def test_obj_batch_four_versions_and_read_path(trace_server, client):
     """Batch upload 4 versions and verify reads over all and latest work."""
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: insert batching")
     server = trace_server._internal_trace_server
     pid = _internal_pid()
     wb_user_id = _internal_wb_user_id()
@@ -350,6 +359,8 @@ def test_obj_batch_four_versions_and_read_path(trace_server, client):
 
 def test_obj_batch_delete_version_preserves_indices(trace_server, client):
     """Delete one version and ensure indices remain intact and deletion is reflected."""
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: insert batching")
     server = trace_server._internal_trace_server
     pid = _internal_pid()
     wb_user_id = _internal_wb_user_id()
@@ -406,6 +417,8 @@ def test_str_digest_is_key_order_independent():
 
 def test_obj_batch_different_key_order_deduplicates(trace_server, client):
     """Objects with identical values but different key ordering share the same digest."""
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: insert batching")
     server = trace_server._internal_trace_server
     pid = _internal_pid()
     wb_user_id = _internal_wb_user_id()
@@ -508,6 +521,8 @@ def test_call_start_batch_invalid_trace_id_returns_400():
 
 def test_obj_batch_mixed_projects_errors(trace_server, client):
     """Uploading objects to different projects in one batch should error."""
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: insert batching")
     server = trace_server._internal_trace_server
     pid1 = _internal_pid()
     wb_user_id = _internal_wb_user_id()

--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import uuid
 from datetime import datetime
@@ -171,6 +172,24 @@ def setup_test_environment(mock_secret_fetcher=None):
     return mock_secret_fetcher, token
 
 
+@contextlib.contextmanager
+def patch_server_obj_read(mock_obj_read):
+    """Patch obj_read on both backend classes so provider/model objects come
+    from the mock regardless of which trace server the client fixture uses.
+    """
+    with (
+        patch(
+            "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
+        ) as ch_read,
+        patch(
+            "weave.trace_server.in_memory_trace_server.InMemoryTraceServer.obj_read"
+        ) as mem_read,
+    ):
+        ch_read.side_effect = mock_obj_read
+        mem_read.side_effect = mock_obj_read
+        yield
+
+
 def create_mock_obj_read(
     provider_obj: tsi.ObjSchema, provider_model_obj: tsi.ObjSchema
 ):
@@ -303,10 +322,7 @@ def test_custom_provider_completions_create(client):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
+            with patch_server_obj_read(mock_obj_read):
                 with patch("litellm.completion") as mock_completion:
                     mock_completion.return_value = ModelResponse.model_validate(
                         mock_response
@@ -406,10 +422,7 @@ def test_custom_provider_ollama_model(client):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
+            with patch_server_obj_read(mock_obj_read):
                 with patch("litellm.completion") as mock_completion:
                     mock_completion.return_value = ModelResponse.model_validate(
                         mock_response
@@ -485,10 +498,7 @@ def test_custom_provider_trailing_slash_normalization(client):
     with override_settings(disabled=True):
         mock_secret_fetcher, token = setup_test_environment()
         try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
+            with patch_server_obj_read(mock_obj_read):
                 with patch("litellm.completion") as mock_completion:
                     mock_completion.return_value = ModelResponse.model_validate(
                         mock_response
@@ -575,10 +585,7 @@ def test_error_handling_custom_provider(client):
         # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
+            with patch_server_obj_read(mock_obj_read):
                 res = client.server.completions_create(
                     tsi.CompletionsCreateReq.model_validate(
                         {

--- a/tests/trace_server/test_otel_calls_complete.py
+++ b/tests/trace_server/test_otel_calls_complete.py
@@ -35,6 +35,7 @@ from tests.trace_server.conftest_lib.trace_server_external_adapter import b64
 from weave.shared import refs_internal as ri
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.calls_query_builder.utils import param_slot
+from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
 from weave.trace_server.errors import CallsCompleteModeRequired
 from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.project_version.types import CallsStorageServerMode
@@ -48,6 +49,8 @@ from weave.trace_server.project_version.types import CallsStorageServerMode
 def clickhouse_trace_server(trace_server):
     """Get internal ClickHouse server with AUTO routing mode enabled."""
     internal_server = trace_server._internal_trace_server
+    if not isinstance(internal_server, ClickHouseTraceServer):
+        pytest.skip("ClickHouse-only test")
     internal_server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
     return internal_server
 

--- a/tests/trace_server/test_project_version.py
+++ b/tests/trace_server/test_project_version.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.trace.util import client_is_clickhouse
 from weave.trace_server.project_version.clickhouse_project_version import (
     get_project_data_residence,
 )
@@ -101,6 +102,9 @@ def test_version_resolution_by_table_contents(
     log_collector,
 ):
     """Test routing resolution for different project data residency states."""
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: table routing/residence")
+
     ch_server = trace_server._internal_trace_server
     resolver = ch_server.table_routing_resolver
     # manually set this to auto so we can test the switching
@@ -139,6 +143,9 @@ def test_version_resolution_by_table_contents(
 
 
 def test_caching_behavior(client, trace_server):
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: table routing/residence")
+
     ch_server = trace_server._internal_trace_server
     resolver = ch_server.table_routing_resolver
     resolver._mode = CallsStorageServerMode.AUTO
@@ -167,6 +174,9 @@ def test_caching_behavior(client, trace_server):
 
 
 def test_mode_off_and_force_legacy(client, trace_server):
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: table routing/residence")
+
     ch_server = trace_server._internal_trace_server
     resolver = ch_server.table_routing_resolver
 
@@ -192,6 +202,9 @@ def test_mode_off_and_force_legacy(client, trace_server):
 
 
 def test_clickhouse_provider_directly(client, trace_server):
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: table routing/residence")
+
     ch_server = trace_server._internal_trace_server
     project_id = make_project_id("provider_direct")
     insert_call(ch_server.ch_client, "calls_merged", project_id)
@@ -203,6 +216,9 @@ def test_clickhouse_provider_directly(client, trace_server):
 
 def test_resolver_as_trace_server_member(client, trace_server):
     """Test that the resolver is properly integrated as a trace server member."""
+    if not client_is_clickhouse(client):
+        pytest.skip("ClickHouse-only: table routing/residence")
+
     ch_server = trace_server._internal_trace_server
 
     # Test that the resolver is lazily initialized

--- a/tests/trace_server/test_rescore_evaluation.py
+++ b/tests/trace_server/test_rescore_evaluation.py
@@ -13,6 +13,7 @@ import pytest
 
 from tests.trace.server_utils import find_server_layer
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.in_memory_trace_server import InMemoryTraceServer
 from weave.trace_server.trace_server_interface import (
     CallReadReq,
     EvaluationRunCreateReq,
@@ -95,7 +96,17 @@ def _setup_server_with_dispatcher(server):
     _evaluate_model_dispatcher, then swaps it for a MagicMock so rescore()
     can be tested without real worker invocation.
     """
-    target = find_server_layer(server, ClickHouseTraceServer)
+    target = None
+    last_err: TypeError | None = None
+    for server_type in (InMemoryTraceServer, ClickHouseTraceServer):
+        try:
+            target = find_server_layer(server, server_type)
+            break
+        except TypeError as err:
+            last_err = err
+    if target is None:
+        # No known concrete server found — re-raise the last lookup error
+        raise last_err from None
     mock_dispatcher = MagicMock()
     target._evaluate_model_dispatcher = mock_dispatcher
     return mock_dispatcher

--- a/tests/trace_server/test_trace_server_conftest.py
+++ b/tests/trace_server/test_trace_server_conftest.py
@@ -1,12 +1,18 @@
+from tests.trace_server.conftest import get_trace_server_flag
 from tests.trace_server.conftest_lib.trace_server_external_adapter import (
     UserInjectingExternalTraceServer,
 )
 from weave.trace_server.clickhouse_trace_server_batched import ClickHouseTraceServer
+from weave.trace_server.in_memory_trace_server import InMemoryTraceServer
 
 
-def test_trace_server_fixture(trace_server: UserInjectingExternalTraceServer):
+def test_trace_server_fixture(request, trace_server: UserInjectingExternalTraceServer):
     assert isinstance(trace_server, UserInjectingExternalTraceServer)
-    assert isinstance(trace_server._internal_trace_server, ClickHouseTraceServer)
+    flag = get_trace_server_flag(request)
+    if flag == "fake":
+        assert isinstance(trace_server._internal_trace_server, InMemoryTraceServer)
+    else:
+        assert isinstance(trace_server._internal_trace_server, ClickHouseTraceServer)
 
 
 # All instance attributes set in ClickHouseTraceServer.__init__.

--- a/tests/trace_server/test_ttl_insert_paths.py
+++ b/tests/trace_server/test_ttl_insert_paths.py
@@ -50,7 +50,8 @@ def _clear_ttl_cache():
 @pytest.fixture
 def internal_server(trace_server):
     server = trace_server._internal_trace_server
-    assert isinstance(server, ClickHouseTraceServer)
+    if not isinstance(server, ClickHouseTraceServer):
+        pytest.skip("ClickHouse-only: raw expire_at table reads + routing modes")
     server.table_routing_resolver._mode = CallsStorageServerMode.AUTO
     return server
 


### PR DESCRIPTION
## Description

Part 10/10 of the in-memory fake trace server stack — this is where the fake
becomes selectable and the whole stack is exercised end to end. The stack
sits on #7153 (sqlite removal), which simplified this PR considerably:
clickhouse and fake are now the only test backends.

Test wiring:
- `--trace-server=fake` (shorthand `--fk`/`--fake`) selects
  InMemoryTraceServer for every test using the client / trace_server
  fixtures; anything else raises. No files, no SQL, no Docker. The ClickHouse
  session fixture short-circuits through `get_trace_server_flag`, so the
  `--fake` shorthand never spins up a ClickHouse server.
- A new `client_is_clickhouse` predicate (tests/trace/util.py) gates tests
  that assert ClickHouse *internals* — SQL text, table routing/residence,
  insert batching, bucket file storage, raw DB manipulation, and SQL built
  for `server._query`. Those tests skip on the fake with explicit reasons.
- The ClickHouse-only fixtures that #7153 turned into bare asserts (CH was
  briefly the only backend) skip again on the fake: `ch_server`, the
  calls_complete / otel_calls_complete fixtures, and test_ttl_insert_paths'
  `internal_server` (that file raw-reads call_parts/calls_complete and
  mutates routing modes — internals by this stack's taxonomy).
- `test_custom_provider`'s obj_read patch targets both backend classes via
  one helper; `force_optimize` no-ops without a ClickHouse client; AGENTS.md
  documents the two-backend world.

## Testing

Fake and ClickHouse both run against this exact tree (the ClickHouse runs
double as a regression check on the test-file edits):

- tests/trace_server — fake 1203 passed / 115 skipped / 0 failed; ClickHouse
  1317 passed / 1 skipped / 0 failed. Totals match at 1318.
- tests/trace — fake 1665 passed / 42 skipped / 1 failed; ClickHouse 1681
  passed / 26 skipped / 1 failed (the same pre-existing `test_flask_server`
  env failure). Totals match at 1708.
- Every fake-side skip beyond the environment skips shared with ClickHouse is
  an explicit ClickHouse-internals gate — the skip lists were audited with
  `-rs`.
- Secondary shards (flow/compat/utils/wandb_interface/session/shared/object)
  pass identically; their 6 failures are pre-existing, backend-independent
  env issues.

## Why fake over clickhouse in tests

tests/trace_server wall-clock on the same machine: fake ~60s vs ClickHouse
~2-8m (local binary vs Docker); no Docker, no external processes.