### PR TITLE
test(weave): densify tests/trace suite

### DIFF
--- a/tests/trace/concurrent/test_futures.py
+++ b/tests/trace/concurrent/test_futures.py
@@ -122,45 +122,31 @@ def test_then_multiple_futures_duplicate() -> None:
 
 
 @pytest.mark.disable_logging_error_check
-def test_then_with_exception_in_future(log_collector) -> None:
+@pytest.mark.parametrize("fail_in", ["future", "callback"])
+def test_then_propagates_exception_and_logs(log_collector, fail_in) -> None:
+    """A raise in the upstream future or `then` callback propagates and logs once."""
     executor: FutureExecutor = FutureExecutor()
-
-    def failing_task() -> None:
-        raise ValueError("Future exception")
-
-    def process_data(data_list: list[Any]) -> Any:
-        return data_list[0]
-
-    future_data: Future[None] = executor.defer(failing_task)
-    future_result: Future[Any] = executor.then([future_data], process_data)
-
-    with pytest.raises(ValueError, match="Future exception"):
-        future_result.result()
-
-    logs = log_collector.get_error_logs()
-    assert len(logs) == 1
-    assert "ValueError: Future exception" in logs[0].getMessage()
-
-
-@pytest.mark.disable_logging_error_check
-def test_then_with_exception_in_callback(log_collector) -> None:
-    executor: FutureExecutor = FutureExecutor()
+    message = f"{fail_in} exception"
 
     def fetch_data() -> list[int]:
+        if fail_in == "future":
+            raise ValueError(message)
         return [1, 2, 3]
 
-    def failing_process(data_list: list[list[int]]) -> None:
-        raise ValueError("Callback exception")
+    def process_data(data_list: list[Any]) -> Any:
+        if fail_in == "callback":
+            raise ValueError(message)
+        return data_list[0]
 
-    future_data: Future[list[int]] = executor.defer(fetch_data)
-    future_result: Future[None] = executor.then([future_data], failing_process)
+    future_data: Future[Any] = executor.defer(fetch_data)
+    future_result: Future[Any] = executor.then([future_data], process_data)
 
-    with pytest.raises(ValueError, match="Callback exception"):
+    with pytest.raises(ValueError, match=message):
         future_result.result()
 
     logs = log_collector.get_error_logs()
     assert len(logs) == 1
-    assert "ValueError: Callback exception" in logs[0].getMessage()
+    assert f"ValueError: {message}" in logs[0].getMessage()
 
 
 def test_concurrent_execution() -> None:
@@ -381,8 +367,12 @@ def test_flush_drains_work_added_after_snapshot() -> None:
     assert flush_finished.is_set()
 
 
-def test_nested_futures_with_1_max_worker_classic_deadlock_case() -> None:
-    executor: FutureExecutor = FutureExecutor(max_workers=1)
+@pytest.mark.parametrize("max_workers", [1, 0])
+def test_nested_futures_resolve_without_deadlock(max_workers: int) -> None:
+    """Nested defer().result() must not deadlock with 1 worker or 0 (direct exec)."""
+    executor: FutureExecutor = FutureExecutor(max_workers=max_workers)
+    if max_workers == 0:
+        assert executor._executor is None
 
     def inner_0() -> list[int]:
         return [0]
@@ -394,22 +384,6 @@ def test_nested_futures_with_1_max_worker_classic_deadlock_case() -> None:
         return executor.defer(inner_1).result() + [2]
 
     res = executor.defer(inner_2).result()
-    assert res == [0, 1, 2]
-
-
-def test_nested_futures_with_0_max_workers_direct() -> None:
-    executor: FutureExecutor = FutureExecutor(max_workers=0)
-    assert executor._executor is None
-
-    def inner_0() -> list[int]:
-        return [0]
-
-    def inner_1() -> list[int]:
-        return executor.defer(inner_0).result() + [1]
-
-    def inner_2() -> list[int]:
-        return executor.defer(inner_1).result() + [2]
-
-    res = executor.defer(inner_2).result()
-    assert executor._executor is None
+    if max_workers == 0:
+        assert executor._executor is None
     assert res == [0, 1, 2]

--- a/tests/trace/test_annotation_feedback.py
+++ b/tests/trace/test_annotation_feedback.py
@@ -258,80 +258,51 @@ def test_field_schema_with_pydantic_field(client):
     assert enum_spec.val["field_schema"]["description"] == "Category selection"
 
 
-def test_annotation_spec_validation():
-    # Test validation with direct schema
+def test_annotation_spec_value_is_valid():
+    """value_is_valid across dict, Pydantic model, Pydantic Field, and nested schemas."""
+    # direct numeric schema
     number_spec = AnnotationSpec(
         name="Number Rating",
-        field_schema={
-            "type": "number",
-            "minimum": 1,
-            "maximum": 5,
-        },
+        field_schema={"type": "number", "minimum": 1, "maximum": 5},
     )
-
-    # Valid cases
     assert number_spec.value_is_valid(3)
     assert number_spec.value_is_valid(1)
     assert number_spec.value_is_valid(5)
-
-    # Invalid cases
     assert not number_spec.value_is_valid(0)  # too low
     assert not number_spec.value_is_valid(6)  # too high
     assert not number_spec.value_is_valid("3")  # wrong type
 
-    # Test validation with Pydantic model schema
+    # Pydantic model schema
     class FeedbackModel(BaseModel):
         rating: int = Field(ge=1, le=5)
         comment: str = Field(max_length=100)
         tags: list[str] = Field(min_length=1, max_length=3)
 
     model_spec = AnnotationSpec(name="Complex Feedback", field_schema=FeedbackModel)
-
-    # Valid cases
     assert model_spec.value_is_valid(
         {"rating": 4, "comment": "Good work!", "tags": ["positive", "helpful"]}
     )
-
-    # Invalid cases
     assert not model_spec.value_is_valid(
-        {
-            "rating": 4,
-            "comment": "Good work!",
-            # missing tags
-        }
+        {"rating": 4, "comment": "Good work!"}  # missing tags
+    )
+    assert not model_spec.value_is_valid(
+        {"rating": 6, "comment": "Good work!", "tags": ["positive"]}  # invalid rating
+    )
+    assert not model_spec.value_is_valid(
+        {"rating": 4, "comment": "Good work!", "tags": []}  # empty tags list
     )
 
-    assert not model_spec.value_is_valid(
-        {
-            "rating": 6,  # invalid rating
-            "comment": "Good work!",
-            "tags": ["positive"],
-        }
+    # Pydantic Field enum schema
+    enum_spec = AnnotationSpec(
+        name="Simple Enum",
+        field_schema=(str, Field(enum=["excellent", "good", "fair", "poor"])),
     )
-
-    assert not model_spec.value_is_valid(
-        {
-            "rating": 4,
-            "comment": "Good work!",
-            "tags": [],  # empty tags list
-        }
-    )
-
-    # Test validation with Pydantic Field schema
-    enum_field = Field(enum=["excellent", "good", "fair", "poor"])
-    enum_spec = AnnotationSpec(name="Simple Enum", field_schema=(str, enum_field))
-
-    # Valid cases
     assert enum_spec.value_is_valid("good")
     assert enum_spec.value_is_valid("excellent")
-
-    # Invalid cases
     assert not enum_spec.value_is_valid("invalid_choice")
     assert not enum_spec.value_is_valid(123)
 
-
-def test_annotation_spec_validation_with_complex_types():
-    # Test nested object validation
+    # nested-object schema
     class Address(BaseModel):
         street: str
         city: str
@@ -343,119 +314,24 @@ def test_annotation_spec_validation_with_complex_types():
         addresses: list[Address] = Field(min_length=1, max_length=3)
 
     person_spec = AnnotationSpec(name="Person Feedback", field_schema=PersonFeedback)
-
-    # Valid case
+    valid_address = {
+        "street": "123 Main St",
+        "city": "Springfield",
+        "zip_code": "12345",
+    }
     assert person_spec.value_is_valid(
-        {
-            "name": "John Doe",
-            "age": 30,
-            "addresses": [
-                {"street": "123 Main St", "city": "Springfield", "zip_code": "12345"}
-            ],
-        }
+        {"name": "John Doe", "age": 30, "addresses": [valid_address]}
     )
-
-    # Invalid cases
     assert not person_spec.value_is_valid(
         {
             "name": "John Doe",
             "age": 30,
-            "addresses": [
-                {
-                    "street": "123 Main St",
-                    "city": "Springfield",
-                    "zip_code": "123",  # invalid zip code
-                }
-            ],
+            "addresses": [{**valid_address, "zip_code": "123"}],  # invalid zip code
         }
     )
-
     assert not person_spec.value_is_valid(
-        {
-            "name": "John Doe",
-            "age": 150,  # invalid age
-            "addresses": [
-                {
-                    "street": "123 Main St",
-                    "city": "Springfield",
-                    "zip_code": "12345",
-                }
-            ],
-        }
+        {"name": "John Doe", "age": 150, "addresses": [valid_address]}  # invalid age
     )
-
-
-def test_annotation_spec_validate_return_value():
-    # Test with a simple numeric schema
-    number_spec = AnnotationSpec(
-        name="Number Rating",
-        field_schema={
-            "type": "number",
-            "minimum": 1,
-            "maximum": 5,
-        },
-    )
-
-    # Valid cases should return True
-    assert number_spec.value_is_valid(3)
-    assert number_spec.value_is_valid(1)
-    assert number_spec.value_is_valid(5)
-
-    # Invalid cases should return False
-    assert not number_spec.value_is_valid(0)  # too low
-    assert not number_spec.value_is_valid(6)  # too high
-    assert not number_spec.value_is_valid("3")  # wrong type
-
-    # Test with a Pydantic model schema
-    class FeedbackModel(BaseModel):
-        rating: int = Field(ge=1, le=5)
-        comment: str = Field(max_length=100)
-        tags: list[str] = Field(min_length=1, max_length=3)
-
-    model_spec = AnnotationSpec(name="Complex Feedback", field_schema=FeedbackModel)
-
-    # Valid case should return True
-    assert model_spec.value_is_valid(
-        {"rating": 4, "comment": "Good work!", "tags": ["positive", "helpful"]}
-    )
-
-    # Invalid cases should return False
-    assert not model_spec.value_is_valid(
-        {
-            "rating": 4,
-            "comment": "Good work!",
-            # missing tags
-        }
-    )
-
-    assert not model_spec.value_is_valid(
-        {
-            "rating": 6,  # invalid rating
-            "comment": "Good work!",
-            "tags": ["positive"],
-        }
-    )
-    assert not model_spec.value_is_valid(
-        {
-            "rating": 4,
-            "comment": "Good work!",
-            "tags": [],  # empty tags list
-        }
-    )
-
-    # Test with a Pydantic Field schema
-    enum_spec = AnnotationSpec(
-        name="Simple Enum",
-        field_schema=(str, Field(enum=["excellent", "good", "fair", "poor"])),
-    )
-
-    # Valid cases should return True
-    assert enum_spec.value_is_valid("good")
-    assert enum_spec.value_is_valid("excellent")
-
-    # Invalid cases should return False
-    assert not enum_spec.value_is_valid("invalid_choice")
-    assert not enum_spec.value_is_valid(123)
 
 
 def test_annotation_feedback_sdk(weave_active):

--- a/tests/trace/test_base_object_classes.py
+++ b/tests/trace/test_base_object_classes.py
@@ -920,24 +920,29 @@ def test_inherited_builtin_object_class_hierarchy(client: WeaveClient):
 
 
 def test_exclude_base_object_classes(client: WeaveClient):
-    """Test that exclude_base_object_classes filter correctly excludes objects by their base classes."""
-    # Create several objects with different base classes
-    nested_obj = base_objects.TestOnlyNestedBaseObject(b=100)
-    nested_ref = weave.publish(nested_obj)
+    """exclude_base_object_classes filtering: single, multiple, non-existent,
+    combined-with-include, and inherited-object handling.
+    """
+    # Objects across both base classes, plus an inherited object whose base
+    # class is TestOnlyNestedBaseObject.
+    nested_obj1 = base_objects.TestOnlyNestedBaseObject(b=100)
+    nested_ref1 = weave.publish(nested_obj1)
+    nested_obj2 = base_objects.TestOnlyNestedBaseObject(b=222)
+    weave.publish(nested_obj2)
 
     top_obj = base_objects.TestOnlyExample(
         primitive=200,
         nested_base_model=TestOnlyNestedBaseModel(a=300, aliased_property_alias=400),
-        nested_base_object=nested_ref.uri,
+        nested_base_object=nested_ref1.uri,
     )
-    top_ref = weave.publish(top_obj)
+    weave.publish(top_obj)
 
     inherited_obj = base_objects.TestOnlyInheritedBaseObject(
         b=500, c=600, additional_field="test_exclude"
     )
-    inherited_ref = weave.publish(inherited_obj)
+    weave.publish(inherited_obj)
 
-    # Test excluding TestOnlyExample - should get nested and inherited objects
+    # Excluding TestOnlyExample keeps the nested base class.
     exclude_example_res = client.server.objs_query(
         tsi.ObjQueryReq.model_validate(
             {
@@ -946,13 +951,12 @@ def test_exclude_base_object_classes(client: WeaveClient):
             }
         )
     )
-
-    # Should exclude only TestOnlyExample, include TestOnlyNestedBaseObject and inherited
     base_classes = {obj.base_object_class for obj in exclude_example_res.objs}
     assert "TestOnlyExample" not in base_classes
     assert "TestOnlyNestedBaseObject" in base_classes
 
-    # Test excluding TestOnlyNestedBaseObject - should get only TestOnlyExample
+    # Excluding TestOnlyNestedBaseObject drops both the base and inherited
+    # objects (the inherited object's base_object_class is the nested class).
     exclude_nested_res = client.server.objs_query(
         tsi.ObjQueryReq.model_validate(
             {
@@ -961,12 +965,15 @@ def test_exclude_base_object_classes(client: WeaveClient):
             }
         )
     )
-
     base_classes_excluded = {obj.base_object_class for obj in exclude_nested_res.objs}
     assert "TestOnlyNestedBaseObject" not in base_classes_excluded
     assert "TestOnlyExample" in base_classes_excluded
+    assert all(
+        obj.base_object_class != "TestOnlyNestedBaseObject"
+        for obj in exclude_nested_res.objs
+    )
 
-    # Test excluding multiple base classes
+    # Excluding multiple base classes drops both.
     exclude_multiple_res = client.server.objs_query(
         tsi.ObjQueryReq.model_validate(
             {
@@ -980,13 +987,11 @@ def test_exclude_base_object_classes(client: WeaveClient):
             }
         )
     )
-
-    # Should exclude both, so result should be empty or only non-test objects
     base_classes_multi = {obj.base_object_class for obj in exclude_multiple_res.objs}
     assert "TestOnlyExample" not in base_classes_multi
     assert "TestOnlyNestedBaseObject" not in base_classes_multi
 
-    # Test excluding non-existent class - should return all objects
+    # Excluding a non-existent class returns everything.
     exclude_nonexistent_res = client.server.objs_query(
         tsi.ObjQueryReq.model_validate(
             {
@@ -995,34 +1000,10 @@ def test_exclude_base_object_classes(client: WeaveClient):
             }
         )
     )
-
-    # Should return all objects since we're not excluding anything that exists
     assert len(exclude_nonexistent_res.objs) >= 3
 
-
-def test_exclude_base_object_classes_with_include_filter(client: WeaveClient):
-    """Test that exclude_base_object_classes works correctly when combined with base_object_classes."""
-    # Create objects with different base classes
-    nested_obj1 = base_objects.TestOnlyNestedBaseObject(b=111)
-    nested_ref1 = weave.publish(nested_obj1)
-
-    nested_obj2 = base_objects.TestOnlyNestedBaseObject(b=222)
-    nested_ref2 = weave.publish(nested_obj2)
-
-    top_obj = base_objects.TestOnlyExample(
-        primitive=333,
-        nested_base_model=TestOnlyNestedBaseModel(a=444, aliased_property_alias=555),
-        nested_base_object=nested_ref1.uri,
-    )
-    top_ref = weave.publish(top_obj)
-
-    inherited_obj = base_objects.TestOnlyInheritedBaseObject(
-        b=666, c=777, additional_field="test_combined"
-    )
-    inherited_ref = weave.publish(inherited_obj)
-
-    # Test combining include and exclude (should be treated as AND logic)
-    # Include TestOnlyNestedBaseObject but exclude nothing -> should get TestOnlyNestedBaseObject objects
+    # Combining include and exclude is AND logic: include the nested base class
+    # (base + inherited) while excluding TestOnlyExample.
     combined_res = client.server.objs_query(
         tsi.ObjQueryReq.model_validate(
             {
@@ -1034,45 +1015,9 @@ def test_exclude_base_object_classes_with_include_filter(client: WeaveClient):
             }
         )
     )
-
-    # Should get TestOnlyNestedBaseObject objects (base and inherited), not TestOnlyExample
-    base_classes = {obj.base_object_class for obj in combined_res.objs}
-    assert base_classes == {"TestOnlyNestedBaseObject"}
+    combined_base_classes = {obj.base_object_class for obj in combined_res.objs}
+    assert combined_base_classes == {"TestOnlyNestedBaseObject"}
     assert len(combined_res.objs) >= 3  # nested_obj1, nested_obj2, inherited_obj
-
-
-def test_exclude_base_object_classes_with_inherited_objects(client: WeaveClient):
-    """Test that exclude_base_object_classes correctly handles inherited objects."""
-    # Create base and inherited objects
-    base_obj = base_objects.TestOnlyNestedBaseObject(b=1000)
-    base_ref = weave.publish(base_obj)
-
-    inherited_obj = base_objects.TestOnlyInheritedBaseObject(
-        b=2000, c=3000, additional_field="test_inheritance_exclude"
-    )
-    inherited_ref = weave.publish(inherited_obj)
-
-    # Exclude the base class - should exclude both base and inherited objects
-    exclude_base_res = client.server.objs_query(
-        tsi.ObjQueryReq.model_validate(
-            {
-                "project_id": client.project_id,
-                "filter": {"exclude_base_object_classes": ["TestOnlyNestedBaseObject"]},
-            }
-        )
-    )
-
-    # Should not include objects with base_object_class == TestOnlyNestedBaseObject
-    base_classes = {obj.base_object_class for obj in exclude_base_res.objs}
-    assert "TestOnlyNestedBaseObject" not in base_classes
-
-    # Verify the inherited object is also excluded (since its base class is TestOnlyNestedBaseObject)
-    object_ids = {obj.object_id for obj in exclude_base_res.objs}
-    # The inherited object should be excluded since it has base_object_class = TestOnlyNestedBaseObject
-    assert all(
-        obj.base_object_class != "TestOnlyNestedBaseObject"
-        for obj in exclude_base_res.objs
-    )
 
 
 def test_obj_create_rejects_name_type_collision(client: WeaveClient):

--- a/tests/trace/test_client_annotation_queues.py
+++ b/tests/trace/test_client_annotation_queues.py
@@ -961,27 +961,73 @@ def test_annotation_queue_items_query_with_multiple_sort_fields(client):
     assert len(query_res.items) == 5
 
 
-def test_annotation_queue_items_query_filter_by_call_id(client):
-    """Test filtering queue items by call_id."""
-    # Create queue with 5 calls
+def test_annotation_queue_items_query_single_field_filters(client):
+    """Filter a single 5-call queue by call_id, trace_id, added_by, and state."""
     fixture = create_queue_with_calls(
-        client, num_calls=5, queue_name="Filter By Call ID Queue"
+        client, num_calls=5, queue_name="Single Field Filter Queue"
     )
+    calls = list(client.get_calls())
+    target_call = next(c for c in calls if c.id in fixture.call_ids)
 
-    # Pick one call_id to filter by
-    target_call_id = fixture.call_ids[2]
-
-    # Query with call_id filter
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        filter=AnnotationQueueItemsFilter(call_id=target_call_id),
+    # call_id matches exactly one item
+    res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id,
+            queue_id=fixture.queue_id,
+            filter=AnnotationQueueItemsFilter(call_id=fixture.call_ids[2]),
+        )
     )
-    query_res = client.server.annotation_queue_items_query(query_req)
+    assert len(res.items) == 1
+    assert res.items[0].call_id == fixture.call_ids[2]
 
-    # Should return only 1 item
-    assert len(query_res.items) == 1
-    assert query_res.items[0].call_id == target_call_id
+    # call_trace_id matches at least one item, all with the target trace
+    res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id,
+            queue_id=fixture.queue_id,
+            filter=AnnotationQueueItemsFilter(call_trace_id=target_call.trace_id),
+        )
+    )
+    assert len(res.items) >= 1
+    assert all(item.call_trace_id == target_call.trace_id for item in res.items)
+
+    # added_by matches all 5 when correct, none when unknown
+    res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id,
+            queue_id=fixture.queue_id,
+            filter=AnnotationQueueItemsFilter(added_by="test_user"),
+        )
+    )
+    assert len(res.items) == 5
+    assert all(item.added_by == "test_user" for item in res.items)
+    res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id,
+            queue_id=fixture.queue_id,
+            filter=AnnotationQueueItemsFilter(added_by="nonexistent_user"),
+        )
+    )
+    assert len(res.items) == 0
+
+    # annotation_states: all unstarted initially, none completed
+    res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id,
+            queue_id=fixture.queue_id,
+            filter=AnnotationQueueItemsFilter(annotation_states=["unstarted"]),
+        )
+    )
+    assert len(res.items) == 5
+    assert all(item.annotation_state == "unstarted" for item in res.items)
+    res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id,
+            queue_id=fixture.queue_id,
+            filter=AnnotationQueueItemsFilter(annotation_states=["completed"]),
+        )
+    )
+    assert len(res.items) == 0
 
 
 def test_annotation_queue_items_query_filter_by_call_op_name(client):
@@ -1016,106 +1062,6 @@ def test_annotation_queue_items_query_filter_by_call_op_name(client):
     assert len(query_res.items) == 3
     for item in query_res.items:
         assert item.call_op_name == target_op_name
-
-
-def test_annotation_queue_items_query_filter_by_call_trace_id(client):
-    """Test filtering queue items by call_trace_id."""
-    # Create queue with 5 calls
-    fixture = create_queue_with_calls(
-        client, num_calls=5, queue_name="Filter By Trace ID Queue"
-    )
-
-    # Get trace_id from one of the calls
-    calls = list(client.get_calls())
-    target_trace_id = None
-    for call in calls:
-        if call.id in fixture.call_ids:
-            target_trace_id = call.trace_id
-            break
-
-    assert target_trace_id is not None
-
-    # Query with trace_id filter
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        filter=AnnotationQueueItemsFilter(call_trace_id=target_trace_id),
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-
-    # Should return at least 1 item (might be more if multiple calls share trace)
-    assert len(query_res.items) >= 1
-    for item in query_res.items:
-        assert item.call_trace_id == target_trace_id
-
-
-def test_annotation_queue_items_query_filter_by_added_by(client):
-    """Test filtering queue items by added_by."""
-    # Create queue with 5 calls added by test_user
-    fixture = create_queue_with_calls(
-        client, num_calls=5, queue_name="Filter By Added By Queue"
-    )
-
-    # Query with added_by filter
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        filter=AnnotationQueueItemsFilter(added_by="test_user"),
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-
-    # Should return all 5 items
-    assert len(query_res.items) == 5
-    for item in query_res.items:
-        assert item.added_by == "test_user"
-
-    # Query with non-existent added_by
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        filter=AnnotationQueueItemsFilter(added_by="nonexistent_user"),
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-
-    # Should return no items
-    assert len(query_res.items) == 0
-
-
-def test_annotation_queue_items_query_filter_by_annotation_states(client):
-    """Test filtering queue items by annotation_states.
-
-    Note: This test only validates filtering for 'unstarted' state.
-    Tests for other states (in_progress, completed, skipped) will be added
-    once the queue item progress update API is available.
-    """
-    # Create queue with 5 calls
-    fixture = create_queue_with_calls(
-        client, num_calls=5, queue_name="Filter By States Queue"
-    )
-
-    # Query for unstarted items (all items should be unstarted initially)
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        filter=AnnotationQueueItemsFilter(annotation_states=["unstarted"]),
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-
-    # Should return all 5 items
-    assert len(query_res.items) == 5
-    for item in query_res.items:
-        assert item.annotation_state == "unstarted"
-
-    # Query for completed items (should be none)
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        filter=AnnotationQueueItemsFilter(annotation_states=["completed"]),
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-
-    # Should return no items
-    assert len(query_res.items) == 0
 
 
 def test_annotation_queue_items_query_filter_combined(client):
@@ -1370,252 +1316,182 @@ def test_annotation_queue_items_query_position_with_filter_unstarted(client):
 # ============================================================================
 
 
-def test_annotator_queue_items_progress_update_completed(client):
-    """Test updating queue item state to 'completed'."""
-    # Create queue with 1 call
+@pytest.mark.parametrize("target_state", ["completed", "skipped", "in_progress"])
+def test_annotator_queue_items_progress_update_from_unstarted(client, target_state):
+    """Set a fresh (unstarted) item to each terminal/in-progress state and persist it."""
     fixture = create_queue_with_calls(
-        client, num_calls=1, queue_name="Progress Update Completed Queue"
+        client, num_calls=1, queue_name="Progress Update From Unstarted Queue"
     )
-
-    # Get the queue item
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
+    query_res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id, queue_id=fixture.queue_id
+        )
     )
-    query_res = client.server.annotation_queue_items_query(query_req)
     assert len(query_res.items) == 1
     item = query_res.items[0]
 
-    # Verify initial state is unstarted with no annotator
     # ClickHouse String default value is empty string, not NULL
     assert item.annotation_state == "unstarted"
     assert item.annotator_user_id == ""
 
-    # Update state to completed
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="completed",
-        wb_user_id="test_annotator",
+    update_res = client.server.annotator_queue_items_progress_update(
+        tsi.AnnotatorQueueItemsProgressUpdateReq(
+            project_id=client.project_id,
+            queue_id=fixture.queue_id,
+            item_id=item.id,
+            annotation_state=target_state,
+            wb_user_id="test_annotator",
+        )
     )
-    update_res = client.server.annotator_queue_items_progress_update(update_req)
 
-    # Verify response contains updated item with annotator_user_id
-    # Note: wb_user_id is stored in base64 format in the database
+    # wb_user_id is stored base64-encoded in the database
     expected_annotator_id = base64.b64encode(b"test_annotator").decode()
     assert update_res.item.id == item.id
-    assert update_res.item.annotation_state == "completed"
+    assert update_res.item.annotation_state == target_state
     assert update_res.item.annotator_user_id == expected_annotator_id
 
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
+    query_res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id, queue_id=fixture.queue_id
+        )
     )
-
-    # Query again to verify the state and annotator_user_id persisted
-    query_res = client.server.annotation_queue_items_query(query_req)
     assert len(query_res.items) == 1
-    assert query_res.items[0].annotation_state == "completed"
+    assert query_res.items[0].annotation_state == target_state
     assert query_res.items[0].annotator_user_id == expected_annotator_id
 
 
-def test_annotator_queue_items_progress_update_skipped(client):
-    """Test updating queue item state to 'skipped'."""
-    # Create queue with 1 call
+def test_annotator_queue_items_progress_update_invalid_inputs(client):
+    """Invalid state, missing user_id, and nonexistent item all raise ValueError."""
     fixture = create_queue_with_calls(
-        client, num_calls=1, queue_name="Progress Update Skipped Queue"
+        client, num_calls=1, queue_name="Invalid Inputs Queue"
     )
-
-    # Get the queue item
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
+    query_res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id, queue_id=fixture.queue_id
+        )
     )
-    query_res = client.server.annotation_queue_items_query(query_req)
-    assert len(query_res.items) == 1
     item = query_res.items[0]
 
-    # Update state to skipped
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="skipped",
-        wb_user_id="test_annotator",
-    )
-    update_res = client.server.annotator_queue_items_progress_update(update_req)
-
-    # Verify response contains updated item
-    assert update_res.item.id == item.id
-    assert update_res.item.annotation_state == "skipped"
-
-
-def test_annotator_queue_items_progress_update_invalid_state(client):
-    """Test that updating to invalid state raises error."""
-    # Create queue with 1 call
-    fixture = create_queue_with_calls(
-        client, num_calls=1, queue_name="Invalid State Queue"
-    )
-
-    # Get the queue item
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-    item = query_res.items[0]
-
-    # Try to update to invalid state
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="invalid_state",
-        wb_user_id="test_annotator",
-    )
-
-    # Should raise ValueError
     with pytest.raises(ValueError, match="Invalid annotation_state"):
-        client.server.annotator_queue_items_progress_update(update_req)
+        client.server.annotator_queue_items_progress_update(
+            tsi.AnnotatorQueueItemsProgressUpdateReq(
+                project_id=client.project_id,
+                queue_id=fixture.queue_id,
+                item_id=item.id,
+                annotation_state="invalid_state",
+                wb_user_id="test_annotator",
+            )
+        )
 
-
-def test_annotator_queue_items_progress_update_nonexistent_item(client):
-    """Test that updating nonexistent item raises error."""
-    # Create an empty queue
-    queue_id = create_annotation_queue(client, name="Nonexistent Item Queue")
-
-    # Try to update nonexistent item
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=queue_id,
-        item_id="nonexistent_item_id",
-        annotation_state="completed",
-        wb_user_id="test_annotator",
-    )
-
-    # Should raise ValueError
-    with pytest.raises(ValueError, match="Queue item .* not found"):
-        client.server.annotator_queue_items_progress_update(update_req)
-
-
-def test_annotator_queue_items_progress_update_no_user_id(client):
-    """Test that updating without user_id raises error."""
-    # Create queue with 1 call
-    fixture = create_queue_with_calls(
-        client, num_calls=1, queue_name="No User ID Queue"
-    )
-
-    # Get the queue item
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-    item = query_res.items[0]
-
-    # Try to update without user_id
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="completed",
-        wb_user_id=None,
-    )
-
-    # Should raise ValueError
     with pytest.raises(ValueError, match="wb_user_id is required"):
-        client.server.annotator_queue_items_progress_update(update_req)
+        client.server.annotator_queue_items_progress_update(
+            tsi.AnnotatorQueueItemsProgressUpdateReq(
+                project_id=client.project_id,
+                queue_id=fixture.queue_id,
+                item_id=item.id,
+                annotation_state="completed",
+                wb_user_id=None,
+            )
+        )
+
+    with pytest.raises(ValueError, match="Queue item .* not found"):
+        client.server.annotator_queue_items_progress_update(
+            tsi.AnnotatorQueueItemsProgressUpdateReq(
+                project_id=client.project_id,
+                queue_id=fixture.queue_id,
+                item_id="nonexistent_item_id",
+                annotation_state="completed",
+                wb_user_id="test_annotator",
+            )
+        )
 
 
-def test_annotator_queue_items_progress_update_transition_from_in_progress(client):
-    """Test valid state transition from in_progress to completed."""
-    # Create queue with 1 call
+def test_annotator_queue_items_progress_in_progress_to_completed(client):
+    """Valid transition: in_progress -> completed, response and read-back both updated."""
     fixture = create_queue_with_calls(
-        client, num_calls=1, queue_name="Transition From In Progress Queue"
+        client, num_calls=1, queue_name="In Progress To Completed Queue"
     )
-
-    # Get the queue item
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
+    query_res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id, queue_id=fixture.queue_id
+        )
     )
-    query_res = client.server.annotation_queue_items_query(query_req)
     item = query_res.items[0]
 
-    # First, mark as in_progress using the API
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="in_progress",
-        wb_user_id="test_annotator",
+    update_res = client.server.annotator_queue_items_progress_update(
+        tsi.AnnotatorQueueItemsProgressUpdateReq(
+            project_id=client.project_id,
+            queue_id=fixture.queue_id,
+            item_id=item.id,
+            annotation_state="in_progress",
+            wb_user_id="test_annotator",
+        )
     )
-    client.server.annotator_queue_items_progress_update(update_req)
+    assert update_res.item.annotation_state == "in_progress"
 
-    # Verify state is in_progress
-    # Create new query_req to avoid mutation issues
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
+    update_res = client.server.annotator_queue_items_progress_update(
+        tsi.AnnotatorQueueItemsProgressUpdateReq(
+            project_id=client.project_id,
+            queue_id=fixture.queue_id,
+            item_id=item.id,
+            annotation_state="completed",
+            wb_user_id="test_annotator",
+        )
     )
-    query_res = client.server.annotation_queue_items_query(query_req)
-    assert query_res.items[0].annotation_state == "in_progress"
-
-    # Update from in_progress to completed should succeed
-    # Create new update_req to avoid mutation issues
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="completed",
-        wb_user_id="test_annotator",
-    )
-    update_res = client.server.annotator_queue_items_progress_update(update_req)
-
-    # Verify state is now completed
     assert update_res.item.annotation_state == "completed"
 
+    query_res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id, queue_id=fixture.queue_id
+        )
+    )
+    assert query_res.items[0].annotation_state == "completed"
 
-def test_annotator_queue_items_progress_update_invalid_transition_from_completed(
-    client,
+
+@pytest.mark.parametrize(
+    ("target_state", "match"),
+    [
+        ("skipped", "Invalid state transition"),
+        (
+            "in_progress",
+            "Cannot transition to 'in_progress' when a record already exists",
+        ),
+    ],
+)
+def test_annotator_queue_items_progress_invalid_transition_from_completed(
+    client, target_state, match
 ):
-    """Test invalid state transition from completed to skipped."""
-    # Create queue with 1 call
+    """From completed, transitioning to skipped or in_progress both raise."""
     fixture = create_queue_with_calls(
-        client, num_calls=1, queue_name="Invalid Transition Queue"
+        client, num_calls=1, queue_name="Invalid Transition From Completed Queue"
     )
-
-    # Get the queue item
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
+    query_res = client.server.annotation_queue_items_query(
+        tsi.AnnotationQueueItemsQueryReq(
+            project_id=client.project_id, queue_id=fixture.queue_id
+        )
     )
-    query_res = client.server.annotation_queue_items_query(query_req)
     item = query_res.items[0]
 
-    # First, mark as completed
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="completed",
-        wb_user_id="test_annotator",
-    )
-    client.server.annotator_queue_items_progress_update(update_req)
-
-    # Try to transition from completed to skipped (should fail)
-    update_req2 = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="skipped",
-        wb_user_id="test_annotator",
+    client.server.annotator_queue_items_progress_update(
+        tsi.AnnotatorQueueItemsProgressUpdateReq(
+            project_id=client.project_id,
+            queue_id=fixture.queue_id,
+            item_id=item.id,
+            annotation_state="completed",
+            wb_user_id="test_annotator",
+        )
     )
 
-    # Should raise ValueError about invalid state transition
-    with pytest.raises(ValueError, match="Invalid state transition"):
-        client.server.annotator_queue_items_progress_update(update_req2)
+    with pytest.raises(ValueError, match=match):
+        client.server.annotator_queue_items_progress_update(
+            tsi.AnnotatorQueueItemsProgressUpdateReq(
+                project_id=client.project_id,
+                queue_id=fixture.queue_id,
+                item_id=item.id,
+                annotation_state=target_state,
+                wb_user_id="test_annotator",
+            )
+        )
 
 
 @pytest.mark.parametrize("state", ["completed", "skipped"])
@@ -1722,50 +1598,6 @@ def test_annotator_queue_items_progress_update_stats_integration(client):
     assert stats_res.stats[0].completed_items == 3
 
 
-def test_annotator_queue_items_progress_update_in_progress_new(client):
-    """Test updating queue item state to 'in_progress' for a new record."""
-    # Create queue with 1 call
-    fixture = create_queue_with_calls(
-        client, num_calls=1, queue_name="In Progress New Queue"
-    )
-
-    # Get the queue item
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-    assert len(query_res.items) == 1
-    item = query_res.items[0]
-
-    # Verify initial state is unstarted
-    assert item.annotation_state == "unstarted"
-
-    # Update state to in_progress (should succeed for new record)
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="in_progress",
-        wb_user_id="test_annotator",
-    )
-    update_res = client.server.annotator_queue_items_progress_update(update_req)
-
-    # Verify response contains updated item
-    assert update_res.item.id == item.id
-    assert update_res.item.annotation_state == "in_progress"
-
-    # Query again to verify the state persisted
-    # Create new query_req to avoid mutation issues
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-    assert len(query_res.items) == 1
-    assert query_res.items[0].annotation_state == "in_progress"
-
-
 def test_annotator_queue_items_progress_update_in_progress_existing(client):
     """Test that in_progress -> in_progress is idempotent (no-op, succeeds)."""
     # Create queue with 1 call
@@ -1805,98 +1637,6 @@ def test_annotator_queue_items_progress_update_in_progress_existing(client):
     )
     update_res2 = client.server.annotator_queue_items_progress_update(update_req2)
     assert update_res2.item.annotation_state == "in_progress"
-
-
-def test_annotator_queue_items_progress_update_in_progress_from_completed(client):
-    """Test that completed -> in_progress fails (can't restart a finished item)."""
-    # Create queue with 1 call
-    fixture = create_queue_with_calls(
-        client, num_calls=1, queue_name="In Progress From Completed Queue"
-    )
-
-    # Get the queue item
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-    assert len(query_res.items) == 1
-    item = query_res.items[0]
-
-    # First, mark it as completed
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="completed",
-        wb_user_id="test_annotator",
-    )
-    update_res = client.server.annotator_queue_items_progress_update(update_req)
-    assert update_res.item.annotation_state == "completed"
-
-    # Try to transition from completed to in_progress (should fail)
-    update_req2 = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="in_progress",
-        wb_user_id="test_annotator",
-    )
-    with pytest.raises(
-        Exception,
-        match="Cannot transition to 'in_progress' when a record already exists",
-    ):
-        client.server.annotator_queue_items_progress_update(update_req2)
-
-
-def test_annotator_queue_items_progress_in_progress_to_completed(client):
-    """Test transitioning from 'in_progress' to 'completed'."""
-    # Create queue with 1 call
-    fixture = create_queue_with_calls(
-        client, num_calls=1, queue_name="In Progress to Completed Queue"
-    )
-
-    # Get the queue item
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-    assert len(query_res.items) == 1
-    item = query_res.items[0]
-
-    # First, mark it as in_progress
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="in_progress",
-        wb_user_id="test_annotator",
-    )
-    update_res = client.server.annotator_queue_items_progress_update(update_req)
-    assert update_res.item.annotation_state == "in_progress"
-
-    # Now update to completed (should succeed)
-    # Create new update_req to avoid mutation issues
-    update_req = tsi.AnnotatorQueueItemsProgressUpdateReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-        item_id=item.id,
-        annotation_state="completed",
-        wb_user_id="test_annotator",
-    )
-    update_res = client.server.annotator_queue_items_progress_update(update_req)
-    assert update_res.item.annotation_state == "completed"
-
-    # Query again to verify
-    # Create new query_req to avoid mutation issues
-    query_req = tsi.AnnotationQueueItemsQueryReq(
-        project_id=client.project_id,
-        queue_id=fixture.queue_id,
-    )
-    query_res = client.server.annotation_queue_items_query(query_req)
-    assert len(query_res.items) == 1
-    assert query_res.items[0].annotation_state == "completed"
 
 
 def test_annotator_queue_items_progress_in_progress_workflow(client):

--- a/tests/trace/test_client_server_caching.py
+++ b/tests/trace/test_client_server_caching.py
@@ -558,158 +558,73 @@ def test_cache_directory_creation(tmp_path):
     cache_server.close()
 
 
-def test_cache_invalidation_on_add_tags(client):
-    """obj_read cache should be invalidated when tags are added."""
+def test_cache_invalidation_on_tag_and_alias_mutations(client):
+    """obj_read cache is invalidated by every tag/alias mutation path.
+
+    Covers add/remove tags and set/remove aliases: each primes the cache (and
+    verifies a hit on re-read), mutates, then asserts the next read misses and
+    reflects the mutation.
+    """
     caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
-    ref = weave.publish({"data": "test"}, name="cache_inv_add_tags")
 
-    # Prime the cache with an obj_read that includes tags
-    caching_server.reset_cache_recorder()
-    res1 = client.server.obj_read(
-        ObjReadReq(
-            project_id=client.project_id,
-            object_id=ref.name,
-            digest=ref.digest,
-            include_tags_and_aliases=True,
+    def read(ref):
+        return client.server.obj_read(
+            ObjReadReq(
+                project_id=client.project_id,
+                object_id=ref.name,
+                digest=ref.digest,
+                include_tags_and_aliases=True,
+            )
         )
-    )
+
+    # add tags: starts empty, second read hits cache, mutation invalidates.
+    add_ref = weave.publish({"data": "test"}, name="cache_inv_add_tags")
+    caching_server.reset_cache_recorder()
+    assert read(add_ref).obj.tags == []
     assert caching_server.get_cache_recorder()["misses"] == 1
-    assert res1.obj.tags == []
-
-    # Second read should hit cache
     caching_server.reset_cache_recorder()
-    client.server.obj_read(
-        ObjReadReq(
-            project_id=client.project_id,
-            object_id=ref.name,
-            digest=ref.digest,
-            include_tags_and_aliases=True,
-        )
-    )
+    read(add_ref)
     assert caching_server.get_cache_recorder()["hits"] == 1
-
-    # Add tags — should invalidate cache
-    client.add_tags(ref, ["new-tag"])
-
-    # Next read should miss (cache was invalidated)
+    client.add_tags(add_ref, ["new-tag"])
     caching_server.reset_cache_recorder()
-    res2 = client.server.obj_read(
-        ObjReadReq(
-            project_id=client.project_id,
-            object_id=ref.name,
-            digest=ref.digest,
-            include_tags_and_aliases=True,
-        )
-    )
+    res = read(add_ref)
     assert caching_server.get_cache_recorder()["misses"] == 1
-    assert res2.obj.tags == ["new-tag"]
+    assert res.obj.tags == ["new-tag"]
 
-
-def test_cache_invalidation_on_remove_tags(client):
-    """obj_read cache should be invalidated when tags are removed."""
-    caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
-    ref = weave.publish({"data": "test"}, name="cache_inv_rm_tags")
-    client.add_tags(ref, ["removable"])
-
-    # Prime cache
+    # remove tags.
+    rm_tag_ref = weave.publish({"data": "test"}, name="cache_inv_rm_tags")
+    client.add_tags(rm_tag_ref, ["removable"])
     caching_server.reset_cache_recorder()
-    res1 = client.server.obj_read(
-        ObjReadReq(
-            project_id=client.project_id,
-            object_id=ref.name,
-            digest=ref.digest,
-            include_tags_and_aliases=True,
-        )
-    )
-    assert res1.obj.tags == ["removable"]
+    assert read(rm_tag_ref).obj.tags == ["removable"]
     assert caching_server.get_cache_recorder()["misses"] == 1
-
-    # Remove tags — should invalidate cache
-    client.remove_tags(ref, ["removable"])
-
-    # Next read should miss
+    client.remove_tags(rm_tag_ref, ["removable"])
     caching_server.reset_cache_recorder()
-    res2 = client.server.obj_read(
-        ObjReadReq(
-            project_id=client.project_id,
-            object_id=ref.name,
-            digest=ref.digest,
-            include_tags_and_aliases=True,
-        )
-    )
+    res = read(rm_tag_ref)
     assert caching_server.get_cache_recorder()["misses"] == 1
-    assert res2.obj.tags == []
+    assert res.obj.tags == []
 
-
-def test_cache_invalidation_on_set_alias(client):
-    """obj_read cache should be invalidated when an alias is set."""
-    caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
-    ref = weave.publish({"data": "test"}, name="cache_inv_set_alias")
-
-    # Prime cache
+    # set alias.
+    set_alias_ref = weave.publish({"data": "test"}, name="cache_inv_set_alias")
     caching_server.reset_cache_recorder()
-    res1 = client.server.obj_read(
-        ObjReadReq(
-            project_id=client.project_id,
-            object_id=ref.name,
-            digest=ref.digest,
-            include_tags_and_aliases=True,
-        )
-    )
+    assert read(set_alias_ref).obj.aliases == ["latest"]
     assert caching_server.get_cache_recorder()["misses"] == 1
-    assert res1.obj.aliases == ["latest"]
-
-    # Set alias — should invalidate cache
-    client.set_aliases(ref, "prod")
-
-    # Next read should miss
+    client.set_aliases(set_alias_ref, "prod")
     caching_server.reset_cache_recorder()
-    res2 = client.server.obj_read(
-        ObjReadReq(
-            project_id=client.project_id,
-            object_id=ref.name,
-            digest=ref.digest,
-            include_tags_and_aliases=True,
-        )
-    )
+    res = read(set_alias_ref)
     assert caching_server.get_cache_recorder()["misses"] == 1
-    assert "prod" in res2.obj.aliases
+    assert "prod" in res.obj.aliases
 
-
-def test_cache_invalidation_on_remove_aliases(client):
-    """obj_read cache should be invalidated when aliases are removed."""
-    caching_server = find_server_layer(client.server, CachingMiddlewareTraceServer)
-    ref = weave.publish({"data": "test"}, name="cache_inv_rm_alias")
-    client.set_aliases(ref, "staging")
-
-    # Prime cache
+    # remove aliases.
+    rm_alias_ref = weave.publish({"data": "test"}, name="cache_inv_rm_alias")
+    client.set_aliases(rm_alias_ref, "staging")
     caching_server.reset_cache_recorder()
-    res1 = client.server.obj_read(
-        ObjReadReq(
-            project_id=client.project_id,
-            object_id=ref.name,
-            digest=ref.digest,
-            include_tags_and_aliases=True,
-        )
-    )
-    assert "staging" in res1.obj.aliases
+    assert "staging" in read(rm_alias_ref).obj.aliases
     assert caching_server.get_cache_recorder()["misses"] == 1
-
-    # Remove alias — should invalidate cache
-    client.remove_aliases(ref, "staging")
-
-    # Next read should miss
+    client.remove_aliases(rm_alias_ref, "staging")
     caching_server.reset_cache_recorder()
-    res2 = client.server.obj_read(
-        ObjReadReq(
-            project_id=client.project_id,
-            object_id=ref.name,
-            digest=ref.digest,
-            include_tags_and_aliases=True,
-        )
-    )
+    res = read(rm_alias_ref)
     assert caching_server.get_cache_recorder()["misses"] == 1
-    assert "staging" not in res2.obj.aliases
+    assert "staging" not in res.obj.aliases
 
 
 def test_invalidation_prefix_is_prefix_of_cache_key():

--- a/tests/trace/test_client_side_digests.py
+++ b/tests/trace/test_client_side_digests.py
@@ -7,6 +7,8 @@ the expected_digest field.
 
 from __future__ import annotations
 
+from collections.abc import Callable
+
 import pytest
 from PIL import Image
 
@@ -58,477 +60,370 @@ def _publish_with_digests(
     return ref.digest
 
 
+def _make_op():
+    """Return a fresh `@weave.op` for publish/digest tests."""
+
+    @weave.op
+    def my_test_op(x: int) -> int:
+        return x + 1
+
+    return my_test_op
+
+
 @pytest.fixture
 def fast_path(client: WeaveClient):
     """Enable the client-side digest fast path for a test."""
     _configure_digests(client, enable=True)
 
 
-class TestClientServerDigestConsistency:
-    """Client-side and server-side digests must agree for the same data."""
-
-    def test_object(self, client: WeaveClient):
-        obj = {"model": "gpt-4", "temperature": 0.7, "tags": ["a", "b"]}
-
-        digest_client = _publish_with_digests(client, obj, "obj_client", enable=True)
-        digest_server = _publish_with_digests(client, obj, "obj_server", enable=False)
-
-        assert digest_client == digest_server
-
-    def test_dataset(self, client: WeaveClient):
-        rows = [{"x": i, "y": str(i)} for i in range(10)]
-
-        ds_client = weave.Dataset(name="bench_ds", rows=rows)
-        digest_client = _publish_with_digests(
-            client, ds_client, "ds_client", enable=True
-        )
-
-        ds_server = weave.Dataset(name="bench_ds", rows=rows)
-        digest_server = _publish_with_digests(
-            client, ds_server, "ds_server", enable=False
-        )
-
-        assert digest_client == digest_server
-
-    def test_nested_object(self, client: WeaveClient):
-        obj = {
+# Client-side and server-side digests must agree for the same data. Each case
+# supplies a factory so dataset/image inputs are rebuilt fresh per publish.
+@pytest.mark.parametrize(
+    "make",
+    [
+        lambda: {"model": "gpt-4", "temperature": 0.7, "tags": ["a", "b"]},
+        lambda: weave.Dataset(
+            name="bench_ds", rows=[{"x": i, "y": str(i)} for i in range(10)]
+        ),
+        lambda: {
             "config": {"a": 1, "b": [2, 3]},
             "metadata": {"nested": {"deep": True}},
-        }
-
-        digest_client = _publish_with_digests(client, obj, "nested_client", enable=True)
-        digest_server = _publish_with_digests(
-            client, obj, "nested_server", enable=False
-        )
-
-        assert digest_client == digest_server
-
-    def test_op(self, client: WeaveClient):
-        @weave.op
-        def my_test_op(x: int) -> int:
-            return x + 1
-
-        digest_client = _publish_with_digests(
-            client, my_test_op, "op_client", enable=True
-        )
-        digest_server = _publish_with_digests(
-            client, my_test_op, "op_server", enable=False
-        )
-
-        assert digest_client == digest_server
-
-    def test_empty_dict(self, client: WeaveClient):
-        obj: dict = {}
-
-        digest_client = _publish_with_digests(client, obj, "empty_client", enable=True)
-        digest_server = _publish_with_digests(client, obj, "empty_server", enable=False)
-
-        assert digest_client == digest_server
-
-    def test_unicode_content(self, client: WeaveClient):
-        obj = {
+        },
+        _make_op,
+        lambda: {},
+        lambda: {
             "emoji": "\U0001f680\U0001f30d",
             "cjk": "\u4f60\u597d\u4e16\u754c",
             "accent": "\u00e9\u00e0\u00fc",
-        }
+        },
+        lambda: weave.Dataset(
+            name="bench_large_ds",
+            rows=[
+                {"idx": i, "val": f"row_{i}", "data": list(range(i % 10))}
+                for i in range(100)
+            ],
+        ),
+        lambda: Image.new("RGB", (16, 16), color=(0, 128, 255)),
+    ],
+    ids=[
+        "object",
+        "dataset",
+        "nested_object",
+        "op",
+        "empty_dict",
+        "unicode_content",
+        "large_dataset",
+        "custom_weave_type",
+    ],
+)
+def test_client_server_digest_consistency(
+    client: WeaveClient, make: Callable[[], object]
+) -> None:
+    digest_client = _publish_with_digests(
+        client, make(), "consistency_client", enable=True
+    )
+    digest_server = _publish_with_digests(
+        client, make(), "consistency_server", enable=False
+    )
+    assert digest_client == digest_server
 
-        digest_client = _publish_with_digests(
-            client, obj, "unicode_client", enable=True
+
+def test_client_server_digest_consistency_with_ref(client: WeaveClient) -> None:
+    # Object containing a ref to another object hashes identically both ways.
+    inner_ref = weave.publish({"inner_key": "inner_value"}, name="inner_obj")
+    client._flush()
+    outer = {"ref": inner_ref.uri(), "extra": "data"}
+
+    digest_client = _publish_with_digests(client, outer, "outer_client", enable=True)
+    digest_server = _publish_with_digests(client, outer, "outer_server", enable=False)
+    assert digest_client == digest_server
+
+
+def test_republish_same_project_object_keeps_ref(client: WeaveClient) -> None:
+    # Re-saving an instance that already carries a same-project ref is a no-op
+    # in _save_nested_objects (the ref.project == self.project early return).
+    obj = weave.Dataset(name="republish_ds", rows=[{"a": 1}, {"a": 2}])
+    first = weave.publish(obj, name="republish_obj")
+    client._flush()
+    second = weave.publish(obj, name="republish_obj")
+    client._flush()
+    assert first.digest == second.digest
+
+
+def test_client_table_row_digests_match_server(client: WeaveClient) -> None:
+    rows = [{"x": i, "y": str(i)} for i in range(5)]
+    client_row_digests = [compute_row_digest(r) for r in rows]
+    client_table_digest = compute_table_digest(client_row_digests)
+
+    req = tsi.TableCreateReq(
+        table=tsi.TableSchemaForInsert(project_id=client.project_id, rows=rows)
+    )
+    res = client.server.table_create(req)
+
+    assert res.row_digests == client_row_digests
+    assert res.digest == client_table_digest
+
+
+# Publish via the fast path, read back, verify data is intact across types.
+def test_data_correctness_scalar_and_nested_objects(
+    client: WeaveClient, fast_path: None
+) -> None:
+    flat = weave.publish(
+        {"key": "value", "number": 42, "list": [1, 2, 3]}, name="round_trip_obj"
+    )
+    nested = weave.publish(
+        {"config": {"a": 1, "b": [2, 3]}, "metadata": {"nested": {"deep": True}}},
+        name="nested_rt",
+    )
+    empty = weave.publish({}, name="empty_rt")
+    unicode_ref = weave.publish(
+        {"emoji": "\U0001f680", "cjk": "\u4f60\u597d"}, name="unicode_rt"
+    )
+    client._flush()
+
+    flat_got = flat.get()
+    assert flat_got["key"] == "value"
+    assert flat_got["number"] == 42
+    assert flat_got["list"] == [1, 2, 3]
+
+    nested_got = nested.get()
+    assert nested_got["config"]["a"] == 1
+    assert nested_got["metadata"]["nested"]["deep"] is True
+
+    assert empty.get() == {}
+
+    unicode_got = unicode_ref.get()
+    assert unicode_got["emoji"] == "\U0001f680"
+    assert unicode_got["cjk"] == "\u4f60\u597d"
+
+
+def test_data_correctness_dataset_op_and_image(
+    client: WeaveClient, fast_path: None
+) -> None:
+    ds_ref = weave.publish(
+        weave.Dataset(
+            name="round_trip_ds", rows=[{"a": i, "b": i * 2} for i in range(5)]
         )
-        digest_server = _publish_with_digests(
-            client, obj, "unicode_server", enable=False
-        )
+    )
+    op_ref = weave.publish(_make_op(), name="op_rt")
+    img_ref = weave.publish(
+        Image.new("RGB", (32, 32), color=(255, 0, 0)), name="fast_path_image"
+    )
+    client._flush()
 
-        assert digest_client == digest_server
+    got_rows = list(ds_ref.get().rows)
+    assert len(got_rows) == 5
+    for i, row in enumerate(got_rows):
+        assert row["a"] == i
+        assert row["b"] == i * 2
 
-    def test_large_dataset(self, client: WeaveClient):
-        rows = [
-            {"idx": i, "val": f"row_{i}", "data": list(range(i % 10))}
-            for i in range(100)
-        ]
+    assert op_ref.get()(3) == 4
 
-        ds_client = weave.Dataset(name="bench_large_ds", rows=rows)
-        digest_client = _publish_with_digests(
-            client, ds_client, "large_client", enable=True
-        )
-
-        ds_server = weave.Dataset(name="bench_large_ds", rows=rows)
-        digest_server = _publish_with_digests(
-            client, ds_server, "large_server", enable=False
-        )
-
-        assert digest_client == digest_server
-
-    def test_object_with_ref(self, client: WeaveClient):
-        """Object containing a ref to another object."""
-        inner = {"inner_key": "inner_value"}
-        inner_ref = weave.publish(inner, name="inner_obj")
-        client._flush()
-
-        outer = {"ref": inner_ref.uri(), "extra": "data"}
-
-        digest_client = _publish_with_digests(
-            client, outer, "outer_client", enable=True
-        )
-        digest_server = _publish_with_digests(
-            client, outer, "outer_server", enable=False
-        )
-
-        assert digest_client == digest_server
-
-    def test_custom_weave_type(self, client: WeaveClient):
-        """CustomWeaveType (PIL Image) produces the same digest on both paths."""
-        img_client = Image.new("RGB", (16, 16), color=(0, 128, 255))
-        digest_client = _publish_with_digests(
-            client, img_client, "img_client", enable=True
-        )
-
-        img_server = Image.new("RGB", (16, 16), color=(0, 128, 255))
-        digest_server = _publish_with_digests(
-            client, img_server, "img_server", enable=False
-        )
-
-        assert digest_client == digest_server
-
-    def test_table_row_digests(self, client: WeaveClient):
-        """Client-computed row and table digests match the server's."""
-        rows = [{"x": i, "y": str(i)} for i in range(5)]
-
-        client_row_digests = [compute_row_digest(r) for r in rows]
-        client_table_digest = compute_table_digest(client_row_digests)
-
-        req = tsi.TableCreateReq(
-            table=tsi.TableSchemaForInsert(
-                project_id=client.project_id,
-                rows=rows,
-            )
-        )
-        res = client.server.table_create(req)
-
-        assert res.row_digests == client_row_digests
-        assert res.digest == client_table_digest
+    img_got = img_ref.get()
+    assert isinstance(img_got, Image.Image)
+    assert img_got.size == (32, 32)
+    assert img_got.getpixel((0, 0)) == (255, 0, 0)
 
 
-class TestDataCorrectness:
-    """Publish (client-side and server-side), read back, verify data is intact."""
-
-    def test_object(self, client: WeaveClient, fast_path: None):
-        obj = {"key": "value", "number": 42, "list": [1, 2, 3]}
-        ref = weave.publish(obj, name="round_trip_obj")
-        client._flush()
-
-        got = ref.get()
-        assert got["key"] == "value"
-        assert got["number"] == 42
-        assert got["list"] == [1, 2, 3]
-
-    def test_dataset(self, client: WeaveClient, fast_path: None):
-        rows = [{"a": i, "b": i * 2} for i in range(5)]
-        ds = weave.Dataset(name="round_trip_ds", rows=rows)
-        ref = weave.publish(ds)
-        client._flush()
-
-        got = ref.get()
-        got_rows = list(got.rows)
-        assert len(got_rows) == 5
-        for i, row in enumerate(got_rows):
-            assert row["a"] == i
-            assert row["b"] == i * 2
-
-    def test_nested_object(self, client: WeaveClient, fast_path: None):
-        obj = {
-            "config": {"a": 1, "b": [2, 3]},
-            "metadata": {"nested": {"deep": True}},
-        }
-        ref = weave.publish(obj, name="nested_rt")
-        client._flush()
-
-        got = ref.get()
-        assert got["config"]["a"] == 1
-        assert got["metadata"]["nested"]["deep"] is True
-
-    def test_op(self, client: WeaveClient, fast_path: None):
-        @weave.op
-        def my_rt_op(x: int) -> int:
-            return x + 1
-
-        ref = weave.publish(my_rt_op, name="op_rt")
-        client._flush()
-
-        got = ref.get()
-        assert got(3) == 4
-
-    def test_empty_dict(self, client: WeaveClient, fast_path: None):
-        ref = weave.publish({}, name="empty_rt")
-        client._flush()
-        assert ref.get() == {}
-
-    def test_unicode_content(self, client: WeaveClient, fast_path: None):
-        obj = {"emoji": "\U0001f680", "cjk": "\u4f60\u597d"}
-        ref = weave.publish(obj, name="unicode_rt")
-        client._flush()
-
-        got = ref.get()
-        assert got["emoji"] == "\U0001f680"
-        assert got["cjk"] == "\u4f60\u597d"
-
-    def test_custom_weave_type(self, client: WeaveClient, fast_path: None):
-        img = Image.new("RGB", (32, 32), color=(255, 0, 0))
-        ref = weave.publish(img, name="fast_path_image")
-        client._flush()
-
-        got = ref.get()
-        assert isinstance(got, Image.Image)
-        assert got.size == (32, 32)
-        assert got.getpixel((0, 0)) == (255, 0, 0)
-
-    def test_get_without_explicit_flush(self, weave_active, fast_path: None):
-        """ref.get() must work without an explicit _flush() call.
-
-        In production, the FutureExecutor resolves deferred work when the
-        digest or data is accessed. The test client auto-flushes, but this
-        test documents the contract that callers don't need to flush manually.
-        """
-        obj = {"immediate": "access", "count": 99}
-        ref = weave.publish(obj, name="no-flush-get-test")
-
-        got = ref.get()
-        assert got["immediate"] == "access"
-        assert got["count"] == 99
+def test_data_correctness_get_without_explicit_flush(
+    weave_active, fast_path: None
+) -> None:
+    # ref.get() resolves deferred work via the FutureExecutor, so callers
+    # don't need an explicit _flush() (the test client auto-flushes).
+    ref = weave.publish({"immediate": "access", "count": 99}, name="no-flush-get-test")
+    got = ref.get()
+    assert got["immediate"] == "access"
+    assert got["count"] == 99
 
 
-class TestServerDigestValidation:
-    """Server must reject wrong expected_digest and accept correct ones."""
-
-    @pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
-    def test_object(self, client: WeaveClient, correct: bool):
-        val = {"hello": "world"}
-        expected_digest = compute_object_digest(val) if correct else "definitely_wrong"
-
-        req = tsi.ObjCreateReq(
-            obj=tsi.ObjSchemaForInsert(
-                project_id=client.project_id,
-                object_id="digest_obj",
-                val=val,
-                expected_digest=expected_digest,
-            )
-        )
-
-        if correct:
-            res = client.server.obj_create(req)
-            assert res.digest == expected_digest
-        else:
-            with pytest.raises(DigestMismatchError):
-                client.server.obj_create(req)
-
-    @pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
-    def test_table(self, client: WeaveClient, correct: bool):
-        rows = [{"a": 1}, {"a": 2}, {"a": 3}]
-        row_digests = [compute_row_digest(r) for r in rows]
-        expected_digest = (
-            compute_table_digest(row_digests) if correct else "definitely_wrong"
-        )
-
-        req = tsi.TableCreateReq(
-            table=tsi.TableSchemaForInsert(
-                project_id=client.project_id,
-                rows=rows,
-                expected_digest=expected_digest,
-            )
-        )
-
-        if correct:
-            res = client.server.table_create(req)
-            assert res.digest == expected_digest
-            assert res.row_digests == row_digests
-        else:
-            with pytest.raises(DigestMismatchError):
-                client.server.table_create(req)
-
-    @pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
-    def test_file(self, client: WeaveClient, correct: bool):
-        content = b"hello world"
-        expected_digest = (
-            compute_file_digest(content) if correct else "definitely_wrong"
-        )
-
-        req = tsi.FileCreateReq(
+# Server must reject a wrong expected_digest and accept a correct one.
+@pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
+def test_server_digest_validation_object(client: WeaveClient, correct: bool) -> None:
+    val = {"hello": "world"}
+    expected_digest = compute_object_digest(val) if correct else "definitely_wrong"
+    req = tsi.ObjCreateReq(
+        obj=tsi.ObjSchemaForInsert(
             project_id=client.project_id,
-            name="test.txt",
-            content=content,
+            object_id="digest_obj",
+            val=val,
             expected_digest=expected_digest,
         )
-
-        if correct:
-            res = client.server.file_create(req)
-            assert res.digest == expected_digest
-        else:
-            with pytest.raises(DigestMismatchError):
-                client.server.file_create(req)
-
-
-class TestConvertRefsToInternal:
-    """Unit tests for _convert_refs_to_internal."""
-
-    def test_raises_when_no_internal_id(self, client: WeaveClient) -> None:
-        """Raises NoInternalProjectIDError when the resolver returns None.
-
-        This happens when the feature flag is off (default) or the resolver
-        is disabled — get_internal_project_id returns None.
-        """
-        json_val = {
-            "key": "value",
-            "ref": f"weave:///{client.entity}/{client.project}/object/foo:abc123",
-        }
-
-        # Ensure the setting is off so the resolver returns None
-        with (
-            override_settings(enable_client_side_digests=False),
-            pytest.raises(NoInternalProjectIDError),
-        ):
-            client._convert_refs_to_internal(json_val)
-
-    def test_raises_for_cross_project_ref(
-        self, client: WeaveClient, fast_path: None
-    ) -> None:
-        """Raises CrossProjectRefError when cross-project refs are present."""
-        json_val = {
-            "same_project": f"weave:///{client.entity}/{client.project}/object/foo:abc123",
-            "cross_project": f"weave:///{client.entity}/other-project/object/bar:def456",
-        }
-
-        with pytest.raises(CrossProjectRefError):
-            client._convert_refs_to_internal(json_val)
-
-    def test_cross_project_ref_skips_expected_digest(
-        self, client: WeaveClient, fast_path: None, monkeypatch
-    ) -> None:
-        """Publishing with a cross-project ref falls back to no expected_digest.
-
-        When the client encounters an unresolvable cross-project ref, it raises
-        CrossProjectRefError which is caught by the caller, causing it to skip
-        expected_digest and let the server compute the digest instead.
-        """
-        # Spy on the adapter's obj_create to capture expected_digest values
-        captured: list[str | None] = []
-        adapter = find_server_layer(client.server, ExternalTraceServer)
-        original = type(adapter).obj_create
-
-        def spy(self, req):
-            captured.append(req.obj.expected_digest)
-            return original(self, req)
-
-        monkeypatch.setattr(type(adapter), "obj_create", spy)
-
-        # Publish an inner object in a different project to get a cross-project ref
-        original_project = client.project
-        client.project = "other-project"
-        inner_ref = client._save_object({"msg": "hi"}, "inner")
-        client._flush()
-
-        # Now publish an outer object in the original project that references it
-        client.project = original_project
-        outer = {"cross_ref": inner_ref.uri(), "data": "test"}
-        weave.publish(outer, name="outer-with-cross-ref")
-        client._flush()
-
-        # The outer object's obj_create should have expected_digest=None
-        # because of the unresolvable cross-project ref
-        assert len(captured) >= 1
-        assert captured[-1] is None
+    )
+    if correct:
+        assert client.server.obj_create(req).digest == expected_digest
+    else:
+        with pytest.raises(DigestMismatchError):
+            client.server.obj_create(req)
 
 
-class TestDigestMismatchAutoDisable:
-    """On DigestMismatchError the client retries without expected_digest
-    and disables client-side digests for the rest of the session.
-    """
+@pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
+def test_server_digest_validation_table(client: WeaveClient, correct: bool) -> None:
+    rows = [{"a": 1}, {"a": 2}, {"a": 3}]
+    row_digests = [compute_row_digest(r) for r in rows]
+    expected_digest = (
+        compute_table_digest(row_digests) if correct else "definitely_wrong"
+    )
+    req = tsi.TableCreateReq(
+        table=tsi.TableSchemaForInsert(
+            project_id=client.project_id, rows=rows, expected_digest=expected_digest
+        )
+    )
+    if correct:
+        res = client.server.table_create(req)
+        assert res.digest == expected_digest
+        assert res.row_digests == row_digests
+    else:
+        with pytest.raises(DigestMismatchError):
+            client.server.table_create(req)
 
-    @pytest.mark.disable_logging_error_check
-    def test_object_mismatch_retries_and_disables(
-        self, client: WeaveClient, fast_path: None, monkeypatch
-    ) -> None:
-        """First obj_create with expected_digest fails; client retries without
-        it and disables fast path for subsequent saves.
-        """
-        adapter = find_server_layer(client.server, ExternalTraceServer)
-        original = adapter.obj_create
-        seen_digests: list[str | None] = []
-        injected = False
 
-        def mismatch_once(req: tsi.ObjCreateReq) -> tsi.ObjCreateRes:
-            nonlocal injected
-            seen_digests.append(req.obj.expected_digest)
-            if not injected and req.obj.expected_digest is not None:
-                injected = True
-                raise DigestMismatchError("forced mismatch")
-            return original(req)
+@pytest.mark.parametrize("correct", [True, False], ids=["correct", "wrong"])
+def test_server_digest_validation_file(client: WeaveClient, correct: bool) -> None:
+    content = b"hello world"
+    expected_digest = compute_file_digest(content) if correct else "definitely_wrong"
+    req = tsi.FileCreateReq(
+        project_id=client.project_id,
+        name="test.txt",
+        content=content,
+        expected_digest=expected_digest,
+    )
+    if correct:
+        assert client.server.file_create(req).digest == expected_digest
+    else:
+        with pytest.raises(DigestMismatchError):
+            client.server.file_create(req)
 
-        monkeypatch.setattr(adapter, "obj_create", mismatch_once)
 
-        # First publish: expected_digest sent, server rejects, client retries
-        ref = weave.publish({"first": True}, name="mismatch-first")
-        client._flush()
+# _convert_refs_to_internal unit behavior.
+def test_convert_refs_raises_when_no_internal_id(client: WeaveClient) -> None:
+    # Resolver returns None when the flag is off (default), so conversion raises.
+    json_val = {
+        "key": "value",
+        "ref": f"weave:///{client.entity}/{client.project}/object/foo:abc123",
+    }
+    with (
+        override_settings(enable_client_side_digests=False),
+        pytest.raises(NoInternalProjectIDError),
+    ):
+        client._convert_refs_to_internal(json_val)
 
-        # Should have seen: [digest, None] (first attempt + retry)
-        assert seen_digests == [ref.digest, None]
-        assert client.project_id_resolver.is_disabled
 
-        # Second publish: fast path is disabled, no expected_digest
-        seen_digests.clear()
-        weave.publish({"second": True}, name="mismatch-second")
-        client._flush()
+def test_convert_refs_raises_for_cross_project_ref(
+    client: WeaveClient, fast_path: None
+) -> None:
+    json_val = {
+        "same_project": f"weave:///{client.entity}/{client.project}/object/foo:abc123",
+        "cross_project": f"weave:///{client.entity}/other-project/object/bar:def456",
+    }
+    with pytest.raises(CrossProjectRefError):
+        client._convert_refs_to_internal(json_val)
 
-        assert seen_digests == [None]
 
-    @pytest.mark.disable_logging_error_check
-    def test_table_mismatch_retries_and_disables(
-        self, client: WeaveClient, fast_path: None, monkeypatch
-    ) -> None:
-        """Table digest mismatch retries and disables fast path."""
-        adapter = find_server_layer(client.server, ExternalTraceServer)
-        original = adapter.table_create
-        injected = False
+def test_cross_project_ref_skips_expected_digest(
+    client: WeaveClient, fast_path: None, monkeypatch
+) -> None:
+    # An unresolvable cross-project ref makes the caller skip expected_digest
+    # and let the server compute the digest instead.
+    captured: list[str | None] = []
+    adapter = find_server_layer(client.server, ExternalTraceServer)
+    original = type(adapter).obj_create
 
-        def mismatch_once(req: tsi.TableCreateReq) -> tsi.TableCreateRes:
-            nonlocal injected
-            if not injected and req.table.expected_digest is not None:
-                injected = True
-                raise DigestMismatchError("forced table mismatch")
-            return original(req)
+    def spy(self, req):
+        captured.append(req.obj.expected_digest)
+        return original(self, req)
 
-        monkeypatch.setattr(adapter, "table_create", mismatch_once)
+    monkeypatch.setattr(type(adapter), "obj_create", spy)
 
-        ds = weave.Dataset(name="mismatch-ds", rows=[{"x": 1}, {"x": 2}])
-        ref = weave.publish(ds, name="mismatch-ds")
-        client._flush()
+    original_project = client.project
+    client.project = "other-project"
+    inner_ref = client._save_object({"msg": "hi"}, "inner")
+    client._flush()
 
-        assert client.project_id_resolver.is_disabled
+    client.project = original_project
+    weave.publish(
+        {"cross_ref": inner_ref.uri(), "data": "test"}, name="outer-with-cross-ref"
+    )
+    client._flush()
 
-        # Data should still be readable (retry succeeded)
-        got = ref.get()
-        got_rows = list(got.rows)
-        assert len(got_rows) == 2
+    assert len(captured) >= 1
+    assert captured[-1] is None
 
-    @pytest.mark.disable_logging_error_check
-    def test_file_mismatch_retries_and_disables(
-        self, client: WeaveClient, fast_path: None, monkeypatch
-    ) -> None:
-        """File digest mismatch retries and disables fast path."""
-        adapter = find_server_layer(client.server, ExternalTraceServer)
-        original = adapter.file_create
-        injected = False
 
-        def mismatch_once(req: tsi.FileCreateReq) -> tsi.FileCreateRes:
-            nonlocal injected
-            if not injected and req.expected_digest is not None:
-                injected = True
-                raise DigestMismatchError("forced file mismatch")
-            return original(req)
+# On DigestMismatchError the client retries without expected_digest and
+# disables client-side digests for the rest of the session.
+@pytest.mark.disable_logging_error_check
+def test_object_mismatch_retries_and_disables(
+    client: WeaveClient, fast_path: None, monkeypatch
+) -> None:
+    adapter = find_server_layer(client.server, ExternalTraceServer)
+    original = adapter.obj_create
+    seen_digests: list[str | None] = []
+    injected = False
 
-        monkeypatch.setattr(adapter, "file_create", mismatch_once)
+    def mismatch_once(req: tsi.ObjCreateReq) -> tsi.ObjCreateRes:
+        nonlocal injected
+        seen_digests.append(req.obj.expected_digest)
+        if not injected and req.obj.expected_digest is not None:
+            injected = True
+            raise DigestMismatchError("forced mismatch")
+        return original(req)
 
-        img = Image.new("RGB", (2, 2), color="red")
-        weave.publish(img, name="mismatch-img")
-        client._flush()
+    monkeypatch.setattr(adapter, "obj_create", mismatch_once)
 
-        assert client.project_id_resolver.is_disabled
+    ref = weave.publish({"first": True}, name="mismatch-first")
+    client._flush()
+
+    assert seen_digests == [ref.digest, None]
+    assert client.project_id_resolver.is_disabled
+
+    seen_digests.clear()
+    weave.publish({"second": True}, name="mismatch-second")
+    client._flush()
+    assert seen_digests == [None]
+
+
+@pytest.mark.disable_logging_error_check
+def test_table_mismatch_retries_and_disables(
+    client: WeaveClient, fast_path: None, monkeypatch
+) -> None:
+    adapter = find_server_layer(client.server, ExternalTraceServer)
+    original = adapter.table_create
+    injected = False
+
+    def mismatch_once(req: tsi.TableCreateReq) -> tsi.TableCreateRes:
+        nonlocal injected
+        if not injected and req.table.expected_digest is not None:
+            injected = True
+            raise DigestMismatchError("forced table mismatch")
+        return original(req)
+
+    monkeypatch.setattr(adapter, "table_create", mismatch_once)
+
+    ds = weave.Dataset(name="mismatch-ds", rows=[{"x": 1}, {"x": 2}])
+    ref = weave.publish(ds, name="mismatch-ds")
+    client._flush()
+
+    assert client.project_id_resolver.is_disabled
+    assert len(list(ref.get().rows)) == 2
+
+
+@pytest.mark.disable_logging_error_check
+def test_file_mismatch_retries_and_disables(
+    client: WeaveClient, fast_path: None, monkeypatch
+) -> None:
+    adapter = find_server_layer(client.server, ExternalTraceServer)
+    original = adapter.file_create
+    injected = False
+
+    def mismatch_once(req: tsi.FileCreateReq) -> tsi.FileCreateRes:
+        nonlocal injected
+        if not injected and req.expected_digest is not None:
+            injected = True
+            raise DigestMismatchError("forced file mismatch")
+        return original(req)
+
+    monkeypatch.setattr(adapter, "file_create", mismatch_once)
+
+    weave.publish(Image.new("RGB", (2, 2), color="red"), name="mismatch-img")
+    client._flush()
+    assert client.project_id_resolver.is_disabled

--- a/tests/trace/test_client_trace.py
+++ b/tests/trace/test_client_trace.py
@@ -791,7 +791,7 @@ def test_trace_call_query_filter_output_object_version_refs(client):
         assert len(inner_res.calls) == exp_count
 
 
-def test_trace_call_query_filter_parent_ids(client):
+def test_trace_call_query_filter_id_fields(client):
     call_spec = simple_line_call_bootstrap()
 
     res = get_all_calls_asserting_finished(client, call_spec)
@@ -800,84 +800,58 @@ def test_trace_call_query_filter_parent_ids(client):
         [call.parent_id for call in res.calls if call.parent_id is not None]
     )
     assert len(parent_ids) > 3
+    trace_ids = [call.trace_id for call in res.calls]
+    call_ids = [call.id for call in res.calls]
 
-    for parent_id_list, exp_count in [
-        # Test the None case
+    parent_cases = [
         (None, call_spec.total_calls),
-        # Test the empty list case
         ([], call_spec.total_calls),
-        # Test single
         (
             parent_ids[:1],
             len([call for call in res.calls if call.parent_id in parent_ids[:1]]),
         ),
-        # Test multiple
         (
             parent_ids[:3],
             len([call for call in res.calls if call.parent_id in parent_ids[:3]]),
         ),
-    ]:
+    ]
+    for parent_id_list, exp_count in parent_cases:
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
                 filter=tsi.CallsFilter(parent_ids=parent_id_list),
             )
         )
-
         assert len(inner_res.calls) == exp_count
 
-
-def test_trace_call_query_filter_trace_ids(client):
-    call_spec = simple_line_call_bootstrap()
-
-    res = get_all_calls_asserting_finished(client, call_spec)
-
-    trace_ids = [call.trace_id for call in res.calls]
-
-    for trace_id_list, exp_count in [
-        # Test the None case
+    trace_cases = [
         (None, call_spec.total_calls),
-        # Test the empty list case
         ([], call_spec.total_calls),
-        # Test single
         ([trace_ids[0]], 1),
-        # Test multiple
         (trace_ids[:3], 3),
-    ]:
+    ]
+    for trace_id_list, exp_count in trace_cases:
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
                 filter=tsi.CallsFilter(trace_ids=trace_id_list),
             )
         )
-
         assert len(inner_res.calls) == exp_count
 
-
-def test_trace_call_query_filter_call_ids(client):
-    call_spec = simple_line_call_bootstrap()
-
-    res = get_all_calls_asserting_finished(client, call_spec)
-
-    call_ids = [call.id for call in res.calls]
-
-    for call_id_list, exp_count in [
-        # Test the None case
+    call_cases = [
         (None, call_spec.total_calls),
-        # Test the empty list case
         ([], call_spec.total_calls),
-        # Test single
         ([call_ids[0]], 1),
-        # Test multiple
         (call_ids[:3], 3),
-    ]:
+    ]
+    for call_id_list, exp_count in call_cases:
         inner_res = get_client_trace_server(client).calls_query(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
                 filter=tsi.CallsFilter(call_ids=call_id_list),
             )
         )
-
         assert len(inner_res.calls) == exp_count
 
 
@@ -1012,16 +986,13 @@ def test_trace_call_query_filter_wb_user_ids(client, trace_server, no_autoflush)
         assert len(inner_res.calls) == exp_count
 
 
-def test_trace_call_query_limit(client, no_autoflush):
+def test_trace_call_query_limit_and_offset(client, no_autoflush):
     call_spec = simple_line_call_bootstrap()
     client.flush()
 
     for limit, exp_count in [
-        # Test the None case
         (None, call_spec.total_calls),
-        # Test limit of 1
         (1, 1),
-        # Test limit of 10
         (10, 10),
     ]:
         inner_res = get_client_trace_server(client).calls_query(
@@ -1030,20 +1001,11 @@ def test_trace_call_query_limit(client, no_autoflush):
                 limit=limit,
             )
         )
-
         assert len(inner_res.calls) == exp_count
 
-
-def test_trace_call_query_offset(client, no_autoflush):
-    call_spec = simple_line_call_bootstrap()
-    client.flush()
-
     for offset, exp_count in [
-        # Test the None case
         (None, call_spec.total_calls),
-        # Test offset of 1
         (1, call_spec.total_calls - 1),
-        # Test offset of 10
         (10, call_spec.total_calls - 10),
     ]:
         inner_res = get_client_trace_server(client).calls_query(
@@ -1052,7 +1014,6 @@ def test_trace_call_query_offset(client, no_autoflush):
                 offset=offset,
             )
         )
-
         assert len(inner_res.calls) == exp_count
 
 
@@ -3443,49 +3404,33 @@ def test_object_with_disallowed_keys(client):
 CHAR_LIMIT = 128
 
 
-def test_object_with_char_limit(client):
-    name = "l" * CHAR_LIMIT
+@pytest.mark.parametrize("over_limit", [False, True])
+def test_object_with_char_limit_boundary(client, over_limit):
+    length = CHAR_LIMIT + 1 if over_limit else CHAR_LIMIT
+    name = "l" * length
     obj = Custom(name=name, val={"1": 1})
 
     weave.publish(obj)
 
-    # we sanitize the name
-    assert obj.ref.name == name
+    # at the limit the name is preserved; over the limit it is truncated by one
+    assert obj.ref.name == (name[:-1] if over_limit else name)
 
-    # Use a distinct name for the raw obj_create path: re-using `name` would
+    # Use a distinct object_id for the raw obj_create path: re-using `name` would
     # collide with the SDK publish above (Custom-typed -> untyped), which the
     # server now rejects (WB-30574).
     create_req = tsi.ObjCreateReq.model_validate(
         {
             "obj": {
                 "project_id": client.project_id,
-                "object_id": "r" * CHAR_LIMIT,
+                "object_id": "r" * length,
                 "val": {"1": 1},
             }
         }
     )
-    client.server.obj_create(create_req)
-
-
-def test_object_with_char_over_limit(client):
-    name = "l" * (CHAR_LIMIT + 1)
-    obj = Custom(name=name, val={"1": 1})
-
-    weave.publish(obj)
-
-    # we sanitize the name
-    assert obj.ref.name == name[:-1]
-
-    create_req = tsi.ObjCreateReq.model_validate(
-        {
-            "obj": {
-                "project_id": client.project_id,
-                "object_id": "r" * (CHAR_LIMIT + 1),
-                "val": {"1": 1},
-            }
-        }
-    )
-    with pytest.raises(CHValidationError):
+    if over_limit:
+        with pytest.raises(CHValidationError):
+            client.server.obj_create(create_req)
+    else:
         client.server.obj_create(create_req)
 
 
@@ -3646,16 +3591,15 @@ def test_feedback_filter_finds_minority_reaction(client):
     assert results[0].id == calls[0].id
 
 
-def test_inline_dataclass_generates_no_refs_in_function(client):
-    @dataclasses.dataclass
-    class A:
-        b: int
+@pytest.mark.parametrize("kind", ["dataclass", "basemodel"])
+def test_inline_type_generates_no_refs_in_function(client, kind):
+    inline_type = _make_inline_type(kind)
 
     @weave.op
-    def func(a: A):
-        return A(b=a.b + 1)
+    def func(a: inline_type):
+        return inline_type(b=a.b + 1)
 
-    a = A(b=1)
+    a = inline_type(b=1)
     func(a)
 
     res = get_client_trace_server(client).calls_query(
@@ -3674,15 +3618,14 @@ def test_inline_dataclass_generates_no_refs_in_function(client):
     assert len(output_object_version_refs) == 0
 
 
-def test_inline_dataclass_generates_no_refs_in_object(client):
-    @dataclasses.dataclass
-    class A:
-        b: int
+@pytest.mark.parametrize("kind", ["dataclass", "basemodel"])
+def test_inline_type_generates_no_refs_in_object(client, kind):
+    inline_type = _make_inline_type(kind)
 
     class WeaveObject(weave.Object):
-        a: A
+        a: inline_type
 
-    wo = WeaveObject(a=A(b=1))
+    wo = WeaveObject(a=inline_type(b=1))
     ref = weave.publish(wo)
 
     res = get_client_trace_server(client).objs_query(
@@ -3690,52 +3633,7 @@ def test_inline_dataclass_generates_no_refs_in_object(client):
             project_id=get_client_project_id(client),
         )
     )
-    assert len(res.objs) == 1  # Just the weave object, and not the dataclass
-
-
-def test_inline_pydantic_basemodel_generates_no_refs_in_function(client):
-    class A(BaseModel):
-        b: int
-
-    @weave.op
-    def func(a: A):
-        return A(b=a.b + 1)
-
-    a = A(b=1)
-    func(a)
-
-    res = get_client_trace_server(client).calls_query(
-        tsi.CallsQueryReq(
-            project_id=get_client_project_id(client),
-        )
-    )
-    input_object_version_refs = unique_vals(
-        [ref for call in res.calls for ref in extract_refs_from_values(call.inputs)]
-    )
-    assert len(input_object_version_refs) == 0
-
-    output_object_version_refs = unique_vals(
-        [ref for call in res.calls for ref in extract_refs_from_values(call.output)]
-    )
-    assert len(output_object_version_refs) == 0
-
-
-def test_inline_pydantic_basemodel_generates_no_refs_in_object(client):
-    class A(BaseModel):
-        b: int
-
-    class WeaveObject(weave.Object):
-        a: A
-
-    wo = WeaveObject(a=A(b=1))
-    ref = weave.publish(wo)
-
-    res = get_client_trace_server(client).objs_query(
-        tsi.ObjQueryReq(
-            project_id=get_client_project_id(client),
-        )
-    )
-    assert len(res.objs) == 1  # Just the weave object, and not the pydantic model
+    assert len(res.objs) == 1  # Just the weave object, not the inline type
 
 
 def test_large_keys_are_stripped_call(client, caplog, monkeypatch):
@@ -4439,8 +4337,11 @@ def test_calls_query_with_storage_size_clickhouse(client, clickhouse_client):
     assert call.storage_size_bytes is not None
 
 
-def test_calls_query_with_total_storage_size_clickhouse(client, clickhouse_client):
-    """Test querying calls with total storage size."""
+@pytest.mark.parametrize("include_storage_size", [False, True])
+def test_calls_query_with_total_storage_size_clickhouse(
+    client, clickhouse_client, include_storage_size
+):
+    """Total storage size on a parent/child trace, with and without per-call storage size."""
 
     @weave.op
     def parent_op(x: dict):
@@ -4459,86 +4360,31 @@ def test_calls_query_with_total_storage_size_clickhouse(client, clickhouse_clien
     # to return the correct results.
     force_optimize(clickhouse_client, "calls_merged_stats")
 
-    # Query with total storage size
     calls = list(
         client.server.calls_query_stream(
             tsi.CallsQueryReq(
                 project_id=get_client_project_id(client),
+                include_storage_size=include_storage_size,
                 include_total_storage_size=True,
             )
         )
     )
     assert len(calls) == 2  # Parent and child calls
 
-    # Find parent and child calls
     parent_call = next(c for c in calls if c.parent_id is None)
     child_call = next(c for c in calls if c.parent_id is not None)
-
-    # Verify that both parent and child calls are present
     assert parent_call is not None
     assert child_call is not None
 
-    # Verify the total storage size is present, despite that the race condition
-    # that the calls_merged_stats table is not updated in time, and we are unable to
-    # verify the value against an expected value.
-    assert (
-        parent_call.total_storage_size_bytes is not None
-    )  # Parent should have total size
-    assert child_call.storage_size_bytes is None
-    assert (
-        child_call.total_storage_size_bytes is None
-    )  # Child should not have total size
-
-
-def test_calls_query_with_both_storage_sizes_clickhouse(client, clickhouse_client):
-    """Test querying calls with total storage size."""
-
-    @weave.op
-    def parent_op(x: dict):
-        return child_op(x)  # Call child op to create a trace
-
-    @weave.op
-    def child_op(x: dict):
-        return x
-
-    # Create a call with nested structure
-    parent_op({"data": "x" * 1000})
-
-    # This is a best effort to achive consistency in the calls_merged_stats table.
-    # due to some race condition/optimizations in clickhouse, there is a chance
-    # that the calls_merged_stats table is not updated in time for the query below
-    # to return the correct results.
-    force_optimize(clickhouse_client, "calls_merged_stats")
-
-    # Query with total storage size
-    calls = list(
-        client.server.calls_query_stream(
-            tsi.CallsQueryReq(
-                project_id=get_client_project_id(client),
-                include_storage_size=True,
-                include_total_storage_size=True,
-            )
-        )
-    )
-
-    assert len(calls) == 2  # Parent and child calls
-
-    # Find parent and child calls
-    parent_call = next(c for c in calls if c.parent_id is None)
-    child_call = next(c for c in calls if c.parent_id is not None)
-
-    # Verify that both parent and child calls are present
-    assert parent_call is not None
-    assert child_call is not None
-
-    # Verify the storage sizes are present, despite that the race condition
-    # that the calls_merged_stats table is not updated in time, and we are unable to
-    # verify the value against an expected value.
-    assert parent_call.storage_size_bytes is not None
+    # Storage sizes are present despite the calls_merged_stats race; values are
+    # not asserted. Total size only attaches to the parent (trace root).
     assert parent_call.total_storage_size_bytes is not None
-    assert child_call.storage_size_bytes is not None
-    # Child should not have total size
     assert child_call.total_storage_size_bytes is None
+    if include_storage_size:
+        assert parent_call.storage_size_bytes is not None
+        assert child_call.storage_size_bytes is not None
+    else:
+        assert child_call.storage_size_bytes is None
 
 
 def test_calls_hydrated(client):
@@ -6831,3 +6677,21 @@ def test_sentinel_round_trip_none_values(client):
     assert c.started_at is not None
     assert c.ended_at is not None
     assert c.op_name is not None
+
+
+def _make_inline_type(kind: str) -> type:
+    """Build an inline single-field type as either a dataclass or a pydantic model."""
+    if kind == "dataclass":
+
+        @dataclasses.dataclass
+        class A:
+            b: int
+
+        return A
+    if kind == "basemodel":
+
+        class A(BaseModel):
+            b: int
+
+        return A
+    raise ValueError(f"unknown inline type kind: {kind}")

--- a/tests/trace/test_custom_objs.py
+++ b/tests/trace/test_custom_objs.py
@@ -162,34 +162,6 @@ def test_setting_disables_unsafe_decode_globally(client):
 
 
 def test_encode_custom_obj_save_exception_returns_none(client, failing_serializer):
-    """Requirement: Type handler save exceptions should not crash user code
-    Interface: encode_custom_obj function
-    Given: A serializer is registered whose save function raises an exception
-    When: encode_custom_obj is called with an object of that type
-    Then: Returns None (graceful degradation)
-    """
+    """A type handler save exception degrades gracefully to None, never propagating."""
     obj = FailingSaveType("test_value")
-
-    # This should NOT raise - if it does, the test fails
-    result = encode_custom_obj(obj)
-
-    # Should return None instead of raising
-    assert result is None
-
-
-def test_encode_custom_obj_save_exception_does_not_propagate(
-    client, failing_serializer
-):
-    """Requirement: Type handler save exceptions must not propagate to user code
-    Interface: encode_custom_obj function
-    Given: A serializer is registered whose save function raises RuntimeError
-    When: encode_custom_obj is called
-    Then: No exception is raised to the caller
-    """
-    obj = FailingSaveType("test_value")
-
-    # This should NOT raise - if it does, the test fails
-    result = encode_custom_obj(obj)
-
-    # We expect None as the graceful degradation
-    assert result is None
+    assert encode_custom_obj(obj) is None

--- a/tests/trace/test_dataset.py
+++ b/tests/trace/test_dataset.py
@@ -17,22 +17,16 @@ def test_basic_dataset_lifecycle(weave_active):
         )
 
 
-def test_dataset_iteration(weave_active):
+def test_dataset_iteration_and_pythonic_access(weave_active):
+    # Iteration is repeatable; len/__getitem__ work and negative indices raise.
     dataset = weave.Dataset(rows=[{"a": 5, "b": 6}, {"a": 7, "b": 10}])
     rows = list(dataset)
     assert rows == [{"a": 5, "b": 6}, {"a": 7, "b": 10}]
+    assert list(dataset) == rows
 
-    # Test that we can iterate multiple times
-    rows2 = list(dataset)
-    assert rows2 == rows
-
-
-def test_pythonic_access(weave_active):
-    rows = [{"a": 1}, {"a": 2}, {"a": 3}, {"a": 4}, {"a": 5}]
-    ds = weave.Dataset(rows=rows)
+    ds = weave.Dataset(rows=[{"a": i} for i in range(1, 6)])
     assert len(ds) == 5
     assert ds[0] == {"a": 1}
-
     with pytest.raises(IndexError):
         ds[-1]
 
@@ -231,11 +225,10 @@ def test_add_rows(weave_active):
     ds4 = weave.publish(ds3).get()
     assert ds3.rows == ds4.rows
 
-
-def test_add_rows_to_unsaved_dataset(weave_active):
-    ds = weave.Dataset(rows=[{"a": i} for i in range(10)])
+    # add_rows on an unsaved (never-published) dataset raises TypeError.
+    unsaved = weave.Dataset(rows=[{"a": i} for i in range(10)])
     with pytest.raises(TypeError):
-        ds.add_rows([{"a": 10}])
+        unsaved.add_rows([{"a": 10}])
 
 
 def test_hf_conversion(weave_active):

--- a/tests/trace/test_deepcopy.py
+++ b/tests/trace/test_deepcopy.py
@@ -37,61 +37,44 @@ def example_class():
     return Example, expected_record
 
 
-def test_deepcopy_weavelist(client):
-    lst = WeaveList([1, 2, 3], server=client.server)
-    res = deepcopy(lst)
-    assert res == [1, 2, 3]
-    assert id(res) != id(lst)
-
-
-def test_deepcopy_weavelist_e2e(weave_active):
-    lst = [1, 2, 3]
-    ref = weave.publish(lst)
-    lst2 = ref.get()
-    res = deepcopy(lst2)
-    assert res == [1, 2, 3]
-    assert id(res) != id(lst2)
-
-
-def test_deepcopy_weavedict(client):
-    d = WeaveDict({"a": 1, "b": 2}, server=client.server)
-    res = deepcopy(d)
-    assert res == {"a": 1, "b": 2}
-    assert id(res) != id(d)
-
-
-def test_deepcopy_weavedict_e2e(weave_active):
-    d = {"a": 1, "b": 2}
-    ref = weave.publish(d)
-    d2 = ref.get()
-    res = deepcopy(d2)
-    assert res == {"a": 1, "b": 2}
-    assert id(res) != id(d2)
-
-
-def test_deepcopy_weaveobject(client, example_class):
+def test_deepcopy_weave_containers(client, example_class):
+    """Deepcopy of server-backed WeaveList/WeaveDict/WeaveObject yields equal, distinct copies."""
     _, expected_record = example_class
 
-    o = WeaveObject(
-        expected_record,
-        ref=None,
-        root=None,
-        server=client.server,
-    )
-    res = deepcopy(o)
-    assert res == expected_record
-    assert id(res) != id(o)
+    lst = WeaveList([1, 2, 3], server=client.server)
+    lst_copy = deepcopy(lst)
+    assert lst_copy == [1, 2, 3]
+    assert id(lst_copy) != id(lst)
+
+    d = WeaveDict({"a": 1, "b": 2}, server=client.server)
+    d_copy = deepcopy(d)
+    assert d_copy == {"a": 1, "b": 2}
+    assert id(d_copy) != id(d)
+
+    o = WeaveObject(expected_record, ref=None, root=None, server=client.server)
+    o_copy = deepcopy(o)
+    assert o_copy == expected_record
+    assert id(o_copy) != id(o)
 
 
-def test_deepcopy_weaveobject_e2e(weave_active, example_class):
+def test_deepcopy_weave_containers_e2e(weave_active, example_class):
+    """Deepcopy of published-then-fetched list/dict/object yields equal, distinct copies."""
     cls, expected_record = example_class
 
-    o = cls()
-    ref = weave.publish(o)
-    o2 = ref.get()
-    res = deepcopy(o2)
-    assert res == expected_record
-    assert id(res) != id(o2)
+    lst2 = weave.publish([1, 2, 3]).get()
+    lst_copy = deepcopy(lst2)
+    assert lst_copy == [1, 2, 3]
+    assert id(lst_copy) != id(lst2)
+
+    d2 = weave.publish({"a": 1, "b": 2}).get()
+    d_copy = deepcopy(d2)
+    assert d_copy == {"a": 1, "b": 2}
+    assert id(d_copy) != id(d2)
+
+    o2 = weave.publish(cls()).get()
+    o_copy = deepcopy(o2)
+    assert o_copy == expected_record
+    assert id(o_copy) != id(o2)
 
 
 @pytest.mark.parametrize(
@@ -132,16 +115,3 @@ def test_deepcopy_ref_with_future():
 
     assert res == ref
     assert id(res) != id(ref)
-
-
-# # Not sure about the implications here yet
-# def test_deepcopy_weavetable(client):
-#     t = WeaveTable(
-#         table_ref=None,
-#         ref=None,
-#         server=client.server,
-#         filter=TableRowFilter(),
-#         root=None,
-#     )
-#     res = deepcopy(t)
-#     assert res == t

--- a/tests/trace/test_display.py
+++ b/tests/trace/test_display.py
@@ -15,20 +15,36 @@ from weave.trace.display import display
 from weave.trace.display.types import Style
 
 
-# Test viewer auto-detection and fallback mechanism
-def test_auto_viewer_with_rich_available():
-    """Test that auto viewer uses rich when available."""
-    console = display.Console(viewer="auto")
+def test_viewer_selection_auto_explicit_and_env():
+    """auto/print/rich selection works directly and via WEAVE_DISPLAY_VIEWER."""
+    auto_console = display.Console(viewer="auto")
+    assert auto_console is not None
+    assert hasattr(auto_console, "print")
+    assert hasattr(auto_console, "rule")
 
-    # Check that a console was created successfully
-    assert console is not None
-    assert hasattr(console, "print")
-    assert hasattr(console, "rule")
+    assert display.Console(viewer="print") is not None
+    try:
+        import rich  # noqa: F401
+
+        assert display.Console(viewer="rich") is not None
+    except ImportError:
+        pass
+
+    original_viewer = os.environ.get("WEAVE_DISPLAY_VIEWER")
+    try:
+        os.environ["WEAVE_DISPLAY_VIEWER"] = "print"
+        assert display.Console() is not None
+        os.environ["WEAVE_DISPLAY_VIEWER"] = "auto"
+        assert display.Console() is not None
+    finally:
+        if original_viewer is not None:
+            os.environ["WEAVE_DISPLAY_VIEWER"] = original_viewer
+        else:
+            os.environ.pop("WEAVE_DISPLAY_VIEWER", None)
 
 
-def test_auto_viewer_without_rich():
-    """Test that auto viewer falls back to print when rich is not available."""
-    # Mock ImportError for rich
+def test_auto_viewer_falls_back_to_print():
+    """Auto viewer survives a rich ImportError, both at construction and in get."""
     import builtins
 
     original_import = builtins.__import__
@@ -40,185 +56,142 @@ def test_auto_viewer_without_rich():
 
     with patch("builtins.__import__", side_effect=mock_import):
         console = display.Console(viewer="auto")
-
-        # Should still work with print viewer
         assert console is not None
         assert hasattr(console, "print")
 
+    from weave.trace.display.display import _get_auto_viewer
 
-def test_explicit_viewer_selection():
-    """Test that explicit viewer selection works."""
-    # Test print viewer
-    print_console = display.Console(viewer="print")
-    assert print_console is not None
-
-    # Test rich viewer (if available)
-    try:
-        import rich  # noqa: F401
-
-        rich_console = display.Console(viewer="rich")
-        assert rich_console is not None
-    except ImportError:
-        pass  # Rich not available, skip this part
+    with patch(
+        "weave.trace.display.viewers.rich_viewer.RichViewer", side_effect=ImportError
+    ):
+        viewer = _get_auto_viewer()
+        assert viewer is not None
+        assert hasattr(viewer, "print")
+        assert hasattr(viewer, "rule")
 
 
-def test_viewer_configuration_from_environment():
-    """Test that viewer can be configured via environment variable."""
-    # Save original value
-    original_viewer = os.environ.get("WEAVE_DISPLAY_VIEWER")
-
-    try:
-        # Test with print viewer
-        os.environ["WEAVE_DISPLAY_VIEWER"] = "print"
-        console = display.Console()
-        assert console is not None
-
-        # Test with auto viewer
-        os.environ["WEAVE_DISPLAY_VIEWER"] = "auto"
-        console = display.Console()
-        assert console is not None
-    finally:
-        # Restore original value
-        if original_viewer is not None:
-            os.environ["WEAVE_DISPLAY_VIEWER"] = original_viewer
-        else:
-            os.environ.pop("WEAVE_DISPLAY_VIEWER", None)
+def test_error_handling_for_unknown_viewer():
+    """An unknown viewer name raises ValueError."""
+    with pytest.raises(ValueError, match="Unknown viewer"):
+        display.Console(viewer="nonexistent_viewer")
 
 
-def test_console_print_functionality():
-    """Test that console print works with different viewers."""
-    for viewer_name in ["print", "auto"]:
-        # Capture output by passing file to console
-        captured_output = StringIO()
-        console = display.Console(viewer=viewer_name, file=captured_output)
-
-        console.print("Hello, World!")
-        output = captured_output.getvalue()
-
-        # Check that something was printed
-        assert "Hello, World!" in output
-
-
-def test_console_with_styling():
-    """Test that console handles styling correctly."""
-    # Capture output
+def test_console_print_styling_objects_and_end():
+    """Console print handles plain text, styling, multiple objects, and custom end."""
     captured_output = StringIO()
     console = display.Console(viewer="print", file=captured_output)
 
-    # Create a style
-    style = Style(color="green", bold=True)
+    console.print("Hello, World!")
+    console.print("Styled text", style=Style(color="green", bold=True))
+    console.print("First", "Second", "Third", sep=" | ")
+    console.print("Line 1", end=" -> ")
+    console.print("Line 2")
 
-    console.print("Styled text", style=style)
     output = captured_output.getvalue()
-
-    # Should contain the text (exact formatting depends on viewer)
+    assert "Hello, World!" in output
     assert "Styled text" in output
+    assert "First | Second | Third" in output
+    assert "Line 1 -> Line 2" in output
 
 
-def test_table_creation_and_display():
-    """Test that tables can be created and displayed."""
+def test_multiple_console_instances():
+    """Test that multiple console instances can coexist."""
+    # Both should work independently
+    captured1 = StringIO()
+    captured2 = StringIO()
+
+    console1 = display.Console(viewer="print", file=captured1)
+    console2 = display.Console(viewer="auto", file=captured2)
+
+    console1.print("Console 1")
+    console2.print("Console 2")
+
+    assert "Console 1" in captured1.getvalue()
+    assert "Console 2" in captured2.getvalue()
+
+
+def test_console_rule():
+    """Console rule prints its title."""
+    captured_output = StringIO()
+    console = display.Console(viewer="print", file=captured_output)
+
+    console.rule("Section Title")
+    assert "Section Title" in captured_output.getvalue()
+
+
+def test_table_with_and_without_header():
+    """Tables render their data with a header and with show_header=False."""
     console = display.Console(viewer="print")
 
-    # Create a table
     table = display.Table(title="Test Table")
     table.add_column("Name", justify="left")
     table.add_column("Value", justify="right")
     table.add_row("Item 1", "100")
     table.add_row("Item 2", "200")
-
-    # Convert to string
     table_str = table.to_string(console)
-
-    # Should contain the data
     assert "Test Table" in table_str
     assert "Item 1" in table_str
     assert "100" in table_str
     assert "Item 2" in table_str
     assert "200" in table_str
 
-
-def test_table_without_header():
-    """Test that tables can be created without headers."""
-    console = display.Console(viewer="print")
-
-    # Create a table without header
-    table = display.Table(show_header=False)
-    table.add_column("Key")
-    table.add_column("Value")
-    table.add_row("name", "test")
-    table.add_row("count", "42")
-
-    # Convert to string
-    table_str = table.to_string(console)
-
-    # Should contain the data
-    assert "name" in table_str
-    assert "test" in table_str
-    assert "42" in table_str
-
-
-def test_console_rule():
-    """Test that console rule works."""
-    # Capture output
-    captured_output = StringIO()
-    console = display.Console(viewer="print", file=captured_output)
-
-    console.rule("Section Title")
-    output = captured_output.getvalue()
-
-    # Should contain the title
-    assert "Section Title" in output
+    headerless = display.Table(show_header=False)
+    headerless.add_column("Key")
+    headerless.add_column("Value")
+    headerless.add_row("name", "test")
+    headerless.add_row("count", "42")
+    headerless_str = headerless.to_string(console)
+    assert "name" in headerless_str
+    assert "test" in headerless_str
+    assert "42" in headerless_str
 
 
 def test_progress_bar_operations():
-    """Test basic progress bar operations."""
+    """Progress start/add_task/update/stop run without error."""
     console = display.Console(viewer="print")
     progress = display.Progress(console=console)
 
-    # Start progress
     progress.start()
-
-    # Add a task
     task_id = progress.add_task("Processing", total=100)
     assert task_id is not None
-
-    # Update progress
     progress.update(task_id, completed=50)
-
-    # Stop progress
     progress.stop()
 
 
-def test_text_creation():
-    """Test that styled text can be created."""
-    # Create styled text
+def test_text_and_style_creation():
+    """Text wraps a string; Style records attributes and renders ANSI."""
     text = display.Text("Hello", style=Style(color="blue"))
+    assert "Hello" in str(text)
 
-    # Should have a string representation
-    text_str = str(text)
-    assert "Hello" in text_str
+    style1 = Style(color="red")
+    assert style1.color == "red"
+
+    style2 = Style(color="blue", bold=True, italic=True, underline=True)
+    assert style2.color == "blue"
+    assert style2.bold is True
+    assert style2.italic is True
+    assert style2.underline is True
+
+    ansi_text = Style(color="green", bold=True).to_ansi("Hello")
+    assert "Hello" in ansi_text
+    assert "\033[" in ansi_text
 
 
 def test_syntax_highlighting():
-    """Test that syntax highlighting objects can be created."""
-    # Create syntax highlighted code
+    """Syntax highlighting preserves the raw code text."""
     code = """def hello():
     print("Hello, World!")"""
 
     syntax = display.SyntaxHighlight(code=code, lexer="python")
-
-    # Should have a string representation
     console = display.Console(viewer="print")
     syntax_str = syntax.to_string(console)
-    # The syntax highlighter may add ANSI codes, so check for the raw text
     assert "hello" in syntax_str
     assert "print" in syntax_str
     assert "Hello, World!" in syntax_str
 
 
 def test_padding_wrapper():
-    """Test that padding wrapper works correctly."""
-    # Test indent
+    """PaddingWrapper.indent prefixes every non-empty line with spaces."""
     indented = display.PaddingWrapper.indent("Line 1\nLine 2", 4)
 
     lines = indented.split("\n")
@@ -255,67 +228,9 @@ def test_capture_context():
         assert output is not None
 
 
-def test_multiple_console_instances():
-    """Test that multiple console instances can coexist."""
-    # Both should work independently
-    captured1 = StringIO()
-    captured2 = StringIO()
-
-    console1 = display.Console(viewer="print", file=captured1)
-    console2 = display.Console(viewer="auto", file=captured2)
-
-    console1.print("Console 1")
-    console2.print("Console 2")
-
-    assert "Console 1" in captured1.getvalue()
-    assert "Console 2" in captured2.getvalue()
-
-
 def test_viewer_registry():
-    """Test that custom viewers can be registered."""
-
-    class CustomViewer:
-        """A minimal custom viewer for testing."""
-
-        def __init__(self, **kwargs):
-            """Accept kwargs for compatibility with viewer initialization."""
-            pass
-
-        def print(self, *objects, sep=" ", end="\n", style=None, **kwargs):
-            output = sep.join(str(obj) for obj in objects)
-            print(f"[CUSTOM] {output}", end=end)
-
-        def rule(self, title="", style=None):
-            print(f"=== {title} ===")
-
-        def clear(self):
-            pass
-
-        def create_table(
-            self, title=None, show_header=True, header_style=None, **kwargs
-        ):
-            return MagicMock()
-
-        def create_progress(self, console=None, **kwargs):
-            return MagicMock()
-
-        def create_syntax(self, code, lexer, theme="ansi_dark", line_numbers=False):
-            return MagicMock()
-
-        def create_text(self, text="", style=None):
-            return MagicMock()
-
-        def indent(self, content, amount):
-            return " " * amount + content.replace("\n", "\n" + " " * amount)
-
-        def capture(self):
-            return MagicMock()
-
-    # Register the custom viewer
-    display.register_viewer("custom_test", CustomViewer)
-
-    # Test that it works - CustomViewer prints to stdout, not the file parameter
-    from io import StringIO
+    """A custom viewer can be registered and used by name."""
+    display.register_viewer("custom_test", _CustomViewer)
 
     old_stdout = sys.stdout
     try:
@@ -330,68 +245,36 @@ def test_viewer_registry():
     assert "Test message" in output
 
 
-def test_error_handling_for_unknown_viewer():
-    """Test that appropriate error is raised for unknown viewer."""
-    with pytest.raises(ValueError, match="Unknown viewer"):
-        display.Console(viewer="nonexistent_viewer")
+class _CustomViewer:
+    """A minimal custom viewer for registry testing."""
 
+    def __init__(self, **kwargs):
+        pass
 
-def test_console_print_multiple_objects():
-    """Test printing multiple objects at once."""
-    captured_output = StringIO()
-    console = display.Console(viewer="print", file=captured_output)
+    def print(self, *objects, sep=" ", end="\n", style=None, **kwargs):
+        output = sep.join(str(obj) for obj in objects)
+        print(f"[CUSTOM] {output}", end=end)
 
-    console.print("First", "Second", "Third", sep=" | ")
-    output = captured_output.getvalue()
+    def rule(self, title="", style=None):
+        print(f"=== {title} ===")
 
-    assert "First | Second | Third" in output
+    def clear(self):
+        pass
 
+    def create_table(self, title=None, show_header=True, header_style=None, **kwargs):
+        return MagicMock()
 
-def test_console_print_with_custom_end():
-    """Test printing with custom end character."""
-    captured_output = StringIO()
-    console = display.Console(viewer="print", file=captured_output)
+    def create_progress(self, console=None, **kwargs):
+        return MagicMock()
 
-    console.print("Line 1", end=" -> ")
-    console.print("Line 2")
-    output = captured_output.getvalue()
+    def create_syntax(self, code, lexer, theme="ansi_dark", line_numbers=False):
+        return MagicMock()
 
-    assert "Line 1 -> Line 2" in output
+    def create_text(self, text="", style=None):
+        return MagicMock()
 
+    def indent(self, content, amount):
+        return " " * amount + content.replace("\n", "\n" + " " * amount)
 
-def test_style_creation():
-    """Test that styles can be created with various attributes."""
-    # Test basic style
-    style1 = Style(color="red")
-    assert style1.color == "red"
-
-    # Test style with multiple attributes
-    style2 = Style(color="blue", bold=True, italic=True, underline=True)
-    assert style2.color == "blue"
-    assert style2.bold is True
-    assert style2.italic is True
-    assert style2.underline is True
-
-    # Test style ANSI conversion
-    style3 = Style(color="green", bold=True)
-    ansi_text = style3.to_ansi("Hello")
-    assert "Hello" in ansi_text
-    assert "\033[" in ansi_text  # Should contain ANSI codes
-
-
-def test_fallback_behavior_simulation():
-    """Test that auto viewer handles ImportError correctly when getting the viewer.
-
-    This is tested by using display.get_viewer with "auto" which internally calls _get_auto_viewer
-    """
-    from weave.trace.display.display import _get_auto_viewer
-
-    with patch(
-        "weave.trace.display.viewers.rich_viewer.RichViewer", side_effect=ImportError
-    ):
-        # Should fall back to print viewer
-        viewer = _get_auto_viewer()
-        assert viewer is not None
-        # Verify it's a print viewer by checking it has expected methods
-        assert hasattr(viewer, "print")
-        assert hasattr(viewer, "rule")
+    def capture(self):
+        return MagicMock()

--- a/tests/trace/test_evaluate_oldstyle.py
+++ b/tests/trace/test_evaluate_oldstyle.py
@@ -91,24 +91,16 @@ async def test_can_preprocess_model_input(weave_active):
 
 
 @pytest.mark.asyncio
-async def test_evaluate_rows_only(weave_active):
-    evaluation = Evaluation(
-        dataset=dataset_rows,
-        scorers=[score_oldstyle],
-    )
+async def test_evaluate_model_with_scorers(weave_active):
+    # EvalModel against a rows dataset: single oldstyle scorer, then both styles.
     model = EvalModel()
-    result = await evaluation.evaluate(model)
+
+    oldstyle_only = Evaluation(dataset=dataset_rows, scorers=[score_oldstyle])
+    result = await oldstyle_only.evaluate(model)
     assert result == expected_eval_result
 
-
-@pytest.mark.asyncio
-async def test_evaluate_both_styles(weave_active):
-    evaluation = Evaluation(
-        dataset=dataset_rows,
-        scorers=[score_oldstyle, score_newstyle],
-    )
-    model = EvalModel()
-    result = await evaluation.evaluate(model)
+    both = Evaluation(dataset=dataset_rows, scorers=[score_oldstyle, score_newstyle])
+    result = await both.evaluate(model)
     assert result == {
         "model_output": {"mean": 9.5},
         "score_oldstyle": {"true_count": 1, "true_fraction": 0.5},
@@ -135,29 +127,13 @@ async def test_evaluate_other_model_method_names():
 
 @pytest.mark.asyncio
 async def test_score_as_class(weave_active):
+    # Scorer subclass: default summarize, then a custom summarize override.
     class MyScorerOldstyle(weave.Scorer):
         @weave.op
         def score(self, model_output, target):
             return model_output == target
 
-    evaluation = Evaluation(
-        dataset=dataset_rows,
-        scorers=[MyScorerOldstyle()],
-    )
-    model = EvalModel()
-    result = await evaluation.evaluate(model)
-    assert result == {
-        "model_output": {"mean": 9.5},
-        "MyScorerOldstyle": {"true_count": 1, "true_fraction": 0.5},
-        "model_latency": {
-            "mean": pytest.approx(0, abs=LATENCY_TOL),
-        },
-    }
-
-
-@pytest.mark.asyncio
-async def test_score_with_custom_summarize(weave_active):
-    class MyScorerOldstyle(weave.Scorer):
+    class MyScorerCustomSummarize(weave.Scorer):
         @weave.op
         def summarize(self, score_rows):
             assert list(score_rows) == [True, False]
@@ -167,15 +143,23 @@ async def test_score_with_custom_summarize(weave_active):
         def score(self, model_output, target):
             return model_output == target
 
-    evaluation = Evaluation(
-        dataset=dataset_rows,
-        scorers=[MyScorerOldstyle()],
-    )
     model = EvalModel()
-    result = await evaluation.evaluate(model)
+
+    default_eval = Evaluation(dataset=dataset_rows, scorers=[MyScorerOldstyle()])
+    result = await default_eval.evaluate(model)
     assert result == {
         "model_output": {"mean": 9.5},
-        "MyScorerOldstyle": {"awesome": 3},
+        "MyScorerOldstyle": {"true_count": 1, "true_fraction": 0.5},
+        "model_latency": {
+            "mean": pytest.approx(0, abs=LATENCY_TOL),
+        },
+    }
+
+    custom_eval = Evaluation(dataset=dataset_rows, scorers=[MyScorerCustomSummarize()])
+    result = await custom_eval.evaluate(model)
+    assert result == {
+        "model_output": {"mean": 9.5},
+        "MyScorerCustomSummarize": {"awesome": 3},
         "model_latency": {
             "mean": pytest.approx(0, abs=LATENCY_TOL),
         },

--- a/tests/trace/test_evaluations.py
+++ b/tests/trace/test_evaluations.py
@@ -837,45 +837,8 @@ async def test_eval_with_complex_types(client):
 
 @pytest.mark.asyncio
 async def test_evaluation_with_column_map():
-    # Define a dummy scorer that uses column_map
-    class DummyScorer(weave.Scorer):
-        @weave.op
-        def score(self, foo: str, bar: str, output: str, target: str) -> dict:
-            # Return whether foo + bar equals output
-            return {"match": (foo + bar) == output == target}
+    """A correct column_map remaps scorer args to dataset columns; bad maps raise."""
 
-    # Create the scorer with column_map mapping 'foo'->'col1', 'bar'->'col2'
-    dummy_scorer = DummyScorer(column_map={"foo": "col1", "bar": "col2"})
-
-    @weave.op
-    def model_function(col1, col2):
-        # For testing, return the concatenation of col1 and col2
-        return col1 + col2
-
-    dataset = [
-        {"col1": "Hello", "col2": "World", "target": "HelloWorld"},
-        {"col1": "Hi", "col2": "There", "target": "HiThere"},
-        {"col1": "Good", "col2": "Morning", "target": "GoodMorning"},
-        {"col1": "Bad", "col2": "Evening", "target": "GoodEvening"},
-    ]
-
-    evaluation = Evaluation(dataset=dataset, scorers=[dummy_scorer])
-
-    # Run the evaluation
-    eval_out = await evaluation.evaluate(model_function)
-
-    # Check that 'DummyScorer' is in the results
-    assert "DummyScorer" in eval_out
-
-    # The expected summary should show that 3 out of 4 predictions matched
-    expected_results = {"true_count": 3, "true_fraction": 0.75}
-    assert eval_out["DummyScorer"]["match"] == expected_results, (
-        "The summary should reflect the correct number of matches"
-    )
-
-
-@pytest.mark.asyncio
-async def test_evaluation_with_wrong_column_map():
     # Define a dummy scorer that uses column_map
     class DummyScorer(weave.Scorer):
         @weave.op
@@ -992,6 +955,9 @@ async def test_evaluation_with_multiple_column_maps():
 
 @pytest.mark.asyncio
 async def test_feedback_is_correctly_linked(client):
+    """Scorer output links back to the predict call as runnable feedback (op + subclass)."""
+
+    # Function-op scorer: feedback type derived from the op name, call_ref set.
     @weave.op
     def predict(text: str) -> str:
         return text
@@ -1000,11 +966,8 @@ async def test_feedback_is_correctly_linked(client):
     def score(text, model_output) -> bool:
         return text == model_output
 
-    eval = weave.Evaluation(
-        dataset=[{"text": "hello"}],
-        scorers=[score],
-    )
-    res = await eval.evaluate(predict)
+    eval = weave.Evaluation(dataset=[{"text": "hello"}], scorers=[score])
+    await eval.evaluate(predict)
     calls = client.server.calls_query(
         tsi.CallsQueryReq(
             project_id=client.project_id,
@@ -1013,7 +976,6 @@ async def test_feedback_is_correctly_linked(client):
         )
     )
     assert len(calls.calls) == 1
-    assert calls.calls[0].summary["weave"]["feedback"]
     feedbacks = calls.calls[0].summary["weave"]["feedback"]
     assert len(feedbacks) == 1
     feedback = feedbacks[0]
@@ -1029,11 +991,9 @@ async def test_feedback_is_correctly_linked(client):
         ).uri
     )
 
-
-@pytest.mark.asyncio
-async def test_feedback_is_correctly_linked_with_scorer_subclass(client):
+    # Scorer subclass: feedback type derived from the class name.
     @weave.op
-    def predict(text: str) -> str:
+    def predict_sub(text: str) -> str:
         return text
 
     class MyScorer(weave.Scorer):
@@ -1042,20 +1002,16 @@ async def test_feedback_is_correctly_linked_with_scorer_subclass(client):
             return text == output
 
     scorer = MyScorer()
-    eval = weave.Evaluation(
-        dataset=[{"text": "hello"}],
-        scorers=[scorer],
-    )
-    res = await eval.evaluate(predict)
+    eval_sub = weave.Evaluation(dataset=[{"text": "hello"}], scorers=[scorer])
+    await eval_sub.evaluate(predict_sub)
     calls = client.server.calls_query(
         tsi.CallsQueryReq(
             project_id=client.project_id,
             include_feedback=True,
-            filter=tsi.CallsFilter(op_names=[get_ref(predict).uri]),
+            filter=tsi.CallsFilter(op_names=[get_ref(predict_sub).uri]),
         )
     )
     assert len(calls.calls) == 1
-    assert calls.calls[0].summary["weave"]["feedback"]
     feedbacks = calls.calls[0].summary["weave"]["feedback"]
     assert len(feedbacks) == 1
     feedback = feedbacks[0]
@@ -1110,58 +1066,34 @@ async def test_evaluation_with_custom_name(client):
     assert call.display_name == "wow-custom!"
 
 
-def test_get_evaluate_calls(client, make_evals):
+def test_eval_accessors(client, make_evals):
+    """Evaluation.get_evaluate_calls / get_score_calls / get_scores on two evals."""
     ref, ref2 = make_evals
-    ev = ref.get()
+    ev, ev2 = ref.get(), ref2.get()
+
+    # get_evaluate_calls: one evaluate call per eval, linked to its model.
     evaluate_calls = ev.get_evaluate_calls()
     assert len(evaluate_calls) == 1
+    assert evaluate_calls[0].inputs["self"].ref.uri == ref.uri
+    assert evaluate_calls[0].inputs["model"].name == "abc"
 
-    call1 = evaluate_calls[0]
-    assert call1.inputs["self"].ref.uri == ref.uri
-    assert call1.inputs["model"].name == "abc"
-
-    ev2 = ref2.get()
     evaluate_calls2 = ev2.get_evaluate_calls()
     assert len(evaluate_calls2) == 1
+    assert evaluate_calls2[0].inputs["self"].ref.uri == ref2.uri
+    assert evaluate_calls2[0].inputs["model"].name == "ghi"
 
-    call2 = evaluate_calls2[0]
-    assert call2.inputs["self"].ref.uri == ref2.uri
-    assert call2.inputs["model"].name == "ghi"
-
-
-def test_get_score_calls(client, make_evals):
-    ref, ref2 = make_evals
-    ev = ref.get()
+    # get_score_calls: four score calls per eval, in dataset order.
     score_calls = next(iter(ev.get_score_calls().values()))
-    assert len(score_calls) == 4
-
-    assert score_calls[0].output == 3
-    assert score_calls[1].output == 4
-    assert score_calls[2].output == 33
-    assert score_calls[3].output == 44
-
-    ev2 = ref2.get()
+    assert [c.output for c in score_calls] == [3, 4, 33, 44]
     score_calls2 = next(iter(ev2.get_score_calls().values()))
-    assert len(score_calls2) == 4
+    assert [c.output for c in score_calls2] == [56, 78, 5656, 7878]
 
-    assert score_calls2[0].output == 56
-    assert score_calls2[1].output == 78
-    assert score_calls2[2].output == 5656
-    assert score_calls2[3].output == 7878
-
-
-def test_get_scores(client, make_evals):
-    ref, ref2 = make_evals
-    ev = ref.get()
-    scores = next(iter(ev.get_scores().values()))
-    assert scores == {
+    # get_scores: grouped by scorer name.
+    assert next(iter(ev.get_scores().values())) == {
         "score": [3, 33],
         "score2": [4, 44],
     }
-
-    ev2 = ref2.get()
-    scores2 = next(iter(ev2.get_scores().values()))
-    assert scores2 == {
+    assert next(iter(ev2.get_scores().values())) == {
         "second_score": [56, 5656],
         "second_score2": [78, 7878],
     }

--- a/tests/trace/test_feedback.py
+++ b/tests/trace/test_feedback.py
@@ -1935,44 +1935,20 @@ def test_feedback_with_queue_id(client: WeaveClient) -> None:
     )
     assert no_queue_feedback["queue_id"] is None
 
-
-def test_feedback_with_invalid_queue_id(client: WeaveClient) -> None:
-    """Test feedback creation with invalid queue_id."""
-    project_id = client.project_id
-    weave_ref = f"weave:///{project_id}/call/call_id_invalid"
-    invalid_queue_id = "00000000-0000-0000-0000-000000000000"
-
-    # Case 1: Error with non-existent queue_id
+    # Case 3: non-existent queue_id is rejected.
     with pytest.raises(InvalidRequest, match="Queue .* not found or has been deleted"):
         client.server.feedback_create(
             FeedbackCreateReq(
                 project_id=project_id,
-                weave_ref=weave_ref,
+                weave_ref=f"weave:///{project_id}/call/call_id_invalid",
                 feedback_type="custom.score",
                 payload={"score": 5},
-                queue_id=invalid_queue_id,
+                queue_id="00000000-0000-0000-0000-000000000000",
             )
         )
 
-
-def test_feedback_with_queue_id_from_different_project(client: WeaveClient) -> None:
-    """Test feedback creation with queue_id from a different project."""
-    project_id = client.project_id
+    # Case 4: a valid queue_id from another project does not cross over.
     other_project_id = f"{project_id}_other"
-
-    # Create a queue in the original project
-    queue_create_req = tsi.AnnotationQueueCreateReq(
-        project_id=project_id,
-        name="Original Project Queue",
-        description="Queue in original project",
-        scorer_refs=[],
-        wb_user_id="test_user",
-    )
-    queue_res = client.server.annotation_queue_create(queue_create_req)
-    queue_id = queue_res.id
-
-    # Try to create feedback in a different project with the queue_id
-    # This should fail because the queue doesn't belong to the target project
     with pytest.raises(InvalidRequest, match="Queue .* not found or has been deleted"):
         client.server.feedback_create(
             FeedbackCreateReq(
@@ -2170,6 +2146,18 @@ def test_feedback_stats(client: WeaveClient) -> None:
     assert ws["max"] == pytest.approx(1.0)
     assert ws["avg"] == pytest.approx(sum(scores) / len(scores), abs=1e-6)
 
+    # Empty metrics list returns empty buckets at the default granularity.
+    empty = client.server.feedback_stats(
+        tsi.FeedbackStatsReq(
+            project_id=project_id,
+            start=now - datetime.timedelta(hours=1),
+            end=now + datetime.timedelta(minutes=5),
+            metrics=[],
+        )
+    )
+    assert empty.buckets == []
+    assert empty.granularity == 3600
+
 
 def test_feedback_payload_schema(client: WeaveClient) -> None:
     """End-to-end: seed varied feedback, discover payload schema paths."""
@@ -2213,23 +2201,6 @@ def test_feedback_payload_schema(client: WeaveClient) -> None:
     assert path_map["output.score"] == "numeric"
     assert "label" in path_map
     assert path_map["label"] == "categorical"
-
-
-def test_feedback_stats_empty_metrics(client: WeaveClient) -> None:
-    """Empty metrics list returns empty buckets without error."""
-    project_id = client.project_id
-    now = datetime.datetime.now(datetime.timezone.utc)
-    res = client.server.feedback_stats(
-        tsi.FeedbackStatsReq(
-            project_id=project_id,
-            start=now - datetime.timedelta(hours=1),
-            end=now + datetime.timedelta(minutes=5),
-            metrics=[],
-        )
-    )
-
-    assert res.buckets == []
-    assert res.granularity == 3600
 
 
 def test_feedback_query_returns_tz_aware_created_at(client: WeaveClient) -> None:

--- a/tests/trace/test_file_storage_uris.py
+++ b/tests/trace/test_file_storage_uris.py
@@ -18,9 +18,17 @@ from weave.trace_server.file_storage_uris import (
     ],
 )
 def test_parse_uri_str(uri: str, expected_class):
-    """Test that URIs are parsed into the correct class type."""
+    """Test that URIs are parsed into the correct class type and round-trip."""
     parsed = FileStorageURI.parse_uri_str(uri)
     assert isinstance(parsed, expected_class)
+    assert parsed.to_uri_str() == uri
+
+
+def test_parse_uri_str_from_subclass():
+    """Test parsing URI string directly from a storage class."""
+    uri = "s3://bucket/path"
+    parsed = S3FileStorageURI.parse_uri_str(uri)
+    assert isinstance(parsed, S3FileStorageURI)
     assert parsed.to_uri_str() == uri
 
 
@@ -29,17 +37,26 @@ def test_parse_uri_str(uri: str, expected_class):
     [
         "invalid://blah",
         "invalid://blah/blah",
+        "invalid://bucket/path",
         "s3://",
-        "gs://",
-        "az://",
+        "s3:///",
         "s3:///path",
+        "gs://",
+        "gs:///",
         "gs:///path",
+        "az://",
         "az://container",
         "az:///container",
+        "az://account",
+        "az://account/",
+        "az:///container/path",
+        "s3://bucket/path?query",
+        "s3://bucket/path#fragment",
+        "az://account/container/path#fragment",
     ],
 )
 def test_parse_uri_str_failure(uri: str):
-    """Test that URIs are parsed into the correct class type."""
+    """Malformed schemes, missing components, and query/fragment extras all raise."""
     with pytest.raises(URIParseError):
         FileStorageURI.parse_uri_str(uri)
 
@@ -63,57 +80,21 @@ def test_parse_uri_str_failure(uri: str):
                 "path": "path/to/blob",
             },
         ),
+        (
+            "az://account/container",
+            {"account": "account", "container": "container", "path": ""},
+        ),
+        (
+            "az://account/container/path",
+            {"account": "account", "container": "container", "path": "path"},
+        ),
     ],
 )
 def test_uri_attributes(uri: str, expected_attrs: dict):
-    """Test that parsed URIs have correct attribute values."""
+    """Test that parsed URIs have correct attribute values, including no-path Azure."""
     parsed = FileStorageURI.parse_uri_str(uri)
     for attr, value in expected_attrs.items():
         assert getattr(parsed, attr) == value
-
-
-@pytest.mark.parametrize(
-    "uri",
-    [
-        "invalid://bucket/path",
-        "s3://",
-        "s3:///",
-        "gs://",
-        "gs:///",
-        "az://account",
-        "az://account/",
-        "az:///container/path",
-    ],
-)
-def test_invalid_uris(uri: str):
-    """Test that invalid URIs raise appropriate errors."""
-    with pytest.raises(URIParseError):
-        FileStorageURI.parse_uri_str(uri)
-
-
-def test_with_path():
-    """Test modifying URI paths."""
-    uri = S3FileStorageURI("bucket", "original/path")
-    new_uri = uri.with_path("new/path")
-
-    assert isinstance(new_uri, S3FileStorageURI)
-    assert new_uri.bucket == "bucket"
-    assert new_uri.path == "new/path"
-    assert new_uri.to_uri_str() == "s3://bucket/new/path"
-
-
-@pytest.mark.parametrize(
-    "uri",
-    [
-        ("s3://bucket/path?query"),
-        ("s3://bucket/path#fragment"),
-        ("az://account/container/path#fragment"),
-    ],
-)
-def test_uri_with_extra_components(uri: str):
-    """Test that URIs with params, query, or fragments are rejected."""
-    with pytest.raises(URIParseError):
-        FileStorageURI.parse_uri_str(uri)
 
 
 @pytest.mark.parametrize(
@@ -132,43 +113,48 @@ def test_uri_with_extra_components(uri: str):
     ],
 )
 def test_empty_paths(storage_class, constructor_args, expected_uri):
-    """Test handling of empty paths for all storage types."""
+    """Test handling of empty paths for all storage types, with round trip."""
     uri = storage_class(*constructor_args)
     assert uri.to_uri_str() == expected_uri
-    # Test round trip
     parsed = FileStorageURI.parse_uri_str(expected_uri)
     assert parsed.to_uri_str() == expected_uri
 
 
 @pytest.mark.parametrize(
-    ("storage_class", "constructor_args", "new_path", "expected_uri"),
+    ("storage_class", "constructor_args", "new_path", "expected_class", "expected_uri"),
     [
         (
             S3FileStorageURI,
             ("bucket", "old/path"),
             "new/path",
+            S3FileStorageURI,
             "s3://bucket/new/path",
         ),
         (
             GCSFileStorageURI,
             ("bucket", "old/path"),
             "new/path",
+            GCSFileStorageURI,
             "gs://bucket/new/path",
         ),
         (
             AzureFileStorageURI,
             ("account", "container", "old/path"),
             "new/path",
+            AzureFileStorageURI,
             "az://account/container/new/path",
         ),
     ],
 )
-def test_with_path_all_types(storage_class, constructor_args, new_path, expected_uri):
-    """Test with_path for all storage types."""
+def test_with_path_all_types(
+    storage_class, constructor_args, new_path, expected_class, expected_uri
+):
+    """Test with_path returns the right subclass and leaves the original unchanged."""
     uri = storage_class(*constructor_args)
     new_uri = uri.with_path(new_path)
+    assert isinstance(new_uri, expected_class)
+    assert new_uri.path == new_path
     assert new_uri.to_uri_str() == expected_uri
-    # Ensure original URI is unchanged
     assert uri.path != new_path
 
 
@@ -212,26 +198,3 @@ def test_roundtrip_all_types(original_uri):
     # The regenerated URI should be normalized
     assert not regenerated.endswith("/")
     assert "//" not in regenerated[5:]  # Skip scheme://
-
-
-def test_parse_uri_str_from_subclass():
-    """Test parsing URI string directly from a storage class."""
-    uri = "s3://bucket/path"
-    parsed = S3FileStorageURI.parse_uri_str(uri)
-    assert isinstance(parsed, S3FileStorageURI)
-    assert parsed.to_uri_str() == uri
-
-
-def test_azure_container_path_parsing():
-    """Test Azure URI parsing edge cases with container and path."""
-    # Just container, no path
-    uri = "az://account/container"
-    parsed = FileStorageURI.parse_uri_str(uri)
-    assert parsed.container == "container"
-    assert parsed.path == ""
-
-    # Container with path
-    uri = "az://account/container/path"
-    parsed = FileStorageURI.parse_uri_str(uri)
-    assert parsed.container == "container"
-    assert parsed.path == "path"

--- a/tests/trace/test_grid.py
+++ b/tests/trace/test_grid.py
@@ -3,19 +3,16 @@ import pytest
 from weave.trace.display.grid import Grid, Row
 
 
-def test_grid_creation():
+def test_grid_build_columns_and_rows():
+    """Empty grid, column metadata (id/label/display_name), and row append + validation."""
     grid = Grid()
     assert grid.num_rows == 0
     assert grid.num_columns == 0
     assert grid.columns == []
     assert grid.rows == []
 
-
-def test_add_column():
-    grid = Grid()
     grid.add_column("name")
     grid.add_column("age", label="User Age")
-
     assert grid.num_columns == 2
     assert grid.columns[0].id == "name"
     assert grid.columns[0].label is None
@@ -24,33 +21,24 @@ def test_add_column():
     assert grid.columns[1].label == "User Age"
     assert grid.columns[1].display_name == "User Age"
 
-
-def test_add_row():
-    grid = Grid()
-    grid.add_column("name")
-    grid.add_column("age")
-
     grid.add_row(["Alice", 30])
     grid.add_row(["Bob", 25])
-
     assert grid.num_rows == 2
     assert grid.rows[0] == ["Alice", 30]
     assert grid.rows[1] == ["Bob", 25]
 
-
-def test_add_row_validation():
-    grid = Grid()
-    grid.add_column("name")
-
     with pytest.raises(ValueError, match="does not match number of columns"):
-        grid.add_row(["Alice", 30])  # Too many values
+        grid.add_row(["Carol", 40, "extra"])
 
 
-def test_get_row():
+def test_grid_row_and_column_access():
+    """Row access by name/index/attribute and get_column_values by name/index."""
     grid = Grid()
     grid.add_column("name")
     grid.add_column("age")
     grid.add_row(["Alice", 30])
+    grid.add_row(["Bob", 25])
+    grid.add_row(["Charlie", 35])
 
     row = grid.get_row(0)
     assert isinstance(row, Row)
@@ -61,8 +49,14 @@ def test_get_row():
     assert row.name == "Alice"
     assert row.age == 30
 
+    assert grid.get_column_values("name") == ["Alice", "Bob", "Charlie"]
+    assert grid.get_column_values("age") == [30, 25, 35]
+    assert grid.get_column_values(0) == ["Alice", "Bob", "Charlie"]
+    assert grid.get_column_values(1) == [30, 25, 35]
 
-def test_get_row_errors():
+
+def test_grid_access_errors():
+    """Out-of-range row, bad row keys, and bad get_column_values keys all raise."""
     grid = Grid()
     grid.add_column("name")
     grid.add_row(["Alice"])
@@ -73,41 +67,16 @@ def test_get_row_errors():
     row = grid.get_row(0)
     with pytest.raises(KeyError):
         row["invalid"]  # Invalid column name
-
     with pytest.raises(IndexError):
         row[1]  # Invalid column index
-
     with pytest.raises(TypeError):
         row[1.5]  # Invalid key type
-
     with pytest.raises(AttributeError):
         _ = row.invalid  # Invalid attribute name
 
-
-def test_get_column_values():
-    grid = Grid()
-    grid.add_column("name")
-    grid.add_column("age")
-    grid.add_row(["Alice", 30])
-    grid.add_row(["Bob", 25])
-    grid.add_row(["Charlie", 35])
-
-    assert grid.get_column_values("name") == ["Alice", "Bob", "Charlie"]
-    assert grid.get_column_values("age") == [30, 25, 35]
-    assert grid.get_column_values(0) == ["Alice", "Bob", "Charlie"]
-    assert grid.get_column_values(1) == [30, 25, 35]
-
-
-def test_get_column_values_errors():
-    grid = Grid()
-    grid.add_column("name")
-    grid.add_row(["Alice"])
-
     with pytest.raises(KeyError):
         grid.get_column_values("invalid")  # Invalid column name
-
     with pytest.raises(IndexError):
         grid.get_column_values(1)  # Invalid column index
-
     with pytest.raises(TypeError):
         grid.get_column_values(1.5)  # Invalid key type

--- a/tests/trace/test_integration_metadata.py
+++ b/tests/trace/test_integration_metadata.py
@@ -126,12 +126,43 @@ def test_with_integration_metadata_preserves_existing_attributes():
 # --- op-level default attributes (end to end) ---------------------------------
 
 
-def test_op_level_attributes_land_on_call(client):
-    @weave.op(attributes={"integration": {"name": "demo"}})
-    def func():
-        return 1
+@pytest.mark.asyncio
+@pytest.mark.parametrize("flavor", ["sync", "async", "sync_gen", "async_gen"])
+async def test_op_level_attributes_land_on_call(client, flavor):
+    """op(attributes=...) stamps the integration block on every call flavor."""
+    if flavor == "sync":
 
-    func()
+        @weave.op(attributes={"integration": {"name": "demo"}})
+        def func():
+            return 1
+
+        func()
+    elif flavor == "async":
+
+        @weave.op(attributes={"integration": {"name": "demo"}})
+        async def func():
+            return 1
+
+        await func()
+    elif flavor == "sync_gen":
+
+        @weave.op(attributes={"integration": {"name": "demo"}})
+        def func():
+            yield 1
+            yield 2
+
+        list(func())
+    elif flavor == "async_gen":
+
+        @weave.op(attributes={"integration": {"name": "demo"}})
+        async def func():
+            yield 1
+            yield 2
+
+        [x async for x in func()]
+    else:
+        raise AssertionError(f"unhandled flavor {flavor}")
+
     call = _only_call(client)
     assert call.attributes["integration"] == {"name": "demo"}
 
@@ -190,40 +221,6 @@ def test_op_without_attributes_has_no_integration_key(client):
     func()
     call = _only_call(client)
     assert "integration" not in call.attributes
-
-
-@pytest.mark.asyncio
-async def test_op_level_attributes_on_async_call(client):
-    @weave.op(attributes={"integration": {"name": "demo"}})
-    async def afunc():
-        return 1
-
-    await afunc()
-    call = _only_call(client)
-    assert call.attributes["integration"] == {"name": "demo"}
-
-
-def test_op_level_attributes_on_sync_generator(client):
-    @weave.op(attributes={"integration": {"name": "demo"}})
-    def gen():
-        yield 1
-        yield 2
-
-    list(gen())
-    call = _only_call(client)
-    assert call.attributes["integration"] == {"name": "demo"}
-
-
-@pytest.mark.asyncio
-async def test_op_level_attributes_on_async_generator(client):
-    @weave.op(attributes={"integration": {"name": "demo"}})
-    async def agen():
-        yield 1
-        yield 2
-
-    [x async for x in agen()]
-    call = _only_call(client)
-    assert call.attributes["integration"] == {"name": "demo"}
 
 
 # --- callback/tracer path (Family B: direct create_call) ----------------------

--- a/tests/trace/test_link_prompt_to_registry.py
+++ b/tests/trace/test_link_prompt_to_registry.py
@@ -134,27 +134,25 @@ def test_resolves_input_and_builds_request(
     assert req.aliases == expected_aliases
 
 
-def test_rejects_unpublished_prompt(client):
-    """Raise before making the transport call when the prompt has no ref."""
-    with patch(MOCK_TARGET) as transport:
-        with pytest.raises(ValueError, match="published prompt"):
-            client.link_prompt_to_registry(
-                StringPrompt("Hello {name}"),
-                target_path="wandb-registry-prompts/my-prompt-collection",
-            )
-
-    transport.assert_not_called()
-
-
-def test_rejects_published_non_prompt_object(client):
-    """Reject published non-prompt objects before making the transport call."""
+def _published_non_prompt() -> weave.Object:
     obj = weave.Object(name="not-a-prompt")
     obj.ref = PROMPT_REF
+    return obj
 
+
+@pytest.mark.parametrize(
+    "asset",
+    [
+        pytest.param(StringPrompt("Hello {name}"), id="unpublished-prompt"),
+        pytest.param(_published_non_prompt(), id="published-non-prompt"),
+    ],
+)
+def test_rejects_non_published_prompt_assets(client, asset):
+    """Reject unpublished prompts and published non-prompt objects before the call."""
     with patch(MOCK_TARGET) as transport:
         with pytest.raises(ValueError, match="published prompt"):
             client.link_prompt_to_registry(
-                obj,
+                asset,
                 target_path="wandb-registry-prompts/my-prompt-collection",
             )
 

--- a/tests/trace/test_llm_as_a_judge_scorer.py
+++ b/tests/trace/test_llm_as_a_judge_scorer.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 import weave
 from weave.prompt.prompt import MessagesPrompt
 from weave.scorers import LLMAsAJudgeScorer
@@ -50,8 +52,37 @@ def test_publish_and_load_scorer_with_prompt_ref(weave_active):
     assert len(loaded_scorer.scoring_prompt.messages) == 1
 
 
-def test_score_with_string_prompt():
-    """Test score() with a simple string prompt."""
+# score() renders the scoring prompt (string or MessagesPrompt) into the
+# message list passed to the model's predict, then returns predict's result.
+@pytest.mark.parametrize(
+    ("scoring_prompt", "score_kwargs", "mock_result", "expected_messages"),
+    [
+        (
+            "Output: {output}",
+            {"output": "hello"},
+            {"score": 1.0},
+            [{"role": "user", "content": "Output: hello"}],
+        ),
+        (
+            MessagesPrompt(
+                messages=[
+                    {"role": "system", "content": "You are a {judge_type} judge."},
+                    {"role": "user", "content": "Expected: {expected}, Got: {output}"},
+                ]
+            ),
+            {"output": "4", "expected": "4", "judge_type": "math"},
+            {"score": 0.95},
+            [
+                {"role": "system", "content": "You are a math judge."},
+                {"role": "user", "content": "Expected: 4, Got: 4"},
+            ],
+        ),
+    ],
+    ids=["string-prompt", "messages-prompt-with-vars"],
+)
+def test_score_renders_prompt_into_predict_messages(
+    scoring_prompt, score_kwargs, mock_result, expected_messages
+):
     scorer = LLMAsAJudgeScorer(
         model=LLMStructuredCompletionModel(
             llm_model_id="gpt-4o-mini",
@@ -59,49 +90,13 @@ def test_score_with_string_prompt():
                 response_format="json_object",
             ),
         ),
-        scoring_prompt="Output: {output}",
+        scoring_prompt=scoring_prompt,
     )
-
-    mock_result = {"score": 1.0}
     with patch.object(
         LLMStructuredCompletionModel, "predict", return_value=mock_result
     ) as mock_predict:
-        result = scorer.score(output="hello")
+        result = scorer.score(**score_kwargs)
 
-        assert result == mock_result
-        mock_predict.assert_called_once()
-        messages = mock_predict.call_args[0][0]
-        assert messages == [{"role": "user", "content": "Output: hello"}]
-
-
-def test_score_with_messages_prompt():
-    """Test score() with a MessagesPrompt and template variables."""
-    prompt = MessagesPrompt(
-        messages=[
-            {"role": "system", "content": "You are a {judge_type} judge."},
-            {"role": "user", "content": "Expected: {expected}, Got: {output}"},
-        ]
-    )
-
-    scorer = LLMAsAJudgeScorer(
-        model=LLMStructuredCompletionModel(
-            llm_model_id="gpt-4o-mini",
-            default_params=LLMStructuredCompletionModelDefaultParams(
-                response_format="json_object",
-            ),
-        ),
-        scoring_prompt=prompt,
-    )
-
-    mock_result = {"score": 0.95}
-    with patch.object(
-        LLMStructuredCompletionModel, "predict", return_value=mock_result
-    ) as mock_predict:
-        result = scorer.score(output="4", expected="4", judge_type="math")
-
-        assert result == mock_result
-        mock_predict.assert_called_once()
-        messages = mock_predict.call_args[0][0]
-        assert len(messages) == 2
-        assert messages[0]["content"] == "You are a math judge."
-        assert messages[1]["content"] == "Expected: 4, Got: 4"
+    assert result == mock_result
+    mock_predict.assert_called_once()
+    assert mock_predict.call_args[0][0] == expected_messages

--- a/tests/trace/test_llm_structured_completion_model.py
+++ b/tests/trace/test_llm_structured_completion_model.py
@@ -195,121 +195,55 @@ def test_llm_structured_completion_model_filtering(client: WeaveClient):
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
-def test_llm_structured_completion_model_predict_text_response(mock_get_client):
-    """Test the predict function with mocked LLM API response for text format."""
-    # Setup mock client
-    mock_client = Mock()
-    mock_client.entity = "test_entity"
-    mock_client.project = "test_project"
+def test_predict_text_and_json_response(mock_get_client):
+    """predict() returns raw text for response_format=text and parsed dict for json_object."""
+    mock_client = _mock_client(mock_get_client)
 
-    # Mock successful API response
-    mock_response = tsi.CompletionsCreateRes(
-        response={
-            "choices": [
-                {
-                    "message": {
-                        "role": "assistant",
-                        "content": "Hello! How can I help you today?",
-                    }
-                }
-            ]
-        }
+    mock_client.server.completions_create.return_value = _completion_res(
+        "Hello! How can I help you today?"
     )
-    mock_client.server.completions_create.return_value = mock_response
-    mock_get_client.return_value = mock_client
-
-    # Create model with text response format
-    model = LLMStructuredCompletionModel(
+    text_model = LLMStructuredCompletionModel(
         llm_model_id="gpt-4",
         default_params=LLMStructuredCompletionModelDefaultParams(
-            temperature=0.7,
-            max_tokens=100,
-            response_format="text",
+            temperature=0.7, max_tokens=100, response_format="text"
         ),
     )
-
-    # Test predict with simple string input
-    result = model.predict(user_input="Hello")
-
-    # Verify result
-    assert result == "Hello! How can I help you today?"
-
-    # Verify API call was made correctly
+    assert text_model.predict(user_input="Hello") == "Hello! How can I help you today?"
     mock_client.server.completions_create.assert_called_once()
-    call_args = mock_client.server.completions_create.call_args[1]["req"]
-    assert call_args.project_id == "test_entity/test_project"
-    assert call_args.inputs.model == "gpt-4"
-    assert call_args.inputs.temperature == 0.7
-    assert call_args.inputs.max_tokens == 100
-    assert call_args.inputs.messages == [{"role": "user", "content": "Hello"}]
+    text_args = mock_client.server.completions_create.call_args[1]["req"]
+    assert text_args.project_id == "test_entity/test_project"
+    assert text_args.inputs.model == "gpt-4"
+    assert text_args.inputs.temperature == 0.7
+    assert text_args.inputs.max_tokens == 100
+    assert text_args.inputs.messages == [{"role": "user", "content": "Hello"}]
 
-
-@patch(
-    "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
-)
-def test_llm_structured_completion_model_predict_json_response(mock_get_client):
-    """Test the predict function with mocked LLM API response for JSON format."""
-    # Setup mock client
-    mock_client = Mock()
-    mock_client.entity = "test_entity"
-    mock_client.project = "test_project"
-
-    # Mock successful API response with JSON content
     json_content = {"result": "success", "data": {"message": "Hello World"}}
-    mock_response = tsi.CompletionsCreateRes(
-        response={
-            "choices": [
-                {"message": {"role": "assistant", "content": json.dumps(json_content)}}
-            ]
-        }
+    mock_client.server.completions_create.return_value = _completion_res(
+        json.dumps(json_content)
     )
-    mock_client.server.completions_create.return_value = mock_response
-    mock_get_client.return_value = mock_client
-
-    # Create model with JSON response format
-    model = LLMStructuredCompletionModel(
+    json_model = LLMStructuredCompletionModel(
         llm_model_id="gpt-4",
         default_params=LLMStructuredCompletionModelDefaultParams(
-            response_format="json_object",
+            response_format="json_object"
         ),
     )
-
-    # Test predict
-    result = model.predict(user_input="Generate JSON")
-
-    # Verify result is parsed JSON
-    assert result == json_content
-    assert isinstance(result, dict)
-    assert result["result"] == "success"
+    json_result = json_model.predict(user_input="Generate JSON")
+    assert isinstance(json_result, dict)
+    assert json_result == json_content
+    assert json_result["result"] == "success"
 
 
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
-def test_llm_structured_completion_model_predict_with_template(mock_get_client):
-    """Test the predict function with message templates and template variables."""
-    # Setup mock client
-    mock_client = Mock()
-    mock_client.entity = "test_entity"
-    mock_client.project = "test_project"
+def test_predict_with_template_and_config_override(mock_get_client):
+    """Template vars are substituted into messages; a `config` arg overrides defaults."""
+    mock_client = _mock_client(mock_get_client)
 
-    mock_response = tsi.CompletionsCreateRes(
-        response={
-            "choices": [
-                {
-                    "message": {
-                        "role": "assistant",
-                        "content": "Hello Alice! I'm Claude, nice to meet you.",
-                    }
-                }
-            ]
-        }
+    mock_client.server.completions_create.return_value = _completion_res(
+        "Hello Alice! I'm Claude, nice to meet you."
     )
-    mock_client.server.completions_create.return_value = mock_response
-    mock_get_client.return_value = mock_client
-
-    # Create model with message template
-    model = LLMStructuredCompletionModel(
+    template_model = LLMStructuredCompletionModel(
         llm_model_id="claude-3",
         default_params=LLMStructuredCompletionModelDefaultParams(
             messages_template=[
@@ -321,77 +255,37 @@ def test_llm_structured_completion_model_predict_with_template(mock_get_client):
             response_format="text",
         ),
     )
-
-    # Test predict with template variables
-    result = model.predict(
+    template_result = template_model.predict(
         user_input=[Message(role="user", content="What's your name?")],
         assistant_name="Claude",
         user_name="Alice",
     )
-
-    # Verify result
-    assert result == "Hello Alice! I'm Claude, nice to meet you."
-
-    # Verify the messages were properly prepared with template substitution
-    call_args = mock_client.server.completions_create.call_args[1]["req"]
-    expected_messages = [
+    assert template_result == "Hello Alice! I'm Claude, nice to meet you."
+    template_args = mock_client.server.completions_create.call_args[1]["req"]
+    assert template_args.inputs.messages == [
         {"role": "system", "content": "You are Claude, a helpful AI."},
         {"role": "user", "content": "Hello, my name is Alice"},
         {"role": "user", "content": "What's your name?"},
     ]
-    assert call_args.inputs.messages == expected_messages
 
-
-@patch(
-    "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
-)
-def test_llm_structured_completion_model_predict_with_config_override(mock_get_client):
-    """Test the predict function with config parameter overriding defaults."""
-    # Setup mock client
-    mock_client = Mock()
-    mock_client.entity = "test_entity"
-    mock_client.project = "test_project"
-
-    mock_response = tsi.CompletionsCreateRes(
-        response={
-            "choices": [
-                {
-                    "message": {
-                        "role": "assistant",
-                        "content": "Response with overridden config",
-                    }
-                }
-            ]
-        }
+    mock_client.server.completions_create.return_value = _completion_res(
+        "Response with overridden config"
     )
-    mock_client.server.completions_create.return_value = mock_response
-    mock_get_client.return_value = mock_client
-
-    # Create model with default parameters
-    model = LLMStructuredCompletionModel(
+    override_model = LLMStructuredCompletionModel(
         llm_model_id="gpt-4",
         default_params=LLMStructuredCompletionModelDefaultParams(
-            temperature=0.5,
-            max_tokens=100,
-            response_format="text",
+            temperature=0.5, max_tokens=100, response_format="text"
         ),
     )
-
-    # Test predict with config override
-    override_config = LLMStructuredCompletionModelDefaultParams(
-        temperature=0.9,
-        max_tokens=200,
-    )
-
-    result = model.predict(
+    override_model.predict(
         user_input="Test message",
-        config=override_config,
+        config=LLMStructuredCompletionModelDefaultParams(
+            temperature=0.9, max_tokens=200
+        ),
     )
-
-    # Verify override was applied
-    call_args = mock_client.server.completions_create.call_args[1]["req"]
-    assert call_args.inputs.temperature == 0.9  # Overridden
-    assert call_args.inputs.max_tokens == 200  # Overridden
+    override_args = mock_client.server.completions_create.call_args[1]["req"]
+    assert override_args.inputs.temperature == 0.9
+    assert override_args.inputs.max_tokens == 200
 
 
 @patch(
@@ -438,12 +332,10 @@ def test_llm_structured_completion_model_predict_error_handling(mock_get_client)
         model.predict(user_input="Test")
 
 
-def test_parse_response_user_facing_errors():
-    """Guards in `parse_response` should surface user-actionable messages.
+def test_parse_response_errors_and_happy_paths():
+    """`parse_response` surfaces user-actionable errors and returns good content unchanged.
 
-    Replaces raw Python TypeError/JSONDecodeError when the LLM returns no
-    content or unparseable content. These were the top sources of
-    scoring-worker error noise (WB-34500).
+    Guards replace raw TypeError/JSONDecodeError noise from the scoring worker (WB-34500).
     """
     # API-level error: still RuntimeError (unchanged contract).
     with pytest.raises(RuntimeError, match="LLM API returned an error"):
@@ -476,9 +368,7 @@ def test_parse_response_user_facing_errors():
             "json_object",
         )
 
-
-def test_parse_response_happy_paths():
-    """`parse_response` returns the content / parsed JSON unchanged on good input."""
+    # Happy paths: content / parsed JSON returned unchanged on good input.
     assert (
         parse_response({"choices": [{"message": {"content": "hello"}}]}, "text")
         == "hello"
@@ -591,203 +481,128 @@ def test_parse_params_to_litellm_params():
     assert result_with_prompt["temperature"] == 0.5
 
 
-def test_cast_to_message_list():
-    """Test the cast_to_message_list function."""
-    # Test single Message object
+def test_cast_to_message_and_message_list():
+    """`cast_to_message` and `cast_to_message_list` coerce Message/str/dict, reject bad types."""
+    # cast_to_message: passthrough, string, dict, and invalid type.
     msg = Message(role="user", content="Hello")
-    result = cast_to_message_list(msg)
-    assert len(result) == 1
-    assert result[0] == msg
+    assert cast_to_message(msg) == msg
+    from_str = cast_to_message("Hello world")
+    assert from_str.role == "user"
+    assert from_str.content == "Hello world"
+    from_dict = cast_to_message({"role": "system", "content": "System message"})
+    assert from_dict.role == "system"
+    assert from_dict.content == "System message"
+    with pytest.raises(TypeError):
+        cast_to_message(123)
 
-    # Test single string
-    result = cast_to_message_list("Hello world")
-    assert len(result) == 1
-    assert result[0].role == "user"
-    assert result[0].content == "Hello world"
+    # cast_to_message_list: single Message, single string, single dict.
+    single_msg = cast_to_message_list(msg)
+    assert len(single_msg) == 1
+    assert single_msg[0] == msg
+    single_str = cast_to_message_list("Hello world")
+    assert len(single_str) == 1
+    assert single_str[0].role == "user"
+    assert single_str[0].content == "Hello world"
+    single_dict = cast_to_message_list({"role": "system", "content": "You are helpful"})
+    assert len(single_dict) == 1
+    assert single_dict[0].role == "system"
+    assert single_dict[0].content == "You are helpful"
 
-    # Test single dict
-    msg_dict = {"role": "system", "content": "You are helpful"}
-    result = cast_to_message_list(msg_dict)
-    assert len(result) == 1
-    assert result[0].role == "system"
-    assert result[0].content == "You are helpful"
-
-    # Test list of mixed types
-    mixed_list = [
-        "Hello",
-        {"role": "assistant", "content": "Hi there"},
-        Message(role="user", content="How are you?"),
-    ]
-    result = cast_to_message_list(mixed_list)
-    assert len(result) == 3
-    assert result[0].role == "user"
-    assert result[0].content == "Hello"
-    assert result[1].role == "assistant"
-    assert result[1].content == "Hi there"
-    assert result[2].role == "user"
-    assert result[2].content == "How are you?"
-
-    # Test invalid type
+    # cast_to_message_list: mixed list and invalid type.
+    mixed = cast_to_message_list(
+        [
+            "Hello",
+            {"role": "assistant", "content": "Hi there"},
+            Message(role="user", content="How are you?"),
+        ]
+    )
+    assert len(mixed) == 3
+    assert mixed[0].role == "user"
+    assert mixed[0].content == "Hello"
+    assert mixed[1].role == "assistant"
+    assert mixed[1].content == "Hi there"
+    assert mixed[2].role == "user"
+    assert mixed[2].content == "How are you?"
     with pytest.raises(TypeError):
         cast_to_message_list(123)
 
 
-def test_cast_to_message():
-    """Test the cast_to_message function."""
-    # Test Message object (passthrough)
-    msg = Message(role="user", content="Hello")
-    result = cast_to_message(msg)
-    assert result == msg
-
-    # Test string conversion
-    result = cast_to_message("Hello world")
-    assert result.role == "user"
-    assert result.content == "Hello world"
-
-    # Test dict conversion
-    msg_dict = {"role": "system", "content": "System message"}
-    result = cast_to_message(msg_dict)
-    assert result.role == "system"
-    assert result.content == "System message"
-
-    # Test invalid type
-    with pytest.raises(TypeError):
-        cast_to_message(123)
-
-
 @patch(
     "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
 )
-def test_llm_structured_completion_model_predict_with_prompt(
+def test_predict_with_prompt_delegates_and_takes_precedence(
     mock_get_client, client: WeaveClient
 ):
-    """Test the predict function with a prompt that references a MessagesPrompt object.
+    """A `prompt` ref + template_vars are delegated to completions_create.
 
-    With the current architecture, the model passes the prompt reference and template_vars
-    to the completions endpoint, which handles resolution and substitution.
+    The model no longer resolves prompts itself; it passes the ref through and, when both
+    prompt and messages_template are set, prompt wins (messages_template is dropped).
     """
-    # Create and publish a MessagesPrompt
-    messages_prompt = MessagesPrompt(
-        messages=[
-            {"role": "system", "content": "You are {assistant_name}, a helpful AI."},
-            {"role": "user", "content": "Hello, my name is {user_name}"},
-        ]
+    mock_client = _mock_client(
+        mock_get_client, entity=client.entity, project=client.project
     )
-    prompt_ref = publish(messages_prompt, name="test_messages_prompt")
 
-    # Setup mock client
-    mock_client = Mock()
-    mock_client.entity = client.entity
-    mock_client.project = client.project
-
-    mock_response = tsi.CompletionsCreateRes(
-        response={
-            "choices": [
+    # Prompt-only model: delegates prompt + template_vars, keeps only user_input messages.
+    prompt_ref = publish(
+        MessagesPrompt(
+            messages=[
                 {
-                    "message": {
-                        "role": "assistant",
-                        "content": "Hello Alice! I'm Claude, nice to meet you.",
-                    }
-                }
+                    "role": "system",
+                    "content": "You are {assistant_name}, a helpful AI.",
+                },
+                {"role": "user", "content": "Hello, my name is {user_name}"},
             ]
-        }
+        ),
+        name="test_messages_prompt",
     )
-    mock_client.server.completions_create.return_value = mock_response
-    mock_get_client.return_value = mock_client
-
-    # Create model with prompt
-    model = LLMStructuredCompletionModel(
+    mock_client.server.completions_create.return_value = _completion_res(
+        "Hello Alice! I'm Claude, nice to meet you."
+    )
+    prompt_model = LLMStructuredCompletionModel(
         llm_model_id="claude-3",
         default_params=LLMStructuredCompletionModelDefaultParams(
-            prompt=prompt_ref.uri,
-            response_format="text",
+            prompt=prompt_ref.uri, response_format="text"
         ),
     )
-
-    # Test predict with template variables
-    result = model.predict(
+    prompt_result = prompt_model.predict(
         user_input=[Message(role="user", content="What's your name?")],
         assistant_name="Claude",
         user_name="Alice",
     )
-
-    # Verify result
-    assert result == "Hello Alice! I'm Claude, nice to meet you."
-
-    # Verify the prompt reference and template_vars were passed to completions_create
-    # The model no longer does prompt resolution - it delegates to the completions endpoint
-    call_args = mock_client.server.completions_create.call_args[1]["req"]
-
-    # Should have the prompt reference and template_vars in the request
-    assert call_args.inputs.prompt == prompt_ref.uri
-    assert call_args.inputs.template_vars == {
+    assert prompt_result == "Hello Alice! I'm Claude, nice to meet you."
+    prompt_args = mock_client.server.completions_create.call_args[1]["req"]
+    assert prompt_args.inputs.prompt == prompt_ref.uri
+    assert prompt_args.inputs.template_vars == {
         "assistant_name": "Claude",
         "user_name": "Alice",
     }
-
-    # Should have only the user_input messages (prompt resolution happens in completions endpoint)
-    expected_messages = [
-        {"role": "user", "content": "What's your name?"},
+    assert prompt_args.inputs.messages == [
+        {"role": "user", "content": "What's your name?"}
     ]
-    assert call_args.inputs.messages == expected_messages
 
-
-@patch(
-    "weave.trace_server.interface.builtin_object_classes.llm_structured_model.get_weave_client"
-)
-def test_llm_structured_completion_model_prompt_takes_precedence(
-    mock_get_client, client: WeaveClient
-):
-    """Test that prompt takes precedence over messages_template when both are provided.
-
-    When prompt is set, the model passes it to completions_create and ignores messages_template.
-    """
-    # Create and publish a MessagesPrompt
-    messages_prompt = MessagesPrompt(
-        messages=[
-            {"role": "system", "content": "Message from prompt: {var}"},
-        ]
+    # prompt + messages_template: prompt takes precedence, no user_input -> empty messages.
+    precedence_ref = publish(
+        MessagesPrompt(
+            messages=[{"role": "system", "content": "Message from prompt: {var}"}]
+        ),
+        name="test_precedence_prompt",
     )
-    prompt_ref = publish(messages_prompt, name="test_precedence_prompt")
-
-    # Setup mock client
-    mock_client = Mock()
-    mock_client.entity = client.entity
-    mock_client.project = client.project
-
-    mock_response = tsi.CompletionsCreateRes(
-        response={
-            "choices": [{"message": {"role": "assistant", "content": "Response"}}]
-        }
-    )
-    mock_client.server.completions_create.return_value = mock_response
-    mock_get_client.return_value = mock_client
-
-    # Create model with both prompt and messages_template
-    model = LLMStructuredCompletionModel(
+    mock_client.server.completions_create.return_value = _completion_res("Response")
+    precedence_model = LLMStructuredCompletionModel(
         llm_model_id="gpt-4",
         default_params=LLMStructuredCompletionModelDefaultParams(
-            prompt=prompt_ref.uri,
+            prompt=precedence_ref.uri,
             messages_template=[
                 Message(role="system", content="Message from template: {var}"),
             ],
             response_format="text",
         ),
     )
-
-    # Test predict
-    result = model.predict(var="test_value")
-
-    # Verify that prompt was passed (not messages_template)
-    call_args = mock_client.server.completions_create.call_args[1]["req"]
-
-    # Should have prompt reference and template_vars
-    assert call_args.inputs.prompt == prompt_ref.uri
-    assert call_args.inputs.template_vars == {"var": "test_value"}
-
-    # Should NOT have messages from messages_template (prompt takes precedence)
-    # Messages should be empty since no user_input was provided
-    assert call_args.inputs.messages == []
+    precedence_model.predict(var="test_value")
+    precedence_args = mock_client.server.completions_create.call_args[1]["req"]
+    assert precedence_args.inputs.prompt == precedence_ref.uri
+    assert precedence_args.inputs.template_vars == {"var": "test_value"}
+    assert precedence_args.inputs.messages == []
 
 
 def test_llm_structured_completion_model_schema_validation(client: WeaveClient):
@@ -852,3 +667,21 @@ def test_cast_to_llm_structured_model_params_handles_weave_object():
     assert isinstance(result, LLMStructuredCompletionModelDefaultParams)
     assert result.response_format == "json_object"
     assert result.temperature == 0.5
+
+
+def _mock_client(
+    mock_get_client, entity: str = "test_entity", project: str = "test_project"
+) -> Mock:
+    """Wire a Mock weave client into the patched `get_weave_client` and return it."""
+    mock_client = Mock()
+    mock_client.entity = entity
+    mock_client.project = project
+    mock_get_client.return_value = mock_client
+    return mock_client
+
+
+def _completion_res(content: str) -> tsi.CompletionsCreateRes:
+    """Build a single-choice assistant CompletionsCreateRes with `content`."""
+    return tsi.CompletionsCreateRes(
+        response={"choices": [{"message": {"role": "assistant", "content": content}}]}
+    )

--- a/tests/trace/test_log_call.py
+++ b/tests/trace/test_log_call.py
@@ -1,12 +1,15 @@
 """Tests for the log_call function."""
 
+import pytest
+
 import weave
 from weave.trace.weave_client import WeaveClient
 
 
-def test_log_call_basic(client: WeaveClient):
-    """Test basic log_call functionality."""
-    call = weave.log_call("test", {"a": 1}, 2)
+def test_log_call_basic_fields(client: WeaveClient):
+    """Single log_call records op name, inputs, output, and no exception."""
+    weave.log_call("test", {"a": 1}, 2)
+
     fetched_calls = client.get_calls()
     assert len(fetched_calls) == 1
     call = fetched_calls[0]
@@ -14,33 +17,73 @@ def test_log_call_basic(client: WeaveClient):
     assert call.inputs == {"a": 1}
     assert call.output == 2
     assert call.exception is None
+    # returned call should be finished, with consistent timestamps
+    assert call.started_at is not None
+    assert call.ended_at is not None
+    assert call.ended_at >= call.started_at
 
 
-def test_log_call_with_display_name(client: WeaveClient):
-    """Test log_call with a custom display name."""
-    call = weave.log_call("test_op", {"x": 5}, 10, display_name="Custom Display Name")
+@pytest.mark.parametrize(
+    ("inputs", "output"),
+    [
+        ({}, "result"),
+        ({"x": 1}, None),
+        (
+            {
+                "simple": 42,
+                "nested": {"a": 1, "b": [2, 3, 4]},
+                "list": [{"x": 1}, {"y": 2}],
+            },
+            {"result": [1, 2, 3], "metadata": {"count": 3, "sum": 6}},
+        ),
+    ],
+)
+def test_log_call_inputs_outputs(client: WeaveClient, inputs, output):
+    """Empty, None, and deeply-nested inputs/outputs round-trip unchanged."""
+    weave.log_call("io_op", inputs, output)
+
     fetched_calls = client.get_calls()
     assert len(fetched_calls) == 1
     fetched_call = fetched_calls[0]
-    assert fetched_call.display_name == "Custom Display Name"
+    assert fetched_call.inputs == inputs
+    assert fetched_call.output == output
 
 
-def test_log_call_with_attributes(client: WeaveClient):
-    """Test log_call with custom attributes."""
+def test_log_call_display_name_string_and_callable(client: WeaveClient):
+    """display_name accepts a literal string or a callable evaluated at creation."""
+    weave.log_call("op_a", {"x": 5}, 10, display_name="Custom Display Name")
+
+    def make_display_name(call):
+        return f"Call-{call.inputs.get('id', 'unknown')}"
+
+    weave.log_call(
+        "op_b", {"id": 123, "value": "test"}, "result", display_name=make_display_name
+    )
+
+    fetched_calls = client.get_calls()
+    assert len(fetched_calls) == 2
+    by_op = {c.func_name: c for c in fetched_calls}
+    assert by_op["op_a"].display_name == "Custom Display Name"
+    assert by_op["op_b"].display_name == "Call-123"
+
+
+def test_log_call_attributes(client: WeaveClient):
+    """Custom attributes are preserved (system may add additional ones)."""
     attrs = {"version": "1.0", "env": "test", "user": "test_user"}
-    call = weave.log_call("test_op", {"x": 5}, 10, attributes=attrs)
+    weave.log_call("test_op", {"x": 5}, 10, attributes=attrs)
+
     fetched_calls = client.get_calls()
     assert len(fetched_calls) == 1
     fetched_call = fetched_calls[0]
-    # Check that our custom attributes are present (system may add additional attributes)
     for key, value in attrs.items():
         assert fetched_call.attributes[key] == value
 
 
-def test_log_call_with_exception(client: WeaveClient):
-    """Test log_call with an exception."""
+def test_log_call_exception(client: WeaveClient):
+    """An exception is captured into the call's exception string."""
     exc = ValueError("Something went wrong")
-    call = weave.log_call("test_op", {"x": 5}, None, exception=exc)
+    weave.log_call("test_op", {"x": 5}, None, exception=exc)
+
     fetched_calls = client.get_calls()
     assert len(fetched_calls) == 1
     fetched_call = fetched_calls[0]
@@ -49,116 +92,33 @@ def test_log_call_with_exception(client: WeaveClient):
     assert "Something went wrong" in fetched_call.exception
 
 
-def test_log_call_nested_with_parent(client: WeaveClient):
-    """Test log_call with parent-child relationship."""
-    parent_call = weave.log_call("parent_op", {"parent_input": 1}, {"parent_output": 2})
-    child_call = weave.log_call(
-        "child_op", {"child_input": 3}, {"child_output": 4}, parent=parent_call
-    )
-
-    fetched_calls = client.get_calls()
-    assert len(fetched_calls) == 2
-
-    # Find parent and child in fetched calls
-    parent = next(c for c in fetched_calls if c.id == parent_call.id)
-    child = next(c for c in fetched_calls if c.id == child_call.id)
-
-    # Verify parent-child relationship
-    assert child.parent_id == parent.id
-    assert parent.parent_id is None
-
-
-def test_log_call_multiple_calls(client: WeaveClient):
-    """Test multiple log_call invocations."""
-    call1 = weave.log_call("op1", {"a": 1}, 2)
-    call2 = weave.log_call("op2", {"b": 3}, 4)
-    call3 = weave.log_call("op3", {"c": 5}, 6)
-
-    fetched_calls = client.get_calls()
-    assert len(fetched_calls) == 3
-
-    # Verify all calls are distinct
-    ids = {c.id for c in fetched_calls}
-    assert len(ids) == 3
-
-
-def test_log_call_with_complex_inputs_outputs(client: WeaveClient):
-    """Test log_call with complex nested data structures."""
-    inputs = {
-        "simple": 42,
-        "nested": {"a": 1, "b": [2, 3, 4]},
-        "list": [{"x": 1}, {"y": 2}],
-    }
-    output = {
-        "result": [1, 2, 3],
-        "metadata": {"count": 3, "sum": 6},
-    }
-
-    call = weave.log_call("complex_op", inputs, output)
-    fetched_calls = client.get_calls()
-    assert len(fetched_calls) == 1
-    fetched_call = fetched_calls[0]
-    assert fetched_call.inputs == inputs
-    assert fetched_call.output == output
-
-
-def test_log_call_with_empty_inputs(client: WeaveClient):
-    """Test log_call with empty inputs dictionary."""
-    call = weave.log_call("no_input_op", {}, "result")
-    fetched_calls = client.get_calls()
-    assert len(fetched_calls) == 1
-    fetched_call = fetched_calls[0]
-    assert fetched_call.inputs == {}
-    assert fetched_call.output == "result"
-
-
-def test_log_call_with_none_output(client: WeaveClient):
-    """Test log_call with None as output."""
-    call = weave.log_call("none_output_op", {"x": 1}, None)
-    fetched_calls = client.get_calls()
-    assert len(fetched_calls) == 1
-    fetched_call = fetched_calls[0]
-    assert fetched_call.output is None
-
-
-def test_log_call_with_callable_display_name(client: WeaveClient):
-    """Test log_call with a callable display name."""
-
-    def make_display_name(call):
-        return f"Call-{call.inputs.get('id', 'unknown')}"
-
-    call = weave.log_call(
-        "test_op",
-        {"id": 123, "value": "test"},
-        "result",
-        display_name=make_display_name,
-    )
-    fetched_calls = client.get_calls()
-    assert len(fetched_calls) == 1
-    fetched_call = fetched_calls[0]
-    # The callable should have been evaluated during call creation
-    assert fetched_call.display_name == "Call-123"
-
-
-def test_log_call_different_op_names(client: WeaveClient):
-    """Test log_call with different operation names."""
+def test_log_call_multiple_distinct_calls(client: WeaveClient):
+    """Multiple log_call invocations create distinct calls with distinct names."""
     ops = ["op1", "op2", "my_custom_op", "process_data", "analyze"]
     for op_name in ops:
         weave.log_call(op_name, {"input": op_name}, f"output_{op_name}")
 
     fetched_calls = client.get_calls()
     assert len(fetched_calls) == len(ops)
-
-    # Verify each op has the correct name
-    op_names = {c.func_name for c in fetched_calls}
-    assert op_names == set(ops)
+    assert len({c.id for c in fetched_calls}) == len(ops)
+    assert {c.func_name for c in fetched_calls} == set(ops)
 
 
-def test_log_call_with_combined_params(client: WeaveClient):
-    """Test log_call with all parameters combined."""
+def test_log_call_returned_matches_fetched(client: WeaveClient):
+    """The returned call object matches the fetched persisted data."""
+    returned_call = weave.log_call("test_op", {"input": "test"}, {"output": "result"})
+
+    fetched_call = client.get_calls()[0]
+    assert returned_call.id == fetched_call.id
+    assert returned_call.inputs == fetched_call.inputs
+    assert returned_call.output == fetched_call.output
+    assert returned_call.op_name == fetched_call.op_name
+
+
+def test_log_call_nested_parent_and_combined_params(client: WeaveClient):
+    """A child references its parent; combined params all persist on the child."""
     parent_call = weave.log_call("parent", {}, "parent_result")
-
-    call = weave.log_call(
+    child_call = weave.log_call(
         op="combined_op",
         inputs={"x": 1, "y": 2},
         output={"sum": 3},
@@ -170,107 +130,48 @@ def test_log_call_with_combined_params(client: WeaveClient):
     fetched_calls = client.get_calls()
     assert len(fetched_calls) == 2
 
-    child = next(c for c in fetched_calls if c.id == call.id)
+    parent = next(c for c in fetched_calls if c.id == parent_call.id)
+    child = next(c for c in fetched_calls if c.id == child_call.id)
+    assert parent.parent_id is None
+    assert child.parent_id == parent.id
     assert child.inputs == {"x": 1, "y": 2}
     assert child.output == {"sum": 3}
-    assert child.parent_id == parent_call.id
-    # Check that our custom attributes are present (system may add additional attributes)
     assert child.attributes["version"] == "2.0"
     assert child.attributes["important"] is True
     assert child.display_name == "Combined Test"
 
 
-def test_log_call_preserves_call_data(client: WeaveClient):
-    """Test that the returned call object matches fetched data."""
-    returned_call = weave.log_call("test_op", {"input": "test"}, {"output": "result"})
-
-    fetched_calls = client.get_calls()
-    fetched_call = fetched_calls[0]
-
-    # The returned call should match the fetched one
-    assert returned_call.id == fetched_call.id
-    assert returned_call.inputs == fetched_call.inputs
-    assert returned_call.output == fetched_call.output
-    assert returned_call.op_name == fetched_call.op_name
-
-
-def test_log_call_returns_finished_call(client: WeaveClient):
-    """Test that log_call returns a finished call with timestamps."""
-    call = weave.log_call("test_op", {"x": 1}, 2)
-
-    # Fetch the call to get the complete data including timestamps
-    fetched_calls = client.get_calls()
-    assert len(fetched_calls) == 1
-    fetched_call = fetched_calls[0]
-
-    # The call should have both started_at and ended_at set
-    assert fetched_call.started_at is not None
-    assert fetched_call.ended_at is not None
-    assert fetched_call.ended_at >= fetched_call.started_at
-
-
-def test_log_call_with_use_stack_false(client: WeaveClient):
-    """Test log_call with use_stack=False doesn't add to call stack."""
-    # Log a call without adding to stack
+def test_log_call_use_stack_false_does_not_set_current(client: WeaveClient):
+    """use_stack=False logs the call but leaves no current call in context."""
     call = weave.log_call("test_op", {"x": 1}, 2, use_stack=False)
 
-    # The call should still be logged
     fetched_calls = client.get_calls()
     assert len(fetched_calls) == 1
     assert fetched_calls[0].id == call.id
-
-    # But it shouldn't be in the current call context
-    current_call = weave.get_current_call()
-    assert current_call is None
+    assert weave.get_current_call() is None
 
 
-def test_log_call_with_use_stack_true(client: WeaveClient):
-    """Test log_call with use_stack=True adds to and removes from call stack."""
+def test_log_call_use_stack_true_and_default_push_and_pop(client: WeaveClient):
+    """use_stack=True (explicit) and the default both push then pop the inner call,
+    leaving the enclosing op current and parenting the inner call under it.
+    """
 
-    # Create an op context first
     @weave.op
-    def parent_op():
+    def explicit_op():
         parent = weave.require_current_call()
-
-        # Log a call with use_stack=True - it will be pushed then immediately popped
-        # when finished, so the parent remains current
         inner_call = weave.log_call("inner_op", {"x": 1}, 2, use_stack=True)
-
-        # After the call is finished, we should be back to the parent
         current = weave.require_current_call()
         return parent.id, current.id, inner_call.id
-
-    parent_id, current_id, inner_id = parent_op()
-
-    # After finishing the inner call, we should be back to the parent
-    assert parent_id == current_id
-
-    # Verify the inner call was created with the correct parent
-    fetched_calls = client.get_calls()
-    inner = next(c for c in fetched_calls if c.id == inner_id)
-    assert inner.parent_id == parent_id
-
-
-def test_log_call_use_stack_default_behavior(client: WeaveClient):
-    """Test that use_stack defaults to True."""
 
     @weave.op
-    def outer_op():
+    def default_op():
         parent = weave.require_current_call()
-
-        # Log a call without specifying use_stack (should default to True)
         inner_call = weave.log_call("inner_op", {"x": 1}, 2)
-
-        # After finishing, we should be back to the parent
         current = weave.require_current_call()
         return parent.id, current.id, inner_call.id
 
-    parent_id, current_id, inner_id = outer_op()
-
-    # Should have been pushed and popped from stack
-    assert parent_id == current_id
-
-    # Verify the inner call was created with the correct parent
-    fetched_calls = client.get_calls()
-    inner = next(c for c in fetched_calls if c.id == inner_id)
-    assert inner.parent_id == parent_id
+    for op in (explicit_op, default_op):
+        parent_id, current_id, inner_id = op()
+        assert parent_id == current_id
+        inner = next(c for c in client.get_calls() if c.id == inner_id)
+        assert inner.parent_id == parent_id

--- a/tests/trace/test_obj_delete.py
+++ b/tests/trace/test_obj_delete.py
@@ -108,41 +108,32 @@ def test_delete_version_correctness(client: WeaveClient):
     assert objs[1].version_index == 2
 
 
-def test_delete_object_max_limit(client: WeaveClient):
-    # Create more than MAX_OBJECTS_TO_DELETE objects
+def test_delete_error_and_edge_cases(client: WeaveClient):
+    """Over-limit, nonexistent id, mixed valid/invalid digests, and duplicate digests."""
+    # Over the MAX_OBJECTS_TO_DELETE limit raises before touching storage.
     max_objs = 100
-    digests = []
-    for i in range(max_objs + 1):
-        digests.append(f"test_{i}")
-
+    too_many = [f"test_{i}" for i in range(max_objs + 1)]
     with pytest.raises(
         ValueError, match=f"Please delete {max_objs} or fewer objects at a time"
     ):
-        _obj_delete(client, "obj_1", digests)
+        _obj_delete(client, "obj_limit", too_many)
 
-
-def test_delete_nonexistent_object_id(client: WeaveClient):
+    # Deleting a nonexistent object id.
     with pytest.raises(weave.trace_server.errors.NotFoundError):
         _obj_delete(client, "nonexistent_obj", None)
 
-
-def test_delete_mixed_valid_invalid_digests(client: WeaveClient):
-    v0 = weave.publish({"i": 1}, name="obj_1")
-    v1 = weave.publish({"i": 2}, name="obj_1")
-
-    invalid_digests = [v0.digest, "invalid-digest", v1.digest]
+    # Mixed valid/invalid digests rejects the whole request.
+    v0 = weave.publish({"i": 1}, name="obj_mixed")
+    v1 = weave.publish({"i": 2}, name="obj_mixed")
     with pytest.raises(
         weave.trace_server.errors.NotFoundError,
         match="Delete request contains 3 digests, but found 2 objects to delete. Diff digests: {'invalid-digest'}",
     ):
-        _obj_delete(client, "obj_1", invalid_digests)
+        _obj_delete(client, "obj_mixed", [v0.digest, "invalid-digest", v1.digest])
 
-
-def test_delete_duplicate_digests(client: WeaveClient):
-    v0 = weave.publish({"i": 1}, name="obj_1")
-
-    num_deleted = _obj_delete(client, "obj_1", [v0.digest, v0.digest])
-    assert num_deleted == 1
+    # Duplicate digests collapse to a single delete.
+    dv0 = weave.publish({"i": 1}, name="obj_dup")
+    assert _obj_delete(client, "obj_dup", [dv0.digest, dv0.digest]) == 1
 
 
 def test_delete_with_digest_aliases(client: WeaveClient):
@@ -215,30 +206,36 @@ def test_republish_after_deleting_all_versions(
     assert latest[0].val == republish_val
 
 
-def test_read_deleted_object(client: WeaveClient):
+def test_read_deleted_object_and_op(client: WeaveClient):
+    """Reading a deleted object or op raises ObjectDeletedError and refs resolve to None."""
     weave.publish({"i": 1}, name="obj_1")
     weave.publish({"i": 2}, name="obj_1")
     obj1_v2 = weave.publish({"i": 3}, name="obj_1")
-
     _obj_delete(client, "obj_1", [obj1_v2.digest])
 
-    with pytest.raises(weave.trace_server.errors.ObjectDeletedError) as e:
-        client.server.obj_read(
-            tsi.ObjReadReq(
-                project_id=client.project_id,
-                object_id="obj_1",
-                digest=obj1_v2.digest,
-            )
-        )
-    assert e.value.deleted_at is not None
+    @weave.op
+    def my_op(x: int) -> int:
+        return x + 1
 
-    ref_res = client.server.refs_read_batch(
-        tsi.RefsReadBatchReq(
-            refs=[obj1_v2.uri],
+    op_ref = weave.publish(my_op, name="my_op")
+    _obj_delete(client, "my_op", [op_ref.digest])
+
+    for object_id, published in (("obj_1", obj1_v2), ("my_op", op_ref)):
+        with pytest.raises(weave.trace_server.errors.ObjectDeletedError) as e:
+            client.server.obj_read(
+                tsi.ObjReadReq(
+                    project_id=client.project_id,
+                    object_id=object_id,
+                    digest=published.digest,
+                )
+            )
+        assert e.value.deleted_at is not None
+
+        ref_res = client.server.refs_read_batch(
+            tsi.RefsReadBatchReq(refs=[published.uri])
         )
-    )
-    assert len(ref_res.vals) == 1
-    assert ref_res.vals[0] is None
+        assert len(ref_res.vals) == 1
+        assert ref_res.vals[0] is None
 
 
 def test_op_versions(client: WeaveClient):
@@ -268,34 +265,6 @@ def test_op_versions(client: WeaveClient):
 
     objs3 = _objs_query(client, "my_op")
     assert len(objs3) == 0
-
-
-def test_read_deleted_op(client: WeaveClient):
-    @weave.op
-    def my_op(x: int) -> int:
-        return x + 1
-
-    op_ref = weave.publish(my_op, name="my_op")
-
-    _obj_delete(client, "my_op", [op_ref.digest])
-
-    with pytest.raises(weave.trace_server.errors.ObjectDeletedError) as e:
-        client.server.obj_read(
-            tsi.ObjReadReq(
-                project_id=client.project_id,
-                object_id="my_op",
-                digest=op_ref.digest,
-            )
-        )
-    assert e.value.deleted_at is not None
-
-    ref_res = client.server.refs_read_batch(
-        tsi.RefsReadBatchReq(
-            refs=[op_ref.uri],
-        )
-    )
-    assert len(ref_res.vals) == 1
-    assert ref_res.vals[0] is None
 
 
 def test_delete_all_object_versions_api(client: WeaveClient):

--- a/tests/trace/test_obj_tags_aliases.py
+++ b/tests/trace/test_obj_tags_aliases.py
@@ -433,11 +433,7 @@ def test_server_alias_crud(client: WeaveClient):
 
 
 def test_server_tag_errors(client: WeaveClient):
-    """Tags on nonexistent or deleted objects raise NotFoundError.
-
-    Note: each error scenario lives in its own test function to keep the
-    failure modes isolated.
-    """
+    """Tags on nonexistent or deleted objects raise NotFoundError."""
     # Nonexistent object
     with pytest.raises(NotFoundError):
         client.server.obj_add_tags(
@@ -449,23 +445,7 @@ def test_server_tag_errors(client: WeaveClient):
             )
         )
 
-
-def test_server_alias_errors(client: WeaveClient):
-    """Aliases on nonexistent or deleted objects raise NotFoundError."""
-    # Nonexistent object
-    with pytest.raises(NotFoundError):
-        client.server.obj_set_aliases(
-            tsi.ObjSetAliasesReq(
-                project_id=client.project_id,
-                object_id="nonexistent_object",
-                digest="0" * 64,
-                aliases=["prod"],
-            )
-        )
-
-
-def test_server_tag_on_deleted_object(client: WeaveClient):
-    """Tags on deleted objects raise NotFoundError."""
+    # Deleted object
     oid, digest = _publish_obj(client, "srv_err_deleted")
     client.server.obj_delete(
         tsi.ObjDeleteReq(
@@ -485,8 +465,20 @@ def test_server_tag_on_deleted_object(client: WeaveClient):
         )
 
 
-def test_server_alias_on_deleted_object(client: WeaveClient):
-    """Aliases on deleted objects raise NotFoundError."""
+def test_server_alias_errors(client: WeaveClient):
+    """Aliases on nonexistent or deleted objects raise NotFoundError."""
+    # Nonexistent object
+    with pytest.raises(NotFoundError):
+        client.server.obj_set_aliases(
+            tsi.ObjSetAliasesReq(
+                project_id=client.project_id,
+                object_id="nonexistent_object",
+                digest="0" * 64,
+                aliases=["prod"],
+            )
+        )
+
+    # Deleted object
     oid, digest = _publish_obj(client, "srv_err_deleted2")
     client.server.obj_delete(
         tsi.ObjDeleteReq(
@@ -1341,8 +1333,8 @@ def test_sdk_uri_strings(client: WeaveClient):
 # ---------------------------------------------------------------------------
 
 
-def test_sdk_add_tags_error_nonexistent(client: WeaveClient):
-    """SDK add_tags raises NotFoundError on fake ref."""
+def test_sdk_errors_nonexistent(client: WeaveClient):
+    """SDK add_tags and set_aliases both raise NotFoundError on a fake ref."""
     fake_ref = ObjectRef(
         entity="test",
         project="test",
@@ -1351,16 +1343,6 @@ def test_sdk_add_tags_error_nonexistent(client: WeaveClient):
     )
     with pytest.raises(NotFoundError):
         client.add_tags(fake_ref, ["tag"])
-
-
-def test_sdk_set_aliases_error_nonexistent(client: WeaveClient):
-    """SDK set_aliases raises NotFoundError on fake ref."""
-    fake_ref = ObjectRef(
-        entity="test",
-        project="test",
-        name="nonexistent_object",
-        _digest="0" * 43,
-    )
     with pytest.raises(NotFoundError):
         client.set_aliases(fake_ref, "prod")
 

--- a/tests/trace/test_objs_query.py
+++ b/tests/trace/test_objs_query.py
@@ -16,166 +16,98 @@ def generate_objects(weave_client: WeaveClient, obj_count: int, version_count: i
             weave.publish({"i": i, "j": j}, name=f"obj_{i}")
 
 
-def test_objs_query_all(client: WeaveClient):
+def test_objs_query_filters_over_shared_fixture(client: WeaveClient):
+    """Against 10 objects x 10 versions: all/object_ids/is_op/latest_only/metadata_only filters."""
     generate_objects(client, 10, 10)
+    project_id = client.project_id
 
-    res = client.server.objs_query(
+    all_res = client.server.objs_query(tsi.ObjQueryReq(project_id=project_id))
+    assert len(all_res.objs) == 100
+
+    ids_res = client.server.objs_query(
         tsi.ObjQueryReq(
-            project_id=client.project_id,
-        )
-    )
-    assert len(res.objs) == 100
-
-
-def test_objs_query_filter_object_ids(client: WeaveClient):
-    generate_objects(client, 10, 10)
-
-    res = client.server.objs_query(
-        tsi.ObjQueryReq(
-            project_id=client.project_id,
+            project_id=project_id,
             filter=tsi.ObjectVersionFilter(object_ids=["obj_0", "obj_1"]),
         )
     )
-    assert len(res.objs) == 20
-    assert all(obj.object_id in {"obj_0", "obj_1"} for obj in res.objs)
+    assert len(ids_res.objs) == 20
+    assert all(obj.object_id in {"obj_0", "obj_1"} for obj in ids_res.objs)
 
-
-def test_objs_query_filter_is_op(client: WeaveClient):
-    generate_objects(client, 10, 10)
-
-    res = client.server.objs_query(
+    op_res = client.server.objs_query(
         tsi.ObjQueryReq(
-            project_id=client.project_id, filter=tsi.ObjectVersionFilter(is_op=True)
+            project_id=project_id, filter=tsi.ObjectVersionFilter(is_op=True)
         )
     )
-    assert len(res.objs) == 0
-    res = client.server.objs_query(
+    assert len(op_res.objs) == 0
+    non_op_res = client.server.objs_query(
         tsi.ObjQueryReq(
-            project_id=client.project_id, filter=tsi.ObjectVersionFilter(is_op=False)
+            project_id=project_id, filter=tsi.ObjectVersionFilter(is_op=False)
         )
     )
-    assert len(res.objs) == 100
+    assert len(non_op_res.objs) == 100
 
-
-def test_objs_query_filter_latest_only(client: WeaveClient):
-    generate_objects(client, 10, 10)
-
-    res = client.server.objs_query(
+    latest_res = client.server.objs_query(
         tsi.ObjQueryReq(
-            project_id=client.project_id,
+            project_id=project_id,
             filter=tsi.ObjectVersionFilter(latest_only=True),
         )
     )
-    assert len(res.objs) == 10
-    assert all(obj.is_latest for obj in res.objs)
-    assert all(obj.val["j"] == 9 for obj in res.objs)
+    assert len(latest_res.objs) == 10
+    assert all(obj.is_latest for obj in latest_res.objs)
+    assert all(obj.val["j"] == 9 for obj in latest_res.objs)
 
-
-def test_objs_query_filter_limit_offset_sort_by_created_at(client: WeaveClient):
-    generate_objects(client, 10, 10)
-
-    res = client.server.objs_query(
+    meta_res = client.server.objs_query(
         tsi.ObjQueryReq(
-            project_id=client.project_id,
-            filter=tsi.ObjectVersionFilter(latest_only=True),
-            limit=3,
-            offset=5,
-            sort_by=[SortBy(field="created_at", direction="desc")],
-        )
-    )
-    assert len(res.objs) == 3
-    assert all(obj.is_latest for obj in res.objs)
-    assert res.objs[0].val["j"] == 9
-    assert res.objs[0].val["i"] == 4
-    assert res.objs[1].val["j"] == 9
-    assert res.objs[1].val["i"] == 3
-    assert res.objs[2].val["j"] == 9
-    assert res.objs[2].val["i"] == 2
-
-    res = client.server.objs_query(
-        tsi.ObjQueryReq(
-            project_id=client.project_id,
-            filter=tsi.ObjectVersionFilter(latest_only=True),
-            limit=3,
-            offset=5,
-            sort_by=[SortBy(field="created_at", direction="asc")],
-        )
-    )
-    assert len(res.objs) == 3
-    assert all(obj.is_latest for obj in res.objs)
-    assert res.objs[0].val["j"] == 9
-    assert res.objs[0].val["i"] == 5
-    assert res.objs[1].val["j"] == 9
-    assert res.objs[1].val["i"] == 6
-    assert res.objs[2].val["j"] == 9
-    assert res.objs[2].val["i"] == 7
-
-
-def test_objs_query_filter_limit_offset_sort_by_object_id(client: WeaveClient):
-    generate_objects(client, 10, 10)
-
-    res = client.server.objs_query(
-        tsi.ObjQueryReq(
-            project_id=client.project_id,
-            filter=tsi.ObjectVersionFilter(latest_only=True),
-            limit=3,
-            offset=5,
-            sort_by=[SortBy(field="object_id", direction="desc")],
-        )
-    )
-    assert len(res.objs) == 3
-    assert all(obj.is_latest for obj in res.objs)
-    assert res.objs[0].val["j"] == 9
-    assert res.objs[0].val["i"] == 4
-    assert res.objs[1].val["j"] == 9
-    assert res.objs[1].val["i"] == 3
-    assert res.objs[2].val["j"] == 9
-    assert res.objs[2].val["i"] == 2
-
-    res = client.server.objs_query(
-        tsi.ObjQueryReq(
-            project_id=client.project_id,
-            filter=tsi.ObjectVersionFilter(latest_only=True),
-            limit=3,
-            offset=5,
-            sort_by=[SortBy(field="object_id", direction="asc")],
-        )
-    )
-    assert len(res.objs) == 3
-    assert all(obj.is_latest for obj in res.objs)
-    assert res.objs[0].val["j"] == 9
-    assert res.objs[0].val["i"] == 5
-    assert res.objs[1].val["j"] == 9
-    assert res.objs[1].val["i"] == 6
-    assert res.objs[2].val["j"] == 9
-    assert res.objs[2].val["i"] == 7
-
-
-def test_objs_query_filter_metadata_only(client: WeaveClient):
-    generate_objects(client, 10, 10)
-
-    res = client.server.objs_query(
-        tsi.ObjQueryReq(
-            project_id=client.project_id,
+            project_id=project_id,
             filter=tsi.ObjectVersionFilter(latest_only=True),
             metadata_only=True,
         )
     )
-    assert len(res.objs) == 10
-    for obj in res.objs:
-        assert obj.val == {}
-
-    # sanity check that we get the full object when we don't ask for metadata only
-    res = client.server.objs_query(
+    assert len(meta_res.objs) == 10
+    assert all(obj.val == {} for obj in meta_res.objs)
+    full_res = client.server.objs_query(
         tsi.ObjQueryReq(
-            project_id=client.project_id,
+            project_id=project_id,
             filter=tsi.ObjectVersionFilter(latest_only=True),
             metadata_only=False,
         )
     )
-    assert len(res.objs) == 10
-    for obj in res.objs:
-        assert obj.val
+    assert len(full_res.objs) == 10
+    assert all(obj.val for obj in full_res.objs)
+
+
+@pytest.mark.parametrize("sort_field", ["created_at", "object_id"])
+def test_objs_query_filter_limit_offset_sort(client: WeaveClient, sort_field: str):
+    """limit/offset with desc and asc sort by created_at or object_id (same order here)."""
+    generate_objects(client, 10, 10)
+
+    desc_res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client.project_id,
+            filter=tsi.ObjectVersionFilter(latest_only=True),
+            limit=3,
+            offset=5,
+            sort_by=[SortBy(field=sort_field, direction="desc")],
+        )
+    )
+    assert len(desc_res.objs) == 3
+    assert all(obj.is_latest for obj in desc_res.objs)
+    assert [obj.val["i"] for obj in desc_res.objs] == [4, 3, 2]
+    assert all(obj.val["j"] == 9 for obj in desc_res.objs)
+
+    asc_res = client.server.objs_query(
+        tsi.ObjQueryReq(
+            project_id=client.project_id,
+            filter=tsi.ObjectVersionFilter(latest_only=True),
+            limit=3,
+            offset=5,
+            sort_by=[SortBy(field=sort_field, direction="asc")],
+        )
+    )
+    assert len(asc_res.objs) == 3
+    assert all(obj.is_latest for obj in asc_res.objs)
+    assert [obj.val["i"] for obj in asc_res.objs] == [5, 6, 7]
+    assert all(obj.val["j"] == 9 for obj in asc_res.objs)
 
 
 def test_objs_query_wb_user_id(client: WeaveClient):

--- a/tests/trace/test_op_accumulator.py
+++ b/tests/trace/test_op_accumulator.py
@@ -12,6 +12,7 @@ from tests.trace.util import DummyTestException
 from weave.trace.context import call_context
 from weave.trace.context.tests_context import raise_on_captured_errors
 from weave.trace.op import (
+    Op,
     _add_accumulator,
     _IteratorWrapper,
 )
@@ -154,41 +155,59 @@ def test_process_exit_closes_unfinished_iterator_wrapper(tmp_path):
     assert marker_path.read_text(encoding="utf-8") == "closed"
 
 
+# Each case configures _add_accumulator so a different stage raises, with the
+# error-log message that stage is expected to produce.
+SYNC_RESILIENCE_CASES = [
+    ("make_accumulator", "Error capturing call output"),
+    (
+        "accumulation",
+        "Error capturing value from iterator, call data may be incomplete",
+    ),
+    ("should_accumulate", "Error capturing call output"),
+]
+
+ASYNC_RESILIENCE_CASES = [
+    ("make_accumulator", "Error capturing call output"),
+    (
+        "accumulation",
+        "Error capturing async value from iterator, call data may be incomplete",
+    ),
+    ("should_accumulate", "Error capturing call output"),
+]
+
+
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_collector):
+@pytest.mark.parametrize(("stage", "expected_msg"), SYNC_RESILIENCE_CASES)
+def test_resilience_to_sync_accumulator_errors(
+    weave_active, log_collector, stage, expected_msg
+):
     def do_test():
         @weave.op
         def simple_op():
             yield from [1, 2, 3]
 
-        def make_accumulator(*args, **kwargs):
-            raise DummyTestException("FAILURE!")
-
-        _add_accumulator(simple_op, make_accumulator=make_accumulator)
-
+        _configure_failing_accumulator(simple_op, stage)
         return simple_op()
 
-    # The user's exception should be raised - even if we're capturing errors
+    # The user's exception should be raised even when capturing errors.
     with raise_on_captured_errors(True):
         with pytest.raises(DummyTestException):
-            # Consume the generator to trigger the make_accumulator call
             list(do_test())
 
-    # We should gracefully handle the error and return a value
-    res = do_test()
-    assert list(res) == [1, 2, 3]
-
+    # With capture enabled the error is swallowed and the op still yields.
+    assert list(do_test()) == [1, 2, 3]
     assert_no_current_call()
 
     logs = log_collector.get_error_logs()
     assert len(logs) == 1
-    assert logs[0].msg.startswith("Error capturing call output")
+    assert logs[0].msg.startswith(expected_msg)
 
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_accumulator_make_accumulator_errors_async(
-    weave_active, log_collector
+@pytest.mark.parametrize(("stage", "expected_msg"), ASYNC_RESILIENCE_CASES)
+async def test_resilience_to_async_accumulator_errors(
+    weave_active, log_collector, stage, expected_msg
 ):
     async def do_test():
         @weave.op
@@ -197,191 +216,19 @@ async def test_resilience_to_accumulator_make_accumulator_errors_async(
             yield 2
             yield 3
 
-        def make_accumulator(*args, **kwargs):
-            raise DummyTestException("FAILURE!")
-
-        _add_accumulator(simple_op, make_accumulator=make_accumulator)
-
+        _configure_failing_accumulator(simple_op, stage)
         return simple_op()
 
-    # The user's exception should be raised - even if we're capturing errors
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            # Consume the generator to trigger the make_accumulator call
-            _ = [item async for item in await do_test()]
-
-    # We should gracefully handle the error and return a value
-    res = await do_test()
-    assert [item async for item in res] == [1, 2, 3]
-
-    assert_no_current_call()
-
-    logs = log_collector.get_error_logs()
-    assert len(logs) == 1
-    assert logs[0].msg.startswith("Error capturing call output")
-
-
-@pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collector):
-    def do_test():
-        @weave.op
-        def simple_op():
-            yield from [1, 2, 3]
-
-        def make_accumulator(*args, **kwargs):
-            def accumulate(*args, **kwargs):
-                raise DummyTestException("FAILURE!")
-
-            return accumulate
-
-        _add_accumulator(simple_op, make_accumulator=make_accumulator)
-
-        return simple_op()
-
-    # The user's exception should be raised - even if we're capturing errors
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            list(do_test())
-
-    # We should gracefully handle the error and return a value
-    res = do_test()
-    assert list(res) == [1, 2, 3]
-
-    assert_no_current_call()
-
-    logs = log_collector.get_error_logs()
-    assert len(logs) == 1
-    assert logs[0].msg.startswith(
-        "Error capturing value from iterator, call data may be incomplete"
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.disable_logging_error_check
-async def test_resilience_to_accumulator_accumulation_errors_async(
-    weave_active, log_collector
-):
-    async def do_test():
-        @weave.op
-        async def simple_op():
-            yield 1
-            yield 2
-            yield 3
-
-        def make_accumulator(*args, **kwargs):
-            def accumulate(*args, **kwargs):
-                raise DummyTestException("FAILURE!")
-
-            return accumulate
-
-        _add_accumulator(simple_op, make_accumulator=make_accumulator)
-
-        return simple_op()
-
-    # The user's exception should be raised - even if we're capturing errors
     with raise_on_captured_errors(True):
         with pytest.raises(DummyTestException):
             _ = [item async for item in await do_test()]
 
-    # We should gracefully handle the error and return a value
-    res = await do_test()
-    assert [item async for item in res] == [1, 2, 3]
-
+    assert [item async for item in await do_test()] == [1, 2, 3]
     assert_no_current_call()
 
     logs = log_collector.get_error_logs()
     assert len(logs) == 1
-    assert logs[0].msg.startswith(
-        "Error capturing async value from iterator, call data may be incomplete"
-    )
-
-
-@pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_should_accumulate_errors(
-    weave_active, log_collector
-):
-    def do_test():
-        @weave.op
-        def simple_op():
-            yield from [1, 2, 3]
-
-        def make_accumulator(*args, **kwargs):
-            def accumulate(*args, **kwargs):
-                return {}
-
-            return accumulate
-
-        def should_accumulate(*args, **kwargs):
-            raise DummyTestException("FAILURE!")
-
-        _add_accumulator(
-            simple_op,
-            make_accumulator=make_accumulator,
-            should_accumulate=should_accumulate,
-        )
-
-        return simple_op()
-
-    # The user's exception should be raised - even if we're capturing errors
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            list(do_test())
-
-    # We should gracefully handle the error and return a value
-    res = do_test()
-    assert list(res) == [1, 2, 3]
-
-    assert_no_current_call()
-
-    logs = log_collector.get_error_logs()
-    assert len(logs) == 1
-    assert logs[0].msg.startswith("Error capturing call output")
-
-
-@pytest.mark.asyncio
-@pytest.mark.disable_logging_error_check
-async def test_resilience_to_accumulator_should_accumulate_errors_async(
-    weave_active, log_collector
-):
-    async def do_test():
-        @weave.op
-        async def simple_op():
-            yield 1
-            yield 2
-            yield 3
-
-        def make_accumulator(*args, **kwargs):
-            def accumulate(*args, **kwargs):
-                return {}
-
-            return accumulate
-
-        def should_accumulate(*args, **kwargs):
-            raise DummyTestException("FAILURE!")
-
-        _add_accumulator(
-            simple_op,
-            make_accumulator=make_accumulator,
-            should_accumulate=should_accumulate,
-        )
-
-        return simple_op()
-
-    # The user's exception should be raised - even if we're capturing errors
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            # Consume the generator
-            _ = [i async for i in await do_test()]
-
-    # We should gracefully handle the error and return a value
-    res = await do_test()
-    assert [item async for item in res] == [1, 2, 3]
-
-    assert_no_current_call()
-
-    logs = log_collector.get_error_logs()
-    assert len(logs) == 1
-    assert logs[0].msg.startswith("Error capturing call output")
+    assert logs[0].msg.startswith(expected_msg)
 
 
 # Here we are ignoring this warning because the exception IS being raised,
@@ -519,3 +366,30 @@ async def test_resilience_to_accumulator_internal_errors_async(weave_active):
     with raise_on_captured_errors(False):
         with pytest.raises(DummyTestException):
             _ = [item async for item in await do_test()]
+
+
+def _configure_failing_accumulator(op: Op, stage: str) -> None:
+    """Attach an accumulator to `op` where `stage` raises DummyTestException."""
+
+    def make_accumulator(*args, **kwargs):
+        if stage == "make_accumulator":
+            raise DummyTestException("FAILURE!")
+
+        def accumulate(*args, **kwargs):
+            if stage == "accumulation":
+                raise DummyTestException("FAILURE!")
+            return {}
+
+        return accumulate
+
+    def should_accumulate(*args, **kwargs):
+        raise DummyTestException("FAILURE!")
+
+    if stage == "should_accumulate":
+        _add_accumulator(
+            op,
+            make_accumulator=make_accumulator,
+            should_accumulate=should_accumulate,
+        )
+    else:
+        _add_accumulator(op, make_accumulator=make_accumulator)

--- a/tests/trace/test_op_argument_forms.py
+++ b/tests/trace/test_op_argument_forms.py
@@ -433,144 +433,162 @@ def test_general_arg_variations(client, fn, arg_variations):
 # a bit easier to read and understand (technically, the above test is more comprehensive and should be enough)
 
 
-def test_no_args(client):
+def _no_args_op():
     @weave.op
     def my_op() -> int:
         return 1
 
-    my_op()
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    assert res.calls[0].op_name == my_op.ref.uri
-    assert res.calls[0].inputs == {}
+    return my_op
 
 
-def test_args_concrete(client):
+def _concrete_op():
     @weave.op
     def my_op(val):
         return [val]
 
-    my_op(1)
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    assert res.calls[0].op_name == my_op.ref.uri
-    assert res.calls[0].inputs == {"val": 1}
-    assert res.calls[0].output == [1]
+    return my_op
 
 
-def test_args_concrete_splat(client):
+def _concrete_splat_op():
     @weave.op
     def my_op(val, *args):
         return [val, args]
 
-    my_op(1)
-    my_op(1, 2, 3)
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    assert res.calls[0].op_name == my_op.ref.uri
-    assert res.calls[0].inputs == {"val": 1, "args": []}
-    assert res.calls[0].output == [1, []]
-    assert res.calls[1].op_name == my_op.ref.uri
-    assert res.calls[1].inputs == {"val": 1, "args": [2, 3]}
-    assert res.calls[1].output == [1, [2, 3]]
+    return my_op
 
 
-def test_args_concrete_splats(client):
+def _concrete_splats_op():
     @weave.op
     def my_op(val, *args, **kwargs):
         return [val, args, kwargs]
 
-    my_op(1)
-    my_op(1, 2, 3)
-    my_op(1, a=2, b=3)
-    my_op(1, 2, 3, a=4, b=5)
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    assert res.calls[0].op_name == my_op.ref.uri
-    assert res.calls[0].inputs == {"val": 1, "args": [], "kwargs": {}}
-    assert res.calls[0].output == [1, [], {}]
-    assert res.calls[1].op_name == my_op.ref.uri
-    assert res.calls[1].inputs == {"val": 1, "args": [2, 3], "kwargs": {}}
-    assert res.calls[1].output == [1, [2, 3], {}]
-    assert res.calls[2].op_name == my_op.ref.uri
-    assert res.calls[2].inputs == {"val": 1, "args": [], "kwargs": {"a": 2, "b": 3}}
-    assert res.calls[2].output == [1, [], {"a": 2, "b": 3}]
-    assert res.calls[3].op_name == my_op.ref.uri
-    assert res.calls[3].inputs == {"val": 1, "args": [2, 3], "kwargs": {"a": 4, "b": 5}}
-    assert res.calls[3].output == [1, [2, 3], {"a": 4, "b": 5}]
+    return my_op
 
 
-def test_args_concrete_splat_concrete(client):
+def _concrete_splat_concrete_op():
     @weave.op
     def my_op(val, *args, a=0):
         return [val, args, a]
 
-    my_op(1)
-    my_op(1, a=2)
-    my_op(1, 2, 3, a=4)
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    assert res.calls[0].op_name == my_op.ref.uri
-    assert res.calls[0].inputs == {"val": 1, "args": [], "a": 0}
-    assert res.calls[0].output == [1, [], 0]
-    assert res.calls[1].op_name == my_op.ref.uri
-    assert res.calls[1].inputs == {"val": 1, "args": [], "a": 2}
-    assert res.calls[1].output == [1, [], 2]
-    assert res.calls[2].op_name == my_op.ref.uri
-    assert res.calls[2].inputs == {"val": 1, "args": [2, 3], "a": 4}
-    assert res.calls[2].output == [1, [2, 3], 4]
+    return my_op
 
 
-def test_args_concrete_splat_concrete_splat(client):
+def _concrete_splat_concrete_splat_op():
     @weave.op
     def my_op(val, *args, a=0, **kwargs):
         return [val, args, a, kwargs]
 
-    my_op(1)
-    my_op(1, a=2)
-    my_op(1, 2, 3, a=4)
-    my_op(1, 2, 3, a=4, b=5)
+    return my_op
 
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
 
-    assert res.calls[0].op_name == my_op.ref.uri
-    assert res.calls[0].inputs == {"val": 1, "args": [], "a": 0, "kwargs": {}}
-    assert res.calls[0].output == [1, [], 0, {}]
-    assert res.calls[1].op_name == my_op.ref.uri
-    assert res.calls[1].inputs == {"val": 1, "args": [], "a": 2, "kwargs": {}}
-    assert res.calls[1].output == [1, [], 2, {}]
-    assert res.calls[2].op_name == my_op.ref.uri
-    assert res.calls[2].inputs == {"val": 1, "args": [2, 3], "a": 4, "kwargs": {}}
-    assert res.calls[2].output == [1, [2, 3], 4, {}]
-    assert res.calls[3].op_name == my_op.ref.uri
-    assert res.calls[3].inputs == {"val": 1, "args": [2, 3], "a": 4, "kwargs": {"b": 5}}
-    assert res.calls[3].output == [1, [2, 3], 4, {"b": 5}]
+@pytest.mark.parametrize(
+    ("op_factory", "expected_calls"),
+    [
+        # | fn()  -> no inputs recorded, output unchecked (matches original)
+        (_no_args_op, [((), {}, {}, None)]),
+        # | fn(val)
+        (_concrete_op, [((1,), {}, {"val": 1}, [1])]),
+        # | fn(val, *args)
+        (
+            _concrete_splat_op,
+            [
+                ((1,), {}, {"val": 1, "args": []}, [1, []]),
+                ((1, 2, 3), {}, {"val": 1, "args": [2, 3]}, [1, [2, 3]]),
+            ],
+        ),
+        # | fn(val, *args, **kwargs)
+        (
+            _concrete_splats_op,
+            [
+                ((1,), {}, {"val": 1, "args": [], "kwargs": {}}, [1, [], {}]),
+                (
+                    (1, 2, 3),
+                    {},
+                    {"val": 1, "args": [2, 3], "kwargs": {}},
+                    [1, [2, 3], {}],
+                ),
+                (
+                    (1,),
+                    {"a": 2, "b": 3},
+                    {"val": 1, "args": [], "kwargs": {"a": 2, "b": 3}},
+                    [1, [], {"a": 2, "b": 3}],
+                ),
+                (
+                    (1, 2, 3),
+                    {"a": 4, "b": 5},
+                    {"val": 1, "args": [2, 3], "kwargs": {"a": 4, "b": 5}},
+                    [1, [2, 3], {"a": 4, "b": 5}],
+                ),
+            ],
+        ),
+        # | fn(val, *args, a=0)
+        (
+            _concrete_splat_concrete_op,
+            [
+                ((1,), {}, {"val": 1, "args": [], "a": 0}, [1, [], 0]),
+                ((1,), {"a": 2}, {"val": 1, "args": [], "a": 2}, [1, [], 2]),
+                (
+                    (1, 2, 3),
+                    {"a": 4},
+                    {"val": 1, "args": [2, 3], "a": 4},
+                    [1, [2, 3], 4],
+                ),
+            ],
+        ),
+        # | fn(val, *args, a=0, **kwargs)
+        (
+            _concrete_splat_concrete_splat_op,
+            [
+                (
+                    (1,),
+                    {},
+                    {"val": 1, "args": [], "a": 0, "kwargs": {}},
+                    [1, [], 0, {}],
+                ),
+                (
+                    (1,),
+                    {"a": 2},
+                    {"val": 1, "args": [], "a": 2, "kwargs": {}},
+                    [1, [], 2, {}],
+                ),
+                (
+                    (1, 2, 3),
+                    {"a": 4},
+                    {"val": 1, "args": [2, 3], "a": 4, "kwargs": {}},
+                    [1, [2, 3], 4, {}],
+                ),
+                (
+                    (1, 2, 3),
+                    {"a": 4, "b": 5},
+                    {"val": 1, "args": [2, 3], "a": 4, "kwargs": {"b": 5}},
+                    [1, [2, 3], 4, {"b": 5}],
+                ),
+            ],
+        ),
+    ],
+    ids=[
+        "no-args",
+        "concrete",
+        "concrete-splat",
+        "concrete-splats",
+        "concrete-splat-concrete",
+        "concrete-splat-concrete-splat",
+    ],
+)
+def test_specific_arg_forms(client, op_factory, expected_calls):
+    """Concrete per-stub coverage: each call's recorded inputs/output by position.
+
+    The general parametrized test above is more comprehensive; these are the
+    individually-readable per-stub forms.
+    """
+    my_op = op_factory()
+    for call_args, call_kwargs, _, _ in expected_calls:
+        my_op(*call_args, **call_kwargs)
+
+    res = client.server.calls_query(tsi.CallsQueryReq(project_id=client.project_id))
+
+    for ndx, (_, _, expected_inputs, expected_output) in enumerate(expected_calls):
+        assert res.calls[ndx].op_name == my_op.ref.uri
+        assert res.calls[ndx].inputs == expected_inputs
+        if expected_output is not None:
+            assert res.calls[ndx].output == expected_output

--- a/tests/trace/test_op_coroutines.py
+++ b/tests/trace/test_op_coroutines.py
@@ -8,36 +8,41 @@ from weave.trace.call import Call
 
 
 def test_sync_val(weave_active):
+    """A sync op returning a plain value, as a free function and as a method."""
+
     @weave.op
     def sync_val():
         return 1
 
-    res = sync_val()
-    assert res == 1
-    res, call = sync_val.call()
-    assert isinstance(call, Call)
-    assert res == 1
-
-
-def test_sync_val_method(weave_active):
     class TestClass:
         @weave.op
         def sync_val(self):
             return 1
 
-    test_inst = TestClass()
-    res = test_inst.sync_val()
+    assert sync_val() == 1
+    res, call = sync_val.call()
+    assert isinstance(call, Call)
     assert res == 1
-    res, call = test_inst.sync_val.call(test_inst)
+
+    inst = TestClass()
+    assert inst.sync_val() == 1
+    res, call = inst.sync_val.call(inst)
     assert isinstance(call, Call)
     assert res == 1
 
 
 @pytest.mark.asyncio
 async def test_sync_coro(weave_active):
+    """A sync op returning a coroutine, as a free function and as a method."""
+
     @weave.op
     def sync_coro():
         return asyncio.to_thread(lambda: 1)
+
+    class TestClass:
+        @weave.op
+        def sync_coro(self):
+            return asyncio.to_thread(lambda: 1)
 
     res = sync_coro()
     assert isinstance(res, Coroutine)
@@ -47,19 +52,11 @@ async def test_sync_coro(weave_active):
     assert isinstance(res, Coroutine)
     assert await res == 1
 
-
-@pytest.mark.asyncio
-async def test_sync_coro_method(weave_active):
-    class TestClass:
-        @weave.op
-        def sync_coro(self):
-            return asyncio.to_thread(lambda: 1)
-
-    test_inst = TestClass()
-    res = test_inst.sync_coro()
+    inst = TestClass()
+    res = inst.sync_coro()
     assert isinstance(res, Coroutine)
     assert await res == 1
-    res, call = test_inst.sync_coro.call(test_inst)
+    res, call = inst.sync_coro.call(inst)
     assert isinstance(call, Call)
     assert isinstance(res, Coroutine)
     assert await res == 1
@@ -67,9 +64,16 @@ async def test_sync_coro_method(weave_active):
 
 @pytest.mark.asyncio
 async def test_async_coro(weave_active):
+    """An async op returning a coroutine (double-wrapped), as a free function and a method."""
+
     @weave.op
     async def async_coro():
         return asyncio.to_thread(lambda: 1)
+
+    class TestClass:
+        @weave.op
+        async def async_coro(self):
+            return asyncio.to_thread(lambda: 1)
 
     res = async_coro()
     assert isinstance(res, Coroutine)
@@ -81,22 +85,13 @@ async def test_async_coro(weave_active):
     assert isinstance(res, Coroutine)
     assert await res == 1
 
-
-@pytest.mark.asyncio
-async def test_async_coro_method(weave_active):
-    class TestClass:
-        @weave.op
-        async def async_coro(self):
-            return asyncio.to_thread(lambda: 1)
-
-    test_inst = TestClass()
-
-    res = test_inst.async_coro()
+    inst = TestClass()
+    res = inst.async_coro()
     assert isinstance(res, Coroutine)
     res2 = await res
     assert isinstance(res2, Coroutine)
     assert await res2 == 1
-    res, call = await test_inst.async_coro.call(test_inst)
+    res, call = await inst.async_coro.call(inst)
     assert isinstance(call, Call)
     assert isinstance(res, Coroutine)
     assert await res == 1
@@ -104,9 +99,16 @@ async def test_async_coro_method(weave_active):
 
 @pytest.mark.asyncio
 async def test_async_awaited_coro(weave_active):
+    """An async op that awaits internally, returning a value, as a free function and a method."""
+
     @weave.op
     async def async_awaited_coro():
         return await asyncio.to_thread(lambda: 1)
+
+    class TestClass:
+        @weave.op
+        async def async_awaited_coro(self):
+            return await asyncio.to_thread(lambda: 1)
 
     res = async_awaited_coro()
     assert isinstance(res, Coroutine)
@@ -115,28 +117,27 @@ async def test_async_awaited_coro(weave_active):
     assert isinstance(call, Call)
     assert res == 1
 
-
-@pytest.mark.asyncio
-async def test_async_awaited_coro_method(weave_active):
-    class TestClass:
-        @weave.op
-        async def async_awaited_coro(self):
-            return await asyncio.to_thread(lambda: 1)
-
-    test_inst = TestClass()
-    res = test_inst.async_awaited_coro()
+    inst = TestClass()
+    res = inst.async_awaited_coro()
     assert isinstance(res, Coroutine)
     assert await res == 1
-    res, call = await test_inst.async_awaited_coro.call(test_inst)
+    res, call = await inst.async_awaited_coro.call(inst)
     assert isinstance(call, Call)
     assert res == 1
 
 
 @pytest.mark.asyncio
 async def test_async_val(weave_active):
+    """An async op returning a plain value, as a free function and as a method."""
+
     @weave.op
     async def async_val():
         return 1
+
+    class TestClass:
+        @weave.op
+        async def async_val(self):
+            return 1
 
     res = async_val()
     assert isinstance(res, Coroutine)
@@ -145,27 +146,26 @@ async def test_async_val(weave_active):
     assert isinstance(call, Call)
     assert res == 1
 
-
-@pytest.mark.asyncio
-async def test_async_val_method(weave_active):
-    class TestClass:
-        @weave.op
-        async def async_val(self):
-            return 1
-
-    test_inst = TestClass()
-    res = test_inst.async_val()
+    inst = TestClass()
+    res = inst.async_val()
     assert isinstance(res, Coroutine)
     assert await res == 1
-    res, call = await test_inst.async_val.call(test_inst)
+    res, call = await inst.async_val.call(inst)
     assert isinstance(call, Call)
     assert res == 1
 
 
 def test_sync_with_exception(weave_active):
+    """A sync op that raises records the exception on the call, as a free function and a method."""
+
     @weave.op
     def sync_with_exception():
         raise ValueError("test")
+
+    class TestClass:
+        @weave.op
+        def sync_with_exception(self):
+            raise ValueError("test")
 
     with pytest.raises(ValueError, match="test"):
         sync_with_exception()
@@ -174,17 +174,10 @@ def test_sync_with_exception(weave_active):
     assert call.exception is not None
     assert res is None
 
-
-def test_sync_with_exception_method(weave_active):
-    class TestClass:
-        @weave.op
-        def sync_with_exception(self):
-            raise ValueError("test")
-
-    test_inst = TestClass()
+    inst = TestClass()
     with pytest.raises(ValueError, match="test"):
-        test_inst.sync_with_exception()
-    res, call = test_inst.sync_with_exception.call(test_inst)
+        inst.sync_with_exception()
+    res, call = inst.sync_with_exception.call(inst)
     assert isinstance(call, Call)
     assert call.exception is not None
     assert res is None
@@ -192,9 +185,16 @@ def test_sync_with_exception_method(weave_active):
 
 @pytest.mark.asyncio
 async def test_async_with_exception(weave_active):
+    """An async op that raises records the exception on the call, as a free function and a method."""
+
     @weave.op
     async def async_with_exception():
         raise ValueError("test")
+
+    class TestClass:
+        @weave.op
+        async def async_with_exception(self):
+            raise ValueError("test")
 
     with pytest.raises(ValueError, match="test"):
         await async_with_exception()
@@ -203,18 +203,10 @@ async def test_async_with_exception(weave_active):
     assert call.exception is not None
     assert res is None
 
-
-@pytest.mark.asyncio
-async def test_async_with_exception_method(weave_active):
-    class TestClass:
-        @weave.op
-        async def async_with_exception(self):
-            raise ValueError("test")
-
-    test_inst = TestClass()
+    inst = TestClass()
     with pytest.raises(ValueError, match="test"):
-        await test_inst.async_with_exception()
-    res, call = await test_inst.async_with_exception.call(test_inst)
+        await inst.async_with_exception()
+    res, call = await inst.async_with_exception.call(inst)
     assert isinstance(call, Call)
     assert call.exception is not None
     assert res is None

--- a/tests/trace/test_op_decorator_behaviour.py
+++ b/tests/trace/test_op_decorator_behaviour.py
@@ -65,13 +65,6 @@ def py_obj():
 def test_sync_func(weave_active, func):
     assert func(1) == 2
 
-    ref = weave.publish(func)
-    func2 = ref.get()
-
-    assert func2(1) == 2
-
-
-def test_sync_func_call(weave_active, func):
     res, call = func.call(1)
     assert isinstance(call, Call)
     assert call.inputs == {"a": 1}
@@ -81,6 +74,7 @@ def test_sync_func_call(weave_active, func):
     ref = weave.publish(func)
     func2 = ref.get()
 
+    assert func2(1) == 2
     res2, call2 = func2.call(1)
     assert isinstance(call2, Call)
     assert call2.inputs == {"a": 1}
@@ -92,14 +86,6 @@ def test_sync_func_call(weave_active, func):
 async def test_async_func(weave_active, afunc):
     assert await afunc(1) == 2
 
-    ref = weave.publish(afunc)
-    afunc2 = ref.get()
-
-    assert await afunc2(1) == 2
-
-
-@pytest.mark.asyncio
-async def test_async_func_call(weave_active, afunc):
     res, call = await afunc.call(1)
     assert isinstance(call, Call)
     assert call.inputs == {"a": 1}
@@ -109,6 +95,7 @@ async def test_async_func_call(weave_active, afunc):
     ref = weave.publish(afunc)
     afunc2 = ref.get()
 
+    assert await afunc2(1) == 2
     res2, call2 = await afunc2.call(1)
     assert isinstance(call2, Call)
     assert call2.inputs == {"a": 1}
@@ -120,12 +107,6 @@ def test_sync_method(weave_active, weave_obj, py_obj):
     assert weave_obj.method(1) == 2
     assert py_obj.method(1) == 2
 
-    weave_obj_method_ref = weave.publish(weave_obj.method)
-    with pytest.raises(MissingSelfInstanceError):
-        weave_obj_method2 = weave_obj_method_ref.get()
-
-
-def test_sync_method_call(weave_active, weave_obj, py_obj):
     res, call = weave_obj.method.call(weave_obj, 1)
     assert isinstance(call, Call)
     assert call.inputs == {
@@ -154,13 +135,6 @@ async def test_async_method(weave_active, weave_obj, py_obj):
     assert await weave_obj.amethod(1) == 2
     assert await py_obj.amethod(1) == 2
 
-    weave_obj_amethod_ref = weave.publish(weave_obj.amethod)
-    with pytest.raises(MissingSelfInstanceError):
-        weave_obj_amethod2 = weave_obj_amethod_ref.get()
-
-
-@pytest.mark.asyncio
-async def test_async_method_call(weave_active, weave_obj, py_obj):
     res, call = await weave_obj.amethod.call(weave_obj, 1)
     assert isinstance(call, Call)
     assert call.inputs == {
@@ -184,29 +158,21 @@ async def test_async_method_call(weave_active, weave_obj, py_obj):
         res2, call2 = await py_obj.amethod.call(1)
 
 
-def test_sync_func_patching_passes_inspection(func):
+def test_patching_passes_inspection(func, afunc, weave_obj, py_obj):
     assert is_op(func)
     assert inspect.isfunction(func)
 
-
-def test_async_func_patching_passes_inspection(afunc):
     assert is_op(afunc)
     assert inspect.iscoroutinefunction(afunc)
 
-
-def test_sync_method_patching_passes_inspection(weave_obj, py_obj):
     assert is_op(weave_obj.method)
     assert inspect.ismethod(weave_obj.method)
-
     assert is_op(py_obj.method)
     assert inspect.ismethod(py_obj.method)
 
-
-def test_async_method_patching_passes_inspection(weave_obj, py_obj):
     assert is_op(weave_obj.amethod)
     assert inspect.iscoroutinefunction(weave_obj.amethod)
     assert inspect.ismethod(weave_obj.amethod)
-
     assert is_op(py_obj.amethod)
     assert inspect.iscoroutinefunction(py_obj.amethod)
     assert inspect.ismethod(py_obj.amethod)
@@ -301,19 +267,6 @@ def test_postprocessing_funcs(client):
     assert call.output == {"postprocessed_b": 2}
 
 
-def test_op_call_display_name_str(client):
-    @op(call_display_name="example")
-    def func():
-        return 1
-
-    func()
-
-    calls = list(client.get_calls())
-    call = calls[0]
-
-    assert call.display_name == "example"
-
-
 def test_op_call_display_name_callable_invalid():
     with pytest.raises(ValueError, match="must take exactly 1 argument"):
 
@@ -322,35 +275,32 @@ def test_op_call_display_name_callable_invalid():
             return 1
 
 
-def test_op_call_display_name_callable_lambda(client):
-    @op(call_display_name=lambda call: f"{call.project_id}-123")
-    def func():
-        return 1
-
-    func()
-
-    calls = list(client.get_calls())
-    call = calls[0]
-
-    assert call.display_name == "shawn/test-project-123"
-
-
-def test_op_call_display_name_callable_func(client):
-    def custom_display_name_func(call) -> str:
+def test_op_call_display_name(client):
+    def reversed_project_name(call) -> str:
         reversed_project = call.project_id[::-1]
         name_ascii_sum = sum(ord(c) for c in reversed_project)
         return f"wow-{name_ascii_sum}-{reversed_project}"
 
-    @op(call_display_name=custom_display_name_func)
-    def func():
+    @op(call_display_name="example")
+    def str_func():
         return 1
 
-    func()
+    @op(call_display_name=lambda call: f"{call.project_id}-123")
+    def lambda_func():
+        return 1
+
+    @op(call_display_name=reversed_project_name)
+    def func_func():
+        return 1
+
+    str_func()
+    lambda_func()
+    func_func()
 
     calls = list(client.get_calls())
-    call = calls[0]
-
-    assert call.display_name == "wow-1844-tcejorp-tset/nwahs"
+    assert calls[0].display_name == "example"
+    assert calls[1].display_name == "shawn/test-project-123"
+    assert calls[2].display_name == "wow-1844-tcejorp-tset/nwahs"
 
 
 def test_op_call_display_name_callable_other_attributes(client):
@@ -544,49 +494,33 @@ def test_op_signature_failure_at_call_raises_op_call_error(monkeypatch):
         _default_on_input_handler(my_op, (5,), {})
 
 
-def test_op_kind_attribute():
-    """Test that setting kind on op decorator sets attributes.weave.kind."""
+@pytest.mark.parametrize(
+    ("kind", "color", "expected_kind", "expected_color"),
+    [
+        ("tool", None, "tool", None),
+        (None, "blue", None, "blue"),
+        ("guardrail", None, "guardrail", None),
+        ("llm", "green", "llm", "green"),
+    ],
+)
+def test_op_kind_and_color_attributes(kind, color, expected_kind, expected_color):
+    """Setting kind/color on the op decorator populates attributes.weave."""
+    op_kwargs = {}
+    if kind is not None:
+        op_kwargs["kind"] = kind
+    if color is not None:
+        op_kwargs["color"] = color
 
-    @op(kind="tool")
-    def tool_func(x: int) -> int:
+    @op(**op_kwargs)
+    def func(x: int) -> int:
         return x + 1
 
-    result = setup_dunder_weave_dict(tool_func)
-    assert result["attributes"]["weave"]["kind"] == "tool"
-    assert "color" not in result["attributes"]["weave"]
-
-
-def test_op_color_attribute():
-    """Test that setting color on op decorator sets attributes.weave.color."""
-
-    @op(color="blue")
-    def colored_func(x: int) -> int:
-        return x + 1
-
-    result = setup_dunder_weave_dict(colored_func)
-    assert result["attributes"]["weave"]["color"] == "blue"
-    assert "kind" not in result["attributes"]["weave"]
-
-
-def test_op_kind_guardrail_attribute():
-    """Test that setting kind='guardrail' on op decorator sets attributes.weave.kind."""
-
-    @op(kind="guardrail")
-    def guardrail_func(x: str) -> bool:
-        return True
-
-    result = setup_dunder_weave_dict(guardrail_func)
-    assert result["attributes"]["weave"]["kind"] == "guardrail"
-    assert "color" not in result["attributes"]["weave"]
-
-
-def test_op_kind_and_color_attributes():
-    """Test that setting both kind and color on op decorator sets both attributes."""
-
-    @op(kind="llm", color="green")
-    def llm_func(x: int) -> int:
-        return x + 1
-
-    result = setup_dunder_weave_dict(llm_func)
-    assert result["attributes"]["weave"]["kind"] == "llm"
-    assert result["attributes"]["weave"]["color"] == "green"
+    weave_attrs = setup_dunder_weave_dict(func)["attributes"]["weave"]
+    if expected_kind is None:
+        assert "kind" not in weave_attrs
+    else:
+        assert weave_attrs["kind"] == expected_kind
+    if expected_color is None:
+        assert "color" not in weave_attrs
+    else:
+        assert weave_attrs["color"] == expected_color

--- a/tests/trace/test_op_return_forms.py
+++ b/tests/trace/test_op_return_forms.py
@@ -5,10 +5,20 @@ from weave.trace.ref_util import get_ref
 from weave.trace_server import trace_server_interface as tsi
 
 
-def test_op_return_sync_empty(client):
-    @weave.op
-    def fn():
-        return
+@pytest.mark.parametrize("expected_output", [None, 1])
+def test_op_return_sync_value(client, expected_output):
+    # Ops return literals (no closure) to exercise the global-var resolution
+    # branch in op serialization.
+    if expected_output is None:
+
+        @weave.op
+        def fn():
+            return
+    else:
+
+        @weave.op
+        def fn():
+            return 1
 
     fn()
 
@@ -22,14 +32,22 @@ def test_op_return_sync_empty(client):
     assert obj_ref is not None
     assert res.calls[0].op_name == obj_ref.uri
     assert res.calls[0].inputs == {}
-    assert res.calls[0].output is None
+    assert res.calls[0].output == expected_output
 
 
 @pytest.mark.asyncio
-async def test_op_return_async_empty(client):
-    @weave.op
-    async def fn():
-        return
+@pytest.mark.parametrize("expected_output", [None, 1])
+async def test_op_return_async_value(client, expected_output):
+    if expected_output is None:
+
+        @weave.op
+        async def fn():
+            return
+    else:
+
+        @weave.op
+        async def fn():
+            return 1
 
     await fn()
 
@@ -43,15 +61,194 @@ async def test_op_return_async_empty(client):
     assert obj_ref is not None
     assert res.calls[0].op_name == obj_ref.uri
     assert res.calls[0].inputs == {}
-    assert res.calls[0].output is None
+    assert res.calls[0].output == expected_output
 
 
-def test_op_return_sync_obj(client):
-    @weave.op
+""" The streaming tests below are permutations of:
+    - (2x) sync/async
+    - (2x) generator/iterator
+    - (4x) never iterated/fully iterated/partially iterated/exception thrown
+"""
+
+FULLY = list(range(9, -1, -1))
+PARTIAL = list(range(9, 4, -1))
+
+
+@pytest.mark.parametrize(
+    ("consume", "expected_output", "expect_exception"),
+    [
+        ("never", None, False),
+        ("full", FULLY, False),
+        ("partial", PARTIAL, False),
+        ("exception", PARTIAL, True),
+    ],
+)
+def test_op_return_sync_generator(client, consume, expected_output, expect_exception):
+    # Distinct closure-free op bodies so op serialization sees no free vars.
+    if expect_exception:
+
+        @weave.op(accumulator=simple_list_accumulator)
+        def fn():
+            size = 10
+            while size > 0:
+                size -= 1
+                yield size
+                if size == 5:
+                    raise ValueError("test")
+    else:
+
+        @weave.op(accumulator=simple_list_accumulator)
+        def fn():
+            size = 10
+            while size > 0:
+                size -= 1
+                yield size
+
+    if consume == "never":
+        fn()
+    elif consume == "full":
+        for _item in fn():
+            pass
+    elif consume == "partial":
+        for item in fn():
+            if item == 5:
+                break
+    elif consume == "exception":
+        try:
+            for _item in fn():
+                pass
+        except ValueError:
+            pass
+    else:
+        raise AssertionError(f"unknown consume mode: {consume}")
+
+    res = client.server.calls_query(
+        tsi.CallsQueryReq(
+            project_id=client.project_id,
+        )
+    )
+
+    obj_ref = get_ref(fn)
+    assert obj_ref is not None
+    assert res.calls[0].op_name == obj_ref.uri
+    assert res.calls[0].inputs == {}
+    assert res.calls[0].output == expected_output
+    if expect_exception:
+        assert res.calls[0].exception is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("consume", "expected_output", "expect_exception"),
+    [
+        ("never", None, False),
+        ("full", FULLY, False),
+        ("partial", PARTIAL, False),
+        ("exception", PARTIAL, True),
+    ],
+)
+async def test_op_return_async_generator(
+    client, consume, expected_output, expect_exception
+):
+    if expect_exception:
+
+        @weave.op(accumulator=simple_list_accumulator)
+        async def fn():
+            size = 10
+            while size > 0:
+                size -= 1
+                yield size
+                if size == 5:
+                    raise ValueError("test")
+    else:
+
+        @weave.op(accumulator=simple_list_accumulator)
+        async def fn():
+            size = 10
+            while size > 0:
+                size -= 1
+                yield size
+
+    if consume == "never":
+        async for _item in fn():
+            return  # `return` raises StopAsyncIteration to close the op
+    elif consume == "full":
+        async for _item in fn():
+            pass
+    elif consume == "partial":
+        async for item in fn():
+            if item == 5:
+                break
+            return  # required to raise StopAsyncIteration
+    elif consume == "exception":
+        try:
+            async for _item in fn():
+                pass
+        except ValueError:
+            pass
+    else:
+        raise AssertionError(f"unknown consume mode: {consume}")
+
+    res = client.server.calls_query(
+        tsi.CallsQueryReq(
+            project_id=client.project_id,
+        )
+    )
+
+    obj_ref = get_ref(fn)
+    assert obj_ref is not None
+    assert res.calls[0].op_name == obj_ref.uri
+    assert res.calls[0].inputs == {}
+    assert res.calls[0].output == expected_output
+    if expect_exception:
+        assert res.calls[0].exception is not None
+
+
+@pytest.mark.parametrize(
+    ("consume", "expected_output", "expect_exception"),
+    [
+        ("never", None, False),
+        ("full", FULLY, False),
+        ("partial", PARTIAL, False),
+        ("exception", PARTIAL, True),
+    ],
+)
+def test_op_return_sync_iterator(client, consume, expected_output, expect_exception):
+    class MyIterator:
+        size = 10
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self.size == 0:
+                raise StopIteration
+            if expect_exception and self.size == 5:
+                raise ValueError("test")
+            self.size -= 1
+            return self.size
+
+    @weave.op(accumulator=simple_list_accumulator)
     def fn():
-        return 1
+        return MyIterator()
 
-    fn()
+    if consume == "never":
+        fn()
+    elif consume == "full":
+        for _item in fn():
+            pass
+    elif consume == "partial":
+        for item in fn():
+            if item == 5:
+                break
+    elif consume == "exception":
+        try:
+            for _item in fn():
+                pass
+        except ValueError:
+            pass
+    else:
+        raise AssertionError(f"unknown consume mode: {consume}")
 
     res = client.server.calls_query(
         tsi.CallsQueryReq(
@@ -63,16 +260,59 @@ def test_op_return_sync_obj(client):
     assert obj_ref is not None
     assert res.calls[0].op_name == obj_ref.uri
     assert res.calls[0].inputs == {}
-    assert res.calls[0].output == 1
+    assert res.calls[0].output == expected_output
+    if expect_exception:
+        assert res.calls[0].exception is not None
 
 
 @pytest.mark.asyncio
-async def test_op_return_async_obj(client):
-    @weave.op
-    async def fn():
-        return 1
+@pytest.mark.parametrize(
+    ("consume", "expected_output", "expect_exception"),
+    [
+        ("never", None, False),
+        ("full", FULLY, False),
+        ("partial", PARTIAL, False),
+        ("exception", PARTIAL, True),
+    ],
+)
+async def test_op_return_async_iterator(
+    client, consume, expected_output, expect_exception
+):
+    class MyAsyncIterator:
+        size = 10
 
-    await fn()
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self.size == 0:
+                raise StopAsyncIteration
+            if expect_exception and self.size == 5:
+                raise ValueError("test")
+            self.size -= 1
+            return self.size
+
+    @weave.op(accumulator=simple_list_accumulator)
+    def fn():
+        return MyAsyncIterator()
+
+    if consume == "never":
+        fn()
+    elif consume == "full":
+        async for _item in fn():
+            pass
+    elif consume == "partial":
+        async for item in fn():
+            if item == 5:
+                break
+    elif consume == "exception":
+        try:
+            async for _item in fn():
+                pass
+        except ValueError:
+            pass
+    else:
+        raise AssertionError(f"unknown consume mode: {consume}")
 
     res = client.server.calls_query(
         tsi.CallsQueryReq(
@@ -84,7 +324,9 @@ async def test_op_return_async_obj(client):
     assert obj_ref is not None
     assert res.calls[0].op_name == obj_ref.uri
     assert res.calls[0].inputs == {}
-    assert res.calls[0].output == 1
+    assert res.calls[0].output == expected_output
+    if expect_exception:
+        assert res.calls[0].exception is not None
 
 
 def simple_list_accumulator(acc, value):
@@ -92,500 +334,3 @@ def simple_list_accumulator(acc, value):
         acc = []
     acc.append(value)
     return acc
-
-
-""" There are 16 tests that follow, permutations of the following:
-    - (2x) sync/async
-    - (2x) generator/iterator
-    - (4x) never iterated/partially iterated/fully iterated/exception thrown
-"""
-
-
-def test_op_return_sync_generator(client):
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        size = 10
-        while size > 0:
-            size -= 1
-            yield size
-
-    for _item in fn():
-        pass
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, -1, -1))
-
-
-@pytest.mark.asyncio
-async def test_op_return_async_generator(client):
-    @weave.op(accumulator=simple_list_accumulator)
-    async def fn():
-        size = 10
-        while size > 0:
-            size -= 1
-            yield size
-
-    async for _item in fn():
-        pass
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, -1, -1))
-
-
-def test_op_return_sync_iterator(client):
-    class MyIterator:
-        size = 10
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            if self.size == 0:
-                raise StopIteration
-            self.size -= 1
-            return self.size
-
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        return MyIterator()
-
-    for _item in fn():
-        pass
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, -1, -1))
-
-
-@pytest.mark.asyncio
-async def test_op_return_async_iterator(client):
-    class MyAsyncIterator:
-        size = 10
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if self.size == 0:
-                raise StopAsyncIteration
-            self.size -= 1
-            return self.size
-
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        return MyAsyncIterator()
-
-    async for _item in fn():
-        pass
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, -1, -1))
-
-
-def test_op_return_sync_generator_never_iter(client):
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        size = 10
-        while size > 0:
-            size -= 1
-            yield size
-
-    fn()
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output is None
-
-
-@pytest.mark.asyncio
-async def test_op_return_async_generator_never_iter(client):
-    @weave.op(accumulator=simple_list_accumulator)
-    async def fn():
-        size = 10
-        while size > 0:
-            size -= 1
-            yield size
-
-    async for _item in fn():
-        return
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output is None
-
-
-def test_op_return_sync_iterator_never_iter(client):
-    class MyIterator:
-        size = 10
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            if self.size == 0:
-                raise StopIteration
-            self.size -= 1
-            return self.size
-
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        return MyIterator()
-
-    fn()
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output is None
-
-
-@pytest.mark.asyncio
-async def test_op_return_async_iterator_never_iter(client):
-    class MyAsyncIterator:
-        size = 10
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if self.size == 0:
-                raise StopAsyncIteration
-            self.size -= 1
-            return self.size
-
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        return MyAsyncIterator()
-
-    fn()
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output is None
-
-
-def test_op_return_sync_generator_partial(client):
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        size = 10
-        while size > 0:
-            size -= 1
-            yield size
-
-    for item in fn():
-        if item == 5:
-            break
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, 4, -1))
-
-
-@pytest.mark.asyncio
-async def test_op_return_async_generator_partial(client):
-    @weave.op(accumulator=simple_list_accumulator)
-    async def fn():
-        size = 10
-        while size > 0:
-            size -= 1
-            yield size
-
-    async for item in fn():
-        if item == 5:
-            break
-        return  # This return is required to raise StopAsyncIteration
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, 4, -1))
-
-
-def test_op_return_sync_iterator_partial(client):
-    class MyIterator:
-        size = 10
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            if self.size == 0:
-                raise StopIteration
-            self.size -= 1
-            return self.size
-
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        return MyIterator()
-
-    for item in fn():
-        if item == 5:
-            break
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, 4, -1))
-
-
-@pytest.mark.asyncio
-async def test_op_return_async_iterator_partial(client):
-    class MyAsyncIterator:
-        size = 10
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if self.size == 0:
-                raise StopAsyncIteration
-            self.size -= 1
-            return self.size
-
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        return MyAsyncIterator()
-
-    async for item in fn():
-        if item == 5:
-            break
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, 4, -1))
-
-
-def test_op_return_sync_generator_exception(client):
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        size = 10
-        while size > 0:
-            size -= 1
-            yield size
-            if size == 5:
-                raise ValueError("test")
-
-    try:
-        for _item in fn():
-            pass
-    except ValueError:
-        pass
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, 4, -1))
-    assert res.calls[0].exception is not None
-
-
-@pytest.mark.asyncio
-async def test_op_return_async_generator_exception(client):
-    @weave.op(accumulator=simple_list_accumulator)
-    async def fn():
-        size = 10
-        while size > 0:
-            size -= 1
-            yield size
-            if size == 5:
-                raise ValueError("test")
-
-    try:
-        async for _item in fn():
-            pass
-    except ValueError:
-        pass
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, 4, -1))
-    assert res.calls[0].exception is not None
-
-
-def test_op_return_sync_iterator_exception(client):
-    class MyIterator:
-        size = 10
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            if self.size == 0:
-                raise StopIteration
-            if self.size == 5:
-                raise ValueError("test")
-            self.size -= 1
-            return self.size
-
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        return MyIterator()
-
-    try:
-        for _item in fn():
-            pass
-    except ValueError:
-        pass
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, 4, -1))
-    assert res.calls[0].exception is not None
-
-
-@pytest.mark.asyncio
-async def test_op_return_async_iterator_exception(client):
-    class MyAsyncIterator:
-        size = 10
-
-        def __aiter__(self):
-            return self
-
-        async def __anext__(self):
-            if self.size == 0:
-                raise StopAsyncIteration
-            if self.size == 5:
-                raise ValueError("test")
-            self.size -= 1
-            return self.size
-
-    @weave.op(accumulator=simple_list_accumulator)
-    def fn():
-        return MyAsyncIterator()
-
-    try:
-        async for _item in fn():
-            pass
-    except ValueError:
-        pass
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(
-            project_id=client.project_id,
-        )
-    )
-
-    obj_ref = get_ref(fn)
-    assert obj_ref is not None
-    assert res.calls[0].op_name == obj_ref.uri
-    assert res.calls[0].inputs == {}
-    assert res.calls[0].output == list(range(9, 4, -1))
-    assert res.calls[0].exception is not None

--- a/tests/trace/test_op_versioning.py
+++ b/tests/trace/test_op_versioning.py
@@ -99,19 +99,17 @@ def test_op_versioning_importfrom(client):
     assert saved_code == EXPECTED_IMPORTFROM_OP_CODE
 
 
-def test_op_versioning_lotsofstuff():
+def test_op_decoration_smoke():
+    """Decorating ops with comprehensions, generators, recursion, and try/except
+    must not raise during AST/closure extraction.
+    """
+
     @weave.op
     def versioned_op_lotsofstuff(a: int) -> float:
         j = [x + 1 for x in range(a)]
         k = (y - 3 for y in j)
         return np.array(k).mean()
 
-
-def test_op_versioning_inline_import():
-    pass
-
-
-def test_op_versioning_inline_func_decl():
     @weave.op
     def versioned_op_inline_func_decl(a: int) -> float:
         def inner_func(x):
@@ -121,6 +119,17 @@ def test_op_versioning_inline_func_decl():
             return inner_func(x - 1) * 2
 
         return inner_func(a)
+
+    @weave.op
+    def versioned_op_exception(a: int) -> float:
+        try:
+            x = 1 / 0
+        except Exception as e:
+            print("E", e)
+            return 9999
+        return x
+
+    assert versioned_op_exception(0) == 9999
 
 
 EXPECTED_CLOSURE_CONTANT_OP_CODE = """import weave
@@ -318,18 +327,6 @@ def test_op_versioning_mixed(client):
     assert saved_code == EXPECTED_MIXED_OP_CODE
     op2 = weave.ref(str(ref)).get()
     assert op2(1) == 102.0
-
-
-def test_op_versioning_exception():
-    # Just ensure this doesn't raise by running it.
-    @weave.op
-    def versioned_op_exception(a: int) -> float:
-        try:
-            x = 1 / 0
-        except Exception as e:
-            print("E", e)
-            return 9999
-        return x
 
 
 def test_op_versioning_2ops(client):
@@ -614,48 +611,17 @@ def test_op_import_from_as(client):
     assert saved_code == EXPECTED_IMPORT_FROM_AS_CODE
 
 
-def save_and_get_code(func: Callable) -> str:
-    artifact = MemTraceFilesArtifact()
-    save_instance(func, artifact, "obj")
-    saved_code = artifact.path_contents["obj.py"]
-    if isinstance(saved_code, bytes):
-        saved_code = saved_code.decode()
-    return saved_code
-
-
 STANDARD_FUNC_CODE = """import weave
 
 @weave.op
 def standard_func(): ...
 """
 
-
-def test_standard_import():
-    """Test that standard import weave works correctly."""
-
-    @weave.op
-    def standard_func(): ...
-
-    code = save_and_get_code(standard_func)
-    assert code == STANDARD_FUNC_CODE
-
-
 ALIASED_FUNC_CODE = """import weave as wv
 
 @wv.op
 def aliased_func(): ...
 """
-
-
-def test_aliased_import_wv():
-    """Test that aliased import (wv) is handled correctly - should preserve the alias."""
-
-    @wv.op
-    def aliased_func(): ...
-
-    code = save_and_get_code(aliased_func)
-    assert code == ALIASED_FUNC_CODE
-
 
 PAREN_FUNC_CODE = """import weave as wv
 
@@ -664,11 +630,31 @@ def paren_func(): ...
 """
 
 
-def test_op_with_parentheses():
-    """Test that @wv.op() with parentheses is normalized to @wv.op - should preserve the alias."""
+def test_op_decorator_import_styles():
+    """`weave.op`, aliased `wv.op`, and `wv.op()` each preserve their decorator form
+    and import alias in the saved source.
+    """
+
+    @weave.op
+    def standard_func(): ...
+
+    assert save_and_get_code(standard_func) == STANDARD_FUNC_CODE
+
+    @wv.op
+    def aliased_func(): ...
+
+    assert save_and_get_code(aliased_func) == ALIASED_FUNC_CODE
 
     @wv.op()
     def paren_func(): ...
 
-    code = save_and_get_code(paren_func)
-    assert code == PAREN_FUNC_CODE
+    assert save_and_get_code(paren_func) == PAREN_FUNC_CODE
+
+
+def save_and_get_code(func: Callable) -> str:
+    artifact = MemTraceFilesArtifact()
+    save_instance(func, artifact, "obj")
+    saved_code = artifact.path_contents["obj.py"]
+    if isinstance(saved_code, bytes):
+        saved_code = saved_code.decode()
+    return saved_code

--- a/tests/trace/test_project_id_resolver.py
+++ b/tests/trace/test_project_id_resolver.py
@@ -17,143 +17,109 @@ def enable_client_side_digests(monkeypatch):
     monkeypatch.setenv("WEAVE_ENABLE_CLIENT_SIDE_DIGESTS", "true")
 
 
+def test_cache_miss_hit_and_per_project() -> None:
+    resolver = _make_resolver("int-abc")
+
+    # miss hits the server and returns the resolved id
+    assert resolver.resolve("entity/proj") == "int-abc"
+    assert resolver._server.projects_info.call_count == 1
+
+    # second resolve of the same project is served from cache
+    assert resolver.resolve("entity/proj") == "int-abc"
+    assert resolver._server.projects_info.call_count == 1
+
+    # a distinct project is cached separately, so it misses
+    resolver.resolve("entity/proj-b")
+    assert resolver._server.projects_info.call_count == 2
+
+
+def test_attribute_error_permanently_disables() -> None:
+    server = MagicMock()
+    server.projects_info.side_effect = AttributeError("no such method")
+    resolver = ProjectIdResolver(server)
+
+    assert resolver.resolve("entity/proj") is None
+    assert resolver.is_disabled
+
+
+def test_transient_and_empty_results_not_cached() -> None:
+    # transient errors are not cached: a later success re-queries and resolves
+    server = MagicMock()
+    server.projects_info.side_effect = TimeoutError("network timeout")
+    resolver = ProjectIdResolver(server)
+
+    assert resolver.resolve("entity/proj") is None
+    assert not resolver.is_disabled
+
+    mock_result = MagicMock()
+    mock_result.internal_project_id = "int-abc"
+    server.projects_info.side_effect = None
+    server.projects_info.return_value = [mock_result]
+
+    assert resolver.resolve("entity/proj") == "int-abc"
+    assert server.projects_info.call_count == 2
+
+    # empty results are likewise not cached, so a repeat re-queries
+    empty_server = MagicMock()
+    empty_server.projects_info.return_value = []
+    empty_resolver = ProjectIdResolver(empty_server)
+
+    assert empty_resolver.resolve("entity/proj") is None
+    empty_resolver.resolve("entity/proj")
+    assert empty_server.projects_info.call_count == 2
+
+
+def test_disable_enable_and_idempotent_validation_error(caplog) -> None:
+    resolver = _make_resolver("int-abc")
+    resolver.resolve("entity/proj")
+
+    # disabling makes resolve raise but get_internal_project_id return None
+    resolver.disable()
+    with pytest.raises(ResolverDisabledError):
+        resolver.resolve("entity/proj")
+    assert resolver.get_internal_project_id("entity/proj") is None
+
+    # re-enabling restores lookups
+    resolver.enable()
+    assert resolver.resolve("entity/proj") == "int-abc"
+
+    # disable_after_validation_error clears the cache, disables, warns once
+    resolver._cache["a/b"] = "cached-id"
+    caplog.set_level(logging.WARNING, logger="weave.trace.project_id_resolver")
+    exc = DigestMismatchError("mismatch")
+    resolver.disable_after_validation_error(exc, "ref1")
+    resolver.disable_after_validation_error(exc, "ref2")
+
+    assert resolver.is_disabled
+    assert len(resolver._cache) == 0
+    warnings = [r for r in caplog.records if "disabling fast path" in r.getMessage()]
+    assert len(warnings) == 1
+
+
+@pytest.mark.parametrize(
+    ("exc", "result", "expect_disabled"),
+    [
+        (DigestMismatchError("mismatch"), None, True),
+        (ValueError("unrelated"), None, False),
+        (None, MagicMock(), False),
+    ],
+)
+def test_on_fire_and_forget_done(exc, result, expect_disabled) -> None:
+    resolver = _make_resolver("int-abc")
+    future: Future = Future()
+    if exc is not None:
+        future.set_exception(exc)
+    else:
+        future.set_result(result)
+
+    resolver.on_fire_and_forget_done(future, ref_uri="weave:///a/b/obj")
+
+    assert resolver.is_disabled is expect_disabled
+
+
 def _make_resolver(internal_id: str) -> ProjectIdResolver:
     server = MagicMock()
     result = MagicMock()
     result.internal_project_id = internal_id
     server.projects_info.return_value = [result]
     return ProjectIdResolver(server)
-
-
-class TestCache:
-    def test_calls_server_on_miss(self) -> None:
-        resolver = _make_resolver("int-abc")
-        result = resolver.resolve("entity/proj")
-
-        assert result == "int-abc"
-        resolver._server.projects_info.assert_called_once()
-
-    def test_returns_cached_on_hit(self) -> None:
-        resolver = _make_resolver("int-abc")
-        resolver.resolve("entity/proj")
-        resolver.resolve("entity/proj")
-
-        assert resolver._server.projects_info.call_count == 1
-
-    def test_caches_per_project(self) -> None:
-        resolver = _make_resolver("int-abc")
-        resolver.resolve("entity/proj-a")
-        resolver.resolve("entity/proj-b")
-
-        assert resolver._server.projects_info.call_count == 2
-
-
-class TestErrorHandling:
-    def test_attribute_error_permanently_disables(self) -> None:
-        server = MagicMock()
-        server.projects_info.side_effect = AttributeError("no such method")
-        resolver = ProjectIdResolver(server)
-
-        result = resolver.resolve("entity/proj")
-
-        assert result is None
-        assert resolver.is_disabled
-
-    def test_transient_error_not_cached(self) -> None:
-        server = MagicMock()
-        server.projects_info.side_effect = TimeoutError("network timeout")
-        resolver = ProjectIdResolver(server)
-
-        result1 = resolver.resolve("entity/proj")
-        assert result1 is None
-        assert not resolver.is_disabled
-
-        mock_result = MagicMock()
-        mock_result.internal_project_id = "int-abc"
-        server.projects_info.side_effect = None
-        server.projects_info.return_value = [mock_result]
-
-        result2 = resolver.resolve("entity/proj")
-        assert result2 == "int-abc"
-        assert server.projects_info.call_count == 2
-
-    def test_empty_result_not_cached(self) -> None:
-        server = MagicMock()
-        server.projects_info.return_value = []
-        resolver = ProjectIdResolver(server)
-
-        result = resolver.resolve("entity/proj")
-        assert result is None
-
-        resolver.resolve("entity/proj")
-        assert server.projects_info.call_count == 2
-
-
-class TestDisable:
-    def test_disable_makes_resolve_raise(self) -> None:
-        resolver = _make_resolver("int-abc")
-        resolver.resolve("entity/proj")
-
-        resolver.disable()
-
-        with pytest.raises(ResolverDisabledError):
-            resolver.resolve("entity/proj")
-
-    def test_disable_makes_get_internal_project_id_return_none(self) -> None:
-        resolver = _make_resolver("int-abc")
-        resolver.disable()
-
-        assert resolver.get_internal_project_id("entity/proj") is None
-
-    def test_enable_restores_lookups(self) -> None:
-        resolver = _make_resolver("int-abc")
-        resolver.disable()
-        resolver.enable()
-
-        result = resolver.resolve("entity/proj")
-        assert result == "int-abc"
-
-    def test_disable_after_validation_error_is_idempotent(self, caplog) -> None:
-        resolver = _make_resolver("int-abc")
-        resolver._cache["a/b"] = "cached-id"
-        caplog.set_level(logging.WARNING, logger="weave.trace.project_id_resolver")
-
-        exc = DigestMismatchError("mismatch")
-        resolver.disable_after_validation_error(exc, "ref1")
-        resolver.disable_after_validation_error(exc, "ref2")
-
-        assert resolver.is_disabled
-        assert len(resolver._cache) == 0
-        warnings = [
-            r for r in caplog.records if "disabling fast path" in r.getMessage()
-        ]
-        assert len(warnings) == 1
-
-
-class TestOnFireAndForgetDone:
-    def test_disables_on_digest_mismatch(self) -> None:
-        resolver = _make_resolver("int-abc")
-        future: Future = Future()
-        future.set_exception(DigestMismatchError("mismatch"))
-
-        resolver.on_fire_and_forget_done(future, ref_uri="weave:///a/b/obj")
-
-        assert resolver.is_disabled
-
-    def test_ignores_non_digest_errors(self) -> None:
-        resolver = _make_resolver("int-abc")
-        future: Future = Future()
-        future.set_exception(ValueError("unrelated"))
-
-        resolver.on_fire_and_forget_done(future, ref_uri="weave:///a/b/obj")
-
-        assert not resolver.is_disabled
-
-    def test_ignores_success(self) -> None:
-        resolver = _make_resolver("int-abc")
-        future: Future = Future()
-        future.set_result(MagicMock())
-
-        resolver.on_fire_and_forget_done(future, ref_uri="weave:///a/b/obj")
-
-        assert not resolver.is_disabled

--- a/tests/trace/test_publish_round_trip.py
+++ b/tests/trace/test_publish_round_trip.py
@@ -26,7 +26,11 @@ def test_publish_round_trip_query_object(client) -> None:
     assert query_2 == query
 
 
-def test_publish_round_trip_register_object_nested(weave_active) -> None:
+def test_publish_round_trip_get_and_unwrap(weave_active) -> None:
+    """A register_object nested pydantic model round-trips via .get() as its real
+    type, and a plain nested dict round-trips via .unwrap().
+    """
+
     class Inner(BaseModel):
         name: str
 
@@ -39,24 +43,12 @@ def test_publish_round_trip_register_object_nested(weave_active) -> None:
             return cls.model_validate(obj.unwrap())
 
     outer = Outer(inner=Inner(name="test"))
-    outer_ref = weave.publish(outer)
-    outer_gotten = outer_ref.get()
+    outer_gotten = weave.publish(outer).get()
     assert isinstance(outer_gotten, Outer)
     assert isinstance(outer_gotten.inner, Inner)
     assert outer_gotten.inner.name == "test"
     assert outer == outer_gotten
 
-
-def test_round_trip_unwrap(weave_active) -> None:
-    data = {
-        "a": 1,
-        "b": [
-            {
-                "c": 2,
-                "d": 3,
-            }
-        ],
-    }
-    ref = weave.publish(data)
-    gotten = ref.get()
+    data = {"a": 1, "b": [{"c": 2, "d": 3}]}
+    gotten = weave.publish(data).get()
     assert gotten.unwrap() == data

--- a/tests/trace/test_queue_filtering.py
+++ b/tests/trace/test_queue_filtering.py
@@ -80,6 +80,22 @@ def test_filter_calls_by_queue_inner_join_behavior(client):
     excluded_ids = set(call_ids[:2] + call_ids[7:])
     assert returned_ids.isdisjoint(excluded_ids)
 
+    # A non-existent queue id matches no queue items, so INNER JOIN -> empty.
+    nonexistent_query = tsi.Query(
+        **{
+            "$expr": {
+                "$eq": [
+                    {"$getField": "annotation_queue_items.queue_id"},
+                    {"$literal": generate_id()},
+                ]
+            }
+        }
+    )
+    empty_res = client.server.calls_query(
+        tsi.CallsQueryReq(project_id=client.project_id, query=nonexistent_query)
+    )
+    assert len(empty_res.calls) == 0
+
 
 def test_filter_calls_by_multiple_distinct_queues(client):
     """Test that queue filtering correctly isolates calls by queue_id.
@@ -258,42 +274,6 @@ def test_filter_calls_by_queue_combined_with_other_filters(client):
     # Should return only the 2 op_include calls in the queue
     assert len(res.calls) == 2
     assert {call.id for call in res.calls} == set(include_ids[:2])
-
-
-def test_filter_calls_by_nonexistent_queue(client):
-    """Test that filtering by a non-existent queue returns empty results.
-
-    Verifies INNER JOIN behavior when no matching queue items exist.
-    """
-
-    # Create some calls
-    @weave.op(name="test_nonexistent")
-    def test_op(x: int) -> int:
-        return x
-
-    for i in range(3):
-        test_op(i)
-
-    # Use a random queue ID that doesn't exist
-    nonexistent_queue_id = generate_id()
-
-    query = tsi.Query(
-        **{
-            "$expr": {
-                "$eq": [
-                    {"$getField": "annotation_queue_items.queue_id"},
-                    {"$literal": nonexistent_queue_id},
-                ]
-            }
-        }
-    )
-
-    res = client.server.calls_query(
-        tsi.CallsQueryReq(project_id=client.project_id, query=query)
-    )
-
-    # Should return no calls
-    assert len(res.calls) == 0
 
 
 def test_filter_calls_by_queue_with_calls_complete_table(trace_server):

--- a/tests/trace/test_redaction.py
+++ b/tests/trace/test_redaction.py
@@ -21,175 +21,119 @@ def test_code_capture_redacts_sensitive_values(weave_active):
     assert 'api_key = "REDACTED"' in captured_code
 
 
-def test_redact_dataclass_fields() -> None:
-    """Test that dataclass fields are redacted when their names are in the redact set."""
+def test_redact_dataclass_structures() -> None:
+    """Redaction covers flat, nested, and list-of-dataclass containers."""
     original_keys = sanitize.get_redact_keys()
 
     try:
         sanitize.add_redact_key("api_token")
-
-        @dataclasses.dataclass
-        class UserConfig:
-            api_key: str
-            username: str
-            api_token: str
-
-        config = UserConfig(
-            api_key="secret-key-123",
-            username="testuser",
-            api_token="token-456",
-        )
-
-        redacted = redact_sensitive_keys(config)
-
-        # Both api_key (default) and api_token (added) should be redacted
-        assert redacted.api_key == sanitize.REDACTED_VALUE
-        assert redacted.api_token == sanitize.REDACTED_VALUE
-        # username should not be redacted
-        assert redacted.username == "testuser"
-
-    finally:
-        sanitize._REDACT_KEYS = original_keys
-
-
-def test_redact_dataclass_nested() -> None:
-    """Test that nested dataclasses are redacted correctly."""
-    original_keys = sanitize.get_redact_keys()
-
-    try:
         sanitize.add_redact_key("secret")
 
-        @dataclasses.dataclass
-        class InnerConfig:
-            secret: str
-            public: str
-
-        @dataclasses.dataclass
-        class OuterConfig:
-            inner: InnerConfig
-            name: str
-
-        config = OuterConfig(
-            inner=InnerConfig(secret="hidden", public="visible"),
-            name="test",
+        flat = UserConfig(
+            api_key="secret-key-123", username="testuser", api_token="token-456"
         )
+        redacted_flat = redact_sensitive_keys(flat)
+        # api_key (default) and api_token (added) redacted; username untouched
+        assert redacted_flat.api_key == sanitize.REDACTED_VALUE
+        assert redacted_flat.api_token == sanitize.REDACTED_VALUE
+        assert redacted_flat.username == "testuser"
 
-        redacted = redact_sensitive_keys(config)
-
-        # Nested dataclass field should be redacted
-        assert redacted.inner.secret == sanitize.REDACTED_VALUE
-        assert redacted.inner.public == "visible"
-        assert redacted.name == "test"
-
-    finally:
-        sanitize._REDACT_KEYS = original_keys
-
-
-def test_redact_dataclass_in_list() -> None:
-    """Test that dataclasses in lists are redacted."""
-    original_keys = sanitize.get_redact_keys()
-
-    try:
-        sanitize.add_redact_key("api_key")
-
-        @dataclasses.dataclass
-        class Credential:
-            api_key: str
-            username: str
+        nested = OuterSecretConfig(
+            inner=InnerSecretConfig(secret="hidden", public="visible"), name="test"
+        )
+        redacted_nested = redact_sensitive_keys(nested)
+        assert redacted_nested.inner.secret == sanitize.REDACTED_VALUE
+        assert redacted_nested.inner.public == "visible"
+        assert redacted_nested.name == "test"
 
         credentials = [
             Credential(api_key="key1", username="user1"),
             Credential(api_key="key2", username="user2"),
         ]
-
-        redacted = redact_sensitive_keys(credentials)
-
-        # All dataclass instances in the list should have api_key redacted
-        assert redacted[0].api_key == sanitize.REDACTED_VALUE
-        assert redacted[0].username == "user1"
-        assert redacted[1].api_key == sanitize.REDACTED_VALUE
-        assert redacted[1].username == "user2"
+        redacted_list = redact_sensitive_keys(credentials)
+        assert redacted_list[0].api_key == sanitize.REDACTED_VALUE
+        assert redacted_list[0].username == "user1"
+        assert redacted_list[1].api_key == sanitize.REDACTED_VALUE
+        assert redacted_list[1].username == "user2"
 
     finally:
         sanitize._REDACT_KEYS = original_keys
 
 
 def test_redact_dataclass_add_field_to_redact_list() -> None:
-    """Test that adding a field name to the redact list causes it to be redacted."""
+    """Adding a field name to the redact list redacts it in flat and nested dataclasses."""
     original_keys = sanitize.get_redact_keys()
 
     try:
-        # Create a dataclass with a field "foo" that is not in the redact list
-        @dataclasses.dataclass
-        class TestConfig:
-            foo: str
-            bar: str
-
-        config = TestConfig(foo="sensitive-value", bar="public-value")
-
-        # Initially, "foo" should not be redacted
-        assert "foo" not in sanitize.get_redact_keys()
-
-        # Before adding to redact list, foo should not be redacted
-        redacted_before = redact_sensitive_keys(config)
-        assert redacted_before.foo == "sensitive-value"
-        assert redacted_before.bar == "public-value"
-
-        # Add "foo" to the redact list
-        sanitize.add_redact_key("foo")
-
-        # Now "foo" should be redacted
-        assert "foo" in sanitize.get_redact_keys()
-        redacted_after = redact_sensitive_keys(config)
-
-        # After adding to redact list, foo should be redacted
-        assert redacted_after.foo == sanitize.REDACTED_VALUE
-        assert redacted_after.bar == "public-value"
-
-    finally:
-        sanitize._REDACT_KEYS = original_keys
-
-
-def test_redact_dataclass_nested_add_field_to_redact_list() -> None:
-    """Test that nested dataclasses redact fields after adding them to the redact list."""
-    original_keys = sanitize.get_redact_keys()
-
-    try:
-        # Create nested dataclasses with a field "foo" that is not in the redact list
-        @dataclasses.dataclass
-        class InnerConfig:
-            foo: str
-            public: str
-
-        @dataclasses.dataclass
-        class OuterConfig:
-            inner: InnerConfig
-            name: str
-
-        config = OuterConfig(
-            inner=InnerConfig(foo="sensitive-nested-value", public="visible"),
+        flat = FooConfig(foo="sensitive-value", bar="public-value")
+        nested = OuterFooConfig(
+            inner=InnerFooConfig(foo="sensitive-nested-value", public="visible"),
             name="test",
         )
 
-        # Initially, "foo" should not be redacted
         assert "foo" not in sanitize.get_redact_keys()
 
-        # Before adding to redact list, foo should not be redacted
-        redacted_before = redact_sensitive_keys(config)
-        assert redacted_before.inner.foo == "sensitive-nested-value"
-        assert redacted_before.inner.public == "visible"
-        assert redacted_before.name == "test"
+        before_flat = redact_sensitive_keys(flat)
+        assert before_flat.foo == "sensitive-value"
+        assert before_flat.bar == "public-value"
+        before_nested = redact_sensitive_keys(nested)
+        assert before_nested.inner.foo == "sensitive-nested-value"
+        assert before_nested.inner.public == "visible"
+        assert before_nested.name == "test"
 
-        # Add "foo" to the redact list
         sanitize.add_redact_key("foo")
+        assert "foo" in sanitize.get_redact_keys()
 
-        # Now "foo" should be redacted in nested dataclass
-        redacted_after = redact_sensitive_keys(config)
-
-        # After adding to redact list, foo should be redacted
-        assert redacted_after.inner.foo == sanitize.REDACTED_VALUE
-        assert redacted_after.inner.public == "visible"
-        assert redacted_after.name == "test"
+        after_flat = redact_sensitive_keys(flat)
+        assert after_flat.foo == sanitize.REDACTED_VALUE
+        assert after_flat.bar == "public-value"
+        after_nested = redact_sensitive_keys(nested)
+        assert after_nested.inner.foo == sanitize.REDACTED_VALUE
+        assert after_nested.inner.public == "visible"
+        assert after_nested.name == "test"
 
     finally:
         sanitize._REDACT_KEYS = original_keys
+
+
+@dataclasses.dataclass
+class UserConfig:
+    api_key: str
+    username: str
+    api_token: str
+
+
+@dataclasses.dataclass
+class InnerSecretConfig:
+    secret: str
+    public: str
+
+
+@dataclasses.dataclass
+class OuterSecretConfig:
+    inner: InnerSecretConfig
+    name: str
+
+
+@dataclasses.dataclass
+class Credential:
+    api_key: str
+    username: str
+
+
+@dataclasses.dataclass
+class FooConfig:
+    foo: str
+    bar: str
+
+
+@dataclasses.dataclass
+class InnerFooConfig:
+    foo: str
+    public: str
+
+
+@dataclasses.dataclass
+class OuterFooConfig:
+    inner: InnerFooConfig
+    name: str

--- a/tests/trace/test_ref_conversion.py
+++ b/tests/trace/test_ref_conversion.py
@@ -33,133 +33,124 @@ from weave.trace.ref_conversion import (
 # ---------------------------------------------------------------------------
 
 
-def test_same_project_object_ref() -> None:
+@pytest.mark.parametrize(
+    ("uri", "expected_type", "expected_uri", "field_name", "field_value"),
+    [
+        (
+            "weave:///entity/proj/object/my_obj:abc123",
+            InternalObjectRef,
+            "weave-trace-internal:///int-id-1/object/my_obj:abc123",
+            "name",
+            "my_obj",
+        ),
+        (
+            "weave:///entity/proj/op/my_op:def456",
+            InternalOpRef,
+            "weave-trace-internal:///int-id-1/op/my_op:def456",
+            None,
+            None,
+        ),
+        (
+            "weave:///entity/proj/table/abc123",
+            InternalTableRef,
+            "weave-trace-internal:///int-id-1/table/abc123",
+            "digest",
+            "abc123",
+        ),
+        (
+            "weave:///entity/proj/call/call-id-123",
+            InternalCallRef,
+            "weave-trace-internal:///int-id-1/call/call-id-123",
+            "id",
+            "call-id-123",
+        ),
+        (
+            "weave:///entity/proj/agent_turn/0123456789abcdef0123456789abcdef",
+            InternalAgentTurnRef,
+            "weave-trace-internal:///int-id-1/agent_turn/0123456789abcdef0123456789abcdef",
+            "trace_id",
+            "0123456789abcdef0123456789abcdef",
+        ),
+        (
+            "weave:///entity/proj/agent_span/0123456789abcdef",
+            InternalAgentSpanRef,
+            "weave-trace-internal:///int-id-1/agent_span/0123456789abcdef",
+            "span_id",
+            "0123456789abcdef",
+        ),
+        (
+            "weave:///entity/proj/agent_conversation/sess-abc-123",
+            InternalAgentConversationRef,
+            "weave-trace-internal:///int-id-1/agent_conversation/sess-abc-123",
+            "conversation_id",
+            "sess-abc-123",
+        ),
+        (
+            "weave:///entity/proj/agent_conversation/user%2F42%3Asession",
+            InternalAgentConversationRef,
+            "weave-trace-internal:///int-id-1/agent_conversation/user%2F42%3Asession",
+            "conversation_id",
+            "user/42:session",
+        ),
+    ],
+    ids=[
+        "object",
+        "op",
+        "table",
+        "call",
+        "agent_turn",
+        "agent_span",
+        "agent_conversation",
+        "agent_conversation_encoded",
+    ],
+)
+def test_same_project_happy_path(
+    uri: str,
+    expected_type: type,
+    expected_uri: str,
+    field_name: str | None,
+    field_value: object,
+) -> None:
+    """Each ref kind parses to its Internal*Ref with the rewritten internal uri."""
     result = convert_same_project_ref(
-        "weave:///entity/proj/object/my_obj:abc123",
+        uri,
+        ext_project_id="entity/proj",
+        internal_project_id="int-id-1",
+    )
+    assert isinstance(result, expected_type)
+    assert result.uri == expected_uri
+    if field_name is not None:
+        assert getattr(result, field_name) == field_value
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected_extra", "expected_uri"),
+    [
+        (
+            "weave:///entity/proj/object/ds:abc/attr/rows/id/rowdigest",
+            ["attr", "rows", "id", "rowdigest"],
+            "weave-trace-internal:///int-id-1/object/ds:abc/attr/rows/id/rowdigest",
+        ),
+        (
+            "weave:///entity/proj/object/ds:abc/attr/items/index/3",
+            ["attr", "items", "index", "3"],
+            "weave-trace-internal:///int-id-1/object/ds:abc/attr/items/index/3",
+        ),
+    ],
+    ids=["rows_id", "items_index"],
+)
+def test_same_project_preserves_extra_path(
+    uri: str, expected_extra: list[str], expected_uri: str
+) -> None:
+    """Extra path (attr/rows/id/... or .../index/N) is validated and preserved."""
+    result = convert_same_project_ref(
+        uri,
         ext_project_id="entity/proj",
         internal_project_id="int-id-1",
     )
     assert isinstance(result, InternalObjectRef)
-    assert result.name == "my_obj"
-    assert result.version == "abc123"
-    assert result.uri == "weave-trace-internal:///int-id-1/object/my_obj:abc123"
-
-
-def test_same_project_op_ref() -> None:
-    result = convert_same_project_ref(
-        "weave:///entity/proj/op/my_op:def456",
-        ext_project_id="entity/proj",
-        internal_project_id="int-id-1",
-    )
-    assert isinstance(result, InternalOpRef)
-    assert result.uri == "weave-trace-internal:///int-id-1/op/my_op:def456"
-
-
-def test_same_project_table_ref() -> None:
-    result = convert_same_project_ref(
-        "weave:///entity/proj/table/abc123",
-        ext_project_id="entity/proj",
-        internal_project_id="int-id-1",
-    )
-    assert isinstance(result, InternalTableRef)
-    assert result.digest == "abc123"
-    assert result.uri == "weave-trace-internal:///int-id-1/table/abc123"
-
-
-def test_same_project_call_ref() -> None:
-    result = convert_same_project_ref(
-        "weave:///entity/proj/call/call-id-123",
-        ext_project_id="entity/proj",
-        internal_project_id="int-id-1",
-    )
-    assert isinstance(result, InternalCallRef)
-    assert result.id == "call-id-123"
-    assert result.uri == "weave-trace-internal:///int-id-1/call/call-id-123"
-
-
-def test_same_project_preserves_extra_path() -> None:
-    """Extra path (attr/rows/id/...) is validated and preserved.
-
-    Internal*Ref dataclasses run validate_extra in __post_init__,
-    matching the server's validation in refs_internal.py.
-    """
-    result = convert_same_project_ref(
-        "weave:///entity/proj/object/ds:abc/attr/rows/id/rowdigest",
-        ext_project_id="entity/proj",
-        internal_project_id="int-id-1",
-    )
-    assert isinstance(result, InternalObjectRef)
-    assert result.extra == ["attr", "rows", "id", "rowdigest"]
-    assert (
-        result.uri
-        == "weave-trace-internal:///int-id-1/object/ds:abc/attr/rows/id/rowdigest"
-    )
-
-
-def test_same_project_with_index_extra() -> None:
-    result = convert_same_project_ref(
-        "weave:///entity/proj/object/ds:abc/attr/items/index/3",
-        ext_project_id="entity/proj",
-        internal_project_id="int-id-1",
-    )
-    assert isinstance(result, InternalObjectRef)
-    assert result.extra == ["attr", "items", "index", "3"]
-    assert (
-        result.uri
-        == "weave-trace-internal:///int-id-1/object/ds:abc/attr/items/index/3"
-    )
-
-
-def test_same_project_agent_turn_ref() -> None:
-    result = convert_same_project_ref(
-        "weave:///entity/proj/agent_turn/0123456789abcdef0123456789abcdef",
-        ext_project_id="entity/proj",
-        internal_project_id="int-id-1",
-    )
-    assert isinstance(result, InternalAgentTurnRef)
-    assert result.trace_id == "0123456789abcdef0123456789abcdef"
-    assert (
-        result.uri
-        == "weave-trace-internal:///int-id-1/agent_turn/0123456789abcdef0123456789abcdef"
-    )
-
-
-def test_same_project_agent_span_ref() -> None:
-    result = convert_same_project_ref(
-        "weave:///entity/proj/agent_span/0123456789abcdef",
-        ext_project_id="entity/proj",
-        internal_project_id="int-id-1",
-    )
-    assert isinstance(result, InternalAgentSpanRef)
-    assert result.span_id == "0123456789abcdef"
-    assert result.uri == "weave-trace-internal:///int-id-1/agent_span/0123456789abcdef"
-
-
-def test_same_project_agent_conversation_ref_simple() -> None:
-    result = convert_same_project_ref(
-        "weave:///entity/proj/agent_conversation/sess-abc-123",
-        ext_project_id="entity/proj",
-        internal_project_id="int-id-1",
-    )
-    assert isinstance(result, InternalAgentConversationRef)
-    assert result.conversation_id == "sess-abc-123"
-    assert (
-        result.uri == "weave-trace-internal:///int-id-1/agent_conversation/sess-abc-123"
-    )
-
-
-def test_same_project_agent_conversation_ref_encoded() -> None:
-    result = convert_same_project_ref(
-        "weave:///entity/proj/agent_conversation/user%2F42%3Asession",
-        ext_project_id="entity/proj",
-        internal_project_id="int-id-1",
-    )
-    assert isinstance(result, InternalAgentConversationRef)
-    assert result.conversation_id == "user/42:session"
-    assert (
-        result.uri
-        == "weave-trace-internal:///int-id-1/agent_conversation/user%2F42%3Asession"
-    )
+    assert result.extra == expected_extra
+    assert result.uri == expected_uri
 
 
 # ---------------------------------------------------------------------------
@@ -167,46 +158,30 @@ def test_same_project_agent_conversation_ref_encoded() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_same_project_raises_cross_project_for_different_project() -> None:
-    with pytest.raises(CrossProjectRefError, match="other/proj"):
-        convert_same_project_ref(
+@pytest.mark.parametrize(
+    ("uri", "exc", "match"),
+    [
+        (
             "weave:///other/proj/object/thing:xyz",
-            ext_project_id="entity/proj",
-            internal_project_id="int-id-1",
-        )
-
-
-def test_same_project_raises_for_non_weave_uri() -> None:
-    with pytest.raises(ValueError, match="Invalid URI"):
-        convert_same_project_ref(
-            "https://example.com/foo",
-            ext_project_id="entity/proj",
-            internal_project_id="int-id-1",
-        )
-
-
-def test_same_project_raises_for_malformed_ref() -> None:
-    with pytest.raises(ValueError, match="Invalid URI"):
-        convert_same_project_ref(
-            "weave:///onlyonepart",
-            ext_project_id="entity/proj",
-            internal_project_id="int-id-1",
-        )
-
-
-def test_same_project_raises_for_already_internal_ref() -> None:
-    with pytest.raises(ValueError, match="Invalid URI"):
-        convert_same_project_ref(
+            CrossProjectRefError,
+            "other/proj",
+        ),
+        ("https://example.com/foo", ValueError, "Invalid URI"),
+        ("weave:///onlyonepart", ValueError, "Invalid URI"),
+        (
             "weave-trace-internal:///int-id/object/thing:abc",
-            ext_project_id="entity/proj",
-            internal_project_id="int-id-1",
-        )
-
-
-def test_same_project_raises_for_unknown_kind() -> None:
-    with pytest.raises(ValueError, match="Unknown ref kind"):
+            ValueError,
+            "Invalid URI",
+        ),
+        ("weave:///entity/proj/unknown/foo:bar", ValueError, "Unknown ref kind"),
+    ],
+    ids=["cross_project", "non_weave", "malformed", "already_internal", "unknown_kind"],
+)
+def test_same_project_error_cases(uri: str, exc: type[Exception], match: str) -> None:
+    """Cross-project, non-weave, malformed, already-internal, and unknown kinds all raise."""
+    with pytest.raises(exc, match=match):
         convert_same_project_ref(
-            "weave:///entity/proj/unknown/foo:bar",
+            uri,
             ext_project_id="entity/proj",
             internal_project_id="int-id-1",
         )
@@ -217,36 +192,36 @@ def test_same_project_raises_for_unknown_kind() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_cross_project_resolves_via_resolver() -> None:
+@pytest.mark.parametrize(
+    ("uri", "expected_type", "expected_uri"),
+    [
+        (
+            "weave:///other_entity/other_proj/object/thing:xyz",
+            InternalObjectRef,
+            "weave-trace-internal:///other-int-id/object/thing:xyz",
+        ),
+        (
+            "weave:///other_entity/other_proj/agent_turn/0123456789abcdef0123456789abcdef",
+            InternalAgentTurnRef,
+            "weave-trace-internal:///other-int-id/agent_turn/0123456789abcdef0123456789abcdef",
+        ),
+    ],
+    ids=["object", "agent_turn"],
+)
+def test_cross_project_resolves_via_resolver(
+    uri: str, expected_type: type, expected_uri: str
+) -> None:
+    """Foreign project id is resolved and the ref is rewritten to the internal uri."""
     resolver = MagicMock()
     resolver.resolve_external_to_internal_project_id.return_value = "other-int-id"
 
     result = convert_cross_project_ref(
-        "weave:///other_entity/other_proj/object/thing:xyz",
+        uri,
         ext_project_id="entity/proj",
         resolver=resolver,
     )
-    assert isinstance(result, InternalObjectRef)
-    assert result.uri == "weave-trace-internal:///other-int-id/object/thing:xyz"
-    resolver.resolve_external_to_internal_project_id.assert_called_once_with(
-        "other_entity/other_proj"
-    )
-
-
-def test_cross_project_resolves_agent_turn_ref() -> None:
-    resolver = MagicMock()
-    resolver.resolve_external_to_internal_project_id.return_value = "other-int-id"
-
-    result = convert_cross_project_ref(
-        "weave:///other_entity/other_proj/agent_turn/0123456789abcdef0123456789abcdef",
-        ext_project_id="entity/proj",
-        resolver=resolver,
-    )
-    assert isinstance(result, InternalAgentTurnRef)
-    assert (
-        result.uri
-        == "weave-trace-internal:///other-int-id/agent_turn/0123456789abcdef0123456789abcdef"
-    )
+    assert isinstance(result, expected_type)
+    assert result.uri == expected_uri
     resolver.resolve_external_to_internal_project_id.assert_called_once_with(
         "other_entity/other_proj"
     )

--- a/tests/trace/test_ref_json_encoder.py
+++ b/tests/trace/test_ref_json_encoder.py
@@ -8,6 +8,66 @@ from weave.trace.refs import ObjectRef
 from weave.trace.serialization.op_type import RefJSONEncoder
 
 
+def test_ref_json_encoder_default_hook(object_ref: ObjectRef) -> None:
+    """The default() override wraps an ObjectRef in the special token as a
+    weave.ref(...).get() call containing its URI, and still raises TypeError for
+    a genuinely non-serializable object.
+    """
+    result = json.dumps(object_ref, cls=RefJSONEncoder)
+    assert RefJSONEncoder.SPECIAL_REF_TOKEN in result
+    assert "weave.ref(" in result
+    assert ".get()" in result
+    assert str(object_ref) in result
+
+    with pytest.raises(TypeError):
+        json.dumps({"not": "serializable", "value": object()}, cls=RefJSONEncoder)
+
+
+def test_ref_json_encoder_strip_tokens_pipeline(object_ref: ObjectRef) -> None:
+    """After encode-then-strip, refs become bare weave.ref('...').get() calls (not
+    quoted strings) wherever they appear: top-level, alongside plain values, multiple
+    refs, nested dicts, and inside lists.
+    """
+    simple = strip_ref_tokens(
+        json.dumps({"key": object_ref}, cls=RefJSONEncoder, indent=4)
+    )
+    assert f"weave.ref('{object_ref!s}').get()" in simple
+    assert '"weave.ref(' not in simple
+
+    mixed = strip_ref_tokens(
+        json.dumps(
+            {"plain": "hello", "number": 42, "ref_val": object_ref},
+            cls=RefJSONEncoder,
+            indent=4,
+        )
+    )
+    assert '"hello"' in mixed
+    assert "42" in mixed
+    assert f"weave.ref('{object_ref!s}').get()" in mixed
+
+    ref1 = ObjectRef(
+        entity="my-entity", project="my-project", name="obj-a", _digest="aaa"
+    )
+    ref2 = ObjectRef(
+        entity="my-entity", project="my-project", name="obj-b", _digest="bbb"
+    )
+    multiple = strip_ref_tokens(
+        json.dumps({"first": ref1, "second": ref2}, cls=RefJSONEncoder, indent=4)
+    )
+    assert f"weave.ref('{ref1!s}').get()" in multiple
+    assert f"weave.ref('{ref2!s}').get()" in multiple
+
+    nested = strip_ref_tokens(
+        json.dumps({"outer": {"inner": object_ref}}, cls=RefJSONEncoder, indent=4)
+    )
+    assert f"weave.ref('{object_ref!s}').get()" in nested
+
+    in_list = strip_ref_tokens(
+        json.dumps([1, object_ref, "hello"], cls=RefJSONEncoder, indent=4)
+    )
+    assert f"weave.ref('{object_ref!s}').get()" in in_list
+
+
 @pytest.fixture
 def object_ref() -> ObjectRef:
     return ObjectRef(
@@ -16,95 +76,10 @@ def object_ref() -> ObjectRef:
 
 
 def strip_ref_tokens(json_str: str) -> str:
-    """Apply the same token-replacement that _get_code_deps uses.
-
-    RefJSONEncoder wraps weave.ref() calls in a special token so they survive
-    JSON serialization as quoted strings.  _get_code_deps later strips those
-    tokens to produce valid Python (bare function calls, not strings).
-    This helper replicates that step so we can assert on the final output.
+    """Strip RefJSONEncoder's special ref tokens, as _get_code_deps does, so the
+    quoted weave.ref() wrappers become bare calls.
     """
     token = RefJSONEncoder.SPECIAL_REF_TOKEN
     json_str = json_str.replace(f'"{token}', "")
     json_str = json_str.replace(f'{token}"', "")
     return json_str
-
-
-class TestRefJSONEncoderDefault:
-    """Tests for the json.JSONEncoder.default() override.
-
-    json.JSONEncoder.default() is a stdlib hook — it's called whenever
-    json.dumps encounters an object it can't serialize natively.
-    RefJSONEncoder overrides it to handle ObjectRef instances.
-    """
-
-    def test_object_ref_returns_wrapped_ref_string(self, object_ref: ObjectRef) -> None:
-        result = json.dumps(object_ref, cls=RefJSONEncoder)
-
-        assert RefJSONEncoder.SPECIAL_REF_TOKEN in result
-        assert "weave.ref(" in result
-        assert ".get()" in result
-
-    def test_object_ref_contains_correct_uri(self, object_ref: ObjectRef) -> None:
-        result = json.dumps(object_ref, cls=RefJSONEncoder)
-
-        assert str(object_ref) in result
-
-    def test_non_object_ref_raises_type_error(self) -> None:
-        with pytest.raises(TypeError):
-            json.dumps({"not": "serializable", "value": object()}, cls=RefJSONEncoder)
-
-
-class TestRefJSONEncoderIntegration:
-    """Tests for the full encode-then-strip-tokens pipeline.
-
-    In production, _get_code_deps calls json.dumps(..., cls=RefJSONEncoder)
-    then strips the special tokens to produce valid Python where ObjectRef
-    values become bare weave.ref('...').get() calls instead of quoted strings.
-    """
-
-    def test_simple_ref_value(self, object_ref: ObjectRef) -> None:
-        result = strip_ref_tokens(
-            json.dumps({"key": object_ref}, cls=RefJSONEncoder, indent=4)
-        )
-
-        assert f"weave.ref('{object_ref!s}').get()" in result
-        # The ref call should NOT be inside quotes
-        assert '"weave.ref(' not in result
-
-    def test_mixed_ref_and_plain_values(self, object_ref: ObjectRef) -> None:
-        data = {"plain": "hello", "number": 42, "ref_val": object_ref}
-        result = strip_ref_tokens(json.dumps(data, cls=RefJSONEncoder, indent=4))
-
-        # Plain values should be unaffected
-        assert '"hello"' in result
-        assert "42" in result
-        # Ref should be a bare call
-        assert f"weave.ref('{object_ref!s}').get()" in result
-
-    def test_multiple_refs(self) -> None:
-        ref1 = ObjectRef(
-            entity="my-entity", project="my-project", name="obj-a", _digest="aaa"
-        )
-        ref2 = ObjectRef(
-            entity="my-entity", project="my-project", name="obj-b", _digest="bbb"
-        )
-        result = strip_ref_tokens(
-            json.dumps({"first": ref1, "second": ref2}, cls=RefJSONEncoder, indent=4)
-        )
-
-        assert f"weave.ref('{ref1!s}').get()" in result
-        assert f"weave.ref('{ref2!s}').get()" in result
-
-    def test_nested_structure_with_ref(self, object_ref: ObjectRef) -> None:
-        result = strip_ref_tokens(
-            json.dumps({"outer": {"inner": object_ref}}, cls=RefJSONEncoder, indent=4)
-        )
-
-        assert f"weave.ref('{object_ref!s}').get()" in result
-
-    def test_ref_in_list(self, object_ref: ObjectRef) -> None:
-        result = strip_ref_tokens(
-            json.dumps([1, object_ref, "hello"], cls=RefJSONEncoder, indent=4)
-        )
-
-        assert f"weave.ref('{object_ref!s}').get()" in result

--- a/tests/trace/test_ref_trace.py
+++ b/tests/trace/test_ref_trace.py
@@ -10,7 +10,11 @@ from weave.trace.refs import (
     CallRef,
     ObjectRef,
     OpRef,
+    Ref,
     TableRef,
+)
+from weave.trace_server.interface.builtin_object_classes.leaderboard import (
+    LeaderboardColumn,
 )
 
 
@@ -53,30 +57,17 @@ def test_str_returns_uri(ref, expected_uri):
     assert f"{ref!s}" == expected_uri
 
 
-def test_repr_is_unchanged_dataclass_form():
-    # repr() must keep the verbose dataclass form for debugging; only str()
-    # was changed to the URI.
+def test_object_ref_str_repr_and_round_trip():
+    """str() is the URI; repr() stays the verbose dataclass form and parses back."""
     ref = ObjectRef(entity="e", project="p", name="obj", _digest="dig", _extra=())
+
     assert repr(ref).startswith("ObjectRef(")
     assert "_digest='dig'" in repr(ref)
-
-
-def test_str_round_trips_through_parse_uri():
-    original = ObjectRef(entity="e", project="p", name="obj", _digest="dig", _extra=())
-    from weave.trace.refs import Ref
-
-    parsed = Ref.parse_uri(str(original))
-    assert parsed == original
+    assert Ref.parse_uri(str(ref)) == ref
 
 
 def test_leaderboard_column_accepts_str_of_ref():
-    # LeaderboardColumn.evaluation_object_ref is typed as RefStr (= str), so
-    # pydantic accepts any string. str(ref) now produces a URI, so a column
-    # built from str(ref) matches calls keyed by ref.uri() downstream.
-    from weave.trace_server.interface.builtin_object_classes.leaderboard import (
-        LeaderboardColumn,
-    )
-
+    """LeaderboardColumn.evaluation_object_ref (RefStr) accepts the URI from str(ref)."""
     ref = ObjectRef(entity="e", project="p", name="Eval", _digest="dig", _extra=())
     col = LeaderboardColumn(
         evaluation_object_ref=str(ref),
@@ -87,32 +78,18 @@ def test_leaderboard_column_accepts_str_of_ref():
     assert col.evaluation_object_ref.startswith("weave:///")
 
 
-def test_ref_hashable(weave_active):
+def test_ref_hashable_and_immutable(weave_active):
+    """Published refs are usable as dict keys and frozen against mutation."""
+
     class Thing(weave.Object):
         val: int
 
-    a = Thing(val=1)
-    b = Thing(val=2)
-    c = Thing(val=3)
+    ref_a = weave.publish(Thing(val=1))
+    ref_b = weave.publish(Thing(val=2))
+    ref_c = weave.publish(Thing(val=3))
 
-    ref_a = weave.publish(a)
-    ref_b = weave.publish(b)
-    ref_c = weave.publish(c)
-
-    comments = {
-        ref_a: "amazing",
-        ref_b: "bravo",
-        ref_c: "cool",
-    }
-
-
-def test_ref_immutable(weave_active):
-    class Thing(weave.Object):
-        val: int
-
-    a = Thing(val=1)
-
-    ref = weave.publish(a)
+    comments = {ref_a: "amazing", ref_b: "bravo", ref_c: "cool"}
+    assert comments[ref_a] == "amazing"
 
     with pytest.raises(FrozenInstanceError):
-        ref.val = 2
+        ref_a.val = 2

--- a/tests/trace/test_saved_view.py
+++ b/tests/trace/test_saved_view.py
@@ -25,12 +25,9 @@ def test_to_seconds():
     assert to_seconds(dt) == 1740873600.0
 
 
-def test_filters_to_query():
+def test_filters_query_empty_inputs_return_none():
     assert filters_to_query(None) is None
     assert filters_to_query([]) is None
-
-
-def test_query_to_filters_none():
     assert query_to_filters(None) is None
 
 
@@ -218,18 +215,17 @@ def test_column_manipulation():
     assert view.base.definition.columns[0].path == ["inputs", "foo"]
 
 
-def test_saved_view_create(weave_active):
-    view = weave.SavedView("traces", "My saved view").hide_column("feedback").save()
-    assert view.label == "My saved view"
-    assert isinstance(view.ref, ObjectRef)
+def test_saved_view_create_save_and_load(weave_active):
+    # save() returns a view with a label and ObjectRef; load(uri) round-trips
+    # label, view_type, and column visibility back out.
+    created = weave.SavedView("traces", "My saved view").hide_column("feedback").save()
+    assert created.label == "My saved view"
+    assert isinstance(created.ref, ObjectRef)
 
-
-def test_saved_view_load(weave_active):
     saved_view = weave.SavedView("traces", "My saved view")
     saved_view.show_column("attributes.weave.client_version")
     saved_view.save()
-    uri = saved_view.ref.uri
-    loaded_view = weave.SavedView.load(uri)
+    loaded_view = weave.SavedView.load(saved_view.ref.uri)
     assert loaded_view.label == saved_view.label
     assert loaded_view.view_type == saved_view.view_type
     assert loaded_view.base.definition.cols["attributes.weave.client_version"] is True

--- a/tests/trace/test_scored_calls_query.py
+++ b/tests/trace/test_scored_calls_query.py
@@ -13,55 +13,54 @@ from weave.trace_server.trace_server_interface import (
 )
 
 
-def assert_number_of_calls(client: WeaveClient, count: int):
-    stats = client.server.calls_query_stats(
-        CallsQueryStatsReq(
-            project_id=client.project_id,
-        )
-    )
-    assert stats.count == count
+def make_op_scorers() -> tuple[Op, Op, Op]:
+    @weave.op
+    def fn0(x, output):
+        return x == output
+
+    @weave.op
+    def fn1(x, output):
+        return x == output
+
+    fn0_v0 = fn0
+
+    # Must have the same name as fn0
+    @weave.op
+    def fn0(x, output):
+        return x == output + 1
+
+    return fn0_v0, fn0, fn1
 
 
-def output_field_for_name(name: str) -> str:
-    return f"feedback.[wandb.runnable.{name}].payload.output"
+def make_obj_scorers() -> tuple[Scorer, Scorer, Scorer]:
+    class MyScorer0(weave.Scorer):
+        offset: int
+
+        @weave.op
+        def score(self, x, output):
+            return output - x - self.offset
+
+    class MyScorer1(weave.Scorer):
+        offset: int
+
+        @weave.op
+        def score(self, x, output):
+            return output - x - self.offset + 1
+
+    return MyScorer0(offset=0), MyScorer0(offset=1), MyScorer1(offset=0)
 
 
-def runnable_ref_field_for_name(name: str) -> str:
-    return f"feedback.[wandb.runnable.{name}].runnable_ref"
+@pytest.mark.asyncio
+@pytest.mark.parametrize("make_scorers", [make_op_scorers, make_obj_scorers])
+async def test_scorer_query(client: WeaveClient, make_scorers):
+    """Query calls by scorer for both op-based and object-based scorers.
 
-
-def exists_expr(field: str) -> str:
-    return {"$not": [{"$eq": [{"$getField": field}, {"$literal": ""}]}]}
-
-
-def eq_expr(field: str, value: str) -> str:
-    return {"$eq": [{"$getField": field}, {"$literal": value}]}
-
-
-def call_ids(calls: list[weave.Call]) -> list[str]:
-    return [c.id for c in calls]
-
-
-def stats_query(client: WeaveClient, query: Query) -> CallsQueryStatsReq:
-    return client.server.calls_query_stats(
-        CallsQueryStatsReq(project_id=client.project_id, query=query)
-    ).count
-
-
-async def perform_scorer_tests(
-    client: WeaveClient, s0_v0: Scorer | Op, s0_v1: Scorer | Op, s1_v0: Scorer | Op
-):
-    """This is a unified test for both scorer and op tests. It ensures that we can query for calls
-    that have been scored by any type of scorer and ensures that we correctly differentiate between
-    versions of the same scorer.
-
-    We also ensure that the low-level and high-level queries return the same results. This is because
-    we will likely implement a better query at the service layer and we want to ensure that the high
-    level api continues to work correctly. We don't really want users to manually write the mongo
-    query, so that part of these tests is just here for correctness.
-
-    The only user-facing api we really want to maintain is the param `scored_by` on the client.
+    Ensures we can query for calls scored by any scorer type and that we
+    correctly differentiate between versions of the same scorer. We also check
+    that the low-level mongo query and the high-level `scored_by` api return the
+    same results; users should only need the `scored_by` param.
     """
+    s0_v0, s0_v1, s1_v0 = make_scorers()
 
     @weave.op
     def predict(x):
@@ -113,13 +112,6 @@ async def perform_scorer_tests(
 
     # Verify Baseline
     assert_number_of_calls(client, 10)  # 5 predictions, 5 scores
-
-    # Now, we will perform a few tests:
-    # 1. Query for calls that have been scored by s0:*
-    # 2. Query for calls that have been scored by s0:v0
-    # 3. Query for calls that have been scored by s0:v1
-    # 4. Query for calls that have been scored by s1:*
-    # 5. Query for calls that have been scored by s1:v0
 
     # 1. Query for calls that have been scored by s0:*
     expected_ids = call_ids(
@@ -184,44 +176,36 @@ async def perform_scorer_tests(
     assert len(calls_high_level) == len(calls_low_level) == count
 
 
-@pytest.mark.asyncio
-async def test_scorer_query_op(client: WeaveClient):
-    @weave.op
-    def fn0(x, output):
-        return x == output
-
-    @weave.op
-    def fn1(x, output):
-        return x == output
-
-    fn0_v0 = fn0
-
-    # Must have the same name as fn0
-    @weave.op
-    def fn0(x, output):
-        return x == output + 1
-
-    await perform_scorer_tests(client, fn0_v0, fn0, fn1)
+def assert_number_of_calls(client: WeaveClient, count: int):
+    stats = client.server.calls_query_stats(
+        CallsQueryStatsReq(
+            project_id=client.project_id,
+        )
+    )
+    assert stats.count == count
 
 
-@pytest.mark.asyncio
-async def test_scorer_query_obj(client: WeaveClient):
-    class MyScorer0(weave.Scorer):
-        offset: int
+def output_field_for_name(name: str) -> str:
+    return f"feedback.[wandb.runnable.{name}].payload.output"
 
-        @weave.op
-        def score(self, x, output):
-            return output - x - self.offset
 
-    class MyScorer1(weave.Scorer):
-        offset: int
+def runnable_ref_field_for_name(name: str) -> str:
+    return f"feedback.[wandb.runnable.{name}].runnable_ref"
 
-        @weave.op
-        def score(self, x, output):
-            return output - x - self.offset + 1
 
-    s0_v0 = MyScorer0(offset=0)
-    s0_v1 = MyScorer0(offset=1)
-    s1_v0 = MyScorer1(offset=0)
+def exists_expr(field: str) -> str:
+    return {"$not": [{"$eq": [{"$getField": field}, {"$literal": ""}]}]}
 
-    await perform_scorer_tests(client, s0_v0, s0_v1, s1_v0)
+
+def eq_expr(field: str, value: str) -> str:
+    return {"$eq": [{"$getField": field}, {"$literal": value}]}
+
+
+def call_ids(calls: list[weave.Call]) -> list[str]:
+    return [c.id for c in calls]
+
+
+def stats_query(client: WeaveClient, query: Query) -> CallsQueryStatsReq:
+    return client.server.calls_query_stats(
+        CallsQueryStatsReq(project_id=client.project_id, query=query)
+    ).count

--- a/tests/trace/test_sentry_disable.py
+++ b/tests/trace/test_sentry_disable.py
@@ -16,44 +16,45 @@ import pytest
 
 from weave.telemetry import trace_sentry
 
-
-@pytest.mark.parametrize(
-    "value",
-    ["false", "False", "FALSE", "0", "no", "off", "anything-else", ""],
-)
-def test_disabled_when_wandb_error_reporting_is_not_truthy(
-    monkeypatch: pytest.MonkeyPatch, value: str
-) -> None:
-    """Anything that is not a recognized truthy value disables Sentry."""
-    monkeypatch.setenv("WANDB_ERROR_REPORTING", value)
-    sentry = trace_sentry.Sentry()
-    assert sentry._disabled is True
+# `None` means leave `WANDB_ERROR_REPORTING` unset entirely.
+_UNSET = None
 
 
 @pytest.mark.parametrize(
-    "value",
-    ["true", "True", "TRUE", "1", "yes", "Yes", "on", "ON"],
+    ("value", "disabled"),
+    [
+        # Not-truthy values disable Sentry outright.
+        ("false", True),
+        ("False", True),
+        ("FALSE", True),
+        ("0", True),
+        ("no", True),
+        ("off", True),
+        ("anything-else", True),
+        ("", True),
+        # Truthy values and an unset var keep reporting enabled (modulo the
+        # optional `sentry-sdk` dependency reflected by `SENTRY_AVAILABLE`).
+        ("true", not trace_sentry.SENTRY_AVAILABLE),
+        ("True", not trace_sentry.SENTRY_AVAILABLE),
+        ("TRUE", not trace_sentry.SENTRY_AVAILABLE),
+        ("1", not trace_sentry.SENTRY_AVAILABLE),
+        ("yes", not trace_sentry.SENTRY_AVAILABLE),
+        ("Yes", not trace_sentry.SENTRY_AVAILABLE),
+        ("on", not trace_sentry.SENTRY_AVAILABLE),
+        ("ON", not trace_sentry.SENTRY_AVAILABLE),
+        (_UNSET, not trace_sentry.SENTRY_AVAILABLE),
+    ],
 )
-def test_enabled_when_wandb_error_reporting_is_truthy(
-    monkeypatch: pytest.MonkeyPatch, value: str
+def test_wandb_error_reporting_controls_disabled(
+    monkeypatch: pytest.MonkeyPatch, value: str | None, disabled: bool
 ) -> None:
-    """Recognized truthy values leave Sentry enabled (modulo `SENTRY_AVAILABLE`).
-
-    `_disabled` still reflects whether the optional `sentry-sdk` dependency is
-    installed in the env, so this passes whether or not Sentry is importable.
-    """
-    monkeypatch.setenv("WANDB_ERROR_REPORTING", value)
+    """`WANDB_ERROR_REPORTING` truthiness (and absence) drives `Sentry._disabled`."""
+    if value is _UNSET:
+        monkeypatch.delenv("WANDB_ERROR_REPORTING", raising=False)
+    else:
+        monkeypatch.setenv("WANDB_ERROR_REPORTING", value)
     sentry = trace_sentry.Sentry()
-    assert sentry._disabled == (not trace_sentry.SENTRY_AVAILABLE)
-
-
-def test_enabled_when_wandb_error_reporting_unset(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """An unset `WANDB_ERROR_REPORTING` defaults to enabled (no opt-out)."""
-    monkeypatch.delenv("WANDB_ERROR_REPORTING", raising=False)
-    sentry = trace_sentry.Sentry()
-    assert sentry._disabled == (not trace_sentry.SENTRY_AVAILABLE)
+    assert sentry._disabled is disabled
 
 
 def test_setup_is_a_noop_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/trace/test_serialize.py
+++ b/tests/trace/test_serialize.py
@@ -13,7 +13,9 @@ from weave.trace.serialization.serialize import (
 )
 
 
-def test_dictify_simple() -> None:
+def test_dictify_objects() -> None:
+    # Plain object (attribute scan, methods ignored), nested list of
+    # dataclasses, and the `to_dict` protocol override.
     class Point:
         x: int
         y: int
@@ -28,37 +30,35 @@ def test_dictify_simple() -> None:
     assert dictify(pt) == {
         "__class__": {
             "module": "test_serialize",
-            "qualname": "test_dictify_simple.<locals>.Point",
+            "qualname": "test_dictify_objects.<locals>.Point",
             "name": "Point",
         },
         "x": 1,
         "y": 2,
     }
 
-
-def test_dictify_complex() -> None:
     @dataclass
-    class Point:
+    class DataPoint:
         x: int
         y: int
 
     class Points:
         def __init__(self) -> None:
-            self.points = [Point(1, 2), Point(3, 4)]
+            self.points = [DataPoint(1, 2), DataPoint(3, 4)]
 
     pts = Points()
     assert dictify(pts) == {
         "__class__": {
             "module": "test_serialize",
-            "qualname": "test_dictify_complex.<locals>.Points",
+            "qualname": "test_dictify_objects.<locals>.Points",
             "name": "Points",
         },
         "points": [
             {
                 "__class__": {
                     "module": "test_serialize",
-                    "qualname": "test_dictify_complex.<locals>.Point",
-                    "name": "Point",
+                    "qualname": "test_dictify_objects.<locals>.DataPoint",
+                    "name": "DataPoint",
                 },
                 "x": 1,
                 "y": 2,
@@ -66,13 +66,32 @@ def test_dictify_complex() -> None:
             {
                 "__class__": {
                     "module": "test_serialize",
-                    "qualname": "test_dictify_complex.<locals>.Point",
-                    "name": "Point",
+                    "qualname": "test_dictify_objects.<locals>.DataPoint",
+                    "name": "DataPoint",
                 },
                 "x": 3,
                 "y": 4,
             },
         ],
+    }
+
+    class ToDictPoint:
+        x: int
+        y: int
+
+        def __init__(self, x: int, y: int) -> None:
+            self.x = x
+            self.y = y
+
+        def to_dict(self) -> dict:
+            return {
+                "foo": "bar",
+                "baz": 42,
+            }
+
+    assert dictify(ToDictPoint(1, 2)) == {
+        "foo": "bar",
+        "baz": 42,
     }
 
 
@@ -122,28 +141,6 @@ def test_dictify_maxdepth() -> None:
     }
 
 
-def test_dictify_to_dict() -> None:
-    class Point:
-        x: int
-        y: int
-
-        def __init__(self, x: int, y: int) -> None:
-            self.x = x
-            self.y = y
-
-        def to_dict(self) -> dict:
-            return {
-                "foo": "bar",
-                "baz": 42,
-            }
-
-    pt = Point(1, 2)
-    assert dictify(pt) == {
-        "foo": "bar",
-        "baz": 42,
-    }
-
-
 def test_stringify_returns_repr() -> None:
     @dataclass
     class Point:
@@ -155,6 +152,7 @@ def test_stringify_returns_repr() -> None:
 
 
 def test_dictify_sanitizes() -> None:
+    # Sensitive keys are redacted at top level and through nested objects.
     @dataclass
     class MyClass:
         api_key: str
@@ -169,8 +167,6 @@ def test_dictify_sanitizes() -> None:
         "api_key": "REDACTED",
     }
 
-
-def test_dictify_sanitizes_nested() -> None:
     @dataclass
     class MyClassA:
         api_key: str
@@ -179,17 +175,17 @@ def test_dictify_sanitizes_nested() -> None:
     class MyClassB:
         a: MyClassA
 
-    instance = MyClassB(MyClassA("sk-1234567890qwertyuiop"))
-    assert dictify(instance) == {
+    nested = MyClassB(MyClassA("sk-1234567890qwertyuiop"))
+    assert dictify(nested) == {
         "__class__": {
             "module": "test_serialize",
-            "qualname": "test_dictify_sanitizes_nested.<locals>.MyClassB",
+            "qualname": "test_dictify_sanitizes.<locals>.MyClassB",
             "name": "MyClassB",
         },
         "a": {
             "__class__": {
                 "module": "test_serialize",
-                "qualname": "test_dictify_sanitizes_nested.<locals>.MyClassA",
+                "qualname": "test_dictify_sanitizes.<locals>.MyClassA",
                 "name": "MyClassA",
             },
             "api_key": "REDACTED",

--- a/tests/trace/test_serialize_encoders.py
+++ b/tests/trace/test_serialize_encoders.py
@@ -12,6 +12,7 @@ higher-priority encoders win when multiple could match — and that the terminal
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, NamedTuple
@@ -41,11 +42,29 @@ PROJECT_ID = "entity/project"
 
 class _ExampleModel(BaseModel):
     """Concrete pydantic subclass. Only used to get an INSTANCE for miss
-    tests — the class itself needs to live at module scope so ``_ExampleModel(x=1)``
+    tests. The class itself needs to live at module scope so `_ExampleModel(x=1)`
     can appear inside a parametrize decorator (evaluated at import time).
     """
 
     x: int
+
+
+# Helper classes for the dictify cases below. They live at module scope (like
+# `_ExampleModel`) so the parametrize factories can reference them at import time.
+class _PlainXY:  # noqa: B903 — plain class intentional (no auto __repr__)
+    def __init__(self, x: int, y: str = "") -> None:
+        self.x = x
+        self.y = y
+
+
+@dataclass
+class _DictifyDataclass:
+    x: int
+
+
+class _CustomRepr:
+    def __repr__(self) -> str:
+        return "CustomFoo"
 
 
 # ---------- _encode_ref ----------
@@ -74,37 +93,38 @@ def test_encode_ref_non_ref_returns_miss(value: Any) -> None:
 # ---------- _encode_object_record ----------
 
 
-def test_encode_object_record_basic() -> None:
-    # The encoder adds "_type" at the top then copies every attribute from
-    # __dict__, which includes the raw "_class_name" as well. Both keys end
-    # up in the payload; downstream code treats "_type" as authoritative.
-    rec = ObjectRecord({"_class_name": "Foo", "x": 1, "y": "hi"})
-    result = _encode_object_record(rec, PROJECT_ID, None, False)
-    assert result == {"_type": "Foo", "_class_name": "Foo", "x": 1, "y": "hi"}
-
-
-def test_encode_object_record_recurses_into_nested_values() -> None:
-    rec = ObjectRecord(
-        {
-            "_class_name": "Foo",
-            "nested_list": [1, 2, 3],
-            "nested_dict": {"k": "v"},
-        }
+def test_encode_object_record_copies_attrs_recurses_and_drops_null_ref() -> None:
+    # "_type" is added at the top, then __dict__ is copied verbatim (so raw
+    # "_class_name" survives; "_type" is authoritative). Nested values recurse,
+    # and a null "ref" is dropped.
+    basic = _encode_object_record(
+        ObjectRecord({"_class_name": "Foo", "x": 1, "y": "hi"}), PROJECT_ID, None, False
     )
-    result = _encode_object_record(rec, PROJECT_ID, None, False)
-    assert result == {
+    assert basic == {"_type": "Foo", "_class_name": "Foo", "x": 1, "y": "hi"}
+
+    nested = _encode_object_record(
+        ObjectRecord(
+            {"_class_name": "Foo", "nested_list": [1, 2, 3], "nested_dict": {"k": "v"}}
+        ),
+        PROJECT_ID,
+        None,
+        False,
+    )
+    assert nested == {
         "_type": "Foo",
         "_class_name": "Foo",
         "nested_list": [1, 2, 3],
         "nested_dict": {"k": "v"},
     }
 
-
-def test_encode_object_record_drops_null_ref() -> None:
-    rec = ObjectRecord({"_class_name": "Foo", "ref": None, "x": 1})
-    result = _encode_object_record(rec, PROJECT_ID, None, False)
-    assert "ref" not in result
-    assert result == {"_type": "Foo", "_class_name": "Foo", "x": 1}
+    dropped = _encode_object_record(
+        ObjectRecord({"_class_name": "Foo", "ref": None, "x": 1}),
+        PROJECT_ID,
+        None,
+        False,
+    )
+    assert "ref" not in dropped
+    assert dropped == {"_type": "Foo", "_class_name": "Foo", "x": 1}
 
 
 def test_encode_object_record_logs_on_non_null_ref(
@@ -228,24 +248,21 @@ def test_encode_primitive_non_primitive_returns_miss(value: Any) -> None:
 # ---------- _encode_weave_scorer_result ----------
 
 
-def test_encode_weave_scorer_result_basic() -> None:
-    result = WeaveScorerResult(passed=True, metadata={"score": 0.9})
-    encoded = _encode_weave_scorer_result(result, PROJECT_ID, None, False)
-    assert encoded == {"passed": True, "metadata": {"score": 0.9}}
-
-
-def test_encode_weave_scorer_result_recurses_into_metadata() -> None:
-    # Metadata values are recursively encoded via to_json — nested containers
-    # should flatten through the ladder.
-    result = WeaveScorerResult(
-        passed=False,
-        metadata={"list": [1, 2], "dict": {"a": 1}},
+def test_encode_weave_scorer_result_basic_and_recurses_into_metadata() -> None:
+    # Encodes to a plain {passed, metadata} dict; metadata values recurse
+    # through to_json so nested containers flatten through the ladder.
+    basic = _encode_weave_scorer_result(
+        WeaveScorerResult(passed=True, metadata={"score": 0.9}), PROJECT_ID, None, False
     )
-    encoded = _encode_weave_scorer_result(result, PROJECT_ID, None, False)
-    assert encoded == {
-        "passed": False,
-        "metadata": {"list": [1, 2], "dict": {"a": 1}},
-    }
+    assert basic == {"passed": True, "metadata": {"score": 0.9}}
+
+    recursed = _encode_weave_scorer_result(
+        WeaveScorerResult(passed=False, metadata={"list": [1, 2], "dict": {"a": 1}}),
+        PROJECT_ID,
+        None,
+        False,
+    )
+    assert recursed == {"passed": False, "metadata": {"list": [1, 2], "dict": {"a": 1}}}
 
 
 @pytest.mark.parametrize(
@@ -282,42 +299,32 @@ def test_encode_custom_obj_unregistered_returns_miss() -> None:
 
 
 def test_encode_dictify_with_flag_scans_attributes() -> None:
-    # Dataclasses generate __repr__ which trips has_custom_repr — must use
-    # a plain class so dictify actually runs.
-    class Foo:  # noqa: B903 — plain class intentional (see comment above)
-        def __init__(self, x: int, y: str) -> None:
-            self.x = x
-            self.y = y
-
-    result = _encode_dictify(Foo(1, "hi"), PROJECT_ID, None, True)
+    # Plain class (no auto __repr__) so dictify actually runs.
+    result = _encode_dictify(_PlainXY(1, "hi"), PROJECT_ID, None, True)
     assert result is not _MISS
     assert result["x"] == 1
     assert result["y"] == "hi"
     assert "__class__" in result
 
 
-def test_encode_dictify_without_flag_returns_miss() -> None:
-    class Foo:  # noqa: B903 — plain class intentional
-        def __init__(self, x: int) -> None:
-            self.x = x
-
-    assert _encode_dictify(Foo(1), PROJECT_ID, None, False) is _MISS
-
-
-def test_encode_dictify_dataclass_returns_miss_due_to_custom_repr() -> None:
-    # Dataclasses auto-generate __repr__, which opts them out of the dictify
-    # fallback (assumption: the repr is the intended human form).
-    @dataclass
-    class Foo:
-        x: int
-
-    assert _encode_dictify(Foo(1), PROJECT_ID, None, True) is _MISS
-
-
-def test_encode_dictify_logger_returns_miss() -> None:
-    # Loggers are in ALWAYS_STRINGIFY — recursing attributes causes problems.
-    logger = logging.getLogger("test_encoder")
-    assert _encode_dictify(logger, PROJECT_ID, None, True) is _MISS
+@pytest.mark.parametrize(
+    ("make", "use_dictify"),
+    [
+        # Plain dictifiable class, but the flag is off -> miss.
+        (lambda: _PlainXY(1, "z"), False),
+        # Dataclass auto-__repr__ opts out of dictify (repr is the human form).
+        (lambda: _DictifyDataclass(1), True),
+        # Loggers are in ALWAYS_STRINGIFY; recursing attributes causes problems.
+        (lambda: logging.getLogger("test_encoder"), True),
+        # Custom __repr__ is assumed sensible; dictify would be redundant.
+        (_CustomRepr, True),
+    ],
+    ids=["flag-off", "dataclass-repr", "logger", "custom-repr"],
+)
+def test_encode_dictify_returns_miss(
+    make: Callable[[], object], use_dictify: bool
+) -> None:
+    assert _encode_dictify(make(), PROJECT_ID, None, use_dictify) is _MISS
 
 
 def test_encode_dictify_coroutine_returns_miss() -> None:
@@ -329,16 +336,6 @@ def test_encode_dictify_coroutine_returns_miss() -> None:
         assert _encode_dictify(c, PROJECT_ID, None, True) is _MISS
     finally:
         c.close()
-
-
-def test_encode_dictify_custom_repr_returns_miss() -> None:
-    # Objects with a custom __repr__ are assumed to have a sensible string
-    # form; dictify would be redundant or lossy.
-    class Foo:
-        def __repr__(self) -> str:
-            return "CustomFoo"
-
-    assert _encode_dictify(Foo(), PROJECT_ID, None, True) is _MISS
 
 
 # ---------- _encode_try_to_dict ----------
@@ -397,13 +394,20 @@ def test_to_json_pydantic_class_emits_schema_not_stringified(
     assert "properties" in result
 
 
-def test_to_json_primitive_passes_through() -> None:
-    # Primitives skip the custom-obj registry entirely — no client required.
+def test_to_json_primitive_and_scorer_pass_through_without_client() -> None:
+    # Primitives skip the custom-obj registry entirely; WeaveScorerResult
+    # round-trips as a plain dict (no CustomWeaveType wrapper). Neither needs
+    # a client, pinning the no-client fast paths through the ladder.
     assert to_json(42, PROJECT_ID, None) == 42
     assert to_json(3.14, PROJECT_ID, None) == 3.14
     assert to_json("hi", PROJECT_ID, None) == "hi"
     assert to_json(True, PROJECT_ID, None) is True
     assert to_json(None, PROJECT_ID, None) is None
+    scorer = WeaveScorerResult(passed=True, metadata={"score": 1.0})
+    assert to_json(scorer, PROJECT_ID, None) == {
+        "passed": True,
+        "metadata": {"score": 1.0},
+    }
 
 
 def test_to_json_container_recurses(client: Any) -> None:
@@ -426,14 +430,6 @@ def test_to_json_object_record_recurses_values(client: Any) -> None:
         "nested": [1, 2, 3],
         "obj": {"a": 1},
     }
-
-
-def test_to_json_weave_scorer_result_emits_plain_dict() -> None:
-    # WeaveScorerResult round-trips as a plain dict (no CustomWeaveType
-    # wrapper) — this is the wire contract the encoder preserves.
-    result = WeaveScorerResult(passed=True, metadata={"score": 1.0})
-    encoded = to_json(result, PROJECT_ID, None)
-    assert encoded == {"passed": True, "metadata": {"score": 1.0}}
 
 
 def test_to_json_custom_obj_datetime_roundtrips_via_registry(client: Any) -> None:

--- a/tests/trace/test_server_file_storage.py
+++ b/tests/trace/test_server_file_storage.py
@@ -1,8 +1,8 @@
 """Tests for file storage implementations (S3, GCS, Azure Blob).
 
-This module tests the different cloud storage backends used for file storage.
-Each storage implementation is tested with similar patterns but with their
-specific setup requirements.
+Each cloud backend is tested with a similar store-then-read pattern, plus the
+write-once (no-overwrite) contract and the call_batch fan-out path. Only the
+cloud SDKs are mocked (external services); the trace server runs for real.
 """
 
 import base64
@@ -20,370 +20,201 @@ from weave.trace.weave_client import WeaveClient
 from weave.trace_server import clickhouse_trace_server_settings
 from weave.trace_server.trace_server_interface import FileContentReadReq, FileCreateReq
 
-# Test Data Constants
 TEST_CONTENT = b"Hello, world!"
 TEST_BUCKET = "test-bucket"
 
 
-@pytest.fixture
-def run_storage_test(client: WeaveClient):
-    """Shared test runner for all storage implementations."""
+@pytest.mark.usefixtures("aws_storage_env")
+def test_aws_storage(run_storage_test, s3):
+    """File storage round-trips through AWS S3 and the object lands in the bucket."""
+    res = run_storage_test()
 
-    def _run_test():
-        # Create a new trace
+    response = s3.list_objects_v2(Bucket=TEST_BUCKET)
+    assert "Contents" in response
+    assert len(response["Contents"]) == 1
+
+    obj = response["Contents"][0]
+    obj_response = s3.get_object(Bucket=TEST_BUCKET, Key=obj["Key"])
+    assert obj_response["Body"].read() == TEST_CONTENT
+
+
+def test_large_file_migration(s3, client: WeaveClient):
+    """Large files read back identically with storage disabled, enabled, then
+    disabled again, yielding a stable digest across the migration.
+    """
+    chunk_size = 100000
+    num_chunks = 3
+    file_part = b"1234567890"
+    large_file = file_part * (chunk_size * num_chunks // len(file_part))
+
+    def _run_single_test():
         res = client.server.file_create(
             FileCreateReq(
-                project_id=client.project_id,
-                name="test.txt",
-                content=TEST_CONTENT,
+                project_id=client.project_id, name="test.txt", content=large_file
             )
         )
         assert res.digest is not None
         assert res.digest != ""
-
-        # Get the file
         file = client.server.file_content_read(
             FileContentReadReq(project_id=client.project_id, digest=res.digest)
         )
-        assert file.content == TEST_CONTENT
-        return res
+        assert file.content == large_file
+        return res.digest
 
-    return _run_test
-
-
-class TestS3Storage:
-    """Tests for AWS S3 storage implementation."""
-
-    @pytest.fixture
-    def s3(self):
-        """Moto S3 mock that implements the S3 API."""
-        with mock_aws():
-            s3_client = boto3.client(
-                "s3",
-                aws_access_key_id="test-key",
-                aws_secret_access_key="test-secret",
-                region_name="us-east-1",
-            )
-            s3_client.create_bucket(Bucket=TEST_BUCKET)
-            yield s3_client
-
-    @pytest.fixture
-    def aws_storage_env(self):
-        """Setup AWS storage environment."""
-        with mock.patch.dict(
-            os.environ,
-            {
-                "WF_FILE_STORAGE_AWS_ACCESS_KEY_ID": "test-key",
-                "WF_FILE_STORAGE_AWS_SECRET_ACCESS_KEY": "test-secret",
-                "WF_FILE_STORAGE_URI": f"s3://{TEST_BUCKET}",
-                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "c2hhd24vdGVzdC1wcm9qZWN0",
-            },
-        ):
-            yield
-
-    @pytest.mark.usefixtures("aws_storage_env")
-    def test_aws_storage(self, run_storage_test, s3):
-        """Test file storage using AWS S3."""
-        res = run_storage_test()
-
-        # Verify the object exists in S3
-        response = s3.list_objects_v2(Bucket=TEST_BUCKET)
-        assert "Contents" in response
-        assert len(response["Contents"]) == 1
-
-        # Verify content
-        obj = response["Contents"][0]
-        obj_response = s3.get_object(Bucket=TEST_BUCKET, Key=obj["Key"])
-        assert obj_response["Body"].read() == TEST_CONTENT
-
-    def test_large_file_migration(self, run_storage_test, s3, client: WeaveClient):
-        # This test is critical in that it ensures that the system works correctly for large files. Both
-        # before and after the migration to file storage, we should be able to read the file correctly.
-        def _run_single_test():
-            chunk_size = 100000
-            num_chunks = 3
-            file_part = b"1234567890"
-            large_file = file_part * (chunk_size * num_chunks // len(file_part))
-
-            # Create a new trace
-            res = client.server.file_create(
-                FileCreateReq(
-                    project_id=client.project_id,
-                    name="test.txt",
-                    content=large_file,
-                )
-            )
-            assert res.digest is not None
-            assert res.digest != ""
-
-            # Get the file
-            file = client.server.file_content_read(
-                FileContentReadReq(project_id=client.project_id, digest=res.digest)
-            )
-            assert file.content == large_file
-            return res.digest
-
-        def _run_test():
-            # Run with disabled storage:
-            d1 = _run_single_test()
-            # Now "enable" bucket storage:
-            with mock.patch.dict(
-                os.environ,
-                {
-                    "WF_FILE_STORAGE_AWS_ACCESS_KEY_ID": "test-key",
-                    "WF_FILE_STORAGE_AWS_SECRET_ACCESS_KEY": "test-secret",
-                    "WF_FILE_STORAGE_URI": f"s3://{TEST_BUCKET}",
-                    "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "c2hhd24vdGVzdC1wcm9qZWN0",
-                },
-            ):
-                # This line would error before the fix
-                d2 = _run_single_test()
-            # Run again with disabled storage:
-            d3 = _run_single_test()
-            assert d1 == d2 == d3
-
-        _run_test()
+    d1 = _run_single_test()
+    with mock.patch.dict(
+        os.environ,
+        {
+            "WF_FILE_STORAGE_AWS_ACCESS_KEY_ID": "test-key",
+            "WF_FILE_STORAGE_AWS_SECRET_ACCESS_KEY": "test-secret",
+            "WF_FILE_STORAGE_URI": f"s3://{TEST_BUCKET}",
+            "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "c2hhd24vdGVzdC1wcm9qZWN0",
+        },
+    ):
+        d2 = _run_single_test()
+    d3 = _run_single_test()
+    assert d1 == d2 == d3
 
 
-class TestGCSStorage:
-    """Tests for Google Cloud Storage implementation.
+@pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
+def test_gcp_storage(run_storage_test, gcs, client: WeaveClient):
+    """File storage round-trips through Google Cloud Storage under the b64 project key."""
+    res = run_storage_test()
 
-    `gcs`, `gcp_storage_env`, and `mock_gcp_credentials` live in
-    `tests/trace/conftest.py` so other suites in the package can drive the
-    bucket write path without copy-pasting the SDK mock.
+    project_b64 = base64.b64encode(client.project_id.encode()).decode()
+    expected_key = f"weave/projects/{project_b64}/files/{res.digest}"
+    assert gcs.state.blob_data[expected_key] == TEST_CONTENT
+    assert gcs.state.upload_count == 1
+
+
+@pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
+def test_gcp_storage_skips_duplicate_write(client: WeaveClient):
+    """The if_generation_match=0 conditional write skips a second write of identical
+    content, returning the same digest and remaining readable.
     """
+    upload_count = 0
+    blob_data = {}
 
-    @pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
-    def test_gcp_storage(self, run_storage_test, gcs, client: WeaveClient):
-        """Test file storage using Google Cloud Storage."""
-        res = run_storage_test()
+    def mock_upload_from_string(data, timeout=None, if_generation_match=None, **kwargs):
+        nonlocal upload_count
+        blob_name = mock_blob.name
+        if if_generation_match == 0 and blob_name in blob_data:
+            raise exceptions.PreconditionFailed("Object already exists")
+        upload_count += 1
+        blob_data[blob_name] = data
 
-        # GCS path uses the base64-encoded project_id (matches azure test).
-        project_b64 = base64.b64encode(client.project_id.encode()).decode()
-        expected_key = f"weave/projects/{project_b64}/files/{res.digest}"
-        assert gcs.state.blob_data[expected_key] == TEST_CONTENT
-        assert gcs.state.upload_count == 1
+    def mock_download_as_bytes(timeout=None, **kwargs):
+        return blob_data.get(mock_blob.name, b"")
 
-    @pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
-    def test_gcp_storage_skips_duplicate_write(self, client: WeaveClient):
-        """Test that writing the same content twice skips the second write.
+    mock_storage_client = mock.MagicMock()
+    mock_bucket = mock.MagicMock()
+    mock_blob = mock.MagicMock()
+    mock_storage_client.bucket.return_value = mock_bucket
+    mock_bucket.blob.return_value = mock_blob
+    mock_blob.upload_from_string.side_effect = mock_upload_from_string
+    mock_blob.download_as_bytes.side_effect = mock_download_as_bytes
 
-        This verifies the if_generation_match=0 conditional write works correctly
-        to prevent GCS rate limiting when multiple pods write the same object.
-        """
-        upload_count = 0
-        blob_data = {}
-
-        def mock_upload_from_string(
-            data, timeout=None, if_generation_match=None, **kwargs
-        ):
-            nonlocal upload_count
-            blob_name = mock_blob.name
-
-            # Simulate GCS behavior: if_generation_match=0 means only write if not exists
-            if if_generation_match == 0 and blob_name in blob_data:
-                raise exceptions.PreconditionFailed("Object already exists")
-
-            upload_count += 1
-            blob_data[blob_name] = data
-
-        def mock_download_as_bytes(timeout=None, **kwargs):
-            blob_name = mock_blob.name
-            return blob_data.get(blob_name, b"")
-
-        mock_storage_client = mock.MagicMock()
-        mock_bucket = mock.MagicMock()
-        mock_blob = mock.MagicMock()
-
-        mock_storage_client.bucket.return_value = mock_bucket
-        mock_bucket.blob.return_value = mock_blob
-        mock_blob.upload_from_string.side_effect = mock_upload_from_string
-        mock_blob.download_as_bytes.side_effect = mock_download_as_bytes
-
-        with mock.patch(
-            "google.cloud.storage.Client", return_value=mock_storage_client
-        ):
-            # First write should succeed
-            res1 = client.server.file_create(
-                FileCreateReq(
-                    project_id=client.project_id,
-                    name="test.txt",
-                    content=TEST_CONTENT,
-                )
+    with mock.patch("google.cloud.storage.Client", return_value=mock_storage_client):
+        res1 = client.server.file_create(
+            FileCreateReq(
+                project_id=client.project_id, name="test.txt", content=TEST_CONTENT
             )
-            assert upload_count == 1
-
-            # Second write with same content should be skipped (no error, no upload)
-            res2 = client.server.file_create(
-                FileCreateReq(
-                    project_id=client.project_id,
-                    name="test.txt",
-                    content=TEST_CONTENT,
-                )
-            )
-            # Should still be 1 - second write was skipped
-            assert upload_count == 1
-            # Both should return the same digest
-            assert res1.digest == res2.digest
-
-            # Verify we can still read the content
-            file = client.server.file_content_read(
-                FileContentReadReq(project_id=client.project_id, digest=res1.digest)
-            )
-            assert file.content == TEST_CONTENT
-
-
-class TestAzureStorage:
-    """Tests for Azure Blob Storage implementation using mocks."""
-
-    @pytest.fixture
-    def azure_blob(self):
-        """Fully mocked Azure Blob Storage client."""
-        mock_service_client = mock.MagicMock()
-        mock_container_client = mock.MagicMock()
-        mock_blob_client = mock.MagicMock()
-
-        mock_service_client.get_container_client.return_value = mock_container_client
-        mock_container_client.get_blob_client.return_value = mock_blob_client
-
-        # In-memory storage for blobs
-        blob_data = {}
-
-        def mock_upload_blob(data, overwrite=False, **kwargs):
-            blob_name = mock_blob_client.blob_name
-            blob_data[blob_name] = data
-
-        def mock_download_blob(**kwargs):
-            blob_name = mock_blob_client.blob_name
-            download = mock.MagicMock()
-            download.readall.return_value = blob_data.get(blob_name, b"")
-            return download
-
-        # Track blob_name through get_blob_client calls
-        def mock_get_blob_client(name):
-            mock_blob_client.blob_name = name
-            return mock_blob_client
-
-        mock_container_client.get_blob_client.side_effect = mock_get_blob_client
-        mock_blob_client.upload_blob.side_effect = mock_upload_blob
-        mock_blob_client.download_blob.side_effect = mock_download_blob
-
-        with mock.patch(
-            "weave.trace_server.file_storage.BlobServiceClient",
-            return_value=mock_service_client,
-        ) as mock_cls:
-            mock_cls.from_connection_string.return_value = mock_service_client
-            yield mock_service_client
-
-    @pytest.fixture
-    def azure_storage_env(self):
-        """Setup Azure storage environment."""
-        with mock.patch.dict(
-            os.environ,
-            {
-                "WF_FILE_STORAGE_AZURE_ACCESS_KEY": "fake-key",
-                "WF_FILE_STORAGE_AZURE_ACCOUNT_URL": "http://fake-account.blob.core.windows.net",
-                "WF_FILE_STORAGE_URI": f"az://fakeaccount/{TEST_BUCKET}",
-                "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "c2hhd24vdGVzdC1wcm9qZWN0",
-            },
-        ):
-            yield
-
-    @pytest.mark.usefixtures("azure_storage_env")
-    def test_azure_storage(self, run_storage_test, azure_blob):
-        """Test file storage using Azure Blob Storage."""
-        res = run_storage_test()
-
-        # Verify upload was called
-        azure_blob.get_container_client.assert_called()
-        container_client = azure_blob.get_container_client(TEST_BUCKET)
-        project = "c2hhd24vdGVzdC1wcm9qZWN0"
-        blob_client = container_client.get_blob_client(
-            f"weave/projects/{project}/files/{res.digest}"
         )
-        assert blob_client.download_blob().readall() == TEST_CONTENT
-
-    @pytest.mark.usefixtures("azure_storage_env")
-    def test_azure_storage_does_not_overwrite_existing_blob(self, client: WeaveClient):
-        """Azure store must not clobber an existing content-addressable blob.
-
-        Mirrors `test_gcp_storage_skips_duplicate_write`. Content-addressable
-        storage is a write-once contract: re-uploading at a known digest must
-        be a no-op, not an overwrite. Otherwise any project with write scope
-        can substitute content at a known URI.
-        """
-        blob_data: dict[str, bytes] = {}
-        upload_calls: list[dict] = []
-
-        mock_service_client = mock.MagicMock()
-        mock_container_client = mock.MagicMock()
-        mock_blob_client = mock.MagicMock()
-        mock_service_client.get_container_client.return_value = mock_container_client
-
-        def mock_get_blob_client(name):
-            mock_blob_client.blob_name = name
-            return mock_blob_client
-
-        def mock_upload_blob(data, overwrite=False, **kwargs):
-            blob_name = mock_blob_client.blob_name
-            upload_calls.append({"name": blob_name, "overwrite": overwrite})
-            # Azure semantics: overwrite=False on an existing blob raises.
-            if blob_name in blob_data and not overwrite:
-                raise ResourceExistsError("blob already exists")
-            blob_data[blob_name] = data
-
-        def mock_download_blob(**kwargs):
-            blob_name = mock_blob_client.blob_name
-            download = mock.MagicMock()
-            download.readall.return_value = blob_data.get(blob_name, b"")
-            return download
-
-        mock_container_client.get_blob_client.side_effect = mock_get_blob_client
-        mock_blob_client.upload_blob.side_effect = mock_upload_blob
-        mock_blob_client.download_blob.side_effect = mock_download_blob
-
-        original = b"original-content"
-
-        with mock.patch(
-            "weave.trace_server.file_storage.BlobServiceClient",
-            return_value=mock_service_client,
-        ) as mock_cls:
-            mock_cls.from_connection_string.return_value = mock_service_client
-
-            res1 = client.server.file_create(
-                FileCreateReq(
-                    project_id=client.project_id,
-                    name="test.txt",
-                    content=original,
-                )
+        assert upload_count == 1
+        res2 = client.server.file_create(
+            FileCreateReq(
+                project_id=client.project_id, name="test.txt", content=TEST_CONTENT
             )
-            res2 = client.server.file_create(
-                FileCreateReq(
-                    project_id=client.project_id,
-                    name="test.txt",
-                    content=original,
-                )
-            )
+        )
+        assert upload_count == 1
+        assert res1.digest == res2.digest
 
-            assert res1.digest == res2.digest
-            assert upload_calls, "upload_blob was never invoked"
-            assert all(call["overwrite"] is False for call in upload_calls), (
-                f"upload_blob called with overwrite=True: {upload_calls}"
-            )
+        file = client.server.file_content_read(
+            FileContentReadReq(project_id=client.project_id, digest=res1.digest)
+        )
+        assert file.content == TEST_CONTENT
 
-            stored = blob_data[next(iter(blob_data))]
-            assert stored == original
 
-            file = client.server.file_content_read(
-                FileContentReadReq(project_id=client.project_id, digest=res1.digest)
+@pytest.mark.usefixtures("azure_storage_env")
+def test_azure_storage(run_storage_test, azure_blob):
+    """File storage round-trips through Azure Blob Storage under the b64 project key."""
+    res = run_storage_test()
+
+    azure_blob.get_container_client.assert_called()
+    container_client = azure_blob.get_container_client(TEST_BUCKET)
+    project = "c2hhd24vdGVzdC1wcm9qZWN0"
+    blob_client = container_client.get_blob_client(
+        f"weave/projects/{project}/files/{res.digest}"
+    )
+    assert blob_client.download_blob().readall() == TEST_CONTENT
+
+
+@pytest.mark.usefixtures("azure_storage_env")
+def test_azure_storage_does_not_overwrite_existing_blob(client: WeaveClient):
+    """Content-addressable storage is write-once: re-uploading at a known digest is a
+    no-op (overwrite=False), so a write-scoped project cannot substitute content.
+    """
+    blob_data: dict[str, bytes] = {}
+    upload_calls: list[dict] = []
+
+    mock_service_client = mock.MagicMock()
+    mock_container_client = mock.MagicMock()
+    mock_blob_client = mock.MagicMock()
+    mock_service_client.get_container_client.return_value = mock_container_client
+
+    def mock_get_blob_client(name):
+        mock_blob_client.blob_name = name
+        return mock_blob_client
+
+    def mock_upload_blob(data, overwrite=False, **kwargs):
+        blob_name = mock_blob_client.blob_name
+        upload_calls.append({"name": blob_name, "overwrite": overwrite})
+        if blob_name in blob_data and not overwrite:
+            raise ResourceExistsError("blob already exists")
+        blob_data[blob_name] = data
+
+    def mock_download_blob(**kwargs):
+        download = mock.MagicMock()
+        download.readall.return_value = blob_data.get(mock_blob_client.blob_name, b"")
+        return download
+
+    mock_container_client.get_blob_client.side_effect = mock_get_blob_client
+    mock_blob_client.upload_blob.side_effect = mock_upload_blob
+    mock_blob_client.download_blob.side_effect = mock_download_blob
+
+    original = b"original-content"
+    with mock.patch(
+        "weave.trace_server.file_storage.BlobServiceClient",
+        return_value=mock_service_client,
+    ) as mock_cls:
+        mock_cls.from_connection_string.return_value = mock_service_client
+
+        res1 = client.server.file_create(
+            FileCreateReq(
+                project_id=client.project_id, name="test.txt", content=original
             )
-            assert file.content == original
+        )
+        res2 = client.server.file_create(
+            FileCreateReq(
+                project_id=client.project_id, name="test.txt", content=original
+            )
+        )
+        assert res1.digest == res2.digest
+        assert upload_calls, "upload_blob was never invoked"
+        assert all(call["overwrite"] is False for call in upload_calls), (
+            f"upload_blob called with overwrite=True: {upload_calls}"
+        )
+        stored = blob_data[next(iter(blob_data))]
+        assert stored == original
+
+        file = client.server.file_content_read(
+            FileContentReadReq(project_id=client.project_id, digest=res1.digest)
+        )
+        assert file.content == original
 
 
 def test_support_for_variable_length_chunks(client: WeaveClient):
-    """Test that the system supports variable length chunks.
-    We don't actually want to change this often, but we need to make sure it works.
-    """
+    """File read-back is stable across a range of increasing and decreasing chunk sizes."""
 
     def create_and_read_file(content: bytes):
         res = client.server.file_create(
@@ -393,12 +224,10 @@ def test_support_for_variable_length_chunks(client: WeaveClient):
         )
         assert res.digest is not None
         assert res.digest != ""
-
         file = client.server.file_content_read(
             FileContentReadReq(project_id=client.project_id, digest=res.digest)
         )
         assert file.content == content
-
         return res.digest
 
     base_chunk_size = 100000
@@ -407,7 +236,6 @@ def test_support_for_variable_length_chunks(client: WeaveClient):
     large_file = file_part * (base_chunk_size * num_chunks // len(file_part))
     large_digest = create_and_read_file(large_file)
 
-    #  Test increasing and decreasing chunk sizes
     for size in [
         base_chunk_size,
         2 * base_chunk_size,
@@ -419,21 +247,17 @@ def test_support_for_variable_length_chunks(client: WeaveClient):
         with mock.patch.object(
             clickhouse_trace_server_settings, "FILE_CHUNK_SIZE", size
         ):
-            digest = create_and_read_file(large_file)
-            assert digest == large_digest
+            assert create_and_read_file(large_file) == large_digest
 
 
 @pytest.mark.disable_logging_error_check
 def test_file_storage_retry_limit(client: WeaveClient):
-    """Test that file storage operations retry exactly 3 times on storage failures."""
+    """File storage retries a 429 exactly 3 times, then falls back to database storage."""
     attempt_count = 0
 
     def mock_upload_fail(*args, **kwargs):
         nonlocal attempt_count
         attempt_count += 1
-        # Simulate a 429 rate limit error
-        from google.api_core import exceptions
-
         raise exceptions.TooManyRequests("Rate limit exceeded")
 
     with mock.patch.dict(
@@ -455,12 +279,9 @@ def test_file_storage_retry_limit(client: WeaveClient):
             "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "*",
         },
     ):
-        # Mock GCS client
         mock_storage_client = mock.MagicMock()
         mock_bucket = mock.MagicMock()
         mock_blob = mock.MagicMock()
-
-        # Setup mock chain
         mock_storage_client.bucket.return_value = mock_bucket
         mock_bucket.blob.return_value = mock_blob
         mock_blob.upload_from_string.side_effect = mock_upload_fail
@@ -471,55 +292,31 @@ def test_file_storage_retry_limit(client: WeaveClient):
                 "google.oauth2.service_account.Credentials.from_service_account_info"
             ),
         ):
-            # GCS should fail after 3 attempts, then fall back to database storage
             result = client.server.file_create(
                 FileCreateReq(
-                    project_id=client.project_id,
-                    name="test.txt",
-                    content=TEST_CONTENT,
+                    project_id=client.project_id, name="test.txt", content=TEST_CONTENT
                 )
             )
-            # Should succeed via database fallback
             assert result.digest is not None
 
-        # Verify GCS was attempted exactly 3 times before fallback
         assert attempt_count == 3, f"Expected 3 GCS attempts, got {attempt_count}"
-
-
-# ---------------------------------------------------------------------------
-# Parallel bucket-upload fan-out during call_batch
-# ---------------------------------------------------------------------------
-#
-# These drive the trace server's bucket-storage path with the shared `gcs`
-# fixture (mocked at `google.cloud.storage.Client`). Multiple `file_create`
-# calls inside one `call_batch()` context should stage and then fan out to
-# GCS in parallel on context exit.
-
-
-def _unique_payload(unique: str, size: int) -> bytes:
-    """Build a deterministic, unique payload of the requested size."""
-    body = (unique + "_" + ("x" * size)).encode()
-    return body
 
 
 @pytest.mark.usefixtures("gcp_storage_env", "mock_gcp_credentials")
 @pytest.mark.disable_logging_error_check
 def test_call_batch_uploads_files_to_bucket_in_parallel(client: WeaveClient, gcs):
-    """Multiple file_create calls inside one call_batch fan out to GCS in
-    parallel: concurrent uploads happen, identical content within the batch
-    collapses to one upload, and every stored object lands under the
-    expected project prefix.
+    """file_create calls inside one call_batch fan out to GCS in parallel, identical
+    content collapses to one upload, and every object lands under the project prefix.
     """
     gcs.state.delay = 0.1
-    # 4 unique blobs + 2 duplicates of the first => 4 GCS uploads after dedup.
     payload_size = 50_000
     payloads = [
         _unique_payload("alpha", payload_size),
         _unique_payload("beta", payload_size),
         _unique_payload("gamma", payload_size),
         _unique_payload("delta", payload_size),
-        _unique_payload("alpha", payload_size),  # dup
-        _unique_payload("alpha", payload_size),  # dup
+        _unique_payload("alpha", payload_size),
+        _unique_payload("alpha", payload_size),
     ]
     server = client.server
 
@@ -531,14 +328,11 @@ def test_call_batch_uploads_files_to_bucket_in_parallel(client: WeaveClient, gcs
                 )
             )
 
-    # Pool defaults to 8 workers, so all 4 unique uploads should run
-    # concurrently. concurrent_peak is the load-bearing parallelism signal;
-    # wall-time assertions on top would flake on contended CI runners.
+    # concurrent_peak is the load-bearing parallelism signal; wall-time assertions
+    # would flake on contended CI runners.
     assert gcs.state.concurrent_peak >= 4, (
         f"expected 4 concurrent uploads, peak={gcs.state.concurrent_peak}"
     )
-
-    # Dedup: 4 unique blobs => 4 GCS uploads, not 6.
     assert gcs.state.upload_count == 4
     project_b64 = base64.b64encode(client.project_id.encode()).decode()
     expected_prefix = f"weave/projects/{project_b64}/files/"
@@ -549,33 +343,21 @@ def test_call_batch_uploads_files_to_bucket_in_parallel(client: WeaveClient, gcs
 @pytest.mark.disable_logging_error_check
 @pytest.mark.parametrize(
     "fail_payload_size",
-    [
-        # Single inline-CH chunk fallback (< FILE_CHUNK_SIZE = 100_000).
-        50_000,
-        # Multi-chunk fallback: 250KB content splits into 3 inline-CH chunks,
-        # exercising the chunk_index / n_chunks reassembly on read.
-        250_000,
-    ],
+    [50_000, 250_000],
     ids=["single-chunk-fallback", "multi-chunk-fallback"],
 )
 def test_call_batch_falls_back_to_clickhouse_on_per_file_bucket_failure(
     client: WeaveClient, gcs, fail_payload_size: int
 ):
-    """When one upload in a batch hits a non-retriable GCS error, the server
-    should fall back to inline ClickHouse chunks for that file only; other
-    uploads in the same batch keep their bucket URIs, and the whole batch
-    still completes. We verify by reading the failed file back through the
-    server's read path -- it must reassemble bit-for-bit from CH chunks for
-    both single-chunk and multi-chunk payloads.
+    """When one upload in a batch hits a non-retriable GCS error, that file falls back
+    to inline ClickHouse chunks while the others keep bucket URIs; the failed file
+    reassembles bit-for-bit on read for single- and multi-chunk payloads.
     """
     server = client.server
     project_b64 = base64.b64encode(client.project_id.encode()).decode()
 
-    # Compute the digest directly so the only `files` row at
-    # (project, digest, chunk_index=0) comes from the in-batch fallback.
-    # Doing a probe file_create first would write a bucket-URI row with the
-    # same primary key, and the read query's row_number() pick across two
-    # rows at the same key is non-deterministic.
+    # Compute the digest directly so the only `files` row at chunk_index=0 comes
+    # from the in-batch fallback (a probe file_create would race the read query).
     fail_payload = _unique_payload("fail", fail_payload_size)
     fail_digest = compute_file_digest(fail_payload)
     fail_key = f"weave/projects/{project_b64}/files/{fail_digest}"
@@ -594,17 +376,115 @@ def test_call_batch_falls_back_to_clickhouse_on_per_file_bucket_failure(
             )
         )
 
-    # The successful upload made it through.
     assert any(
         k.startswith(f"weave/projects/{project_b64}/files/")
         for k in gcs.state.blob_data
     )
-    # The failing one is not present in the bucket.
     assert fail_key not in gcs.state.blob_data
-    # ...but is readable via the server, because it landed as inline chunks.
-    # For multi-chunk payloads, byte-equality here implicitly verifies that
-    # all chunk_index rows reassembled correctly.
     fallback_read = server.file_content_read(
         FileContentReadReq(project_id=client.project_id, digest=fail_digest)
     )
     assert fallback_read.content == fail_payload
+
+
+@pytest.fixture
+def run_storage_test(client: WeaveClient):
+    """Store TEST_CONTENT and read it back, asserting the digest round-trips."""
+
+    def _run_test():
+        res = client.server.file_create(
+            FileCreateReq(
+                project_id=client.project_id, name="test.txt", content=TEST_CONTENT
+            )
+        )
+        assert res.digest is not None
+        assert res.digest != ""
+        file = client.server.file_content_read(
+            FileContentReadReq(project_id=client.project_id, digest=res.digest)
+        )
+        assert file.content == TEST_CONTENT
+        return res
+
+    return _run_test
+
+
+@pytest.fixture
+def s3():
+    """Moto S3 mock implementing the S3 API with TEST_BUCKET created."""
+    with mock_aws():
+        s3_client = boto3.client(
+            "s3",
+            aws_access_key_id="test-key",
+            aws_secret_access_key="test-secret",
+            region_name="us-east-1",
+        )
+        s3_client.create_bucket(Bucket=TEST_BUCKET)
+        yield s3_client
+
+
+@pytest.fixture
+def aws_storage_env():
+    with mock.patch.dict(
+        os.environ,
+        {
+            "WF_FILE_STORAGE_AWS_ACCESS_KEY_ID": "test-key",
+            "WF_FILE_STORAGE_AWS_SECRET_ACCESS_KEY": "test-secret",
+            "WF_FILE_STORAGE_URI": f"s3://{TEST_BUCKET}",
+            "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "c2hhd24vdGVzdC1wcm9qZWN0",
+        },
+    ):
+        yield
+
+
+@pytest.fixture
+def azure_blob():
+    """Fully mocked Azure Blob Storage client backed by an in-memory dict."""
+    mock_service_client = mock.MagicMock()
+    mock_container_client = mock.MagicMock()
+    mock_blob_client = mock.MagicMock()
+    mock_service_client.get_container_client.return_value = mock_container_client
+    mock_container_client.get_blob_client.return_value = mock_blob_client
+
+    blob_data = {}
+
+    def mock_upload_blob(data, overwrite=False, **kwargs):
+        blob_data[mock_blob_client.blob_name] = data
+
+    def mock_download_blob(**kwargs):
+        download = mock.MagicMock()
+        download.readall.return_value = blob_data.get(mock_blob_client.blob_name, b"")
+        return download
+
+    def mock_get_blob_client(name):
+        mock_blob_client.blob_name = name
+        return mock_blob_client
+
+    mock_container_client.get_blob_client.side_effect = mock_get_blob_client
+    mock_blob_client.upload_blob.side_effect = mock_upload_blob
+    mock_blob_client.download_blob.side_effect = mock_download_blob
+
+    with mock.patch(
+        "weave.trace_server.file_storage.BlobServiceClient",
+        return_value=mock_service_client,
+    ) as mock_cls:
+        mock_cls.from_connection_string.return_value = mock_service_client
+        yield mock_service_client
+
+
+@pytest.fixture
+def azure_storage_env():
+    with mock.patch.dict(
+        os.environ,
+        {
+            "WF_FILE_STORAGE_AZURE_ACCESS_KEY": "fake-key",
+            "WF_FILE_STORAGE_AZURE_ACCOUNT_URL": "http://fake-account.blob.core.windows.net",
+            "WF_FILE_STORAGE_URI": f"az://fakeaccount/{TEST_BUCKET}",
+            "WF_FILE_STORAGE_PROJECT_ALLOW_LIST": "c2hhd24vdGVzdC1wcm9qZWN0",
+        },
+    ):
+        yield
+
+
+def _unique_payload(unique: str, size: int) -> bytes:
+    """Build a deterministic, unique payload of the requested size."""
+    return (unique + "_" + ("x" * size)).encode()

--- a/tests/trace/test_server_object_creation_utils.py
+++ b/tests/trace/test_server_object_creation_utils.py
@@ -201,45 +201,32 @@ def test_helper_serializes_evaluation_same_way_as_sdk(client: WeaveClient) -> No
     assert helper_val == sdk_val
 
 
-def test_make_safe_name_with_angle_brackets() -> None:
-    """Test that make_safe_name correctly handles angle bracket characters.
+def test_make_safe_name() -> None:
+    r"""make_safe_name strips every character invalid for object names.
 
-    Tests various positions of < and > characters and verifies that ops can be
-    successfully created with the sanitized names.
+    The object name validator only allows [\\w._-] (alphanumeric, underscore,
+    dot, dash). Angle brackets are removed (and ops can be created with the
+    sanitized name); other invalid chars are stripped or mapped to underscores.
     """
-    # Test cases with angle brackets in different positions
-    # All should sanitize to "opname" after removing < and >
-    test_cases = [
+    # Angle brackets in any position sanitize to "opname", and the op builds.
+    for test_input in (
         "<opname",
         "opname>",
         "<opname>",
         "op<name",
         "op>name",
         "op<>name",
-    ]
-
-    for test_input in test_cases:
-        # Apply make_safe_name to sanitize the input
+    ):
         safe_name = object_creation_utils.make_safe_name(test_input)
 
-        # Create an op with the safe name and verify it succeeds without error
         @weave.op(name=safe_name)
         def test_op(x: int) -> int:
             return x + 1
 
-        # Verify the op was successfully created
         assert test_op.name == "opname", (
             f"Op creation failed for input '{test_input}': got name '{test_op.name}'"
         )
 
-
-def test_make_safe_name_strips_all_invalid_characters() -> None:
-    r"""Test that make_safe_name strips all characters invalid for object names.
-
-    The object name validator only allows [\\w._-] (alphanumeric, underscore,
-    dot, dash). make_safe_name must strip everything else so that downstream
-    validation never rejects a sanitized name.
-    """
     # Characters that previously slipped through and caused InvalidFieldError
     assert object_creation_utils.make_safe_name("prefix:suffix") == "prefixsuffix"
     assert object_creation_utils.make_safe_name("base64data==end") == "base64dataend"

--- a/tests/trace/test_table_query.py
+++ b/tests/trace/test_table_query.py
@@ -6,8 +6,253 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.common_interface import SortBy
 
 
+def test_table_query_and_stream(client: WeaveClient):
+    """table_query and table_query_stream return the same rows, digests, and indices."""
+    digest, row_digests, data = generate_table_data(client, 10, 10)
+
+    res = client.server.table_query(
+        tsi.TableQueryReq(project_id=client.project_id, digest=digest)
+    )
+    assert [r.val for r in res.rows] == data
+    assert [r.digest for r in res.rows] == row_digests
+    assert [r.original_index for r in res.rows] == list(range(len(data)))
+
+    stream = client.server.table_query_stream(
+        tsi.TableQueryReq(project_id=client.project_id, digest=digest)
+    )
+    assert isinstance(stream, Iterator)
+    stream_rows = list(stream)
+    assert [r.val for r in stream_rows] == data
+    assert [r.digest for r in stream_rows] == row_digests
+    assert [r.original_index for r in stream_rows] == list(range(len(data)))
+
+
+def test_table_query_invalid_and_filter(client: WeaveClient):
+    """Invalid table/row digests yield no rows; a row_digests filter returns only the
+    matching rows with their original indices.
+    """
+    invalid = client.server.table_query(
+        tsi.TableQueryReq(project_id=client.project_id, digest="invalid")
+    )
+    assert invalid.rows == []
+
+    digest, row_digests, data = generate_table_data(client, 10, 5)
+
+    filtered_digests = row_digests[2:5]
+    res = client.server.table_query(
+        tsi.TableQueryReq(
+            project_id=client.project_id,
+            digest=digest,
+            filter=tsi.TableRowFilter(row_digests=filtered_digests),
+        )
+    )
+    assert [r.digest for r in res.rows] == filtered_digests
+    assert [r.original_index for r in res.rows] == [2, 3, 4]
+
+    invalid_row = client.server.table_query(
+        tsi.TableQueryReq(
+            project_id=client.project_id,
+            digest=digest,
+            filter=tsi.TableRowFilter(row_digests=["invalid"]),
+        )
+    )
+    assert invalid_row.rows == []
+
+
+def test_table_query_limit_offset_combined(client: WeaveClient):
+    """limit, offset, and limit+offset+sort compose as expected over the row set."""
+    digest, row_digests, data = generate_table_data(client, 10, 5)
+
+    limit = 5
+    limited = client.server.table_query(
+        tsi.TableQueryReq(project_id=client.project_id, digest=digest, limit=limit)
+    )
+    assert [r.val for r in limited.rows] == list(data[:limit])
+    assert [r.digest for r in limited.rows] == row_digests[:limit]
+    assert [r.original_index for r in limited.rows] == list(range(limit))
+
+    offset = 3
+    offsetted = client.server.table_query(
+        tsi.TableQueryReq(project_id=client.project_id, digest=digest, offset=offset)
+    )
+    assert [r.val for r in offsetted.rows] == list(data[offset:])
+    assert [r.digest for r in offsetted.rows] == row_digests[offset:]
+    assert [r.original_index for r in offsetted.rows] == list(range(offset, len(data)))
+
+    big_digest, _, big_data = generate_table_data(client, 20, 5)
+    c_limit, c_offset = 5, 2
+    combined = client.server.table_query(
+        tsi.TableQueryReq(
+            project_id=client.project_id,
+            digest=big_digest,
+            limit=c_limit,
+            offset=c_offset,
+            sort_by=[SortBy(field="id", direction="desc")],
+        )
+    )
+    sorted_data = sorted(big_data, key=lambda x: x["id"], reverse=True)
+    expected_data = sorted_data[c_offset : c_offset + c_limit]
+    id_to_index = {d["id"]: i for i, d in enumerate(big_data)}
+    assert len(combined.rows) == c_limit
+    assert [r.val for r in combined.rows] == expected_data
+    assert [r.original_index for r in combined.rows] == [
+        id_to_index[d["id"]] for d in expected_data
+    ]
+
+
+def test_table_query_sort_variants(client: WeaveClient):
+    """Sorting by a column, a nested column, and multiple criteria all reorder rows
+    and preserve original indices.
+    """
+    digest, _, data = generate_table_data(client, 10, 5)
+    id_to_index = {d["id"]: i for i, d in enumerate(data)}
+
+    by_col = client.server.table_query(
+        tsi.TableQueryReq(
+            project_id=client.project_id,
+            digest=digest,
+            sort_by=[SortBy(field="id", direction="desc")],
+        )
+    )
+    sorted_data = sorted(data, key=lambda x: x["id"], reverse=True)
+    assert [r.val for r in by_col.rows] == sorted_data
+    assert [r.val["id"] for r in by_col.rows] != [d["id"] for d in data]
+    assert [r.original_index for r in by_col.rows] == [
+        id_to_index[d["id"]] for d in sorted_data
+    ]
+
+    by_nested = client.server.table_query(
+        tsi.TableQueryReq(
+            project_id=client.project_id,
+            digest=digest,
+            sort_by=[SortBy(field="nested_col.prop_a", direction="asc")],
+        )
+    )
+    sorted_nested = sorted(data, key=lambda x: x["nested_col"]["prop_a"])
+    assert [r.val for r in by_nested.rows] == sorted_nested
+    assert [r.original_index for r in by_nested.rows] == [
+        id_to_index[d["id"]] for d in sorted_nested
+    ]
+
+    multi_digest, _, multi_data = generate_table_data(client, 20, 5)
+    multi_index = {d["id"]: i for i, d in enumerate(multi_data)}
+    by_multi = client.server.table_query(
+        tsi.TableQueryReq(
+            project_id=client.project_id,
+            digest=multi_digest,
+            sort_by=[
+                SortBy(field="col_0", direction="asc"),
+                SortBy(field="id", direction="desc"),
+            ],
+        )
+    )
+    sorted_multi = sorted(multi_data, key=lambda x: (x["col_0"], -x["id"]))
+    assert [r.val for r in by_multi.rows] == sorted_multi
+    assert [r.original_index for r in by_multi.rows] == [
+        multi_index[d["id"]] for d in sorted_multi
+    ]
+
+
+def test_table_query_stats_variants(client: WeaveClient):
+    """Stats batch reports counts (incl. empty), skips missing digests, optionally
+    reports storage size, and the legacy single-digest endpoint reports count=0 for
+    a missing digest instead of erroring.
+    """
+    digest, _, data = generate_table_data(client, 10, 10)
+    stats = client.server.table_query_stats_batch(
+        tsi.TableQueryStatsBatchReq(project_id=client.project_id, digests=[digest])
+    )
+    assert stats.tables[0].count == len(data)
+
+    empty_digest, _, empty_data = generate_table_data(client, 0, 0)
+    empty_stats = client.server.table_query_stats_batch(
+        tsi.TableQueryStatsBatchReq(
+            project_id=client.project_id, digests=[empty_digest]
+        )
+    )
+    assert empty_stats.tables[0].count == len(empty_data)
+
+    missing_stats = client.server.table_query_stats_batch(
+        tsi.TableQueryStatsBatchReq(project_id=client.project_id, digests=["missing"])
+    )
+    assert len(missing_stats.tables) == 0
+
+    sized_stats = client.server.table_query_stats_batch(
+        tsi.TableQueryStatsBatchReq(
+            project_id=client.project_id,
+            digests=[digest],
+            include_storage_size=True,
+        )
+    )
+    assert sized_stats.tables[0].count == len(data)
+    assert sized_stats.tables[0].storage_size_bytes > 0
+
+    # Legacy single-digest endpoint must not IndexError on a missing digest.
+    legacy = client.server.table_query_stats(
+        tsi.TableQueryStatsReq(project_id=client.project_id, digest="missing")
+    )
+    assert legacy.count == 0
+
+
+def test_table_query_with_duplicate_row_digests(client: WeaveClient):
+    """Tables with duplicated rows return every physical row with distinct original
+    indices, and filtering by a duplicated row digest returns all copies.
+    """
+    for copy_count in (1, 2, 3):
+        res_data = generate_duplication_simple_table_data(client, 10, copy_count)
+        total = 10 * copy_count
+
+        full = client.server.table_query(
+            tsi.TableQueryReq(project_id=client.project_id, digest=res_data["digest"])
+        )
+        stats = client.server.table_query_stats_batch(
+            tsi.TableQueryStatsBatchReq(
+                project_id=client.project_id, digests=[res_data["digest"]]
+            )
+        )
+        assert len(full.rows) == stats.tables[0].count == total
+        assert [r.original_index for r in full.rows] == list(range(total))
+
+        filtered = client.server.table_query(
+            tsi.TableQueryReq(
+                project_id=client.project_id,
+                digest=res_data["digest"],
+                filter=tsi.TableRowFilter(row_digests=[res_data["row_digests"][0]]),
+            )
+        )
+        assert len(filtered.rows) == copy_count
+        assert [r.original_index for r in filtered.rows] == list(range(copy_count))
+
+
+def test_duplicate_table_with_identical_rows(client: WeaveClient):
+    """Creating the same table twice is idempotent: identical digest, full row set."""
+    data = [{"val": i} for i in range(10)]
+
+    res1 = client.server.table_create(
+        tsi.TableCreateReq(
+            table=tsi.TableSchemaForInsert(rows=data, project_id=client.project_id)
+        )
+    )
+    res2 = client.server.table_create(
+        tsi.TableCreateReq(
+            table=tsi.TableSchemaForInsert(rows=data, project_id=client.project_id)
+        )
+    )
+    assert len(res1.row_digests) == 10
+    assert res1.digest == res2.digest
+
+    res = client.server.table_query(
+        tsi.TableQueryReq(
+            project_id=client.project_id,
+            digest=res1.digest,
+            sort_by=[SortBy(field="val", direction="asc")],
+        )
+    )
+    assert len(res.rows) == 10
+    assert [r.original_index for r in res.rows] == list(range(10))
+
+
 def generate_table_data(client: WeaveClient, n_rows: int, n_cols: int):
-    # Create a list of IDs and shuffle them to ensure random order
     ids = list(range(n_rows))
     random.shuffle(ids)
 
@@ -15,8 +260,8 @@ def generate_table_data(client: WeaveClient, n_rows: int, n_cols: int):
         {
             "id": i,
             "nested_col": {
-                "prop_a": f"value_{chr(97 + (i % 26))}",  # Use letters a-z cyclically
-                "prop_b": f"value_{random.randint(0, 100)}",  # Random integer
+                "prop_a": f"value_{chr(97 + (i % 26))}",
+                "prop_b": f"value_{random.randint(0, 100)}",
             },
             **{
                 f"col_{j}": f"value_{random.randint(0, 100)}_{chr(97 + (i % 26))}"
@@ -28,450 +273,19 @@ def generate_table_data(client: WeaveClient, n_rows: int, n_cols: int):
 
     res = client.server.table_create(
         tsi.TableCreateReq(
-            table=tsi.TableSchemaForInsert(
-                rows=data,
-                project_id=client.project_id,
-            ),
+            table=tsi.TableSchemaForInsert(rows=data, project_id=client.project_id)
         )
     )
-    digest = res.digest
-    row_digests = res.row_digests
-
-    return digest, row_digests, data
-
-
-def test_table_query(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 10)
-
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=digest,
-        )
-    )
-
-    result_vals = [r.val for r in res.rows]
-    result_digests = [r.digest for r in res.rows]
-    result_indices = [r.original_index for r in res.rows]
-
-    assert result_vals == data
-    assert result_digests == row_digests
-    assert result_indices == list(range(len(data)))
-
-
-def test_table_query_stream(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 10)
-
-    res = client.server.table_query_stream(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=digest,
-        )
-    )
-
-    assert isinstance(res, Iterator)
-    rows = []
-    for r in res:
-        rows.append(r)
-
-    result_vals = [r.val for r in rows]
-    result_digests = [r.digest for r in rows]
-    result_indices = [r.original_index for r in rows]
-
-    assert result_vals == data
-    assert result_digests == row_digests
-    assert result_indices == list(range(len(data)))
-
-
-def test_table_query_invalid_digest(client: WeaveClient):
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest="invalid",
-        )
-    )
-
-    assert res.rows == []
-
-
-def test_table_query_filter_by_row_digests(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 5)
-
-    filtered_digests = row_digests[2:5]
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=digest,
-            filter=tsi.TableRowFilter(row_digests=filtered_digests),
-        )
-    )
-
-    result_digests = [r.digest for r in res.rows]
-    result_indices = [r.original_index for r in res.rows]
-
-    assert len(result_digests) == 3
-    assert result_digests == filtered_digests
-    assert result_indices == [2, 3, 4]
-
-
-def test_table_query_invalid_row_digest(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 10)
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=digest,
-            filter=tsi.TableRowFilter(row_digests=["invalid"]),
-        )
-    )
-
-    assert res.rows == []
-
-
-def test_table_query_limit(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 5)
-
-    limit = 5
-    res = client.server.table_query(
-        tsi.TableQueryReq(project_id=client.project_id, digest=digest, limit=limit)
-    )
-
-    result_vals = [r.val for r in res.rows]
-    result_digests = [r.digest for r in res.rows]
-    result_indices = [r.original_index for r in res.rows]
-
-    assert len(result_vals) == limit
-    assert result_digests == row_digests[:limit]
-    assert result_vals == list(data[:limit])
-    assert result_indices == list(range(limit))
-
-
-def test_table_query_offset(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 5)
-
-    offset = 3
-    res = client.server.table_query(
-        tsi.TableQueryReq(project_id=client.project_id, digest=digest, offset=offset)
-    )
-
-    result_vals = [r.val for r in res.rows]
-    result_digests = [r.digest for r in res.rows]
-    result_indices = [r.original_index for r in res.rows]
-
-    assert len(result_vals) == len(data) - offset
-    assert result_digests == row_digests[offset:]
-    assert result_vals == list(data[offset:])
-    assert result_indices == list(range(offset, len(data)))
-
-
-def test_table_query_sort_by_column(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 5)
-
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=digest,
-            sort_by=[SortBy(field="id", direction="desc")],
-        )
-    )
-
-    result_vals = [r.val for r in res.rows]
-    result_digests = [r.digest for r in res.rows]
-    result_indices = [r.original_index for r in res.rows]
-
-    sorted_data = sorted(data, key=lambda x: x["id"], reverse=True)
-    id_to_index = {d["id"]: i for i, d in enumerate(data)}
-    expected_indices = [id_to_index[d["id"]] for d in sorted_data]
-
-    assert result_vals == sorted_data
-    assert [r.val["id"] for r in res.rows] != [
-        d["id"] for d in data
-    ]  # Ensure order is different from original (assertion on the test itself)
-    assert result_indices == expected_indices
-
-
-def test_table_query_sort_by_nested_column(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 5)
-
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=digest,
-            sort_by=[SortBy(field="nested_col.prop_a", direction="asc")],
-        )
-    )
-
-    result_vals = [r.val for r in res.rows]
-    result_indices = [r.original_index for r in res.rows]
-
-    sorted_data = sorted(data, key=lambda x: x["nested_col"]["prop_a"])
-    id_to_index = {d["id"]: i for i, d in enumerate(data)}
-    expected_indices = [id_to_index[d["id"]] for d in sorted_data]
-
-    assert result_vals == sorted_data
-    assert result_indices == expected_indices
-
-
-def test_table_query_combined(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 20, 5)
-
-    limit = 5
-    offset = 2
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=digest,
-            limit=limit,
-            offset=offset,
-            sort_by=[SortBy(field="id", direction="desc")],
-        )
-    )
-
-    result_vals = [r.val for r in res.rows]
-    result_indices = [r.original_index for r in res.rows]
-
-    sorted_data = sorted(data, key=lambda x: x["id"], reverse=True)
-    expected_data = sorted_data[offset : offset + limit]
-    id_to_index = {d["id"]: i for i, d in enumerate(data)}
-    expected_indices = [id_to_index[d["id"]] for d in expected_data]
-
-    assert len(res.rows) == limit
-    assert result_vals == expected_data
-    assert result_indices == expected_indices
-
-
-def test_table_query_multiple_sort_criteria(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 20, 5)
-
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=digest,
-            sort_by=[
-                SortBy(field="col_0", direction="asc"),
-                SortBy(field="id", direction="desc"),
-            ],
-        )
-    )
-    result_vals = [r.val for r in res.rows]
-    result_indices = [r.original_index for r in res.rows]
-
-    sorted_data = sorted(data, key=lambda x: (x["col_0"], -x["id"]))
-    id_to_index = {d["id"]: i for i, d in enumerate(data)}
-    expected_indices = [id_to_index[d["id"]] for d in sorted_data]
-
-    assert result_vals == sorted_data
-    assert result_indices == expected_indices
-
-
-def test_table_query_stats(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 10)
-
-    stats_res = client.server.table_query_stats_batch(
-        tsi.TableQueryStatsBatchReq(
-            project_id=client.project_id,
-            digests=[digest],
-        )
-    )
-
-    assert stats_res.tables[0].count == len(data)
-
-
-def test_table_query_stats_empty(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 0, 0)
-
-    stats_res = client.server.table_query_stats_batch(
-        tsi.TableQueryStatsBatchReq(
-            project_id=client.project_id,
-            digests=[digest],
-        )
-    )
-
-    assert stats_res.tables[0].count == len(data)
-
-
-def test_table_query_stats_missing(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 10)
-
-    stats_res = client.server.table_query_stats_batch(
-        tsi.TableQueryStatsBatchReq(
-            project_id=client.project_id,
-            digests=["missing"],
-        )
-    )
-
-    assert len(stats_res.tables) == 0
-
-
-def test_table_query_stats_legacy_missing(client: WeaveClient):
-    # The legacy single-digest endpoint must not IndexError when the digest
-    # doesn't exist; it should report count=0.
-    stats_res = client.server.table_query_stats(
-        tsi.TableQueryStatsReq(
-            project_id=client.project_id,
-            digest="missing",
-        )
-    )
-
-    assert stats_res.count == 0
+    return res.digest, res.row_digests, data
 
 
 def generate_duplication_simple_table_data(
     client: WeaveClient, n_rows: int, copy_count: int
 ):
-    # Create a list of IDs and shuffle them to ensure random order
     data = [{"val": i} for i in range(n_rows) for _ in range(copy_count)]
-
     res = client.server.table_create(
         tsi.TableCreateReq(
-            table=tsi.TableSchemaForInsert(
-                rows=data,
-                project_id=client.project_id,
-            ),
+            table=tsi.TableSchemaForInsert(rows=data, project_id=client.project_id)
         )
     )
-    digest = res.digest
-    row_digests = res.row_digests
-
-    return {"digest": digest, "row_digests": row_digests, "data": data}
-
-
-def test_table_query_with_duplicate_row_digests(client: WeaveClient):
-    res1 = generate_duplication_simple_table_data(client, 10, 1)
-    res2 = generate_duplication_simple_table_data(client, 10, 2)
-    res3 = generate_duplication_simple_table_data(client, 10, 3)
-
-    # Test res1 (copy_count=1)
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=res1["digest"],
-        )
-    )
-    stats_res = client.server.table_query_stats_batch(
-        tsi.TableQueryStatsBatchReq(
-            project_id=client.project_id,
-            digests=[res1["digest"]],
-        )
-    )
-    assert len(res.rows) == stats_res.tables[0].count == 10
-    assert [r.original_index for r in res.rows] == list(range(10))
-
-    # Test filtered query for res1
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=res1["digest"],
-            filter=tsi.TableRowFilter(row_digests=[res1["row_digests"][0]]),
-        )
-    )
-    assert len(res.rows) == 1
-    assert [r.original_index for r in res.rows] == [0]
-
-    # Test res2 (copy_count=2)
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=res2["digest"],
-        )
-    )
-    stats_res = client.server.table_query_stats_batch(
-        tsi.TableQueryStatsBatchReq(
-            project_id=client.project_id,
-            digests=[res2["digest"]],
-        )
-    )
-    assert len(res.rows) == stats_res.tables[0].count == 20
-    assert [r.original_index for r in res.rows] == list(range(20))
-
-    # Test filtered query for res2
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=res2["digest"],
-            filter=tsi.TableRowFilter(row_digests=[res2["row_digests"][0]]),
-        )
-    )
-    assert len(res.rows) == 2
-    assert [r.original_index for r in res.rows] == [0, 1]
-
-    # Test res3 (copy_count=3)
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=res3["digest"],
-        )
-    )
-    stats_res = client.server.table_query_stats_batch(
-        tsi.TableQueryStatsBatchReq(
-            project_id=client.project_id,
-            digests=[res3["digest"]],
-        )
-    )
-    assert len(res.rows) == stats_res.tables[0].count == 30
-    assert [r.original_index for r in res.rows] == list(range(30))
-
-    # Test filtered query for res3
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=res3["digest"],
-            filter=tsi.TableRowFilter(row_digests=[res3["row_digests"][0]]),
-        )
-    )
-    assert len(res.rows) == 3
-    assert [r.original_index for r in res.rows] == [0, 1, 2]
-
-
-def test_duplicate_table_with_identical_rows(client: WeaveClient):
-    data = [{"val": i} for i in range(10)]
-
-    res1 = client.server.table_create(
-        tsi.TableCreateReq(
-            table=tsi.TableSchemaForInsert(
-                rows=data,
-                project_id=client.project_id,
-            ),
-        )
-    )
-
-    # now create the same table with the same data
-    res2 = client.server.table_create(
-        tsi.TableCreateReq(
-            table=tsi.TableSchemaForInsert(
-                rows=data,
-                project_id=client.project_id,
-            ),
-        )
-    )
-
-    assert len(res1.row_digests) == 10
-
-    # this is the same table!
-    assert res1.digest == res2.digest
-
-    res = client.server.table_query(
-        tsi.TableQueryReq(
-            project_id=client.project_id,
-            digest=res1.digest,
-            sort_by=[SortBy(field="val", direction="asc")],
-        )
-    )
-
-    # this is the same table, so we should get the same number of rows
-    assert len(res.rows) == 10
-    assert [r.original_index for r in res.rows] == list(range(10))
-
-
-def test_table_query_stats_with_storage_size(client: WeaveClient):
-    digest, row_digests, data = generate_table_data(client, 10, 10)
-
-    stats_res = client.server.table_query_stats_batch(
-        tsi.TableQueryStatsBatchReq(
-            project_id=client.project_id,
-            digests=[digest],
-            include_storage_size=True,
-        )
-    )
-
-    assert stats_res.tables[0].count == len(data)
-    assert stats_res.tables[0].storage_size_bytes > 0
+    return {"digest": res.digest, "row_digests": res.row_digests, "data": data}

--- a/tests/trace/test_trace_server_v2_api.py
+++ b/tests/trace/test_trace_server_v2_api.py
@@ -25,205 +25,164 @@ from weave.trace_server.ids import generate_id
 from weave.utils.project_id import from_project_id
 
 
-class TestOpsV2API:
-    """Tests for Ops V2 API endpoints."""
+def test_op_create_and_read(client):
+    """Create then read an op via V2 API, covering both create and read responses."""
+    project_id = client.project_id
 
-    def test_op_create(self, client):
-        """Test creating an op via V2 API."""
-        project_id = client.project_id
-
-        # Create an op
-        req = tsi.OpCreateReq(
+    # Create response shape.
+    res = client.server.op_create(
+        tsi.OpCreateReq(
             project_id=project_id,
             name="test_op",
             source_code="def test_op():\n    return 42",
         )
-        res = client.server.op_create(req)
+    )
+    assert res.object_id == "test_op"
+    assert res.digest is not None
+    assert res.version_index == 0
 
-        # Verify response
-        assert res.object_id == "test_op"
-        assert res.digest is not None
-        assert res.version_index == 0
-
-    def test_op_read(self, client):
-        """Test reading an op via V2 API."""
-        project_id = client.project_id
-
-        # Create an op first
-        source_code = "def my_test_op():\n    return 'hello world'"
-        create_req = tsi.OpCreateReq(
+    # Create a second op and read it back.
+    source_code = "def my_test_op():\n    return 'hello world'"
+    create_res = client.server.op_create(
+        tsi.OpCreateReq(
             project_id=project_id,
             name="readable_op",
             source_code=source_code,
         )
-        create_res = client.server.op_create(create_req)
-
-        # Read the op
-        read_req = tsi.OpReadReq(
+    )
+    read_res = client.server.op_read(
+        tsi.OpReadReq(
             project_id=project_id,
             object_id="readable_op",
             digest=create_res.digest,
         )
-        read_res = client.server.op_read(read_req)
+    )
+    assert read_res.object_id == "readable_op"
+    assert read_res.digest == create_res.digest
+    assert read_res.version_index == 0
+    assert read_res.code == source_code
+    assert read_res.created_at is not None
 
-        # Verify response
-        assert read_res.object_id == "readable_op"
-        assert read_res.digest == create_res.digest
-        assert read_res.version_index == 0
-        assert read_res.code == source_code
-        assert read_res.created_at is not None
 
-    def test_op_list(self, client):
-        """Test listing ops via V2 API."""
-        project_id = client.project_id
+def test_op_list(client):
+    """List ops, plus the limit-respecting variant, via V2 API."""
+    project_id = client.project_id
 
-        # Create multiple ops
-        for i in range(3):
-            req = tsi.OpCreateReq(
+    for i in range(3):
+        client.server.op_create(
+            tsi.OpCreateReq(
                 project_id=project_id,
                 name=f"list_test_op_{i}",
                 source_code=f"def op_{i}():\n    return {i}",
             )
-            client.server.op_create(req)
+        )
 
-        # List ops
-        list_req = tsi.OpListReq(project_id=project_id)
-        ops = list(client.server.op_list(list_req))
+    ops = list(client.server.op_list(tsi.OpListReq(project_id=project_id)))
+    assert len(ops) >= 3
+    op_names = [op.object_id for op in ops]
+    assert "list_test_op_0" in op_names
+    assert "list_test_op_1" in op_names
+    assert "list_test_op_2" in op_names
 
-        # Verify we get at least our 3 ops
-        assert len(ops) >= 3
-        op_names = [op.object_id for op in ops]
-        assert "list_test_op_0" in op_names
-        assert "list_test_op_1" in op_names
-        assert "list_test_op_2" in op_names
-
-    def test_op_list_with_limit(self, client):
-        """Test listing ops with limit via V2 API."""
-        project_id = client.project_id
-
-        # Create multiple ops
-        for i in range(5):
-            req = tsi.OpCreateReq(
+    for i in range(5):
+        client.server.op_create(
+            tsi.OpCreateReq(
                 project_id=project_id,
                 name=f"limit_test_op_{i}",
                 source_code=f"def op_{i}():\n    return {i}",
             )
-            client.server.op_create(req)
+        )
+    limited = list(client.server.op_list(tsi.OpListReq(project_id=project_id, limit=2)))
+    assert len(limited) == 2
 
-        # List ops with limit
-        list_req = tsi.OpListReq(project_id=project_id, limit=2)
-        ops = list(client.server.op_list(list_req))
 
-        # Verify limit is respected
-        assert len(ops) == 2
+def test_op_delete(client):
+    """Delete a single op version and, separately, all versions of an op."""
+    project_id = client.project_id
 
-    def test_op_delete(self, client):
-        """Test deleting an op via V2 API."""
-        project_id = client.project_id
-
-        # Create an op
-        create_req = tsi.OpCreateReq(
+    create_res = client.server.op_create(
+        tsi.OpCreateReq(
             project_id=project_id,
             name="deletable_op",
             source_code="def deletable():\n    pass",
         )
-        create_res = client.server.op_create(create_req)
-
-        # Delete the op
-        delete_req = tsi.OpDeleteReq(
+    )
+    delete_res = client.server.op_delete(
+        tsi.OpDeleteReq(
             project_id=project_id,
             object_id="deletable_op",
             digests=[create_res.digest],
         )
-        delete_res = client.server.op_delete(delete_req)
+    )
+    assert delete_res.num_deleted == 1
 
-        # Verify deletion
-        assert delete_res.num_deleted == 1
-
-    def test_op_delete_all_versions(self, client):
-        """Test deleting all versions of an op via V2 API."""
-        project_id = client.project_id
-
-        # Create multiple versions
-        digests = []
-        for i in range(3):
-            create_req = tsi.OpCreateReq(
+    for i in range(3):
+        client.server.op_create(
+            tsi.OpCreateReq(
                 project_id=project_id,
                 name="multi_version_op",
                 source_code=f"def multi_version():\n    return {i}",
             )
-            create_res = client.server.op_create(create_req)
-            digests.append(create_res.digest)
-
-        # Delete all versions (None means delete all)
-        delete_req = tsi.OpDeleteReq(
+        )
+    # digests=None means delete all versions.
+    delete_all_res = client.server.op_delete(
+        tsi.OpDeleteReq(
             project_id=project_id,
             object_id="multi_version_op",
             digests=None,
         )
-        delete_res = client.server.op_delete(delete_req)
-
-        # Verify all versions deleted
-        assert delete_res.num_deleted == 3
+    )
+    assert delete_all_res.num_deleted == 3
 
 
 class TestDatasetsV2API:
     """Tests for Datasets V2 API endpoints."""
 
-    def test_dataset_create(self, client):
-        """Test creating a dataset via V2 API."""
+    def test_dataset_create_and_read(self, client):
+        """Create then read a dataset via V2 API, covering both responses."""
         project_id = client.project_id
 
-        # Create a dataset
-        req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name="test_dataset",
-            description="A test dataset",
-            rows=[
-                {"input": "hello", "output": "world"},
-                {"input": "foo", "output": "bar"},
-            ],
+        # Create response shape (object_id is the sanitized name).
+        res = client.server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id,
+                name="test_dataset",
+                description="A test dataset",
+                rows=[
+                    {"input": "hello", "output": "world"},
+                    {"input": "foo", "output": "bar"},
+                ],
+            )
         )
-        res = client.server.dataset_create(req)
-
-        # Verify response
-        # When name is provided, object_id should be the sanitized name
         assert res.object_id == "test_dataset"
         assert res.digest is not None
         assert res.version_index == 0
 
-    def test_dataset_read(self, client):
-        """Test reading a dataset via V2 API."""
-        project_id = client.project_id
-
-        # Create a dataset first
         rows = [
             {"question": "What is 2+2?", "answer": "4"},
             {"question": "What is the capital of France?", "answer": "Paris"},
         ]
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name="readable_dataset",
-            description="Test dataset for reading",
-            rows=rows,
+        create_res = client.server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id,
+                name="readable_dataset",
+                description="Test dataset for reading",
+                rows=rows,
+            )
         )
-        create_res = client.server.dataset_create(create_req)
-
-        # Read the dataset
-        read_req = tsi.DatasetReadReq(
-            project_id=project_id,
-            object_id=create_res.object_id,
-            digest=create_res.digest,
+        read_res = client.server.dataset_read(
+            tsi.DatasetReadReq(
+                project_id=project_id,
+                object_id=create_res.object_id,
+                digest=create_res.digest,
+            )
         )
-        read_res = client.server.dataset_read(read_req)
-
-        # Verify response
         assert read_res.object_id == create_res.object_id
         assert read_res.digest == create_res.digest
         assert read_res.version_index == 0
         assert read_res.name == "readable_dataset"
         assert read_res.description == "Test dataset for reading"
-        assert read_res.rows is not None  # Field is 'rows', not 'rows_ref'
+        assert read_res.rows is not None
         assert read_res.created_at is not None
 
     def test_dataset_list(self, client):
@@ -277,56 +236,47 @@ class TestDatasetsV2API:
 class TestScorersV2API:
     """Tests for Scorers V2 API endpoints."""
 
-    def test_scorer_create(self, client):
-        """Test creating a scorer via V2 API."""
+    def test_scorer_create_and_read(self, client):
+        """Create then read a scorer via V2 API, covering both responses."""
         project_id = client.project_id
 
-        # Create a scorer
-        req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name="test_scorer",
-            description="A test scorer",
-            op_source_code="def score(output, target):\n    return output == target",
+        # Create response shape (object_id is the sanitized name).
+        res = client.server.scorer_create(
+            tsi.ScorerCreateReq(
+                project_id=project_id,
+                name="test_scorer",
+                description="A test scorer",
+                op_source_code="def score(output, target):\n    return output == target",
+            )
         )
-        res = client.server.scorer_create(req)
-
-        # Verify response
-        # When name is provided, object_id should be the sanitized name
         assert res.object_id == "test_scorer"
         assert res.digest is not None
         assert res.version_index == 0
 
-    def test_scorer_read(self, client):
-        """Test reading a scorer via V2 API."""
-        project_id = client.project_id
-
-        # Create a scorer first
         source_code = (
             "def accuracy_score(output, target):\n    return int(output == target)"
         )
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name="accuracy_scorer",
-            description="Measures accuracy",
-            op_source_code=source_code,
+        create_res = client.server.scorer_create(
+            tsi.ScorerCreateReq(
+                project_id=project_id,
+                name="accuracy_scorer",
+                description="Measures accuracy",
+                op_source_code=source_code,
+            )
         )
-        create_res = client.server.scorer_create(create_req)
-
-        # Read the scorer
-        read_req = tsi.ScorerReadReq(
-            project_id=project_id,
-            object_id=create_res.object_id,
-            digest=create_res.digest,
+        read_res = client.server.scorer_read(
+            tsi.ScorerReadReq(
+                project_id=project_id,
+                object_id=create_res.object_id,
+                digest=create_res.digest,
+            )
         )
-        read_res = client.server.scorer_read(read_req)
-
-        # Verify response
         assert read_res.object_id == create_res.object_id
         assert read_res.digest == create_res.digest
         assert read_res.version_index == 0
         assert read_res.name == "accuracy_scorer"
         assert read_res.description == "Measures accuracy"
-        assert read_res.score_op is not None  # ScorerReadRes has 'score_op', not 'code'
+        assert read_res.score_op is not None
         assert read_res.created_at is not None
 
     def test_scorer_list(self, client):

--- a/tests/trace/test_trace_server_version.py
+++ b/tests/trace/test_trace_server_version.py
@@ -1,89 +1,37 @@
 """Tests for trace server version checking."""
 
+import pytest
+
 from weave.trace.init_message import check_min_trace_server_version
 
 TEST_SERVER_URL = "https://test.trace.server"
 
 
-class TestCheckMinTraceServerVersion:
-    """Test check_min_trace_server_version with various client/server version combinations."""
-
-    # Client has no requirement (MIN_TRACE_SERVER_VERSION = None)
-
-    def test_client_none_server_none(self):
-        """Client has no requirement, server doesn't report version -> compatible."""
-        result = check_min_trace_server_version(
-            trace_server_version=None,
-            min_required_version=None,
-            trace_server_url=TEST_SERVER_URL,
-        )
-        assert result is True
-
-    def test_client_none_server_has_value(self):
-        """Client has no requirement, server reports a version -> compatible."""
-        result = check_min_trace_server_version(
-            trace_server_version="1.0.0",
-            min_required_version=None,
-            trace_server_url=TEST_SERVER_URL,
-        )
-        assert result is True
-
-    # Client has a requirement (MIN_TRACE_SERVER_VERSION = "0.5.0")
-
-    def test_client_has_value_server_none(self):
-        """Client requires version, server doesn't report -> incompatible."""
-        result = check_min_trace_server_version(
-            trace_server_version=None,
-            min_required_version="0.5.0",
-            trace_server_url=TEST_SERVER_URL,
-        )
-        assert result is False
-
-    def test_client_has_value_server_too_low(self):
-        """Client requires version, server version is too low -> incompatible."""
-        result = check_min_trace_server_version(
-            trace_server_version="0.3.0",
-            min_required_version="0.5.0",
-            trace_server_url=TEST_SERVER_URL,
-        )
-        assert result is False
-
-    def test_client_has_value_server_exact_match(self):
-        """Client requires version, server version matches exactly -> compatible."""
-        result = check_min_trace_server_version(
-            trace_server_version="0.5.0",
-            min_required_version="0.5.0",
-            trace_server_url=TEST_SERVER_URL,
-        )
-        assert result is True
-
-    def test_client_has_value_server_higher(self):
-        """Client requires version, server version exceeds requirement -> compatible."""
-        result = check_min_trace_server_version(
-            trace_server_version="1.0.0",
-            min_required_version="0.5.0",
-            trace_server_url=TEST_SERVER_URL,
-        )
-        assert result is True
-
-    # Edge cases
-
-    def test_prerelease_version_comparison(self):
-        """Pre-release versions are lower than release versions."""
-        # 0.5.0-dev0 < 0.5.0, so if client requires 0.5.0, server at 0.5.0-dev0 should fail
-        result = check_min_trace_server_version(
-            trace_server_version="0.5.0-dev0",
-            min_required_version="0.5.0",
-            trace_server_url=TEST_SERVER_URL,
-        )
-        assert result is False
-
-    def test_prerelease_requirement_satisfied_by_release(self):
-        """Release version satisfies pre-release requirement."""
-        # 0.5.0 > 0.5.0-dev0, so server at 0.5.0 satisfies client requiring 0.5.0-dev0
-        result = check_min_trace_server_version(
-            trace_server_version="0.5.0",
-            min_required_version="0.5.0-dev0",
-            trace_server_url=TEST_SERVER_URL,
-        )
-        assert result is True
+@pytest.mark.parametrize(
+    ("trace_server_version", "min_required_version", "expected"),
+    [
+        # Client has no requirement -> always compatible.
+        (None, None, True),
+        ("1.0.0", None, True),
+        # Client requires a version.
+        (None, "0.5.0", False),
+        ("0.3.0", "0.5.0", False),
+        ("0.5.0", "0.5.0", True),
+        ("1.0.0", "0.5.0", True),
+        # Pre-release ordering: 0.5.0-dev0 < 0.5.0.
+        ("0.5.0-dev0", "0.5.0", False),
+        ("0.5.0", "0.5.0-dev0", True),
+    ],
+)
+def test_check_min_trace_server_version(
+    trace_server_version: str | None,
+    min_required_version: str | None,
+    expected: bool,
+) -> None:
+    """Client/server version combinations resolve to the expected compatibility."""
+    result = check_min_trace_server_version(
+        trace_server_version=trace_server_version,
+        min_required_version=min_required_version,
+        trace_server_url=TEST_SERVER_URL,
+    )
+    assert result is expected

--- a/tests/trace/test_trace_settings.py
+++ b/tests/trace/test_trace_settings.py
@@ -75,73 +75,41 @@ def test_disabled_env(client):
     )
 
 
+class _NamedObj:
+    name = "my_obj"
+
+
+class _UnnamedClass:
+    pass
+
+
 def test_publish_when_disabled(weave_active, monkeypatch):
-    """Test that weave.publish() returns a dummy ref when WEAVE_DISABLED=true."""
+    """publish() returns a DISABLED dummy ref and makes no network call when WEAVE_DISABLED=true.
+
+    Covers explicit name, name from obj attribute, name from class, and that
+    tags/aliases are silently ignored.
+    """
     monkeypatch.setenv("WEAVE_DISABLED", "true")
 
     with mock.patch(
         "weave.trace.api.weave_client_context.require_weave_client"
     ) as mock_require_client:
         ref = weave.publish({"foo": "bar"}, name="test_obj")
+        ref_obj_name = weave.publish(_NamedObj())
+        ref_class_name = weave.publish(_UnnamedClass())
+        ref_tagged = weave.publish(
+            {"data": "test"}, name="disabled_obj", tags=["prod"], aliases=["v1"]
+        )
         mock_require_client.assert_not_called()
 
     assert ref.entity == "DISABLED"
     assert ref.project == "DISABLED"
     assert ref.name == "test_obj"
     assert ref.digest == "DISABLED"
-
-
-def test_publish_when_disabled_uses_obj_name(weave_active, monkeypatch):
-    """Test that publish uses object's name attribute when no explicit name given."""
-    monkeypatch.setenv("WEAVE_DISABLED", "true")
-
-    class NamedObj:
-        name = "my_obj"
-
-    # Assert there is no network call made
-    with mock.patch(
-        "weave.trace.api.weave_client_context.require_weave_client"
-    ) as mock_require_client:
-        ref = weave.publish(NamedObj())
-        mock_require_client.assert_not_called()
-
-    assert ref.name == "my_obj"
-
-
-def test_publish_when_disabled_uses_class_name(weave_active, monkeypatch):
-    """Test that publish uses class name when object has no name attribute."""
-    monkeypatch.setenv("WEAVE_DISABLED", "true")
-
-    class MyClass:
-        pass
-
-    # Assert there is no network call made
-    with mock.patch(
-        "weave.trace.api.weave_client_context.require_weave_client"
-    ) as mock_require_client:
-        ref = weave.publish(MyClass())
-        mock_require_client.assert_not_called()
-
-    assert ref.name == "MyClass"
-
-
-def test_publish_when_disabled_ignores_tags_aliases(weave_active, monkeypatch):
-    """Tags and aliases should be silently ignored when weave is disabled."""
-    monkeypatch.setenv("WEAVE_DISABLED", "true")
-
-    with mock.patch(
-        "weave.trace.api.weave_client_context.require_weave_client"
-    ) as mock_require_client:
-        ref = weave.publish(
-            {"data": "test"},
-            name="disabled_obj",
-            tags=["prod"],
-            aliases=["v1"],
-        )
-        mock_require_client.assert_not_called()
-
-    assert ref.entity == "DISABLED"
-    assert ref.digest == "DISABLED"
+    assert ref_obj_name.name == "my_obj"
+    assert ref_class_name.name == "_UnnamedClass"
+    assert ref_tagged.entity == "DISABLED"
+    assert ref_tagged.digest == "DISABLED"
 
 
 def test_print_call_link_setting(client_creator):
@@ -484,158 +452,138 @@ def clean_settings_env(monkeypatch):
 
 
 @pytest.mark.usefixtures("clean_settings_env")
-class TestReplaceSettings:
-    def test_installs_snapshot(self):
-        replace_settings(UserSettings(disabled=True, print_call_link=False))
-        assert should_disable_weave() is True
-        assert should_print_call_link() is False
+def test_replace_settings_snapshot_semantics():
+    """replace_settings installs a full snapshot, resets unmentioned fields, and
+    None/no-args/dict inputs behave as documented.
+    """
+    replace_settings(UserSettings(disabled=True, print_call_link=False))
+    assert should_disable_weave() is True
+    assert should_print_call_link() is False
 
-    def test_resets_unmentioned_fields(self):
-        replace_settings(UserSettings(disabled=True, print_call_link=False))
-        # Replacing with a fresh UserSettings(disabled=True) should NOT
-        # preserve print_call_link=False — replace-all semantics.
-        replace_settings(UserSettings(disabled=True))
-        assert should_disable_weave() is True
-        assert should_print_call_link() is True
+    # Replace-all semantics: a fresh UserSettings(disabled=True) drops the prior
+    # print_call_link=False.
+    replace_settings(UserSettings(disabled=True))
+    assert should_disable_weave() is True
+    assert should_print_call_link() is True
 
-    def test_none_resets_to_defaults(self):
-        replace_settings(UserSettings(disabled=True))
-        assert should_disable_weave() is True
-        replace_settings(None)
-        assert should_disable_weave() is False
+    replace_settings(None)
+    assert should_disable_weave() is False
 
-    def test_no_args_resets_to_defaults(self):
-        replace_settings(UserSettings(disabled=True))
-        replace_settings()
-        assert should_disable_weave() is False
+    replace_settings(UserSettings(disabled=True))
+    replace_settings()
+    assert should_disable_weave() is False
 
-    def test_dict_input(self):
-        replace_settings({"disabled": True, "redact_pii": True})
-        assert should_disable_weave() is True
-        assert should_redact_pii() is True
-
-    def test_dict_unknown_field_raises(self):
-        with pytest.raises(TypeError):
-            replace_settings({"definitely_not_a_real_field": True})
-
-    def test_invalid_type_raises(self):
-        with pytest.raises(TypeError):
-            replace_settings(42)
+    replace_settings({"disabled": True, "redact_pii": True})
+    assert should_disable_weave() is True
+    assert should_redact_pii() is True
 
 
 @pytest.mark.usefixtures("clean_settings_env")
-class TestOverrideSettings:
-    def test_scopes_one_field(self):
-        replace_settings(UserSettings(print_call_link=False))
-        assert should_disable_weave() is False
-        with override_settings(disabled=True):
+def test_replace_settings_invalid_inputs_raise():
+    with pytest.raises(TypeError):
+        replace_settings({"definitely_not_a_real_field": True})
+    with pytest.raises(TypeError):
+        replace_settings(42)
+
+
+@pytest.mark.usefixtures("clean_settings_env")
+def test_override_settings_scopes_and_nests():
+    """override_settings scopes a single field, restores on exit, and nests."""
+    replace_settings(UserSettings(print_call_link=False))
+    assert should_disable_weave() is False
+    with override_settings(disabled=True):
+        assert should_disable_weave() is True
+        assert should_print_call_link() is False
+        with override_settings(print_call_link=False):
             assert should_disable_weave() is True
-            # Other fields keep the surrounding snapshot's values
             assert should_print_call_link() is False
-        assert should_disable_weave() is False
+        assert should_disable_weave() is True
         assert should_print_call_link() is False
+    assert should_disable_weave() is False
+    assert should_print_call_link() is False
 
-    def test_nested(self):
+
+@pytest.mark.usefixtures("clean_settings_env")
+def test_override_settings_unknown_field_raises():
+    with pytest.raises(TypeError), override_settings(not_a_real_field=True):
+        pass
+
+
+@pytest.mark.usefixtures("clean_settings_env")
+def test_override_settings_async_context_does_not_leak():
+    """Each async context gets its own override stack."""
+
+    async def child():
         with override_settings(disabled=True):
             assert should_disable_weave() is True
-            with override_settings(print_call_link=False):
-                assert should_disable_weave() is True
-                assert should_print_call_link() is False
+            await asyncio.sleep(0)
             assert should_disable_weave() is True
-            assert should_print_call_link() is True
+
+    async def parent():
+        assert should_disable_weave() is False
+        await child()
         assert should_disable_weave() is False
 
-    def test_unknown_field_raises(self):
-        with pytest.raises(TypeError), override_settings(not_a_real_field=True):
-            pass
-
-    def test_async_context_does_not_leak(self):
-        """Each async context gets its own override stack."""
-
-        async def child():
-            with override_settings(disabled=True):
-                assert should_disable_weave() is True
-                await asyncio.sleep(0)
-                assert should_disable_weave() is True
-
-        async def parent():
-            # Parent does not override; child should see its own override;
-            # parent should not see leakage.
-            assert should_disable_weave() is False
-            await child()
-            assert should_disable_weave() is False
-
-        asyncio.run(parent())
+    asyncio.run(parent())
 
 
 @pytest.mark.usefixtures("clean_settings_env")
-class TestEnvOverlay:
-    def test_env_var_wins_over_snapshot(self, monkeypatch):
-        replace_settings(UserSettings(disabled=False))
-        assert should_disable_weave() is False
-        monkeypatch.setenv("WEAVE_DISABLED", "true")
-        assert should_disable_weave() is True
+def test_env_overlay_precedence_and_immediacy(monkeypatch):
+    """Env vars win over the snapshot, take effect immediately on change, and an
+    empty env var falls through to the snapshot value.
+    """
+    replace_settings(UserSettings(disabled=False))
+    assert should_disable_weave() is False
+    monkeypatch.setenv("WEAVE_DISABLED", "true")
+    assert should_disable_weave() is True
+    monkeypatch.setenv("WEAVE_DISABLED", "false")
+    assert should_disable_weave() is False
+    monkeypatch.delenv("WEAVE_DISABLED")
+    assert should_disable_weave() is False
 
-    def test_env_var_change_takes_effect_immediately(self, monkeypatch):
-        """Q2 contract: users may flip env vars mid-process and reads pick it up."""
-        assert should_disable_weave() is False
-        monkeypatch.setenv("WEAVE_DISABLED", "true")
-        assert should_disable_weave() is True
-        monkeypatch.setenv("WEAVE_DISABLED", "false")
-        assert should_disable_weave() is False
-        monkeypatch.delenv("WEAVE_DISABLED")
-        assert should_disable_weave() is False
-
-    def test_empty_env_var_falls_through_to_snapshot(self, monkeypatch):
-        """An env var that exists but is empty is treated as unset."""
-        replace_settings(UserSettings(disabled=True))
-        monkeypatch.setenv("WEAVE_DISABLED", "")
-        assert should_disable_weave() is True
-
-    def test_coerces_int(self, monkeypatch):
-        monkeypatch.setenv("WEAVE_MAX_CALLS_QUEUE_SIZE", "42")
-        assert max_calls_queue_size() == 42
-
-    def test_coerces_float(self, monkeypatch):
-        monkeypatch.setenv("WEAVE_HTTP_TIMEOUT", "12.5")
-        assert http_timeout() == 12.5
-
-    def test_coerces_list(self, monkeypatch):
-        monkeypatch.setenv("WEAVE_REDACT_PII_FIELDS", "a,b,c")
-        assert redact_pii_fields() == ["a", "b", "c"]
-
-    def test_coerces_optional_int(self, monkeypatch):
-        monkeypatch.setenv("WEAVE_CLIENT_PARALLELISM", "7")
-        assert client_parallelism() == 7
+    # Empty env var is treated as unset, so the snapshot value shows through.
+    replace_settings(UserSettings(disabled=True))
+    monkeypatch.setenv("WEAVE_DISABLED", "")
+    assert should_disable_weave() is True
 
 
 @pytest.mark.usefixtures("clean_settings_env")
-class TestBackCompat:
-    def test_parse_and_apply_settings_is_alias_for_replace_settings(self):
-        """Back-compat: the prior public name still works."""
-        parse_and_apply_settings(UserSettings(disabled=True))
-        assert should_disable_weave() is True
-        parse_and_apply_settings(None)
-        assert should_disable_weave() is False
+def test_env_overlay_type_coercion(monkeypatch):
+    """Env values coerce to int, float, list, and optional-int."""
+    monkeypatch.setenv("WEAVE_MAX_CALLS_QUEUE_SIZE", "42")
+    monkeypatch.setenv("WEAVE_HTTP_TIMEOUT", "12.5")
+    monkeypatch.setenv("WEAVE_REDACT_PII_FIELDS", "a,b,c")
+    monkeypatch.setenv("WEAVE_CLIENT_PARALLELISM", "7")
+    assert max_calls_queue_size() == 42
+    assert http_timeout() == 12.5
+    assert redact_pii_fields() == ["a", "b", "c"]
+    assert client_parallelism() == 7
 
 
-class TestUserSettingsValue:
-    def test_is_frozen(self):
-        settings = UserSettings()
-        with pytest.raises(dataclasses.FrozenInstanceError):
-            settings.disabled = True
+@pytest.mark.usefixtures("clean_settings_env")
+def test_parse_and_apply_settings_is_alias_for_replace_settings():
+    """Back-compat: the prior public name still works."""
+    parse_and_apply_settings(UserSettings(disabled=True))
+    assert should_disable_weave() is True
+    parse_and_apply_settings(None)
+    assert should_disable_weave() is False
 
-    def test_rejects_unknown_kwargs(self):
-        with pytest.raises(TypeError):
-            UserSettings(not_a_field=True)
 
-    def test_settings_overrides_typeddict_matches_user_settings(self):
-        """The _SettingsOverrides TypedDict that types override_settings(**fields)
-        must mirror UserSettings exactly (same names, same types).  Drift means
-        the types lie to callers.
-        """
-        user_settings_hints = typing.get_type_hints(UserSettings)
-        overrides_hints = typing.get_type_hints(_SettingsOverrides)
-        assert user_settings_hints == overrides_hints, (
-            "_SettingsOverrides drift: add/update fields to match UserSettings"
-        )
+def test_user_settings_value_is_frozen_and_strict():
+    """UserSettings is a frozen dataclass that rejects unknown kwargs."""
+    settings = UserSettings()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        settings.disabled = True
+    with pytest.raises(TypeError):
+        UserSettings(not_a_field=True)
+
+
+def test_settings_overrides_typeddict_matches_user_settings():
+    """The _SettingsOverrides TypedDict typing override_settings(**fields) must
+    mirror UserSettings exactly; drift means the types lie to callers.
+    """
+    user_settings_hints = typing.get_type_hints(UserSettings)
+    overrides_hints = typing.get_type_hints(_SettingsOverrides)
+    assert user_settings_hints == overrides_hints, (
+        "_SettingsOverrides drift: add/update fields to match UserSettings"
+    )

--- a/tests/trace/test_tracing_resilience.py
+++ b/tests/trace/test_tracing_resilience.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import gc
 import weakref
 from collections import Counter
+from collections.abc import Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -19,17 +20,64 @@ from tests.trace.util import DummyTestException
 from weave.trace import weave_client
 from weave.trace.context import call_context
 from weave.trace.context.tests_context import raise_on_captured_errors
-from weave.trace.op import _add_accumulator
+from weave.trace.op import Op, _add_accumulator
+
+# Raising callbacks and op factories below are referenced eagerly by
+# @pytest.mark.parametrize, so they must be defined before the tests.
 
 
-def assert_no_current_call():
-    assert call_context.get_current_call() is None
+def _bad_postprocess_inputs(inputs):
+    raise DummyTestException("FAILURE in postprocess_inputs!")
 
 
-def reset_call_context():
-    """Force reset the call context to an empty stack."""
-    token = call_context._call_stack.set([])
-    call_context._call_stack.reset(token)
+def _bad_postprocess_output(output):
+    raise DummyTestException("FAILURE in postprocess_output!")
+
+
+def _bad_display_name(call):
+    raise DummyTestException("FAILURE in call_display_name!")
+
+
+def _bad_input_handler(op, args, kwargs):
+    raise DummyTestException("FAILURE in on_input_handler!")
+
+
+def _bad_finish_handler(call, output, exception):
+    raise DummyTestException("FAILURE in on_finish_handler!")
+
+
+def _define_func_op() -> Op:
+    @weave.op
+    def simple_op():
+        return "hello"
+
+    return simple_op
+
+
+def _define_gen_op() -> Op:
+    @weave.op
+    def gen_op():
+        yield from [1, 2, 3]
+
+    return gen_op
+
+
+def _define_async_func_op() -> Op:
+    @weave.op
+    async def simple_op():
+        return "hello"
+
+    return simple_op
+
+
+def _define_async_gen_op() -> Op:
+    @weave.op
+    async def gen_op():
+        yield 1
+        yield 2
+        yield 3
+
+    return gen_op
 
 
 def test_resilience_to_user_code_errors(weave_active):
@@ -187,88 +235,50 @@ async def test_resilience_to_output_handler_errors_async(weave_active, log_colle
     assert logs[0].msg.startswith("Error capturing call output")
 
 
+def _raising_make_accumulator() -> dict[str, object]:
+    """make_accumulator kwargs whose make_accumulator itself raises."""
+
+    def make_accumulator(*args, **kwargs):
+        raise DummyTestException("FAILURE!")
+
+    return {"make_accumulator": make_accumulator}
+
+
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_make_accumulator_errors(weave_active, log_collector):
-    def do_test():
-        @weave.op
-        def simple_op():
-            yield from [1, 2, 3]
-
-        def make_accumulator(*args, **kwargs):
-            raise DummyTestException("FAILURE!")
-
-        _add_accumulator(simple_op, make_accumulator=make_accumulator)
-
-        return simple_op()
-
-    # The user's exception should be raised - even if we're capturing errors
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            # Consume the generator to trigger the make_accumulator call
-            list(do_test())
-
-    # We should gracefully handle the error and return a value
-    res = do_test()
-    assert list(res) == [1, 2, 3]
-
-    assert_no_current_call()
-
-    logs = log_collector.get_error_logs()
-    assert len(logs) == 1
-    assert logs[0].msg.startswith("Error capturing call output")
-
-
-@pytest.mark.asyncio
-@pytest.mark.disable_logging_error_check
-async def test_resilience_to_accumulator_make_accumulator_errors_async(
-    weave_active, log_collector
+@pytest.mark.parametrize(
+    ("build_accumulator", "expected_msg"),
+    [
+        pytest.param(
+            _raising_make_accumulator,
+            "Error capturing call output",
+            id="make-accumulator",
+        ),
+        pytest.param(
+            lambda: {"make_accumulator": _accumulator_with_raising_accumulate()},
+            "Error capturing value from iterator, call data may be incomplete",
+            id="accumulation",
+        ),
+        pytest.param(
+            lambda: {
+                "make_accumulator": _empty_accumulator(),
+                "should_accumulate": _raising_callback(),
+            },
+            "Error capturing call output",
+            id="should-accumulate",
+        ),
+    ],
+)
+def test_resilience_to_accumulator_errors(
+    weave_active, log_collector, build_accumulator, expected_msg
 ):
-    async def do_test():
-        @weave.op
-        async def simple_op():
-            yield 1
-            yield 2
-            yield 3
+    """Sync accumulator callbacks that raise must not crash the user's op."""
 
-        def make_accumulator(*args, **kwargs):
-            raise DummyTestException("FAILURE!")
-
-        _add_accumulator(simple_op, make_accumulator=make_accumulator)
-
-        return simple_op()
-
-    # The user's exception should be raised - even if we're capturing errors
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            # Consume the generator to trigger the make_accumulator call
-            _ = [item async for item in await do_test()]
-
-    # We should gracefully handle the error and return a value
-    res = await do_test()
-    assert [item async for item in res] == [1, 2, 3]
-
-    assert_no_current_call()
-
-    logs = log_collector.get_error_logs()
-    assert len(logs) == 1
-    assert logs[0].msg.startswith("Error capturing call output")
-
-
-@pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collector):
     def do_test():
         @weave.op
         def simple_op():
             yield from [1, 2, 3]
 
-        def make_accumulator(*args, **kwargs):
-            def accumulate(*args, **kwargs):
-                raise DummyTestException("FAILURE!")
-
-            return accumulate
-
-        _add_accumulator(simple_op, make_accumulator=make_accumulator)
-
+        _add_accumulator(simple_op, **build_accumulator())
         return simple_op()
 
     # The user's exception should be raised - even if we're capturing errors
@@ -284,16 +294,39 @@ def test_resilience_to_accumulator_accumulation_errors(weave_active, log_collect
 
     logs = log_collector.get_error_logs()
     assert len(logs) == 1
-    assert logs[0].msg.startswith(
-        "Error capturing value from iterator, call data may be incomplete"
-    )
+    assert logs[0].msg.startswith(expected_msg)
 
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_accumulator_accumulation_errors_async(
-    weave_active, log_collector
+@pytest.mark.parametrize(
+    ("build_accumulator", "expected_msg"),
+    [
+        pytest.param(
+            _raising_make_accumulator,
+            "Error capturing call output",
+            id="make-accumulator",
+        ),
+        pytest.param(
+            lambda: {"make_accumulator": _accumulator_with_raising_accumulate()},
+            "Error capturing async value from iterator, call data may be incomplete",
+            id="accumulation",
+        ),
+        pytest.param(
+            lambda: {
+                "make_accumulator": _empty_accumulator(),
+                "should_accumulate": _raising_callback(),
+            },
+            "Error capturing call output",
+            id="should-accumulate",
+        ),
+    ],
+)
+async def test_resilience_to_accumulator_errors_async(
+    weave_active, log_collector, build_accumulator, expected_msg
 ):
+    """Async accumulator callbacks that raise must not crash the user's op."""
+
     async def do_test():
         @weave.op
         async def simple_op():
@@ -301,14 +334,7 @@ async def test_resilience_to_accumulator_accumulation_errors_async(
             yield 2
             yield 3
 
-        def make_accumulator(*args, **kwargs):
-            def accumulate(*args, **kwargs):
-                raise DummyTestException("FAILURE!")
-
-            return accumulate
-
-        _add_accumulator(simple_op, make_accumulator=make_accumulator)
-
+        _add_accumulator(simple_op, **build_accumulator())
         return simple_op()
 
     # The user's exception should be raised - even if we're capturing errors
@@ -324,97 +350,7 @@ async def test_resilience_to_accumulator_accumulation_errors_async(
 
     logs = log_collector.get_error_logs()
     assert len(logs) == 1
-    assert logs[0].msg.startswith(
-        "Error capturing async value from iterator, call data may be incomplete"
-    )
-
-
-@pytest.mark.disable_logging_error_check
-def test_resilience_to_accumulator_should_accumulate_errors(
-    weave_active, log_collector
-):
-    def do_test():
-        @weave.op
-        def simple_op():
-            yield from [1, 2, 3]
-
-        def make_accumulator(*args, **kwargs):
-            def accumulate(*args, **kwargs):
-                return {}
-
-            return accumulate
-
-        def should_accumulate(*args, **kwargs):
-            raise DummyTestException("FAILURE!")
-
-        _add_accumulator(
-            simple_op,
-            make_accumulator=make_accumulator,
-            should_accumulate=should_accumulate,
-        )
-
-        return simple_op()
-
-    # The user's exception should be raised - even if we're capturing errors
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            list(do_test())
-
-    # We should gracefully handle the error and return a value
-    res = do_test()
-    assert list(res) == [1, 2, 3]
-
-    assert_no_current_call()
-
-    logs = log_collector.get_error_logs()
-    assert len(logs) == 1
-    assert logs[0].msg.startswith("Error capturing call output")
-
-
-@pytest.mark.asyncio
-@pytest.mark.disable_logging_error_check
-async def test_resilience_to_accumulator_should_accumulate_errors_async(
-    weave_active, log_collector
-):
-    async def do_test():
-        @weave.op
-        async def simple_op():
-            yield 1
-            yield 2
-            yield 3
-
-        def make_accumulator(*args, **kwargs):
-            def accumulate(*args, **kwargs):
-                return {}
-
-            return accumulate
-
-        def should_accumulate(*args, **kwargs):
-            raise DummyTestException("FAILURE!")
-
-        _add_accumulator(
-            simple_op,
-            make_accumulator=make_accumulator,
-            should_accumulate=should_accumulate,
-        )
-
-        return simple_op()
-
-    # The user's exception should be raised - even if we're capturing errors
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            # Consume the generator
-            _ = [i async for i in await do_test()]
-
-    # We should gracefully handle the error and return a value
-    res = await do_test()
-    assert [item async for item in res] == [1, 2, 3]
-
-    assert_no_current_call()
-
-    logs = log_collector.get_error_logs()
-    assert len(logs) == 1
-    assert logs[0].msg.startswith("Error capturing call output")
+    assert logs[0].msg.startswith(expected_msg)
 
 
 # Here we are ignoring this warning because the exception IS being raised,
@@ -431,19 +367,10 @@ def test_resilience_to_accumulator_on_finish_post_processor_errors(
         def simple_op():
             yield from [1, 2, 3]
 
-        def make_accumulator(*args, **kwargs):
-            def accumulate(*args, **kwargs):
-                return {}
-
-            return accumulate
-
-        def on_finish_post_processor(*args, **kwargs):
-            raise DummyTestException("FAILURE!")
-
         _add_accumulator(
             simple_op,
-            make_accumulator=make_accumulator,
-            on_finish_post_processor=on_finish_post_processor,
+            make_accumulator=_empty_accumulator(),
+            on_finish_post_processor=_raising_callback(),
         )
 
         return simple_op()
@@ -478,19 +405,10 @@ async def test_resilience_to_accumulator_on_finish_post_processor_errors_async(
             yield 2
             yield 3
 
-        def make_accumulator(*args, **kwargs):
-            def accumulate(*args, **kwargs):
-                return {}
-
-            return accumulate
-
-        def on_finish_post_processor(*args, **kwargs):
-            raise DummyTestException("FAILURE!")
-
         _add_accumulator(
             simple_op,
-            make_accumulator=make_accumulator,
-            on_finish_post_processor=on_finish_post_processor,
+            make_accumulator=_empty_accumulator(),
+            on_finish_post_processor=_raising_callback(),
         )
 
         return simple_op()
@@ -559,31 +477,23 @@ async def test_resilience_to_accumulator_internal_errors_async(weave_active):
 # =============================================================================
 
 
-def _bad_postprocess_inputs(inputs):
-    raise DummyTestException("FAILURE in postprocess_inputs!")
-
-
-def _bad_postprocess_output(output):
-    raise DummyTestException("FAILURE in postprocess_output!")
-
-
-def _bad_display_name(call):
-    raise DummyTestException("FAILURE in call_display_name!")
-
-
-def _bad_input_handler(op, args, kwargs):
-    raise DummyTestException("FAILURE in on_input_handler!")
-
-
-def _bad_finish_handler(call, output, exception):
-    raise DummyTestException("FAILURE in on_finish_handler!")
-
-
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_postprocess_inputs_errors(weave_active, log_collector):
-    """Test that errors in postprocess_inputs don't crash the user's program."""
+@pytest.mark.parametrize(
+    "op_kwargs",
+    [
+        pytest.param(
+            {"postprocess_inputs": _bad_postprocess_inputs}, id="postprocess-inputs"
+        ),
+        pytest.param(
+            {"postprocess_output": _bad_postprocess_output}, id="postprocess-output"
+        ),
+        pytest.param({"call_display_name": _bad_display_name}, id="call-display-name"),
+    ],
+)
+def test_resilience_to_op_kwarg_callback_errors(weave_active, log_collector, op_kwargs):
+    """A raising postprocess_inputs/output or call_display_name must not crash the op."""
 
-    @weave.op(postprocess_inputs=_bad_postprocess_inputs)
+    @weave.op(**op_kwargs)
     def simple_op():
         return "hello"
 
@@ -598,12 +508,24 @@ def test_resilience_to_postprocess_inputs_errors(weave_active, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_postprocess_inputs_errors_async(
-    weave_active, log_collector
+@pytest.mark.parametrize(
+    "op_kwargs",
+    [
+        pytest.param(
+            {"postprocess_inputs": _bad_postprocess_inputs}, id="postprocess-inputs"
+        ),
+        pytest.param(
+            {"postprocess_output": _bad_postprocess_output}, id="postprocess-output"
+        ),
+        pytest.param({"call_display_name": _bad_display_name}, id="call-display-name"),
+    ],
+)
+async def test_resilience_to_op_kwarg_callback_errors_async(
+    weave_active, log_collector, op_kwargs
 ):
-    """Test that errors in postprocess_inputs don't crash async ops."""
+    """Async variant: a raising postprocess/display_name callback must not crash the op."""
 
-    @weave.op(postprocess_inputs=_bad_postprocess_inputs)
+    @weave.op(**op_kwargs)
     async def simple_op():
         return "hello"
 
@@ -617,12 +539,25 @@ async def test_resilience_to_postprocess_inputs_errors_async(
 
 
 @pytest.mark.disable_logging_error_check
-def test_resilience_to_postprocess_output_errors(weave_active, log_collector):
-    """Test that errors in postprocess_output don't crash the user's program."""
+@pytest.mark.parametrize(
+    "set_handler",
+    [
+        pytest.param(
+            lambda op: op._set_on_input_handler(_bad_input_handler), id="on-input"
+        ),
+        pytest.param(
+            lambda op: op._set_on_finish_handler(_bad_finish_handler), id="on-finish"
+        ),
+    ],
+)
+def test_resilience_to_handler_errors(weave_active, log_collector, set_handler):
+    """A raising _on_input_handler or _on_finish_handler must not crash the op."""
 
-    @weave.op(postprocess_output=_bad_postprocess_output)
+    @weave.op
     def simple_op():
         return "hello"
+
+    set_handler(simple_op)
 
     with raise_on_captured_errors(True):
         with pytest.raises(DummyTestException):
@@ -635,131 +570,27 @@ def test_resilience_to_postprocess_output_errors(weave_active, log_collector):
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
-async def test_resilience_to_postprocess_output_errors_async(
-    weave_active, log_collector
+@pytest.mark.parametrize(
+    "set_handler",
+    [
+        pytest.param(
+            lambda op: op._set_on_input_handler(_bad_input_handler), id="on-input"
+        ),
+        pytest.param(
+            lambda op: op._set_on_finish_handler(_bad_finish_handler), id="on-finish"
+        ),
+    ],
+)
+async def test_resilience_to_handler_errors_async(
+    weave_active, log_collector, set_handler
 ):
-    """Test that errors in postprocess_output don't crash async ops."""
-
-    @weave.op(postprocess_output=_bad_postprocess_output)
-    async def simple_op():
-        return "hello"
-
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            await simple_op()
-
-    res = await simple_op()
-    assert res == "hello"
-    assert_no_current_call()
-
-
-@pytest.mark.disable_logging_error_check
-def test_resilience_to_call_display_name_errors(weave_active, log_collector):
-    """Test that errors in call_display_name callable don't crash the user's program."""
-
-    @weave.op(call_display_name=_bad_display_name)
-    def simple_op():
-        return "hello"
-
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            simple_op()
-
-    res = simple_op()
-    assert res == "hello"
-    assert_no_current_call()
-
-
-@pytest.mark.asyncio
-@pytest.mark.disable_logging_error_check
-async def test_resilience_to_call_display_name_errors_async(
-    weave_active, log_collector
-):
-    """Test that errors in call_display_name callable don't crash async ops."""
-
-    @weave.op(call_display_name=_bad_display_name)
-    async def simple_op():
-        return "hello"
-
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            await simple_op()
-
-    res = await simple_op()
-    assert res == "hello"
-    assert_no_current_call()
-
-
-@pytest.mark.disable_logging_error_check
-def test_resilience_to_on_input_handler_errors(weave_active, log_collector):
-    """Test that errors in _on_input_handler don't crash the user's program."""
-
-    @weave.op
-    def simple_op():
-        return "hello"
-
-    simple_op._set_on_input_handler(_bad_input_handler)
-
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            simple_op()
-
-    res = simple_op()
-    assert res == "hello"
-    assert_no_current_call()
-
-
-@pytest.mark.asyncio
-@pytest.mark.disable_logging_error_check
-async def test_resilience_to_on_input_handler_errors_async(weave_active, log_collector):
-    """Test that errors in _on_input_handler don't crash async ops."""
+    """Async variant: a raising _on_input/_on_finish handler must not crash the op."""
 
     @weave.op
     async def simple_op():
         return "hello"
 
-    simple_op._set_on_input_handler(_bad_input_handler)
-
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            await simple_op()
-
-    res = await simple_op()
-    assert res == "hello"
-    assert_no_current_call()
-
-
-@pytest.mark.disable_logging_error_check
-def test_resilience_to_on_finish_handler_errors(weave_active, log_collector):
-    """Test that errors in _on_finish_handler don't crash the user's program."""
-
-    @weave.op
-    def simple_op():
-        return "hello"
-
-    simple_op._set_on_finish_handler(_bad_finish_handler)
-
-    with raise_on_captured_errors(True):
-        with pytest.raises(DummyTestException):
-            simple_op()
-
-    res = simple_op()
-    assert res == "hello"
-    assert_no_current_call()
-
-
-@pytest.mark.asyncio
-@pytest.mark.disable_logging_error_check
-async def test_resilience_to_on_finish_handler_errors_async(
-    weave_active, log_collector
-):
-    """Test that errors in _on_finish_handler don't crash async ops."""
-
-    @weave.op
-    async def simple_op():
-        return "hello"
-
-    simple_op._set_on_finish_handler(_bad_finish_handler)
+    set_handler(simple_op)
 
     with raise_on_captured_errors(True):
         with pytest.raises(DummyTestException):
@@ -775,93 +606,48 @@ async def test_resilience_to_on_finish_handler_errors_async(
 # =============================================================================
 
 
-def _make_leaking_create_call():
-    """Return a fake _create_call that pushes a call onto the stack then raises.
-
-    This simulates the scenario where client.create_call partially succeeds
-    (pushes a call) but then something fails, leaving an orphaned call on the
-    context stack.
-    """
-
-    def leaking_create_call(func, *args, **kwargs):
-        # Create a minimal mock call with an id, push it, then fail
-        fake_call = MagicMock()
-        fake_call.id = "leaked-call-id"
-        call_context.push_call(fake_call)
-        raise DummyTestException("Simulated _create_call failure after push")
-
-    return leaking_create_call
-
-
 @pytest.mark.disable_logging_error_check
+@pytest.mark.parametrize(
+    ("define_op", "run_op"),
+    [
+        pytest.param(_define_func_op, lambda op: op(), id="func"),
+        pytest.param(_define_gen_op, lambda op: list(op()), id="gen"),
+    ],
+)
 def test_create_call_leak_restores_call_stack_sync(
-    weave_active, monkeypatch, log_collector
+    weave_active, monkeypatch, log_collector, define_op, run_op
 ):
-    """If _create_call pushes a call then throws, the stack must be cleaned up."""
-
-    @weave.op
-    def simple_op():
-        return "hello"
-
+    """If _create_call pushes a call then throws, the stack must be cleaned up (sync + sync-gen)."""
+    op = define_op()
     monkeypatch.setattr("weave.trace.op._create_call", _make_leaking_create_call())
 
-    res = simple_op()
-    assert res == "hello"
+    res = run_op(op)
+    assert res == _expected_result_for(define_op)
     assert_no_current_call()
 
 
 @pytest.mark.asyncio
 @pytest.mark.disable_logging_error_check
+@pytest.mark.parametrize(
+    ("define_op", "is_gen"),
+    [
+        pytest.param(_define_async_func_op, False, id="async"),
+        pytest.param(_define_async_gen_op, True, id="async-gen"),
+    ],
+)
 async def test_create_call_leak_restores_call_stack_async(
-    weave_active, monkeypatch, log_collector
+    weave_active, monkeypatch, log_collector, define_op, is_gen
 ):
-    """Async variant: leaked call from _create_call is cleaned up."""
-
-    @weave.op
-    async def simple_op():
-        return "hello"
-
+    """If _create_call pushes a call then throws, the stack must be cleaned up (async + async-gen)."""
+    op = define_op()
     monkeypatch.setattr("weave.trace.op._create_call", _make_leaking_create_call())
 
-    res = await simple_op()
-    assert res == "hello"
-    assert_no_current_call()
-
-
-@pytest.mark.disable_logging_error_check
-def test_create_call_leak_restores_call_stack_sync_gen(
-    weave_active, monkeypatch, log_collector
-):
-    """Sync generator variant: leaked call from _create_call is cleaned up."""
-
-    @weave.op
-    def gen_op():
-        yield from [1, 2, 3]
-
-    monkeypatch.setattr("weave.trace.op._create_call", _make_leaking_create_call())
-
-    res = list(gen_op())
-    assert res == [1, 2, 3]
-    assert_no_current_call()
-
-
-@pytest.mark.asyncio
-@pytest.mark.disable_logging_error_check
-async def test_create_call_leak_restores_call_stack_async_gen(
-    weave_active, monkeypatch, log_collector
-):
-    """Async generator variant: leaked call from _create_call is cleaned up."""
-
-    @weave.op
-    async def gen_op():
-        yield 1
-        yield 2
-        yield 3
-
-    monkeypatch.setattr("weave.trace.op._create_call", _make_leaking_create_call())
-
-    res = [item async for item in gen_op()]
-    assert res == [1, 2, 3]
+    if is_gen:
+        res = [item async for item in op()]
+        assert res == [1, 2, 3]
+    else:
+        res = await op()
+        assert res == "hello"
     assert_no_current_call()
 
 
@@ -894,3 +680,73 @@ def test_create_call_leak_preserves_parent_call(
     # The parent (outer) call should have been preserved during inner's failure
     assert inner_saw_parent is not None
     assert inner_saw_parent.id != "leaked-call-id"
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+
+def assert_no_current_call():
+    assert call_context.get_current_call() is None
+
+
+def reset_call_context():
+    """Force reset the call context to an empty stack."""
+    token = call_context._call_stack.set([])
+    call_context._call_stack.reset(token)
+
+
+def _raising_callback() -> Callable[..., object]:
+    """A callback that always raises, used for should_accumulate/on_finish."""
+
+    def callback(*args, **kwargs):
+        raise DummyTestException("FAILURE!")
+
+    return callback
+
+
+def _empty_accumulator() -> Callable[..., object]:
+    """make_accumulator returning an accumulate fn that yields an empty dict."""
+
+    def make_accumulator(*args, **kwargs):
+        def accumulate(*args, **kwargs):
+            return {}
+
+        return accumulate
+
+    return make_accumulator
+
+
+def _accumulator_with_raising_accumulate() -> Callable[..., object]:
+    """make_accumulator returning an accumulate fn that raises."""
+
+    def make_accumulator(*args, **kwargs):
+        def accumulate(*args, **kwargs):
+            raise DummyTestException("FAILURE!")
+
+        return accumulate
+
+    return make_accumulator
+
+
+def _make_leaking_create_call():
+    """Return a fake _create_call that pushes a call onto the stack then raises.
+
+    This simulates the scenario where client.create_call partially succeeds
+    (pushes a call) but then something fails, leaving an orphaned call on the
+    context stack.
+    """
+
+    def leaking_create_call(func, *args, **kwargs):
+        # Create a minimal mock call with an id, push it, then fail
+        fake_call = MagicMock()
+        fake_call.id = "leaked-call-id"
+        call_context.push_call(fake_call)
+        raise DummyTestException("Simulated _create_call failure after push")
+
+    return leaking_create_call
+
+
+def _expected_result_for(define_op: Callable[[], Op]) -> object:
+    return [1, 2, 3] if define_op is _define_gen_op else "hello"

--- a/tests/trace/test_traverse.py
+++ b/tests/trace/test_traverse.py
@@ -11,151 +11,108 @@ def test_escape_key() -> None:
     assert escape_key("user.name[0].name") == "user\\.name\\[0\\]\\.name"
 
 
-class TestObjectPathToStr:
-    def test_handles_empty_path(self) -> None:
-        assert ObjectPath([]).to_str() == ""
-
-    def test_handles_simple_cases(self) -> None:
-        assert ObjectPath(["foo"]).to_str() == "foo"
-        assert ObjectPath(["foo", "bar"]).to_str() == "foo.bar"
-        assert ObjectPath(["foo", "4"]).to_str() == "foo.4"
-        assert ObjectPath(["foo", 4]).to_str() == "foo[4]"
-
-    def test_escapes_periods(self) -> None:
-        assert ObjectPath(["foo.bar.baz"]).to_str() == "foo\\.bar\\.baz"
-
-    def test_escapes_brackets(self) -> None:
-        assert ObjectPath(["foo[5]"]).to_str() == "foo\\[5\\]"
-
-    def test_str(self) -> None:
-        assert str(ObjectPath(["foo", "bar"])) == "foo.bar"
-        assert str(ObjectPath(["foo", 4])) == "foo[4]"
+def test_object_path_to_str_and_str() -> None:
+    """to_str renders dotted/indexed paths, escaping periods and brackets; str mirrors it."""
+    assert ObjectPath([]).to_str() == ""
+    assert ObjectPath(["foo"]).to_str() == "foo"
+    assert ObjectPath(["foo", "bar"]).to_str() == "foo.bar"
+    assert ObjectPath(["foo", "4"]).to_str() == "foo.4"
+    assert ObjectPath(["foo", 4]).to_str() == "foo[4]"
+    assert ObjectPath(["foo.bar.baz"]).to_str() == "foo\\.bar\\.baz"
+    assert ObjectPath(["foo[5]"]).to_str() == "foo\\[5\\]"
+    assert str(ObjectPath(["foo", "bar"])) == "foo.bar"
+    assert str(ObjectPath(["foo", 4])) == "foo[4]"
 
 
-class TestObjectPathParseStr:
-    def test_handles_empty_path(self) -> None:
-        assert ObjectPath.parse_str("").elements == []
-
-    def test_handles_simple_cases(self) -> None:
-        assert ObjectPath.parse_str("foo").elements == ["foo"]
-        assert ObjectPath.parse_str("foo.bar").elements == ["foo", "bar"]
-
-    def test_handles_numeric_keys(self) -> None:
-        assert ObjectPath.parse_str("0").elements == ["0"]
-        assert ObjectPath.parse_str("42").elements == ["42"]
-
-    def test_handles_punctuation_in_keys(self) -> None:
-        assert ObjectPath.parse_str("a,b!").elements == ["a,b!"]
-
-    def test_handles_key_access_errors(self) -> None:
-        with pytest.raises(ValueError, match="Invalid object access"):
-            ObjectPath.parse_str(".")
-        with pytest.raises(ValueError, match="Invalid object access"):
-            ObjectPath.parse_str("a[0].")
-        with pytest.raises(ValueError, match="Invalid object access"):
-            ObjectPath.parse_str("a..b")
-
-    def test_handles_array_index_cases(self) -> None:
-        assert ObjectPath.parse_str("foo[2]").elements == ["foo", 2]
-        assert ObjectPath.parse_str("foo[2][3]").elements == ["foo", 2, 3]
-
-    def test_handles_array_index_errors(self) -> None:
-        with pytest.raises(ValueError, match="Invalid array index"):
-            ObjectPath.parse_str("foo[")
-        with pytest.raises(ValueError, match="Invalid array index"):
-            ObjectPath.parse_str("foo[]")
-        with pytest.raises(ValueError, match="Invalid array index"):
-            ObjectPath.parse_str("foo[1e3]")
-        with pytest.raises(ValueError, match="Invalid object access"):
-            ObjectPath.parse_str("foo.[1]")
-
-    def test_handles_escaped_chars(self) -> None:
-        assert ObjectPath.parse_str("foo\\.bar").elements == ["foo.bar"]
-        assert ObjectPath.parse_str("foo\\[").elements == ["foo["]
-
-    def test_handles_escaping_errors(self) -> None:
-        with pytest.raises(ValueError, match="Invalid escape sequence"):
-            ObjectPath.parse_str("foo\\")
-
-    def test_handles_complex_cases(self) -> None:
-        assert ObjectPath.parse_str("fo\\.o[1].bar.baz.bim[3][5].wat").elements == [
-            "fo.o",
-            1,
-            "bar",
-            "baz",
-            "bim",
-            3,
-            5,
-            "wat",
-        ]
+def test_object_path_parse_str_valid() -> None:
+    """parse_str handles empty, simple, numeric, punctuation, array-index, escapes, and complex paths."""
+    assert ObjectPath.parse_str("").elements == []
+    assert ObjectPath.parse_str("foo").elements == ["foo"]
+    assert ObjectPath.parse_str("foo.bar").elements == ["foo", "bar"]
+    assert ObjectPath.parse_str("0").elements == ["0"]
+    assert ObjectPath.parse_str("42").elements == ["42"]
+    assert ObjectPath.parse_str("a,b!").elements == ["a,b!"]
+    assert ObjectPath.parse_str("foo[2]").elements == ["foo", 2]
+    assert ObjectPath.parse_str("foo[2][3]").elements == ["foo", 2, 3]
+    assert ObjectPath.parse_str("foo\\.bar").elements == ["foo.bar"]
+    assert ObjectPath.parse_str("foo\\[").elements == ["foo["]
+    assert ObjectPath.parse_str("fo\\.o[1].bar.baz.bim[3][5].wat").elements == [
+        "fo.o",
+        1,
+        "bar",
+        "baz",
+        "bim",
+        3,
+        5,
+        "wat",
+    ]
 
 
-class TestObjectPathDunderMethods:
-    def test_hash(self) -> None:
-        assert isinstance(hash(ObjectPath(["foo", 42, "bar"])), int)
-
-    def test_getitem(self) -> None:
-        path = ObjectPath(["foo", 42, "bar"])
-        assert path[0] == "foo"
-        assert path[1] == 42
-        assert path[2] == "bar"
-
-    def test_add(self) -> None:
-        assert ObjectPath() + ["foo"] == ObjectPath(["foo"])
-        assert ObjectPath(["foo"]) + [0] == ObjectPath(["foo", 0])
-        assert ObjectPath(["foo"]) + [0, "bar"] == ObjectPath(["foo", 0, "bar"])
-
-    def test_len(self) -> None:
-        assert len(ObjectPath(["foo", 42, "bar"])) == 3
-
-    def test_repr(self) -> None:
-        assert repr(ObjectPath(["foo", 42, "bar"])) == "ObjectPath(['foo', 42, 'bar'])"
+@pytest.mark.parametrize(
+    ("text", "match"),
+    [
+        (".", "Invalid object access"),
+        ("a[0].", "Invalid object access"),
+        ("a..b", "Invalid object access"),
+        ("foo.[1]", "Invalid object access"),
+        ("foo[", "Invalid array index"),
+        ("foo[]", "Invalid array index"),
+        ("foo[1e3]", "Invalid array index"),
+        ("foo\\", "Invalid escape sequence"),
+    ],
+)
+def test_object_path_parse_str_errors(text: str, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        ObjectPath.parse_str(text)
 
 
-class TestObjectPathComparePaths:
-    def test_simple_cases(self) -> None:
-        assert ObjectPath(["foo"]).__eq__(42) is NotImplemented  # noqa: PLC2801
-        assert ObjectPath(["foo"]).__ne__(42) is NotImplemented  # noqa: PLC2801
-        assert ObjectPath(["foo"]) == ObjectPath(["foo"])
-        assert ObjectPath(["foo"]) != ObjectPath(["foo", 42])
-        assert ObjectPath(["foo", 10]) == ObjectPath(["foo", 10])
-        assert ObjectPath(["foo"]) < ObjectPath(["foo", "bar"])
-        assert ObjectPath(["foo"]) <= ObjectPath(["foo", "bar"])
-        assert ObjectPath(["foo"]) <= ObjectPath(["foo"])
-        assert ObjectPath(["foo", "bar"]) > ObjectPath(["foo"])
-        assert ObjectPath(["foo", "bar"]) < ObjectPath(["foo", "baz"])
-        assert ObjectPath(["foo", 9]) < ObjectPath(["foo", 10])
-        assert ObjectPath(["foo", 11]) > ObjectPath(["foo", 1])
-        assert ObjectPath(["foo", 11]) >= ObjectPath(["foo", 11])
-        assert ObjectPath(["foo", "z"]) < ObjectPath(["foo", 0])
-        assert not (ObjectPath(["foo", 0]) < ObjectPath(["foo", "a"]))
+def test_object_path_dunder_methods() -> None:
+    """hash, getitem, add, len, and repr behave as expected."""
+    path = ObjectPath(["foo", 42, "bar"])
+    assert isinstance(hash(path), int)
+    assert path[0] == "foo"
+    assert path[1] == 42
+    assert path[2] == "bar"
+    assert len(path) == 3
+    assert repr(path) == "ObjectPath(['foo', 42, 'bar'])"
+    assert ObjectPath() + ["foo"] == ObjectPath(["foo"])
+    assert ObjectPath(["foo"]) + [0] == ObjectPath(["foo", 0])
+    assert ObjectPath(["foo"]) + [0, "bar"] == ObjectPath(["foo", 0, "bar"])
 
 
-class TestObjectPathGetPaths:
-    def test_object_cases(self) -> None:
-        assert get_paths({}) == []
-        assert get_paths({"foo": 42}) == [ObjectPath(["foo"])]
-        assert get_paths({"foo": {"bar": 42}}) == [
-            ObjectPath(["foo"]),
-            ObjectPath(["foo", "bar"]),
-        ]
-
-    def test_list_cases(self) -> None:
-        obj = {
-            "foo": [
-                {"bar": 42},
-                {"baz": 43},
-            ]
-        }
-        assert get_paths(obj) == [
-            ObjectPath(["foo"]),
-            ObjectPath(["foo", 0]),
-            ObjectPath(["foo", 0, "bar"]),
-            ObjectPath(["foo", 1]),
-            ObjectPath(["foo", 1, "baz"]),
-        ]
+def test_object_path_comparisons() -> None:
+    """Equality returns NotImplemented for foreign types; ordering compares element-wise."""
+    assert ObjectPath(["foo"]).__eq__(42) is NotImplemented  # noqa: PLC2801
+    assert ObjectPath(["foo"]).__ne__(42) is NotImplemented  # noqa: PLC2801
+    assert ObjectPath(["foo"]) == ObjectPath(["foo"])
+    assert ObjectPath(["foo"]) != ObjectPath(["foo", 42])
+    assert ObjectPath(["foo", 10]) == ObjectPath(["foo", 10])
+    assert ObjectPath(["foo"]) < ObjectPath(["foo", "bar"])
+    assert ObjectPath(["foo"]) <= ObjectPath(["foo", "bar"])
+    assert ObjectPath(["foo"]) <= ObjectPath(["foo"])
+    assert ObjectPath(["foo", "bar"]) > ObjectPath(["foo"])
+    assert ObjectPath(["foo", "bar"]) < ObjectPath(["foo", "baz"])
+    assert ObjectPath(["foo", 9]) < ObjectPath(["foo", 10])
+    assert ObjectPath(["foo", 11]) > ObjectPath(["foo", 1])
+    assert ObjectPath(["foo", 11]) >= ObjectPath(["foo", 11])
+    assert ObjectPath(["foo", "z"]) < ObjectPath(["foo", 0])
+    assert not (ObjectPath(["foo", 0]) < ObjectPath(["foo", "a"]))
 
 
-class TestObjectPathSortPaths:
-    def test_sorting(self) -> None:
-        assert sort_paths([]) == []
+def test_get_paths_and_sort_paths() -> None:
+    """get_paths walks objects and nested lists depth-first; sort_paths handles empty input."""
+    assert get_paths({}) == []
+    assert get_paths({"foo": 42}) == [ObjectPath(["foo"])]
+    assert get_paths({"foo": {"bar": 42}}) == [
+        ObjectPath(["foo"]),
+        ObjectPath(["foo", "bar"]),
+    ]
+    list_obj = {"foo": [{"bar": 42}, {"baz": 43}]}
+    assert get_paths(list_obj) == [
+        ObjectPath(["foo"]),
+        ObjectPath(["foo", 0]),
+        ObjectPath(["foo", 0, "bar"]),
+        ObjectPath(["foo", 1]),
+        ObjectPath(["foo", 1, "baz"]),
+    ]
+    assert sort_paths([]) == []

--- a/tests/trace/test_vals.py
+++ b/tests/trace/test_vals.py
@@ -11,6 +11,9 @@ from weave.trace.refs import ObjectRef
 
 
 def test_dict_refs(client):
+    """Saved dict keeps descended refs; materializing via `dict()` drops the
+    container ref but children still descend from the original.
+    """
     d = client.save({"a": 1, "b": 2}, name="d")
 
     assert d["a"] == 1
@@ -23,25 +26,26 @@ def test_dict_refs(client):
     assert d["b"].ref.is_descended_from(d.ref)
     assert d["b"].ref.extra == (DICT_KEY_EDGE_NAME, "b")
 
-
-def test_dict_iter(client):
     d_orig = client.save({"a": 1, "b": 2, "c": 3}, name="d")
-    d = dict(d_orig)
+    materialized = dict(d_orig)
     with pytest.raises(AttributeError):
-        _ = d.ref
+        _ = materialized.ref
 
-    assert d["a"] == 1
-    assert isinstance(d["a"].ref, ObjectRef)
-    assert d["a"].ref.is_descended_from(d_orig.ref)
-    assert d["a"].ref.extra == (DICT_KEY_EDGE_NAME, "a")
+    assert materialized["a"] == 1
+    assert isinstance(materialized["a"].ref, ObjectRef)
+    assert materialized["a"].ref.is_descended_from(d_orig.ref)
+    assert materialized["a"].ref.extra == (DICT_KEY_EDGE_NAME, "a")
 
-    assert d["b"] == 2
-    assert isinstance(d["b"].ref, ObjectRef)
-    assert d["b"].ref.is_descended_from(d_orig.ref)
-    assert d["b"].ref.extra == (DICT_KEY_EDGE_NAME, "b")
+    assert materialized["b"] == 2
+    assert isinstance(materialized["b"].ref, ObjectRef)
+    assert materialized["b"].ref.is_descended_from(d_orig.ref)
+    assert materialized["b"].ref.extra == (DICT_KEY_EDGE_NAME, "b")
 
 
 def test_list_refs(client):
+    """Saved list keeps descended refs; materializing via `list()` drops the
+    container ref but children still descend from the original.
+    """
     l = client.save([1, 2], name="l")
 
     assert l[0] == 1
@@ -54,20 +58,18 @@ def test_list_refs(client):
     assert l[1].ref.is_descended_from(l.ref)
     assert l[1].ref.extra == (LIST_INDEX_EDGE_NAME, "1")
 
-
-def test_list_iter(client):
     l_orig = client.save([1, 2], name="l")
-    l = list(l_orig)
+    materialized = list(l_orig)
     with pytest.raises(AttributeError):
-        _ = l.ref
+        _ = materialized.ref
 
-    assert l[0] == 1
-    assert l[0].ref.is_descended_from(l_orig.ref)
-    assert isinstance(l[0].ref, ObjectRef)
+    assert materialized[0] == 1
+    assert materialized[0].ref.is_descended_from(l_orig.ref)
+    assert isinstance(materialized[0].ref, ObjectRef)
 
-    assert l[1] == 2
-    assert l[1].ref.is_descended_from(l_orig.ref)
-    assert isinstance(l[1].ref, ObjectRef)
+    assert materialized[1] == 2
+    assert materialized[1].ref.is_descended_from(l_orig.ref)
+    assert isinstance(materialized[1].ref, ObjectRef)
 
 
 def test_row_ref_inside_dict(client):

--- a/tests/trace/test_wal_client_writes.py
+++ b/tests/trace/test_wal_client_writes.py
@@ -34,6 +34,397 @@ from weave.trace import weave_client
 from weave.trace.settings import UserSettings, override_settings
 from weave.trace_server import trace_server_interface as tsi
 
+# The initial WAL points at the shared ~/.weave/wal/<entity>/<project>/
+# directory, so starting a sender there races with parallel xdist workers
+# and has triggered Windows file-handle errors.  Both fixtures redirect
+# to an isolated tmp_path, so no sender needs to run against the default.
+_INITIAL_WAL_SETTINGS = UserSettings(enable_wal=True, disable_wal_sender=True)
+
+
+@pytest.fixture
+def wal_client(client_creator, tmp_path):
+    """Create a client with WAL enabled but sender stopped (write-only)."""
+    wal_dir = str(tmp_path / "wal")
+    with client_creator(settings=_INITIAL_WAL_SETTINGS) as client:
+        _redirect_wal_to(client, wal_dir)
+        yield client
+
+
+@pytest.fixture
+def wal_client_with_sender(client_creator, tmp_path):
+    """Create a client with WAL enabled and sender running."""
+    wal_dir = str(tmp_path / "wal")
+    with client_creator(settings=_INITIAL_WAL_SETTINGS) as client:
+        _redirect_wal_to(client, wal_dir)
+        client._wal._sender = create_sender(wal_dir, client.server)
+        client._wal._sender.start()
+        yield client
+
+
+def test_obj_table_and_file_create_write_records(wal_client):
+    """obj_create, table_create, and image publish (file+obj) all hit the WAL."""
+    project_id = f"{wal_client.entity}/{wal_client.project}"
+
+    weave.publish({"model": "gpt-4", "temp": 0.7}, name="my_obj")
+    wal_client._flush()
+    records = _read_all_wal_records(wal_client)
+    assert len(records) == 1
+    assert records[0] == {
+        "type": "obj_create",
+        "req": {
+            "obj": {
+                "project_id": project_id,
+                "object_id": "my_obj",
+                "val": {"model": "gpt-4", "temp": 0.7},
+                "builtin_object_class": None,
+                "expected_digest": None,
+                "wb_user_id": None,
+            }
+        },
+    }
+
+    wal_client._send_table_create([{"x": 1}, {"x": 2}])
+    wal_client._flush()
+    table_recs = [
+        r for r in _read_all_wal_records(wal_client) if r["type"] == "table_create"
+    ]
+    assert len(table_recs) == 1
+    assert table_recs[0] == {
+        "type": "table_create",
+        "req": {
+            "table": {
+                "project_id": project_id,
+                "rows": [{"x": 1}, {"x": 2}],
+                "expected_digest": None,
+            }
+        },
+    }
+
+    img = Image.new("RGB", (2, 2), color="red")
+    weave.publish(img, name="my_image")
+    wal_client._flush()
+    img_records = _read_all_wal_records(wal_client)
+    file_recs = [r for r in img_records if r["type"] == "file_create"]
+    assert any(
+        r["req"]["project_id"] == project_id and r["req"]["name"] == "obj.py"
+        for r in file_recs
+    )
+    image_obj = next(
+        r
+        for r in img_records
+        if r["type"] == "obj_create" and r["req"]["obj"]["object_id"] == "my_image"
+    )
+    assert image_obj["req"]["obj"]["val"]["weave_type"] == {"type": "PIL.Image.Image"}
+
+
+def test_call_start_and_end_records(wal_client):
+    """A traced op writes one call_start and one call_end with all fields populated."""
+
+    @weave.op
+    def add(a: int, b: int) -> int:
+        return a + b
+
+    add(1, 2)
+    wal_client._flush()
+
+    records = _read_all_wal_records(wal_client)
+    project_id = f"{wal_client.entity}/{wal_client.project}"
+
+    call_starts = [r for r in records if r["type"] == "call_start"]
+    call_ends = [r for r in records if r["type"] == "call_end"]
+    assert len(call_starts) == 1
+    assert len(call_ends) == 1
+
+    start = call_starts[0]["req"]["start"]
+    assert start["project_id"] == project_id
+    assert "/op/add:" in start["op_name"]
+    assert start["inputs"] == {"a": 1, "b": 2}
+    assert start["id"] is not None
+    assert start["trace_id"] is not None
+    assert start["started_at"] is not None
+    assert isinstance(start["attributes"], dict)
+    assert start["parent_id"] is None
+
+    end = call_ends[0]["req"]["end"]
+    assert end["project_id"] == project_id
+    assert end["id"] is not None
+    assert end["output"] == 3
+    assert end["ended_at"] is not None
+    assert end["exception"] is None
+    assert isinstance(end["summary"], dict)
+
+
+def test_call_with_exception(wal_client):
+    """A failing op should record the exception in call_end."""
+
+    @weave.op
+    def fail() -> None:
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        fail()
+    wal_client._flush()
+
+    records = _read_all_wal_records(wal_client)
+    call_ends = [r for r in records if r["type"] == "call_end"]
+    assert len(call_ends) == 1
+    assert "boom" in call_ends[0]["req"]["end"]["exception"]
+
+
+def test_nested_calls(wal_client):
+    """Nested op calls should produce parent-child call_start records."""
+
+    @weave.op
+    def inner(x: int) -> int:
+        return x * 2
+
+    @weave.op
+    def outer(x: int) -> int:
+        return inner(x)
+
+    outer(5)
+    wal_client._flush()
+
+    records = _read_all_wal_records(wal_client)
+    call_starts = [r for r in records if r["type"] == "call_start"]
+    call_ends = [r for r in records if r["type"] == "call_end"]
+    assert len(call_starts) == 2
+    assert len(call_ends) == 2
+
+    outer_start = next(
+        s for s in call_starts if "outer" in s["req"]["start"]["op_name"]
+    )
+    inner_start = next(
+        s for s in call_starts if "inner" in s["req"]["start"]["op_name"]
+    )
+    assert inner_start["req"]["start"]["parent_id"] == outer_start["req"]["start"]["id"]
+    assert (
+        inner_start["req"]["start"]["trace_id"]
+        == outer_start["req"]["start"]["trace_id"]
+    )
+
+    outer_end = next(
+        e
+        for e in call_ends
+        if e["req"]["end"]["id"] == outer_start["req"]["start"]["id"]
+    )
+    inner_end = next(
+        e
+        for e in call_ends
+        if e["req"]["end"]["id"] == inner_start["req"]["start"]["id"]
+    )
+    assert inner_end["req"]["end"]["output"] == 10
+    assert outer_end["req"]["end"]["output"] == 10
+
+
+def test_wal_records_json_serializable_and_flush_fsyncs(wal_client):
+    """Records round-trip through JSON, and flush() fsyncs (records survive a crash)."""
+    weave.publish({"nested": {"list": [1, 2, 3]}}, name="json_obj")
+    wal_client._flush()
+    records = _read_all_wal_records(wal_client)
+    assert len(records) == 1
+    assert json.loads(json.dumps(records[0])) == records[0]
+
+    weave.publish({"a": 1}, name="fsync_obj")
+    wal_client.flush()
+    records = _read_all_wal_records(wal_client)
+    fsync_recs = [r for r in records if r["req"]["obj"]["object_id"] == "fsync_obj"]
+    assert len(fsync_recs) == 1
+    assert fsync_recs[0]["type"] == "obj_create"
+
+
+def test_client_works_when_wal_disabled(client, weave_active):
+    """Default client has _wal=None; publish/dataset-publish/flush all work."""
+    assert client._wal is None
+
+    assert weave.publish({"key": "value"}, name="no_wal_obj") is not None
+    ds = weave.Dataset(name="no_wal_ds", rows=[{"x": 1}])
+    assert weave.publish(ds, name="no_wal_ds") is not None
+
+    weave.publish({"a": 1}, name="flush_obj")
+    client.flush()  # must not raise
+
+
+@pytest.mark.parametrize("publish_fn", ["obj", "dataset"])
+def test_sender_drains_wal_on_close(wal_client_with_sender, publish_fn):
+    """The in-process sender drains obj and table records, leaving no files on close."""
+    if publish_fn == "obj":
+        weave.publish({"k": "v"}, name="sender_obj")
+    else:
+        weave.publish(
+            weave.Dataset(name="sender_ds", rows=[{"x": 1}]), name="sender_ds"
+        )
+    wal_client_with_sender._flush()
+    wal_dir = Path(wal_client_with_sender._wal.wal_dir)
+    wal_client_with_sender._wal.close()
+    assert len(list(wal_dir.glob("*.jsonl"))) == 0
+
+
+def test_write_only_manager_persists_records(tmp_path):
+    """WALManager without sender writes records but doesn't drain them."""
+    mgr = WALManager("test-entity", "test-project")
+    mgr.wal_dir = str(tmp_path)
+    mgr._writer = JSONLWALWriter(FileWALDirectoryManager(str(tmp_path)))
+
+    mgr.write(
+        "obj_create",
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id="test-entity/test-project",
+                object_id="test_obj",
+                val={"hello": "world"},
+            )
+        ),
+    )
+    mgr.flush()
+
+    records: list[dict] = []
+    for path in sorted(tmp_path.glob("*.jsonl")):
+        consumer = JSONLWALConsumer(str(path))
+        try:
+            for entry in consumer.read_pending():
+                records.append(entry.record)
+        finally:
+            consumer.close()
+
+    assert len(records) == 1
+    assert records[0] == {
+        "type": "obj_create",
+        "req": {
+            "obj": {
+                "project_id": "test-entity/test-project",
+                "object_id": "test_obj",
+                "val": {"hello": "world"},
+                "builtin_object_class": None,
+                "expected_digest": None,
+                "wb_user_id": None,
+            }
+        },
+    }
+    # No sender — file should still be on disk.
+    assert len(list(tmp_path.glob("*.jsonl"))) == 1
+    mgr.close()
+
+
+@pytest.mark.disable_logging_error_check
+def test_close_is_idempotent(tmp_path, wal_client_with_sender):
+    """close() is safe to call twice, both bare-manager and with a running sender."""
+    mgr = WALManager("test-entity", "test-project")
+    mgr.close()
+    mgr.close()
+
+    wal_client_with_sender._wal.close()
+    wal_client_with_sender._wal.close()
+
+
+def test_trace_server_handlers_dispatch():
+    """Handlers cover every record type and each replays the dict to the matching method.
+
+    Covers the obj_create, table_create, and call_start replay paths plus parity
+    between the class `as_dict()` and the `build_trace_server_handlers` convenience.
+    """
+    mock_server = MagicMock()
+    handlers = TraceServerHandlers(mock_server).as_dict()
+    assert set(handlers.keys()) == set(_RECORD_TYPE_TO_REQ.keys())
+    assert set(build_trace_server_handlers(mock_server).keys()) == set(handlers.keys())
+
+    obj_req = tsi.ObjCreateReq(
+        obj=tsi.ObjSchemaForInsert(project_id="e/p", object_id="test", val={"x": 1})
+    )
+    handlers["obj_create"](
+        {"type": "obj_create", "req": obj_req.model_dump(mode="json")}
+    )
+    mock_server.obj_create.assert_called_once()
+    obj_arg = mock_server.obj_create.call_args[0][0]
+    assert isinstance(obj_arg, tsi.ObjCreateReq)
+    assert obj_arg.obj.object_id == "test"
+
+    table_req = tsi.TableCreateReq(
+        table=tsi.TableSchemaForInsert(
+            project_id="e/p", rows=[{"val": {"x": 1}, "digest": "abc123"}]
+        )
+    )
+    handlers["table_create"](
+        {"type": "table_create", "req": table_req.model_dump(mode="json")}
+    )
+    mock_server.table_create.assert_called_once()
+
+    started = datetime.datetime.now(datetime.timezone.utc)
+    start_req = tsi.CallStartReq(
+        start=tsi.StartedCallSchemaForInsert(
+            project_id="e/p",
+            op_name="predict",
+            trace_id="t1",
+            started_at=started,
+            attributes={"k": "v"},
+            inputs={"x": 1},
+        )
+    )
+    handlers["call_start"](
+        {"type": "call_start", "req": start_req.model_dump(mode="json")}
+    )
+    mock_server.call_start.assert_called_once()
+    start_arg = mock_server.call_start.call_args[0][0]
+    assert isinstance(start_arg, tsi.CallStartReq)
+    assert start_arg.start.op_name == "predict"
+    assert start_arg.start.started_at == started
+    assert start_arg.start.attributes == {"k": "v"}
+    assert start_arg.start.inputs == {"x": 1}
+
+
+def test_file_create_roundtrips_bytes_content():
+    """file_create handler must preserve bytes content through replay.
+
+    Pydantic v2 dumps bytes fields as utf-8 strings under mode="json" and
+    model_validate re-encodes them; the round-trip must be lossless for content
+    that actually reaches the WAL (non-utf8 bytes fail at write time).
+    """
+    mock_server = MagicMock()
+    handlers = TraceServerHandlers(mock_server).as_dict()
+
+    original_content = "small file body — including non-ascii: café 🎉".encode()
+    req = tsi.FileCreateReq(project_id="e/p", name="note.txt", content=original_content)
+    handlers["file_create"]({"type": "file_create", "req": req.model_dump(mode="json")})
+
+    mock_server.file_create.assert_called_once()
+    call_arg = mock_server.file_create.call_args[0][0]
+    assert isinstance(call_arg, tsi.FileCreateReq)
+    assert call_arg.content == original_content
+
+
+def test_create_sender_returns_startable_sender(tmp_path):
+    """create_sender returns a configured BackgroundWALSender that starts and stops."""
+    mock_server = MagicMock()
+    sender = create_sender(str(tmp_path), mock_server, poll_interval=0.5)
+    assert isinstance(sender, BackgroundWALSender)
+    assert sender._poll_interval == 0.5
+
+    sender2 = create_sender(str(tmp_path), mock_server, poll_interval=0.1)
+    sender2.start()
+    sender2.stop()
+
+
+@pytest.mark.parametrize("with_api_key", [True, False])
+def test_wal_directory_namespacing_by_api_key(client, with_api_key):
+    """With api_key the WAL dir ends in an HMAC subdir; without it, the flat project path."""
+    api_key = "wk-test-key-for-wal-namespacing" if with_api_key else None
+    with override_settings(enable_wal=True, disable_wal_sender=True):
+        wc = weave_client.WeaveClient(
+            client.entity,
+            client.project,
+            client.server,
+            ensure_project_exists=False,
+            api_key=api_key,
+        )
+        try:
+            assert wc._wal is not None
+            if with_api_key:
+                assert wc._wal.wal_dir.endswith(compute_client_id(api_key))
+            else:
+                assert wc._wal.wal_dir.endswith(wc.project)
+        finally:
+            wc._wal.close()
+
 
 def _read_all_wal_records(client: weave.WeaveClient) -> list[dict]:
     """Read all records from a client's WAL directory."""
@@ -52,544 +443,8 @@ def _read_all_wal_records(client: weave.WeaveClient) -> list[dict]:
 
 
 def _redirect_wal_to(client: weave.WeaveClient, wal_dir: str) -> None:
-    """Replace the client's WAL writer (and optionally sender) to use *wal_dir*.
-
-    This gives each test an isolated WAL directory so parallel xdist
-    workers never interfere with each other.
-    """
+    """Replace the client's WAL writer to use *wal_dir* for test isolation."""
     wal = client._wal
-    # Tear down whatever was created during init.
     wal.close()
-    # Re-create writer (and optionally sender) in the isolated directory.
     wal.wal_dir = wal_dir
-    dir_mgr = FileWALDirectoryManager(wal_dir)
-    wal._writer = JSONLWALWriter(dir_mgr)
-
-
-# The initial WAL points at the shared ~/.weave/wal/<entity>/<project>/
-# directory, so starting a sender there races with parallel xdist workers
-# and has triggered Windows file-handle errors.  Both fixtures redirect
-# to an isolated tmp_path, so no sender needs to run against the default.
-_INITIAL_WAL_SETTINGS = UserSettings(enable_wal=True, disable_wal_sender=True)
-
-
-@pytest.fixture
-def wal_client(client_creator, tmp_path):
-    """Create a client with WAL enabled but sender stopped (write-only).
-
-    Redirects the WAL to ``tmp_path`` for test isolation.
-    """
-    wal_dir = str(tmp_path / "wal")
-    with client_creator(settings=_INITIAL_WAL_SETTINGS) as client:
-        _redirect_wal_to(client, wal_dir)
-        yield client
-
-
-@pytest.fixture
-def wal_client_with_sender(client_creator, tmp_path):
-    """Create a client with WAL enabled and sender running.
-
-    Redirects the WAL to ``tmp_path`` for test isolation.
-    """
-    wal_dir = str(tmp_path / "wal")
-    with client_creator(settings=_INITIAL_WAL_SETTINGS) as client:
-        _redirect_wal_to(client, wal_dir)
-        # Create sender pointing at the isolated directory.
-        client._wal._sender = create_sender(wal_dir, client.server)
-        client._wal._sender.start()
-        yield client
-
-
-class TestWALClientWrites:
-    """Verify that client operations produce WAL records when enabled."""
-
-    def test_obj_create(self, wal_client):
-        weave.publish({"model": "gpt-4", "temp": 0.7}, name="my_obj")
-        wal_client._flush()
-
-        records = _read_all_wal_records(wal_client)
-        assert len(records) == 1
-        project_id = f"{wal_client.entity}/{wal_client.project}"
-        assert records[0] == {
-            "type": "obj_create",
-            "req": {
-                "obj": {
-                    "project_id": project_id,
-                    "object_id": "my_obj",
-                    "val": {"model": "gpt-4", "temp": 0.7},
-                    "builtin_object_class": None,
-                    "expected_digest": None,
-                    "wb_user_id": None,
-                }
-            },
-        }
-
-    def test_table_create(self, wal_client):
-        wal_client._send_table_create([{"x": 1}, {"x": 2}])
-        wal_client._flush()
-
-        records = _read_all_wal_records(wal_client)
-        project_id = f"{wal_client.entity}/{wal_client.project}"
-
-        assert len(records) == 1
-        assert records[0] == {
-            "type": "table_create",
-            "req": {
-                "table": {
-                    "project_id": project_id,
-                    "rows": [{"x": 1}, {"x": 2}],
-                    "expected_digest": None,
-                }
-            },
-        }
-
-    def test_file_create(self, wal_client):
-        img = Image.new("RGB", (2, 2), color="red")
-        weave.publish(img, name="my_image")
-        wal_client._flush()
-
-        records = _read_all_wal_records(wal_client)
-        project_id = f"{wal_client.entity}/{wal_client.project}"
-
-        # Image publish produces: 1 file_create (op code) + 1 obj_create (load op)
-        # + 1 obj_create (image object).  The file_create for the image.png
-        # binary is embedded within the image obj_create's val.files.
-        assert len(records) == 3
-        file_rec = records[0]
-        assert file_rec["type"] == "file_create"
-        assert file_rec["req"]["project_id"] == project_id
-        assert file_rec["req"]["name"] == "obj.py"
-
-        image_obj = records[2]
-        assert image_obj["type"] == "obj_create"
-        assert image_obj["req"]["obj"]["object_id"] == "my_image"
-        assert image_obj["req"]["obj"]["val"]["weave_type"] == {
-            "type": "PIL.Image.Image"
-        }
-
-    def test_call_start(self, wal_client):
-        """Calling an op should produce a call_start WAL record with all fields."""
-
-        @weave.op
-        def add(a: int, b: int) -> int:
-            return a + b
-
-        add(1, 2)
-        wal_client._flush()
-
-        records = _read_all_wal_records(wal_client)
-        project_id = f"{wal_client.entity}/{wal_client.project}"
-
-        call_starts = [r for r in records if r["type"] == "call_start"]
-        assert len(call_starts) == 1
-
-        start = call_starts[0]["req"]["start"]
-        assert start["project_id"] == project_id
-        assert "/op/add:" in start["op_name"]
-        assert start["inputs"] == {"a": 1, "b": 2}
-        assert start["id"] is not None
-        assert start["trace_id"] is not None
-        assert start["started_at"] is not None
-        assert isinstance(start["attributes"], dict)
-        assert start["parent_id"] is None  # root call
-
-    def test_call_end(self, wal_client):
-        """Calling an op should produce a call_end WAL record with all fields."""
-
-        @weave.op
-        def add(a: int, b: int) -> int:
-            return a + b
-
-        add(1, 2)
-        wal_client._flush()
-
-        records = _read_all_wal_records(wal_client)
-        project_id = f"{wal_client.entity}/{wal_client.project}"
-
-        call_ends = [r for r in records if r["type"] == "call_end"]
-        assert len(call_ends) == 1
-
-        end = call_ends[0]["req"]["end"]
-        assert end["project_id"] == project_id
-        assert end["id"] is not None
-        assert end["output"] == 3
-        assert end["ended_at"] is not None
-        assert end["exception"] is None
-        assert isinstance(end["summary"], dict)
-
-    def test_call_with_exception(self, wal_client):
-        """A failing op should record the exception in call_end."""
-
-        @weave.op
-        def fail() -> None:
-            raise ValueError("boom")
-
-        with pytest.raises(ValueError, match="boom"):
-            fail()
-        wal_client._flush()
-
-        records = _read_all_wal_records(wal_client)
-
-        call_ends = [r for r in records if r["type"] == "call_end"]
-        assert len(call_ends) == 1
-        assert "boom" in call_ends[0]["req"]["end"]["exception"]
-
-    def test_nested_calls(self, wal_client):
-        """Nested op calls should produce parent-child call_start records."""
-
-        @weave.op
-        def inner(x: int) -> int:
-            return x * 2
-
-        @weave.op
-        def outer(x: int) -> int:
-            return inner(x)
-
-        outer(5)
-        wal_client._flush()
-
-        records = _read_all_wal_records(wal_client)
-
-        call_starts = [r for r in records if r["type"] == "call_start"]
-        call_ends = [r for r in records if r["type"] == "call_end"]
-        assert len(call_starts) == 2
-        assert len(call_ends) == 2
-
-        # Find outer and inner by op_name
-        outer_start = next(
-            s for s in call_starts if "outer" in s["req"]["start"]["op_name"]
-        )
-        inner_start = next(
-            s for s in call_starts if "inner" in s["req"]["start"]["op_name"]
-        )
-
-        # Inner call's parent_id should match outer call's id
-        assert (
-            inner_start["req"]["start"]["parent_id"]
-            == outer_start["req"]["start"]["id"]
-        )
-        # Both should share the same trace_id
-        assert (
-            inner_start["req"]["start"]["trace_id"]
-            == outer_start["req"]["start"]["trace_id"]
-        )
-
-        # Verify outputs
-        outer_end = next(
-            e
-            for e in call_ends
-            if e["req"]["end"]["id"] == outer_start["req"]["start"]["id"]
-        )
-        inner_end = next(
-            e
-            for e in call_ends
-            if e["req"]["end"]["id"] == inner_start["req"]["start"]["id"]
-        )
-        assert inner_end["req"]["end"]["output"] == 10
-        assert outer_end["req"]["end"]["output"] == 10
-
-    def test_wal_records_are_json_serializable(self, wal_client):
-        """Ensure WAL records round-trip through JSON without loss."""
-        weave.publish({"nested": {"list": [1, 2, 3]}}, name="json_obj")
-        wal_client._flush()
-
-        records = _read_all_wal_records(wal_client)
-        assert len(records) == 1
-        roundtripped = json.loads(json.dumps(records[0]))
-        assert roundtripped == records[0]
-
-    def test_flush_fsyncs_wal(self, wal_client):
-        """flush() should fsync the WAL so records survive a process crash."""
-        weave.publish({"a": 1}, name="fsync_obj")
-        wal_client.flush()
-
-        records = _read_all_wal_records(wal_client)
-        assert len(records) == 1
-        assert records[0]["type"] == "obj_create"
-
-
-class TestWALDisabled:
-    """Verify the client works normally when WAL is disabled (the default)."""
-
-    def test_wal_is_none_by_default(self, client):
-        """Default client should have _wal=None."""
-        assert client._wal is None
-
-    def test_publish_works_without_wal(self, weave_active):
-        """publish() should succeed and return a ref when WAL is disabled."""
-        ref = weave.publish({"key": "value"}, name="no_wal_obj")
-        assert ref is not None
-
-    def test_dataset_publish_works_without_wal(self, weave_active):
-        """Dataset publish should succeed when WAL is disabled."""
-        ds = weave.Dataset(name="no_wal_ds", rows=[{"x": 1}])
-        ref = weave.publish(ds, name="no_wal_ds")
-        assert ref is not None
-
-    def test_flush_works_without_wal(self, client):
-        """flush() should not raise when WAL is disabled."""
-        weave.publish({"a": 1}, name="flush_obj")
-        client.flush()
-
-
-class TestWALSender:
-    """Verify that the in-process sender drains WAL records automatically."""
-
-    def test_sender_drains_on_close(self, wal_client_with_sender):
-        """After close(), the sender's final drain should consume all records."""
-        weave.publish({"k": "v"}, name="sender_obj")
-        wal_client_with_sender._flush()
-        wal_dir = Path(wal_client_with_sender._wal.wal_dir)
-        wal_client_with_sender._wal.close()
-
-        remaining = list(wal_dir.glob("*.jsonl"))
-        assert len(remaining) == 0
-
-    def test_sender_drains_table_create(self, wal_client_with_sender):
-        """Table-create records should be drained and files cleaned up."""
-        ds = weave.Dataset(name="sender_ds", rows=[{"x": 1}])
-        weave.publish(ds, name="sender_ds")
-        wal_client_with_sender._flush()
-        wal_dir = Path(wal_client_with_sender._wal.wal_dir)
-        wal_client_with_sender._wal.close()
-
-        remaining = list(wal_dir.glob("*.jsonl"))
-        assert len(remaining) == 0
-
-
-class TestWALManagerLifecycle:
-    """Unit tests for WALManager without a full client."""
-
-    def test_write_only_manager(self, tmp_path):
-        """WALManager without sender writes records but doesn't drain them."""
-        mgr = WALManager("test-entity", "test-project")
-        mgr.wal_dir = str(tmp_path)
-        dir_mgr = FileWALDirectoryManager(str(tmp_path))
-        mgr._writer = JSONLWALWriter(dir_mgr)
-
-        mgr.write(
-            "obj_create",
-            tsi.ObjCreateReq(
-                obj=tsi.ObjSchemaForInsert(
-                    project_id="test-entity/test-project",
-                    object_id="test_obj",
-                    val={"hello": "world"},
-                )
-            ),
-        )
-        mgr.flush()
-
-        records: list[dict] = []
-        for path in sorted(tmp_path.glob("*.jsonl")):
-            consumer = JSONLWALConsumer(str(path))
-            try:
-                for entry in consumer.read_pending():
-                    records.append(entry.record)
-            finally:
-                consumer.close()
-
-        assert len(records) == 1
-        assert records[0] == {
-            "type": "obj_create",
-            "req": {
-                "obj": {
-                    "project_id": "test-entity/test-project",
-                    "object_id": "test_obj",
-                    "val": {"hello": "world"},
-                    "builtin_object_class": None,
-                    "expected_digest": None,
-                    "wb_user_id": None,
-                }
-            },
-        }
-
-        # No sender — file should still be on disk.
-        assert len(list(tmp_path.glob("*.jsonl"))) == 1
-        mgr.close()
-
-    def test_close_is_idempotent(self, tmp_path):
-        """Calling close() multiple times should not raise."""
-        mgr = WALManager("test-entity", "test-project")
-        mgr.close()
-        mgr.close()  # second call should be a no-op
-
-    @pytest.mark.disable_logging_error_check
-    def test_close_with_sender_is_idempotent(self, wal_client_with_sender):
-        """close() on a manager with sender should be safe to call twice."""
-        wal_client_with_sender._wal.close()
-        wal_client_with_sender._wal.close()  # should not raise
-
-
-class TestTraceServerHandlers:
-    """Verify TraceServerHandlers and build_trace_server_handlers."""
-
-    def test_builds_handler_for_every_record_type(self):
-        """Should produce a handler for each type in _RECORD_TYPE_TO_REQ."""
-        mock_server = MagicMock()
-        h = TraceServerHandlers(mock_server)
-        handlers = h.as_dict()
-
-        assert set(handlers.keys()) == set(_RECORD_TYPE_TO_REQ.keys())
-
-    def test_handler_calls_correct_server_method(self):
-        """Each handler should call the matching method on the server."""
-        mock_server = MagicMock()
-        handlers = TraceServerHandlers(mock_server).as_dict()
-
-        req = tsi.ObjCreateReq(
-            obj=tsi.ObjSchemaForInsert(
-                project_id="e/p",
-                object_id="test",
-                val={"x": 1},
-            )
-        )
-        record = {"type": "obj_create", "req": req.model_dump(mode="json")}
-        handlers["obj_create"](record)
-
-        mock_server.obj_create.assert_called_once()
-        call_arg = mock_server.obj_create.call_args[0][0]
-        assert isinstance(call_arg, tsi.ObjCreateReq)
-        assert call_arg.obj.object_id == "test"
-
-    def test_handler_calls_table_create(self):
-        """table_create handler should call server.table_create."""
-        mock_server = MagicMock()
-        handlers = TraceServerHandlers(mock_server).as_dict()
-
-        req = tsi.TableCreateReq(
-            table=tsi.TableSchemaForInsert(
-                project_id="e/p",
-                rows=[{"val": {"x": 1}, "digest": "abc123"}],
-            )
-        )
-        record = {"type": "table_create", "req": req.model_dump(mode="json")}
-        handlers["table_create"](record)
-
-        mock_server.table_create.assert_called_once()
-
-    def test_file_create_roundtrips_bytes_content(self):
-        """file_create handler must preserve bytes content through replay.
-
-        Regression guard for the model_validate(dict) replay path: Pydantic
-        v2 dumps bytes fields as utf-8 strings under mode="json", and
-        model_validate accepts strings for bytes fields by re-encoding them.
-        The round-trip must be lossless for content that actually reaches
-        the WAL (non-utf8 bytes already fail at write time, so they never
-        reach replay).
-        """
-        mock_server = MagicMock()
-        handlers = TraceServerHandlers(mock_server).as_dict()
-
-        # utf-8-decodable content — this is the only kind that can reach the
-        # WAL today (model_dump(mode="json") rejects non-utf8 bytes at write
-        # time, so non-utf8 content never appears in a replayed record).
-        original_content = "small file body — including non-ascii: café 🎉".encode()
-        req = tsi.FileCreateReq(
-            project_id="e/p",
-            name="note.txt",
-            content=original_content,
-        )
-        # Match the write path exactly: same call as wal_manager.write does.
-        record = {"type": "file_create", "req": req.model_dump(mode="json")}
-        handlers["file_create"](record)
-
-        mock_server.file_create.assert_called_once()
-        call_arg = mock_server.file_create.call_args[0][0]
-        assert isinstance(call_arg, tsi.FileCreateReq)
-        assert call_arg.content == original_content
-
-    def test_call_start_roundtrips_through_handler(self):
-        """call_start handler validates the dict directly (no json.dumps).
-
-        Regression guard for the dominant WAL replay path — every traced
-        op produces a call_start record.  datetime, dict, and string
-        fields must all round-trip correctly via model_validate(dict).
-        """
-        mock_server = MagicMock()
-        handlers = TraceServerHandlers(mock_server).as_dict()
-
-        started = datetime.datetime.now(datetime.timezone.utc)
-        req = tsi.CallStartReq(
-            start=tsi.StartedCallSchemaForInsert(
-                project_id="e/p",
-                op_name="predict",
-                trace_id="t1",
-                started_at=started,
-                attributes={"k": "v"},
-                inputs={"x": 1},
-            )
-        )
-        record = {"type": "call_start", "req": req.model_dump(mode="json")}
-        handlers["call_start"](record)
-
-        mock_server.call_start.assert_called_once()
-        call_arg = mock_server.call_start.call_args[0][0]
-        assert isinstance(call_arg, tsi.CallStartReq)
-        assert call_arg.start.op_name == "predict"
-        assert call_arg.start.started_at == started
-        assert call_arg.start.attributes == {"k": "v"}
-        assert call_arg.start.inputs == {"x": 1}
-
-    def test_convenience_function_matches_class(self):
-        """build_trace_server_handlers should return the same keys as the class."""
-        mock_server = MagicMock()
-        from_func = build_trace_server_handlers(mock_server)
-        from_class = TraceServerHandlers(mock_server).as_dict()
-
-        assert set(from_func.keys()) == set(from_class.keys())
-
-
-class TestCreateSender:
-    """Verify the create_sender factory wires things up correctly."""
-
-    def test_returns_configured_sender(self, tmp_path):
-        """create_sender should return a BackgroundWALSender ready to start."""
-        mock_server = MagicMock()
-        sender = create_sender(str(tmp_path), mock_server, poll_interval=0.5)
-
-        assert isinstance(sender, BackgroundWALSender)
-        assert sender._poll_interval == 0.5
-
-    def test_sender_can_start_and_stop(self, tmp_path):
-        """The created sender should be startable and stoppable."""
-        mock_server = MagicMock()
-        sender = create_sender(str(tmp_path), mock_server, poll_interval=0.1)
-        sender.start()
-        sender.stop()
-
-
-class TestWALClientApiKeyNamespacing:
-    """Verify that WeaveClient threads the api_key through to WALManager."""
-
-    def test_wal_directory_is_namespaced_by_api_key(self, client):
-        """When api_key is provided, the WAL dir includes an HMAC subdirectory."""
-        api_key = "wk-test-key-for-wal-namespacing"
-        with override_settings(enable_wal=True, disable_wal_sender=True):
-            wc = weave_client.WeaveClient(
-                client.entity,
-                client.project,
-                client.server,
-                ensure_project_exists=False,
-                api_key=api_key,
-            )
-            try:
-                assert wc._wal is not None
-                expected_suffix = compute_client_id(api_key)
-                assert wc._wal.wal_dir.endswith(expected_suffix)
-            finally:
-                wc._wal.close()
-
-    def test_wal_directory_not_namespaced_without_api_key(self, client):
-        """When api_key is None, the WAL dir is the flat entity/project path."""
-        with override_settings(enable_wal=True, disable_wal_sender=True):
-            wc = weave_client.WeaveClient(
-                client.entity,
-                client.project,
-                client.server,
-                ensure_project_exists=False,
-            )
-            try:
-                assert wc._wal is not None
-                assert wc._wal.wal_dir.endswith(wc.project)
-            finally:
-                wc._wal.close()
+    wal._writer = JSONLWALWriter(FileWALDirectoryManager(wal_dir))

--- a/tests/trace/test_wave_client_file_cache.py
+++ b/tests/trace/test_wave_client_file_cache.py
@@ -14,387 +14,245 @@ from weave.trace_server.trace_server_interface import FileCreateReq, FileCreateR
 from weave.trace_server_bindings.remote_http_trace_server import RemoteHTTPTraceServer
 
 
-class TestThreadSafeLRUCache:
-    """Test the ThreadSafeLRUCache class."""
-
-    def test_init_default(self):
-        """Test that the cache initializes with default max_size."""
-        cache = ThreadSafeLRUCache()
-        assert cache.max_size == 1000
-
-    def test_init_custom_size(self):
-        """Test that the cache initializes with custom max_size."""
-        cache = ThreadSafeLRUCache(max_size=100)
-        assert cache.max_size == 100
-
-    def test_init_zero_size(self):
-        """Test that the cache initializes with zero max_size (unlimited)."""
-        cache = ThreadSafeLRUCache(max_size=0)
-        assert cache.max_size == 0
-
-    def test_init_negative_size(self):
-        """Test that negative max_size is handled correctly (converted to 0)."""
-        cache = ThreadSafeLRUCache(max_size=-10)
-        assert cache.max_size == 0
-
-    def test_put_get_basic(self):
-        """Test basic put and get operations."""
-        cache = ThreadSafeLRUCache()
-        cache.put("key1", "value1")
-        assert cache.get("key1") == "value1"
-
-    def test_get_nonexistent(self):
-        """Test get on a non-existent key."""
-        cache = ThreadSafeLRUCache()
-        assert cache.get("nonexistent") is None
-
-    def test_put_update(self):
-        """Test updating an existing key."""
-        cache = ThreadSafeLRUCache()
-        cache.put("key1", "value1")
-        cache.put("key1", "value2")
-        assert cache.get("key1") == "value2"
-
-    def test_delete(self):
-        """Test deleting a key."""
-        cache = ThreadSafeLRUCache()
-        cache.put("key1", "value1")
-        cache.delete("key1")
-        assert cache.get("key1") is None
-
-    def test_delete_nonexistent(self):
-        """Test deleting a non-existent key (should not raise an error)."""
-        cache = ThreadSafeLRUCache()
-        cache.delete("nonexistent")  # Should not raise an error
-
-    def test_contains(self):
-        """Test the contains method."""
-        cache = ThreadSafeLRUCache()
-        cache.put("key1", "value1")
-        assert cache.contains("key1") is True
-        assert cache.contains("nonexistent") is False
-
-    def test_clear(self):
-        """Test clearing the cache."""
-        cache = ThreadSafeLRUCache()
-        cache.put("key1", "value1")
-        cache.put("key2", "value2")
-        cache.clear()
-        assert cache.size() == 0
-        assert cache.get("key1") is None
-        assert cache.get("key2") is None
-
-    def test_size(self):
-        """Test the size method."""
-        cache = ThreadSafeLRUCache()
-        assert cache.size() == 0
-        cache.put("key1", "value1")
-        assert cache.size() == 1
-        cache.put("key2", "value2")
-        assert cache.size() == 2
-        cache.delete("key1")
-        assert cache.size() == 1
-        cache.clear()
-        assert cache.size() == 0
-
-    def test_max_size_property(self):
-        """Test getting and setting the max_size property."""
-        cache = ThreadSafeLRUCache(max_size=100)
-        assert cache.max_size == 100
-        cache.max_size = 200
-        assert cache.max_size == 200
-        cache.max_size = 0  # unlimited
-        assert cache.max_size == 0
-        cache.max_size = -10  # should convert to 0
-        assert cache.max_size == 0
-
-    def test_lru_eviction(self):
-        """Test that LRU eviction works correctly."""
-        cache = ThreadSafeLRUCache(max_size=3)
-        cache.put("key1", "value1")
-        cache.put("key2", "value2")
-        cache.put("key3", "value3")
-        # Cache is now at max size (3)
-
-        # Add a new key, should evict the least recently used (key1)
-        cache.put("key4", "value4")
-        assert cache.get("key1") is None
-        assert cache.get("key2") == "value2"
-        assert cache.get("key3") == "value3"
-        assert cache.get("key4") == "value4"
-
-        # Access key2, making key3 the least recently used
-        cache.get("key2")
-
-        # Add a new key, should evict the least recently used (key3)
-        cache.put("key5", "value5")
-        assert cache.get("key2") == "value2"
-        assert cache.get("key3") is None
-        assert cache.get("key4") == "value4"
-        assert cache.get("key5") == "value5"
-
-    def test_lru_update(self):
-        """Test that updating an existing key preserves LRU order."""
-        cache = ThreadSafeLRUCache(max_size=3)
-        cache.put("key1", "value1")
-        cache.put("key2", "value2")
-        cache.put("key3", "value3")
-
-        # Update key1, making it the most recently used
-        cache.put("key1", "value1_updated")
-
-        # Add a new key, should evict the least recently used (key2)
-        cache.put("key4", "value4")
-        assert cache.get("key1") == "value1_updated"
-        assert cache.get("key2") is None
-        assert cache.get("key3") == "value3"
-        assert cache.get("key4") == "value4"
-
-    def test_thread_safety(self):
-        """Test that the cache is thread-safe."""
-        cache = ThreadSafeLRUCache(max_size=1000)
-        num_threads = 10
-        operations_per_thread = 100
-
-        def worker(thread_id):
-            for i in range(operations_per_thread):
-                key = f"key{thread_id}_{i}"
-                value = f"value{thread_id}_{i}"
-                cache.put(key, value)
-                assert cache.get(key) == value
-
-        threads = []
-        for i in range(num_threads):
-            thread = threading.Thread(target=worker, args=(i,))
-            threads.append(thread)
-            thread.start()
-
-        for thread in threads:
-            thread.join()
-
-        # Verify all keys are still there
-        for i in range(num_threads):
-            for j in range(operations_per_thread):
-                key = f"key{i}_{j}"
-                value = f"value{i}_{j}"
-                assert cache.get(key) == value
-
-        assert cache.size() == num_threads * operations_per_thread
-
-    def test_max_size_reduction(self):
-        """Test reducing max_size evicts the least recently used items."""
-        cache = ThreadSafeLRUCache(max_size=5)
-        for i in range(5):
-            cache.put(f"key{i}", f"value{i}")
-
-        assert cache.size() == 5
-
-        # Access keys in a specific order to establish LRU order
-        # Order of access (oldest to newest): key0, key1, key2, key3, key4
-        for i in range(5):
-            cache.get(f"key{i}")
-
-        # Reduce max_size to 3, should keep the 3 most recently used: key2, key3, key4
-        cache.max_size = 3
-
-        assert cache.size() == 3
-        # The 2 least recently used keys should be evicted (key0, key1)
-        assert cache.get("key0") is None
-        assert cache.get("key1") is None
-        # The 3 most recently used keys should remain
-        assert cache.get("key2") == "value2"
-        assert cache.get("key3") == "value3"
-        assert cache.get("key4") == "value4"
-
-    def test_unlimited_size(self):
-        """Test that setting max_size to 0 allows unlimited entries."""
-        cache = ThreadSafeLRUCache(max_size=0)  # unlimited
-
-        # Add many entries, should not evict any
-        for i in range(1000):
-            cache.put(f"key{i}", f"value{i}")
-
-        assert cache.size() == 1000
-
-        # Check all entries are still there
-        for i in range(1000):
-            assert cache.get(f"key{i}") == f"value{i}"
-
-
-class TestWeaveClientSendFileCache:
-    """Test the WeaveClientSendFileCache class."""
-
-    def test_init_default(self):
-        """Test that the cache initializes with default max_size."""
-        cache = WeaveClientSendFileCache()
-        assert cache.max_size == 1000
-
-    def test_init_custom_size(self):
-        """Test that the cache initializes with custom max_size."""
-        cache = WeaveClientSendFileCache(max_size=100)
-        assert cache.max_size == 100
-
-    def test_key_generation(self):
-        """Test that the _key method generates unique keys for different requests."""
-        cache = WeaveClientSendFileCache()
-
-        req1 = FileCreateReq(project_id="test", name="file1", content=b"content1")
-        req2 = FileCreateReq(project_id="test", name="file2", content=b"content1")
-        req3 = FileCreateReq(project_id="other", name="file1", content=b"content1")
-        req4 = FileCreateReq(project_id="test", name="file1", content=b"different")
-
-        key1 = cache._key(req1)
-        key2 = cache._key(req2)
-        key3 = cache._key(req3)
-        key4 = cache._key(req4)
-
-        # Different requests should have different keys
-        assert key1 != key2
-        assert key1 != key3
-        assert key1 != key4
-
-        # Same request should have the same key
-        assert key1 == cache._key(
-            FileCreateReq(project_id="test", name="file1", content=b"content1")
-        )
-
-    def test_put_get_basic(self):
-        """Test basic put and get operations."""
-        cache = WeaveClientSendFileCache()
-        req = FileCreateReq(project_id="test", name="test", content=b"test")
-        res = FileCreateRes(digest="test_digest")
-
-        cache.put(req, res)
-        assert cache.get(req) == res
-
-    def test_get_nonexistent(self):
-        """Test get on a non-existent key."""
-        cache = WeaveClientSendFileCache()
-        req = FileCreateReq(project_id="test", name="nonexistent", content=b"test")
-        assert cache.get(req) is None
-
-    def test_put_update(self):
-        """Test updating an existing key."""
-        cache = WeaveClientSendFileCache()
-        req = FileCreateReq(project_id="test", name="test", content=b"test")
-        res1 = FileCreateRes(digest="digest1")
-        res2 = FileCreateRes(digest="digest2")
-
-        cache.put(req, res1)
-        cache.put(req, res2)
-        assert cache.get(req) == res2
-
-    def test_clear(self):
-        """Test clearing the cache."""
-        cache = WeaveClientSendFileCache()
-        req1 = FileCreateReq(project_id="test", name="file1", content=b"content1")
-        req2 = FileCreateReq(project_id="test", name="file2", content=b"content2")
-        res1 = FileCreateRes(digest="digest1")
-        res2 = FileCreateRes(digest="digest2")
-
-        cache.put(req1, res1)
-        cache.put(req2, res2)
-        assert cache.size() == 2
-
-        cache.clear()
-        assert cache.size() == 0
-        assert cache.get(req1) is None
-        assert cache.get(req2) is None
-
-    def test_delete(self):
-        """Test deleting a cached entry by request."""
-        cache = WeaveClientSendFileCache()
-        req = FileCreateReq(project_id="test", name="file", content=b"content")
-        cache.put(req, FileCreateRes(digest="d"))
-        assert cache.get(req) is not None
-        cache.delete(req)
-        assert cache.get(req) is None
-
-    def test_delete_nonexistent(self):
-        """Deleting a missing entry should not raise."""
-        cache = WeaveClientSendFileCache()
-        req = FileCreateReq(project_id="test", name="missing", content=b"x")
-        cache.delete(req)  # no-op
-
-    def test_size(self):
-        """Test the size method."""
-        cache = WeaveClientSendFileCache()
-        assert cache.size() == 0
-
-        req1 = FileCreateReq(project_id="test", name="file1", content=b"content1")
-        req2 = FileCreateReq(project_id="test", name="file2", content=b"content2")
-        res1 = FileCreateRes(digest="digest1")
-        res2 = FileCreateRes(digest="digest2")
-
-        cache.put(req1, res1)
-        assert cache.size() == 1
-        cache.put(req2, res2)
-        assert cache.size() == 2
-        cache.clear()
-        assert cache.size() == 0
-
-    def test_max_size_property(self):
-        """Test getting and setting the max_size property."""
-        cache = WeaveClientSendFileCache(max_size=100)
-        assert cache.max_size == 100
-
-        cache.max_size = 200
-        assert cache.max_size == 200
-
-        cache.max_size = 0  # unlimited
-        assert cache.max_size == 0
-
-    def test_lru_eviction(self):
-        """Test that LRU eviction works correctly."""
-        cache = WeaveClientSendFileCache(max_size=2)
-
-        req1 = FileCreateReq(project_id="test", name="file1", content=b"content1")
-        req2 = FileCreateReq(project_id="test", name="file2", content=b"content2")
-        req3 = FileCreateReq(project_id="test", name="file3", content=b"content3")
-
-        res1 = FileCreateRes(digest="digest1")
-        res2 = FileCreateRes(digest="digest2")
-        res3 = FileCreateRes(digest="digest3")
-
-        # Add two items, filling the cache
-        cache.put(req1, res1)
-        cache.put(req2, res2)
-        assert cache.size() == 2
-
-        # Add a third item, should evict the least recently used (req1)
-        cache.put(req3, res3)
-        assert cache.size() == 2
-        assert cache.get(req1) is None
-        assert cache.get(req2) == res2
-        assert cache.get(req3) == res3
-
-        # Access req2, making req3 the least recently used
-        cache.get(req2)
-
-        # Add req1 back, should evict req3
-        cache.put(req1, res1)
-        assert cache.size() == 2
-        assert cache.get(req1) == res1
-        assert cache.get(req2) == res2
-        assert cache.get(req3) is None
-
-
-def test_wave_client_file_cache_backwards_compatible():
-    """Test that the cache is backwards compatible with the original test."""
-    cache = WeaveClientSendFileCache()
-    req = FileCreateReq(project_id="test", name="test", content=b"test")
-    res = FileCreateRes(digest="test")
-    cache.put(req, res)
-    assert cache.get(req) == res
-
-
-def _make_502() -> httpx.HTTPStatusError:
-    response = httpx.Response(
-        status_code=502,
-        request=httpx.Request("POST", "http://example.com/file/create"),
-        content=b"Bad Gateway",
+@pytest.mark.parametrize(
+    ("init_size", "expected"),
+    [(None, 1000), (100, 100), (0, 0), (-10, 0)],
+)
+def test_lru_cache_init_max_size(init_size, expected):
+    """Default, custom, zero (unlimited), and negative (clamped to 0) max_size."""
+    cache = (
+        ThreadSafeLRUCache()
+        if init_size is None
+        else ThreadSafeLRUCache(max_size=init_size)
     )
-    return httpx.HTTPStatusError("502", request=response.request, response=response)
+    assert cache.max_size == expected
+
+
+def test_lru_cache_put_get_update_delete_contains():
+    """Basic put/get, overwrite, missing-key, delete, delete-missing, contains."""
+    cache = ThreadSafeLRUCache()
+    assert cache.get("nonexistent") is None
+    assert cache.contains("nonexistent") is False
+
+    cache.put("key1", "value1")
+    assert cache.get("key1") == "value1"
+    assert cache.contains("key1") is True
+
+    cache.put("key1", "value2")
+    assert cache.get("key1") == "value2"
+
+    cache.delete("key1")
+    assert cache.get("key1") is None
+    cache.delete("nonexistent")  # no-op, must not raise
+
+
+def test_lru_cache_size_and_clear():
+    """size() tracks puts/deletes/clear; clear() empties the cache."""
+    cache = ThreadSafeLRUCache()
+    assert cache.size() == 0
+    cache.put("key1", "value1")
+    assert cache.size() == 1
+    cache.put("key2", "value2")
+    assert cache.size() == 2
+    cache.delete("key1")
+    assert cache.size() == 1
+    cache.clear()
+    assert cache.size() == 0
+    assert cache.get("key2") is None
+
+
+def test_lru_cache_max_size_property():
+    """max_size getter/setter; setting negative clamps to 0 (unlimited)."""
+    cache = ThreadSafeLRUCache(max_size=100)
+    assert cache.max_size == 100
+    cache.max_size = 200
+    assert cache.max_size == 200
+    cache.max_size = 0
+    assert cache.max_size == 0
+    cache.max_size = -10
+    assert cache.max_size == 0
+
+
+def test_lru_cache_eviction_and_update_order():
+    """Insertion evicts oldest; get() and put()-update both refresh recency."""
+    cache = ThreadSafeLRUCache(max_size=3)
+    cache.put("key1", "value1")
+    cache.put("key2", "value2")
+    cache.put("key3", "value3")
+
+    # Insert key4 -> evicts LRU (key1).
+    cache.put("key4", "value4")
+    assert cache.get("key1") is None
+    assert cache.get("key2") == "value2"
+    assert cache.get("key3") == "value3"
+    assert cache.get("key4") == "value4"
+
+    # get(key2) makes key3 the LRU; key5 evicts key3.
+    cache.get("key2")
+    cache.put("key5", "value5")
+    assert cache.get("key2") == "value2"
+    assert cache.get("key3") is None
+    assert cache.get("key4") == "value4"
+    assert cache.get("key5") == "value5"
+
+    # put-update refreshes recency: re-fill, update key_a, insert evicts key_b.
+    cache.clear()
+    cache.put("key_a", "a")
+    cache.put("key_b", "b")
+    cache.put("key_c", "c")
+    cache.put("key_a", "a_updated")
+    cache.put("key_d", "d")
+    assert cache.get("key_a") == "a_updated"
+    assert cache.get("key_b") is None
+    assert cache.get("key_c") == "c"
+    assert cache.get("key_d") == "d"
+
+
+def test_lru_cache_max_size_reduction_evicts_lru():
+    """Shrinking max_size evicts the least recently used entries."""
+    cache = ThreadSafeLRUCache(max_size=5)
+    for i in range(5):
+        cache.put(f"key{i}", f"value{i}")
+    assert cache.size() == 5
+
+    for i in range(5):
+        cache.get(f"key{i}")
+
+    cache.max_size = 3
+    assert cache.size() == 3
+    assert cache.get("key0") is None
+    assert cache.get("key1") is None
+    assert cache.get("key2") == "value2"
+    assert cache.get("key3") == "value3"
+    assert cache.get("key4") == "value4"
+
+
+def test_lru_cache_unlimited_size_keeps_all():
+    """max_size=0 disables eviction; many entries all persist."""
+    cache = ThreadSafeLRUCache(max_size=0)
+    for i in range(1000):
+        cache.put(f"key{i}", f"value{i}")
+    assert cache.size() == 1000
+    for i in range(1000):
+        assert cache.get(f"key{i}") == f"value{i}"
+
+
+def test_lru_cache_thread_safety():
+    """Concurrent put/get from many threads preserves every entry."""
+    cache = ThreadSafeLRUCache(max_size=1000)
+    num_threads = 10
+    operations_per_thread = 100
+
+    def worker(thread_id):
+        for i in range(operations_per_thread):
+            key = f"key{thread_id}_{i}"
+            value = f"value{thread_id}_{i}"
+            cache.put(key, value)
+            assert cache.get(key) == value
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(num_threads)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    for i in range(num_threads):
+        for j in range(operations_per_thread):
+            assert cache.get(f"key{i}_{j}") == f"value{i}_{j}"
+    assert cache.size() == num_threads * operations_per_thread
+
+
+@pytest.mark.parametrize("init_size", [None, 100])
+def test_send_file_cache_init_and_max_size_property(init_size):
+    """Default/custom init plus max_size getter/setter including unlimited."""
+    expected = 1000 if init_size is None else init_size
+    cache = (
+        WeaveClientSendFileCache()
+        if init_size is None
+        else (WeaveClientSendFileCache(max_size=init_size))
+    )
+    assert cache.max_size == expected
+    cache.max_size = 200
+    assert cache.max_size == 200
+    cache.max_size = 0
+    assert cache.max_size == 0
+
+
+def test_send_file_cache_key_generation():
+    """`_key` is unique per (project_id, name, content) and stable for equal reqs."""
+    cache = WeaveClientSendFileCache()
+    req1 = FileCreateReq(project_id="test", name="file1", content=b"content1")
+    req2 = FileCreateReq(project_id="test", name="file2", content=b"content1")
+    req3 = FileCreateReq(project_id="other", name="file1", content=b"content1")
+    req4 = FileCreateReq(project_id="test", name="file1", content=b"different")
+
+    key1 = cache._key(req1)
+    assert key1 != cache._key(req2)
+    assert key1 != cache._key(req3)
+    assert key1 != cache._key(req4)
+    assert key1 == cache._key(
+        FileCreateReq(project_id="test", name="file1", content=b"content1")
+    )
+
+
+def test_send_file_cache_put_get_update_delete_size():
+    """put/get, overwrite, missing-key, delete, delete-missing, size, clear."""
+    cache = WeaveClientSendFileCache()
+    assert cache.size() == 0
+
+    miss = FileCreateReq(project_id="test", name="nonexistent", content=b"test")
+    assert cache.get(miss) is None
+
+    req = FileCreateReq(project_id="test", name="test", content=b"test")
+    cache.put(req, FileCreateRes(digest="digest1"))
+    assert cache.get(req) == FileCreateRes(digest="digest1")
+    assert cache.size() == 1
+
+    cache.put(req, FileCreateRes(digest="digest2"))
+    assert cache.get(req) == FileCreateRes(digest="digest2")
+    assert cache.size() == 1
+
+    cache.delete(req)
+    assert cache.get(req) is None
+    cache.delete(req)  # delete-missing no-op
+
+    req1 = FileCreateReq(project_id="test", name="file1", content=b"content1")
+    req2 = FileCreateReq(project_id="test", name="file2", content=b"content2")
+    cache.put(req1, FileCreateRes(digest="d1"))
+    cache.put(req2, FileCreateRes(digest="d2"))
+    assert cache.size() == 2
+    cache.clear()
+    assert cache.size() == 0
+    assert cache.get(req1) is None
+    assert cache.get(req2) is None
+
+
+def test_send_file_cache_lru_eviction():
+    """LRU eviction over FileCreateReq keys, with get() refreshing recency."""
+    cache = WeaveClientSendFileCache(max_size=2)
+    req1 = FileCreateReq(project_id="test", name="file1", content=b"content1")
+    req2 = FileCreateReq(project_id="test", name="file2", content=b"content2")
+    req3 = FileCreateReq(project_id="test", name="file3", content=b"content3")
+    res1 = FileCreateRes(digest="digest1")
+    res2 = FileCreateRes(digest="digest2")
+    res3 = FileCreateRes(digest="digest3")
+
+    cache.put(req1, res1)
+    cache.put(req2, res2)
+    assert cache.size() == 2
+
+    cache.put(req3, res3)
+    assert cache.size() == 2
+    assert cache.get(req1) is None
+    assert cache.get(req2) == res2
+    assert cache.get(req3) == res3
+
+    cache.get(req2)  # req3 becomes LRU
+    cache.put(req1, res1)
+    assert cache.size() == 2
+    assert cache.get(req1) == res1
+    assert cache.get(req2) == res2
+    assert cache.get(req3) is None
 
 
 @pytest.fixture
@@ -521,3 +379,12 @@ def test_stale_failure_callback_does_not_evict_replacement_entry(offline_client)
     )
 
     assert client.send_file_cache.get(req_a) is fut_a_v2
+
+
+def _make_502() -> httpx.HTTPStatusError:
+    response = httpx.Response(
+        status_code=502,
+        request=httpx.Request("POST", "http://example.com/file/create"),
+        content=b"Bad Gateway",
+    )
+    return httpx.HTTPStatusError("502", request=response.request, response=response)

--- a/tests/trace/test_weave_client.py
+++ b/tests/trace/test_weave_client.py
@@ -1312,7 +1312,11 @@ def test_op_query(client):
     assert len(res) == 1
 
 
-def test_refs_read_batch_noextra(client):
+def test_refs_read_batch(client):
+    """refs_read_batch over top-level objects, refs with extra (list/dataset
+    rows), cross-project refs, and the unsupported call-ref error.
+    """
+    # Top-level object refs.
     ref = client._save_object([1, 2, 3], "my-list")
     ref2 = client._save_object({"a": [3, 4, 5]}, "my-obj")
     res = client.server.refs_read_batch(RefsReadBatchReq(refs=[ref.uri, ref2.uri]))
@@ -1320,49 +1324,45 @@ def test_refs_read_batch_noextra(client):
     assert res.vals[0] == [1, 2, 3]
     assert res.vals[1] == {"a": [3, 4, 5]}
 
-
-def test_refs_read_batch_with_extra(client):
+    # Refs that descend into a saved list.
     saved = client.save([{"a": 5}, {"a": 6}], "my-list")
-    ref1 = saved[0]["a"].ref
-    ref2 = saved[1].ref
-    res = client.server.refs_read_batch(RefsReadBatchReq(refs=[ref1.uri, ref2.uri]))
+    res = client.server.refs_read_batch(
+        RefsReadBatchReq(refs=[saved[0]["a"].ref.uri, saved[1].ref.uri])
+    )
     assert len(res.vals) == 2
     assert res.vals[0] == 5
     assert res.vals[1] == {"a": 6}
 
-
-def test_refs_read_batch_dataset_rows(client):
-    saved = client.save(weave.Dataset(rows=[{"a": 5}, {"a": 6}]), "my-dataset")
-    ref1 = saved.rows[0]["a"].ref
-    ref2 = saved.rows[1]["a"].ref
-    res = client.server.refs_read_batch(RefsReadBatchReq(refs=[ref1.uri, ref2.uri]))
+    # Refs that descend into dataset rows.
+    saved_ds = client.save(weave.Dataset(rows=[{"a": 5}, {"a": 6}]), "my-dataset")
+    res = client.server.refs_read_batch(
+        RefsReadBatchReq(
+            refs=[saved_ds.rows[0]["a"].ref.uri, saved_ds.rows[1]["a"].ref.uri]
+        )
+    )
     assert len(res.vals) == 2
     assert res.vals[0] == 5
     assert res.vals[1] == 6
 
+    # Call refs are not supported.
+    call_ref = refs.CallRef(entity="shawn", project="test-project", id="my-call")
+    with pytest.raises(ValueError, match="Call refs not supported"):
+        client.server.refs_read_batch(RefsReadBatchReq(refs=[call_ref.uri]))
 
-def test_refs_read_batch_multi_project(client):
+    # A single batch can resolve refs spanning multiple projects.
     client.project = "test111"
-    ref = client._save_object([1, 2, 3], "my-list")
-
+    mp_ref = client._save_object([1, 2, 3], "my-list")
     client.project = "test222"
-    ref2 = client._save_object({"a": [3, 4, 5]}, "my-obj")
-
+    mp_ref2 = client._save_object({"a": [3, 4, 5]}, "my-obj")
     client.project = "test333"
-    ref3 = client._save_object({"ab": [3, 4, 5]}, "my-obj-2")
-
-    refs = [ref.uri, ref2.uri, ref3.uri]
-    res = client.server.refs_read_batch(RefsReadBatchReq(refs=refs))
+    mp_ref3 = client._save_object({"ab": [3, 4, 5]}, "my-obj-2")
+    res = client.server.refs_read_batch(
+        RefsReadBatchReq(refs=[mp_ref.uri, mp_ref2.uri, mp_ref3.uri])
+    )
     assert len(res.vals) == 3
     assert res.vals[0] == [1, 2, 3]
     assert res.vals[1] == {"a": [3, 4, 5]}
     assert res.vals[2] == {"ab": [3, 4, 5]}
-
-
-def test_refs_read_batch_call_ref(client):
-    call_ref = refs.CallRef(entity="shawn", project="test-project", id="my-call")
-    with pytest.raises(ValueError, match="Call refs not supported"):
-        client.server.refs_read_batch(RefsReadBatchReq(refs=[call_ref.uri]))
 
 
 def test_large_files(client):
@@ -1810,30 +1810,22 @@ def _setup_calls_for_storage_size_test(client):
     return [call0, call0_child1, call1]
 
 
-def test_get_calls_storage_size_with_filter(client):
-    """Test that storage size parameters can be combined with other get_calls parameters."""
+def test_get_calls_storage_size_combined_params(client):
+    """Storage size params combine with both an op_names filter and a limit."""
     all_calls = _setup_calls_for_storage_size_test(client)
     assert len(all_calls) > 2
 
-    call0 = all_calls[0]
-
-    # Test that parameters can be combined with other parameters
+    # Combined with an op_names filter (call0 + its child both have op "x").
     calls_filtered = list(
         client.get_calls(
-            filter=tsi.CallsFilter(op_names=[call0.op_name]),
+            filter=tsi.CallsFilter(op_names=[all_calls[0].op_name]),
             include_storage_size=True,
             include_total_storage_size=True,
         )
     )
     assert len(calls_filtered) == 2
 
-
-def test_get_calls_storage_size_with_limit(client):
-    """Test that storage size parameters can be combined with other get_calls parameters."""
-    all_calls = _setup_calls_for_storage_size_test(client)
-    assert len(all_calls) > 2
-
-    # Test that parameters can be combined with other parameters
+    # Combined with a limit.
     calls_limited = list(
         client.get_calls(
             include_storage_size=True,
@@ -2270,7 +2262,10 @@ def test_flush_progress_bar(client):
     def op_1():
         time.sleep(0.01)
 
-    op_1()
+    # Enqueue enough work that the flush spans multiple progress-bar refresh
+    # intervals, so the "jobs completed since last update" branch is exercised.
+    for _ in range(20):
+        op_1()
 
     # flush with progress bar
     client.finish(use_progress_bar=True)
@@ -4069,23 +4064,19 @@ def test_files_stats(client):
     assert read_res.total_size_bytes == 10000005
 
 
-def test_no_400_on_invalid_artifact_url(client):
+@pytest.mark.parametrize(
+    "bad_output",
+    [
+        # Over-long artifact url: should be wandb-artifact:///entity/project/name:version
+        "wandb-artifact:///entity/project/toxic-extra-path/artifact:latest",
+        # Over-long ref: should be weave:///entity/project/object/name:version
+        "weave:///entity/project/object/toxic-extra-path/object:latest",
+    ],
+)
+def test_no_400_on_invalid_ref_like_output(client, bad_output):
     @weave.op
     def test() -> str:
-        # This url is too long, should be wandb-artifact:///entity/project/name:version
-        return "wandb-artifact:///entity/project/toxic-extra-path/artifact:latest"
-
-    _, call = test.call()
-    id = call.id
-    server_call = client.get_call(id)
-    assert server_call.id == id
-
-
-def test_no_400_on_invalid_refs(client):
-    @weave.op
-    def test() -> str:
-        # This ref is too long, should be weave:///entity/project/object/name:version
-        return "weave:///entity/project/object/toxic-extra-path/object:latest"
+        return bad_output
 
     _, call = test.call()
     id = call.id
@@ -4094,14 +4085,14 @@ def test_no_400_on_invalid_refs(client):
 
 
 def test_get_evaluation(client, make_evals):
-    ref, _ = make_evals
+    ref, ref2 = make_evals
+
+    # Single lookup by ref.
     ev = client.get_evaluation(ref.uri)
     assert isinstance(ev, Evaluation)
     assert ev.ref.uri == ref.uri
 
-
-def test_get_evaluations(client, make_evals):
-    ref, ref2 = make_evals
+    # Listing returns both evaluations with their datasets.
     evs = client.get_evaluations()
     assert len(evs) == 2
     assert isinstance(evs[0], Evaluation)

--- a/tests/trace/test_weave_client_mutations.py
+++ b/tests/trace/test_weave_client_mutations.py
@@ -249,14 +249,16 @@ def test_dict_mutation_saving_nested_lists(weave_active):
     assert d3["c"] == [5, 6]
 
 
-def test_table_mutation_saving_append_rows(weave_active):
-    t = weave.Table(rows=[{"a": 1, "b": 2}])
+def test_table_mutation_saving(weave_active):
+    # Append/pop on a fresh table, then append/pop/replace on published tables.
+    t = weave.Table(rows=[{"a": 1, "b": 2}, {"a": 9, "b": 10}])
     t.append({"a": 3, "b": 4})
+    t.pop(0)
     ref = weave.publish(t)
 
     t2 = ref.get()
     assert t2.rows == [
-        {"a": 1, "b": 2},
+        {"a": 9, "b": 10},
         {"a": 3, "b": 4},
     ]
     t2.append({"a": 5, "b": 6})
@@ -264,69 +266,33 @@ def test_table_mutation_saving_append_rows(weave_active):
 
     t3 = ref2.get()
     assert t3.rows == [
-        {"a": 1, "b": 2},
+        {"a": 9, "b": 10},
+        {"a": 3, "b": 4},
+        {"a": 5, "b": 6},
+    ]
+    t3.pop(0)
+    ref3 = weave.publish(t3)
+
+    t4 = ref3.get()
+    assert t4.rows == [
         {"a": 3, "b": 4},
         {"a": 5, "b": 6},
     ]
 
+    t4.rows = [{"a": 7, "b": 8}]
+    ref4 = weave.publish(t4)
 
-def test_table_mutation_saving_pop_rows(weave_active):
-    t = weave.Table(
-        rows=[
-            {"a": 1, "b": 2},
-            {"a": 3, "b": 4},
-            {"a": 5, "b": 6},
-        ]
-    )
-    t.pop(0)
-    ref = weave.publish(t)
-
-    t2 = ref.get()
-    assert t2.rows == [
-        {"a": 3, "b": 4},
-        {"a": 5, "b": 6},
-    ]
-    t2.pop(0)
-    ref2 = weave.publish(t2)
-
-    t3 = ref2.get()
-    assert t3.rows == [{"a": 5, "b": 6}]
+    t5 = ref4.get()
+    assert t5.rows == [{"a": 7, "b": 8}]
 
 
-def test_table_mutation_saving_replace_rows(weave_active):
-    t = weave.Table(
-        rows=[
-            {"a": 1, "b": 2},
-            {"a": 3, "b": 4},
-        ]
-    )
-    ref = weave.publish(t)
-
-    t2 = ref.get()
-    t2.rows = [{"a": 5, "b": 6}]
-    ref2 = weave.publish(t2)
-
-    t3 = ref2.get()
-    assert t3.rows == [{"a": 5, "b": 6}]
-
-
-def test_table_cant_append_bad_data(weave_active):
+def test_table_validation_rejects_bad_data(weave_active):
+    # Bad append payloads and bad row assignments, on fresh and published tables.
     t = weave.Table(rows=[{"a": 1, "b": 2}])
     with pytest.raises(TypeError):
         t.append(1)
     with pytest.raises(TypeError):
         t.append([1, 2, 3])
-
-    ref = weave.publish(t)
-    t2 = ref.get()
-    with pytest.raises(TypeError):
-        t2.append(1)
-    with pytest.raises(TypeError):
-        t2.append([1, 2, 3])
-
-
-def test_table_cant_set_bad_data(weave_active):
-    t = weave.Table(rows=[{"a": 1, "b": 2}])
     with pytest.raises(ValueError, match="must be (a list of )?dicts"):
         t.rows = [1, 2, 3]
     with pytest.raises(ValueError, match="must be (a list of )?dicts"):
@@ -334,6 +300,10 @@ def test_table_cant_set_bad_data(weave_active):
 
     ref = weave.publish(t)
     t2 = ref.get()
+    with pytest.raises(TypeError):
+        t2.append(1)
+    with pytest.raises(TypeError):
+        t2.append([1, 2, 3])
     with pytest.raises(ValueError, match="must be (a list of )?dicts"):
         t2.rows = [1, 2, 3]
     with pytest.raises(ValueError, match="must be (a list of )?dicts"):

--- a/tests/trace/test_weave_init_availability.py
+++ b/tests/trace/test_weave_init_availability.py
@@ -7,24 +7,17 @@ from weave.trace import weave_init
 from weave.trace_server_bindings import remote_http_trace_server
 
 
-def test_get_server_info_json_decode_error():
-    """Test that _get_server_info returns None when server info cannot be decoded."""
-    mock_server = MagicMock(spec=remote_http_trace_server.RemoteHTTPTraceServer)
-    mock_server.server_info.side_effect = json.JSONDecodeError("test error", "doc", 0)
-
-    result = weave_init._get_server_info(mock_server)
-
-    assert result is None
-    mock_server.server_info.assert_called_once()
-
-
-def test_get_server_info_success():
-    """Test that _get_server_info returns server info when server is available."""
-    mock_server = MagicMock(spec=remote_http_trace_server.RemoteHTTPTraceServer)
+def test_get_server_info_success_and_json_decode_error():
+    """_get_server_info returns the server info on success and None when the
+    response cannot be decoded; either way it calls server_info exactly once.
+    """
+    ok_server = MagicMock(spec=remote_http_trace_server.RemoteHTTPTraceServer)
     server_info = {"version": "1.0.0"}
-    mock_server.server_info.return_value = server_info
+    ok_server.server_info.return_value = server_info
+    assert weave_init._get_server_info(ok_server) == server_info
+    ok_server.server_info.assert_called_once()
 
-    result = weave_init._get_server_info(mock_server)
-
-    assert result == server_info
-    mock_server.server_info.assert_called_once()
+    bad_server = MagicMock(spec=remote_http_trace_server.RemoteHTTPTraceServer)
+    bad_server.server_info.side_effect = json.JSONDecodeError("test error", "doc", 0)
+    assert weave_init._get_server_info(bad_server) is None
+    bad_server.server_info.assert_called_once()

--- a/tests/trace/type_handlers/Content/test_content.py
+++ b/tests/trace/type_handlers/Content/test_content.py
@@ -13,12 +13,6 @@ from weave.type_wrappers.Content.content import Content
 from weave.utils import http_requests as _http_requests
 
 
-class _FakeHTTPError(Exception):
-    """Custom exception used by FakeResponse.raise_for_status in tests."""
-
-    pass
-
-
 @pytest.fixture(scope="session")
 def video_file(tmp_path_factory) -> Path:
     file = generate_media("MP4")
@@ -51,7 +45,6 @@ def audio_file(tmp_path_factory) -> Path:
     return fn
 
 
-# New parameterization list using fixture names
 MEDIA_TEST_PARAMS = [
     ("image_file", ".png", "image/png"),
     ("audio_file", ".wav", "audio/wav"),
@@ -60,451 +53,314 @@ MEDIA_TEST_PARAMS = [
 ]
 
 
-class TestWeaveContent:
-    @pytest.mark.parametrize(
-        ("fixture_name", "extension", "mimetype"), MEDIA_TEST_PARAMS
-    )
-    def test_content_from_path(
-        self, fixture_name: str, extension: str, mimetype: str, request
-    ):
-        """Test creating Content from file path."""
-        file_path = request.getfixturevalue(fixture_name)
+@pytest.mark.parametrize(("fixture_name", "extension", "mimetype"), MEDIA_TEST_PARAMS)
+def test_content_from_path_str_and_pathlib(fixture_name, extension, mimetype, request):
+    """from_path accepts both str and pathlib.Path with identical results."""
+    file_path = request.getfixturevalue(fixture_name)
 
-        # Test Content.from_path()
-        content = Content.from_path(str(file_path))
+    for path_arg in (str(file_path), file_path):
+        content = Content.from_path(path_arg)
         assert content is not None
         assert content.extension == extension
         assert content.mimetype == mimetype
         assert content.filename == file_path.name
         assert content.size > 0
         assert isinstance(content.data, bytes)
-        assert content.input_type == "str"
         assert content.content_type == "file"
+        cls = type(path_arg)
+        expected_input_type = (
+            cls.__qualname__
+            if cls.__module__ == "builtins"
+            else f"{cls.__module__}.{cls.__qualname__}"
+        )
+        assert content.input_type == expected_input_type
 
-    @pytest.mark.parametrize(
-        ("fixture_name", "extension", "mimetype"), MEDIA_TEST_PARAMS
+
+@pytest.mark.parametrize(("fixture_name", "extension", "mimetype"), MEDIA_TEST_PARAMS)
+def test_content_from_bytes_and_base64(fixture_name, extension, mimetype, request):
+    """from_bytes (by extension and by mimetype) and from_base64 reproduce the file."""
+    file_path = request.getfixturevalue(fixture_name)
+    file_bytes = file_path.read_bytes()
+
+    content = Content.from_bytes(file_bytes, extension=extension)
+    assert content is not None
+    assert content.extension == extension
+    assert content.mimetype == mimetype
+    assert content.size == len(file_bytes)
+    assert content.data == file_bytes
+    assert content.input_type == "bytes"
+    assert content.content_type == "bytes"
+
+    assert Content.from_bytes(file_bytes, mimetype=mimetype).mimetype == mimetype
+
+    b64_string = base64.b64encode(file_bytes).decode("utf-8")
+    b64_content = Content.from_base64(b64_string, extension=extension)
+    assert b64_content is not None
+    assert b64_content.extension == extension
+    assert b64_content.mimetype == mimetype
+    assert b64_content.data == file_bytes
+    assert b64_content.encoding == "base64"
+    assert b64_content.input_type == "str"
+    assert b64_content.content_type == "base64"
+
+
+@pytest.mark.parametrize(("fixture_name", "extension", "mimetype"), MEDIA_TEST_PARAMS)
+def test_content_in_ops(fixture_name, extension, mimetype, request):
+    """Content round-trips as both an op return value and an op input."""
+    file_path = request.getfixturevalue(fixture_name)
+
+    @weave.op
+    def load_content_direct(path: str) -> Content:
+        return Content.from_path(path)
+
+    @weave.op
+    def process_content(content: Content) -> dict:
+        return {
+            "size": content.size,
+            "extension": content.extension,
+            "mimetype": content.mimetype,
+        }
+
+    content = load_content_direct(str(file_path))
+    assert isinstance(content, Content)
+    assert content.extension == extension
+
+    result = process_content(content)
+    assert result["size"] == content.size
+    assert result["extension"] == extension
+    assert result["mimetype"] == mimetype
+
+
+def test_content_save_method(image_file):
+    """save() writes to an explicit filename and to a directory (original filename)."""
+    content = Content.from_path(image_file)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dest_path = Path(tmpdir) / "saved_file.png"
+        content.save(dest_path)
+        assert dest_path.exists()
+        assert dest_path.read_bytes() == content.data
+
+        Content.from_path(image_file).save(tmpdir)
+        assert (Path(tmpdir) / image_file.name).exists()
+
+
+def test_content_from_text_and_as_string():
+    """from_text honors encoding, and as_string decodes every encoding/edge case."""
+    text_data = "Hello, this is a test file!\nWith multiple lines."
+
+    content = Content.from_text(text_data, extension="txt")
+    assert content is not None
+    assert content.extension == ".txt"
+    assert content.mimetype == "text/plain"
+    assert content.data == text_data.encode("utf-8")
+    assert content.encoding == "utf-8"
+    assert content.input_type == "str"
+    assert content.content_type == "text"
+    assert content.as_string() == text_data
+
+    content_utf16 = Content.from_text(text_data, extension=".txt", encoding="utf-16")
+    assert content_utf16.data == text_data.encode("utf-16")
+    assert content_utf16.encoding == "utf-16"
+
+    assert (
+        Content.from_bytes(text_data.encode("utf-8"), extension="txt").as_string()
+        == text_data
     )
-    def test_content_from_bytes(
-        self, fixture_name: str, extension: str, mimetype: str, request
-    ):
-        """Test creating Content from bytes."""
-        file_path = request.getfixturevalue(fixture_name)
-        file_bytes = file_path.read_bytes()
-
-        # Test Content.from_bytes() with extension
-        content = Content.from_bytes(file_bytes, extension=extension)
-        assert content is not None
-        assert content.extension == extension
-        assert content.mimetype == mimetype
-        assert content.size == len(file_bytes)
-        assert content.data == file_bytes
-        assert content.input_type == "bytes"
-        assert content.content_type == "bytes"
-
-        # Test with mimetype
-        content2 = Content.from_bytes(file_bytes, mimetype=mimetype)
-        assert content2.mimetype == mimetype
-
-    @pytest.mark.parametrize(
-        ("fixture_name", "extension", "mimetype"), MEDIA_TEST_PARAMS
-    )
-    def test_content_from_base64(
-        self, fixture_name: str, extension: str, mimetype: str, request
-    ):
-        """Test creating Content from base64 encoded string."""
-        file_path = request.getfixturevalue(fixture_name)
-        file_bytes = file_path.read_bytes()
-
-        # Create base64 encoded string
-        b64_string = base64.b64encode(file_bytes).decode("utf-8")
-
-        # Test Content.from_base64() with base64 string
-        content = Content.from_base64(b64_string, extension=extension)
-        assert content is not None
-        assert content.extension == extension
-        assert content.mimetype == mimetype
-        assert content.data == file_bytes
-        assert content.encoding == "base64"
-        assert content.input_type == "str"
-        assert content.content_type == "base64"
-
-    @pytest.mark.parametrize(
-        ("fixture_name", "extension", "mimetype"), MEDIA_TEST_PARAMS
-    )
-    def test_content_from_pathlib(
-        self, fixture_name: str, extension: str, mimetype: str, request
-    ):
-        """Test creating Content from pathlib.Path object."""
-        file_path = request.getfixturevalue(fixture_name)
-
-        # Test Content.from_path() with Path object
-        content = Content.from_path(file_path)
-        assert content is not None
-        assert content.extension == extension
-        assert content.mimetype == mimetype
-        assert content.filename == file_path.name
-        assert content.content_type == "file"
-
-    def test_content_save_method(self, image_file):
-        """Test saving Content to a file."""
-        content = Content.from_path(image_file)
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Test save with filename
-            dest_path = Path(tmpdir) / "saved_file.png"
-            content.save(dest_path)
-            assert dest_path.exists()
-
-            # Verify saved content
-            saved_data = dest_path.read_bytes()
-            assert saved_data == content.data
-
-            # Test save to directory (should use original filename)
-            content_with_filename = Content.from_path(image_file)
-            content_with_filename.save(tmpdir)
-            expected_path = Path(tmpdir) / image_file.name
-            assert expected_path.exists()
-
-    @pytest.mark.parametrize(
-        ("fixture_name", "extension", "mimetype"), MEDIA_TEST_PARAMS
-    )
-    def test_content_in_ops(
-        self, fixture_name: str, extension: str, mimetype: str, request
-    ):
-        """Test Content as input/output of weave ops."""
-        file_path = request.getfixturevalue(fixture_name)
-
-        # Op that returns Content object directly
-        @weave.op
-        def load_content_direct(path: str) -> Content:
-            return Content.from_path(path)
-
-        # Op that takes Content as input
-        @weave.op
-        def process_content(content: Content) -> dict:
-            return {
-                "size": content.size,
-                "extension": content.extension,
-                "mimetype": content.mimetype,
-            }
-
-        # Test direct Content return
-        content = load_content_direct(str(file_path))
-        assert isinstance(content, Content)
-        assert content.extension == extension
-
-        # Test Content as input
-        result = process_content(content)
-        assert result["size"] == content.size
-        assert result["extension"] == extension
-        assert result["mimetype"] == mimetype
-
-    def test_content_from_text(self):
-        """Test creating Content from text string."""
-        text_data = "Hello, this is a test file!\nWith multiple lines."
-
-        # Test Content.from_text()
-        content = Content.from_text(text_data, extension="txt")
-        assert content is not None
-        assert content.extension == ".txt"
-        assert content.mimetype == "text/plain"
-        assert content.data == text_data.encode("utf-8")
-        assert content.encoding == "utf-8"
-        assert content.input_type == "str"
-        assert content.content_type == "text"
-
-        # Test with custom encoding
-        content2 = Content.from_text(text_data, extension=".txt", encoding="utf-16")
-        assert content2.data == text_data.encode("utf-16")
-        assert content2.encoding == "utf-16"
-
-    def test_content_as_string(self):
-        """Test converting Content to string for text files using as_string method."""
-        # Test 1: Basic UTF-8 text content
-        text_data = "Hello, this is a test file!\nWith multiple lines."
-        content = Content.from_text(text_data)
-        assert content.as_string() == text_data
-
-        # Test 2: UTF-8 content from bytes
-        content_bytes = Content.from_bytes(text_data.encode("utf-8"), extension="txt")
-        assert content_bytes.as_string() == text_data
-
-        # Test 3: UTF-16 encoded content
-        content_utf16 = Content.from_bytes(
+    assert (
+        Content.from_bytes(
             text_data.encode("utf-16"), extension="txt", encoding="utf-16"
-        )
-        assert content_utf16.as_string() == text_data
-
-        # Test 4: Latin-1 encoded content
-        latin_text = "Café, naïve, résumé"
-        content_latin1 = Content.from_bytes(
-            latin_text.encode("latin-1"), extension="txt", encoding="latin-1"
-        )
-        assert content_latin1.as_string() == latin_text
-
-        # Test 5: Base64 encoded content
-        b64_data = base64.b64encode(b"Binary data \x00\x01\x02").decode("ascii")
-        content_b64 = Content.from_base64(b64_data, extension="bin")
-        assert content_b64.as_string() == b64_data
-
-        # Test 6: Empty content
-        empty_content = Content.from_text("")
-        assert empty_content.as_string() == ""
-
-        # Test 7: Content with special characters
-        special_chars = "Special chars: \t\n\r€£¥"
-        content_special = Content.from_text(special_chars)
-        assert content_special.as_string() == special_chars
-
-        # Test 8: Japanese text (UTF-8)
-        japanese_text = "こんにちは世界"
-        content_japanese = Content.from_text(japanese_text)
-        assert content_japanese.as_string() == japanese_text
-
-        # Test 9: Emoji content
-        emoji_text = "Hello 👋 World 🌍!"
-        content_emoji = Content.from_text(emoji_text)
-        assert content_emoji.as_string() == emoji_text
-
-        # Test 10: ASCII art
-        ascii_art = """
-        ╔═══════════╗
-        ║  ASCII    ║
-        ║   ART     ║
-        ╚═══════════╝
-        """
-        content_ascii_art = Content.from_text(ascii_art)
-        assert content_ascii_art.as_string() == ascii_art
-
-        # Test 11: Binary data through base64
-        binary_data = bytes(list(range(256)))
-        b64_binary = base64.b64encode(binary_data).decode("ascii")
-        content_binary = Content.from_base64(b64_binary)
-        assert content_binary.as_string() == b64_binary
-
-        # Test 12: Multiline with different line endings
-        multiline = "Line1\nLine2\rLine3\r\nLine4"
-        content_multiline = Content.from_text(multiline)
-        assert content_multiline.as_string() == multiline
-
-        # Test 13: UTF-32 encoded content
-        content_utf32 = Content.from_bytes(
+        ).as_string()
+        == text_data
+    )
+    assert (
+        Content.from_bytes(
             text_data.encode("utf-32"), extension="txt", encoding="utf-32"
-        )
-        assert content_utf32.as_string() == text_data
+        ).as_string()
+        == text_data
+    )
 
-        # Test 14: Windows-1252 encoded content
-        win_text = "Windows specific: ''"
-        content_win1252 = Content.from_bytes(
+    latin_text = "Café, naïve, résumé"
+    assert (
+        Content.from_bytes(
+            latin_text.encode("latin-1"), extension="txt", encoding="latin-1"
+        ).as_string()
+        == latin_text
+    )
+    win_text = "Windows specific: ''"
+    assert (
+        Content.from_bytes(
             win_text.encode("windows-1252"), extension="txt", encoding="windows-1252"
-        )
-        assert content_win1252.as_string() == win_text
+        ).as_string()
+        == win_text
+    )
 
-        # Test 15: Very long string
-        long_text = "A" * 10000 + "\n" + "B" * 10000
-        content_long = Content.from_text(long_text)
-        assert content_long.as_string() == long_text
-        assert (
-            len(content_long.as_string()) == 20001
-        )  # 10000 A's + 1 newline + 10000 B's
+    b64_data = base64.b64encode(b"Binary data \x00\x01\x02").decode("ascii")
+    assert Content.from_base64(b64_data, extension="bin").as_string() == b64_data
+    b64_binary = base64.b64encode(bytes(range(256))).decode("ascii")
+    assert Content.from_base64(b64_binary).as_string() == b64_binary
 
-    def test_content_metadata(self, image_file):
-        """Test Content extra metadata property."""
-        metadata = {"test": "value", "author": "test_user"}
-        content = Content.from_path(image_file, metadata=metadata)
+    assert Content.from_text("").as_string() == ""
+    for txt in (
+        "Special chars: \t\n\r€£¥",
+        "こんにちは世界",
+        "Hello 👋 World 🌍!",
+        "\n        ╔═══╗\n        ║ART║\n        ╚═══╝\n        ",
+        "Line1\nLine2\rLine3\r\nLine4",
+    ):
+        assert Content.from_text(txt).as_string() == txt
 
-        # Check that metadata was stored in extra field
-        assert content.metadata == metadata
+    long_text = "A" * 10000 + "\n" + "B" * 10000
+    long_content = Content.from_text(long_text)
+    assert long_content.as_string() == long_text
+    assert len(long_content.as_string()) == 20001
 
-        # Check other fields are accessible
-        assert content.size > 0
-        assert content.filename == "file.png"
+
+def test_content_metadata_and_kwargs(image_file):
+    """Metadata and encoding kwargs are stored, alongside the derived file fields."""
+    metadata = {"test": "value", "author": "test_user"}
+    content = Content.from_path(image_file, metadata=metadata)
+    assert content.metadata == metadata
+    assert content.size > 0
+    assert content.filename == "file.png"
+    assert content.extension == ".png"
+    assert content.mimetype == "image/png"
+    assert content.encoding == "utf-8"
+
+    kw_meta = {"author": "test", "version": "1.0"}
+    bytes_content = Content.from_bytes(
+        b"Test content", extension="txt", metadata=kw_meta
+    )
+    assert bytes_content.metadata == kw_meta
+    assert (
+        Content.from_bytes(
+            b"Test content", extension="txt", encoding="latin-1"
+        ).encoding
+        == "latin-1"
+    )
+
+
+def test_content_type_hint_variations(image_file):
+    """from_bytes accepts extension w/o dot, extension w/ dot, and explicit mimetype."""
+    file_bytes = image_file.read_bytes()
+    for content in (
+        Content.from_bytes(file_bytes, extension="png"),
+        Content.from_bytes(file_bytes, extension=".png"),
+        Content.from_bytes(file_bytes, mimetype="image/png"),
+    ):
         assert content.extension == ".png"
         assert content.mimetype == "image/png"
-        assert content.encoding == "utf-8"
 
-    def test_content_type_hint_variations(self, image_file):
-        """Test different type hint formats."""
-        with open(image_file, "rb") as f:
-            file_bytes = f.read()
 
-        # Test with extension without dot
-        content1 = Content.from_bytes(file_bytes, extension="png")
-        assert content1.extension == ".png"
-        assert content1.mimetype == "image/png"
+def test_content_error_handling():
+    """Missing file raises FileNotFoundError; bad base64 raises ValueError."""
+    with pytest.raises(FileNotFoundError):
+        Content.from_path("/non/existent/file.txt")
+    with pytest.raises(ValueError, match="Invalid base64 data provided"):
+        Content.from_base64("not-valid-base64!")
 
-        # Test with extension with dot
-        content2 = Content.from_bytes(file_bytes, extension=".png")
-        assert content2.extension == ".png"
-        assert content2.mimetype == "image/png"
 
-        # Test with mimetype
-        content3 = Content.from_bytes(file_bytes, mimetype="image/png")
-        assert content3.extension == ".png"
-        assert content3.mimetype == "image/png"
-
-    def test_content_error_handling(self):
-        """Test error handling in Content class."""
-        # Test with non-existent file
-        with pytest.raises(FileNotFoundError):
-            Content.from_path("/non/existent/file.txt")
-
-        # Test with invalid base64
-        with pytest.raises(ValueError, match="Invalid base64 data provided"):
-            Content.from_base64("not-valid-base64!")
-
-    def test_content_with_kwargs(self):
-        """Test Content initialization with additional kwargs."""
-        file_bytes = b"Test content"
-
-        # Test with custom metadata
-        metadata = {"author": "test", "version": "1.0"}
-        content = Content.from_bytes(file_bytes, extension="txt", metadata=metadata)
-        assert content.metadata == metadata
-
-        # Test with custom encoding
-        content2 = Content.from_bytes(file_bytes, extension="txt", encoding="latin-1")
-        assert content2.encoding == "latin-1"
-
-    def test_content_save_and_retrieve(self, image_file, weave_active):
-        """Test publishing and retrieving Content objects."""
-        content = Content.from_path(image_file)
-
-        # Publish the content
-        ref = weave.publish(content, name=f"test_content_{content.extension}")
-        assert ref is not None
-
-        # Retrieve and verify
-        retrieved = ref.get()
-        assert isinstance(retrieved, Content)
-        assert retrieved.data == content.data
-        assert retrieved.extension == content.extension
-        assert retrieved.mimetype == content.mimetype
-        assert retrieved.size == content.size
-
-    def test_content_in_dataset(
-        self, image_file, audio_file, video_file, pdf_file, weave_active
+def test_empty_content_across_constructors():
+    """Empty payloads via bytes/text/base64, with and without extension, are size 0."""
+    empty = b""
+    for ext, mimetype in (
+        ("txt", "text/plain"),
+        ("json", "application/json"),
+        ("png", "image/png"),
     ):
-        """Test Content objects as dataset values."""
-        rows = []
-        original_files = {}
+        content = Content.from_bytes(empty, extension=ext)
+        assert content.data == b""
+        assert content.extension == f".{ext}"
+        assert content.mimetype == mimetype
+        assert content.size == 0
+    assert Content.from_bytes(empty, extension="txt").as_string() == ""
 
-        # Use fixtures to create content and store original data for verification
-        for file_path in [image_file, audio_file, video_file, pdf_file]:
-            content = Content.from_path(file_path)
-            rows.append(
-                {
-                    "name": file_path.name,
-                    "content": content,
-                    "expected_mimetype": content.mimetype,
-                }
-            )
-            original_files[file_path.name] = file_path.read_bytes()
+    no_ext = Content.from_bytes(empty)
+    assert no_ext.data == b""
+    assert no_ext.extension == ""
+    assert no_ext.mimetype == "application/octet-stream"
+    assert no_ext.size == 0
 
-        # Create and publish dataset
-        dataset = Dataset(rows=Table(rows))
-        ref = weave.publish(dataset, name="test_content_dataset")
+    with tempfile.NamedTemporaryFile(delete=False, suffix="") as tmp:
+        tmp_path = tmp.name
+    try:
+        content_file = Content.from_path(tmp_path)
+        assert content_file.data == b""
+        assert content_file.extension == ""
+        assert content_file.mimetype == "application/octet-stream"
+        assert content_file.size == 0
+        assert content_file.filename == Path(tmp_path).name
+    finally:
+        Path(tmp_path).unlink()
 
-        # Retrieve and verify
-        retrieved_dataset = ref.get()
-        assert len(retrieved_dataset.rows) == len(rows)
+    text_empty = Content.from_text("", extension="txt")
+    assert text_empty.data == b""
+    assert text_empty.extension == ".txt"
+    assert text_empty.size == 0
+    assert text_empty.as_string() == ""
 
-        for row in retrieved_dataset.rows:
-            assert isinstance(row["content"], Content)
-            assert row["content"].mimetype == row["expected_mimetype"]
-            # Verify data integrity
-            original_data = original_files[row["name"]]
-            assert row["content"].data == original_data
+    text_no_ext = Content.from_text("")
+    assert text_no_ext.data == b""
+    assert text_no_ext.extension == ".txt"
+    assert text_no_ext.size == 0
 
-    def test_content_postprocessing(self, weave_active):
-        """Test that Content postprocessing works correctly in ops."""
+    b64_empty = Content.from_base64("", extension="bin")
+    assert b64_empty.data == b""
+    assert b64_empty.extension == ".bin"
+    assert b64_empty.size == 0
 
-        @weave.op
-        def create_content_from_bytes(data: bytes, hint: str) -> Content:
-            return Content.from_bytes(data, extension=hint)
 
-        test_data = b"Test content for postprocessing"
-        result = create_content_from_bytes(test_data, "txt")
+def test_content_save_retrieve_and_dataset(
+    image_file, audio_file, video_file, pdf_file, weave_active
+):
+    """Publish/retrieve a single Content and a Dataset of Content rows, verifying bytes."""
+    content = Content.from_path(image_file)
+    ref = weave.publish(content, name=f"test_content_{content.extension}")
+    assert ref is not None
+    retrieved = ref.get()
+    assert isinstance(retrieved, Content)
+    assert retrieved.data == content.data
+    assert retrieved.extension == content.extension
+    assert retrieved.mimetype == content.mimetype
+    assert retrieved.size == content.size
 
-        assert isinstance(result, Content)
-        assert result.data == test_data
-        assert result.extension == ".txt"
-        assert result.mimetype == "text/plain"  # Simplified in mock
+    rows = []
+    original_files = {}
+    for file_path in [image_file, audio_file, video_file, pdf_file]:
+        c = Content.from_path(file_path)
+        rows.append(
+            {"name": file_path.name, "content": c, "expected_mimetype": c.mimetype}
+        )
+        original_files[file_path.name] = file_path.read_bytes()
 
-    def test_empty_file_with_extension(self):
-        """Test handling empty file with extension."""
-        empty_data = b""
+    dataset = Dataset(rows=Table(rows))
+    ds_ref = weave.publish(dataset, name="test_content_dataset")
+    retrieved_dataset = ds_ref.get()
+    assert len(retrieved_dataset.rows) == len(rows)
+    for row in retrieved_dataset.rows:
+        assert isinstance(row["content"], Content)
+        assert row["content"].mimetype == row["expected_mimetype"]
+        assert row["content"].data == original_files[row["name"]]
 
-        # Test empty bytes with .txt extension
-        content_txt = Content.from_bytes(empty_data, extension="txt")
-        assert content_txt.data == b""
-        assert content_txt.extension == ".txt"
-        assert content_txt.mimetype == "text/plain"
-        assert content_txt.size == 0
-        assert content_txt.as_string() == ""
 
-        # Test empty bytes with .json extension
-        content_json = Content.from_bytes(empty_data, extension="json")
-        assert content_json.data == b""
-        assert content_json.extension == ".json"
-        assert content_json.mimetype == "application/json"
-        assert content_json.size == 0
+def test_content_postprocessing(weave_active):
+    """Content postprocessing works through an op that builds Content from bytes."""
 
-        # Test empty bytes with .png extension
-        content_png = Content.from_bytes(empty_data, extension="png")
-        assert content_png.data == b""
-        assert content_png.extension == ".png"
-        assert content_png.mimetype == "image/png"
-        assert content_png.size == 0
+    @weave.op
+    def create_content_from_bytes(data: bytes, hint: str) -> Content:
+        return Content.from_bytes(data, extension=hint)
 
-        # Test empty text content
-        content_text = Content.from_text("", extension="txt")
-        assert content_text.data == b""
-        assert content_text.extension == ".txt"
-        assert content_text.size == 0
-        assert content_text.as_string() == ""
+    test_data = b"Test content for postprocessing"
+    result = create_content_from_bytes(test_data, "txt")
+    assert isinstance(result, Content)
+    assert result.data == test_data
+    assert result.extension == ".txt"
+    assert result.mimetype == "text/plain"
 
-        # Test empty base64 content
-        content_b64 = Content.from_base64("", extension="bin")
-        assert content_b64.data == b""
-        assert content_b64.extension == ".bin"
-        assert content_b64.size == 0
 
-    def test_file_no_extension_no_contents(self):
-        """Test handling file with no extension and no contents."""
-        empty_data = b""
-
-        # Test empty bytes with no extension
-        content_no_ext = Content.from_bytes(empty_data)
-        assert content_no_ext.data == b""
-        assert content_no_ext.extension == ""
-        assert content_no_ext.mimetype == "application/octet-stream"  # Default mimetype
-        assert content_no_ext.size == 0
-
-        # Test empty file path with no extension
-        with tempfile.NamedTemporaryFile(delete=False, suffix="") as tmp:
-            tmp_path = tmp.name
-            # File is created empty by default
-
-        try:
-            content_file = Content.from_path(tmp_path)
-            assert content_file.data == b""
-            assert content_file.extension == ""
-            assert content_file.mimetype == "application/octet-stream"
-            assert content_file.size == 0
-            assert content_file.filename == Path(tmp_path).name
-        finally:
-            # Clean up
-            Path(tmp_path).unlink()
-
-        # Test empty text with no extension
-        content_text_no_ext = Content.from_text("")
-        assert content_text_no_ext.data == b""
-        assert content_text_no_ext.extension == ".txt"  # Default for text
-        assert content_text_no_ext.size == 0
-
-    def test_emoji_content(self):
-        doc = """
+def test_emoji_content():
+    """Markdown text is detected via both from_text and _from_guess."""
+    doc = """
 My Awesome Emoji Document 👋
 This is a simple document to show how you can use emojis in Markdown. It's a great way to add some personality and visual interest to your text! 🥳
 
@@ -523,59 +379,57 @@ Here is a list of things I want to accomplish:
 
 That's all for now. Have a great day! ☀️
 """
-        # First do it with the correct constructor
-        content = Content.from_text(doc, extension=".md")
-        assert content.mimetype == "text/markdown"
-        # Next guess from annotated value
-        content = Content._from_guess(doc, extension=".md")
-        assert content.mimetype == "text/markdown"
+    assert Content.from_text(doc, extension=".md").mimetype == "text/markdown"
+    # _from_guess feeds the text to is_valid_path, exercising its except branch.
+    assert Content._from_guess(doc, extension=".md").mimetype == "text/markdown"
 
-    def test_content_from_url_basic(self):
-        class FakeResponse:
-            def __init__(self):
-                self.content = b"hello world"
-                self.headers = {"Content-Type": "text/plain; charset=utf-8"}
-                self.encoding = "utf-8"
-                self.status_code = 200
 
-            def raise_for_status(self):
-                if self.status_code >= 400:
-                    raise _FakeHTTPError("HTTP error")
+def test_content_from_url_basic_and_content_disposition():
+    """from_url uses Content-Type; _from_guess honors a Content-Disposition filename."""
+    txt_resp = _FakeResponse(
+        b"hello world", {"Content-Type": "text/plain; charset=utf-8"}, encoding="utf-8"
+    )
+    with patch.object(_http_requests, "get", return_value=txt_resp):
+        c = Content.from_url("https://example.com/path/to/test.txt")
+    assert isinstance(c.data, bytes)
+    assert c.data == b"hello world"
+    assert c.mimetype == "text/plain"
+    assert c.extension == ".txt"
+    assert c.filename == "test.txt"
+    assert c.size == len(b"hello world")
+    assert c.content_type == "bytes"
+    assert c.input_type == "str"
 
-        url = "https://example.com/path/to/test.txt"
-        with patch.object(_http_requests, "get", return_value=FakeResponse()):
-            c = Content.from_url(url)
+    pdf_resp = _FakeResponse(
+        b"%PDF-1.4 Mock PDF bytes",
+        {
+            "Content-Type": "application/pdf",
+            "Content-Disposition": 'attachment; filename="report.pdf"',
+        },
+        encoding=None,
+    )
+    with patch.object(_http_requests, "get", return_value=pdf_resp):
+        c2 = Content._from_guess("http://example.com/download")
+    assert c2.mimetype == "application/pdf"
+    assert c2.extension == ".pdf"
+    assert c2.filename == "report.pdf"
+    assert c2.content_type == "bytes"
+    assert c2.input_type == "str"
 
-        assert isinstance(c.data, bytes)
-        assert c.data == b"hello world"
-        assert c.mimetype == "text/plain"
-        assert c.extension == ".txt"
-        assert c.filename == "test.txt"
-        assert c.size == len(b"hello world")
-        assert c.content_type == "bytes"
-        assert c.input_type == "str"
 
-    def test__from_guess_http_url_with_content_disposition(self):
-        class FakeResponse:
-            def __init__(self):
-                self.content = b"%PDF-1.4 Mock PDF bytes"
-                self.headers = {
-                    "Content-Type": "application/pdf",
-                    "Content-Disposition": 'attachment; filename="report.pdf"',
-                }
-                self.encoding = None
-                self.status_code = 200
+class _FakeHTTPError(Exception):
+    """Raised by `_FakeResponse.raise_for_status` for non-2xx status codes."""
 
-            def raise_for_status(self):
-                if self.status_code >= 400:
-                    raise _FakeHTTPError("HTTP error")
 
-        url = "http://example.com/download"
-        with patch.object(_http_requests, "get", return_value=FakeResponse()):
-            c = Content._from_guess(url)
+class _FakeResponse:
+    """Stand-in for an http_requests response object in from_url tests."""
 
-        assert c.mimetype == "application/pdf"
-        assert c.extension == ".pdf"
-        assert c.filename == "report.pdf"
-        assert c.content_type == "bytes"
-        assert c.input_type == "str"
+    def __init__(self, content: bytes, headers: dict, encoding: str | None):
+        self.content = content
+        self.headers = headers
+        self.encoding = encoding
+        self.status_code = 200
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise _FakeHTTPError("HTTP error")

--- a/tests/trace/type_handlers/Content/test_content_resolvers.py
+++ b/tests/trace/type_handlers/Content/test_content_resolvers.py
@@ -12,6 +12,7 @@ Each test is parametrized to run under three resolver configurations:
 
 from __future__ import annotations
 
+import importlib
 import io
 import logging
 import tempfile
@@ -43,23 +44,6 @@ from weave.type_wrappers.Content.utils import (
 # ---------------------------------------------------------------------------
 
 RESOLVER_IDS = ["python_magic", "polyfile", "auto"]
-
-
-def _make_unavailable(module: Any) -> Any:
-    """Return a patched is_available that always returns False."""
-    return patch.object(module, "is_available", return_value=False)
-
-
-def _get_utils_module():
-    """Import the utils module avoiding the Content class re-export."""
-    import importlib
-
-    return importlib.import_module("weave.type_wrappers.Content.utils")
-
-
-def _reset_resolver():
-    mod = _get_utils_module()
-    mod._resolver = mod._UNSET
 
 
 @pytest.fixture(params=RESOLVER_IDS)
@@ -209,7 +193,7 @@ def extensionless_png_file(tmp_path_factory, png_bytes) -> Path:
 
 
 # ---------------------------------------------------------------------------
-# Test: resolver detection from buffer
+# Resolver detection from buffer
 # ---------------------------------------------------------------------------
 
 BUFFER_CASES = [
@@ -222,49 +206,34 @@ BUFFER_CASES = [
 ]
 
 
-class TestResolverDetectFromBuffer:
-    """Verify that each resolver correctly identifies MIME type from raw bytes."""
+@pytest.mark.parametrize(("fixture_name", "expected_mime"), BUFFER_CASES)
+def test_detect_from_buffer(fixture_name, expected_mime, resolver_backend, request):
+    """MIME from raw bytes, plus extension-presence contract per backend."""
+    buffer = request.getfixturevalue(fixture_name)
+    mime, ext = _detect_from_resolver(filename=None, buffer=buffer)
+    assert mime == expected_mime
+    if resolver_backend == "polyfile":
+        assert ext is None, "polyfile should not return extension"
+    else:
+        assert ext is not None, "python-magic should return an extension"
+        assert ext.startswith(".")
 
-    @pytest.mark.parametrize(("fixture_name", "expected_mime"), BUFFER_CASES)
-    def test_mime_from_buffer(
-        self, fixture_name: str, expected_mime: str, resolver_backend, request
-    ):
-        buffer = request.getfixturevalue(fixture_name)
-        mime, ext = _detect_from_resolver(filename=None, buffer=buffer)
-        assert mime == expected_mime
 
-    @pytest.mark.parametrize(("fixture_name", "expected_mime"), BUFFER_CASES)
-    def test_extension_from_buffer_python_magic(
-        self, fixture_name: str, expected_mime: str, resolver_backend, request
-    ):
-        """python-magic returns extensions; polyfile returns None."""
-        buffer = request.getfixturevalue(fixture_name)
-        _, ext = _detect_from_resolver(filename=None, buffer=buffer)
-
-        if resolver_backend == "polyfile":
-            assert ext is None, "polyfile should not return extension"
-        else:
-            # python_magic and auto (when python-magic is available)
-            assert ext is not None, "python-magic should return an extension"
-            assert ext.startswith(".")
-
-    def test_empty_buffer(self, resolver_backend):
-        """Empty buffer: polyfile returns None, python-magic returns application/x-empty."""
-        mime, ext = _detect_from_resolver(filename=None, buffer=b"")
-        if resolver_backend == "polyfile":
-            assert mime is None
-        else:
-            # python-magic / auto may return "application/x-empty"
-            assert mime is None or mime == "application/x-empty"
-
-    def test_none_buffer_returns_none(self, resolver_backend):
-        mime, ext = _detect_from_resolver(filename=None, buffer=None)
+def test_detect_from_buffer_edge_cases(resolver_backend):
+    """Empty and None buffers across backends."""
+    mime, ext = _detect_from_resolver(filename=None, buffer=b"")
+    if resolver_backend == "polyfile":
         assert mime is None
-        assert ext is None
+    else:
+        assert mime is None or mime == "application/x-empty"
+
+    mime, ext = _detect_from_resolver(filename=None, buffer=None)
+    assert mime is None
+    assert ext is None
 
 
 # ---------------------------------------------------------------------------
-# Test: resolver detection from file
+# Resolver detection from file
 # ---------------------------------------------------------------------------
 
 FILE_CASES = [
@@ -276,480 +245,380 @@ FILE_CASES = [
 ]
 
 
-class TestResolverDetectFromFile:
-    """Verify detection from an actual file path on disk."""
-
-    @pytest.mark.parametrize(
-        ("fixture_name", "expected_mime", "expected_ext"), FILE_CASES
-    )
-    def test_mime_from_file(
-        self,
-        fixture_name: str,
-        expected_mime: str,
-        expected_ext: str,
-        resolver_backend,
-        request,
-    ):
-        file_path = request.getfixturevalue(fixture_name)
-        mime, ext = _detect_from_resolver(filename=str(file_path), buffer=None)
-
-        if resolver_backend == "polyfile":
-            # polyfile ignores filename, needs buffer
-            assert mime is None
-        else:
-            assert mime == expected_mime
-
-    @pytest.mark.parametrize(
-        ("fixture_name", "expected_mime", "expected_ext"), FILE_CASES
-    )
-    def test_extension_from_file_python_magic(
-        self,
-        fixture_name: str,
-        expected_mime: str,
-        expected_ext: str,
-        resolver_backend,
-        request,
-    ):
-        """python-magic can detect extension from file; polyfile cannot."""
-        file_path = request.getfixturevalue(fixture_name)
-        _, ext = _detect_from_resolver(filename=str(file_path), buffer=None)
-
-        if resolver_backend == "polyfile":
-            assert ext is None
-        else:
-            assert ext is not None
-            assert ext.startswith(".")
-
-    def test_nonexistent_file_falls_back_to_buffer(self, resolver_backend, png_bytes):
-        """When filename doesn't exist, should fall back to buffer detection."""
-        mime, ext = _detect_from_resolver(
-            filename="/nonexistent/file.png", buffer=png_bytes
-        )
-        assert mime == "image/png"
-
-    def test_extensionless_file_detected_from_content(
-        self, resolver_backend, extensionless_png_file, png_bytes
-    ):
-        """A file with no extension should still be identified by its content."""
-        mime, ext = _detect_from_resolver(
-            filename=str(extensionless_png_file),
-            buffer=png_bytes,
-        )
-        assert mime == "image/png"
-
-
-# ---------------------------------------------------------------------------
-# Test: get_mime_and_extension (full pipeline)
-# ---------------------------------------------------------------------------
-
-
-class TestGetMimeAndExtension:
-    """Test the full detection pipeline in utils.get_mime_and_extension."""
-
-    def test_both_provided_returns_immediately(self, resolver_backend):
-        mime, ext = get_mime_and_extension(
-            mimetype="text/html",
-            extension=".html",
-            filename=None,
-            buffer=None,
-        )
-        assert mime == "text/html"
-        assert ext == ".html"
-
-    def test_mimetype_only_resolves_extension(self, resolver_backend):
-        mime, ext = get_mime_and_extension(
-            mimetype="image/png",
-            extension=None,
-            filename=None,
-            buffer=None,
-        )
-        assert mime == "image/png"
-        assert ext == ".png"
-
-    def test_extension_only_resolves_mimetype(self, resolver_backend):
-        mime, ext = get_mime_and_extension(
-            mimetype=None,
-            extension=".pdf",
-            filename=None,
-            buffer=None,
-        )
-        assert mime == "application/pdf"
-        assert ext == ".pdf"
-
-    def test_filename_resolves_via_mimetypes(self, resolver_backend):
-        """Filename-based detection (mimetypes) runs before content detection."""
-        mime, ext = get_mime_and_extension(
-            mimetype=None,
-            extension=None,
-            filename="report.pdf",
-            buffer=None,
-        )
-        assert mime == "application/pdf"
-
-    def test_buffer_detection_as_fallback(self, resolver_backend, png_bytes):
-        """When filename and extension are absent, buffer detection kicks in."""
-        mime, ext = get_mime_and_extension(
-            mimetype=None,
-            extension=None,
-            filename=None,
-            buffer=png_bytes,
-        )
-        assert mime == "image/png"
-
-    def test_filename_takes_priority_over_buffer(self, resolver_backend, wav_bytes):
-        """Mimetypes from filename should be tried before buffer detection."""
-        mime, ext = get_mime_and_extension(
-            mimetype=None,
-            extension=None,
-            filename="music.mp3",  # mimetypes says audio/mpeg
-            buffer=wav_bytes,  # buffer would detect audio/wav
-        )
-        # Filename-based detection should win
-        assert mime == "audio/mpeg"
-
-    @pytest.mark.parametrize(
-        ("buffer_fixture", "expected_mime"),
-        [
-            ("png_bytes", "image/png"),
-            ("pdf_bytes", "application/pdf"),
-            ("wav_bytes", "audio/wav"),
-            ("jpeg_bytes", "image/jpeg"),
-        ],
-    )
-    def test_buffer_only_detection(
-        self,
-        buffer_fixture: str,
-        expected_mime: str,
-        resolver_backend,
-        request,
-    ):
-        buffer = request.getfixturevalue(buffer_fixture)
-        mime, ext = get_mime_and_extension(
-            mimetype=None,
-            extension=None,
-            filename=None,
-            buffer=buffer,
-        )
-        assert mime == expected_mime
-
-    def test_defaults_when_nothing_available(self, resolver_backend):
-        mime, ext = get_mime_and_extension(
-            mimetype=None,
-            extension=None,
-            filename=None,
-            buffer=None,
-        )
-        assert mime == "application/octet-stream"
-        assert ext == ""
-
-    def test_custom_defaults(self, resolver_backend):
-        mime, ext = get_mime_and_extension(
-            mimetype=None,
-            extension=None,
-            filename=None,
-            buffer=None,
-            default_mimetype="text/plain",
-            default_extension=".txt",
-        )
-        assert mime == "text/plain"
-        assert ext == ".txt"
-
-    def test_extension_normalized_with_dot(self, resolver_backend):
-        """Extensions without a dot prefix should be normalized."""
-        mime, ext = get_mime_and_extension(
-            mimetype="image/png",
-            extension="png",
-            filename=None,
-            buffer=None,
-        )
-        assert ext == ".png"
-
-    def test_empty_buffer_treated_as_none(self, resolver_backend):
-        mime, ext = get_mime_and_extension(
-            mimetype=None,
-            extension=".txt",
-            filename=None,
-            buffer=b"",
-        )
-        assert mime == "text/plain"
-        assert ext == ".txt"
-
-
-# ---------------------------------------------------------------------------
-# Test: guess_from_buffer (public API)
-# ---------------------------------------------------------------------------
-
-
-class TestGuessFromBuffer:
-    @pytest.mark.parametrize(("fixture_name", "expected_mime"), BUFFER_CASES)
-    def test_returns_correct_mime(
-        self,
-        fixture_name: str,
-        expected_mime: str,
-        resolver_backend,
-        request,
-    ):
-        buffer = request.getfixturevalue(fixture_name)
-        mime = guess_from_buffer(buffer)
-        assert mime == expected_mime
-
-    def test_empty_buffer_returns_none(self, resolver_backend):
-        assert guess_from_buffer(b"") is None
-
-
-# ---------------------------------------------------------------------------
-# Test: guess_from_filename and guess_from_extension (stdlib mimetypes)
-# ---------------------------------------------------------------------------
-
-
-class TestMimetypesHelpers:
-    """These don't depend on the resolver but are exercised for completeness."""
-
-    @pytest.mark.parametrize(
-        ("filename", "expected_mime"),
-        [
-            ("image.png", "image/png"),
-            ("doc.pdf", "application/pdf"),
-            ("song.mp3", "audio/mpeg"),
-            ("page.html", "text/html"),
-            ("data.json", "application/json"),
-            ("readme.md", "text/markdown"),
-            ("style.css", "text/css"),
-        ],
-    )
-    def test_guess_from_filename(self, filename, expected_mime):
-        assert guess_from_filename(filename) == expected_mime
-
-    @pytest.mark.parametrize(
-        ("ext", "expected_mime"),
-        [
-            (".png", "image/png"),
-            ("png", "image/png"),
-            (".pdf", "application/pdf"),
-            ("mp3", "audio/mpeg"),
-        ],
-    )
-    def test_guess_from_extension(self, ext, expected_mime):
-        assert guess_from_extension(ext) == expected_mime
-
-    @pytest.mark.parametrize(
-        ("mime", "expected_ext"),
-        [
-            ("image/png", ".png"),
-            ("application/pdf", ".pdf"),
-            ("text/html", ".html"),
-        ],
-    )
-    def test_get_extension_from_mimetype(self, mime, expected_ext):
-        assert get_extension_from_mimetype(mime) == expected_ext
-
-
-# ---------------------------------------------------------------------------
-# Test: Content class integration with each resolver
-# ---------------------------------------------------------------------------
-
-
-class TestContentIntegration:
-    """End-to-end tests creating Content objects under each resolver backend."""
-
-    def test_from_path_png(self, resolver_backend, png_file):
-        c = Content.from_path(png_file)
-        assert c.mimetype == "image/png"
-        assert c.extension == ".png"
-        assert c.size > 0
-
-    def test_from_path_pdf(self, resolver_backend, pdf_file):
-        c = Content.from_path(pdf_file)
-        assert c.mimetype == "application/pdf"
-        assert c.extension == ".pdf"
-
-    def test_from_path_wav(self, resolver_backend, wav_file):
-        c = Content.from_path(wav_file)
-        # Detected audio/x-wav is normalized to canonical audio/wav.
-        assert c.mimetype == "audio/wav"
-        assert c.extension == ".wav"
-
-    def test_from_bytes_with_extension(self, resolver_backend, png_bytes):
-        c = Content.from_bytes(png_bytes, extension="png")
-        assert c.mimetype == "image/png"
-        assert c.extension == ".png"
-
-    def test_from_bytes_without_hint(self, resolver_backend, pdf_bytes):
-        """With no extension or mimetype hint, must detect from buffer."""
-        c = Content.from_bytes(pdf_bytes)
-        assert c.mimetype == "application/pdf"
-
-    def test_from_bytes_mimetype_only(self, resolver_backend, wav_bytes):
-        # Explicit caller mimetype is preserved; only detected types are normalized.
-        c = Content.from_bytes(wav_bytes, mimetype="audio/x-wav")
-        assert c.mimetype == "audio/x-wav"
-        assert c.extension is not None  # should be resolved from mimetype
-
-    def test_from_text(self, resolver_backend):
-        c = Content.from_text("hello world", extension="txt")
-        assert c.mimetype == "text/plain"
-        assert c.extension == ".txt"
-
-    def test_from_path_extensionless(self, resolver_backend, extensionless_png_file):
-        """File with no extension should still detect MIME from content."""
-        c = Content.from_path(extensionless_png_file)
-        assert c.mimetype == "image/png"
-
-    def test_from_bytes_empty(self, resolver_backend):
-        c = Content.from_bytes(b"", extension="bin")
-        assert c.size == 0
-        assert c.extension == ".bin"
-
-    def test_roundtrip_save_load(self, resolver_backend, png_bytes):
-        """Save content to disk and re-read it via from_path."""
-        c = Content.from_bytes(png_bytes, extension="png")
-        with tempfile.TemporaryDirectory() as tmpdir:
-            dest = Path(tmpdir) / "roundtrip.png"
-            c.save(dest)
-            c2 = Content.from_path(dest)
-            assert c2.data == c.data
-            assert c2.mimetype == c.mimetype
-            assert c2.extension == c.extension
-
-
-# ---------------------------------------------------------------------------
-# Test: no resolver available (graceful degradation)
-# ---------------------------------------------------------------------------
-
-
-class TestNoResolverAvailable:
-    """Verify behaviour when neither python-magic nor polyfile is installed."""
-
-    @pytest.fixture(autouse=True)
-    def _disable_all_resolvers(self):
-        _reset_resolver()
-        with (
-            _make_unavailable(python_magic_resolver),
-            _make_unavailable(polyfile_magic_resolver),
-        ):
-            _reset_resolver()
-            yield
-        _reset_resolver()
-
-    def test_guess_from_buffer_warns(self, caplog):
-        with caplog.at_level(
-            logging.WARNING, logger="weave.type_wrappers.Content.utils"
-        ):
-            result = guess_from_buffer(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
-        assert result is None
-        assert "python-magic or polyfile" in caplog.text
-
-    def test_get_mime_and_extension_uses_defaults(self):
-        mime, ext = get_mime_and_extension(
-            mimetype=None,
-            extension=None,
-            filename=None,
-            buffer=b"\x89PNG\r\n",
-        )
-        assert mime == "application/octet-stream"
-        assert ext == ""
-
-    def test_mimetypes_still_works_without_resolver(self):
-        """Stdlib mimetypes detection should work even without a resolver."""
-        mime, ext = get_mime_and_extension(
-            mimetype=None,
-            extension=None,
-            filename="image.png",
-            buffer=None,
-        )
-        assert mime == "image/png"
-
-    def test_content_from_bytes_with_extension_still_works(self):
-        """When extension is provided, no resolver needed."""
-        c = Content.from_bytes(b"data", extension="txt")
-        assert c.mimetype == "text/plain"
-        assert c.extension == ".txt"
-
-    def test_detect_from_resolver_returns_none(self):
-        mime, ext = _detect_from_resolver(filename=None, buffer=b"test")
+@pytest.mark.parametrize(("fixture_name", "expected_mime", "expected_ext"), FILE_CASES)
+def test_detect_from_file(
+    fixture_name, expected_mime, expected_ext, resolver_backend, request
+):
+    """MIME + extension contract from a real file path; polyfile ignores filename."""
+    file_path = request.getfixturevalue(fixture_name)
+    mime, ext = _detect_from_resolver(filename=str(file_path), buffer=None)
+    if resolver_backend == "polyfile":
         assert mime is None
         assert ext is None
-
-
-# ---------------------------------------------------------------------------
-# Test: python-magic specific from_file behaviour
-# ---------------------------------------------------------------------------
-
-
-class TestPythonMagicFromFile:
-    """Tests specific to python-magic's from_file capability."""
-
-    @pytest.fixture(autouse=True)
-    def _force_python_magic(self):
-        _reset_resolver()
-        with _make_unavailable(polyfile_magic_resolver):
-            _reset_resolver()
-            yield
-        _reset_resolver()
-
-    def test_from_file_detects_mime_and_extension(self, png_file):
-        mime, ext = python_magic_resolver.detect(filename=str(png_file), buffer=None)
-        assert mime == "image/png"
+    else:
+        assert mime == expected_mime
         assert ext is not None
         assert ext.startswith(".")
 
-    def test_from_file_nonexistent_falls_back_to_buffer(self, png_bytes):
-        mime, ext = python_magic_resolver.detect(
-            filename="/does/not/exist.png", buffer=png_bytes
-        )
-        assert mime == "image/png"
 
-    def test_from_file_nonexistent_no_buffer_returns_none(self):
-        mime, ext = python_magic_resolver.detect(
-            filename="/does/not/exist.png", buffer=None
-        )
-        assert mime is None
-        assert ext is None
+def test_detect_from_file_fallbacks(
+    resolver_backend, extensionless_png_file, png_bytes
+):
+    """Nonexistent path falls back to buffer; extensionless file detected by content."""
+    mime, _ = _detect_from_resolver(filename="/nonexistent/file.png", buffer=png_bytes)
+    assert mime == "image/png"
 
-    def test_extensionless_file_detected(self, extensionless_png_file):
-        """python-magic detects MIME from file content, ignoring extension."""
-        mime, ext = python_magic_resolver.detect(
-            filename=str(extensionless_png_file), buffer=None
-        )
-        assert mime == "image/png"
+    mime, _ = _detect_from_resolver(
+        filename=str(extensionless_png_file), buffer=png_bytes
+    )
+    assert mime == "image/png"
 
 
 # ---------------------------------------------------------------------------
-# Test: polyfile specific behaviour
+# get_mime_and_extension (full pipeline)
 # ---------------------------------------------------------------------------
 
 
-class TestPolyfileResolver:
-    """Tests specific to polyfile's buffer-only detection."""
+def test_get_mime_and_extension_priority(resolver_backend, png_bytes, wav_bytes):
+    """Resolution priority: explicit args > filename mimetypes > buffer detection."""
+    # both provided returns immediately
+    assert get_mime_and_extension(
+        mimetype="text/html", extension=".html", filename=None, buffer=None
+    ) == ("text/html", ".html")
+    # mimetype only resolves extension
+    assert get_mime_and_extension(
+        mimetype="image/png", extension=None, filename=None, buffer=None
+    ) == ("image/png", ".png")
+    # extension only resolves mimetype
+    assert get_mime_and_extension(
+        mimetype=None, extension=".pdf", filename=None, buffer=None
+    ) == ("application/pdf", ".pdf")
+    # filename resolves via mimetypes (before content detection)
+    mime, _ = get_mime_and_extension(
+        mimetype=None, extension=None, filename="report.pdf", buffer=None
+    )
+    assert mime == "application/pdf"
+    # buffer detection as fallback
+    mime, _ = get_mime_and_extension(
+        mimetype=None, extension=None, filename=None, buffer=png_bytes
+    )
+    assert mime == "image/png"
+    # filename takes priority over buffer (mimetypes audio/mpeg beats audio/wav)
+    mime, _ = get_mime_and_extension(
+        mimetype=None, extension=None, filename="music.mp3", buffer=wav_bytes
+    )
+    assert mime == "audio/mpeg"
 
-    @pytest.fixture(autouse=True)
-    def _force_polyfile(self):
+
+@pytest.mark.parametrize(
+    ("buffer_fixture", "expected_mime"),
+    [
+        ("png_bytes", "image/png"),
+        ("pdf_bytes", "application/pdf"),
+        ("wav_bytes", "audio/wav"),
+        ("jpeg_bytes", "image/jpeg"),
+    ],
+)
+def test_get_mime_and_extension_buffer_only(
+    buffer_fixture, expected_mime, resolver_backend, request
+):
+    buffer = request.getfixturevalue(buffer_fixture)
+    mime, _ = get_mime_and_extension(
+        mimetype=None, extension=None, filename=None, buffer=buffer
+    )
+    assert mime == expected_mime
+
+
+def test_get_mime_and_extension_defaults_and_normalization(resolver_backend):
+    """Default fallbacks, custom defaults, dot-normalization, empty-buffer handling."""
+    assert get_mime_and_extension(
+        mimetype=None, extension=None, filename=None, buffer=None
+    ) == ("application/octet-stream", "")
+    assert get_mime_and_extension(
+        mimetype=None,
+        extension=None,
+        filename=None,
+        buffer=None,
+        default_mimetype="text/plain",
+        default_extension=".txt",
+    ) == ("text/plain", ".txt")
+    # extension without dot prefix is normalized
+    _, ext = get_mime_and_extension(
+        mimetype="image/png", extension="png", filename=None, buffer=None
+    )
+    assert ext == ".png"
+    # empty buffer treated as none -> falls to provided extension
+    assert get_mime_and_extension(
+        mimetype=None, extension=".txt", filename=None, buffer=b""
+    ) == ("text/plain", ".txt")
+
+
+# ---------------------------------------------------------------------------
+# Public mimetypes helpers (resolver-independent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("fixture_name", "expected_mime"), BUFFER_CASES)
+def test_guess_from_buffer(fixture_name, expected_mime, resolver_backend, request):
+    buffer = request.getfixturevalue(fixture_name)
+    assert guess_from_buffer(buffer) == expected_mime
+
+
+def test_guess_from_buffer_empty(resolver_backend):
+    assert guess_from_buffer(b"") is None
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_mime"),
+    [
+        ("image.png", "image/png"),
+        ("doc.pdf", "application/pdf"),
+        ("song.mp3", "audio/mpeg"),
+        ("page.html", "text/html"),
+        ("data.json", "application/json"),
+        ("readme.md", "text/markdown"),
+        ("style.css", "text/css"),
+    ],
+)
+def test_guess_from_filename(filename, expected_mime):
+    assert guess_from_filename(filename) == expected_mime
+
+
+@pytest.mark.parametrize(
+    ("ext", "expected_mime"),
+    [
+        (".png", "image/png"),
+        ("png", "image/png"),
+        (".pdf", "application/pdf"),
+        ("mp3", "audio/mpeg"),
+    ],
+)
+def test_guess_from_extension(ext, expected_mime):
+    assert guess_from_extension(ext) == expected_mime
+
+
+@pytest.mark.parametrize(
+    ("mime", "expected_ext"),
+    [
+        ("image/png", ".png"),
+        ("application/pdf", ".pdf"),
+        ("text/html", ".html"),
+    ],
+)
+def test_get_extension_from_mimetype(mime, expected_ext):
+    assert get_extension_from_mimetype(mime) == expected_ext
+
+
+# ---------------------------------------------------------------------------
+# Content class integration with each resolver
+# ---------------------------------------------------------------------------
+
+
+def test_content_from_path(resolver_backend, png_file, pdf_file, wav_file):
+    """from_path detects mime + extension + size for png/pdf/wav."""
+    c = Content.from_path(png_file)
+    assert c.mimetype == "image/png"
+    assert c.extension == ".png"
+    assert c.size > 0
+
+    c = Content.from_path(pdf_file)
+    assert c.mimetype == "application/pdf"
+    assert c.extension == ".pdf"
+
+    c = Content.from_path(wav_file)
+    # Detected audio/x-wav is normalized to canonical audio/wav.
+    assert c.mimetype == "audio/wav"
+    assert c.extension == ".wav"
+
+
+def test_content_from_path_extensionless(resolver_backend, extensionless_png_file):
+    """File with no extension still detects MIME from content."""
+    c = Content.from_path(extensionless_png_file)
+    assert c.mimetype == "image/png"
+
+
+def test_content_from_bytes(resolver_backend, png_bytes, pdf_bytes, wav_bytes):
+    """from_bytes with explicit extension, no hint, and explicit mimetype."""
+    c = Content.from_bytes(png_bytes, extension="png")
+    assert c.mimetype == "image/png"
+    assert c.extension == ".png"
+
+    # no extension or mimetype hint -> detect from buffer
+    c = Content.from_bytes(pdf_bytes)
+    assert c.mimetype == "application/pdf"
+
+    # explicit caller mimetype is preserved; only detected types are normalized
+    c = Content.from_bytes(wav_bytes, mimetype="audio/x-wav")
+    assert c.mimetype == "audio/x-wav"
+    assert c.extension is not None
+
+
+def test_content_from_text_and_empty(resolver_backend):
+    """from_text resolves text/plain; empty from_bytes keeps size 0 + extension."""
+    c = Content.from_text("hello world", extension="txt")
+    assert c.mimetype == "text/plain"
+    assert c.extension == ".txt"
+
+    c = Content.from_bytes(b"", extension="bin")
+    assert c.size == 0
+    assert c.extension == ".bin"
+
+
+def test_content_roundtrip_save_load(resolver_backend, png_bytes):
+    """Save content to disk and re-read it via from_path."""
+    c = Content.from_bytes(png_bytes, extension="png")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        dest = Path(tmpdir) / "roundtrip.png"
+        c.save(dest)
+        c2 = Content.from_path(dest)
+        assert c2.data == c.data
+        assert c2.mimetype == c.mimetype
+        assert c2.extension == c.extension
+
+
+# ---------------------------------------------------------------------------
+# No resolver available (graceful degradation)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _no_resolvers():
+    _reset_resolver()
+    with (
+        _make_unavailable(python_magic_resolver),
+        _make_unavailable(polyfile_magic_resolver),
+    ):
         _reset_resolver()
-        with _make_unavailable(python_magic_resolver):
-            _reset_resolver()
-            yield
+        yield
+    _reset_resolver()
+
+
+@pytest.mark.usefixtures("_no_resolvers")
+def test_no_resolver_buffer_paths(caplog):
+    """Without a resolver: buffer detect warns + returns None, defaults applied."""
+    with caplog.at_level(logging.WARNING, logger="weave.type_wrappers.Content.utils"):
+        result = guess_from_buffer(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)
+    assert result is None
+    assert "python-magic or polyfile" in caplog.text
+
+    mime, ext = _detect_from_resolver(filename=None, buffer=b"test")
+    assert mime is None
+    assert ext is None
+
+    assert get_mime_and_extension(
+        mimetype=None, extension=None, filename=None, buffer=b"\x89PNG\r\n"
+    ) == ("application/octet-stream", "")
+
+
+@pytest.mark.usefixtures("_no_resolvers")
+def test_no_resolver_mimetypes_still_work():
+    """Stdlib mimetypes + explicit-extension paths work without any resolver."""
+    mime, _ = get_mime_and_extension(
+        mimetype=None, extension=None, filename="image.png", buffer=None
+    )
+    assert mime == "image/png"
+
+    c = Content.from_bytes(b"data", extension="txt")
+    assert c.mimetype == "text/plain"
+    assert c.extension == ".txt"
+
+
+# ---------------------------------------------------------------------------
+# python-magic specific from_file behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _force_python_magic():
+    _reset_resolver()
+    with _make_unavailable(polyfile_magic_resolver):
         _reset_resolver()
+        yield
+    _reset_resolver()
 
-    def test_detect_ignores_filename(self, png_bytes):
-        """Polyfile should return the same result regardless of filename."""
-        mime_with, _ = polyfile_magic_resolver.detect(
-            filename="image.png", buffer=png_bytes
-        )
-        mime_without, _ = polyfile_magic_resolver.detect(
-            filename=None, buffer=png_bytes
-        )
-        assert mime_with == mime_without == "image/png"
 
-    def test_detect_never_returns_extension(self, pdf_bytes):
-        _, ext = polyfile_magic_resolver.detect(filename=None, buffer=pdf_bytes)
-        assert ext is None
+@pytest.mark.usefixtures("_force_python_magic")
+def test_python_magic_from_file(png_file, extensionless_png_file, png_bytes):
+    """python-magic detects from file (incl. extensionless) and via buffer fallback."""
+    mime, ext = python_magic_resolver.detect(filename=str(png_file), buffer=None)
+    assert mime == "image/png"
+    assert ext is not None
+    assert ext.startswith(".")
 
-    def test_detect_no_buffer_returns_none(self):
-        mime, ext = polyfile_magic_resolver.detect(filename="report.pdf", buffer=None)
-        assert mime is None
-        assert ext is None
+    mime, _ = python_magic_resolver.detect(
+        filename=str(extensionless_png_file), buffer=None
+    )
+    assert mime == "image/png"
 
-    def test_detect_empty_buffer_returns_none(self):
-        mime, ext = polyfile_magic_resolver.detect(filename=None, buffer=b"")
-        assert mime is None
-        assert ext is None
+    mime, _ = python_magic_resolver.detect(
+        filename="/does/not/exist.png", buffer=png_bytes
+    )
+    assert mime == "image/png"
+
+
+@pytest.mark.usefixtures("_force_python_magic")
+def test_python_magic_from_file_no_buffer_none():
+    mime, ext = python_magic_resolver.detect(
+        filename="/does/not/exist.png", buffer=None
+    )
+    assert mime is None
+    assert ext is None
+
+
+# ---------------------------------------------------------------------------
+# polyfile specific behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _force_polyfile():
+    _reset_resolver()
+    with _make_unavailable(python_magic_resolver):
+        _reset_resolver()
+        yield
+    _reset_resolver()
+
+
+@pytest.mark.usefixtures("_force_polyfile")
+def test_polyfile_buffer_only(png_bytes, pdf_bytes):
+    """Polyfile ignores filename, is buffer-only, never returns an extension."""
+    mime_with, _ = polyfile_magic_resolver.detect(
+        filename="image.png", buffer=png_bytes
+    )
+    mime_without, _ = polyfile_magic_resolver.detect(filename=None, buffer=png_bytes)
+    assert mime_with == mime_without == "image/png"
+
+    _, ext = polyfile_magic_resolver.detect(filename=None, buffer=pdf_bytes)
+    assert ext is None
+
+
+@pytest.mark.usefixtures("_force_polyfile")
+def test_polyfile_no_buffer_none():
+    """No buffer (with or without filename) and empty buffer both return None."""
+    mime, ext = polyfile_magic_resolver.detect(filename="report.pdf", buffer=None)
+    assert mime is None
+    assert ext is None
+
+    mime, ext = polyfile_magic_resolver.detect(filename=None, buffer=b"")
+    assert mime is None
+    assert ext is None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_unavailable(module: Any) -> Any:
+    """Return a patched is_available that always returns False."""
+    return patch.object(module, "is_available", return_value=False)
+
+
+def _get_utils_module():
+    """Import the utils module avoiding the Content class re-export."""
+    return importlib.import_module("weave.type_wrappers.Content.utils")
+
+
+def _reset_resolver() -> None:
+    mod = _get_utils_module()
+    mod._resolver = mod._UNSET


### PR DESCRIPTION
## Summary
- Split from #7235. Densify `tests/trace` tests into fewer, denser parametrized / multi-assert functions: 58 files, +5082/-8557.

## Testing
per-file coverage-superset gate (each touched file's executed weave/ lines+branches after >= before); tests/trace dir run shows no new failures vs master.