### PR TITLE
perf(weave): avoid deep-copying table rows on table_create

### DIFF
--- a/tests/trace/test_table_query.py
+++ b/tests/trace/test_table_query.py
@@ -1,3 +1,4 @@
+import copy
 import random
 from collections.abc import Iterator
 
@@ -483,3 +484,44 @@ def test_table_query_stats_with_storage_size(client: WeaveClient):
 
     assert stats_res.tables[0].count == len(data)
     assert stats_res.tables[0].storage_size_bytes > 0
+
+
+def test_table_create_does_not_mutate_caller_rows(client: WeaveClient):
+    """table_create shares the caller's rows yet still converts embedded refs."""
+    project_id = client.project_id
+    nested_ref = f"weave:///{project_id}/object/my_obj:abc123"
+    list_ref = f"weave:///{project_id}/op/my_op:def456"
+    rows = [
+        {"idx": 0, "meta": {"ref": nested_ref}, "tags": ["plain", list_ref]},
+        {"idx": 1, "meta": {"ref": None}, "tags": ["no-refs-here"]},
+    ]
+    req = tsi.TableCreateReq(
+        table=tsi.TableSchemaForInsert(rows=rows, project_id=project_id),
+    )
+    rows_snapshot = copy.deepcopy(req.table.rows)
+    caller_rows = req.table.rows
+    caller_row_ids = [id(r) for r in caller_rows]
+
+    res = client.server.table_create(req)
+
+    # The converter is copy-on-write; the caller's rows must be untouched.
+    assert req.table.rows == rows_snapshot
+    assert req.table.rows is caller_rows
+    # No deep copy: the caller's row objects keep their identity (the old
+    # model_copy(deep=True) would have replaced every row).
+    assert [id(r) for r in req.table.rows] == caller_row_ids
+    # project_id rewrite happened on our copy, not the caller's table.
+    assert req.table.project_id == project_id
+
+    # Stored rows round-trip: int refs convert back to the original external
+    # refs, and the digest is stable across an identical re-create.
+    query_res = client.server.table_query(
+        tsi.TableQueryReq(project_id=project_id, digest=res.digest)
+    )
+    assert [r.val for r in query_res.rows] == rows
+    assert query_res.rows[0].val["meta"]["ref"] == nested_ref
+    assert query_res.rows[0].val["tags"][1] == list_ref
+
+    res2 = client.server.table_create(req)
+    assert res2.digest == res.digest
+    assert res2.row_digests == res.row_digests

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -464,10 +464,13 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
         return self._internal_trace_server.aliases_list(req)
 
     def table_create(self, req: tsi.TableCreateReq) -> tsi.TableCreateRes:
-        req = req.model_copy(deep=True)
-        req.table.project_id = self._idc.ext_to_int_project_id(req.table.project_id)
+        # Shallow-copy the wrapper + table (not the rows): the ref converter is
+        # copy-on-write, so the caller's rows stay unmutated without a deep copy.
+        internal_project_id = self._idc.ext_to_int_project_id(req.table.project_id)
+        table = req.table.model_copy(update={"project_id": internal_project_id})
+        req = req.model_copy(update={"table": table})
         return self._ref_apply(
-            self._internal_trace_server.table_create, req, req.table.project_id
+            self._internal_trace_server.table_create, req, internal_project_id
         )
 
     def table_update(self, req: tsi.TableUpdateReq) -> tsi.TableUpdateRes:


### PR DESCRIPTION
## Summary
- `table_create` deep-copied every row (`req.model_copy(deep=True)`) just to rewrite `project_id`. Replaced with a shallow copy of the request wrapper + table that shares the `rows` list; the ref converter is already copy-on-write for rows, so the caller's request stays unmutated.
- Drops one full recursive copy + ~2x peak memory of the payload on the hot table-write path. No behavior change: digests, stored values, and ref conversion are unchanged.

Context: prod `POST /table/create` is slow on multi-MB payloads (Datadog us5, env:prod) - [27.6s/10MB inserted](https://us5.datadoghq.com/apm/trace/6a2abef300000000d0f9f450884f06a7), [37.2s rejected](https://us5.datadoghq.com/apm/trace/6a2abef200000000d7e6387b40d189f3). This deep copy is a pure-waste CPU/memory pass per request under concurrent large uploads.

## Performance
Local ClickHouse, end-to-end `server.table_create`, median of 12 runs with fresh rows (no CH dedup). Isolated, the deep-copy step alone is ~46ms / 7MB peak on a 10MB payload; the shallow copy is ~0.03ms / ~0MB.

| payload | median ms | p90 ms | peak MB | peak reduction |
|---|---|---|---|---|
| 2 MB | 135 -> 128 | 149 -> 136 | 7.86 -> 6.78 | -14% |
| 2 MB (20% ref rows) | 140 -> 143 | 191 -> 184 | 7.33 -> 6.52 | -11% |
| 10 MB | 328 -> 266 | 354 -> 276 | 23.3 -> 17.9 | -23% |
| 10 MB (20% ref rows) | 303 -> 268 | 315 -> 287 | 22.8 -> 18.7 | -18% |

## Testing
added a functional test asserting the caller's rows are not mutated and embedded refs still convert; existing table_create tests pass.
