### PR TITLE
feat(weave): send trace_id on calls-ingest requests that lack it

### DIFF
--- a/tests/trace_server_bindings/test_http_behavior_remote.py
+++ b/tests/trace_server_bindings/test_http_behavior_remote.py
@@ -28,6 +28,7 @@ from weave.trace_server_bindings.async_batch_processor import AsyncBatchProcesso
 from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
 from weave.trace_server_bindings.http_utils import (
     ERROR_CODE_CALLS_COMPLETE_MODE_REQUIRED,
+    TRACE_ID_HEADER,
 )
 from weave.trace_server_bindings.models import (
     CompleteBatchItem,
@@ -49,6 +50,11 @@ def make_calls_complete_required_response() -> httpx.Response:
         },
         request=httpx.Request("POST", "http://example.com/call/upsert_batch"),
     )
+
+
+def _request_headers(mock_call) -> dict:
+    """Pull the headers kwarg from a mocked http_requests.* call."""
+    return mock_call.kwargs.get("headers", {})
 
 
 @pytest.fixture
@@ -143,11 +149,15 @@ def test_eager_calls_use_v2_start_end_endpoints(mock_post):
     server = RemoteHTTPTraceServer("http://example.com", should_batch=True)
 
     start = generate_start(id="call-id", project_id="entity/project")
+    start.trace_id = "trace-eager-start"
     ended_at = datetime.datetime.now(tz=datetime.timezone.utc)
     started_at = ended_at - datetime.timedelta(seconds=1)
+    # Distinct from the start's trace_id so the assertions below prove each
+    # post stamps its OWN item's trace_id, not a single shared value.
     end = tsi.EndedCallSchemaForInsertWithStartedAt(
         project_id="entity/project",
         id="call-id",
+        trace_id="trace-eager-end",
         ended_at=ended_at,
         started_at=started_at,
         summary={"result": "Test summary"},
@@ -171,6 +181,17 @@ def test_eager_calls_use_v2_start_end_endpoints(mock_post):
             "http://example.com/v2/entity/project/call/start",
             "http://example.com/v2/entity/project/call/end",
         ]
+
+        # Both eager v2 single-call posts carry the X-Weave-Trace-Id header
+        # (this is the path Evaluation.evaluate eager ops use).
+        assert (
+            _request_headers(mock_post.call_args_list[0])[TRACE_ID_HEADER]
+            == start.trace_id
+        )
+        assert (
+            _request_headers(mock_post.call_args_list[1])[TRACE_ID_HEADER]
+            == end.trace_id
+        )
 
         end_payload = json.loads(mock_post.call_args_list[1][1]["data"].decode("utf-8"))
         payload_started_at = datetime.datetime.fromisoformat(
@@ -456,6 +477,163 @@ def test_eager_calls_complete_required_is_reraised(mock_post, monkeypatch):
             server._flush_calls_eager([start])
     finally:
         if server.call_processor and server.call_processor.is_accepting_new_work():
+            server.call_processor.stop_accepting_new_work_and_flush_queue()
+        if server.feedback_processor:
+            server.feedback_processor.stop_accepting_new_work_and_flush_queue()
+
+
+# =============================================================================
+# X-Weave-Trace-Id on single-call ingest requests + trace_id in end bodies
+#
+# A future server-side ingest sampler needs the trace_id where it can read it
+# cheaply: in a header for single calls (the door reads it before parsing the
+# body) and in the body for batched end-parts (a hook parses the batch). These
+# tests pin both wiring points and the backward-compatible "no trace_id" case.
+# =============================================================================
+
+
+@patch("weave.utils.http_requests.post")
+def test_call_start_single_sends_trace_id_header(mock_post, unbatched_server):
+    """Single /call/start attaches the trace_id as the X-Weave-Trace-Id header."""
+    call_id = generate_id()
+    mock_post.return_value = httpx.Response(
+        200,
+        json=dict(tsi.CallStartRes(id=call_id, trace_id="test_trace_id")),
+        request=httpx.Request("POST", "http://test.com"),
+    )
+
+    start = generate_start(call_id)
+    unbatched_server.call_start(tsi.CallStartReq(start=start))
+
+    assert _request_headers(mock_post.call_args)[TRACE_ID_HEADER] == start.trace_id
+
+
+@patch("weave.utils.http_requests.post")
+def test_call_end_single_sends_trace_id_header_and_body(mock_post, unbatched_server):
+    """Single /call/end carries trace_id in both the header and the body."""
+    call_id = generate_id()
+    mock_post.return_value = httpx.Response(
+        200, json={}, request=httpx.Request("POST", "http://test.com")
+    )
+
+    end = tsi.EndedCallSchemaForInsert(
+        project_id="test",
+        id=call_id,
+        trace_id="trace-456",
+        ended_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        summary={"result": "ok"},
+    )
+    unbatched_server.call_end(tsi.CallEndReq(end=end))
+
+    assert _request_headers(mock_post.call_args)[TRACE_ID_HEADER] == "trace-456"
+    body = json.loads(mock_post.call_args.kwargs["data"].decode("utf-8"))
+    assert body["end"]["trace_id"] == "trace-456"
+
+
+@patch("weave.utils.http_requests.post")
+def test_call_end_single_without_trace_id_omits_header(mock_post, unbatched_server):
+    """Backward compat: an end with no trace_id sends no X-Weave-Trace-Id header."""
+    call_id = generate_id()
+    mock_post.return_value = httpx.Response(
+        200, json={}, request=httpx.Request("POST", "http://test.com")
+    )
+
+    end = tsi.EndedCallSchemaForInsert(
+        project_id="test",
+        id=call_id,
+        ended_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        summary={"result": "ok"},
+    )
+    unbatched_server.call_end(tsi.CallEndReq(end=end))
+
+    assert TRACE_ID_HEADER not in _request_headers(mock_post.call_args)
+
+
+@patch("weave.utils.http_requests.post")
+def test_call_start_v2_sends_trace_id_header(mock_post, unbatched_server):
+    """v2 single /call/start attaches the X-Weave-Trace-Id header."""
+    mock_post.return_value = httpx.Response(
+        200,
+        json=dict(tsi.CallStartV2Res(id="call-id", trace_id="trace-v2-start")),
+        request=httpx.Request("POST", "http://test.com"),
+    )
+
+    start = generate_start(id="call-id", project_id="entity/project")
+    start.trace_id = "trace-v2-start"
+    unbatched_server.call_start_v2(tsi.CallStartV2Req(start=start))
+
+    assert (
+        mock_post.call_args[0][0] == "http://example.com/v2/entity/project/call/start"
+    )
+    assert _request_headers(mock_post.call_args)[TRACE_ID_HEADER] == "trace-v2-start"
+
+
+@patch("weave.utils.http_requests.post")
+def test_call_end_v2_sends_trace_id_header(mock_post, unbatched_server):
+    """v2 single /call/end attaches the X-Weave-Trace-Id header."""
+    mock_post.return_value = httpx.Response(
+        200, json={}, request=httpx.Request("POST", "http://test.com")
+    )
+
+    ended_at = datetime.datetime.now(tz=datetime.timezone.utc)
+    end = tsi.EndedCallSchemaForInsertWithStartedAt(
+        project_id="entity/project",
+        id="call-id",
+        trace_id="trace-v2",
+        ended_at=ended_at,
+        started_at=ended_at - datetime.timedelta(seconds=1),
+        summary={"result": "ok"},
+    )
+    unbatched_server.call_end_v2(tsi.CallEndV2Req(end=end))
+
+    assert mock_post.call_args[0][0] == "http://example.com/v2/entity/project/call/end"
+    assert _request_headers(mock_post.call_args)[TRACE_ID_HEADER] == "trace-v2"
+
+
+@patch("weave.utils.http_requests.post")
+def test_legacy_upsert_batch_end_carries_trace_id_in_body(mock_post):
+    """Legacy /call/upsert_batch end-parts carry trace_id in the body (hook path)."""
+    server = RemoteHTTPTraceServer("http://example.com", should_batch=True)
+    mock_post.return_value = httpx.Response(
+        200, json={}, request=httpx.Request("POST", "http://example.com")
+    )
+
+    call_id = "call-id"
+    start = StartBatchItem(
+        req=tsi.CallStartReq(start=generate_start(call_id, "entity/project"))
+    )
+    end = EndBatchItem(
+        req=tsi.CallEndReq(
+            end=tsi.EndedCallSchemaForInsert(
+                project_id="entity/project",
+                id=call_id,
+                trace_id="trace-batch",
+                ended_at=datetime.datetime.now(tz=datetime.timezone.utc),
+                summary={"result": "ok"},
+            )
+        )
+    )
+
+    try:
+        server._flush_calls([start, end])
+
+        urls = [call[0][0] for call in mock_post.call_args_list]
+        assert urls
+        assert all(url == "http://example.com/call/upsert_batch" for url in urls)
+        # A batch can span many traces, so it must NOT carry the per-trace
+        # header; the hook reads trace_id from each item's body instead.
+        for call in mock_post.call_args_list:
+            assert TRACE_ID_HEADER not in _request_headers(call)
+        end_items = [
+            item
+            for call in mock_post.call_args_list
+            for item in json.loads(call.kwargs["data"].decode("utf-8"))["batch"]
+            if item.get("mode") == "end"
+        ]
+        assert end_items, "expected an end item in the posted batch"
+        assert end_items[0]["req"]["end"]["trace_id"] == "trace-batch"
+    finally:
+        if server.call_processor:
             server.call_processor.stop_accepting_new_work_and_flush_queue()
         if server.feedback_processor:
             server.feedback_processor.stop_accepting_new_work_and_flush_queue()

--- a/weave/trace/weave_client.py
+++ b/weave/trace/weave_client.py
@@ -1258,6 +1258,7 @@ class WeaveClient:
                 end=EndedCallSchemaForInsertWithStartedAt(
                     project_id=project_id,
                     id=call.id,
+                    trace_id=call.trace_id,
                     started_at=call.started_at,
                     ended_at=ended_at,
                     output=output_json,

--- a/weave/trace_server/trace_server_interface.py
+++ b/weave/trace_server/trace_server_interface.py
@@ -222,6 +222,13 @@ class EndedCallSchemaForInsert(BaseModel):
     project_id: str
     id: str
 
+    # Trace ID. Optional for backward compatibility: older clients omit it and
+    # the server derives it from the matching call-start. Carried here so a
+    # server-side ingest sampler can make a consistent keep/drop decision on the
+    # call-end message too. One field covers /call/end, the end-parts of
+    # /call/upsert_batch, and v2 call/end (via EndedCallSchemaForInsertWithStartedAt).
+    trace_id: str | None = None
+
     # End time is required
     ended_at: datetime.datetime
 

--- a/weave/trace_server_bindings/http_utils.py
+++ b/weave/trace_server_bindings/http_utils.py
@@ -24,6 +24,12 @@ _ENDPOINT_CACHE: set[str] = set()
 REMOTE_REQUEST_BYTES_LIMIT = (32 - 1) * 1024 * 1024
 ROW_COUNT_CHUNKING_THRESHOLD = 1000
 
+# Request header carrying the call's trace_id on single-call ingest requests
+# (/call/start, /call/end and their v2 variants). Lets a server-side ingest
+# sampler make a consistent keep/drop decision per trace before the body is
+# parsed, the same cheap-header pattern RequestSizeLimitMiddleware already uses.
+TRACE_ID_HEADER = "X-Weave-Trace-Id"
+
 # Fixed wait between 404 retries. Short, because eventual-consistency windows
 # on reads-after-write are typically sub-second; longer waits just pad latency
 # when the object is genuinely missing.

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -25,6 +25,7 @@ from weave.trace_server_bindings.call_batch_processor import CallBatchProcessor
 from weave.trace_server_bindings.client_interface import TraceServerClientInterface
 from weave.trace_server_bindings.http_utils import (
     REMOTE_REQUEST_BYTES_LIMIT,
+    TRACE_ID_HEADER,
     CallsCompleteModeRequired,
     handle_response_error,
     log_dropped_call_batch,
@@ -109,11 +110,20 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
     def set_auth(self, auth: tuple[str, str]) -> None:
         self._auth = auth
 
-    def _build_dynamic_request_headers(self) -> dict[str, str]:
-        """Build headers for HTTP requests, including extra headers and retry ID."""
+    def _build_dynamic_request_headers(
+        self, trace_id: str | None = None
+    ) -> dict[str, str]:
+        """Build headers for HTTP requests, including extra headers and retry ID.
+
+        When ``trace_id`` is provided (single-call ingest requests), it is
+        attached as ``X-Weave-Trace-Id`` so a server-side ingest sampler can
+        decide keep/drop per trace without parsing the body.
+        """
         headers = dict(self._extra_headers) if self._extra_headers else {}
         if retry_id := get_current_retry_id():
             headers["X-Weave-Retry-Id"] = retry_id
+        if trace_id is not None:
+            headers[TRACE_ID_HEADER] = trace_id
         return headers
 
     def get(self, url: str, *args: Any, **kwargs: Any) -> httpx.Response:
@@ -127,14 +137,16 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             **kwargs,
         )
 
-    def post(self, url: str, *args: Any, **kwargs: Any) -> httpx.Response:
-        headers = self._build_dynamic_request_headers()
+    def post(
+        self, url: str, *args: Any, trace_id: str | None = None, **kwargs: Any
+    ) -> httpx.Response:
+        headers = self._build_dynamic_request_headers(trace_id=trace_id)
 
         return http_requests.post(
             self.trace_server_url + url,
             *args,
             auth=self._auth,
-            headers=headers,
+            headers={**headers, **kwargs.pop("headers", {})},
             **kwargs,
         )
 
@@ -300,7 +312,11 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         entity, project = project_id.split("/", 1)
         url = f"/v2/{entity}/{project}/call/start"
         req = tsi.CallStartV2Req(start=start)
-        r = self.post(url, data=req.model_dump_json().encode("utf-8"))
+        r = self.post(
+            url,
+            data=req.model_dump_json().encode("utf-8"),
+            trace_id=start.trace_id,
+        )
         handle_response_error(r, url)
 
     @with_retry
@@ -310,7 +326,11 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         entity, project = project_id.split("/", 1)
         url = f"/v2/{entity}/{project}/call/end"
         req = tsi.CallEndV2Req(end=end)
-        r = self.post(url, data=req.model_dump_json().encode("utf-8"))
+        r = self.post(
+            url,
+            data=req.model_dump_json().encode("utf-8"),
+            trace_id=end.trace_id,
+        )
         handle_response_error(r, url)
 
     def _extract_entity_project(
@@ -484,6 +504,7 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         url: str,
         req: BaseModel,
         stream: bool = False,
+        trace_id: str | None = None,
     ) -> httpx.Response:
         r = self.post(
             url,
@@ -493,6 +514,7 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             # not valid for the `model_validate` step.
             data=req.model_dump_json(by_alias=True).encode("utf-8"),
             stream=stream,
+            trace_id=trace_id,
         )
         handle_response_error(r, url)
         return r
@@ -541,9 +563,10 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
         res_model: type[BaseModel],
         method: str = "POST",
         params: dict[str, Any] | None = None,
+        trace_id: str | None = None,
     ) -> BaseModel:
         if method == "POST":
-            r = self._post_request_executor(url, req)
+            r = self._post_request_executor(url, req, trace_id=trace_id)
         elif method == "PUT":
             r = self._put_request_executor(url, req)
         elif method == "GET":
@@ -611,7 +634,11 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             self.call_processor.enqueue_start(StartBatchItem(req=req))
             return tsi.CallStartRes(id=req.start.id, trace_id=req.start.trace_id)
         return self._generic_request(
-            "/call/start", req, tsi.CallStartReq, tsi.CallStartRes
+            "/call/start",
+            req,
+            tsi.CallStartReq,
+            tsi.CallStartRes,
+            trace_id=req.start.trace_id,
         )
 
     def call_start_batch(self, req: tsi.CallCreateBatchReq) -> tsi.CallCreateBatchRes:
@@ -626,7 +653,13 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
 
             self.call_processor.enqueue([EndBatchItem(req=req)])
             return tsi.CallEndRes()
-        return self._generic_request("/call/end", req, tsi.CallEndReq, tsi.CallEndRes)
+        return self._generic_request(
+            "/call/end",
+            req,
+            tsi.CallEndReq,
+            tsi.CallEndRes,
+            trace_id=req.end.trace_id,
+        )
 
     @validate_call
     def call_read(self, req: tsi.CallReadReq) -> tsi.CallReadRes:
@@ -1780,6 +1813,7 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             req,
             tsi.CallStartV2Req,
             tsi.CallStartV2Res,
+            trace_id=req.start.trace_id,
         )
 
     def call_end_v2(self, req: tsi.CallEndV2Req) -> tsi.CallEndV2Res:
@@ -1796,4 +1830,5 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             req,
             tsi.CallEndV2Req,
             tsi.CallEndV2Res,
+            trace_id=req.end.trace_id,
         )

--- a/weave/trace_server_bindings/remote_http_trace_server.py
+++ b/weave/trace_server_bindings/remote_http_trace_server.py
@@ -146,7 +146,7 @@ class RemoteHTTPTraceServer(TraceServerClientInterface):
             self.trace_server_url + url,
             *args,
             auth=self._auth,
-            headers={**headers, **kwargs.pop("headers", {})},
+            headers=headers,
             **kwargs,
         )
 


### PR DESCRIPTION
## JIRA Issue(s)
https://coreweave.atlassian.net/browse/WB-35682

## Description
Today a call's `trace_id` reaches the server on only some calls-ingest messages. Call-start carries it, but call-end and the end-parts of the batched upsert path do not. A trace arrives as many separate messages (start, end, children, batches), so without the trace key on every message the server cannot reason about a whole trace at ingest time — it has to merge first.

This change carries `trace_id` on every calls-ingest message that currently lacks it, in the cheapest place to read it later. Single-call requests (`/call/start`, `/call/end`, their v2 variants, and the eager v2 path that evaluations use) now send an `X-Weave-Trace-Id` header, so a server-side middleware can read it without parsing the body. Batched requests can't use a header because one request spans many traces, so the end schema (`EndedCallSchemaForInsert`) gains an optional `trace_id` field that a body-parsing reader can use; this single field covers `/call/end`, the end-parts of `/call/upsert_batch`, and v2 `call/end`. The `calls/complete` path already carries `trace_id` and is untouched.

This is groundwork with no server behavior change yet. `/call/update`, `/calls/delete`, and the feedback endpoints are a separate follow-up.

## Why this approach
The header keeps the trace key where a cheap pre-body check can see it, the same pattern `RequestSizeLimitMiddleware` and the existing `X-Weave-Retry-Id` header already use. The schema field reuses the exact path that recently added `started_at` to the same end message, so one optional field fans out to the three end endpoints.

## Backward compatibility
The header and the field are both optional with safe defaults, so it is fail-open in both directions: a new client against an old server has its extra header/field ignored, and an old client against a new server simply omits them. The server-side call-end path doesn't read the field, so nothing is written or changed.

## Testing
Added transport tests that decode the posted request and assert the header on single-call and eager-v2 requests, the field in the end body, that a batch post (which spans traces) carries no per-trace header, and the no-trace_id backward-compat case. Verified locally: the `trace_server_bindings` shard (61 passed), the full client-trace suite (127 passed), and the evaluation suite (20 passed).
