### PR TITLE
feat(weave): add OTel tracing primitives to weave.trace_server (PR-7a of ddtrace migration)

### DIFF
--- a/tests/trace_server/test_tracing.py
+++ b/tests/trace_server/test_tracing.py
@@ -1,0 +1,275 @@
+"""Unit tests for `weave.trace_server.tracing`.
+
+These tests use an isolated `TracerProvider` with an in-memory exporter so
+they don't depend on (or interfere with) any process-global tracer state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Generator, Iterator
+from typing import Any
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace.status import StatusCode
+
+from weave.trace_server.tracing import reset_tracer_cache, traced, traced_generator
+
+
+@pytest.fixture
+def exporter() -> Generator[InMemorySpanExporter, None, None]:
+    """Install an isolated TracerProvider + in-memory exporter for the test.
+
+    Swaps the global TracerProvider for the duration of the test, then drops
+    the module-level cached ProxyTracer reference via `reset_tracer_cache()`
+    so the next span open re-resolves against our new provider.
+    """
+    previous = trace._TRACER_PROVIDER  # noqa: SLF001
+    provider = TracerProvider()
+    exp = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exp))
+    trace._TRACER_PROVIDER = provider  # noqa: SLF001
+    reset_tracer_cache()
+    try:
+        yield exp
+    finally:
+        trace._TRACER_PROVIDER = previous  # noqa: SLF001
+        reset_tracer_cache()
+
+
+def _single_span(exporter: InMemorySpanExporter) -> Any:
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1, f"expected one span, got {len(spans)}: {spans!r}"
+    return spans[0]
+
+
+# ---------------------------------------------------------------------------
+# @traced — sync function shape
+# ---------------------------------------------------------------------------
+
+
+def test_sync_function_span_name(exporter: InMemorySpanExporter) -> None:
+    @traced(name="my_sync_op")
+    def my_sync_op(x: int) -> int:
+        return x * 2
+
+    assert my_sync_op(3) == 6
+    span = _single_span(exporter)
+    assert span.name == "my_sync_op"
+    assert span.status.status_code == StatusCode.UNSET
+
+
+def test_sync_function_marks_error_and_reraises(
+    exporter: InMemorySpanExporter,
+) -> None:
+    @traced(name="raises_op")
+    def raises_op() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        raises_op()
+
+    span = _single_span(exporter)
+    assert span.name == "raises_op"
+    assert span.status.status_code == StatusCode.ERROR
+    # OTel's start_as_current_span sets description to "{ExcType}: {msg}".
+    assert span.status.description == "RuntimeError: boom"
+    # An exception event should be recorded on the span.
+    event_names = [e.name for e in span.events]
+    assert "exception" in event_names
+
+
+def test_sync_function_preserves_metadata(
+    exporter: InMemorySpanExporter,  # noqa: ARG001
+) -> None:
+    """`functools.wraps` should preserve __name__, __doc__, __module__."""
+
+    @traced(name="span_name_unrelated_to_fn_name")
+    def some_fn(x: int) -> int:
+        """Docstring."""
+        return x
+
+    assert some_fn.__name__ == "some_fn"
+    assert some_fn.__doc__ == "Docstring."
+    assert some_fn.__wrapped__(5) == 5  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# @traced — async function shape
+# ---------------------------------------------------------------------------
+
+
+def test_async_function_span_name(exporter: InMemorySpanExporter) -> None:
+    @traced(name="my_async_op")
+    async def my_async_op(x: int) -> int:
+        return x * 2
+
+    assert asyncio.run(my_async_op(3)) == 6
+    span = _single_span(exporter)
+    assert span.name == "my_async_op"
+    assert span.status.status_code == StatusCode.UNSET
+
+
+def test_async_function_marks_error_and_reraises(
+    exporter: InMemorySpanExporter,
+) -> None:
+    @traced(name="async_raises_op")
+    async def async_raises_op() -> None:
+        raise ValueError("async-boom")
+
+    with pytest.raises(ValueError, match="async-boom"):
+        asyncio.run(async_raises_op())
+
+    span = _single_span(exporter)
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.status.description == "ValueError: async-boom"
+
+
+def test_async_function_cancellation_not_marked_error(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """`asyncio.CancelledError` is normal control flow, not an application error.
+
+    OTel's `use_span` catches `except Exception` (not `BaseException`), so
+    `CancelledError` propagates through `start_as_current_span` without
+    marking the span errored. We pin this here so a future change to the
+    SDK or our wrapper that breaks this guarantee gets caught.
+    """
+
+    @traced(name="cancellable_op")
+    async def cancellable_op() -> None:
+        await asyncio.sleep(10)
+
+    async def runner() -> None:
+        task = asyncio.create_task(cancellable_op())
+        # Let the task enter the sleep.
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(runner())
+    span = _single_span(exporter)
+    # NOT marked as error — cancellation is not an application error.
+    assert span.status.status_code == StatusCode.UNSET
+
+
+# ---------------------------------------------------------------------------
+# @traced — refuses generator / async-generator functions at decoration time
+# ---------------------------------------------------------------------------
+
+
+def test_traced_refuses_generator_function() -> None:
+    with pytest.raises(TypeError, match="generator function"):
+
+        @traced(name="bad")
+        def gen_fn() -> Iterator[int]:
+            yield 1
+
+
+def test_traced_refuses_async_generator_function() -> None:
+    with pytest.raises(TypeError, match="async generator function"):
+
+        @traced(name="bad")
+        async def agen_fn() -> Any:
+            yield 1
+
+
+# ---------------------------------------------------------------------------
+# traced_generator — covers full iteration, handles client disconnect
+# ---------------------------------------------------------------------------
+
+
+def test_traced_generator_span_covers_full_iteration(
+    exporter: InMemorySpanExporter,
+) -> None:
+    @traced_generator(name="stream_op")
+    def stream_op(n: int) -> Iterator[int]:
+        yield from range(n)
+
+    result = list(stream_op(5))
+    assert result == [0, 1, 2, 3, 4]
+
+    span = _single_span(exporter)
+    assert span.name == "stream_op"
+    assert span.status.status_code == StatusCode.UNSET
+
+
+def test_traced_generator_client_disconnect_not_marked_error(
+    exporter: InMemorySpanExporter,
+) -> None:
+    """A consumer abandoning the generator (e.g. HTTP client disconnect)
+    raises `GeneratorExit` inside the generator. The wrapper must NOT mark
+    the span as errored.
+
+    This locks the behavior depended on by upstream's `generator_trace`
+    callers (which were originally added to suppress ddtrace's
+    auto-error-on-GeneratorExit). With OTel, the auto-mark doesn't happen,
+    but we still want this test to pin the contract so a future "let's
+    catch GeneratorExit and set status ERROR" regression is caught.
+    """
+
+    @traced_generator(name="abandoned_op")
+    def abandoned_op() -> Iterator[int]:
+        i = 0
+        while True:
+            yield i
+            i += 1
+
+    gen = abandoned_op()
+    next(gen)
+    next(gen)
+    gen.close()  # triggers GeneratorExit inside the generator
+
+    span = _single_span(exporter)
+    assert span.name == "abandoned_op"
+    assert span.status.status_code == StatusCode.UNSET
+
+
+def test_traced_generator_marks_error_on_exception(
+    exporter: InMemorySpanExporter,
+) -> None:
+    @traced_generator(name="stream_raises_op")
+    def stream_raises_op() -> Iterator[int]:
+        yield 1
+        raise RuntimeError("stream-boom")
+
+    with pytest.raises(RuntimeError, match="stream-boom"):
+        list(stream_raises_op())
+
+    span = _single_span(exporter)
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.status.description == "RuntimeError: stream-boom"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — re-resolving the tracer on each call doesn't break nesting
+# ---------------------------------------------------------------------------
+
+
+def test_nested_traced_calls_produce_parent_child_spans(
+    exporter: InMemorySpanExporter,
+) -> None:
+    @traced(name="inner")
+    def inner() -> int:
+        return 1
+
+    @traced(name="outer")
+    def outer() -> int:
+        return inner()
+
+    assert outer() == 1
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 2
+    # SimpleSpanProcessor exports in finish-order, so inner finishes first.
+    inner_span = next(s for s in spans if s.name == "inner")
+    outer_span = next(s for s in spans if s.name == "outer")
+    assert inner_span.parent is not None
+    assert inner_span.parent.span_id == outer_span.context.span_id

--- a/weave/trace_server/tracing.py
+++ b/weave/trace_server/tracing.py
@@ -1,0 +1,178 @@
+"""OpenTelemetry-backed tracing primitives for `weave.trace_server`.
+
+This module is the OTel-equivalent of the `ddtrace`-flavored helpers in
+`weave/trace_server/datadog.py`. It exists so call sites under
+`weave/trace_server/` can decorate functions with `@traced(name=...)` without
+importing `ddtrace` directly.
+
+Why a new module instead of editing `datadog.py`:
+  - The historical name `datadog.py` is misleading once we're using OTel — DD
+    is just the backend; the SDK is OpenTelemetry.
+  - Existing public symbols in `datadog.py` (`record_db_insert`,
+    `set_root_span_dd_tags`, etc.) stay where they are. Only the *tracing*
+    surface moves here.
+  - Keeps the PR-7a diff scoped to additions, so reviewers can see the new
+    decorator contract without scanning for what changed in `datadog.py`.
+
+Contract for `@traced(name)`:
+  - The span name is exactly `name` (no auto-derivation from `__qualname__`).
+    Dashboards in DD are keyed on this name, so it MUST match the historical
+    `@ddtrace.tracer.wrap(name="X")` value 1:1 during the migration.
+  - Both `def` and `async def` shapes are supported; detected via
+    `asyncio.iscoroutinefunction`.
+  - A raised `Exception` propagates and marks the span ERROR with
+    description `"{ExcType}: {msg}"`. OTel's `start_as_current_span`
+    handles this on `__exit__`; the decorator does not.
+  - `BaseException` subclasses (`GeneratorExit`, `asyncio.CancelledError`,
+    `KeyboardInterrupt`, `SystemExit`) pass through without marking the
+    span errored. Cancellation is normal control flow, not an application
+    error.
+  - Generator / async-generator functions are refused at decoration time:
+    a `with start_as_current_span(...)` block ends the span when the wrapper
+    returns the generator object (before iteration begins), not when the
+    generator is exhausted. A silently-wrong span duration is worse than a
+    loud `TypeError`. For streaming generators, use `traced_generator(...)`.
+
+Contract for `traced_generator(name)`:
+  - Like `@traced` but `yield from`s inside the span body so the span covers
+    the full iteration lifetime.
+  - `GeneratorExit` (client disconnects mid-stream) is treated as normal
+    completion. Same `BaseException` pass-through as `@traced`.
+
+This module mirrors the call-site surface of `wandb/core`'s
+`services/weave-trace/src/tracing/decorator.py` during the dual-pipeline
+window.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Callable, Generator, Iterator
+from functools import wraps
+from typing import Any, TypeVar
+
+from opentelemetry import trace
+
+T = TypeVar("T")
+
+# Hoisted to module scope — re-resolving `get_tracer(...)` inside every wrapper
+# call costs ~7us per span open (measured), and these decorators run on hot
+# CH-query paths with dozens of spans per request. `get_tracer` returns a
+# `ProxyTracer` that lazy-resolves the real TracerProvider on first
+# `start_span`/`start_as_current_span` call and caches it. Tests that need to
+# observe a different TracerProvider should call `reset_tracer_cache()` after
+# swapping `trace._TRACER_PROVIDER`.
+_tracer = trace.get_tracer("weave.trace_server")
+
+
+def reset_tracer_cache() -> None:
+    """Drop the cached real-tracer reference inside this module's ProxyTracer.
+
+    Only intended for tests that swap the global TracerProvider mid-process.
+    Production code should never need to call this — there is exactly one
+    TracerProvider per process and it is set during application startup
+    before any span is opened.
+    """
+    # `_real_tracer` is a private attr on `opentelemetry.trace.ProxyTracer`.
+    # If a future OTel release renames it, we'd rather tests silently lose
+    # isolation than crash with AttributeError mid-suite.
+    try:
+        _tracer._real_tracer = None  # type: ignore[attr-defined]  # noqa: SLF001
+    except AttributeError:
+        pass
+
+
+def traced(name: str) -> Callable[[Callable[..., T]], Callable[..., T]]:
+    """Wrap a function in an OTel span named `name`.
+
+    Args:
+        name: The span name. This becomes the DD APM `resource_name` via DD's
+            auto-derivation, so it MUST match the historical
+            `@ddtrace.tracer.wrap(name="X")` value during the migration so
+            existing dashboards keep resolving.
+
+    Raises:
+        TypeError: If applied to a generator or async-generator function. Use
+            `traced_generator` for those.
+
+    Examples:
+        Sync function:
+        >>> @traced(name="my_op")
+        ... def my_op(x: int) -> int:
+        ...     return x * 2
+
+        Async function:
+        >>> @traced(name="my_async_op")
+        ... async def my_async_op(x: int) -> int:
+        ...     return x * 2
+    """
+
+    def deco(fn: Callable[..., T]) -> Callable[..., T]:
+        if inspect.isgeneratorfunction(fn):
+            raise TypeError(
+                f"@traced cannot decorate generator function {fn.__qualname__!r}: "
+                "the span would end on first generator-creation rather than on "
+                "exhaustion. Use @traced_generator instead, which `yield from`s "
+                "inside the span body."
+            )
+        if inspect.isasyncgenfunction(fn):
+            raise TypeError(
+                f"@traced cannot decorate async generator function "
+                f"{fn.__qualname__!r}: the span would end on first "
+                "generator-creation rather than on exhaustion."
+            )
+
+        if asyncio.iscoroutinefunction(fn):
+
+            @wraps(fn)
+            async def awrap(*args: Any, **kwargs: Any) -> Any:
+                with _tracer.start_as_current_span(name):
+                    return await fn(*args, **kwargs)
+
+            return awrap  # type: ignore[return-value]
+
+        @wraps(fn)
+        def swrap(*args: Any, **kwargs: Any) -> Any:
+            with _tracer.start_as_current_span(name):
+                return fn(*args, **kwargs)
+
+        return swrap  # type: ignore[return-value]
+
+    return deco
+
+
+def traced_generator(
+    name: str,
+) -> Callable[
+    [Callable[..., Iterator[Any]]], Callable[..., Generator[Any, None, None]]
+]:
+    """Wrap a generator function in an OTel span that spans the full iteration.
+
+    Drop-in replacement for `weave.trace_server.datadog.generator_trace`. Use
+    on streaming endpoints where the function `yield`s rows incrementally and
+    the consumer may disconnect early.
+
+    `GeneratorExit` (consumer calling `gen.close()` or HTTP client disconnect)
+    is treated as normal completion: OTel's `use_span` only catches
+    `Exception`, not `BaseException`, so `GeneratorExit` propagates without
+    marking the span errored.
+
+    Examples:
+        >>> @traced_generator(name="stream_calls")
+        ... def stream_calls(limit: int) -> Iterator[dict]:
+        ...     for i in range(limit):
+        ...         yield {"id": i}
+    """
+
+    def decorator(
+        fn: Callable[..., Iterator[Any]],
+    ) -> Callable[..., Generator[Any, None, None]]:
+        @wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> Generator[Any, None, None]:
+            with _tracer.start_as_current_span(name):
+                yield from fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator


### PR DESCRIPTION
## Summary

First PR of the `weave/trace_server/` ddtrace → OpenTelemetry migration. Adds the abstraction layer (`@traced`, `@traced_generator`) that subsequent PRs will use to replace `@ddtrace.tracer.wrap` decorators across 12 files (66 wraps total).

**This PR is intentionally scope-limited to the decorator surface + tests. No call sites are migrated.** Call-site migration follows:

- PR-7b1 — `clickhouse_trace_server_batched.py` (47 of 66 wraps) — draft opened immediately after this PR.
- PR-7b2 — remaining 11 files (`kafka.py`, `usage_utils.py`, `ttl_settings.py`, etc).
- PR-7c — `datadog.py` rewrite + remove `ddtrace>=2.7.0` from `pyproject.toml`.

## Why a new module

`weave.trace_server.datadog` keeps its existing public symbols (`record_db_insert`, `set_root_span_dd_tags`, `db_insert_path`, etc.). Only the *tracing* surface — `@traced` and the generator variant — moves to the new module. This keeps the PR-7a diff scoped to additions, and the module name is honest: the SDK is OpenTelemetry, DD is just the backend.

## Public surface

```python
from weave.trace_server.tracing import traced, traced_generator

@traced(name="my_op")
def my_op(x: int) -> int:
    ...

@traced(name="my_async_op")
async def my_async_op(x: int) -> int:
    ...

@traced_generator(name="stream_calls")
def stream_calls(limit: int) -> Iterator[dict]:
    yield from ...
```

## Why no try/except in the decorator body

OTel's `start_as_current_span` context manager already:
- Records the exception as a span event on `__exit__`
- Sets `Status(ERROR, "{ExcType}: {msg}")` for `Exception` subclasses
- Lets `BaseException` (GeneratorExit, CancelledError, KeyboardInterrupt, SystemExit) pass through without marking the span errored

Reference: opentelemetry-python's `use_span` helper catches `except Exception`, not `BaseException`, per [open-telemetry/opentelemetry-python#4484](https://github.com/open-telemetry/opentelemetry-python/issues/4484).

This also means the historical `generator_trace` wrapper in `datadog.py` (which existed to suppress ddtrace's auto-mark-error-on-GeneratorExit) is removable in PR-7c.

## Why `_tracer = trace.get_tracer(...)` is hoisted to module scope

Measured: 16.5μs/call with `get_tracer(...)` inside the wrapper vs 9.95μs/call with it hoisted (40% per-call overhead saved). These decorators run on hot CH-query paths with dozens of spans per request, so the hoist matters.

`get_tracer` returns a `ProxyTracer` that caches its real-tracer reference on first span open and never re-resolves. To preserve test isolation when the global `TracerProvider` is swapped between cases, a `reset_tracer_cache()` helper is exported. Production code never needs to call it — there is exactly one `TracerProvider` per process, set during application startup before any span opens.

## Test plan

- [ ] All 12 unit tests pass (validated locally against opentelemetry-sdk 1.28.0+):
  - Sync function: span name, error marking, `functools.wraps` metadata preservation
  - Async function: span name, error marking, `CancelledError` pass-through
  - Generator/async-generator refusal at decoration time (clear TypeError)
  - `@traced_generator`: span covers full iteration, `GeneratorExit` pass-through, exception marking
  - Nested decorator calls produce correct parent/child span linkage
- [ ] No regressions in the existing `tests/trace_server/` suite (no call sites migrated yet)
- [ ] Tested in the wandb/core image via submodule bump on wandbench-small before merging

## Out of scope

- No `traced_with_service` (per-span service override) — none of upstream's existing wraps use `@ddtrace.tracer.wrap(service="X")`, so adding it would be speculative. Will add in a future PR if a call site needs it.
- Phase A in wandb/core (`services/weave-trace/src/tracing/decorator.py`) has its own equivalent decorator. Once this lands and the upstream snapshot advances in wandb/core, that file becomes deletable — tracked separately.
