### PR TITLE
chore(weave): raise default kafka producer buffer to 100k

### DIFF
--- a/weave/trace_server/kafka.py
+++ b/weave/trace_server/kafka.py
@@ -30,7 +30,7 @@ from weave.trace_server.environment import (
 CALL_ENDED_TOPIC = "weave.call_ended"
 SCORE_CALLS_TOPIC = "weave.score_calls"
 
-DEFAULT_MAX_BUFFER_SIZE = 10000
+DEFAULT_MAX_BUFFER_SIZE = 100000
 # Fraction of `max_buffer_size` at which a "buffer pressure" warning is logged.
 BUFFER_WARN_THRESHOLD = 0.5
 


### PR DESCRIPTION
## Summary
- Raise `DEFAULT_MAX_BUFFER_SIZE` 10k -> 100k in the trace-server kafka producer (~10x headroom before `call_end` produce drops). The `KAFKA_PRODUCER_MAX_BUFFER_SIZE` env override is unchanged.
- No data-loss risk: the ClickHouse insert is synchronous-first; the kafka `call_end` event is a best-effort online-eval trigger, so a drop only skips scoring for that call.
- Supersedes the prod-only chart override in wandb/core#45622 with an all-deployments default.

Datadog (us5, env:prod, 6h): 28,926 `Kafka producer buffer full, dropping message 'call_end'`; `@kafka.producer.buffer_size` caps at 10001; one request (trace 6a2ae3b2000000004da31ea01b2a80a3) dropped ~tens of thousands while `bufstream.kafka.produce.delay.duration` spiked ~1-3s->11s.

## Testing
default-value change; no test asserts the default (the only `10000` test assertion is on the `KAFKA_PRODUCER_MAX_BUFFER_SIZE` env override, left untouched).