### PR TITLE
test(weave): isolate replicated-cluster env in on-cluster query builder test

### DIFF
--- a/tests/trace_server/query_builder/test_on_cluster_query_builder.py
+++ b/tests/trace_server/query_builder/test_on_cluster_query_builder.py
@@ -168,6 +168,7 @@ def test_annotation_queue_mutations_use_caller_provided_local_name() -> None:
     ids=["cloud", "replicated", "distributed"],
 )
 def test_calls_complete_table_resolution_by_mode(
+    monkeypatch: pytest.MonkeyPatch,
     use_distributed: bool,
     cluster_name: str | None,
     expected_table: str,
@@ -180,27 +181,30 @@ def test_calls_complete_table_resolution_by_mode(
     in replicated mode (cluster_name set, distributed=False), the old code produced
     'calls_complete_local ON CLUSTER ...' but calls_complete_local doesn't exist.
     """
-    env_vars = {
-        "WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES": str(use_distributed).lower(),
-    }
+    monkeypatch.setenv(
+        "WF_CLICKHOUSE_USE_DISTRIBUTED_TABLES", str(use_distributed).lower()
+    )
+    # delenv (not just skip-set): replicated CI sets this ambiently, so the
+    # cloud case must clear it to exercise the no-cluster path.
     if cluster_name:
-        env_vars["WF_CLICKHOUSE_REPLICATED_CLUSTER"] = cluster_name
+        monkeypatch.setenv("WF_CLICKHOUSE_REPLICATED_CLUSTER", cluster_name)
+    else:
+        monkeypatch.delenv("WF_CLICKHOUSE_REPLICATED_CLUSTER", raising=False)
 
-    with patch.dict("os.environ", env_vars, clear=False):
-        table_name = (
-            "calls_complete_local"
-            if wf_env.wf_clickhouse_use_distributed_tables()
-            else "calls_complete"
-        )
-        result = _format_table_name_with_cluster(
-            table_name, wf_env.wf_clickhouse_replicated_cluster()
-        )
-        expected = (
-            f"{expected_table} ON CLUSTER {cluster_name}"
-            if expected_on_cluster
-            else expected_table
-        )
-        assert result == expected
+    table_name = (
+        "calls_complete_local"
+        if wf_env.wf_clickhouse_use_distributed_tables()
+        else "calls_complete"
+    )
+    result = _format_table_name_with_cluster(
+        table_name, wf_env.wf_clickhouse_replicated_cluster()
+    )
+    expected = (
+        f"{expected_table} ON CLUSTER {cluster_name}"
+        if expected_on_cluster
+        else expected_table
+    )
+    assert result == expected
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- `test_calls_complete_table_resolution_by_mode[cloud]` reads `wf_clickhouse_replicated_cluster()` unconditionally. The replicated nightly leg sets `WF_CLICKHOUSE_REPLICATED_CLUSTER=weave_cluster` in the job env and `patch.dict(clear=False)` let it leak, so the cloud case got `calls_complete ON CLUSTER weave_cluster` instead of `calls_complete`. Red on every replicated `trace_server` shard; single-node passed only because the var is unset there.
- Switch to `monkeypatch` + `delenv` so the no-cluster case is hermetic.

## Testing
ran the file with `WF_CLICKHOUSE_REPLICATED_CLUSTER=weave_cluster` set: `[cloud]` fails before, all 9 pass after.