### PR TITLE
fix(weave): don't stall flush() on unpaired eager calls under calls_complete

### DIFF
--- a/tests/trace_server_bindings/test_call_batch_processor.py
+++ b/tests/trace_server_bindings/test_call_batch_processor.py
@@ -217,8 +217,8 @@ def test_missing_trace_id_raises_value_error() -> None:
         processor.stop_accepting_new_work_and_flush_queue()
 
 
-def test_flush_eager_sends_unpaired_items_and_clears_state() -> None:
-    """Flush sends unpaired items via the eager v2 endpoints and clears caches."""
+def test_flush_sends_unpaired_items_via_eager_endpoints() -> None:
+    """Flush sends unpaired items via the eager v2 endpoints."""
     complete_fn = MagicMock()
     eager_fn = MagicMock()
     processor = CallBatchProcessor(complete_fn, eager_fn, min_batch_interval=0.01)
@@ -246,14 +246,14 @@ def test_flush_eager_sends_unpaired_items_and_clears_state() -> None:
     assert orphan_end in sent_items
 
 
-def test_flush_skips_wait_for_eager_unpaired_but_waits_for_non_eager() -> None:
-    """Flush returns promptly for unpaired eager ends, but still waits for non-eager work."""
+def test_flush_does_not_stall_on_eager_end_after_intermediate_flush() -> None:
+    """Eager tracking survives a mid-eval flush, so the later end never orphans."""
     eager_fn = MagicMock()
-    timeout = 3.0
-
-    # Eager start, then a mid-eval flush: eager tracking must survive the flush so
-    # the later end pairs eagerly instead of becoming a never-pairing orphan.
+    timeout = 2.0
     processor = CallBatchProcessor(MagicMock(), eager_fn, min_batch_interval=0.01)
+
+    # Eager start, then a flush before the eval finishes. Eager tracking must
+    # survive the flush or the end below becomes a never-pairing orphan.
     processor.enqueue_start(_make_start_item("ev-1", "trace-1"), eager_call_start=True)
     with patch(
         "weave.trace_server_bindings.call_batch_processor.FLUSH_TIMEOUT_SECONDS",
@@ -263,7 +263,8 @@ def test_flush_skips_wait_for_eager_unpaired_but_waits_for_non_eager() -> None:
     assert "ev-1" in processor._eager_call_ids
     processor.accept_new_work()
 
-    # Eval finishes: the eager end pairs via _eager_call_ids and is never parked.
+    # Eval finishes: the end pairs via _eager_call_ids and is sent immediately,
+    # so the flush returns well under the timeout instead of waiting it out.
     processor.enqueue([_make_end_item("ev-1")])
     start = time.monotonic()
     with patch(
@@ -271,30 +272,15 @@ def test_flush_skips_wait_for_eager_unpaired_but_waits_for_non_eager() -> None:
         timeout,
     ):
         processor.stop_accepting_new_work_and_flush_queue()
-    eager_flush_elapsed = time.monotonic() - start
-    assert eager_flush_elapsed < timeout
+    assert time.monotonic() - start < timeout
     assert processor._pending_ends == {}
-    sent_ids = {
+    sent_end_ids = {
         item.req.end.id
         for call in eager_fn.call_args_list
         for item in call.args[0]
         if isinstance(item, EndBatchItem)
     }
-    assert "ev-1" in sent_ids
-
-    # A non-eager start with no end is genuine in-flight work and must consume the
-    # full pairing window before its leftovers are flushed eagerly.
-    non_eager = CallBatchProcessor(MagicMock(), MagicMock(), min_batch_interval=0.01)
-    non_eager.enqueue([_make_start_item("normal-1", "trace-2")])
-    short_timeout = 0.5
-    start = time.monotonic()
-    with patch(
-        "weave.trace_server_bindings.call_batch_processor.FLUSH_TIMEOUT_SECONDS",
-        short_timeout,
-    ):
-        non_eager.stop_accepting_new_work_and_flush_queue()
-    non_eager_elapsed = time.monotonic() - start
-    assert non_eager_elapsed >= short_timeout
+    assert sent_end_ids == {"ev-1"}
 
 
 def test_queue_full_writes_to_disk(tmp_path: pathlib.Path) -> None:

--- a/tests/trace_server_bindings/test_call_batch_processor.py
+++ b/tests/trace_server_bindings/test_call_batch_processor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import pathlib
+import time
 from unittest.mock import MagicMock, patch
 
 import httpx
@@ -243,6 +244,57 @@ def test_flush_eager_sends_unpaired_items_and_clears_state() -> None:
     sent_items = [item for call in eager_fn.call_args_list for item in call.args[0]]
     assert orphan_start in sent_items
     assert orphan_end in sent_items
+
+
+def test_flush_skips_wait_for_eager_unpaired_but_waits_for_non_eager() -> None:
+    """Flush returns promptly for unpaired eager ends, but still waits for non-eager work."""
+    eager_fn = MagicMock()
+    timeout = 3.0
+
+    # Eager start, then a mid-eval flush: eager tracking must survive the flush so
+    # the later end pairs eagerly instead of becoming a never-pairing orphan.
+    processor = CallBatchProcessor(MagicMock(), eager_fn, min_batch_interval=0.01)
+    processor.enqueue_start(_make_start_item("ev-1", "trace-1"), eager_call_start=True)
+    with patch(
+        "weave.trace_server_bindings.call_batch_processor.FLUSH_TIMEOUT_SECONDS",
+        timeout,
+    ):
+        processor.stop_accepting_new_work_and_flush_queue()
+    assert "ev-1" in processor._eager_call_ids
+    processor.accept_new_work()
+
+    # Eval finishes: the eager end pairs via _eager_call_ids and is never parked.
+    processor.enqueue([_make_end_item("ev-1")])
+    start = time.monotonic()
+    with patch(
+        "weave.trace_server_bindings.call_batch_processor.FLUSH_TIMEOUT_SECONDS",
+        timeout,
+    ):
+        processor.stop_accepting_new_work_and_flush_queue()
+    eager_flush_elapsed = time.monotonic() - start
+    assert eager_flush_elapsed < timeout
+    assert processor._pending_ends == {}
+    sent_ids = {
+        item.req.end.id
+        for call in eager_fn.call_args_list
+        for item in call.args[0]
+        if isinstance(item, EndBatchItem)
+    }
+    assert "ev-1" in sent_ids
+
+    # A non-eager start with no end is genuine in-flight work and must consume the
+    # full pairing window before its leftovers are flushed eagerly.
+    non_eager = CallBatchProcessor(MagicMock(), MagicMock(), min_batch_interval=0.01)
+    non_eager.enqueue([_make_start_item("normal-1", "trace-2")])
+    short_timeout = 0.5
+    start = time.monotonic()
+    with patch(
+        "weave.trace_server_bindings.call_batch_processor.FLUSH_TIMEOUT_SECONDS",
+        short_timeout,
+    ):
+        non_eager.stop_accepting_new_work_and_flush_queue()
+    non_eager_elapsed = time.monotonic() - start
+    assert non_eager_elapsed >= short_timeout
 
 
 def test_queue_full_writes_to_disk(tmp_path: pathlib.Path) -> None:

--- a/tests/trace_server_bindings/test_call_batch_processor.py
+++ b/tests/trace_server_bindings/test_call_batch_processor.py
@@ -237,7 +237,6 @@ def test_flush_sends_unpaired_items_via_eager_endpoints() -> None:
     assert processor.num_pending == 0
     assert processor._pending_starts == {}
     assert processor._pending_ends == {}
-    assert len(processor._eager_call_ids) == 0
     complete_fn.assert_not_called()
     # Both orphans should have been handed to the eager processor (possibly
     # across one or multiple batched invocations).

--- a/weave/trace_server_bindings/call_batch_processor.py
+++ b/weave/trace_server_bindings/call_batch_processor.py
@@ -171,24 +171,20 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
     def stop_accepting_new_work_and_flush_queue(self) -> None:
         """Stop accepting work and flush the queue.
 
-        Pending ends whose start was already sent eagerly can never pair into a
-        complete call, so they are sent via the eager v2 endpoint immediately.
-        The remaining non-eager pending work is given up to FLUSH_TIMEOUT_SECONDS
-        to pair before its leftovers are sent eagerly too.
+        Waits up to FLUSH_TIMEOUT_SECONDS for in-flight calls to pair (start
+        meets end). Anything still unpaired is sent via the eager v2
+        start/end endpoints.
         """
-        # Eager ends will never pair (their start went out via the eager path),
-        # so flush them now instead of waiting out the pairing window.
-        self._flush_eager_unpaired_ends()
-
-        # Wait for non-eager pending items to pair (in-flight calls completing).
-        # Don't set stop event yet - processing thread needs to keep running and
-        # ends need to be able to come in and pair with pending starts. Break
-        # early once nothing non-eager remains.
+        # Wait for pending items to pair (in-flight calls completing)
+        # Don't set stop event yet - processing thread needs to keep running
+        # and ends need to be able to come in and pair with pending starts
+        # Break early if all calls are matched (done)
         deadline = time.monotonic() + FLUSH_TIMEOUT_SECONDS
         while time.monotonic() < deadline:
             with self.lock:
-                if self._num_non_eager_pending() == 0:
-                    break
+                pending_count = len(self._pending_starts) + len(self._pending_ends)
+            if pending_count == 0:
+                break
             time.sleep(FLUSH_POLL_INTERVAL_SECONDS)
 
         # Push any remaining unpaired items onto the queue so the processing
@@ -218,6 +214,9 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
                     _, end_item = self._pending_ends.popitem()
                     self._queue_item(end_item)
 
+            # Intentionally keep _eager_call_ids: a flush mid-eval must not orphan
+            # the still-pending end of an in-progress eager call (TTL bounds it).
+
         # Shutdown, processing thread will drain queue (including the orphans
         # we just queued) then exit
         self.stop_accepting_work_event.set()
@@ -227,34 +226,6 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
         # but we don't drop queue items if they've already been paired.
         self.processing_thread.join()
         self.health_check_thread.join()
-
-    def _num_non_eager_pending(self) -> int:
-        """Count pending items that can still pair into a complete call.
-
-        Pending ends whose start was sent eagerly never pair, so they are
-        excluded; callers must hold self.lock.
-        """
-        eager_pending_ends = sum(
-            1 for call_id in self._pending_ends if call_id in self._eager_call_ids
-        )
-        return len(self._pending_starts) + len(self._pending_ends) - eager_pending_ends
-
-    def _flush_eager_unpaired_ends(self) -> None:
-        """Send pending ends whose start was already sent via the eager path.
-
-        These can never pair into a complete call, so they go straight to the
-        eager v2 endpoint via the queue (respecting batching/pacing).
-        """
-        with self.lock:
-            eager_end_ids = [
-                call_id
-                for call_id in self._pending_ends
-                if call_id in self._eager_call_ids
-            ]
-            for call_id in eager_end_ids:
-                end_item = self._pending_ends.pop(call_id)
-                self._eager_call_ids.pop(call_id, None)
-                self._queue_item(end_item)
 
     def _handle_start(
         self, item: StartBatchItem, *, eager_call_start: bool = False

--- a/weave/trace_server_bindings/call_batch_processor.py
+++ b/weave/trace_server_bindings/call_batch_processor.py
@@ -171,20 +171,24 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
     def stop_accepting_new_work_and_flush_queue(self) -> None:
         """Stop accepting work and flush the queue.
 
-        Waits up to FLUSH_TIMEOUT_SECONDS for in-flight calls to pair (start
-        meets end). Anything still unpaired is sent via the eager v2
-        start/end endpoints.
+        Pending ends whose start was already sent eagerly can never pair into a
+        complete call, so they are sent via the eager v2 endpoint immediately.
+        The remaining non-eager pending work is given up to FLUSH_TIMEOUT_SECONDS
+        to pair before its leftovers are sent eagerly too.
         """
-        # Wait for pending items to pair (in-flight calls completing)
-        # Don't set stop event yet - processing thread needs to keep running
-        # and ends need to be able to come in and pair with pending starts
-        # Break early if all calls are matched (done)
+        # Eager ends will never pair (their start went out via the eager path),
+        # so flush them now instead of waiting out the pairing window.
+        self._flush_eager_unpaired_ends()
+
+        # Wait for non-eager pending items to pair (in-flight calls completing).
+        # Don't set stop event yet - processing thread needs to keep running and
+        # ends need to be able to come in and pair with pending starts. Break
+        # early once nothing non-eager remains.
         deadline = time.monotonic() + FLUSH_TIMEOUT_SECONDS
         while time.monotonic() < deadline:
             with self.lock:
-                pending_count = len(self._pending_starts) + len(self._pending_ends)
-            if pending_count == 0:
-                break
+                if self._num_non_eager_pending() == 0:
+                    break
             time.sleep(FLUSH_POLL_INTERVAL_SECONDS)
 
         # Push any remaining unpaired items onto the queue so the processing
@@ -214,8 +218,6 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
                     _, end_item = self._pending_ends.popitem()
                     self._queue_item(end_item)
 
-            self._eager_call_ids.clear()
-
         # Shutdown, processing thread will drain queue (including the orphans
         # we just queued) then exit
         self.stop_accepting_work_event.set()
@@ -225,6 +227,34 @@ class CallBatchProcessor(AsyncBatchProcessor[BatchItem]):
         # but we don't drop queue items if they've already been paired.
         self.processing_thread.join()
         self.health_check_thread.join()
+
+    def _num_non_eager_pending(self) -> int:
+        """Count pending items that can still pair into a complete call.
+
+        Pending ends whose start was sent eagerly never pair, so they are
+        excluded; callers must hold self.lock.
+        """
+        eager_pending_ends = sum(
+            1 for call_id in self._pending_ends if call_id in self._eager_call_ids
+        )
+        return len(self._pending_starts) + len(self._pending_ends) - eager_pending_ends
+
+    def _flush_eager_unpaired_ends(self) -> None:
+        """Send pending ends whose start was already sent via the eager path.
+
+        These can never pair into a complete call, so they go straight to the
+        eager v2 endpoint via the queue (respecting batching/pacing).
+        """
+        with self.lock:
+            eager_end_ids = [
+                call_id
+                for call_id in self._pending_ends
+                if call_id in self._eager_call_ids
+            ]
+            for call_id in eager_end_ids:
+                end_item = self._pending_ends.pop(call_id)
+                self._eager_call_ids.pop(call_id, None)
+                self._queue_item(end_item)
 
     def _handle_start(
         self, item: StartBatchItem, *, eager_call_start: bool = False


### PR DESCRIPTION
## Summary
- A mid-eval `client.flush()` cleared `_eager_call_ids`, so the later eager call-end no longer matched and parked in `_pending_ends` as a never-pairing orphan; the next flush then waited the full 5-min `FLUSH_TIMEOUT_SECONDS` on it.
- Keep eager tracking across a flush, exclude eager-unpaired ends from the pairing wait, and send them via the eager v2 endpoint right away. Non-eager in-flight work keeps the full pairing budget.
- WB-34557: https://coreweave.atlassian.net/browse/WB-34557

## Testing
new test asserts eager-unpaired flush returns fast while non-eager pending still consumes the full timeout.