### PR TITLE
chore(weave_ts): Pull up other module-level state.

### DIFF
--- a/sdks/node/src/clientApi.ts
+++ b/sdks/node/src/clientApi.ts
@@ -8,15 +8,7 @@ import {createFetchWithRetry} from './utils/retry';
 import {getWandbConfigs} from './wandb/settings';
 import {WandbServerApi} from './wandb/wandbServerApi';
 import {type CallStackEntry, WeaveClient} from './weaveClient';
-import {globalSingleton} from './utils/globalSingleton';
-
-// Held behind a globalThis-backed container so that a dual-package-hazard load
-// (same module loaded as both CJS and ESM) resolves to a single shared client
-// across both copies.
-const _globalClientHolder = globalSingleton<{client: WeaveClient | null}>(
-  '_weave_global_client',
-  () => ({client: null})
-);
+import state from './state';
 
 /**
  * Log in to Weights & Biases (W&B) using the provided API key.
@@ -170,7 +162,7 @@ export function requireCurrentChildSummary(): {[key: string]: any} {
 }
 
 export function getGlobalClient(): WeaveClient | null {
-  return _globalClientHolder.client;
+  return state.client;
 }
 
 export function requireGlobalClient(): WeaveClient {
@@ -182,7 +174,7 @@ export function requireGlobalClient(): WeaveClient {
 }
 
 export function setGlobalClient(client: WeaveClient | null) {
-  _globalClientHolder.client = client;
+  state.client = client;
 }
 
 /**

--- a/sdks/node/src/evalLinkSpanProcessor.ts
+++ b/sdks/node/src/evalLinkSpanProcessor.ts
@@ -20,13 +20,8 @@ import {
   WEAVE_ATTRIBUTES_NAMESPACE,
 } from './constants';
 import {ATTR_GEN_AI_OPERATION_NAME} from './genai/semconv';
-import {globalSingleton} from './utils/globalSingleton';
 import type {CallStackEntry, WeaveClient} from './weaveClient';
-
-const registeredProviders = globalSingleton<WeakSet<TracerProvider>>(
-  '_weave_eval_link_registered_providers',
-  () => new WeakSet()
-);
+import state from './state';
 
 // The API TracerProvider type only exposes getTracer. addSpanProcessor is an
 // SDK-specific, deprecated late-registration hook, so we feature-detect it and
@@ -172,7 +167,7 @@ export function registerEvalLinkSpanProcessor(
   getClient: ClientGetter,
   provider: TracerProvider = trace.getTracerProvider()
 ): boolean {
-  if (registeredProviders.has(provider)) {
+  if (state.evalLink.registeredProviders.has(provider)) {
     return true;
   }
 
@@ -181,6 +176,6 @@ export function registerEvalLinkSpanProcessor(
   }
 
   provider.addSpanProcessor(new EvalLinkSpanProcessor(getClient));
-  registeredProviders.add(provider);
+  state.evalLink.registeredProviders.add(provider);
   return true;
 }

--- a/sdks/node/src/state.ts
+++ b/sdks/node/src/state.ts
@@ -3,6 +3,8 @@ import type OpenAIAgents from '@openai/agents';
 import {BasicTracerProvider} from '@opentelemetry/sdk-trace-base';
 import {globalSingleton} from './utils/globalSingleton';
 import {GenAIState} from './genai/context';
+import {WeaveClient} from './weaveClient';
+import {TracerProvider} from '@opentelemetry/api';
 
 /**
  * Holds all SDK-wide mutable state.
@@ -16,6 +18,9 @@ import {GenAIState} from './genai/context';
  * See: https://github.com/wandb/weave/pull/6682
  */
 type State = {
+  client: WeaveClient | null;
+  domain: string | null;
+
   genAi: {
     provider: BasicTracerProvider | null;
 
@@ -72,15 +77,26 @@ type State = {
       patched: boolean;
     };
   };
+
+  evalLink: {
+    registeredProviders: WeakSet<TracerProvider>;
+  };
 };
 
 function defaultState(): State {
   return {
+    client: null,
+    domain: null,
+
     genAi: {
       provider: null,
       providerRegistered: false,
       state: new AsyncLocalStorage<GenAIState>(),
       defaultState: {session: null, turn: null, llm: null},
+    },
+
+    evalLink: {
+      registeredProviders: new WeakSet(),
     },
 
     integrations: {

--- a/sdks/node/src/urls.ts
+++ b/sdks/node/src/urls.ts
@@ -1,4 +1,4 @@
-import {globalSingleton} from './utils/globalSingleton';
+import state from './state';
 
 export const defaultHost = 'api.wandb.ai';
 export const defaultDomain = 'wandb.ai';
@@ -67,16 +67,9 @@ export function getUrls(hostOrUrl?: string) {
   };
 }
 
-// Held behind a globalThis-backed container so that a dual-package-hazard load
-// (same module as both CJS and ESM) still observes a single shared domain.
-const _globalDomainHolder = globalSingleton<{domain: string | undefined}>(
-  '_weave_global_domain',
-  () => ({domain: undefined})
-);
-
 export function getGlobalDomain() {
-  return _globalDomainHolder.domain;
+  return state.domain;
 }
 export function setGlobalDomain(domain: string) {
-  _globalDomainHolder.domain = domain;
+  state.domain = domain;
 }


### PR DESCRIPTION
## Description

* This is the same PR as already-approved https://github.com/wandb/weave/pull/7182, which was accidentally merged into the `graphite-base/` branch instead of `master`.

* Continuing on the thread kicked off in #7180, this change finishes pulling up module-level state.

