### PR TITLE
feat(weave_ts)!: Remove export of `WeaveClient` value, only export as type.

### DIFF
--- a/sdks/node/scripts/loadTest.ts
+++ b/sdks/node/scripts/loadTest.ts
@@ -1,4 +1,5 @@
 import * as weave from 'weave';
+import type {WeaveClient} from 'weave';
 
 const func = weave.op(async () => 1);
 const myFunction = async (a: number = 1, b: string = 'hello', c: boolean = true) => {
@@ -13,7 +14,7 @@ const myFunction2 = async ({ a, b = 'wuh' }: { a?: number; b?: string }) => {
 };
 const func4 = weave.op(myFunction2, { parameterNames: 'useParam0Object' });
 
-async function bench(func: weave.Op<any>, calls: number, client: weave.WeaveClient) {
+async function bench(func: weave.Op<any>, calls: number, client: WeaveClient) {
   console.log(`Benchmarking with ${calls} calls...`);
   const startTime = Date.now();
   const promises = Array(calls)

--- a/sdks/node/src/__tests__/call.manipulation.test.ts
+++ b/sdks/node/src/__tests__/call.manipulation.test.ts
@@ -1,4 +1,4 @@
-import * as weave from 'weave';
+import {WeaveClient} from '../weaveClient';
 import {op, Op} from 'weave';
 import {CallState, InternalCall} from 'weave/call';
 import {getGlobalClient} from 'weave/clientApi';
@@ -10,7 +10,7 @@ const mockUpdateCall = jest.fn();
 
 jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => {
-    const weaveClient = new weave.WeaveClient(
+    const weaveClient = new WeaveClient(
       null as any,
       null as any,
       mockProjectId

--- a/sdks/node/src/__tests__/call.test.ts
+++ b/sdks/node/src/__tests__/call.test.ts
@@ -1,5 +1,6 @@
 import * as weave from 'weave';
 import {op, type Op} from 'weave';
+import {WeaveClient} from '../weaveClient';
 
 const mockOpName = 'weave://test-project-id/op/test-op';
 const mockCallId = 'test-call-id';
@@ -7,7 +8,7 @@ const mockProjectId = 'test-project-id';
 
 jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => {
-    const weaveClient = new weave.WeaveClient(
+    const weaveClient = new WeaveClient(
       null as any,
       null as any,
       mockProjectId
@@ -22,7 +23,7 @@ jest.mock('weave/clientApi', () => ({
         newStack: [],
       }),
       createCall: (...args: any) => {
-        return weave.WeaveClient.prototype.createCall.apply(weaveClient, args);
+        return WeaveClient.prototype.createCall.apply(weaveClient, args);
       },
       startCall: (...args: any[]) => {
         return Promise.resolve();

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -66,9 +66,16 @@ export {
   type WeaveImage,
 } from './media';
 export {op} from './op';
-export * from './types';
+export type {Op, OpDecorator} from './opType';
+/**
+ * @deprecated Create clients via `weave.init()` — direct construction is
+ * not part of the supported public API and the runtime export will be
+ * removed in a future release.
+ */
+export {WeaveClient} from "./weaveClient";
 export {WeaveObject, ObjectRef} from './weaveObject';
 export {MessagesPrompt, StringPrompt} from './prompt';
+
 // CJS-only side-effect: install the `require()` patcher so CJS hosts
 // auto-instrument supported modules. ESM hosts use the loader hook in
 // `./esm/instrument.mjs` instead, registered via `--import=weave/instrument`.

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -72,7 +72,7 @@ export type {Op, OpDecorator} from './opType';
  * not part of the supported public API and the runtime export will be
  * removed in a future release.
  */
-export {WeaveClient} from "./weaveClient";
+export {WeaveClient} from './weaveClient';
 export {WeaveObject, ObjectRef} from './weaveObject';
 export {MessagesPrompt, StringPrompt} from './prompt';
 

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -14,7 +14,7 @@ export type {
   Query,
   SortBy,
 } from './generated/traceServerApi';
-export type {GetCallsOptions} from './weaveClient';
+export type {GetCallsOptions, WeaveClient} from './weaveClient';
 export {
   wrapOpenAI,
   wrapGoogleGenAI,
@@ -67,12 +67,6 @@ export {
 } from './media';
 export {op} from './op';
 export type {Op, OpDecorator} from './opType';
-/**
- * @deprecated Create clients via `weave.init()` — direct construction is
- * not part of the supported public API and the runtime export will be
- * removed in a future release.
- */
-export {WeaveClient} from './weaveClient';
 export {WeaveObject, ObjectRef} from './weaveObject';
 export {MessagesPrompt, StringPrompt} from './prompt';
 

--- a/sdks/node/src/types.ts
+++ b/sdks/node/src/types.ts
@@ -1,2 +1,0 @@
-export type {Op, OpDecorator} from './opType';
-export {WeaveClient} from './weaveClient';

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -187,6 +187,11 @@ export class WeaveClient {
   private errorCount = 0;
   private readonly MAX_ERRORS = 10;
 
+  /**
+   * @deprecated Create clients via `weave.init()` — direct construction is
+   * not part of the supported public API and the runtime export will be
+   * removed in a future release.
+   */
   constructor(
     public traceServerApi: TraceServerApi<any>,
     private wandbServerApi: WandbServerApi,

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -187,11 +187,6 @@ export class WeaveClient {
   private errorCount = 0;
   private readonly MAX_ERRORS = 10;
 
-  /**
-   * @deprecated Create clients via `weave.init()` — direct construction is
-   * not part of the supported public API and the runtime export will be
-   * removed in a future release.
-   */
   constructor(
     public traceServerApi: TraceServerApi<any>,
     private wandbServerApi: WandbServerApi,


### PR DESCRIPTION
## Description

* `WeaveClient` is currently exported as a value, likely accidentally since it's by way of a wildcard export here:

```js
// src/index.ts
export * from './types';
```

* This class is very likely unused directly by consumers -- clients are typically instantiated by way of `weave.init()`. (Functions for constructing the required argument types are also not exposed via the public API (`TraceServerApi`, `WandbServerApi`, `Settings`).

* ~This change marks this export (and the `constructor` itself) as deprecated, so we may remove it from the public API in a future version of the SDK.~

* This change remove the export as a value, while still exporting as a `type`. Breaking change, so we'll consider when bumping version number for next release.
