### PR TITLE
chore(weave_ts): Don't pass unused `wandbServerApi` argument when creating `WeaveClient`s

### DIFF
--- a/sdks/node/src/__tests__/call.manipulation.test.ts
+++ b/sdks/node/src/__tests__/call.manipulation.test.ts
@@ -1,4 +1,4 @@
-import {WeaveClient} from '../weaveClient';
+import {createWeaveClient, WeaveClient} from '../weaveClient';
 import {op, Op} from 'weave';
 import {CallState, InternalCall} from 'weave/call';
 import {getGlobalClient} from 'weave/clientApi';
@@ -10,11 +10,10 @@ const mockUpdateCall = jest.fn();
 
 jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => {
-    const weaveClient = new WeaveClient(
-      null as any,
-      null as any,
-      mockProjectId
-    );
+    const weaveClient = createWeaveClient({
+      traceServerApi: null as any,
+      projectId: mockProjectId,
+    });
 
     Object.assign(weaveClient, {
       getCall: async (callId: string) => {

--- a/sdks/node/src/__tests__/call.manipulation.test.ts
+++ b/sdks/node/src/__tests__/call.manipulation.test.ts
@@ -1,5 +1,4 @@
-import {createWeaveClient, WeaveClient} from '../weaveClient';
-import {op, Op} from 'weave';
+import {WeaveClient} from '../weaveClient';
 import {CallState, InternalCall} from 'weave/call';
 import {getGlobalClient} from 'weave/clientApi';
 
@@ -10,7 +9,7 @@ const mockUpdateCall = jest.fn();
 
 jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => {
-    const weaveClient = createWeaveClient({
+    const weaveClient = new WeaveClient({
       traceServerApi: null as any,
       projectId: mockProjectId,
     });

--- a/sdks/node/src/__tests__/call.test.ts
+++ b/sdks/node/src/__tests__/call.test.ts
@@ -1,6 +1,6 @@
 import * as weave from 'weave';
 import {op, type Op} from 'weave';
-import {createWeaveClient, WeaveClient} from '../weaveClient';
+import {WeaveClient} from '../weaveClient';
 
 const mockOpName = 'weave://test-project-id/op/test-op';
 const mockCallId = 'test-call-id';
@@ -8,7 +8,7 @@ const mockProjectId = 'test-project-id';
 
 jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => {
-    const weaveClient = createWeaveClient({
+    const weaveClient = new WeaveClient({
       traceServerApi: null as any,
       projectId: mockProjectId,
     });

--- a/sdks/node/src/__tests__/call.test.ts
+++ b/sdks/node/src/__tests__/call.test.ts
@@ -1,6 +1,6 @@
 import * as weave from 'weave';
 import {op, type Op} from 'weave';
-import {WeaveClient} from '../weaveClient';
+import {createWeaveClient, WeaveClient} from '../weaveClient';
 
 const mockOpName = 'weave://test-project-id/op/test-op';
 const mockCallId = 'test-call-id';
@@ -8,11 +8,10 @@ const mockProjectId = 'test-project-id';
 
 jest.mock('weave/clientApi', () => ({
   getGlobalClient: jest.fn(() => {
-    const weaveClient = new WeaveClient(
-      null as any,
-      null as any,
-      mockProjectId
-    );
+    const weaveClient = createWeaveClient({
+      traceServerApi: null as any,
+      projectId: mockProjectId,
+    });
 
     Object.assign(weaveClient, {
       pushNewCall: () => ({

--- a/sdks/node/src/__tests__/clientMock.ts
+++ b/sdks/node/src/__tests__/clientMock.ts
@@ -2,15 +2,14 @@ import {setGlobalClient} from '../clientApi';
 import {type Api as TraceServerApi} from '../generated/traceServerApi';
 import {type InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {Settings} from '../settings';
-import {type WandbServerApi} from '../wandb/wandbServerApi';
-import {createWeaveClient, WeaveClient} from '../weaveClient';
+import {WeaveClient} from '../weaveClient';
 
 export function initWithCustomTraceServer(
   projectId: string,
   customTraceServer: InMemoryTraceServer,
   settings: Settings = new Settings(true)
 ) {
-  const client = createWeaveClient({
+  const client = new WeaveClient({
     traceServerApi: customTraceServer as unknown as TraceServerApi<any>,
     projectId,
     settings,

--- a/sdks/node/src/__tests__/clientMock.ts
+++ b/sdks/node/src/__tests__/clientMock.ts
@@ -3,18 +3,17 @@ import {type Api as TraceServerApi} from '../generated/traceServerApi';
 import {type InMemoryTraceServer} from './helpers/inMemoryTraceServer';
 import {Settings} from '../settings';
 import {type WandbServerApi} from '../wandb/wandbServerApi';
-import {WeaveClient} from '../weaveClient';
+import {createWeaveClient, WeaveClient} from '../weaveClient';
 
 export function initWithCustomTraceServer(
-  projectName: string,
+  projectId: string,
   customTraceServer: InMemoryTraceServer,
   settings: Settings = new Settings(true)
 ) {
-  const client = new WeaveClient(
-    customTraceServer as unknown as TraceServerApi<any>,
-    {} as WandbServerApi, // Placeholder, as we don't use WandbServerApi in this case
-    projectName,
-    settings
-  );
+  const client = createWeaveClient({
+    traceServerApi: customTraceServer as unknown as TraceServerApi<any>,
+    projectId,
+    settings,
+  });
   setGlobalClient(client);
 }

--- a/sdks/node/src/__tests__/genai/common.ts
+++ b/sdks/node/src/__tests__/genai/common.ts
@@ -7,8 +7,7 @@ import {
 import {setGlobalClient} from '../../clientApi';
 import {type Api as TraceServerApi} from '../../generated/traceServerApi';
 import {Settings, type SettingsInit} from '../../settings';
-import {type WandbServerApi} from '../../wandb/wandbServerApi';
-import {createWeaveClient, WeaveClient} from '../../weaveClient';
+import {WeaveClient} from '../../weaveClient';
 import state from 'weave/state';
 
 export const TEST_BASE_URL = 'http://localhost:8080';
@@ -16,7 +15,7 @@ export const TEST_PROJECT = 'test-entity/test-project';
 
 export function installFakeClient(settings: SettingsInit = {}): WeaveClient {
   const traceServerApi = {baseUrl: TEST_BASE_URL} as TraceServerApi<any>;
-  const client = createWeaveClient({
+  const client = new WeaveClient({
     traceServerApi,
     projectId: TEST_PROJECT,
     settings: new Settings(

--- a/sdks/node/src/__tests__/genai/common.ts
+++ b/sdks/node/src/__tests__/genai/common.ts
@@ -8,7 +8,7 @@ import {setGlobalClient} from '../../clientApi';
 import {type Api as TraceServerApi} from '../../generated/traceServerApi';
 import {Settings, type SettingsInit} from '../../settings';
 import {type WandbServerApi} from '../../wandb/wandbServerApi';
-import {WeaveClient} from '../../weaveClient';
+import {createWeaveClient, WeaveClient} from '../../weaveClient';
 import state from 'weave/state';
 
 export const TEST_BASE_URL = 'http://localhost:8080';
@@ -16,16 +16,15 @@ export const TEST_PROJECT = 'test-entity/test-project';
 
 export function installFakeClient(settings: SettingsInit = {}): WeaveClient {
   const traceServerApi = {baseUrl: TEST_BASE_URL} as TraceServerApi<any>;
-  const client = new WeaveClient(
+  const client = createWeaveClient({
     traceServerApi,
-    {} as WandbServerApi,
-    TEST_PROJECT,
-    new Settings(
+    projectId: TEST_PROJECT,
+    settings: new Settings(
       settings.printCallLink ?? true,
       settings.globalAttributes ?? {},
       settings.genai ?? {}
-    )
-  );
+    ),
+  });
   setGlobalClient(client);
   return client;
 }

--- a/sdks/node/src/__tests__/integrations/openai2.test.ts
+++ b/sdks/node/src/__tests__/integrations/openai2.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../integrations/openai';
 import {isWeaveImage} from '../../media';
 import {type WandbServerApi} from '../../wandb/wandbServerApi';
-import {createWeaveClient, WeaveClient} from '../../weaveClient';
+import {WeaveClient} from '../../weaveClient';
 import {makeAPIPromiseShim} from '../openaiMock';
 
 // Mock WeaveClient dependencies
@@ -55,7 +55,7 @@ describe('OpenAI Integration', () => {
       },
     } as any;
     mockWandbServerApi = {} as any;
-    weaveClient = createWeaveClient({
+    weaveClient = new WeaveClient({
       traceServerApi: mockTraceServerApi,
       projectId: 'test-project',
     });

--- a/sdks/node/src/__tests__/integrations/openai2.test.ts
+++ b/sdks/node/src/__tests__/integrations/openai2.test.ts
@@ -6,7 +6,7 @@ import {
 } from '../../integrations/openai';
 import {isWeaveImage} from '../../media';
 import {type WandbServerApi} from '../../wandb/wandbServerApi';
-import {WeaveClient} from '../../weaveClient';
+import {createWeaveClient, WeaveClient} from '../../weaveClient';
 import {makeAPIPromiseShim} from '../openaiMock';
 
 // Mock WeaveClient dependencies
@@ -55,11 +55,10 @@ describe('OpenAI Integration', () => {
       },
     } as any;
     mockWandbServerApi = {} as any;
-    weaveClient = new WeaveClient(
-      mockTraceServerApi,
-      mockWandbServerApi,
-      'test-project'
-    );
+    weaveClient = createWeaveClient({
+      traceServerApi: mockTraceServerApi,
+      projectId: 'test-project',
+    });
 
     wrappedOpenAI = wrapOpenAI(mockOpenAI);
   });

--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -3,7 +3,7 @@ import {type Api as TraceServerApi} from '../generated/traceServerApi';
 import {StringPrompt} from '../prompt';
 import * as registryLinkBindings from '../traceServerBindings/linkAssetToRegistry';
 import {type WandbServerApi} from '../wandb/wandbServerApi';
-import {WeaveClient} from '../weaveClient';
+import {createWeaveClient, WeaveClient} from '../weaveClient';
 import {ObjectRef} from '../weaveObject';
 
 // Mock the TraceServerApi and WandbServerApi
@@ -46,11 +46,10 @@ describe('WeaveClient', () => {
       },
     } as any;
     mockWandbServerApi = {} as any;
-    client = new WeaveClient(
-      mockTraceServerApi,
-      mockWandbServerApi,
-      'test-project'
-    );
+    client = createWeaveClient({
+      traceServerApi: mockTraceServerApi,
+      projectId: 'test-project',
+    });
   });
 
   describe('getCalls', () => {
@@ -198,11 +197,10 @@ describe('WeaveClient', () => {
         },
       } as any;
       mockWandbServerApi = {} as any;
-      client = new WeaveClient(
-        mockTraceServerApi,
-        mockWandbServerApi,
-        'test-project'
-      );
+      client = createWeaveClient({
+        traceServerApi: mockTraceServerApi,
+        projectId: 'test-project',
+      });
       // Speed up tests by reducing batch interval
       (client as any).BATCH_INTERVAL = 10;
     });
@@ -372,11 +370,10 @@ describe('WeaveClient', () => {
         request: jest.fn(),
       } as any;
       mockWandbServerApi = {} as any;
-      client = new WeaveClient(
-        mockTraceServerApi,
-        mockWandbServerApi,
-        'current-entity/current-project'
-      );
+      client = createWeaveClient({
+        traceServerApi: mockTraceServerApi,
+        projectId: 'current-entity/current-project',
+      });
       mockTransport = jest
         .spyOn(registryLinkBindings, 'linkAssetToRegistry')
         .mockResolvedValue({version_index: 0});
@@ -474,11 +471,10 @@ describe('WeaveClient', () => {
     });
 
     it('rejects projectId without entity scope', async () => {
-      const unscopedClient = new WeaveClient(
-        mockTraceServerApi,
-        mockWandbServerApi,
-        'project-only'
-      );
+      const unscopedClient = createWeaveClient({
+        traceServerApi: mockTraceServerApi,
+        projectId: 'project-only',
+      });
       const promptRef = new ObjectRef(
         'source-entity/source-project',
         'my-prompt',

--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -3,7 +3,7 @@ import {type Api as TraceServerApi} from '../generated/traceServerApi';
 import {StringPrompt} from '../prompt';
 import * as registryLinkBindings from '../traceServerBindings/linkAssetToRegistry';
 import {type WandbServerApi} from '../wandb/wandbServerApi';
-import {createWeaveClient, WeaveClient} from '../weaveClient';
+import {WeaveClient} from '../weaveClient';
 import {ObjectRef} from '../weaveObject';
 
 // Mock the TraceServerApi and WandbServerApi
@@ -46,7 +46,7 @@ describe('WeaveClient', () => {
       },
     } as any;
     mockWandbServerApi = {} as any;
-    client = createWeaveClient({
+    client = new WeaveClient({
       traceServerApi: mockTraceServerApi,
       projectId: 'test-project',
     });
@@ -197,7 +197,7 @@ describe('WeaveClient', () => {
         },
       } as any;
       mockWandbServerApi = {} as any;
-      client = createWeaveClient({
+      client = new WeaveClient({
         traceServerApi: mockTraceServerApi,
         projectId: 'test-project',
       });
@@ -370,7 +370,7 @@ describe('WeaveClient', () => {
         request: jest.fn(),
       } as any;
       mockWandbServerApi = {} as any;
-      client = createWeaveClient({
+      client = new WeaveClient({
         traceServerApi: mockTraceServerApi,
         projectId: 'current-entity/current-project',
       });
@@ -471,7 +471,7 @@ describe('WeaveClient', () => {
     });
 
     it('rejects projectId without entity scope', async () => {
-      const unscopedClient = createWeaveClient({
+      const unscopedClient = new WeaveClient({
         traceServerApi: mockTraceServerApi,
         projectId: 'project-only',
       });

--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -7,11 +7,7 @@ import {Netrc} from './utils/netrc';
 import {createFetchWithRetry} from './utils/retry';
 import {getWandbConfigs} from './wandb/settings';
 import {WandbServerApi} from './wandb/wandbServerApi';
-import {
-  type CallStackEntry,
-  createWeaveClient,
-  WeaveClient,
-} from './weaveClient';
+import {type CallStackEntry, WeaveClient} from './weaveClient';
 import {globalSingleton} from './utils/globalSingleton';
 
 // Held behind a globalThis-backed container so that a dual-package-hazard load
@@ -139,7 +135,7 @@ export async function init(
       customFetch: concurrencyLimitedFetch,
     });
 
-    const client = createWeaveClient({
+    const client = new WeaveClient({
       traceServerApi,
       projectId,
       settings: resolvedSettings,

--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -7,7 +7,11 @@ import {Netrc} from './utils/netrc';
 import {createFetchWithRetry} from './utils/retry';
 import {getWandbConfigs} from './wandb/settings';
 import {WandbServerApi} from './wandb/wandbServerApi';
-import {type CallStackEntry, WeaveClient} from './weaveClient';
+import {
+  type CallStackEntry,
+  createWeaveClient,
+  WeaveClient,
+} from './weaveClient';
 import {globalSingleton} from './utils/globalSingleton';
 
 // Held behind a globalThis-backed container so that a dual-package-hazard load
@@ -135,12 +139,11 @@ export async function init(
       customFetch: concurrencyLimitedFetch,
     });
 
-    const client = new WeaveClient(
+    const client = createWeaveClient({
       traceServerApi,
-      wandbServerApi,
       projectId,
-      resolvedSettings
-    );
+      settings: resolvedSettings,
+    });
     setGlobalClient(client);
     setGlobalDomain(domain);
     registerEvalLinkSpanProcessor(getGlobalClient);

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -38,7 +38,6 @@ import type {
   LinkAssetToRegistryRes,
 } from './traceServerBindings/linkAssetToRegistry';
 import {packageVersion} from './utils/userAgent';
-import {type WandbServerApi} from './wandb/wandbServerApi';
 import {ObjectRef, WeaveObject, getClassChain} from './weaveObject';
 import {type Call, CallState, InternalCall} from './call';
 import {CallRef} from './refs';
@@ -176,6 +175,18 @@ type CallEndParams = EndedCallSchemaForInsert;
 // We count characters item by item, and try to limit batches to about this size.
 const MAX_BATCH_SIZE_CHARS = 10 * 1024 * 1024;
 
+export function createWeaveClient({
+  traceServerApi,
+  projectId,
+  settings = new Settings(),
+}: {
+  traceServerApi: TraceServerApi<any>;
+  projectId: string;
+  settings?: Settings;
+}) {
+  return new WeaveClient(traceServerApi, null, projectId, settings);
+}
+
 export class WeaveClient {
   private stackContext = new AsyncLocalStorage<CallStack>();
   private attributesContext = new AsyncLocalStorage<Record<string, any>>();
@@ -189,7 +200,7 @@ export class WeaveClient {
 
   constructor(
     public traceServerApi: TraceServerApi<any>,
-    private wandbServerApi: WandbServerApi,
+    private _wandbServerApi: unknown,
     public projectId: string,
     public settings: Settings = new Settings()
   ) {}

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -174,19 +174,6 @@ type CallEndParams = EndedCallSchemaForInsert;
 
 // We count characters item by item, and try to limit batches to about this size.
 const MAX_BATCH_SIZE_CHARS = 10 * 1024 * 1024;
-
-export function createWeaveClient({
-  traceServerApi,
-  projectId,
-  settings = new Settings(),
-}: {
-  traceServerApi: TraceServerApi<any>;
-  projectId: string;
-  settings?: Settings;
-}) {
-  return new WeaveClient(traceServerApi, null, projectId, settings);
-}
-
 export class WeaveClient {
   private stackContext = new AsyncLocalStorage<CallStack>();
   private attributesContext = new AsyncLocalStorage<Record<string, any>>();
@@ -197,13 +184,23 @@ export class WeaveClient {
   private readonly BATCH_INTERVAL: number = 200;
   private errorCount = 0;
   private readonly MAX_ERRORS = 10;
+  public traceServerApi: TraceServerApi<any>;
+  public projectId: string;
+  public settings: Settings;
 
-  constructor(
-    public traceServerApi: TraceServerApi<any>,
-    private _wandbServerApi: unknown,
-    public projectId: string,
-    public settings: Settings = new Settings()
-  ) {}
+  constructor({
+    traceServerApi,
+    projectId,
+    settings = new Settings(),
+  }: {
+    traceServerApi: TraceServerApi<any>;
+    projectId: string;
+    settings?: Settings;
+  }) {
+    this.traceServerApi = traceServerApi;
+    this.projectId = projectId;
+    this.settings = settings;
+  }
 
   private scheduleBatchProcessing() {
     if (this.batchProcessTimeout || this.isBatchProcessing) return;


### PR DESCRIPTION
## Description

* The 2nd argument passed when instantiating `WeaveClient` is unused (https://github.com/wandb/weave/pull/7209/changes#diff-543f8d3b4bb3ced8ebb1d41bd385ee4852c8cad0a8e5064706edcf62dab32986L197-R208).

* ~This change removes some boilerplate around that argument, and pulls out a `createWeaveClient` helper function with named options, to use in the timebeing, while the constructor itself is `@deprecated`.~

* This change updates the interface for the `WeaveClient` constructor to take named options rather than positional arguments for readability, and then drops the unused `wandbServerApi` property & option.

* This will let us refactor some settings plumbing further up this stack to make it more clear which client settings are actually supported by the TS SDK.
