### PR TITLE
feat(weave_ts): exclude ADK-internal GoogleGenAI clients from genai wrapping

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,6 +235,9 @@ npm run test
 - `@google/adk`'s CJS dist `require()`s the ESM-only `lodash-es` (legal under
   Node >= 22 `require(esm)`, fatal under jest); the default jest project maps
   `^lodash-es$` → `lodash`.
+- Google ADK gotchas: ADK-internal `GoogleGenAI` clients are detected by the
+  `google-adk/` marker in their `x-goog-api-client` header and excluded from
+  the genai wrapper to avoid double-counted usage.
 
 ## Code Review & PR Guidelines
 

--- a/sdks/node/src/__tests__/integrations/googleAdk.test.ts
+++ b/sdks/node/src/__tests__/integrations/googleAdk.test.ts
@@ -28,6 +28,7 @@ import {
 import * as weave from '../..';
 import {clearWeaveTracerProvider} from '../../genai/provider';
 import {WeaveAdkPlugin} from '../../integrations/googleAdk';
+import {commonPatchGoogleGenAI} from '../../integrations/googleGenAI';
 import {Settings} from '../../settings';
 import {initWithCustomTraceServer} from '../clientMock';
 import {InMemoryTraceServer} from '../helpers/inMemoryTraceServer';
@@ -683,6 +684,47 @@ describe('Google ADK integration', () => {
       expect(resultAttr).toContain('"count":"42"'); // bigint stringified
       expect(resultAttr).toContain('"label":"ok"');
       expect(resultAttr).toContain('[Circular]'); // cycle replaced
+    });
+  });
+
+  describe('google genai client exclusion', () => {
+    function fakeGenAIExports() {
+      class FakeModels {
+        async generateContent(..._args: any[]) {
+          return {text: 'ok'};
+        }
+        async generateContentStream(..._args: any[]) {
+          return (async function* () {})();
+        }
+      }
+      class FakeGoogleGenAI {
+        models: any;
+        constructor(public readonly options: any) {
+          this.models = new FakeModels();
+        }
+      }
+      return {GoogleGenAI: FakeGoogleGenAI};
+    }
+
+    test('ADK-internal clients (x-goog-api-client: google-adk/…) are not wrapped', () => {
+      const exports = commonPatchGoogleGenAI(fakeGenAIExports());
+      const adkClient = new exports.GoogleGenAI({
+        apiKey: 'k',
+        httpOptions: {
+          headers: {
+            'x-goog-api-client': 'google-adk/1.2.0 gl-typescript/v24.0.0',
+            'user-agent': 'google-adk/1.2.0 gl-typescript/v24.0.0',
+          },
+        },
+      });
+      // Unwrapped: plain models object, no weave op replacement.
+      expect(adkClient.models.generateContent.name).toBe('generateContent');
+
+      const userClient = new exports.GoogleGenAI({apiKey: 'k'});
+      // Wrapped: generateContent is replaced by a weave op.
+      expect(userClient.models.generateContent.name).not.toBe(
+        'generateContent'
+      );
     });
   });
 });

--- a/sdks/node/src/integrations/googleGenAI.ts
+++ b/sdks/node/src/integrations/googleGenAI.ts
@@ -11,6 +11,14 @@ const GOOGLE_GENAI_INTEGRATION = libraryIntegration('google_genai', {
 const weaveGeminiModelHint = Symbol.for('_weave_gemini_model_hint');
 const weaveGeminiModelsWrapped = Symbol.for('_weave_gemini_models_wrapped');
 
+// Marker found in the `x-goog-api-client` header of GoogleGenAI clients that
+// the Google ADK (`@google/adk`) constructs internally (its `trackingHeaders`).
+// Those clients are excluded from wrapping: the ADK integration (WeaveAdkPlugin)
+// already records each model call as a `chat` agent span with usage, so
+// wrapping here would double-count tokens and emit orphan root traces.
+const ADK_INTERNAL_CLIENT_HEADER = 'x-goog-api-client';
+const ADK_INTERNAL_CLIENT_MARKER = 'google-adk/';
+
 type GeminiUsageMetadata = {
   promptTokenCount?: number;
   candidatesTokenCount?: number;
@@ -245,12 +253,33 @@ export function wrapGoogleGenAI<T extends GoogleGenAIAPI>(googleGenAI: T): T {
   return googleGenAI;
 }
 
+/** True for clients constructed by `@google/adk` internally (see marker above). */
+function isAdkInternalClientOptions(options: any): boolean {
+  const headers = options?.httpOptions?.headers;
+  if (headers == null || typeof headers !== 'object') {
+    return false;
+  }
+  for (const [key, value] of Object.entries(headers)) {
+    if (
+      key.toLowerCase() === ADK_INTERNAL_CLIENT_HEADER &&
+      typeof value === 'string' &&
+      value.includes(ADK_INTERNAL_CLIENT_MARKER)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function commonProxy(exports: any) {
   const OriginalGoogleGenAIClass = exports.GoogleGenAI;
 
   return new Proxy(OriginalGoogleGenAIClass, {
     construct(target, args, newTarget) {
       const instance = Reflect.construct(target, args, newTarget);
+      if (isAdkInternalClientOptions(args[0])) {
+        return instance;
+      }
       return wrapGoogleGenAI(instance);
     },
   });


### PR DESCRIPTION
## Description

The Google ADK constructs @google/genai GoogleGenAI clients internally for
its Gemini calls. With the genai integration active, those clients would be
wrapped too, producing a second record of every ADK model call: orphan
root-level google.genai.models.generateContent traces (Weave's call stack is
empty inside ADK's async flow, so they cannot parent correctly) and
double-counted token usage on top of the chat agent spans emitted by
WeaveAdkPlugin.

ADK marks its internal clients via BaseLlm.trackingHeaders: the
x-goog-api-client header always contains 'google-adk/<version>'. The
GoogleGenAI constructor proxy now skips wrapping when that marker is present
in the construction options, leaving the ADK plugin as the single source of
truth for ADK model calls. User-constructed GoogleGenAI clients in the same
process carry no such marker and keep being wrapped as before.

## Testing

Integration test pins both sides of the marker check (an ADK-marked
construction stays unwrapped; a plain construction is wrapped); existing
googleGenAI/genai suites pass unchanged; cjs/esm typechecks pass.

