### PR TITLE
chore(weave): tag calls_delete inserts with db_insert_path

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -1815,6 +1815,7 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
                     set_nested_key(calls[i], col, val)
 
     @ddtrace.tracer.wrap(name="clickhouse_trace_server_batched.calls_delete")
+    @tag_db_insert_path("calls_delete")
     def calls_delete(self, req: tsi.CallsDeleteReq) -> tsi.CallsDeleteRes:
         assert_non_null_wb_user_id(req)
         if len(req.call_ids) > ch_settings.MAX_DELETE_CALLS_COUNT:


### PR DESCRIPTION
## Summary
- `calls_delete` writes soft-delete tombstone rows into `call_parts` via `_insert_call`, but was the only call-write method missing `@tag_db_insert_path`, so its inserts fell through to `path:unknown` on the `weave_trace_server.db_inserts` metric.
- A customer doing bulk call deletion (~1000 calls/req) lit up the `path:unknown` leak-check panel; this attributes those inserts to `calls_delete`.

## Testing
non-functional change (adds a metric tag only).