### PR TITLE
feat(weave_ts)!: Consolidate settings, expose reference in `docs/`.

### DIFF
--- a/sdks/node/examples/attributes.ts
+++ b/sdks/node/examples/attributes.ts
@@ -13,7 +13,7 @@ const parentOp = op(async function parentOp(input: string) {
 async function main() {
   // Replace with your entity/project
   await init('your-entity/your-project', {
-    globalAttributes: {tenant: 'acme-co', env: 'prod'},
+    attributes: {tenant: 'acme-co', env: 'prod'},
   });
 
   const result = await withAttributes(

--- a/sdks/node/src/__tests__/attributes.test.ts
+++ b/sdks/node/src/__tests__/attributes.test.ts
@@ -71,7 +71,7 @@ describe('attributes context', () => {
   test('applies global attributes from init settings', async () => {
     traceServer = new InMemoryTraceServer();
     initWithCustomTraceServer(projectId, traceServer, {
-      globalAttributes: {tenant: 'acme', base: 'global'},
+      attributes: {tenant: 'acme', base: 'global'},
     });
 
     const leafOp = op(async function leafOp() {

--- a/sdks/node/src/__tests__/attributes.test.ts
+++ b/sdks/node/src/__tests__/attributes.test.ts
@@ -70,11 +70,9 @@ describe('attributes context', () => {
 
   test('applies global attributes from init settings', async () => {
     traceServer = new InMemoryTraceServer();
-    initWithCustomTraceServer(
-      projectId,
-      traceServer,
-      new Settings(true, {tenant: 'acme', base: 'global'})
-    );
+    initWithCustomTraceServer(projectId, traceServer, {
+      globalAttributes: {tenant: 'acme', base: 'global'},
+    });
 
     const leafOp = op(async function leafOp() {
       return 'leaf';

--- a/sdks/node/src/__tests__/call.test.ts
+++ b/sdks/node/src/__tests__/call.test.ts
@@ -35,7 +35,7 @@ jest.mock('weave/clientApi', () => ({
       runWithCallStack: async (stack: any, fn: () => any) => fn(),
       finishCall: () => Promise.resolve(),
       finishCallWithException: () => Promise.resolve(),
-      settings: {shouldPrintCallLink: false},
+      settings: {printCallLink: false},
       waitForBatchProcessing: () => Promise.resolve(),
       processBatch: () => Promise.resolve(),
     });

--- a/sdks/node/src/__tests__/clientMock.ts
+++ b/sdks/node/src/__tests__/clientMock.ts
@@ -7,7 +7,7 @@ import {WeaveClient} from '../weaveClient';
 export function initWithCustomTraceServer(
   projectId: string,
   customTraceServer: InMemoryTraceServer,
-  settings: Settings = new Settings(true)
+  settings: Partial<Settings> = {}
 ) {
   const client = new WeaveClient({
     traceServerApi: customTraceServer as unknown as TraceServerApi<any>,

--- a/sdks/node/src/__tests__/genai/common.ts
+++ b/sdks/node/src/__tests__/genai/common.ts
@@ -6,23 +6,21 @@ import {
 
 import {setGlobalClient} from '../../clientApi';
 import {type Api as TraceServerApi} from '../../generated/traceServerApi';
-import {Settings, type SettingsInit} from '../../settings';
+import {makeSettings, type Settings} from '../../settings';
 import {WeaveClient} from '../../weaveClient';
 import state from 'weave/state';
 
 export const TEST_BASE_URL = 'http://localhost:8080';
 export const TEST_PROJECT = 'test-entity/test-project';
 
-export function installFakeClient(settings: SettingsInit = {}): WeaveClient {
+export function installFakeClient(
+  settings: Partial<Settings> = {}
+): WeaveClient {
   const traceServerApi = {baseUrl: TEST_BASE_URL} as TraceServerApi<any>;
   const client = new WeaveClient({
     traceServerApi,
     projectId: TEST_PROJECT,
-    settings: new Settings(
-      settings.printCallLink ?? true,
-      settings.globalAttributes ?? {},
-      settings.genai ?? {}
-    ),
+    settings: makeSettings(settings),
   });
   setGlobalClient(client);
   return client;

--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -243,11 +243,9 @@ describe('OpenAI Agents Integration (with WEAVE_USE_OTEL_V2=true)', () => {
     inMemoryTraceServer = new InMemoryTraceServer();
     exporter = new InMemorySpanExporter();
 
-    initWithCustomTraceServer(
-      testProjectName,
-      inMemoryTraceServer,
-      new Settings(true, {}, {spanProcessor: new SimpleSpanProcessor(exporter)})
-    );
+    initWithCustomTraceServer(testProjectName, inMemoryTraceServer, {
+      genai: {spanProcessor: new SimpleSpanProcessor(exporter)},
+    });
 
     clearWeaveTracerProvider();
     setTraceProcessors([]);

--- a/sdks/node/src/__tests__/legacy/op.test.ts
+++ b/sdks/node/src/__tests__/legacy/op.test.ts
@@ -14,7 +14,7 @@ jest.mock('weave/clientApi', () => ({
     runWithCallStack: async (stack: any, fn: () => any) => fn(),
     finishCall: () => Promise.resolve(),
     finishCallWithException: () => Promise.resolve(),
-    settings: {shouldPrintCallLink: false},
+    settings: {printCallLink: false},
     waitForBatchProcessing: () => Promise.resolve(),
   })),
 }));

--- a/sdks/node/src/__tests__/modern/op.test.ts
+++ b/sdks/node/src/__tests__/modern/op.test.ts
@@ -15,7 +15,7 @@ jest.mock('weave/clientApi', () => ({
     runWithCallStack: async (stack: any, fn: () => any) => fn(),
     finishCall: () => Promise.resolve(),
     finishCallWithException: () => Promise.resolve(),
-    settings: {shouldPrintCallLink: false},
+    settings: {printCallLink: false},
     waitForBatchProcessing: () => Promise.resolve(),
   })),
 }));

--- a/sdks/node/src/__tests__/op.test.ts
+++ b/sdks/node/src/__tests__/op.test.ts
@@ -20,7 +20,7 @@ const createFreshMockClient = () => ({
   runWithCallStack: jest.fn(async (stack: any, fn: () => any) => fn()),
   finishCall: jest.fn(() => Promise.resolve()),
   finishCallWithException: jest.fn(() => Promise.resolve()),
-  settings: {shouldPrintCallLink: false},
+  settings: {printCallLink: false},
   waitForBatchProcessing: jest.fn(() => Promise.resolve()),
 });
 

--- a/sdks/node/src/__tests__/settings.test.ts
+++ b/sdks/node/src/__tests__/settings.test.ts
@@ -20,7 +20,6 @@ describe('makeSettings', () => {
         attributes: {},
         genai: {},
         printCallLink: true,
-        useOTelV2: true,
       });
     });
 
@@ -30,7 +29,6 @@ describe('makeSettings', () => {
         attributes: {},
         genai: {},
         printCallLink: true,
-        useOTelV2: true,
       });
     });
   });

--- a/sdks/node/src/__tests__/settings.test.ts
+++ b/sdks/node/src/__tests__/settings.test.ts
@@ -1,0 +1,124 @@
+import {defaultSettings, makeSettings} from '../settings';
+
+describe('makeSettings', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {...originalEnv};
+    delete process.env.WEAVE_PRINT_CALL_LINK;
+    delete process.env.WEAVE_USE_OTEL_V2;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('defaults', () => {
+    it('returns defaults with no args', () => {
+      const settings = makeSettings();
+      expect(settings).toEqual({
+        attributes: {},
+        genai: {},
+        printCallLink: true,
+        useOTelV2: true,
+      });
+    });
+
+    it('returns defaults with empty object', () => {
+      const settings = makeSettings({});
+      expect(settings).toEqual({
+        attributes: {},
+        genai: {},
+        printCallLink: true,
+        useOTelV2: true,
+      });
+    });
+  });
+
+  describe('explicit settings', () => {
+    it('honors printCallLink', () => {
+      expect(makeSettings({printCallLink: false}).printCallLink).toBe(false);
+    });
+
+    it('honors useOTelV2', () => {
+      expect(makeSettings({useOTelV2: false}).useOTelV2).toBe(false);
+    });
+
+    it('honors attributes', () => {
+      const attrs = {tenant: 'acme', region: 'us-west'};
+      expect(makeSettings({attributes: attrs}).attributes).toEqual(
+        attrs
+      );
+    });
+
+    it('honors genai settings', () => {
+      const genai = {spanProcessor: 'simple' as const};
+      expect(makeSettings({genai}).genai).toEqual(genai);
+    });
+  });
+
+  describe('env var precedence', () => {
+    it('WEAVE_PRINT_CALL_LINK=true overrides explicit false', () => {
+      process.env.WEAVE_PRINT_CALL_LINK = 'true';
+      expect(makeSettings({printCallLink: false}).printCallLink).toBe(true);
+    });
+
+    it('WEAVE_PRINT_CALL_LINK=false overrides explicit true', () => {
+      process.env.WEAVE_PRINT_CALL_LINK = 'false';
+      expect(makeSettings({printCallLink: true}).printCallLink).toBe(false);
+    });
+
+    it('WEAVE_PRINT_CALL_LINK parses case-insensitively', () => {
+      process.env.WEAVE_PRINT_CALL_LINK = 'FALSE';
+      expect(makeSettings().printCallLink).toBe(false);
+      process.env.WEAVE_PRINT_CALL_LINK = 'True';
+      expect(makeSettings().printCallLink).toBe(true);
+    });
+
+    it('WEAVE_PRINT_CALL_LINK with invalid value falls back to explicit setting', () => {
+      process.env.WEAVE_PRINT_CALL_LINK = 'maybe';
+      expect(makeSettings({printCallLink: false}).printCallLink).toBe(false);
+    });
+
+    it('WEAVE_PRINT_CALL_LINK with invalid value falls back to default when no explicit setting', () => {
+      process.env.WEAVE_PRINT_CALL_LINK = 'maybe';
+      expect(makeSettings().printCallLink).toBe(true);
+    });
+
+    it('WEAVE_USE_OTEL_V2=true overrides explicit false', () => {
+      process.env.WEAVE_USE_OTEL_V2 = 'true';
+      expect(makeSettings({useOTelV2: false}).useOTelV2).toBe(true);
+    });
+
+    it('WEAVE_USE_OTEL_V2=false overrides explicit true', () => {
+      process.env.WEAVE_USE_OTEL_V2 = 'false';
+      expect(makeSettings({useOTelV2: true}).useOTelV2).toBe(false);
+    });
+  });
+});
+
+describe('defaultSettings', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {...originalEnv};
+    delete process.env.WEAVE_PRINT_CALL_LINK;
+    delete process.env.WEAVE_USE_OTEL_V2;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('matches makeSettings() with no args', () => {
+    expect(defaultSettings()).toEqual(makeSettings());
+  });
+
+  it('applies env vars', () => {
+    process.env.WEAVE_PRINT_CALL_LINK = 'false';
+    process.env.WEAVE_USE_OTEL_V2 = 'false';
+    const s = defaultSettings();
+    expect(s.printCallLink).toBe(false);
+    expect(s.useOTelV2).toBe(false);
+  });
+});

--- a/sdks/node/src/__tests__/settings.test.ts
+++ b/sdks/node/src/__tests__/settings.test.ts
@@ -1,4 +1,4 @@
-import {defaultSettings, makeSettings} from '../settings';
+import {makeSettings} from '../settings';
 
 describe('makeSettings', () => {
   const originalEnv = process.env;
@@ -38,10 +38,6 @@ describe('makeSettings', () => {
   describe('explicit settings', () => {
     it('honors printCallLink', () => {
       expect(makeSettings({printCallLink: false}).printCallLink).toBe(false);
-    });
-
-    it('honors useOTelV2', () => {
-      expect(makeSettings({useOTelV2: false}).useOTelV2).toBe(false);
     });
 
     it('honors attributes', () => {
@@ -84,41 +80,5 @@ describe('makeSettings', () => {
       process.env.WEAVE_PRINT_CALL_LINK = 'maybe';
       expect(makeSettings().printCallLink).toBe(true);
     });
-
-    it('WEAVE_USE_OTEL_V2=true overrides explicit false', () => {
-      process.env.WEAVE_USE_OTEL_V2 = 'true';
-      expect(makeSettings({useOTelV2: false}).useOTelV2).toBe(true);
-    });
-
-    it('WEAVE_USE_OTEL_V2=false overrides explicit true', () => {
-      process.env.WEAVE_USE_OTEL_V2 = 'false';
-      expect(makeSettings({useOTelV2: true}).useOTelV2).toBe(false);
-    });
-  });
-});
-
-describe('defaultSettings', () => {
-  const originalEnv = process.env;
-
-  beforeEach(() => {
-    process.env = {...originalEnv};
-    delete process.env.WEAVE_PRINT_CALL_LINK;
-    delete process.env.WEAVE_USE_OTEL_V2;
-  });
-
-  afterAll(() => {
-    process.env = originalEnv;
-  });
-
-  it('matches makeSettings() with no args', () => {
-    expect(defaultSettings()).toEqual(makeSettings());
-  });
-
-  it('applies env vars', () => {
-    process.env.WEAVE_PRINT_CALL_LINK = 'false';
-    process.env.WEAVE_USE_OTEL_V2 = 'false';
-    const s = defaultSettings();
-    expect(s.printCallLink).toBe(false);
-    expect(s.useOTelV2).toBe(false);
   });
 });

--- a/sdks/node/src/__tests__/settings.test.ts
+++ b/sdks/node/src/__tests__/settings.test.ts
@@ -42,9 +42,7 @@ describe('makeSettings', () => {
 
     it('honors attributes', () => {
       const attrs = {tenant: 'acme', region: 'us-west'};
-      expect(makeSettings({attributes: attrs}).attributes).toEqual(
-        attrs
-      );
+      expect(makeSettings({attributes: attrs}).attributes).toEqual(attrs);
     });
 
     it('honors genai settings', () => {

--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -1,6 +1,6 @@
 import {Api as TraceServerApi} from './generated/traceServerApi';
 import {registerEvalLinkSpanProcessor} from './evalLinkSpanProcessor';
-import {makeSettings, type SettingsInit} from './settings';
+import {makeSettings, Settings} from './settings';
 import {defaultHost, getUrls, setGlobalDomain} from './urls';
 import {ConcurrencyLimiter} from './utils/concurrencyLimit';
 import {Netrc} from './utils/netrc';
@@ -81,7 +81,7 @@ export async function login(apiKey: string, host?: string) {
  */
 export async function init(
   project: string,
-  settings?: SettingsInit
+  settings?: Partial<Settings>
 ): Promise<WeaveClient> {
   const {apiKey, baseUrl, traceBaseUrl, domain} = getWandbConfigs();
   try {

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -14,6 +14,7 @@ export type {
   Query,
   SortBy,
 } from './generated/traceServerApi';
+export type {Settings} from './settings';
 export type {GetCallsOptions, WeaveClient} from './weaveClient';
 export {
   wrapOpenAI,

--- a/sdks/node/src/op.ts
+++ b/sdks/node/src/op.ts
@@ -136,7 +136,7 @@ function createOpWrapper<T extends (...args: any[]) => any>(
 
     const {currentCall, parentCall, newStack} = client.pushNewCall();
     const startTime = new Date();
-    if (client.settings.shouldPrintCallLink && parentCall == null) {
+    if (client.settings.printCallLink && parentCall == null) {
       const domain = getGlobalDomain();
       console.log(
         `${TRACE_CALL_EMOJI} https://${domain}/${client.projectId}/r/call/${currentCall.callId}`

--- a/sdks/node/src/settings.ts
+++ b/sdks/node/src/settings.ts
@@ -1,24 +1,6 @@
 import type {BufferConfig, SpanProcessor} from '@opentelemetry/sdk-trace-base';
 
 export type Settings = {
-  /**
-   * Prints links in terminal to Weave UI for ops.
-   *
-   * @default `true`
-   */
-  readonly printCallLink: boolean;
-
-  /** @deprecated Use `printCallLink` instead. */
-  readonly shouldPrintCallLink: boolean;
-
-  /**
-   * A map of attributes applied to every trace produced by this client.
-   */
-  globalAttributes: Record<string, any>;
-
-  /** @deprecated Use `globalAttributes` instead. */
-  readonly attributes: Record<string, any>;
-
   genai: {
     /**
      * How GenAI spans are exported.
@@ -37,6 +19,24 @@ export type Settings = {
     /** `BatchSpanProcessor` configuration. Ignored unless `spanProcessor === 'batch'`. */
     batchOptions?: BufferConfig;
   };
+
+  /**
+   * Prints links in terminal to Weave UI for ops.
+   *
+   * @default `true`
+   */
+  readonly printCallLink: boolean;
+
+  /** @deprecated Use `printCallLink` instead. */
+  readonly shouldPrintCallLink: boolean;
+
+  /**
+   * A map of attributes applied to every trace produced by this client.
+   */
+  readonly globalAttributes: Record<string, any>;
+
+  /** @deprecated Use `globalAttributes` instead. */
+  readonly attributes: Record<string, any>;
 };
 
 export function makeSettings(settings: Partial<Settings> = {}): Settings {

--- a/sdks/node/src/settings.ts
+++ b/sdks/node/src/settings.ts
@@ -1,55 +1,64 @@
 import type {BufferConfig, SpanProcessor} from '@opentelemetry/sdk-trace-base';
 
-export interface GenAISettingsInit {
+export type Settings = {
   /**
-   * How GenAI spans are exported.
+   * Prints links in terminal to Weave UI for ops.
    *
-   * - `'batch'` (default): `BatchSpanProcessor`, suitable for production
-   *   agents and long-lived processes.
-   * - `'simple'`: `SimpleSpanProcessor`, one HTTP POST per span. Useful for
-   *   tests and short-lived CLIs where deterministic flush matters more than
-   *   throughput.
-   * - `SpanProcessor` instance: a user-supplied processor. The caller owns
-   *   its lifecycle; the Weave OTLP exporter targeting `/agents/otel/v1/traces`
-   *   is not used.
+   * @default `true`
    */
-  spanProcessor?: 'batch' | 'simple' | SpanProcessor;
+  readonly printCallLink: boolean;
 
-  /** `BatchSpanProcessor` configuration. Ignored unless `spanProcessor === 'batch'`. */
-  batchOptions?: BufferConfig;
-}
+  /** @deprecated Use `printCallLink` instead. */
+  readonly shouldPrintCallLink: boolean;
 
-export interface SettingsInit {
-  printCallLink?: boolean;
-  globalAttributes?: Record<string, any>;
-  genai?: GenAISettingsInit;
-}
+  /**
+   * A map of attributes applied to every trace produced by this client.
+   */
+  globalAttributes: Record<string, any>;
 
-export class Settings {
-  constructor(
-    private printCallLink: boolean = true,
-    private globalAttributes: Record<string, any> = {},
-    public readonly genai: GenAISettingsInit = {}
-  ) {}
+  /** @deprecated Use `globalAttributes` instead. */
+  readonly attributes: Record<string, any>;
 
-  get shouldPrintCallLink(): boolean {
-    return parseEnvVar(process.env.WEAVE_PRINT_CALL_LINK) ?? this.printCallLink;
-  }
+  genai: {
+    /**
+     * How GenAI spans are exported.
+     *
+     * - `'batch'` (default): `BatchSpanProcessor`, suitable for production
+     *   agents and long-lived processes.
+     * - `'simple'`: `SimpleSpanProcessor`, one HTTP POST per span. Useful for
+     *   tests and short-lived CLIs where deterministic flush matters more than
+     *   throughput.
+     * - `SpanProcessor` instance: a user-supplied processor. The caller owns
+     *   its lifecycle; the Weave OTLP exporter targeting `/agents/otel/v1/traces`
+     *   is not used.
+     */
+    spanProcessor?: 'batch' | 'simple' | SpanProcessor;
 
-  get attributes(): Record<string, any> {
-    return this.globalAttributes;
-  }
-}
+    /** `BatchSpanProcessor` configuration. Ignored unless `spanProcessor === 'batch'`. */
+    batchOptions?: BufferConfig;
+  };
+};
 
-export function makeSettings(settings?: SettingsInit): Settings {
-  if (!settings) {
-    return new Settings();
-  }
-  return new Settings(
-    settings.printCallLink ?? true,
-    settings.globalAttributes ?? {},
-    settings.genai ?? {}
-  );
+export function makeSettings(settings: Partial<Settings> = {}): Settings {
+  // Env vars take precedence over provided settings.
+  const printCallLink =
+    parseEnvVar(process.env.WEAVE_PRINT_CALL_LINK) ??
+    settings.printCallLink ??
+    true;
+
+  const globalAttributes = settings.globalAttributes ?? {};
+
+  return {
+    printCallLink,
+    globalAttributes,
+    genai: settings.genai ?? {},
+
+    /** @deprecated Use `printCallLink` instead. */
+    shouldPrintCallLink: printCallLink,
+
+    /** @deprecated Use `globalAttributes` instead. */
+    attributes: globalAttributes,
+  };
 }
 
 export function shouldUseOtelV2(): boolean {

--- a/sdks/node/src/settings.ts
+++ b/sdks/node/src/settings.ts
@@ -27,15 +27,9 @@ export type Settings = {
    */
   readonly printCallLink: boolean;
 
-  /** @deprecated Use `printCallLink` instead. */
-  readonly shouldPrintCallLink: boolean;
-
   /**
    * A map of attributes applied to every trace produced by this client.
    */
-  readonly globalAttributes: Record<string, any>;
-
-  /** @deprecated Use `globalAttributes` instead. */
   readonly attributes: Record<string, any>;
 };
 
@@ -46,18 +40,10 @@ export function makeSettings(settings: Partial<Settings> = {}): Settings {
     settings.printCallLink ??
     true;
 
-  const globalAttributes = settings.globalAttributes ?? {};
-
   return {
     printCallLink,
-    globalAttributes,
+    attributes: settings.attributes ?? {},
     genai: settings.genai ?? {},
-
-    /** @deprecated Use `printCallLink` instead. */
-    shouldPrintCallLink: printCallLink,
-
-    /** @deprecated Use `globalAttributes` instead. */
-    attributes: globalAttributes,
   };
 }
 

--- a/sdks/node/src/settings.ts
+++ b/sdks/node/src/settings.ts
@@ -1,7 +1,19 @@
 import type {BufferConfig, SpanProcessor} from '@opentelemetry/sdk-trace-base';
 
 export type Settings = {
-  genai: {
+  /**
+   * Prints links in terminal to Weave UI for ops.
+   *
+   * @default `true`
+   */
+  readonly printCallLink: boolean;
+
+  /**
+   * A map of attributes applied to every trace produced by this client.
+   */
+  readonly attributes: Record<string, any>;
+
+  readonly genai: {
     /**
      * How GenAI spans are exported.
      *
@@ -16,21 +28,11 @@ export type Settings = {
      */
     spanProcessor?: 'batch' | 'simple' | SpanProcessor;
 
-    /** `BatchSpanProcessor` configuration. Ignored unless `spanProcessor === 'batch'`. */
+    /**
+     * `BatchSpanProcessor` configuration. Ignored unless `spanProcessor === 'batch'`.
+     */
     batchOptions?: BufferConfig;
   };
-
-  /**
-   * Prints links in terminal to Weave UI for ops.
-   *
-   * @default `true`
-   */
-  readonly printCallLink: boolean;
-
-  /**
-   * A map of attributes applied to every trace produced by this client.
-   */
-  readonly attributes: Record<string, any>;
 };
 
 export function makeSettings(settings: Partial<Settings> = {}): Settings {

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -30,7 +30,7 @@ import {
   getOpWrappedFunction,
   isOp,
 } from './opType';
-import {Settings} from './settings';
+import {makeSettings, Settings} from './settings';
 import {Table, TableRef, TableRowRef} from './table';
 import {linkAssetToRegistry} from './traceServerBindings/linkAssetToRegistry';
 import type {
@@ -191,15 +191,15 @@ export class WeaveClient {
   constructor({
     traceServerApi,
     projectId,
-    settings = new Settings(),
+    settings = {},
   }: {
     traceServerApi: TraceServerApi<any>;
     projectId: string;
-    settings?: Settings;
+    settings?: Partial<Settings>;
   }) {
     this.traceServerApi = traceServerApi;
     this.projectId = projectId;
-    this.settings = settings;
+    this.settings = makeSettings(settings);
   }
 
   private scheduleBatchProcessing() {
@@ -1015,7 +1015,7 @@ export class WeaveClient {
 
     // Merge custom attributes with default weave attributes
     const combinedAttributes = {
-      ...this.settings.attributes,
+      ...this.settings.globalAttributes,
       ...this.getCurrentAttributes(),
       ...(attributes || {}),
     };

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -1015,7 +1015,7 @@ export class WeaveClient {
 
     // Merge custom attributes with default weave attributes
     const combinedAttributes = {
-      ...this.settings.globalAttributes,
+      ...this.settings.attributes,
       ...this.getCurrentAttributes(),
       ...(attributes || {}),
     };


### PR DESCRIPTION
## Description

* The only reference to settings the TS client supports exists on [this page](https://docs.wandb.ai/weave/reference/typescript-sdk/functions/init), and just references a `SettingsInit` type without any add'l information:

<img width="1533" height="1132" alt="Screenshot 2026-06-15 at 12 12 49 PM" src="https://github.com/user-attachments/assets/46ff874e-9500-433c-a665-f1206569d4eb" />

* Without an IDE or looking through the codebase, this isn't useful.

* This change simplifies some plumbing we have around our settings -- passing around a plain-old-javascript `Settings` object instead of a `Settings` instance with a separate `SettingsInit` type. This type is now exported from the public API so it can be included in our client reference docs.

* At the moment, the client supports setting only the following via `init`:

```ts
export type Settings = {
  /**
   * Prints links in terminal to Weave UI for ops.
   *
   * @default `true`
   */
  readonly printCallLink: boolean;

  /**
   * A map of attributes applied to every trace produced by this client.
   */
  readonly attributes: Record<string, any>;

  readonly genai: {
    /**
     * How GenAI spans are exported.
     *
     * - `'batch'` (default): `BatchSpanProcessor`, suitable for production
     *   agents and long-lived processes.
     * - `'simple'`: `SimpleSpanProcessor`, one HTTP POST per span. Useful for
     *   tests and short-lived CLIs where deterministic flush matters more than
     *   throughput.
     * - `SpanProcessor` instance: a user-supplied processor. The caller owns
     *   its lifecycle; the Weave OTLP exporter targeting `/agents/otel/v1/traces`
     *   is not used.
     */
    spanProcessor?: 'batch' | 'simple' | SpanProcessor;

    /**
     * `BatchSpanProcessor` configuration. Ignored unless `spanProcessor === 'batch'`.
     */
    batchOptions?: BufferConfig;
  };
};
```

* Efforts to bring supported settings closer to parity with the Python SDK are forthcoming.

* ~Aliases are exposed as `shouldPrintCallLink` and `attributes`, for backwards compatibility on the off-chance that a customer is reading these directly via `client.settings.shouldPrintCallLink` or `client.settings.attributes`.~

* Removing `shouldPrintCallLink` and `globalAttributes` is a breaking change which we'll consider when bumping the version number of the next release.
