### PR TITLE
feat(weave_ts): Add `getAgents` fn to `WeaveClient`.

### DIFF
--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_errors_with_invalid_project_id.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_errors_with_invalid_project_id.yaml
@@ -1,0 +1,65 @@
+- request:
+    url: https://trace.wandb.ai/health
+    method: GET
+    headers:
+      authorization: masked
+      user-agent: W&B Weave JS Client unknown
+    body: ""
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "15"
+      content-type: application/json
+      date: Tue, 16 Jun 2026 19:50:19 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"status":"ok"}'
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Tue, 16 Jun 2026 19:50:19 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+      x-wandb-trace-id: 7598c1c9c9008bb0f09b593154269a65
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/agents/query
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"project_id":"drtangible-mocha/nonexistent-project"}'
+  response:
+    status: 403
+    statusText: Forbidden
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "30"
+      content-type: application/json
+      date: Tue, 16 Jun 2026 19:50:18 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"detail":"Project not found"}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_gets_agents.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_gets_agents.yaml
@@ -1,0 +1,65 @@
+- request:
+    url: https://trace.wandb.ai/health
+    method: GET
+    headers:
+      authorization: masked
+      user-agent: W&B Weave JS Client unknown
+    body: ""
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "15"
+      content-type: application/json
+      date: Tue, 16 Jun 2026 19:50:18 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"status":"ok"}'
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Tue, 16 Jun 2026 19:50:18 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+      x-wandb-trace-id: 0b60f8e2aea3c24f1e9e2334b2e319a6
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/agents/query
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"project_id":"drtangible-mocha/example"}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "870"
+      content-type: application/json
+      date: Tue, 16 Jun 2026 19:50:18 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"agents":[{"project_id":"drtangible-mocha/example","agent_name":"my-cool-agent-with-attributes","invocation_count":3,"span_count":3,"total_input_tokens":0,"total_output_tokens":0,"total_duration_ms":2,"error_count":0,"first_seen":"2026-06-15T21:32:12.358000","last_seen":"2026-06-15T21:51:03.879000"},{"project_id":"drtangible-mocha/example","agent_name":"my-cool-agent","invocation_count":33,"span_count":33,"total_input_tokens":0,"total_output_tokens":0,"total_duration_ms":4,"error_count":0,"first_seen":"2026-06-15T20:37:39.749000","last_seen":"2026-06-15T20:49:24.875000"},{"project_id":"drtangible-mocha/example","agent_name":"Assistant","invocation_count":5,"span_count":5,"total_input_tokens":0,"total_output_tokens":0,"total_duration_ms":9117,"error_count":0,"first_seen":"2026-06-10T22:36:48.879000","last_seen":"2026-06-10T22:39:35.019000"}],"total_count":3}'

--- a/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_supports_limit_and_offset.yaml
+++ b/sdks/node/src/__tests__/__cassettes__/weaveclient_getagents_supports_limit_and_offset.yaml
@@ -1,0 +1,122 @@
+- request:
+    url: https://trace.wandb.ai/health
+    method: GET
+    headers:
+      authorization: masked
+      user-agent: W&B Weave JS Client unknown
+    body: ""
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "15"
+      content-type: application/json
+      date: Tue, 16 Jun 2026 19:50:18 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"status":"ok"}'
+- request:
+    url: https://api.wandb.ai/graphql
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: Weave JS Client 0.15.1
+    body: '{"query":"\nquery DefaultEntity {\n    viewer
+      {\n        username\n        defaultEntity
+      {\n            name\n        }\n    }\n}\n","variables":{}}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-encoding: br
+      content-length: "69"
+      content-type: application/json; charset=utf-8
+      date: Tue, 16 Jun 2026 19:50:19 GMT
+      ratelimit-limit: "1000"
+      ratelimit-remaining: "1000"
+      vary: Origin
+      via: 1.1 google
+      x-content-type-options: nosniff
+      x-ratelimit-limit: "1000"
+      x-ratelimit-remaining: "1000"
+      x-wandb-trace-id: 0fecf9ab5f3c0b346832dc5b72d63221
+    body: '{"data":{"viewer":{"username":"drtangible","defaultEntity":{"name":"drtangible-mocha"}}}}'
+- request:
+    url: https://trace.wandb.ai/agents/query
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"project_id":"drtangible-mocha/example","limit":1}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "319"
+      content-type: application/json
+      date: Tue, 16 Jun 2026 19:50:18 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"agents":[{"project_id":"drtangible-mocha/example","agent_name":"my-cool-agent-with-attributes","invocation_count":3,"span_count":3,"total_input_tokens":0,"total_output_tokens":0,"total_duration_ms":2,"error_count":0,"first_seen":"2026-06-15T21:32:12.358000","last_seen":"2026-06-15T21:51:03.879000"}],"total_count":3}'
+- request:
+    url: https://trace.wandb.ai/agents/query
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"project_id":"drtangible-mocha/example","limit":1,"offset":1}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "305"
+      content-type: application/json
+      date: Tue, 16 Jun 2026 19:50:18 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"agents":[{"project_id":"drtangible-mocha/example","agent_name":"my-cool-agent","invocation_count":33,"span_count":33,"total_input_tokens":0,"total_output_tokens":0,"total_duration_ms":4,"error_count":0,"first_seen":"2026-06-15T20:37:39.749000","last_seen":"2026-06-15T20:49:24.875000"}],"total_count":3}'
+- request:
+    url: https://trace.wandb.ai/agents/query
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"project_id":"drtangible-mocha/example","limit":1,"offset":2}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "302"
+      content-type: application/json
+      date: Tue, 16 Jun 2026 19:50:18 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"agents":[{"project_id":"drtangible-mocha/example","agent_name":"Assistant","invocation_count":5,"span_count":5,"total_input_tokens":0,"total_output_tokens":0,"total_duration_ms":9117,"error_count":0,"first_seen":"2026-06-10T22:36:48.879000","last_seen":"2026-06-10T22:39:35.019000"}],"total_count":3}'
+- request:
+    url: https://trace.wandb.ai/agents/query
+    method: POST
+    headers:
+      authorization: masked
+      content-type: application/json
+      user-agent: W&B Weave JS Client unknown
+    body: '{"project_id":"drtangible-mocha/example","limit":1,"offset":3}'
+  response:
+    status: 200
+    statusText: OK
+    headers:
+      alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-length: "29"
+      content-type: application/json
+      date: Tue, 16 Jun 2026 19:50:18 GMT
+      server: uvicorn
+      via: 1.1 google
+    body: '{"agents":[],"total_count":3}'

--- a/sdks/node/src/__tests__/live/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/live/weaveClient.test.ts
@@ -1,0 +1,149 @@
+import {init, login} from '../../clientApi';
+import {getWandbConfigs} from '../../wandb/settings';
+import {vcrTest} from '../helpers/vcrTest';
+
+async function authenticate() {
+  const {apiKey} = getWandbConfigs();
+  await login(apiKey ?? '');
+}
+
+describe('WeaveClient', () => {
+  describe('getAgents', () => {
+    vcrTest('gets agents', async () => {
+      await authenticate();
+      const client = await init('example');
+      const resp = await client.getAgents();
+      expect(resp.data).toMatchInlineSnapshot(`
+        {
+          "agents": [
+            {
+              "agent_name": "my-cool-agent-with-attributes",
+              "error_count": 0,
+              "first_seen": "2026-06-15T21:32:12.358000",
+              "invocation_count": 3,
+              "last_seen": "2026-06-15T21:51:03.879000",
+              "project_id": "drtangible-mocha/example",
+              "span_count": 3,
+              "total_duration_ms": 2,
+              "total_input_tokens": 0,
+              "total_output_tokens": 0,
+            },
+            {
+              "agent_name": "my-cool-agent",
+              "error_count": 0,
+              "first_seen": "2026-06-15T20:37:39.749000",
+              "invocation_count": 33,
+              "last_seen": "2026-06-15T20:49:24.875000",
+              "project_id": "drtangible-mocha/example",
+              "span_count": 33,
+              "total_duration_ms": 4,
+              "total_input_tokens": 0,
+              "total_output_tokens": 0,
+            },
+            {
+              "agent_name": "Assistant",
+              "error_count": 0,
+              "first_seen": "2026-06-10T22:36:48.879000",
+              "invocation_count": 5,
+              "last_seen": "2026-06-10T22:39:35.019000",
+              "project_id": "drtangible-mocha/example",
+              "span_count": 5,
+              "total_duration_ms": 9117,
+              "total_input_tokens": 0,
+              "total_output_tokens": 0,
+            },
+          ],
+          "total_count": 3,
+        }
+      `);
+    });
+
+    vcrTest('supports limit and offset', async () => {
+      await authenticate();
+      const client = await init('example');
+
+      let resp = await client.getAgents({limit: 1});
+      expect(resp.data).toMatchInlineSnapshot(`
+        {
+          "agents": [
+            {
+              "agent_name": "my-cool-agent-with-attributes",
+              "error_count": 0,
+              "first_seen": "2026-06-15T21:32:12.358000",
+              "invocation_count": 3,
+              "last_seen": "2026-06-15T21:51:03.879000",
+              "project_id": "drtangible-mocha/example",
+              "span_count": 3,
+              "total_duration_ms": 2,
+              "total_input_tokens": 0,
+              "total_output_tokens": 0,
+            },
+          ],
+          "total_count": 3,
+        }
+      `);
+
+      resp = await client.getAgents({limit: 1, offset: 1});
+      expect(resp.data).toMatchInlineSnapshot(`
+        {
+          "agents": [
+            {
+              "agent_name": "my-cool-agent",
+              "error_count": 0,
+              "first_seen": "2026-06-15T20:37:39.749000",
+              "invocation_count": 33,
+              "last_seen": "2026-06-15T20:49:24.875000",
+              "project_id": "drtangible-mocha/example",
+              "span_count": 33,
+              "total_duration_ms": 4,
+              "total_input_tokens": 0,
+              "total_output_tokens": 0,
+            },
+          ],
+          "total_count": 3,
+        }
+      `);
+
+      resp = await client.getAgents({limit: 1, offset: 2});
+      expect(resp.data).toMatchInlineSnapshot(`
+        {
+          "agents": [
+            {
+              "agent_name": "Assistant",
+              "error_count": 0,
+              "first_seen": "2026-06-10T22:36:48.879000",
+              "invocation_count": 5,
+              "last_seen": "2026-06-10T22:39:35.019000",
+              "project_id": "drtangible-mocha/example",
+              "span_count": 5,
+              "total_duration_ms": 9117,
+              "total_input_tokens": 0,
+              "total_output_tokens": 0,
+            },
+          ],
+          "total_count": 3,
+        }
+      `);
+
+      resp = await client.getAgents({limit: 1, offset: 3});
+      expect(resp.data).toMatchInlineSnapshot(`
+        {
+          "agents": [],
+          "total_count": 3,
+        }
+      `);
+    });
+
+    vcrTest('errors with invalid project id', async () => {
+      await authenticate();
+      const client = await init('nonexistent-project');
+
+      expect(client.getAgents()).rejects.toMatchObject({
+        data: null,
+        error: {
+          detail: 'Project not found',
+        },
+      });
+    });
+  });
+});

--- a/sdks/node/src/__tests__/weaveClient.test.ts
+++ b/sdks/node/src/__tests__/weaveClient.test.ts
@@ -22,6 +22,7 @@ function createStreamFromCalls(calls: any[] = []) {
   });
   return stream;
 }
+
 function mockStreamResponse(
   api: jest.Mocked<TraceServerApi<any>>,
   calls: any[]
@@ -34,15 +35,23 @@ function mockStreamResponse(
   } as any);
 }
 
+type MockedTraceServer = jest.Mocked<TraceServerApi<any>> & {
+  calls: {callsQueryStreamCallsStreamQueryPost: jest.Mock};
+  agents: {genaiAgentsQueryAgentsQueryPost: jest.Mock};
+};
+
 describe('WeaveClient', () => {
   let client: WeaveClient;
-  let mockTraceServerApi: jest.Mocked<TraceServerApi<any>>;
+  let mockTraceServerApi: MockedTraceServer;
   let mockWandbServerApi: jest.Mocked<WandbServerApi>;
 
   beforeEach(() => {
     mockTraceServerApi = {
       calls: {
         callsQueryStreamCallsStreamQueryPost: jest.fn(),
+      },
+      agents: {
+        genaiAgentsQueryAgentsQueryPost: jest.fn(),
       },
     } as any;
     mockWandbServerApi = {} as any;
@@ -356,6 +365,62 @@ describe('WeaveClient', () => {
       expect(client.getCall('non-existent-id')).rejects.toThrow(
         'Call not found: non-existent-id'
       );
+    });
+  });
+
+  describe('getAgents', () => {
+    it('gets agents from the server', async () => {
+      const agents = [{agent_name: 'Assistant', total_input_tokens: 42}];
+      mockTraceServerApi.agents.genaiAgentsQueryAgentsQueryPost.mockResolvedValue(
+        {data: {agents, total_count: 1}} as any
+      );
+
+      const result = await client.getAgents({
+        limit: 50,
+        offset: 10,
+        sortBy: [{field: 'last_seen', direction: 'desc'}],
+      });
+
+      expect(
+        mockTraceServerApi.agents.genaiAgentsQueryAgentsQueryPost
+      ).toHaveBeenCalledWith({
+        project_id: 'test-project',
+        sort_by: [{field: 'last_seen', direction: 'desc'}],
+        limit: 50,
+        offset: 10,
+      });
+
+      expect(result).toEqual({data: {agents, total_count: 1}});
+    });
+
+    it('gets agent by name', async () => {
+      const agents = [{agent_name: 'Assistant', total_input_tokens: 42}];
+      mockTraceServerApi.agents.genaiAgentsQueryAgentsQueryPost.mockResolvedValue(
+        {data: {agents, total_count: 1}} as any
+      );
+
+      const result = await client.getAgents({
+        agentName: 'my-cool-agent',
+      });
+
+      expect(
+        mockTraceServerApi.agents.genaiAgentsQueryAgentsQueryPost
+      ).toHaveBeenCalledWith({
+        project_id: 'test-project',
+        filters: {
+          agent_name: 'my-cool-agent',
+        },
+      });
+
+      expect(result).toEqual({data: {agents, total_count: 1}});
+    });
+
+    it('propagates errors from the underlying API', async () => {
+      mockTraceServerApi.agents.genaiAgentsQueryAgentsQueryPost.mockRejectedValue(
+        new Error('boom')
+      );
+
+      await expect(client.getAgents()).rejects.toThrow('boom');
     });
   });
 

--- a/sdks/node/src/index.ts
+++ b/sdks/node/src/index.ts
@@ -11,11 +11,20 @@ export {EvaluationLogger, ScoreLogger} from './evaluationLogger';
 export type {
   CallSchema,
   CallsFilter,
+  HttpResponse,
+  HTTPValidationError,
   Query,
   SortBy,
 } from './generated/traceServerApi';
 export type {Settings} from './settings';
-export type {GetCallsOptions, WeaveClient} from './weaveClient';
+export type {
+  Agent,
+  GetAgentsOptions,
+  GetAgentsResult,
+  GetCallsOptions,
+  Response,
+  WeaveClient,
+} from './weaveClient';
 export {
   wrapOpenAI,
   wrapGoogleGenAI,

--- a/sdks/node/src/weaveClient.ts
+++ b/sdks/node/src/weaveClient.ts
@@ -5,6 +5,7 @@ import {uuidv7} from 'uuidv7';
 import {MAX_OBJECT_NAME_LENGTH} from './constants';
 import {computeDigest} from './digest';
 import {
+  type AgentSchema,
   type CallSchema,
   type CallsQueryReq,
   type CallsFilter,
@@ -13,6 +14,8 @@ import {
   type SortBy,
   type StartedCallSchemaForInsert,
   type Api as TraceServerApi,
+  type HttpResponse,
+  type HTTPValidationError,
 } from './generated/traceServerApi';
 import {
   type AudioType,
@@ -45,6 +48,8 @@ import type {Prompt} from './prompt';
 
 const WEAVE_ERRORS_LOG_FNAME = 'weaveErrors.log';
 const DEFAULT_GET_CALLS_LIMIT = 1000;
+
+export type Response<T extends unknown> = HttpResponse<T, HTTPValidationError>;
 
 /**
  * Serialized representation of a file blob stored in the Weave content store.
@@ -83,6 +88,26 @@ export interface GetCallsOptions {
   columns?: string[];
   expandColumns?: string[];
 }
+
+export type Agent = AgentSchema;
+
+/**
+ * Options for {@link WeaveClient.getAgents}.
+ */
+export interface GetAgentsOptions {
+  agentName?: string;
+  limit?: number;
+  offset?: number;
+  sortBy?: SortBy[];
+}
+
+/**
+ * Result shape returned by {@link WeaveClient.getAgents}.
+ */
+export type GetAgentsResult = {
+  agents: Agent[];
+  total_count?: number;
+};
 
 /**
  * Distinguishes the object-based getCalls options form from the legacy
@@ -200,6 +225,40 @@ export class WeaveClient {
     this.traceServerApi = traceServerApi;
     this.projectId = projectId;
     this.settings = makeSettings(settings);
+  }
+
+  /**
+   * List agents with aggregated stats.
+   *
+   * @example
+   * ```ts
+   * const client = await weave.init('entity/project');
+   * const resp = await client.getAgents({limit: 20});
+   *
+   * for (const agent of resp.data.agents) {
+   *   console.log(agent.agent_name, agent.total_input_tokens);
+   * }
+   *
+   * console.log(`total count: ${resp.data.total_count}`)
+   * ```
+   */
+  public getAgents(
+    options: GetAgentsOptions = {}
+  ): Promise<Response<GetAgentsResult>> {
+    const params = {
+      project_id: this.projectId,
+      sort_by: options.sortBy,
+      limit: options.limit,
+      offset: options.offset,
+    };
+
+    if (options.agentName) {
+      Object.assign(params, {
+        filters: {agent_name: options.agentName},
+      });
+    }
+
+    return this.traceServerApi.agents.genaiAgentsQueryAgentsQueryPost(params);
   }
 
   private scheduleBatchProcessing() {


### PR DESCRIPTION
## Description

* Adds `getAgents` to `WeaveClient`.

* Exposes associated types in the public API to link through reference docs. Maintains a thin wrapper on top of codegen'ed types to more tightly control the SDK interface.


