### PR TITLE
feat(weave_ts): add Turn.setAttributes (plural), deprecate setAttribute

### DIFF
--- a/sdks/node/src/__tests__/genai/turn.test.ts
+++ b/sdks/node/src/__tests__/genai/turn.test.ts
@@ -52,34 +52,44 @@ describe('Turn', () => {
   });
 });
 
-describe('Turn.setAttribute', () => {
+describe('Turn.setAttributes', () => {
   setupGenAITestEnvironment();
   const getExporter = setupExporterPerTest();
 
-  it('writes an attribute to the underlying span', () => {
+  it('writes attributes to the underlying span', () => {
     const turn = Turn.create({});
-    turn.setAttribute('weave.cost.usd', 0.42);
+    turn.setAttributes({'weave.cost.usd': 0.42, 'weave.tag': 'enterprise'});
     turn.end();
     const spans = getExporter().getFinishedSpans();
-    expect(findSpan(spans, 'invoke_agent').attributes['weave.cost.usd']).toBe(
-      0.42
-    );
+    const turnSpan = findSpan(spans, 'invoke_agent');
+    expect(turnSpan.attributes['weave.cost.usd']).toBe(0.42);
+    expect(turnSpan.attributes['weave.tag']).toBe('enterprise');
   });
 
   it('returns this for chaining', () => {
     const turn = Turn.create({});
-    expect(turn.setAttribute('k', 'v')).toBe(turn);
+    expect(turn.setAttributes({k: 'v'})).toBe(turn);
     turn.end();
   });
 
   it('is a no-op after end()', () => {
     const turn = Turn.create({});
     turn.end();
-    turn.setAttribute('after.end', 'x');
+    turn.setAttributes({'after.end': 'x'});
     const spans = getExporter().getFinishedSpans();
     expect(
       findSpan(spans, 'invoke_agent').attributes['after.end']
     ).toBeUndefined();
+  });
+
+  it('deprecated setAttribute alias delegates to setAttributes', () => {
+    const turn = Turn.create({});
+    expect(turn.setAttribute('weave.cost.usd', 0.42)).toBe(turn);
+    turn.end();
+    const spans = getExporter().getFinishedSpans();
+    expect(findSpan(spans, 'invoke_agent').attributes['weave.cost.usd']).toBe(
+      0.42
+    );
   });
 });
 

--- a/sdks/node/src/genai/turn.ts
+++ b/sdks/node/src/genai/turn.ts
@@ -1,6 +1,6 @@
 import {
-  type AttributeValue,
   type Attributes,
+  type AttributeValue,
   type Context,
   ROOT_CONTEXT,
   type Span,
@@ -128,17 +128,28 @@ export class Turn {
   }
 
   /**
-   * Set a single attribute on the Turn span. Useful for stamping running
-   * totals (e.g. cumulative cost, token usage) or other metadata that becomes
-   * known mid-turn. No-op after `end()`. Mirrors OTel `Span.setAttribute`.
+   * Stamp arbitrary attributes on the Turn span. Pass an object whether you
+   * have one key or many. Useful for stamping running totals (e.g. cumulative
+   * cost, token usage) or other metadata that becomes known mid-turn. No-op
+   * after `end()`. Mirrors OTel `Span.setAttributes` and the Python SDK's
+   * `set_attributes`.
    *
    * @example
-   * turn.setAttribute('gen_ai.usage.input_tokens', totalInputTokens);
+   * turn.setAttributes({'gen_ai.usage.input_tokens': totalInputTokens});
+   */
+  setAttributes(attributes: Attributes): this {
+    if (this._ended) return this;
+    this.span.setAttributes(attributes);
+    return this;
+  }
+
+  /**
+   * @deprecated Use {@link setAttributes} instead, which mirrors the Python
+   * SDK's `set_attributes` and OTel's `Span.setAttributes`. Retained as a
+   * thin alias so existing single-attribute callers keep working.
    */
   setAttribute(key: string, value: AttributeValue): this {
-    if (this._ended) return this;
-    this.span.setAttribute(key, value);
-    return this;
+    return this.setAttributes({[key]: value});
   }
 
   /**


### PR DESCRIPTION
## Description

Aligns `Turn`'s attribute API with the landed Python SDK (#7131), which exposes `set_attributes(dict)` on the shared span mixin.

- **Adds `Turn.setAttributes(attributes)`** (plural, object arg) — "pass an object whether you have one key or many." Mirrors the Python `set_attributes` and OTel JS's `Span.setAttributes`.
- **Keeps `Turn.setAttribute(key, value)` as a `@deprecated` alias** that delegates to `setAttributes({[key]: value})`. `Turn.setAttribute` already shipped on `master` and has live consumers (e.g. `weave-openclaw`, ~8 call sites), so this is intentionally **non-breaking** — existing callers keep working, with the doc-comment steering new code to the plural form.

This completes a coordinated plural rename across the GenAI emitter family:

| Emitter | PR | Surface |
|---|---|---|
| Tool | #7076 | `setAttributes` only (never released singular) |
| LLM | #7078 | `setAttributes` only |
| SubAgent | #7077 | `setAttributes` only |
| Turn | this PR | `setAttributes` + `@deprecated setAttribute` alias |

Only `Turn` carries the back-compat alias because it's the only one whose singular form had shipped; adding a "deprecated-from-birth" alias to the others would be dead surface.

## Testing

`cd sdks/node && npx jest src/__tests__/genai/turn.test.ts` — 10 passing. Coverage:
- `setAttributes` writes multiple keys, returns `this`, no-ops after `end()`.
- The deprecated `setAttribute` alias still lands its attribute and chains.

Also clean: `npx prettier --check`, `npx tsc --noEmit -p tsconfig.cjs.json`.
