### PR TITLE
chore(weave): validate monitor query fields on save

### DIFF
--- a/tests/trace/test_base_object_classes.py
+++ b/tests/trace/test_base_object_classes.py
@@ -24,10 +24,15 @@ from weave.trace.serialization.serialize import to_json
 from weave.trace.weave_client import WeaveClient, map_to_refs
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.calls_query_builder.calls_query_builder import (
+    _DUMP_SUFFIX,
     ALLOWED_CALL_FIELDS,
     ALLOWED_DYNAMIC_FIELD_PREFIXES,
 )
-from weave.trace_server.errors import InvalidFieldError, ObjectNameTypeCollision
+from weave.trace_server.errors import (
+    InvalidFieldError,
+    InvalidRequest,
+    ObjectNameTypeCollision,
+)
 from weave.trace_server.interface.builtin_object_classes.test_only_example import (
     TestOnlyNestedBaseModel,
 )
@@ -1185,17 +1190,28 @@ def test_monitor_create_rejects_unknown_query_field(client: WeaveClient):
     with pytest.raises(InvalidFieldError) as exc_info:
         _create_monitor(client, "bad-monitor", bad_query)
 
+    allowed = ", ".join(
+        sorted(k for k in ALLOWED_CALL_FIELDS if not k.endswith(_DUMP_SUFFIX))
+    )
     expected_message = (
         "Field operation_name is not allowed. "
-        f"Allowed fields: {', '.join(sorted(ALLOWED_CALL_FIELDS))}. "
+        f"Allowed fields: {allowed}. "
         f"Allowed dynamic field prefixes: {', '.join(ALLOWED_DYNAMIC_FIELD_PREFIXES)}"
     )
     assert str(exc_info.value) == expected_message
+    assert _DUMP_SUFFIX not in str(exc_info.value)
 
-    # Nothing was stored for the rejected monitor.
+    # A structurally invalid query (empty $and) is a bad request, not a field error.
+    with pytest.raises(InvalidRequest):
+        _create_monitor(client, "empty-and-monitor", {"$expr": {"$and": []}})
+
+    # Neither rejected monitor was stored.
     objs_res = client.server.objs_query(
         tsi.ObjQueryReq.model_validate(
-            {"project_id": client.project_id, "filter": {"object_ids": ["bad-monitor"]}}
+            {
+                "project_id": client.project_id,
+                "filter": {"object_ids": ["bad-monitor", "empty-and-monitor"]},
+            }
         )
     )
     assert objs_res.objs == []
@@ -1224,6 +1240,23 @@ def test_monitor_create_accepts_valid_query_fields(client: WeaveClient):
     _create_monitor(client, "dynamic-monitor", dynamic_query)
     _create_monitor(client, "no-query-monitor", None)
 
+    # A Monitor-classed object whose `query` is not a recognizable query shape is
+    # left untouched (we only validate queries we understand), never 500'd.
+    monitor = weave.Monitor(name="opaque-monitor", scorers=[], query=None)
+    opaque_val = to_json(map_to_refs(monitor), client.project_id, client)
+    opaque_val["query"] = "not-a-query"
+    client.server.obj_create(
+        tsi.ObjCreateReq.model_validate(
+            {
+                "obj": {
+                    "project_id": client.project_id,
+                    "object_id": "opaque-monitor",
+                    "val": opaque_val,
+                }
+            }
+        )
+    )
+
     objs_res = client.server.objs_query(
         tsi.ObjQueryReq.model_validate(
             {
@@ -1233,6 +1266,7 @@ def test_monitor_create_accepts_valid_query_fields(client: WeaveClient):
                         "valid-monitor",
                         "dynamic-monitor",
                         "no-query-monitor",
+                        "opaque-monitor",
                     ]
                 },
             }
@@ -1242,4 +1276,5 @@ def test_monitor_create_accepts_valid_query_fields(client: WeaveClient):
         "valid-monitor",
         "dynamic-monitor",
         "no-query-monitor",
+        "opaque-monitor",
     }

--- a/tests/trace/test_base_object_classes.py
+++ b/tests/trace/test_base_object_classes.py
@@ -22,7 +22,7 @@ from weave.trace import base_objects
 from weave.trace.refs import ObjectRef
 from weave.trace.weave_client import WeaveClient
 from weave.trace_server import trace_server_interface as tsi
-from weave.trace_server.errors import ObjectNameTypeCollision
+from weave.trace_server.errors import InvalidFieldError, ObjectNameTypeCollision
 from weave.trace_server.interface.builtin_object_classes.test_only_example import (
     TestOnlyNestedBaseModel,
 )
@@ -1153,3 +1153,105 @@ def test_obj_create_rejects_name_type_collision(client: WeaveClient):
             }
         )
     )
+
+
+def _monitor_val(query: dict | None) -> dict:
+    """A serialized Monitor object val carrying a query and weave class hierarchy."""
+    return {
+        "name": "test-monitor",
+        "description": None,
+        "sampling_rate": 1.0,
+        "scorers": [],
+        "op_names": [],
+        "query": query,
+        "is_traced": True,
+        "active": False,
+        "scorer_debounce_config": None,
+        "_type": "Monitor",
+        "_class_name": "Monitor",
+        "_bases": ["Object", "BaseModel"],
+    }
+
+
+def _create_monitor(client: WeaveClient, object_id: str, query: dict | None):
+    return client.server.obj_create(
+        tsi.ObjCreateReq.model_validate(
+            {
+                "obj": {
+                    "project_id": client.project_id,
+                    "object_id": object_id,
+                    "val": _monitor_val(query),
+                }
+            }
+        )
+    )
+
+
+def test_monitor_create_rejects_unknown_query_field(client: WeaveClient):
+    """A Monitor query on an unknown field is rejected at create with the allowed list."""
+    bad_query = {
+        "$expr": {"$eq": [{"$getField": "operation_name"}, {"$literal": "predict"}]}
+    }
+    with pytest.raises(InvalidFieldError) as exc_info:
+        _create_monitor(client, "bad-monitor", bad_query)
+    message = str(exc_info.value)
+    assert "Field operation_name is not allowed" in message
+    assert "op_name" in message
+    assert "summary.weave.*" in message
+    assert "inputs.*" in message
+
+    # Nothing was stored for the rejected monitor.
+    objs_res = client.server.objs_query(
+        tsi.ObjQueryReq.model_validate(
+            {"project_id": client.project_id, "filter": {"object_ids": ["bad-monitor"]}}
+        )
+    )
+    assert objs_res.objs == []
+
+
+def test_monitor_create_accepts_valid_query_fields(client: WeaveClient):
+    """Static, dynamic, and absent monitor queries all create successfully."""
+    valid_query = {
+        "$expr": {
+            "$and": [
+                {"$eq": [{"$getField": "parent_id"}, {"$literal": None}]},
+                {
+                    "$eq": [
+                        {"$getField": "summary.weave.status"},
+                        {"$literal": "success"},
+                    ]
+                },
+            ]
+        }
+    }
+    dynamic_query = {
+        "$expr": {"$eq": [{"$getField": "inputs.foo"}, {"$literal": "bar"}]}
+    }
+
+    valid_res = _create_monitor(client, "valid-monitor", valid_query)
+    dynamic_res = _create_monitor(client, "dynamic-monitor", dynamic_query)
+    no_query_res = _create_monitor(client, "no-query-monitor", None)
+
+    assert valid_res.object_id == "valid-monitor"
+    assert dynamic_res.object_id == "dynamic-monitor"
+    assert no_query_res.object_id == "no-query-monitor"
+
+    objs_res = client.server.objs_query(
+        tsi.ObjQueryReq.model_validate(
+            {
+                "project_id": client.project_id,
+                "filter": {
+                    "object_ids": [
+                        "valid-monitor",
+                        "dynamic-monitor",
+                        "no-query-monitor",
+                    ]
+                },
+            }
+        )
+    )
+    assert {obj.object_id for obj in objs_res.objs} == {
+        "valid-monitor",
+        "dynamic-monitor",
+        "no-query-monitor",
+    }

--- a/tests/trace/test_base_object_classes.py
+++ b/tests/trace/test_base_object_classes.py
@@ -20,8 +20,13 @@ from pydantic import ValidationError
 import weave
 from weave.trace import base_objects
 from weave.trace.refs import ObjectRef
-from weave.trace.weave_client import WeaveClient
+from weave.trace.serialization.serialize import to_json
+from weave.trace.weave_client import WeaveClient, map_to_refs
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.calls_query_builder.calls_query_builder import (
+    ALLOWED_CALL_FIELDS,
+    ALLOWED_DYNAMIC_FIELD_PREFIXES,
+)
 from weave.trace_server.errors import InvalidFieldError, ObjectNameTypeCollision
 from weave.trace_server.interface.builtin_object_classes.test_only_example import (
     TestOnlyNestedBaseModel,
@@ -1155,32 +1160,17 @@ def test_obj_create_rejects_name_type_collision(client: WeaveClient):
     )
 
 
-def _monitor_val(query: dict | None) -> dict:
-    """A serialized Monitor object val carrying a query and weave class hierarchy."""
-    return {
-        "name": "test-monitor",
-        "description": None,
-        "sampling_rate": 1.0,
-        "scorers": [],
-        "op_names": [],
-        "query": query,
-        "is_traced": True,
-        "active": False,
-        "scorer_debounce_config": None,
-        "_type": "Monitor",
-        "_class_name": "Monitor",
-        "_bases": ["Object", "BaseModel"],
-    }
-
-
-def _create_monitor(client: WeaveClient, object_id: str, query: dict | None):
+def _create_monitor(client: WeaveClient, name: str, query: dict | None):
+    """Create a Monitor via the client's serialization so the stored `query` carries weave bookkeeping keys, exercising the server-side strip + validation."""
+    monitor = weave.Monitor(name=name, scorers=[], query=query)
+    val = to_json(map_to_refs(monitor), client.project_id, client)
     return client.server.obj_create(
         tsi.ObjCreateReq.model_validate(
             {
                 "obj": {
                     "project_id": client.project_id,
-                    "object_id": object_id,
-                    "val": _monitor_val(query),
+                    "object_id": name,
+                    "val": val,
                 }
             }
         )
@@ -1188,17 +1178,19 @@ def _create_monitor(client: WeaveClient, object_id: str, query: dict | None):
 
 
 def test_monitor_create_rejects_unknown_query_field(client: WeaveClient):
-    """A Monitor query on an unknown field is rejected at create with the allowed list."""
+    """A Monitor query on an unknown field is rejected with the complete allowed-field list."""
     bad_query = {
         "$expr": {"$eq": [{"$getField": "operation_name"}, {"$literal": "predict"}]}
     }
     with pytest.raises(InvalidFieldError) as exc_info:
         _create_monitor(client, "bad-monitor", bad_query)
-    message = str(exc_info.value)
-    assert "Field operation_name is not allowed" in message
-    assert "op_name" in message
-    assert "summary.weave.*" in message
-    assert "inputs.*" in message
+
+    expected_message = (
+        "Field operation_name is not allowed. "
+        f"Allowed fields: {', '.join(sorted(ALLOWED_CALL_FIELDS))}. "
+        f"Allowed dynamic field prefixes: {', '.join(ALLOWED_DYNAMIC_FIELD_PREFIXES)}"
+    )
+    assert str(exc_info.value) == expected_message
 
     # Nothing was stored for the rejected monitor.
     objs_res = client.server.objs_query(
@@ -1228,13 +1220,9 @@ def test_monitor_create_accepts_valid_query_fields(client: WeaveClient):
         "$expr": {"$eq": [{"$getField": "inputs.foo"}, {"$literal": "bar"}]}
     }
 
-    valid_res = _create_monitor(client, "valid-monitor", valid_query)
-    dynamic_res = _create_monitor(client, "dynamic-monitor", dynamic_query)
-    no_query_res = _create_monitor(client, "no-query-monitor", None)
-
-    assert valid_res.object_id == "valid-monitor"
-    assert dynamic_res.object_id == "dynamic-monitor"
-    assert no_query_res.object_id == "no-query-monitor"
+    _create_monitor(client, "valid-monitor", valid_query)
+    _create_monitor(client, "dynamic-monitor", dynamic_query)
+    _create_monitor(client, "no-query-monitor", None)
 
     objs_res = client.server.objs_query(
         tsi.ObjQueryReq.model_validate(

--- a/tests/trace/test_base_object_classes.py
+++ b/tests/trace/test_base_object_classes.py
@@ -24,8 +24,10 @@ from weave.trace.serialization.serialize import to_json
 from weave.trace.weave_client import WeaveClient, map_to_refs
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.calls_query_builder.calls_query_builder import (
-    _DUMP_SUFFIX,
     ALLOWED_CALL_FIELDS,
+)
+from weave.trace_server.calls_query_builder.monitor_query_validation import (
+    _DUMP_SUFFIX,
     ALLOWED_DYNAMIC_FIELD_PREFIXES,
 )
 from weave.trace_server.errors import (

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -31,7 +31,7 @@ from collections.abc import Callable, KeysView, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 from typing_extensions import Self
 
 from weave.shared.trace_server_interface_util import (
@@ -64,7 +64,7 @@ from weave.trace_server.calls_query_builder.utils import (
     trace_id_index_expr,
 )
 from weave.trace_server.common_interface import SortBy
-from weave.trace_server.errors import InvalidFieldError
+from weave.trace_server.errors import InvalidFieldError, InvalidRequest
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.interface.feedback_types import MULTI_VALUE_FEEDBACK_TYPES
 from weave.trace_server.interface.query import (
@@ -1956,9 +1956,11 @@ def get_field_by_name(name: str) -> CallsMergedField:
     return ALLOWED_CALL_FIELDS[name]
 
 
-# Dotted prefixes get_field_by_name accepts beyond ALLOWED_CALL_FIELDS. The
-# dynamic-field prefixes are derived from ALLOWED_CALL_FIELDS so they can't
-# drift as `*_dump` dynamic fields are added or removed.
+# Field references get_field_by_name accepts beyond exact ALLOWED_CALL_FIELDS
+# keys, used only to build the user-facing error message. The `*_dump` prefixes
+# are derived so they can't drift; the special entries must be kept in sync by
+# hand with the explicit branches in get_field_by_name above
+# (`annotation_queue_items.queue_id` is an exact ref, not a prefix).
 _DUMP_SUFFIX = "_dump"
 _SPECIAL_DYNAMIC_FIELD_PREFIXES = (
     "feedback.*",
@@ -1995,15 +1997,26 @@ def validate_monitor_query_fields(
     if raw_query is None:
         return
     cleaned = _strip_weave_object_keys(raw_query)
-    validate_query_field_names(tsi_query.Query.model_validate(cleaned))
+    try:
+        query = tsi_query.Query.model_validate(cleaned)
+    except ValidationError:
+        # Not a recognizable query (e.g. a user object that happens to share
+        # the Monitor class name); leave the write untouched.
+        return
+    validate_query_compiles(query)
 
 
-def validate_query_field_names(query: tsi_query.Query) -> None:
-    """Validate every field reference in `query` against the allowed call fields."""
+def validate_query_compiles(query: tsi_query.Query) -> None:
+    """Validate that `query` references only allowed call fields and is well-formed."""
     try:
         process_query_to_conditions(query, ParamBuilder(), "calls_merged")
     except InvalidFieldError as e:
         raise InvalidFieldError(_invalid_field_message(str(e))) from e
+    except (ValueError, TypeError) as e:
+        raise InvalidRequest(f"Invalid query: {e}") from e
+
+
+_WEAVE_BOOKKEEPING_KEYS = frozenset({"_type", "_class_name", "_bases"})
 
 
 def _strip_weave_object_keys(value: object) -> object:
@@ -2012,7 +2025,7 @@ def _strip_weave_object_keys(value: object) -> object:
         return {
             k: _strip_weave_object_keys(v)
             for k, v in value.items()
-            if not k.startswith("_")
+            if k not in _WEAVE_BOOKKEEPING_KEYS
         }
     if isinstance(value, list):
         return [_strip_weave_object_keys(v) for v in value]
@@ -2021,7 +2034,9 @@ def _strip_weave_object_keys(value: object) -> object:
 
 def _invalid_field_message(reason: str) -> str:
     """Append the allowed field list and dynamic prefixes to a field rejection."""
-    allowed = ", ".join(sorted(ALLOWED_CALL_FIELDS))
+    allowed = ", ".join(
+        sorted(k for k in ALLOWED_CALL_FIELDS if not k.endswith(_DUMP_SUFFIX))
+    )
     prefixes = ", ".join(ALLOWED_DYNAMIC_FIELD_PREFIXES)
     return (
         f"{reason}. Allowed fields: {allowed}. "

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -31,7 +31,7 @@ from collections.abc import Callable, KeysView, Sequence
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field
 from typing_extensions import Self
 
 from weave.shared.trace_server_interface_util import (
@@ -64,7 +64,7 @@ from weave.trace_server.calls_query_builder.utils import (
     trace_id_index_expr,
 )
 from weave.trace_server.common_interface import SortBy
-from weave.trace_server.errors import InvalidFieldError, InvalidRequest
+from weave.trace_server.errors import InvalidFieldError
 from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.interface.feedback_types import MULTI_VALUE_FEEDBACK_TYPES
 from weave.trace_server.interface.query import (
@@ -1954,94 +1954,6 @@ def get_field_by_name(name: str) -> CallsMergedField:
                 return field
             raise InvalidFieldError(f"Field {name} is not allowed")
     return ALLOWED_CALL_FIELDS[name]
-
-
-# Field references get_field_by_name accepts beyond exact ALLOWED_CALL_FIELDS
-# keys, used only to build the user-facing error message. The `*_dump` prefixes
-# are derived so they can't drift; the special entries must be kept in sync by
-# hand with the explicit branches in get_field_by_name above
-# (`annotation_queue_items.queue_id` is an exact ref, not a prefix).
-_DUMP_SUFFIX = "_dump"
-_SPECIAL_DYNAMIC_FIELD_PREFIXES = (
-    "feedback.*",
-    "annotation_queue_items.queue_id",
-    "summary.weave.*",
-)
-ALLOWED_DYNAMIC_FIELD_PREFIXES = _SPECIAL_DYNAMIC_FIELD_PREFIXES + tuple(
-    f"{name[: -len(_DUMP_SUFFIX)]}.*"
-    for name, field in ALLOWED_CALL_FIELDS.items()
-    if isinstance(field, CallsMergedDynamicField) and name.endswith(_DUMP_SUFFIX)
-)
-
-
-# Serialized `_class_name`/`_bases` values for Monitor objects. These mirror the
-# SDK classes in weave/flow/monitor.py but are kept as server-side strings on
-# purpose: the trace server must not import from weave/flow.
-MONITOR_OBJECT_CLASSES = frozenset({"Monitor", "ClassifierMonitor"})
-
-
-def validate_monitor_query_fields(
-    base_object_class: str | None,
-    leaf_object_class: str | None,
-    val: object,
-) -> None:
-    """Reject a Monitor whose `query` references a field outside the allowed set."""
-    if (
-        base_object_class not in MONITOR_OBJECT_CLASSES
-        and leaf_object_class not in MONITOR_OBJECT_CLASSES
-    ):
-        return
-    if not isinstance(val, dict):
-        return
-    raw_query = val.get("query")
-    if raw_query is None:
-        return
-    cleaned = _strip_weave_object_keys(raw_query)
-    try:
-        query = tsi_query.Query.model_validate(cleaned)
-    except ValidationError:
-        # Not a recognizable query (e.g. a user object that happens to share
-        # the Monitor class name); leave the write untouched.
-        return
-    validate_query_compiles(query)
-
-
-def validate_query_compiles(query: tsi_query.Query) -> None:
-    """Validate that `query` references only allowed call fields and is well-formed."""
-    try:
-        process_query_to_conditions(query, ParamBuilder(), "calls_merged")
-    except InvalidFieldError as e:
-        raise InvalidFieldError(_invalid_field_message(str(e))) from e
-    except (ValueError, TypeError) as e:
-        raise InvalidRequest(f"Invalid query: {e}") from e
-
-
-_WEAVE_BOOKKEEPING_KEYS = frozenset({"_type", "_class_name", "_bases"})
-
-
-def _strip_weave_object_keys(value: object) -> object:
-    """Drop weave bookkeeping keys (`_type`, `_class_name`, `_bases`) from a serialized query."""
-    if isinstance(value, dict):
-        return {
-            k: _strip_weave_object_keys(v)
-            for k, v in value.items()
-            if k not in _WEAVE_BOOKKEEPING_KEYS
-        }
-    if isinstance(value, list):
-        return [_strip_weave_object_keys(v) for v in value]
-    return value
-
-
-def _invalid_field_message(reason: str) -> str:
-    """Append the allowed field list and dynamic prefixes to a field rejection."""
-    allowed = ", ".join(
-        sorted(k for k in ALLOWED_CALL_FIELDS if not k.endswith(_DUMP_SUFFIX))
-    )
-    prefixes = ", ".join(ALLOWED_DYNAMIC_FIELD_PREFIXES)
-    return (
-        f"{reason}. Allowed fields: {allowed}. "
-        f"Allowed dynamic field prefixes: {prefixes}"
-    )
 
 
 def _field_as_sql_maybe_agg(

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1956,6 +1956,72 @@ def get_field_by_name(name: str) -> CallsMergedField:
     return ALLOWED_CALL_FIELDS[name]
 
 
+# Dotted prefixes get_field_by_name accepts beyond ALLOWED_CALL_FIELDS.
+ALLOWED_DYNAMIC_FIELD_PREFIXES = (
+    "feedback.*",
+    "annotation_queue_items.queue_id",
+    "summary.weave.*",
+    "inputs.*",
+    "output.*",
+    "attributes.*",
+    "summary.*",
+)
+
+
+MONITOR_OBJECT_CLASSES = frozenset({"Monitor", "ClassifierMonitor"})
+
+
+def validate_monitor_query_fields(
+    base_object_class: str | None,
+    leaf_object_class: str | None,
+    val: object,
+) -> None:
+    """Reject a Monitor whose `query` references a field outside the allowed set."""
+    if (
+        base_object_class not in MONITOR_OBJECT_CLASSES
+        and leaf_object_class not in MONITOR_OBJECT_CLASSES
+    ):
+        return
+    if not isinstance(val, dict):
+        return
+    raw_query = val.get("query")
+    if raw_query is None:
+        return
+    cleaned = _strip_weave_object_keys(raw_query)
+    validate_query_field_names(tsi_query.Query.model_validate(cleaned))
+
+
+def validate_query_field_names(query: tsi_query.Query) -> None:
+    """Validate every field reference in `query` against the allowed call fields."""
+    try:
+        process_query_to_conditions(query, ParamBuilder(), "calls_merged")
+    except InvalidFieldError as e:
+        raise InvalidFieldError(_invalid_field_message(str(e))) from e
+
+
+def _strip_weave_object_keys(value: object) -> object:
+    """Drop weave bookkeeping keys (`_type`, `_class_name`, `_bases`) from a serialized query."""
+    if isinstance(value, dict):
+        return {
+            k: _strip_weave_object_keys(v)
+            for k, v in value.items()
+            if not k.startswith("_")
+        }
+    if isinstance(value, list):
+        return [_strip_weave_object_keys(v) for v in value]
+    return value
+
+
+def _invalid_field_message(reason: str) -> str:
+    """Append the allowed field list and dynamic prefixes to a field rejection."""
+    allowed = ", ".join(sorted(ALLOWED_CALL_FIELDS))
+    prefixes = ", ".join(ALLOWED_DYNAMIC_FIELD_PREFIXES)
+    return (
+        f"{reason}. Allowed fields: {allowed}. "
+        f"Allowed dynamic field prefixes: {prefixes}"
+    )
+
+
 def _field_as_sql_maybe_agg(
     field: CallsMergedField,
     pb: ParamBuilder,

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -1956,18 +1956,25 @@ def get_field_by_name(name: str) -> CallsMergedField:
     return ALLOWED_CALL_FIELDS[name]
 
 
-# Dotted prefixes get_field_by_name accepts beyond ALLOWED_CALL_FIELDS.
-ALLOWED_DYNAMIC_FIELD_PREFIXES = (
+# Dotted prefixes get_field_by_name accepts beyond ALLOWED_CALL_FIELDS. The
+# dynamic-field prefixes are derived from ALLOWED_CALL_FIELDS so they can't
+# drift as `*_dump` dynamic fields are added or removed.
+_DUMP_SUFFIX = "_dump"
+_SPECIAL_DYNAMIC_FIELD_PREFIXES = (
     "feedback.*",
     "annotation_queue_items.queue_id",
     "summary.weave.*",
-    "inputs.*",
-    "output.*",
-    "attributes.*",
-    "summary.*",
+)
+ALLOWED_DYNAMIC_FIELD_PREFIXES = _SPECIAL_DYNAMIC_FIELD_PREFIXES + tuple(
+    f"{name[: -len(_DUMP_SUFFIX)]}.*"
+    for name, field in ALLOWED_CALL_FIELDS.items()
+    if isinstance(field, CallsMergedDynamicField) and name.endswith(_DUMP_SUFFIX)
 )
 
 
+# Serialized `_class_name`/`_bases` values for Monitor objects. These mirror the
+# SDK classes in weave/flow/monitor.py but are kept as server-side strings on
+# purpose: the trace server must not import from weave/flow.
 MONITOR_OBJECT_CLASSES = frozenset({"Monitor", "ClassifierMonitor"})
 
 

--- a/weave/trace_server/calls_query_builder/monitor_query_validation.py
+++ b/weave/trace_server/calls_query_builder/monitor_query_validation.py
@@ -29,10 +29,10 @@ def validate_monitor_query_fields(
     query = _monitor_query(val)
     if query is None:
         return
-    validate_calls_query(query)
+    _validate_calls_query(query)
 
 
-def validate_calls_query(query: tsi_query.Query) -> None:
+def _validate_calls_query(query: tsi_query.Query) -> None:
     """Reject a calls query referencing a disallowed field or that is structurally invalid.
 
     Validates by compiling the query to SQL conditions: compilation is what
@@ -95,11 +95,8 @@ def _strip_weave_object_keys(value: object) -> object:
     return value
 
 
-# Field references get_field_by_name accepts beyond exact ALLOWED_CALL_FIELDS
-# keys, used only to build the user-facing error message. The `*_dump` prefixes
-# are derived so they can't drift; the special entries must be kept in sync by
-# hand with the explicit branches in get_field_by_name
-# (`annotation_queue_items.queue_id` is an exact ref, not a prefix).
+# Built only for the error message. `*_dump` prefixes are derived (can't drift);
+# the specials must be hand-synced with get_field_by_name (queue_id is exact, not a prefix).
 _DUMP_SUFFIX = "_dump"
 _SPECIAL_DYNAMIC_FIELD_PREFIXES = (
     "feedback.*",

--- a/weave/trace_server/calls_query_builder/monitor_query_validation.py
+++ b/weave/trace_server/calls_query_builder/monitor_query_validation.py
@@ -1,0 +1,125 @@
+"""Server-side validation for saved Monitor object queries.
+
+A Monitor carries a `query` over call fields that the scoring worker runs every
+cycle. We reject queries referencing disallowed fields or that are structurally
+invalid at obj_create time, so a bad monitor fails loudly on save instead of
+silently erroring per scoring cycle.
+"""
+
+from pydantic import ValidationError
+
+from weave.trace_server.calls_query_builder.calls_query_builder import (
+    ALLOWED_CALL_FIELDS,
+    CallsMergedDynamicField,
+    process_query_to_conditions,
+)
+from weave.trace_server.errors import InvalidFieldError, InvalidRequest
+from weave.trace_server.interface import query as tsi_query
+from weave.trace_server.orm import ParamBuilder
+
+
+def validate_monitor_query_fields(
+    base_object_class: str | None,
+    leaf_object_class: str | None,
+    val: object,
+) -> None:
+    """Reject a saved Monitor whose `query` is malformed or uses a disallowed field."""
+    if not _is_monitor_object(base_object_class, leaf_object_class):
+        return
+    query = _monitor_query(val)
+    if query is None:
+        return
+    validate_calls_query(query)
+
+
+def validate_calls_query(query: tsi_query.Query) -> None:
+    """Reject a calls query referencing a disallowed field or that is structurally invalid.
+
+    Validates by compiling the query to SQL conditions: compilation is what
+    surfaces both bad field refs (InvalidFieldError) and malformed structure.
+    """
+    try:
+        process_query_to_conditions(query, ParamBuilder(), "calls_merged")
+    except InvalidFieldError as e:
+        raise InvalidFieldError(_invalid_field_message(str(e))) from e
+    except (ValueError, TypeError) as e:
+        raise InvalidRequest(f"Invalid query: {e}") from e
+
+
+# Serialized `_class_name`/`_bases` values for Monitor objects. Kept as
+# server-side strings on purpose: the trace server must not import weave/flow.
+MONITOR_OBJECT_CLASSES = frozenset({"Monitor", "ClassifierMonitor"})
+
+
+def _is_monitor_object(
+    base_object_class: str | None, leaf_object_class: str | None
+) -> bool:
+    """Whether a written object is a Monitor, by its serialized class name."""
+    return (
+        base_object_class in MONITOR_OBJECT_CLASSES
+        or leaf_object_class in MONITOR_OBJECT_CLASSES
+    )
+
+
+def _monitor_query(val: object) -> tsi_query.Query | None:
+    """Extract a recognizable calls query from a serialized Monitor, else None.
+
+    None when there is no query or the value is not a query we understand (e.g. a
+    non-Monitor object sharing the class name); such writes are left untouched.
+    """
+    if not isinstance(val, dict):
+        return None
+    raw_query = val.get("query")
+    if raw_query is None:
+        return None
+    cleaned = _strip_weave_object_keys(raw_query)
+    try:
+        return tsi_query.Query.model_validate(cleaned)
+    except ValidationError:
+        return None
+
+
+_WEAVE_BOOKKEEPING_KEYS = frozenset({"_type", "_class_name", "_bases"})
+
+
+def _strip_weave_object_keys(value: object) -> object:
+    """Drop weave bookkeeping keys (`_type`, `_class_name`, `_bases`) from a serialized query."""
+    if isinstance(value, dict):
+        return {
+            k: _strip_weave_object_keys(v)
+            for k, v in value.items()
+            if k not in _WEAVE_BOOKKEEPING_KEYS
+        }
+    if isinstance(value, list):
+        return [_strip_weave_object_keys(v) for v in value]
+    return value
+
+
+# Field references get_field_by_name accepts beyond exact ALLOWED_CALL_FIELDS
+# keys, used only to build the user-facing error message. The `*_dump` prefixes
+# are derived so they can't drift; the special entries must be kept in sync by
+# hand with the explicit branches in get_field_by_name
+# (`annotation_queue_items.queue_id` is an exact ref, not a prefix).
+_DUMP_SUFFIX = "_dump"
+_SPECIAL_DYNAMIC_FIELD_PREFIXES = (
+    "feedback.*",
+    "annotation_queue_items.queue_id",
+    "summary.weave.*",
+)
+ALLOWED_DYNAMIC_FIELD_PREFIXES = _SPECIAL_DYNAMIC_FIELD_PREFIXES + tuple(
+    f"{name[: -len(_DUMP_SUFFIX)]}.*"
+    for name, field in ALLOWED_CALL_FIELDS.items()
+    if isinstance(field, CallsMergedDynamicField) and name.endswith(_DUMP_SUFFIX)
+)
+
+
+def _invalid_field_message(reason: str) -> str:
+    """Append the allowed field list and dynamic prefixes to a field rejection."""
+    allowed = ", ".join(
+        sorted(k for k in ALLOWED_CALL_FIELDS if not k.endswith(_DUMP_SUFFIX))
+    )
+    prefixes = ", ".join(ALLOWED_DYNAMIC_FIELD_PREFIXES)
+    return (
+        f"{reason}. Allowed fields: {allowed}. "
+        f"Allowed dynamic field prefixes: {prefixes}"
+    )

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -103,6 +103,8 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     build_calls_complete_update_query,
     build_calls_stats_query,
     combine_conditions,
+)
+from weave.trace_server.calls_query_builder.monitor_query_validation import (
     validate_monitor_query_fields,
 )
 from weave.trace_server.calls_query_builder.usage_query_builder import (

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -103,6 +103,7 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
     build_calls_complete_update_query,
     build_calls_stats_query,
     combine_conditions,
+    validate_monitor_query_fields,
 )
 from weave.trace_server.calls_query_builder.usage_query_builder import (
     build_usage_query,
@@ -1993,6 +1994,11 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
             expected=req.obj.expected_digest,
             actual=digest,
             label=f"obj {req.obj.object_id!r}",
+        )
+        validate_monitor_query_fields(
+            digest_result.base_object_class,
+            digest_result.leaf_object_class,
+            processed_val,
         )
 
         kind = get_kind(processed_val)


### PR DESCRIPTION
## Summary
- Validate `Monitor.query` field refs against `ALLOWED_CALL_FIELDS` at object-create time; reject unknown fields (e.g. `operation_name`) with the allowed list in the error.
- Prevents the silent per-cycle InvalidFieldError storm in the scoring worker (a bad monitor query fails sampling forever today with no user signal).
- Validation lives in its own `monitor_query_validation.py` (keeps `calls_query_builder.py` untouched).

## Testing
functional obj_create tests: bad field rejected with allowed list + not stored; malformed query rejected; static/dynamic/absent queries accepted.