### PR TITLE
feat(weave): add generic agent_name_override for OTel invoke_agent spans

### DIFF
--- a/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
+++ b/tests/integrations/claude_agent_sdk/claude_agent_sdk_otel_test.py
@@ -8,6 +8,7 @@ Agent SDK talks over a subprocess transport, so messages are replayed via
 
 from __future__ import annotations
 
+import asyncio
 import json
 from collections.abc import Generator
 from typing import Any
@@ -24,6 +25,7 @@ from tests.integrations.claude_agent_sdk.conftest import ReplayTransport, load_c
 from weave.integrations.claude_agent_sdk.otel_integration import (
     get_claude_agent_sdk_otel_patcher,
 )
+from weave.session import agent_name_override
 
 
 @pytest.fixture
@@ -317,3 +319,95 @@ async def test_multi_turn_client_otel(otel_spans: InMemorySpanExporter) -> None:
         for agent_span in agent_spans
     }
     assert prompts == {"Hello", "What is the capital of France?"}
+
+
+# --- agent name override ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_custom_agent_name_query_otel(otel_spans: InMemorySpanExporter) -> None:
+    """A custom name lands on both the span name and gen_ai.agent.name."""
+    with agent_name_override("research_agent"):
+        await run_query("simple_text_response", "What is 2+2?")
+
+    agent_span = get_spans_by_op(otel_spans.get_finished_spans(), "invoke_agent")[0]
+    assert agent_span.name == "invoke_agent research_agent"
+    attrs = check_integration_and_strip(get_attrs(agent_span))
+    assert attrs["gen_ai.agent.name"] == "research_agent"
+    # Only the agent name is overridden — the rest of the GenAI shape is intact.
+    assert attrs["gen_ai.provider.name"] == "anthropic"
+    assert attrs["gen_ai.request.model"] == "claude-sonnet-4-6"
+
+
+@pytest.mark.asyncio
+async def test_agent_name_restored_after_context_otel(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    """Inside the block the custom name applies; outside it reverts to default."""
+    with agent_name_override("scoped_agent"):
+        await run_query("simple_text_response", "What is 2+2?")
+    await run_query("simple_text_response", "What is 2+2?")
+
+    agent_spans = get_spans_by_op(otel_spans.get_finished_spans(), "invoke_agent")
+    names = sorted(get_attrs(span)["gen_ai.agent.name"] for span in agent_spans)
+    assert names == ["claude_agent_sdk", "scoped_agent"]
+    span_names = sorted(span.name for span in agent_spans)
+    assert span_names == [
+        "invoke_agent claude_agent_sdk",
+        "invoke_agent scoped_agent",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_custom_agent_name_multi_turn_otel(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    """The override applies to every turn of a ClaudeSDKClient session."""
+    with agent_name_override("support_agent"):
+        sdk_client = ClaudeSDKClient(
+            options=ClaudeAgentOptions(),
+            transport=ReplayTransport(load_cassette("multi_turn_response")),
+        )
+        await sdk_client.connect()
+        await sdk_client.query("Hello")
+        _ = [message async for message in sdk_client.receive_response()]
+        await sdk_client.query("What is the capital of France?")
+        _ = [message async for message in sdk_client.receive_response()]
+        await sdk_client.disconnect()
+
+    agent_spans = get_spans_by_op(otel_spans.get_finished_spans(), "invoke_agent")
+    assert len(agent_spans) == 2
+    assert {span.name for span in agent_spans} == {"invoke_agent support_agent"}
+    assert {get_attrs(span)["gen_ai.agent.name"] for span in agent_spans} == {
+        "support_agent"
+    }
+
+
+@pytest.mark.asyncio
+async def test_concurrent_queries_distinct_agent_names_otel(
+    otel_spans: InMemorySpanExporter,
+) -> None:
+    """Concurrent queries each keep their own name (ContextVar isolation)."""
+
+    async def named_query(agent_name: str, prompt: str) -> None:
+        with agent_name_override(agent_name):
+            await run_query("simple_text_response", prompt)
+
+    await asyncio.gather(
+        named_query("agent_a", "What is 2+2?"),
+        named_query("agent_b", "What is 3+3?"),
+    )
+
+    agent_spans = get_spans_by_op(otel_spans.get_finished_spans(), "invoke_agent")
+    assert {get_attrs(span)["gen_ai.agent.name"] for span in agent_spans} == {
+        "agent_a",
+        "agent_b",
+    }
+
+
+@pytest.mark.parametrize("bad_name", ["", "   ", "\n\t"])
+def test_agent_name_rejects_empty(bad_name: str) -> None:
+    """An empty/whitespace name fails loudly rather than mislabeling spans."""
+    with pytest.raises(ValueError, match="non-empty"):
+        with agent_name_override(bad_name):
+            pass

--- a/tests/integrations/openai_agents/openai_agents_otel_test.py
+++ b/tests/integrations/openai_agents/openai_agents_otel_test.py
@@ -37,6 +37,7 @@ from weave.integrations.openai_agents.otel_processor import (
     WeaveOtelTracingProcessor,
     _iso_to_ns,
 )
+from weave.session import agent_name_override
 from weave.trace.weave_client import WeaveClient
 
 
@@ -211,6 +212,40 @@ def test_agent_span_carries_provider_name(
     spans = otel_spans.get_finished_spans()
     agent = next(s for s in spans if s.name == "invoke_agent Bot")
     assert _attrs(agent)["gen_ai.provider.name"] == "openai"
+
+
+def test_agent_name_override_wins_over_native(
+    client: WeaveClient, otel_spans: InMemorySpanExporter
+) -> None:
+    """An explicit override replaces the SDK-native agent name on the span."""
+    processor = WeaveOtelTracingProcessor()
+    trace = Mock(spec=Trace)
+    trace.trace_id = "trace_o"
+    trace.name = "wf"
+    trace.group_id = None
+
+    agent_span = Mock(spec=Span)
+    agent_span.trace_id = "trace_o"
+    agent_span.span_id = "span_o"
+    agent_span.parent_id = None
+    agent_span.span_data = AgentSpanData(name="Bot")
+    agent_span.started_at = None
+    agent_span.ended_at = None
+    agent_span.error = None
+
+    # The name is resolved at span start/end, so the override must be active then.
+    with agent_name_override("research_agent"):
+        processor.on_trace_start(trace)
+        processor.on_span_start(agent_span)
+        processor.on_span_end(agent_span)
+        processor.on_trace_end(trace)
+
+    spans = otel_spans.get_finished_spans()
+    agent = next(
+        s for s in spans if _attrs(s).get("gen_ai.operation.name") == "invoke_agent"
+    )
+    assert agent.name == "invoke_agent research_agent"
+    assert _attrs(agent)["gen_ai.agent.name"] == "research_agent"
 
 
 def test_response_span_emits_chat_with_messages(

--- a/tests/session/test_agent_context.py
+++ b/tests/session/test_agent_context.py
@@ -1,0 +1,40 @@
+"""Unit tests for the generic agent-name override.
+
+Exercises ``weave.session.agent_name_override`` and the internal
+``resolve_agent_name`` resolver that auto-instrumentation integrations call.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from weave.session import agent_name_override
+from weave.session.agent_context import resolve_agent_name
+
+
+def test_resolve_returns_default_when_unset() -> None:
+    assert resolve_agent_name("claude_agent_sdk") == "claude_agent_sdk"
+
+
+def test_override_wins_over_default_and_native_name() -> None:
+    with agent_name_override("researcher"):
+        # over an integration default...
+        assert resolve_agent_name("claude_agent_sdk") == "researcher"
+        # ...and over a non-empty SDK-native name.
+        assert resolve_agent_name("Assistant") == "researcher"
+
+
+def test_nested_overrides_restore_outer_then_default() -> None:
+    with agent_name_override("outer"):
+        assert resolve_agent_name("d") == "outer"
+        with agent_name_override("inner"):
+            assert resolve_agent_name("d") == "inner"
+        assert resolve_agent_name("d") == "outer"
+    assert resolve_agent_name("d") == "d"
+
+
+@pytest.mark.parametrize("bad_name", ["", "   ", "\n\t"])
+def test_override_rejects_empty(bad_name: str) -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        with agent_name_override(bad_name):
+            pass

--- a/weave/integrations/claude_agent_sdk/otel_integration.py
+++ b/weave/integrations/claude_agent_sdk/otel_integration.py
@@ -8,6 +8,12 @@ Each ``query()`` call / ``ClaudeSDKClient`` turn becomes an ``invoke_agent``
 span, with a child ``chat`` span per model response and an ``execute_tool``
 span per tool call. The SDK reports token usage only on the final
 ``ResultMessage``, so it is attached to the last ``chat`` span.
+
+The Claude Agent SDK has no agent-name concept, so ``invoke_agent`` spans
+default to ``claude_agent_sdk``. Users relabel them for a block of work with the
+generic ``weave.session.agent_name_override(...)`` context manager; the name is
+resolved per turn at span creation, so it is robust to (implicit) patch timing
+and correct under concurrent async queries.
 """
 
 from __future__ import annotations
@@ -36,6 +42,7 @@ from opentelemetry.trace import StatusCode
 
 from weave.integrations.integration_metadata import library_integration
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
+from weave.session.agent_context import resolve_agent_name
 from weave.session.session_otel import (
     execute_tool_attributes,
     invoke_agent_attributes,
@@ -48,7 +55,7 @@ from weave.trace.settings import should_disable_weave
 logger = logging.getLogger(__name__)
 
 _TRACER_NAME = "weave.claude_agent_sdk"
-_AGENT_NAME = "claude_agent_sdk"
+_DEFAULT_AGENT_NAME = "claude_agent_sdk"
 _PROVIDER_NAME = "anthropic"
 
 _claude_agent_sdk_otel_patcher: MultiPatcher | None = None
@@ -147,6 +154,9 @@ class _TurnState:
     """
 
     user_prompt: str | None
+    # Resolved once at turn start so the span name and gen_ai.agent.name stay
+    # consistent even if finalization runs outside the context that set it.
+    agent_name: str = _DEFAULT_AGENT_NAME
     conversation_id: str = ""
     model: str = ""
     final_text: str = ""
@@ -277,7 +287,7 @@ def _finalize_turn(root: Any, state: _TurnState) -> None:
     state.open_tool_spans.clear()
 
     attrs = invoke_agent_attributes(
-        agent_name=_AGENT_NAME,
+        agent_name=state.agent_name,
         conversation_id=state.conversation_id,
         provider_name=_PROVIDER_NAME,
         model=state.model,
@@ -309,9 +319,12 @@ async def _trace_turn(
     session_id) is only sent on the first turn, so later turns must inherit it.
     """
     tracer = _tracer()
-    root = tracer.start_span(f"invoke_agent {_AGENT_NAME}")
+    # Resolve once here: this runs on the first __anext__, inside the user's
+    # ``agent_name_override(...)`` block, so the override contextvar is visible.
+    agent_name = resolve_agent_name(_DEFAULT_AGENT_NAME)
+    root = tracer.start_span(f"invoke_agent {agent_name}")
     token = otel_context.attach(otel_trace.set_span_in_context(root))
-    state = _TurnState(user_prompt=user_prompt)
+    state = _TurnState(user_prompt=user_prompt, agent_name=agent_name)
     if conversation_id_holder is not None and conversation_id_holder[0]:
         state.conversation_id = conversation_id_holder[0]
     try:

--- a/weave/integrations/openai_agents/otel_processor.py
+++ b/weave/integrations/openai_agents/otel_processor.py
@@ -72,6 +72,7 @@ from weave.session.adapters.openai import (
     reasoning_from_openai_responses,
     usage_from_openai_responses,
 )
+from weave.session.agent_context import resolve_agent_name
 from weave.session.session_otel import (
     execute_tool_attributes,
     invoke_agent_attributes,
@@ -140,7 +141,8 @@ def _agent_attrs(span: Span[AgentSpanData], conversation_id: str) -> dict[str, A
     """
     sd = span.span_data
     attrs = invoke_agent_attributes(
-        agent_name=sd.name or "",
+        # An explicit ambient override wins over the SDK-native agent name.
+        agent_name=resolve_agent_name(sd.name or ""),
         conversation_id=conversation_id,
         provider_name=_PROVIDER_NAME,
     )
@@ -629,7 +631,9 @@ def _otel_span_name(span: Span) -> str:
     sd = span.span_data
     name = _call_name(span)
     if isinstance(sd, AgentSpanData):
-        return f"invoke_agent {name}"
+        # Keep the span name aligned with gen_ai.agent.name in _agent_attrs:
+        # an explicit ambient override wins over the SDK-native name.
+        return f"invoke_agent {resolve_agent_name(name)}"
     if _is_task_span_data(sd):
         # Structural span — NOT invoke_agent, since a Task wraps a workflow
         # not an agent. See _task_attrs.

--- a/weave/session/__init__.py
+++ b/weave/session/__init__.py
@@ -8,6 +8,7 @@ the ``langchain_core.messages`` pattern: callers building structured
 messages do ``from weave.session import TextPart, ToolCallPart``.
 """
 
+from weave.session.agent_context import agent_name_override
 from weave.session.session import (
     LLM,
     BlobPart,
@@ -61,6 +62,7 @@ __all__ = [
     "Turn",
     "UriPart",
     "Usage",
+    "agent_name_override",
     "end_llm",
     "end_session",
     "end_turn",

--- a/weave/session/agent_context.py
+++ b/weave/session/agent_context.py
@@ -1,0 +1,65 @@
+"""Ambient agent-name override for OTel auto-instrumentation.
+
+Auto-instrumentation integrations (``claude_agent_sdk``, ``openai_agents``, …)
+each create their own ``invoke_agent`` OTel span and stamp ``gen_ai.agent.name``
+on it. Some SDKs expose a native agent name (OpenAI Agents); others don't
+(``claude_agent_sdk`` falls back to ``"claude_agent_sdk"``). ``agent_name_override``
+lets a user name those auto-created spans for a block of work, regardless of
+which integration produced them.
+
+This is deliberately distinct from ``weave.session.start_turn(agent_name=...)``,
+which *creates* a manual ``invoke_agent`` span. The override here only relabels a
+span created elsewhere — it never creates a span of its own.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+# ``None`` means "no override" — integrations fall back to their native/default
+# name. An active override is always a validated non-empty string.
+_current_agent_name: ContextVar[str | None] = ContextVar(
+    "weave_agent_name_override", default=None
+)
+
+
+@contextmanager
+def agent_name_override(agent_name: str) -> Iterator[None]:
+    """Name the OTel ``invoke_agent`` spans emitted within this block.
+
+    Overrides the ``gen_ai.agent.name`` (and span name) that auto-instrumentation
+    integrations stamp on their ``invoke_agent`` span::
+
+        import weave
+        from weave.session import agent_name_override
+
+        weave.init("my-project")
+
+        with agent_name_override("research_agent"):
+            async for message in query(prompt="...", options=options):
+                ...
+
+    The name is resolved per span at creation, so concurrent async runs may each
+    set their own name. Nested blocks restore the outer name on exit. Unlike
+    ``start_turn(agent_name=...)`` this creates no span itself — it only relabels
+    spans produced by the integration in scope.
+    """
+    if not isinstance(agent_name, str) or not agent_name.strip():
+        raise ValueError("agent_name must be a non-empty string")
+    token = _current_agent_name.set(agent_name)
+    try:
+        yield
+    finally:
+        _current_agent_name.reset(token)
+
+
+def resolve_agent_name(default: str) -> str:
+    """Return the ambient override if one is set, else ``default``.
+
+    Precedence at an auto-instrumentation call site: explicit override >
+    integration-native name (passed as ``default``) > integration default.
+    """
+    override = _current_agent_name.get()
+    return override if override is not None else default


### PR DESCRIPTION
By default, our auto-instrumentation for OTEL integrations create their own `invoke_agent` span and set `gen_ai.agent.name`.  This is not configurable today, so this PR introduces a way to configure it.
