### PR TITLE
chore(weave): add weave-sdk as code owner for weave/ (excluding trace_server/)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,6 @@
 * @wandb/weave-team
 /docs/ @wandb/docs-team @wandb/weave-team
 /sdks/node/ @wandb/weave-sdk @wandb/weave-team
+/weave/ @wandb/weave-sdk @wandb/weave-team
+/weave/trace_server/ @wandb/weave-team
 /weave/trace_server/migrations @tssweeney @gtarpenning @neutralino1


### PR DESCRIPTION
## Purpose

Make `@wandb/weave-sdk` a code owner for the `weave/` Python tree, while keeping `weave/trace_server/` owned by the broader team.

## Changes

`.github/CODEOWNERS` now reads:

```
* @wandb/weave-team
/docs/ @wandb/docs-team @wandb/weave-team
/sdks/node/ @wandb/weave-sdk @wandb/weave-team
/weave/ @wandb/weave-sdk @wandb/weave-team
/weave/trace_server/ @wandb/weave-team
/weave/trace_server/migrations @tssweeney @gtarpenning @neutralino1
```

CODEOWNERS is **last-match-wins**:

- `/weave/` grants `@wandb/weave-sdk` (alongside the existing `@wandb/weave-team`) across `weave/`.
- `/weave/trace_server/` overrides that back to `@wandb/weave-team` only, so weave-sdk does **not** own `trace_server/`.
- The existing `/weave/trace_server/migrations` rule stays last (most-specific), unchanged.
- `sdks/node/` already granted weave-sdk; no change there.

## Note for reviewers

`trace_server/` is read literally as the directory `weave/trace_server/`. The sibling paths `weave/trace_server_bindings/` and `weave/trace_server_version.py` match `/weave/` and are therefore owned by weave-sdk. If those should also be excluded, say so and I'll add rules.

## Testing

N/A — config-only change. No CODEOWNERS linter exists in-repo.