### PR TITLE
fix(weave): handle bedrock tool-use and reasoning stream deltas

### DIFF
--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -101,6 +101,60 @@ MOCK_STREAM_EVENTS = [
     },
 ]
 
+# Converse stream emitting a reasoning block followed by a tool-use block.
+# A reasoning-capable, tool-bound Claude model produces these non-text deltas,
+# which the accumulator must not choke on.
+MOCK_STREAM_EVENTS_TOOL_USE = [
+    {"messageStart": {"role": "assistant"}},
+    {
+        "contentBlockDelta": {
+            "delta": {"reasoningContent": {"text": "Let me check"}},
+            "contentBlockIndex": 0,
+        }
+    },
+    {
+        "contentBlockDelta": {
+            "delta": {"reasoningContent": {"text": " the weather."}},
+            "contentBlockIndex": 0,
+        }
+    },
+    {
+        "contentBlockDelta": {
+            "delta": {"reasoningContent": {"signature": "c2lnbmF0dXJl"}},
+            "contentBlockIndex": 0,
+        }
+    },
+    {"contentBlockStop": {"contentBlockIndex": 0}},
+    {
+        "contentBlockStart": {
+            "start": {
+                "toolUse": {"toolUseId": "tooluse_abc123", "name": "get_weather"}
+            },
+            "contentBlockIndex": 1,
+        }
+    },
+    {
+        "contentBlockDelta": {
+            "delta": {"toolUse": {"input": '{"city":'}},
+            "contentBlockIndex": 1,
+        }
+    },
+    {
+        "contentBlockDelta": {
+            "delta": {"toolUse": {"input": ' "Paris"}'}},
+            "contentBlockIndex": 1,
+        }
+    },
+    {"contentBlockStop": {"contentBlockIndex": 1}},
+    {"messageStop": {"stopReason": "tool_use"}},
+    {
+        "metadata": {
+            "usage": {"inputTokens": 60, "outputTokens": 25, "totalTokens": 85},
+            "metrics": {"latencyMs": 500},
+        }
+    },
+]
+
 MOCK_INVOKE_RESPONSE = {
     "body": io.BytesIO(
         json.dumps(
@@ -241,6 +295,19 @@ def mock_converse_make_api_call(self, operation_name: str, api_params: dict) -> 
         class MockStream:
             def __iter__(self):
                 yield from MOCK_STREAM_EVENTS
+
+        return {"stream": MockStream()}
+    return orig(self, operation_name, api_params)
+
+
+def mock_converse_tool_use_make_api_call(
+    self, operation_name: str, api_params: dict
+) -> dict:
+    if operation_name == "ConverseStream":
+
+        class MockStream:
+            def __iter__(self):
+                yield from MOCK_STREAM_EVENTS_TOOL_USE
 
         return {"stream": MockStream()}
     return orig(self, operation_name, api_params)
@@ -404,6 +471,60 @@ def test_bedrock_converse_stream(
     assert model_usage["requests"] == 1
     assert output["usage"]["inputTokens"] == model_usage["prompt_tokens"] == 55
     assert output["usage"]["outputTokens"] == model_usage["completion_tokens"] == 30
+    assert output["usage"]["totalTokens"] == model_usage["total_tokens"] == 85
+
+
+@mock_aws
+def test_bedrock_converse_stream_tool_use(
+    client: weave.trace.weave_client.WeaveClient,
+) -> None:
+    """Tool-use and reasoning deltas must not raise KeyError mid-stream (issue #7215)."""
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    patch_client(bedrock_client)
+
+    with patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=mock_converse_tool_use_make_api_call,
+    ):
+        response = bedrock_client.converse_stream(
+            modelId=model_id,
+            system=[{"text": system_message}],
+            messages=messages,
+            inferenceConfig={"maxTokens": 100},
+        )
+        stream = response.get("stream")
+        assert stream is not None, "Stream not found in response"
+
+        # The user must receive every event unchanged: non-text deltas previously
+        # crashed the wrapper and terminated this loop.
+        consumed = list(stream)
+        assert consumed == MOCK_STREAM_EVENTS_TOOL_USE
+
+    calls = client.get_calls()
+    assert len(calls) == 1, "Expected exactly one trace call for the stream test"
+    call = calls[0]
+    assert call.exception is None
+    assert call.ended_at is not None
+
+    output = call.output
+    assert output["role"] == "assistant"
+    assert output["content"] == ""
+    assert output["reasoning"] == "Let me check the weather."
+    assert output["tool_calls"] == [
+        {
+            "toolUseId": "tooluse_abc123",
+            "name": "get_weather",
+            "input": '{"city": "Paris"}',
+        }
+    ]
+    assert output["stop_reason"] == "tool_use"
+
+    summary = call.summary
+    assert summary is not None, "Summary should not be None"
+    model_usage = summary["usage"][model_id]
+    assert model_usage["requests"] == 1
+    assert output["usage"]["inputTokens"] == model_usage["prompt_tokens"] == 60
+    assert output["usage"]["outputTokens"] == model_usage["completion_tokens"] == 25
     assert output["usage"]["totalTokens"] == model_usage["total_tokens"] == 85
 
 

--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -1,5 +1,6 @@
 import io
 import json
+from collections.abc import Callable
 from unittest.mock import patch
 
 import boto3
@@ -155,6 +156,54 @@ MOCK_STREAM_EVENTS_TOOL_USE = [
     },
 ]
 
+# A turn with a leading text block followed by two tool-use blocks: exercises
+# text/tool interleaving and arg routing across multiple contentBlockStart events.
+MOCK_STREAM_EVENTS_TEXT_AND_TOOLS = [
+    {"messageStart": {"role": "assistant"}},
+    {"contentBlockDelta": {"delta": {"text": "Checking"}, "contentBlockIndex": 0}},
+    {"contentBlockDelta": {"delta": {"text": " both."}, "contentBlockIndex": 0}},
+    {"contentBlockStop": {"contentBlockIndex": 0}},
+    {
+        "contentBlockStart": {
+            "start": {"toolUse": {"toolUseId": "tool_1", "name": "get_weather"}},
+            "contentBlockIndex": 1,
+        }
+    },
+    {
+        "contentBlockDelta": {
+            "delta": {"toolUse": {"input": '{"city": "Paris"}'}},
+            "contentBlockIndex": 1,
+        }
+    },
+    {"contentBlockStop": {"contentBlockIndex": 1}},
+    {
+        "contentBlockStart": {
+            "start": {"toolUse": {"toolUseId": "tool_2", "name": "get_time"}},
+            "contentBlockIndex": 2,
+        }
+    },
+    {
+        "contentBlockDelta": {
+            "delta": {"toolUse": {"input": '{"tz":'}},
+            "contentBlockIndex": 2,
+        }
+    },
+    {
+        "contentBlockDelta": {
+            "delta": {"toolUse": {"input": ' "CET"}'}},
+            "contentBlockIndex": 2,
+        }
+    },
+    {"contentBlockStop": {"contentBlockIndex": 2}},
+    {"messageStop": {"stopReason": "tool_use"}},
+    {
+        "metadata": {
+            "usage": {"inputTokens": 70, "outputTokens": 40, "totalTokens": 110},
+            "metrics": {"latencyMs": 700},
+        }
+    },
+]
+
 MOCK_INVOKE_RESPONSE = {
     "body": io.BytesIO(
         json.dumps(
@@ -300,17 +349,20 @@ def mock_converse_make_api_call(self, operation_name: str, api_params: dict) -> 
     return orig(self, operation_name, api_params)
 
 
-def mock_converse_tool_use_make_api_call(
-    self, operation_name: str, api_params: dict
-) -> dict:
-    if operation_name == "ConverseStream":
+def converse_stream_make_api_call(events: list[dict]) -> Callable:
+    """Build a _make_api_call that streams the given events for ConverseStream."""
 
-        class MockStream:
-            def __iter__(self):
-                yield from MOCK_STREAM_EVENTS_TOOL_USE
+    def mock(self, operation_name: str, api_params: dict) -> dict:
+        if operation_name == "ConverseStream":
 
-        return {"stream": MockStream()}
-    return orig(self, operation_name, api_params)
+            class MockStream:
+                def __iter__(self):
+                    yield from events
+
+            return {"stream": MockStream()}
+        return orig(self, operation_name, api_params)
+
+    return mock
 
 
 def mock_invoke_make_api_call(self, operation_name: str, api_params: dict) -> dict:
@@ -484,7 +536,7 @@ def test_bedrock_converse_stream_tool_use(
 
     with patch(
         "botocore.client.BaseClient._make_api_call",
-        new=mock_converse_tool_use_make_api_call,
+        new=converse_stream_make_api_call(MOCK_STREAM_EVENTS_TOOL_USE),
     ):
         response = bedrock_client.converse_stream(
             modelId=model_id,
@@ -526,6 +578,53 @@ def test_bedrock_converse_stream_tool_use(
     assert output["usage"]["inputTokens"] == model_usage["prompt_tokens"] == 60
     assert output["usage"]["outputTokens"] == model_usage["completion_tokens"] == 25
     assert output["usage"]["totalTokens"] == model_usage["total_tokens"] == 85
+
+
+@mock_aws
+def test_bedrock_converse_stream_text_and_tools(
+    client: weave.trace.weave_client.WeaveClient,
+) -> None:
+    """Leading text plus two tool calls: args route to the right tool block."""
+    bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
+    patch_client(bedrock_client)
+
+    with patch(
+        "botocore.client.BaseClient._make_api_call",
+        new=converse_stream_make_api_call(MOCK_STREAM_EVENTS_TEXT_AND_TOOLS),
+    ):
+        response = bedrock_client.converse_stream(
+            modelId=model_id,
+            system=[{"text": system_message}],
+            messages=messages,
+            inferenceConfig={"maxTokens": 100},
+        )
+        stream = response.get("stream")
+        assert stream is not None, "Stream not found in response"
+        consumed = list(stream)
+        assert consumed == MOCK_STREAM_EVENTS_TEXT_AND_TOOLS
+
+    calls = client.get_calls()
+    assert len(calls) == 1, "Expected exactly one trace call for the stream test"
+    call = calls[0]
+    assert call.exception is None
+    assert call.ended_at is not None
+
+    output = call.output
+    assert output["content"] == "Checking both."
+    assert output["reasoning"] == ""
+    assert output["tool_calls"] == [
+        {"toolUseId": "tool_1", "name": "get_weather", "input": '{"city": "Paris"}'},
+        {"toolUseId": "tool_2", "name": "get_time", "input": '{"tz": "CET"}'},
+    ]
+    assert output["stop_reason"] == "tool_use"
+
+    summary = call.summary
+    assert summary is not None, "Summary should not be None"
+    model_usage = summary["usage"][model_id]
+    assert model_usage["requests"] == 1
+    assert output["usage"]["inputTokens"] == model_usage["prompt_tokens"] == 70
+    assert output["usage"]["outputTokens"] == model_usage["completion_tokens"] == 40
+    assert output["usage"]["totalTokens"] == model_usage["total_tokens"] == 110
 
 
 @mock_aws

--- a/weave/integrations/bedrock/bedrock_sdk.py
+++ b/weave/integrations/bedrock/bedrock_sdk.py
@@ -350,6 +350,8 @@ def bedrock_stream_accumulator(
 ) -> dict:
     """Accumulates streaming events into a final response dictionary."""
     if acc is None:
+        # Flat accumulation shape (not the Converse message.content block list);
+        # tool_calls[].input is the raw partial-JSON arg string, not a dict.
         acc = {
             "role": None,
             "content": "",
@@ -388,15 +390,11 @@ def bedrock_stream_accumulator(
         delta = value["contentBlockDelta"]["delta"]
         if "text" in delta:
             acc["content"] += delta["text"]
-        elif "toolUse" in delta:
-            tool_input = delta["toolUse"].get("input", "")
-            if acc["tool_calls"]:
-                acc["tool_calls"][-1]["input"] += tool_input
-            else:
-                acc["tool_calls"].append(
-                    {"toolUseId": None, "name": None, "input": tool_input}
-                )
+        elif "toolUse" in delta and acc["tool_calls"]:
+            # Args always follow their opening contentBlockStart.
+            acc["tool_calls"][-1]["input"] += delta["toolUse"].get("input", "")
         elif "reasoningContent" in delta:
+            # Only human-readable text; signature/redactedContent are dropped.
             acc["reasoning"] += delta["reasoningContent"].get("text", "")
 
     # Handle 'messageStop' event

--- a/weave/integrations/bedrock/bedrock_sdk.py
+++ b/weave/integrations/bedrock/bedrock_sdk.py
@@ -353,6 +353,8 @@ def bedrock_stream_accumulator(
         acc = {
             "role": None,
             "content": "",
+            "reasoning": "",
+            "tool_calls": [],
             "stop_reason": None,
             "usage": {
                 "inputTokens": 0,
@@ -366,9 +368,36 @@ def bedrock_stream_accumulator(
     if "messageStart" in value:
         acc["role"] = value["messageStart"]["role"]
 
-    # Handle 'contentBlockDelta' event
+    # A tool-use block opens with its id and name; the args arrive as deltas.
+    if "contentBlockStart" in value:
+        start = value["contentBlockStart"].get("start", {})
+        if "toolUse" in start:
+            tool_use = start["toolUse"]
+            acc["tool_calls"].append(
+                {
+                    "toolUseId": tool_use.get("toolUseId"),
+                    "name": tool_use.get("name"),
+                    "input": "",
+                }
+            )
+
+    # Converse streams text, tool-use args, and reasoning as distinct delta
+    # shapes. Unknown shapes are ignored so a new delta type cannot break the
+    # caller's stream.
     if "contentBlockDelta" in value:
-        acc["content"] += value["contentBlockDelta"]["delta"]["text"]
+        delta = value["contentBlockDelta"]["delta"]
+        if "text" in delta:
+            acc["content"] += delta["text"]
+        elif "toolUse" in delta:
+            tool_input = delta["toolUse"].get("input", "")
+            if acc["tool_calls"]:
+                acc["tool_calls"][-1]["input"] += tool_input
+            else:
+                acc["tool_calls"].append(
+                    {"toolUseId": None, "name": None, "input": tool_input}
+                )
+        elif "reasoningContent" in delta:
+            acc["reasoning"] += delta["reasoningContent"].get("text", "")
 
     # Handle 'messageStop' event
     if "messageStop" in value:


### PR DESCRIPTION
## Summary
- `bedrock_stream_accumulator` assumed every Converse `contentBlockDelta` was `{"delta": {"text": ...}}`, so `toolUse` / `reasoningContent` deltas raised `KeyError: 'text'` (drops tool-use/reasoning from the trace, spams errors, and on older weave terminates the user's stream).
- Branch on the delta shape: text -> `content`, tool args -> `tool_calls` (id/name from `contentBlockStart`), reasoning -> `reasoning`. Unknown shapes are ignored so a new delta type can't break the caller's stream.
- Fixes #7215

## Testing
adds `test_bedrock_converse_stream_tool_use` (reasoning + tool-use mock stream); fails with `KeyError: 'text'` before the fix.