### PR TITLE
chore(weave): fix flaky test_call_batch_uploads_files_to_bucket_in_parallel

### DIFF
--- a/tests/trace/conftest.py
+++ b/tests/trace/conftest.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import os
 import threading
-import time
 from dataclasses import dataclass, field
 from unittest import mock
 
@@ -51,8 +50,6 @@ class GCSMockState:
 
     Test-side knobs:
       `fail_paths` - inject `PreconditionFailed`-style failures by GCS path.
-      `delay`      - sleep inside upload_from_string so parallel tests can
-                     assert wall-time savings + concurrent peak.
       `expected_concurrency` - when set, uploads block on a barrier until this
                      many are simultaneously in-flight, making `concurrent_peak`
                      deterministic instead of dependent on scheduler timing.
@@ -67,7 +64,6 @@ class GCSMockState:
     upload_count: int = 0
     concurrent_peak: int = 0
     fail_paths: set[str] = field(default_factory=set)
-    delay: float = 0.0
     expected_concurrency: int | None = None
 
 
@@ -145,8 +141,6 @@ def gcs():
                         barrier["b"].wait(timeout=_BARRIER_TIMEOUT_SECONDS)
                     except threading.BrokenBarrierError:
                         pass
-                if state.delay:
-                    time.sleep(state.delay)
                 with state_lock:
                     state.blob_data[path] = data
                     state.upload_count += 1

--- a/tests/trace/conftest.py
+++ b/tests/trace/conftest.py
@@ -41,6 +41,9 @@ def failing_serializer():
 # handling, retry decorators, and the `if_generation_match=0` skip path.
 # ---------------------------------------------------------------------------
 
+# Safety net so a barrier never deadlocks if fewer uploads arrive than expected.
+_BARRIER_TIMEOUT_SECONDS = 30.0
+
 
 @dataclass
 class GCSMockState:
@@ -50,6 +53,9 @@ class GCSMockState:
       `fail_paths` - inject `PreconditionFailed`-style failures by GCS path.
       `delay`      - sleep inside upload_from_string so parallel tests can
                      assert wall-time savings + concurrent peak.
+      `expected_concurrency` - when set, uploads block on a barrier until this
+                     many are simultaneously in-flight, making `concurrent_peak`
+                     deterministic instead of dependent on scheduler timing.
 
     Read-back:
       `blob_data`        - the in-memory backing store, keyed by full path.
@@ -62,6 +68,7 @@ class GCSMockState:
     concurrent_peak: int = 0
     fail_paths: set[str] = field(default_factory=set)
     delay: float = 0.0
+    expected_concurrency: int | None = None
 
 
 @pytest.fixture
@@ -114,6 +121,7 @@ def gcs():
     state = GCSMockState()
     state_lock = threading.Lock()
     inflight = {"n": 0}
+    barrier: dict[str, threading.Barrier | None] = {"b": None}
 
     def make_blob(path: str):
         blob = mock.MagicMock()
@@ -127,7 +135,16 @@ def gcs():
             with state_lock:
                 inflight["n"] += 1
                 state.concurrent_peak = max(state.concurrent_peak, inflight["n"])
+                if state.expected_concurrency and barrier["b"] is None:
+                    barrier["b"] = threading.Barrier(state.expected_concurrency)
             try:
+                # Block until expected_concurrency uploads are in-flight so the
+                # peak is deterministic; timeout avoids hanging on under-count.
+                if barrier["b"] is not None:
+                    try:
+                        barrier["b"].wait(timeout=_BARRIER_TIMEOUT_SECONDS)
+                    except threading.BrokenBarrierError:
+                        pass
                 if state.delay:
                     time.sleep(state.delay)
                 with state_lock:

--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -556,8 +556,10 @@ def test_call_batch_uploads_files_to_bucket_in_parallel(client: WeaveClient, gcs
     collapses to one upload, and every stored object lands under the
     expected project prefix.
     """
-    gcs.state.delay = 0.1
     # 4 unique blobs + 2 duplicates of the first => 4 GCS uploads after dedup.
+    # Barrier makes the peak deterministic so it can't flake under CI scheduler
+    # jitter (each upload blocks until all 4 are simultaneously in-flight).
+    gcs.state.expected_concurrency = 4
     payload_size = 50_000
     payloads = [
         _unique_payload("alpha", payload_size),
@@ -577,10 +579,9 @@ def test_call_batch_uploads_files_to_bucket_in_parallel(client: WeaveClient, gcs
                 )
             )
 
-    # Pool defaults to 8 workers, so all 4 unique uploads should run
-    # concurrently. concurrent_peak is the load-bearing parallelism signal;
-    # wall-time assertions on top would flake on contended CI runners.
-    assert gcs.state.concurrent_peak >= 4, (
+    # Pool defaults to 8 workers, so all 4 unique uploads run concurrently;
+    # the upload barrier guarantees the peak reaches 4.
+    assert gcs.state.concurrent_peak == 4, (
         f"expected 4 concurrent uploads, peak={gcs.state.concurrent_peak}"
     )
 


### PR DESCRIPTION
## Summary
- `test_call_batch_uploads_files_to_bucket_in_parallel` asserted `concurrent_peak >= 4`, but the gcs mock recorded the peak then slept \`delay=0.1s\`. Under \`-n8\` xdist CI contention the 4th upload thread could be scheduled only after the 1st finished its sleep and decremented \`inflight\`, so the peak capped at 3.
- Production parallelism is correct (pool dispatches all 4 unique uploads); this is purely a test-side measurement race. Replaced the timing window with a \`threading.Barrier\` so all 4 uploads are provably in-flight at once.

Original failure ([CI job](https://github.com/wandb/weave/actions/runs/27635430571/job/81721250225?pr=7246)):
```
E  AssertionError: expected 4 concurrent uploads, peak=3
E  assert 3 >= 4
```

## Testing
test only change.