### PR TITLE
fix(weave): exempt started_at from float convert in saved view filters

### DIFF
--- a/tests/trace/test_saved_view.py
+++ b/tests/trace/test_saved_view.py
@@ -6,6 +6,7 @@ import weave
 from weave.flow.saved_view import (
     Filter,
     Filters,
+    filter_to_clause,
     filters_to_query,
     query_to_filters,
     to_seconds,
@@ -122,6 +123,27 @@ def test_roundtrip_operators():
         query = filters_to_query(filters)
         filters2 = query_to_filters(query)
         assert filters == filters2
+
+
+def test_number_filter_skips_float_convert_for_typed_columns():
+    """Typed columns (started_at, latency_ms) skip the `$convert` to double; JSON fields keep it."""
+    assert filter_to_clause(
+        Filter(field="started_at", operator="(number): >=", value=1777593600)
+    ) == {"$gte": [{"$getField": "started_at"}, {"$literal": 1777593600.0}]}
+    assert filter_to_clause(
+        Filter(field="started_at", operator="(number): <=", value=1778889599)
+    ) == {"$not": [{"$gt": [{"$getField": "started_at"}, {"$literal": 1778889599.0}]}]}
+    assert filter_to_clause(
+        Filter(field="summary.weave.latency_ms", operator="(number): >", value=100)
+    ) == {"$gt": [{"$getField": "summary.weave.latency_ms"}, {"$literal": 100.0}]}
+    assert filter_to_clause(
+        Filter(field="inputs.score", operator="(number): >", value=5)
+    ) == {
+        "$gt": [
+            {"$convert": {"input": {"$getField": "inputs.score"}, "to": "double"}},
+            {"$literal": 5.0},
+        ]
+    }
 
 
 def test_filter_op_without_client():

--- a/weave/flow/saved_view.py
+++ b/weave/flow/saved_view.py
@@ -154,11 +154,9 @@ OPERATOR_MAP = {
 
 VALUELESS_OPERATORS = {"(any): isEmpty", "(any): isNotEmpty"}
 
-# We return a real float from the backend! do not convert to double!
-# When option clicking latency, because we are generating this field
-# manually on the backend, it is actually a float, not a string stored
-# in json, so we need to omit the conversion params from the filter
-FIELDS_NO_FLOAT_CONVERT = {"summary.weave.latency_ms"}
+# Real typed columns (a backend float, a DateTime64), not JSON strings, so they
+# skip the `to: double` cast. toFloat64OrNull on started_at is rejected by ClickHouse.
+FIELDS_NO_FLOAT_CONVERT = {"summary.weave.latency_ms", "started_at"}
 
 
 def py_to_api_filter(filter: tsi.CallsFilter | None) -> tsi.CallsFilter | None:


### PR DESCRIPTION
## Summary
- Numeric SavedView filters on `started_at` wrapped the `DateTime64` column in `$convert -> double`, so the server emitted `toFloat64OrNull(any(started_at))`, which ClickHouse 25.12 rejects (`*OrNull` takes String only) -> 403 `QueryIllegalTypeofArgumentError` in prod.
- Root cause: SDK `FIELDS_NO_FLOAT_CONVERT` only listed `summary.weave.latency_ms`. The frontend added `started_at` in #35256 (2025-10-13); the Python SDK (`saved_view.py`, ported in #4385) was never updated, so SDK-built queries kept casting it. This fixes that divergence.
- Jira: [WB-35575](https://coreweave.atlassian.net/browse/WB-35575)

## Impact
Datadog last 15d: 16 failed read requests, 5 users / 4 entities. Read-only paths (`/calls/stream_query`, `/calls/query_stats`) -> no data loss; users get a 403 when filtering calls by `started_at`.

## Testing
unit test asserts started_at/latency_ms stay bare `$getField` while JSON fields keep the `$convert`; fails on master with the exact prod payload.


[WB-35575]: https://coreweave.atlassian.net/browse/WB-35575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ