### PR TITLE
feat(weave): per-conversation span sequences for the spans minimap

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -1,9 +1,9 @@
-"""SQL shape assertions for every ``make_*_query`` function in the agent
+"""SQL shape assertions for every `make_*_query` function in the agent
 query builder.
 
-Each test builds a ``ParamBuilder``, calls the builder, and compares the full
+Each test builds a `ParamBuilder`, calls the builder, and compares the full
 formatted SQL + param dict against an expected value, matching the style of
-``test_annotation_queues_query_builder.py`` etc.
+`test_annotation_queues_query_builder.py` etc.
 """
 
 import datetime
@@ -47,6 +47,7 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_conversation_chat_spans_query,
     make_conversation_chat_turns_count_query,
     make_conversation_previews_query,
+    make_conversation_spans_query,
     make_custom_attrs_schema_query,
     make_message_search_query,
     make_span_group_categorical_distributions_query,
@@ -366,7 +367,7 @@ class TestMakeSpansListQuery:
 
 
 #: The fixed aggregate tail emitted by the grouped list query, as it would
-#: appear after ``SELECT <group_cols>,``. Used to keep test expected SQL
+#: appear after `SELECT <group_cols>,`. Used to keep test expected SQL
 #: readable without duplicating the bundle across every test.
 _GROUPED_AGG_TAIL = """count() AS span_count,
                countIf(s.operation_name = 'invoke_agent') AS invocation_count,
@@ -434,6 +435,59 @@ class TestMakeConversationPreviewsQuery:
             query,
             pb.get_params(),
         )
+
+
+def test_make_conversation_spans_query() -> None:
+    # Scoped to the page's conversation_ids (like the previews query), reading
+    # only narrow scalar columns: an ordered, capped array of per-span tuples
+    # aliased `spans`. Kind is classified from operation_name; ERROR comes from
+    # status_code.
+    pb = ParamBuilder("genai")
+    query = make_conversation_spans_query(pb, "p1", ["conv-a", "conv-b"])
+    expected = """
+        SELECT s.conversation_id AS conversation_id,
+               arraySlice(arraySort(x -> x.1, groupArray(tuple(s.started_at, multiIf(s.operation_name = 'invoke_agent', 'agent', s.operation_name = 'execute_tool', 'tool', 'assistant'), s.trace_id, s.span_id, s.status_code, if(s.ended_at > s.started_at, toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), 0)))), -200) AS spans
+        FROM spans s
+        WHERE s.project_id = {genai_0:String}
+          AND s.conversation_id IN {genai_1:Array(String)}
+        GROUP BY conversation_id
+    """
+    assert_sql(
+        expected,
+        {"genai_0": "p1", "genai_1": ["conv-a", "conv-b"]},
+        query,
+        pb.get_params(),
+    )
+
+
+def test_make_conversation_spans_query_with_time_range() -> None:
+    pb = ParamBuilder("genai")
+    start = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+    query = make_conversation_spans_query(
+        pb, "p1", ["conv-a", "conv-b"], started_after=start, started_before=end
+    )
+    expected = """
+        SELECT s.conversation_id AS conversation_id,
+               arraySlice(arraySort(x -> x.1, groupArray(tuple(s.started_at, multiIf(s.operation_name = 'invoke_agent', 'agent', s.operation_name = 'execute_tool', 'tool', 'assistant'), s.trace_id, s.span_id, s.status_code, if(s.ended_at > s.started_at, toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), 0)))), -200) AS spans
+        FROM spans s
+        WHERE s.project_id = {genai_0:String}
+          AND s.conversation_id IN {genai_1:Array(String)}
+          AND s.started_at >= {genai_2:DateTime64(6)}
+          AND s.started_at < {genai_3:DateTime64(6)}
+        GROUP BY conversation_id
+    """
+    assert_sql(
+        expected,
+        {
+            "genai_0": "p1",
+            "genai_1": ["conv-a", "conv-b"],
+            "genai_2": start,
+            "genai_3": end,
+        },
+        query,
+        pb.get_params(),
+    )
 
 
 class TestMakeGroupedSpansCountQuery:

--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -446,7 +446,7 @@ def test_make_conversation_spans_query() -> None:
     query = make_conversation_spans_query(pb, "p1", ["conv-a", "conv-b"])
     expected = """
         SELECT s.conversation_id AS conversation_id,
-               arraySlice(arraySort(x -> x.1, groupArray(tuple(s.started_at, multiIf(s.operation_name = 'invoke_agent', 'agent', s.operation_name = 'execute_tool', 'tool', 'assistant'), s.trace_id, s.span_id, s.status_code, if(s.ended_at > s.started_at, toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), 0)))), -200) AS spans
+               arraySlice(arraySort(x -> (x.1, x.4), groupArray(tuple(s.started_at, multiIf(s.operation_name = 'invoke_agent', 'agent', s.operation_name = 'execute_tool', 'tool', 'assistant'), s.trace_id, s.span_id, s.status_code, if(s.ended_at > s.started_at, toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), 0)))), -200) AS spans
         FROM spans s
         WHERE s.project_id = {genai_0:String}
           AND s.conversation_id IN {genai_1:Array(String)}
@@ -469,7 +469,7 @@ def test_make_conversation_spans_query_with_time_range() -> None:
     )
     expected = """
         SELECT s.conversation_id AS conversation_id,
-               arraySlice(arraySort(x -> x.1, groupArray(tuple(s.started_at, multiIf(s.operation_name = 'invoke_agent', 'agent', s.operation_name = 'execute_tool', 'tool', 'assistant'), s.trace_id, s.span_id, s.status_code, if(s.ended_at > s.started_at, toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), 0)))), -200) AS spans
+               arraySlice(arraySort(x -> (x.1, x.4), groupArray(tuple(s.started_at, multiIf(s.operation_name = 'invoke_agent', 'agent', s.operation_name = 'execute_tool', 'tool', 'assistant'), s.trace_id, s.span_id, s.status_code, if(s.ended_at > s.started_at, toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), 0)))), -200) AS spans
         FROM spans s
         WHERE s.project_id = {genai_0:String}
           AND s.conversation_id IN {genai_1:Array(String)}

--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -446,7 +446,7 @@ def test_make_conversation_spans_query() -> None:
     query = make_conversation_spans_query(pb, "p1", ["conv-a", "conv-b"])
     expected = """
         SELECT s.conversation_id AS conversation_id,
-               arraySlice(arraySort(x -> (x.1, x.4), groupArray(tuple(s.started_at, multiIf(s.operation_name = 'invoke_agent', 'agent', s.operation_name = 'execute_tool', 'tool', 'assistant'), s.trace_id, s.span_id, s.status_code, if(s.ended_at > s.started_at, toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), 0)))), -200) AS spans
+               arraySlice(arraySort(x -> (x.1, x.4), groupArray(tuple(s.started_at, s.operation_name, s.trace_id, s.span_id, s.status_code, if(s.ended_at > s.started_at, toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), 0)))), -200) AS spans
         FROM spans s
         WHERE s.project_id = {genai_0:String}
           AND s.conversation_id IN {genai_1:Array(String)}
@@ -469,7 +469,7 @@ def test_make_conversation_spans_query_with_time_range() -> None:
     )
     expected = """
         SELECT s.conversation_id AS conversation_id,
-               arraySlice(arraySort(x -> (x.1, x.4), groupArray(tuple(s.started_at, multiIf(s.operation_name = 'invoke_agent', 'agent', s.operation_name = 'execute_tool', 'tool', 'assistant'), s.trace_id, s.span_id, s.status_code, if(s.ended_at > s.started_at, toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), 0)))), -200) AS spans
+               arraySlice(arraySort(x -> (x.1, x.4), groupArray(tuple(s.started_at, s.operation_name, s.trace_id, s.span_id, s.status_code, if(s.ended_at > s.started_at, toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), 0)))), -200) AS spans
         FROM spans s
         WHERE s.project_id = {genai_0:String}
           AND s.conversation_id IN {genai_1:Array(String)}

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -37,8 +37,9 @@ from weave.trace_server.agents.types import (
     AgentsQueryReq,
 )
 from weave.trace_server.interface.feedback_types import (
+    AGENT_MONITOR_FEEDBACK_TYPE,
+    AGENT_USER_FEEDBACK_TYPE,
     NOTE_FEEDBACK_TYPE,
-    REACTION_FEEDBACK_TYPE,
 )
 from weave.trace_server.interface.query import Query
 
@@ -589,15 +590,17 @@ def _create_feedback(
     project_id: str,
     weave_ref: str,
     feedback_type: str,
-    payload: dict,
+    payload: dict | None = None,
+    **scorer_fields,
 ) -> None:
     ch_server.feedback_create(
         tsi.FeedbackCreateReq(
             project_id=project_id,
             weave_ref=weave_ref,
             feedback_type=feedback_type,
-            payload=payload,
+            payload=payload or {},
             wb_user_id="test-user",
+            **scorer_fields,
         )
     )
 
@@ -622,7 +625,8 @@ def test_conversation_spans_unknown_id_returns_empty(ch_server):
 def test_conversation_spans_sequence_and_feedback(ch_server):
     """agent_conversation_spans returns an ordered per-span sequence (kinds from
     operation_name, ERROR surfaced via status) plus turn-anchored feedback
-    markers carrying the feedback_type and any detoned tags.
+    markers carrying detoned tags and scorer ratings. Only agent_user_feedback
+    and agent_monitor are surfaced; other feedback types are dropped.
     """
     project_id = _make_project_id("conv-spans")
     now = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -673,11 +677,32 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     ]
     _insert_spans(ch_server.ch_client, spans)
 
-    # Turn-level reaction (👍 -> positive) on turn A; a note on turn B.
+    # Turn A: a human thumbs-up tag. Turn B: a scorer with a tag + a rating.
+    # Plus an unsupported note on turn B that must be filtered out.
     turn_a_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_a).uri
     turn_b_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_b).uri
     _create_feedback(
-        ch_server, project_id, turn_a_ref, REACTION_FEEDBACK_TYPE, {"emoji": "👍"}
+        ch_server,
+        project_id,
+        turn_a_ref,
+        AGENT_USER_FEEDBACK_TYPE,
+        scorer_tags=["\U0001f44d"],
+    )
+    _create_feedback(
+        ch_server,
+        project_id,
+        turn_b_ref,
+        AGENT_MONITOR_FEEDBACK_TYPE,
+        runnable_ref=ri.InternalOpRef(
+            project_id=project_id, name="quality_scorer", version="v1"
+        ).uri,
+        call_ref=ri.InternalCallRef(project_id=project_id, id=trace_b).uri,
+        trigger_ref=ri.InternalObjectRef(
+            project_id=project_id, name="quality_scorer_trigger", version="v1"
+        ).uri,
+        scorer_tags=["helpful"],
+        scorer_ratings={"quality": 0.8},
+        scorer_rating_reasons={"quality": "clear answer"},
     )
     _create_feedback(
         ch_server, project_id, turn_b_ref, NOTE_FEEDBACK_TYPE, {"note": "nice"}
@@ -703,13 +728,18 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     assert row.spans[-1].trace_id == trace_b
     assert any(e.span_id == tool_span for e in row.spans)
 
-    # Feedback markers are keyed by turn (trace_id) and carry the feedback_type
-    # plus any detoned tags (empty for a note). An emoji tag is the glyph itself.
+    # Markers are keyed by turn (trace_id); the note is dropped, so each turn
+    # has exactly one marker. Emoji tags come back as the detoned glyph.
     by_trace = {f.trace_id: f for f in row.spans_feedback}
-    assert by_trace[trace_a].feedback_type == REACTION_FEEDBACK_TYPE
+    assert by_trace[trace_a].feedback_type == AGENT_USER_FEEDBACK_TYPE
     assert by_trace[trace_a].tags == ["\U0001f44d"]
-    assert by_trace[trace_b].feedback_type == NOTE_FEEDBACK_TYPE
-    assert by_trace[trace_b].tags == []
+    assert by_trace[trace_a].scores == []
+
+    assert by_trace[trace_b].feedback_type == AGENT_MONITOR_FEEDBACK_TYPE
+    assert by_trace[trace_b].tags == ["helpful"]
+    assert len(by_trace[trace_b].scores) == 1
+    score = by_trace[trace_b].scores[0]
+    assert (score.name, score.value, score.reason) == ("quality", 0.8, "clear answer")
 
 
 def test_group_by_conversation_id_filters_numeric_aggregates(ch_server):

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -39,7 +39,6 @@ from weave.trace_server.agents.types import (
 from weave.trace_server.interface.feedback_types import (
     AGENT_MONITOR_FEEDBACK_TYPE,
     AGENT_USER_FEEDBACK_TYPE,
-    NOTE_FEEDBACK_TYPE,
 )
 from weave.trace_server.interface.query import Query
 
@@ -625,8 +624,7 @@ def test_conversation_spans_unknown_id_returns_empty(ch_server):
 def test_conversation_spans_sequence_and_feedback(ch_server):
     """agent_conversation_spans returns an ordered per-span sequence (kinds from
     operation_name, ERROR surfaced via status) plus turn-anchored feedback
-    markers carrying detoned tags and scorer ratings. Only agent_user_feedback
-    and agent_monitor are surfaced; other feedback types are dropped.
+    markers carrying detoned tags and scorer ratings.
     """
     project_id = _make_project_id("conv-spans")
     now = datetime.datetime.now(tz=datetime.timezone.utc)
@@ -678,7 +676,6 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     _insert_spans(ch_server.ch_client, spans)
 
     # Turn A: a human thumbs-up tag. Turn B: a scorer with a tag + a rating.
-    # Plus an unsupported note on turn B that must be filtered out.
     turn_a_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_a).uri
     turn_b_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_b).uri
     _create_feedback(
@@ -704,10 +701,6 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
         scorer_ratings={"quality": 0.8},
         scorer_rating_reasons={"quality": "clear answer"},
     )
-    _create_feedback(
-        ch_server, project_id, turn_b_ref, NOTE_FEEDBACK_TYPE, {"note": "nice"}
-    )
-
     res = ch_server.agent_conversation_spans(
         AgentConversationSpansReq(
             project_id=project_id,
@@ -728,8 +721,8 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     assert row.spans[-1].trace_id == trace_b
     assert any(e.span_id == tool_span for e in row.spans)
 
-    # Markers are keyed by turn (trace_id); the note is dropped, so each turn
-    # has exactly one marker. Emoji tags come back as the detoned glyph.
+    # Markers are keyed by turn (trace_id). Emoji tags come back as the detoned
+    # glyph; scorer ratings come back as scores.
     by_trace = {f.trace_id: f for f in row.spans_feedback}
     assert by_trace[trace_a].feedback_type == AGENT_USER_FEEDBACK_TYPE
     assert by_trace[trace_a].tags == ["\U0001f44d"]

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -709,12 +709,13 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     )
     row = {c.conversation_id: c for c in res.conversations}[conv]
 
-    # Ordered by started_at: agent, tool, tool(ERROR), assistant.
-    assert [(e.kind, e.status) for e in row.spans] == [
-        ("agent", "OK"),
-        ("tool", "OK"),
-        ("tool", "ERROR"),
-        ("assistant", "OK"),
+    # Spans carry the raw operation_name (the client classifies), ordered by
+    # started_at; ERROR surfaces via status.
+    assert [(e.operation_name, e.status) for e in row.spans] == [
+        ("invoke_agent", "OK"),
+        ("execute_tool", "OK"),
+        ("execute_tool", "ERROR"),
+        ("chat", "OK"),
     ]
     # Each span carries its turn (trace_id) and its own span_id.
     assert row.spans[0].trace_id == trace_a
@@ -722,17 +723,21 @@ def test_conversation_spans_sequence_and_feedback(ch_server):
     assert any(e.span_id == tool_span for e in row.spans)
 
     # Markers are keyed by turn (trace_id). Emoji tags come back as the detoned
-    # glyph; scorer ratings come back as scores.
+    # glyph; scorer ratings come back as ratings.
     by_trace = {f.trace_id: f for f in row.spans_feedback}
     assert by_trace[trace_a].feedback_type == AGENT_USER_FEEDBACK_TYPE
-    assert by_trace[trace_a].tags == ["\U0001f44d"]
-    assert by_trace[trace_a].scores == []
+    assert by_trace[trace_a].tags == ["👍"]
+    assert by_trace[trace_a].ratings == []
 
     assert by_trace[trace_b].feedback_type == AGENT_MONITOR_FEEDBACK_TYPE
     assert by_trace[trace_b].tags == ["helpful"]
-    assert len(by_trace[trace_b].scores) == 1
-    score = by_trace[trace_b].scores[0]
-    assert (score.name, score.value, score.reason) == ("quality", 0.8, "clear answer")
+    assert len(by_trace[trace_b].ratings) == 1
+    rating = by_trace[trace_b].ratings[0]
+    assert (rating.name, rating.value, rating.reason) == (
+        "quality",
+        0.8,
+        "clear answer",
+    )
 
 
 def test_group_by_conversation_id_filters_numeric_aggregates(ch_server):

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -10,6 +10,8 @@ import uuid
 import pytest
 
 from tests.trace_server.helpers import make_project_id as _make_project_id
+from weave.shared import refs_internal as ri
+from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.agents.clickhouse import AgentWriteHandler
 from weave.trace_server.agents.helpers import genai_span_to_row
 from weave.trace_server.agents.schema import (
@@ -19,6 +21,7 @@ from weave.trace_server.agents.schema import (
 )
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
+    AgentConversationSpansReq,
     AgentCustomAttrsSchemaReq,
     AgentGroupByRef,
     AgentSearchReq,
@@ -32,6 +35,10 @@ from weave.trace_server.agents.types import (
     AgentSpanStatsReq,
     AgentSpanValueRef,
     AgentsQueryReq,
+)
+from weave.trace_server.interface.feedback_types import (
+    NOTE_FEEDBACK_TYPE,
+    REACTION_FEEDBACK_TYPE,
 )
 from weave.trace_server.interface.query import Query
 
@@ -575,6 +582,134 @@ def test_group_by_conversation_id_message_previews(ch_server):
     assert row.last_message is not None
     assert row.last_message.role == "assistant_message"
     assert row.last_message.text == "final reply"
+
+
+def _create_feedback(
+    ch_server,
+    project_id: str,
+    weave_ref: str,
+    feedback_type: str,
+    payload: dict,
+) -> None:
+    ch_server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type=feedback_type,
+            payload=payload,
+            wb_user_id="test-user",
+        )
+    )
+
+
+def test_conversation_spans_unknown_id_returns_empty(ch_server):
+    """The endpoint returns one entry per requested conversation; an id with no
+    matching spans comes back with empty sequences rather than being dropped.
+    """
+    project_id = _make_project_id("conv-spans-empty")
+    res = ch_server.agent_conversation_spans(
+        AgentConversationSpansReq(
+            project_id=project_id,
+            conversation_ids=["conv-does-not-exist"],
+        )
+    )
+    assert len(res.conversations) == 1
+    assert res.conversations[0].conversation_id == "conv-does-not-exist"
+    assert res.conversations[0].spans == []
+    assert res.conversations[0].spans_feedback == []
+
+
+def test_conversation_spans_sequence_and_feedback(ch_server):
+    """agent_conversation_spans returns an ordered per-span sequence (kinds from
+    operation_name, ERROR surfaced via status) plus turn-anchored feedback
+    markers carrying the feedback_type and any detoned tags.
+    """
+    project_id = _make_project_id("conv-spans")
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    conv = f"conv-{uuid.uuid4().hex[:8]}"
+    trace_a = uuid.uuid4().hex
+    trace_b = uuid.uuid4().hex
+    tool_span = uuid.uuid4().hex[:16]
+
+    spans = [
+        # Turn A: an agent invocation, then two tool calls (the second errored).
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            trace_id=trace_a,
+            operation_name="invoke_agent",
+            started_at=now,
+            ended_at=now + datetime.timedelta(seconds=1),
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            trace_id=trace_a,
+            span_id=tool_span,
+            operation_name="execute_tool",
+            tool_name="search",
+            started_at=now + datetime.timedelta(seconds=2),
+            ended_at=now + datetime.timedelta(seconds=3),
+        ),
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            trace_id=trace_a,
+            operation_name="execute_tool",
+            tool_name="broken",
+            status_code="ERROR",
+            started_at=now + datetime.timedelta(seconds=4),
+            ended_at=now + datetime.timedelta(seconds=5),
+        ),
+        # Turn B: a later content span -> classified assistant.
+        _make_span(
+            project_id,
+            conversation_id=conv,
+            trace_id=trace_b,
+            operation_name="chat",
+            started_at=now + datetime.timedelta(seconds=6),
+            ended_at=now + datetime.timedelta(seconds=7),
+        ),
+    ]
+    _insert_spans(ch_server.ch_client, spans)
+
+    # Turn-level reaction (👍 -> positive) on turn A; a note on turn B.
+    turn_a_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_a).uri
+    turn_b_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_b).uri
+    _create_feedback(
+        ch_server, project_id, turn_a_ref, REACTION_FEEDBACK_TYPE, {"emoji": "👍"}
+    )
+    _create_feedback(
+        ch_server, project_id, turn_b_ref, NOTE_FEEDBACK_TYPE, {"note": "nice"}
+    )
+
+    res = ch_server.agent_conversation_spans(
+        AgentConversationSpansReq(
+            project_id=project_id,
+            conversation_ids=[conv],
+        )
+    )
+    row = {c.conversation_id: c for c in res.conversations}[conv]
+
+    # Ordered by started_at: agent, tool, tool(ERROR), assistant.
+    assert [(e.kind, e.status) for e in row.spans] == [
+        ("agent", "OK"),
+        ("tool", "OK"),
+        ("tool", "ERROR"),
+        ("assistant", "OK"),
+    ]
+    # Each span carries its turn (trace_id) and its own span_id.
+    assert row.spans[0].trace_id == trace_a
+    assert row.spans[-1].trace_id == trace_b
+    assert any(e.span_id == tool_span for e in row.spans)
+
+    # Feedback markers are keyed by turn (trace_id) and carry the feedback_type
+    # plus any detoned tags (empty for a note). An emoji tag is the glyph itself.
+    by_trace = {f.trace_id: f for f in row.spans_feedback}
+    assert by_trace[trace_a].feedback_type == REACTION_FEEDBACK_TYPE
+    assert by_trace[trace_a].tags == ["\U0001f44d"]
+    assert by_trace[trace_b].feedback_type == NOTE_FEEDBACK_TYPE
+    assert by_trace[trace_b].tags == []
 
 
 def test_group_by_conversation_id_filters_numeric_aggregates(ch_server):

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -27,6 +27,10 @@ from weave.trace_server.agents.constants import (
     MAX_INGEST_ERRORS_REPORTED,
     NO_CONVERSATION_LABEL,
 )
+from weave.trace_server.agents.conversation_spans import (
+    parse_conversation_spans,
+    span_feedback_marker,
+)
 from weave.trace_server.agents.helpers import (
     genai_span_to_row,
     messages_from_ch_value,
@@ -43,6 +47,11 @@ from weave.trace_server.agents.types import (
     AgentConversationChatReq,
     AgentConversationChatRes,
     AgentConversationMessagePreview,
+    AgentConversationSpan,
+    AgentConversationSpanFeedback,
+    AgentConversationSpans,
+    AgentConversationSpansReq,
+    AgentConversationSpansRes,
     AgentCustomAttrSchemaItem,
     AgentCustomAttrsSchemaReq,
     AgentCustomAttrsSchemaRes,
@@ -88,6 +97,7 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_conversation_chat_spans_query,
     make_conversation_chat_turns_count_query,
     make_conversation_previews_query,
+    make_conversation_spans_query,
     make_custom_attrs_schema_query,
     make_message_search_query,
     make_span_group_categorical_distributions_query,
@@ -152,7 +162,7 @@ class AgentQueryHandler:
     Takes a `query_fn` (typically the server's `_query` method) so queries
     participate in the same logging / ddtrace / error-handling wrapper as the
     rest of the trace server. Also takes a `feedback_query_fn` (the server's
-    `feedback_query` method), invoked only when ``include_feedback=True`` to
+    `feedback_query` method), invoked only when `include_feedback=True` to
     fold agent-target feedback into the chat response.
     """
 
@@ -231,6 +241,111 @@ class AgentQueryHandler:
             preview = previews_by_conv.get(cid) if isinstance(cid, str) else None
             if preview is not None:
                 g.first_message, g.last_message = preview
+
+    def conversation_spans(
+        self, req: AgentConversationSpansReq
+    ) -> AgentConversationSpansRes:
+        """Return per-conversation span sequences + feedback markers.
+
+        Runs one bounded query scoped to the requested conversation_ids that
+        reads only scalar columns (no message bodies), then a single batched
+        feedback query for those conversations and their turns. Best-effort:
+        failures yield empty sequences so the spans minimap never hard-fails.
+        """
+        if not req.conversation_ids:
+            return AgentConversationSpansRes()
+        pb = ParamBuilder(PARAM_NAMESPACE)
+        sql = make_conversation_spans_query(
+            pb,
+            req.project_id,
+            req.conversation_ids,
+            started_after=req.started_after,
+            started_before=req.started_before,
+        )
+        try:
+            rows = _rows_as_dicts(self._query(sql, pb.get_params()))
+        except Exception:
+            logger.exception(
+                "failed to query conversation spans (project=%s, conversations=%d)",
+                req.project_id,
+                len(req.conversation_ids),
+            )
+            rows = []
+
+        spans_by_conv: dict[str, list[AgentConversationSpan]] = {}
+        # Map each turn (trace_id) back to its conversation so turn-level
+        # feedback can be bucketed without a second lookup.
+        trace_to_conv: dict[str, str] = {}
+        for row in rows:
+            cid = safe_str(row.get("conversation_id"))
+            if not cid:
+                continue
+            spans = parse_conversation_spans(row.get("spans"))
+            spans_by_conv[cid] = spans
+            for span in spans:
+                if span.trace_id:
+                    trace_to_conv.setdefault(span.trace_id, cid)
+
+        feedback_by_conv = self._fetch_conversation_spans_feedback(
+            req.project_id, req.conversation_ids, trace_to_conv
+        )
+
+        return AgentConversationSpansRes(
+            conversations=[
+                AgentConversationSpans(
+                    conversation_id=cid,
+                    spans=spans_by_conv.get(cid, []),
+                    spans_feedback=feedback_by_conv.get(cid, []),
+                )
+                for cid in req.conversation_ids
+            ]
+        )
+
+    def _fetch_conversation_spans_feedback(
+        self,
+        project_id: str,
+        conversation_ids: list[str],
+        trace_to_conv: dict[str, str],
+    ) -> dict[str, list[AgentConversationSpanFeedback]]:
+        """Batch-fetch conversation- and turn-level feedback for one list page.
+
+        One feedback query covering every conversation + turn target on the
+        page; results are bucketed per conversation and shaped into positioned
+        markers (turn markers carry their trace_id; conversation-level markers
+        carry none). Step-level (span) feedback is intentionally not fetched —
+        markers are anchored to turns for the list view. Best-effort.
+        """
+        by_conv: dict[str, list[AgentConversationSpanFeedback]] = {
+            cid: [] for cid in conversation_ids
+        }
+        try:
+            grouped = self._fetch_agent_feedback(
+                project_id=project_id,
+                conversation_ids=list(conversation_ids),
+                trace_ids=list(trace_to_conv),
+            )
+        except Exception:
+            logger.exception(
+                "failed to fetch conversation spans feedback "
+                "(project=%s, conversations=%d, turns=%d)",
+                project_id,
+                len(conversation_ids),
+                len(trace_to_conv),
+            )
+            return by_conv
+
+        for cid, items in grouped.by_conversation_id.items():
+            if cid in by_conv:
+                by_conv[cid].extend(
+                    span_feedback_marker(raw, trace_id="") for raw in items
+                )
+        for tid, items in grouped.by_trace_id.items():
+            conv_id = trace_to_conv.get(tid)
+            if conv_id is not None and conv_id in by_conv:
+                by_conv[conv_id].extend(
+                    span_feedback_marker(raw, trace_id=tid) for raw in items
+                )
+        return by_conv
 
     def spans_stats(self, req: AgentSpanStatsReq) -> AgentSpanStatsRes:
         """Return chart-ready aggregations over spans."""
@@ -779,9 +894,9 @@ class AgentWriteHandler:
     def insert_span(self, span: AgentSpanCHInsertable) -> None:
         """Insert a single pre-built span into the spans table.
 
-        Unlike ``insert_otel_spans`` this skips OTel protobuf parsing and
+        Unlike `insert_otel_spans` this skips OTel protobuf parsing and
         GenAI extraction — the caller is responsible for constructing a
-        fully populated ``AgentSpanCHInsertable``.
+        fully populated `AgentSpanCHInsertable`.
         """
         self.insert_spans([span])
 

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -28,6 +28,7 @@ from weave.trace_server.agents.constants import (
     NO_CONVERSATION_LABEL,
 )
 from weave.trace_server.agents.conversation_spans import (
+    is_supported_feedback,
     parse_conversation_spans,
     span_feedback_marker,
 )
@@ -337,13 +338,17 @@ class AgentQueryHandler:
         for cid, items in grouped.by_conversation_id.items():
             if cid in by_conv:
                 by_conv[cid].extend(
-                    span_feedback_marker(raw, trace_id=None) for raw in items
+                    span_feedback_marker(raw, trace_id=None)
+                    for raw in items
+                    if is_supported_feedback(safe_str(raw.get("feedback_type")))
                 )
         for tid, items in grouped.by_trace_id.items():
             conv_id = trace_to_conv.get(tid)
             if conv_id is not None and conv_id in by_conv:
                 by_conv[conv_id].extend(
-                    span_feedback_marker(raw, trace_id=tid) for raw in items
+                    span_feedback_marker(raw, trace_id=tid)
+                    for raw in items
+                    if is_supported_feedback(safe_str(raw.get("feedback_type")))
                 )
         return by_conv
 

--- a/weave/trace_server/agents/clickhouse.py
+++ b/weave/trace_server/agents/clickhouse.py
@@ -337,7 +337,7 @@ class AgentQueryHandler:
         for cid, items in grouped.by_conversation_id.items():
             if cid in by_conv:
                 by_conv[cid].extend(
-                    span_feedback_marker(raw, trace_id="") for raw in items
+                    span_feedback_marker(raw, trace_id=None) for raw in items
                 )
         for tid, items in grouped.by_trace_id.items():
             conv_id = trace_to_conv.get(tid)

--- a/weave/trace_server/agents/constants.py
+++ b/weave/trace_server/agents/constants.py
@@ -26,6 +26,12 @@ MAX_AGENT_STATS_RESULT_ROWS = 10_000
 # Maximum number of traces to render in the multi-turn conversation chat view.
 MAX_CONVERSATION_CHAT_TURNS = 50
 
+# Maximum number of spans returned per conversation by agent_conversation_spans.
+# Bounds the payload of the per-conversation spans sequence (the "minimap"); the
+# client downsamples further for narrow columns. Conversations longer than this
+# truncate their tail.
+MAX_CONVERSATION_SPANS = 200
+
 # ---------------------------------------------------------------------------
 # Chat view walk limits
 # ---------------------------------------------------------------------------

--- a/weave/trace_server/agents/conversation_spans.py
+++ b/weave/trace_server/agents/conversation_spans.py
@@ -85,9 +85,13 @@ def _feedback_tags(feedback_type: str, raw: dict[str, Any]) -> list[str]:
 
 
 def span_feedback_marker(
-    raw: dict[str, Any], *, trace_id: str
+    raw: dict[str, Any], *, trace_id: str | None
 ) -> AgentConversationSpanFeedback:
-    """Shape a raw feedback row into a positioned spans feedback marker."""
+    """Shape a raw feedback row into a positioned feedback marker.
+
+    `trace_id` is the turn the feedback is anchored to, or None for
+    conversation-level feedback.
+    """
     feedback_type = safe_str(raw.get("feedback_type"))
     return AgentConversationSpanFeedback(
         trace_id=trace_id,

--- a/weave/trace_server/agents/conversation_spans.py
+++ b/weave/trace_server/agents/conversation_spans.py
@@ -1,0 +1,96 @@
+"""Pure transforms for a conversation's span sequence and its feedback markers.
+
+These helpers shape raw ClickHouse output into the typed `AgentConversationSpan`
+/ `AgentConversationSpanFeedback` models returned by `agent_conversation_spans`.
+They hold no database or `self` state — the query execution lives in
+`clickhouse.py`, which imports from here — so they can be reasoned about and
+tested in isolation.
+"""
+
+from typing import Any, get_args
+
+from weave.trace_server.agents.schema import StatusCodeLiteral
+from weave.trace_server.agents.types import (
+    AgentConversationSpan,
+    AgentConversationSpanFeedback,
+    ConversationSpanKind,
+)
+from weave.trace_server.emoji_util import detone_emojis
+from weave.trace_server.interface.feedback_types import (
+    AGENT_USER_FEEDBACK_TYPE,
+    REACTION_FEEDBACK_TYPE,
+)
+from weave.trace_server.query_builder.agent_query_builder import (
+    coerce_literal,
+    safe_int,
+    safe_str,
+)
+
+# Valid span kinds; unexpected SQL values coerce to "unknown".
+_SPAN_KINDS: frozenset[ConversationSpanKind] = frozenset(get_args(ConversationSpanKind))
+
+# Valid span status codes; unexpected SQL values coerce to "UNSET".
+_STATUS_CODES: frozenset[StatusCodeLiteral] = frozenset(get_args(StatusCodeLiteral))
+
+
+def parse_conversation_spans(raw: object) -> list[AgentConversationSpan]:
+    """Parse a conversation's `spans` array into typed spans.
+
+    Defensive: skips malformed tuples and coerces unknown kinds to "unknown" so
+    one bad row never breaks the best-effort spans hydration. Tuple shape is
+    `(started_at, kind, trace_id, span_id, status_code, duration_ms)`;
+    `started_at` was only the sort key and is dropped here.
+    """
+    if not isinstance(raw, (list, tuple)):
+        return []
+    spans: list[AgentConversationSpan] = []
+    for item in raw:
+        if not isinstance(item, (list, tuple)) or len(item) < 6:
+            continue
+        kind: ConversationSpanKind = coerce_literal(
+            safe_str(item[1]), _SPAN_KINDS, "unknown"
+        )
+        status: StatusCodeLiteral = coerce_literal(
+            safe_str(item[4]), _STATUS_CODES, "UNSET"
+        )
+        spans.append(
+            AgentConversationSpan(
+                kind=kind,
+                trace_id=safe_str(item[2]),
+                span_id=safe_str(item[3]),
+                status=status,
+                duration_ms=safe_int(item[5]),
+            )
+        )
+    return spans
+
+
+def _feedback_tags(feedback_type: str, raw: dict[str, Any]) -> list[str]:
+    """Return the human tags on a feedback row, skin-tone-detoned.
+
+    Agent user feedback carries its tags in `scorer_tags`; a classic reaction is
+    a single emoji tag in its payload. Emoji tags come back as the detoned glyph
+    (so the client renders it directly); text tags pass through unchanged.
+    """
+    if feedback_type == REACTION_FEEDBACK_TYPE:
+        payload = raw.get("payload")
+        glyph = payload.get("detoned") if isinstance(payload, dict) else None
+        return [glyph] if isinstance(glyph, str) and glyph else []
+    if feedback_type == AGENT_USER_FEEDBACK_TYPE:
+        tags = raw.get("scorer_tags")
+        if not isinstance(tags, list):
+            return []
+        return [detone_emojis(tag) for tag in tags if isinstance(tag, str) and tag]
+    return []
+
+
+def span_feedback_marker(
+    raw: dict[str, Any], *, trace_id: str
+) -> AgentConversationSpanFeedback:
+    """Shape a raw feedback row into a positioned spans feedback marker."""
+    feedback_type = safe_str(raw.get("feedback_type"))
+    return AgentConversationSpanFeedback(
+        trace_id=trace_id,
+        feedback_type=feedback_type,
+        tags=_feedback_tags(feedback_type, raw),
+    )

--- a/weave/trace_server/agents/conversation_spans.py
+++ b/weave/trace_server/agents/conversation_spans.py
@@ -13,18 +13,29 @@ from weave.trace_server.agents.schema import StatusCodeLiteral
 from weave.trace_server.agents.types import (
     AgentConversationSpan,
     AgentConversationSpanFeedback,
+    AgentConversationSpanScore,
+    AgentSpanFeedbackType,
     ConversationSpanKind,
 )
 from weave.trace_server.emoji_util import detone_emojis
-from weave.trace_server.interface.feedback_types import (
-    AGENT_USER_FEEDBACK_TYPE,
-    REACTION_FEEDBACK_TYPE,
-)
 from weave.trace_server.query_builder.agent_query_builder import (
     coerce_literal,
+    safe_float,
     safe_int,
     safe_str,
 )
+
+# Feedback types this endpoint surfaces (agent_user_feedback, agent_monitor);
+# every other row is skipped before a marker is built.
+_FEEDBACK_TYPES: frozenset[AgentSpanFeedbackType] = frozenset(
+    get_args(AgentSpanFeedbackType)
+)
+
+
+def is_supported_feedback(feedback_type: str) -> bool:
+    """Whether a feedback row's type is surfaced by agent_conversation_spans."""
+    return feedback_type in _FEEDBACK_TYPES
+
 
 # Valid span kinds; unexpected SQL values coerce to "unknown".
 _SPAN_KINDS: frozenset[ConversationSpanKind] = frozenset(get_args(ConversationSpanKind))
@@ -65,36 +76,64 @@ def parse_conversation_spans(raw: object) -> list[AgentConversationSpan]:
     return spans
 
 
-def _feedback_tags(feedback_type: str, raw: dict[str, Any]) -> list[str]:
-    """Return the human tags on a feedback row, skin-tone-detoned.
+def _feedback_tags(raw: dict[str, Any]) -> list[str]:
+    """Return the `scorer_tags` on a feedback row, skin-tone-detoned.
 
-    Agent user feedback carries its tags in `scorer_tags`; a classic reaction is
-    a single emoji tag in its payload. Emoji tags come back as the detoned glyph
-    (so the client renders it directly); text tags pass through unchanged.
+    Emoji tags come back as the detoned glyph (so the client renders it
+    directly); text tags pass through unchanged.
     """
-    if feedback_type == REACTION_FEEDBACK_TYPE:
-        payload = raw.get("payload")
-        glyph = payload.get("detoned") if isinstance(payload, dict) else None
-        return [glyph] if isinstance(glyph, str) and glyph else []
-    if feedback_type == AGENT_USER_FEEDBACK_TYPE:
-        tags = raw.get("scorer_tags")
-        if not isinstance(tags, list):
-            return []
-        return [detone_emojis(tag) for tag in tags if isinstance(tag, str) and tag]
-    return []
+    tags = raw.get("scorer_tags")
+    if not isinstance(tags, list):
+        return []
+    return [detone_emojis(tag) for tag in tags if isinstance(tag, str) and tag]
+
+
+def _feedback_scores(raw: dict[str, Any]) -> list[AgentConversationSpanScore]:
+    """Return the `scorer_ratings` on a feedback row as scores.
+
+    Each rating is a name -> value pair; optional reason/confidence are joined
+    in from the parallel `scorer_rating_reasons` / `scorer_rating_confidences`
+    maps by rating name.
+    """
+    ratings = raw.get("scorer_ratings")
+    if not isinstance(ratings, dict):
+        return []
+    reasons = raw.get("scorer_rating_reasons")
+    confidences = raw.get("scorer_rating_confidences")
+    reasons = reasons if isinstance(reasons, dict) else {}
+    confidences = confidences if isinstance(confidences, dict) else {}
+    scores: list[AgentConversationSpanScore] = []
+    for name, value in ratings.items():
+        if not isinstance(name, str):
+            continue
+        reason = reasons.get(name)
+        confidence = confidences.get(name)
+        scores.append(
+            AgentConversationSpanScore(
+                name=name,
+                value=safe_float(value),
+                reason=reason if isinstance(reason, str) and reason else None,
+                confidence=safe_float(confidence)
+                if isinstance(confidence, (int, float))
+                else None,
+            )
+        )
+    return scores
 
 
 def span_feedback_marker(
     raw: dict[str, Any], *, trace_id: str | None
 ) -> AgentConversationSpanFeedback:
-    """Shape a raw feedback row into a positioned feedback marker.
+    """Shape a supported feedback row into a positioned feedback marker.
 
     `trace_id` is the turn the feedback is anchored to, or None for
-    conversation-level feedback.
+    conversation-level feedback. Callers must filter to `is_supported_feedback`
+    rows first, since `feedback_type` is a constrained literal.
     """
     feedback_type = safe_str(raw.get("feedback_type"))
     return AgentConversationSpanFeedback(
         trace_id=trace_id,
-        feedback_type=feedback_type,
-        tags=_feedback_tags(feedback_type, raw),
+        feedback_type=feedback_type,  # type: ignore[arg-type]  # caller filters
+        tags=_feedback_tags(raw),
+        scores=_feedback_scores(raw),
     )

--- a/weave/trace_server/agents/conversation_spans.py
+++ b/weave/trace_server/agents/conversation_spans.py
@@ -13,11 +13,10 @@ from weave.trace_server.agents.schema import StatusCodeLiteral
 from weave.trace_server.agents.types import (
     AgentConversationSpan,
     AgentConversationSpanFeedback,
-    AgentConversationSpanScore,
-    AgentSpanFeedbackType,
-    ConversationSpanKind,
+    AgentConversationSpanRating,
 )
 from weave.trace_server.emoji_util import detone_emojis
+from weave.trace_server.interface.feedback_types import AGENT_SPAN_FEEDBACK_TYPES
 from weave.trace_server.query_builder.agent_query_builder import (
     coerce_literal,
     safe_float,
@@ -25,20 +24,11 @@ from weave.trace_server.query_builder.agent_query_builder import (
     safe_str,
 )
 
-# Feedback types this endpoint surfaces (agent_user_feedback, agent_monitor);
-# every other row is skipped before a marker is built.
-_FEEDBACK_TYPES: frozenset[AgentSpanFeedbackType] = frozenset(
-    get_args(AgentSpanFeedbackType)
-)
-
 
 def is_supported_feedback(feedback_type: str) -> bool:
     """Whether a feedback row's type is surfaced by agent_conversation_spans."""
-    return feedback_type in _FEEDBACK_TYPES
+    return feedback_type in AGENT_SPAN_FEEDBACK_TYPES
 
-
-# Valid span kinds; unexpected SQL values coerce to "unknown".
-_SPAN_KINDS: frozenset[ConversationSpanKind] = frozenset(get_args(ConversationSpanKind))
 
 # Valid span status codes; unexpected SQL values coerce to "UNSET".
 _STATUS_CODES: frozenset[StatusCodeLiteral] = frozenset(get_args(StatusCodeLiteral))
@@ -47,9 +37,9 @@ _STATUS_CODES: frozenset[StatusCodeLiteral] = frozenset(get_args(StatusCodeLiter
 def parse_conversation_spans(raw: object) -> list[AgentConversationSpan]:
     """Parse a conversation's `spans` array into typed spans.
 
-    Defensive: skips malformed tuples and coerces unknown kinds to "unknown" so
-    one bad row never breaks the best-effort spans hydration. Tuple shape is
-    `(started_at, kind, trace_id, span_id, status_code, duration_ms)`;
+    Defensive: skips malformed tuples and coerces an unknown status to "UNSET"
+    so one bad row never breaks the best-effort spans hydration. Tuple shape is
+    `(started_at, operation_name, trace_id, span_id, status_code, duration_ms)`;
     `started_at` was only the sort key and is dropped here.
     """
     if not isinstance(raw, (list, tuple)):
@@ -58,15 +48,12 @@ def parse_conversation_spans(raw: object) -> list[AgentConversationSpan]:
     for item in raw:
         if not isinstance(item, (list, tuple)) or len(item) < 6:
             continue
-        kind: ConversationSpanKind = coerce_literal(
-            safe_str(item[1]), _SPAN_KINDS, "unknown"
-        )
         status: StatusCodeLiteral = coerce_literal(
             safe_str(item[4]), _STATUS_CODES, "UNSET"
         )
         spans.append(
             AgentConversationSpan(
-                kind=kind,
+                operation_name=safe_str(item[1]),
                 trace_id=safe_str(item[2]),
                 span_id=safe_str(item[3]),
                 status=status,
@@ -88,8 +75,8 @@ def _feedback_tags(raw: dict[str, Any]) -> list[str]:
     return [detone_emojis(tag) for tag in tags if isinstance(tag, str) and tag]
 
 
-def _feedback_scores(raw: dict[str, Any]) -> list[AgentConversationSpanScore]:
-    """Return the `scorer_ratings` on a feedback row as scores.
+def _feedback_ratings(raw: dict[str, Any]) -> list[AgentConversationSpanRating]:
+    """Return the `scorer_ratings` on a feedback row.
 
     Each rating is a name -> value pair; optional reason/confidence are joined
     in from the parallel `scorer_rating_reasons` / `scorer_rating_confidences`
@@ -102,14 +89,14 @@ def _feedback_scores(raw: dict[str, Any]) -> list[AgentConversationSpanScore]:
     confidences = raw.get("scorer_rating_confidences")
     reasons = reasons if isinstance(reasons, dict) else {}
     confidences = confidences if isinstance(confidences, dict) else {}
-    scores: list[AgentConversationSpanScore] = []
+    out: list[AgentConversationSpanRating] = []
     for name, value in ratings.items():
         if not isinstance(name, str):
             continue
         reason = reasons.get(name)
         confidence = confidences.get(name)
-        scores.append(
-            AgentConversationSpanScore(
+        out.append(
+            AgentConversationSpanRating(
                 name=name,
                 value=safe_float(value),
                 reason=reason if isinstance(reason, str) and reason else None,
@@ -118,7 +105,7 @@ def _feedback_scores(raw: dict[str, Any]) -> list[AgentConversationSpanScore]:
                 else None,
             )
         )
-    return scores
+    return out
 
 
 def span_feedback_marker(
@@ -135,5 +122,5 @@ def span_feedback_marker(
         trace_id=trace_id,
         feedback_type=feedback_type,  # type: ignore[arg-type]  # caller filters
         tags=_feedback_tags(raw),
-        scores=_feedback_scores(raw),
+        ratings=_feedback_ratings(raw),
     )

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -34,6 +34,7 @@ from weave.trace_server.agents.schema import (
     SpanKindLiteral,
     StatusCodeLiteral,
 )
+from weave.trace_server.interface.feedback_types import AgentSpanFeedbackType
 from weave.trace_server.interface.query import Query
 
 if TYPE_CHECKING:
@@ -628,35 +629,25 @@ class AgentConversationMessagePreview(BaseModel):
     text: str = ""
 
 
-# Coarse span kind classified from operation_name / status_code. Distinct from
-# AgentChatMessageType: the classifier only emits these values, not the full
-# message taxonomy (which needs message bodies).
-ConversationSpanKind = Literal["agent", "tool", "assistant", "unknown"]
-
-
 class AgentConversationSpan(BaseModel):
     """One span in a conversation's trace.
 
     Returned by `agent_conversation_spans`, which reads span scalar columns
     only (no message bodies). Spans are ordered by `started_at`, which
     approximates — but does not exactly match — the detail chat view's
-    parent/child tree-walk order.
+    parent/child tree-walk order. `operation_name` is the raw OTel value; the
+    client maps it to a display category.
     """
 
-    kind: ConversationSpanKind
+    operation_name: str
     trace_id: str
     span_id: str
     status: StatusCodeLiteral
     duration_ms: int
 
 
-# Feedback types this endpoint surfaces: human tags (agent_user_feedback) and
-# scorer tags + ratings (agent_monitor). Other feedback types are ignored.
-AgentSpanFeedbackType = Literal["wandb.agent_user_feedback", "wandb.agent_monitor"]
-
-
-class AgentConversationSpanScore(BaseModel):
-    """One numeric score (rating) applied to a turn or conversation."""
+class AgentConversationSpanRating(BaseModel):
+    """One numeric rating (a scorer score) applied to a turn or conversation."""
 
     name: str
     value: float
@@ -665,7 +656,7 @@ class AgentConversationSpanScore(BaseModel):
 
 
 class AgentConversationSpanFeedback(BaseModel):
-    """Tags and scores applied to a conversation's turn (or the conversation).
+    """Tags and ratings applied to a conversation's turn (or the conversation).
 
     Positioned client-side by matching `trace_id` (turn) against the spans;
     `trace_id` is None for conversation-level feedback.
@@ -678,11 +669,11 @@ class AgentConversationSpanFeedback(BaseModel):
     tags: list[str] = Field(
         default_factory=list,
         description="Arbitrary descriptive tags applied to this feedback.",
-        examples=[["\U0001f44d"]],
+        examples=[["👍", "needs-review"]],
     )
-    scores: list[AgentConversationSpanScore] = Field(
+    ratings: list[AgentConversationSpanRating] = Field(
         default_factory=list,
-        description="Numeric scores (ratings) applied to this feedback.",
+        description="Numeric scorer ratings applied to this feedback.",
     )
 
 

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -650,8 +650,22 @@ class AgentConversationSpan(BaseModel):
     duration_ms: int
 
 
+# Feedback types this endpoint surfaces: human tags (agent_user_feedback) and
+# scorer tags + ratings (agent_monitor). Other feedback types are ignored.
+AgentSpanFeedbackType = Literal["wandb.agent_user_feedback", "wandb.agent_monitor"]
+
+
+class AgentConversationSpanScore(BaseModel):
+    """One numeric score (rating) applied to a turn or conversation."""
+
+    name: str
+    value: float
+    reason: str | None = None
+    confidence: float | None = None
+
+
 class AgentConversationSpanFeedback(BaseModel):
-    """A feedback marker for a conversation's trace.
+    """Tags and scores applied to a conversation's turn (or the conversation).
 
     Positioned client-side by matching `trace_id` (turn) against the spans;
     `trace_id` is None for conversation-level feedback.
@@ -660,11 +674,15 @@ class AgentConversationSpanFeedback(BaseModel):
     trace_id: str | None = Field(
         description="The turn this feedback is anchored to; None for conversation-level."
     )
-    feedback_type: str
+    feedback_type: AgentSpanFeedbackType
     tags: list[str] = Field(
         default_factory=list,
         description="Arbitrary descriptive tags applied to this feedback.",
         examples=[["\U0001f44d"]],
+    )
+    scores: list[AgentConversationSpanScore] = Field(
+        default_factory=list,
+        description="Numeric scores (ratings) applied to this feedback.",
     )
 
 

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -628,18 +628,10 @@ class AgentConversationMessagePreview(BaseModel):
     text: str = ""
 
 
-# Coarse span kind from operation_name / status_code. Distinct from
-# AgentChatMessageType: the classifier only emits agent / tool / assistant
-# (+ unknown), not the full message taxonomy.
-ConversationSpanKind = Literal[
-    "user",
-    "assistant",
-    "tool",
-    "agent",
-    "handoff",
-    "compaction",
-    "unknown",
-]
+# Coarse span kind classified from operation_name / status_code. Distinct from
+# AgentChatMessageType: the classifier only emits these values, not the full
+# message taxonomy (which needs message bodies).
+ConversationSpanKind = Literal["agent", "tool", "assistant", "unknown"]
 
 
 class AgentConversationSpan(BaseModel):
@@ -651,28 +643,27 @@ class AgentConversationSpan(BaseModel):
     parent/child tree-walk order.
     """
 
-    kind: ConversationSpanKind = "unknown"
-    trace_id: str = ""
-    span_id: str = ""
-    status: StatusCodeLiteral = "UNSET"
-    duration_ms: int = 0
+    kind: ConversationSpanKind
+    trace_id: str
+    span_id: str
+    status: StatusCodeLiteral
+    duration_ms: int
 
 
 class AgentConversationSpanFeedback(BaseModel):
     """A feedback marker for a conversation's trace.
 
-    Positioned client-side by matching `trace_id` (turn) against the spans.
-    `tags` holds the human tags on this feedback (emoji reactions are tags too).
+    Positioned client-side by matching `trace_id` (turn) against the spans;
+    `trace_id` is None for conversation-level feedback.
     """
 
-    trace_id: str = ""
-    feedback_type: str = ""
+    trace_id: str | None = Field(
+        description="The turn this feedback is anchored to; None for conversation-level."
+    )
+    feedback_type: str
     tags: list[str] = Field(
         default_factory=list,
-        description=(
-            "Human tags on this feedback, skin-tone-detoned. Emoji tags are the "
-            "glyph itself (e.g. a thumbs-up); empty when it carries none."
-        ),
+        description="Arbitrary descriptive tags applied to this feedback.",
         examples=[["\U0001f44d"]],
     )
 
@@ -693,7 +684,9 @@ class AgentConversationSpansReq(BaseModel):
     """
 
     project_id: str
-    conversation_ids: list[str] = Field(default_factory=list)
+    conversation_ids: list[str] = Field(
+        default_factory=list, max_length=MAX_AGENT_QUERY_LIMIT
+    )
     started_after: AwareDatetime | None = None  # filter started_at >= start
     started_before: AwareDatetime | None = None  # filter started_at < end
 

--- a/weave/trace_server/agents/types.py
+++ b/weave/trace_server/agents/types.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import AwareDatetime, BaseModel, Field, model_validator
 
 from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import (
@@ -566,7 +566,7 @@ class AgentSpanGroupDistributionSpec(BaseModel):
         return self
 
     def custom_attr_source(self) -> AgentCustomAttrSource:
-        """Return ``value.source`` narrowed to ``AgentCustomAttrSource``.
+        """Return `value.source` narrowed to `AgentCustomAttrSource`.
 
         The model validator guarantees this at construction time; this helper
         re-checks each literal so callers avoid `cast()` at use sites.
@@ -626,6 +626,82 @@ class AgentConversationMessagePreview(BaseModel):
 
     role: str = ""
     text: str = ""
+
+
+# Coarse span kind from operation_name / status_code. Distinct from
+# AgentChatMessageType: the classifier only emits agent / tool / assistant
+# (+ unknown), not the full message taxonomy.
+ConversationSpanKind = Literal[
+    "user",
+    "assistant",
+    "tool",
+    "agent",
+    "handoff",
+    "compaction",
+    "unknown",
+]
+
+
+class AgentConversationSpan(BaseModel):
+    """One span in a conversation's trace.
+
+    Returned by `agent_conversation_spans`, which reads span scalar columns
+    only (no message bodies). Spans are ordered by `started_at`, which
+    approximates — but does not exactly match — the detail chat view's
+    parent/child tree-walk order.
+    """
+
+    kind: ConversationSpanKind = "unknown"
+    trace_id: str = ""
+    span_id: str = ""
+    status: StatusCodeLiteral = "UNSET"
+    duration_ms: int = 0
+
+
+class AgentConversationSpanFeedback(BaseModel):
+    """A feedback marker for a conversation's trace.
+
+    Positioned client-side by matching `trace_id` (turn) against the spans.
+    `tags` holds the human tags on this feedback (emoji reactions are tags too).
+    """
+
+    trace_id: str = ""
+    feedback_type: str = ""
+    tags: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Human tags on this feedback, skin-tone-detoned. Emoji tags are the "
+            "glyph itself (e.g. a thumbs-up); empty when it carries none."
+        ),
+        examples=[["\U0001f44d"]],
+    )
+
+
+class AgentConversationSpans(BaseModel):
+    """One conversation's span sequence and its feedback markers."""
+
+    conversation_id: str
+    spans: list[AgentConversationSpan] = Field(default_factory=list)
+    spans_feedback: list[AgentConversationSpanFeedback] = Field(default_factory=list)
+
+
+class AgentConversationSpansReq(BaseModel):
+    """Request the span sequences for an explicit set of conversations.
+
+    Reads span scalar columns only (no message bodies) for the given
+    `conversation_ids`. Powers the conversations-list spans minimap.
+    """
+
+    project_id: str
+    conversation_ids: list[str] = Field(default_factory=list)
+    started_after: AwareDatetime | None = None  # filter started_at >= start
+    started_before: AwareDatetime | None = None  # filter started_at < end
+
+
+class AgentConversationSpansRes(BaseModel):
+    """Span sequences + feedback markers, one entry per requested conversation."""
+
+    conversations: list[AgentConversationSpans] = Field(default_factory=list)
 
 
 class AgentSpanGroupRow(BaseModel):

--- a/weave/trace_server/clickhouse_trace_server_batched.py
+++ b/weave/trace_server/clickhouse_trace_server_batched.py
@@ -63,6 +63,8 @@ from weave.trace_server.agents.schema import AgentSpanCHInsertable
 from weave.trace_server.agents.types import (
     AgentConversationChatReq,
     AgentConversationChatRes,
+    AgentConversationSpansReq,
+    AgentConversationSpansRes,
     AgentCustomAttrsSchemaReq,
     AgentCustomAttrsSchemaRes,
     AgentSearchReq,
@@ -6995,6 +6997,13 @@ class ClickHouseTraceServer(tsi.FullTraceServerInterface):
         self, req: AgentConversationChatReq
     ) -> AgentConversationChatRes:
         return AgentQueryHandler(self._query, self.feedback_query).conversation_chat(
+            req
+        )
+
+    def agent_conversation_spans(
+        self, req: AgentConversationSpansReq
+    ) -> AgentConversationSpansRes:
+        return AgentQueryHandler(self._query, self.feedback_query).conversation_spans(
             req
         )
 

--- a/weave/trace_server/external_to_internal_trace_server_adapter.py
+++ b/weave/trace_server/external_to_internal_trace_server_adapter.py
@@ -1369,6 +1369,16 @@ class ExternalTraceServer(tsi.FullTraceServerInterface):
             req.project_id,
         )
 
+    def agent_conversation_spans(
+        self, req: tsi.agent_types.AgentConversationSpansReq
+    ) -> tsi.agent_types.AgentConversationSpansRes:
+        req.project_id = self._idc.ext_to_int_project_id(req.project_id)
+        return self._ref_apply(
+            self._internal_trace_server.agent_conversation_spans,
+            req,
+            req.project_id,
+        )
+
     def projects_info(self, req: tsi.ProjectsInfoReq) -> list[tsi.ProjectsInfoRes]:
         req = req.model_copy(deep=True)
         """Resolve external project IDs to internal project IDs."""

--- a/weave/trace_server/interface/feedback_types.py
+++ b/weave/trace_server/interface/feedback_types.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -20,6 +20,13 @@ AGENT_MONITOR_FEEDBACK_TYPE = "wandb.agent_monitor"
 # stored in scorer_tags. Covers any human tag, e.g. an emoji reaction or a
 # manual label like "low-quality".
 AGENT_USER_FEEDBACK_TYPE = "wandb.agent_user_feedback"
+
+# The agent feedback types that carry tags/ratings: human-applied
+# (agent_user_feedback) and scorer-applied (agent_monitor).
+AgentSpanFeedbackType = Literal["wandb.agent_user_feedback", "wandb.agent_monitor"]
+AGENT_SPAN_FEEDBACK_TYPES: frozenset[str] = frozenset(
+    {AGENT_USER_FEEDBACK_TYPE, AGENT_MONITOR_FEEDBACK_TYPE}
+)
 
 # Feedback types where multiple entries can exist per call per type.
 # When filtering on these, we use groupArrayIf (collect all values) + has()

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -15,10 +15,12 @@ import datetime
 import re
 from collections.abc import Callable, Collection, Sequence
 from dataclasses import dataclass
-from typing import Any, NamedTuple, TypeAlias
+from typing import Any, NamedTuple, TypeAlias, TypeVar
 
 from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import (
+    MAX_CONVERSATION_SPANS,
+    OP_EXECUTE_TOOL,
     OP_INVOKE_AGENT,
     SEARCH_CONTENT_PREVIEW_CHARS,
     SPAN_GROUP_AGGREGATE_COLS,
@@ -1122,15 +1124,15 @@ def make_conversation_previews_query(
 ) -> str:
     """First/last message previews for an explicit set of conversations.
 
-    Deliberately scoped to ``conversation_id IN (...)`` — the page's already
-    computed conversation_ids — so the wide ``input_messages`` / ``output_messages``
+    Deliberately scoped to `conversation_id IN (...)` — the page's already
+    computed conversation_ids — so the wide `input_messages` / `output_messages`
     columns are only read for the conversations actually shown, not for every
-    span matching the list filters. (A grouped ``argMin``/``argMax`` folded into
+    span matching the list filters. (A grouped `argMin`/`argMax` folded into
     the main list query would read those columns for the entire filter match
-    before LIMIT.) The bloom-filter skip index on ``conversation_id`` plus the
+    before LIMIT.) The bloom-filter skip index on `conversation_id` plus the
     optional time range bound the scan further.
 
-    ``argMinIf``/``argMaxIf`` pick the earliest input and latest output span that
+    `argMinIf`/`argMaxIf` pick the earliest input and latest output span that
     actually carries messages; the handler turns the arrays into preview text.
     """
     pid_slot = pb.add(project_id, param_type="String")
@@ -1150,6 +1152,96 @@ def make_conversation_previews_query(
         SELECT s.conversation_id AS conversation_id,
                argMinIf(s.input_messages, s.started_at, length(s.input_messages) > 0) AS first_input_messages,
                argMaxIf(s.output_messages, s.ended_at, length(s.output_messages) > 0) AS last_output_messages
+        FROM spans s
+        WHERE {where}
+        GROUP BY conversation_id
+    """
+
+
+def _span_kind_sql(op_col: str) -> str:
+    """SQL expr mapping a span's `operation_name` to a ConversationSpanKind.
+
+    A span-level approximation of the chat taxonomy: agent invocations classify
+    as `agent`, tool executions as `tool`, and every other span (LLM / content)
+    as `assistant`. So this expr only ever emits those three of the
+    ConversationSpanKind values.
+    """
+    return (
+        "multiIf("
+        f"{op_col} = '{OP_INVOKE_AGENT}', 'agent', "
+        f"{op_col} = '{OP_EXECUTE_TOOL}', 'tool', "
+        "'assistant')"
+    )
+
+
+def make_conversation_spans_query(
+    pb: ParamBuilder,
+    project_id: str,
+    conversation_ids: Collection[str],
+    *,
+    started_after: datetime.datetime | None = None,
+    started_before: datetime.datetime | None = None,
+    max_spans: int = MAX_CONVERSATION_SPANS,
+) -> str:
+    """Per-conversation spans sequence for an explicit set of conversations.
+
+    Mirrors `make_conversation_previews_query`: scoped to the page's already
+    computed `conversation_id IN (...)` so the scan is bounded by the
+    bloom-filter skip index plus the optional time range. Reads only narrow
+    scalar columns (no message bodies), so it stays cheap across a list page.
+
+    Returns one row per conversation with an `spans` array of per-span
+    tuples `(started_at, kind, trace_id, span_id, status_code, duration_ms)`
+    sorted by `started_at` and capped at `max_spans`, keeping the most recent
+    spans (the head is dropped beyond the cap) so the minimap reflects the
+    latest activity. `started_at` is carried only as the sort key; the handler
+    ignores it when building `AgentConversationSpan` rows.
+
+    `max_spans` bounds the returned (and wire) payload, not the intermediate
+    aggregation: `groupArray` still materializes the full per-conversation
+    tuple array before the sort + slice, so server-side memory is bounded by
+    page-size x spans-per-conversation. A `groupArraySorted(max_spans)` could
+    bound the intermediate too, but it sorts ascending (keeping the head), so
+    keeping the recent tail would need a descending sort key.
+    """
+    pid_slot = pb.add(project_id, param_type="String")
+    ids_slot = pb.add(list(conversation_ids), param_type="Array(String)")
+    where_conditions = [
+        _project_filter_sql("s.project_id", pid_slot),
+        f"s.conversation_id IN {ids_slot}",
+    ]
+    add_time_filters(
+        where_conditions,
+        pb,
+        started_after=started_after,
+        started_before=started_before,
+    )
+    where = " AND ".join(where_conditions)
+    cap = int(max_spans)
+    duration_ms = (
+        "if(s.ended_at > s.started_at, "
+        "toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), "
+        "0)"
+    )
+    kind = _span_kind_sql("s.operation_name")
+    return f"""
+        SELECT s.conversation_id AS conversation_id,
+               arraySlice(
+                   arraySort(
+                       x -> x.1,
+                       groupArray(
+                           tuple(
+                               s.started_at,
+                               {kind},
+                               s.trace_id,
+                               s.span_id,
+                               s.status_code,
+                               {duration_ms}
+                           )
+                       )
+                   ),
+                   -{cap}
+               ) AS spans
         FROM spans s
         WHERE {where}
         GROUP BY conversation_id
@@ -1744,3 +1836,24 @@ def safe_str(val: Any) -> str:
     if val is None:
         return ""
     return str(val)
+
+
+_LiteralT = TypeVar("_LiteralT", bound=str)
+
+
+def coerce_literal(
+    val: Any, allowed: frozenset[_LiteralT], default: _LiteralT
+) -> _LiteralT:
+    """Narrow an untyped value to one of `allowed`, falling back to `default`.
+
+    Turns a raw ClickHouse scalar into a Literal-typed value without letting an
+    unexpected input raise downstream: anything not in `allowed` becomes
+    `default`. `allowed` is typically `frozenset(get_args(SomeLiteral))`.
+
+    Returns the matching member of `allowed` (already typed `_LiteralT`) rather
+    than `val` itself, so no cast is needed.
+    """
+    for candidate in allowed:
+        if candidate == val:
+            return candidate
+    return default

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -20,7 +20,6 @@ from typing import Any, NamedTuple, TypeAlias, TypeVar
 from weave.trace_server.agents import semconv
 from weave.trace_server.agents.constants import (
     MAX_CONVERSATION_SPANS,
-    OP_EXECUTE_TOOL,
     OP_INVOKE_AGENT,
     SEARCH_CONTENT_PREVIEW_CHARS,
     SPAN_GROUP_AGGREGATE_COLS,
@@ -1171,7 +1170,7 @@ def make_conversation_spans_query(
 
     Scoped to `conversation_id IN (...)` and reads only scalar columns (no
     message bodies). Returns one row per conversation with a `spans` array of
-    `(started_at, kind, trace_id, span_id, status_code, duration_ms)` tuples,
+    `(started_at, operation_name, trace_id, span_id, status_code, duration_ms)` tuples,
     sorted by `(started_at, span_id)` and capped at `max_spans` keeping the most
     recent; `started_at` is only the sort key and is dropped by the handler.
     """
@@ -1194,14 +1193,6 @@ def make_conversation_spans_query(
         "toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), "
         "0)"
     )
-    # Coarse span kind from operation_name (see ConversationSpanKind): agent
-    # invocations -> agent, tool executions -> tool, everything else -> assistant.
-    kind = (
-        "multiIf("
-        f"s.operation_name = '{OP_INVOKE_AGENT}', 'agent', "
-        f"s.operation_name = '{OP_EXECUTE_TOOL}', 'tool', "
-        "'assistant')"
-    )
     return f"""
         SELECT s.conversation_id AS conversation_id,
                arraySlice(
@@ -1210,7 +1201,7 @@ def make_conversation_spans_query(
                        groupArray(
                            tuple(
                                s.started_at,
-                               {kind},
+                               s.operation_name,
                                s.trace_id,
                                s.span_id,
                                s.status_code,

--- a/weave/trace_server/query_builder/agent_query_builder.py
+++ b/weave/trace_server/query_builder/agent_query_builder.py
@@ -1158,22 +1158,6 @@ def make_conversation_previews_query(
     """
 
 
-def _span_kind_sql(op_col: str) -> str:
-    """SQL expr mapping a span's `operation_name` to a ConversationSpanKind.
-
-    A span-level approximation of the chat taxonomy: agent invocations classify
-    as `agent`, tool executions as `tool`, and every other span (LLM / content)
-    as `assistant`. So this expr only ever emits those three of the
-    ConversationSpanKind values.
-    """
-    return (
-        "multiIf("
-        f"{op_col} = '{OP_INVOKE_AGENT}', 'agent', "
-        f"{op_col} = '{OP_EXECUTE_TOOL}', 'tool', "
-        "'assistant')"
-    )
-
-
 def make_conversation_spans_query(
     pb: ParamBuilder,
     project_id: str,
@@ -1183,26 +1167,13 @@ def make_conversation_spans_query(
     started_before: datetime.datetime | None = None,
     max_spans: int = MAX_CONVERSATION_SPANS,
 ) -> str:
-    """Per-conversation spans sequence for an explicit set of conversations.
+    """Per-conversation span sequence for an explicit set of conversations.
 
-    Mirrors `make_conversation_previews_query`: scoped to the page's already
-    computed `conversation_id IN (...)` so the scan is bounded by the
-    bloom-filter skip index plus the optional time range. Reads only narrow
-    scalar columns (no message bodies), so it stays cheap across a list page.
-
-    Returns one row per conversation with an `spans` array of per-span
-    tuples `(started_at, kind, trace_id, span_id, status_code, duration_ms)`
-    sorted by `started_at` and capped at `max_spans`, keeping the most recent
-    spans (the head is dropped beyond the cap) so the minimap reflects the
-    latest activity. `started_at` is carried only as the sort key; the handler
-    ignores it when building `AgentConversationSpan` rows.
-
-    `max_spans` bounds the returned (and wire) payload, not the intermediate
-    aggregation: `groupArray` still materializes the full per-conversation
-    tuple array before the sort + slice, so server-side memory is bounded by
-    page-size x spans-per-conversation. A `groupArraySorted(max_spans)` could
-    bound the intermediate too, but it sorts ascending (keeping the head), so
-    keeping the recent tail would need a descending sort key.
+    Scoped to `conversation_id IN (...)` and reads only scalar columns (no
+    message bodies). Returns one row per conversation with a `spans` array of
+    `(started_at, kind, trace_id, span_id, status_code, duration_ms)` tuples,
+    sorted by `(started_at, span_id)` and capped at `max_spans` keeping the most
+    recent; `started_at` is only the sort key and is dropped by the handler.
     """
     pid_slot = pb.add(project_id, param_type="String")
     ids_slot = pb.add(list(conversation_ids), param_type="Array(String)")
@@ -1223,12 +1194,19 @@ def make_conversation_spans_query(
         "toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at), "
         "0)"
     )
-    kind = _span_kind_sql("s.operation_name")
+    # Coarse span kind from operation_name (see ConversationSpanKind): agent
+    # invocations -> agent, tool executions -> tool, everything else -> assistant.
+    kind = (
+        "multiIf("
+        f"s.operation_name = '{OP_INVOKE_AGENT}', 'agent', "
+        f"s.operation_name = '{OP_EXECUTE_TOOL}', 'tool', "
+        "'assistant')"
+    )
     return f"""
         SELECT s.conversation_id AS conversation_id,
                arraySlice(
                    arraySort(
-                       x -> x.1,
+                       x -> (x.1, x.4),
                        groupArray(
                            tuple(
                                s.started_at,

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -3449,6 +3449,9 @@ class TraceServerInterface(Protocol):
     def agent_conversation_chat(
         self, req: agent_types.AgentConversationChatReq
     ) -> agent_types.AgentConversationChatRes: ...
+    def agent_conversation_spans(
+        self, req: agent_types.AgentConversationSpansReq
+    ) -> agent_types.AgentConversationSpansRes: ...
 
     # Call API
     def call_start(self, req: CallStartReq) -> CallStartRes: ...


### PR DESCRIPTION
## JIRA Issue(s)

- [Turns / Events Minimap in Sessions list (Notion)](https://www.notion.so/wandbai/Turns-Minimap-in-Sessions-list-375e2f5c7ef380ec8e5fd994696125b2)

## Description

Feature half of the Sessions spans minimap backend (the trace-server interface/adapter/delegate wiring is in the stacked follow-up wandb/weave#7323).

Adds the query + transforms that produce, for a set of conversations:

- `spans` — an ordered per-span sequence (`kind`, `trace_id`, `span_id`, `status`, `duration_ms`), classified from span scalar columns (`operation_name` / `status_code`); no message bodies read. Capped at `MAX_CONVERSATION_SPANS`, keeping the most recent spans.
- `spans_feedback` — turn-anchored feedback markers (`trace_id`, `feedback_type`, detoned emoji `reactions`), fetched in one batched feedback query.

Exposed as `AgentQueryHandler.conversation_spans`. Replaces the `include_spans` flag on the grouped `agentSpansQuery` (removed here, along with `spans`/`spans_feedback` on `AgentSpanGroupRow`).

Also renames `ConversationEventKind` to `ConversationSpanKind` and documents why it is distinct from `AgentChatMessageType` (a coarse span-level classification, not the message taxonomy).

Stacked: wandb/weave#7323 (wiring). Frontend: wandb/core#45791 (+ wandb/core#45792).

## Testing

- [x] Manual
- [x] Unit
- [x] QA