### PR TITLE
chore(weave_ts): Pull up module-level genai state

### DIFF
--- a/sdks/node/src/__tests__/genai/common.ts
+++ b/sdks/node/src/__tests__/genai/common.ts
@@ -5,12 +5,11 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 
 import {setGlobalClient} from '../../clientApi';
-import {DEFAULT_STATE_SYMBOL_NAME} from '../../genai/context';
 import {Api as TraceServerApi} from '../../generated/traceServerApi';
-import {PROVIDER_HOLDER_SYMBOL_NAME} from '../../genai/provider';
 import {Settings, type SettingsInit} from '../../settings';
 import {WandbServerApi} from '../../wandb/wandbServerApi';
 import {WeaveClient} from '../../weaveClient';
+import state from 'weave/state';
 
 export const TEST_BASE_URL = 'http://localhost:8080';
 export const TEST_PROJECT = 'test-entity/test-project';
@@ -40,26 +39,16 @@ export function clearGlobalClient(): void {
 
 // Reach into the global singleton's holder directly to reset its state.
 export function resetProviderSingleton(): void {
-  const holder = (globalThis as Record<symbol, unknown>)[
-    Symbol.for(PROVIDER_HOLDER_SYMBOL_NAME)
-  ] as {provider: unknown; beforeExitRegistered: boolean} | undefined;
-  if (holder) {
-    holder.provider = null;
-    holder.beforeExitRegistered = false;
-  }
+  state.genAi.provider = null;
+  state.genAi.providerRegistered = false;
 }
 
 // Reach into the GenAI default-state singleton and null out its slots so each
 // test body starts clean even when prior tests in the same worker mutated it.
 export function resetGenaiDefaultState(): void {
-  const state = (globalThis as Record<symbol, unknown>)[
-    Symbol.for(DEFAULT_STATE_SYMBOL_NAME)
-  ] as {session: unknown; turn: unknown; llm: unknown} | undefined;
-  if (state) {
-    state.session = null;
-    state.turn = null;
-    state.llm = null;
-  }
+  state.genAi.defaultState.session = null;
+  state.genAi.defaultState.turn = null;
+  state.genAi.defaultState.llm = null;
 }
 
 /**

--- a/sdks/node/src/genai/context.ts
+++ b/sdks/node/src/genai/context.ts
@@ -1,10 +1,7 @@
-import {AsyncLocalStorage} from 'node:async_hooks';
-
-import {globalSingleton} from '../utils/globalSingleton';
-
 import type {LLM} from './llm';
 import type {Session} from './session';
 import type {Turn} from './turn';
+import state from '../state';
 
 /**
  * Mutable container holding the SDK's "current" instances.
@@ -25,39 +22,6 @@ function freshState(): GenAIState {
 }
 
 /**
- * The AsyncLocalStorage that holds the per-frame state container.
- *
- * When the user calls `runIsolated(fn)`, this AsyncLocalStorage is `.run`-installed with
- * a fresh `GenAIState` container for that frame. Inside the frame,
- * `_getGenaiState()` reads back that fresh container. When `runIsolated`
- * isn't on the call stack, `_genaiState.getStore()` returns `undefined`
- * and `_getGenaiState()` falls back to `_defaultState`.
- *
- * The AsyncLocalStorage provides the isolation boundary for concurrent work — each
- * `runIsolated` frame has its own container object, so mutations inside
- * one frame do not affect siblings or the outer chain.
- */
-const _genaiState = globalSingleton<AsyncLocalStorage<GenAIState>>(
-  '_weave_genai_state_async_local_storage',
-  () => new AsyncLocalStorage<GenAIState>()
-);
-
-/** Symbol-registry key for the process-wide default `GenAIState` container. */
-export const DEFAULT_STATE_SYMBOL_NAME = '_weave_genai_state_default';
-
-/**
- * Process-wide fallback container used when no `runIsolated()` frame is
- * active. Lets users call `weave.startSession(...)` etc. directly without
- * any wrapper — the casual, sequential single-flight path. Shared across
- * the whole process, so it is NOT safe for concurrent independent
- * sessions; those need `runIsolated()`.
- */
-const _defaultState = globalSingleton<GenAIState>(
-  DEFAULT_STATE_SYMBOL_NAME,
-  freshState
-);
-
-/**
  * Return the GenAI state in effect on the current async chain.
  *
  * If we're inside a `runIsolated()` frame, that frame's container is
@@ -66,7 +30,7 @@ const _defaultState = globalSingleton<GenAIState>(
  * Internal helper, not part of the public API.
  */
 export function _getGenaiState(): GenAIState {
-  return _genaiState.getStore() ?? _defaultState;
+  return state.genAi.state.getStore() ?? state.genAi.defaultState;
 }
 
 /**
@@ -88,7 +52,7 @@ export function _getGenaiState(): GenAIState {
  * process-wide default state handles it.
  */
 export function runIsolated<T>(fn: () => T): T {
-  return _genaiState.run(freshState(), fn);
+  return state.genAi.state.run(freshState(), fn);
 }
 
 /** Returns the current Session, or undefined. */

--- a/sdks/node/src/genai/provider.ts
+++ b/sdks/node/src/genai/provider.ts
@@ -10,29 +10,15 @@ import {
 } from '@opentelemetry/sdk-trace-base';
 
 import {getGlobalClient} from '../clientApi';
-import {globalSingleton} from '../utils/globalSingleton';
 import {packageVersion} from '../utils/packageVersion';
 import type {WeaveClient} from '../weaveClient';
 import {getWandbConfigs} from '../wandb/settings';
 
 import {WEAVE_RESOURCE_ATTR} from './weaveResource';
+import state from '../state';
 
 const SDK_LANGUAGE = 'node';
 const GENAI_OTLP_PATH = '/agents/otel/v1/traces';
-
-/** Key for the dual-package-hazard-safe singleton holder routed through
- *  `globalThis`. Exported so tests can reset the holder via `Symbol.for`. */
-export const PROVIDER_HOLDER_SYMBOL_NAME = '_weave_genai_provider';
-
-// Dual-package-hazard-safe: routed through globalThis so CJS and ESM copies
-// of this module share one provider instance per process.
-const _providerHolder = globalSingleton<{
-  provider: BasicTracerProvider | null;
-  beforeExitRegistered: boolean;
-}>(PROVIDER_HOLDER_SYMBOL_NAME, () => ({
-  provider: null,
-  beforeExitRegistered: false,
-}));
 
 // Standalone no-op provider for the "weave.init() not called" path. The
 // `AlwaysOffSampler` makes every emitted span non-recording, so all
@@ -65,16 +51,16 @@ export function getWeaveTracer(name: string): Tracer {
  * has been pulled yet. Used by the `flushOTel` / `beforeExit` paths.
  */
 export function getWeaveTracerProvider(): BasicTracerProvider | null {
-  return _providerHolder.provider;
+  return state.genAi.provider;
 }
 
 export function clearWeaveTracerProvider() {
-  _providerHolder.provider = null;
+  state.genAi.provider = null;
 }
 
 function getOrBuildProvider(client: WeaveClient): BasicTracerProvider {
-  if (_providerHolder.provider) {
-    return _providerHolder.provider;
+  if (state.genAi.provider) {
+    return state.genAi.provider;
   }
 
   const [entity, project] = client.projectId.includes('/')
@@ -88,28 +74,28 @@ function getOrBuildProvider(client: WeaveClient): BasicTracerProvider {
     [WEAVE_RESOURCE_ATTR.WEAVE_SDK_LANGUAGE]: SDK_LANGUAGE,
   });
 
-  _providerHolder.provider = new BasicTracerProvider({
+  state.genAi.provider = new BasicTracerProvider({
     resource,
     spanProcessors: [buildSpanProcessor(client)],
   });
   registerBeforeExitHookOnce();
-  return _providerHolder.provider;
+  return state.genAi.provider;
 }
 
 // Best-effort flush on process exit. Registered the first time a real
 // provider is built, so processes that never use the GenAI surface don't pay
 // the hook cost.
 function registerBeforeExitHookOnce(): void {
-  if (_providerHolder.beforeExitRegistered) {
+  if (state.genAi.providerRegistered) {
     return;
   }
-  _providerHolder.beforeExitRegistered = true;
+  state.genAi.providerRegistered = true;
   process.once('beforeExit', async () => {
-    if (!_providerHolder.provider) {
+    if (!state.genAi.provider) {
       return;
     }
     try {
-      await _providerHolder.provider.shutdown();
+      await state.genAi.provider.shutdown();
     } catch {
       // If shutdown fails we have no good place to surface it — the
       // process is already on its way out.

--- a/sdks/node/src/state.ts
+++ b/sdks/node/src/state.ts
@@ -1,0 +1,62 @@
+import {AsyncLocalStorage} from 'node:async_hooks';
+import {BasicTracerProvider} from '@opentelemetry/sdk-trace-base';
+import {globalSingleton} from './utils/globalSingleton';
+import {GenAIState} from './genai/context';
+
+/**
+ * Holds all SDK-wide mutable state.
+ *
+ * Every field is reachable through one `globalSingleton` holder
+ * (`'weave_module_state'`) routed through `globalThis`, which is what makes
+ * the SDK dual-package-hazard-safe: if CJS and ESM copies of these modules
+ * both end up loaded in the same process, they resolve to the same `State`
+ * object instead of each owning its own module-scoped copy.
+ *
+ * See: https://github.com/wandb/weave/pull/6682
+ */
+type State = {
+  genAi: {
+    provider: BasicTracerProvider | null;
+
+    providerRegistered: boolean;
+
+    /**
+     * The AsyncLocalStorage that holds the per-frame state container.
+     *
+     * When the user calls `runIsolated(fn)`, this AsyncLocalStorage is `.run`-installed with
+     * a fresh `GenAIState` container for that frame. Inside the frame,
+     * `_getGenaiState()` reads back that fresh container. When `runIsolated`
+     * isn't on the call stack, `_genaiState.getStore()` returns `undefined`
+     * and `_getGenaiState()` falls back to `_defaultState`.
+     *
+     * The AsyncLocalStorage provides the isolation boundary for concurrent work — each
+     * `runIsolated` frame has its own container object, so mutations inside
+     * one frame do not affect siblings or the outer chain.
+     */
+    state: AsyncLocalStorage<GenAIState>;
+
+    /**
+     * Process-wide fallback container used when no `runIsolated()` frame is
+     * active. Lets users call `weave.startSession(...)` etc. directly without
+     * any wrapper — the casual, sequential single-flight path. Shared across
+     * the whole process, so it is NOT safe for concurrent independent
+     * sessions; those need `runIsolated()`.
+     */
+    defaultState: GenAIState;
+  };
+};
+
+function defaultState(): State {
+  return {
+    genAi: {
+      provider: null,
+      providerRegistered: false,
+      state: new AsyncLocalStorage<GenAIState>(),
+      defaultState: {session: null, turn: null, llm: null},
+    },
+  };
+}
+
+const state = globalSingleton<State>('weave_module_state', defaultState);
+
+export default state;


### PR DESCRIPTION
## Description

* We reference the "dual package hazard" (see: https://github.com/wandb/weave/pull/6682) a bunch of places in the codebase.

* Think our integrations would be a bit more readable if we consolidated some of this boilerplate and hoisted up module-level state. This'll also give us a clearer picture about _what_ global state we're relying on, rather than needing to jump through different call sites.

* This first change is just a POC of that -- starting with the state in the `genai/` stuff.
