### PR TITLE
chore(weave): tidy agent_name_override resolver and tests

### DIFF
--- a/tests/integrations/openai_agents/openai_agents_otel_test.py
+++ b/tests/integrations/openai_agents/openai_agents_otel_test.py
@@ -215,34 +215,26 @@ def test_agent_span_carries_provider_name(
 
 
 def test_agent_name_override_wins_over_native(
-    client: WeaveClient, otel_spans: InMemorySpanExporter
+    otel_spans: InMemorySpanExporter,
 ) -> None:
-    """An explicit override replaces the SDK-native agent name on the span."""
-    processor = WeaveOtelTracingProcessor()
-    trace = Mock(spec=Trace)
-    trace.trace_id = "trace_o"
-    trace.name = "wf"
-    trace.group_id = None
-
+    """An override replaces the SDK-native agent name on the emitted span."""
     agent_span = Mock(spec=Span)
-    agent_span.trace_id = "trace_o"
-    agent_span.span_id = "span_o"
-    agent_span.parent_id = None
     agent_span.span_data = AgentSpanData(name="Bot")
-    agent_span.started_at = None
-    agent_span.ended_at = None
-    agent_span.error = None
+    agent_span.span_id = "s1"
+    agent_span.trace_id = "t1"
+    agent_span.parent_id = None
+    # Timing/error aren't asserted here, but the processor reads them.
+    agent_span.started_at = agent_span.ended_at = agent_span.error = None
 
-    # The name is resolved at span start/end, so the override must be active then.
+    processor = WeaveOtelTracingProcessor()
     with agent_name_override("research_agent"):
-        processor.on_trace_start(trace)
         processor.on_span_start(agent_span)
         processor.on_span_end(agent_span)
-        processor.on_trace_end(trace)
 
-    spans = otel_spans.get_finished_spans()
     agent = next(
-        s for s in spans if _attrs(s).get("gen_ai.operation.name") == "invoke_agent"
+        s
+        for s in otel_spans.get_finished_spans()
+        if _attrs(s).get("gen_ai.operation.name") == "invoke_agent"
     )
     assert agent.name == "invoke_agent research_agent"
     assert _attrs(agent)["gen_ai.agent.name"] == "research_agent"

--- a/tests/session/test_agent_context.py
+++ b/tests/session/test_agent_context.py
@@ -1,7 +1,15 @@
 """Unit tests for the generic agent-name override.
 
-Exercises ``weave.session.agent_name_override`` and the internal
-``resolve_agent_name`` resolver that auto-instrumentation integrations call.
+These exercise the integration-agnostic mechanism only:
+``weave.session.agent_name_override`` (the public context manager) and the
+internal ``resolve_agent_name_or_default(default)`` that auto-instrumentation integrations
+call when naming their ``invoke_agent`` span.
+
+``resolve_agent_name_or_default(default)`` returns the user's active override
+when one is set, otherwise the ``default`` name the calling integration would use
+on its own (claude uses ``"claude_agent_sdk"``; openai_agents uses the SDK-native
+agent name). The agent names below are illustrative — the resolver is
+integration-agnostic and doesn't know who is calling.
 """
 
 from __future__ import annotations
@@ -9,28 +17,42 @@ from __future__ import annotations
 import pytest
 
 from weave.session import agent_name_override
-from weave.session.agent_context import resolve_agent_name
+from weave.session.agent_context import resolve_agent_name_or_default
 
 
-def test_resolve_returns_default_when_unset() -> None:
-    assert resolve_agent_name("claude_agent_sdk") == "claude_agent_sdk"
+def test_no_override_keeps_the_default_name() -> None:
+    # No override active: the agent keeps the default name it would otherwise get.
+    assert resolve_agent_name_or_default("default_agent_name") == "default_agent_name"
 
 
-def test_override_wins_over_default_and_native_name() -> None:
-    with agent_name_override("researcher"):
-        # over an integration default...
-        assert resolve_agent_name("claude_agent_sdk") == "researcher"
-        # ...and over a non-empty SDK-native name.
-        assert resolve_agent_name("Assistant") == "researcher"
+def test_override_replaces_the_default_name() -> None:
+    # A user labels their agent; that name is what gets used...
+    with agent_name_override("research_agent"):
+        assert resolve_agent_name_or_default("default_agent_name") == "research_agent"
+        # ...and it wins no matter what default the integration would have used.
+        assert (
+            resolve_agent_name_or_default("customer_support_agent") == "research_agent"
+        )
 
 
 def test_nested_overrides_restore_outer_then_default() -> None:
-    with agent_name_override("outer"):
-        assert resolve_agent_name("d") == "outer"
-        with agent_name_override("inner"):
-            assert resolve_agent_name("d") == "inner"
-        assert resolve_agent_name("d") == "outer"
-    assert resolve_agent_name("d") == "d"
+    with agent_name_override("research_agent"):
+        assert resolve_agent_name_or_default("default_agent_name") == "research_agent"
+        with agent_name_override("summarizer_agent"):
+            assert (
+                resolve_agent_name_or_default("default_agent_name")
+                == "summarizer_agent"
+            )
+        assert resolve_agent_name_or_default("default_agent_name") == "research_agent"
+    assert resolve_agent_name_or_default("default_agent_name") == "default_agent_name"
+
+
+def test_none_default_coalesces_to_empty_string() -> None:
+    # An integration that didn't name the agent passes None; the resolver returns
+    # "" so callers never have to write `or ""`. An override still wins.
+    assert resolve_agent_name_or_default(None) == ""
+    with agent_name_override("research_agent"):
+        assert resolve_agent_name_or_default(None) == "research_agent"
 
 
 @pytest.mark.parametrize("bad_name", ["", "   ", "\n\t"])

--- a/weave/integrations/claude_agent_sdk/otel_integration.py
+++ b/weave/integrations/claude_agent_sdk/otel_integration.py
@@ -42,7 +42,7 @@ from opentelemetry.trace import StatusCode
 
 from weave.integrations.integration_metadata import library_integration
 from weave.integrations.patcher import MultiPatcher, NoOpPatcher, SymbolPatcher
-from weave.session.agent_context import resolve_agent_name
+from weave.session.agent_context import resolve_agent_name_or_default
 from weave.session.session_otel import (
     execute_tool_attributes,
     invoke_agent_attributes,
@@ -321,7 +321,7 @@ async def _trace_turn(
     tracer = _tracer()
     # Resolve once here: this runs on the first __anext__, inside the user's
     # ``agent_name_override(...)`` block, so the override contextvar is visible.
-    agent_name = resolve_agent_name(_DEFAULT_AGENT_NAME)
+    agent_name = resolve_agent_name_or_default(_DEFAULT_AGENT_NAME)
     root = tracer.start_span(f"invoke_agent {agent_name}")
     token = otel_context.attach(otel_trace.set_span_in_context(root))
     state = _TurnState(user_prompt=user_prompt, agent_name=agent_name)

--- a/weave/integrations/openai_agents/otel_processor.py
+++ b/weave/integrations/openai_agents/otel_processor.py
@@ -72,7 +72,7 @@ from weave.session.adapters.openai import (
     reasoning_from_openai_responses,
     usage_from_openai_responses,
 )
-from weave.session.agent_context import resolve_agent_name
+from weave.session.agent_context import resolve_agent_name_or_default
 from weave.session.session_otel import (
     execute_tool_attributes,
     invoke_agent_attributes,
@@ -142,7 +142,7 @@ def _agent_attrs(span: Span[AgentSpanData], conversation_id: str) -> dict[str, A
     sd = span.span_data
     attrs = invoke_agent_attributes(
         # An explicit ambient override wins over the SDK-native agent name.
-        agent_name=resolve_agent_name(sd.name or ""),
+        agent_name=resolve_agent_name_or_default(sd.name),
         conversation_id=conversation_id,
         provider_name=_PROVIDER_NAME,
     )
@@ -633,7 +633,7 @@ def _otel_span_name(span: Span) -> str:
     if isinstance(sd, AgentSpanData):
         # Keep the span name aligned with gen_ai.agent.name in _agent_attrs:
         # an explicit ambient override wins over the SDK-native name.
-        return f"invoke_agent {resolve_agent_name(name)}"
+        return f"invoke_agent {resolve_agent_name_or_default(name)}"
     if _is_task_span_data(sd):
         # Structural span — NOT invoke_agent, since a Task wraps a workflow
         # not an agent. See _task_attrs.

--- a/weave/session/agent_context.py
+++ b/weave/session/agent_context.py
@@ -55,11 +55,15 @@ def agent_name_override(agent_name: str) -> Iterator[None]:
         _current_agent_name.reset(token)
 
 
-def resolve_agent_name(default: str) -> str:
-    """Return the ambient override if one is set, else ``default``.
+def resolve_agent_name_or_default(default: str | None) -> str:
+    """Return the active override if one is set, else ``default`` (or ``""``).
 
     Precedence at an auto-instrumentation call site: explicit override >
-    integration-native name (passed as ``default``) > integration default.
+    integration-native name (passed as ``default``) > ``""``. ``default`` may be
+    ``None`` (e.g. an SDK that didn't name the agent); it is coalesced to ``""``
+    so callers never have to, and the return is always a ``str``.
     """
     override = _current_agent_name.get()
-    return override if override is not None else default
+    if override is not None:
+        return override
+    return default or ""


### PR DESCRIPTION
Follow-up to #7219. That PR was opened as a draft, but it **merged** before this round of review feedback was committed — so these refinements land as their own PR. **No behavior change** to the public `weave.session.agent_name_override` API.

## Changes (all review feedback on #7219)

- **Rename** `resolve_agent_name` → `resolve_agent_name_or_default` — clearer about what it returns.
- **Drop the `or ""` at call sites.** The resolver now takes `str | None` and coalesces to `""` internally, so callers don't have to:
  ```python
  agent_name=resolve_agent_name_or_default(sd.name)   # was: resolve_agent_name(sd.name or "")
  ```
- **Generic unit test reads generically.** `tests/session/test_agent_context.py` now uses integration-agnostic, user-meaningful names (`default_agent_name`, `research_agent`, …) instead of integration internals, and adds a `None`-default coalescing test.
- **Leaner openai_agents override test.** Driven through `Mock(spec=Span)` + `on_span_start`/`on_span_end` (the public path) — no `Trace` mock, no `on_trace_start`/`on_trace_end`, no `client` fixture, and no reaching into processor internals.

## Testing
- `tests/session/test_agent_context.py`, the claude OTel suite, and the openai_agents override test all pass (22).
- `ruff check` + `ruff format --check` clean.