### PR TITLE
fix(weave): parse Bedrock inference profile ARN to model ID for invoke api

### DIFF
--- a/tests/integrations/bedrock/bedrock_test.py
+++ b/tests/integrations/bedrock/bedrock_test.py
@@ -101,29 +101,24 @@ MOCK_STREAM_EVENTS = [
     },
 ]
 
-MOCK_INVOKE_RESPONSE = {
-    "body": io.BytesIO(
-        json.dumps(
+MOCK_INVOKE_BODY = json.dumps(
+    {
+        "id": "msg_bdrk_01WpFc3918C93ZG9ZMKVqzCd",
+        "type": "message",
+        "role": "assistant",
+        "model": "claude-3-5-sonnet-20240620",
+        "content": [
             {
-                "id": "msg_bdrk_01WpFc3918C93ZG9ZMKVqzCd",
-                "type": "message",
-                "role": "assistant",
-                "model": "claude-3-5-sonnet-20240620",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": "To list all text files in the current directory (excluding subdirectories) "
-                        "that have been modified in the last month using Bash, you can use",
-                    }
-                ],
-                "stop_reason": "end_turn",
-                "stop_sequence": None,
-                "usage": {"input_tokens": 40, "output_tokens": 30, "total_tokens": 70},
+                "type": "text",
+                "text": "To list all text files in the current directory (excluding subdirectories) "
+                "that have been modified in the last month using Bash, you can use",
             }
-        ).encode("utf-8")
-    ),
-    "ContentType": "application/json",
-}
+        ],
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 40, "output_tokens": 30, "total_tokens": 70},
+    }
+).encode("utf-8")
 
 # Mock response for apply_guardrail
 MOCK_APPLY_GUARDRAIL_RESPONSE = {
@@ -248,7 +243,12 @@ def mock_converse_make_api_call(self, operation_name: str, api_params: dict) -> 
 
 def mock_invoke_make_api_call(self, operation_name: str, api_params: dict) -> dict:
     if operation_name == "InvokeModel":
-        return MOCK_INVOKE_RESPONSE
+        # Return a fresh body stream on each call so the response can be consumed
+        # independently across parametrized test runs.
+        return {
+            "body": io.BytesIO(MOCK_INVOKE_BODY),
+            "ContentType": "application/json",
+        }
     return orig(self, operation_name, api_params)
 
 
@@ -408,7 +408,10 @@ def test_bedrock_converse_stream(
 
 
 @mock_aws
-def test_bedrock_invoke(client: weave.trace.weave_client.WeaveClient) -> None:
+@pytest.mark.parametrize("model_identifier", [model_id, inference_profile_id])
+def test_bedrock_invoke(
+    client: weave.trace.weave_client.WeaveClient, model_identifier: str
+) -> None:
     bedrock_client = boto3.client("bedrock-runtime", region_name="us-east-1")
     patch_client(bedrock_client)
 
@@ -426,7 +429,7 @@ def test_bedrock_invoke(client: weave.trace.weave_client.WeaveClient) -> None:
         )
 
         response = bedrock_client.invoke_model(
-            modelId=model_id,
+            modelId=model_identifier,
             body=body,
             contentType="application/json",
             accept="application/json",

--- a/weave/integrations/bedrock/bedrock_sdk.py
+++ b/weave/integrations/bedrock/bedrock_sdk.py
@@ -161,7 +161,16 @@ def postprocess_inputs_invoke_agent(inputs: dict[str, Any]) -> dict[str, Any]:
 
 
 def postprocess_inputs_invoke(inputs: dict[str, Any]) -> dict[str, Any]:
+    """Post-process the inputs for the invoke_model API call.
+
+    This function extracts the model name from the inference profile ARN if any
+    and updates the modelId in the kwargs to match model-cost list.
+    """
     exploded_kwargs = inputs.get("kwargs", {})
+    if "modelId" in exploded_kwargs and "arn" in exploded_kwargs["modelId"]:
+        exploded_kwargs["modelId"] = extract_model_name_from_inference_profile_arn(
+            exploded_kwargs["modelId"]
+        )
     if "body" in exploded_kwargs:
         exploded_kwargs["body"] = json.loads(exploded_kwargs["body"])
     return exploded_kwargs


### PR DESCRIPTION
## Description

Extends #4220 (which fixed the Converse API) to the `invoke_model` path.

When an inference profile ARN is passed as `modelId` to `invoke_model`, Weave logs usage
keyed by the raw ARN. Cost is computed from the usage summary, which is keyed off the
input `modelId` — so the trace-server cost lookup never matches and no cost is shown in
the UI. (The resolved model appears in the response body, but that value is not used for
cost.)

`postprocess_inputs_invoke` now resolves an inference-profile ARN to the underlying model
id before the usage summary is built, reusing `extract_model_name_from_inference_profile_arn`
— the same helper the Converse path already uses. Behavior is unchanged for plain model-id
inputs.

## Testing

- `uv run --group test python -m pytest tests/integrations/bedrock/bedrock_test.py` — 9 passed.
- Parametrized `test_bedrock_invoke` over a plain model id and an inference-profile ARN
  (mirrors the existing Converse tests). Also fixed a shared mock-body-stream leak the
  parametrization exposed — each invoke call now gets a fresh response-body stream.
- Verified end-to-end against wandb.ai SaaS: invoked a real application inference-profile
  ARN through the patched SDK and confirmed cost now renders in the Weave UI (was blank
  before the fix).

🤖 AI-assisted (Claude Code); reviewed and validated by the author.