### PR TITLE
fix(node-sdk/genai): preserve caller-set start/end times on Tool/LLM/SubAgent/Turn

### DIFF
--- a/sdks/node/src/__tests__/genai/postHocTimes.test.ts
+++ b/sdks/node/src/__tests__/genai/postHocTimes.test.ts
@@ -1,0 +1,106 @@
+import type {HrTime, TimeInput} from '@opentelemetry/api';
+import type {ReadableSpan} from '@opentelemetry/sdk-trace-base';
+
+import {ATTR_GEN_AI_AGENT_NAME} from '../../genai/semconv';
+import {Turn} from '../../genai/turn';
+
+import {
+  findSpan,
+  setupExporterPerTest,
+  setupGenAITestEnvironment,
+} from './common';
+
+/**
+ * Parametrized coverage for caller-set start/end times across all four span
+ * wrappers. Mirrors the Python SDK's `test_post_hoc_times.py`: a backdated
+ * `startTime` passed at creation and an `endTime` passed at `end()` must reach
+ * the emitted OTel span verbatim; omitting them falls back to wall-clock now.
+ */
+const START: HrTime = [1700000000, 0]; // 2023-11-14, well in the past
+const END: HrTime = [1700000005, 500];
+
+interface TimeCase {
+  label: string;
+  run: (times?: {startTime?: TimeInput; endTime?: TimeInput}) => void;
+  locate: (spans: ReadableSpan[]) => ReadableSpan;
+}
+
+const CASES: TimeCase[] = [
+  {
+    label: 'Turn',
+    run: times => {
+      const turn = Turn.create({startTime: times?.startTime});
+      turn.end({endTime: times?.endTime});
+    },
+    locate: spans => findSpan(spans, 'invoke_agent'),
+  },
+  {
+    label: 'LLM',
+    run: times => {
+      const turn = Turn.create({});
+      const llm = turn.startLLM({model: 'gpt-4o', startTime: times?.startTime});
+      llm.end({endTime: times?.endTime});
+      turn.end();
+    },
+    locate: spans => findSpan(spans, 'chat'),
+  },
+  {
+    label: 'Tool',
+    run: times => {
+      const turn = Turn.create({});
+      const tool = turn.startTool({
+        name: 'get_weather',
+        startTime: times?.startTime,
+      });
+      tool.end({endTime: times?.endTime});
+      turn.end();
+    },
+    locate: spans => findSpan(spans, 'execute_tool'),
+  },
+  {
+    label: 'SubAgent',
+    run: times => {
+      const turn = Turn.create({agentName: 'parent'});
+      const sub = turn.startSubagent({
+        name: 'child-bot',
+        startTime: times?.startTime,
+      });
+      sub.end({endTime: times?.endTime});
+      turn.end();
+    },
+    locate: spans => {
+      const found = spans.find(
+        s =>
+          s.name === 'invoke_agent' &&
+          s.attributes[ATTR_GEN_AI_AGENT_NAME] === 'child-bot'
+      );
+      if (!found) {
+        throw new Error('no child-bot invoke_agent span found');
+      }
+      return found;
+    },
+  },
+];
+
+describe.each(CASES)('post-hoc times on $label', ({run, locate}) => {
+  setupGenAITestEnvironment();
+  const getExporter = setupExporterPerTest();
+
+  it('records a caller-set startTime on the span', () => {
+    run({startTime: START, endTime: END});
+    expect(locate(getExporter().getFinishedSpans()).startTime).toEqual(START);
+  });
+
+  it('records a caller-set endTime on the span', () => {
+    run({startTime: START, endTime: END});
+    expect(locate(getExporter().getFinishedSpans()).endTime).toEqual(END);
+  });
+
+  it('falls back to wall-clock now when no times are given', () => {
+    run();
+    const span = locate(getExporter().getFinishedSpans());
+    // No fixture times → OTel stamps real now, which is far newer than START.
+    expect(span.startTime[0]).toBeGreaterThan(START[0]);
+    expect(span.endTime[0]).toBeGreaterThanOrEqual(span.startTime[0]);
+  });
+});

--- a/sdks/node/src/genai/llm.ts
+++ b/sdks/node/src/genai/llm.ts
@@ -3,6 +3,7 @@ import {
   type Span,
   SpanKind,
   SpanStatusCode,
+  type TimeInput,
   trace,
 } from '@opentelemetry/api';
 
@@ -31,6 +32,9 @@ import type {Message, MessagePart, Modality, Reasoning, Usage} from './types';
 export interface LLMInit {
   model: string;
   providerName?: string;
+  /** Backdate the span's start time. Used when reconstructing chat spans from
+   *  post-hoc data (e.g. transcript replay). */
+  startTime?: TimeInput;
 }
 
 /** Discriminated union for `LLM.attachMedia`: pick one of content / uri / fileId. */
@@ -120,7 +124,11 @@ export class LLM extends SpanBase {
     }
     const span = tracer.startSpan(
       'chat',
-      {kind: SpanKind.CLIENT, attributes},
+      {
+        kind: SpanKind.CLIENT,
+        attributes,
+        ...(opts.startTime !== undefined ? {startTime: opts.startTime} : {}),
+      },
       opts.parentContext
     );
     const llm = new LLM(
@@ -241,10 +249,10 @@ export class LLM extends SpanBase {
   // ---------------------------------------------------------------------------
 
   /**
-   * Flush accumulated state to the span and close it. Idempotent. Pass
-   * `error` to mark the span as failed.
+   * Flush accumulated state to the span and close it. Idempotent. Pass `error`
+   * to mark the span as failed; pass `endTime` to backdate the close.
    */
-  end(opts?: {error?: Error}): void {
+  end(opts?: {error?: Error; endTime?: TimeInput}): void {
     if (this._ended) {
       return;
     }
@@ -304,7 +312,7 @@ export class LLM extends SpanBase {
         message: opts.error.message,
       });
     }
-    this.span.end();
+    this.span.end(opts?.endTime);
     const state = _getGenaiState();
     if (state.llm === this) {
       state.llm = null;

--- a/sdks/node/src/genai/subagent.ts
+++ b/sdks/node/src/genai/subagent.ts
@@ -1,4 +1,9 @@
-import {type Span, SpanKind, SpanStatusCode} from '@opentelemetry/api';
+import {
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+  type TimeInput,
+} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
 import {getWeaveTracer} from './provider';
@@ -14,6 +19,9 @@ import {
 export interface SubAgentInit {
   name: string;
   model?: string;
+  /** Backdate the span's start time. Used when reconstructing agent spans from
+   *  post-hoc data (e.g. transcript replay). */
+  startTime?: TimeInput;
 }
 
 /**
@@ -56,14 +64,21 @@ export class SubAgent extends SpanBase {
     }
     const span = tracer.startSpan(
       'invoke_agent',
-      {kind: SpanKind.CLIENT, attributes},
+      {
+        kind: SpanKind.CLIENT,
+        attributes,
+        ...(opts.startTime !== undefined ? {startTime: opts.startTime} : {}),
+      },
       opts.parentContext
     );
     return new SubAgent(span, opts.name, opts.model ?? '');
   }
 
-  /** Close the SubAgent span. Idempotent. Pass `error` to mark it as failed. */
-  end(opts?: {error?: Error}): void {
+  /**
+   * Close the SubAgent span. Idempotent. Pass `error` to mark it as failed;
+   * pass `endTime` to backdate the close.
+   */
+  end(opts?: {error?: Error; endTime?: TimeInput}): void {
     if (this._ended) {
       return;
     }
@@ -75,6 +90,6 @@ export class SubAgent extends SpanBase {
         message: opts.error.message,
       });
     }
-    this.span.end();
+    this.span.end(opts?.endTime);
   }
 }

--- a/sdks/node/src/genai/tool.ts
+++ b/sdks/node/src/genai/tool.ts
@@ -1,4 +1,9 @@
-import {type Span, SpanKind, SpanStatusCode} from '@opentelemetry/api';
+import {
+  type Span,
+  SpanKind,
+  SpanStatusCode,
+  type TimeInput,
+} from '@opentelemetry/api';
 
 import type {ChildSpanContext} from './common';
 import {getWeaveTracer} from './provider';
@@ -17,6 +22,9 @@ export interface ToolInit {
   name: string;
   args?: string;
   toolCallId?: string;
+  /** Backdate the span's start time. Used when reconstructing tool spans from
+   *  post-hoc data (e.g. transcript replay). */
+  startTime?: TimeInput;
 }
 
 /**
@@ -71,17 +79,21 @@ export class Tool extends SpanBase {
     }
     const span = tracer.startSpan(
       'execute_tool',
-      {kind: SpanKind.INTERNAL, attributes},
+      {
+        kind: SpanKind.INTERNAL,
+        attributes,
+        ...(opts.startTime !== undefined ? {startTime: opts.startTime} : {}),
+      },
       opts.parentContext
     );
     return new Tool(span, opts.name, opts.args ?? '', opts.toolCallId ?? '');
   }
 
   /**
-   * Flush `result` to the span and close it. Idempotent. Pass `error` to
-   * mark the span as failed.
+   * Flush `result` to the span and close it. Idempotent. Pass `error` to mark
+   * the span as failed; pass `endTime` to backdate the close.
    */
-  end(opts?: {error?: Error}): void {
+  end(opts?: {error?: Error; endTime?: TimeInput}): void {
     if (this._ended) {
       return;
     }
@@ -96,6 +108,6 @@ export class Tool extends SpanBase {
         message: opts.error.message,
       });
     }
-    this.span.end();
+    this.span.end(opts?.endTime);
   }
 }

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -4,6 +4,7 @@ import {
   type Span,
   SpanKind,
   SpanStatusCode,
+  type TimeInput,
   trace,
 } from '@opentelemetry/api';
 
@@ -24,6 +25,9 @@ import {Tool, type ToolInit} from './tool';
 export interface TurnInit {
   agentName?: string;
   model?: string;
+  /** Backdate the span's start time. Used when reconstructing agent spans from
+   *  post-hoc data (e.g. transcript replay). */
+  startTime?: TimeInput;
 }
 
 /**
@@ -84,7 +88,11 @@ export class Turn extends SpanBase {
     // library's active context.
     const span = tracer.startSpan(
       'invoke_agent',
-      {kind: SpanKind.CLIENT, attributes},
+      {
+        kind: SpanKind.CLIENT,
+        attributes,
+        ...(opts.startTime !== undefined ? {startTime: opts.startTime} : {}),
+      },
       ROOT_CONTEXT
     );
     const turn = new Turn(
@@ -125,8 +133,11 @@ export class Turn extends SpanBase {
     });
   }
 
-  /** Close the Turn span. Idempotent. Pass `error` to mark it as failed. */
-  end(opts?: {error?: Error}): void {
+  /**
+   * Close the Turn span. Idempotent. Pass `error` to mark it as failed; pass
+   * `endTime` to backdate the close.
+   */
+  end(opts?: {error?: Error; endTime?: TimeInput}): void {
     if (this._ended) {
       return;
     }
@@ -138,7 +149,7 @@ export class Turn extends SpanBase {
         message: opts.error.message,
       });
     }
-    this.span.end();
+    this.span.end(opts?.endTime);
     const state = _getGenaiState();
     if (state.turn === this) {
       state.turn = null;


### PR DESCRIPTION
## Summary

Stacked on #7154.

`Tool`, `LLM`, `SubAgent`, and `Turn` take an optional `startTime` at creation (forwarded to the OTel span start time) and `endTime` on `end()` (forwarded to `span.end()`). Both fall back to wall-clock now, so existing callers are unaffected.

Reconstructing spans from upstream transcripts (replay, queue worker, callback) needs to backdate the span to when the work actually happened, not when `end()` was called — previously no span type honored a caller-set time.

Mirrors the Python SDK fix (wandb/weave#7132).

## Test plan

- 12 parametrized tests in `postHocTimes.test.ts` over `(Tool, LLM, SubAgent, Turn)`: `startTime` round-trip, `endTime` round-trip, default now() fallback
- `npx jest --selectProjects default --coverage=false src/__tests__/genai` — pass
- `npx prettier --check "src/**/*.ts"` — clean
