### PR TITLE
fix(weave): add storage_size_bytes otel dump bytes 

### DIFF
--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2225,7 +2225,7 @@ def test_storage_size_fields():
         FROM calls_merged
         LEFT JOIN
         (SELECT id,
-                sum(COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) + COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0)) AS storage_size_bytes
+                sum(COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) + COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0) + COALESCE(otel_dump_size_bytes, 0)) AS storage_size_bytes
         FROM calls_merged_stats
         WHERE project_id = {pb_0:String}
         GROUP BY id) AS storage_size_tbl ON calls_merged.id = storage_size_tbl.id
@@ -2318,7 +2318,7 @@ def test_total_storage_size(with_filter: bool):
             FROM calls_merged
             LEFT JOIN (SELECT
                 trace_id,
-                sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0)) AS total_storage_size_bytes
+                sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0) + COALESCE(otel_dump_size_bytes,0)) AS total_storage_size_bytes
             FROM calls_merged_stats
             WHERE project_id = {pb_1:String}
             AND trace_id IN (
@@ -2350,7 +2350,7 @@ def test_total_storage_size(with_filter: bool):
             FROM calls_merged
             LEFT JOIN (SELECT
                 trace_id,
-                sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0)) AS total_storage_size_bytes
+                sum(COALESCE(attributes_size_bytes,0) + COALESCE(inputs_size_bytes,0) + COALESCE(output_size_bytes,0) + COALESCE(summary_size_bytes,0) + COALESCE(otel_dump_size_bytes,0)) AS total_storage_size_bytes
             FROM calls_merged_stats
             WHERE project_id = {pb_0:String}
             GROUP BY trace_id) AS rolled_up_cms
@@ -4257,7 +4257,7 @@ def test_stats_query_calls_complete_flat_with_total_storage_size() -> None:
         SELECT count() AS count,
                toUInt8(0) AS has_more,
                coalesce(
-                          (SELECT sum(COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) + COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0))
+                          (SELECT sum(COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) + COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0) + COALESCE(otel_size_bytes, 0))
                            FROM calls_complete_stats
                            WHERE project_id = {pb_0:String}), 0) AS total_storage_size_bytes
         FROM calls_complete
@@ -4413,7 +4413,7 @@ def test_stats_query_calls_merged_unfiltered_storage_uses_flat_sum() -> None:
                            OR isNotNull(calls_merged.deleted_at)) - uniqExactIf(calls_merged.id, isNotNull(calls_merged.deleted_at)) AS count,
                toUInt8(0) AS has_more,
                coalesce(
-                          (SELECT sum(COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) + COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0))
+                          (SELECT sum(COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) + COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0) + COALESCE(otel_dump_size_bytes, 0))
                            FROM calls_merged_stats
                            WHERE project_id = {pb_0:String}), 0) AS total_storage_size_bytes
         FROM calls_merged

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -2239,6 +2239,39 @@ def test_storage_size_fields():
     )
 
 
+def test_storage_size_includes_otel_dump_bytes():
+    """Per-call storage_size_bytes must include OTel dump bytes, like project stats do.
+
+    project_query_builder sums the same stats table WITH `+ COALESCE(otel_dump_size_bytes, 0)`,
+    so a call's storage_size_bytes and the project trace_storage_size_bytes (derived from the
+    same rows) disagree for any OTel-ingesting project. This pins the reconciled sum.
+    """
+    cq = CallsQuery(project_id="test/project", include_storage_size=True)
+    cq.add_field("id")
+    cq.add_field("storage_size_bytes")
+
+    assert_sql(
+        cq,
+        """
+        SELECT calls_merged.id AS id,
+           any(storage_size_tbl.storage_size_bytes) AS storage_size_bytes
+        FROM calls_merged
+        LEFT JOIN
+        (SELECT id,
+                sum(COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) + COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0) + COALESCE(otel_dump_size_bytes, 0)) AS storage_size_bytes
+        FROM calls_merged_stats
+        WHERE project_id = {pb_0:String}
+        GROUP BY id) AS storage_size_tbl ON calls_merged.id = storage_size_tbl.id
+        PREWHERE calls_merged.project_id = {pb_0:String}
+        GROUP BY (calls_merged.project_id,
+                calls_merged.id)
+        HAVING (((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+        """,
+        {"pb_0": "test/project"},
+    )
+
+
 @pytest.mark.parametrize("with_filter", [False, True])
 def test_total_storage_size(with_filter: bool):
     """Test querying with total storage size.

--- a/weave/trace_server/calls_query_builder/calls_query_builder.py
+++ b/weave/trace_server/calls_query_builder/calls_query_builder.py
@@ -96,14 +96,6 @@ CTE_FILTER_CANDIDATE_IDS = "filter_candidate_ids"
 # >>1M-count requests in the wild.
 DEFAULT_STATS_MAX_LIMIT = 1_000_000
 
-# Per-row payload size sum, the inner expression behind storage_size_bytes /
-# total_storage_size_bytes wherever a stats table is read. Single source so a new
-# size column can't silently desync one path's storage number from another's.
-STORAGE_SIZE_BYTES_SUM = (
-    "COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) "
-    "+ COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0)"
-)
-
 
 @dataclass(frozen=True, slots=True)
 class FilterConditionsResult:
@@ -1514,7 +1506,7 @@ class CallsQuery(BaseModel):
             LEFT JOIN (
                 SELECT
                     id,
-                    sum({STORAGE_SIZE_BYTES_SUM}) AS storage_size_bytes
+                    sum({config.storage_size_bytes_sum}) AS storage_size_bytes
                 FROM {config.stats_table_name}
                 WHERE project_id = {param_slot(project_param, "String")}
                 GROUP BY id
@@ -1545,7 +1537,7 @@ class CallsQuery(BaseModel):
             LEFT JOIN (
                 SELECT
                     trace_id,
-                    sum({STORAGE_SIZE_BYTES_SUM}) AS total_storage_size_bytes
+                    sum({config.storage_size_bytes_sum}) AS total_storage_size_bytes
                 FROM {config.stats_table_name}
                 WHERE project_id = {param_slot(project_param, "String")}
                 {trace_id_filter}
@@ -3222,7 +3214,7 @@ def _optimized_unfiltered_storage_query(
         {count_expr} AS count,
         toUInt8(0) AS has_more,
         coalesce(
-            (SELECT sum({STORAGE_SIZE_BYTES_SUM})
+            (SELECT sum({config.storage_size_bytes_sum})
              FROM {config.stats_table_name}
              WHERE project_id = {project_id_slot}),
             0

--- a/weave/trace_server/project_version/types.py
+++ b/weave/trace_server/project_version/types.py
@@ -81,6 +81,8 @@ class TableConfig:
             False for calls_complete (single-row per call, no aggregation needed).
         datetime_filter_field: Column name for datetime-based optimizations.
             "sortable_datetime" for calls_merged, "started_at" for calls_complete.
+        otel_size_column: Stats-table column holding OTel dump bytes.
+            "otel_dump_size_bytes" for calls_merged, "otel_size_bytes" for calls_complete.
     """
 
     read_table: ReadTable
@@ -88,6 +90,7 @@ class TableConfig:
     stats_table_name: str
     use_aggregation: bool
     datetime_filter_field: str
+    otel_size_column: str
 
     @classmethod
     def from_read_table(cls, read_table: ReadTable) -> "TableConfig":
@@ -111,6 +114,7 @@ class TableConfig:
                 stats_table_name="calls_merged_stats",
                 use_aggregation=True,
                 datetime_filter_field="sortable_datetime",
+                otel_size_column="otel_dump_size_bytes",
             )
         elif read_table == ReadTable.CALLS_COMPLETE:
             return cls(
@@ -119,6 +123,20 @@ class TableConfig:
                 stats_table_name="calls_complete_stats",
                 use_aggregation=False,
                 datetime_filter_field="started_at",
+                otel_size_column="otel_size_bytes",
             )
         else:
             raise ValueError(f"Invalid read table: {read_table}")
+
+    @property
+    def storage_size_bytes_sum(self) -> str:
+        """Per-row payload size sum behind every storage_size_bytes figure.
+
+        Single source so per-call, per-trace, and project totals can't desync on
+        which size columns (including OTel dump bytes) they count.
+        """
+        return (
+            "COALESCE(attributes_size_bytes, 0) + COALESCE(inputs_size_bytes, 0) "
+            "+ COALESCE(output_size_bytes, 0) + COALESCE(summary_size_bytes, 0) "
+            f"+ COALESCE({self.otel_size_column}, 0)"
+        )

--- a/weave/trace_server/query_builder/project_query_builder.py
+++ b/weave/trace_server/query_builder/project_query_builder.py
@@ -41,12 +41,6 @@ def make_project_stats_query(
 
     table_config = TableConfig.from_read_table(read_table)
     calls_stats_table = table_config.stats_table_name
-    # calls_merged_stats and calls_complete_stats name the otel column differently
-    otel_size_column = (
-        "otel_dump_size_bytes"
-        if read_table == ReadTable.CALLS_MERGED
-        else "otel_size_bytes"
-    )
 
     columns = []
     sub_sqls = []
@@ -54,13 +48,7 @@ def make_project_stats_query(
         columns.append("trace_storage_size_bytes")
         sub_sqls.append(
             f"""
-            (SELECT sum(
-                COALESCE(attributes_size_bytes, 0) +
-                COALESCE(inputs_size_bytes, 0) +
-                COALESCE(output_size_bytes, 0) +
-                COALESCE(summary_size_bytes, 0) +
-                COALESCE({otel_size_column}, 0)
-                )
+            (SELECT sum({table_config.storage_size_bytes_sum})
                 FROM {calls_stats_table}
                 WHERE project_id = {{{project_id_param}: String}}
             ) AS {columns[-1]}


### PR DESCRIPTION
## Summary
- Per-call `storage_size_bytes` / `total_storage_size_bytes` summed only attributes+inputs+output+summary, while project `trace_storage_size_bytes` (same stats table) also adds otel dump bytes, so the two desynced for any OTel-ingesting project.
- Fix: `TableConfig.storage_size_bytes_sum` is now the single source for the sum (it owns the table-specific otel column name), used by both `calls_query_builder` and `project_query_builder`.
- Sibling of #7134.

## Testing
[1f16500](https://github.com/wandb/weave/pull/7220/commits/1f1650004fe77bc31aebd45a5754874a8c36a656) now green; unit-test SQL pinned for both stats tables.