### PR TITLE
feat(weave): add wandb.agent_user_feedback feedback type

### DIFF
--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -578,6 +578,10 @@ def test_agent_user_feedback(client: WeaveClient) -> None:
             feedback_type=feedback_type,
             payload={"emoji": "👍", "scorer_tags": ["👍"]},
             scorer_tags=["👍"],
+            # Denormalized agent metadata the UI attaches for dashboard filtering.
+            span_agent_name="support-bot",
+            span_agent_version="1.2.0",
+            span_status_code="OK",
         )
     )
     assert create_res.id is not None
@@ -592,6 +596,9 @@ def test_agent_user_feedback(client: WeaveClient) -> None:
     assert row["runnable_ref"] is None
     assert row["trigger_ref"] is None
     assert row["scorer_ratings"] == {}
+    assert row["span_agent_name"] == "support-bot"
+    assert row["span_agent_version"] == "1.2.0"
+    assert row["span_status_code"] == "OK"
 
 
 def test_agent_monitor_feedback_filters(client: WeaveClient) -> None:

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -538,6 +538,37 @@ def test_agent_monitor_feedback_empty_defaults(client: WeaveClient) -> None:
     assert query_res.result[0]["scorer_rating_confidences"] == {}
 
 
+def test_agent_user_feedback(client: WeaveClient) -> None:
+    """A human agent score's value is a tag in scorer_tags (e.g. an emoji
+    glyph), carrying no scorer refs. Non-emoji tags are allowed too.
+    """
+    project_id = client.project_id
+    feedback_type = "wandb.agent_user_feedback"
+    weave_ref = f"weave:///{project_id}/object/agent_turn:turn_id_123"
+
+    create_res = client.server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type=feedback_type,
+            payload={"emoji": "👍", "scorer_tags": ["👍"]},
+            scorer_tags=["👍"],
+        )
+    )
+    assert create_res.id is not None
+
+    query_res = client.server.feedback_query(
+        tsi.FeedbackQueryReq(project_id=project_id)
+    )
+    assert len(query_res.result) == 1
+    row = query_res.result[0]
+    assert row["feedback_type"] == feedback_type
+    assert row["scorer_tags"] == ["👍"]
+    assert row["runnable_ref"] is None
+    assert row["trigger_ref"] is None
+    assert row["scorer_ratings"] == {}
+
+
 def test_agent_monitor_feedback_filters(client: WeaveClient) -> None:
     """Filter agent_monitor rows by typed scorer columns.
 

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -232,6 +232,36 @@ def test_full_agent_turn() -> None:
     assert _assistant_payload(by_type["assistant_message"]).output_tokens == 105
 
 
+def test_chat_view_exposes_agent_metadata_for_reactions() -> None:
+    """The chat view surfaces agent_version + status_code so reaction feedback
+    can carry them: per-message from the message's span, and the trace root's
+    metadata on AgentTraceChatRes (used for turn-level reactions).
+    """
+    spans = [
+        _span(
+            span_id="agent",
+            operation_name="invoke_agent",
+            agent_name="my-bot",
+            agent_version="1.2.0",  # `_span` hardcodes status_code="OK"
+            output_messages=[{"role": "assistant", "content": "done"}],
+        ),
+    ]
+
+    res = build_trace_chat(spans, "trace-1")
+
+    # Root span metadata on the trace — turn-level reactions read these.
+    assert res.agent_name == "my-bot"
+    assert res.agent_version == "1.2.0"
+    assert res.status_code == "OK"
+
+    # Each message built from the span carries the same metadata.
+    span_messages = [m for m in res.messages if m.span_id == "agent"]
+    assert span_messages
+    for m in span_messages:
+        assert m.agent_version == "1.2.0"
+        assert m.status_code == "OK"
+
+
 def test_agent_start_uses_agent_id_when_name_missing() -> None:
     messages = build_chat_messages(
         [

--- a/weave/trace_server/agents/chat_view.py
+++ b/weave/trace_server/agents/chat_view.py
@@ -151,12 +151,18 @@ def build_trace_chat(
     messages = build_chat_messages(spans)
 
     root_span_name: str | None = None
+    root_agent_name: str | None = None
+    root_agent_version: str | None = None
+    root_status_code: str | None = None
     provider: str | None = None
     total_duration_ms: int | None = None
 
     if spans:
         root = _select_root_span(spans)
         root_span_name = root.agent_name or root.span_name
+        root_agent_name = root.agent_name
+        root_agent_version = root.agent_version
+        root_status_code = root.status_code
         provider = root.provider_name
         # `total_duration_ms` == root span wall-clock duration
         # (`root.ended_at - root.started_at`). Under OTel convention the
@@ -168,6 +174,9 @@ def build_trace_chat(
     return AgentTraceChatRes(
         trace_id=trace_id,
         root_span_name=root_span_name,
+        agent_name=root_agent_name,
+        agent_version=root_agent_version,
+        status_code=root_status_code,
         provider=provider,
         total_duration_ms=total_duration_ms,
         messages=messages,
@@ -245,6 +254,8 @@ class ChatTraversal:
                     type="agent_start",
                     span_id=span.span_id,
                     agent_name=agent_start_label,
+                    agent_version=span.agent_version,
+                    status_code=span.status_code,
                     started_at=span.started_at,
                     agent_start=AgentChatAgentStart(
                         model=span.request_model,
@@ -266,6 +277,8 @@ class ChatTraversal:
                     type="context_compacted",
                     span_id=span.span_id,
                     agent_name=subtree_agent,
+                    agent_version=span.agent_version,
+                    status_code=span.status_code,
                     started_at=span.started_at,
                     context_compacted=AgentChatContextCompacted(
                         compaction_summary=span.compaction_summary,
@@ -297,6 +310,8 @@ class ChatTraversal:
                 type="tool_call",
                 span_id=span.span_id,
                 agent_name=agent_name,
+                agent_version=span.agent_version,
+                status_code=span.status_code,
                 started_at=span.started_at,
                 tool_call=AgentChatToolCall(
                     tool_name=tool_name,
@@ -673,6 +688,8 @@ def _emit_assistant_message(
         type="assistant_message",
         span_id=span.span_id,
         agent_name=agent_name,
+        agent_version=span.agent_version,
+        status_code=span.status_code,
         started_at=span.started_at,
         assistant_message=AgentChatAssistantMessage(
             model=span.response_model or span.request_model,

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -962,7 +962,6 @@ class AgentTraceChatRes(BaseModel):
 
     trace_id: str
     root_span_name: str | None = None
-    # Root span's agent metadata, so a turn-level reaction can carry them.
     agent_name: str | None = None
     agent_version: str | None = None
     status_code: str | None = None

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -909,7 +909,7 @@ class AgentChatMessage(BaseModel):
     span_id: str | None = None
     agent_name: str | None = None
     agent_version: str | None = None
-    status_code: str | None = None
+    status_code: StatusCodeLiteral | None = None
     started_at: datetime.datetime | None = None
 
     user_message: AgentChatUserMessage | None = None
@@ -964,7 +964,7 @@ class AgentTraceChatRes(BaseModel):
     root_span_name: str | None = None
     agent_name: str | None = None
     agent_version: str | None = None
-    status_code: str | None = None
+    status_code: StatusCodeLiteral | None = None
     provider: str | None = None
     total_duration_ms: int | None = Field(
         default=None,

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -908,7 +908,6 @@ class AgentChatMessage(BaseModel):
     type: AgentChatMessageType
     span_id: str | None = None
     agent_name: str | None = None
-    # Denormalized from the message's span so reaction feedback can carry them.
     agent_version: str | None = None
     status_code: str | None = None
     started_at: datetime.datetime | None = None

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -908,6 +908,9 @@ class AgentChatMessage(BaseModel):
     type: AgentChatMessageType
     span_id: str | None = None
     agent_name: str | None = None
+    # Denormalized from the message's span so reaction feedback can carry them.
+    agent_version: str | None = None
+    status_code: str | None = None
     started_at: datetime.datetime | None = None
 
     user_message: AgentChatUserMessage | None = None
@@ -960,6 +963,10 @@ class AgentTraceChatRes(BaseModel):
 
     trace_id: str
     root_span_name: str | None = None
+    # Root span's agent metadata, so a turn-level reaction can carry them.
+    agent_name: str | None = None
+    agent_version: str | None = None
+    status_code: str | None = None
     provider: str | None = None
     total_duration_ms: int | None = Field(
         default=None,

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -201,9 +201,7 @@ def validate_feedback_create_req(
 
     # An agent user feedback's value is the tag in scorer_tags; an empty one is noise.
     if is_agent_user_feedback and not req.scorer_tags:
-        raise InvalidRequest(
-            "scorer_tags is required for agent user feedback"
-        )
+        raise InvalidRequest("scorer_tags is required for agent user feedback")
 
     # Validate the ref formats (we could even query the DB to ensure they exist and are valid)
     if req.annotation_ref:

--- a/weave/trace_server/feedback.py
+++ b/weave/trace_server/feedback.py
@@ -23,6 +23,7 @@ from weave.trace_server.interface.feedback_types import (
     AnnotationPayloadSchema,
     RunnablePayloadSchema,
     feedback_type_is_agent_monitor,
+    feedback_type_is_agent_user_feedback,
     feedback_type_is_annotation,
     feedback_type_is_runnable,
 )
@@ -184,13 +185,21 @@ def validate_feedback_create_req(
 
     is_runnable = feedback_type_is_runnable(req.feedback_type)
     is_agent_monitor = feedback_type_is_agent_monitor(req.feedback_type)
-    scorer_fields_allowed = is_runnable or is_agent_monitor
+    is_agent_user_feedback = feedback_type_is_agent_user_feedback(req.feedback_type)
+    scorer_fields_allowed = is_runnable or is_agent_monitor or is_agent_user_feedback
 
     if scorer_fields_set and not scorer_fields_allowed:
         raise InvalidRequest(
             "scorer_tags, scorer_tag_reasons, scorer_tag_confidences, "
             "scorer_ratings, scorer_rating_reasons, and scorer_rating_confidences "
-            "are only allowed on wandb.agent_monitor or wandb.runnable feedback"
+            "are only allowed on wandb.agent_monitor, wandb.agent_user_feedback, or "
+            "wandb.runnable feedback"
+        )
+
+    # An agent user feedback's value is the tag in scorer_tags; an empty one is noise.
+    if is_agent_user_feedback and not req.scorer_tags:
+        raise InvalidRequest(
+            "scorer_tags is required for agent user feedback"
         )
 
     # Validate the ref formats (we could even query the DB to ensure they exist and are valid)

--- a/weave/trace_server/interface/feedback_types.py
+++ b/weave/trace_server/interface/feedback_types.py
@@ -16,11 +16,19 @@ class FeedbackPayloadNoteReq(BaseModel):
 REACTION_FEEDBACK_TYPE = "wandb.reaction.1"
 NOTE_FEEDBACK_TYPE = "wandb.note.1"
 AGENT_MONITOR_FEEDBACK_TYPE = "wandb.agent_monitor"
+# Human-applied tags on agents (vs scorer-applied wandb.agent_monitor tags),
+# stored in scorer_tags. Covers any human tag, e.g. an emoji reaction or a
+# manual label like "low-quality".
+AGENT_USER_FEEDBACK_TYPE = "wandb.agent_user_feedback"
 
 # Feedback types where multiple entries can exist per call per type.
 # When filtering on these, we use groupArrayIf (collect all values) + has()
 # instead of anyIf (pick one arbitrary value), which could miss matches.
-MULTI_VALUE_FEEDBACK_TYPES = {REACTION_FEEDBACK_TYPE, NOTE_FEEDBACK_TYPE}
+MULTI_VALUE_FEEDBACK_TYPES = {
+    REACTION_FEEDBACK_TYPE,
+    NOTE_FEEDBACK_TYPE,
+    AGENT_USER_FEEDBACK_TYPE,
+}
 
 FEEDBACK_PAYLOAD_SCHEMAS: dict[str, type[BaseModel]] = {
     REACTION_FEEDBACK_TYPE: FeedbackPayloadReactionReq,
@@ -53,6 +61,10 @@ def feedback_type_is_runnable(feedback_type: str) -> bool:
 
 def feedback_type_is_agent_monitor(feedback_type: str) -> bool:
     return feedback_type == AGENT_MONITOR_FEEDBACK_TYPE
+
+
+def feedback_type_is_agent_user_feedback(feedback_type: str) -> bool:
+    return feedback_type == AGENT_USER_FEEDBACK_TYPE
 
 
 def runnable_feedback_selector(name: str) -> str:


### PR DESCRIPTION
## What

Backend support for human reactions on agents.

- New `wandb.agent_user_feedback` feedback type for human-applied tags (vs scorer-applied `wandb.agent_monitor`). The value is stored as a tag in `scorer_tags`.
- The chat view now exposes each turn/message's agent name, version, and status, so the UI can attach them to a reaction (used for dashboard filtering).

Frontend: wandb/core#45619.

## Testing
- [x] Manual
- [x] Unit
- [x] QA