### PR TITLE
feat(weave): allow unbounded range for ungrouped agent spans/stats

### DIFF
--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -822,8 +822,18 @@ def test_request_validation_rejects_numeric_bucket_group_by() -> None:
         )
 
 
-def test_request_validation_rejects_large_range() -> None:
+def test_request_validation_rejects_large_range_when_grouped() -> None:
     with pytest.raises(ValidationError):
         _req(
             end=datetime.datetime(2026, 2, 15, tzinfo=datetime.timezone.utc),
+            group_by=[
+                AgentGroupByRef(source="column", key="agent_name", alias="agent")
+            ],
         )
+
+
+def test_request_validation_allows_large_range_when_ungrouped() -> None:
+    # No group_by / group_filters / numeric bucket: a single-series rollup may
+    # span any range (used for all-time totals), so the cap does not apply.
+    req = _req(end=datetime.datetime(2026, 2, 15, tzinfo=datetime.timezone.utc))
+    assert req.end == datetime.datetime(2026, 2, 15, tzinfo=datetime.timezone.utc)

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -899,6 +899,49 @@ def test_agent_span_stats_ungrouped_metrics(ch_server):
     assert row["count_true_invocations"] == 1
 
 
+def test_agent_span_stats_ungrouped_all_time(ch_server):
+    """Ungrouped >31-day request with the whole range as one bucket returns a
+    single row of all-time totals (no range-cap rejection).
+
+    Mirrors the client recipe: start=epoch, end=now, granularity=now-epoch.
+    Time buckets anchor to the epoch origin, so this is the range that
+    collapses to exactly one bucket.
+    """
+    project_id = _make_project_id("stats-all-time")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+    # Both spans predate `now` (started_at < end is exclusive) and one is far
+    # past MAX_AGENT_STATS_RANGE_DAYS.
+    recent = now - datetime.timedelta(minutes=1)
+    old = now - datetime.timedelta(days=100)
+
+    spans = [
+        _make_span(project_id, started_at=recent),
+        _make_span(project_id, started_at=old),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    res = ch_server.agent_spans_stats(
+        AgentSpanStatsReq(
+            project_id=project_id,
+            start=epoch,
+            end=now,
+            granularity=int((now - epoch).total_seconds()) + 1,
+            metrics=[
+                AgentSpanStatsMetricSpec(
+                    alias="spans",
+                    value_type="datetime",
+                    value=AgentSpanValueRef(source="field", key="started_at"),
+                    aggregations=["count"],
+                )
+            ],
+        )
+    )
+
+    assert len(res.rows) == 1
+    assert res.rows[0]["count_spans"] == 2
+
+
 def test_agent_span_stats_numeric_value_buckets(ch_server):
     """Stats API can bucket the full filtered span set by numeric value range."""
     project_id = _make_project_id("stats_hist")

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -373,8 +373,15 @@ class AgentSpanStatsReq(BaseModel):
         end = self.end or datetime.datetime.now(datetime.timezone.utc)
         if end < self.start:
             raise ValueError("AgentSpanStatsReq end must be after start")
+        # Unfiltered, ungrouped requests are not bound by
+        # MAX_AGENT_STATS_RANGE_DAYS.
+        apply_max_range_days = (
+            bool(self.group_by)
+            or bool(self.group_filters)
+            or numeric_bucket is not None
+        )
         max_range = datetime.timedelta(days=MAX_AGENT_STATS_RANGE_DAYS)
-        if end - self.start > max_range:
+        if apply_max_range_days and end - self.start > max_range:
             raise ValueError(
                 "AgentSpanStatsReq date range cannot exceed "
                 f"{MAX_AGENT_STATS_RANGE_DAYS} days"


### PR DESCRIPTION
## Summary
`MAX_AGENT_STATS_RANGE_DAYS` (31d) caps the `/agents/spans/stats` time range. That cap exists to guard expensive grouped/bucketed/filtered aggregations — but it also blocks a plain ungrouped rollup (e.g. an all-time span count).

This lifts the cap **only** for a single-series request — no `group_by`, no `group_filters`, no numeric bucket. Grouped/bucketed/filtered requests are still capped.

No request/response shape or query-builder changes (per review): clients get an all-time scalar by requesting the whole range as one bucket — `start=epoch`, `end=now`, `granularity=now-epoch` — which the existing time-bucket path already collapses to a single row.

## Testing
- [x] Manual tests
- [x] Unit tests
- [x] QA tests
