### PR TITLE
feat(weave_ts): synthesize per-agent spans for the ADK agent hierarchy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,9 +235,12 @@ npm run test
 - `@google/adk`'s CJS dist `require()`s the ESM-only `lodash-es` (legal under
   Node >= 22 `require(esm)`, fatal under jest); the default jest project maps
   `^lodash-es$` → `lodash`.
-- Google ADK gotchas: ADK-internal `GoogleGenAI` clients are detected by the
-  `google-adk/` marker in their `x-goog-api-client` header and excluded from
-  the genai wrapper to avoid double-counted usage.
+- Google ADK gotchas: ADK 1.2.0 never dispatches plugin agent callbacks
+  (`runBefore/AfterAgentCallback` have no call sites), so `WeaveAdkPlugin`
+  synthesizes `invoke_agent` spans from `agentName` + the agent tree.
+  ADK-internal `GoogleGenAI` clients are detected by the `google-adk/` marker
+  in their `x-goog-api-client` header and excluded from the genai wrapper to
+  avoid double-counted usage.
 
 ## Code Review & PR Guidelines
 

--- a/sdks/node/src/__tests__/integrations/googleAdk.test.ts
+++ b/sdks/node/src/__tests__/integrations/googleAdk.test.ts
@@ -3,10 +3,10 @@
  *
  * The main tests run the real ADK runner (InMemoryRunner + a scripted
  * BaseLlm, no network) so they exercise ADK's actual plugin dispatch — this
- * matters because the integration depends on which callbacks ADK invokes.
- * Edge cases that are hard to reach through the runner (streaming partials,
- * synthetic tool keys, dangling-span cleanup) drive the plugin callbacks
- * directly.
+ * matters because the integration depends on which callbacks ADK invokes
+ * (e.g. ADK 1.2.0 never dispatches plugin agent callbacks). Edge cases that
+ * are hard to reach through the runner (streaming partials, synthetic tool
+ * keys, dangling-span cleanup) drive the plugin callbacks directly.
  *
  * Spans are captured with an `InMemorySpanExporter` injected through
  * `settings.genai.spanProcessor`, exactly how a user-supplied processor
@@ -38,6 +38,7 @@ import {
   FunctionTool,
   InMemoryRunner,
   LlmAgent,
+  SequentialAgent,
   type LlmRequest,
   type LlmResponse,
 } from '@google/adk';
@@ -235,33 +236,37 @@ describe('Google ADK integration', () => {
       const chatSpans = byOperation(spans, 'chat');
       const toolSpans = byOperation(spans, 'execute_tool');
 
-      expect(invokeAgentSpans).toHaveLength(1);
+      // Root invocation + the synthesized per-agent span.
+      expect(invokeAgentSpans).toHaveLength(2);
       expect(chatSpans).toHaveLength(2);
       expect(toolSpans).toHaveLength(1);
 
-      const [root] = invokeAgentSpans;
+      const root = invokeAgentSpans.find(span => !span.parentSpanId);
+      const agentSpan = invokeAgentSpans.find(span => span.parentSpanId);
       const [toolSpan] = toolSpans;
-      expect(root.parentSpanId).toBeUndefined();
+      expect(root).toBeDefined();
+      expect(agentSpan).toBeDefined();
 
       // Every span shares the root's OTel trace and the session id.
       for (const span of spans) {
-        expect(span.spanContext().traceId).toBe(root.spanContext().traceId);
+        expect(span.spanContext().traceId).toBe(root!.spanContext().traceId);
         expect(span.attributes['gen_ai.conversation.id']).toBe(session.id);
         expect(span.attributes['gen_ai.provider.name']).toBe('gemini');
       }
 
-      // Structure: root invoke_agent → (chat, chat, tool).
-      expect(root.name).toBe('invoke_agent weather_agent');
-      expect(root.attributes['gen_ai.agent.name']).toBe('weather_agent');
+      // Structure: root invoke_agent → invoke_agent → (chat, chat, tool).
+      expect(root!.name).toBe('invoke_agent weather_agent');
+      expect(agentSpan!.parentSpanId).toBe(spanId(root!));
+      expect(agentSpan!.attributes['gen_ai.agent.name']).toBe('weather_agent');
       for (const span of [...chatSpans, ...toolSpans]) {
-        expect(span.parentSpanId).toBe(spanId(root));
+        expect(span.parentSpanId).toBe(spanId(agentSpan!));
       }
 
       // Root carries the user message in and the final answer out.
-      expect(root.attributes['gen_ai.input.messages']).toContain(
+      expect(root!.attributes['gen_ai.input.messages']).toContain(
         'What is the weather in Paris?'
       );
-      expect(root.attributes['gen_ai.output.messages']).toContain(
+      expect(root!.attributes['gen_ai.output.messages']).toContain(
         'It is sunny in Paris.'
       );
 
@@ -295,6 +300,68 @@ describe('Google ADK integration', () => {
         'Paris'
       );
       expect(toolSpan.attributes['gen_ai.tool.call.result']).toContain('sunny');
+    });
+
+    test('nests sub-agents under workflow agents', async () => {
+      const first = new LlmAgent({
+        name: 'first_agent',
+        description: 'first',
+        model: new ScriptedLlm(TEST_MODEL, [[textResponse('first done')]]),
+      });
+      const second = new LlmAgent({
+        name: 'second_agent',
+        description: 'second',
+        model: new ScriptedLlm(TEST_MODEL, [[textResponse('second done')]]),
+      });
+      const pipeline = new SequentialAgent({
+        name: 'pipeline',
+        description: 'runs both agents',
+        subAgents: [first, second],
+      });
+
+      const runner = new InMemoryRunner({
+        agent: pipeline,
+        appName: 'weave-adk-test',
+        plugins: [new WeaveAdkPlugin()],
+      });
+      const session = await runner.sessionService.createSession({
+        appName: 'weave-adk-test',
+        userId: 'user-1',
+      });
+
+      await runToCompletion(runner, {
+        userId: 'user-1',
+        sessionId: session.id,
+        newMessage: userMessage('go'),
+      });
+
+      const spans = exporter.getFinishedSpans();
+      const invokeAgentSpans = byOperation(spans, 'invoke_agent');
+      const chatSpans = byOperation(spans, 'chat');
+
+      const root = invokeAgentSpans.find(span => !span.parentSpanId);
+      const byAgent = (name: string) =>
+        invokeAgentSpans.find(
+          span =>
+            span.parentSpanId && span.attributes['gen_ai.agent.name'] === name
+        );
+      const pipelineSpan = byAgent('pipeline');
+      const firstSpan = byAgent('first_agent');
+      const secondSpan = byAgent('second_agent');
+      expect(root).toBeDefined();
+      expect(pipelineSpan).toBeDefined();
+      expect(firstSpan).toBeDefined();
+      expect(secondSpan).toBeDefined();
+
+      expect(pipelineSpan!.parentSpanId).toBe(spanId(root!));
+      expect(firstSpan!.parentSpanId).toBe(spanId(pipelineSpan!));
+      expect(secondSpan!.parentSpanId).toBe(spanId(pipelineSpan!));
+
+      expect(chatSpans).toHaveLength(2);
+      const chatParents = chatSpans.map(span => span.parentSpanId).sort();
+      expect(chatParents).toEqual(
+        [spanId(firstSpan!), spanId(secondSpan!)].sort()
+      );
     });
 
     test('records model errors as span errors and still closes the run', async () => {
@@ -503,6 +570,45 @@ describe('Google ADK integration', () => {
       expect(
         toolSpans[0].attributes['gen_ai.tool.call.result']
       ).toBeUndefined();
+    });
+
+    test('agents outside the agent tree nest under the innermost open tool span', async () => {
+      const plugin = new WeaveAdkPlugin();
+      const tool = {name: 'agent_tool', description: 'wraps an agent'};
+      const toolContext = {
+        invocationId: INVOCATION_ID,
+        agentName: 'agent_a',
+        functionCallId: 'fc-2',
+      } as any;
+
+      await plugin.beforeRunCallback({
+        invocationContext: invocationContext(),
+      });
+      await plugin.beforeToolCallback({tool, toolArgs: {}, toolContext});
+      // An AgentTool-wrapped agent is not in the root agent's tree.
+      await plugin.beforeModelCallback({
+        callbackContext: callbackContext('outside_agent'),
+        llmRequest: {model: TEST_MODEL, contents: []},
+      });
+      await plugin.afterModelCallback({
+        callbackContext: callbackContext('outside_agent'),
+        llmResponse: {content: {role: 'model', parts: [{text: 'ok'}]}},
+      });
+      await plugin.afterToolCallback({
+        tool,
+        toolArgs: {},
+        toolContext,
+        result: {ok: true},
+      });
+      await plugin.afterRunCallback({invocationContext: invocationContext()});
+
+      const spans = exporter.getFinishedSpans();
+      const toolSpan = byOperation(spans, 'execute_tool')[0];
+      const outsideAgent = byOperation(spans, 'invoke_agent').find(
+        span => span.attributes['gen_ai.agent.name'] === 'outside_agent'
+      );
+      expect(outsideAgent).toBeDefined();
+      expect(outsideAgent!.parentSpanId).toBe(spanId(toolSpan));
     });
 
     test('afterRun ends dangling spans and marks them interrupted', async () => {

--- a/sdks/node/src/integrations/googleAdk.ts
+++ b/sdks/node/src/integrations/googleAdk.ts
@@ -14,6 +14,12 @@
  * callbacks also hand us live `LlmRequest` / `LlmResponse` / tool objects
  * instead of JSON-serialized span attributes.
  *
+ * Agent nesting: `@google/adk` 1.2.0 never dispatches plugin
+ * `beforeAgentCallback` / `afterAgentCallback`, so per-agent spans are
+ * synthesized lazily from `agentName` on model/tool callbacks, parented via
+ * the agent tree captured at run start. The agent callbacks are still
+ * implemented so nesting tightens once ADK wires them up.
+ *
  * Usage:
  * ```typescript
  * import {init, WeaveAdkPlugin} from 'weave';
@@ -127,6 +133,8 @@ const ATTR_ADK_INTERRUPTED = `${WEAVE_ATTR_PREFIX}.interrupted`;
 const ATTR_ADK_INVOCATION_ID = `${WEAVE_ATTR_PREFIX}.invocation_id`;
 const ATTR_ADK_APP_NAME = `${WEAVE_ATTR_PREFIX}.app_name`;
 const ATTR_ADK_USER_ID = `${WEAVE_ATTR_PREFIX}.user_id`;
+// Defensive bound when walking `parentAgent` chains.
+const MAX_AGENT_ANCESTRY_DEPTH = 100;
 
 // ADK's own opt-out env var for message-content capture: regulated users set
 // it to keep message bodies, system instructions and tool payloads off spans.
@@ -151,11 +159,19 @@ let beforeExitHookRegistered = false;
 interface InvocationState {
   invocationId: string;
   rootSpan: OtelSpan;
+  rootAgent: AdkBaseAgent | null;
   conversationId: string | undefined;
+  /** agentName → synthesized invoke_agent span. */
+  agentSpans: Map<string, OtelSpan>;
+  /** Creation order of agentSpans keys; ended in reverse (children first). */
+  agentSpanOrder: string[];
   /** agentName → in-flight chat span. */
   modelSpans: Map<string, OtelSpan>;
   /** functionCallId (or synthetic key) → in-flight execute_tool span. */
   toolSpans: Map<string, OtelSpan>;
+  /** Open tool keys, innermost last — fallback parent for out-of-tree
+   *  agents (e.g. agents wrapped as AgentTool). */
+  openToolKeys: string[];
   /** Per-(agent, tool) FIFO of synthetic keys when functionCallId is absent. */
   syntheticToolKeys: Map<string, string[]>;
   /** Content of the last non-partial event — the root span's output. */
@@ -492,6 +508,43 @@ function setLlmResponseAttributes(
 }
 
 // ---------------------------------------------------------------------------
+// Agent tree helpers
+// ---------------------------------------------------------------------------
+
+/** Finds `name` in the agent tree under `root` without trusting ADK methods. */
+function findAgentInTree(
+  root: AdkBaseAgent,
+  name: string
+): AdkBaseAgent | undefined {
+  if (typeof root.findAgent === 'function') {
+    try {
+      const found = root.findAgent(name);
+      if (found) {
+        return found;
+      }
+    } catch {
+      // fall through to the manual walk
+    }
+  }
+  const queue: AdkBaseAgent[] = [root];
+  const visited = new Set<AdkBaseAgent>();
+  while (queue.length > 0) {
+    const agent = queue.shift()!;
+    if (visited.has(agent)) {
+      continue;
+    }
+    visited.add(agent);
+    if (agent.name === name) {
+      return agent;
+    }
+    if (Array.isArray(agent.subAgents)) {
+      queue.push(...agent.subAgents);
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
 // Plugin
 // ---------------------------------------------------------------------------
 
@@ -592,9 +645,13 @@ export class WeaveAdkPlugin {
       this.invocations.set(invocationId, {
         invocationId,
         rootSpan,
+        rootAgent,
         conversationId,
+        agentSpans: new Map(),
+        agentSpanOrder: [],
         modelSpans: new Map(),
         toolSpans: new Map(),
+        openToolKeys: [],
         syntheticToolKeys: new Map(),
         finalContent: null,
         rootErrorType: undefined,
@@ -654,21 +711,45 @@ export class WeaveAdkPlugin {
   }
 
   // -------------------------------------------------------------------------
-  // Agent lifecycle (not dispatched by @google/adk 1.2.0 — no PluginManager
-  // call sites; no-ops so the full BasePlugin surface is present)
+  // Agent lifecycle (not dispatched by @google/adk 1.2.0; implemented so
+  // agent timing becomes exact once ADK wires them up)
   // -------------------------------------------------------------------------
 
-  async beforeAgentCallback(_params: {
+  async beforeAgentCallback(params: {
     agent: AdkBaseAgent;
     callbackContext: AdkCallbackContext;
   }): Promise<undefined> {
+    this.guard(() => {
+      const state = this.invocations.get(params.callbackContext?.invocationId);
+      if (!state || !params.agent?.name) {
+        return;
+      }
+      this.ensureAgentSpan(state, params.agent.name);
+    });
     return undefined;
   }
 
-  async afterAgentCallback(_params: {
+  async afterAgentCallback(params: {
     agent: AdkBaseAgent;
     callbackContext: AdkCallbackContext;
   }): Promise<undefined> {
+    this.guard(() => {
+      const state = this.invocations.get(params.callbackContext?.invocationId);
+      const agentName = params.agent?.name;
+      if (!state || !agentName) {
+        return;
+      }
+      const span = state.agentSpans.get(agentName);
+      if (!span) {
+        return;
+      }
+      span.end();
+      // Remove so a LoopAgent re-run of the same agent opens a fresh span.
+      state.agentSpans.delete(agentName);
+      state.agentSpanOrder = state.agentSpanOrder.filter(
+        name => name !== agentName
+      );
+    });
     return undefined;
   }
 
@@ -691,6 +772,7 @@ export class WeaveAdkPlugin {
       if (state.modelSpans.has(ctx.agentName)) {
         return;
       }
+      const agentSpan = this.ensureAgentSpan(state, ctx.agentName);
       const model = params.llmRequest?.model ?? UNKNOWN_MODEL;
       const attributes: Attributes = {
         [ATTR_GEN_AI_OPERATION_NAME]: OPERATION_CHAT,
@@ -704,7 +786,7 @@ export class WeaveAdkPlugin {
       const span = this.tracer().startSpan(
         `${OPERATION_CHAT} ${model}`,
         {attributes},
-        this.childContext(state.rootSpan)
+        this.childContext(agentSpan)
       );
       setLlmRequestAttributes(span, params.llmRequest ?? {});
       state.modelSpans.set(ctx.agentName, span);
@@ -792,6 +874,7 @@ export class WeaveAdkPlugin {
       if (!state || !ctx?.agentName || !params.tool?.name) {
         return;
       }
+      const agentSpan = this.ensureAgentSpan(state, ctx.agentName);
       let key = ctx.functionCallId;
       if (!key || state.toolSpans.has(key)) {
         // Missing/duplicate functionCallId: mint a synthetic key, recovered
@@ -822,9 +905,10 @@ export class WeaveAdkPlugin {
       const span = this.tracer().startSpan(
         `${OPERATION_EXECUTE_TOOL} ${params.tool.name}`,
         {attributes},
-        this.childContext(state.rootSpan)
+        this.childContext(agentSpan)
       );
       state.toolSpans.set(key, span);
+      state.openToolKeys.push(key);
     });
     return undefined;
   }
@@ -885,6 +969,80 @@ export class WeaveAdkPlugin {
     }
   }
 
+  /**
+   * Returns the invoke_agent span for `agentName`, creating it and any
+   * missing ancestors on first activity.
+   */
+  private ensureAgentSpan(
+    state: InvocationState,
+    agentName: string,
+    depth: number = 0
+  ): OtelSpan {
+    const existing = state.agentSpans.get(agentName);
+    if (existing) {
+      return existing;
+    }
+
+    let parentSpan: OtelSpan;
+    let agent: AdkBaseAgent | undefined;
+    if (state.rootAgent) {
+      agent = findAgentInTree(state.rootAgent, agentName);
+    }
+    if (!agent || depth >= MAX_AGENT_ANCESTRY_DEPTH) {
+      // Out-of-tree agent (e.g. AgentTool): nest under the innermost open
+      // tool span, else the root.
+      parentSpan = this.innermostOpenToolSpan(state) ?? state.rootSpan;
+    } else if (
+      agent === state.rootAgent ||
+      !agent.parentAgent ||
+      agent.parentAgent.name === agentName
+    ) {
+      parentSpan = state.rootSpan;
+    } else {
+      parentSpan = this.ensureAgentSpan(
+        state,
+        agent.parentAgent.name,
+        depth + 1
+      );
+    }
+
+    const attributes: Attributes = {
+      [ATTR_GEN_AI_OPERATION_NAME]: OPERATION_INVOKE_AGENT,
+      [ATTR_GEN_AI_PROVIDER_NAME]: providerName(),
+      [ATTR_GEN_AI_AGENT_NAME]: agentName,
+      [ATTR_GEN_AI_AGENT_ID]: state.invocationId,
+    };
+    if (agent?.description) {
+      attributes[ATTR_GEN_AI_AGENT_DESCRIPTION] = agent.description;
+    }
+    // `agent.model` is a model name string or a BaseLlm instance; only the
+    // string form is the OTel request.model (Python-integration parity).
+    if (typeof agent?.model === 'string' && agent.model) {
+      attributes[ATTR_GEN_AI_REQUEST_MODEL] = agent.model;
+    }
+    if (state.conversationId) {
+      attributes[ATTR_GEN_AI_CONVERSATION_ID] = state.conversationId;
+    }
+    const span = this.tracer().startSpan(
+      `${OPERATION_INVOKE_AGENT} ${agentName}`,
+      {attributes},
+      this.childContext(parentSpan)
+    );
+    state.agentSpans.set(agentName, span);
+    state.agentSpanOrder.push(agentName);
+    return span;
+  }
+
+  private innermostOpenToolSpan(state: InvocationState): OtelSpan | null {
+    for (let i = state.openToolKeys.length - 1; i >= 0; i--) {
+      const span = state.toolSpans.get(state.openToolKeys[i]);
+      if (span) {
+        return span;
+      }
+    }
+    return null;
+  }
+
   private endToolSpan(
     params: {
       tool: AdkBaseTool;
@@ -920,6 +1078,7 @@ export class WeaveAdkPlugin {
     }
     span.end();
     state.toolSpans.delete(key);
+    state.openToolKeys = state.openToolKeys.filter(k => k !== key);
   }
 
   private recordEventError(state: InvocationState, event: AdkEvent): void {
@@ -995,8 +1154,9 @@ export class WeaveAdkPlugin {
   }
 
   /**
-   * Ends every span of an invocation: model/tool leaves first, then the
-   * root. Leaves that never completed are marked interrupted.
+   * Ends every span of an invocation: model/tool leaves first, then agents
+   * in reverse creation order, then the root. Leaves that never completed
+   * are marked interrupted.
    */
   private finishInvocation(
     state: InvocationState,
@@ -1013,6 +1173,16 @@ export class WeaveAdkPlugin {
       span.end();
     }
     state.toolSpans.clear();
+    state.openToolKeys = [];
+
+    for (let i = state.agentSpanOrder.length - 1; i >= 0; i--) {
+      const span = state.agentSpans.get(state.agentSpanOrder[i]);
+      if (span) {
+        span.end();
+      }
+    }
+    state.agentSpans.clear();
+    state.agentSpanOrder = [];
 
     if (options.interrupted) {
       state.rootSpan.setAttribute(ATTR_ADK_INTERRUPTED, true);

--- a/sdks/node/src/integrations/googleAdk.types.ts
+++ b/sdks/node/src/integrations/googleAdk.types.ts
@@ -47,10 +47,15 @@ export interface AdkContent {
   parts?: AdkPart[];
 }
 
-/** `BaseAgent` — the fields the integration records. */
+/** `BaseAgent` — the fields needed to resolve the agent tree. `model` is
+ *  `string | BaseLlm` on `LlmAgent`; only the string form is recorded. */
 export interface AdkBaseAgent {
   name: string;
   description?: string;
+  model?: unknown;
+  parentAgent?: AdkBaseAgent;
+  subAgents?: AdkBaseAgent[];
+  findAgent?: (name: string) => AdkBaseAgent | undefined;
 }
 
 export interface AdkSession {


### PR DESCRIPTION
## Description

Deepens ADK traces from a flat root -> (chat, tool) structure to the real
agent hierarchy: every chat/tool span now nests under a synthesized
`invoke_agent {agent}` span for the agent that performed it, and sub-agents
nest under their parents (root -> invoke_agent(pipeline) ->
invoke_agent(child) -> chat).

@google/adk 1.2.0 never dispatches plugin beforeAgentCallback /
afterAgentCallback (the PluginManager methods exist but have no call sites),
so agent spans cannot be opened/closed at the natural boundaries. Instead
they are synthesized lazily: the first chat/tool activity from an agent
creates its invoke_agent span (and any missing ancestors) by walking the
agent tree captured at run start. Agents that are not in the tree (e.g.
agents wrapped as AgentTool) nest under the innermost open tool span when
there is one, else the root. Synthesized agent spans are ended at afterRun
in reverse creation order (children first). Agent spans carry
gen_ai.agent.name/description, the invocation id, the conversation id, and
the agent's configured model when it is a plain string
(Python-integration parity). The plugin agent callbacks are now implemented
as well, so open/close timing tightens automatically once ADK wires them
up; afterAgentCallback also removes the agent entry so a LoopAgent re-run
opens a fresh span.

## Testing

The single-agent runner test now pins the deeper structure
(root invoke_agent -> invoke_agent -> {chat, execute_tool}); new runner
test covers SequentialAgent sub-agent nesting via the agent tree; new
direct-drive test covers out-of-tree agents nesting under the innermost
open tool span. cjs/esm typechecks and prettier pass.

