### PR TITLE
feat(weave_ts): Add 'useOTelv2' setting to init()

### DIFF
--- a/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
+++ b/sdks/node/src/__tests__/integrations/openaiAgent.test.ts
@@ -35,6 +35,7 @@ import {InMemoryTraceServer, type Call} from '../helpers/inMemoryTraceServer';
 import state from 'weave/state';
 
 describe('OpenAI Agents Integration', () => {
+  withEnv({WEAVE_USE_OTEL_V2: false});
   withOpenAITracingEnabled();
 
   let inMemoryTraceServer: InMemoryTraceServer;

--- a/sdks/node/src/__tests__/settings.test.ts
+++ b/sdks/node/src/__tests__/settings.test.ts
@@ -46,9 +46,7 @@ describe('makeSettings', () => {
 
     it('honors attributes', () => {
       const attrs = {tenant: 'acme', region: 'us-west'};
-      expect(makeSettings({attributes: attrs}).attributes).toEqual(
-        attrs
-      );
+      expect(makeSettings({attributes: attrs}).attributes).toEqual(attrs);
     });
 
     it('honors genai settings', () => {

--- a/sdks/node/src/__tests__/settings.test.ts
+++ b/sdks/node/src/__tests__/settings.test.ts
@@ -20,6 +20,7 @@ describe('makeSettings', () => {
         attributes: {},
         genai: {},
         printCallLink: true,
+        useOTelV2: true,
       });
     });
 
@@ -29,6 +30,7 @@ describe('makeSettings', () => {
         attributes: {},
         genai: {},
         printCallLink: true,
+        useOTelV2: true,
       });
     });
   });

--- a/sdks/node/src/__tests__/settings.test.ts
+++ b/sdks/node/src/__tests__/settings.test.ts
@@ -1,4 +1,4 @@
-import {makeSettings} from '../settings';
+import {defaultSettings, makeSettings} from '../settings';
 
 describe('makeSettings', () => {
   const originalEnv = process.env;
@@ -38,9 +38,15 @@ describe('makeSettings', () => {
       expect(makeSettings({printCallLink: false}).printCallLink).toBe(false);
     });
 
+    it('honors useOTelV2', () => {
+      expect(makeSettings({useOTelV2: false}).useOTelV2).toBe(false);
+    });
+
     it('honors attributes', () => {
       const attrs = {tenant: 'acme', region: 'us-west'};
-      expect(makeSettings({attributes: attrs}).attributes).toEqual(attrs);
+      expect(makeSettings({attributes: attrs}).attributes).toEqual(
+        attrs
+      );
     });
 
     it('honors genai settings', () => {
@@ -76,5 +82,41 @@ describe('makeSettings', () => {
       process.env.WEAVE_PRINT_CALL_LINK = 'maybe';
       expect(makeSettings().printCallLink).toBe(true);
     });
+
+    it('WEAVE_USE_OTEL_V2=true overrides explicit false', () => {
+      process.env.WEAVE_USE_OTEL_V2 = 'true';
+      expect(makeSettings({useOTelV2: false}).useOTelV2).toBe(true);
+    });
+
+    it('WEAVE_USE_OTEL_V2=false overrides explicit true', () => {
+      process.env.WEAVE_USE_OTEL_V2 = 'false';
+      expect(makeSettings({useOTelV2: true}).useOTelV2).toBe(false);
+    });
+  });
+});
+
+describe('defaultSettings', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {...originalEnv};
+    delete process.env.WEAVE_PRINT_CALL_LINK;
+    delete process.env.WEAVE_USE_OTEL_V2;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it('matches makeSettings() with no args', () => {
+    expect(defaultSettings()).toEqual(makeSettings());
+  });
+
+  it('applies env vars', () => {
+    process.env.WEAVE_PRINT_CALL_LINK = 'false';
+    process.env.WEAVE_USE_OTEL_V2 = 'false';
+    const s = defaultSettings();
+    expect(s.printCallLink).toBe(false);
+    expect(s.useOTelV2).toBe(false);
   });
 });

--- a/sdks/node/src/integrations/openai.agent.ts
+++ b/sdks/node/src/integrations/openai.agent.ts
@@ -14,7 +14,8 @@
 import type OpenAIAgents from '@openai/agents';
 import {addCJSInstrumentation, addESMInstrumentation} from './instrumentations';
 import type {SpanData, TracingProcessor} from '@openai/agents';
-import {shouldUseOtelV2} from '../settings';
+import {getGlobalClient} from '../clientApi';
+import {defaultSettings} from '../settings';
 import {WeaveOtelTracingProcessor} from './openai-agents/weave-otel-tracing-processor';
 import {WeaveTracingProcessor} from './openai-agents/weave-tracing-processor';
 import state from '../state';
@@ -99,7 +100,8 @@ export function getCurrentSpan(): OpenAIAgents.Span<any> | null {
  * ```
  */
 export function createOpenAIAgentsTracingProcessor(): TracingProcessor {
-  if (shouldUseOtelV2()) {
+  const settings = getGlobalClient()?.settings ?? defaultSettings();
+  if (settings.useOTelV2) {
     return new WeaveOtelTracingProcessor();
   }
 

--- a/sdks/node/src/integrations/openai.ts
+++ b/sdks/node/src/integrations/openai.ts
@@ -11,7 +11,7 @@ import {
   getCallStackFromOpenAIAgents,
   isInOpenAIAgentsContext,
 } from './openai-agents/weave-tracing-processor';
-import {shouldUseOtelV2} from '../settings';
+import {defaultSettings} from '../settings';
 
 // Integration provenance stamped onto every call this integration produces.
 const OPENAI_INTEGRATION = libraryIntegration('openai');
@@ -35,7 +35,8 @@ function runWithOpenAIAgentsContext<T>(fn: () => T): T {
 }
 
 function shouldSkipTracingInAgentContext(): boolean {
-  return shouldUseOtelV2() && isInOpenAIAgentsContext();
+  const settings = getGlobalClient()?.settings ?? defaultSettings();
+  return settings.useOTelV2 && isInOpenAIAgentsContext();
 }
 
 // exported just for testing

--- a/sdks/node/src/settings.ts
+++ b/sdks/node/src/settings.ts
@@ -13,6 +13,13 @@ export type Settings = {
    */
   readonly attributes: Record<string, any>;
 
+  /**
+   * Routes OTel-capable integrations through their OTel variant.
+   *
+   * @default `true`
+   */
+  useOTelV2: boolean;
+
   readonly genai: {
     /**
      * How GenAI spans are exported.
@@ -42,15 +49,19 @@ export function makeSettings(settings: Partial<Settings> = {}): Settings {
     settings.printCallLink ??
     true;
 
+  const useOTelV2 =
+    parseEnvVar(process.env.WEAVE_USE_OTEL_V2) ?? settings.useOTelV2 ?? true;
+
   return {
     printCallLink,
+    useOTelV2,
     attributes: settings.attributes ?? {},
     genai: settings.genai ?? {},
   };
 }
 
-export function shouldUseOtelV2(): boolean {
-  return parseEnvVar(process.env.WEAVE_USE_OTEL_V2) ?? false;
+export function defaultSettings(): Settings {
+  return makeSettings();
 }
 
 function parseEnvVar(val: string | undefined): boolean | undefined {

--- a/weave/trace/api.py
+++ b/weave/trace/api.py
@@ -108,6 +108,8 @@ def init(
                     call data (start and end) into a single request instead of separate start/end requests.
                     This reduces server load and improves performance, especially for short-lived ops.
                     Default: `True`
+                - `use_otel_v2`: (bool): Routes OTel-capable integrations through their OTel variant.
+                    Default: `True`
         autopatch_settings: (Deprecated) Configuration for autopatch integrations. Use explicit patching instead.
         postprocess_inputs: A function applied to the inputs of every op traced by this client.
         postprocess_output: A function applied to the output of every op traced by this client.


### PR DESCRIPTION
## Description

* Adds a `useOTelV2` setting, for parity with the `use_otel_v2` setting on the Python side.

* Addes to the `Settings` type for reference and introduces a test suite documenting fallbacks to env vars.

* Also adds the Python-side setting to the comment documenting available settings to `init()`.
