### PR TITLE
chore(weave): add RemoteScorer serialization test case

### DIFF
--- a/tests/trace/data_serialization/test_cases/__init__.py
+++ b/tests/trace/data_serialization/test_cases/__init__.py
@@ -47,6 +47,7 @@ from tests.trace.data_serialization.test_cases.primitive_cases import primitive_
 ### Weave Evaluation Library Specialized Objects:
 [x] LLMStructuredCompletionModel
 [x] LLMAsAJudgeScorer
+[x] RemoteScorer
 
 ## Weave Config Objects:
 [x] AnnotationSpec

--- a/tests/trace/data_serialization/test_cases/library_cases.py
+++ b/tests/trace/data_serialization/test_cases/library_cases.py
@@ -2,7 +2,8 @@ import sys
 
 import weave
 from tests.trace.data_serialization.spec import SerializationTestCase
-from weave.scorers import LLMAsAJudgeScorer
+from weave.scorers import LLMAsAJudgeScorer, RemoteScorer
+from weave.scorers.remote_scorer import OAuthClientCredentialsConfig
 from weave.trace_server.interface.builtin_object_classes.builtin_object_registry import (
     LLMStructuredCompletionModel,
 )
@@ -56,6 +57,23 @@ def make_evaluation():
 
 def make_model():
     return MyModel(prompt=weave.StringPrompt("Hello {user_input}"))
+
+
+def make_remote_scorer():
+    # RemoteScorer is scored by the Weave scoring worker (it POSTs to endpoint_url),
+    # so its score/summarize ops are excluded from the record. This case locks in
+    # that op-free shape, plus the nested auth_config discriminated union.
+    return RemoteScorer(
+        endpoint_url="https://scoring.example.com/v1/score",
+        config={"threshold": 0.9},
+        auth_config=OAuthClientCredentialsConfig(
+            mode="oauth_client_credentials",
+            token_endpoint_url="https://idp.example.com/oauth2/token",
+            client_id="weave-remote-scorer",
+            client_secret_name="REMOTE_SCORER_CLIENT_SECRET",
+            scope="remote-score",
+        ),
+    )
 
 
 def evaluation_equality_check(a, b):
@@ -1397,6 +1415,39 @@ library_cases = [
         ],
         # Sad ... equality is really a pain to assert here (and is broken)
         # TODO: Write a good equality check and make it work
+        equality_check=lambda a, b: True,
+    ),
+    SerializationTestCase(
+        id="Library Objects - RemoteScorer",
+        runtime_object_factory=make_remote_scorer,
+        inline_call_param=False,
+        is_legacy=False,
+        # No score/summarize op refs: RemoteScorer sets _weave_exclude_ops_from_record,
+        # so the published shape carries no captured op code (hence no exp_objects/exp_files).
+        exp_json={
+            "_type": "RemoteScorer",
+            "name": None,
+            "description": None,
+            "column_map": None,
+            "endpoint_url": "https://scoring.example.com/v1/score",
+            "config": {"threshold": 0.9},
+            "auth_config": {
+                "_type": "OAuthClientCredentialsConfig",
+                "mode": "oauth_client_credentials",
+                "token_endpoint_url": "https://idp.example.com/oauth2/token",
+                "client_id": "weave-remote-scorer",
+                "client_secret_name": "REMOTE_SCORER_CLIENT_SECRET",
+                "scope": "remote-score",
+                "_class_name": "OAuthClientCredentialsConfig",
+                "_bases": ["BaseModel"],
+            },
+            "_class_name": "RemoteScorer",
+            "_bases": ["Scorer", "Object", "BaseModel"],
+        },
+        exp_objects=[],
+        exp_files=[],
+        # Round-trip correctness is covered by tests/scorers/test_remote_scorer.py;
+        # this case only pins the serialized format.
         equality_check=lambda a, b: True,
     ),
 ]


### PR DESCRIPTION
## JIRA Issue(s)
[WB-35583](https://coreweave.atlassian.net/browse/WB-35583)

## Description
The data-serialization suite (`library_cases.py`) pins the exact stored JSON for each Weave object. If a serialized shape ever changes by accident, a test fails and forces us to handle backward compatibility on purpose. RemoteScorer was never added to that suite, so its format had no such guard — a future change could silently break reading data written by older clients and nothing would catch it. This surfaced in review of the LLMAsAJudgeScorer serialization fix, which touched this file while the earlier RemoteScorer change had not.

This adds one non-legacy case that pins RemoteScorer's current shape, including the nested `auth_config`. No legacy snapshot is needed because the feature has not shipped yet, so there is no older on-disk format to stay compatible with. The case is small because RemoteScorer excludes its `score`/`summarize` ops from the record (the scoring worker calls the endpoint, not the Python methods); with no captured op code there are no support objects or files, and the object's digest does not depend on the Python version.

## Testing
The serialization suite passes across the trace shard's Python matrix — 3.10, 3.11, and 3.13 in CI (and 3.12 locally) — confirming the shape is version-independent; the single skip is the macOS-only image case. `tests/scorers/test_remote_scorer.py` still passes (45). Lint and type-checks (ruff, ty, pyright, mypy) are clean.


[WB-35583]: https://coreweave.atlassian.net/browse/WB-35583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ