### PR TITLE
fix(weave): scope gcs credentials for keep-alive session

### DIFF
--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -13,11 +13,13 @@ import boto3
 import pytest
 from azure.core.exceptions import ResourceExistsError
 from google.api_core import exceptions
+from google.auth import credentials as ga_credentials
+from google.cloud import storage
 from moto import mock_aws
 
 from weave.shared.digest import compute_file_digest
 from weave.trace.weave_client import WeaveClient
-from weave.trace_server import clickhouse_trace_server_settings
+from weave.trace_server import clickhouse_trace_server_settings, file_storage
 from weave.trace_server.trace_server_interface import FileContentReadReq, FileCreateReq
 
 # Test Data Constants
@@ -231,6 +233,50 @@ class TestGCSStorage:
                 FileContentReadReq(project_id=client.project_id, digest=res1.digest)
             )
             assert file.content == TEST_CONTENT
+
+
+class _ScopedFakeCredentials(ga_credentials.Credentials, ga_credentials.Scoped):
+    """Service-account-like credentials that require scoping before use."""
+
+    def __init__(self, scopes: list[str] | None = None):
+        super().__init__()
+        self._scopes = scopes
+
+    @property
+    def requires_scopes(self) -> bool:
+        return not self._scopes
+
+    @property
+    def scopes(self) -> list[str] | None:
+        return self._scopes
+
+    def with_scopes(self, scopes, default_scopes=None) -> "_ScopedFakeCredentials":
+        return _ScopedFakeCredentials(scopes=list(scopes))
+
+    def refresh(self, request) -> None:
+        self.token = "fake-token"
+
+
+def test_keepalive_gcs_client_scopes_credentials_for_session():
+    """Regression for #7221: the keep-alive GCS session must carry scoped credentials."""
+    expected_scopes = list(storage.Client.SCOPE)
+
+    unscoped = _ScopedFakeCredentials()
+    assert unscoped.requires_scopes
+    client = file_storage._build_keepalive_gcs_client(unscoped)
+
+    # The session that mints tokens must hold scoped creds, else invalid_scope.
+    assert client._http.credentials.scopes == expected_scopes
+    assert not client._http.credentials.requires_scopes
+    assert isinstance(
+        client._http.get_adapter("https://storage.googleapis.com"),
+        file_storage._KeepAliveHTTPAdapter,
+    )
+
+    # Already-scoped creds (local user creds) pass through, so prod-only repro.
+    prescoped = _ScopedFakeCredentials(scopes=["existing-scope"])
+    passthrough = file_storage._build_keepalive_gcs_client(prescoped)
+    assert passthrough._http.credentials.scopes == ["existing-scope"]
 
 
 class TestAzureStorage:

--- a/weave/trace_server/file_storage.py
+++ b/weave/trace_server/file_storage.py
@@ -53,6 +53,7 @@ from botocore.config import Config
 from botocore.exceptions import ClientError
 from google.api_core import exceptions as gcp_exceptions
 from google.auth import default as google_auth_default
+from google.auth.credentials import with_scopes_if_required
 from google.auth.transport.requests import AuthorizedSession
 from google.cloud import storage
 from google.oauth2.credentials import Credentials as GCPCredentials
@@ -449,12 +450,17 @@ def _build_keepalive_gcs_client(credentials: GCPCredentials | None) -> storage.C
         resolved_credentials, project = google_auth_default()
     else:
         resolved_credentials = credentials
-    session = AuthorizedSession(resolved_credentials)
+    # A custom _http session bypasses storage.Client's built-in credential
+    # scoping, so scope here or service-account token refresh hits invalid_scope.
+    scoped_credentials = with_scopes_if_required(
+        resolved_credentials, list(storage.Client.SCOPE)
+    )
+    session = AuthorizedSession(scoped_credentials)
     adapter = _KeepAliveHTTPAdapter(pool_maxsize=GCS_POOL_MAXSIZE)
     session.mount("https://", adapter)
     session.mount("http://", adapter)
     return storage.Client(
-        credentials=resolved_credentials, project=project, _http=session
+        credentials=scoped_credentials, project=project, _http=session
     )
 
 


### PR DESCRIPTION
## Summary
- Re-lands the keep-alive GCS fix from #7221 (6f6eb98), which took down 100% of prod file reads+writes with `invalid_scope`.
- Root cause: that PR built a custom `AuthorizedSession` + `_http=` client, which bypasses `storage.Client`'s built-in credential scoping. Prod service-account creds were left unscoped, so every GCS token refresh failed. Local/user creds already carry scopes, which is why it passed pre-merge. Fix: `with_scopes_if_required(creds, storage.Client.SCOPE)`.
- Impact: 17 distinct users / 14 entities, ~22:02-22:09 UTC on 2026-06-15 (deploy rolled back).

## Testing
regression test in `test_server_file_storage.py`: asserts the session credentials are GCS-scoped. fails on pre-fix code (session creds unscoped -> `scopes is None`), passes after.