### PR TITLE
fix(weave): fix issue where `dictify` could get stuck in a cycle

### DIFF
--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -144,6 +144,71 @@ def test_dictify_to_dict() -> None:
     }
 
 
+def test_dictify_circular_reference() -> None:
+    # A reference cycle routed through `to_dict` must terminate rather than
+    # recurse forever. This is the CrewAI/litellm hang from issue #5158:
+    # those models expose `to_dict`, and dropping cycle detection at that
+    # boundary made `dictify` loop indefinitely.
+    class Node:
+        def __init__(self, name: str) -> None:
+            self.name = name
+            self.peer: Node | None = None
+
+        def to_dict(self) -> dict:
+            return {"name": self.name, "peer": self.peer}
+
+    a = Node("a")
+    b = Node("b")
+    a.peer = b
+    b.peer = a
+
+    result = dictify(a)
+    assert result["name"] == "a"
+    assert result["peer"]["name"] == "b"
+    # The hop back to `a` closes the cycle and is broken via stringify.
+    assert isinstance(result["peer"]["peer"], str)
+
+
+def test_dictify_self_reference() -> None:
+    class Box:
+        def __init__(self) -> None:
+            self.me: Box | None = None
+
+        def to_dict(self) -> dict:
+            return {"me": self.me}
+
+    box = Box()
+    box.me = box
+
+    result = dictify(box)
+    assert isinstance(result["me"], str)
+
+
+def test_dictify_shared_reference_traversed_once() -> None:
+    # A shared `to_dict`-bearing child reached by two paths must be expanded
+    # only once. Re-expanding it on every path (the bug behind issue #5158)
+    # turns a shared/diamond graph into exponential work — the practical
+    # symptom of the "hang".
+    class Counter:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def to_dict(self) -> dict:
+            self.calls += 1
+            return {"leaf": 1}
+
+    shared = Counter()
+
+    class Parent:
+        def to_dict(self) -> dict:
+            return {"a": shared, "b": shared}
+
+    result = dictify(Parent())
+    assert result["a"] == {"leaf": 1}
+    assert isinstance(result["b"], str)
+    assert shared.calls == 1
+
+
 def test_stringify_returns_repr() -> None:
     @dataclass
     class Point:

--- a/weave/integrations/dspy/dspy_utils.py
+++ b/weave/integrations/dspy/dspy_utils.py
@@ -192,7 +192,10 @@ def dictify(
                     if isinstance(key, str) and should_redact(key):
                         to_dict_result[key] = REDACTED_VALUE
                     elif maxdepth == 0 or depth < maxdepth:
-                        to_dict_result[key] = dictify(v, maxdepth, depth + 1)
+                        # Thread `seen` so cycle detection survives across the
+                        # to_dict boundary; dropping it lets cyclic or shared
+                        # object graphs recurse forever. See issue #5158.
+                        to_dict_result[key] = dictify(v, maxdepth, depth + 1, seen)
                     else:
                         to_dict_result[key] = stringify(v)
                 return to_dict_result

--- a/weave/trace/serialization/serialize.py
+++ b/weave/trace/serialization/serialize.py
@@ -346,7 +346,12 @@ def dictify(
                     if isinstance(k, str) and should_redact(k):
                         to_dict_result[k] = REDACTED_VALUE
                     elif maxdepth == 0 or depth < maxdepth:
-                        to_dict_result[k] = dictify(v, maxdepth, depth + 1)
+                        # Thread `seen` so cycle detection survives across the
+                        # to_dict boundary. Dropping it here lets a cyclic or
+                        # heavily-shared object graph (e.g. CrewAI/litellm
+                        # models, which expose to_dict) recurse forever or
+                        # blow up exponentially. See issue #5158.
+                        to_dict_result[k] = dictify(v, maxdepth, depth + 1, seen)
                     else:
                         to_dict_result[k] = stringify(v)
                 return to_dict_result


### PR DESCRIPTION
## Description

Resolves #5158.  There was an issue where `dictify` could get stuck in a cycle causing agents to appear to hang until they hit `RecursionError`.
