### PR TITLE
feat(node-sdk/genai): add setAttribute/addEvent to Tool/LLM/SubAgent/Turn via shared base

### DIFF
--- a/sdks/node/src/__tests__/genai/spanBase.test.ts
+++ b/sdks/node/src/__tests__/genai/spanBase.test.ts
@@ -1,0 +1,169 @@
+import type {ReadableSpan} from '@opentelemetry/sdk-trace-base';
+
+import {ATTR_GEN_AI_AGENT_NAME} from '../../genai/semconv';
+import type {SpanBase} from '../../genai/spanBase';
+import {Turn} from '../../genai/turn';
+
+import {
+  findSpan,
+  setupExporterPerTest,
+  setupGenAITestEnvironment,
+} from './common';
+
+/**
+ * Parametrized coverage for the shared `SpanBase` mutators
+ * (`setAttribute` / `setAttributes` / `addEvent`) across all four span
+ * wrappers. Mirrors the Python SDK's `test_span_attributes.py`, which runs the
+ * same assertions over `(Tool, LLM, SubAgent, Turn)`.
+ */
+interface SpanCase {
+  label: string;
+  start: () => {
+    target: SpanBase;
+    endAll: () => void;
+    locate: (spans: ReadableSpan[]) => ReadableSpan;
+  };
+}
+
+const CASES: SpanCase[] = [
+  {
+    label: 'Turn',
+    start: () => {
+      const turn = Turn.create({});
+      return {
+        target: turn,
+        endAll: () => turn.end(),
+        locate: spans => findSpan(spans, 'invoke_agent'),
+      };
+    },
+  },
+  {
+    label: 'LLM',
+    start: () => {
+      const turn = Turn.create({});
+      const llm = turn.startLLM({model: 'gpt-4o'});
+      return {
+        target: llm,
+        endAll: () => {
+          llm.end();
+          turn.end();
+        },
+        locate: spans => findSpan(spans, 'chat'),
+      };
+    },
+  },
+  {
+    label: 'Tool',
+    start: () => {
+      const turn = Turn.create({});
+      const tool = turn.startTool({name: 'get_weather'});
+      return {
+        target: tool,
+        endAll: () => {
+          tool.end();
+          turn.end();
+        },
+        locate: spans => findSpan(spans, 'execute_tool'),
+      };
+    },
+  },
+  {
+    label: 'SubAgent',
+    start: () => {
+      const turn = Turn.create({agentName: 'parent'});
+      const sub = turn.startSubagent({name: 'child-bot'});
+      return {
+        target: sub,
+        endAll: () => {
+          sub.end();
+          turn.end();
+        },
+        locate: spans => {
+          const found = spans.find(
+            s =>
+              s.name === 'invoke_agent' &&
+              s.attributes[ATTR_GEN_AI_AGENT_NAME] === 'child-bot'
+          );
+          if (!found) {
+            throw new Error('no child-bot invoke_agent span found');
+          }
+          return found;
+        },
+      };
+    },
+  },
+];
+
+describe.each(CASES)('SpanBase mutators on $label', ({start}) => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('setAttribute writes a single attribute to the span', () => {
+    const {target, endAll, locate} = start();
+    target.setAttribute('weave.cost.usd', 0.42);
+    endAll();
+    expect(
+      locate(getExporter().getFinishedSpans()).attributes['weave.cost.usd']
+    ).toBe(0.42);
+  });
+
+  it('setAttribute returns this for chaining', () => {
+    const {target, endAll} = start();
+    expect(target.setAttribute('k', 'v')).toBe(target);
+    endAll();
+  });
+
+  it('setAttribute is a no-op after end()', () => {
+    const {target, endAll, locate} = start();
+    endAll();
+    target.setAttribute('after.end', 'x');
+    expect(
+      locate(getExporter().getFinishedSpans()).attributes['after.end']
+    ).toBeUndefined();
+  });
+
+  it('setAttributes writes multiple attributes at once', () => {
+    const {target, endAll, locate} = start();
+    target.setAttributes({'weave.tag': 'prod', 'weave.run': 7});
+    endAll();
+    const attrs = locate(getExporter().getFinishedSpans()).attributes;
+    expect(attrs['weave.tag']).toBe('prod');
+    expect(attrs['weave.run']).toBe(7);
+  });
+
+  it('setAttributes is a no-op after end()', () => {
+    const {target, endAll, locate} = start();
+    endAll();
+    target.setAttributes({'after.end': 'x'});
+    expect(
+      locate(getExporter().getFinishedSpans()).attributes['after.end']
+    ).toBeUndefined();
+  });
+
+  it('addEvent writes a named event with attributes', () => {
+    const {target, endAll, locate} = start();
+    target.addEvent('context_compacted', {items_before: 50, items_after: 10});
+    endAll();
+    const ev = locate(getExporter().getFinishedSpans()).events.find(
+      e => e.name === 'context_compacted'
+    );
+    expect(ev?.attributes).toMatchObject({items_before: 50, items_after: 10});
+  });
+
+  it('addEvent returns this for chaining', () => {
+    const {target, endAll} = start();
+    expect(target.addEvent('e')).toBe(target);
+    endAll();
+  });
+
+  it('addEvent is a no-op after end()', () => {
+    const {target, endAll, locate} = start();
+    endAll();
+    target.addEvent('after.end');
+    expect(
+      locate(getExporter().getFinishedSpans()).events.find(
+        e => e.name === 'after.end'
+      )
+    ).toBeUndefined();
+  });
+});

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -9,6 +9,7 @@ import {
 import type {ChildSpanContext} from './common';
 import {_getGenaiState} from './context';
 import {getWeaveTracer} from './provider';
+import {SpanBase} from './spanBase';
 import {
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_INPUT_MESSAGES,
@@ -68,7 +69,7 @@ export interface LLMRecordOpts {
  *   llm.end();
  * }
  */
-export class LLM {
+export class LLM extends SpanBase {
   /** Mutable data populated between `create()` and `end()`. */
 
   /**
@@ -89,15 +90,15 @@ export class LLM {
    */
   reasoning?: Reasoning;
 
-  private _ended = false;
-
   private constructor(
-    private readonly span: Span,
+    span: Span,
     private readonly context: Context,
     private readonly conversationId: string,
     public readonly model: string,
     public readonly providerName: string
-  ) {}
+  ) {
+    super(span);
+  }
 
   static create(opts: LLMInit & ChildSpanContext): LLM {
     const state = _getGenaiState();

--- a/sdks/node/src/genai/spanBase.ts
+++ b/sdks/node/src/genai/spanBase.ts
@@ -1,0 +1,66 @@
+import type {
+  Attributes,
+  AttributeValue,
+  Span,
+  TimeInput,
+} from '@opentelemetry/api';
+
+/**
+ * Shared base for the four GenAI span wrappers (`Tool`, `LLM`, `SubAgent`,
+ * `Turn`). Holds the underlying OTel span plus the `_ended` guard and exposes
+ * the common escape-hatch mutators so every span type gets an identical
+ * surface.
+ *
+ * Mirrors the Python SDK's `_SpanBase` mixin (wandb/weave#7131): rather than
+ * re-declaring `setAttribute`/`addEvent` on each class, the implementation
+ * lives here once and covers all four uniformly.
+ *
+ * All mutators are no-ops after `end()` — the span is closed, so further
+ * mutation can no longer reach the trace — and return `this` for chaining.
+ */
+export abstract class SpanBase {
+  protected _ended = false;
+
+  protected constructor(protected readonly span: Span) {}
+
+  /**
+   * Set a single attribute on the span. Useful for stamping metadata that
+   * becomes known mid-span (e.g. `weave.display_name`, cumulative cost, token
+   * usage). No-op after `end()`. Mirrors OTel `Span.setAttribute`.
+   *
+   * @example
+   * span.setAttribute('weave.cost.usd', 0.42);
+   */
+  setAttribute(key: string, value: AttributeValue): this {
+    if (this._ended) return this;
+    this.span.setAttribute(key, value);
+    return this;
+  }
+
+  /**
+   * Set multiple attributes on the span at once. No-op after `end()`. Mirrors
+   * OTel `Span.setAttributes` (and the Python SDK's `set_attributes`).
+   *
+   * @example
+   * span.setAttributes({'weave.tag': 'prod', 'gen_ai.response.id': id});
+   */
+  setAttributes(attributes: Attributes): this {
+    if (this._ended) return this;
+    this.span.setAttributes(attributes);
+    return this;
+  }
+
+  /**
+   * Add a named event to the span. Useful for marking non-span moments such as
+   * context compaction, tool-loop detection, or guardrail trips. No-op after
+   * `end()`. Mirrors OTel `Span.addEvent`.
+   *
+   * @example
+   * span.addEvent('context_compacted', {removedMessages: 12});
+   */
+  addEvent(name: string, attributes?: Attributes, startTime?: TimeInput): this {
+    if (this._ended) return this;
+    this.span.addEvent(name, attributes, startTime);
+    return this;
+  }
+}

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -2,6 +2,7 @@ import {type Span, SpanKind, SpanStatusCode} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
 import {getWeaveTracer} from './provider';
+import {SpanBase} from './spanBase';
 import {
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_CONVERSATION_ID,
@@ -32,14 +33,14 @@ export interface SubAgentInit {
  *   sub.end();
  * }
  */
-export class SubAgent {
-  private _ended = false;
-
+export class SubAgent extends SpanBase {
   private constructor(
-    private readonly span: Span,
+    span: Span,
     public readonly name: string,
     public readonly model: string
-  ) {}
+  ) {
+    super(span);
+  }
 
   static create(opts: SubAgentInit & ChildSpanContext): SubAgent {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);

--- a/sdks/node/src/genai/tool.ts
+++ b/sdks/node/src/genai/tool.ts
@@ -2,6 +2,7 @@ import {type Span, SpanKind, SpanStatusCode} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
 import {getWeaveTracer} from './provider';
+import {SpanBase} from './spanBase';
 import {
   ATTR_GEN_AI_CONVERSATION_ID,
   ATTR_GEN_AI_OPERATION_NAME,
@@ -38,20 +39,20 @@ export interface ToolInit {
  *   tool.end();
  * }
  */
-export class Tool {
+export class Tool extends SpanBase {
   /**
    * Tool output as a string. Recorded on `gen_ai.tool.call.result` at `end()`.
    */
   result?: string;
 
-  private _ended = false;
-
   private constructor(
-    private readonly span: Span,
+    span: Span,
     public readonly name: string,
     public readonly args: string,
     public readonly toolCallId: string
-  ) {}
+  ) {
+    super(span);
+  }
 
   static create(opts: ToolInit & ChildSpanContext): Tool {
     const tracer = getWeaveTracer(WEAVE_GENAI_TRACER_NAME);

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -1,18 +1,16 @@
 import {
-  type AttributeValue,
-  type Attributes,
   type Context,
   ROOT_CONTEXT,
   type Span,
   SpanKind,
   SpanStatusCode,
-  type TimeInput,
   trace,
 } from '@opentelemetry/api';
 
 import {_getGenaiState} from './context';
 import {LLM, type LLMInit} from './llm';
 import {getWeaveTracer} from './provider';
+import {SpanBase} from './spanBase';
 import {
   ATTR_GEN_AI_AGENT_NAME,
   ATTR_GEN_AI_CONVERSATION_ID,
@@ -50,16 +48,16 @@ export interface TurnInit {
  *   turn.end();
  * }
  */
-export class Turn {
-  private _ended = false;
-
+export class Turn extends SpanBase {
   private constructor(
-    private readonly span: Span,
+    span: Span,
     private readonly context: Context,
     private readonly conversationId: string,
     public readonly agentName: string,
     public readonly model: string
-  ) {}
+  ) {
+    super(span);
+  }
 
   static create(opts: TurnInit & {conversationId?: string} = {}): Turn {
     const state = _getGenaiState();
@@ -125,34 +123,6 @@ export class Turn {
       parentContext: this.context,
       conversationId: this.conversationId,
     });
-  }
-
-  /**
-   * Set a single attribute on the Turn span. Useful for stamping running
-   * totals (e.g. cumulative cost, token usage) or other metadata that becomes
-   * known mid-turn. No-op after `end()`. Mirrors OTel `Span.setAttribute`.
-   *
-   * @example
-   * turn.setAttribute('gen_ai.usage.input_tokens', totalInputTokens);
-   */
-  setAttribute(key: string, value: AttributeValue): this {
-    if (this._ended) return this;
-    this.span.setAttribute(key, value);
-    return this;
-  }
-
-  /**
-   * Add a named event to the Turn span. Useful for marking non-span moments
-   * such as context compaction, tool-loop detection, or guardrail trips.
-   * No-op after `end()`. Mirrors OTel `Span.addEvent`.
-   *
-   * @example
-   * turn.addEvent('context_compacted', {removedMessages: 12});
-   */
-  addEvent(name: string, attributes?: Attributes, startTime?: TimeInput): this {
-    if (this._ended) return this;
-    this.span.addEvent(name, attributes, startTime);
-    return this;
   }
 
   /** Close the Turn span. Idempotent. Pass `error` to mark it as failed. */


### PR DESCRIPTION
## Summary

A shared `SpanBase` class now holds the OTel span plus the `_ended` guard and exposes the common mutators, so every span type gets one identical surface:

- `setAttribute(key, value)` / `setAttributes(attrs)` — stamp OTel attributes that become known mid-span (e.g. `weave.display_name`, running cost/usage).
- `addEvent(name, attrs?, startTime?)` — record an OTel span event (e.g. context compaction, guardrail trips).

`Tool`, `LLM`, `SubAgent`, and `Turn` extend `SpanBase`; `Turn`'s own `setAttribute`/`addEvent` are dropped for the inherited ones. All mutators no-op after `end()` and return `this` for chaining. `SpanBase` stays internal — not exported from `index.ts`.

Mirrors the Python SDK's `_SpanBase` mixin (wandb/weave#7131).

## Test plan

- 32 parametrized tests in `spanBase.test.ts` over `(Tool, LLM, SubAgent, Turn)`: single/multi attribute writes, event writes, returns-`this`, no-op-after-`end()`
- `npx jest --selectProjects default --coverage=false src/__tests__/genai` — 93 pass
- `npx prettier --check "src/**/*.ts"` — clean
