### PR TITLE
fix(weave_ts): close agents-OTLP connections so processes can exit promptly

### DIFF
--- a/sdks/node/src/genai/provider.ts
+++ b/sdks/node/src/genai/provider.ts
@@ -157,5 +157,12 @@ function buildOtlpExporter(client: WeaveClient): OTLPTraceExporter {
   return new OTLPTraceExporter({
     url,
     headers: {Authorization: authHeader, project_id: client.projectId},
+    // No connection reuse: an idle keep-alive socket is a ref'd handle that
+    // holds the event loop open after the last export, so short-lived
+    // processes hang until the SERVER closes the connection (measured ~6s
+    // against a default node server) instead of exiting when their work is
+    // done. Cost is one TCP+TLS handshake per export batch (every ~5s under
+    // the default BatchSpanProcessor) — negligible for tracing traffic.
+    keepAlive: false,
   });
 }


### PR DESCRIPTION
## Description

The Weave OTLP exporter (agents endpoint, /agents/otel/v1/traces) used
node's default keep-alive HTTP agent. The idle keep-alive socket left after
the last export is a ref'd libuv handle: it keeps the event loop alive, so
short-lived processes (scripts, CLIs, examples) do not exit when their work
is done — they hang until the SERVER closes the idle connection (~6s
measured against a default node server; longer for servers with higher idle
timeouts). The same socket also delays the provider's beforeExit flush hook,
since beforeExit cannot fire while a ref'd handle exists.

Set keepAlive: false on the exporter: each export batch opens and closes
its own connection, so the loop drains as soon as the last export
completes. Cost is one TCP+TLS handshake per export batch — at the default
BatchSpanProcessor cadence (one batch per ~5s at most) this is negligible
for tracing traffic. Affects every agents-endpoint emitter (Google ADK,
Pi coding agent, openai-agents under WEAVE_USE_OTEL_V2).

Measured with a scripted ADK agent (3 invocations, 15 spans) against a
local stand-in server:
- agent run loop: ~16ms with tracing active vs ~10ms baseline — span
  building is in-memory and exports are async; even a 3s-per-request
  endpoint does not slow the run loop (17ms)
- exit-after-done before this fix: ~6.0s (fast endpoint), ~9.0s (slow:
  3s flush + 6s socket linger)
- exit-after-done after this fix: bounded by the final flush alone

## Testing

Genai jest suites pass; cjs/esm typechecks pass; before/after
timings above reproduced with the experiment script (see commit note).

