### PR TITLE
chore(weave_ts): Bump TS trace server API

### DIFF
--- a/sdks/node/src/generated/traceServerApi.ts
+++ b/sdks/node/src/generated/traceServerApi.ts
@@ -10,7 +10,1295 @@
  * ---------------------------------------------------------------
  */
 
-/** AndOperation */
+/** TraceStatus */
+export enum TraceStatus {
+  Success = 'success',
+  Error = 'error',
+  Running = 'running',
+  DescendantError = 'descendant_error',
+}
+
+/**
+ * AggregationType
+ * Aggregation functions supported by feedback and call stats metrics.
+ */
+export enum AggregationType {
+  Sum = 'sum',
+  Avg = 'avg',
+  Min = 'min',
+  Max = 'max',
+  Count = 'count',
+  CountTrue = 'count_true',
+  CountFalse = 'count_false',
+}
+
+/**
+ * AgentChatAgentHandoff
+ * Payload for a future agent-to-agent handoff event.
+ */
+export type AgentChatAgentHandoff = object;
+
+/**
+ * AgentChatAgentStart
+ * Payload for an agent lifecycle boundary.
+ */
+export interface AgentChatAgentStart {
+  /** Model */
+  model?: string | null;
+  /** System Instructions */
+  system_instructions?: string | null;
+  /** Tool Definitions */
+  tool_definitions?: string | null;
+  /** Status */
+  status?: 'UNSET' | 'OK' | 'ERROR' | null;
+}
+
+/**
+ * AgentChatAssistantMessage
+ * Payload for assistant text emitted by an agent or LLM span.
+ */
+export interface AgentChatAssistantMessage {
+  /** Text */
+  text: string;
+  /** Model */
+  model?: string | null;
+  /** Reasoning Content */
+  reasoning_content?: string | null;
+  /** Reasoning Tokens */
+  reasoning_tokens?: number | null;
+  /** Input Tokens */
+  input_tokens?: number | null;
+  /** Output Tokens */
+  output_tokens?: number | null;
+  /** Duration Ms */
+  duration_ms?: number | null;
+  /** Status */
+  status?: 'UNSET' | 'OK' | 'ERROR' | null;
+  /** Content Refs */
+  content_refs?: string[];
+}
+
+/**
+ * AgentChatContextCompacted
+ * Payload for a context-window compaction event.
+ */
+export interface AgentChatContextCompacted {
+  /** Compaction Summary */
+  compaction_summary?: string | null;
+  /** Compaction Items Before */
+  compaction_items_before?: number | null;
+  /** Compaction Items After */
+  compaction_items_after?: number | null;
+}
+
+/**
+ * AgentChatMessage
+ * A single element in the structured agent trajectory / chat view.
+ *
+ * Common event fields live at the top level. Type-specific fields are
+ * grouped under the payload matching `type`, and exactly one payload must be
+ * set. This keeps subtype nullability explicit while preserving a single
+ * ordered timeline model for callers.
+ */
+export interface AgentChatMessage {
+  /** Type */
+  type:
+    | 'user_message'
+    | 'assistant_message'
+    | 'tool_call'
+    | 'agent_handoff'
+    | 'agent_start'
+    | 'context_compacted';
+  /** Span Id */
+  span_id?: string | null;
+  /** Agent Name */
+  agent_name?: string | null;
+  /** Started At */
+  started_at?: string | null;
+  user_message?: AgentChatUserMessage | null;
+  assistant_message?: AgentChatAssistantMessage | null;
+  tool_call?: AgentChatToolCall | null;
+  agent_start?: AgentChatAgentStart | null;
+  agent_handoff?: AgentChatAgentHandoff | null;
+  context_compacted?: AgentChatContextCompacted | null;
+  /** Feedback */
+  feedback?: Record<string, any>[] | null;
+}
+
+/**
+ * AgentChatToolCall
+ * Payload for a tool call timeline event.
+ */
+export interface AgentChatToolCall {
+  /** Tool Name */
+  tool_name?: string | null;
+  /** Tool Arguments */
+  tool_arguments?: string | null;
+  /** Tool Result */
+  tool_result?: string | null;
+  /** Duration Ms */
+  duration_ms?: number | null;
+  /** Status */
+  status?: 'UNSET' | 'OK' | 'ERROR' | null;
+  /** Content Refs */
+  content_refs?: string[];
+}
+
+/**
+ * AgentChatUserMessage
+ * Payload for a user prompt in the chat timeline.
+ */
+export interface AgentChatUserMessage {
+  /** Text */
+  text: string;
+  /** Content Refs */
+  content_refs?: string[];
+}
+
+/**
+ * AgentConversationChatReq
+ * Request to get the multi-turn chat view for a conversation.
+ */
+export interface AgentConversationChatReq {
+  /** Project Id */
+  project_id: string;
+  /** Conversation Id */
+  conversation_id: string;
+  /**
+   * Limit
+   * Maximum number of conversation turns to return.
+   * @min 0
+   * @max 50
+   * @default 50
+   */
+  limit?: number;
+  /**
+   * Offset
+   * Number of most-recent turns to skip. Results are returned in chronological order within the selected page.
+   * @min 0
+   * @default 0
+   */
+  offset?: number;
+  /**
+   * Include Feedback
+   * @default false
+   */
+  include_feedback?: boolean;
+}
+
+/**
+ * AgentConversationChatRes
+ * Multi-turn chat view: an ordered list of per-turn chat responses.
+ *
+ * Each entry in `turns` corresponds to one trace_id, which Weave treats as
+ * one conversation turn. This is not necessarily one `invoke_agent` span:
+ * a turn can contain zero, one, or many agent invocations. The frontend can
+ * render turn-number dividers between entries and still reuse
+ * `AgentTraceChatRes` rendering for each individual turn.
+ */
+export interface AgentConversationChatRes {
+  /** Conversation Id */
+  conversation_id: string;
+  /** Turns */
+  turns?: AgentTraceChatRes[];
+  /**
+   * Total Turns
+   * @default 0
+   */
+  total_turns?: number;
+  /**
+   * Has More
+   * @default false
+   */
+  has_more?: boolean;
+  /**
+   * Limit
+   * @default 50
+   */
+  limit?: number;
+  /**
+   * Offset
+   * @default 0
+   */
+  offset?: number;
+  /** Feedback */
+  feedback?: Record<string, any>[] | null;
+}
+
+/**
+ * AgentConversationMessagePreview
+ * A truncated first/last message snippet for a grouped conversation row.
+ *
+ * `role` is the chat-timeline message type (e.g. "user_message",
+ * "assistant_message") so clients can style it consistently with the full
+ * chat view; `text` is the trimmed, length-capped preview content.
+ */
+export interface AgentConversationMessagePreview {
+  /**
+   * Role
+   * @default ""
+   */
+  role?: string;
+  /**
+   * Text
+   * @default ""
+   */
+  text?: string;
+}
+
+/**
+ * AgentCustomAttrSchemaItem
+ * One custom attribute key/type observed in the matching spans.
+ */
+export interface AgentCustomAttrSchemaItem {
+  /** Source */
+  source:
+    | 'custom_attrs_string'
+    | 'custom_attrs_int'
+    | 'custom_attrs_float'
+    | 'custom_attrs_bool';
+  /** Key */
+  key: string;
+  /** Value Type */
+  value_type: 'string' | 'int' | 'float' | 'bool';
+  /** Span Count */
+  span_count: number;
+}
+
+/**
+ * AgentCustomAttrsSchemaReq
+ * Request to discover typed custom attribute keys for matching spans.
+ */
+export interface AgentCustomAttrsSchemaReq {
+  /** Project Id */
+  project_id: string;
+  query?: Query | null;
+  /** Started After */
+  started_after?: string | null;
+  /** Started Before */
+  started_before?: string | null;
+  /**
+   * Limit
+   * @min 1
+   * @max 2000
+   * @default 200
+   */
+  limit?: number;
+  /**
+   * Offset
+   * @min 0
+   * @default 0
+   */
+  offset?: number;
+}
+
+/**
+ * AgentCustomAttrsSchemaRes
+ * Typed custom attribute keys available for spans query/group/stats APIs.
+ */
+export interface AgentCustomAttrsSchemaRes {
+  /** Attributes */
+  attributes?: AgentCustomAttrSchemaItem[];
+  /**
+   * Limit
+   * @default 200
+   */
+  limit?: number;
+  /**
+   * Offset
+   * @default 0
+   */
+  offset?: number;
+  /**
+   * Has More
+   * @default false
+   */
+  has_more?: boolean;
+}
+
+/**
+ * AgentGroupByRef
+ * Reference to a field or map-key that spans should be grouped by.
+ *
+ * `source="field"` targets a semantic span field (`agent.name`) or direct
+ * span column (`agent_name`), allowlisted server-side. `source="column"` is
+ * accepted for existing callers.
+ * The other sources target keys inside the typed custom attribute Map columns,
+ * which accept arbitrary user-defined keys.
+ */
+export interface AgentGroupByRef {
+  /**
+   * Source
+   * @default "field"
+   */
+  source?:
+    | 'field'
+    | 'column'
+    | 'custom_attrs_string'
+    | 'custom_attrs_int'
+    | 'custom_attrs_float'
+    | 'custom_attrs_bool';
+  /** Key */
+  key: string;
+  /** Alias */
+  alias?: string | null;
+}
+
+/**
+ * AgentSchema
+ * Aggregated per-agent stats from the agents table.
+ */
+export interface AgentSchema {
+  /** Project Id */
+  project_id: string;
+  /** Agent Name */
+  agent_name: string;
+  /** Invocation Count */
+  invocation_count: number;
+  /** Span Count */
+  span_count: number;
+  /** Total Input Tokens */
+  total_input_tokens: number;
+  /** Total Output Tokens */
+  total_output_tokens: number;
+  /** Total Duration Ms */
+  total_duration_ms: number;
+  /** Error Count */
+  error_count: number;
+  /** First Seen */
+  first_seen: string | null;
+  /** Last Seen */
+  last_seen: string | null;
+}
+
+/**
+ * AgentSearchConversationResult
+ * A conversation containing messages that matched the search query.
+ */
+export interface AgentSearchConversationResult {
+  /** Conversation Id */
+  conversation_id: string;
+  /** Conversation Name */
+  conversation_name: string;
+  /** Agent Name */
+  agent_name: string;
+  /** Matched Messages */
+  matched_messages: AgentSearchMatchedMessage[];
+  /**
+   * Last Activity
+   * @format date-time
+   */
+  last_activity: string;
+}
+
+/**
+ * AgentSearchMatchedMessage
+ * A single message that matched the search query.
+ */
+export interface AgentSearchMatchedMessage {
+  /** Span Id */
+  span_id: string;
+  /** Trace Id */
+  trace_id: string;
+  /** Role */
+  role:
+    | ''
+    | 'user'
+    | 'assistant'
+    | 'system'
+    | 'tool'
+    | 'tool_call'
+    | 'tool_result';
+  /** Content Preview */
+  content_preview: string;
+  /** Content Digest */
+  content_digest: string;
+  /**
+   * Started At
+   * @format date-time
+   */
+  started_at: string;
+}
+
+/**
+ * AgentSearchReq
+ * Full-text search across message content and span metadata.
+ *
+ * Scans the `messages` table (one row per message occurrence, populated
+ * by an MV from spans) and returns matching span-level hits. The caller
+ * groups by conversation for the response shape.
+ */
+export interface AgentSearchReq {
+  /** Project Id */
+  project_id: string;
+  /** Query */
+  query: string;
+  /** Roles */
+  roles?:
+    | (
+        | ''
+        | 'user'
+        | 'assistant'
+        | 'system'
+        | 'tool'
+        | 'tool_call'
+        | 'tool_result'
+      )[]
+    | null;
+  /** Conversation Id */
+  conversation_id?: string | null;
+  /** Agent Name */
+  agent_name?: string | null;
+  /** Provider Name */
+  provider_name?: string | null;
+  /** Request Model */
+  request_model?: string | null;
+  /** Started After */
+  started_after?: string | null;
+  /** Started Before */
+  started_before?: string | null;
+  /**
+   * Limit
+   * @min 0
+   * @max 1000
+   * @default 20
+   */
+  limit?: number;
+  /**
+   * Offset
+   * @min 0
+   * @default 0
+   */
+  offset?: number;
+}
+
+/**
+ * AgentSearchRes
+ * Response from a full-text search across agent messages.
+ */
+export interface AgentSearchRes {
+  /** Results */
+  results: AgentSearchConversationResult[];
+  /**
+   * Total Conversations
+   * @default 0
+   */
+  total_conversations?: number;
+}
+
+/**
+ * AgentSortBy
+ * Sort specification for agent query endpoints.
+ */
+export interface AgentSortBy {
+  /** Field */
+  field: string;
+  /**
+   * Direction
+   * @default "desc"
+   */
+  direction?: 'asc' | 'desc';
+}
+
+/**
+ * AgentSpanGroupDistributionBin
+ * One numeric histogram bin for a custom attribute in a span group.
+ */
+export interface AgentSpanGroupDistributionBin {
+  /** Index */
+  index: number;
+  /** Min */
+  min: number;
+  /** Max */
+  max: number;
+  /** Count */
+  count: number;
+}
+
+/**
+ * AgentSpanGroupDistributionItem
+ * Distribution data for one span-group/custom-attribute pair.
+ */
+export interface AgentSpanGroupDistributionItem {
+  /** Alias */
+  alias: string;
+  /** Source */
+  source:
+    | 'custom_attrs_string'
+    | 'custom_attrs_int'
+    | 'custom_attrs_float'
+    | 'custom_attrs_bool';
+  /** Key */
+  key: string;
+  /** Value Type */
+  value_type: 'string' | 'int' | 'float' | 'bool';
+  /**
+   * Total Count
+   * @default 0
+   */
+  total_count?: number;
+  /**
+   * Present Count
+   * @default 0
+   */
+  present_count?: number;
+  /**
+   * Missing Count
+   * @default 0
+   */
+  missing_count?: number;
+  /**
+   * Other Count
+   * @default 0
+   */
+  other_count?: number;
+  /** Bins */
+  bins?: AgentSpanGroupDistributionBin[];
+  /** Values */
+  values?: AgentSpanGroupDistributionValue[];
+}
+
+/**
+ * AgentSpanGroupDistributionSpec
+ * One custom attribute distribution to compute per returned span group.
+ */
+export interface AgentSpanGroupDistributionSpec {
+  /**
+   * Alias
+   * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
+   */
+  alias: string;
+  /** Reference to a span field or typed custom attribute map value. */
+  value: AgentSpanValueRef;
+  /**
+   * Bins
+   * @min 1
+   * @max 50
+   * @default 12
+   */
+  bins?: number;
+  /**
+   * Top N
+   * @min 1
+   * @max 20
+   * @default 5
+   */
+  top_n?: number;
+}
+
+/**
+ * AgentSpanGroupDistributionValue
+ * One categorical custom attribute value count in a span group.
+ */
+export interface AgentSpanGroupDistributionValue {
+  /** Value */
+  value: string;
+  /** Count */
+  count: number;
+}
+
+/**
+ * AgentSpanGroupFilter
+ * Range filter over one grouped span measure.
+ */
+export interface AgentSpanGroupFilter {
+  /** Group By */
+  group_by?: AgentGroupByRef[];
+  /** One aggregate measure computed over spans in a group or bucket. */
+  measure: AgentSpanMeasureSpec;
+  /** Min */
+  min?: number | string | null;
+  /** Max */
+  max?: number | string | null;
+}
+
+/**
+ * AgentSpanGroupRow
+ * A single row in a grouped spans query response.
+ *
+ * `group_keys` maps each group_by ref's alias to its value for this row.
+ * The remaining fields are a fixed aggregate bundle computed per group.
+ */
+export interface AgentSpanGroupRow {
+  /** Group Keys */
+  group_keys?: Record<string, string | number | boolean | null>;
+  /**
+   * Span Count
+   * @default 0
+   */
+  span_count?: number;
+  /**
+   * Invocation Count
+   * @default 0
+   */
+  invocation_count?: number;
+  /**
+   * Conversation Count
+   * @default 0
+   */
+  conversation_count?: number;
+  /**
+   * Total Input Tokens
+   * @default 0
+   */
+  total_input_tokens?: number;
+  /**
+   * Total Cache Creation Input Tokens
+   * @default 0
+   */
+  total_cache_creation_input_tokens?: number;
+  /**
+   * Total Cache Read Input Tokens
+   * @default 0
+   */
+  total_cache_read_input_tokens?: number;
+  /**
+   * Total Output Tokens
+   * @default 0
+   */
+  total_output_tokens?: number;
+  /**
+   * Total Reasoning Tokens
+   * @default 0
+   */
+  total_reasoning_tokens?: number;
+  /**
+   * Total Duration Ms
+   * @default 0
+   */
+  total_duration_ms?: number;
+  /**
+   * Error Count
+   * @default 0
+   */
+  error_count?: number;
+  /** Agent Names */
+  agent_names?: string[];
+  /** Agent Versions */
+  agent_versions?: string[];
+  /** Provider Names */
+  provider_names?: string[];
+  /** Request Models */
+  request_models?: string[];
+  /** Conversation Names */
+  conversation_names?: string[];
+  /** First Seen */
+  first_seen?: string | null;
+  /** Last Seen */
+  last_seen?: string | null;
+  first_message?: AgentConversationMessagePreview | null;
+  last_message?: AgentConversationMessagePreview | null;
+  /** Metrics */
+  metrics?: Record<string, string | number | boolean | null>;
+  /** Distributions */
+  distributions?: Record<string, AgentSpanGroupDistributionItem>;
+}
+
+/**
+ * AgentSpanMeasureSpec
+ * One aggregate measure computed over spans in a group or bucket.
+ */
+export interface AgentSpanMeasureSpec {
+  /**
+   * Alias
+   * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
+   */
+  alias: string;
+  /** Aggregation */
+  aggregation:
+    | 'sum'
+    | 'avg'
+    | 'min'
+    | 'max'
+    | 'count'
+    | 'count_distinct'
+    | 'count_true'
+    | 'count_false';
+  value?: AgentSpanValueRef | null;
+  /** Value Type */
+  value_type?: 'datetime' | 'number' | 'boolean' | 'string' | null;
+  filter?: Query | null;
+}
+
+/**
+ * AgentSpanSchema
+ * A normalized agent span returned by query APIs.
+ */
+export interface AgentSpanSchema {
+  /** Project Id */
+  project_id: string;
+  /** Trace Id */
+  trace_id: string;
+  /** Span Id */
+  span_id: string;
+  /** Parent Span Id */
+  parent_span_id?: string | null;
+  /** Span Name */
+  span_name?: string | null;
+  /** Span Kind */
+  span_kind?:
+    | 'UNSPECIFIED'
+    | 'INTERNAL'
+    | 'SERVER'
+    | 'CLIENT'
+    | 'PRODUCER'
+    | 'CONSUMER'
+    | null;
+  /** Started At */
+  started_at?: string | null;
+  /** Ended At */
+  ended_at?: string | null;
+  /** Status Code */
+  status_code?: 'UNSET' | 'OK' | 'ERROR' | null;
+  /** Status Message */
+  status_message?: string | null;
+  /** Operation Name */
+  operation_name?: string | null;
+  /** Provider Name */
+  provider_name?: string | null;
+  /** Agent Name */
+  agent_name?: string | null;
+  /** Agent Id */
+  agent_id?: string | null;
+  /** Agent Description */
+  agent_description?: string | null;
+  /** Agent Version */
+  agent_version?: string | null;
+  /** Request Model */
+  request_model?: string | null;
+  /** Response Model */
+  response_model?: string | null;
+  /** Response Id */
+  response_id?: string | null;
+  /** Input Tokens */
+  input_tokens?: number | null;
+  /** Output Tokens */
+  output_tokens?: number | null;
+  /** Reasoning Tokens */
+  reasoning_tokens?: number | null;
+  /** Cache Creation Input Tokens */
+  cache_creation_input_tokens?: number | null;
+  /** Cache Read Input Tokens */
+  cache_read_input_tokens?: number | null;
+  /** Reasoning Content */
+  reasoning_content?: string | null;
+  /** Conversation Id */
+  conversation_id?: string | null;
+  /** Conversation Name */
+  conversation_name?: string | null;
+  /** Tool Name */
+  tool_name?: string | null;
+  /** Tool Type */
+  tool_type?: string | null;
+  /** Tool Call Id */
+  tool_call_id?: string | null;
+  /** Tool Description */
+  tool_description?: string | null;
+  /** Tool Definitions */
+  tool_definitions?: string | null;
+  /** Finish Reasons */
+  finish_reasons?: string[];
+  /** Error Type */
+  error_type?: string | null;
+  /** Request Temperature */
+  request_temperature?: number | null;
+  /** Request Max Tokens */
+  request_max_tokens?: number | null;
+  /** Request Top P */
+  request_top_p?: number | null;
+  /** Request Frequency Penalty */
+  request_frequency_penalty?: number | null;
+  /** Request Presence Penalty */
+  request_presence_penalty?: number | null;
+  /** Request Seed */
+  request_seed?: number | null;
+  /** Request Stop Sequences */
+  request_stop_sequences?: string[];
+  /** Request Choice Count */
+  request_choice_count?: number | null;
+  /** Output Type */
+  output_type?: string | null;
+  /** Input Messages */
+  input_messages?: NormalizedMessage[];
+  /** Output Messages */
+  output_messages?: NormalizedMessage[];
+  /** System Instructions */
+  system_instructions?: string[];
+  /** Tool Call Arguments */
+  tool_call_arguments?: string | null;
+  /** Tool Call Result */
+  tool_call_result?: string | null;
+  /** Compaction Summary */
+  compaction_summary?: string | null;
+  /** Compaction Items Before */
+  compaction_items_before?: number | null;
+  /** Compaction Items After */
+  compaction_items_after?: number | null;
+  /** Content Refs */
+  content_refs?: string[];
+  /** Artifact Refs */
+  artifact_refs?: string[];
+  /** Object Refs */
+  object_refs?: string[];
+  /** Custom Attrs String */
+  custom_attrs_string?: Record<string, string>;
+  /** Custom Attrs Int */
+  custom_attrs_int?: Record<string, number>;
+  /** Custom Attrs Float */
+  custom_attrs_float?: Record<string, number>;
+  /** Custom Attrs Bool */
+  custom_attrs_bool?: Record<string, boolean>;
+  /** Server Address */
+  server_address?: string | null;
+  /** Server Port */
+  server_port?: number | null;
+  /** Wb User Id */
+  wb_user_id?: string | null;
+  /** Wb Run Id */
+  wb_run_id?: string | null;
+  /** Wb Run Step */
+  wb_run_step?: number | null;
+  /** Wb Run Step End */
+  wb_run_step_end?: number | null;
+  /** Raw Span Dump */
+  raw_span_dump?: string | null;
+}
+
+/**
+ * AgentSpanStatsColumn
+ * Metadata describing one column in an agent span stats result row.
+ */
+export interface AgentSpanStatsColumn {
+  /** Name */
+  name: string;
+  /** Role */
+  role: 'time' | 'bucket' | 'group' | 'metric';
+  /** Value Type */
+  value_type: 'datetime' | 'number' | 'boolean' | 'string';
+  /** Metric */
+  metric?: string | null;
+  /** Aggregation */
+  aggregation?: string | null;
+}
+
+/**
+ * AgentSpanStatsMetricSpec
+ * Metric to extract from each matching span and aggregate into chart rows.
+ */
+export interface AgentSpanStatsMetricSpec {
+  /**
+   * Alias
+   * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
+   */
+  alias: string;
+  /** Value Type */
+  value_type: 'datetime' | 'number' | 'boolean' | 'string';
+  /** Aggregations */
+  aggregations?: (
+    | 'sum'
+    | 'avg'
+    | 'min'
+    | 'max'
+    | 'count'
+    | 'count_distinct'
+    | 'count_true'
+    | 'count_false'
+  )[];
+  /** Percentiles */
+  percentiles?: number[];
+  /** Reference to a span field or typed custom attribute map value. */
+  value: AgentSpanValueRef;
+}
+
+/**
+ * AgentSpanStatsNumericBucketSpec
+ * Bucket stats rows by ranges of one numeric span or grouped value.
+ */
+export interface AgentSpanStatsNumericBucketSpec {
+  /**
+   * Type
+   * @default "number"
+   */
+  type?: 'number';
+  /**
+   * Alias
+   * @default "value"
+   * @pattern ^[a-zA-Z_][a-zA-Z0-9_]*$
+   */
+  alias?: string;
+  /**
+   * Bins
+   * @min 1
+   * @max 200
+   * @default 24
+   */
+  bins?: number;
+  /** Min */
+  min?: number | null;
+  /** Max */
+  max?: number | null;
+  value?: AgentSpanValueRef | null;
+  /** Group By */
+  group_by?: AgentGroupByRef[];
+  measure?: AgentSpanMeasureSpec | null;
+}
+
+/**
+ * AgentSpanStatsReq
+ * Request chart-ready aggregations over GenAI agent spans.
+ */
+export interface AgentSpanStatsReq {
+  /** Project Id */
+  project_id: string;
+  query?: Query | null;
+  /**
+   * Start
+   * @format date-time
+   */
+  start: string;
+  /** End */
+  end?: string | null;
+  /** Granularity */
+  granularity?: number | null;
+  /**
+   * Timezone
+   * @default "UTC"
+   */
+  timezone?: string;
+  /** Group By */
+  group_by?: AgentGroupByRef[];
+  /** Metrics */
+  metrics?: AgentSpanStatsMetricSpec[];
+  /**
+   * Group Limit
+   * @min 1
+   * @max 1000
+   * @default 50
+   */
+  group_limit?: number;
+  /** Bucket By */
+  bucket_by?:
+    | (
+        | ({
+            type: 'number';
+          } & AgentSpanStatsNumericBucketSpec)
+        | ({
+            type: 'time';
+          } & AgentSpanStatsTimeBucketSpec)
+      )
+    | null;
+  /** Group Filters */
+  group_filters?: AgentSpanGroupFilter[];
+}
+
+/**
+ * AgentSpanStatsRes
+ * Response containing chart-ready agent span stats rows.
+ */
+export interface AgentSpanStatsRes {
+  /**
+   * Start
+   * @format date-time
+   */
+  start: string;
+  /**
+   * End
+   * @format date-time
+   */
+  end: string;
+  /** Granularity */
+  granularity?: number | null;
+  /** Timezone */
+  timezone: string;
+  /**
+   * Bucket Type
+   * @default "time"
+   */
+  bucket_type?: 'time' | 'number';
+  /** Columns */
+  columns?: AgentSpanStatsColumn[];
+  /** Rows */
+  rows?: Record<string, string | number | boolean | null>[];
+}
+
+/**
+ * AgentSpanStatsTimeBucketSpec
+ * Bucket stats rows by started_at time intervals.
+ */
+export interface AgentSpanStatsTimeBucketSpec {
+  /**
+   * Type
+   * @default "time"
+   */
+  type?: 'time';
+}
+
+/**
+ * AgentSpanValueRef
+ * Reference to a span field or typed custom attribute map value.
+ */
+export interface AgentSpanValueRef {
+  /**
+   * Source
+   * @default "field"
+   */
+  source?:
+    | 'field'
+    | 'derived'
+    | 'custom_attrs_string'
+    | 'custom_attrs_int'
+    | 'custom_attrs_float'
+    | 'custom_attrs_bool';
+  /** Key */
+  key: string;
+}
+
+/**
+ * AgentSpansQueryReq
+ * Request to query agent spans for a project.
+ *
+ * When `group_by` is empty (or omitted), returns raw span rows in the
+ * response's `spans` field. When `group_by` is non-empty, returns
+ * aggregate group rows in the response's `groups` field.
+ */
+export interface AgentSpansQueryReq {
+  /** Project Id */
+  project_id: string;
+  query?: Query | null;
+  /** Group By */
+  group_by?: AgentGroupByRef[] | null;
+  /** Measures */
+  measures?: AgentSpanMeasureSpec[];
+  /** Group Filters */
+  group_filters?: AgentSpanGroupFilter[];
+  /**
+   * Group Distributions
+   * @maxItems 20
+   */
+  group_distributions?: AgentSpanGroupDistributionSpec[];
+  /** Custom Attr Columns */
+  custom_attr_columns?: AgentSpanValueRef[];
+  /**
+   * Include Details
+   * @default false
+   */
+  include_details?: boolean;
+  /** Sort By */
+  sort_by?: AgentSortBy[] | null;
+  /**
+   * Limit
+   * @min 0
+   * @max 10000
+   * @default 100
+   */
+  limit?: number;
+  /**
+   * Offset
+   * @min 0
+   * @default 0
+   */
+  offset?: number;
+  /** Started After */
+  started_after?: string | null;
+  /** Started Before */
+  started_before?: string | null;
+}
+
+/**
+ * AgentSpansQueryRes
+ * Response from a spans query.
+ *
+ * Exactly one of `spans` or `groups` will be populated, based on
+ * whether the request specified `group_by`.
+ */
+export interface AgentSpansQueryRes {
+  /** Spans */
+  spans?: AgentSpanSchema[];
+  /** Groups */
+  groups?: AgentSpanGroupRow[];
+  /**
+   * Total Count
+   * @default 0
+   */
+  total_count?: number;
+}
+
+/**
+ * AgentTraceChatReq
+ * Request to get the structured chat / trajectory view for a trace.
+ */
+export interface AgentTraceChatReq {
+  /** Project Id */
+  project_id: string;
+  /** Trace Id */
+  trace_id: string;
+  /**
+   * Include Feedback
+   * @default false
+   */
+  include_feedback?: boolean;
+}
+
+/**
+ * AgentTraceChatRes
+ * Structured chat view: a linear sequence of messages representing
+ * the agent trajectory for a single trace.
+ */
+export interface AgentTraceChatRes {
+  /** Trace Id */
+  trace_id: string;
+  /** Root Span Name */
+  root_span_name?: string | null;
+  /** Provider */
+  provider?: string | null;
+  /**
+   * Total Duration Ms
+   * Wall-clock duration of the trace root span in milliseconds. This is not a sum of child span durations.
+   */
+  total_duration_ms?: number | null;
+  /** Messages */
+  messages?: AgentChatMessage[];
+  /** Feedback */
+  feedback?: Record<string, any>[] | null;
+}
+
+/**
+ * AgentVersionSchema
+ * Aggregated per-version stats from the agent_versions AMT.
+ */
+export interface AgentVersionSchema {
+  /** Project Id */
+  project_id: string;
+  /** Agent Name */
+  agent_name: string;
+  /** Invocation Count */
+  invocation_count: number;
+  /** Span Count */
+  span_count: number;
+  /** Total Input Tokens */
+  total_input_tokens: number;
+  /** Total Output Tokens */
+  total_output_tokens: number;
+  /** Total Duration Ms */
+  total_duration_ms: number;
+  /** Error Count */
+  error_count: number;
+  /** First Seen */
+  first_seen: string | null;
+  /** Last Seen */
+  last_seen: string | null;
+  /** Agent Version */
+  agent_version: string;
+}
+
+/**
+ * AgentVersionsQueryReq
+ * Request to list versions for an agent.
+ */
+export interface AgentVersionsQueryReq {
+  /** Project Id */
+  project_id: string;
+  /** Agent Name */
+  agent_name: string;
+  /** Sort By */
+  sort_by?: AgentSortBy[] | null;
+  /**
+   * Limit
+   * @min 0
+   * @max 10000
+   * @default 100
+   */
+  limit?: number;
+  /**
+   * Offset
+   * @min 0
+   * @default 0
+   */
+  offset?: number;
+}
+
+/**
+ * AgentVersionsQueryRes
+ * Response containing agent version stats.
+ */
+export interface AgentVersionsQueryRes {
+  /** Versions */
+  versions: AgentVersionSchema[];
+  /**
+   * Total Count
+   * @default 0
+   */
+  total_count?: number;
+}
+
+/**
+ * AgentsQueryFilters
+ * Optional filters for querying agents.
+ */
+export interface AgentsQueryFilters {
+  /** Agent Name */
+  agent_name?: string | null;
+}
+
+/**
+ * AgentsQueryReq
+ * Request to list agents with aggregated stats for a project.
+ */
+export interface AgentsQueryReq {
+  /** Project Id */
+  project_id: string;
+  filters?: AgentsQueryFilters | null;
+  /** Sort By */
+  sort_by?: AgentSortBy[] | null;
+  /**
+   * Limit
+   * @min 0
+   * @max 10000
+   * @default 100
+   */
+  limit?: number;
+  /**
+   * Offset
+   * @min 0
+   * @default 0
+   */
+  offset?: number;
+}
+
+/**
+ * AgentsQueryRes
+ * Response containing aggregated agent stats.
+ */
+export interface AgentsQueryRes {
+  /** Agents */
+  agents: AgentSchema[];
+  /**
+   * Total Count
+   * @default 0
+   */
+  total_count?: number;
+}
+
+/** AliasesListRes */
+export interface AliasesListRes {
+  /** Aliases */
+  aliases: string[];
+}
+
+/**
+ * AndOperation
+ * Logical AND. All conditions must evaluate to true.
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$and": [
+ *             {"$eq": [{"$getField": "op_name"}, {"$literal": "predict"}]},
+ *             {"$gt": [{"$getField": "summary.usage.tokens"}, {"$literal": 1000}]}
+ *         ]
+ *     }
+ *     ```
+ */
 export interface AndOperation {
   /** $And */
   $and: (
@@ -22,10 +1310,365 @@ export interface AndOperation {
     | NotOperation
     | EqOperation
     | GtOperation
+    | LtOperation
     | GteOperation
+    | LteOperation
     | InOperation
     | ContainsOperation
   )[];
+}
+
+/**
+ * AnnotationQueueAddCallsBody
+ * Request body for adding calls to an annotation queue (queue_id comes from path).
+ */
+export interface AnnotationQueueAddCallsBody {
+  /** Project Id */
+  project_id: string;
+  /** Call Ids */
+  call_ids: string[];
+  /**
+   * Display Fields
+   * JSON paths to display to annotators
+   */
+  display_fields: string[];
+}
+
+/**
+ * AnnotationQueueAddCallsRes
+ * Response from adding calls to a queue.
+ */
+export interface AnnotationQueueAddCallsRes {
+  /** Added Count */
+  added_count: number;
+  /** Duplicates */
+  duplicates: number;
+}
+
+/**
+ * AnnotationQueueCreateReq
+ * Request to create a new annotation queue.
+ */
+export interface AnnotationQueueCreateReq {
+  /** Project Id */
+  project_id: string;
+  /** Name */
+  name: string;
+  /**
+   * Description
+   * @default ""
+   */
+  description?: string;
+  /** Scorer Refs */
+  scorer_refs: string[];
+  /**
+   * Wb User Id
+   * Do not set directly. Server will automatically populate this field.
+   */
+  wb_user_id?: string | null;
+}
+
+/**
+ * AnnotationQueueCreateRes
+ * Response from creating an annotation queue.
+ */
+export interface AnnotationQueueCreateRes {
+  /** Id */
+  id: string;
+}
+
+/**
+ * AnnotationQueueDeleteRes
+ * Response from deleting an annotation queue.
+ */
+export interface AnnotationQueueDeleteRes {
+  /** Schema for annotation queue responses. */
+  queue: AnnotationQueueSchema;
+}
+
+/**
+ * AnnotationQueueItemProgressUpdateBody
+ * Request body for updating annotation progress (queue_id and item_id come from path).
+ *
+ * Note: wb_user_id is not included in the body - it's set server-side from the authenticated session.
+ */
+export interface AnnotationQueueItemProgressUpdateBody {
+  /** Project Id */
+  project_id: string;
+  /**
+   * Annotation State
+   * New state: 'in_progress', 'completed', or 'skipped'
+   */
+  annotation_state: string;
+}
+
+/**
+ * AnnotationQueueItemSchema
+ * Schema for annotation queue item responses.
+ */
+export interface AnnotationQueueItemSchema {
+  /** Id */
+  id: string;
+  /** Project Id */
+  project_id: string;
+  /** Queue Id */
+  queue_id: string;
+  /** Call Id */
+  call_id: string;
+  /**
+   * Call Started At
+   * @format date-time
+   */
+  call_started_at: string;
+  /** Call Ended At */
+  call_ended_at?: string | null;
+  /** Call Op Name */
+  call_op_name: string;
+  /** Call Trace Id */
+  call_trace_id: string;
+  /** Display Fields */
+  display_fields: string[];
+  /** Added By */
+  added_by?: string | null;
+  /** Annotation State */
+  annotation_state: 'unstarted' | 'in_progress' | 'completed' | 'skipped';
+  /** Annotator User Id */
+  annotator_user_id?: string | null;
+  /**
+   * Created At
+   * @format date-time
+   */
+  created_at: string;
+  /** Created By */
+  created_by: string;
+  /**
+   * Updated At
+   * @format date-time
+   */
+  updated_at: string;
+  /** Deleted At */
+  deleted_at?: string | null;
+  /** Position In Queue */
+  position_in_queue?: number | null;
+}
+
+/**
+ * AnnotationQueueItemsFilter
+ * Simple filter for annotation queue items.
+ *
+ * Supports equality filtering on call metadata fields and IN filtering on annotation state.
+ */
+export interface AnnotationQueueItemsFilter {
+  /**
+   * Id
+   * Filter by exact queue item ID
+   */
+  id?: string | null;
+  /**
+   * Call Id
+   * Filter by exact call ID
+   */
+  call_id?: string | null;
+  /**
+   * Call Op Name
+   * Filter by exact operation name
+   */
+  call_op_name?: string | null;
+  /**
+   * Call Trace Id
+   * Filter by exact trace ID
+   */
+  call_trace_id?: string | null;
+  /**
+   * Added By
+   * Filter by W&B user ID who added the call
+   */
+  added_by?: string | null;
+  /**
+   * Annotation States
+   * Filter by annotation states (unstarted, in_progress, completed, skipped)
+   */
+  annotation_states?:
+    | ('unstarted' | 'in_progress' | 'completed' | 'skipped')[]
+    | null;
+}
+
+/**
+ * AnnotationQueueItemsQueryBody
+ * Request body for querying items in an annotation queue (queue_id comes from path).
+ */
+export interface AnnotationQueueItemsQueryBody {
+  /** Project Id */
+  project_id: string;
+  /** Filter queue items by call metadata and annotation state */
+  filter?: AnnotationQueueItemsFilter | null;
+  /**
+   * Sort By
+   * Sort by multiple fields (e.g., created_at, updated_at)
+   */
+  sort_by?: SortBy[] | null;
+  /** Limit */
+  limit?: number | null;
+  /** Offset */
+  offset?: number | null;
+  /**
+   * Include Position
+   * Include position_in_queue field (1-based index in full queue)
+   * @default false
+   */
+  include_position?: boolean;
+}
+
+/**
+ * AnnotationQueueItemsQueryRes
+ * Response from querying annotation queue items.
+ */
+export interface AnnotationQueueItemsQueryRes {
+  /** Items */
+  items: AnnotationQueueItemSchema[];
+}
+
+/**
+ * AnnotationQueueReadRes
+ * Response from reading an annotation queue.
+ */
+export interface AnnotationQueueReadRes {
+  /** Schema for annotation queue responses. */
+  queue: AnnotationQueueSchema;
+}
+
+/**
+ * AnnotationQueueSchema
+ * Schema for annotation queue responses.
+ */
+export interface AnnotationQueueSchema {
+  /** Id */
+  id: string;
+  /** Project Id */
+  project_id: string;
+  /** Name */
+  name: string;
+  /** Description */
+  description: string;
+  /** Scorer Refs */
+  scorer_refs: string[];
+  /**
+   * Created At
+   * @format date-time
+   */
+  created_at: string;
+  /** Created By */
+  created_by: string;
+  /**
+   * Updated At
+   * @format date-time
+   */
+  updated_at: string;
+  /** Deleted At */
+  deleted_at?: string | null;
+}
+
+/**
+ * AnnotationQueueStatsSchema
+ * Statistics for a single annotation queue.
+ */
+export interface AnnotationQueueStatsSchema {
+  /**
+   * Queue Id
+   * The queue ID
+   */
+  queue_id: string;
+  /**
+   * Total Items
+   * Total number of items in the queue
+   */
+  total_items: number;
+  /**
+   * Completed Items
+   * Number of items completed or skipped by at least one annotator
+   */
+  completed_items: number;
+}
+
+/**
+ * AnnotationQueueUpdateBody
+ * Request body for updating an annotation queue (queue_id comes from path).
+ *
+ * All fields except project_id are optional - only provided fields will be updated.
+ */
+export interface AnnotationQueueUpdateBody {
+  /** Project Id */
+  project_id: string;
+  /** Name */
+  name?: string | null;
+  /** Description */
+  description?: string | null;
+  /** Scorer Refs */
+  scorer_refs?: string[] | null;
+}
+
+/**
+ * AnnotationQueueUpdateRes
+ * Response from updating an annotation queue.
+ */
+export interface AnnotationQueueUpdateRes {
+  /** Schema for annotation queue responses. */
+  queue: AnnotationQueueSchema;
+}
+
+/**
+ * AnnotationQueuesQueryReq
+ * Request to query annotation queues for a project.
+ */
+export interface AnnotationQueuesQueryReq {
+  /** Project Id */
+  project_id: string;
+  /**
+   * Name
+   * Filter by queue name (case-insensitive partial match)
+   */
+  name?: string | null;
+  /**
+   * Sort By
+   * Sort by multiple fields (e.g., created_at, updated_at, name)
+   */
+  sort_by?: SortBy[] | null;
+  /** Limit */
+  limit?: number | null;
+  /** Offset */
+  offset?: number | null;
+}
+
+/**
+ * AnnotationQueuesStatsReq
+ * Request to get stats for multiple annotation queues.
+ */
+export interface AnnotationQueuesStatsReq {
+  /** Project Id */
+  project_id: string;
+  /**
+   * Queue Ids
+   * List of queue IDs to get stats for
+   */
+  queue_ids: string[];
+}
+
+/**
+ * AnnotationQueuesStatsRes
+ * Response with stats for multiple annotation queues.
+ */
+export interface AnnotationQueuesStatsRes {
+  /** Stats */
+  stats: AnnotationQueueStatsSchema[];
+}
+
+/**
+ * AnnotatorQueueItemsProgressUpdateRes
+ * Response from updating annotation state.
+ */
+export interface AnnotatorQueueItemsProgressUpdateRes {
+  /** Schema for annotation queue item responses. */
+  item: AnnotationQueueItemSchema;
 }
 
 /** Body_file_create_file_create_post */
@@ -79,6 +1722,30 @@ export interface CallEndReq {
 /** CallEndRes */
 export type CallEndRes = object;
 
+/**
+ * CallMetricSpec
+ * Specification for a call-level metric to aggregate (not grouped by model).
+ */
+export interface CallMetricSpec {
+  /**
+   * Metric
+   * Metric to aggregate.
+   */
+  metric: 'latency_ms' | 'call_count' | 'error_count';
+  /**
+   * Aggregations
+   * Basic aggregation functions to apply
+   * @default ["sum"]
+   */
+  aggregations?: AggregationType[];
+  /**
+   * Percentiles
+   * Percentile values to compute (0-100). E.g., [50, 95, 99] for p50, p95, p99
+   * @default []
+   */
+  percentiles?: number[];
+}
+
 /** CallReadReq */
 export interface CallReadReq {
   /** Project Id */
@@ -90,6 +1757,16 @@ export interface CallReadReq {
    * @default false
    */
   include_costs?: boolean | null;
+  /**
+   * Include Storage Size
+   * @default false
+   */
+  include_storage_size?: boolean | null;
+  /**
+   * Include Total Storage Size
+   * @default false
+   */
+  include_total_storage_size?: boolean | null;
 }
 
 /** CallReadRes */
@@ -111,28 +1788,47 @@ export interface CallSchema {
   trace_id: string;
   /** Parent Id */
   parent_id?: string | null;
+  /** Thread Id */
+  thread_id?: string | null;
+  /** Turn Id */
+  turn_id?: string | null;
   /**
    * Started At
    * @format date-time
    */
   started_at: string;
   /** Attributes */
-  attributes: object;
+  attributes: Record<string, any>;
   /** Inputs */
-  inputs: object;
+  inputs: Record<string, any>;
   /** Ended At */
   ended_at?: string | null;
   /** Exception */
   exception?: string | null;
   /** Output */
   output?: null;
-  summary?: object;
+  summary?: Record<string, any>;
   /** Wb User Id */
   wb_user_id?: string | null;
+  /** Wb Username */
+  wb_username?: string | null;
   /** Wb Run Id */
   wb_run_id?: string | null;
+  /** Wb Run Step */
+  wb_run_step?: number | null;
+  /** Wb Run Step End */
+  wb_run_step_end?: number | null;
   /** Deleted At */
   deleted_at?: string | null;
+  /**
+   * Expire At
+   * Expiration timestamp for this call. None = no TTL configured for the project (the row will not be expired).
+   */
+  expire_at?: string | null;
+  /** Storage Size Bytes */
+  storage_size_bytes?: number | null;
+  /** Total Storage Size Bytes */
+  total_storage_size_bytes?: number | null;
 }
 
 /** CallStartReq */
@@ -146,6 +1842,89 @@ export interface CallStartRes {
   id: string;
   /** Trace Id */
   trace_id: string;
+}
+
+/**
+ * CallStatsReq
+ * Request for aggregated call statistics over a time range.
+ */
+export interface CallStatsReq {
+  /** Project Id */
+  project_id: string;
+  /**
+   * Start
+   * Inclusive start time (UTC, ISO 8601).
+   * @format date-time
+   */
+  start: string;
+  /**
+   * End
+   * Exclusive end time (UTC, ISO 8601). Defaults to now if omitted.
+   */
+  end?: string | null;
+  /**
+   * Granularity
+   * Bucket size in seconds (e.g., 3600 for 1 hour). If omitted, auto-selected based on time range. Will be adjusted if it would produce more than 10,000 buckets.
+   */
+  granularity?: number | null;
+  /**
+   * Usage Metrics
+   * Usage metrics (tokens, cost) to compute. Grouped by timestamp and model.
+   */
+  usage_metrics?: UsageMetricSpec[] | null;
+  /**
+   * Call Metrics
+   * Call-level metrics (latency, counts) to compute. Grouped by timestamp only.
+   */
+  call_metrics?: CallMetricSpec[] | null;
+  filter?: CallsFilter | null;
+  /**
+   * Timezone
+   * IANA timezone for bucket alignment (e.g., 'America/New_York')
+   * @default "UTC"
+   */
+  timezone?: string;
+}
+
+/**
+ * CallStatsRes
+ * Response containing time-series call statistics.
+ */
+export interface CallStatsRes {
+  /**
+   * Start
+   * Resolved start time (UTC)
+   * @format date-time
+   */
+  start: string;
+  /**
+   * End
+   * Resolved end time (UTC)
+   * @format date-time
+   */
+  end: string;
+  /**
+   * Granularity
+   * Bucket size used (in seconds)
+   */
+  granularity: number;
+  /**
+   * Timezone
+   * Timezone used for bucket alignment
+   */
+  timezone: string;
+  /**
+   * Usage Buckets
+   * Usage metrics by model. Each bucket contains 'timestamp', 'model', and aggregated metric values.
+   * @default []
+   */
+  usage_buckets?: Record<string, any>[];
+  /**
+   * Call Buckets
+   * Call-level metrics. Each bucket contains 'timestamp' and aggregated metric values.
+   * @default []
+   */
+  call_buckets?: Record<string, any>[];
 }
 
 /** CallUpdateReq */
@@ -180,7 +1959,13 @@ export interface CallsDeleteReq {
 }
 
 /** CallsDeleteRes */
-export type CallsDeleteRes = object;
+export interface CallsDeleteRes {
+  /**
+   * Num Deleted
+   * The number of calls deleted
+   */
+  num_deleted: number;
+}
 
 /** CallsFilter */
 export interface CallsFilter {
@@ -196,6 +1981,10 @@ export interface CallsFilter {
   trace_ids?: string[] | null;
   /** Call Ids */
   call_ids?: string[] | null;
+  /** Thread Ids */
+  thread_ids?: string[] | null;
+  /** Turn Ids */
+  turn_ids?: string[] | null;
   /** Trace Roots Only */
   trace_roots_only?: boolean | null;
   /** Wb User Ids */
@@ -228,6 +2017,24 @@ export interface CallsQueryReq {
    * @default false
    */
   include_feedback?: boolean | null;
+  /**
+   * Include Storage Size
+   * Beta, subject to change. If true, the response will include the storage size for a call.
+   * @default false
+   */
+  include_storage_size?: boolean | null;
+  /**
+   * Include Total Storage Size
+   * Beta, subject to change. If true, the response will include the total storage size for a trace.
+   * @default false
+   */
+  include_total_storage_size?: boolean | null;
+  /**
+   * Include Usernames
+   * If true, the response will attempt to resolve each call's wb_user_id to a username for the duration of this request.
+   * @default false
+   */
+  include_usernames?: boolean | null;
   /** Columns */
   columns?: string[] | null;
   /**
@@ -235,6 +2042,12 @@ export interface CallsQueryReq {
    * Columns to expand, i.e. refs to other objects
    */
   expand_columns?: string[] | null;
+  /**
+   * Return Expanded Column Values
+   * If true, the response will include raw values for expanded columns. If false, the response expand_columns will only be used for filtering and ordering. This is useful for clients that want to resolve refs themselves, e.g. for performance reasons.
+   * @default true
+   */
+  return_expanded_column_values?: boolean | null;
 }
 
 /** CallsQueryStatsReq */
@@ -243,6 +2056,18 @@ export interface CallsQueryStatsReq {
   project_id: string;
   filter?: CallsFilter | null;
   query?: Query | null;
+  /** Limit */
+  limit?: number | null;
+  /**
+   * Include Total Storage Size
+   * @default false
+   */
+  include_total_storage_size?: boolean | null;
+  /**
+   * Expand Columns
+   * Columns with refs to objects or table rows that require expansion during filtering or ordering.
+   */
+  expand_columns?: string[] | null;
 }
 
 /** CallsQueryStatsRes */
@@ -251,18 +2076,136 @@ export interface CallsQueryStatsRes {
   count: number;
   /**
    * Has More
-   * True when count saturated the request's limit (caller-supplied or the server's defense-in-depth ceiling). Clients should render the count as e.g. '10,000+'.
    * @default false
    */
   has_more?: boolean;
+  /** Total Storage Size Bytes */
+  total_storage_size_bytes?: number | null;
 }
 
-/** ContainsOperation */
+/**
+ * CallsScoreReq
+ * Request to enqueue scoring jobs for a list of calls.
+ *
+ * Scoring is performed asynchronously by the call_scoring_worker, which
+ * consumes messages from Kafka and applies each scorer_ref to each call_id.
+ */
+export interface CallsScoreReq {
+  /** Project Id */
+  project_id: string;
+  /**
+   * Call Ids
+   * List of call IDs to score
+   */
+  call_ids: string[];
+  /**
+   * Scorer Refs
+   * List of scorer refs to apply
+   */
+  scorer_refs: string[];
+  /**
+   * Wb User Id
+   * Do not set directly. Server will automatically populate this field.
+   */
+  wb_user_id?: string | null;
+}
+
+/**
+ * CallsScoreRes
+ * Empty response for calls_score.
+ *
+ * Defined as a model (rather than returning None) to follow the convention
+ * used throughout this interface and to allow fields to be added later
+ * without a breaking change.
+ */
+export type CallsScoreRes = object;
+
+/**
+ * CallsUsageReq
+ * Request to compute aggregated usage for multiple root calls.
+ *
+ * This endpoint returns usage metrics for each requested root call, where each
+ * root's metrics include the sum of its own usage plus all descendants' usage.
+ *
+ * Note: All matching calls are loaded into memory for aggregation. For very large
+ * result sets (>10k calls), consider batching root call IDs or using narrower
+ * filters at the application layer.
+ */
+export interface CallsUsageReq {
+  /** Project Id */
+  project_id: string;
+  /**
+   * Call Ids
+   * Root call IDs to aggregate. Each result key corresponds to one input call ID.
+   */
+  call_ids: string[];
+  /**
+   * Include Costs
+   * If true, include cost calculations in the usage.
+   * @default false
+   */
+  include_costs?: boolean;
+  /**
+   * Limit
+   * Maximum number of calls to process across all traces. Acts as a safety limit to prevent unbounded memory usage.
+   * @default 10000
+   */
+  limit?: number;
+}
+
+/**
+ * CallsUsageRes
+ * Response with aggregated usage metrics per root call.
+ */
+export interface CallsUsageRes {
+  /** Call Usage */
+  call_usage?: Record<string, Record<string, LLMAggregatedUsage>>;
+  /** Unfinished Call Ids */
+  unfinished_call_ids?: string[];
+}
+
+/** CatalogModelsRes */
+export interface CatalogModelsRes {
+  /** Models */
+  models: LLMModelDetails[];
+}
+
+/**
+ * ContainsOperation
+ * Case-insensitive substring match.
+ *
+ * Not part of MongoDB. Weave-specific addition.
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$contains": {
+ *             "input": {"$getField": "display_name"},
+ *             "substr": {"$literal": "llm"},
+ *             "case_insensitive": true
+ *         }
+ *     }
+ *     ```
+ */
 export interface ContainsOperation {
+  /**
+   * Specification for the `$contains` operation.
+   *
+   * - `input`: The string to search.
+   * - `substr`: The substring to search for.
+   * - `case_insensitive`: If true, match is case-insensitive.
+   */
   $contains: ContainsSpec;
 }
 
-/** ContainsSpec */
+/**
+ * ContainsSpec
+ * Specification for the `$contains` operation.
+ *
+ * - `input`: The string to search.
+ * - `substr`: The substring to search for.
+ * - `case_insensitive`: If true, match is case-insensitive.
+ */
 export interface ContainsSpec {
   /** Input */
   input:
@@ -274,7 +2217,9 @@ export interface ContainsSpec {
     | NotOperation
     | EqOperation
     | GtOperation
+    | LtOperation
     | GteOperation
+    | LteOperation
     | InOperation
     | ContainsOperation;
   /** Substr */
@@ -287,7 +2232,9 @@ export interface ContainsSpec {
     | NotOperation
     | EqOperation
     | GtOperation
+    | LtOperation
     | GteOperation
+    | LteOperation
     | InOperation
     | ContainsOperation;
   /**
@@ -297,12 +2244,37 @@ export interface ContainsSpec {
   case_insensitive?: boolean | null;
 }
 
-/** ConvertOperation */
+/**
+ * ConvertOperation
+ * Convert the input value to a specific type (e.g., `int`, `bool`, `string`).
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$convert": {
+ *             "input": {"$getField": "inputs.value"},
+ *             "to": "int"
+ *         }
+ *     }
+ *     ```
+ */
 export interface ConvertOperation {
+  /**
+   * Specifies conversion details for `$convert`.
+   *
+   * - `input`: The operand to convert.
+   * - `to`: The type to convert to.
+   */
   $convert: ConvertSpec;
 }
 
-/** ConvertSpec */
+/**
+ * ConvertSpec
+ * Specifies conversion details for `$convert`.
+ *
+ * - `input`: The operand to convert.
+ * - `to`: The type to convert to.
+ */
 export interface ConvertSpec {
   /** Input */
   input:
@@ -314,7 +2286,9 @@ export interface ConvertSpec {
     | NotOperation
     | EqOperation
     | GtOperation
+    | LtOperation
     | GteOperation
+    | LteOperation
     | InOperation
     | ContainsOperation;
   /** To */
@@ -327,6 +2301,16 @@ export interface CostCreateInput {
   prompt_token_cost: number;
   /** Completion Token Cost */
   completion_token_cost: number;
+  /**
+   * Cache Read Input Token Cost
+   * @default 0
+   */
+  cache_read_input_token_cost?: number;
+  /**
+   * Cache Creation Input Token Cost
+   * @default 0
+   */
+  cache_creation_input_token_cost?: number;
   /**
    * Prompt Token Cost Unit
    * The unit of the cost for the prompt tokens
@@ -421,6 +2405,139 @@ export interface CostQueryRes {
   results: CostQueryOutput[];
 }
 
+/** CreateAndLinkPayload */
+export interface CreateAndLinkPayload {
+  /**
+   * Ref
+   * @minLength 1
+   */
+  ref: string;
+  target: CreateAndLinkTarget;
+  /**
+   * Aliases
+   * @default []
+   */
+  aliases?: string[];
+}
+
+/** CreateAndLinkTarget */
+export interface CreateAndLinkTarget {
+  /**
+   * Portfolio Name
+   * @minLength 1
+   */
+  portfolio_name: string;
+  /**
+   * Entity Name
+   * @minLength 1
+   */
+  entity_name: string;
+  /**
+   * Project Name
+   * @minLength 1
+   */
+  project_name: string;
+}
+
+/** CreateAndLinkWeaveAssetRes */
+export interface CreateAndLinkWeaveAssetRes {
+  /** Version Index */
+  version_index?: number | null;
+}
+
+/** Datacenter */
+export interface Datacenter {
+  /** Country Code */
+  country_code: string;
+}
+
+/** DatasetCreateBody */
+export interface DatasetCreateBody {
+  /**
+   * Name
+   * The name of this dataset.  Datasets with the same name will be versioned together.
+   */
+  name?: string | null;
+  /**
+   * Description
+   * A description of this dataset
+   */
+  description?: string | null;
+  /**
+   * Rows
+   * Dataset rows
+   */
+  rows: Record<string, any>[];
+}
+
+/** DatasetCreateRes */
+export interface DatasetCreateRes {
+  /**
+   * Digest
+   * The digest of the created dataset
+   */
+  digest: string;
+  /**
+   * Object Id
+   * The ID of the created dataset
+   */
+  object_id: string;
+  /**
+   * Version Index
+   * The version index of the created dataset
+   */
+  version_index: number;
+}
+
+/** DatasetDeleteRes */
+export interface DatasetDeleteRes {
+  /**
+   * Num Deleted
+   * Number of dataset versions deleted
+   */
+  num_deleted: number;
+}
+
+/** DatasetReadRes */
+export interface DatasetReadRes {
+  /**
+   * Object Id
+   * The dataset ID
+   */
+  object_id: string;
+  /**
+   * Digest
+   * The digest of the dataset object
+   */
+  digest: string;
+  /**
+   * Version Index
+   * The version index of the object
+   */
+  version_index: number;
+  /**
+   * Created At
+   * When the object was created
+   * @format date-time
+   */
+  created_at: string;
+  /**
+   * Name
+   * The name of the dataset
+   */
+  name: string;
+  /**
+   * Description
+   * Description of the dataset
+   */
+  description?: string | null;
+  /**
+   * Rows
+   * Reference to the dataset rows data
+   */
+  rows: string;
+}
+
 /** EndedCallSchemaForInsert */
 export interface EndedCallSchemaForInsert {
   /** Project Id */
@@ -432,15 +2549,29 @@ export interface EndedCallSchemaForInsert {
    * @format date-time
    */
   ended_at: string;
+  /** Started At */
+  started_at?: string | null;
   /** Exception */
   exception?: string | null;
   /** Output */
   // TODO: This type is manually updated at the moment. https://github.com/wandb/weave/pull/6195/changes#r2850346035
   output?: any;
   summary: SummaryInsertMap;
+  /** Wb Run Step End */
+  wb_run_step_end?: number | null;
 }
 
-/** EqOperation */
+/**
+ * EqOperation
+ * Equality check between two operands.
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$eq": [{"$getField": "op_name"}, {"$literal": "predict"}]
+ *     }
+ *     ```
+ */
 export interface EqOperation {
   /**
    * $Eq
@@ -450,8 +2581,598 @@ export interface EqOperation {
   $eq: any[];
 }
 
+/** EvalResultsEvaluationSummary */
+export interface EvalResultsEvaluationSummary {
+  /** Evaluation Call Id */
+  evaluation_call_id: string;
+  /**
+   * Trial Count
+   * @default 0
+   */
+  trial_count?: number;
+  /** Scorer Stats */
+  scorer_stats?: EvalResultsScorerStats[];
+  /** Evaluation Ref */
+  evaluation_ref?: string | null;
+  /** Model Ref */
+  model_ref?: string | null;
+  /** Display Name */
+  display_name?: string | null;
+  /** Trace Id */
+  trace_id?: string | null;
+  /** Started At */
+  started_at?: string | null;
+}
+
+/**
+ * EvalResultsFilter
+ * A filter scoped to an optional evaluation.
+ */
+export interface EvalResultsFilter {
+  /**
+   * Evaluation Call Id
+   * When set, filter fields are scoped to this evaluation's data.
+   */
+  evaluation_call_id?: string | null;
+  /** Filter expression. Supported field prefixes: scores.<name>, inputs.<path>, outputs.<path>. */
+  query: Query;
+}
+
+/** EvalResultsQueryBody */
+export interface EvalResultsQueryBody {
+  /**
+   * Evaluation Call Ids
+   * Evaluation root call IDs to include.
+   */
+  evaluation_call_ids?: string[] | null;
+  /**
+   * Evaluation Run Ids
+   * Alias for evaluation call IDs from the Evaluation Runs API.
+   */
+  evaluation_run_ids?: string[] | null;
+  /**
+   * Require Intersection
+   * When true, only include rows present in all requested evaluations.
+   * @default false
+   */
+  require_intersection?: boolean;
+  /**
+   * Include Raw Data Rows
+   * When true, populate raw_data_row on each result row. Inline rows are returned as their dict value; dataset-referenced rows are returned as the ref string unless resolve_row_refs is also true.
+   * @default false
+   */
+  include_raw_data_rows?: boolean;
+  /**
+   * Resolve Row Refs
+   * When true (requires include_raw_data_rows=True), resolve dataset-row reference strings to actual row data via a table lookup. When false, dataset-row refs are returned as-is.
+   * @default false
+   */
+  resolve_row_refs?: boolean;
+  /**
+   * Include Rows
+   * When true, include grouped row/trial data in `rows` and compute `total_rows` for the requested row-level view.
+   * @default true
+   */
+  include_rows?: boolean;
+  /**
+   * Include Summary
+   * When true, include aggregated scorer/evaluation summary data in `summary`.
+   * @default false
+   */
+  include_summary?: boolean;
+  /**
+   * Summary Require Intersection
+   * Optional intersection behavior for the summary section. When null, the value of `require_intersection` is used.
+   */
+  summary_require_intersection?: boolean | null;
+  /**
+   * Include Predict And Score Children
+   * When true (default), fetch child calls (predict/score) of each predict_and_score call to populate predict_call_id, scorer_call_ids, and more precise latency/token data. When false, these fields are derived from the predict_and_score call itself (predict_call_id and scorer_call_ids will be null/empty).
+   * @default true
+   */
+  include_predict_and_score_children?: boolean;
+  /**
+   * Sort By
+   * Sort specification for result rows. Supported field prefixes: scores.<name>, inputs.<path>, outputs.<path>. When null, rows are sorted by row_digest ASC.
+   */
+  sort_by?: EvalResultsSortBy[] | null;
+  /**
+   * Filters
+   * Filters applied to grouped rows. Multiple filters are AND'd together.
+   */
+  filters?: EvalResultsFilter[] | null;
+  /**
+   * Limit
+   * Optional row-level page size applied after grouping and intersection.
+   */
+  limit?: number | null;
+  /**
+   * Offset
+   * Optional row-level page offset applied after grouping and intersection.
+   * @default 0
+   */
+  offset?: number;
+}
+
+/** EvalResultsQueryRes */
+export interface EvalResultsQueryRes {
+  /** Rows */
+  rows: EvalResultsRow[];
+  /** Total Rows */
+  total_rows: number;
+  summary?: EvalResultsSummaryRes | null;
+  /**
+   * Warnings
+   * Non-fatal warnings (e.g. failed to resolve dataset row refs).
+   */
+  warnings?: string[];
+}
+
+/** EvalResultsRow */
+export interface EvalResultsRow {
+  /** Row Digest */
+  row_digest: string;
+  /** Raw Data Row */
+  raw_data_row?: null;
+  /** Evaluations */
+  evaluations?: EvalResultsRowEvaluation[];
+}
+
+/** EvalResultsRowEvaluation */
+export interface EvalResultsRowEvaluation {
+  /** Evaluation Call Id */
+  evaluation_call_id: string;
+  /** Trials */
+  trials?: EvalResultsTrial[];
+}
+
+/**
+ * EvalResultsScorerStats
+ * Stats for a single flattened score dimension (scorer_key or scorer_key.path.to.leaf).
+ */
+export interface EvalResultsScorerStats {
+  /** Scorer Key */
+  scorer_key: string;
+  /**
+   * Path
+   * Dot-joined subpath for nested dimensions, e.g. 'passed' for token_distance.passed. None for root-level scalar scorers.
+   */
+  path?: string | null;
+  /**
+   * Value Type
+   * Type of the leaf value: binary (bool), continuous (number), or text (string).
+   */
+  value_type?: 'binary' | 'continuous' | 'text' | null;
+  /**
+   * Trial Count
+   * @default 0
+   */
+  trial_count?: number;
+  /**
+   * Numeric Count
+   * @default 0
+   */
+  numeric_count?: number;
+  /** Numeric Mean */
+  numeric_mean?: number | null;
+  /**
+   * Pass True Count
+   * @default 0
+   */
+  pass_true_count?: number;
+  /**
+   * Pass Known Count
+   * @default 0
+   */
+  pass_known_count?: number;
+  /** Pass Rate */
+  pass_rate?: number | null;
+  /** Pass Signal Coverage */
+  pass_signal_coverage?: number | null;
+}
+
+/**
+ * EvalResultsSortBy
+ * Sort specification for evaluation results, extending SortBy
+ */
+export interface EvalResultsSortBy {
+  /** Field */
+  field: string;
+  /** Direction */
+  direction: 'asc' | 'desc';
+  /**
+   * Evaluation Call Id
+   * Scope the sort to a specific evaluation's scores.
+   */
+  evaluation_call_id?: string | null;
+  /**
+   * Mode
+   * When 'value', sort by the field value for the specified evaluation. When 'difference', sort by max-min spread of the field across all evaluations (evaluation_call_id is ignored).
+   * @default "value"
+   */
+  mode?: 'value' | 'difference';
+}
+
+/** EvalResultsSummaryRes */
+export interface EvalResultsSummaryRes {
+  /**
+   * Row Count
+   * @default 0
+   */
+  row_count?: number;
+  /** Evaluations */
+  evaluations?: EvalResultsEvaluationSummary[];
+}
+
+/** EvalResultsTrial */
+export interface EvalResultsTrial {
+  /** Predict And Score Call Id */
+  predict_and_score_call_id: string;
+  /** Predict Call Id */
+  predict_call_id?: string | null;
+  /** Model Output */
+  model_output?: null;
+  /** Scores */
+  scores?: Record<string, any>;
+  /** Model Latency Seconds */
+  model_latency_seconds?: number | null;
+  /** Total Tokens */
+  total_tokens?: number | null;
+  /** Scorer Call Ids */
+  scorer_call_ids?: Record<string, string>;
+  /** Genai Span Ref */
+  genai_span_ref?: GenAISpanRef[] | null;
+}
+
+/** EvaluateModelReq */
+export interface EvaluateModelReq {
+  /** Project Id */
+  project_id: string;
+  /** Evaluation Ref */
+  evaluation_ref: string;
+  /** Model Ref */
+  model_ref: string;
+  /**
+   * Wb User Id
+   * Do not set directly. Server will automatically populate this field.
+   */
+  wb_user_id?: string | null;
+}
+
+/** EvaluateModelRes */
+export interface EvaluateModelRes {
+  /** Call Id */
+  call_id: string;
+}
+
+/** EvaluationCreateBody */
+export interface EvaluationCreateBody {
+  /**
+   * Name
+   * The name of this evaluation.  Evaluations with the same name will be versioned together.
+   */
+  name: string;
+  /**
+   * Description
+   * A description of this evaluation
+   */
+  description?: string | null;
+  /**
+   * Dataset
+   * Reference to the dataset (weave:// URI)
+   */
+  dataset: string;
+  /**
+   * Scorers
+   * List of scorer references (weave:// URIs)
+   */
+  scorers?: string[] | null;
+  /**
+   * Trials
+   * Number of trials to run
+   * @default 1
+   */
+  trials?: number;
+  /**
+   * Evaluation Name
+   * Name for the evaluation run
+   */
+  evaluation_name?: string | null;
+  /**
+   * Eval Attributes
+   * Optional attributes for the evaluation
+   */
+  eval_attributes?: Record<string, any> | null;
+}
+
+/** EvaluationCreateRes */
+export interface EvaluationCreateRes {
+  /**
+   * Digest
+   * The digest of the created evaluation
+   */
+  digest: string;
+  /**
+   * Object Id
+   * The ID of the created evaluation
+   */
+  object_id: string;
+  /**
+   * Version Index
+   * The version index of the created evaluation
+   */
+  version_index: number;
+  /**
+   * Evaluation Ref
+   * Full reference to the created evaluation
+   */
+  evaluation_ref: string;
+}
+
+/** EvaluationDeleteRes */
+export interface EvaluationDeleteRes {
+  /**
+   * Num Deleted
+   * Number of evaluation versions deleted
+   */
+  num_deleted: number;
+}
+
+/** EvaluationReadRes */
+export interface EvaluationReadRes {
+  /**
+   * Object Id
+   * The evaluation ID
+   */
+  object_id: string;
+  /**
+   * Digest
+   * The digest of the evaluation
+   */
+  digest: string;
+  /**
+   * Version Index
+   * The version index of the evaluation
+   */
+  version_index: number;
+  /**
+   * Created At
+   * When the evaluation was created
+   * @format date-time
+   */
+  created_at: string;
+  /**
+   * Name
+   * The name of the evaluation
+   */
+  name: string;
+  /**
+   * Description
+   * A description of the evaluation
+   */
+  description?: string | null;
+  /**
+   * Dataset
+   * Dataset reference (weave:// URI)
+   */
+  dataset: string;
+  /**
+   * Scorers
+   * List of scorer references (weave:// URIs)
+   */
+  scorers: string[];
+  /**
+   * Trials
+   * Number of trials
+   */
+  trials: number;
+  /**
+   * Evaluation Name
+   * Name for the evaluation run
+   */
+  evaluation_name?: string | null;
+  /**
+   * Evaluate Op
+   * Evaluate op reference (weave:// URI)
+   */
+  evaluate_op?: string | null;
+  /**
+   * Predict And Score Op
+   * Predict and score op reference (weave:// URI)
+   */
+  predict_and_score_op?: string | null;
+  /**
+   * Summarize Op
+   * Summarize op reference (weave:// URI)
+   */
+  summarize_op?: string | null;
+}
+
+/** EvaluationRunCreateBody */
+export interface EvaluationRunCreateBody {
+  /**
+   * Evaluation
+   * Reference to the evaluation (weave:// URI)
+   */
+  evaluation: string;
+  /**
+   * Model
+   * Reference to the model (weave:// URI)
+   */
+  model: string;
+  /**
+   * Source Evaluation Run Id
+   * Source evaluation run ID if this run was created by rescoring — provenance link
+   */
+  source_evaluation_run_id?: string | null;
+}
+
+/** EvaluationRunCreateRes */
+export interface EvaluationRunCreateRes {
+  /**
+   * Evaluation Run Id
+   * The ID of the created evaluation run
+   */
+  evaluation_run_id: string;
+}
+
+/** EvaluationRunDeleteRes */
+export interface EvaluationRunDeleteRes {
+  /**
+   * Num Deleted
+   * Number of evaluation runs deleted
+   */
+  num_deleted: number;
+}
+
+/**
+ * EvaluationRunFinishBody
+ * Request body for finishing an evaluation run via REST API.
+ *
+ * This model excludes project_id and evaluation_run_id since they come from the URL path in RESTful endpoints.
+ */
+export interface EvaluationRunFinishBody {
+  /**
+   * Summary
+   * Optional summary dictionary for the evaluation run
+   */
+  summary?: Record<string, any> | null;
+}
+
+/** EvaluationRunFinishRes */
+export interface EvaluationRunFinishRes {
+  /**
+   * Success
+   * Whether the evaluation run was finished successfully
+   */
+  success: boolean;
+}
+
+/** EvaluationRunReadRes */
+export interface EvaluationRunReadRes {
+  /**
+   * Evaluation Run Id
+   * The evaluation run ID
+   */
+  evaluation_run_id: string;
+  /**
+   * Evaluation
+   * Reference to the evaluation (weave:// URI)
+   */
+  evaluation: string;
+  /**
+   * Model
+   * Reference to the model (weave:// URI)
+   */
+  model: string;
+  /**
+   * Status
+   * Status of the evaluation run
+   */
+  status?: string | null;
+  /**
+   * Started At
+   * When the evaluation run started
+   */
+  started_at?: string | null;
+  /**
+   * Finished At
+   * When the evaluation run finished
+   */
+  finished_at?: string | null;
+  /**
+   * Summary
+   * Summary data for the evaluation run
+   */
+  summary?: Record<string, any> | null;
+  /**
+   * Source Evaluation Run Id
+   * Source evaluation run ID if this run was created by rescoring
+   */
+  source_evaluation_run_id?: string | null;
+}
+
+/** EvaluationStatusComplete */
+export interface EvaluationStatusComplete {
+  /**
+   * Code
+   * @default "complete"
+   */
+  code?: 'complete';
+  /** Output */
+  output: Record<string, any>;
+}
+
+/** EvaluationStatusFailed */
+export interface EvaluationStatusFailed {
+  /**
+   * Code
+   * @default "failed"
+   */
+  code?: 'failed';
+  /** Error */
+  error?: string | null;
+}
+
+/** EvaluationStatusNotFound */
+export interface EvaluationStatusNotFound {
+  /**
+   * Code
+   * @default "not_found"
+   */
+  code?: 'not_found';
+}
+
+/** EvaluationStatusReq */
+export interface EvaluationStatusReq {
+  /** Project Id */
+  project_id: string;
+  /** Call Id */
+  call_id: string;
+}
+
+/** EvaluationStatusRes */
+export interface EvaluationStatusRes {
+  /** Status */
+  status:
+    | EvaluationStatusNotFound
+    | EvaluationStatusRunning
+    | EvaluationStatusFailed
+    | EvaluationStatusComplete;
+}
+
+/** EvaluationStatusRunning */
+export interface EvaluationStatusRunning {
+  /**
+   * Code
+   * @default "running"
+   */
+  code?: 'running';
+  /** Completed Rows */
+  completed_rows: number;
+  /** Total Rows */
+  total_rows: number;
+}
+
+/** FeedbackCreateBatchReq */
+export interface FeedbackCreateBatchReq {
+  /** Batch */
+  batch: FeedbackCreateReq[];
+}
+
+/** FeedbackCreateBatchRes */
+export interface FeedbackCreateBatchRes {
+  /** Res */
+  res: FeedbackCreateRes[];
+}
+
 /** FeedbackCreateReq */
 export interface FeedbackCreateReq {
+  /**
+   * Id
+   * If provided by the client, this ID will be used for the feedback row instead of a server-generated one.
+   */
+  id?: string | null;
   /** Project Id */
   project_id: string;
   /** Weave Ref */
@@ -461,7 +3182,7 @@ export interface FeedbackCreateReq {
   /** Feedback Type */
   feedback_type: string;
   /** Payload */
-  payload: object;
+  payload: Record<string, any>;
   /** Annotation Ref */
   annotation_ref?: string | null;
   /** Runnable Ref */
@@ -470,6 +3191,59 @@ export interface FeedbackCreateReq {
   call_ref?: string | null;
   /** Trigger Ref */
   trigger_ref?: string | null;
+  /**
+   * Queue Id
+   * The annotation queue ID this feedback was created from. References annotation_queues.id. NULL when feedback is created outside of queues.
+   */
+  queue_id?: string | null;
+  /**
+   * Scorer Tags
+   * Tags applied to the ref by a scorer
+   */
+  scorer_tags?: string[];
+  /**
+   * Scorer Tag Reasons
+   * reason text per tag, keyed by tag name
+   */
+  scorer_tag_reasons?: Record<string, string>;
+  /**
+   * Scorer Tag Confidences
+   * confidence (0-1) per tag, keyed by tag name
+   */
+  scorer_tag_confidences?: Record<string, number>;
+  /**
+   * Scorer Ratings
+   * numeric ratings (0-1) keyed by rating name
+   */
+  scorer_ratings?: Record<string, number>;
+  /**
+   * Scorer Rating Reasons
+   * reason text per rating, keyed by rating name
+   */
+  scorer_rating_reasons?: Record<string, string>;
+  /**
+   * Scorer Rating Confidences
+   * confidence (0-1) per rating, keyed by rating name
+   */
+  scorer_rating_confidences?: Record<string, number>;
+  /**
+   * Span Agent Name
+   * Display name of the scored agent (from spans.agent_name)
+   * @default ""
+   */
+  span_agent_name?: string;
+  /**
+   * Span Agent Version
+   * Version of the scored agent (from spans.agent_version)
+   * @default ""
+   */
+  span_agent_version?: string;
+  /**
+   * Span Status Code
+   * Status of the scored turn (from spans.status_code)
+   * @default "UNSET"
+   */
+  span_status_code?: string;
   /**
    * Wb User Id
    * Do not set directly. Server will automatically populate this field.
@@ -489,7 +3263,103 @@ export interface FeedbackCreateRes {
   /** Wb User Id */
   wb_user_id: string;
   /** Payload */
-  payload: object;
+  payload: Record<string, any>;
+}
+
+/**
+ * FeedbackMetricSpec
+ * Specification for a feedback payload metric to aggregate.
+ */
+export interface FeedbackMetricSpec {
+  /**
+   * Json Path
+   * Dot path into payload_dump (e.g. 'output', 'output.score').
+   */
+  json_path: string;
+  /**
+   * Value Type
+   * Type of value at path. numeric: avg/min/max; boolean: count_true/count_false.
+   * @default "numeric"
+   */
+  value_type?: 'numeric' | 'boolean' | 'categorical';
+  /**
+   * Aggregations
+   * Aggregation functions to compute. If empty, defaults are chosen based on value_type: numeric->avg/min/max, boolean->count_true/count_false.
+   */
+  aggregations?: AggregationType[];
+  /**
+   * Percentiles
+   * Percentile values to compute (0–100), e.g. [5, 50, 95]. Only applicable for numeric value_type fields; ignored for boolean/categorical.
+   */
+  percentiles?: number[];
+}
+
+/**
+ * FeedbackPayloadPath
+ * Discovered path in feedback payload with inferred type.
+ */
+export interface FeedbackPayloadPath {
+  /**
+   * Json Path
+   * Dot path into payload (e.g. 'output.score').
+   */
+  json_path: string;
+  /**
+   * Value Type
+   * Inferred type of value at path.
+   * @default "numeric"
+   */
+  value_type?: 'numeric' | 'boolean' | 'categorical';
+}
+
+/**
+ * FeedbackPayloadSchemaReq
+ * Request for feedback payload schema discovery.
+ */
+export interface FeedbackPayloadSchemaReq {
+  /** Project Id */
+  project_id: string;
+  /**
+   * Start
+   * Inclusive start time (UTC, ISO 8601).
+   * @format date-time
+   */
+  start: string;
+  /**
+   * End
+   * Exclusive end time (UTC, ISO 8601). Defaults to now if omitted.
+   */
+  end?: string | null;
+  /**
+   * Feedback Type
+   * Filter by feedback_type.
+   */
+  feedback_type?: string | null;
+  /**
+   * Trigger Ref
+   * Filter by trigger_ref (exact or prefix match for all-versions).
+   */
+  trigger_ref?: string | null;
+  /**
+   * Sample Limit
+   * Max distinct trigger_refs to sample when discovering the payload schema. Each distinct trigger_ref (monitor/source) typically has a fixed payload structure, so sampling one payload per ref is usually enough to see the full schema. 2 000 covers virtually all real-world projects while keeping the query fast; the hard cap of 5 000 prevents runaway scans.
+   * @min 1
+   * @max 5000
+   * @default 2000
+   */
+  sample_limit?: number;
+}
+
+/**
+ * FeedbackPayloadSchemaRes
+ * Response with discovered feedback payload paths and types.
+ */
+export interface FeedbackPayloadSchemaRes {
+  /**
+   * Paths
+   * Discovered leaf paths with inferred value types.
+   */
+  paths?: FeedbackPayloadPath[];
 }
 
 /** FeedbackPurgeReq */
@@ -520,11 +3390,16 @@ export interface FeedbackQueryReq {
 /** FeedbackQueryRes */
 export interface FeedbackQueryRes {
   /** Result */
-  result: object[];
+  result: Record<string, any>[];
 }
 
 /** FeedbackReplaceReq */
 export interface FeedbackReplaceReq {
+  /**
+   * Id
+   * If provided by the client, this ID will be used for the feedback row instead of a server-generated one.
+   */
+  id?: string | null;
   /** Project Id */
   project_id: string;
   /** Weave Ref */
@@ -534,7 +3409,7 @@ export interface FeedbackReplaceReq {
   /** Feedback Type */
   feedback_type: string;
   /** Payload */
-  payload: object;
+  payload: Record<string, any>;
   /** Annotation Ref */
   annotation_ref?: string | null;
   /** Runnable Ref */
@@ -543,6 +3418,59 @@ export interface FeedbackReplaceReq {
   call_ref?: string | null;
   /** Trigger Ref */
   trigger_ref?: string | null;
+  /**
+   * Queue Id
+   * The annotation queue ID this feedback was created from. References annotation_queues.id. NULL when feedback is created outside of queues.
+   */
+  queue_id?: string | null;
+  /**
+   * Scorer Tags
+   * Tags applied to the ref by a scorer
+   */
+  scorer_tags?: string[];
+  /**
+   * Scorer Tag Reasons
+   * reason text per tag, keyed by tag name
+   */
+  scorer_tag_reasons?: Record<string, string>;
+  /**
+   * Scorer Tag Confidences
+   * confidence (0-1) per tag, keyed by tag name
+   */
+  scorer_tag_confidences?: Record<string, number>;
+  /**
+   * Scorer Ratings
+   * numeric ratings (0-1) keyed by rating name
+   */
+  scorer_ratings?: Record<string, number>;
+  /**
+   * Scorer Rating Reasons
+   * reason text per rating, keyed by rating name
+   */
+  scorer_rating_reasons?: Record<string, string>;
+  /**
+   * Scorer Rating Confidences
+   * confidence (0-1) per rating, keyed by rating name
+   */
+  scorer_rating_confidences?: Record<string, number>;
+  /**
+   * Span Agent Name
+   * Display name of the scored agent (from spans.agent_name)
+   * @default ""
+   */
+  span_agent_name?: string;
+  /**
+   * Span Agent Version
+   * Version of the scored agent (from spans.agent_version)
+   * @default ""
+   */
+  span_agent_version?: string;
+  /**
+   * Span Status Code
+   * Status of the scored turn (from spans.status_code)
+   * @default "UNSET"
+   */
+  span_status_code?: string;
   /**
    * Wb User Id
    * Do not set directly. Server will automatically populate this field.
@@ -564,7 +3492,92 @@ export interface FeedbackReplaceRes {
   /** Wb User Id */
   wb_user_id: string;
   /** Payload */
-  payload: object;
+  payload: Record<string, any>;
+}
+
+/**
+ * FeedbackStatsReq
+ * Request for aggregated feedback statistics over time buckets.
+ */
+export interface FeedbackStatsReq {
+  /** Project Id */
+  project_id: string;
+  /**
+   * Start
+   * Inclusive start time (UTC, ISO 8601).
+   * @format date-time
+   */
+  start: string;
+  /**
+   * End
+   * Exclusive end time (UTC, ISO 8601). Defaults to now if omitted.
+   */
+  end?: string | null;
+  /**
+   * Feedback Type
+   * Filter by feedback_type.
+   */
+  feedback_type?: string | null;
+  /**
+   * Trigger Ref
+   * Filter by trigger_ref (exact or prefix match for all-versions).
+   */
+  trigger_ref?: string | null;
+  /**
+   * Granularity
+   * Bucket size in seconds. If omitted, auto-selected based on time range.
+   */
+  granularity?: number | null;
+  /**
+   * Timezone
+   * IANA timezone for bucket alignment.
+   * @default "UTC"
+   */
+  timezone?: string;
+  /**
+   * Metrics
+   * Metrics to aggregate from payload_dump.
+   */
+  metrics?: FeedbackMetricSpec[];
+}
+
+/**
+ * FeedbackStatsRes
+ * Response with time-series feedback statistics.
+ */
+export interface FeedbackStatsRes {
+  /**
+   * Start
+   * Resolved start time (always UTC, regardless of the requested timezone).
+   * @format date-time
+   */
+  start: string;
+  /**
+   * End
+   * Resolved end time (always UTC, regardless of the requested timezone).
+   * @format date-time
+   */
+  end: string;
+  /**
+   * Granularity
+   * Bucket size used (in seconds)
+   */
+  granularity: number;
+  /**
+   * Timezone
+   * Timezone used for bucket alignment
+   */
+  timezone: string;
+  /**
+   * Buckets
+   * Time-bucketed aggregations. Each dict has 'timestamp' (ISO string), 'count' (int), and '{agg}_{slug}' keys for each requested metric+aggregation.
+   */
+  buckets?: Record<string, any>[];
+  /**
+   * Window Stats
+   * Aggregations over the full query window, keyed by metric slug (e.g. 'output_score'). Each value maps agg name to result.
+   */
+  window_stats?: Record<string, Record<string, number | null>> | null;
 }
 
 /** FileContentReadReq */
@@ -581,13 +3594,113 @@ export interface FileCreateRes {
   digest: string;
 }
 
-/** GetFieldOperator */
+/** FilesStatsReq */
+export interface FilesStatsReq {
+  /** Project Id */
+  project_id: string;
+}
+
+/** FilesStatsRes */
+export interface FilesStatsRes {
+  /** Total Size Bytes */
+  total_size_bytes: number;
+}
+
+/** GenAISpanRef */
+export interface GenAISpanRef {
+  /** Trace Id */
+  trace_id: string;
+  /** Span Id */
+  span_id: string;
+}
+
+/** Geolocation */
+export interface Geolocation {
+  /**
+   * File Index
+   * row in CSV file
+   */
+  file_index: number;
+  /**
+   * Range Start Int
+   * Start of IP range as integer
+   */
+  range_start_int: number;
+  /**
+   * Range End Int
+   * End of IP range as integer
+   */
+  range_end_int: number;
+  /**
+   * Range Start Ip
+   * Start of IP range in dotted decimal notation
+   */
+  range_start_ip: string;
+  /**
+   * Range End Ip
+   * End of IP range in dotted decimal notation
+   */
+  range_end_ip: string;
+  /**
+   * Country Code
+   * 2-letter country code in ISO 3166-1 Alpha 2 format
+   */
+  country_code: string;
+  /**
+   * Country Name
+   * Country name, None if could not be determined
+   */
+  country_name?: string | null;
+}
+
+/** GeolocationRes */
+export interface GeolocationRes {
+  /**
+   * Ip
+   * Resolved IP address, useful for debugging
+   */
+  ip: string;
+  /** Information about the location of the IP address, None if could not be determined */
+  location?: Geolocation | null;
+  /**
+   * Allowed
+   * Whether the IP address is allowed to be used for inference.
+   * @default false
+   */
+  allowed?: boolean;
+}
+
+/**
+ * GetFieldOperator
+ * Access a field on the traced call.
+ *
+ * Supports dot notation for nested access, e.g. `summary.usage.tokens`.
+ *
+ * Only works on fields present in the `CallSchema`, including:
+ * - Top-level fields like `op_name`, `trace_id`, `started_at`
+ * - Nested fields like `inputs.input_name`, `summary.usage.tokens`, etc.
+ *
+ * Example:
+ *     ```
+ *     {"$getField": "op_name"}
+ *     ```
+ */
 export interface GetFieldOperator {
   /** $Getfield */
   $getField: string;
 }
 
-/** GtOperation */
+/**
+ * GtOperation
+ * Greater than comparison.
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$gt": [{"$getField": "summary.usage.tokens"}, {"$literal": 100}]
+ *     }
+ *     ```
+ */
 export interface GtOperation {
   /**
    * $Gt
@@ -597,7 +3710,17 @@ export interface GtOperation {
   $gt: any[];
 }
 
-/** GteOperation */
+/**
+ * GteOperation
+ * Greater than or equal comparison.
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$gte": [{"$getField": "summary.usage.tokens"}, {"$literal": 100}]
+ *     }
+ *     ```
+ */
 export interface GteOperation {
   /**
    * $Gte
@@ -613,7 +3736,58 @@ export interface HTTPValidationError {
   detail?: ValidationError[];
 }
 
-/** InOperation */
+/** ImageGenerationCreateReq */
+export interface ImageGenerationCreateReq {
+  /** Project Id */
+  project_id: string;
+  inputs: ImageGenerationRequestInputs;
+  /**
+   * Wb User Id
+   * Do not set directly. Server will automatically populate this field.
+   */
+  wb_user_id?: string | null;
+  /**
+   * Track Llm Call
+   * Whether to track this image generation call in the trace server
+   * @default true
+   */
+  track_llm_call?: boolean | null;
+}
+
+/** ImageGenerationCreateRes */
+export interface ImageGenerationCreateRes {
+  /** Response */
+  response: Record<string, any>;
+  /** Weave Call Id */
+  weave_call_id?: string | null;
+}
+
+/** ImageGenerationRequestInputs */
+export interface ImageGenerationRequestInputs {
+  /** Model */
+  model: string;
+  /** Prompt */
+  prompt: string;
+  /** N */
+  n?: number | null;
+}
+
+/**
+ * InOperation
+ * Membership check.
+ *
+ * Returns true if the left operand is in the list provided as the second operand.
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$in": [
+ *             {"$getField": "op_name"},
+ *             [{"$literal": "predict"}, {"$literal": "generate"}]
+ *         ]
+ *     }
+ *     ```
+ */
 export interface InOperation {
   /**
    * $In
@@ -621,6 +3795,133 @@ export interface InOperation {
    * @minItems 2
    */
   $in: any[];
+}
+
+/**
+ * LLMAggregatedUsage
+ * Aggregated usage metrics for a specific LLM.
+ */
+export interface LLMAggregatedUsage {
+  /**
+   * Requests
+   * @default 0
+   */
+  requests?: number;
+  /**
+   * Prompt Tokens
+   * @default 0
+   */
+  prompt_tokens?: number;
+  /**
+   * Completion Tokens
+   * @default 0
+   */
+  completion_tokens?: number;
+  /**
+   * Total Tokens
+   * @default 0
+   */
+  total_tokens?: number;
+  /**
+   * Cache Read Input Tokens
+   * @default 0
+   */
+  cache_read_input_tokens?: number;
+  /**
+   * Cache Creation Input Tokens
+   * @default 0
+   */
+  cache_creation_input_tokens?: number;
+  /** Prompt Tokens Total Cost */
+  prompt_tokens_total_cost?: number | null;
+  /** Completion Tokens Total Cost */
+  completion_tokens_total_cost?: number | null;
+  /** Cache Read Input Tokens Total Cost */
+  cache_read_input_tokens_total_cost?: number | null;
+  /** Cache Creation Input Tokens Total Cost */
+  cache_creation_input_tokens_total_cost?: number | null;
+}
+
+/** LLMModelDetails */
+export interface LLMModelDetails {
+  /** Provider */
+  provider: string;
+  /** Id */
+  id: string;
+  /** Idplayground */
+  idPlayground: string;
+  /** Idhuggingface */
+  idHuggingFace: string;
+  /** Label */
+  label: string;
+  /** Labelopenrouter */
+  labelOpenRouter: string;
+  /** Status */
+  status: string;
+  /** Lifecyclestage */
+  lifecycleStage: 'general-availability' | 'experimental' | 'retired';
+  /** Availablein */
+  availableIn: ('cw-prod' | 'cw-qa')[];
+  /** Launchedquarter */
+  launchedQuarter: string;
+  /** Descriptionshort */
+  descriptionShort: string;
+  /** Descriptionmedium */
+  descriptionMedium: string;
+  /** Launchdate */
+  launchDate: string;
+  /** Featurereasoning */
+  featureReasoning: boolean;
+  /** Featurejsonmode */
+  featureJsonMode: boolean;
+  /** Featurestructuredoutput */
+  featureStructuredOutput: boolean;
+  /** Featuretoolcalling */
+  featureToolCalling: boolean;
+  /** Featurelora */
+  featureLoRA: boolean;
+  /** Featuretrainableserverlessrl */
+  featureTrainableServerlessRL: boolean;
+  /** Parametercounttotal */
+  parameterCountTotal: number;
+  /** Parametercountactive */
+  parameterCountActive?: number;
+  /** Contextwindow */
+  contextWindow: number;
+  /** Quantization */
+  quantization:
+    | 'int4'
+    | 'int8'
+    | 'fp4'
+    | 'fp6'
+    | 'fp8'
+    | 'fp16'
+    | 'bf16'
+    | 'fp32';
+  /** Pricecentsperbilliontokensinput */
+  priceCentsPerBillionTokensInput: number;
+  /** Pricecentsperbilliontokenscached */
+  priceCentsPerBillionTokensCached: number;
+  /** Pricecentsperbilliontokensoutput */
+  priceCentsPerBillionTokensOutput: number;
+  /** Isavailableopenrouter */
+  isAvailableOpenRouter: boolean;
+  /** Apistyle */
+  apiStyle: string;
+  /** Modalities */
+  modalities: string[];
+  /** Modalitiesinput */
+  modalitiesInput: string[];
+  /** Modalitiesoutput */
+  modalitiesOutput: string[];
+  /** Tags */
+  tags: string[];
+  /** Likeshuggingface */
+  likesHuggingFace: number;
+  /** Downloadshuggingface */
+  downloadsHuggingFace: number;
+  /** License */
+  license: string;
 }
 
 /** LLMUsageSchema */
@@ -637,9 +3938,24 @@ export interface LLMUsageSchema {
   requests?: number | null;
   /** Total Tokens */
   total_tokens?: number | null;
+  /** Cache Creation Input Tokens */
+  cache_creation_input_tokens?: number | null;
+  /** Cache Read Input Tokens */
+  cache_read_input_tokens?: number | null;
+  [key: string]: any;
 }
 
-/** LiteralOperation */
+/**
+ * LiteralOperation
+ * Represents a constant value in the query language.
+ *
+ * This can be any standard JSON-serializable value.
+ *
+ * Example:
+ *     ```
+ *     {"$literal": "predict"}
+ *     ```
+ */
 export interface LiteralOperation {
   /** $Literal */
   $literal:
@@ -651,7 +3967,187 @@ export interface LiteralOperation {
     | null;
 }
 
-/** NotOperation */
+/**
+ * LtOperation
+ * Less than comparison.
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$lt": [{"$getField": "summary.usage.tokens"}, {"$literal": 100}]
+ *     }
+ *     ```
+ */
+export interface LtOperation {
+  /**
+   * $Lt
+   * @maxItems 2
+   * @minItems 2
+   */
+  $lt: any[];
+}
+
+/**
+ * LteOperation
+ * Less than or equal comparison.
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$lte": [{"$getField": "summary.usage.tokens"}, {"$literal": 100}]
+ *     }
+ *     ```
+ */
+export interface LteOperation {
+  /**
+   * $Lte
+   * @maxItems 2
+   * @minItems 2
+   */
+  $lte: any[];
+}
+
+/** ModelCreateBody */
+export interface ModelCreateBody {
+  /**
+   * Name
+   * The name of this model. Models with the same name will be versioned together.
+   */
+  name: string;
+  /**
+   * Description
+   * A description of this model
+   */
+  description?: string | null;
+  /**
+   * Source Code
+   * Complete source code for the Model class including imports
+   */
+  source_code: string;
+  /**
+   * Attributes
+   * Additional attributes to be stored with the model
+   */
+  attributes?: Record<string, any> | null;
+}
+
+/** ModelCreateRes */
+export interface ModelCreateRes {
+  /**
+   * Digest
+   * The digest of the created model
+   */
+  digest: string;
+  /**
+   * Object Id
+   * The ID of the created model
+   */
+  object_id: string;
+  /**
+   * Version Index
+   * The version index of the created model
+   */
+  version_index: number;
+  /**
+   * Model Ref
+   * Full reference to the created model
+   */
+  model_ref: string;
+}
+
+/** ModelDeleteRes */
+export interface ModelDeleteRes {
+  /**
+   * Num Deleted
+   * Number of model versions deleted
+   */
+  num_deleted: number;
+}
+
+/** ModelReadRes */
+export interface ModelReadRes {
+  /**
+   * Object Id
+   * The model ID
+   */
+  object_id: string;
+  /**
+   * Digest
+   * The digest of the model
+   */
+  digest: string;
+  /**
+   * Version Index
+   * The version index of the object
+   */
+  version_index: number;
+  /**
+   * Created At
+   * When the model was created
+   * @format date-time
+   */
+  created_at: string;
+  /**
+   * Name
+   * The name of the model
+   */
+  name: string;
+  /**
+   * Description
+   * Description of the model
+   */
+  description?: string | null;
+  /**
+   * Source Code
+   * The source code of the model
+   */
+  source_code: string;
+  /**
+   * Attributes
+   * Additional attributes stored with the model
+   */
+  attributes?: Record<string, any> | null;
+}
+
+/**
+ * NormalizedMessage
+ * A single message normalized from any provider format.
+ *
+ * Maps to ClickHouse ``Tuple(role String, content String, finish_reason String)``.
+ *
+ * - role: message role (user, assistant, tool, system)
+ * - content: plain text for simple messages, or JSON-serialized parts
+ *   array for multimodal/structured messages
+ * - finish_reason: per-message finish reason (output messages only)
+ */
+export interface NormalizedMessage {
+  /**
+   * Role
+   * @default ""
+   */
+  role?: string;
+  /** Content */
+  content: string;
+  /**
+   * Finish Reason
+   * @default ""
+   */
+  finish_reason?: string;
+}
+
+/**
+ * NotOperation
+ * Logical NOT. Inverts the condition.
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$not": [
+ *             {"$eq": [{"$getField": "op_name"}, {"$literal": "debug"}]}
+ *         ]
+ *     }
+ *     ```
+ */
 export interface NotOperation {
   /**
    * $Not
@@ -660,6 +4156,36 @@ export interface NotOperation {
    */
   $not: any[];
 }
+
+/** NvidiaHardwareOption */
+export interface NvidiaHardwareOption {
+  /** Id */
+  id: string;
+  /** Name */
+  name: string;
+  /** Type */
+  type: string;
+  pricing: NvidiaServerlessPricing;
+  /** Specs */
+  specs?: Record<string, string> | null;
+}
+
+/** NvidiaHardwareRes */
+export interface NvidiaHardwareRes {
+  /** Hardware */
+  hardware: NvidiaHardwareOption[];
+}
+
+/** NvidiaServerlessPricing */
+export interface NvidiaServerlessPricing {
+  /** Cents Per Million Input Tokens */
+  cents_per_million_input_tokens: number;
+  /** Cents Per Million Output Tokens */
+  cents_per_million_output_tokens: number;
+}
+
+/** ObjAddTagsRes */
+export type ObjAddTagsRes = object;
 
 /** ObjCreateReq */
 export interface ObjCreateReq {
@@ -670,6 +4196,27 @@ export interface ObjCreateReq {
 export interface ObjCreateRes {
   /** Digest */
   digest: string;
+  /** Object Id */
+  object_id?: string | null;
+}
+
+/** ObjDeleteReq */
+export interface ObjDeleteReq {
+  /** Project Id */
+  project_id: string;
+  /** Object Id */
+  object_id: string;
+  /**
+   * Digests
+   * List of digests to delete. If not provided, all digests for the object will be deleted.
+   */
+  digests?: string[] | null;
+}
+
+/** ObjDeleteRes */
+export interface ObjDeleteRes {
+  /** Num Deleted */
+  num_deleted: number;
 }
 
 /** ObjQueryReq */
@@ -702,6 +4249,18 @@ export interface ObjQueryReq {
    * @default false
    */
   metadata_only?: boolean | null;
+  /**
+   * Include Storage Size
+   * If true, the `size_bytes` column is returned.
+   * @default false
+   */
+  include_storage_size?: boolean | null;
+  /**
+   * Include Tags And Aliases
+   * If true, tags and aliases are fetched and included in the response.
+   * @default false
+   */
+  include_tags_and_aliases?: boolean | null;
 }
 
 /** ObjQueryRes */
@@ -718,12 +4277,41 @@ export interface ObjReadReq {
   object_id: string;
   /** Digest */
   digest: string;
+  /**
+   * Metadata Only
+   * If true, the `val` column is not read from the database and is empty.All other fields are returned.
+   * @default false
+   */
+  metadata_only?: boolean | null;
+  /**
+   * Include Tags And Aliases
+   * If true, tags and aliases are fetched and included in the response.
+   * @default false
+   */
+  include_tags_and_aliases?: boolean | null;
 }
 
 /** ObjReadRes */
 export interface ObjReadRes {
   obj: ObjSchema;
 }
+
+/**
+ * ObjRemoveAliasesBody
+ * Request body for removing aliases (object_id comes from path).
+ */
+export interface ObjRemoveAliasesBody {
+  /** Project Id */
+  project_id: string;
+  /** Aliases */
+  aliases: string[];
+}
+
+/** ObjRemoveAliasesRes */
+export type ObjRemoveAliasesRes = object;
+
+/** ObjRemoveTagsRes */
+export type ObjRemoveTagsRes = object;
 
 /** ObjSchema */
 export interface ObjSchema {
@@ -748,8 +4336,21 @@ export interface ObjSchema {
   kind: string;
   /** Base Object Class */
   base_object_class: string | null;
+  /** Leaf Object Class */
+  leaf_object_class?: string | null;
   /** Val */
   val: any;
+  /**
+   * Wb User Id
+   * Do not set directly. Server will automatically populate this field.
+   */
+  wb_user_id?: string | null;
+  /** Size Bytes */
+  size_bytes?: number | null;
+  /** Tags */
+  tags?: string[] | null;
+  /** Aliases */
+  aliases?: string[] | null;
 }
 
 /** ObjSchemaForInsert */
@@ -767,6 +4368,43 @@ export interface ObjSchemaForInsert {
    * @deprecated
    */
   set_base_object_class?: string | null;
+  /**
+   * Expected Digest
+   * Client-computed digest for server-side validation. If provided, the server will verify it matches the server-computed digest.
+   */
+  expected_digest?: string | null;
+  /**
+   * Wb User Id
+   * Do not set directly. Server will automatically populate this field.
+   */
+  wb_user_id?: string | null;
+}
+
+/**
+ * ObjSetAliasesBody
+ * Request body for setting aliases (object_id comes from path).
+ */
+export interface ObjSetAliasesBody {
+  /** Project Id */
+  project_id: string;
+  /** Digest */
+  digest: string;
+  /** Aliases */
+  aliases: string[];
+}
+
+/** ObjSetAliasesRes */
+export type ObjSetAliasesRes = object;
+
+/**
+ * ObjTagsBody
+ * Request body for adding/removing tags (object_id and digest come from path).
+ */
+export interface ObjTagsBody {
+  /** Project Id */
+  project_id: string;
+  /** Tags */
+  tags: string[];
 }
 
 /** ObjectVersionFilter */
@@ -776,6 +4414,16 @@ export interface ObjectVersionFilter {
    * Filter objects by their base classes
    */
   base_object_classes?: string[] | null;
+  /**
+   * Exclude Base Object Classes
+   * Exclude objects by their base classes
+   */
+  exclude_base_object_classes?: string[] | null;
+  /**
+   * Leaf Object Classes
+   * Filter objects by their leaf classes
+   */
+  leaf_object_classes?: string[] | null;
   /**
    * Object Ids
    * Filter objects by their IDs
@@ -791,9 +4439,117 @@ export interface ObjectVersionFilter {
    * If True, return only the latest version of each object. `False` and `None` will return all versions
    */
   latest_only?: boolean | null;
+  /**
+   * Tags
+   * Filter object versions that have any of the specified tags
+   */
+  tags?: string[] | null;
+  /**
+   * Aliases
+   * Filter objects that have any of the specified aliases
+   */
+  aliases?: string[] | null;
 }
 
-/** OrOperation */
+/**
+ * OpCreateBody
+ * Request body for creating an Op object via REST API.
+ *
+ * This model excludes project_id since it comes from the URL path in RESTful endpoints.
+ */
+export interface OpCreateBody {
+  /**
+   * Name
+   * The name of this op. Ops with the same name will be versioned together.
+   */
+  name?: string | null;
+  /**
+   * Source Code
+   * Complete source code for this op, including imports
+   */
+  source_code?: string | null;
+}
+
+/**
+ * OpCreateRes
+ * Response model for creating an Op object.
+ */
+export interface OpCreateRes {
+  /**
+   * Digest
+   * The digest of the created op
+   */
+  digest: string;
+  /**
+   * Object Id
+   * The ID of the created op
+   */
+  object_id: string;
+  /**
+   * Version Index
+   * The version index of the created op
+   */
+  version_index: number;
+}
+
+/** OpDeleteRes */
+export interface OpDeleteRes {
+  /**
+   * Num Deleted
+   * Number of op versions deleted from this op
+   */
+  num_deleted: number;
+}
+
+/**
+ * OpReadRes
+ * Response model for reading an Op object.
+ *
+ * The code field contains the actual source code of the op.
+ */
+export interface OpReadRes {
+  /**
+   * Object Id
+   * The op ID
+   */
+  object_id: string;
+  /**
+   * Digest
+   * The digest of the op
+   */
+  digest: string;
+  /**
+   * Version Index
+   * The version index of this op
+   */
+  version_index: number;
+  /**
+   * Created At
+   * When this op was created
+   * @format date-time
+   */
+  created_at: string;
+  /**
+   * Code
+   * The actual op source code
+   */
+  code: string;
+}
+
+/**
+ * OrOperation
+ * Logical OR. At least one condition must be true.
+ *
+ * Example:
+ *     ```
+ *     {
+ *         "$or": [
+ *             {"$eq": [{"$getField": "op_name"}, {"$literal": "a"}]},
+ *             {"$eq": [{"$getField": "op_name"}, {"$literal": "b"}]}
+ *         ]
+ *     }
+ *     ```
+ */
 export interface OrOperation {
   /** $Or */
   $or: (
@@ -805,10 +4561,149 @@ export interface OrOperation {
     | NotOperation
     | EqOperation
     | GtOperation
+    | LtOperation
     | GteOperation
+    | LteOperation
     | InOperation
     | ContainsOperation
   )[];
+}
+
+/**
+ * PredictionCreateBody
+ * Request body for creating a Prediction via REST API.
+ *
+ * This model excludes project_id since it comes from the URL path in RESTful endpoints.
+ */
+export interface PredictionCreateBody {
+  /**
+   * Model
+   * The model reference (weave:// URI)
+   */
+  model: string;
+  /**
+   * Inputs
+   * The inputs to the prediction
+   */
+  inputs: Record<string, any>;
+  /**
+   * Output
+   * The output of the prediction
+   */
+  output: any;
+  /**
+   * Evaluation Run Id
+   * Optional evaluation run ID to link this prediction as a child call
+   */
+  evaluation_run_id?: string | null;
+  /**
+   * Genai Span Ref
+   * Optional GenAI span reference(s) produced by this prediction.
+   */
+  genai_span_ref?: GenAISpanRef[] | null;
+}
+
+/** PredictionCreateRes */
+export interface PredictionCreateRes {
+  /**
+   * Prediction Id
+   * The prediction ID
+   */
+  prediction_id: string;
+}
+
+/** PredictionDeleteRes */
+export interface PredictionDeleteRes {
+  /**
+   * Num Deleted
+   * Number of predictions deleted
+   */
+  num_deleted: number;
+}
+
+/** PredictionFinishRes */
+export interface PredictionFinishRes {
+  /**
+   * Success
+   * Whether the prediction was finished successfully
+   */
+  success: boolean;
+}
+
+/** PredictionReadRes */
+export interface PredictionReadRes {
+  /**
+   * Prediction Id
+   * The prediction ID
+   */
+  prediction_id: string;
+  /**
+   * Model
+   * The model reference (weave:// URI)
+   */
+  model: string;
+  /**
+   * Inputs
+   * The inputs to the prediction
+   */
+  inputs: Record<string, any>;
+  /**
+   * Output
+   * The output of the prediction
+   */
+  output: any;
+  /**
+   * Evaluation Run Id
+   * Evaluation run ID if this prediction is linked to one
+   */
+  evaluation_run_id?: string | null;
+  /**
+   * Wb User Id
+   * Do not set directly. Server will automatically populate this field.
+   */
+  wb_user_id?: string | null;
+}
+
+/**
+ * Pricing
+ * All pricing values are in USD per 1 token.
+ *
+ * Pricing fields are in string format to avoid floating point precision issues.
+ */
+export interface Pricing {
+  /** Prompt */
+  prompt: string;
+  /** Completion */
+  completion: string;
+  /** Image */
+  image: string;
+  /** Request */
+  request: string;
+  /** Input Cache Read */
+  input_cache_read: string;
+}
+
+/** ProjectsInfoReq */
+export interface ProjectsInfoReq {
+  /**
+   * Project Ids
+   * External project IDs in 'entity/project' format.
+   */
+  project_ids: string[];
+}
+
+/** ProjectsInfoRes */
+export interface ProjectsInfoRes {
+  /**
+   * External Project Id
+   * External project ID in 'entity/project' format.
+   */
+  external_project_id: string;
+  /**
+   * Internal Project Id
+   * Internal project ID.
+   */
+  internal_project_id: string;
 }
 
 /** Query */
@@ -820,7 +4715,9 @@ export interface Query {
     | NotOperation
     | EqOperation
     | GtOperation
+    | LtOperation
     | GteOperation
+    | LteOperation
     | InOperation
     | ContainsOperation;
 }
@@ -837,10 +4734,290 @@ export interface RefsReadBatchRes {
   vals: any[];
 }
 
+/**
+ * RescoreReq
+ * Full rescore request including server-set fields.
+ */
+export interface RescoreReq {
+  /**
+   * Source Evaluation Run Id
+   * The evaluation run whose predictions will be rescored
+   */
+  source_evaluation_run_id: string;
+  /**
+   * Scorer Refs
+   * Scorer references (weave:// URIs) to apply; must be non-empty
+   * @minItems 1
+   */
+  scorer_refs: string[];
+  /** Project Id */
+  project_id: string;
+  /**
+   * Wb User Id
+   * Do not set directly. Server will automatically populate this field.
+   */
+  wb_user_id?: string | null;
+}
+
+/**
+ * RescoreRes
+ * Response for a rescore request.
+ */
+export interface RescoreRes {
+  /**
+   * Call Id
+   * Call ID for /evaluations/status polling
+   */
+  call_id: string;
+  /**
+   * Evaluation Run Id
+   * The newly created EvaluationRun ID
+   */
+  evaluation_run_id: string;
+}
+
+/** RouterOpenRouterModel */
+export interface RouterOpenRouterModel {
+  /** Id */
+  id: string;
+  /** Hugging Face Id */
+  hugging_face_id: string;
+  /** Name */
+  name: string;
+  /** Created */
+  created: number;
+  /** Input Modalities */
+  input_modalities: string[];
+  /** Output Modalities */
+  output_modalities: string[];
+  /** Quantization */
+  quantization:
+    | 'int4'
+    | 'int8'
+    | 'fp4'
+    | 'fp6'
+    | 'fp8'
+    | 'fp16'
+    | 'bf16'
+    | 'fp32';
+  /** Context Length */
+  context_length: number;
+  /** Max Output Length */
+  max_output_length: number;
+  /**
+   * All pricing values are in USD per 1 token.
+   *
+   * Pricing fields are in string format to avoid floating point precision issues.
+   */
+  pricing: Pricing;
+  /** Supported Sampling Parameters */
+  supported_sampling_parameters: (
+    | 'temperature'
+    | 'top_p'
+    | 'top_k'
+    | 'repetition_penalty'
+    | 'frequency_penalty'
+    | 'presence_penalty'
+    | 'stop'
+    | 'seed'
+  )[];
+  /** Supported Features */
+  supported_features: (
+    | 'tools'
+    | 'json_mode'
+    | 'structured_outputs'
+    | 'web_search'
+    | 'reasoning'
+  )[];
+  /** Datacenters */
+  datacenters: Datacenter[];
+  /**
+   * Deprecation Date
+   * Date when the model is deprecated (YYYY-MM-DD). Omitted from output if not set.
+   */
+  deprecation_date?: string | null;
+}
+
+/** RouterOpenRouterModelsRes */
+export interface RouterOpenRouterModelsRes {
+  /** Data */
+  data: RouterOpenRouterModel[];
+}
+
+/**
+ * ScoreCreateBody
+ * Request body for creating a Score via REST API.
+ *
+ * This model excludes project_id since it comes from the URL path in RESTful endpoints.
+ */
+export interface ScoreCreateBody {
+  /**
+   * Prediction Id
+   * The prediction ID
+   */
+  prediction_id: string;
+  /**
+   * Scorer
+   * The scorer reference (weave:// URI)
+   */
+  scorer: string;
+  /**
+   * Value
+   * The raw output of the scorer
+   */
+  value: any;
+  /**
+   * Evaluation Run Id
+   * Optional evaluation run ID to link this score as a child call
+   */
+  evaluation_run_id?: string | null;
+}
+
+/** ScoreCreateRes */
+export interface ScoreCreateRes {
+  /**
+   * Score Id
+   * The score ID
+   */
+  score_id: string;
+}
+
+/** ScoreDeleteRes */
+export interface ScoreDeleteRes {
+  /**
+   * Num Deleted
+   * Number of scores deleted
+   */
+  num_deleted: number;
+}
+
+/** ScoreReadRes */
+export interface ScoreReadRes {
+  /**
+   * Score Id
+   * The score ID
+   */
+  score_id: string;
+  /**
+   * Scorer
+   * The scorer reference (weave:// URI)
+   */
+  scorer: string;
+  /**
+   * Value
+   * The raw output of the scorer
+   */
+  value: any;
+  /**
+   * Evaluation Run Id
+   * Evaluation run ID if this score is linked to one
+   */
+  evaluation_run_id?: string | null;
+  /**
+   * Wb User Id
+   * Do not set directly. Server will automatically populate this field.
+   */
+  wb_user_id?: string | null;
+}
+
+/** ScorerCreateBody */
+export interface ScorerCreateBody {
+  /**
+   * Name
+   * The name of this scorer.  Scorers with the same name will be versioned together.
+   */
+  name: string;
+  /**
+   * Description
+   * A description of this scorer
+   */
+  description?: string | null;
+  /**
+   * Op Source Code
+   * Complete source code for the Scorer.score op including imports
+   */
+  op_source_code: string;
+}
+
+/** ScorerCreateRes */
+export interface ScorerCreateRes {
+  /**
+   * Digest
+   * The digest of the created scorer
+   */
+  digest: string;
+  /**
+   * Object Id
+   * The ID of the created scorer
+   */
+  object_id: string;
+  /**
+   * Version Index
+   * The version index of the created scorer
+   */
+  version_index: number;
+  /**
+   * Scorer
+   * Full reference to the created scorer
+   */
+  scorer: string;
+}
+
+/** ScorerDeleteRes */
+export interface ScorerDeleteRes {
+  /**
+   * Num Deleted
+   * Number of scorer versions deleted
+   */
+  num_deleted: number;
+}
+
+/** ScorerReadRes */
+export interface ScorerReadRes {
+  /**
+   * Object Id
+   * The scorer ID
+   */
+  object_id: string;
+  /**
+   * Digest
+   * The digest of the scorer
+   */
+  digest: string;
+  /**
+   * Version Index
+   * The version index of the object
+   */
+  version_index: number;
+  /**
+   * Created At
+   * When the scorer was created
+   * @format date-time
+   */
+  created_at: string;
+  /**
+   * Name
+   * The name of the scorer
+   */
+  name: string;
+  /**
+   * Description
+   * Description of the scorer
+   */
+  description?: string | null;
+  /**
+   * Score Op
+   * The Scorer.score op reference
+   */
+  score_op: string;
+}
+
 /** ServerInfoRes */
 export interface ServerInfoRes {
   /** Min Required Weave Python Version */
   min_required_weave_python_version: string;
+  /** Trace Server Version */
+  trace_server_version: string;
 }
 
 /** SortBy */
@@ -865,15 +5042,21 @@ export interface StartedCallSchemaForInsert {
   trace_id?: string | null;
   /** Parent Id */
   parent_id?: string | null;
+  /** Thread Id */
+  thread_id?: string | null;
+  /** Turn Id */
+  turn_id?: string | null;
   /**
    * Started At
    * @format date-time
    */
   started_at: string;
   /** Attributes */
-  attributes: object;
+  attributes: Record<string, any>;
   /** Inputs */
-  inputs: object;
+  inputs: Record<string, any>;
+  /** Otel Dump */
+  otel_dump?: Record<string, any> | null;
   /**
    * Wb User Id
    * Do not set directly. Server will automatically populate this field.
@@ -881,12 +5064,16 @@ export interface StartedCallSchemaForInsert {
   wb_user_id?: string | null;
   /** Wb Run Id */
   wb_run_id?: string | null;
+  /** Wb Run Step */
+  wb_run_step?: number | null;
 }
 
 /** SummaryInsertMap */
 export interface SummaryInsertMap {
   /** Usage */
   usage?: Record<string, LLMUsageSchema>;
+  /** Status Counts */
+  status_counts?: Partial<Record<TraceStatus, number>>;
   [key: string]: any;
 }
 
@@ -898,7 +5085,26 @@ export interface TableAppendSpec {
 /** TableAppendSpecPayload */
 export interface TableAppendSpecPayload {
   /** Row */
-  row: object;
+  row: Record<string, any>;
+}
+
+/** TableCreateFromDigestsReq */
+export interface TableCreateFromDigestsReq {
+  /** Project Id */
+  project_id: string;
+  /** Row Digests */
+  row_digests: string[];
+  /**
+   * Expected Digest
+   * Client-computed table digest for server-side validation.
+   */
+  expected_digest?: string | null;
+}
+
+/** TableCreateFromDigestsRes */
+export interface TableCreateFromDigestsRes {
+  /** Digest */
+  digest: string;
 }
 
 /** TableCreateReq */
@@ -927,7 +5133,7 @@ export interface TableInsertSpecPayload {
   /** Index */
   index: number;
   /** Row */
-  row: object;
+  row: Record<string, any>;
 }
 
 /** TablePopSpec */
@@ -978,6 +5184,33 @@ export interface TableQueryRes {
   rows: TableRowSchema[];
 }
 
+/** TableQueryStatsBatchReq */
+export interface TableQueryStatsBatchReq {
+  /**
+   * Project Id
+   * The ID of the project
+   */
+  project_id: string;
+  /**
+   * Digests
+   * The digests of the tables to query
+   * @default []
+   */
+  digests?: string[] | null;
+  /**
+   * Include Storage Size
+   * If true, the `storage_size_bytes` column is returned.
+   * @default false
+   */
+  include_storage_size?: boolean | null;
+}
+
+/** TableQueryStatsBatchRes */
+export interface TableQueryStatsBatchRes {
+  /** Tables */
+  tables: TableStatsRow[];
+}
+
 /** TableQueryStatsReq */
 export interface TableQueryStatsReq {
   /**
@@ -1013,6 +5246,8 @@ export interface TableRowSchema {
   digest: string;
   /** Val */
   val: any;
+  /** Original Index */
+  original_index?: number | null;
 }
 
 /** TableSchemaForInsert */
@@ -1020,7 +5255,22 @@ export interface TableSchemaForInsert {
   /** Project Id */
   project_id: string;
   /** Rows */
-  rows: object[];
+  rows: Record<string, any>[];
+  /**
+   * Expected Digest
+   * Client-computed table digest for server-side validation.
+   */
+  expected_digest?: string | null;
+}
+
+/** TableStatsRow */
+export interface TableStatsRow {
+  /** Count */
+  count: number;
+  /** Digest */
+  digest: string;
+  /** Storage Size Bytes */
+  storage_size_bytes?: number | null;
 }
 
 /** TableUpdateReq */
@@ -1042,6 +5292,140 @@ export interface TableUpdateRes {
    * The digests of the rows that were updated
    */
   updated_row_digests?: string[];
+}
+
+/** TagsListRes */
+export interface TagsListRes {
+  /** Tags */
+  tags: string[];
+}
+
+/** ThreadsQueryFilter */
+export interface ThreadsQueryFilter {
+  /**
+   * After Datetime
+   * Only include threads with start_time after this timestamp
+   */
+  after_datetime?: string | null;
+  /**
+   * Before Datetime
+   * Only include threads with last_updated before this timestamp
+   */
+  before_datetime?: string | null;
+  /**
+   * Thread Ids
+   * Only include threads with thread_ids in this list
+   */
+  thread_ids?: string[] | null;
+}
+
+/**
+ * ThreadsQueryReq
+ * Query threads with aggregated statistics based on turn calls only.
+ *
+ * Turn calls are the immediate children of thread contexts (where call.id == turn_id).
+ * This provides meaningful conversation-level statistics rather than including all
+ * nested implementation details.
+ */
+export interface ThreadsQueryReq {
+  /**
+   * Project Id
+   * The ID of the project
+   */
+  project_id: string;
+  /** Filter criteria for the threads query */
+  filter?: ThreadsQueryFilter | null;
+  /**
+   * Limit
+   * Maximum number of threads to return
+   */
+  limit?: number | null;
+  /**
+   * Offset
+   * Number of threads to skip
+   */
+  offset?: number | null;
+  /**
+   * Sort By
+   * Sorting criteria for the threads. Supported fields: 'thread_id', 'turn_count', 'start_time', 'last_updated', 'p50_turn_duration_ms', 'p99_turn_duration_ms'.
+   */
+  sort_by?: SortBy[] | null;
+}
+
+/**
+ * TraceUsageReq
+ * Request to compute per-call usage for a trace, with descendant rollup.
+ *
+ * This endpoint returns usage metrics for each call in the trace, where each
+ * call's metrics include the sum of its own usage plus all descendants' usage.
+ * Use this for trace view where you want to see rolled-up metrics per call.
+ *
+ * Note: All matching calls are loaded into memory for aggregation. For very large
+ * result sets (>10k calls), consider using more specific filters or pagination
+ * at the application layer.
+ */
+export interface TraceUsageReq {
+  /** Project Id */
+  project_id: string;
+  /** Filter to select calls. Typically use trace_ids to get all calls in a trace. */
+  filter?: CallsFilter | null;
+  /** Additional query conditions for filtering calls. */
+  query?: Query | null;
+  /**
+   * Include Costs
+   * If true, include cost calculations in the usage.
+   * @default false
+   */
+  include_costs?: boolean;
+  /**
+   * Limit
+   * Maximum number of calls to process. Acts as a safety limit to prevent unbounded memory usage.
+   * @default 10000
+   */
+  limit?: number;
+}
+
+/**
+ * TraceUsageRes
+ * Response with per-call usage metrics (each includes descendant contributions).
+ */
+export interface TraceUsageRes {
+  /** Call Usage */
+  call_usage?: Record<string, Record<string, LLMAggregatedUsage>>;
+  /** Unfinished Call Ids */
+  unfinished_call_ids?: string[];
+}
+
+/**
+ * UsageMetricSpec
+ * Specification for a usage metric to aggregate (grouped by model).
+ */
+export interface UsageMetricSpec {
+  /**
+   * Metric
+   * Metric to aggregate. Token metrics are normalized across providers.
+   */
+  metric:
+    | 'input_tokens'
+    | 'output_tokens'
+    | 'total_tokens'
+    | 'cache_read_input_tokens'
+    | 'cache_creation_input_tokens'
+    | 'input_cost'
+    | 'output_cost'
+    | 'total_cost';
+  /**
+   * Aggregations
+   * Basic aggregation functions to apply
+   * @default ["sum"]
+   */
+  aggregations?: AggregationType[];
+  /**
+   * Percentiles
+   * Percentile values to compute (0-100). E.g., [50, 95, 99] for p50, p95, p99
+   * @default []
+   */
+  percentiles?: number[];
 }
 
 /** ValidationError */
@@ -1107,7 +5491,7 @@ export enum ContentType {
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-  public baseUrl: string = 'https://api.wandb.ai';
+  public baseUrl: string = '';
   private securityData: SecurityDataType | null = null;
   private securityWorker?: ApiConfig<SecurityDataType>['securityWorker'];
   private abortControllers = new Map<CancelToken, AbortController>();
@@ -1312,7 +5696,6 @@ export class HttpClient<SecurityDataType = unknown> {
 /**
  * @title FastAPI
  * @version 0.1.0
- * @baseUrl https://api.wandb.ai
  */
 export class Api<
   SecurityDataType extends unknown,
@@ -1334,6 +5717,50 @@ export class Api<
         ...params,
       }),
   };
+  version = {
+    /**
+     * No description
+     *
+     * @tags Service
+     * @name ReadVersionVersionGet
+     * @summary Read Version
+     * @request GET:/version
+     */
+    readVersionVersionGet: (params: RequestParams = {}) =>
+      this.request<any, any>({
+        path: `/version`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+  };
+  geolocate = {
+    /**
+     * @description Lookup the geographic location of a user based on their IP address. This API exists for debugging purposes and may not be available in the future.
+     *
+     * @tags Service
+     * @name GetCallerLocationGeolocateGet
+     * @summary Get Caller Location
+     * @request GET:/geolocate
+     */
+    getCallerLocationGeolocateGet: (
+      query?: {
+        /**
+         * Ip
+         * IP address to geolocate, defaults to client IP address
+         */
+        ip?: string | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<GeolocationRes, HTTPValidationError>({
+        path: `/geolocate`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+  };
   serverInfo = {
     /**
      * No description
@@ -1351,6 +5778,208 @@ export class Api<
         ...params,
       }),
   };
+  otel = {
+    /**
+     * No description
+     *
+     * @tags OpenTelemetry
+     * @name ExportTraceOtelV1TracesPost
+     * @summary Export Trace
+     * @request POST:/otel/v1/traces
+     */
+    exportTraceOtelV1TracesPost: (params: RequestParams = {}) =>
+      this.request<any, any>({
+        path: `/otel/v1/traces`,
+        method: 'POST',
+        format: 'json',
+        ...params,
+      }),
+  };
+  agents = {
+    /**
+     * @description Ingest OTel spans into the GenAI observability system.
+     *
+     * @tags Agents
+     * @name ExportGenaiTraceAgentsOtelV1TracesPost
+     * @summary Export Genai Trace
+     * @request POST:/agents/otel/v1/traces
+     */
+    exportGenaiTraceAgentsOtelV1TracesPost: (params: RequestParams = {}) =>
+      this.request<any, any>({
+        path: `/agents/otel/v1/traces`,
+        method: 'POST',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Query agent spans, either as raw rows or grouped aggregates.
+     *
+     * @tags Agents
+     * @name GenaiSpansQueryAgentsSpansQueryPost
+     * @summary Genai Spans Query
+     * @request POST:/agents/spans/query
+     */
+    genaiSpansQueryAgentsSpansQueryPost: (
+      data: AgentSpansQueryReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<AgentSpansQueryRes, HTTPValidationError>({
+        path: `/agents/spans/query`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Query chart-ready aggregations over agent spans.
+     *
+     * @tags Agents
+     * @name GenaiSpansStatsAgentsSpansStatsPost
+     * @summary Genai Spans Stats
+     * @request POST:/agents/spans/stats
+     */
+    genaiSpansStatsAgentsSpansStatsPost: (
+      data: AgentSpanStatsReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<AgentSpanStatsRes, HTTPValidationError>({
+        path: `/agents/spans/stats`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Discover typed custom attribute keys on matching agent spans.
+     *
+     * @tags Agents
+     * @name GenaiCustomAttrsSchemaAgentsSpansCustomAttrsSchemaPost
+     * @summary Genai Custom Attrs Schema
+     * @request POST:/agents/spans/custom-attrs/schema
+     */
+    genaiCustomAttrsSchemaAgentsSpansCustomAttrsSchemaPost: (
+      data: AgentCustomAttrsSchemaReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<AgentCustomAttrsSchemaRes, HTTPValidationError>({
+        path: `/agents/spans/custom-attrs/schema`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Agents
+     * @name GenaiAgentsQueryAgentsQueryPost
+     * @summary Genai Agents Query
+     * @request POST:/agents/query
+     */
+    genaiAgentsQueryAgentsQueryPost: (
+      data: AgentsQueryReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<AgentsQueryRes, HTTPValidationError>({
+        path: `/agents/query`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Agents
+     * @name GenaiAgentVersionsQueryAgentsAgentVersionsQueryPost
+     * @summary Genai Agent Versions Query
+     * @request POST:/agents/agent-versions/query
+     */
+    genaiAgentVersionsQueryAgentsAgentVersionsQueryPost: (
+      data: AgentVersionsQueryReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<AgentVersionsQueryRes, HTTPValidationError>({
+        path: `/agents/agent-versions/query`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Agents
+     * @name GenaiSearchAgentsSearchPost
+     * @summary Genai Search
+     * @request POST:/agents/search
+     */
+    genaiSearchAgentsSearchPost: (
+      data: AgentSearchReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<AgentSearchRes, HTTPValidationError>({
+        path: `/agents/search`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Agents
+     * @name GenaiTracesChatAgentsTracesChatPost
+     * @summary Genai Traces Chat
+     * @request POST:/agents/traces/chat
+     */
+    genaiTracesChatAgentsTracesChatPost: (
+      data: AgentTraceChatReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<AgentTraceChatRes, HTTPValidationError>({
+        path: `/agents/traces/chat`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Agents
+     * @name GenaiConversationChatAgentsConversationsChatPost
+     * @summary Genai Conversation Chat
+     * @request POST:/agents/conversations/chat
+     */
+    genaiConversationChatAgentsConversationsChatPost: (
+      data: AgentConversationChatReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<AgentConversationChatRes, HTTPValidationError>({
+        path: `/agents/conversations/chat`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
   call = {
     /**
      * No description
@@ -1359,14 +5988,12 @@ export class Api<
      * @name CallStartCallStartPost
      * @summary Call Start
      * @request POST:/call/start
-     * @secure
      */
     callStartCallStartPost: (data: CallStartReq, params: RequestParams = {}) =>
       this.request<CallStartRes, HTTPValidationError>({
         path: `/call/start`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1379,14 +6006,12 @@ export class Api<
      * @name CallEndCallEndPost
      * @summary Call End
      * @request POST:/call/end
-     * @secure
      */
     callEndCallEndPost: (data: CallEndReq, params: RequestParams = {}) =>
       this.request<CallEndRes, HTTPValidationError>({
         path: `/call/end`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1399,7 +6024,6 @@ export class Api<
      * @name CallStartBatchCallUpsertBatchPost
      * @summary Call Start Batch
      * @request POST:/call/upsert_batch
-     * @secure
      */
     callStartBatchCallUpsertBatchPost: (
       data: CallCreateBatchReq,
@@ -1409,7 +6033,6 @@ export class Api<
         path: `/call/upsert_batch`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1422,7 +6045,6 @@ export class Api<
      * @name CallUpdateCallUpdatePost
      * @summary Call Update
      * @request POST:/call/update
-     * @secure
      */
     callUpdateCallUpdatePost: (
       data: CallUpdateReq,
@@ -1432,7 +6054,6 @@ export class Api<
         path: `/call/update`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1445,14 +6066,12 @@ export class Api<
      * @name CallReadCallReadPost
      * @summary Call Read
      * @request POST:/call/read
-     * @secure
      */
     callReadCallReadPost: (data: CallReadReq, params: RequestParams = {}) =>
       this.request<CallReadRes, HTTPValidationError>({
         path: `/call/read`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1466,7 +6085,6 @@ export class Api<
      * @name CallsDeleteCallsDeletePost
      * @summary Calls Delete
      * @request POST:/calls/delete
-     * @secure
      */
     callsDeleteCallsDeletePost: (
       data: CallsDeleteReq,
@@ -1476,7 +6094,6 @@ export class Api<
         path: `/calls/delete`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1489,7 +6106,6 @@ export class Api<
      * @name CallsQueryStatsCallsQueryStatsPost
      * @summary Calls Query Stats
      * @request POST:/calls/query_stats
-     * @secure
      */
     callsQueryStatsCallsQueryStatsPost: (
       data: CallsQueryStatsReq,
@@ -1499,7 +6115,27 @@ export class Api<
         path: `/calls/query_stats`,
         method: 'POST',
         body: data,
-        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Compute aggregated usage for multiple root calls, with descendant rollup.
+     *
+     * @tags Calls
+     * @name CallsUsageCallsUsagePost
+     * @summary Calls Usage
+     * @request POST:/calls/usage
+     */
+    callsUsageCallsUsagePost: (
+      data: CallsUsageReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<CallsUsageRes, HTTPValidationError>({
+        path: `/calls/usage`,
+        method: 'POST',
+        body: data,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1512,7 +6148,6 @@ export class Api<
      * @name CallsQueryStreamCallsStreamQueryPost
      * @summary Calls Query Stream
      * @request POST:/calls/stream_query
-     * @secure
      */
     callsQueryStreamCallsStreamQueryPost: (
       data: CallsQueryReq,
@@ -1522,7 +6157,149 @@ export class Api<
         path: `/calls/stream_query`,
         method: 'POST',
         body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Calls
+     * @name CallStatsCallsStatsPost
+     * @summary Call Stats
+     * @request POST:/calls/stats
+     */
+    callStatsCallsStatsPost: (data: CallStatsReq, params: RequestParams = {}) =>
+      this.request<CallStatsRes, HTTPValidationError>({
+        path: `/calls/stats`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Scores
+     * @name CallsScoreCallsScorePost
+     * @summary Calls Score
+     * @request POST:/calls/score
+     */
+    callsScoreCallsScorePost: (
+      data: CallsScoreReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<CallsScoreRes, HTTPValidationError>({
+        path: `/calls/score`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
+  inference = {
+    /**
+     * @description Returns a list of available Serverless Inference models. This API is available without authentication.
+     *
+     * @tags Inference
+     * @name InferenceCatalogModelsInferenceCatalogModelsGet
+     * @summary Inference Catalog Models
+     * @request GET:/inference/catalog/models
+     */
+    inferenceCatalogModelsInferenceCatalogModelsGet: (
+      params: RequestParams = {}
+    ) =>
+      this.request<CatalogModelsRes, any>({
+        path: `/inference/catalog/models`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Returns a list of available models for Artificial Analysis. This API is available without authentication.
+     *
+     * @tags Inference
+     * @name InferenceAnalysisArtificialanalysisModelsInferenceAnalysisArtificialanalysisModelsGet
+     * @summary Inference Analysis Artificialanalysis Models
+     * @request GET:/inference/analysis/artificialanalysis/models
+     */
+    inferenceAnalysisArtificialanalysisModelsInferenceAnalysisArtificialanalysisModelsGet:
+      (params: RequestParams = {}) =>
+        this.request<RouterOpenRouterModelsRes, any>({
+          path: `/inference/analysis/artificialanalysis/models`,
+          method: 'GET',
+          format: 'json',
+          ...params,
+        }),
+
+    /**
+     * @description Returns a list of models that are available to be used with OpenRouter. This API is available without authentication.
+     *
+     * @tags Inference
+     * @name InferenceRouterOpenrouterModelsInferenceRouterOpenrouterModelsGet
+     * @summary Inference Router Openrouter Models
+     * @request GET:/inference/router/openrouter/models
+     */
+    inferenceRouterOpenrouterModelsInferenceRouterOpenrouterModelsGet: (
+      params: RequestParams = {}
+    ) =>
+      this.request<RouterOpenRouterModelsRes, any>({
+        path: `/inference/router/openrouter/models`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Returns available hardware and pricing for a given model. Called by NVIDIA to show users their options and redirect them based on what we support.  Only serverless options are returned.
+     *
+     * @tags Inference
+     * @name NvidiaHardwareInferenceNvidiaV2HardwareGet
+     * @summary Nvidia Hardware
+     * @request GET:/inference/nvidia/v2/hardware
+     * @secure
+     */
+    nvidiaHardwareInferenceNvidiaV2HardwareGet: (
+      query: {
+        /**
+         * Model
+         * Model name without the publisher prefix
+         */
+        model: string;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<NvidiaHardwareRes, HTTPValidationError>({
+        path: `/inference/nvidia/v2/hardware`,
+        method: 'GET',
+        query: query,
         secure: true,
+        format: 'json',
+        ...params,
+      }),
+  };
+  trace = {
+    /**
+     * @description Compute per-call usage for a trace, with descendant rollup.
+     *
+     * @tags Calls
+     * @name TraceUsageTraceUsagePost
+     * @summary Trace Usage
+     * @request POST:/trace/usage
+     */
+    traceUsageTraceUsagePost: (
+      data: TraceUsageReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<TraceUsageRes, HTTPValidationError>({
+        path: `/trace/usage`,
+        method: 'POST',
+        body: data,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1536,14 +6313,12 @@ export class Api<
      * @name ObjCreateObjCreatePost
      * @summary Obj Create
      * @request POST:/obj/create
-     * @secure
      */
     objCreateObjCreatePost: (data: ObjCreateReq, params: RequestParams = {}) =>
       this.request<ObjCreateRes, HTTPValidationError>({
         path: `/obj/create`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1556,14 +6331,30 @@ export class Api<
      * @name ObjReadObjReadPost
      * @summary Obj Read
      * @request POST:/obj/read
-     * @secure
      */
     objReadObjReadPost: (data: ObjReadReq, params: RequestParams = {}) =>
       this.request<ObjReadRes, HTTPValidationError>({
         path: `/obj/read`,
         method: 'POST',
         body: data,
-        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Objects
+     * @name ObjDeleteObjDeletePost
+     * @summary Obj Delete
+     * @request POST:/obj/delete
+     */
+    objDeleteObjDeletePost: (data: ObjDeleteReq, params: RequestParams = {}) =>
+      this.request<ObjDeleteRes, HTTPValidationError>({
+        path: `/obj/delete`,
+        method: 'POST',
+        body: data,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1577,15 +6368,151 @@ export class Api<
      * @name ObjsQueryObjsQueryPost
      * @summary Objs Query
      * @request POST:/objs/query
-     * @secure
      */
     objsQueryObjsQueryPost: (data: ObjQueryReq, params: RequestParams = {}) =>
       this.request<ObjQueryRes, HTTPValidationError>({
         path: `/objs/query`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Add tags to an object version.
+     *
+     * @tags Objects
+     * @name ObjAddTagsObjsObjectIdVersionsDigestTagsPut
+     * @summary Obj Add Tags
+     * @request PUT:/objs/{object_id}/versions/{digest}/tags
+     */
+    objAddTagsObjsObjectIdVersionsDigestTagsPut: (
+      objectId: string,
+      digest: string,
+      data: ObjTagsBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<ObjAddTagsRes, HTTPValidationError>({
+        path: `/objs/${objectId}/versions/${digest}/tags`,
+        method: 'PUT',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Remove tags from an object version.
+     *
+     * @tags Objects
+     * @name ObjRemoveTagsObjsObjectIdVersionsDigestTagsRemovePost
+     * @summary Obj Remove Tags
+     * @request POST:/objs/{object_id}/versions/{digest}/tags/remove
+     */
+    objRemoveTagsObjsObjectIdVersionsDigestTagsRemovePost: (
+      objectId: string,
+      digest: string,
+      data: ObjTagsBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<ObjRemoveTagsRes, HTTPValidationError>({
+        path: `/objs/${objectId}/versions/${digest}/tags/remove`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Set aliases for an object version.
+     *
+     * @tags Objects
+     * @name ObjSetAliasesObjsObjectIdAliasesPut
+     * @summary Obj Set Aliases
+     * @request PUT:/objs/{object_id}/aliases
+     */
+    objSetAliasesObjsObjectIdAliasesPut: (
+      objectId: string,
+      data: ObjSetAliasesBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<ObjSetAliasesRes, HTTPValidationError>({
+        path: `/objs/${objectId}/aliases`,
+        method: 'PUT',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Remove aliases from an object.
+     *
+     * @tags Objects
+     * @name ObjRemoveAliasesObjsObjectIdAliasesRemovePost
+     * @summary Obj Remove Aliases
+     * @request POST:/objs/{object_id}/aliases/remove
+     */
+    objRemoveAliasesObjsObjectIdAliasesRemovePost: (
+      objectId: string,
+      data: ObjRemoveAliasesBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<ObjRemoveAliasesRes, HTTPValidationError>({
+        path: `/objs/${objectId}/aliases/remove`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
+  tags = {
+    /**
+     * @description List all tags in a project.
+     *
+     * @tags Objects
+     * @name TagsListTagsGet
+     * @summary Tags List
+     * @request GET:/tags
+     */
+    tagsListTagsGet: (
+      query: {
+        /** Project Id */
+        project_id: string;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<TagsListRes, HTTPValidationError>({
+        path: `/tags`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+  };
+  aliases = {
+    /**
+     * @description List all aliases in a project.
+     *
+     * @tags Objects
+     * @name AliasesListAliasesGet
+     * @summary Aliases List
+     * @request GET:/aliases
+     */
+    aliasesListAliasesGet: (
+      query: {
+        /** Project Id */
+        project_id: string;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<AliasesListRes, HTTPValidationError>({
+        path: `/aliases`,
+        method: 'GET',
+        query: query,
         format: 'json',
         ...params,
       }),
@@ -1598,7 +6525,6 @@ export class Api<
      * @name TableCreateTableCreatePost
      * @summary Table Create
      * @request POST:/table/create
-     * @secure
      */
     tableCreateTableCreatePost: (
       data: TableCreateReq,
@@ -1608,7 +6534,6 @@ export class Api<
         path: `/table/create`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1621,7 +6546,6 @@ export class Api<
      * @name TableUpdateTableUpdatePost
      * @summary Table Update
      * @request POST:/table/update
-     * @secure
      */
     tableUpdateTableUpdatePost: (
       data: TableUpdateReq,
@@ -1631,7 +6555,27 @@ export class Api<
         path: `/table/update`,
         method: 'POST',
         body: data,
-        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Tables
+     * @name TableCreateFromDigestsTableCreateFromDigestsPost
+     * @summary Table Create From Digests
+     * @request POST:/table/create_from_digests
+     */
+    tableCreateFromDigestsTableCreateFromDigestsPost: (
+      data: TableCreateFromDigestsReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<TableCreateFromDigestsRes, HTTPValidationError>({
+        path: `/table/create_from_digests`,
+        method: 'POST',
+        body: data,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1644,7 +6588,6 @@ export class Api<
      * @name TableQueryTableQueryPost
      * @summary Table Query
      * @request POST:/table/query
-     * @secure
      */
     tableQueryTableQueryPost: (
       data: TableQueryReq,
@@ -1654,7 +6597,6 @@ export class Api<
         path: `/table/query`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1667,7 +6609,6 @@ export class Api<
      * @name TableQueryStatsTableQueryStatsPost
      * @summary Table Query Stats
      * @request POST:/table/query_stats
-     * @secure
      */
     tableQueryStatsTableQueryStatsPost: (
       data: TableQueryStatsReq,
@@ -1677,7 +6618,27 @@ export class Api<
         path: `/table/query_stats`,
         method: 'POST',
         body: data,
-        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Tables
+     * @name TableQueryStatsBatchTableQueryStatsBatchPost
+     * @summary Table Query Stats Batch
+     * @request POST:/table/query_stats_batch
+     */
+    tableQueryStatsBatchTableQueryStatsBatchPost: (
+      data: TableQueryStatsBatchReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<TableQueryStatsBatchRes, HTTPValidationError>({
+        path: `/table/query_stats_batch`,
+        method: 'POST',
+        body: data,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1691,7 +6652,6 @@ export class Api<
      * @name RefsReadBatchRefsReadBatchPost
      * @summary Refs Read Batch
      * @request POST:/refs/read_batch
-     * @secure
      */
     refsReadBatchRefsReadBatchPost: (
       data: RefsReadBatchReq,
@@ -1701,7 +6661,6 @@ export class Api<
         path: `/refs/read_batch`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1715,7 +6674,6 @@ export class Api<
      * @name FileCreateFileCreatePost
      * @summary File Create
      * @request POST:/file/create
-     * @secure
      */
     fileCreateFileCreatePost: (
       data: BodyFileCreateFileCreatePost,
@@ -1725,7 +6683,6 @@ export class Api<
         path: `/file/create`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.FormData,
         format: 'json',
         ...params,
@@ -1738,7 +6695,6 @@ export class Api<
      * @name FileContentFileContentPost
      * @summary File Content
      * @request POST:/file/content
-     * @secure
      */
     fileContentFileContentPost: (
       data: FileContentReadReq,
@@ -1748,7 +6704,28 @@ export class Api<
         path: `/file/content`,
         method: 'POST',
         body: data,
-        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
+  files = {
+    /**
+     * No description
+     *
+     * @tags Files
+     * @name FilesStatsFilesQueryStatsPost
+     * @summary Files Stats
+     * @request POST:/files/query_stats
+     */
+    filesStatsFilesQueryStatsPost: (
+      data: FilesStatsReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<FilesStatsRes, HTTPValidationError>({
+        path: `/files/query_stats`,
+        method: 'POST',
+        body: data,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1762,7 +6739,6 @@ export class Api<
      * @name CostCreateCostCreatePost
      * @summary Cost Create
      * @request POST:/cost/create
-     * @secure
      */
     costCreateCostCreatePost: (
       data: CostCreateReq,
@@ -1772,7 +6748,6 @@ export class Api<
         path: `/cost/create`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1785,14 +6760,12 @@ export class Api<
      * @name CostQueryCostQueryPost
      * @summary Cost Query
      * @request POST:/cost/query
-     * @secure
      */
     costQueryCostQueryPost: (data: CostQueryReq, params: RequestParams = {}) =>
       this.request<CostQueryRes, HTTPValidationError>({
         path: `/cost/query`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1805,14 +6778,12 @@ export class Api<
      * @name CostPurgeCostPurgePost
      * @summary Cost Purge
      * @request POST:/cost/purge
-     * @secure
      */
     costPurgeCostPurgePost: (data: CostPurgeReq, params: RequestParams = {}) =>
       this.request<CostPurgeRes, HTTPValidationError>({
         path: `/cost/purge`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1826,7 +6797,6 @@ export class Api<
      * @name FeedbackCreateFeedbackCreatePost
      * @summary Feedback Create
      * @request POST:/feedback/create
-     * @secure
      */
     feedbackCreateFeedbackCreatePost: (
       data: FeedbackCreateReq,
@@ -1836,7 +6806,27 @@ export class Api<
         path: `/feedback/create`,
         method: 'POST',
         body: data,
-        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Add multiple feedback items to calls or objects.
+     *
+     * @tags Feedback
+     * @name FeedbackCreateBatchFeedbackBatchCreatePost
+     * @summary Feedback Create Batch
+     * @request POST:/feedback/batch/create
+     */
+    feedbackCreateBatchFeedbackBatchCreatePost: (
+      data: FeedbackCreateBatchReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<FeedbackCreateBatchRes, HTTPValidationError>({
+        path: `/feedback/batch/create`,
+        method: 'POST',
+        body: data,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1849,7 +6839,6 @@ export class Api<
      * @name FeedbackQueryFeedbackQueryPost
      * @summary Feedback Query
      * @request POST:/feedback/query
-     * @secure
      */
     feedbackQueryFeedbackQueryPost: (
       data: FeedbackQueryReq,
@@ -1859,7 +6848,6 @@ export class Api<
         path: `/feedback/query`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1872,7 +6860,6 @@ export class Api<
      * @name FeedbackPurgeFeedbackPurgePost
      * @summary Feedback Purge
      * @request POST:/feedback/purge
-     * @secure
      */
     feedbackPurgeFeedbackPurgePost: (
       data: FeedbackPurgeReq,
@@ -1882,7 +6869,6 @@ export class Api<
         path: `/feedback/purge`,
         method: 'POST',
         body: data,
-        secure: true,
         type: ContentType.Json,
         format: 'json',
         ...params,
@@ -1895,7 +6881,6 @@ export class Api<
      * @name FeedbackReplaceFeedbackReplacePost
      * @summary Feedback Replace
      * @request POST:/feedback/replace
-     * @secure
      */
     feedbackReplaceFeedbackReplacePost: (
       data: FeedbackReplaceReq,
@@ -1905,7 +6890,1331 @@ export class Api<
         path: `/feedback/replace`,
         method: 'POST',
         body: data,
-        secure: true,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Return aggregated feedback statistics over time buckets.
+     *
+     * @tags Feedback
+     * @name FeedbackStatsFeedbackStatsPost
+     * @summary Feedback Stats
+     * @request POST:/feedback/stats
+     */
+    feedbackStatsFeedbackStatsPost: (
+      data: FeedbackStatsReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<FeedbackStatsRes, HTTPValidationError>({
+        path: `/feedback/stats`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Discover feedback payload schema (paths and types) from sample rows.
+     *
+     * @tags Feedback
+     * @name FeedbackPayloadSchemaFeedbackPayloadSchemaPost
+     * @summary Feedback Payload Schema
+     * @request POST:/feedback/payload_schema
+     */
+    feedbackPayloadSchemaFeedbackPayloadSchemaPost: (
+      data: FeedbackPayloadSchemaReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<FeedbackPayloadSchemaRes, HTTPValidationError>({
+        path: `/feedback/payload_schema`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
+  service = {
+    /**
+     * No description
+     *
+     * @tags Service
+     * @name ProjectsInfoServiceProjectsInfoPost
+     * @summary Projects Info
+     * @request POST:/service/projects_info
+     */
+    projectsInfoServiceProjectsInfoPost: (
+      data: ProjectsInfoReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<ProjectsInfoRes[], HTTPValidationError>({
+        path: `/service/projects_info`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
+  threads = {
+    /**
+     * No description
+     *
+     * @tags Threads
+     * @name ThreadsQueryStreamThreadsStreamQueryPost
+     * @summary Threads Query Stream
+     * @request POST:/threads/stream_query
+     */
+    threadsQueryStreamThreadsStreamQueryPost: (
+      data: ThreadsQueryReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/threads/stream_query`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
+  annotationQueues = {
+    /**
+     * @description Create a new annotation queue.
+     *
+     * @tags Annotation Queues
+     * @name AnnotationQueueCreateAnnotationQueuesPost
+     * @summary Annotation Queue Create
+     * @request POST:/annotation_queues
+     */
+    annotationQueueCreateAnnotationQueuesPost: (
+      data: AnnotationQueueCreateReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<AnnotationQueueCreateRes, HTTPValidationError>({
+        path: `/annotation_queues`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Query annotation queues for a project (streaming NDJSON response).
+     *
+     * @tags Annotation Queues
+     * @name AnnotationQueuesQueryStreamAnnotationQueuesQueryPost
+     * @summary Annotation Queues Query Stream
+     * @request POST:/annotation_queues/query
+     */
+    annotationQueuesQueryStreamAnnotationQueuesQueryPost: (
+      data: AnnotationQueuesQueryReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/annotation_queues/query`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Read a specific annotation queue.
+     *
+     * @tags Annotation Queues
+     * @name AnnotationQueueReadAnnotationQueuesQueueIdGet
+     * @summary Annotation Queue Read
+     * @request GET:/annotation_queues/{queue_id}
+     */
+    annotationQueueReadAnnotationQueuesQueueIdGet: (
+      queueId: string,
+      query: {
+        /** Project Id */
+        project_id: string;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<AnnotationQueueReadRes, HTTPValidationError>({
+        path: `/annotation_queues/${queueId}`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Delete (soft-delete) an annotation queue.
+     *
+     * @tags Annotation Queues
+     * @name AnnotationQueueDeleteAnnotationQueuesQueueIdDelete
+     * @summary Annotation Queue Delete
+     * @request DELETE:/annotation_queues/{queue_id}
+     */
+    annotationQueueDeleteAnnotationQueuesQueueIdDelete: (
+      queueId: string,
+      query: {
+        /** Project Id */
+        project_id: string;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<AnnotationQueueDeleteRes, HTTPValidationError>({
+        path: `/annotation_queues/${queueId}`,
+        method: 'DELETE',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Update an annotation queue's metadata (name, description, scorer_refs).
+     *
+     * @tags Annotation Queues
+     * @name AnnotationQueueUpdateAnnotationQueuesQueueIdPut
+     * @summary Annotation Queue Update
+     * @request PUT:/annotation_queues/{queue_id}
+     */
+    annotationQueueUpdateAnnotationQueuesQueueIdPut: (
+      queueId: string,
+      data: AnnotationQueueUpdateBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<AnnotationQueueUpdateRes, HTTPValidationError>({
+        path: `/annotation_queues/${queueId}`,
+        method: 'PUT',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Add calls to an annotation queue.
+     *
+     * @tags Annotation Queues
+     * @name AnnotationQueueAddCallsAnnotationQueuesQueueIdItemsPost
+     * @summary Annotation Queue Add Calls
+     * @request POST:/annotation_queues/{queue_id}/items
+     */
+    annotationQueueAddCallsAnnotationQueuesQueueIdItemsPost: (
+      queueId: string,
+      data: AnnotationQueueAddCallsBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<AnnotationQueueAddCallsRes, HTTPValidationError>({
+        path: `/annotation_queues/${queueId}/items`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Query items in an annotation queue with pagination and sorting.
+     *
+     * @tags Annotation Queues
+     * @name AnnotationQueueItemsQueryAnnotationQueuesQueueIdItemsQueryPost
+     * @summary Annotation Queue Items Query
+     * @request POST:/annotation_queues/{queue_id}/items/query
+     */
+    annotationQueueItemsQueryAnnotationQueuesQueueIdItemsQueryPost: (
+      queueId: string,
+      data: AnnotationQueueItemsQueryBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<AnnotationQueueItemsQueryRes, HTTPValidationError>({
+        path: `/annotation_queues/${queueId}/items/query`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Get stats for multiple annotation queues.
+     *
+     * @tags Annotation Queues
+     * @name AnnotationQueuesStatsAnnotationQueuesStatsPost
+     * @summary Annotation Queues Stats
+     * @request POST:/annotation_queues/stats
+     */
+    annotationQueuesStatsAnnotationQueuesStatsPost: (
+      data: AnnotationQueuesStatsReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<AnnotationQueuesStatsRes, HTTPValidationError>({
+        path: `/annotation_queues/stats`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Update the annotation state of a queue item for the current annotator.
+     *
+     * @tags Annotation Queues
+     * @name AnnotationQueueItemProgressUpdateAnnotationQueuesQueueIdItemsItemIdProgressPost
+     * @summary Annotation Queue Item Progress Update
+     * @request POST:/annotation_queues/{queue_id}/items/{item_id}/progress
+     */
+    annotationQueueItemProgressUpdateAnnotationQueuesQueueIdItemsItemIdProgressPost:
+      (
+        queueId: string,
+        itemId: string,
+        data: AnnotationQueueItemProgressUpdateBody,
+        params: RequestParams = {}
+      ) =>
+        this.request<AnnotatorQueueItemsProgressUpdateRes, HTTPValidationError>(
+          {
+            path: `/annotation_queues/${queueId}/items/${itemId}/progress`,
+            method: 'POST',
+            body: data,
+            type: ContentType.Json,
+            format: 'json',
+            ...params,
+          }
+        ),
+  };
+  evaluations = {
+    /**
+     * No description
+     *
+     * @tags Evaluations
+     * @name EvaluateModelEvaluationsEvaluateModelPost
+     * @summary Evaluate Model
+     * @request POST:/evaluations/evaluate_model
+     */
+    evaluateModelEvaluationsEvaluateModelPost: (
+      data: EvaluateModelReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<EvaluateModelRes, HTTPValidationError>({
+        path: `/evaluations/evaluate_model`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Evaluations
+     * @name EvaluationStatusEvaluationsStatusPost
+     * @summary Evaluation Status
+     * @request POST:/evaluations/status
+     */
+    evaluationStatusEvaluationsStatusPost: (
+      data: EvaluationStatusReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<EvaluationStatusRes, HTTPValidationError>({
+        path: `/evaluations/status`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Rescore an existing evaluation run with different scorer(s). Applies the provided scorer(s) to the predictions from source_evaluation_run_id and returns a new evaluation_run_id. Original prediction call IDs are preserved.
+     *
+     * @tags Evaluations
+     * @name RescoreEvaluationEvaluationsRescorePost
+     * @summary Rescore Evaluation
+     * @request POST:/evaluations/rescore
+     */
+    rescoreEvaluationEvaluationsRescorePost: (
+      data: RescoreReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<RescoreRes, HTTPValidationError>({
+        path: `/evaluations/rescore`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
+  image = {
+    /**
+     * No description
+     *
+     * @tags Images
+     * @name ImageCreateImageCreatePost
+     * @summary Image Create
+     * @request POST:/image/create
+     */
+    imageCreateImageCreatePost: (
+      data: ImageGenerationCreateReq,
+      params: RequestParams = {}
+    ) =>
+      this.request<ImageGenerationCreateRes, HTTPValidationError>({
+        path: `/image/create`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
+  linkToRegistry = {
+    /**
+     * No description
+     *
+     * @tags Registry
+     * @name LinkToRegistryLinkToRegistryPost
+     * @summary Link To Registry
+     * @request POST:/link_to_registry
+     */
+    linkToRegistryLinkToRegistryPost: (
+      data: CreateAndLinkPayload,
+      params: RequestParams = {}
+    ) =>
+      this.request<CreateAndLinkWeaveAssetRes, HTTPValidationError>({
+        path: `/link_to_registry`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+  };
+  v2 = {
+    /**
+     * @description Create an op object.
+     *
+     * @tags Ops
+     * @name OpCreateV2EntityProjectOpsPost
+     * @summary Op Create
+     * @request POST:/v2/{entity}/{project}/ops
+     */
+    opCreateV2EntityProjectOpsPost: (
+      entity: string,
+      project: string,
+      data: OpCreateBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<OpCreateRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/ops`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description List op objects.
+     *
+     * @tags Ops
+     * @name OpListV2EntityProjectOpsGet
+     * @summary Op List
+     * @request GET:/v2/{entity}/{project}/ops
+     */
+    opListV2EntityProjectOpsGet: (
+      entity: string,
+      project: string,
+      query?: {
+        /**
+         * Limit
+         * Maximum number of ops to return
+         */
+        limit?: number | null;
+        /**
+         * Offset
+         * Number of ops to skip
+         */
+        offset?: number | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/ops`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Get an op object.
+     *
+     * @tags Ops
+     * @name OpReadV2EntityProjectOpsObjectIdVersionsDigestGet
+     * @summary Op Read
+     * @request GET:/v2/{entity}/{project}/ops/{object_id}/versions/{digest}
+     */
+    opReadV2EntityProjectOpsObjectIdVersionsDigestGet: (
+      entity: string,
+      project: string,
+      objectId: string,
+      digest: string,
+      query?: {
+        /**
+         * Eager
+         * Whether to eagerly load the op code
+         * @default false
+         */
+        eager?: boolean;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<OpReadRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/ops/${objectId}/versions/${digest}`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Delete an op object. If digests are provided, only those versions are deleted. Otherwise, all versions are deleted.
+     *
+     * @tags Ops
+     * @name OpDeleteV2EntityProjectOpsObjectIdDelete
+     * @summary Op Delete
+     * @request DELETE:/v2/{entity}/{project}/ops/{object_id}
+     */
+    opDeleteV2EntityProjectOpsObjectIdDelete: (
+      entity: string,
+      project: string,
+      objectId: string,
+      query?: {
+        /**
+         * Digests
+         * List of digests to delete. If not provided, all digests for the op will be deleted.
+         */
+        digests?: string[] | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<OpDeleteRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/ops/${objectId}`,
+        method: 'DELETE',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Create a dataset object.
+     *
+     * @tags Datasets
+     * @name DatasetCreateV2EntityProjectDatasetsPost
+     * @summary Dataset Create
+     * @request POST:/v2/{entity}/{project}/datasets
+     */
+    datasetCreateV2EntityProjectDatasetsPost: (
+      entity: string,
+      project: string,
+      data: DatasetCreateBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<DatasetCreateRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/datasets`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description List dataset objects.
+     *
+     * @tags Datasets
+     * @name DatasetListV2EntityProjectDatasetsGet
+     * @summary Dataset List
+     * @request GET:/v2/{entity}/{project}/datasets
+     */
+    datasetListV2EntityProjectDatasetsGet: (
+      entity: string,
+      project: string,
+      query?: {
+        /**
+         * Limit
+         * Maximum number of datasets to return
+         */
+        limit?: number | null;
+        /**
+         * Offset
+         * Number of datasets to skip
+         */
+        offset?: number | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/datasets`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Get a dataset object.
+     *
+     * @tags Datasets
+     * @name DatasetReadV2EntityProjectDatasetsObjectIdVersionsDigestGet
+     * @summary Dataset Read
+     * @request GET:/v2/{entity}/{project}/datasets/{object_id}/versions/{digest}
+     */
+    datasetReadV2EntityProjectDatasetsObjectIdVersionsDigestGet: (
+      entity: string,
+      project: string,
+      objectId: string,
+      digest: string,
+      params: RequestParams = {}
+    ) =>
+      this.request<DatasetReadRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/datasets/${objectId}/versions/${digest}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Delete a dataset object. If digests are provided, only those versions are deleted. Otherwise, all versions are deleted.
+     *
+     * @tags Datasets
+     * @name DatasetDeleteV2EntityProjectDatasetsObjectIdDelete
+     * @summary Dataset Delete
+     * @request DELETE:/v2/{entity}/{project}/datasets/{object_id}
+     */
+    datasetDeleteV2EntityProjectDatasetsObjectIdDelete: (
+      entity: string,
+      project: string,
+      objectId: string,
+      query?: {
+        /**
+         * Digests
+         * List of digests to delete. If not provided, all digests for the dataset will be deleted.
+         */
+        digests?: string[] | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<DatasetDeleteRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/datasets/${objectId}`,
+        method: 'DELETE',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Create a scorer object.
+     *
+     * @tags Scorers
+     * @name ScorerCreateV2EntityProjectScorersPost
+     * @summary Scorer Create
+     * @request POST:/v2/{entity}/{project}/scorers
+     */
+    scorerCreateV2EntityProjectScorersPost: (
+      entity: string,
+      project: string,
+      data: ScorerCreateBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<ScorerCreateRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/scorers`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description List scorer objects.
+     *
+     * @tags Scorers
+     * @name ScorerListV2EntityProjectScorersGet
+     * @summary Scorer List
+     * @request GET:/v2/{entity}/{project}/scorers
+     */
+    scorerListV2EntityProjectScorersGet: (
+      entity: string,
+      project: string,
+      params: RequestParams = {}
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/scorers`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Get a scorer object.
+     *
+     * @tags Scorers
+     * @name ScorerReadV2EntityProjectScorersObjectIdVersionsDigestGet
+     * @summary Scorer Read
+     * @request GET:/v2/{entity}/{project}/scorers/{object_id}/versions/{digest}
+     */
+    scorerReadV2EntityProjectScorersObjectIdVersionsDigestGet: (
+      entity: string,
+      project: string,
+      objectId: string,
+      digest: string,
+      params: RequestParams = {}
+    ) =>
+      this.request<ScorerReadRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/scorers/${objectId}/versions/${digest}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Delete a scorer object.
+     *
+     * @tags Scorers
+     * @name ScorerDeleteV2EntityProjectScorersObjectIdDelete
+     * @summary Scorer Delete
+     * @request DELETE:/v2/{entity}/{project}/scorers/{object_id}
+     */
+    scorerDeleteV2EntityProjectScorersObjectIdDelete: (
+      entity: string,
+      project: string,
+      objectId: string,
+      query?: {
+        /**
+         * Digests
+         * List of digests to delete. If not provided, all digests for the scorer will be deleted.
+         */
+        digests?: string[] | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<ScorerDeleteRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/scorers/${objectId}`,
+        method: 'DELETE',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Create an evaluation object.
+     *
+     * @tags Evaluations
+     * @name EvaluationCreateV2EntityProjectEvaluationsPost
+     * @summary Evaluation Create
+     * @request POST:/v2/{entity}/{project}/evaluations
+     */
+    evaluationCreateV2EntityProjectEvaluationsPost: (
+      entity: string,
+      project: string,
+      data: EvaluationCreateBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<EvaluationCreateRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/evaluations`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description List evaluation objects.
+     *
+     * @tags Evaluations
+     * @name EvaluationListV2EntityProjectEvaluationsGet
+     * @summary Evaluation List
+     * @request GET:/v2/{entity}/{project}/evaluations
+     */
+    evaluationListV2EntityProjectEvaluationsGet: (
+      entity: string,
+      project: string,
+      params: RequestParams = {}
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/evaluations`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Get an evaluation object.
+     *
+     * @tags Evaluations
+     * @name EvaluationReadV2EntityProjectEvaluationsObjectIdVersionsDigestGet
+     * @summary Evaluation Read
+     * @request GET:/v2/{entity}/{project}/evaluations/{object_id}/versions/{digest}
+     */
+    evaluationReadV2EntityProjectEvaluationsObjectIdVersionsDigestGet: (
+      entity: string,
+      project: string,
+      objectId: string,
+      digest: string,
+      params: RequestParams = {}
+    ) =>
+      this.request<EvaluationReadRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/evaluations/${objectId}/versions/${digest}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Delete an evaluation object.
+     *
+     * @tags Evaluations
+     * @name EvaluationDeleteV2EntityProjectEvaluationsObjectIdDelete
+     * @summary Evaluation Delete
+     * @request DELETE:/v2/{entity}/{project}/evaluations/{object_id}
+     */
+    evaluationDeleteV2EntityProjectEvaluationsObjectIdDelete: (
+      entity: string,
+      project: string,
+      objectId: string,
+      query?: {
+        /**
+         * Digests
+         * List of digests to delete. If not provided, all digests for the evaluation will be deleted.
+         */
+        digests?: string[] | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<EvaluationDeleteRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/evaluations/${objectId}`,
+        method: 'DELETE',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Create a model object.
+     *
+     * @tags Models
+     * @name ModelCreateV2EntityProjectModelsPost
+     * @summary Model Create
+     * @request POST:/v2/{entity}/{project}/models
+     */
+    modelCreateV2EntityProjectModelsPost: (
+      entity: string,
+      project: string,
+      data: ModelCreateBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<ModelCreateRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/models`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description List model objects.
+     *
+     * @tags Models
+     * @name ModelListV2EntityProjectModelsGet
+     * @summary Model List
+     * @request GET:/v2/{entity}/{project}/models
+     */
+    modelListV2EntityProjectModelsGet: (
+      entity: string,
+      project: string,
+      query?: {
+        /**
+         * Limit
+         * Maximum number of models to return
+         */
+        limit?: number | null;
+        /**
+         * Offset
+         * Number of models to skip
+         */
+        offset?: number | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<any, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/models`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Get a model object.
+     *
+     * @tags Models
+     * @name ModelReadV2EntityProjectModelsObjectIdVersionsDigestGet
+     * @summary Model Read
+     * @request GET:/v2/{entity}/{project}/models/{object_id}/versions/{digest}
+     */
+    modelReadV2EntityProjectModelsObjectIdVersionsDigestGet: (
+      entity: string,
+      project: string,
+      objectId: string,
+      digest: string,
+      params: RequestParams = {}
+    ) =>
+      this.request<ModelReadRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/models/${objectId}/versions/${digest}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Delete a model object. If digests are provided, only those versions are deleted. Otherwise, all versions are deleted.
+     *
+     * @tags Models
+     * @name ModelDeleteV2EntityProjectModelsObjectIdDelete
+     * @summary Model Delete
+     * @request DELETE:/v2/{entity}/{project}/models/{object_id}
+     */
+    modelDeleteV2EntityProjectModelsObjectIdDelete: (
+      entity: string,
+      project: string,
+      objectId: string,
+      query?: {
+        /**
+         * Digests
+         * List of digests to delete. If not provided, all digests for the model will be deleted.
+         */
+        digests?: string[] | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<ModelDeleteRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/models/${objectId}`,
+        method: 'DELETE',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Create an evaluation run.
+     *
+     * @tags Evaluation Runs
+     * @name EvaluationRunCreateV2EntityProjectEvaluationRunsPost
+     * @summary Evaluation Run Create
+     * @request POST:/v2/{entity}/{project}/evaluation_runs
+     */
+    evaluationRunCreateV2EntityProjectEvaluationRunsPost: (
+      entity: string,
+      project: string,
+      data: EvaluationRunCreateBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<EvaluationRunCreateRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/evaluation_runs`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description List evaluation runs.
+     *
+     * @tags Evaluation Runs
+     * @name EvaluationRunListV2EntityProjectEvaluationRunsGet
+     * @summary Evaluation Run List
+     * @request GET:/v2/{entity}/{project}/evaluation_runs
+     */
+    evaluationRunListV2EntityProjectEvaluationRunsGet: (
+      entity: string,
+      project: string,
+      query?: {
+        /**
+         * Evaluations
+         * Filter by evaluation references
+         */
+        evaluations?: string[] | null;
+        /**
+         * Models
+         * Filter by model references
+         */
+        models?: string[] | null;
+        /**
+         * Evaluation Run Ids
+         * Filter by evaluation run IDs
+         */
+        evaluation_run_ids?: string[] | null;
+        /**
+         * Limit
+         * Maximum number of evaluation runs to return
+         */
+        limit?: number | null;
+        /**
+         * Offset
+         * Number of evaluation runs to skip
+         */
+        offset?: number | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<EvaluationRunReadRes[], HTTPValidationError>({
+        path: `/v2/${entity}/${project}/evaluation_runs`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Delete evaluation runs.
+     *
+     * @tags Evaluation Runs
+     * @name EvaluationRunDeleteV2EntityProjectEvaluationRunsDelete
+     * @summary Evaluation Run Delete
+     * @request DELETE:/v2/{entity}/{project}/evaluation_runs
+     */
+    evaluationRunDeleteV2EntityProjectEvaluationRunsDelete: (
+      entity: string,
+      project: string,
+      query: {
+        /**
+         * Evaluation Run Ids
+         * List of evaluation run IDs to delete
+         */
+        evaluation_run_ids: string[];
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<EvaluationRunDeleteRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/evaluation_runs`,
+        method: 'DELETE',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Read an evaluation run.
+     *
+     * @tags Evaluation Runs
+     * @name EvaluationRunReadV2EntityProjectEvaluationRunsEvaluationRunIdGet
+     * @summary Evaluation Run Read
+     * @request GET:/v2/{entity}/{project}/evaluation_runs/{evaluation_run_id}
+     */
+    evaluationRunReadV2EntityProjectEvaluationRunsEvaluationRunIdGet: (
+      entity: string,
+      project: string,
+      evaluationRunId: string,
+      params: RequestParams = {}
+    ) =>
+      this.request<EvaluationRunReadRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/evaluation_runs/${evaluationRunId}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Finish an evaluation run.
+     *
+     * @tags Evaluation Runs
+     * @name EvaluationRunFinishV2EntityProjectEvaluationRunsEvaluationRunIdFinishPost
+     * @summary Evaluation Run Finish
+     * @request POST:/v2/{entity}/{project}/evaluation_runs/{evaluation_run_id}/finish
+     */
+    evaluationRunFinishV2EntityProjectEvaluationRunsEvaluationRunIdFinishPost: (
+      entity: string,
+      project: string,
+      evaluationRunId: string,
+      data: EvaluationRunFinishBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<EvaluationRunFinishRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/evaluation_runs/${evaluationRunId}/finish`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Create a prediction.
+     *
+     * @tags Predictions
+     * @name PredictionCreateV2EntityProjectPredictionsPost
+     * @summary Prediction Create
+     * @request POST:/v2/{entity}/{project}/predictions
+     */
+    predictionCreateV2EntityProjectPredictionsPost: (
+      entity: string,
+      project: string,
+      data: PredictionCreateBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<PredictionCreateRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/predictions`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description List predictions.
+     *
+     * @tags Predictions
+     * @name PredictionListV2EntityProjectPredictionsGet
+     * @summary Prediction List
+     * @request GET:/v2/{entity}/{project}/predictions
+     */
+    predictionListV2EntityProjectPredictionsGet: (
+      entity: string,
+      project: string,
+      query?: {
+        /**
+         * Evaluation Run Id
+         * Filter by evaluation run ID
+         */
+        evaluation_run_id?: string | null;
+        /**
+         * Limit
+         * Maximum number of predictions to return
+         */
+        limit?: number | null;
+        /**
+         * Offset
+         * Number of predictions to skip
+         */
+        offset?: number | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<PredictionReadRes[], HTTPValidationError>({
+        path: `/v2/${entity}/${project}/predictions`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Delete predictions.
+     *
+     * @tags Predictions
+     * @name PredictionDeleteV2EntityProjectPredictionsDelete
+     * @summary Prediction Delete
+     * @request DELETE:/v2/{entity}/{project}/predictions
+     */
+    predictionDeleteV2EntityProjectPredictionsDelete: (
+      entity: string,
+      project: string,
+      query: {
+        /**
+         * Prediction Ids
+         * List of prediction IDs to delete
+         */
+        prediction_ids: string[];
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<PredictionDeleteRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/predictions`,
+        method: 'DELETE',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Read a prediction.
+     *
+     * @tags Predictions
+     * @name PredictionReadV2EntityProjectPredictionsPredictionIdGet
+     * @summary Prediction Read
+     * @request GET:/v2/{entity}/{project}/predictions/{prediction_id}
+     */
+    predictionReadV2EntityProjectPredictionsPredictionIdGet: (
+      entity: string,
+      project: string,
+      predictionId: string,
+      params: RequestParams = {}
+    ) =>
+      this.request<PredictionReadRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/predictions/${predictionId}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Finish a prediction.
+     *
+     * @tags Predictions
+     * @name PredictionFinishV2EntityProjectPredictionsPredictionIdFinishPost
+     * @summary Prediction Finish
+     * @request POST:/v2/{entity}/{project}/predictions/{prediction_id}/finish
+     */
+    predictionFinishV2EntityProjectPredictionsPredictionIdFinishPost: (
+      entity: string,
+      project: string,
+      predictionId: string,
+      params: RequestParams = {}
+    ) =>
+      this.request<PredictionFinishRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/predictions/${predictionId}/finish`,
+        method: 'POST',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Create a score.
+     *
+     * @tags Scores
+     * @name ScoreCreateV2EntityProjectScoresPost
+     * @summary Score Create
+     * @request POST:/v2/{entity}/{project}/scores
+     */
+    scoreCreateV2EntityProjectScoresPost: (
+      entity: string,
+      project: string,
+      data: ScoreCreateBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<ScoreCreateRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/scores`,
+        method: 'POST',
+        body: data,
+        type: ContentType.Json,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description List scores.
+     *
+     * @tags Scores
+     * @name ScoreListV2EntityProjectScoresGet
+     * @summary Score List
+     * @request GET:/v2/{entity}/{project}/scores
+     */
+    scoreListV2EntityProjectScoresGet: (
+      entity: string,
+      project: string,
+      query?: {
+        /**
+         * Evaluation Run Id
+         * Filter by evaluation run ID
+         */
+        evaluation_run_id?: string | null;
+        /**
+         * Limit
+         * Maximum number of scores to return
+         */
+        limit?: number | null;
+        /**
+         * Offset
+         * Number of scores to skip
+         */
+        offset?: number | null;
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<ScoreReadRes[], HTTPValidationError>({
+        path: `/v2/${entity}/${project}/scores`,
+        method: 'GET',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Delete scores.
+     *
+     * @tags Scores
+     * @name ScoreDeleteV2EntityProjectScoresDelete
+     * @summary Score Delete
+     * @request DELETE:/v2/{entity}/{project}/scores
+     */
+    scoreDeleteV2EntityProjectScoresDelete: (
+      entity: string,
+      project: string,
+      query: {
+        /**
+         * Score Ids
+         * List of score IDs to delete
+         */
+        score_ids: string[];
+      },
+      params: RequestParams = {}
+    ) =>
+      this.request<ScoreDeleteRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/scores`,
+        method: 'DELETE',
+        query: query,
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Read a score.
+     *
+     * @tags Scores
+     * @name ScoreReadV2EntityProjectScoresScoreIdGet
+     * @summary Score Read
+     * @request GET:/v2/{entity}/{project}/scores/{score_id}
+     */
+    scoreReadV2EntityProjectScoresScoreIdGet: (
+      entity: string,
+      project: string,
+      scoreId: string,
+      params: RequestParams = {}
+    ) =>
+      this.request<ScoreReadRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/scores/${scoreId}`,
+        method: 'GET',
+        format: 'json',
+        ...params,
+      }),
+
+    /**
+     * @description Read grouped evaluation result rows for one or more evaluations.
+     *
+     * @tags Eval Results
+     * @name EvalResultsQueryV2EntityProjectEvalResultsQueryPost
+     * @summary Eval Results Query
+     * @request POST:/v2/{entity}/{project}/eval_results/query
+     */
+    evalResultsQueryV2EntityProjectEvalResultsQueryPost: (
+      entity: string,
+      project: string,
+      data: EvalResultsQueryBody,
+      params: RequestParams = {}
+    ) =>
+      this.request<EvalResultsQueryRes, HTTPValidationError>({
+        path: `/v2/${entity}/${project}/eval_results/query`,
+        method: 'POST',
+        body: data,
         type: ContentType.Json,
         format: 'json',
         ...params,

--- a/sdks/node/weave.openapi.json
+++ b/sdks/node/weave.openapi.json
@@ -1,7 +1,6 @@
 {
   "openapi": "3.1.0",
   "info": {"title": "FastAPI", "version": "0.1.0"},
-  "servers": [{"url": "https://api.wandb.ai"}],
   "paths": {
     "/health": {
       "get": {
@@ -11,7 +10,79 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {"application/json": {"schema": {}}}
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/version": {
+      "get": {
+        "tags": ["Service"],
+        "summary": "Read Version",
+        "operationId": "read_version_version_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/geolocate": {
+      "get": {
+        "tags": ["Service"],
+        "summary": "Get Caller Location",
+        "description": "Lookup the geographic location of a user based on their IP address.\n\nThis API exists for debugging purposes and may not be available in the future.",
+        "operationId": "get_caller_location_geolocate_get",
+        "parameters": [
+          {
+            "name": "ip",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "IP address to geolocate, defaults to client IP address",
+              "examples": ["1.2.3.4"],
+              "title": "Ip"
+            },
+            "description": "IP address to geolocate, defaults to client IP address"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeolocationRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
           }
         }
       }
@@ -26,7 +97,359 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/ServerInfoRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/ServerInfoRes"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/otel/v1/traces": {
+      "post": {
+        "tags": ["OpenTelemetry"],
+        "summary": "Export Trace",
+        "operationId": "export_trace_otel_v1_traces_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/otel/v1/traces": {
+      "post": {
+        "tags": ["Agents"],
+        "summary": "Export Genai Trace",
+        "description": "Ingest OTel spans into the GenAI observability system.",
+        "operationId": "export_genai_trace_agents_otel_v1_traces_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/spans/query": {
+      "post": {
+        "tags": ["Agents"],
+        "summary": "Genai Spans Query",
+        "description": "Query agent spans, either as raw rows or grouped aggregates.",
+        "operationId": "genai_spans_query_agents_spans_query_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentSpansQueryReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSpansQueryRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/spans/stats": {
+      "post": {
+        "tags": ["Agents"],
+        "summary": "Genai Spans Stats",
+        "description": "Query chart-ready aggregations over agent spans.",
+        "operationId": "genai_spans_stats_agents_spans_stats_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentSpanStatsReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSpanStatsRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/spans/custom-attrs/schema": {
+      "post": {
+        "tags": ["Agents"],
+        "summary": "Genai Custom Attrs Schema",
+        "description": "Discover typed custom attribute keys on matching agent spans.",
+        "operationId": "genai_custom_attrs_schema_agents_spans_custom_attrs_schema_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentCustomAttrsSchemaReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentCustomAttrsSchemaRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/query": {
+      "post": {
+        "tags": ["Agents"],
+        "summary": "Genai Agents Query",
+        "operationId": "genai_agents_query_agents_query_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentsQueryReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentsQueryRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/agent-versions/query": {
+      "post": {
+        "tags": ["Agents"],
+        "summary": "Genai Agent Versions Query",
+        "operationId": "genai_agent_versions_query_agents_agent_versions_query_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentVersionsQueryReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentVersionsQueryRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/search": {
+      "post": {
+        "tags": ["Agents"],
+        "summary": "Genai Search",
+        "operationId": "genai_search_agents_search_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentSearchReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentSearchRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/traces/chat": {
+      "post": {
+        "tags": ["Agents"],
+        "summary": "Genai Traces Chat",
+        "operationId": "genai_traces_chat_agents_traces_chat_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentTraceChatReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTraceChatRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agents/conversations/chat": {
+      "post": {
+        "tags": ["Agents"],
+        "summary": "Genai Conversation Chat",
+        "operationId": "genai_conversation_chat_agents_conversations_chat_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentConversationChatReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentConversationChatRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -41,7 +464,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CallStartReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CallStartReq"
+              }
             }
           },
           "required": true
@@ -51,7 +476,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/CallStartRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/CallStartRes"
+                }
               }
             }
           },
@@ -59,12 +486,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/call/end": {
@@ -75,7 +503,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CallEndReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CallEndReq"
+              }
             }
           },
           "required": true
@@ -85,7 +515,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/CallEndRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/CallEndRes"
+                }
               }
             }
           },
@@ -93,12 +525,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/call/upsert_batch": {
@@ -109,7 +542,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CallCreateBatchReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CallCreateBatchReq"
+              }
             }
           },
           "required": true
@@ -119,7 +554,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/CallCreateBatchRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/CallCreateBatchRes"
+                }
               }
             }
           },
@@ -127,12 +564,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/calls/delete": {
@@ -143,7 +581,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CallsDeleteReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CallsDeleteReq"
+              }
             }
           },
           "required": true
@@ -153,7 +593,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/CallsDeleteRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/CallsDeleteRes"
+                }
               }
             }
           },
@@ -161,12 +603,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/call/update": {
@@ -177,7 +620,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CallUpdateReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CallUpdateReq"
+              }
             }
           },
           "required": true
@@ -187,7 +632,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/CallUpdateRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/CallUpdateRes"
+                }
               }
             }
           },
@@ -195,12 +642,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/call/read": {
@@ -211,7 +659,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CallReadReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CallReadReq"
+              }
             }
           },
           "required": true
@@ -221,7 +671,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/CallReadRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/CallReadRes"
+                }
               }
             }
           },
@@ -229,12 +681,125 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/inference/catalog/models": {
+      "get": {
+        "tags": ["Inference"],
+        "summary": "Inference Catalog Models",
+        "description": "Returns a list of available Serverless Inference models.\n\nThis API is available without authentication.",
+        "operationId": "inference_catalog_models_inference_catalog_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CatalogModelsRes"
+                }
               }
             }
           }
         },
-        "security": [{"HTTPBasic": []}]
+        "x-exclude": true
+      }
+    },
+    "/inference/analysis/artificialanalysis/models": {
+      "get": {
+        "tags": ["Inference"],
+        "summary": "Inference Analysis Artificialanalysis Models",
+        "description": "Returns a list of available models for Artificial Analysis.\n\nThis API is available without authentication.",
+        "operationId": "inference_analysis_artificialanalysis_models_inference_analysis_artificialanalysis_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouterOpenRouterModelsRes"
+                }
+              }
+            }
+          }
+        },
+        "x-exclude": true
+      }
+    },
+    "/inference/router/openrouter/models": {
+      "get": {
+        "tags": ["Inference"],
+        "summary": "Inference Router Openrouter Models",
+        "description": "Returns a list of models that are available to be used with OpenRouter.\n\nThis API is available without authentication.",
+        "operationId": "inference_router_openrouter_models_inference_router_openrouter_models_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouterOpenRouterModelsRes"
+                }
+              }
+            }
+          }
+        },
+        "x-exclude": true
+      }
+    },
+    "/inference/nvidia/v2/hardware": {
+      "get": {
+        "tags": ["Inference"],
+        "summary": "Nvidia Hardware",
+        "description": "Returns available hardware and pricing for a given model.\n\nCalled by NVIDIA to show users their options and redirect them\nbased on what we support.  Only serverless options are returned.",
+        "operationId": "nvidia_hardware_inference_nvidia_v2_hardware_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "model",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "description": "Model name without the publisher prefix",
+              "title": "Model"
+            },
+            "description": "Model name without the publisher prefix"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NvidiaHardwareRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "x-exclude": true
       }
     },
     "/calls/query_stats": {
@@ -245,7 +810,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CallsQueryStatsReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CallsQueryStatsReq"
+              }
             }
           },
           "required": true
@@ -255,7 +822,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/CallsQueryStatsRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/CallsQueryStatsRes"
+                }
               }
             }
           },
@@ -263,12 +832,93 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
+        }
+      }
+    },
+    "/trace/usage": {
+      "post": {
+        "tags": ["Calls"],
+        "summary": "Trace Usage",
+        "description": "Compute per-call usage for a trace, with descendant rollup.",
+        "operationId": "trace_usage_trace_usage_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TraceUsageReq"
+              }
+            }
+          },
+          "required": true
         },
-        "security": [{"HTTPBasic": []}]
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceUsageRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/calls/usage": {
+      "post": {
+        "tags": ["Calls"],
+        "summary": "Calls Usage",
+        "description": "Compute aggregated usage for multiple root calls, with descendant rollup.",
+        "operationId": "calls_usage_calls_usage_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CallsUsageReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallsUsageRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/calls/stream_query": {
@@ -276,7 +926,6 @@
         "tags": ["Calls"],
         "summary": "Calls Query Stream",
         "operationId": "calls_query_stream_calls_stream_query_post",
-        "security": [{"HTTPBasic": []}],
         "parameters": [
           {
             "name": "accept",
@@ -293,20 +942,28 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CallsQueryReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CallsQueryReq"
+              }
             }
           }
         },
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {"application/json": {"schema": {}}}
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
@@ -321,7 +978,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/ObjCreateReq"}
+              "schema": {
+                "$ref": "#/components/schemas/ObjCreateReq"
+              }
             }
           },
           "required": true
@@ -331,7 +990,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/ObjCreateRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/ObjCreateRes"
+                }
               }
             }
           },
@@ -339,12 +1000,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/obj/read": {
@@ -355,7 +1017,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/ObjReadReq"}
+              "schema": {
+                "$ref": "#/components/schemas/ObjReadReq"
+              }
             }
           },
           "required": true
@@ -365,7 +1029,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/ObjReadRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/ObjReadRes"
+                }
               }
             }
           },
@@ -373,12 +1039,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/objs/query": {
@@ -389,7 +1056,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/ObjQueryReq"}
+              "schema": {
+                "$ref": "#/components/schemas/ObjQueryReq"
+              }
             }
           },
           "required": true
@@ -399,7 +1068,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/ObjQueryRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/ObjQueryRes"
+                }
               }
             }
           },
@@ -407,12 +1078,356 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/obj/delete": {
+      "post": {
+        "tags": ["Objects"],
+        "summary": "Obj Delete",
+        "operationId": "obj_delete_obj_delete_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ObjDeleteReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObjDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/objs/{object_id}/versions/{digest}/tags": {
+      "put": {
+        "tags": ["Objects"],
+        "summary": "Obj Add Tags",
+        "description": "Add tags to an object version.",
+        "operationId": "obj_add_tags_objs__object_id__versions__digest__tags_put",
+        "parameters": [
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digest",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Digest"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ObjTagsBody"
               }
             }
           }
         },
-        "security": [{"HTTPBasic": []}]
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObjAddTagsRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/objs/{object_id}/versions/{digest}/tags/remove": {
+      "post": {
+        "tags": ["Objects"],
+        "summary": "Obj Remove Tags",
+        "description": "Remove tags from an object version.",
+        "operationId": "obj_remove_tags_objs__object_id__versions__digest__tags_remove_post",
+        "parameters": [
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digest",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Digest"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ObjTagsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObjRemoveTagsRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/objs/{object_id}/aliases": {
+      "put": {
+        "tags": ["Objects"],
+        "summary": "Obj Set Aliases",
+        "description": "Set aliases for an object version.",
+        "operationId": "obj_set_aliases_objs__object_id__aliases_put",
+        "parameters": [
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ObjSetAliasesBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObjSetAliasesRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/objs/{object_id}/aliases/remove": {
+      "post": {
+        "tags": ["Objects"],
+        "summary": "Obj Remove Aliases",
+        "description": "Remove aliases from an object.",
+        "operationId": "obj_remove_aliases_objs__object_id__aliases_remove_post",
+        "parameters": [
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ObjRemoveAliasesBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObjRemoveAliasesRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tags": {
+      "get": {
+        "tags": ["Objects"],
+        "summary": "Tags List",
+        "description": "List all tags in a project.",
+        "operationId": "tags_list_tags_get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagsListRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/aliases": {
+      "get": {
+        "tags": ["Objects"],
+        "summary": "Aliases List",
+        "description": "List all aliases in a project.",
+        "operationId": "aliases_list_aliases_get",
+        "parameters": [
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AliasesListRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/table/create": {
@@ -423,7 +1438,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/TableCreateReq"}
+              "schema": {
+                "$ref": "#/components/schemas/TableCreateReq"
+              }
             }
           },
           "required": true
@@ -433,7 +1450,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TableCreateRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/TableCreateRes"
+                }
               }
             }
           },
@@ -441,12 +1460,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/table/update": {
@@ -457,7 +1477,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/TableUpdateReq"}
+              "schema": {
+                "$ref": "#/components/schemas/TableUpdateReq"
+              }
             }
           },
           "required": true
@@ -467,7 +1489,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TableUpdateRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/TableUpdateRes"
+                }
               }
             }
           },
@@ -475,12 +1499,52 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
+        }
+      }
+    },
+    "/table/create_from_digests": {
+      "post": {
+        "tags": ["Tables"],
+        "summary": "Table Create From Digests",
+        "operationId": "table_create_from_digests_table_create_from_digests_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TableCreateFromDigestsReq"
+              }
+            }
+          },
+          "required": true
         },
-        "security": [{"HTTPBasic": []}]
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TableCreateFromDigestsRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/table/query": {
@@ -491,7 +1555,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/TableQueryReq"}
+              "schema": {
+                "$ref": "#/components/schemas/TableQueryReq"
+              }
             }
           },
           "required": true
@@ -501,7 +1567,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TableQueryRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/TableQueryRes"
+                }
               }
             }
           },
@@ -509,12 +1577,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/table/query_stats": {
@@ -525,7 +1594,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/TableQueryStatsReq"}
+              "schema": {
+                "$ref": "#/components/schemas/TableQueryStatsReq"
+              }
             }
           },
           "required": true
@@ -535,7 +1606,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/TableQueryStatsRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/TableQueryStatsRes"
+                }
               }
             }
           },
@@ -543,12 +1616,52 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
+        }
+      }
+    },
+    "/table/query_stats_batch": {
+      "post": {
+        "tags": ["Tables"],
+        "summary": "Table Query Stats Batch",
+        "operationId": "table_query_stats_batch_table_query_stats_batch_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TableQueryStatsBatchReq"
+              }
+            }
+          },
+          "required": true
         },
-        "security": [{"HTTPBasic": []}]
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TableQueryStatsBatchRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/refs/read_batch": {
@@ -559,7 +1672,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/RefsReadBatchReq"}
+              "schema": {
+                "$ref": "#/components/schemas/RefsReadBatchReq"
+              }
             }
           },
           "required": true
@@ -569,7 +1684,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/RefsReadBatchRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/RefsReadBatchRes"
+                }
               }
             }
           },
@@ -577,12 +1694,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/file/create": {
@@ -605,7 +1723,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/FileCreateRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/FileCreateRes"
+                }
               }
             }
           },
@@ -613,12 +1733,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/file/content": {
@@ -629,7 +1750,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/FileContentReadReq"}
+              "schema": {
+                "$ref": "#/components/schemas/FileContentReadReq"
+              }
             }
           },
           "required": true
@@ -637,18 +1760,62 @@
         "responses": {
           "200": {
             "description": "Successful Response",
-            "content": {"application/json": {"schema": {}}}
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
           },
           "422": {
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
+        }
+      }
+    },
+    "/files/query_stats": {
+      "post": {
+        "tags": ["Files"],
+        "summary": "Files Stats",
+        "operationId": "files_stats_files_query_stats_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FilesStatsReq"
+              }
+            }
+          },
+          "required": true
         },
-        "security": [{"HTTPBasic": []}]
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilesStatsRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/cost/create": {
@@ -659,7 +1826,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CostCreateReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CostCreateReq"
+              }
             }
           },
           "required": true
@@ -669,7 +1838,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/CostCreateRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/CostCreateRes"
+                }
               }
             }
           },
@@ -677,12 +1848,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/cost/query": {
@@ -693,7 +1865,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CostQueryReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CostQueryReq"
+              }
             }
           },
           "required": true
@@ -703,7 +1877,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/CostQueryRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/CostQueryRes"
+                }
               }
             }
           },
@@ -711,12 +1887,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/cost/purge": {
@@ -727,7 +1904,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CostPurgeReq"}
+              "schema": {
+                "$ref": "#/components/schemas/CostPurgeReq"
+              }
             }
           },
           "required": true
@@ -737,7 +1916,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/CostPurgeRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/CostPurgeRes"
+                }
               }
             }
           },
@@ -745,12 +1926,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/feedback/create": {
@@ -762,7 +1944,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/FeedbackCreateReq"}
+              "schema": {
+                "$ref": "#/components/schemas/FeedbackCreateReq"
+              }
             }
           },
           "required": true
@@ -772,7 +1956,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/FeedbackCreateRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackCreateRes"
+                }
               }
             }
           },
@@ -780,12 +1966,53 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
+        }
+      }
+    },
+    "/feedback/batch/create": {
+      "post": {
+        "tags": ["Feedback"],
+        "summary": "Feedback Create Batch",
+        "description": "Add multiple feedback items to calls or objects.",
+        "operationId": "feedback_create_batch_feedback_batch_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FeedbackCreateBatchReq"
+              }
+            }
+          },
+          "required": true
         },
-        "security": [{"HTTPBasic": []}]
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackCreateBatchRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/feedback/query": {
@@ -797,7 +2024,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/FeedbackQueryReq"}
+              "schema": {
+                "$ref": "#/components/schemas/FeedbackQueryReq"
+              }
             }
           },
           "required": true
@@ -807,7 +2036,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/FeedbackQueryRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackQueryRes"
+                }
               }
             }
           },
@@ -815,12 +2046,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/feedback/purge": {
@@ -832,7 +2064,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/FeedbackPurgeReq"}
+              "schema": {
+                "$ref": "#/components/schemas/FeedbackPurgeReq"
+              }
             }
           },
           "required": true
@@ -842,7 +2076,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/FeedbackPurgeRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackPurgeRes"
+                }
               }
             }
           },
@@ -850,12 +2086,13 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
               }
             }
           }
-        },
-        "security": [{"HTTPBasic": []}]
+        }
       }
     },
     "/feedback/replace": {
@@ -866,7 +2103,9 @@
         "requestBody": {
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/FeedbackReplaceReq"}
+              "schema": {
+                "$ref": "#/components/schemas/FeedbackReplaceReq"
+              }
             }
           },
           "required": true
@@ -876,7 +2115,9 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/FeedbackReplaceRes"}
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackReplaceRes"
+                }
               }
             }
           },
@@ -884,33 +2125,6380 @@
             "description": "Validation Error",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/HTTPValidationError"}
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/feedback/stats": {
+      "post": {
+        "tags": ["Feedback"],
+        "summary": "Feedback Stats",
+        "description": "Return aggregated feedback statistics over time buckets.",
+        "operationId": "feedback_stats_feedback_stats_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FeedbackStatsReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackStatsRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/feedback/payload_schema": {
+      "post": {
+        "tags": ["Feedback"],
+        "summary": "Feedback Payload Schema",
+        "description": "Discover feedback payload schema (paths and types) from sample rows.",
+        "operationId": "feedback_payload_schema_feedback_payload_schema_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FeedbackPayloadSchemaReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeedbackPayloadSchemaRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/service/projects_info": {
+      "post": {
+        "tags": ["Service"],
+        "summary": "Projects Info",
+        "operationId": "projects_info_service_projects_info_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectsInfoReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectsInfoRes"
+                  },
+                  "type": "array",
+                  "title": "Response Projects Info Service Projects Info Post"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/stream_query": {
+      "post": {
+        "tags": ["Threads"],
+        "summary": "Threads Query Stream",
+        "operationId": "threads_query_stream_threads_stream_query_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ThreadsQueryReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/annotation_queues": {
+      "post": {
+        "tags": ["Annotation Queues"],
+        "summary": "Annotation Queue Create",
+        "description": "Create a new annotation queue.",
+        "operationId": "annotation_queue_create_annotation_queues_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationQueueCreateReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationQueueCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/annotation_queues/query": {
+      "post": {
+        "tags": ["Annotation Queues"],
+        "summary": "Annotation Queues Query Stream",
+        "description": "Query annotation queues for a project (streaming NDJSON response).",
+        "operationId": "annotation_queues_query_stream_annotation_queues_query_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationQueuesQueryReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/annotation_queues/{queue_id}": {
+      "get": {
+        "tags": ["Annotation Queues"],
+        "summary": "Annotation Queue Read",
+        "description": "Read a specific annotation queue.",
+        "operationId": "annotation_queue_read_annotation_queues__queue_id__get",
+        "parameters": [
+          {
+            "name": "queue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Queue Id"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationQueueReadRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Annotation Queues"],
+        "summary": "Annotation Queue Delete",
+        "description": "Delete (soft-delete) an annotation queue.",
+        "operationId": "annotation_queue_delete_annotation_queues__queue_id__delete",
+        "parameters": [
+          {
+            "name": "queue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Queue Id"
+            }
+          },
+          {
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationQueueDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["Annotation Queues"],
+        "summary": "Annotation Queue Update",
+        "description": "Update an annotation queue's metadata (name, description, scorer_refs).",
+        "operationId": "annotation_queue_update_annotation_queues__queue_id__put",
+        "parameters": [
+          {
+            "name": "queue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Queue Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationQueueUpdateBody"
               }
             }
           }
         },
-        "security": [{"HTTPBasic": []}]
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationQueueUpdateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/annotation_queues/{queue_id}/items": {
+      "post": {
+        "tags": ["Annotation Queues"],
+        "summary": "Annotation Queue Add Calls",
+        "description": "Add calls to an annotation queue.",
+        "operationId": "annotation_queue_add_calls_annotation_queues__queue_id__items_post",
+        "parameters": [
+          {
+            "name": "queue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Queue Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationQueueAddCallsBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationQueueAddCallsRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/annotation_queues/{queue_id}/items/query": {
+      "post": {
+        "tags": ["Annotation Queues"],
+        "summary": "Annotation Queue Items Query",
+        "description": "Query items in an annotation queue with pagination and sorting.",
+        "operationId": "annotation_queue_items_query_annotation_queues__queue_id__items_query_post",
+        "parameters": [
+          {
+            "name": "queue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Queue Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationQueueItemsQueryBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationQueueItemsQueryRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/annotation_queues/stats": {
+      "post": {
+        "tags": ["Annotation Queues"],
+        "summary": "Annotation Queues Stats",
+        "description": "Get stats for multiple annotation queues.",
+        "operationId": "annotation_queues_stats_annotation_queues_stats_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationQueuesStatsReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotationQueuesStatsRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/annotation_queues/{queue_id}/items/{item_id}/progress": {
+      "post": {
+        "tags": ["Annotation Queues"],
+        "summary": "Annotation Queue Item Progress Update",
+        "description": "Update the annotation state of a queue item for the current annotator.",
+        "operationId": "annotation_queue_item_progress_update_annotation_queues__queue_id__items__item_id__progress_post",
+        "parameters": [
+          {
+            "name": "queue_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Queue Id"
+            }
+          },
+          {
+            "name": "item_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Item Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AnnotationQueueItemProgressUpdateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnnotatorQueueItemsProgressUpdateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/calls/stats": {
+      "post": {
+        "tags": ["Calls"],
+        "summary": "Call Stats",
+        "operationId": "call_stats_calls_stats_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CallStatsReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallStatsRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/evaluations/evaluate_model": {
+      "post": {
+        "tags": ["Evaluations"],
+        "summary": "Evaluate Model",
+        "operationId": "evaluate_model_evaluations_evaluate_model_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluateModelReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluateModelRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/evaluations/status": {
+      "post": {
+        "tags": ["Evaluations"],
+        "summary": "Evaluation Status",
+        "operationId": "evaluation_status_evaluations_status_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationStatusReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationStatusRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/evaluations/rescore": {
+      "post": {
+        "tags": ["Evaluations"],
+        "summary": "Rescore Evaluation",
+        "description": "Rescore an existing evaluation run with different scorer(s).\n\nApplies the provided scorer(s) to the predictions from source_evaluation_run_id\nand returns a new evaluation_run_id. Original prediction call IDs are preserved.",
+        "operationId": "rescore_evaluation_evaluations_rescore_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RescoreReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RescoreRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/calls/score": {
+      "post": {
+        "tags": ["Scores"],
+        "summary": "Calls Score",
+        "operationId": "calls_score_calls_score_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CallsScoreReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CallsScoreRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/image/create": {
+      "post": {
+        "tags": ["Images"],
+        "summary": "Image Create",
+        "operationId": "image_create_image_create_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImageGenerationCreateReq"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageGenerationCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/link_to_registry": {
+      "post": {
+        "tags": ["Registry"],
+        "summary": "Link To Registry",
+        "operationId": "link_to_registry_link_to_registry_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateAndLinkPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateAndLinkWeaveAssetRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/ops": {
+      "post": {
+        "tags": ["Ops"],
+        "summary": "Op Create",
+        "description": "Create an op object.",
+        "operationId": "op_create_v2__entity___project__ops_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OpCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Ops"],
+        "summary": "Op List",
+        "description": "List op objects.",
+        "operationId": "op_list_v2__entity___project__ops_get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum number of ops to return",
+              "title": "Limit"
+            },
+            "description": "Maximum number of ops to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Number of ops to skip",
+              "title": "Offset"
+            },
+            "description": "Number of ops to skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/ops/{object_id}/versions/{digest}": {
+      "get": {
+        "tags": ["Ops"],
+        "summary": "Op Read",
+        "description": "Get an op object.",
+        "operationId": "op_read_v2__entity___project__ops__object_id__versions__digest__get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digest",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Digest"
+            }
+          },
+          {
+            "name": "eager",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Whether to eagerly load the op code",
+              "default": false,
+              "title": "Eager"
+            },
+            "description": "Whether to eagerly load the op code"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpReadRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/ops/{object_id}": {
+      "delete": {
+        "tags": ["Ops"],
+        "summary": "Op Delete",
+        "description": "Delete an op object. If digests are provided, only those versions are deleted. Otherwise, all versions are deleted.",
+        "operationId": "op_delete_v2__entity___project__ops__object_id__delete",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digests",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "List of digests to delete. If not provided, all digests for the op will be deleted.",
+              "title": "Digests"
+            },
+            "description": "List of digests to delete. If not provided, all digests for the op will be deleted."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/datasets": {
+      "post": {
+        "tags": ["Datasets"],
+        "summary": "Dataset Create",
+        "description": "Create a dataset object.",
+        "operationId": "dataset_create_v2__entity___project__datasets_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DatasetCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Datasets"],
+        "summary": "Dataset List",
+        "description": "List dataset objects.",
+        "operationId": "dataset_list_v2__entity___project__datasets_get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum number of datasets to return",
+              "title": "Limit"
+            },
+            "description": "Maximum number of datasets to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Number of datasets to skip",
+              "title": "Offset"
+            },
+            "description": "Number of datasets to skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/datasets/{object_id}/versions/{digest}": {
+      "get": {
+        "tags": ["Datasets"],
+        "summary": "Dataset Read",
+        "description": "Get a dataset object.",
+        "operationId": "dataset_read_v2__entity___project__datasets__object_id__versions__digest__get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digest",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Digest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetReadRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/datasets/{object_id}": {
+      "delete": {
+        "tags": ["Datasets"],
+        "summary": "Dataset Delete",
+        "description": "Delete a dataset object. If digests are provided, only those versions are deleted. Otherwise, all versions are deleted.",
+        "operationId": "dataset_delete_v2__entity___project__datasets__object_id__delete",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digests",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "List of digests to delete. If not provided, all digests for the dataset will be deleted.",
+              "title": "Digests"
+            },
+            "description": "List of digests to delete. If not provided, all digests for the dataset will be deleted."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DatasetDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/scorers": {
+      "post": {
+        "tags": ["Scorers"],
+        "summary": "Scorer Create",
+        "description": "Create a scorer object.",
+        "operationId": "scorer_create_v2__entity___project__scorers_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScorerCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScorerCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Scorers"],
+        "summary": "Scorer List",
+        "description": "List scorer objects.",
+        "operationId": "scorer_list_v2__entity___project__scorers_get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/scorers/{object_id}/versions/{digest}": {
+      "get": {
+        "tags": ["Scorers"],
+        "summary": "Scorer Read",
+        "description": "Get a scorer object.",
+        "operationId": "scorer_read_v2__entity___project__scorers__object_id__versions__digest__get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digest",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Digest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScorerReadRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/scorers/{object_id}": {
+      "delete": {
+        "tags": ["Scorers"],
+        "summary": "Scorer Delete",
+        "description": "Delete a scorer object.",
+        "operationId": "scorer_delete_v2__entity___project__scorers__object_id__delete",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digests",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "List of digests to delete. If not provided, all digests for the scorer will be deleted.",
+              "title": "Digests"
+            },
+            "description": "List of digests to delete. If not provided, all digests for the scorer will be deleted."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScorerDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/evaluations": {
+      "post": {
+        "tags": ["Evaluations"],
+        "summary": "Evaluation Create",
+        "description": "Create an evaluation object.",
+        "operationId": "evaluation_create_v2__entity___project__evaluations_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Evaluations"],
+        "summary": "Evaluation List",
+        "description": "List evaluation objects.",
+        "operationId": "evaluation_list_v2__entity___project__evaluations_get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/evaluations/{object_id}/versions/{digest}": {
+      "get": {
+        "tags": ["Evaluations"],
+        "summary": "Evaluation Read",
+        "description": "Get an evaluation object.",
+        "operationId": "evaluation_read_v2__entity___project__evaluations__object_id__versions__digest__get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digest",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Digest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationReadRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/evaluations/{object_id}": {
+      "delete": {
+        "tags": ["Evaluations"],
+        "summary": "Evaluation Delete",
+        "description": "Delete an evaluation object.",
+        "operationId": "evaluation_delete_v2__entity___project__evaluations__object_id__delete",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digests",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "List of digests to delete. If not provided, all digests for the evaluation will be deleted.",
+              "title": "Digests"
+            },
+            "description": "List of digests to delete. If not provided, all digests for the evaluation will be deleted."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/models": {
+      "post": {
+        "tags": ["Models"],
+        "summary": "Model Create",
+        "description": "Create a model object.",
+        "operationId": "model_create_v2__entity___project__models_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ModelCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Models"],
+        "summary": "Model List",
+        "description": "List model objects.",
+        "operationId": "model_list_v2__entity___project__models_get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum number of models to return",
+              "title": "Limit"
+            },
+            "description": "Maximum number of models to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Number of models to skip",
+              "title": "Offset"
+            },
+            "description": "Number of models to skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/models/{object_id}/versions/{digest}": {
+      "get": {
+        "tags": ["Models"],
+        "summary": "Model Read",
+        "description": "Get a model object.",
+        "operationId": "model_read_v2__entity___project__models__object_id__versions__digest__get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digest",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Digest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelReadRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/models/{object_id}": {
+      "delete": {
+        "tags": ["Models"],
+        "summary": "Model Delete",
+        "description": "Delete a model object. If digests are provided, only those versions are deleted. Otherwise, all versions are deleted.",
+        "operationId": "model_delete_v2__entity___project__models__object_id__delete",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "object_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Object Id"
+            }
+          },
+          {
+            "name": "digests",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "List of digests to delete. If not provided, all digests for the model will be deleted.",
+              "title": "Digests"
+            },
+            "description": "List of digests to delete. If not provided, all digests for the model will be deleted."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/evaluation_runs": {
+      "post": {
+        "tags": ["Evaluation Runs"],
+        "summary": "Evaluation Run Create",
+        "description": "Create an evaluation run.",
+        "operationId": "evaluation_run_create_v2__entity___project__evaluation_runs_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationRunCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationRunCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Evaluation Runs"],
+        "summary": "Evaluation Run List",
+        "description": "List evaluation runs.",
+        "operationId": "evaluation_run_list_v2__entity___project__evaluation_runs_get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "evaluations",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by evaluation references",
+              "title": "Evaluations"
+            },
+            "description": "Filter by evaluation references"
+          },
+          {
+            "name": "models",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by model references",
+              "title": "Models"
+            },
+            "description": "Filter by model references"
+          },
+          {
+            "name": "evaluation_run_ids",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by evaluation run IDs",
+              "title": "Evaluation Run Ids"
+            },
+            "description": "Filter by evaluation run IDs"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum number of evaluation runs to return",
+              "title": "Limit"
+            },
+            "description": "Maximum number of evaluation runs to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Number of evaluation runs to skip",
+              "title": "Offset"
+            },
+            "description": "Number of evaluation runs to skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stream of data in JSONL format",
+            "content": {
+              "application/jsonl": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EvaluationRunReadRes"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Evaluation Runs"],
+        "summary": "Evaluation Run Delete",
+        "description": "Delete evaluation runs.",
+        "operationId": "evaluation_run_delete_v2__entity___project__evaluation_runs_delete",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "evaluation_run_ids",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of evaluation run IDs to delete",
+              "title": "Evaluation Run Ids"
+            },
+            "description": "List of evaluation run IDs to delete"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationRunDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/evaluation_runs/{evaluation_run_id}": {
+      "get": {
+        "tags": ["Evaluation Runs"],
+        "summary": "Evaluation Run Read",
+        "description": "Read an evaluation run.",
+        "operationId": "evaluation_run_read_v2__entity___project__evaluation_runs__evaluation_run_id__get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "evaluation_run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Evaluation Run Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationRunReadRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/evaluation_runs/{evaluation_run_id}/finish": {
+      "post": {
+        "tags": ["Evaluation Runs"],
+        "summary": "Evaluation Run Finish",
+        "description": "Finish an evaluation run.",
+        "operationId": "evaluation_run_finish_v2__entity___project__evaluation_runs__evaluation_run_id__finish_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "evaluation_run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Evaluation Run Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluationRunFinishBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvaluationRunFinishRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/predictions": {
+      "post": {
+        "tags": ["Predictions"],
+        "summary": "Prediction Create",
+        "description": "Create a prediction.",
+        "operationId": "prediction_create_v2__entity___project__predictions_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictionCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Predictions"],
+        "summary": "Prediction List",
+        "description": "List predictions.",
+        "operationId": "prediction_list_v2__entity___project__predictions_get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "evaluation_run_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by evaluation run ID",
+              "title": "Evaluation Run Id"
+            },
+            "description": "Filter by evaluation run ID"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum number of predictions to return",
+              "title": "Limit"
+            },
+            "description": "Maximum number of predictions to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Number of predictions to skip",
+              "title": "Offset"
+            },
+            "description": "Number of predictions to skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stream of data in JSONL format",
+            "content": {
+              "application/jsonl": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PredictionReadRes"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Predictions"],
+        "summary": "Prediction Delete",
+        "description": "Delete predictions.",
+        "operationId": "prediction_delete_v2__entity___project__predictions_delete",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "prediction_ids",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of prediction IDs to delete",
+              "title": "Prediction Ids"
+            },
+            "description": "List of prediction IDs to delete"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/predictions/{prediction_id}": {
+      "get": {
+        "tags": ["Predictions"],
+        "summary": "Prediction Read",
+        "description": "Read a prediction.",
+        "operationId": "prediction_read_v2__entity___project__predictions__prediction_id__get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "prediction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionReadRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/predictions/{prediction_id}/finish": {
+      "post": {
+        "tags": ["Predictions"],
+        "summary": "Prediction Finish",
+        "description": "Finish a prediction.",
+        "operationId": "prediction_finish_v2__entity___project__predictions__prediction_id__finish_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "prediction_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Prediction Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PredictionFinishRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/scores": {
+      "post": {
+        "tags": ["Scores"],
+        "summary": "Score Create",
+        "description": "Create a score.",
+        "operationId": "score_create_v2__entity___project__scores_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoreCreateBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScoreCreateRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Scores"],
+        "summary": "Score List",
+        "description": "List scores.",
+        "operationId": "score_list_v2__entity___project__scores_get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "evaluation_run_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Filter by evaluation run ID",
+              "title": "Evaluation Run Id"
+            },
+            "description": "Filter by evaluation run ID"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Maximum number of scores to return",
+              "title": "Limit"
+            },
+            "description": "Maximum number of scores to return"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Number of scores to skip",
+              "title": "Offset"
+            },
+            "description": "Number of scores to skip"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Stream of data in JSONL format",
+            "content": {
+              "application/jsonl": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ScoreReadRes"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Scores"],
+        "summary": "Score Delete",
+        "description": "Delete scores.",
+        "operationId": "score_delete_v2__entity___project__scores_delete",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "score_ids",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "List of score IDs to delete",
+              "title": "Score Ids"
+            },
+            "description": "List of score IDs to delete"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScoreDeleteRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/scores/{score_id}": {
+      "get": {
+        "tags": ["Scores"],
+        "summary": "Score Read",
+        "description": "Read a score.",
+        "operationId": "score_read_v2__entity___project__scores__score_id__get",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          },
+          {
+            "name": "score_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Score Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScoreReadRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/{entity}/{project}/eval_results/query": {
+      "post": {
+        "tags": ["Eval Results"],
+        "summary": "Eval Results Query",
+        "description": "Read grouped evaluation result rows for one or more evaluations.",
+        "operationId": "eval_results_query_v2__entity___project__eval_results_query_post",
+        "parameters": [
+          {
+            "name": "entity",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Entity"
+            }
+          },
+          {
+            "name": "project",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Project"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvalResultsQueryBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EvalResultsQueryRes"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
   "components": {
     "schemas": {
+      "AgentChatAgentHandoff": {
+        "properties": {},
+        "type": "object",
+        "title": "AgentChatAgentHandoff",
+        "description": "Payload for a future agent-to-agent handoff event."
+      },
+      "AgentChatAgentStart": {
+        "properties": {
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "system_instructions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "System Instructions"
+          },
+          "tool_definitions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Definitions"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["UNSET", "OK", "ERROR"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "title": "AgentChatAgentStart",
+        "description": "Payload for an agent lifecycle boundary."
+      },
+      "AgentChatAssistantMessage": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model"
+          },
+          "reasoning_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning Content"
+          },
+          "reasoning_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning Tokens"
+          },
+          "input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Tokens"
+          },
+          "output_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Tokens"
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["UNSET", "OK", "ERROR"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "content_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Content Refs"
+          }
+        },
+        "type": "object",
+        "required": ["text"],
+        "title": "AgentChatAssistantMessage",
+        "description": "Payload for assistant text emitted by an agent or LLM span."
+      },
+      "AgentChatContextCompacted": {
+        "properties": {
+          "compaction_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Compaction Summary"
+          },
+          "compaction_items_before": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Compaction Items Before"
+          },
+          "compaction_items_after": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Compaction Items After"
+          }
+        },
+        "type": "object",
+        "title": "AgentChatContextCompacted",
+        "description": "Payload for a context-window compaction event."
+      },
+      "AgentChatMessage": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": [
+              "user_message",
+              "assistant_message",
+              "tool_call",
+              "agent_handoff",
+              "agent_start",
+              "context_compacted"
+            ],
+            "title": "Type"
+          },
+          "span_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Span Id"
+          },
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "user_message": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentChatUserMessage"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "assistant_message": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentChatAssistantMessage"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "tool_call": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentChatToolCall"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "agent_start": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentChatAgentStart"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "agent_handoff": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentChatAgentHandoff"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "context_compacted": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentChatContextCompacted"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "feedback": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feedback"
+          }
+        },
+        "type": "object",
+        "required": ["type"],
+        "title": "AgentChatMessage",
+        "description": "A single element in the structured agent trajectory / chat view.\n\nCommon event fields live at the top level. Type-specific fields are\ngrouped under the payload matching `type`, and exactly one payload must be\nset. This keeps subtype nullability explicit while preserving a single\nordered timeline model for callers."
+      },
+      "AgentChatToolCall": {
+        "properties": {
+          "tool_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Name"
+          },
+          "tool_arguments": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Arguments"
+          },
+          "tool_result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Result"
+          },
+          "duration_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Duration Ms"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["UNSET", "OK", "ERROR"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status"
+          },
+          "content_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Content Refs"
+          }
+        },
+        "type": "object",
+        "title": "AgentChatToolCall",
+        "description": "Payload for a tool call timeline event."
+      },
+      "AgentChatUserMessage": {
+        "properties": {
+          "text": {
+            "type": "string",
+            "title": "Text"
+          },
+          "content_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Content Refs"
+          }
+        },
+        "type": "object",
+        "required": ["text"],
+        "title": "AgentChatUserMessage",
+        "description": "Payload for a user prompt in the chat timeline."
+      },
+      "AgentConversationChatReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 50.0,
+            "minimum": 0.0,
+            "title": "Limit",
+            "description": "Maximum number of conversation turns to return.",
+            "default": 50
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Offset",
+            "description": "Number of most-recent turns to skip. Results are returned in chronological order within the selected page.",
+            "default": 0
+          },
+          "include_feedback": {
+            "type": "boolean",
+            "title": "Include Feedback",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": ["project_id", "conversation_id"],
+        "title": "AgentConversationChatReq",
+        "description": "Request to get the multi-turn chat view for a conversation."
+      },
+      "AgentConversationChatRes": {
+        "properties": {
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "turns": {
+            "items": {
+              "$ref": "#/components/schemas/AgentTraceChatRes"
+            },
+            "type": "array",
+            "title": "Turns"
+          },
+          "total_turns": {
+            "type": "integer",
+            "title": "Total Turns",
+            "default": 0
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More",
+            "default": false
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "default": 50
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "default": 0
+          },
+          "feedback": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feedback"
+          }
+        },
+        "type": "object",
+        "required": ["conversation_id"],
+        "title": "AgentConversationChatRes",
+        "description": "Multi-turn chat view: an ordered list of per-turn chat responses.\n\nEach entry in `turns` corresponds to one trace_id, which Weave treats as\none conversation turn. This is not necessarily one `invoke_agent` span:\na turn can contain zero, one, or many agent invocations. The frontend can\nrender turn-number dividers between entries and still reuse\n`AgentTraceChatRes` rendering for each individual turn."
+      },
+      "AgentConversationMessagePreview": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "title": "Role",
+            "default": ""
+          },
+          "text": {
+            "type": "string",
+            "title": "Text",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "title": "AgentConversationMessagePreview",
+        "description": "A truncated first/last message snippet for a grouped conversation row.\n\n`role` is the chat-timeline message type (e.g. \"user_message\",\n\"assistant_message\") so clients can style it consistently with the full\nchat view; `text` is the trimmed, length-capped preview content."
+      },
+      "AgentCustomAttrSchemaItem": {
+        "properties": {
+          "source": {
+            "type": "string",
+            "enum": [
+              "custom_attrs_string",
+              "custom_attrs_int",
+              "custom_attrs_float",
+              "custom_attrs_bool"
+            ],
+            "title": "Source"
+          },
+          "key": {
+            "type": "string",
+            "title": "Key"
+          },
+          "value_type": {
+            "type": "string",
+            "enum": ["string", "int", "float", "bool"],
+            "title": "Value Type"
+          },
+          "span_count": {
+            "type": "integer",
+            "title": "Span Count"
+          }
+        },
+        "type": "object",
+        "required": ["source", "key", "value_type", "span_count"],
+        "title": "AgentCustomAttrSchemaItem",
+        "description": "One custom attribute key/type observed in the matching spans."
+      },
+      "AgentCustomAttrsSchemaReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "query": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Query"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "started_after": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started After"
+          },
+          "started_before": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started Before"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 2000.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 200
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Offset",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": ["project_id"],
+        "title": "AgentCustomAttrsSchemaReq",
+        "description": "Request to discover typed custom attribute keys for matching spans."
+      },
+      "AgentCustomAttrsSchemaRes": {
+        "properties": {
+          "attributes": {
+            "items": {
+              "$ref": "#/components/schemas/AgentCustomAttrSchemaItem"
+            },
+            "type": "array",
+            "title": "Attributes"
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "default": 200
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "default": 0
+          },
+          "has_more": {
+            "type": "boolean",
+            "title": "Has More",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "AgentCustomAttrsSchemaRes",
+        "description": "Typed custom attribute keys available for spans query/group/stats APIs."
+      },
+      "AgentGroupByRef": {
+        "properties": {
+          "source": {
+            "type": "string",
+            "enum": [
+              "field",
+              "column",
+              "custom_attrs_string",
+              "custom_attrs_int",
+              "custom_attrs_float",
+              "custom_attrs_bool"
+            ],
+            "title": "Source",
+            "default": "field"
+          },
+          "key": {
+            "type": "string",
+            "title": "Key"
+          },
+          "alias": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Alias"
+          }
+        },
+        "type": "object",
+        "required": ["key"],
+        "title": "AgentGroupByRef",
+        "description": "Reference to a field or map-key that spans should be grouped by.\n\n`source=\"field\"` targets a semantic span field (`agent.name`) or direct\nspan column (`agent_name`), allowlisted server-side. `source=\"column\"` is\naccepted for existing callers.\nThe other sources target keys inside the typed custom attribute Map columns,\nwhich accept arbitrary user-defined keys."
+      },
+      "AgentSchema": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "invocation_count": {
+            "type": "integer",
+            "title": "Invocation Count"
+          },
+          "span_count": {
+            "type": "integer",
+            "title": "Span Count"
+          },
+          "total_input_tokens": {
+            "type": "integer",
+            "title": "Total Input Tokens"
+          },
+          "total_output_tokens": {
+            "type": "integer",
+            "title": "Total Output Tokens"
+          },
+          "total_duration_ms": {
+            "type": "integer",
+            "title": "Total Duration Ms"
+          },
+          "error_count": {
+            "type": "integer",
+            "title": "Error Count"
+          },
+          "first_seen": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Seen"
+          },
+          "last_seen": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen"
+          }
+        },
+        "type": "object",
+        "required": [
+          "project_id",
+          "agent_name",
+          "invocation_count",
+          "span_count",
+          "total_input_tokens",
+          "total_output_tokens",
+          "total_duration_ms",
+          "error_count",
+          "first_seen",
+          "last_seen"
+        ],
+        "title": "AgentSchema",
+        "description": "Aggregated per-agent stats from the agents table."
+      },
+      "AgentSearchConversationResult": {
+        "properties": {
+          "conversation_id": {
+            "type": "string",
+            "title": "Conversation Id"
+          },
+          "conversation_name": {
+            "type": "string",
+            "title": "Conversation Name"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "matched_messages": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSearchMatchedMessage"
+            },
+            "type": "array",
+            "title": "Matched Messages"
+          },
+          "last_activity": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Last Activity"
+          }
+        },
+        "type": "object",
+        "required": [
+          "conversation_id",
+          "conversation_name",
+          "agent_name",
+          "matched_messages",
+          "last_activity"
+        ],
+        "title": "AgentSearchConversationResult",
+        "description": "A conversation containing messages that matched the search query."
+      },
+      "AgentSearchMatchedMessage": {
+        "properties": {
+          "span_id": {
+            "type": "string",
+            "title": "Span Id"
+          },
+          "trace_id": {
+            "type": "string",
+            "title": "Trace Id"
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "",
+              "user",
+              "assistant",
+              "system",
+              "tool",
+              "tool_call",
+              "tool_result"
+            ],
+            "title": "Role"
+          },
+          "content_preview": {
+            "type": "string",
+            "title": "Content Preview"
+          },
+          "content_digest": {
+            "type": "string",
+            "title": "Content Digest"
+          },
+          "started_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Started At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "span_id",
+          "trace_id",
+          "role",
+          "content_preview",
+          "content_digest",
+          "started_at"
+        ],
+        "title": "AgentSearchMatchedMessage",
+        "description": "A single message that matched the search query."
+      },
+      "AgentSearchReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "query": {
+            "type": "string",
+            "title": "Query"
+          },
+          "roles": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "",
+                    "user",
+                    "assistant",
+                    "system",
+                    "tool",
+                    "tool_call",
+                    "tool_result"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Roles"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Id"
+          },
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
+          },
+          "provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Name"
+          },
+          "request_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Model"
+          },
+          "started_after": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started After"
+          },
+          "started_before": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started Before"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 1000.0,
+            "minimum": 0.0,
+            "title": "Limit",
+            "default": 20
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Offset",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": ["project_id", "query"],
+        "title": "AgentSearchReq",
+        "description": "Full-text search across message content and span metadata.\n\nScans the `messages` table (one row per message occurrence, populated\nby an MV from spans) and returns matching span-level hits. The caller\ngroups by conversation for the response shape."
+      },
+      "AgentSearchRes": {
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSearchConversationResult"
+            },
+            "type": "array",
+            "title": "Results"
+          },
+          "total_conversations": {
+            "type": "integer",
+            "title": "Total Conversations",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": ["results"],
+        "title": "AgentSearchRes",
+        "description": "Response from a full-text search across agent messages."
+      },
+      "AgentSortBy": {
+        "properties": {
+          "field": {
+            "type": "string",
+            "title": "Field"
+          },
+          "direction": {
+            "type": "string",
+            "enum": ["asc", "desc"],
+            "title": "Direction",
+            "default": "desc"
+          }
+        },
+        "type": "object",
+        "required": ["field"],
+        "title": "AgentSortBy",
+        "description": "Sort specification for agent query endpoints."
+      },
+      "AgentSpanGroupDistributionBin": {
+        "properties": {
+          "index": {
+            "type": "integer",
+            "title": "Index"
+          },
+          "min": {
+            "type": "number",
+            "title": "Min"
+          },
+          "max": {
+            "type": "number",
+            "title": "Max"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": ["index", "min", "max", "count"],
+        "title": "AgentSpanGroupDistributionBin",
+        "description": "One numeric histogram bin for a custom attribute in a span group."
+      },
+      "AgentSpanGroupDistributionItem": {
+        "properties": {
+          "alias": {
+            "type": "string",
+            "title": "Alias"
+          },
+          "source": {
+            "type": "string",
+            "enum": [
+              "custom_attrs_string",
+              "custom_attrs_int",
+              "custom_attrs_float",
+              "custom_attrs_bool"
+            ],
+            "title": "Source"
+          },
+          "key": {
+            "type": "string",
+            "title": "Key"
+          },
+          "value_type": {
+            "type": "string",
+            "enum": ["string", "int", "float", "bool"],
+            "title": "Value Type"
+          },
+          "total_count": {
+            "type": "integer",
+            "title": "Total Count",
+            "default": 0
+          },
+          "present_count": {
+            "type": "integer",
+            "title": "Present Count",
+            "default": 0
+          },
+          "missing_count": {
+            "type": "integer",
+            "title": "Missing Count",
+            "default": 0
+          },
+          "other_count": {
+            "type": "integer",
+            "title": "Other Count",
+            "default": 0
+          },
+          "bins": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanGroupDistributionBin"
+            },
+            "type": "array",
+            "title": "Bins"
+          },
+          "values": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanGroupDistributionValue"
+            },
+            "type": "array",
+            "title": "Values"
+          }
+        },
+        "type": "object",
+        "required": ["alias", "source", "key", "value_type"],
+        "title": "AgentSpanGroupDistributionItem",
+        "description": "Distribution data for one span-group/custom-attribute pair."
+      },
+      "AgentSpanGroupDistributionSpec": {
+        "properties": {
+          "alias": {
+            "type": "string",
+            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+            "title": "Alias"
+          },
+          "value": {
+            "$ref": "#/components/schemas/AgentSpanValueRef"
+          },
+          "bins": {
+            "type": "integer",
+            "maximum": 50.0,
+            "minimum": 1.0,
+            "title": "Bins",
+            "default": 12
+          },
+          "top_n": {
+            "type": "integer",
+            "maximum": 20.0,
+            "minimum": 1.0,
+            "title": "Top N",
+            "default": 5
+          }
+        },
+        "type": "object",
+        "required": ["alias", "value"],
+        "title": "AgentSpanGroupDistributionSpec",
+        "description": "One custom attribute distribution to compute per returned span group."
+      },
+      "AgentSpanGroupDistributionValue": {
+        "properties": {
+          "value": {
+            "type": "string",
+            "title": "Value"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": ["value", "count"],
+        "title": "AgentSpanGroupDistributionValue",
+        "description": "One categorical custom attribute value count in a span group."
+      },
+      "AgentSpanGroupFilter": {
+        "properties": {
+          "group_by": {
+            "items": {
+              "$ref": "#/components/schemas/AgentGroupByRef"
+            },
+            "type": "array",
+            "title": "Group By"
+          },
+          "measure": {
+            "$ref": "#/components/schemas/AgentSpanMeasureSpec"
+          },
+          "min": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min"
+          },
+          "max": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max"
+          }
+        },
+        "type": "object",
+        "required": ["measure"],
+        "title": "AgentSpanGroupFilter",
+        "description": "Range filter over one grouped span measure."
+      },
+      "AgentSpanGroupRow": {
+        "properties": {
+          "group_keys": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "object",
+            "title": "Group Keys"
+          },
+          "span_count": {
+            "type": "integer",
+            "title": "Span Count",
+            "default": 0
+          },
+          "invocation_count": {
+            "type": "integer",
+            "title": "Invocation Count",
+            "default": 0
+          },
+          "conversation_count": {
+            "type": "integer",
+            "title": "Conversation Count",
+            "default": 0
+          },
+          "total_input_tokens": {
+            "type": "integer",
+            "title": "Total Input Tokens",
+            "default": 0
+          },
+          "total_cache_creation_input_tokens": {
+            "type": "integer",
+            "title": "Total Cache Creation Input Tokens",
+            "default": 0
+          },
+          "total_cache_read_input_tokens": {
+            "type": "integer",
+            "title": "Total Cache Read Input Tokens",
+            "default": 0
+          },
+          "total_output_tokens": {
+            "type": "integer",
+            "title": "Total Output Tokens",
+            "default": 0
+          },
+          "total_reasoning_tokens": {
+            "type": "integer",
+            "title": "Total Reasoning Tokens",
+            "default": 0
+          },
+          "total_duration_ms": {
+            "type": "integer",
+            "title": "Total Duration Ms",
+            "default": 0
+          },
+          "error_count": {
+            "type": "integer",
+            "title": "Error Count",
+            "default": 0
+          },
+          "agent_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Agent Names"
+          },
+          "agent_versions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Agent Versions"
+          },
+          "provider_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Provider Names"
+          },
+          "request_models": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Request Models"
+          },
+          "conversation_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Conversation Names"
+          },
+          "first_seen": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Seen"
+          },
+          "last_seen": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen"
+          },
+          "first_message": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentConversationMessagePreview"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "last_message": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentConversationMessagePreview"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "metrics": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "object",
+            "title": "Metrics"
+          },
+          "distributions": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/AgentSpanGroupDistributionItem"
+            },
+            "type": "object",
+            "title": "Distributions"
+          }
+        },
+        "type": "object",
+        "title": "AgentSpanGroupRow",
+        "description": "A single row in a grouped spans query response.\n\n`group_keys` maps each group_by ref's alias to its value for this row.\nThe remaining fields are a fixed aggregate bundle computed per group."
+      },
+      "AgentSpanMeasureSpec": {
+        "properties": {
+          "alias": {
+            "type": "string",
+            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+            "title": "Alias"
+          },
+          "aggregation": {
+            "type": "string",
+            "enum": [
+              "sum",
+              "avg",
+              "min",
+              "max",
+              "count",
+              "count_distinct",
+              "count_true",
+              "count_false"
+            ],
+            "title": "Aggregation"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentSpanValueRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "value_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["datetime", "number", "boolean", "string"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Type"
+          },
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Query"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "required": ["alias", "aggregation"],
+        "title": "AgentSpanMeasureSpec",
+        "description": "One aggregate measure computed over spans in a group or bucket."
+      },
+      "AgentSpanSchema": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "trace_id": {
+            "type": "string",
+            "title": "Trace Id"
+          },
+          "span_id": {
+            "type": "string",
+            "title": "Span Id"
+          },
+          "parent_span_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Parent Span Id"
+          },
+          "span_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Span Name"
+          },
+          "span_kind": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "UNSPECIFIED",
+                  "INTERNAL",
+                  "SERVER",
+                  "CLIENT",
+                  "PRODUCER",
+                  "CONSUMER"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Span Kind"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
+          "ended_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ended At"
+          },
+          "status_code": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["UNSET", "OK", "ERROR"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Code"
+          },
+          "status_message": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status Message"
+          },
+          "operation_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Operation Name"
+          },
+          "provider_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider Name"
+          },
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
+          },
+          "agent_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Id"
+          },
+          "agent_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Description"
+          },
+          "agent_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Version"
+          },
+          "request_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Model"
+          },
+          "response_model": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response Model"
+          },
+          "response_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Response Id"
+          },
+          "input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Tokens"
+          },
+          "output_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Tokens"
+          },
+          "reasoning_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning Tokens"
+          },
+          "cache_creation_input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Creation Input Tokens"
+          },
+          "cache_read_input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Read Input Tokens"
+          },
+          "reasoning_content": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reasoning Content"
+          },
+          "conversation_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Id"
+          },
+          "conversation_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Conversation Name"
+          },
+          "tool_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Name"
+          },
+          "tool_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Type"
+          },
+          "tool_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Call Id"
+          },
+          "tool_description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Description"
+          },
+          "tool_definitions": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Definitions"
+          },
+          "finish_reasons": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Finish Reasons"
+          },
+          "error_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error Type"
+          },
+          "request_temperature": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Temperature"
+          },
+          "request_max_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Max Tokens"
+          },
+          "request_top_p": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Top P"
+          },
+          "request_frequency_penalty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Frequency Penalty"
+          },
+          "request_presence_penalty": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Presence Penalty"
+          },
+          "request_seed": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Seed"
+          },
+          "request_stop_sequences": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Request Stop Sequences"
+          },
+          "request_choice_count": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Request Choice Count"
+          },
+          "output_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Type"
+          },
+          "input_messages": {
+            "items": {
+              "$ref": "#/components/schemas/NormalizedMessage"
+            },
+            "type": "array",
+            "title": "Input Messages"
+          },
+          "output_messages": {
+            "items": {
+              "$ref": "#/components/schemas/NormalizedMessage"
+            },
+            "type": "array",
+            "title": "Output Messages"
+          },
+          "system_instructions": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "System Instructions"
+          },
+          "tool_call_arguments": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Call Arguments"
+          },
+          "tool_call_result": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tool Call Result"
+          },
+          "compaction_summary": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Compaction Summary"
+          },
+          "compaction_items_before": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Compaction Items Before"
+          },
+          "compaction_items_after": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Compaction Items After"
+          },
+          "content_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Content Refs"
+          },
+          "artifact_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Artifact Refs"
+          },
+          "object_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Object Refs"
+          },
+          "custom_attrs_string": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Custom Attrs String"
+          },
+          "custom_attrs_int": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "type": "object",
+            "title": "Custom Attrs Int"
+          },
+          "custom_attrs_float": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Custom Attrs Float"
+          },
+          "custom_attrs_bool": {
+            "additionalProperties": {
+              "type": "boolean"
+            },
+            "type": "object",
+            "title": "Custom Attrs Bool"
+          },
+          "server_address": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Server Address"
+          },
+          "server_port": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Server Port"
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id"
+          },
+          "wb_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb Run Id"
+          },
+          "wb_run_step": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb Run Step"
+          },
+          "wb_run_step_end": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb Run Step End"
+          },
+          "raw_span_dump": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Raw Span Dump"
+          }
+        },
+        "type": "object",
+        "required": ["project_id", "trace_id", "span_id"],
+        "title": "AgentSpanSchema",
+        "description": "A normalized agent span returned by query APIs."
+      },
+      "AgentSpanStatsColumn": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "role": {
+            "type": "string",
+            "enum": ["time", "bucket", "group", "metric"],
+            "title": "Role"
+          },
+          "value_type": {
+            "type": "string",
+            "enum": ["datetime", "number", "boolean", "string"],
+            "title": "Value Type"
+          },
+          "metric": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metric"
+          },
+          "aggregation": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aggregation"
+          }
+        },
+        "type": "object",
+        "required": ["name", "role", "value_type"],
+        "title": "AgentSpanStatsColumn",
+        "description": "Metadata describing one column in an agent span stats result row."
+      },
+      "AgentSpanStatsMetricSpec": {
+        "properties": {
+          "alias": {
+            "type": "string",
+            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+            "title": "Alias"
+          },
+          "value_type": {
+            "type": "string",
+            "enum": ["datetime", "number", "boolean", "string"],
+            "title": "Value Type"
+          },
+          "aggregations": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "sum",
+                "avg",
+                "min",
+                "max",
+                "count",
+                "count_distinct",
+                "count_true",
+                "count_false"
+              ]
+            },
+            "type": "array",
+            "title": "Aggregations"
+          },
+          "percentiles": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Percentiles"
+          },
+          "value": {
+            "$ref": "#/components/schemas/AgentSpanValueRef"
+          }
+        },
+        "type": "object",
+        "required": ["alias", "value_type", "value"],
+        "title": "AgentSpanStatsMetricSpec",
+        "description": "Metric to extract from each matching span and aggregate into chart rows."
+      },
+      "AgentSpanStatsNumericBucketSpec": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "number",
+            "title": "Type",
+            "default": "number"
+          },
+          "alias": {
+            "type": "string",
+            "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+            "title": "Alias",
+            "default": "value"
+          },
+          "bins": {
+            "type": "integer",
+            "maximum": 200.0,
+            "minimum": 1.0,
+            "title": "Bins",
+            "default": 24
+          },
+          "min": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Min"
+          },
+          "max": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Max"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentSpanValueRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "group_by": {
+            "items": {
+              "$ref": "#/components/schemas/AgentGroupByRef"
+            },
+            "type": "array",
+            "title": "Group By"
+          },
+          "measure": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentSpanMeasureSpec"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "AgentSpanStatsNumericBucketSpec",
+        "description": "Bucket stats rows by ranges of one numeric span or grouped value."
+      },
+      "AgentSpanStatsReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "query": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Query"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start"
+          },
+          "end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End"
+          },
+          "granularity": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Granularity"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "default": "UTC"
+          },
+          "group_by": {
+            "items": {
+              "$ref": "#/components/schemas/AgentGroupByRef"
+            },
+            "type": "array",
+            "title": "Group By"
+          },
+          "metrics": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanStatsMetricSpec"
+            },
+            "type": "array",
+            "title": "Metrics"
+          },
+          "group_limit": {
+            "type": "integer",
+            "maximum": 1000.0,
+            "minimum": 1.0,
+            "title": "Group Limit",
+            "default": 50
+          },
+          "bucket_by": {
+            "anyOf": [
+              {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/AgentSpanStatsTimeBucketSpec"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AgentSpanStatsNumericBucketSpec"
+                  }
+                ],
+                "discriminator": {
+                  "propertyName": "type",
+                  "mapping": {
+                    "number": "#/components/schemas/AgentSpanStatsNumericBucketSpec",
+                    "time": "#/components/schemas/AgentSpanStatsTimeBucketSpec"
+                  }
+                }
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Bucket By"
+          },
+          "group_filters": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanGroupFilter"
+            },
+            "type": "array",
+            "title": "Group Filters"
+          }
+        },
+        "type": "object",
+        "required": ["project_id", "start"],
+        "title": "AgentSpanStatsReq",
+        "description": "Request chart-ready aggregations over GenAI agent spans."
+      },
+      "AgentSpanStatsRes": {
+        "properties": {
+          "start": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start"
+          },
+          "end": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End"
+          },
+          "granularity": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Granularity"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone"
+          },
+          "bucket_type": {
+            "type": "string",
+            "enum": ["time", "number"],
+            "title": "Bucket Type",
+            "default": "time"
+          },
+          "columns": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanStatsColumn"
+            },
+            "type": "array",
+            "title": "Columns"
+          },
+          "rows": {
+            "items": {
+              "additionalProperties": {
+                "anyOf": [
+                  {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "integer"
+                  },
+                  {
+                    "type": "number"
+                  },
+                  {
+                    "type": "boolean"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Rows"
+          }
+        },
+        "type": "object",
+        "required": ["start", "end", "timezone"],
+        "title": "AgentSpanStatsRes",
+        "description": "Response containing chart-ready agent span stats rows."
+      },
+      "AgentSpanStatsTimeBucketSpec": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "time",
+            "title": "Type",
+            "default": "time"
+          }
+        },
+        "type": "object",
+        "title": "AgentSpanStatsTimeBucketSpec",
+        "description": "Bucket stats rows by started_at time intervals."
+      },
+      "AgentSpanValueRef": {
+        "properties": {
+          "source": {
+            "type": "string",
+            "enum": [
+              "field",
+              "derived",
+              "custom_attrs_string",
+              "custom_attrs_int",
+              "custom_attrs_float",
+              "custom_attrs_bool"
+            ],
+            "title": "Source",
+            "default": "field"
+          },
+          "key": {
+            "type": "string",
+            "title": "Key"
+          }
+        },
+        "type": "object",
+        "required": ["key"],
+        "title": "AgentSpanValueRef",
+        "description": "Reference to a span field or typed custom attribute map value."
+      },
+      "AgentSpansQueryReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "query": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Query"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "group_by": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AgentGroupByRef"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Group By"
+          },
+          "measures": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanMeasureSpec"
+            },
+            "type": "array",
+            "title": "Measures"
+          },
+          "group_filters": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanGroupFilter"
+            },
+            "type": "array",
+            "title": "Group Filters"
+          },
+          "group_distributions": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanGroupDistributionSpec"
+            },
+            "type": "array",
+            "maxItems": 20,
+            "title": "Group Distributions"
+          },
+          "custom_attr_columns": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanValueRef"
+            },
+            "type": "array",
+            "title": "Custom Attr Columns"
+          },
+          "include_details": {
+            "type": "boolean",
+            "title": "Include Details",
+            "default": false
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AgentSortBy"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort By"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 10000.0,
+            "minimum": 0.0,
+            "title": "Limit",
+            "default": 100
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Offset",
+            "default": 0
+          },
+          "started_after": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started After"
+          },
+          "started_before": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started Before"
+          }
+        },
+        "type": "object",
+        "required": ["project_id"],
+        "title": "AgentSpansQueryReq",
+        "description": "Request to query agent spans for a project.\n\nWhen `group_by` is empty (or omitted), returns raw span rows in the\nresponse's `spans` field. When `group_by` is non-empty, returns\naggregate group rows in the response's `groups` field."
+      },
+      "AgentSpansQueryRes": {
+        "properties": {
+          "spans": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanSchema"
+            },
+            "type": "array",
+            "title": "Spans"
+          },
+          "groups": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSpanGroupRow"
+            },
+            "type": "array",
+            "title": "Groups"
+          },
+          "total_count": {
+            "type": "integer",
+            "title": "Total Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "AgentSpansQueryRes",
+        "description": "Response from a spans query.\n\nExactly one of `spans` or `groups` will be populated, based on\nwhether the request specified `group_by`."
+      },
+      "AgentTraceChatReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "trace_id": {
+            "type": "string",
+            "title": "Trace Id"
+          },
+          "include_feedback": {
+            "type": "boolean",
+            "title": "Include Feedback",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": ["project_id", "trace_id"],
+        "title": "AgentTraceChatReq",
+        "description": "Request to get the structured chat / trajectory view for a trace."
+      },
+      "AgentTraceChatRes": {
+        "properties": {
+          "trace_id": {
+            "type": "string",
+            "title": "Trace Id"
+          },
+          "root_span_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Root Span Name"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "total_duration_ms": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Duration Ms",
+            "description": "Wall-clock duration of the trace root span in milliseconds. This is not a sum of child span durations."
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/AgentChatMessage"
+            },
+            "type": "array",
+            "title": "Messages"
+          },
+          "feedback": {
+            "anyOf": [
+              {
+                "items": {
+                  "additionalProperties": true,
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feedback"
+          }
+        },
+        "type": "object",
+        "required": ["trace_id"],
+        "title": "AgentTraceChatRes",
+        "description": "Structured chat view: a linear sequence of messages representing\nthe agent trajectory for a single trace."
+      },
+      "AgentVersionSchema": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "invocation_count": {
+            "type": "integer",
+            "title": "Invocation Count"
+          },
+          "span_count": {
+            "type": "integer",
+            "title": "Span Count"
+          },
+          "total_input_tokens": {
+            "type": "integer",
+            "title": "Total Input Tokens"
+          },
+          "total_output_tokens": {
+            "type": "integer",
+            "title": "Total Output Tokens"
+          },
+          "total_duration_ms": {
+            "type": "integer",
+            "title": "Total Duration Ms"
+          },
+          "error_count": {
+            "type": "integer",
+            "title": "Error Count"
+          },
+          "first_seen": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "First Seen"
+          },
+          "last_seen": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Seen"
+          },
+          "agent_version": {
+            "type": "string",
+            "title": "Agent Version"
+          }
+        },
+        "type": "object",
+        "required": [
+          "project_id",
+          "agent_name",
+          "invocation_count",
+          "span_count",
+          "total_input_tokens",
+          "total_output_tokens",
+          "total_duration_ms",
+          "error_count",
+          "first_seen",
+          "last_seen",
+          "agent_version"
+        ],
+        "title": "AgentVersionSchema",
+        "description": "Aggregated per-version stats from the agent_versions AMT."
+      },
+      "AgentVersionsQueryReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "agent_name": {
+            "type": "string",
+            "title": "Agent Name"
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AgentSortBy"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort By"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 10000.0,
+            "minimum": 0.0,
+            "title": "Limit",
+            "default": 100
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Offset",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": ["project_id", "agent_name"],
+        "title": "AgentVersionsQueryReq",
+        "description": "Request to list versions for an agent."
+      },
+      "AgentVersionsQueryRes": {
+        "properties": {
+          "versions": {
+            "items": {
+              "$ref": "#/components/schemas/AgentVersionSchema"
+            },
+            "type": "array",
+            "title": "Versions"
+          },
+          "total_count": {
+            "type": "integer",
+            "title": "Total Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": ["versions"],
+        "title": "AgentVersionsQueryRes",
+        "description": "Response containing agent version stats."
+      },
+      "AgentsQueryFilters": {
+        "properties": {
+          "agent_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Agent Name"
+          }
+        },
+        "type": "object",
+        "title": "AgentsQueryFilters",
+        "description": "Optional filters for querying agents."
+      },
+      "AgentsQueryReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "filters": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AgentsQueryFilters"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/AgentSortBy"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort By"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 10000.0,
+            "minimum": 0.0,
+            "title": "Limit",
+            "default": 100
+          },
+          "offset": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Offset",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": ["project_id"],
+        "title": "AgentsQueryReq",
+        "description": "Request to list agents with aggregated stats for a project."
+      },
+      "AgentsQueryRes": {
+        "properties": {
+          "agents": {
+            "items": {
+              "$ref": "#/components/schemas/AgentSchema"
+            },
+            "type": "array",
+            "title": "Agents"
+          },
+          "total_count": {
+            "type": "integer",
+            "title": "Total Count",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "required": ["agents"],
+        "title": "AgentsQueryRes",
+        "description": "Response containing aggregated agent stats."
+      },
+      "AggregationType": {
+        "type": "string",
+        "enum": [
+          "sum",
+          "avg",
+          "min",
+          "max",
+          "count",
+          "count_true",
+          "count_false"
+        ],
+        "title": "AggregationType",
+        "description": "Aggregation functions supported by feedback and call stats metrics."
+      },
+      "AliasesListRes": {
+        "properties": {
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Aliases"
+          }
+        },
+        "type": "object",
+        "required": ["aliases"],
+        "title": "AliasesListRes"
+      },
       "AndOperation": {
         "properties": {
           "$and": {
             "items": {
               "anyOf": [
-                {"$ref": "#/components/schemas/LiteralOperation"},
-                {"$ref": "#/components/schemas/GetFieldOperator"},
-                {"$ref": "#/components/schemas/ConvertOperation"},
-                {"$ref": "#/components/schemas/AndOperation"},
-                {"$ref": "#/components/schemas/OrOperation"},
-                {"$ref": "#/components/schemas/NotOperation"},
-                {"$ref": "#/components/schemas/EqOperation"},
-                {"$ref": "#/components/schemas/GtOperation"},
-                {"$ref": "#/components/schemas/GteOperation"},
-                {"$ref": "#/components/schemas/InOperation"},
-                {"$ref": "#/components/schemas/ContainsOperation"}
+                {
+                  "$ref": "#/components/schemas/LiteralOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/GetFieldOperator"
+                },
+                {
+                  "$ref": "#/components/schemas/ConvertOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/AndOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/OrOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/NotOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/EqOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/GtOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/LtOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/GteOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/LteOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/InOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/ContainsOperation"
+                }
               ]
             },
             "type": "array",
@@ -919,12 +8507,752 @@
         },
         "type": "object",
         "required": ["$and"],
-        "title": "AndOperation"
+        "title": "AndOperation",
+        "description": "Logical AND. All conditions must evaluate to true.\n\nExample:\n    ```\n    {\n        \"$and\": [\n            {\"$eq\": [{\"$getField\": \"op_name\"}, {\"$literal\": \"predict\"}]},\n            {\"$gt\": [{\"$getField\": \"summary.usage.tokens\"}, {\"$literal\": 1000}]}\n        ]\n    }\n    ```"
+      },
+      "AnnotationQueueAddCallsBody": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": ["entity/project"]
+          },
+          "call_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Call Ids",
+            "examples": [["call-1", "call-2", "call-3"]]
+          },
+          "display_fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Display Fields",
+            "description": "JSON paths to display to annotators",
+            "examples": [["input.prompt", "output.text"]]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "call_ids", "display_fields"],
+        "title": "AnnotationQueueAddCallsBody",
+        "description": "Request body for adding calls to an annotation queue (queue_id comes from path)."
+      },
+      "AnnotationQueueAddCallsRes": {
+        "properties": {
+          "added_count": {
+            "type": "integer",
+            "title": "Added Count"
+          },
+          "duplicates": {
+            "type": "integer",
+            "title": "Duplicates"
+          }
+        },
+        "type": "object",
+        "required": ["added_count", "duplicates"],
+        "title": "AnnotationQueueAddCallsRes",
+        "description": "Response from adding calls to a queue."
+      },
+      "AnnotationQueueCreateReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": ["entity/project"]
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "examples": ["Error Review Queue"]
+          },
+          "description": {
+            "type": "string",
+            "title": "Description",
+            "default": "",
+            "examples": ["Review calls with exceptions"]
+          },
+          "scorer_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scorer Refs",
+            "examples": [
+              [
+                "weave:///entity/project/scorer/error_severity:abc123",
+                "weave:///entity/project/scorer/resolution_quality:def456"
+              ]
+            ]
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id",
+            "description": "Do not set directly. Server will automatically populate this field."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "name", "scorer_refs"],
+        "title": "AnnotationQueueCreateReq",
+        "description": "Request to create a new annotation queue."
+      },
+      "AnnotationQueueCreateRes": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": ["id"],
+        "title": "AnnotationQueueCreateRes",
+        "description": "Response from creating an annotation queue."
+      },
+      "AnnotationQueueDeleteRes": {
+        "properties": {
+          "queue": {
+            "$ref": "#/components/schemas/AnnotationQueueSchema"
+          }
+        },
+        "type": "object",
+        "required": ["queue"],
+        "title": "AnnotationQueueDeleteRes",
+        "description": "Response from deleting an annotation queue."
+      },
+      "AnnotationQueueItemProgressUpdateBody": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": ["entity/project"]
+          },
+          "annotation_state": {
+            "type": "string",
+            "title": "Annotation State",
+            "description": "New state: 'in_progress', 'completed', or 'skipped'",
+            "examples": ["in_progress", "completed", "skipped"]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "annotation_state"],
+        "title": "AnnotationQueueItemProgressUpdateBody",
+        "description": "Request body for updating annotation progress (queue_id and item_id come from path).\n\nNote: wb_user_id is not included in the body - it's set server-side from the authenticated session."
+      },
+      "AnnotationQueueItemSchema": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "queue_id": {
+            "type": "string",
+            "title": "Queue Id"
+          },
+          "call_id": {
+            "type": "string",
+            "title": "Call Id"
+          },
+          "call_started_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Call Started At"
+          },
+          "call_ended_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Ended At"
+          },
+          "call_op_name": {
+            "type": "string",
+            "title": "Call Op Name"
+          },
+          "call_trace_id": {
+            "type": "string",
+            "title": "Call Trace Id"
+          },
+          "display_fields": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Display Fields"
+          },
+          "added_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Added By"
+          },
+          "annotation_state": {
+            "type": "string",
+            "enum": ["unstarted", "in_progress", "completed", "skipped"],
+            "title": "Annotation State"
+          },
+          "annotator_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Annotator User Id"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "created_by": {
+            "type": "string",
+            "title": "Created By"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "deleted_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deleted At"
+          },
+          "position_in_queue": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Position In Queue"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "project_id",
+          "queue_id",
+          "call_id",
+          "call_started_at",
+          "call_op_name",
+          "call_trace_id",
+          "display_fields",
+          "annotation_state",
+          "created_at",
+          "created_by",
+          "updated_at"
+        ],
+        "title": "AnnotationQueueItemSchema",
+        "description": "Schema for annotation queue item responses."
+      },
+      "AnnotationQueueItemsFilter": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id",
+            "description": "Filter by exact queue item ID"
+          },
+          "call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Id",
+            "description": "Filter by exact call ID"
+          },
+          "call_op_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Op Name",
+            "description": "Filter by exact operation name"
+          },
+          "call_trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Trace Id",
+            "description": "Filter by exact trace ID"
+          },
+          "added_by": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Added By",
+            "description": "Filter by W&B user ID who added the call"
+          },
+          "annotation_states": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": ["unstarted", "in_progress", "completed", "skipped"]
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Annotation States",
+            "description": "Filter by annotation states (unstarted, in_progress, completed, skipped)",
+            "examples": [["unstarted", "in_progress"]]
+          }
+        },
+        "type": "object",
+        "title": "AnnotationQueueItemsFilter",
+        "description": "Simple filter for annotation queue items.\n\nSupports equality filtering on call metadata fields and IN filtering on annotation state."
+      },
+      "AnnotationQueueItemsQueryBody": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": ["entity/project"]
+          },
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/AnnotationQueueItemsFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Filter queue items by call metadata and annotation state"
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SortBy"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort By",
+            "description": "Sort by multiple fields (e.g., created_at, updated_at)"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit",
+            "examples": [50]
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Offset",
+            "examples": [0]
+          },
+          "include_position": {
+            "type": "boolean",
+            "title": "Include Position",
+            "description": "Include position_in_queue field (1-based index in full queue)",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id"],
+        "title": "AnnotationQueueItemsQueryBody",
+        "description": "Request body for querying items in an annotation queue (queue_id comes from path)."
+      },
+      "AnnotationQueueItemsQueryRes": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AnnotationQueueItemSchema"
+            },
+            "type": "array",
+            "title": "Items"
+          }
+        },
+        "type": "object",
+        "required": ["items"],
+        "title": "AnnotationQueueItemsQueryRes",
+        "description": "Response from querying annotation queue items."
+      },
+      "AnnotationQueueReadRes": {
+        "properties": {
+          "queue": {
+            "$ref": "#/components/schemas/AnnotationQueueSchema"
+          }
+        },
+        "type": "object",
+        "required": ["queue"],
+        "title": "AnnotationQueueReadRes",
+        "description": "Response from reading an annotation queue."
+      },
+      "AnnotationQueueSchema": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "scorer_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scorer Refs"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          },
+          "created_by": {
+            "type": "string",
+            "title": "Created By"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Updated At"
+          },
+          "deleted_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deleted At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "project_id",
+          "name",
+          "description",
+          "scorer_refs",
+          "created_at",
+          "created_by",
+          "updated_at"
+        ],
+        "title": "AnnotationQueueSchema",
+        "description": "Schema for annotation queue responses."
+      },
+      "AnnotationQueueStatsSchema": {
+        "properties": {
+          "queue_id": {
+            "type": "string",
+            "title": "Queue Id",
+            "description": "The queue ID",
+            "examples": ["550e8400-e29b-41d4-a716-446655440000"]
+          },
+          "total_items": {
+            "type": "integer",
+            "title": "Total Items",
+            "description": "Total number of items in the queue"
+          },
+          "completed_items": {
+            "type": "integer",
+            "title": "Completed Items",
+            "description": "Number of items completed or skipped by at least one annotator"
+          }
+        },
+        "type": "object",
+        "required": ["queue_id", "total_items", "completed_items"],
+        "title": "AnnotationQueueStatsSchema",
+        "description": "Statistics for a single annotation queue."
+      },
+      "AnnotationQueueUpdateBody": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": ["entity/project"]
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "examples": ["Updated Queue Name"]
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "examples": ["Updated description"]
+          },
+          "scorer_refs": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scorer Refs",
+            "examples": [
+              [
+                "weave:///entity/project/scorer/error_severity:abc123",
+                "weave:///entity/project/scorer/resolution_quality:def456"
+              ]
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id"],
+        "title": "AnnotationQueueUpdateBody",
+        "description": "Request body for updating an annotation queue (queue_id comes from path).\n\nAll fields except project_id are optional - only provided fields will be updated."
+      },
+      "AnnotationQueueUpdateRes": {
+        "properties": {
+          "queue": {
+            "$ref": "#/components/schemas/AnnotationQueueSchema"
+          }
+        },
+        "type": "object",
+        "required": ["queue"],
+        "title": "AnnotationQueueUpdateRes",
+        "description": "Response from updating an annotation queue."
+      },
+      "AnnotationQueuesQueryReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": ["entity/project"]
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "Filter by queue name (case-insensitive partial match)",
+            "examples": ["Error"]
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SortBy"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort By",
+            "description": "Sort by multiple fields (e.g., created_at, updated_at, name)"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit",
+            "examples": [10]
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Offset",
+            "examples": [0]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id"],
+        "title": "AnnotationQueuesQueryReq",
+        "description": "Request to query annotation queues for a project."
+      },
+      "AnnotationQueuesStatsReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": ["entity/project"]
+          },
+          "queue_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Queue Ids",
+            "description": "List of queue IDs to get stats for",
+            "examples": [
+              [
+                "550e8400-e29b-41d4-a716-446655440000",
+                "550e8400-e29b-41d4-a716-446655440001"
+              ]
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "queue_ids"],
+        "title": "AnnotationQueuesStatsReq",
+        "description": "Request to get stats for multiple annotation queues."
+      },
+      "AnnotationQueuesStatsRes": {
+        "properties": {
+          "stats": {
+            "items": {
+              "$ref": "#/components/schemas/AnnotationQueueStatsSchema"
+            },
+            "type": "array",
+            "title": "Stats"
+          }
+        },
+        "type": "object",
+        "required": ["stats"],
+        "title": "AnnotationQueuesStatsRes",
+        "description": "Response with stats for multiple annotation queues."
+      },
+      "AnnotatorQueueItemsProgressUpdateRes": {
+        "properties": {
+          "item": {
+            "$ref": "#/components/schemas/AnnotationQueueItemSchema"
+          }
+        },
+        "type": "object",
+        "required": ["item"],
+        "title": "AnnotatorQueueItemsProgressUpdateRes",
+        "description": "Response from updating annotation state."
       },
       "Body_file_create_file_create_post": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
-          "file": {"type": "string", "format": "binary", "title": "File"}
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
         },
         "type": "object",
         "required": ["project_id", "file"],
@@ -932,8 +9260,14 @@
       },
       "CallBatchEndMode": {
         "properties": {
-          "mode": {"type": "string", "title": "Mode", "default": "end"},
-          "req": {"$ref": "#/components/schemas/CallEndReq"}
+          "mode": {
+            "type": "string",
+            "title": "Mode",
+            "default": "end"
+          },
+          "req": {
+            "$ref": "#/components/schemas/CallEndReq"
+          }
         },
         "type": "object",
         "required": ["req"],
@@ -941,8 +9275,14 @@
       },
       "CallBatchStartMode": {
         "properties": {
-          "mode": {"type": "string", "title": "Mode", "default": "start"},
-          "req": {"$ref": "#/components/schemas/CallStartReq"}
+          "mode": {
+            "type": "string",
+            "title": "Mode",
+            "default": "start"
+          },
+          "req": {
+            "$ref": "#/components/schemas/CallStartReq"
+          }
         },
         "type": "object",
         "required": ["req"],
@@ -953,8 +9293,12 @@
           "batch": {
             "items": {
               "anyOf": [
-                {"$ref": "#/components/schemas/CallBatchStartMode"},
-                {"$ref": "#/components/schemas/CallBatchEndMode"}
+                {
+                  "$ref": "#/components/schemas/CallBatchStartMode"
+                },
+                {
+                  "$ref": "#/components/schemas/CallBatchEndMode"
+                }
               ]
             },
             "type": "array",
@@ -970,8 +9314,12 @@
           "res": {
             "items": {
               "anyOf": [
-                {"$ref": "#/components/schemas/CallStartRes"},
-                {"$ref": "#/components/schemas/CallEndRes"}
+                {
+                  "$ref": "#/components/schemas/CallStartRes"
+                },
+                {
+                  "$ref": "#/components/schemas/CallEndRes"
+                }
               ]
             },
             "type": "array",
@@ -984,23 +9332,101 @@
       },
       "CallEndReq": {
         "properties": {
-          "end": {"$ref": "#/components/schemas/EndedCallSchemaForInsert"}
+          "end": {
+            "$ref": "#/components/schemas/EndedCallSchemaForInsert"
+          }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["end"],
         "title": "CallEndReq"
       },
-      "CallEndRes": {"properties": {}, "type": "object", "title": "CallEndRes"},
+      "CallEndRes": {
+        "properties": {},
+        "type": "object",
+        "title": "CallEndRes"
+      },
+      "CallMetricSpec": {
+        "properties": {
+          "metric": {
+            "type": "string",
+            "enum": ["latency_ms", "call_count", "error_count"],
+            "title": "Metric",
+            "description": "Metric to aggregate."
+          },
+          "aggregations": {
+            "items": {
+              "$ref": "#/components/schemas/AggregationType"
+            },
+            "type": "array",
+            "title": "Aggregations",
+            "description": "Basic aggregation functions to apply",
+            "default": ["sum"]
+          },
+          "percentiles": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Percentiles",
+            "description": "Percentile values to compute (0-100). E.g., [50, 95, 99] for p50, p95, p99",
+            "default": []
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["metric"],
+        "title": "CallMetricSpec",
+        "description": "Specification for a call-level metric to aggregate (not grouped by model)."
+      },
       "CallReadReq": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
-          "id": {"type": "string", "title": "Id"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
           "include_costs": {
-            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Include Costs",
+            "default": false
+          },
+          "include_storage_size": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Storage Size",
+            "default": false
+          },
+          "include_total_storage_size": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Total Storage Size",
             "default": false
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "id"],
         "title": "CallReadReq"
@@ -1009,8 +9435,12 @@
         "properties": {
           "call": {
             "anyOf": [
-              {"$ref": "#/components/schemas/CallSchema"},
-              {"type": "null"}
+              {
+                "$ref": "#/components/schemas/CallSchema"
+              },
+              {
+                "type": "null"
+              }
             ]
           }
         },
@@ -1020,52 +9450,218 @@
       },
       "CallSchema": {
         "properties": {
-          "id": {"type": "string", "title": "Id"},
-          "project_id": {"type": "string", "title": "Project Id"},
-          "op_name": {"type": "string", "title": "Op Name"},
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "op_name": {
+            "type": "string",
+            "title": "Op Name"
+          },
           "display_name": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Display Name"
           },
-          "trace_id": {"type": "string", "title": "Trace Id"},
+          "trace_id": {
+            "type": "string",
+            "title": "Trace Id"
+          },
           "parent_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Parent Id"
+          },
+          "thread_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thread Id"
+          },
+          "turn_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Turn Id"
           },
           "started_at": {
             "type": "string",
             "format": "date-time",
             "title": "Started At"
           },
-          "attributes": {"type": "object", "title": "Attributes"},
-          "inputs": {"type": "object", "title": "Inputs"},
+          "attributes": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Attributes"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Inputs"
+          },
           "ended_at": {
             "anyOf": [
-              {"type": "string", "format": "date-time"},
-              {"type": "null"}
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Ended At"
           },
           "exception": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Exception"
           },
-          "output": {"anyOf": [{}, {"type": "null"}], "title": "Output"},
-          "summary": {"type": "object"},
+          "output": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output"
+          },
+          "summary": {
+            "additionalProperties": true,
+            "type": "object"
+          },
           "wb_user_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Wb User Id"
           },
+          "wb_username": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb Username"
+          },
           "wb_run_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Wb Run Id"
+          },
+          "wb_run_step": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb Run Step"
+          },
+          "wb_run_step_end": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb Run Step End"
           },
           "deleted_at": {
             "anyOf": [
-              {"type": "string", "format": "date-time"},
-              {"type": "null"}
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Deleted At"
+          },
+          "expire_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expire At",
+            "description": "Expiration timestamp for this call. None = no TTL configured for the project (the row will not be expired)."
+          },
+          "storage_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Size Bytes"
+          },
+          "total_storage_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Storage Size Bytes"
           }
         },
         "type": "object",
@@ -1082,35 +9678,205 @@
       },
       "CallStartReq": {
         "properties": {
-          "start": {"$ref": "#/components/schemas/StartedCallSchemaForInsert"}
+          "start": {
+            "$ref": "#/components/schemas/StartedCallSchemaForInsert"
+          }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["start"],
         "title": "CallStartReq"
       },
       "CallStartRes": {
         "properties": {
-          "id": {"type": "string", "title": "Id"},
-          "trace_id": {"type": "string", "title": "Trace Id"}
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "trace_id": {
+            "type": "string",
+            "title": "Trace Id"
+          }
         },
         "type": "object",
         "required": ["id", "trace_id"],
         "title": "CallStartRes"
       },
+      "CallStatsReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start",
+            "description": "Inclusive start time (UTC, ISO 8601)."
+          },
+          "end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End",
+            "description": "Exclusive end time (UTC, ISO 8601). Defaults to now if omitted."
+          },
+          "granularity": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Granularity",
+            "description": "Bucket size in seconds (e.g., 3600 for 1 hour). If omitted, auto-selected based on time range. Will be adjusted if it would produce more than 10,000 buckets."
+          },
+          "usage_metrics": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/UsageMetricSpec"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Usage Metrics",
+            "description": "Usage metrics (tokens, cost) to compute. Grouped by timestamp and model."
+          },
+          "call_metrics": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/CallMetricSpec"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Call Metrics",
+            "description": "Call-level metrics (latency, counts) to compute. Grouped by timestamp only."
+          },
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CallsFilter"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "description": "IANA timezone for bucket alignment (e.g., 'America/New_York')",
+            "default": "UTC"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "start"],
+        "title": "CallStatsReq",
+        "description": "Request for aggregated call statistics over a time range."
+      },
+      "CallStatsRes": {
+        "properties": {
+          "start": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start",
+            "description": "Resolved start time (UTC)"
+          },
+          "end": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End",
+            "description": "Resolved end time (UTC)"
+          },
+          "granularity": {
+            "type": "integer",
+            "title": "Granularity",
+            "description": "Bucket size used (in seconds)"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "description": "Timezone used for bucket alignment"
+          },
+          "usage_buckets": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Usage Buckets",
+            "description": "Usage metrics by model. Each bucket contains 'timestamp', 'model', and aggregated metric values.",
+            "default": []
+          },
+          "call_buckets": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Call Buckets",
+            "description": "Call-level metrics. Each bucket contains 'timestamp' and aggregated metric values.",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["start", "end", "granularity", "timezone"],
+        "title": "CallStatsRes",
+        "description": "Response containing time-series call statistics."
+      },
       "CallUpdateReq": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
-          "call_id": {"type": "string", "title": "Call Id"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "call_id": {
+            "type": "string",
+            "title": "Call Id"
+          },
           "display_name": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Display Name"
           },
           "wb_user_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Wb User Id",
             "description": "Do not set directly. Server will automatically populate this field."
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "call_id"],
         "title": "CallUpdateReq"
@@ -1122,262 +9888,770 @@
       },
       "CallsDeleteReq": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
           "call_ids": {
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Call Ids"
           },
           "wb_user_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Wb User Id",
             "description": "Do not set directly. Server will automatically populate this field."
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "call_ids"],
         "title": "CallsDeleteReq"
       },
       "CallsDeleteRes": {
-        "properties": {},
+        "properties": {
+          "num_deleted": {
+            "type": "integer",
+            "title": "Num Deleted",
+            "description": "The number of calls deleted"
+          }
+        },
         "type": "object",
+        "required": ["num_deleted"],
         "title": "CallsDeleteRes"
       },
       "CallsFilter": {
         "properties": {
           "op_names": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Op Names"
           },
           "input_refs": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Input Refs"
           },
           "output_refs": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Output Refs"
           },
           "parent_ids": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Parent Ids"
           },
           "trace_ids": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Trace Ids"
           },
           "call_ids": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Call Ids"
           },
+          "thread_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thread Ids"
+          },
+          "turn_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Turn Ids"
+          },
           "trace_roots_only": {
-            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Trace Roots Only"
           },
           "wb_user_ids": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Wb User Ids"
           },
           "wb_run_ids": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Wb Run Ids"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "title": "CallsFilter"
       },
       "CallsQueryReq": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
           "filter": {
             "anyOf": [
-              {"$ref": "#/components/schemas/CallsFilter"},
-              {"type": "null"}
+              {
+                "$ref": "#/components/schemas/CallsFilter"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "limit": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Limit"
           },
           "offset": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Offset"
           },
           "sort_by": {
             "anyOf": [
               {
-                "items": {"$ref": "#/components/schemas/SortBy"},
+                "items": {
+                  "$ref": "#/components/schemas/SortBy"
+                },
                 "type": "array"
               },
-              {"type": "null"}
+              {
+                "type": "null"
+              }
             ],
             "title": "Sort By"
           },
           "query": {
-            "anyOf": [{"$ref": "#/components/schemas/Query"}, {"type": "null"}]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Query"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "include_costs": {
-            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Include Costs",
             "description": "Beta, subject to change. If true, the response will include any model costs for each call.",
             "default": false
           },
           "include_feedback": {
-            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Include Feedback",
             "description": "Beta, subject to change. If true, the response will include feedback for each call.",
             "default": false
           },
+          "include_storage_size": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Storage Size",
+            "description": "Beta, subject to change. If true, the response will include the storage size for a call.",
+            "default": false
+          },
+          "include_total_storage_size": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Total Storage Size",
+            "description": "Beta, subject to change. If true, the response will include the total storage size for a trace.",
+            "default": false
+          },
+          "include_usernames": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Usernames",
+            "description": "If true, the response will attempt to resolve each call's wb_user_id to a username for the duration of this request.",
+            "default": false
+          },
           "columns": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Columns"
           },
           "expand_columns": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Expand Columns",
             "description": "Columns to expand, i.e. refs to other objects",
             "examples": [["inputs.self.message", "inputs.model.prompt"]]
+          },
+          "return_expanded_column_values": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Return Expanded Column Values",
+            "description": "If true, the response will include raw values for expanded columns. If false, the response expand_columns will only be used for filtering and ordering. This is useful for clients that want to resolve refs themselves, e.g. for performance reasons.",
+            "default": true
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id"],
         "title": "CallsQueryReq"
       },
       "CallsQueryStatsReq": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
           "filter": {
             "anyOf": [
-              {"$ref": "#/components/schemas/CallsFilter"},
-              {"type": "null"}
+              {
+                "$ref": "#/components/schemas/CallsFilter"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "query": {
-            "anyOf": [{"$ref": "#/components/schemas/Query"}, {"type": "null"}]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Query"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit"
+          },
+          "include_total_storage_size": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Total Storage Size",
+            "default": false
+          },
+          "expand_columns": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expand Columns",
+            "description": "Columns with refs to objects or table rows that require expansion during filtering or ordering.",
+            "examples": [["inputs.self.message", "inputs.model.prompt"]]
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id"],
         "title": "CallsQueryStatsReq"
       },
       "CallsQueryStatsRes": {
         "properties": {
-          "count": {"type": "integer", "title": "Count"},
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
           "has_more": {
             "type": "boolean",
             "title": "Has More",
-            "default": false,
-            "description": "True when count saturated the request's limit (caller-supplied or the server's defense-in-depth ceiling). Clients should render the count as e.g. '10,000+'."
+            "default": false
+          },
+          "total_storage_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Storage Size Bytes"
           }
         },
         "type": "object",
         "required": ["count"],
         "title": "CallsQueryStatsRes"
       },
+      "CallsScoreReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "call_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Call Ids",
+            "description": "List of call IDs to score"
+          },
+          "scorer_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scorer Refs",
+            "description": "List of scorer refs to apply"
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id",
+            "description": "Do not set directly. Server will automatically populate this field."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "call_ids", "scorer_refs"],
+        "title": "CallsScoreReq",
+        "description": "Request to enqueue scoring jobs for a list of calls.\n\nScoring is performed asynchronously by the call_scoring_worker, which\nconsumes messages from Kafka and applies each scorer_ref to each call_id."
+      },
+      "CallsScoreRes": {
+        "properties": {},
+        "type": "object",
+        "title": "CallsScoreRes",
+        "description": "Empty response for calls_score.\n\nDefined as a model (rather than returning None) to follow the convention\nused throughout this interface and to allow fields to be added later\nwithout a breaking change."
+      },
+      "CallsUsageReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "call_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Call Ids",
+            "description": "Root call IDs to aggregate. Each result key corresponds to one input call ID."
+          },
+          "include_costs": {
+            "type": "boolean",
+            "title": "Include Costs",
+            "description": "If true, include cost calculations in the usage.",
+            "default": false
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "description": "Maximum number of calls to process across all traces. Acts as a safety limit to prevent unbounded memory usage.",
+            "default": 10000
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "call_ids"],
+        "title": "CallsUsageReq",
+        "description": "Request to compute aggregated usage for multiple root calls.\n\nThis endpoint returns usage metrics for each requested root call, where each\nroot's metrics include the sum of its own usage plus all descendants' usage.\n\nNote: All matching calls are loaded into memory for aggregation. For very large\nresult sets (>10k calls), consider batching root call IDs or using narrower\nfilters at the application layer."
+      },
+      "CallsUsageRes": {
+        "properties": {
+          "call_usage": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "$ref": "#/components/schemas/LLMAggregatedUsage"
+              },
+              "type": "object"
+            },
+            "type": "object",
+            "title": "Call Usage"
+          },
+          "unfinished_call_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Unfinished Call Ids"
+          }
+        },
+        "type": "object",
+        "title": "CallsUsageRes",
+        "description": "Response with aggregated usage metrics per root call."
+      },
+      "CatalogModelsRes": {
+        "properties": {
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/LLMModelDetails"
+            },
+            "type": "array",
+            "title": "Models"
+          }
+        },
+        "type": "object",
+        "required": ["models"],
+        "title": "CatalogModelsRes"
+      },
       "ContainsOperation": {
         "properties": {
-          "$contains": {"$ref": "#/components/schemas/ContainsSpec"}
+          "$contains": {
+            "$ref": "#/components/schemas/ContainsSpec"
+          }
         },
         "type": "object",
         "required": ["$contains"],
-        "title": "ContainsOperation"
+        "title": "ContainsOperation",
+        "description": "Case-insensitive substring match.\n\nNot part of MongoDB. Weave-specific addition.\n\nExample:\n    ```\n    {\n        \"$contains\": {\n            \"input\": {\"$getField\": \"display_name\"},\n            \"substr\": {\"$literal\": \"llm\"},\n            \"case_insensitive\": true\n        }\n    }\n    ```"
       },
       "ContainsSpec": {
         "properties": {
           "input": {
             "anyOf": [
-              {"$ref": "#/components/schemas/LiteralOperation"},
-              {"$ref": "#/components/schemas/GetFieldOperator"},
-              {"$ref": "#/components/schemas/ConvertOperation"},
-              {"$ref": "#/components/schemas/AndOperation"},
-              {"$ref": "#/components/schemas/OrOperation"},
-              {"$ref": "#/components/schemas/NotOperation"},
-              {"$ref": "#/components/schemas/EqOperation"},
-              {"$ref": "#/components/schemas/GtOperation"},
-              {"$ref": "#/components/schemas/GteOperation"},
-              {"$ref": "#/components/schemas/InOperation"},
-              {"$ref": "#/components/schemas/ContainsOperation"}
+              {
+                "$ref": "#/components/schemas/LiteralOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GetFieldOperator"
+              },
+              {
+                "$ref": "#/components/schemas/ConvertOperation"
+              },
+              {
+                "$ref": "#/components/schemas/AndOperation"
+              },
+              {
+                "$ref": "#/components/schemas/OrOperation"
+              },
+              {
+                "$ref": "#/components/schemas/NotOperation"
+              },
+              {
+                "$ref": "#/components/schemas/EqOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GtOperation"
+              },
+              {
+                "$ref": "#/components/schemas/LtOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GteOperation"
+              },
+              {
+                "$ref": "#/components/schemas/LteOperation"
+              },
+              {
+                "$ref": "#/components/schemas/InOperation"
+              },
+              {
+                "$ref": "#/components/schemas/ContainsOperation"
+              }
             ],
             "title": "Input"
           },
           "substr": {
             "anyOf": [
-              {"$ref": "#/components/schemas/LiteralOperation"},
-              {"$ref": "#/components/schemas/GetFieldOperator"},
-              {"$ref": "#/components/schemas/ConvertOperation"},
-              {"$ref": "#/components/schemas/AndOperation"},
-              {"$ref": "#/components/schemas/OrOperation"},
-              {"$ref": "#/components/schemas/NotOperation"},
-              {"$ref": "#/components/schemas/EqOperation"},
-              {"$ref": "#/components/schemas/GtOperation"},
-              {"$ref": "#/components/schemas/GteOperation"},
-              {"$ref": "#/components/schemas/InOperation"},
-              {"$ref": "#/components/schemas/ContainsOperation"}
+              {
+                "$ref": "#/components/schemas/LiteralOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GetFieldOperator"
+              },
+              {
+                "$ref": "#/components/schemas/ConvertOperation"
+              },
+              {
+                "$ref": "#/components/schemas/AndOperation"
+              },
+              {
+                "$ref": "#/components/schemas/OrOperation"
+              },
+              {
+                "$ref": "#/components/schemas/NotOperation"
+              },
+              {
+                "$ref": "#/components/schemas/EqOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GtOperation"
+              },
+              {
+                "$ref": "#/components/schemas/LtOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GteOperation"
+              },
+              {
+                "$ref": "#/components/schemas/LteOperation"
+              },
+              {
+                "$ref": "#/components/schemas/InOperation"
+              },
+              {
+                "$ref": "#/components/schemas/ContainsOperation"
+              }
             ],
             "title": "Substr"
           },
           "case_insensitive": {
-            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Case Insensitive",
             "default": false
           }
         },
         "type": "object",
         "required": ["input", "substr"],
-        "title": "ContainsSpec"
+        "title": "ContainsSpec",
+        "description": "Specification for the `$contains` operation.\n\n- `input`: The string to search.\n- `substr`: The substring to search for.\n- `case_insensitive`: If true, match is case-insensitive."
       },
       "ConvertOperation": {
         "properties": {
-          "$convert": {"$ref": "#/components/schemas/ConvertSpec"}
+          "$convert": {
+            "$ref": "#/components/schemas/ConvertSpec"
+          }
         },
         "type": "object",
         "required": ["$convert"],
-        "title": "ConvertOperation"
+        "title": "ConvertOperation",
+        "description": "Convert the input value to a specific type (e.g., `int`, `bool`, `string`).\n\nExample:\n    ```\n    {\n        \"$convert\": {\n            \"input\": {\"$getField\": \"inputs.value\"},\n            \"to\": \"int\"\n        }\n    }\n    ```"
       },
       "ConvertSpec": {
         "properties": {
           "input": {
             "anyOf": [
-              {"$ref": "#/components/schemas/LiteralOperation"},
-              {"$ref": "#/components/schemas/GetFieldOperator"},
-              {"$ref": "#/components/schemas/ConvertOperation"},
-              {"$ref": "#/components/schemas/AndOperation"},
-              {"$ref": "#/components/schemas/OrOperation"},
-              {"$ref": "#/components/schemas/NotOperation"},
-              {"$ref": "#/components/schemas/EqOperation"},
-              {"$ref": "#/components/schemas/GtOperation"},
-              {"$ref": "#/components/schemas/GteOperation"},
-              {"$ref": "#/components/schemas/InOperation"},
-              {"$ref": "#/components/schemas/ContainsOperation"}
+              {
+                "$ref": "#/components/schemas/LiteralOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GetFieldOperator"
+              },
+              {
+                "$ref": "#/components/schemas/ConvertOperation"
+              },
+              {
+                "$ref": "#/components/schemas/AndOperation"
+              },
+              {
+                "$ref": "#/components/schemas/OrOperation"
+              },
+              {
+                "$ref": "#/components/schemas/NotOperation"
+              },
+              {
+                "$ref": "#/components/schemas/EqOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GtOperation"
+              },
+              {
+                "$ref": "#/components/schemas/LtOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GteOperation"
+              },
+              {
+                "$ref": "#/components/schemas/LteOperation"
+              },
+              {
+                "$ref": "#/components/schemas/InOperation"
+              },
+              {
+                "$ref": "#/components/schemas/ContainsOperation"
+              }
             ],
             "title": "Input"
           },
@@ -1389,41 +10663,82 @@
         },
         "type": "object",
         "required": ["input", "to"],
-        "title": "ConvertSpec"
+        "title": "ConvertSpec",
+        "description": "Specifies conversion details for `$convert`.\n\n- `input`: The operand to convert.\n- `to`: The type to convert to."
       },
       "CostCreateInput": {
         "properties": {
-          "prompt_token_cost": {"type": "number", "title": "Prompt Token Cost"},
+          "prompt_token_cost": {
+            "type": "number",
+            "title": "Prompt Token Cost"
+          },
           "completion_token_cost": {
             "type": "number",
             "title": "Completion Token Cost"
           },
+          "cache_read_input_token_cost": {
+            "type": "number",
+            "title": "Cache Read Input Token Cost",
+            "default": 0
+          },
+          "cache_creation_input_token_cost": {
+            "type": "number",
+            "title": "Cache Creation Input Token Cost",
+            "default": 0
+          },
           "prompt_token_cost_unit": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Prompt Token Cost Unit",
             "description": "The unit of the cost for the prompt tokens",
             "default": "USD"
           },
           "completion_token_cost_unit": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Completion Token Cost Unit",
             "description": "The unit of the cost for the completion tokens",
             "default": "USD"
           },
           "effective_date": {
             "anyOf": [
-              {"type": "string", "format": "date-time"},
-              {"type": "null"}
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Effective Date",
             "description": "The date after which the cost is effective for, will default to the current date if not provided"
           },
           "provider_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Provider Id",
             "description": "The provider of the LLM, e.g. 'openai' or 'mistral'. If not provided, the provider_id will be set to 'default'"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["prompt_token_cost", "completion_token_cost"],
         "title": "CostCreateInput"
@@ -1443,11 +10758,19 @@
             "title": "Costs"
           },
           "wb_user_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Wb User Id",
             "description": "Do not set directly. Server will automatically populate this field."
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "costs"],
         "title": "CostCreateReq"
@@ -1456,7 +10779,14 @@
         "properties": {
           "ids": {
             "items": {
-              "prefixItems": [{"type": "string"}, {"type": "string"}],
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "string"
+                }
+              ],
               "type": "array",
               "maxItems": 2,
               "minItems": 2
@@ -1476,8 +10806,11 @@
             "title": "Project Id",
             "examples": ["entity/project"]
           },
-          "query": {"$ref": "#/components/schemas/Query"}
+          "query": {
+            "$ref": "#/components/schemas/Query"
+          }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "query"],
         "title": "CostPurgeReq"
@@ -1490,45 +10823,99 @@
       "CostQueryOutput": {
         "properties": {
           "id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id",
             "examples": ["2341-asdf-asdf"]
           },
           "llm_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Llm Id",
             "examples": ["gpt4"]
           },
           "prompt_token_cost": {
-            "anyOf": [{"type": "number"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Prompt Token Cost",
             "examples": [1.0]
           },
           "completion_token_cost": {
-            "anyOf": [{"type": "number"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Completion Token Cost",
             "examples": [1.0]
           },
           "prompt_token_cost_unit": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Prompt Token Cost Unit",
             "examples": ["USD"]
           },
           "completion_token_cost_unit": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Completion Token Cost Unit",
             "examples": ["USD"]
           },
           "effective_date": {
             "anyOf": [
-              {"type": "string", "format": "date-time"},
-              {"type": "null"}
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Effective Date",
             "examples": ["2024-01-01T00:00:00Z"]
           },
           "provider_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Provider Id",
             "examples": ["openai"]
           }
@@ -1545,8 +10932,15 @@
           },
           "fields": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Fields",
             "examples": [
@@ -1563,29 +10957,55 @@
             ]
           },
           "query": {
-            "anyOf": [{"$ref": "#/components/schemas/Query"}, {"type": "null"}]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Query"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "sort_by": {
             "anyOf": [
               {
-                "items": {"$ref": "#/components/schemas/SortBy"},
+                "items": {
+                  "$ref": "#/components/schemas/SortBy"
+                },
                 "type": "array"
               },
-              {"type": "null"}
+              {
+                "type": "null"
+              }
             ],
             "title": "Sort By"
           },
           "limit": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Limit",
             "examples": [10]
           },
           "offset": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Offset",
             "examples": [0]
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id"],
         "title": "CostQueryReq"
@@ -1593,7 +11013,9 @@
       "CostQueryRes": {
         "properties": {
           "results": {
-            "items": {"$ref": "#/components/schemas/CostQueryOutput"},
+            "items": {
+              "$ref": "#/components/schemas/CostQueryOutput"
+            },
             "type": "array",
             "title": "Results"
           }
@@ -1602,21 +11024,271 @@
         "required": ["results"],
         "title": "CostQueryRes"
       },
+      "CreateAndLinkPayload": {
+        "properties": {
+          "ref": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Ref"
+          },
+          "target": {
+            "$ref": "#/components/schemas/CreateAndLinkTarget"
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Aliases",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["ref", "target"],
+        "title": "CreateAndLinkPayload"
+      },
+      "CreateAndLinkTarget": {
+        "properties": {
+          "portfolio_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Portfolio Name"
+          },
+          "entity_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Entity Name"
+          },
+          "project_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Project Name"
+          }
+        },
+        "type": "object",
+        "required": ["portfolio_name", "entity_name", "project_name"],
+        "title": "CreateAndLinkTarget"
+      },
+      "CreateAndLinkWeaveAssetRes": {
+        "properties": {
+          "version_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Version Index"
+          }
+        },
+        "type": "object",
+        "title": "CreateAndLinkWeaveAssetRes"
+      },
+      "Datacenter": {
+        "properties": {
+          "country_code": {
+            "type": "string",
+            "title": "Country Code"
+          }
+        },
+        "type": "object",
+        "required": ["country_code"],
+        "title": "Datacenter"
+      },
+      "DatasetCreateBody": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "The name of this dataset.  Datasets with the same name will be versioned together."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "A description of this dataset"
+          },
+          "rows": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Rows",
+            "description": "Dataset rows"
+          }
+        },
+        "type": "object",
+        "required": ["rows"],
+        "title": "DatasetCreateBody"
+      },
+      "DatasetCreateRes": {
+        "properties": {
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "description": "The digest of the created dataset"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id",
+            "description": "The ID of the created dataset"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index",
+            "description": "The version index of the created dataset"
+          }
+        },
+        "type": "object",
+        "required": ["digest", "object_id", "version_index"],
+        "title": "DatasetCreateRes"
+      },
+      "DatasetDeleteRes": {
+        "properties": {
+          "num_deleted": {
+            "type": "integer",
+            "title": "Num Deleted",
+            "description": "Number of dataset versions deleted"
+          }
+        },
+        "type": "object",
+        "required": ["num_deleted"],
+        "title": "DatasetDeleteRes"
+      },
+      "DatasetReadRes": {
+        "properties": {
+          "object_id": {
+            "type": "string",
+            "title": "Object Id",
+            "description": "The dataset ID"
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "description": "The digest of the dataset object"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index",
+            "description": "The version index of the object"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "When the object was created"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the dataset"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "Description of the dataset"
+          },
+          "rows": {
+            "type": "string",
+            "title": "Rows",
+            "description": "Reference to the dataset rows data"
+          }
+        },
+        "type": "object",
+        "required": [
+          "object_id",
+          "digest",
+          "version_index",
+          "created_at",
+          "name",
+          "rows"
+        ],
+        "title": "DatasetReadRes"
+      },
       "EndedCallSchemaForInsert": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
-          "id": {"type": "string", "title": "Id"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
           "ended_at": {
             "type": "string",
             "format": "date-time",
             "title": "Ended At"
           },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          },
           "exception": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Exception"
           },
-          "output": {"anyOf": [{}, {"type": "null"}], "title": "Output"},
-          "summary": {"$ref": "#/components/schemas/SummaryInsertMap"}
+          "output": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/SummaryInsertMap"
+          },
+          "wb_run_step_end": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb Run Step End"
+          }
         },
         "type": "object",
         "required": ["project_id", "id", "ended_at", "summary"],
@@ -1628,32 +11300,88 @@
             "prefixItems": [
               {
                 "anyOf": [
-                  {"$ref": "#/components/schemas/LiteralOperation"},
-                  {"$ref": "#/components/schemas/GetFieldOperator"},
-                  {"$ref": "#/components/schemas/ConvertOperation"},
-                  {"$ref": "#/components/schemas/AndOperation"},
-                  {"$ref": "#/components/schemas/OrOperation"},
-                  {"$ref": "#/components/schemas/NotOperation"},
-                  {"$ref": "#/components/schemas/EqOperation"},
-                  {"$ref": "#/components/schemas/GtOperation"},
-                  {"$ref": "#/components/schemas/GteOperation"},
-                  {"$ref": "#/components/schemas/InOperation"},
-                  {"$ref": "#/components/schemas/ContainsOperation"}
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
                 ]
               },
               {
                 "anyOf": [
-                  {"$ref": "#/components/schemas/LiteralOperation"},
-                  {"$ref": "#/components/schemas/GetFieldOperator"},
-                  {"$ref": "#/components/schemas/ConvertOperation"},
-                  {"$ref": "#/components/schemas/AndOperation"},
-                  {"$ref": "#/components/schemas/OrOperation"},
-                  {"$ref": "#/components/schemas/NotOperation"},
-                  {"$ref": "#/components/schemas/EqOperation"},
-                  {"$ref": "#/components/schemas/GtOperation"},
-                  {"$ref": "#/components/schemas/GteOperation"},
-                  {"$ref": "#/components/schemas/InOperation"},
-                  {"$ref": "#/components/schemas/ContainsOperation"}
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
                 ]
               }
             ],
@@ -1665,10 +11393,1159 @@
         },
         "type": "object",
         "required": ["$eq"],
-        "title": "EqOperation"
+        "title": "EqOperation",
+        "description": "Equality check between two operands.\n\nExample:\n    ```\n    {\n        \"$eq\": [{\"$getField\": \"op_name\"}, {\"$literal\": \"predict\"}]\n    }\n    ```"
+      },
+      "EvalResultsEvaluationSummary": {
+        "properties": {
+          "evaluation_call_id": {
+            "type": "string",
+            "title": "Evaluation Call Id"
+          },
+          "trial_count": {
+            "type": "integer",
+            "title": "Trial Count",
+            "default": 0
+          },
+          "scorer_stats": {
+            "items": {
+              "$ref": "#/components/schemas/EvalResultsScorerStats"
+            },
+            "type": "array",
+            "title": "Scorer Stats"
+          },
+          "evaluation_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Ref"
+          },
+          "model_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Ref"
+          },
+          "display_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Display Name"
+          },
+          "trace_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trace Id"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At"
+          }
+        },
+        "type": "object",
+        "required": ["evaluation_call_id"],
+        "title": "EvalResultsEvaluationSummary"
+      },
+      "EvalResultsFilter": {
+        "properties": {
+          "evaluation_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Call Id",
+            "description": "When set, filter fields are scoped to this evaluation's data."
+          },
+          "query": {
+            "$ref": "#/components/schemas/Query",
+            "description": "Filter expression. Supported field prefixes: scores.<name>, inputs.<path>, outputs.<path>."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["query"],
+        "title": "EvalResultsFilter",
+        "description": "A filter scoped to an optional evaluation."
+      },
+      "EvalResultsQueryBody": {
+        "properties": {
+          "evaluation_call_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Call Ids",
+            "description": "Evaluation root call IDs to include."
+          },
+          "evaluation_run_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Run Ids",
+            "description": "Alias for evaluation call IDs from the Evaluation Runs API."
+          },
+          "require_intersection": {
+            "type": "boolean",
+            "title": "Require Intersection",
+            "description": "When true, only include rows present in all requested evaluations.",
+            "default": false
+          },
+          "include_raw_data_rows": {
+            "type": "boolean",
+            "title": "Include Raw Data Rows",
+            "description": "When true, populate raw_data_row on each result row. Inline rows are returned as their dict value; dataset-referenced rows are returned as the ref string unless resolve_row_refs is also true.",
+            "default": false
+          },
+          "resolve_row_refs": {
+            "type": "boolean",
+            "title": "Resolve Row Refs",
+            "description": "When true (requires include_raw_data_rows=True), resolve dataset-row reference strings to actual row data via a table lookup. When false, dataset-row refs are returned as-is.",
+            "default": false
+          },
+          "include_rows": {
+            "type": "boolean",
+            "title": "Include Rows",
+            "description": "When true, include grouped row/trial data in `rows` and compute `total_rows` for the requested row-level view.",
+            "default": true
+          },
+          "include_summary": {
+            "type": "boolean",
+            "title": "Include Summary",
+            "description": "When true, include aggregated scorer/evaluation summary data in `summary`.",
+            "default": false
+          },
+          "summary_require_intersection": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary Require Intersection",
+            "description": "Optional intersection behavior for the summary section. When null, the value of `require_intersection` is used."
+          },
+          "include_predict_and_score_children": {
+            "type": "boolean",
+            "title": "Include Predict And Score Children",
+            "description": "When true (default), fetch child calls (predict/score) of each predict_and_score call to populate predict_call_id, scorer_call_ids, and more precise latency/token data. When false, these fields are derived from the predict_and_score call itself (predict_call_id and scorer_call_ids will be null/empty).",
+            "default": true
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/EvalResultsSortBy"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort By",
+            "description": "Sort specification for result rows. Supported field prefixes: scores.<name>, inputs.<path>, outputs.<path>. When null, rows are sorted by row_digest ASC."
+          },
+          "filters": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/EvalResultsFilter"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Filters",
+            "description": "Filters applied to grouped rows. Multiple filters are AND'd together."
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit",
+            "description": "Optional row-level page size applied after grouping and intersection."
+          },
+          "offset": {
+            "type": "integer",
+            "title": "Offset",
+            "description": "Optional row-level page offset applied after grouping and intersection.",
+            "default": 0
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "EvalResultsQueryBody"
+      },
+      "EvalResultsQueryRes": {
+        "properties": {
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/EvalResultsRow"
+            },
+            "type": "array",
+            "title": "Rows"
+          },
+          "total_rows": {
+            "type": "integer",
+            "title": "Total Rows"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EvalResultsSummaryRes"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "warnings": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Warnings",
+            "description": "Non-fatal warnings (e.g. failed to resolve dataset row refs)."
+          }
+        },
+        "type": "object",
+        "required": ["rows", "total_rows"],
+        "title": "EvalResultsQueryRes"
+      },
+      "EvalResultsRow": {
+        "properties": {
+          "row_digest": {
+            "type": "string",
+            "title": "Row Digest"
+          },
+          "raw_data_row": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Raw Data Row"
+          },
+          "evaluations": {
+            "items": {
+              "$ref": "#/components/schemas/EvalResultsRowEvaluation"
+            },
+            "type": "array",
+            "title": "Evaluations"
+          }
+        },
+        "type": "object",
+        "required": ["row_digest"],
+        "title": "EvalResultsRow"
+      },
+      "EvalResultsRowEvaluation": {
+        "properties": {
+          "evaluation_call_id": {
+            "type": "string",
+            "title": "Evaluation Call Id"
+          },
+          "trials": {
+            "items": {
+              "$ref": "#/components/schemas/EvalResultsTrial"
+            },
+            "type": "array",
+            "title": "Trials"
+          }
+        },
+        "type": "object",
+        "required": ["evaluation_call_id"],
+        "title": "EvalResultsRowEvaluation"
+      },
+      "EvalResultsScorerStats": {
+        "properties": {
+          "scorer_key": {
+            "type": "string",
+            "title": "Scorer Key"
+          },
+          "path": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Path",
+            "description": "Dot-joined subpath for nested dimensions, e.g. 'passed' for token_distance.passed. None for root-level scalar scorers."
+          },
+          "value_type": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": ["binary", "continuous", "text"]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Value Type",
+            "description": "Type of the leaf value: binary (bool), continuous (number), or text (string)."
+          },
+          "trial_count": {
+            "type": "integer",
+            "title": "Trial Count",
+            "default": 0
+          },
+          "numeric_count": {
+            "type": "integer",
+            "title": "Numeric Count",
+            "default": 0
+          },
+          "numeric_mean": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Numeric Mean"
+          },
+          "pass_true_count": {
+            "type": "integer",
+            "title": "Pass True Count",
+            "default": 0
+          },
+          "pass_known_count": {
+            "type": "integer",
+            "title": "Pass Known Count",
+            "default": 0
+          },
+          "pass_rate": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pass Rate"
+          },
+          "pass_signal_coverage": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pass Signal Coverage"
+          }
+        },
+        "type": "object",
+        "required": ["scorer_key"],
+        "title": "EvalResultsScorerStats",
+        "description": "Stats for a single flattened score dimension (scorer_key or scorer_key.path.to.leaf)."
+      },
+      "EvalResultsSortBy": {
+        "properties": {
+          "field": {
+            "type": "string",
+            "title": "Field"
+          },
+          "direction": {
+            "type": "string",
+            "enum": ["asc", "desc"],
+            "title": "Direction"
+          },
+          "evaluation_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Call Id",
+            "description": "Scope the sort to a specific evaluation's scores."
+          },
+          "mode": {
+            "type": "string",
+            "enum": ["value", "difference"],
+            "title": "Mode",
+            "description": "When 'value', sort by the field value for the specified evaluation. When 'difference', sort by max-min spread of the field across all evaluations (evaluation_call_id is ignored).",
+            "default": "value"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["field", "direction"],
+        "title": "EvalResultsSortBy",
+        "description": "Sort specification for evaluation results, extending SortBy"
+      },
+      "EvalResultsSummaryRes": {
+        "properties": {
+          "row_count": {
+            "type": "integer",
+            "title": "Row Count",
+            "default": 0
+          },
+          "evaluations": {
+            "items": {
+              "$ref": "#/components/schemas/EvalResultsEvaluationSummary"
+            },
+            "type": "array",
+            "title": "Evaluations"
+          }
+        },
+        "type": "object",
+        "title": "EvalResultsSummaryRes"
+      },
+      "EvalResultsTrial": {
+        "properties": {
+          "predict_and_score_call_id": {
+            "type": "string",
+            "title": "Predict And Score Call Id"
+          },
+          "predict_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predict Call Id"
+          },
+          "model_output": {
+            "anyOf": [
+              {},
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Output"
+          },
+          "scores": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Scores"
+          },
+          "model_latency_seconds": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Model Latency Seconds"
+          },
+          "total_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Total Tokens"
+          },
+          "scorer_call_ids": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Scorer Call Ids"
+          },
+          "genai_span_ref": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/GenAISpanRef"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genai Span Ref"
+          }
+        },
+        "type": "object",
+        "required": ["predict_and_score_call_id"],
+        "title": "EvalResultsTrial"
+      },
+      "EvaluateModelReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "evaluation_ref": {
+            "type": "string",
+            "title": "Evaluation Ref"
+          },
+          "model_ref": {
+            "type": "string",
+            "title": "Model Ref"
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id",
+            "description": "Do not set directly. Server will automatically populate this field."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "evaluation_ref", "model_ref"],
+        "title": "EvaluateModelReq"
+      },
+      "EvaluateModelRes": {
+        "properties": {
+          "call_id": {
+            "type": "string",
+            "title": "Call Id"
+          }
+        },
+        "type": "object",
+        "required": ["call_id"],
+        "title": "EvaluateModelRes"
+      },
+      "EvaluationCreateBody": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of this evaluation.  Evaluations with the same name will be versioned together."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "A description of this evaluation"
+          },
+          "dataset": {
+            "type": "string",
+            "title": "Dataset",
+            "description": "Reference to the dataset (weave:// URI)"
+          },
+          "scorers": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scorers",
+            "description": "List of scorer references (weave:// URIs)"
+          },
+          "trials": {
+            "type": "integer",
+            "title": "Trials",
+            "description": "Number of trials to run",
+            "default": 1
+          },
+          "evaluation_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Name",
+            "description": "Name for the evaluation run"
+          },
+          "eval_attributes": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Eval Attributes",
+            "description": "Optional attributes for the evaluation"
+          }
+        },
+        "type": "object",
+        "required": ["name", "dataset"],
+        "title": "EvaluationCreateBody"
+      },
+      "EvaluationCreateRes": {
+        "properties": {
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "description": "The digest of the created evaluation"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id",
+            "description": "The ID of the created evaluation"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index",
+            "description": "The version index of the created evaluation"
+          },
+          "evaluation_ref": {
+            "type": "string",
+            "title": "Evaluation Ref",
+            "description": "Full reference to the created evaluation"
+          }
+        },
+        "type": "object",
+        "required": ["digest", "object_id", "version_index", "evaluation_ref"],
+        "title": "EvaluationCreateRes"
+      },
+      "EvaluationDeleteRes": {
+        "properties": {
+          "num_deleted": {
+            "type": "integer",
+            "title": "Num Deleted",
+            "description": "Number of evaluation versions deleted"
+          }
+        },
+        "type": "object",
+        "required": ["num_deleted"],
+        "title": "EvaluationDeleteRes"
+      },
+      "EvaluationReadRes": {
+        "properties": {
+          "object_id": {
+            "type": "string",
+            "title": "Object Id",
+            "description": "The evaluation ID"
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "description": "The digest of the evaluation"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index",
+            "description": "The version index of the evaluation"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "When the evaluation was created"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the evaluation"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "A description of the evaluation"
+          },
+          "dataset": {
+            "type": "string",
+            "title": "Dataset",
+            "description": "Dataset reference (weave:// URI)"
+          },
+          "scorers": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scorers",
+            "description": "List of scorer references (weave:// URIs)"
+          },
+          "trials": {
+            "type": "integer",
+            "title": "Trials",
+            "description": "Number of trials"
+          },
+          "evaluation_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Name",
+            "description": "Name for the evaluation run"
+          },
+          "evaluate_op": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluate Op",
+            "description": "Evaluate op reference (weave:// URI)"
+          },
+          "predict_and_score_op": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Predict And Score Op",
+            "description": "Predict and score op reference (weave:// URI)"
+          },
+          "summarize_op": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summarize Op",
+            "description": "Summarize op reference (weave:// URI)"
+          }
+        },
+        "type": "object",
+        "required": [
+          "object_id",
+          "digest",
+          "version_index",
+          "created_at",
+          "name",
+          "dataset",
+          "scorers",
+          "trials"
+        ],
+        "title": "EvaluationReadRes"
+      },
+      "EvaluationRunCreateBody": {
+        "properties": {
+          "evaluation": {
+            "type": "string",
+            "title": "Evaluation",
+            "description": "Reference to the evaluation (weave:// URI)"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model",
+            "description": "Reference to the model (weave:// URI)"
+          },
+          "source_evaluation_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Evaluation Run Id",
+            "description": "Source evaluation run ID if this run was created by rescoring \u2014 provenance link"
+          }
+        },
+        "type": "object",
+        "required": ["evaluation", "model"],
+        "title": "EvaluationRunCreateBody"
+      },
+      "EvaluationRunCreateRes": {
+        "properties": {
+          "evaluation_run_id": {
+            "type": "string",
+            "title": "Evaluation Run Id",
+            "description": "The ID of the created evaluation run"
+          }
+        },
+        "type": "object",
+        "required": ["evaluation_run_id"],
+        "title": "EvaluationRunCreateRes"
+      },
+      "EvaluationRunDeleteRes": {
+        "properties": {
+          "num_deleted": {
+            "type": "integer",
+            "title": "Num Deleted",
+            "description": "Number of evaluation runs deleted"
+          }
+        },
+        "type": "object",
+        "required": ["num_deleted"],
+        "title": "EvaluationRunDeleteRes"
+      },
+      "EvaluationRunFinishBody": {
+        "properties": {
+          "summary": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary",
+            "description": "Optional summary dictionary for the evaluation run"
+          }
+        },
+        "type": "object",
+        "title": "EvaluationRunFinishBody",
+        "description": "Request body for finishing an evaluation run via REST API.\n\nThis model excludes project_id and evaluation_run_id since they come from the URL path in RESTful endpoints."
+      },
+      "EvaluationRunFinishRes": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Whether the evaluation run was finished successfully"
+          }
+        },
+        "type": "object",
+        "required": ["success"],
+        "title": "EvaluationRunFinishRes"
+      },
+      "EvaluationRunReadRes": {
+        "properties": {
+          "evaluation_run_id": {
+            "type": "string",
+            "title": "Evaluation Run Id",
+            "description": "The evaluation run ID"
+          },
+          "evaluation": {
+            "type": "string",
+            "title": "Evaluation",
+            "description": "Reference to the evaluation (weave:// URI)"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model",
+            "description": "Reference to the model (weave:// URI)"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status",
+            "description": "Status of the evaluation run"
+          },
+          "started_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Started At",
+            "description": "When the evaluation run started"
+          },
+          "finished_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Finished At",
+            "description": "When the evaluation run finished"
+          },
+          "summary": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Summary",
+            "description": "Summary data for the evaluation run"
+          },
+          "source_evaluation_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Evaluation Run Id",
+            "description": "Source evaluation run ID if this run was created by rescoring"
+          }
+        },
+        "type": "object",
+        "required": ["evaluation_run_id", "evaluation", "model"],
+        "title": "EvaluationRunReadRes"
+      },
+      "EvaluationStatusComplete": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "const": "complete",
+            "title": "Code",
+            "default": "complete"
+          },
+          "output": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Output"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["output"],
+        "title": "EvaluationStatusComplete"
+      },
+      "EvaluationStatusFailed": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "const": "failed",
+            "title": "Code",
+            "default": "failed"
+          },
+          "error": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Error"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "EvaluationStatusFailed"
+      },
+      "EvaluationStatusNotFound": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "const": "not_found",
+            "title": "Code",
+            "default": "not_found"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "EvaluationStatusNotFound"
+      },
+      "EvaluationStatusReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "call_id": {
+            "type": "string",
+            "title": "Call Id"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "call_id"],
+        "title": "EvaluationStatusReq"
+      },
+      "EvaluationStatusRes": {
+        "properties": {
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EvaluationStatusNotFound"
+              },
+              {
+                "$ref": "#/components/schemas/EvaluationStatusRunning"
+              },
+              {
+                "$ref": "#/components/schemas/EvaluationStatusFailed"
+              },
+              {
+                "$ref": "#/components/schemas/EvaluationStatusComplete"
+              }
+            ],
+            "title": "Status"
+          }
+        },
+        "type": "object",
+        "required": ["status"],
+        "title": "EvaluationStatusRes"
+      },
+      "EvaluationStatusRunning": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "const": "running",
+            "title": "Code",
+            "default": "running"
+          },
+          "completed_rows": {
+            "type": "integer",
+            "title": "Completed Rows"
+          },
+          "total_rows": {
+            "type": "integer",
+            "title": "Total Rows"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["completed_rows", "total_rows"],
+        "title": "EvaluationStatusRunning"
+      },
+      "FeedbackCreateBatchReq": {
+        "properties": {
+          "batch": {
+            "items": {
+              "$ref": "#/components/schemas/FeedbackCreateReq"
+            },
+            "type": "array",
+            "title": "Batch"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["batch"],
+        "title": "FeedbackCreateBatchReq"
+      },
+      "FeedbackCreateBatchRes": {
+        "properties": {
+          "res": {
+            "items": {
+              "$ref": "#/components/schemas/FeedbackCreateRes"
+            },
+            "type": "array",
+            "title": "Res"
+          }
+        },
+        "type": "object",
+        "required": ["res"],
+        "title": "FeedbackCreateBatchRes"
       },
       "FeedbackCreateReq": {
         "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id",
+            "description": "If provided by the client, this ID will be used for the feedback row instead of a server-generated one.",
+            "examples": ["018f1f2a-9c2b-7d3e-b5a1-8c9d2e4f6a7b"]
+          },
           "project_id": {
             "type": "string",
             "title": "Project Id",
@@ -1680,7 +12557,14 @@
             "examples": ["weave:///entity/project/object/name:digest"]
           },
           "creator": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Creator",
             "examples": ["Jane Smith"]
           },
@@ -1690,54 +12574,350 @@
             "examples": ["custom"]
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload",
-            "examples": [{"key": "value"}]
+            "examples": [
+              {
+                "key": "value"
+              }
+            ]
           },
           "annotation_ref": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Annotation Ref",
             "examples": ["weave:///entity/project/object/name:digest"]
           },
           "runnable_ref": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Runnable Ref",
             "examples": ["weave:///entity/project/op/name:digest"]
           },
           "call_ref": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Call Ref",
             "examples": ["weave:///entity/project/call/call_id"]
           },
           "trigger_ref": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Trigger Ref",
             "examples": ["weave:///entity/project/object/name:digest"]
           },
+          "queue_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Queue Id",
+            "description": "The annotation queue ID this feedback was created from. References annotation_queues.id. NULL when feedback is created outside of queues.",
+            "examples": ["018f1f2a-9c2b-7d3e-b5a1-8c9d2e4f6a7b"]
+          },
+          "scorer_tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scorer Tags",
+            "description": "Tags applied to the ref by a scorer",
+            "examples": [["nsfw", "high-quality"]]
+          },
+          "scorer_tag_reasons": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Scorer Tag Reasons",
+            "description": "reason text per tag, keyed by tag name",
+            "examples": [
+              {
+                "nsfw": "Contains explicit language"
+              }
+            ]
+          },
+          "scorer_tag_confidences": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Scorer Tag Confidences",
+            "description": "confidence (0-1) per tag, keyed by tag name",
+            "examples": [
+              {
+                "nsfw": 0.92
+              }
+            ]
+          },
+          "scorer_ratings": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Scorer Ratings",
+            "description": "numeric ratings (0-1) keyed by rating name",
+            "examples": [
+              {
+                "_rating_": 0.87
+              }
+            ]
+          },
+          "scorer_rating_reasons": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Scorer Rating Reasons",
+            "description": "reason text per rating, keyed by rating name",
+            "examples": [
+              {
+                "_rating_": "very confident response"
+              }
+            ]
+          },
+          "scorer_rating_confidences": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Scorer Rating Confidences",
+            "description": "confidence (0-1) per rating, keyed by rating name",
+            "examples": [
+              {
+                "_rating_": 0.92
+              }
+            ]
+          },
+          "span_agent_name": {
+            "type": "string",
+            "title": "Span Agent Name",
+            "description": "Display name of the scored agent (from spans.agent_name)",
+            "default": "",
+            "examples": ["midi-generator"]
+          },
+          "span_agent_version": {
+            "type": "string",
+            "title": "Span Agent Version",
+            "description": "Version of the scored agent (from spans.agent_version)",
+            "default": "",
+            "examples": ["1.2.0"]
+          },
+          "span_status_code": {
+            "type": "string",
+            "title": "Span Status Code",
+            "description": "Status of the scored turn (from spans.status_code)",
+            "default": "UNSET",
+            "examples": ["SUCCESS"]
+          },
           "wb_user_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Wb User Id",
             "description": "Do not set directly. Server will automatically populate this field."
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "weave_ref", "feedback_type", "payload"],
         "title": "FeedbackCreateReq"
       },
       "FeedbackCreateRes": {
         "properties": {
-          "id": {"type": "string", "title": "Id"},
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
-          "wb_user_id": {"type": "string", "title": "Wb User Id"},
-          "payload": {"type": "object", "title": "Payload"}
+          "wb_user_id": {
+            "type": "string",
+            "title": "Wb User Id"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Payload"
+          }
         },
         "type": "object",
         "required": ["id", "created_at", "wb_user_id", "payload"],
         "title": "FeedbackCreateRes"
+      },
+      "FeedbackMetricSpec": {
+        "properties": {
+          "json_path": {
+            "type": "string",
+            "title": "Json Path",
+            "description": "Dot path into payload_dump (e.g. 'output', 'output.score')."
+          },
+          "value_type": {
+            "type": "string",
+            "enum": ["numeric", "boolean", "categorical"],
+            "title": "Value Type",
+            "description": "Type of value at path. numeric: avg/min/max; boolean: count_true/count_false.",
+            "default": "numeric"
+          },
+          "aggregations": {
+            "items": {
+              "$ref": "#/components/schemas/AggregationType"
+            },
+            "type": "array",
+            "title": "Aggregations",
+            "description": "Aggregation functions to compute. If empty, defaults are chosen based on value_type: numeric->avg/min/max, boolean->count_true/count_false."
+          },
+          "percentiles": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Percentiles",
+            "description": "Percentile values to compute (0\u2013100), e.g. [5, 50, 95]. Only applicable for numeric value_type fields; ignored for boolean/categorical."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["json_path"],
+        "title": "FeedbackMetricSpec",
+        "description": "Specification for a feedback payload metric to aggregate."
+      },
+      "FeedbackPayloadPath": {
+        "properties": {
+          "json_path": {
+            "type": "string",
+            "title": "Json Path",
+            "description": "Dot path into payload (e.g. 'output.score')."
+          },
+          "value_type": {
+            "type": "string",
+            "enum": ["numeric", "boolean", "categorical"],
+            "title": "Value Type",
+            "description": "Inferred type of value at path.",
+            "default": "numeric"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["json_path"],
+        "title": "FeedbackPayloadPath",
+        "description": "Discovered path in feedback payload with inferred type."
+      },
+      "FeedbackPayloadSchemaReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start",
+            "description": "Inclusive start time (UTC, ISO 8601)."
+          },
+          "end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End",
+            "description": "Exclusive end time (UTC, ISO 8601). Defaults to now if omitted."
+          },
+          "feedback_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feedback Type",
+            "description": "Filter by feedback_type."
+          },
+          "trigger_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trigger Ref",
+            "description": "Filter by trigger_ref (exact or prefix match for all-versions)."
+          },
+          "sample_limit": {
+            "type": "integer",
+            "maximum": 5000.0,
+            "minimum": 1.0,
+            "title": "Sample Limit",
+            "description": "Max distinct trigger_refs to sample when discovering the payload schema. Each distinct trigger_ref (monitor/source) typically has a fixed payload structure, so sampling one payload per ref is usually enough to see the full schema. 2 000 covers virtually all real-world projects while keeping the query fast; the hard cap of 5 000 prevents runaway scans.",
+            "default": 2000
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "start"],
+        "title": "FeedbackPayloadSchemaReq",
+        "description": "Request for feedback payload schema discovery."
+      },
+      "FeedbackPayloadSchemaRes": {
+        "properties": {
+          "paths": {
+            "items": {
+              "$ref": "#/components/schemas/FeedbackPayloadPath"
+            },
+            "type": "array",
+            "title": "Paths",
+            "description": "Discovered leaf paths with inferred value types."
+          }
+        },
+        "type": "object",
+        "title": "FeedbackPayloadSchemaRes",
+        "description": "Response with discovered feedback payload paths and types."
       },
       "FeedbackPurgeReq": {
         "properties": {
@@ -1746,8 +12926,11 @@
             "title": "Project Id",
             "examples": ["entity/project"]
           },
-          "query": {"$ref": "#/components/schemas/Query"}
+          "query": {
+            "$ref": "#/components/schemas/Query"
+          }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "query"],
         "title": "FeedbackPurgeReq"
@@ -1766,36 +12949,69 @@
           },
           "fields": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Fields",
             "examples": [["id", "feedback_type", "payload.note"]]
           },
           "query": {
-            "anyOf": [{"$ref": "#/components/schemas/Query"}, {"type": "null"}]
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Query"
+              },
+              {
+                "type": "null"
+              }
+            ]
           },
           "sort_by": {
             "anyOf": [
               {
-                "items": {"$ref": "#/components/schemas/SortBy"},
+                "items": {
+                  "$ref": "#/components/schemas/SortBy"
+                },
                 "type": "array"
               },
-              {"type": "null"}
+              {
+                "type": "null"
+              }
             ],
             "title": "Sort By"
           },
           "limit": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Limit",
             "examples": [10]
           },
           "offset": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Offset",
             "examples": [0]
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id"],
         "title": "FeedbackQueryReq"
@@ -1803,7 +13019,10 @@
       "FeedbackQueryRes": {
         "properties": {
           "result": {
-            "items": {"type": "object"},
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
             "type": "array",
             "title": "Result"
           }
@@ -1814,6 +13033,19 @@
       },
       "FeedbackReplaceReq": {
         "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id",
+            "description": "If provided by the client, this ID will be used for the feedback row instead of a server-generated one.",
+            "examples": ["018f1f2a-9c2b-7d3e-b5a1-8c9d2e4f6a7b"]
+          },
           "project_id": {
             "type": "string",
             "title": "Project Id",
@@ -1825,7 +13057,14 @@
             "examples": ["weave:///entity/project/object/name:digest"]
           },
           "creator": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Creator",
             "examples": ["Jane Smith"]
           },
@@ -1835,37 +13074,189 @@
             "examples": ["custom"]
           },
           "payload": {
+            "additionalProperties": true,
             "type": "object",
             "title": "Payload",
-            "examples": [{"key": "value"}]
+            "examples": [
+              {
+                "key": "value"
+              }
+            ]
           },
           "annotation_ref": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Annotation Ref",
             "examples": ["weave:///entity/project/object/name:digest"]
           },
           "runnable_ref": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Runnable Ref",
             "examples": ["weave:///entity/project/op/name:digest"]
           },
           "call_ref": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Call Ref",
             "examples": ["weave:///entity/project/call/call_id"]
           },
           "trigger_ref": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Trigger Ref",
             "examples": ["weave:///entity/project/object/name:digest"]
           },
+          "queue_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Queue Id",
+            "description": "The annotation queue ID this feedback was created from. References annotation_queues.id. NULL when feedback is created outside of queues.",
+            "examples": ["018f1f2a-9c2b-7d3e-b5a1-8c9d2e4f6a7b"]
+          },
+          "scorer_tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scorer Tags",
+            "description": "Tags applied to the ref by a scorer",
+            "examples": [["nsfw", "high-quality"]]
+          },
+          "scorer_tag_reasons": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Scorer Tag Reasons",
+            "description": "reason text per tag, keyed by tag name",
+            "examples": [
+              {
+                "nsfw": "Contains explicit language"
+              }
+            ]
+          },
+          "scorer_tag_confidences": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Scorer Tag Confidences",
+            "description": "confidence (0-1) per tag, keyed by tag name",
+            "examples": [
+              {
+                "nsfw": 0.92
+              }
+            ]
+          },
+          "scorer_ratings": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Scorer Ratings",
+            "description": "numeric ratings (0-1) keyed by rating name",
+            "examples": [
+              {
+                "_rating_": 0.87
+              }
+            ]
+          },
+          "scorer_rating_reasons": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object",
+            "title": "Scorer Rating Reasons",
+            "description": "reason text per rating, keyed by rating name",
+            "examples": [
+              {
+                "_rating_": "very confident response"
+              }
+            ]
+          },
+          "scorer_rating_confidences": {
+            "additionalProperties": {
+              "type": "number"
+            },
+            "type": "object",
+            "title": "Scorer Rating Confidences",
+            "description": "confidence (0-1) per rating, keyed by rating name",
+            "examples": [
+              {
+                "_rating_": 0.92
+              }
+            ]
+          },
+          "span_agent_name": {
+            "type": "string",
+            "title": "Span Agent Name",
+            "description": "Display name of the scored agent (from spans.agent_name)",
+            "default": "",
+            "examples": ["midi-generator"]
+          },
+          "span_agent_version": {
+            "type": "string",
+            "title": "Span Agent Version",
+            "description": "Version of the scored agent (from spans.agent_version)",
+            "default": "",
+            "examples": ["1.2.0"]
+          },
+          "span_status_code": {
+            "type": "string",
+            "title": "Span Status Code",
+            "description": "Status of the scored turn (from spans.status_code)",
+            "default": "UNSET",
+            "examples": ["SUCCESS"]
+          },
           "wb_user_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Wb User Id",
             "description": "Do not set directly. Server will automatically populate this field."
           },
-          "feedback_id": {"type": "string", "title": "Feedback Id"}
+          "feedback_id": {
+            "type": "string",
+            "title": "Feedback Id"
+          }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": [
           "project_id",
@@ -1878,39 +13269,336 @@
       },
       "FeedbackReplaceRes": {
         "properties": {
-          "id": {"type": "string", "title": "Id"},
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
             "title": "Created At"
           },
-          "wb_user_id": {"type": "string", "title": "Wb User Id"},
-          "payload": {"type": "object", "title": "Payload"}
+          "wb_user_id": {
+            "type": "string",
+            "title": "Wb User Id"
+          },
+          "payload": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Payload"
+          }
         },
         "type": "object",
         "required": ["id", "created_at", "wb_user_id", "payload"],
         "title": "FeedbackReplaceRes"
       },
+      "FeedbackStatsReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start",
+            "description": "Inclusive start time (UTC, ISO 8601)."
+          },
+          "end": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "End",
+            "description": "Exclusive end time (UTC, ISO 8601). Defaults to now if omitted."
+          },
+          "feedback_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Feedback Type",
+            "description": "Filter by feedback_type."
+          },
+          "trigger_ref": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Trigger Ref",
+            "description": "Filter by trigger_ref (exact or prefix match for all-versions)."
+          },
+          "granularity": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Granularity",
+            "description": "Bucket size in seconds. If omitted, auto-selected based on time range."
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "description": "IANA timezone for bucket alignment.",
+            "default": "UTC"
+          },
+          "metrics": {
+            "items": {
+              "$ref": "#/components/schemas/FeedbackMetricSpec"
+            },
+            "type": "array",
+            "title": "Metrics",
+            "description": "Metrics to aggregate from payload_dump."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "start"],
+        "title": "FeedbackStatsReq",
+        "description": "Request for aggregated feedback statistics over time buckets."
+      },
+      "FeedbackStatsRes": {
+        "properties": {
+          "start": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Start",
+            "description": "Resolved start time (always UTC, regardless of the requested timezone)."
+          },
+          "end": {
+            "type": "string",
+            "format": "date-time",
+            "title": "End",
+            "description": "Resolved end time (always UTC, regardless of the requested timezone)."
+          },
+          "granularity": {
+            "type": "integer",
+            "title": "Granularity",
+            "description": "Bucket size used (in seconds)"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "description": "Timezone used for bucket alignment"
+          },
+          "buckets": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Buckets",
+            "description": "Time-bucketed aggregations. Each dict has 'timestamp' (ISO string), 'count' (int), and '{agg}_{slug}' keys for each requested metric+aggregation."
+          },
+          "window_stats": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "type": "number"
+                      },
+                      {
+                        "type": "null"
+                      }
+                    ]
+                  },
+                  "type": "object"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Window Stats",
+            "description": "Aggregations over the full query window, keyed by metric slug (e.g. 'output_score'). Each value maps agg name to result."
+          }
+        },
+        "type": "object",
+        "required": ["start", "end", "granularity", "timezone"],
+        "title": "FeedbackStatsRes",
+        "description": "Response with time-series feedback statistics."
+      },
       "FileContentReadReq": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
-          "digest": {"type": "string", "title": "Digest"}
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "digest"],
         "title": "FileContentReadReq"
       },
       "FileCreateRes": {
-        "properties": {"digest": {"type": "string", "title": "Digest"}},
+        "properties": {
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          }
+        },
         "type": "object",
         "required": ["digest"],
         "title": "FileCreateRes"
       },
+      "FilesStatsReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id"],
+        "title": "FilesStatsReq"
+      },
+      "FilesStatsRes": {
+        "properties": {
+          "total_size_bytes": {
+            "type": "integer",
+            "title": "Total Size Bytes"
+          }
+        },
+        "type": "object",
+        "required": ["total_size_bytes"],
+        "title": "FilesStatsRes"
+      },
+      "GenAISpanRef": {
+        "properties": {
+          "trace_id": {
+            "type": "string",
+            "title": "Trace Id"
+          },
+          "span_id": {
+            "type": "string",
+            "title": "Span Id"
+          }
+        },
+        "type": "object",
+        "required": ["trace_id", "span_id"],
+        "title": "GenAISpanRef"
+      },
+      "Geolocation": {
+        "properties": {
+          "file_index": {
+            "type": "integer",
+            "title": "File Index",
+            "description": "row in CSV file"
+          },
+          "range_start_int": {
+            "type": "integer",
+            "title": "Range Start Int",
+            "description": "Start of IP range as integer"
+          },
+          "range_end_int": {
+            "type": "integer",
+            "title": "Range End Int",
+            "description": "End of IP range as integer"
+          },
+          "range_start_ip": {
+            "type": "string",
+            "title": "Range Start Ip",
+            "description": "Start of IP range in dotted decimal notation"
+          },
+          "range_end_ip": {
+            "type": "string",
+            "title": "Range End Ip",
+            "description": "End of IP range in dotted decimal notation"
+          },
+          "country_code": {
+            "type": "string",
+            "title": "Country Code",
+            "description": "2-letter country code in ISO 3166-1 Alpha 2 format"
+          },
+          "country_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Country Name",
+            "description": "Country name, None if could not be determined"
+          }
+        },
+        "type": "object",
+        "required": [
+          "file_index",
+          "range_start_int",
+          "range_end_int",
+          "range_start_ip",
+          "range_end_ip",
+          "country_code"
+        ],
+        "title": "Geolocation"
+      },
+      "GeolocationRes": {
+        "properties": {
+          "ip": {
+            "type": "string",
+            "title": "Ip",
+            "description": "Resolved IP address, useful for debugging"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Geolocation"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Information about the location of the IP address, None if could not be determined"
+          },
+          "allowed": {
+            "type": "boolean",
+            "title": "Allowed",
+            "description": "Whether the IP address is allowed to be used for inference.",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": ["ip"],
+        "title": "GeolocationRes"
+      },
       "GetFieldOperator": {
-        "properties": {"$getField": {"type": "string", "title": "$Getfield"}},
+        "properties": {
+          "$getField": {
+            "type": "string",
+            "title": "$Getfield"
+          }
+        },
         "type": "object",
         "required": ["$getField"],
-        "title": "GetFieldOperator"
+        "title": "GetFieldOperator",
+        "description": "Access a field on the traced call.\n\nSupports dot notation for nested access, e.g. `summary.usage.tokens`.\n\nOnly works on fields present in the `CallSchema`, including:\n- Top-level fields like `op_name`, `trace_id`, `started_at`\n- Nested fields like `inputs.input_name`, `summary.usage.tokens`, etc.\n\nExample:\n    ```\n    {\"$getField\": \"op_name\"}\n    ```"
       },
       "GtOperation": {
         "properties": {
@@ -1918,32 +13606,88 @@
             "prefixItems": [
               {
                 "anyOf": [
-                  {"$ref": "#/components/schemas/LiteralOperation"},
-                  {"$ref": "#/components/schemas/GetFieldOperator"},
-                  {"$ref": "#/components/schemas/ConvertOperation"},
-                  {"$ref": "#/components/schemas/AndOperation"},
-                  {"$ref": "#/components/schemas/OrOperation"},
-                  {"$ref": "#/components/schemas/NotOperation"},
-                  {"$ref": "#/components/schemas/EqOperation"},
-                  {"$ref": "#/components/schemas/GtOperation"},
-                  {"$ref": "#/components/schemas/GteOperation"},
-                  {"$ref": "#/components/schemas/InOperation"},
-                  {"$ref": "#/components/schemas/ContainsOperation"}
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
                 ]
               },
               {
                 "anyOf": [
-                  {"$ref": "#/components/schemas/LiteralOperation"},
-                  {"$ref": "#/components/schemas/GetFieldOperator"},
-                  {"$ref": "#/components/schemas/ConvertOperation"},
-                  {"$ref": "#/components/schemas/AndOperation"},
-                  {"$ref": "#/components/schemas/OrOperation"},
-                  {"$ref": "#/components/schemas/NotOperation"},
-                  {"$ref": "#/components/schemas/EqOperation"},
-                  {"$ref": "#/components/schemas/GtOperation"},
-                  {"$ref": "#/components/schemas/GteOperation"},
-                  {"$ref": "#/components/schemas/InOperation"},
-                  {"$ref": "#/components/schemas/ContainsOperation"}
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
                 ]
               }
             ],
@@ -1955,7 +13699,8 @@
         },
         "type": "object",
         "required": ["$gt"],
-        "title": "GtOperation"
+        "title": "GtOperation",
+        "description": "Greater than comparison.\n\nExample:\n    ```\n    {\n        \"$gt\": [{\"$getField\": \"summary.usage.tokens\"}, {\"$literal\": 100}]\n    }\n    ```"
       },
       "GteOperation": {
         "properties": {
@@ -1963,32 +13708,88 @@
             "prefixItems": [
               {
                 "anyOf": [
-                  {"$ref": "#/components/schemas/LiteralOperation"},
-                  {"$ref": "#/components/schemas/GetFieldOperator"},
-                  {"$ref": "#/components/schemas/ConvertOperation"},
-                  {"$ref": "#/components/schemas/AndOperation"},
-                  {"$ref": "#/components/schemas/OrOperation"},
-                  {"$ref": "#/components/schemas/NotOperation"},
-                  {"$ref": "#/components/schemas/EqOperation"},
-                  {"$ref": "#/components/schemas/GtOperation"},
-                  {"$ref": "#/components/schemas/GteOperation"},
-                  {"$ref": "#/components/schemas/InOperation"},
-                  {"$ref": "#/components/schemas/ContainsOperation"}
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
                 ]
               },
               {
                 "anyOf": [
-                  {"$ref": "#/components/schemas/LiteralOperation"},
-                  {"$ref": "#/components/schemas/GetFieldOperator"},
-                  {"$ref": "#/components/schemas/ConvertOperation"},
-                  {"$ref": "#/components/schemas/AndOperation"},
-                  {"$ref": "#/components/schemas/OrOperation"},
-                  {"$ref": "#/components/schemas/NotOperation"},
-                  {"$ref": "#/components/schemas/EqOperation"},
-                  {"$ref": "#/components/schemas/GtOperation"},
-                  {"$ref": "#/components/schemas/GteOperation"},
-                  {"$ref": "#/components/schemas/InOperation"},
-                  {"$ref": "#/components/schemas/ContainsOperation"}
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
                 ]
               }
             ],
@@ -2000,12 +13801,15 @@
         },
         "type": "object",
         "required": ["$gte"],
-        "title": "GteOperation"
+        "title": "GteOperation",
+        "description": "Greater than or equal comparison.\n\nExample:\n    ```\n    {\n        \"$gte\": [{\"$getField\": \"summary.usage.tokens\"}, {\"$literal\": 100}]\n    }\n    ```"
       },
       "HTTPValidationError": {
         "properties": {
           "detail": {
-            "items": {"$ref": "#/components/schemas/ValidationError"},
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
             "type": "array",
             "title": "Detail"
           }
@@ -2013,39 +13817,183 @@
         "type": "object",
         "title": "HTTPValidationError"
       },
+      "ImageGenerationCreateReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "inputs": {
+            "$ref": "#/components/schemas/ImageGenerationRequestInputs"
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id",
+            "description": "Do not set directly. Server will automatically populate this field."
+          },
+          "track_llm_call": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Track Llm Call",
+            "description": "Whether to track this image generation call in the trace server",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": ["project_id", "inputs"],
+        "title": "ImageGenerationCreateReq"
+      },
+      "ImageGenerationCreateRes": {
+        "properties": {
+          "response": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Response"
+          },
+          "weave_call_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Weave Call Id"
+          }
+        },
+        "type": "object",
+        "required": ["response"],
+        "title": "ImageGenerationCreateRes"
+      },
+      "ImageGenerationRequestInputs": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model"
+          },
+          "prompt": {
+            "type": "string",
+            "title": "Prompt"
+          },
+          "n": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "N"
+          }
+        },
+        "type": "object",
+        "required": ["model", "prompt"],
+        "title": "ImageGenerationRequestInputs"
+      },
       "InOperation": {
         "properties": {
           "$in": {
             "prefixItems": [
               {
                 "anyOf": [
-                  {"$ref": "#/components/schemas/LiteralOperation"},
-                  {"$ref": "#/components/schemas/GetFieldOperator"},
-                  {"$ref": "#/components/schemas/ConvertOperation"},
-                  {"$ref": "#/components/schemas/AndOperation"},
-                  {"$ref": "#/components/schemas/OrOperation"},
-                  {"$ref": "#/components/schemas/NotOperation"},
-                  {"$ref": "#/components/schemas/EqOperation"},
-                  {"$ref": "#/components/schemas/GtOperation"},
-                  {"$ref": "#/components/schemas/GteOperation"},
-                  {"$ref": "#/components/schemas/InOperation"},
-                  {"$ref": "#/components/schemas/ContainsOperation"}
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
                 ]
               },
               {
                 "items": {
                   "anyOf": [
-                    {"$ref": "#/components/schemas/LiteralOperation"},
-                    {"$ref": "#/components/schemas/GetFieldOperator"},
-                    {"$ref": "#/components/schemas/ConvertOperation"},
-                    {"$ref": "#/components/schemas/AndOperation"},
-                    {"$ref": "#/components/schemas/OrOperation"},
-                    {"$ref": "#/components/schemas/NotOperation"},
-                    {"$ref": "#/components/schemas/EqOperation"},
-                    {"$ref": "#/components/schemas/GtOperation"},
-                    {"$ref": "#/components/schemas/GteOperation"},
-                    {"$ref": "#/components/schemas/InOperation"},
-                    {"$ref": "#/components/schemas/ContainsOperation"}
+                    {
+                      "$ref": "#/components/schemas/LiteralOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GetFieldOperator"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ConvertOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/AndOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/OrOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/NotOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/EqOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GtOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LtOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GteOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/LteOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/InOperation"
+                    },
+                    {
+                      "$ref": "#/components/schemas/ContainsOperation"
+                    }
                   ]
                 },
                 "type": "array"
@@ -2059,35 +14007,391 @@
         },
         "type": "object",
         "required": ["$in"],
-        "title": "InOperation"
+        "title": "InOperation",
+        "description": "Membership check.\n\nReturns true if the left operand is in the list provided as the second operand.\n\nExample:\n    ```\n    {\n        \"$in\": [\n            {\"$getField\": \"op_name\"},\n            [{\"$literal\": \"predict\"}, {\"$literal\": \"generate\"}]\n        ]\n    }\n    ```"
+      },
+      "LLMAggregatedUsage": {
+        "properties": {
+          "requests": {
+            "type": "integer",
+            "title": "Requests",
+            "default": 0
+          },
+          "prompt_tokens": {
+            "type": "integer",
+            "title": "Prompt Tokens",
+            "default": 0
+          },
+          "completion_tokens": {
+            "type": "integer",
+            "title": "Completion Tokens",
+            "default": 0
+          },
+          "total_tokens": {
+            "type": "integer",
+            "title": "Total Tokens",
+            "default": 0
+          },
+          "cache_read_input_tokens": {
+            "type": "integer",
+            "title": "Cache Read Input Tokens",
+            "default": 0
+          },
+          "cache_creation_input_tokens": {
+            "type": "integer",
+            "title": "Cache Creation Input Tokens",
+            "default": 0
+          },
+          "prompt_tokens_total_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Prompt Tokens Total Cost"
+          },
+          "completion_tokens_total_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Completion Tokens Total Cost"
+          },
+          "cache_read_input_tokens_total_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Read Input Tokens Total Cost"
+          },
+          "cache_creation_input_tokens_total_cost": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Creation Input Tokens Total Cost"
+          }
+        },
+        "type": "object",
+        "title": "LLMAggregatedUsage",
+        "description": "Aggregated usage metrics for a specific LLM."
+      },
+      "LLMModelDetails": {
+        "properties": {
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "idPlayground": {
+            "type": "string",
+            "title": "Idplayground"
+          },
+          "idHuggingFace": {
+            "type": "string",
+            "title": "Idhuggingface"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "labelOpenRouter": {
+            "type": "string",
+            "title": "Labelopenrouter"
+          },
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "lifecycleStage": {
+            "type": "string",
+            "enum": ["general-availability", "experimental", "retired"],
+            "title": "Lifecyclestage"
+          },
+          "availableIn": {
+            "items": {
+              "type": "string",
+              "enum": ["cw-prod", "cw-qa"]
+            },
+            "type": "array",
+            "title": "Availablein"
+          },
+          "launchedQuarter": {
+            "type": "string",
+            "title": "Launchedquarter"
+          },
+          "descriptionShort": {
+            "type": "string",
+            "title": "Descriptionshort"
+          },
+          "descriptionMedium": {
+            "type": "string",
+            "title": "Descriptionmedium"
+          },
+          "launchDate": {
+            "type": "string",
+            "title": "Launchdate"
+          },
+          "featureReasoning": {
+            "type": "boolean",
+            "title": "Featurereasoning"
+          },
+          "featureJsonMode": {
+            "type": "boolean",
+            "title": "Featurejsonmode"
+          },
+          "featureStructuredOutput": {
+            "type": "boolean",
+            "title": "Featurestructuredoutput"
+          },
+          "featureToolCalling": {
+            "type": "boolean",
+            "title": "Featuretoolcalling"
+          },
+          "featureLoRA": {
+            "type": "boolean",
+            "title": "Featurelora"
+          },
+          "featureTrainableServerlessRL": {
+            "type": "boolean",
+            "title": "Featuretrainableserverlessrl"
+          },
+          "parameterCountTotal": {
+            "type": "integer",
+            "title": "Parametercounttotal"
+          },
+          "parameterCountActive": {
+            "type": "integer",
+            "title": "Parametercountactive"
+          },
+          "contextWindow": {
+            "type": "integer",
+            "title": "Contextwindow"
+          },
+          "quantization": {
+            "type": "string",
+            "enum": [
+              "int4",
+              "int8",
+              "fp4",
+              "fp6",
+              "fp8",
+              "fp16",
+              "bf16",
+              "fp32"
+            ],
+            "title": "Quantization"
+          },
+          "priceCentsPerBillionTokensInput": {
+            "type": "integer",
+            "title": "Pricecentsperbilliontokensinput"
+          },
+          "priceCentsPerBillionTokensCached": {
+            "type": "integer",
+            "title": "Pricecentsperbilliontokenscached"
+          },
+          "priceCentsPerBillionTokensOutput": {
+            "type": "integer",
+            "title": "Pricecentsperbilliontokensoutput"
+          },
+          "isAvailableOpenRouter": {
+            "type": "boolean",
+            "title": "Isavailableopenrouter"
+          },
+          "apiStyle": {
+            "type": "string",
+            "title": "Apistyle"
+          },
+          "modalities": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Modalities"
+          },
+          "modalitiesInput": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Modalitiesinput"
+          },
+          "modalitiesOutput": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Modalitiesoutput"
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags"
+          },
+          "likesHuggingFace": {
+            "type": "integer",
+            "title": "Likeshuggingface"
+          },
+          "downloadsHuggingFace": {
+            "type": "integer",
+            "title": "Downloadshuggingface"
+          },
+          "license": {
+            "type": "string",
+            "title": "License"
+          }
+        },
+        "type": "object",
+        "required": [
+          "provider",
+          "id",
+          "idPlayground",
+          "idHuggingFace",
+          "label",
+          "labelOpenRouter",
+          "status",
+          "lifecycleStage",
+          "availableIn",
+          "launchedQuarter",
+          "descriptionShort",
+          "descriptionMedium",
+          "launchDate",
+          "featureReasoning",
+          "featureJsonMode",
+          "featureStructuredOutput",
+          "featureToolCalling",
+          "featureLoRA",
+          "featureTrainableServerlessRL",
+          "parameterCountTotal",
+          "contextWindow",
+          "quantization",
+          "priceCentsPerBillionTokensInput",
+          "priceCentsPerBillionTokensCached",
+          "priceCentsPerBillionTokensOutput",
+          "isAvailableOpenRouter",
+          "apiStyle",
+          "modalities",
+          "modalitiesInput",
+          "modalitiesOutput",
+          "tags",
+          "likesHuggingFace",
+          "downloadsHuggingFace",
+          "license"
+        ],
+        "title": "LLMModelDetails"
       },
       "LLMUsageSchema": {
         "properties": {
           "prompt_tokens": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Prompt Tokens"
           },
           "input_tokens": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Input Tokens"
           },
           "completion_tokens": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Completion Tokens"
           },
           "output_tokens": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Output Tokens"
           },
           "requests": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Requests"
           },
           "total_tokens": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Total Tokens"
+          },
+          "cache_creation_input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Creation Input Tokens"
+          },
+          "cache_read_input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cache Read Input Tokens"
           }
         },
+        "additionalProperties": true,
         "type": "object",
         "title": "LLMUsageSchema"
       },
@@ -2095,10 +14399,18 @@
         "properties": {
           "$literal": {
             "anyOf": [
-              {"type": "string"},
-              {"type": "integer"},
-              {"type": "number"},
-              {"type": "boolean"},
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
               {
                 "additionalProperties": {
                   "$ref": "#/components/schemas/LiteralOperation"
@@ -2106,17 +14418,399 @@
                 "type": "object"
               },
               {
-                "items": {"$ref": "#/components/schemas/LiteralOperation"},
+                "items": {
+                  "$ref": "#/components/schemas/LiteralOperation"
+                },
                 "type": "array"
               },
-              {"type": "null"}
+              {
+                "type": "null"
+              }
             ],
             "title": "$Literal"
           }
         },
         "type": "object",
         "required": ["$literal"],
-        "title": "LiteralOperation"
+        "title": "LiteralOperation",
+        "description": "Represents a constant value in the query language.\n\nThis can be any standard JSON-serializable value.\n\nExample:\n    ```\n    {\"$literal\": \"predict\"}\n    ```"
+      },
+      "LtOperation": {
+        "properties": {
+          "$lt": {
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
+                ]
+              }
+            ],
+            "type": "array",
+            "maxItems": 2,
+            "minItems": 2,
+            "title": "$Lt"
+          }
+        },
+        "type": "object",
+        "required": ["$lt"],
+        "title": "LtOperation",
+        "description": "Less than comparison.\n\nExample:\n    ```\n    {\n        \"$lt\": [{\"$getField\": \"summary.usage.tokens\"}, {\"$literal\": 100}]\n    }\n    ```"
+      },
+      "LteOperation": {
+        "properties": {
+          "$lte": {
+            "prefixItems": [
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
+                ]
+              },
+              {
+                "anyOf": [
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
+                ]
+              }
+            ],
+            "type": "array",
+            "maxItems": 2,
+            "minItems": 2,
+            "title": "$Lte"
+          }
+        },
+        "type": "object",
+        "required": ["$lte"],
+        "title": "LteOperation",
+        "description": "Less than or equal comparison.\n\nExample:\n    ```\n    {\n        \"$lte\": [{\"$getField\": \"summary.usage.tokens\"}, {\"$literal\": 100}]\n    }\n    ```"
+      },
+      "ModelCreateBody": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of this model. Models with the same name will be versioned together."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "A description of this model"
+          },
+          "source_code": {
+            "type": "string",
+            "title": "Source Code",
+            "description": "Complete source code for the Model class including imports"
+          },
+          "attributes": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attributes",
+            "description": "Additional attributes to be stored with the model"
+          }
+        },
+        "type": "object",
+        "required": ["name", "source_code"],
+        "title": "ModelCreateBody"
+      },
+      "ModelCreateRes": {
+        "properties": {
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "description": "The digest of the created model"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id",
+            "description": "The ID of the created model"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index",
+            "description": "The version index of the created model"
+          },
+          "model_ref": {
+            "type": "string",
+            "title": "Model Ref",
+            "description": "Full reference to the created model"
+          }
+        },
+        "type": "object",
+        "required": ["digest", "object_id", "version_index", "model_ref"],
+        "title": "ModelCreateRes"
+      },
+      "ModelDeleteRes": {
+        "properties": {
+          "num_deleted": {
+            "type": "integer",
+            "title": "Num Deleted",
+            "description": "Number of model versions deleted"
+          }
+        },
+        "type": "object",
+        "required": ["num_deleted"],
+        "title": "ModelDeleteRes"
+      },
+      "ModelReadRes": {
+        "properties": {
+          "object_id": {
+            "type": "string",
+            "title": "Object Id",
+            "description": "The model ID"
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "description": "The digest of the model"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index",
+            "description": "The version index of the object"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "When the model was created"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the model"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "Description of the model"
+          },
+          "source_code": {
+            "type": "string",
+            "title": "Source Code",
+            "description": "The source code of the model"
+          },
+          "attributes": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Attributes",
+            "description": "Additional attributes stored with the model"
+          }
+        },
+        "type": "object",
+        "required": [
+          "object_id",
+          "digest",
+          "version_index",
+          "created_at",
+          "name",
+          "source_code"
+        ],
+        "title": "ModelReadRes"
+      },
+      "NormalizedMessage": {
+        "properties": {
+          "role": {
+            "type": "string",
+            "title": "Role",
+            "default": ""
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "finish_reason": {
+            "type": "string",
+            "title": "Finish Reason",
+            "default": ""
+          }
+        },
+        "type": "object",
+        "required": ["content"],
+        "title": "NormalizedMessage",
+        "description": "A single message normalized from any provider format.\n\nMaps to ClickHouse ``Tuple(role String, content String, finish_reason String)``.\n\n- role: message role (user, assistant, tool, system)\n- content: plain text for simple messages, or JSON-serialized parts\n  array for multimodal/structured messages\n- finish_reason: per-message finish reason (output messages only)"
       },
       "NotOperation": {
         "properties": {
@@ -2124,17 +14818,45 @@
             "prefixItems": [
               {
                 "anyOf": [
-                  {"$ref": "#/components/schemas/LiteralOperation"},
-                  {"$ref": "#/components/schemas/GetFieldOperator"},
-                  {"$ref": "#/components/schemas/ConvertOperation"},
-                  {"$ref": "#/components/schemas/AndOperation"},
-                  {"$ref": "#/components/schemas/OrOperation"},
-                  {"$ref": "#/components/schemas/NotOperation"},
-                  {"$ref": "#/components/schemas/EqOperation"},
-                  {"$ref": "#/components/schemas/GtOperation"},
-                  {"$ref": "#/components/schemas/GteOperation"},
-                  {"$ref": "#/components/schemas/InOperation"},
-                  {"$ref": "#/components/schemas/ContainsOperation"}
+                  {
+                    "$ref": "#/components/schemas/LiteralOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GetFieldOperator"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ConvertOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/AndOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/OrOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/NotOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/EqOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LtOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/GteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/LteOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/InOperation"
+                  },
+                  {
+                    "$ref": "#/components/schemas/ContainsOperation"
+                  }
                 ]
               }
             ],
@@ -2146,21 +14868,156 @@
         },
         "type": "object",
         "required": ["$not"],
-        "title": "NotOperation"
+        "title": "NotOperation",
+        "description": "Logical NOT. Inverts the condition.\n\nExample:\n    ```\n    {\n        \"$not\": [\n            {\"$eq\": [{\"$getField\": \"op_name\"}, {\"$literal\": \"debug\"}]}\n        ]\n    }\n    ```"
+      },
+      "NvidiaHardwareOption": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "type": {
+            "type": "string",
+            "title": "Type"
+          },
+          "pricing": {
+            "$ref": "#/components/schemas/NvidiaServerlessPricing"
+          },
+          "specs": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Specs"
+          }
+        },
+        "type": "object",
+        "required": ["id", "name", "type", "pricing"],
+        "title": "NvidiaHardwareOption"
+      },
+      "NvidiaHardwareRes": {
+        "properties": {
+          "hardware": {
+            "items": {
+              "$ref": "#/components/schemas/NvidiaHardwareOption"
+            },
+            "type": "array",
+            "title": "Hardware"
+          }
+        },
+        "type": "object",
+        "required": ["hardware"],
+        "title": "NvidiaHardwareRes"
+      },
+      "NvidiaServerlessPricing": {
+        "properties": {
+          "cents_per_million_input_tokens": {
+            "type": "number",
+            "title": "Cents Per Million Input Tokens"
+          },
+          "cents_per_million_output_tokens": {
+            "type": "number",
+            "title": "Cents Per Million Output Tokens"
+          }
+        },
+        "type": "object",
+        "required": [
+          "cents_per_million_input_tokens",
+          "cents_per_million_output_tokens"
+        ],
+        "title": "NvidiaServerlessPricing"
+      },
+      "ObjAddTagsRes": {
+        "properties": {},
+        "type": "object",
+        "title": "ObjAddTagsRes"
       },
       "ObjCreateReq": {
         "properties": {
-          "obj": {"$ref": "#/components/schemas/ObjSchemaForInsert"}
+          "obj": {
+            "$ref": "#/components/schemas/ObjSchemaForInsert"
+          }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["obj"],
         "title": "ObjCreateReq"
       },
       "ObjCreateRes": {
-        "properties": {"digest": {"type": "string", "title": "Digest"}},
+        "properties": {
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          },
+          "object_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Object Id"
+          }
+        },
         "type": "object",
         "required": ["digest"],
         "title": "ObjCreateRes"
+      },
+      "ObjDeleteReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id"
+          },
+          "digests": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Digests",
+            "description": "List of digests to delete. If not provided, all digests for the object will be deleted."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "object_id"],
+        "title": "ObjDeleteReq"
+      },
+      "ObjDeleteRes": {
+        "properties": {
+          "num_deleted": {
+            "type": "integer",
+            "title": "Num Deleted"
+          }
+        },
+        "type": "object",
+        "required": ["num_deleted"],
+        "title": "ObjDeleteRes"
       },
       "ObjQueryReq": {
         "properties": {
@@ -2172,22 +15029,43 @@
           },
           "filter": {
             "anyOf": [
-              {"$ref": "#/components/schemas/ObjectVersionFilter"},
-              {"type": "null"}
+              {
+                "$ref": "#/components/schemas/ObjectVersionFilter"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "Filter criteria for the query. See `ObjectVersionFilter`",
             "examples": [
-              {"latest_only": true, "object_ids": ["my_favorite_model"]}
+              {
+                "latest_only": true,
+                "object_ids": ["my_favorite_model"]
+              }
             ]
           },
           "limit": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Limit",
             "description": "Maximum number of results to return",
             "examples": [100]
           },
           "offset": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Offset",
             "description": "Number of results to skip before returning",
             "examples": [0]
@@ -2195,22 +15073,67 @@
           "sort_by": {
             "anyOf": [
               {
-                "items": {"$ref": "#/components/schemas/SortBy"},
+                "items": {
+                  "$ref": "#/components/schemas/SortBy"
+                },
                 "type": "array"
               },
-              {"type": "null"}
+              {
+                "type": "null"
+              }
             ],
             "title": "Sort By",
             "description": "Sorting criteria for the query results. Currently only supports 'object_id' and 'created_at'.",
-            "examples": [[{"direction": "desc", "field": "created_at"}]]
+            "examples": [
+              [
+                {
+                  "direction": "desc",
+                  "field": "created_at"
+                }
+              ]
+            ]
           },
           "metadata_only": {
-            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Metadata Only",
             "description": "If true, the `val` column is not read from the database and is empty.All other fields are returned.",
             "default": false
+          },
+          "include_storage_size": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Storage Size",
+            "description": "If true, the `size_bytes` column is returned.",
+            "default": false
+          },
+          "include_tags_and_aliases": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Tags And Aliases",
+            "description": "If true, tags and aliases are fetched and included in the response.",
+            "default": false
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id"],
         "title": "ObjQueryReq"
@@ -2218,7 +15141,9 @@
       "ObjQueryRes": {
         "properties": {
           "objs": {
-            "items": {"$ref": "#/components/schemas/ObjSchema"},
+            "items": {
+              "$ref": "#/components/schemas/ObjSchema"
+            },
             "type": "array",
             "title": "Objs"
           }
@@ -2229,24 +15154,102 @@
       },
       "ObjReadReq": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
-          "object_id": {"type": "string", "title": "Object Id"},
-          "digest": {"type": "string", "title": "Digest"}
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id"
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          },
+          "metadata_only": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata Only",
+            "description": "If true, the `val` column is not read from the database and is empty.All other fields are returned.",
+            "default": false
+          },
+          "include_tags_and_aliases": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Tags And Aliases",
+            "description": "If true, tags and aliases are fetched and included in the response.",
+            "default": false
+          }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "object_id", "digest"],
         "title": "ObjReadReq"
       },
       "ObjReadRes": {
-        "properties": {"obj": {"$ref": "#/components/schemas/ObjSchema"}},
+        "properties": {
+          "obj": {
+            "$ref": "#/components/schemas/ObjSchema"
+          }
+        },
         "type": "object",
         "required": ["obj"],
         "title": "ObjReadRes"
       },
+      "ObjRemoveAliasesBody": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": ["entity/project"]
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Aliases",
+            "examples": [["staging"]]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "aliases"],
+        "title": "ObjRemoveAliasesBody",
+        "description": "Request body for removing aliases (object_id comes from path)."
+      },
+      "ObjRemoveAliasesRes": {
+        "properties": {},
+        "type": "object",
+        "title": "ObjRemoveAliasesRes"
+      },
+      "ObjRemoveTagsRes": {
+        "properties": {},
+        "type": "object",
+        "title": "ObjRemoveTagsRes"
+      },
       "ObjSchema": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
-          "object_id": {"type": "string", "title": "Object Id"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id"
+          },
           "created_at": {
             "type": "string",
             "format": "date-time",
@@ -2254,20 +15257,108 @@
           },
           "deleted_at": {
             "anyOf": [
-              {"type": "string", "format": "date-time"},
-              {"type": "null"}
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Deleted At"
           },
-          "digest": {"type": "string", "title": "Digest"},
-          "version_index": {"type": "integer", "title": "Version Index"},
-          "is_latest": {"type": "integer", "title": "Is Latest"},
-          "kind": {"type": "string", "title": "Kind"},
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index"
+          },
+          "is_latest": {
+            "type": "integer",
+            "title": "Is Latest"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
           "base_object_class": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Base Object Class"
           },
-          "val": {"title": "Val"}
+          "leaf_object_class": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Leaf Object Class"
+          },
+          "val": {
+            "title": "Val"
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id",
+            "description": "Do not set directly. Server will automatically populate this field."
+          },
+          "size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Size Bytes"
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags"
+          },
+          "aliases": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aliases"
+          }
         },
         "type": "object",
         "required": [
@@ -2285,75 +15376,404 @@
       },
       "ObjSchemaForInsert": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
-          "object_id": {"type": "string", "title": "Object Id"},
-          "val": {"title": "Val"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id"
+          },
+          "val": {
+            "title": "Val"
+          },
           "builtin_object_class": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Builtin Object Class"
           },
           "set_base_object_class": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Set Base Object Class",
             "deprecated": true
+          },
+          "expected_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Digest",
+            "description": "Client-computed digest for server-side validation. If provided, the server will verify it matches the server-computed digest."
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id",
+            "description": "Do not set directly. Server will automatically populate this field."
           }
         },
         "type": "object",
         "required": ["project_id", "object_id", "val"],
         "title": "ObjSchemaForInsert"
       },
+      "ObjSetAliasesBody": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": ["entity/project"]
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "examples": ["abc123def"]
+          },
+          "aliases": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Aliases",
+            "examples": [["staging", "v1-candidate"]]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "digest", "aliases"],
+        "title": "ObjSetAliasesBody",
+        "description": "Request body for setting aliases (object_id comes from path)."
+      },
+      "ObjSetAliasesRes": {
+        "properties": {},
+        "type": "object",
+        "title": "ObjSetAliasesRes"
+      },
+      "ObjTagsBody": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "examples": ["entity/project"]
+          },
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags",
+            "examples": [["production", "reviewed"]]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "tags"],
+        "title": "ObjTagsBody",
+        "description": "Request body for adding/removing tags (object_id and digest come from path)."
+      },
       "ObjectVersionFilter": {
         "properties": {
           "base_object_classes": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Base Object Classes",
             "description": "Filter objects by their base classes",
             "examples": [["Model"], ["Dataset"]]
           },
+          "exclude_base_object_classes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Exclude Base Object Classes",
+            "description": "Exclude objects by their base classes",
+            "examples": [["Model"], ["Dataset"]]
+          },
+          "leaf_object_classes": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Leaf Object Classes",
+            "description": "Filter objects by their leaf classes",
+            "examples": [
+              ["Model"],
+              ["Dataset"],
+              ["LLMStructuredCompletionModel"]
+            ]
+          },
           "object_ids": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Object Ids",
             "description": "Filter objects by their IDs",
             "examples": ["my_favorite_model", "my_favorite_dataset"]
           },
           "is_op": {
-            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Is Op",
             "description": "Filter objects based on whether they are weave.ops or not. `True` will only return ops, `False` will return non-ops, and `None` will return all objects",
             "examples": [true, false, null]
           },
           "latest_only": {
-            "anyOf": [{"type": "boolean"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Latest Only",
             "description": "If True, return only the latest version of each object. `False` and `None` will return all versions",
             "examples": [true, false]
+          },
+          "tags": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Tags",
+            "description": "Filter object versions that have any of the specified tags"
+          },
+          "aliases": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Aliases",
+            "description": "Filter objects that have any of the specified aliases"
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "ObjectVersionFilter"
+      },
+      "OpCreateBody": {
+        "properties": {
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "description": "The name of this op. Ops with the same name will be versioned together."
+          },
+          "source_code": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Code",
+            "description": "Complete source code for this op, including imports"
           }
         },
         "type": "object",
-        "title": "ObjectVersionFilter"
+        "title": "OpCreateBody",
+        "description": "Request body for creating an Op object via REST API.\n\nThis model excludes project_id since it comes from the URL path in RESTful endpoints."
+      },
+      "OpCreateRes": {
+        "properties": {
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "description": "The digest of the created op"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id",
+            "description": "The ID of the created op"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index",
+            "description": "The version index of the created op"
+          }
+        },
+        "type": "object",
+        "required": ["digest", "object_id", "version_index"],
+        "title": "OpCreateRes",
+        "description": "Response model for creating an Op object."
+      },
+      "OpDeleteRes": {
+        "properties": {
+          "num_deleted": {
+            "type": "integer",
+            "title": "Num Deleted",
+            "description": "Number of op versions deleted from this op"
+          }
+        },
+        "type": "object",
+        "required": ["num_deleted"],
+        "title": "OpDeleteRes"
+      },
+      "OpReadRes": {
+        "properties": {
+          "object_id": {
+            "type": "string",
+            "title": "Object Id",
+            "description": "The op ID"
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "description": "The digest of the op"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index",
+            "description": "The version index of this op"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "When this op was created"
+          },
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "description": "The actual op source code"
+          }
+        },
+        "type": "object",
+        "required": [
+          "object_id",
+          "digest",
+          "version_index",
+          "created_at",
+          "code"
+        ],
+        "title": "OpReadRes",
+        "description": "Response model for reading an Op object.\n\nThe code field contains the actual source code of the op."
       },
       "OrOperation": {
         "properties": {
           "$or": {
             "items": {
               "anyOf": [
-                {"$ref": "#/components/schemas/LiteralOperation"},
-                {"$ref": "#/components/schemas/GetFieldOperator"},
-                {"$ref": "#/components/schemas/ConvertOperation"},
-                {"$ref": "#/components/schemas/AndOperation"},
-                {"$ref": "#/components/schemas/OrOperation"},
-                {"$ref": "#/components/schemas/NotOperation"},
-                {"$ref": "#/components/schemas/EqOperation"},
-                {"$ref": "#/components/schemas/GtOperation"},
-                {"$ref": "#/components/schemas/GteOperation"},
-                {"$ref": "#/components/schemas/InOperation"},
-                {"$ref": "#/components/schemas/ContainsOperation"}
+                {
+                  "$ref": "#/components/schemas/LiteralOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/GetFieldOperator"
+                },
+                {
+                  "$ref": "#/components/schemas/ConvertOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/AndOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/OrOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/NotOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/EqOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/GtOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/LtOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/GteOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/LteOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/InOperation"
+                },
+                {
+                  "$ref": "#/components/schemas/ContainsOperation"
+                }
               ]
             },
             "type": "array",
@@ -2362,24 +15782,253 @@
         },
         "type": "object",
         "required": ["$or"],
-        "title": "OrOperation"
+        "title": "OrOperation",
+        "description": "Logical OR. At least one condition must be true.\n\nExample:\n    ```\n    {\n        \"$or\": [\n            {\"$eq\": [{\"$getField\": \"op_name\"}, {\"$literal\": \"a\"}]},\n            {\"$eq\": [{\"$getField\": \"op_name\"}, {\"$literal\": \"b\"}]}\n        ]\n    }\n    ```"
+      },
+      "PredictionCreateBody": {
+        "properties": {
+          "model": {
+            "type": "string",
+            "title": "Model",
+            "description": "The model reference (weave:// URI)"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Inputs",
+            "description": "The inputs to the prediction"
+          },
+          "output": {
+            "title": "Output",
+            "description": "The output of the prediction"
+          },
+          "evaluation_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Run Id",
+            "description": "Optional evaluation run ID to link this prediction as a child call"
+          },
+          "genai_span_ref": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/GenAISpanRef"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Genai Span Ref",
+            "description": "Optional GenAI span reference(s) produced by this prediction."
+          }
+        },
+        "type": "object",
+        "required": ["model", "inputs", "output"],
+        "title": "PredictionCreateBody",
+        "description": "Request body for creating a Prediction via REST API.\n\nThis model excludes project_id since it comes from the URL path in RESTful endpoints."
+      },
+      "PredictionCreateRes": {
+        "properties": {
+          "prediction_id": {
+            "type": "string",
+            "title": "Prediction Id",
+            "description": "The prediction ID"
+          }
+        },
+        "type": "object",
+        "required": ["prediction_id"],
+        "title": "PredictionCreateRes"
+      },
+      "PredictionDeleteRes": {
+        "properties": {
+          "num_deleted": {
+            "type": "integer",
+            "title": "Num Deleted",
+            "description": "Number of predictions deleted"
+          }
+        },
+        "type": "object",
+        "required": ["num_deleted"],
+        "title": "PredictionDeleteRes"
+      },
+      "PredictionFinishRes": {
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "title": "Success",
+            "description": "Whether the prediction was finished successfully"
+          }
+        },
+        "type": "object",
+        "required": ["success"],
+        "title": "PredictionFinishRes"
+      },
+      "PredictionReadRes": {
+        "properties": {
+          "prediction_id": {
+            "type": "string",
+            "title": "Prediction Id",
+            "description": "The prediction ID"
+          },
+          "model": {
+            "type": "string",
+            "title": "Model",
+            "description": "The model reference (weave:// URI)"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Inputs",
+            "description": "The inputs to the prediction"
+          },
+          "output": {
+            "title": "Output",
+            "description": "The output of the prediction"
+          },
+          "evaluation_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Run Id",
+            "description": "Evaluation run ID if this prediction is linked to one"
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id",
+            "description": "Do not set directly. Server will automatically populate this field."
+          }
+        },
+        "type": "object",
+        "required": ["prediction_id", "model", "inputs", "output"],
+        "title": "PredictionReadRes"
+      },
+      "Pricing": {
+        "properties": {
+          "prompt": {
+            "type": "string",
+            "title": "Prompt"
+          },
+          "completion": {
+            "type": "string",
+            "title": "Completion"
+          },
+          "image": {
+            "type": "string",
+            "title": "Image"
+          },
+          "request": {
+            "type": "string",
+            "title": "Request"
+          },
+          "input_cache_read": {
+            "type": "string",
+            "title": "Input Cache Read"
+          }
+        },
+        "type": "object",
+        "required": [
+          "prompt",
+          "completion",
+          "image",
+          "request",
+          "input_cache_read"
+        ],
+        "title": "Pricing",
+        "description": "All pricing values are in USD per 1 token.\n\nPricing fields are in string format to avoid floating point precision issues."
+      },
+      "ProjectsInfoReq": {
+        "properties": {
+          "project_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Project Ids",
+            "description": "External project IDs in 'entity/project' format.",
+            "examples": [["entity-a/project-a", "entity-b/project-b"]]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_ids"],
+        "title": "ProjectsInfoReq"
+      },
+      "ProjectsInfoRes": {
+        "properties": {
+          "external_project_id": {
+            "type": "string",
+            "title": "External Project Id",
+            "description": "External project ID in 'entity/project' format."
+          },
+          "internal_project_id": {
+            "type": "string",
+            "title": "Internal Project Id",
+            "description": "Internal project ID."
+          }
+        },
+        "type": "object",
+        "required": ["external_project_id", "internal_project_id"],
+        "title": "ProjectsInfoRes"
       },
       "Query": {
         "properties": {
           "$expr": {
             "anyOf": [
-              {"$ref": "#/components/schemas/AndOperation"},
-              {"$ref": "#/components/schemas/OrOperation"},
-              {"$ref": "#/components/schemas/NotOperation"},
-              {"$ref": "#/components/schemas/EqOperation"},
-              {"$ref": "#/components/schemas/GtOperation"},
-              {"$ref": "#/components/schemas/GteOperation"},
-              {"$ref": "#/components/schemas/InOperation"},
-              {"$ref": "#/components/schemas/ContainsOperation"}
+              {
+                "$ref": "#/components/schemas/AndOperation"
+              },
+              {
+                "$ref": "#/components/schemas/OrOperation"
+              },
+              {
+                "$ref": "#/components/schemas/NotOperation"
+              },
+              {
+                "$ref": "#/components/schemas/EqOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GtOperation"
+              },
+              {
+                "$ref": "#/components/schemas/LtOperation"
+              },
+              {
+                "$ref": "#/components/schemas/GteOperation"
+              },
+              {
+                "$ref": "#/components/schemas/LteOperation"
+              },
+              {
+                "$ref": "#/components/schemas/InOperation"
+              },
+              {
+                "$ref": "#/components/schemas/ContainsOperation"
+              }
             ],
             "title": "$Expr"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["$expr"],
         "title": "Query"
@@ -2387,80 +16036,625 @@
       "RefsReadBatchReq": {
         "properties": {
           "refs": {
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Refs"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["refs"],
         "title": "RefsReadBatchReq"
       },
       "RefsReadBatchRes": {
-        "properties": {"vals": {"items": {}, "type": "array", "title": "Vals"}},
+        "properties": {
+          "vals": {
+            "items": {},
+            "type": "array",
+            "title": "Vals"
+          }
+        },
         "type": "object",
         "required": ["vals"],
         "title": "RefsReadBatchRes"
+      },
+      "RescoreReq": {
+        "properties": {
+          "source_evaluation_run_id": {
+            "type": "string",
+            "title": "Source Evaluation Run Id",
+            "description": "The evaluation run whose predictions will be rescored"
+          },
+          "scorer_refs": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Scorer Refs",
+            "description": "Scorer references (weave:// URIs) to apply; must be non-empty"
+          },
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id",
+            "description": "Do not set directly. Server will automatically populate this field."
+          }
+        },
+        "type": "object",
+        "required": ["source_evaluation_run_id", "scorer_refs", "project_id"],
+        "title": "RescoreReq",
+        "description": "Full rescore request including server-set fields."
+      },
+      "RescoreRes": {
+        "properties": {
+          "call_id": {
+            "type": "string",
+            "title": "Call Id",
+            "description": "Call ID for /evaluations/status polling"
+          },
+          "evaluation_run_id": {
+            "type": "string",
+            "title": "Evaluation Run Id",
+            "description": "The newly created EvaluationRun ID"
+          }
+        },
+        "type": "object",
+        "required": ["call_id", "evaluation_run_id"],
+        "title": "RescoreRes",
+        "description": "Response for a rescore request."
+      },
+      "RouterOpenRouterModel": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "hugging_face_id": {
+            "type": "string",
+            "title": "Hugging Face Id"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "created": {
+            "type": "integer",
+            "title": "Created"
+          },
+          "input_modalities": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Input Modalities"
+          },
+          "output_modalities": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Output Modalities"
+          },
+          "quantization": {
+            "type": "string",
+            "enum": [
+              "int4",
+              "int8",
+              "fp4",
+              "fp6",
+              "fp8",
+              "fp16",
+              "bf16",
+              "fp32"
+            ],
+            "title": "Quantization"
+          },
+          "context_length": {
+            "type": "integer",
+            "title": "Context Length"
+          },
+          "max_output_length": {
+            "type": "integer",
+            "title": "Max Output Length"
+          },
+          "pricing": {
+            "$ref": "#/components/schemas/Pricing"
+          },
+          "supported_sampling_parameters": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "temperature",
+                "top_p",
+                "top_k",
+                "repetition_penalty",
+                "frequency_penalty",
+                "presence_penalty",
+                "stop",
+                "seed"
+              ]
+            },
+            "type": "array",
+            "title": "Supported Sampling Parameters"
+          },
+          "supported_features": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "tools",
+                "json_mode",
+                "structured_outputs",
+                "web_search",
+                "reasoning"
+              ]
+            },
+            "type": "array",
+            "title": "Supported Features"
+          },
+          "datacenters": {
+            "items": {
+              "$ref": "#/components/schemas/Datacenter"
+            },
+            "type": "array",
+            "title": "Datacenters"
+          },
+          "deprecation_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Deprecation Date",
+            "description": "Date when the model is deprecated (YYYY-MM-DD). Omitted from output if not set."
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "hugging_face_id",
+          "name",
+          "created",
+          "input_modalities",
+          "output_modalities",
+          "quantization",
+          "context_length",
+          "max_output_length",
+          "pricing",
+          "supported_sampling_parameters",
+          "supported_features",
+          "datacenters"
+        ],
+        "title": "RouterOpenRouterModel"
+      },
+      "RouterOpenRouterModelsRes": {
+        "properties": {
+          "data": {
+            "items": {
+              "$ref": "#/components/schemas/RouterOpenRouterModel"
+            },
+            "type": "array",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "required": ["data"],
+        "title": "RouterOpenRouterModelsRes"
+      },
+      "ScoreCreateBody": {
+        "properties": {
+          "prediction_id": {
+            "type": "string",
+            "title": "Prediction Id",
+            "description": "The prediction ID"
+          },
+          "scorer": {
+            "type": "string",
+            "title": "Scorer",
+            "description": "The scorer reference (weave:// URI)"
+          },
+          "value": {
+            "title": "Value",
+            "description": "The raw output of the scorer"
+          },
+          "evaluation_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Run Id",
+            "description": "Optional evaluation run ID to link this score as a child call"
+          }
+        },
+        "type": "object",
+        "required": ["prediction_id", "scorer", "value"],
+        "title": "ScoreCreateBody",
+        "description": "Request body for creating a Score via REST API.\n\nThis model excludes project_id since it comes from the URL path in RESTful endpoints."
+      },
+      "ScoreCreateRes": {
+        "properties": {
+          "score_id": {
+            "type": "string",
+            "title": "Score Id",
+            "description": "The score ID"
+          }
+        },
+        "type": "object",
+        "required": ["score_id"],
+        "title": "ScoreCreateRes"
+      },
+      "ScoreDeleteRes": {
+        "properties": {
+          "num_deleted": {
+            "type": "integer",
+            "title": "Num Deleted",
+            "description": "Number of scores deleted"
+          }
+        },
+        "type": "object",
+        "required": ["num_deleted"],
+        "title": "ScoreDeleteRes"
+      },
+      "ScoreReadRes": {
+        "properties": {
+          "score_id": {
+            "type": "string",
+            "title": "Score Id",
+            "description": "The score ID"
+          },
+          "scorer": {
+            "type": "string",
+            "title": "Scorer",
+            "description": "The scorer reference (weave:// URI)"
+          },
+          "value": {
+            "title": "Value",
+            "description": "The raw output of the scorer"
+          },
+          "evaluation_run_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Evaluation Run Id",
+            "description": "Evaluation run ID if this score is linked to one"
+          },
+          "wb_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb User Id",
+            "description": "Do not set directly. Server will automatically populate this field."
+          }
+        },
+        "type": "object",
+        "required": ["score_id", "scorer", "value"],
+        "title": "ScoreReadRes"
+      },
+      "ScorerCreateBody": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of this scorer.  Scorers with the same name will be versioned together."
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "A description of this scorer"
+          },
+          "op_source_code": {
+            "type": "string",
+            "title": "Op Source Code",
+            "description": "Complete source code for the Scorer.score op including imports"
+          }
+        },
+        "type": "object",
+        "required": ["name", "op_source_code"],
+        "title": "ScorerCreateBody"
+      },
+      "ScorerCreateRes": {
+        "properties": {
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "description": "The digest of the created scorer"
+          },
+          "object_id": {
+            "type": "string",
+            "title": "Object Id",
+            "description": "The ID of the created scorer"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index",
+            "description": "The version index of the created scorer"
+          },
+          "scorer": {
+            "type": "string",
+            "title": "Scorer",
+            "description": "Full reference to the created scorer"
+          }
+        },
+        "type": "object",
+        "required": ["digest", "object_id", "version_index", "scorer"],
+        "title": "ScorerCreateRes"
+      },
+      "ScorerDeleteRes": {
+        "properties": {
+          "num_deleted": {
+            "type": "integer",
+            "title": "Num Deleted",
+            "description": "Number of scorer versions deleted"
+          }
+        },
+        "type": "object",
+        "required": ["num_deleted"],
+        "title": "ScorerDeleteRes"
+      },
+      "ScorerReadRes": {
+        "properties": {
+          "object_id": {
+            "type": "string",
+            "title": "Object Id",
+            "description": "The scorer ID"
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest",
+            "description": "The digest of the scorer"
+          },
+          "version_index": {
+            "type": "integer",
+            "title": "Version Index",
+            "description": "The version index of the object"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At",
+            "description": "When the scorer was created"
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "The name of the scorer"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description",
+            "description": "Description of the scorer"
+          },
+          "score_op": {
+            "type": "string",
+            "title": "Score Op",
+            "description": "The Scorer.score op reference"
+          }
+        },
+        "type": "object",
+        "required": [
+          "object_id",
+          "digest",
+          "version_index",
+          "created_at",
+          "name",
+          "score_op"
+        ],
+        "title": "ScorerReadRes"
       },
       "ServerInfoRes": {
         "properties": {
           "min_required_weave_python_version": {
             "type": "string",
             "title": "Min Required Weave Python Version"
+          },
+          "trace_server_version": {
+            "type": "string",
+            "title": "Trace Server Version"
           }
         },
         "type": "object",
-        "required": ["min_required_weave_python_version"],
+        "required": [
+          "min_required_weave_python_version",
+          "trace_server_version"
+        ],
         "title": "ServerInfoRes"
       },
       "SortBy": {
         "properties": {
-          "field": {"type": "string", "title": "Field"},
+          "field": {
+            "type": "string",
+            "title": "Field"
+          },
           "direction": {
             "type": "string",
             "enum": ["asc", "desc"],
             "title": "Direction"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["field", "direction"],
         "title": "SortBy"
       },
       "StartedCallSchemaForInsert": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
           "id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Id"
           },
-          "op_name": {"type": "string", "title": "Op Name"},
+          "op_name": {
+            "type": "string",
+            "title": "Op Name"
+          },
           "display_name": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Display Name"
           },
           "trace_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Trace Id"
           },
           "parent_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Parent Id"
+          },
+          "thread_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thread Id"
+          },
+          "turn_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Turn Id"
           },
           "started_at": {
             "type": "string",
             "format": "date-time",
             "title": "Started At"
           },
-          "attributes": {"type": "object", "title": "Attributes"},
-          "inputs": {"type": "object", "title": "Inputs"},
+          "attributes": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Attributes"
+          },
+          "inputs": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Inputs"
+          },
+          "otel_dump": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Otel Dump"
+          },
           "wb_user_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Wb User Id",
             "description": "Do not set directly. Server will automatically populate this field."
           },
           "wb_run_id": {
-            "anyOf": [{"type": "string"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Wb Run Id"
+          },
+          "wb_run_step": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Wb Run Step"
           }
         },
         "type": "object",
@@ -2481,6 +16675,16 @@
             },
             "type": "object",
             "title": "Usage"
+          },
+          "status_counts": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "propertyNames": {
+              "$ref": "#/components/schemas/TraceStatus"
+            },
+            "type": "object",
+            "title": "Status Counts"
           }
         },
         "additionalProperties": true,
@@ -2489,31 +16693,89 @@
       },
       "TableAppendSpec": {
         "properties": {
-          "append": {"$ref": "#/components/schemas/TableAppendSpecPayload"}
+          "append": {
+            "$ref": "#/components/schemas/TableAppendSpecPayload"
+          }
         },
         "type": "object",
         "required": ["append"],
         "title": "TableAppendSpec"
       },
       "TableAppendSpecPayload": {
-        "properties": {"row": {"type": "object", "title": "Row"}},
+        "properties": {
+          "row": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Row"
+          }
+        },
         "type": "object",
         "required": ["row"],
         "title": "TableAppendSpecPayload"
       },
+      "TableCreateFromDigestsReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "row_digests": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Row Digests"
+          },
+          "expected_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Digest",
+            "description": "Client-computed table digest for server-side validation."
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id", "row_digests"],
+        "title": "TableCreateFromDigestsReq"
+      },
+      "TableCreateFromDigestsRes": {
+        "properties": {
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          }
+        },
+        "type": "object",
+        "required": ["digest"],
+        "title": "TableCreateFromDigestsRes"
+      },
       "TableCreateReq": {
         "properties": {
-          "table": {"$ref": "#/components/schemas/TableSchemaForInsert"}
+          "table": {
+            "$ref": "#/components/schemas/TableSchemaForInsert"
+          }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["table"],
         "title": "TableCreateReq"
       },
       "TableCreateRes": {
         "properties": {
-          "digest": {"type": "string", "title": "Digest"},
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          },
           "row_digests": {
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Row Digests",
             "description": "The digests of the rows that were created"
@@ -2525,7 +16787,9 @@
       },
       "TableInsertSpec": {
         "properties": {
-          "insert": {"$ref": "#/components/schemas/TableInsertSpecPayload"}
+          "insert": {
+            "$ref": "#/components/schemas/TableInsertSpecPayload"
+          }
         },
         "type": "object",
         "required": ["insert"],
@@ -2533,8 +16797,15 @@
       },
       "TableInsertSpecPayload": {
         "properties": {
-          "index": {"type": "integer", "title": "Index"},
-          "row": {"type": "object", "title": "Row"}
+          "index": {
+            "type": "integer",
+            "title": "Index"
+          },
+          "row": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Row"
+          }
         },
         "type": "object",
         "required": ["index", "row"],
@@ -2542,14 +16813,21 @@
       },
       "TablePopSpec": {
         "properties": {
-          "pop": {"$ref": "#/components/schemas/TablePopSpecPayload"}
+          "pop": {
+            "$ref": "#/components/schemas/TablePopSpecPayload"
+          }
         },
         "type": "object",
         "required": ["pop"],
         "title": "TablePopSpec"
       },
       "TablePopSpecPayload": {
-        "properties": {"index": {"type": "integer", "title": "Index"}},
+        "properties": {
+          "index": {
+            "type": "integer",
+            "title": "Index"
+          }
+        },
         "type": "object",
         "required": ["index"],
         "title": "TablePopSpecPayload"
@@ -2572,8 +16850,12 @@
           },
           "filter": {
             "anyOf": [
-              {"$ref": "#/components/schemas/TableRowFilter"},
-              {"type": "null"}
+              {
+                "$ref": "#/components/schemas/TableRowFilter"
+              },
+              {
+                "type": "null"
+              }
             ],
             "description": "Optional filter to apply to the query. See `TableRowFilter` for more details.",
             "examples": [
@@ -2586,13 +16868,27 @@
             ]
           },
           "limit": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Limit",
             "description": "Maximum number of rows to return",
             "examples": [100]
           },
           "offset": {
-            "anyOf": [{"type": "integer"}, {"type": "null"}],
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Offset",
             "description": "Number of rows to skip before starting to return rows",
             "examples": [10]
@@ -2600,16 +16896,28 @@
           "sort_by": {
             "anyOf": [
               {
-                "items": {"$ref": "#/components/schemas/SortBy"},
+                "items": {
+                  "$ref": "#/components/schemas/SortBy"
+                },
                 "type": "array"
               },
-              {"type": "null"}
+              {
+                "type": "null"
+              }
             ],
             "title": "Sort By",
             "description": "List of fields to sort by. Fields can be dot-separated to access dictionary values. No sorting uses the default table order (insertion order).",
-            "examples": [[{"field": "col_a.prop_b", "order": "desc"}]]
+            "examples": [
+              [
+                {
+                  "field": "col_a.prop_b",
+                  "order": "desc"
+                }
+              ]
+            ]
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "digest"],
         "title": "TableQueryReq"
@@ -2617,7 +16925,9 @@
       "TableQueryRes": {
         "properties": {
           "rows": {
-            "items": {"$ref": "#/components/schemas/TableRowSchema"},
+            "items": {
+              "$ref": "#/components/schemas/TableRowSchema"
+            },
             "type": "array",
             "title": "Rows"
           }
@@ -2625,6 +16935,67 @@
         "type": "object",
         "required": ["rows"],
         "title": "TableQueryRes"
+      },
+      "TableQueryStatsBatchReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "description": "The ID of the project",
+            "examples": ["my_entity/my_project"]
+          },
+          "digests": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Digests",
+            "description": "The digests of the tables to query",
+            "default": [],
+            "examples": [
+              "aonareimsvtl13apimtalpa4435rpmgnaemrpgmarltarstaorsnte134avrims",
+              "smirva431etnsroatsratlrampgrmeangmpr5344aplatmipa31ltvsmi\u0435\u0440\u0430noa"
+            ]
+          },
+          "include_storage_size": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Include Storage Size",
+            "description": "If true, the `storage_size_bytes` column is returned.",
+            "default": false
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id"],
+        "title": "TableQueryStatsBatchReq"
+      },
+      "TableQueryStatsBatchRes": {
+        "properties": {
+          "tables": {
+            "items": {
+              "$ref": "#/components/schemas/TableStatsRow"
+            },
+            "type": "array",
+            "title": "Tables"
+          }
+        },
+        "type": "object",
+        "required": ["tables"],
+        "title": "TableQueryStatsBatchRes"
       },
       "TableQueryStatsReq": {
         "properties": {
@@ -2637,18 +17008,21 @@
           "digest": {
             "type": "string",
             "title": "Digest",
-            "description": "The digest of the table to query",
-            "examples": [
-              "aonareimsvtl13apimtalpa4435rpmgnaemrpgmarltarstaorsnte134avrims"
-            ]
+            "description": "The digest of the table to query"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "digest"],
         "title": "TableQueryStatsReq"
       },
       "TableQueryStatsRes": {
-        "properties": {"count": {"type": "integer", "title": "Count"}},
+        "properties": {
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
         "type": "object",
         "required": ["count"],
         "title": "TableQueryStatsRes"
@@ -2657,8 +17031,15 @@
         "properties": {
           "row_digests": {
             "anyOf": [
-              {"items": {"type": "string"}, "type": "array"},
-              {"type": "null"}
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
             ],
             "title": "Row Digests",
             "description": "List of row digests to filter by",
@@ -2670,13 +17051,30 @@
             ]
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "title": "TableRowFilter"
       },
       "TableRowSchema": {
         "properties": {
-          "digest": {"type": "string", "title": "Digest"},
-          "val": {"title": "Val"}
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          },
+          "val": {
+            "title": "Val"
+          },
+          "original_index": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Original Index"
+          }
         },
         "type": "object",
         "required": ["digest", "val"],
@@ -2684,42 +17082,104 @@
       },
       "TableSchemaForInsert": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
           "rows": {
-            "items": {"type": "object"},
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
             "type": "array",
             "title": "Rows"
+          },
+          "expected_digest": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Expected Digest",
+            "description": "Client-computed table digest for server-side validation."
           }
         },
         "type": "object",
         "required": ["project_id", "rows"],
         "title": "TableSchemaForInsert"
       },
+      "TableStatsRow": {
+        "properties": {
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          },
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          },
+          "storage_size_bytes": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Storage Size Bytes"
+          }
+        },
+        "type": "object",
+        "required": ["count", "digest"],
+        "title": "TableStatsRow"
+      },
       "TableUpdateReq": {
         "properties": {
-          "project_id": {"type": "string", "title": "Project Id"},
-          "base_digest": {"type": "string", "title": "Base Digest"},
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "base_digest": {
+            "type": "string",
+            "title": "Base Digest"
+          },
           "updates": {
             "items": {
               "anyOf": [
-                {"$ref": "#/components/schemas/TableAppendSpec"},
-                {"$ref": "#/components/schemas/TablePopSpec"},
-                {"$ref": "#/components/schemas/TableInsertSpec"}
+                {
+                  "$ref": "#/components/schemas/TableAppendSpec"
+                },
+                {
+                  "$ref": "#/components/schemas/TablePopSpec"
+                },
+                {
+                  "$ref": "#/components/schemas/TableInsertSpec"
+                }
               ]
             },
             "type": "array",
             "title": "Updates"
           }
         },
+        "additionalProperties": false,
         "type": "object",
         "required": ["project_id", "base_digest", "updates"],
         "title": "TableUpdateReq"
       },
       "TableUpdateRes": {
         "properties": {
-          "digest": {"type": "string", "title": "Digest"},
+          "digest": {
+            "type": "string",
+            "title": "Digest"
+          },
           "updated_row_digests": {
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "type": "array",
             "title": "Updated Row Digests",
             "description": "The digests of the rows that were updated"
@@ -2729,21 +17189,297 @@
         "required": ["digest"],
         "title": "TableUpdateRes"
       },
+      "TagsListRes": {
+        "properties": {
+          "tags": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Tags"
+          }
+        },
+        "type": "object",
+        "required": ["tags"],
+        "title": "TagsListRes"
+      },
+      "ThreadsQueryFilter": {
+        "properties": {
+          "after_datetime": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "After Datetime",
+            "description": "Only include threads with start_time after this timestamp",
+            "examples": ["2024-01-01T00:00:00Z"]
+          },
+          "before_datetime": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Before Datetime",
+            "description": "Only include threads with last_updated before this timestamp",
+            "examples": ["2024-12-31T23:59:59Z"]
+          },
+          "thread_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thread Ids",
+            "description": "Only include threads with thread_ids in this list",
+            "examples": [["thread_1", "thread_2", "my_thread_id"]]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "title": "ThreadsQueryFilter"
+      },
+      "ThreadsQueryReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id",
+            "description": "The ID of the project",
+            "examples": ["my_entity/my_project"]
+          },
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ThreadsQueryFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Filter criteria for the threads query"
+          },
+          "limit": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Limit",
+            "description": "Maximum number of threads to return"
+          },
+          "offset": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Offset",
+            "description": "Number of threads to skip"
+          },
+          "sort_by": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/SortBy"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Sort By",
+            "description": "Sorting criteria for the threads. Supported fields: 'thread_id', 'turn_count', 'start_time', 'last_updated', 'p50_turn_duration_ms', 'p99_turn_duration_ms'.",
+            "examples": [
+              [
+                {
+                  "direction": "desc",
+                  "field": "last_updated"
+                }
+              ]
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id"],
+        "title": "ThreadsQueryReq",
+        "description": "Query threads with aggregated statistics based on turn calls only.\n\nTurn calls are the immediate children of thread contexts (where call.id == turn_id).\nThis provides meaningful conversation-level statistics rather than including all\nnested implementation details."
+      },
+      "TraceStatus": {
+        "type": "string",
+        "enum": ["success", "error", "running", "descendant_error"],
+        "title": "TraceStatus"
+      },
+      "TraceUsageReq": {
+        "properties": {
+          "project_id": {
+            "type": "string",
+            "title": "Project Id"
+          },
+          "filter": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CallsFilter"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Filter to select calls. Typically use trace_ids to get all calls in a trace."
+          },
+          "query": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/Query"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Additional query conditions for filtering calls."
+          },
+          "include_costs": {
+            "type": "boolean",
+            "title": "Include Costs",
+            "description": "If true, include cost calculations in the usage.",
+            "default": false
+          },
+          "limit": {
+            "type": "integer",
+            "title": "Limit",
+            "description": "Maximum number of calls to process. Acts as a safety limit to prevent unbounded memory usage.",
+            "default": 10000
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["project_id"],
+        "title": "TraceUsageReq",
+        "description": "Request to compute per-call usage for a trace, with descendant rollup.\n\nThis endpoint returns usage metrics for each call in the trace, where each\ncall's metrics include the sum of its own usage plus all descendants' usage.\nUse this for trace view where you want to see rolled-up metrics per call.\n\nNote: All matching calls are loaded into memory for aggregation. For very large\nresult sets (>10k calls), consider using more specific filters or pagination\nat the application layer."
+      },
+      "TraceUsageRes": {
+        "properties": {
+          "call_usage": {
+            "additionalProperties": {
+              "additionalProperties": {
+                "$ref": "#/components/schemas/LLMAggregatedUsage"
+              },
+              "type": "object"
+            },
+            "type": "object",
+            "title": "Call Usage"
+          },
+          "unfinished_call_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Unfinished Call Ids"
+          }
+        },
+        "type": "object",
+        "title": "TraceUsageRes",
+        "description": "Response with per-call usage metrics (each includes descendant contributions)."
+      },
+      "UsageMetricSpec": {
+        "properties": {
+          "metric": {
+            "type": "string",
+            "enum": [
+              "input_tokens",
+              "output_tokens",
+              "total_tokens",
+              "cache_read_input_tokens",
+              "cache_creation_input_tokens",
+              "input_cost",
+              "output_cost",
+              "total_cost"
+            ],
+            "title": "Metric",
+            "description": "Metric to aggregate. Token metrics are normalized across providers."
+          },
+          "aggregations": {
+            "items": {
+              "$ref": "#/components/schemas/AggregationType"
+            },
+            "type": "array",
+            "title": "Aggregations",
+            "description": "Basic aggregation functions to apply",
+            "default": ["sum"]
+          },
+          "percentiles": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "title": "Percentiles",
+            "description": "Percentile values to compute (0-100). E.g., [50, 95, 99] for p50, p95, p99",
+            "default": []
+          }
+        },
+        "additionalProperties": false,
+        "type": "object",
+        "required": ["metric"],
+        "title": "UsageMetricSpec",
+        "description": "Specification for a usage metric to aggregate (grouped by model)."
+      },
       "ValidationError": {
         "properties": {
           "loc": {
-            "items": {"anyOf": [{"type": "string"}, {"type": "integer"}]},
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
             "type": "array",
             "title": "Location"
           },
-          "msg": {"type": "string", "title": "Message"},
-          "type": {"type": "string", "title": "Error Type"}
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
         },
         "type": "object",
         "required": ["loc", "msg", "type"],
         "title": "ValidationError"
       }
     },
-    "securitySchemes": {"HTTPBasic": {"type": "http", "scheme": "basic"}}
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

* We are going to add functions to the SDKs to that interface wit recently-added endpoints that expose agent-related info (eg, `POST /agents/query`, `POST /agents/agent-versions/query`, etc.)

* This change pulls over the latest OpenAPI spec from `core/` and regenerates `traceServerApi.ts`.

* This'll allow PRs further up this stack to leverage the codegen'ed functions.

