### PR TITLE
feat(weave_ts): auto-instrument Google ADK runners via module hooks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,7 +222,11 @@ npm run test
 
 ### TypeScript SDK integration patterns (sdks/node)
 
-- Integrations live in `sdks/node/src/integrations/`.
+- Integrations live in `sdks/node/src/integrations/`. Auto-instrumentation is
+  registered in `integrations/hooks.ts` via `addCJSInstrumentation` (keyed on
+  `<package>@<resolved subpath>`, e.g. `@google/adk@dist/cjs/index.js`) and
+  `addESMInstrumentation` (keyed on the bare module name, applied by the
+  `--import=weave/instrument` loader).
 - Agent-framework integrations either write calls directly with
   `client.saveCallStart` / `saveCallEnd` (the openai-agents default,
   `openai-agents/weave-tracing-processor.ts`) or emit GenAI-semconv OTel
@@ -232,15 +236,19 @@ npm run test
 - Framework types are duck-typed locally (e.g. `googleAdk.types.ts`) so the
   SDK has no runtime dependency on the framework package. Keep these types
   free of index signatures or the real framework types stop being assignable.
+- Jest replaces Node's module system, so the CJS require hook never fires
+  inside jest tests — call the patch hook (e.g. `commonPatchGoogleADK`)
+  directly, and use the `hostApps` jest project for real loader testing.
 - `@google/adk`'s CJS dist `require()`s the ESM-only `lodash-es` (legal under
   Node >= 22 `require(esm)`, fatal under jest); the default jest project maps
   `^lodash-es$` → `lodash`.
 - Google ADK gotchas: ADK 1.2.0 never dispatches plugin agent callbacks
   (`runBefore/AfterAgentCallback` have no call sites), so `WeaveAdkPlugin`
   synthesizes `invoke_agent` spans from `agentName` + the agent tree.
-  ADK-internal `GoogleGenAI` clients are detected by the `google-adk/` marker
-  in their `x-goog-api-client` header and excluded from the genai wrapper to
-  avoid double-counted usage.
+  ADK-internal
+  `GoogleGenAI` clients are detected by the `google-adk/` marker in their
+  `x-goog-api-client` header and excluded from the genai wrapper to avoid
+  double-counted usage.
 
 ## Code Review & PR Guidelines
 

--- a/sdks/node/examples/googleAdkAgent.ts
+++ b/sdks/node/examples/googleAdkAgent.ts
@@ -1,0 +1,103 @@
+/**
+ * Example: Google ADK (Agent Development Kit) Integration with Weave
+ *
+ * Demonstrates a tool-using Gemini agent built with @google/adk, traced by
+ * Weave. The integration is automatic: importing weave installs module hooks
+ * that register a Weave plugin on every ADK Runner. For environments where
+ * the hooks cannot run (e.g. some bundlers), pass the plugin explicitly:
+ *
+ * ```typescript
+ * import {WeaveAdkPlugin} from 'weave';
+ * new InMemoryRunner({agent, appName, plugins: [new WeaveAdkPlugin()]});
+ * ```
+ *
+ * Requires GEMINI_API_KEY or GOOGLE_GENAI_API_KEY (or Vertex AI env config)
+ * for the Gemini call.
+ *
+ * Run from sdks/node: npx tsx examples/googleAdkAgent.ts
+ *
+ * Traces are emitted as GenAI-semconv OTel spans to Weave's agents endpoint
+ * and appear in the project's Agents view. Expected shape (one trace per
+ * runAsync):
+ *   invoke_agent weather_agent             <- user message in, final answer out
+ *     invoke_agent weather_agent           <- per-agent span
+ *       chat gemini-2.5-flash              <- request/response messages + token usage
+ *       execute_tool get_weather x2
+ *       chat gemini-2.5-flash              <- final answer
+ */
+
+import * as weave from 'weave';
+import {FunctionTool, InMemoryRunner, LlmAgent} from '@google/adk';
+import {z} from 'zod';
+
+// Set your own entity/project name here
+const WANDB_PROJECT = process.env.WANDB_PROJECT || 'examples';
+
+const APP_NAME = 'weave-adk-example';
+const USER_ID = 'example-user';
+const MODEL = 'gemini-2.5-flash';
+
+// --- Tools ---
+
+const getWeatherTool = new FunctionTool({
+  name: 'get_weather',
+  description: 'Get the current weather for a given city.',
+  parameters: z.object({
+    city: z.string().describe('The name of the city'),
+  }),
+  execute: async ({city}) => {
+    // Simulated weather data
+    const weather: Record<string, {temp: number; condition: string}> = {
+      'San Francisco': {temp: 18, condition: 'Foggy'},
+      'New York': {temp: 22, condition: 'Sunny'},
+      London: {temp: 12, condition: 'Cloudy'},
+      Tokyo: {temp: 28, condition: 'Humid'},
+    };
+    const data = weather[city] ?? {temp: 20, condition: 'Clear'};
+    return {city, condition: data.condition, temperature_c: data.temp};
+  },
+});
+
+// --- Agent ---
+
+async function main() {
+  await weave.init(WANDB_PROJECT);
+
+  const agent = new LlmAgent({
+    name: 'weather_agent',
+    description: 'Answers questions about the weather.',
+    instruction:
+      'You answer weather questions. Always use the get_weather tool.',
+    model: MODEL,
+    tools: [getWeatherTool],
+  });
+
+  const runner = new InMemoryRunner({agent, appName: APP_NAME});
+  const session = await runner.sessionService.createSession({
+    appName: APP_NAME,
+    userId: USER_ID,
+  });
+
+  for await (const event of runner.runAsync({
+    userId: USER_ID,
+    sessionId: session.id,
+    newMessage: {
+      role: 'user',
+      parts: [{text: "What's the weather in Tokyo and London?"}],
+    },
+  })) {
+    const text = event.content?.parts
+      ?.map(part => part.text)
+      .filter(Boolean)
+      .join('');
+    if (text) {
+      console.log(`[${event.author}] ${text}`);
+    }
+  }
+
+  // Deterministic span flush for short-lived scripts (a beforeExit hook
+  // also flushes on natural exit).
+  await weave.flushOTel();
+}
+
+main().catch(console.error);

--- a/sdks/node/examples/googleAdkSmoke.ts
+++ b/sdks/node/examples/googleAdkSmoke.ts
@@ -1,0 +1,178 @@
+/**
+ * Offline smoke test for the Google ADK integration — no API keys, no
+ * network. A scripted BaseLlm stands in for Gemini, and a throwaway local
+ * HTTP server stands in for the Weave trace server, recording which
+ * endpoints the SDK hits. Verifies auto-instrumentation (no plugin passed)
+ * and that spans are exported to the AGENTS OTel endpoint
+ * (/agents/otel/v1/traces) and nowhere else. Structural span assertions
+ * live in src/__tests__/integrations/googleAdk.test.ts. Exits 0 on
+ * success, 1 on failure.
+ *
+ * Run from sdks/node (build first so `weave` resolves to dist):
+ *   npm run build && npx tsx examples/googleAdkSmoke.ts
+ */
+
+import http from 'node:http';
+import type {AddressInfo} from 'node:net';
+
+import * as weave from 'weave';
+import {
+  BaseLlm,
+  FunctionTool,
+  InMemoryRunner,
+  LlmAgent,
+  type LlmRequest,
+  type LlmResponse,
+} from '@google/adk';
+import {z} from 'zod';
+
+const PROJECT = 'smoke-entity/smoke-project';
+const APP_NAME = 'weave-adk-smoke';
+const USER_ID = 'smoke-user';
+const MODEL = 'gemini-scripted';
+const AGENTS_OTLP_PATH = '/agents/otel/v1/traces';
+
+/** Replays a fixed script: one tool call, then a final answer. */
+class ScriptedLlm extends BaseLlm {
+  private callIndex = 0;
+
+  async *generateContentAsync(
+    _llmRequest: LlmRequest,
+    _stream?: boolean
+  ): AsyncGenerator<LlmResponse, void> {
+    const responses: LlmResponse[] = [
+      {
+        content: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'fc-1',
+                name: 'get_weather',
+                args: {city: 'Tokyo'},
+              },
+            },
+          ],
+        },
+        usageMetadata: {
+          promptTokenCount: 10,
+          candidatesTokenCount: 5,
+          totalTokenCount: 15,
+        },
+      } as LlmResponse,
+      {
+        content: {role: 'model', parts: [{text: 'It is humid in Tokyo.'}]},
+        turnComplete: true,
+        usageMetadata: {
+          promptTokenCount: 20,
+          candidatesTokenCount: 8,
+          totalTokenCount: 28,
+        },
+      } as LlmResponse,
+    ];
+    yield responses[Math.min(this.callIndex++, responses.length - 1)];
+  }
+
+  async connect(): Promise<never> {
+    throw new Error('live connections are not supported in this smoke test');
+  }
+}
+
+let failures = 0;
+function check(condition: boolean, label: string) {
+  console.log(`${condition ? '  ✓' : '  ✗ FAIL:'} ${label}`);
+  if (!condition) {
+    failures++;
+  }
+}
+
+async function main() {
+  // Throwaway trace-server stand-in: record the paths POSTed to.
+  const posts: Array<{path: string; bytes: number}> = [];
+  const server = http.createServer((req, res) => {
+    let bytes = 0;
+    req.on('data', chunk => (bytes += chunk.length));
+    req.on('end', () => {
+      if (req.method === 'POST') {
+        posts.push({path: req.url ?? '', bytes});
+      }
+      res.writeHead(200, {'content-type': 'application/json'});
+      res.end('{}');
+    });
+  });
+  await new Promise<void>(resolve => server.listen(0, '127.0.0.1', resolve));
+  const port = (server.address() as AddressInfo).port;
+  process.env.WF_TRACE_SERVER_URL = `http://127.0.0.1:${port}`;
+  process.env.WANDB_API_KEY = 'smoke-test-dummy-key';
+
+  // `spanProcessor: 'simple'` keeps the real OTLP exporter (one POST per
+  // span, no batch delay) so the smoke exercises the actual wire path.
+  await weave.init(PROJECT, {genai: {spanProcessor: 'simple'}});
+
+  const agent = new LlmAgent({
+    name: 'weather_agent',
+    description: 'Answers weather questions.',
+    instruction: 'Use the get_weather tool, then answer.',
+    model: new ScriptedLlm({model: MODEL}),
+    tools: [
+      new FunctionTool({
+        name: 'get_weather',
+        description: 'Get the weather for a city.',
+        parameters: z.object({city: z.string()}),
+        execute: async ({city}: {city: string}) => ({city, weather: 'humid'}),
+      }),
+    ],
+  });
+
+  // No plugins passed — auto-instrumentation must register the Weave plugin.
+  const runner = new InMemoryRunner({agent, appName: APP_NAME});
+  const session = await runner.sessionService.createSession({
+    appName: APP_NAME,
+    userId: USER_ID,
+  });
+  for await (const _event of runner.runAsync({
+    userId: USER_ID,
+    sessionId: session.id,
+    newMessage: {role: 'user', parts: [{text: 'Weather in Tokyo?'}]},
+  })) {
+    // drain events
+  }
+
+  await weave.flushOTel();
+  server.close();
+
+  console.log('\nVerifying:');
+  check(
+    runner.pluginManager.getPlugin('weave') != null,
+    'runner auto-registered the Weave plugin (no plugins were passed)'
+  );
+
+  const agentPosts = posts.filter(post => post.path === AGENTS_OTLP_PATH);
+  const otherPosts = posts.filter(post => post.path !== AGENTS_OTLP_PATH);
+  check(
+    agentPosts.length > 0,
+    `spans were POSTed to the agents OTel endpoint (${AGENTS_OTLP_PATH})`
+  );
+  check(
+    agentPosts.every(post => post.bytes > 0),
+    'every agents-endpoint POST carried a payload'
+  );
+  check(
+    otherPosts.length === 0,
+    `nothing was sent anywhere else (saw: ${
+      otherPosts.map(post => post.path).join(', ') || 'none'
+    })`
+  );
+
+  console.log(
+    failures === 0
+      ? '\nPASS: Google ADK integration smoke test'
+      : `\nFAIL: ${failures} check(s) failed`
+  );
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/sdks/node/src/__tests__/integrations/googleAdk.test.ts
+++ b/sdks/node/src/__tests__/integrations/googleAdk.test.ts
@@ -27,7 +27,10 @@ import {
 
 import * as weave from '../..';
 import {clearWeaveTracerProvider} from '../../genai/provider';
-import {WeaveAdkPlugin} from '../../integrations/googleAdk';
+import {
+  commonPatchGoogleADK,
+  WeaveAdkPlugin,
+} from '../../integrations/googleAdk';
 import {commonPatchGoogleGenAI} from '../../integrations/googleGenAI';
 import {Settings} from '../../settings';
 import {initWithCustomTraceServer} from '../clientMock';
@@ -453,6 +456,38 @@ describe('Google ADK integration', () => {
       expect(chatSpan.attributes['gen_ai.output.messages']).toContain(
         'served from cache'
       );
+    });
+
+    test('auto-registers the plugin when the module hook has run', async () => {
+      // Jest's module registry bypasses Module.prototype.require, so the
+      // CJS loader hook never fires here; apply the hook function directly.
+      // The real loader path is covered by host-app/e2e runs.
+      commonPatchGoogleADK(require('@google/adk'));
+
+      const agent = new LlmAgent({
+        name: 'auto_agent',
+        description: 'auto instrumented',
+        model: new ScriptedLlm(TEST_MODEL, [[textResponse('hello')]]),
+      });
+      // No plugins passed — the patched Runner.prototype.runAsync
+      // self-registers the shared Weave plugin.
+      const runner = new InMemoryRunner({agent, appName: 'weave-adk-test'});
+      const session = await runner.sessionService.createSession({
+        appName: 'weave-adk-test',
+        userId: 'user-1',
+      });
+
+      await runToCompletion(runner, {
+        userId: 'user-1',
+        sessionId: session.id,
+        newMessage: userMessage('hi'),
+      });
+
+      expect(runner.pluginManager.getPlugin('weave')).toBeDefined();
+
+      const spans = exporter.getFinishedSpans();
+      expect(byOperation(spans, 'invoke_agent').length).toBeGreaterThan(0);
+      expect(byOperation(spans, 'chat')).toHaveLength(1);
     });
   });
 

--- a/sdks/node/src/integrations/googleAdk.ts
+++ b/sdks/node/src/integrations/googleAdk.ts
@@ -20,7 +20,16 @@
  * the agent tree captured at run start. The agent callbacks are still
  * implemented so nesting tightens once ADK wires them up.
  *
- * Usage:
+ * Automatic usage (module hooks patch `Runner` when `@google/adk` loads):
+ * ```typescript
+ * import * as weave from 'weave';
+ * import {InMemoryRunner} from '@google/adk';
+ *
+ * await weave.init('my-project');
+ * const runner = new InMemoryRunner(myAgent); // auto-traced
+ * ```
+ *
+ * Explicit usage (no module hooks, e.g. bundlers):
  * ```typescript
  * import {init, WeaveAdkPlugin} from 'weave';
  * import {InMemorySessionService, LlmAgent, Runner} from '@google/adk';
@@ -99,6 +108,7 @@ import {
   ATTR_GEN_AI_USAGE_REASONING_OUTPUT_TOKENS,
   ATTR_GEN_AI_USAGE_TOTAL_TOKENS,
 } from '../genai/semconv';
+import {globalSingleton} from '../utils/globalSingleton';
 import {warnOnce} from '../utils/warnOnce';
 import type {
   AdkBaseAgent,
@@ -112,8 +122,10 @@ import type {
   AdkLlmRequest,
   AdkLlmResponse,
   AdkPart,
+  AdkRunnerLike,
   AdkToolContext,
 } from './googleAdk.types';
+import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
 
 /** Name the plugin registers under in ADK's PluginManager (must be unique). */
 export const WEAVE_ADK_PLUGIN_NAME = 'weave';
@@ -150,6 +162,12 @@ const ADK_TO_GENAI_ROLE: Record<string, string> = {
   user: 'user',
   model: 'assistant',
 };
+
+// Tested version range. Every patched surface is typeof-guarded, so minor
+// bumps that keep the plugin API intact keep working.
+const ADK_VERSION_RANGE = '>= 1.0.0';
+// `@google/adk` is `"type": "module"`; its `require` condition resolves here.
+const ADK_CJS_SUBPATH = 'dist/cjs/index.js';
 
 const WARN_KEY_PLUGIN_ERROR = 'weave-adk-plugin-error';
 
@@ -1246,4 +1264,99 @@ function errorMessageOf(error: unknown): string {
     return error.message;
   }
   return String(error);
+}
+
+// ---------------------------------------------------------------------------
+// Automatic instrumentation
+// ---------------------------------------------------------------------------
+
+// Shared across CJS/ESM module copies so both loaders see one plugin
+// instance and one patch state.
+const adkInstrumentationHolder = globalSingleton<{
+  plugin: WeaveAdkPlugin | null;
+}>('_weave_adk_instrumentation', () => ({plugin: null}));
+
+const weaveAdkRunnerPatched = Symbol.for('_weave_adk_runner_patched');
+
+function getSharedPlugin(): WeaveAdkPlugin {
+  if (!adkInstrumentationHolder.plugin) {
+    adkInstrumentationHolder.plugin = new WeaveAdkPlugin();
+  }
+  return adkInstrumentationHolder.plugin;
+}
+
+/** Registers the shared plugin on a runner's PluginManager, idempotently. */
+function ensurePluginRegistered(runner: AdkRunnerLike): void {
+  try {
+    const pluginManager = runner?.pluginManager;
+    if (
+      !pluginManager ||
+      typeof pluginManager.getPlugin !== 'function' ||
+      typeof pluginManager.registerPlugin !== 'function'
+    ) {
+      return;
+    }
+    if (pluginManager.getPlugin(WEAVE_ADK_PLUGIN_NAME)) {
+      return;
+    }
+    pluginManager.registerPlugin(getSharedPlugin());
+  } catch {
+    // Never let instrumentation break a user run.
+  }
+}
+
+/**
+ * Patches `Runner.prototype.runAsync` / `runEphemeral` so every runner
+ * (including subclasses) self-registers the Weave plugin on first use,
+ * before ADK reads the plugin list.
+ */
+function patchRunnerClass(RunnerClass: any): void {
+  const proto = RunnerClass?.prototype;
+  if (!proto || proto[weaveAdkRunnerPatched]) {
+    return;
+  }
+  for (const method of ['runAsync', 'runEphemeral']) {
+    const original = proto[method];
+    if (typeof original !== 'function') {
+      continue;
+    }
+    proto[method] = function (this: AdkRunnerLike, ...args: unknown[]) {
+      ensurePluginRegistered(this);
+      return original.apply(this, args);
+    };
+  }
+  Object.defineProperty(proto, weaveAdkRunnerPatched, {
+    value: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+/** Module-load hook shared by the CJS and ESM paths. */
+export function commonPatchGoogleADK(exports: any) {
+  try {
+    if (exports?.Runner) {
+      patchRunnerClass(exports.Runner);
+    }
+  } catch (error) {
+    warnOnce(
+      WARN_KEY_PLUGIN_ERROR,
+      `Weave: failed to instrument @google/adk: ${error}`
+    );
+  }
+  return exports;
+}
+
+export function instrumentGoogleADK() {
+  addCJSInstrumentation({
+    moduleName: '@google/adk',
+    subPath: ADK_CJS_SUBPATH,
+    version: ADK_VERSION_RANGE,
+    hook: commonPatchGoogleADK,
+  });
+  addESMInstrumentation({
+    moduleName: '@google/adk',
+    version: ADK_VERSION_RANGE,
+    hook: commonPatchGoogleADK,
+  });
 }

--- a/sdks/node/src/integrations/googleAdk.types.ts
+++ b/sdks/node/src/integrations/googleAdk.types.ts
@@ -160,3 +160,14 @@ export interface AdkEvent {
   errorCode?: string;
   errorMessage?: string;
 }
+
+/** The slice of ADK's `PluginManager` used for idempotent registration. */
+export interface AdkPluginManager {
+  getPlugin(name: string): unknown;
+  registerPlugin(plugin: unknown): void;
+}
+
+/** The slice of ADK's `Runner` the instrumentation hook needs. */
+export interface AdkRunnerLike {
+  pluginManager?: AdkPluginManager;
+}

--- a/sdks/node/src/integrations/hooks.ts
+++ b/sdks/node/src/integrations/hooks.ts
@@ -1,10 +1,12 @@
 import {instrumentOpenAI} from '../integrations/openai';
 import {instrumentAnthropic} from './anthropic';
+import {instrumentGoogleADK} from './googleAdk';
 import {instrumentGoogleGenAI} from './googleGenAI';
 import {instrumentOpenAIAgent} from './openai.agent';
 import {instrumentOpenAIRealtimeAgent} from './openai.realtime.agent';
 instrumentOpenAI();
 instrumentAnthropic();
+instrumentGoogleADK();
 instrumentGoogleGenAI();
 instrumentOpenAIAgent();
 instrumentOpenAIRealtimeAgent();


### PR DESCRIPTION
## Description

Makes ADK tracing automatic: when @google/adk loads (CJS require hook or the
--import=weave/instrument ESM loader), Runner.prototype.runAsync/runEphemeral
are patched so every runner — including subclasses like InMemoryRunner —
idempotently self-registers a shared WeaveAdkPlugin instance at
generator-creation time, before ADK reads the plugin list. The shared plugin
and patch state live in a global singleton so the CJS and ESM module copies
see the same instance. Every patched surface is typeof-guarded, and the hook
never throws into a user run. Explicit registration (plugins: [new
WeaveAdkPlugin()]) keeps working for environments where module hooks cannot
run (e.g. bundlers).

Also adds two runnable examples and the remaining AGENTS.md patterns (hook
registration/subpath keys and the jest-vs-module-hooks rule):
- examples/googleAdkAgent.ts — a tool-using Gemini agent traced
  automatically into the Weave Agents view, with the explicit-plugin
  alternative and the expected span tree documented in its header
  (@google/adk 1.2.0 reads GOOGLE_GENAI_API_KEY || GEMINI_API_KEY, not
  GOOGLE_API_KEY); flushes deterministically via weave.flushOTel()
- examples/googleAdkSmoke.ts — offline self-verifying smoke (scripted
  BaseLlm + a local server standing in for the trace server): proves
  auto-registration with no plugin passed and that spans are POSTed to the
  agents OTel endpoint (/agents/otel/v1/traces) and nowhere else

## Testing

New integration test applies the patch hook directly (jest's module
registry bypasses Module.prototype.require, so the real CJS hook cannot fire
inside jest) and verifies a plugin-less InMemoryRunner self-registers and
emits spans; the smoke script passes end to end against the local stand-in;
real loader paths were verified in CJS and ESM host runs. Example compiles
under the examples tsconfig (the only typecheck:examples failures are the
pre-existing openai-v6 type drift in untouched examples). cjs/esm
typechecks pass.

