### PR TITLE
chore(weave): add structured fields when ref objects are not found

### DIFF
--- a/tests/trace/test_trace_server.py
+++ b/tests/trace/test_trace_server.py
@@ -4,6 +4,7 @@ import pytest
 
 from weave.shared.refs_internal import InvalidInternalRef
 from weave.trace_server import trace_server_interface as tsi
+from weave.trace_server.errors import RefObjectsNotFoundError
 
 
 def test_save_object(client):
@@ -81,3 +82,25 @@ def test_robust_to_url_sensitive_chars(client):
         )
     )
     assert read_res.vals[0] == bad_val[bad_key]
+
+
+def test_refs_read_batch_missing_refs_reports_digests(client):
+    project_id = client.project_id
+    create_res = client.server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=project_id, object_id="real-obj", val={"a": 1}
+            )
+        )
+    )
+    real_ref = f"weave:///{project_id}/object/real-obj:{create_res.digest}"
+    missing_digest = "0" * 43
+    missing_ref = f"weave:///{project_id}/object/missing-obj:{missing_digest}"
+
+    # The missing object surfaces as a RefObjectsNotFoundError carrying the missing
+    # digest as a structured field
+    with pytest.raises(RefObjectsNotFoundError) as exc_info:
+        client.server.refs_read_batch(
+            tsi.RefsReadBatchReq(refs=[real_ref, missing_ref])
+        )
+    assert missing_digest in exc_info.value.missing_object_digests

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -5813,7 +5813,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 if len(ref_digests) != len(found_digests):
                     missing_digests = sorted(ref_digests - found_digests)
                     raise RefObjectsNotFoundError(
-                        f"Ref read contains {len(ref_digests)} digests, but found {len(found_digests)} objects. Diff digests: {ref_digests - found_digests}",
+                        f"Ref read contains {len(ref_digests)} digests, but found {len(found_digests)} objects. Diff digests: {missing_digests}",
                         missing_digests,
                     )
                 # filter out deleted objects

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -179,6 +179,7 @@ from weave.trace_server.errors import (
     NotFoundError,
     ObjectDeletedError,
     ObjectNameTypeCollision,
+    RefObjectsNotFoundError,
     RequestTooLarge,
     handle_clickhouse_query_error,
 )
@@ -5810,8 +5811,10 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                 objs = self._select_objs_query(object_query_builder)
                 found_digests = {obj.digest for obj in objs}
                 if len(ref_digests) != len(found_digests):
-                    raise NotFoundError(
-                        f"Ref read contains {len(ref_digests)} digests, but found {len(found_digests)} objects. Diff digests: {ref_digests - found_digests}"
+                    missing_digests = sorted(ref_digests - found_digests)
+                    raise RefObjectsNotFoundError(
+                        f"Ref read contains {len(ref_digests)} digests, but found {len(found_digests)} objects. Diff digests: {ref_digests - found_digests}",
+                        missing_digests,
                     )
                 # filter out deleted objects
                 valid_objects = [obj for obj in objs if obj.deleted_at is None]

--- a/weave/trace_server/errors.py
+++ b/weave/trace_server/errors.py
@@ -156,6 +156,14 @@ class NotFoundError(Error):
     pass
 
 
+class RefObjectsNotFoundError(NotFoundError):
+    """Raised when reference objects are not found."""
+
+    def __init__(self, message: str, missing_object_digests: list[str]):
+        self.missing_object_digests = missing_object_digests
+        super().__init__(message)
+
+
 class MissingLLMApiKeyError(Error):
     """Raised when a LLM API key is missing for completion."""
 
@@ -319,6 +327,13 @@ class ErrorRegistry:
 
         # 404
         self.register(NotFoundError, 404)
+        # Exact-type registration (the registry matches by exact type), so the
+        # missing-digest field is surfaced in the response body.
+        self.register(
+            RefObjectsNotFoundError,
+            404,
+            _format_ref_objects_not_found_error,
+        )
         self.register(ProjectNotFound, 404)
         self.register(RunNotFound, 404)
         self.register(ObjectDeletedError, 404, _format_object_deleted_error)
@@ -491,6 +506,14 @@ def _format_object_deleted_error(exc: Exception) -> dict[str, Any]:
     extra = {}
     if isinstance(exc, ObjectDeletedError):
         extra["deleted_at"] = exc.deleted_at.isoformat()
+    return _format_error_to_json_with_extra(exc, extra)
+
+
+def _format_ref_objects_not_found_error(exc: Exception) -> dict[str, Any]:
+    """Format RefObjectsNotFoundError with the missing object digests."""
+    extra = {}
+    if isinstance(exc, RefObjectsNotFoundError):
+        extra["missing_object_digests"] = exc.missing_object_digests
     return _format_error_to_json_with_extra(exc, extra)
 
 


### PR DESCRIPTION
## Description

- [https://coreweave.atlassian.net/browse/](https://coreweave.atlassian.net/browse/WB-35394)

This PR surfaces the missing refs in a structured field, `missing_digests.` This PR allows for better error handling on the application when a batched read is made. 

See accompanying FE PR for how the error gets surfaced on an eval table: https://github.com/wandb/core/pull/45716

When a run dies before the Weave SDK flushes all of its objects, refs_read_batch references objects the server doesn't have and fails the whole batch with a generic 404:
`{ "reason": "Ref read contains 4 digests, but found 3 objects. Diff digests: {'aq4j…'}" }`

The model evals client, reads every compared run's eval + model objects in one batch) can't tell which object is missing without scraping that human-readable string. This adds the missing digests as a structured field so clients can attribute the failure programmatically (we want to map a digest back to the run that referenced it) instead of parsing the message.

**What changed**
* New `RefObjectsNotFoundError(NotFoundError)` carrying missing_object_digests: list[str]. 
* Subclasses NotFoundError, so existing except NotFoundError callers and 404 handling are unaffected.

**Response shape**
Status code (404) and reason are unchanged; the only addition is the new field:
```json
{
  "reason": "Ref read contains 4 digests, but found 3 objects. Diff digests: {'aq4j…'}",
  "missing_object_digests": ["aq4j…"]
}
```

**Compatibility**
Additive:
* Existing clients that only read reason/status see no change.
* RefObjectsNotFoundError is a NotFoundError, so type-based handling continues to work.

## Testing

How was this PR tested?
* Added a unit test.
