### PR TITLE
fix(weave): raise too-slow query kill threshold to 10s

### DIFF
--- a/weave/trace_server/clickhouse_trace_server_settings.py
+++ b/weave/trace_server/clickhouse_trace_server_settings.py
@@ -52,7 +52,7 @@ DEFAULT_MAX_ESTIMATED_EXECUTION_TIME = DEFAULT_MAX_EXECUTION_TIME
 # ClickHouse waits this long before doing the projection check, avoiding the
 # overhead on short queries.
 # https://clickhouse.com/docs/operations/settings/settings#timeout_before_checking_execution_speed
-DEFAULT_TIMEOUT_BEFORE_CHECKING_EXECUTION_SPEED = 5
+DEFAULT_TIMEOUT_BEFORE_CHECKING_EXECUTION_SPEED = 10
 
 # https://clickhouse.com/docs/sql-reference/functions/json-functions#json_value
 RETURN_TYPE_ALLOW_COMPLEX = "1"


### PR DESCRIPTION
## Summary
- `timeout_before_checking_execution_speed` was `5`, so ClickHouse's projection-based killer (`max_estimated_execution_time` with `timeout_overflow_mode=throw`) could abort a query after only 5s of runtime. Bump to `10` so we don't try to kill queries that are still ramping up.
- Motivating case: [this span](https://us5.datadoghq.com/logs?query=trace_id%3A2698002993082448536&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZ7RYrLYyqjZDQAAABhBWjdSWXIzUEFBQWlkNXNBYk8yS1RRQUYAAAAkZjE5ZWQxNjMtZTNiYS00NjQ1LWFiYjYtY2VmMjVmNTkzYjE5AAUESg&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1781628361548&to_ts=1781630367039&live=false) was killed in prod, but re-running the same query through the console finished in 30ms.

## Testing
non-functional config change.