### PR TITLE
test(weave): densify tests/trace_server suite

### DIFF
--- a/tests/trace_server/test_agent_chat_view_feedback.py
+++ b/tests/trace_server/test_agent_chat_view_feedback.py
@@ -20,47 +20,10 @@ from weave.trace_server.agents.types import (
 )
 
 
-def _make_span(
-    project_id: str,
-    trace_id: str,
-    span_id: str,
-    **overrides: object,
-) -> AgentSpanCHInsertable:
-    defaults = {
-        "project_id": project_id,
-        "trace_id": trace_id,
-        "span_id": span_id,
-        "span_name": "test-span",
-        "started_at": datetime.datetime.now(tz=datetime.timezone.utc),
-        "ended_at": datetime.datetime.now(tz=datetime.timezone.utc),
-        "status_code": "OK",
-        "operation_name": "invoke_agent",
-        "agent_name": "test-agent",
-        "provider_name": "openai",
-        "request_model": "gpt-4o",
-    }
-    defaults.update(overrides)
-    return AgentSpanCHInsertable(**defaults)
-
-
-def _insert_spans(ch_client, spans: list[AgentSpanCHInsertable]) -> None:
-    rows = [genai_span_to_row(s) for s in spans]
-    ch_client.insert("spans", data=rows, column_names=ALL_SPAN_INSERT_COLUMNS)
-
-
-def _create_reaction(ch_server, project_id: str, weave_ref: str, emoji: str) -> None:
-    ch_server.feedback_create(
-        tsi.FeedbackCreateReq(
-            project_id=project_id,
-            weave_ref=weave_ref,
-            feedback_type="reaction",
-            payload={"emoji": emoji},
-            wb_user_id="test-user",
-        )
-    )
-
-
-def test_agent_traces_chat_folds_turn_and_step_feedback(ch_server):
+def test_agent_traces_chat_feedback_fold_in_and_opt_out(ch_server):
+    """include_feedback=True folds turn + step reactions; the default leaves
+    every feedback field None for the same underlying spans/reactions.
+    """
     project_id = _make_project_id("feedback")
     trace_id = uuid.uuid4().hex
     root_span_id = uuid.uuid4().hex[:16]
@@ -103,28 +66,11 @@ def test_agent_traces_chat_folds_turn_and_step_feedback(ch_server):
     assert step_msgs[0].feedback is not None
     assert step_msgs[0].feedback[0]["payload"] == {"emoji": "🔥"}
 
-
-def test_agent_traces_chat_include_feedback_false_leaves_feedback_fields_none(
-    ch_server,
-):
-    project_id = _make_project_id("feedback_off")
-    trace_id = uuid.uuid4().hex
-    root_span_id = uuid.uuid4().hex[:16]
-
-    _insert_spans(
-        ch_server.ch_client,
-        [_make_span(project_id, trace_id, root_span_id, operation_name="invoke_agent")],
-    )
-
-    turn_ref = ri.InternalAgentTurnRef(project_id=project_id, trace_id=trace_id).uri
-    _create_reaction(ch_server, project_id, turn_ref, "👍")
-
-    res = ch_server.agent_traces_chat(
+    off = ch_server.agent_traces_chat(
         AgentTraceChatReq(project_id=project_id, trace_id=trace_id)
     )
-
-    assert res.feedback is None
-    for m in res.messages:
+    assert off.feedback is None
+    for m in off.messages:
         assert m.feedback is None
 
 
@@ -186,3 +132,43 @@ def test_agent_conversation_chat_folds_conversation_turn_and_step_feedback(ch_se
     assert len(step_msgs) == 1
     assert step_msgs[0].feedback is not None
     assert step_msgs[0].feedback[0]["payload"] == {"emoji": "🔥"}
+
+
+def _make_span(
+    project_id: str,
+    trace_id: str,
+    span_id: str,
+    **overrides: object,
+) -> AgentSpanCHInsertable:
+    defaults = {
+        "project_id": project_id,
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "span_name": "test-span",
+        "started_at": datetime.datetime.now(tz=datetime.timezone.utc),
+        "ended_at": datetime.datetime.now(tz=datetime.timezone.utc),
+        "status_code": "OK",
+        "operation_name": "invoke_agent",
+        "agent_name": "test-agent",
+        "provider_name": "openai",
+        "request_model": "gpt-4o",
+    }
+    defaults.update(overrides)
+    return AgentSpanCHInsertable(**defaults)
+
+
+def _insert_spans(ch_client, spans: list[AgentSpanCHInsertable]) -> None:
+    rows = [genai_span_to_row(s) for s in spans]
+    ch_client.insert("spans", data=rows, column_names=ALL_SPAN_INSERT_COLUMNS)
+
+
+def _create_reaction(ch_server, project_id: str, weave_ref: str, emoji: str) -> None:
+    ch_server.feedback_create(
+        tsi.FeedbackCreateReq(
+            project_id=project_id,
+            weave_ref=weave_ref,
+            feedback_type="reaction",
+            payload={"emoji": emoji},
+            wb_user_id="test-user",
+        )
+    )

--- a/tests/trace_server/test_agent_scorer_event_producer.py
+++ b/tests/trace_server/test_agent_scorer_event_producer.py
@@ -13,6 +13,47 @@ from weave.trace_server.agents.kafka_events import (
 from weave.trace_server.kafka import KafkaProducer
 
 
+def test_event_topic_and_round_trip() -> None:
+    """Topic constant is stable and a fully-populated event round-trips through JSON."""
+    assert SCORE_AGENT_SPANS_TOPIC == "weave.score_agent_spans"
+
+    event = _make_event(
+        project_id="proj-1",
+        trace_id="trace-1",
+        span_id="span-root",
+        conversation_id="conv-1",
+        operation_name="invoke_agent",
+    )
+    parsed = ScoreAgentSpansEvent.model_validate_json(event.model_dump_json())
+    assert parsed == event
+
+
+@pytest.mark.disable_logging_error_check
+@pytest.mark.parametrize(
+    ("max_buffer_size", "buffer_len", "expect_publish"),
+    [
+        (2, 5, False),  # buffer full -> drop
+        (100, 0, True),  # under limit -> publish
+    ],
+    ids=["buffer_full_drops", "under_limit_publishes"],
+)
+def test_producer_buffer_pressure(
+    max_buffer_size: int, buffer_len: int, expect_publish: bool
+) -> None:
+    producer = MagicMock(spec=KafkaProducer)
+    producer.max_buffer_size = max_buffer_size
+    producer.__len__ = MagicMock(return_value=buffer_len)
+    _bind_real_methods(producer, "produce_score_agent_spans", "_check_buffer_pressure")
+
+    producer.produce_score_agent_spans(_make_event())
+
+    if expect_publish:
+        producer.produce.assert_called_once()
+        assert producer.produce.call_args.kwargs["topic"] == "weave.score_agent_spans"
+    else:
+        producer.produce.assert_not_called()
+
+
 def _make_event(**overrides) -> ScoreAgentSpansEvent:
     """Minimal valid ScoreAgentSpansEvent for tests; override any field."""
     base = {
@@ -29,49 +70,7 @@ def _make_event(**overrides) -> ScoreAgentSpansEvent:
     return ScoreAgentSpansEvent(**base)
 
 
-def test_topic_constant_value() -> None:
-    assert SCORE_AGENT_SPANS_TOPIC == "weave.score_agent_spans"
-
-
-def test_event_round_trip() -> None:
-    event = _make_event(
-        project_id="proj-1",
-        trace_id="trace-1",
-        span_id="span-root",
-        conversation_id="conv-1",
-        operation_name="invoke_agent",
-    )
-    payload = event.model_dump_json()
-    parsed = ScoreAgentSpansEvent.model_validate_json(payload)
-    assert parsed == event
-
-
 def _bind_real_methods(producer: MagicMock, *names: str) -> None:
     """Replace MagicMock auto-stubs with real `KafkaProducer` methods bound to the mock."""
     for name in names:
         setattr(producer, name, getattr(KafkaProducer, name).__get__(producer))
-
-
-@pytest.mark.disable_logging_error_check
-def test_producer_drops_when_buffer_full() -> None:
-    producer = MagicMock(spec=KafkaProducer)
-    producer.max_buffer_size = 2
-    producer.__len__ = MagicMock(return_value=5)  # buffer full
-    _bind_real_methods(producer, "produce_score_agent_spans", "_check_buffer_pressure")
-
-    producer.produce_score_agent_spans(_make_event())
-
-    producer.produce.assert_not_called()
-
-
-def test_producer_publishes_under_buffer_limit() -> None:
-    producer = MagicMock(spec=KafkaProducer)
-    producer.max_buffer_size = 100
-    producer.__len__ = MagicMock(return_value=0)
-    _bind_real_methods(producer, "produce_score_agent_spans", "_check_buffer_pressure")
-
-    producer.produce_score_agent_spans(_make_event())
-
-    producer.produce.assert_called_once()
-    call_kwargs = producer.produce.call_args.kwargs
-    assert call_kwargs["topic"] == "weave.score_agent_spans"

--- a/tests/trace_server/test_base64_content_conversion.py
+++ b/tests/trace_server/test_base64_content_conversion.py
@@ -2,9 +2,8 @@
 
 import base64
 import json
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
-
-import pytest
 
 from weave.trace_server.base64_content_conversion import (
     AUTO_CONVERSION_MIN_SIZE,
@@ -27,494 +26,322 @@ from weave.type_wrappers.Content.content import Content
 LARGE_TEST_DATA_SIZE = AUTO_CONVERSION_MIN_SIZE + 10
 
 
-class TestBase64AndDataURIDetection:
-    """Test detection heuristics for data URIs only (raw base64 no longer auto-encoded)."""
-
-    def test_is_data_uri_valid(self):
-        """Valid base64 data URIs are detected."""
-        test_data = b"Hello, World!"
-        b64_data = base64.b64encode(test_data).decode("ascii")
-        data_uri = f"data:text/plain;base64,{b64_data}"
-        assert is_data_uri(data_uri)
-
-    def test_is_data_uri_invalid(self):
-        """Invalid data URIs are rejected."""
-        assert not is_data_uri("not a data uri")
-        assert not is_data_uri("data:text/plain,not base64")
+def test_is_data_uri_detection():
+    """Valid base64 data URIs are detected; non-data-URI strings are rejected."""
+    b64_data = base64.b64encode(b"Hello, World!").decode("ascii")
+    assert is_data_uri(f"data:text/plain;base64,{b64_data}")
+    assert not is_data_uri("not a data uri")
+    assert not is_data_uri("data:text/plain,not base64")
 
 
-class TestContentObjectStorage:
-    """Test Content object storage and structure."""
+def test_store_content_object():
+    """Storing a Content object persists content and metadata files."""
+    trace_server = _mock_trace_server(2)
+    test_data = b"Test content"
+    project_id = "test_project"
 
-    def test_store_content_object(self):
-        """Test storing a Content object persists content and metadata files."""
-        # Mock trace server
-        trace_server = MagicMock()
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest"),
-                FileCreateRes(digest="metadata_digest"),
-            ]
-        )
+    content_obj = Content.from_bytes(test_data)
+    result = store_content_object(content_obj, project_id, trace_server)
 
-        test_data = b"Test content"
-        project_id = "test_project"
+    # Verify structure
+    assert result["_type"] == "CustomWeaveType"
+    assert result["weave_type"]["type"] == "weave.type_wrappers.Content.content.Content"
+    assert "files" in result
+    assert result["files"]["content"] == "content_0"
+    assert result["files"]["metadata.json"] == "content_1"
 
-        content_obj = Content.from_bytes(test_data)
-        result = store_content_object(content_obj, project_id, trace_server)
+    # Verify file_create was called for content then metadata.
+    assert trace_server.file_create.call_count == 2
+    calls = trace_server.file_create.call_args_list
+    content_call = calls[0][0][0]
+    assert content_call.project_id == project_id
+    assert content_call.name == "content"
+    assert content_call.content == test_data
 
-        # Verify structure
-        assert result["_type"] == "CustomWeaveType"
-        assert (
-            result["weave_type"]["type"]
-            == "weave.type_wrappers.Content.content.Content"
-        )
-        assert "files" in result
-        assert result["files"]["content"] == "content_digest"
-        assert result["files"]["metadata.json"] == "metadata_digest"
-
-        # Verify file_create was called
-        assert trace_server.file_create.call_count == 2
-        calls = trace_server.file_create.call_args_list
-
-        # First call for content
-        content_call = calls[0][0][0]
-        assert content_call.project_id == project_id
-        assert content_call.name == "content"
-        assert content_call.content == test_data
-
-        # Second call for metadata
-        metadata_call = calls[1][0][0]
-        assert metadata_call.project_id == project_id
-        assert metadata_call.name == "metadata.json"
-        metadata = json.loads(metadata_call.content)
-        # Ensure key metadata fields are present and correct
-        assert metadata["mimetype"] == content_obj.mimetype
-        assert metadata["size"] == content_obj.size
-        assert metadata["filename"] == content_obj.filename
+    metadata_call = calls[1][0][0]
+    assert metadata_call.project_id == project_id
+    assert metadata_call.name == "metadata.json"
+    metadata = json.loads(metadata_call.content)
+    assert metadata["mimetype"] == content_obj.mimetype
+    assert metadata["size"] == content_obj.size
+    assert metadata["filename"] == content_obj.filename
 
 
-class TestBase64Replacement:
-    """Test base64 replacement in data structures."""
+def test_replace_data_uri_only_in_dict_and_list_containers():
+    """Across both dict and list containers, only base64 data URIs are
+    replaced; normal strings and raw (non-data-URI) base64 are left untouched.
+    """
+    test_data = b"a" * LARGE_TEST_DATA_SIZE
+    b64_data = base64.b64encode(test_data).decode("ascii")
 
-    def test_replace_data_uri_in_dict_only(self):
-        """Only base64 data URIs are replaced; raw base64 is left untouched."""
-        # Mock trace server
-        trace_server = MagicMock()
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest1"),
-                FileCreateRes(digest="metadata_digest1"),
-                FileCreateRes(digest="content_digest2"),
-                FileCreateRes(digest="metadata_digest2"),
-            ]
-        )
-
-        test_data = b"a" * LARGE_TEST_DATA_SIZE
-        b64_data = base64.b64encode(test_data).decode("ascii")
-
-        input_data = {
+    dict_server = _mock_trace_server(4)
+    dict_result = replace_base64_with_content_objects(
+        {
             "field1": "normal string",
             "field2": b64_data,  # raw base64 should remain unchanged
             "nested": {"field3": f"data:image/png;base64,{b64_data}"},
-        }
+        },
+        "test_project",
+        dict_server,
+    )
+    assert dict_result["field1"] == "normal string"
+    assert dict_result["field2"] == b64_data
+    assert isinstance(dict_result["nested"]["field3"], dict)
+    assert dict_result["nested"]["field3"]["_type"] == "CustomWeaveType"
+    assert set(dict_result["nested"]["field3"]["files"].keys()) == {
+        "content",
+        "metadata.json",
+    }
 
-        result = replace_base64_with_content_objects(
-            input_data, "test_project", trace_server
-        )
-
-        # Check normal string is unchanged
-        assert result["field1"] == "normal string"
-
-        # Check standalone base64 is NOT replaced
-        assert result["field2"] == b64_data
-
-        # Check data URI was replaced
-        assert isinstance(result["nested"]["field3"], dict)
-        assert result["nested"]["field3"]["_type"] == "CustomWeaveType"
-        assert set(result["nested"]["field3"]["files"].keys()) == {
-            "content",
-            "metadata.json",
-        }
-
-    def test_replace_data_uri_in_list_only(self):
-        """Only base64 data URIs are replaced in lists; raw base64 is left untouched."""
-        # Mock trace server
-        trace_server = MagicMock()
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest1"),
-                FileCreateRes(digest="metadata_digest1"),
-                FileCreateRes(digest="content_digest2"),
-                FileCreateRes(digest="metadata_digest2"),
-            ]
-        )
-
-        test_data = b"a" * LARGE_TEST_DATA_SIZE
-        b64_data = base64.b64encode(test_data).decode("ascii")
-
-        input_data = [
+    list_server = _mock_trace_server(4)
+    list_result = replace_base64_with_content_objects(
+        [
             "normal string",
             b64_data,  # raw base64 should remain unchanged
             {"nested": f"data:text/plain;base64,{b64_data}"},
-        ]
-
-        result = replace_base64_with_content_objects(
-            input_data, "test_project", trace_server
-        )
-
-        # Check list structure is preserved
-        assert len(result) == 3
-        assert result[0] == "normal string"
-        # Raw base64 remains a string
-        assert result[1] == b64_data
-        assert isinstance(result[2]["nested"], dict)
-        assert result[2]["nested"]["_type"] == "CustomWeaveType"
-
-    def test_process_call_req_to_content_start_and_end(self):
-        """Test the main entry point for processing CallStartReq and CallEndReq."""
-        # Mock trace server
-        trace_server = MagicMock()
-        # Two files for start (content + metadata), two for end
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest_start"),
-                FileCreateRes(digest="metadata_digest_start"),
-                FileCreateRes(digest="content_digest_end"),
-                FileCreateRes(digest="metadata_digest_end"),
-            ]
-        )
-
-        test_data = b"x" * LARGE_TEST_DATA_SIZE
-        b64_data = base64.b64encode(test_data).decode("ascii")
-
-        # Start request with data URI in inputs
-        start_req = CallStartReq(
-            start=StartedCallSchemaForInsert(
-                project_id="proj",
-                op_name="op",
-                started_at=__import__("datetime").datetime.utcnow(),
-                attributes={},
-                inputs={
-                    "image": f"data:image/png;base64,{b64_data}",
-                    "text": "Some normal text",
-                },
-            )
-        )
-
-        processed_start = process_call_req_to_content(start_req, trace_server)
-        assert processed_start.start.inputs["text"] == "Some normal text"
-        assert isinstance(processed_start.start.inputs["image"], dict)
-        assert processed_start.start.inputs["image"]["_type"] == "CustomWeaveType"
-
-        long_bytes = b"y" * LARGE_TEST_DATA_SIZE
-        long_b64 = base64.b64encode(long_bytes).decode("ascii")
-        end_req = CallEndReq(
-            end=EndedCallSchemaForInsert(
-                project_id="proj",
-                id="call-id",
-                ended_at=__import__("datetime").datetime.utcnow(),
-                summary={"usage": {}, "status_counts": {}},
-                output=long_b64,
-            )
-        )
-
-        processed_end = process_call_req_to_content(end_req, trace_server)
-        assert processed_end.end.output == long_b64
+        ],
+        "test_project",
+        list_server,
+    )
+    assert len(list_result) == 3
+    assert list_result[0] == "normal string"
+    assert list_result[1] == b64_data
+    assert isinstance(list_result[2]["nested"], dict)
+    assert list_result[2]["nested"]["_type"] == "CustomWeaveType"
 
 
-class TestStandaloneBase64Detection:
-    """Test detection and conversion of standalone base64 strings (new functionality)."""
-
-    def test_non_media_base64_strings_not_converted(self):
-        """Test that various base64 strings of different lengths (mod 4) that decode to
-        text/plain or application/octet-stream are NOT converted.
-        """
-        # Mock trace server
-        trace_server = MagicMock()
-
-        # Test strings of various lengths mod 4
-        # These should all decode to text/plain or application/octet-stream
-        test_cases = [
-            # Length % 4 == 0: "aaaa" decodes to binary data
-            "aaaa",
-            # Length % 4 == 0: "hello" in base64
-            "aGVsbG8=",
-            # Length % 4 == 0: "test message"
-            "dGVzdCBtZXNzYWdl",
-            # Length % 4 == 0: longer text
-            "VGhpcyBpcyBhIGxvbmdlciB0ZXN0IG1lc3NhZ2U=",
-            # Short strings that are valid base64 but not media
-            "YQ==",  # "a"
-            "YWI=",  # "ab"
-            "YWJj",  # "abc"
-            # Random-looking base64 that's still text-like
-            "SGVsbG8gV29ybGQh",  # "Hello World!"
-        ]
-
-        for test_str in test_cases:
-            # First verify these match the base64 pattern
-            assert is_base64(test_str), f"Expected {test_str} to match base64 pattern"
-
-            input_data = {"field": test_str}
-            result = replace_base64_with_content_objects(
-                input_data, "test_project", trace_server
-            )
-
-            # These should NOT be converted because they decode to text/plain or application/octet-stream
-            assert result["field"] == test_str, (
-                f"Expected {test_str} to NOT be converted"
-            )
-
-        # Verify trace server was never called since nothing should be converted
-        assert trace_server.file_create.call_count == 0
-
-    def test_wav_file_base64_converted(self):
-        """Test that a dict with a field containing raw base64 representing a WAV file
-        is detected and converted to Content.
-        """
-        # Mock trace server
-        trace_server = MagicMock()
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest"),
-                FileCreateRes(digest="metadata_digest"),
-            ]
-        )
-
-        # Create a minimal valid WAV file (larger than AUTO_CONVERSION_MIN_SIZE)
-        # WAV format: RIFF header + fmt chunk + data chunk
-        wav_data = bytearray()
-
-        # RIFF header
-        wav_data.extend(b"RIFF")
-        # Placeholder for file size (will update later)
-        file_size_pos = len(wav_data)
-        wav_data.extend(b"\x00\x00\x00\x00")
-        wav_data.extend(b"WAVE")
-
-        # fmt chunk
-        wav_data.extend(b"fmt ")
-        wav_data.extend((16).to_bytes(4, "little"))  # chunk size
-        wav_data.extend((1).to_bytes(2, "little"))  # audio format (PCM)
-        wav_data.extend((1).to_bytes(2, "little"))  # num channels
-        wav_data.extend((44100).to_bytes(4, "little"))  # sample rate
-        wav_data.extend((88200).to_bytes(4, "little"))  # byte rate
-        wav_data.extend((2).to_bytes(2, "little"))  # block align
-        wav_data.extend((16).to_bytes(2, "little"))  # bits per sample
-
-        # data chunk - make it large enough to exceed AUTO_CONVERSION_MIN_SIZE
-        audio_data_size = LARGE_TEST_DATA_SIZE
-        wav_data.extend(b"data")
-        wav_data.extend(audio_data_size.to_bytes(4, "little"))
-        # Add audio data (silence)
-        wav_data.extend(b"\x00" * audio_data_size)
-
-        # Update file size in RIFF header (total size - 8 bytes for RIFF header)
-        file_size = len(wav_data) - 8
-        wav_data[file_size_pos : file_size_pos + 4] = file_size.to_bytes(4, "little")
-
-        # Encode as base64
-        wav_base64 = base64.b64encode(bytes(wav_data)).decode("ascii")
-
-        # Verify it matches base64 pattern
-        assert is_base64(wav_base64)
-
-        # Test that it gets converted
-        input_data = {
-            "audio_field": wav_base64,
-            "other_field": "normal string",
-        }
-
-        result = replace_base64_with_content_objects(
-            input_data, "test_project", trace_server
-        )
-
-        # The WAV file should be converted to Content object
-        assert isinstance(result["audio_field"], dict)
-        assert result["audio_field"]["_type"] == "CustomWeaveType"
-        assert (
-            result["audio_field"]["weave_type"]["type"]
-            == "weave.type_wrappers.Content.content.Content"
-        )
-        assert "files" in result["audio_field"]
-        assert "content" in result["audio_field"]["files"]
-        assert "metadata.json" in result["audio_field"]["files"]
-
-        # Normal string should be unchanged
-        assert result["other_field"] == "normal string"
-
-        # Verify file_create was called twice (content + metadata)
-        assert trace_server.file_create.call_count == 2
-
-        # Detected audio/x-wav is normalized to canonical audio/wav.
-        metadata_call = trace_server.file_create.call_args_list[1][0][0]
-        metadata = json.loads(metadata_call.content)
-        assert metadata["mimetype"] == "audio/wav"
-
-
-class TestThresholdAndStructuralIdentity:
-    """Pins the auto-conversion threshold and the "don't copy unchanged subtrees" behaviour.
-
-    These exist because both knobs are part of the hot path on every
-    ``upsert_batch``: the threshold gates how much expensive regex / decode
-    work runs on long-but-not-binary strings, and the in-place return path
-    avoids allocating a fresh dict/list on each level of a no-binary payload.
+def test_process_call_req_to_content_start_and_end():
+    """The main entry point processes data URIs in CallStartReq inputs but
+    leaves raw base64 in CallEndReq output untouched.
     """
+    trace_server = _mock_trace_server(4)
+    test_data = b"x" * LARGE_TEST_DATA_SIZE
+    b64_data = base64.b64encode(test_data).decode("ascii")
 
-    def test_auto_conversion_threshold_is_eight_kib(self):
-        """Regression guard: the threshold has a real cost when lowered."""
-        # If someone drops this back to 1024, all the mid-sized LLM outputs in
-        # production traces start hitting `is_data_uri` + `is_base64` again —
-        # the very work the threshold bump was meant to skip.
-        assert AUTO_CONVERSION_MIN_SIZE == 8192
+    start_req = CallStartReq(
+        start=StartedCallSchemaForInsert(
+            project_id="proj",
+            op_name="op",
+            started_at=datetime.now(timezone.utc),
+            attributes={},
+            inputs={
+                "image": f"data:image/png;base64,{b64_data}",
+                "text": "Some normal text",
+            },
+        )
+    )
+    processed_start = process_call_req_to_content(start_req, trace_server)
+    assert processed_start.start.inputs["text"] == "Some normal text"
+    assert isinstance(processed_start.start.inputs["image"], dict)
+    assert processed_start.start.inputs["image"]["_type"] == "CustomWeaveType"
 
-    def test_string_below_threshold_does_not_invoke_storage(self):
-        """A 1-8 KiB string must short-circuit on size; no regex, no storage."""
-        trace_server = MagicMock()
-        # 4 KiB string of valid-looking base64 alphabet — would have decoded
-        # successfully under the old threshold and gone through the regex
-        # path. Now it must be returned untouched.
-        below_threshold = "A" * 4096
+    long_bytes = b"y" * LARGE_TEST_DATA_SIZE
+    long_b64 = base64.b64encode(long_bytes).decode("ascii")
+    end_req = CallEndReq(
+        end=EndedCallSchemaForInsert(
+            project_id="proj",
+            id="call-id",
+            ended_at=datetime.now(timezone.utc),
+            summary={"usage": {}, "status_counts": {}},
+            output=long_b64,
+        )
+    )
+    processed_end = process_call_req_to_content(end_req, trace_server)
+    assert processed_end.end.output == long_b64
+
+
+def test_non_media_base64_strings_not_converted():
+    """Base64 strings of various lengths (mod 4) that decode to text/plain or
+    application/octet-stream are NOT converted.
+    """
+    trace_server = MagicMock()
+    test_cases = [
+        "aaaa",  # decodes to binary data
+        "aGVsbG8=",  # "hello"
+        "dGVzdCBtZXNzYWdl",  # "test message"
+        "VGhpcyBpcyBhIGxvbmdlciB0ZXN0IG1lc3NhZ2U=",  # longer text
+        "YQ==",  # "a"
+        "YWI=",  # "ab"
+        "YWJj",  # "abc"
+        "SGVsbG8gV29ybGQh",  # "Hello World!"
+    ]
+    for test_str in test_cases:
+        assert is_base64(test_str), f"Expected {test_str} to match base64 pattern"
         result = replace_base64_with_content_objects(
-            {"field": below_threshold}, "test_project", trace_server
+            {"field": test_str}, "test_project", trace_server
         )
-        assert result["field"] == below_threshold
-        assert trace_server.file_create.call_count == 0
+        assert result["field"] == test_str, f"Expected {test_str} to NOT be converted"
+    assert trace_server.file_create.call_count == 0
 
-    def test_no_replacement_returns_same_object_identity(self):
-        """If nothing changed, the caller gets back the original dict object.
 
-        This is what makes the no-binary hot path cheap: every level whose
-        children are all untouched returns the same reference instead of
-        allocating a fresh copy. Identity matters here — checking equality
-        wouldn't catch a regression to the always-allocate code path.
-        """
-        trace_server = MagicMock()
-        original = {
-            "messages": [
-                {"role": "user", "content": "no binary here"},
-                {"role": "assistant", "content": "still nothing"},
-            ],
-            "metadata": {"trace_id": "abc"},
-        }
-        result = replace_base64_with_content_objects(
-            original, "test_project", trace_server
+def test_wav_file_base64_converted():
+    """A field containing raw base64 representing a WAV file is detected and
+    converted to a Content object, with audio/x-wav normalized to audio/wav.
+    """
+    trace_server = _mock_trace_server(2)
+    wav_base64 = base64.b64encode(_make_wav_bytes()).decode("ascii")
+    assert is_base64(wav_base64)
+
+    result = replace_base64_with_content_objects(
+        {"audio_field": wav_base64, "other_field": "normal string"},
+        "test_project",
+        trace_server,
+    )
+
+    assert isinstance(result["audio_field"], dict)
+    assert result["audio_field"]["_type"] == "CustomWeaveType"
+    assert (
+        result["audio_field"]["weave_type"]["type"]
+        == "weave.type_wrappers.Content.content.Content"
+    )
+    assert "content" in result["audio_field"]["files"]
+    assert "metadata.json" in result["audio_field"]["files"]
+    assert result["other_field"] == "normal string"
+    assert trace_server.file_create.call_count == 2
+
+    metadata_call = trace_server.file_create.call_args_list[1][0][0]
+    metadata = json.loads(metadata_call.content)
+    assert metadata["mimetype"] == "audio/wav"
+
+
+def test_auto_conversion_threshold_gates_storage():
+    """The auto-conversion threshold is 8 KiB; a sub-threshold base64-looking
+    string short-circuits on size with no regex and no storage call.
+    """
+    assert AUTO_CONVERSION_MIN_SIZE == 8192
+
+    trace_server = MagicMock()
+    # 4 KiB of valid-looking base64 alphabet would have decoded under the old
+    # threshold and hit the regex path; now it must be returned untouched.
+    below_threshold = "A" * 4096
+    result = replace_base64_with_content_objects(
+        {"field": below_threshold}, "test_project", trace_server
+    )
+    assert result["field"] == below_threshold
+    assert trace_server.file_create.call_count == 0
+
+
+def test_no_replacement_returns_same_object_identity():
+    """A clean no-binary tree returns the original object at every level.
+
+    Identity (not equality) matters: it's what makes the no-binary hot path
+    cheap and would catch a regression to an always-allocate code path.
+    """
+    trace_server = MagicMock()
+    original = {
+        "messages": [
+            {"role": "user", "content": "no binary here"},
+            {"role": "assistant", "content": "still nothing"},
+        ],
+        "metadata": {"trace_id": "abc"},
+    }
+    result = replace_base64_with_content_objects(original, "test_project", trace_server)
+    assert result is original
+    assert result["messages"] is original["messages"]
+    assert result["messages"][0] is original["messages"][0]
+    assert result["metadata"] is original["metadata"]
+
+
+def test_partial_replacement_isolates_unchanged_subtrees_in_dict_and_list():
+    """A replacement copies only the affected subtree: untouched dict branches
+    and untouched list indices keep their identity, the touched node is a fresh
+    object, and the input payload is never mutated.
+    """
+    # Dict-partial: one message branch holds a data URI, the other is plain.
+    dict_server = _mock_trace_server(2)
+    png_data_uri = _png_data_uri()
+    untouched_branch = {"role": "assistant", "content": "plain reply"}
+    touched_branch = {
+        "role": "user",
+        "content": [{"type": "image_url", "image_url": {"url": png_data_uri}}],
+    }
+    dict_original = {
+        "messages": [untouched_branch, touched_branch],
+        "model": "claude-sonnet-4-6",
+    }
+    dict_result = replace_base64_with_content_objects(
+        dict_original, "test_project", dict_server
+    )
+    assert dict_result["messages"][0] is untouched_branch
+    assert dict_result["messages"][1] is not touched_branch
+    assert touched_branch["content"][0]["image_url"]["url"] == png_data_uri
+
+    # List-partial: the list is copied (one entry changed) but the unchanged
+    # dict entries keep their identity inside the new list.
+    list_server = _mock_trace_server(2)
+    untouched_message = {"role": "user", "content": "plain text"}
+    touched_message = {"role": "assistant", "content": png_data_uri}
+    other_untouched_message = {"role": "tool", "content": "also plain"}
+    list_messages = [untouched_message, touched_message, other_untouched_message]
+    list_original = {"messages": list_messages, "model": "claude-sonnet-4-6"}
+    list_result = replace_base64_with_content_objects(
+        list_original, "test_project", list_server
+    )
+    assert list_result["messages"] is not list_messages
+    assert list_result["messages"][0] is untouched_message
+    assert list_result["messages"][2] is other_untouched_message
+    assert list_result["messages"][1] is not touched_message
+    assert touched_message["content"] == png_data_uri
+
+
+def test_caller_overwrite_safe_after_in_place_return():
+    """The ``req.start.inputs = replace_base64(...)`` caller pattern is safe:
+    the no-copy path rebinds the field without introducing an aliasing bug.
+    """
+    trace_server = MagicMock()
+    inputs_before = {"text": "no binary content here"}
+    start_req = CallStartReq(
+        start=StartedCallSchemaForInsert(
+            project_id="proj",
+            op_name="op",
+            started_at=datetime.now(timezone.utc),
+            attributes={},
+            inputs=inputs_before,
         )
-        # The outer dict, the messages list, every inner message dict, and
-        # the metadata dict must all be the same object as the input — no
-        # copies anywhere on a clean no-binary tree.
-        assert result is original
-        assert result["messages"] is original["messages"]
-        assert result["messages"][0] is original["messages"][0]
-        assert result["metadata"] is original["metadata"]
-
-    def test_partial_replacement_copies_only_affected_subtrees(self):
-        """A replacement on one branch must not allocate copies on the others."""
-        trace_server = MagicMock()
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest"),
-                FileCreateRes(digest="metadata_digest"),
-            ]
-        )
-        png_data_uri = "data:image/png;base64," + base64.b64encode(
-            b"\x89PNG\r\n\x1a\n" + b"\x00" * 12000
-        ).decode("ascii")
-
-        untouched_branch = {"role": "assistant", "content": "plain reply"}
-        touched_branch = {
-            "role": "user",
-            "content": [{"type": "image_url", "image_url": {"url": png_data_uri}}],
-        }
-        original = {
-            "messages": [untouched_branch, touched_branch],
-            "model": "claude-sonnet-4-6",
-        }
-
-        result = replace_base64_with_content_objects(
-            original, "test_project", trace_server
-        )
-
-        # Branches with no replacement keep their identity.
-        assert result["messages"][0] is untouched_branch
-        # The branch that did get a replacement is a fresh object whose
-        # rewritten subtree no longer matches the source.
-        assert result["messages"][1] is not touched_branch
-        # And critically: the input dict was not mutated.
-        assert touched_branch["content"][0]["image_url"]["url"] == png_data_uri
-
-    def test_partial_replacement_in_list_isolates_unchanged_indices(self):
-        """List sibling of the dict-partial test: only the touched index is copied.
-
-        Without this the list branch of ``_visit_children`` is only exercised
-        in the all-changed and all-unchanged extremes, which leaves the
-        "first-change triggers a copy of the whole list" path partially
-        covered (codecov flagged this on the original PR).
-        """
-        trace_server = MagicMock()
-        trace_server.file_create = MagicMock(
-            side_effect=[
-                FileCreateRes(digest="content_digest"),
-                FileCreateRes(digest="metadata_digest"),
-            ]
-        )
-        png_data_uri = "data:image/png;base64," + base64.b64encode(
-            b"\x89PNG\r\n\x1a\n" + b"\x00" * 12000
-        ).decode("ascii")
-
-        untouched_message = {"role": "user", "content": "plain text"}
-        touched_message = {"role": "assistant", "content": png_data_uri}
-        other_untouched_message = {"role": "tool", "content": "also plain"}
-        original_messages = [
-            untouched_message,
-            touched_message,
-            other_untouched_message,
-        ]
-        original = {"messages": original_messages, "model": "claude-sonnet-4-6"}
-
-        result = replace_base64_with_content_objects(
-            original, "test_project", trace_server
-        )
-
-        # The list itself was copied (one of its entries changed), but the
-        # unchanged dict entries keep their identity inside the new list.
-        assert result["messages"] is not original_messages
-        assert result["messages"][0] is untouched_message
-        assert result["messages"][2] is other_untouched_message
-        # The touched entry was replaced — different identity, and the
-        # original dict is left intact.
-        assert result["messages"][1] is not touched_message
-        assert touched_message["content"] == png_data_uri
-
-    def test_caller_overwrite_safe_after_in_place_return(self):
-        """Caller pattern ``req.start.inputs = replace_base64(...)`` is safe.
-
-        Confirms the no-copy path doesn't introduce a subtle aliasing bug:
-        even though the result is the same object as the input, the
-        ``CallStartReq`` machinery in ``process_call_req_to_content`` just
-        rebinds the field, which is fine.
-        """
-        from datetime import datetime, timezone
-
-        trace_server = MagicMock()
-        inputs_before = {"text": "no binary content here"}
-        start_req = CallStartReq(
-            start=StartedCallSchemaForInsert(
-                project_id="proj",
-                op_name="op",
-                started_at=datetime.now(timezone.utc),
-                attributes={},
-                inputs=inputs_before,
-            )
-        )
-        processed = process_call_req_to_content(start_req, trace_server)
-        # Pydantic shallow-copies inputs at model construction, so we compare
-        # by value rather than identity here — content must round-trip
-        # unchanged regardless of the SDK copy.
-        assert processed.start.inputs == inputs_before
-        assert trace_server.file_create.call_count == 0
+    )
+    processed = process_call_req_to_content(start_req, trace_server)
+    # Pydantic shallow-copies inputs at construction, so compare by value.
+    assert processed.start.inputs == inputs_before
+    assert trace_server.file_create.call_count == 0
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+def _mock_trace_server(num_files: int) -> MagicMock:
+    """A trace server whose file_create returns deterministic digests."""
+    trace_server = MagicMock()
+    trace_server.file_create = MagicMock(
+        side_effect=[FileCreateRes(digest=f"content_{i}") for i in range(num_files)]
+    )
+    return trace_server
+
+
+def _png_data_uri() -> str:
+    return "data:image/png;base64," + base64.b64encode(
+        b"\x89PNG\r\n\x1a\n" + b"\x00" * 12000
+    ).decode("ascii")
+
+
+def _make_wav_bytes() -> bytes:
+    """A minimal valid WAV file larger than AUTO_CONVERSION_MIN_SIZE."""
+    wav_data = bytearray()
+    wav_data.extend(b"RIFF")
+    file_size_pos = len(wav_data)
+    wav_data.extend(b"\x00\x00\x00\x00")  # placeholder for file size
+    wav_data.extend(b"WAVE")
+
+    wav_data.extend(b"fmt ")
+    wav_data.extend((16).to_bytes(4, "little"))  # chunk size
+    wav_data.extend((1).to_bytes(2, "little"))  # audio format (PCM)
+    wav_data.extend((1).to_bytes(2, "little"))  # num channels
+    wav_data.extend((44100).to_bytes(4, "little"))  # sample rate
+    wav_data.extend((88200).to_bytes(4, "little"))  # byte rate
+    wav_data.extend((2).to_bytes(2, "little"))  # block align
+    wav_data.extend((16).to_bytes(2, "little"))  # bits per sample
+
+    audio_data_size = LARGE_TEST_DATA_SIZE
+    wav_data.extend(b"data")
+    wav_data.extend(audio_data_size.to_bytes(4, "little"))
+    wav_data.extend(b"\x00" * audio_data_size)
+
+    file_size = len(wav_data) - 8
+    wav_data[file_size_pos : file_size_pos + 4] = file_size.to_bytes(4, "little")
+    return bytes(wav_data)

--- a/tests/trace_server/test_call_stats.py
+++ b/tests/trace_server/test_call_stats.py
@@ -159,11 +159,12 @@ def test_call_stats_usage_sum_aggregation(client: weave_client.WeaveClient):
     )
 
 
-def test_call_stats_date_range_limit_validation():
-    """Reject CallStatsReq with a date range exceeding 31 days."""
+def test_call_stats_date_range_limit(client: weave_client.WeaveClient):
+    """Reject a >31-day range at both the constructor and the query layer."""
     end_time = _BASE_TIME
     start_time = end_time - datetime.timedelta(days=32)
 
+    # Constructor validation rejects the oversized range up front.
     with pytest.raises(ValidationError):
         tsi.CallStatsReq(
             project_id="entity/project",
@@ -172,6 +173,18 @@ def test_call_stats_date_range_limit_validation():
             granularity=3600,
             usage_metrics=[tsi.UsageMetricSpec(metric="total_tokens")],
         )
+
+    # Query layer re-validates a request that bypassed the constructor.
+    req = tsi.CallStatsReq.model_construct(
+        project_id=client.project_id,
+        start=start_time,
+        end=end_time,
+        granularity=3600,
+        usage_metrics=[tsi.UsageMetricSpec(metric="total_tokens")],
+        timezone="UTC",
+    )
+    with pytest.raises(ValidationError):
+        client.server.call_stats(req)
 
 
 def test_call_stats_multiple_models(client: weave_client.WeaveClient):
@@ -466,69 +479,38 @@ def test_call_stats_time_buckets(client: weave_client.WeaveClient):
     )
 
 
-def test_call_stats_op_names_filter(client: weave_client.WeaveClient):
-    """Test op_names filter works correctly."""
+def test_call_stats_filters(client: weave_client.WeaveClient):
+    """Test op_names, trace_roots_only, and trace_ids filters each narrow results."""
     project_id = client.project_id
-    model_name = "gpt-4o-filter-test"
-
     start_time = _BASE_TIME
 
+    # op_names: op1 (100) vs op2 (200); filtering to op1 yields 100
+    op_model = "gpt-4o-filter-test"
     op1 = f"weave:///{project_id}/op/openai.chat:v1"
     op2 = f"weave:///{project_id}/op/anthropic.messages:v1"
-
     create_call_with_usage(
         client,
         op1,
-        {model_name: {"prompt_tokens": 100, "total_tokens": 100, "requests": 1}},
+        {op_model: {"prompt_tokens": 100, "total_tokens": 100, "requests": 1}},
         started_at=start_time + datetime.timedelta(minutes=1),
     )
-
     create_call_with_usage(
         client,
         op2,
-        {model_name: {"prompt_tokens": 200, "total_tokens": 200, "requests": 1}},
+        {op_model: {"prompt_tokens": 200, "total_tokens": 200, "requests": 1}},
         started_at=start_time + datetime.timedelta(minutes=2),
     )
 
-    force_merge_calls(client)
-    result = client.server.call_stats(
-        CallStatsReq(
-            project_id=project_id,
-            start=start_time - datetime.timedelta(minutes=1),
-            end=start_time + datetime.timedelta(hours=1),
-            granularity=3600,
-            usage_metrics=[
-                UsageMetricSpec(
-                    metric="input_tokens",
-                    aggregations=[AggregationType.SUM],
-                ),
-            ],
-            filter=CallsFilter(op_names=[op1]),
-        )
-    )
-    model_buckets = [b for b in result.usage_buckets if b.get("model") == model_name]
-    total_sum = sum(b.get("sum_input_tokens", 0) for b in model_buckets)
-
-    assert total_sum == 100, f"Expected 100 (only op1), got {total_sum}"
-
-
-def test_call_stats_trace_roots_only_filter(client: weave_client.WeaveClient):
-    """Test trace_roots_only filter excludes child calls."""
-    project_id = client.project_id
-    model_name = "gpt-4o-roots-test"
-
-    start_time = _BASE_TIME
-
-    # Create a root call
+    # trace_roots_only: root (100) + child (200); roots-only yields 100
+    roots_model = "gpt-4o-roots-test"
     root_call_id = str(uuid.uuid4())
-    trace_id = str(uuid.uuid4())
-
+    roots_trace_id = str(uuid.uuid4())
     client.server.call_start(
         tsi.CallStartReq(
             start=tsi.StartedCallSchemaForInsert(
                 project_id=project_id,
                 id=root_call_id,
-                trace_id=trace_id,
+                trace_id=roots_trace_id,
                 started_at=start_time,
                 op_name=f"weave:///{project_id}/op/root_op:v1",
                 parent_id=None,
@@ -544,20 +526,18 @@ def test_call_stats_trace_roots_only_filter(client: weave_client.WeaveClient):
                 id=root_call_id,
                 ended_at=start_time + datetime.timedelta(seconds=1),
                 summary={
-                    "usage": {model_name: {"prompt_tokens": 100, "total_tokens": 100}}
+                    "usage": {roots_model: {"prompt_tokens": 100, "total_tokens": 100}}
                 },
             )
         )
     )
-
-    # Create a child call
     child_call_id = str(uuid.uuid4())
     client.server.call_start(
         tsi.CallStartReq(
             start=tsi.StartedCallSchemaForInsert(
                 project_id=project_id,
                 id=child_call_id,
-                trace_id=trace_id,
+                trace_id=roots_trace_id,
                 started_at=start_time + datetime.timedelta(seconds=2),
                 op_name=f"weave:///{project_id}/op/child_op:v1",
                 parent_id=root_call_id,
@@ -573,47 +553,16 @@ def test_call_stats_trace_roots_only_filter(client: weave_client.WeaveClient):
                 id=child_call_id,
                 ended_at=start_time + datetime.timedelta(seconds=3),
                 summary={
-                    "usage": {model_name: {"prompt_tokens": 200, "total_tokens": 200}}
+                    "usage": {roots_model: {"prompt_tokens": 200, "total_tokens": 200}}
                 },
             )
         )
     )
 
-    # Query with trace_roots_only=True should only get root call (100 tokens)
-    force_merge_calls(client)
-    result = client.server.call_stats(
-        CallStatsReq(
-            project_id=project_id,
-            start=start_time - datetime.timedelta(minutes=1),
-            end=start_time + datetime.timedelta(hours=1),
-            granularity=3600,
-            usage_metrics=[
-                UsageMetricSpec(
-                    metric="input_tokens", aggregations=[AggregationType.SUM]
-                ),
-            ],
-            filter=CallsFilter(trace_roots_only=True),
-        )
-    )
-
-    model_buckets = [b for b in result.usage_buckets if b.get("model") == model_name]
-    total_sum = sum(b.get("sum_input_tokens", 0) for b in model_buckets)
-
-    assert total_sum == 100, f"Expected 100 (root only), got {total_sum}"
-
-
-def test_call_stats_trace_ids_filter(client: weave_client.WeaveClient):
-    """Test trace_ids filter limits to specific traces."""
-    project_id = client.project_id
-    model_name = "gpt-4o-trace-filter-test"
-
-    start_time = _BASE_TIME
-
-    # Create two traces
+    # trace_ids: trace_1 (100) vs trace_2 (200); filtering to trace_1 yields 100
+    trace_model = "gpt-4o-trace-filter-test"
     trace_id_1 = str(uuid.uuid4())
     trace_id_2 = str(uuid.uuid4())
-
-    # Call in trace 1
     call_id_1 = str(uuid.uuid4())
     client.server.call_start(
         tsi.CallStartReq(
@@ -635,13 +584,11 @@ def test_call_stats_trace_ids_filter(client: weave_client.WeaveClient):
                 id=call_id_1,
                 ended_at=start_time + datetime.timedelta(seconds=1),
                 summary={
-                    "usage": {model_name: {"prompt_tokens": 100, "total_tokens": 100}}
+                    "usage": {trace_model: {"prompt_tokens": 100, "total_tokens": 100}}
                 },
             )
         )
     )
-
-    # Call in trace 2
     call_id_2 = str(uuid.uuid4())
     client.server.call_start(
         tsi.CallStartReq(
@@ -663,33 +610,23 @@ def test_call_stats_trace_ids_filter(client: weave_client.WeaveClient):
                 id=call_id_2,
                 ended_at=start_time + datetime.timedelta(minutes=1, seconds=1),
                 summary={
-                    "usage": {model_name: {"prompt_tokens": 200, "total_tokens": 200}}
+                    "usage": {trace_model: {"prompt_tokens": 200, "total_tokens": 200}}
                 },
             )
         )
     )
 
-    # Query for only trace_1 should get 100 tokens
     force_merge_calls(client)
-    result = client.server.call_stats(
-        CallStatsReq(
-            project_id=project_id,
-            start=start_time - datetime.timedelta(minutes=1),
-            end=start_time + datetime.timedelta(hours=1),
-            granularity=3600,
-            usage_metrics=[
-                UsageMetricSpec(
-                    metric="input_tokens", aggregations=[AggregationType.SUM]
-                ),
-            ],
-            filter=CallsFilter(trace_ids=[trace_id_1]),
-        )
+
+    assert _filtered_input_sum(client, op_model, CallsFilter(op_names=[op1])) == 100
+    assert (
+        _filtered_input_sum(client, roots_model, CallsFilter(trace_roots_only=True))
+        == 100
     )
-
-    model_buckets = [b for b in result.usage_buckets if b.get("model") == model_name]
-    total_sum = sum(b.get("sum_input_tokens", 0) for b in model_buckets)
-
-    assert total_sum == 100, f"Expected 100 (trace_1 only), got {total_sum}"
+    assert (
+        _filtered_input_sum(client, trace_model, CallsFilter(trace_ids=[trace_id_1]))
+        == 100
+    )
 
 
 def test_call_stats_call_metrics(client: weave_client.WeaveClient):
@@ -827,18 +764,28 @@ def test_call_stats_call_metrics(client: weave_client.WeaveClient):
     assert total_error_count == 1, f"Expected 1 error, got {total_error_count}"
 
 
-def test_call_stats_date_range_limit_query_layer(client: weave_client.WeaveClient):
-    """Ensure call_stats rejects max date range during request handling."""
-    end_time = _BASE_TIME
-    start_time = end_time - datetime.timedelta(days=32)
-    req = tsi.CallStatsReq.model_construct(
-        project_id=client.project_id,
-        start=start_time,
-        end=end_time,
-        granularity=3600,
-        usage_metrics=[tsi.UsageMetricSpec(metric="total_tokens")],
-        timezone="UTC",
+def _filtered_input_sum(
+    client: weave_client.WeaveClient,
+    model_name: str,
+    call_filter: CallsFilter,
+) -> int:
+    """Sum input_tokens for one model under a call_stats filter."""
+    project_id = client.project_id
+    start_time = _BASE_TIME
+    result = client.server.call_stats(
+        CallStatsReq(
+            project_id=project_id,
+            start=start_time - datetime.timedelta(minutes=1),
+            end=start_time + datetime.timedelta(hours=1),
+            granularity=3600,
+            usage_metrics=[
+                UsageMetricSpec(
+                    metric="input_tokens",
+                    aggregations=[AggregationType.SUM],
+                ),
+            ],
+            filter=call_filter,
+        )
     )
-
-    with pytest.raises(ValidationError):
-        client.server.call_stats(req)
+    model_buckets = [b for b in result.usage_buckets if b.get("model") == model_name]
+    return sum(b.get("sum_input_tokens", 0) for b in model_buckets)

--- a/tests/trace_server/test_calls_complete.py
+++ b/tests/trace_server/test_calls_complete.py
@@ -1148,18 +1148,15 @@ def test_calls_query_routing_by_residence(
     assert len(calls) == expected_count
 
 
-def test_v1_call_start_raises_calls_complete_mode_required(
+def test_v1_call_start_end_raise_calls_complete_mode_required(
     trace_server, clickhouse_trace_server
 ):
-    """Verify v1 call_start raises CallsCompleteModeRequired for calls_complete projects.
-
-    When a project is in calls_complete mode (has existing data in calls_complete),
-    attempting to use the legacy v1 call_start API should raise an error directing
-    the user to upgrade their SDK.
+    """Once a project has calls_complete data, the legacy v1 call_start and
+    call_end APIs both raise CallsCompleteModeRequired with an upgrade hint.
     """
-    project_id = f"{TEST_ENTITY}/calls_complete_v1_error_start"
+    project_id = f"{TEST_ENTITY}/calls_complete_v1_error"
 
-    # Seed the project with calls_complete data to establish it as a calls_complete project
+    # Seed calls_complete data so the project reads as a calls_complete project.
     seed_call = _make_completed_call(
         project_id,
         str(uuid.uuid4()),
@@ -1169,8 +1166,7 @@ def test_v1_call_start_raises_calls_complete_mode_required(
     )
     trace_server.calls_complete(tsi.CallsUpsertCompleteReq(batch=[seed_call]))
 
-    # Now attempt v1 call_start - should raise CallsCompleteModeRequired
-    with pytest.raises(CallsCompleteModeRequired) as exc_info:
+    with pytest.raises(CallsCompleteModeRequired) as start_exc:
         trace_server.call_start(
             tsi.CallStartReq(
                 start=tsi.StartedCallSchemaForInsert(
@@ -1184,34 +1180,9 @@ def test_v1_call_start_raises_calls_complete_mode_required(
                 )
             )
         )
+    assert "complete" in str(start_exc.value).lower()
 
-    # Verify error contains helpful information
-    assert "complete" in str(exc_info.value).lower()
-
-
-def test_v1_call_end_raises_calls_complete_mode_required(
-    trace_server, clickhouse_trace_server
-):
-    """Verify v1 call_end raises CallsCompleteModeRequired for calls_complete projects.
-
-    When a project is in calls_complete mode (has existing data in calls_complete),
-    attempting to use the legacy v1 call_end API should raise an error directing
-    the user to upgrade their SDK.
-    """
-    project_id = f"{TEST_ENTITY}/calls_complete_v1_error_end"
-
-    # Seed the project with calls_complete data to establish it as a calls_complete project
-    seed_call = _make_completed_call(
-        project_id,
-        str(uuid.uuid4()),
-        str(uuid.uuid4()),
-        datetime.datetime.now(datetime.timezone.utc),
-        datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(seconds=1),
-    )
-    trace_server.calls_complete(tsi.CallsUpsertCompleteReq(batch=[seed_call]))
-
-    # Now attempt v1 call_end - should raise CallsCompleteModeRequired
-    with pytest.raises(CallsCompleteModeRequired) as exc_info:
+    with pytest.raises(CallsCompleteModeRequired) as end_exc:
         trace_server.call_end(
             tsi.CallEndReq(
                 end=tsi.EndedCallSchemaForInsert(
@@ -1222,9 +1193,7 @@ def test_v1_call_end_raises_calls_complete_mode_required(
                 )
             )
         )
-
-    # Verify error contains helpful information
-    assert "complete" in str(exc_info.value).lower()
+    assert "complete" in str(end_exc.value).lower()
 
 
 def test_calls_complete_query_with_status_filter(trace_server, clickhouse_trace_server):
@@ -1513,82 +1482,16 @@ def test_calls_delete_cascade(trace_server, clickhouse_trace_server):
     assert len(_fetch_calls_stream(trace_server, project3)) == 0
 
 
-def test_project_stats_with_calls_complete(trace_server, clickhouse_trace_server):
-    """Test project_stats uses calls_complete_stats when project uses calls_complete.
-
-    This test verifies that the project_stats endpoint correctly queries
-    from calls_complete_stats (not calls_merged_stats) when the project
-    has data in calls_complete table.
+def test_project_stats_routes_by_residence(trace_server, clickhouse_trace_server):
+    """project_stats reads from the stats table matching each project's residence:
+    a calls_merged project from calls_merged_stats and a calls_complete project
+    from calls_complete_stats (summing all four size fields), and the two never
+    cross-read.
     """
-    project_id = f"{TEST_ENTITY}/project_stats_calls_complete"
-    internal_project_id = b64(project_id)
-
-    # Define test data sizes
-    attr_size = 100
-    inputs_size = 200
-    output_size = 300
-    summary_size = 400
-    expected_trace_size = attr_size + inputs_size + output_size + summary_size
-
-    # Insert data directly into calls_complete_stats table
-    # This bypasses the materialized view to have predictable test data
-    clickhouse_trace_server.ch_client.command(
-        f"""
-        INSERT INTO calls_complete_stats (
-            project_id,
-            id,
-            attributes_size_bytes,
-            inputs_size_bytes,
-            output_size_bytes,
-            summary_size_bytes
-        )
-        VALUES (
-            '{internal_project_id}',
-            '{uuid.uuid4()}',
-            {attr_size},
-            {inputs_size},
-            {output_size},
-            {summary_size}
-        )
-        """
-    )
-
-    # Insert a row into calls_complete to establish project residence
-    _insert_complete_call(clickhouse_trace_server.ch_client, internal_project_id)
-
-    # Verify we're reading from calls_complete
-    read_table = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
-        internal_project_id,
-        clickhouse_trace_server.ch_client,
-    )
-    assert read_table == ReadTable.CALLS_COMPLETE
-
-    # Query project stats - use defaults (all True) to get all fields
-    res = trace_server.project_stats(tsi.ProjectStatsReq(project_id=project_id))
-
-    # Should get the data from calls_complete_stats, not calls_merged_stats
-    # The expected_trace_size is the sum of all _size_bytes fields we inserted
-    # Plus any sizes from the _insert_complete_call (which inserts empty JSON)
-    assert res.trace_storage_size_bytes >= expected_trace_size
-
-
-def test_project_stats_uses_correct_stats_table_based_on_residence(
-    trace_server, clickhouse_trace_server
-):
-    """Test project_stats uses the correct stats table based on data residence.
-
-    This test creates two projects:
-    1. One with data only in calls_merged (should use calls_merged_stats)
-    2. One with data only in calls_complete (should use calls_complete_stats)
-
-    It verifies each project gets stats from its corresponding stats table.
-    """
-    # Project 1: calls_merged only
+    # Project 1: calls_merged only, single size field.
     project1_id = f"{TEST_ENTITY}/stats_merged_only"
     internal_project1_id = b64(project1_id)
     merged_trace_size = 1000
-
-    # Insert into calls_merged_stats
     clickhouse_trace_server.ch_client.command(
         f"""
         INSERT INTO calls_merged_stats (
@@ -1609,16 +1512,13 @@ def test_project_stats_uses_correct_stats_table_based_on_residence(
         )
         """
     )
-
-    # Insert call into calls_merged to establish residence
     _insert_merged_call(clickhouse_trace_server.ch_client, internal_project1_id)
 
-    # Project 2: calls_complete only
+    # Project 2: calls_complete only, four distinct size fields that must be summed.
     project2_id = f"{TEST_ENTITY}/stats_complete_only"
     internal_project2_id = b64(project2_id)
-    complete_trace_size = 2000
-
-    # Insert into calls_complete_stats
+    attr_size, inputs_size, output_size, summary_size = 100, 200, 300, 400
+    complete_trace_size = attr_size + inputs_size + output_size + summary_size
     clickhouse_trace_server.ch_client.command(
         f"""
         INSERT INTO calls_complete_stats (
@@ -1632,40 +1532,30 @@ def test_project_stats_uses_correct_stats_table_based_on_residence(
         VALUES (
             '{internal_project2_id}',
             '{uuid.uuid4()}',
-            {complete_trace_size},
-            0,
-            0,
-            0
+            {attr_size},
+            {inputs_size},
+            {output_size},
+            {summary_size}
         )
         """
     )
-
-    # Insert call into calls_complete to establish residence
     _insert_complete_call(clickhouse_trace_server.ch_client, internal_project2_id)
 
-    # Verify project residences
     read_table1 = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project1_id, clickhouse_trace_server.ch_client
     )
     read_table2 = clickhouse_trace_server.table_routing_resolver.resolve_read_table(
         internal_project2_id, clickhouse_trace_server.ch_client
     )
-
     assert read_table1 == ReadTable.CALLS_MERGED
     assert read_table2 == ReadTable.CALLS_COMPLETE
 
-    # Query stats for both projects using defaults (all True)
+    # >= because _insert_*_call also adds a little size data.
     res1 = trace_server.project_stats(tsi.ProjectStatsReq(project_id=project1_id))
     res2 = trace_server.project_stats(tsi.ProjectStatsReq(project_id=project2_id))
-
-    # Each should get data from its respective stats table
-    # Use >= because _insert_*_call also adds some size data
     assert res1.trace_storage_size_bytes >= merged_trace_size
     assert res2.trace_storage_size_bytes >= complete_trace_size
-
-    # Critically: project1 should NOT have the complete_trace_size and vice versa
-    # This verifies we're reading from the correct table
-    # The values should be different because each project reads from different stats tables
+    # Distinct tables -> distinct totals, proving no cross-read.
     assert res1.trace_storage_size_bytes != res2.trace_storage_size_bytes
 
 

--- a/tests/trace_server/test_ch_sentinel_values.py
+++ b/tests/trace_server/test_ch_sentinel_values.py
@@ -56,78 +56,63 @@ def test_constants() -> None:
     assert set(SENTINEL_DATETIME_VALUES) == set(DATETIME_PRECISION)
 
 
-def test_is_sentinel_field() -> None:
-    """Known sentinel fields return True; other fields return False."""
-    for field in (
-        SENTINEL_STRING_FIELDS | SENTINEL_DATETIME_FIELDS | SENTINEL_INT_FIELDS
-    ):
-        assert is_sentinel_field(field) is True, f"{field} should be sentinel"
-
-    for field in NON_SENTINEL_FIELDS:
-        assert is_sentinel_field(field) is False, f"{field} should not be sentinel"
-
-
-def test_get_sentinel_value() -> None:
-    """Returns correct sentinel for each field type, None otherwise."""
+def test_sentinel_field_membership_and_values() -> None:
+    """is_sentinel_field is True only for the three sentinel partitions, and
+    get_sentinel_value returns the partition's sentinel ('' / epoch / 0) or
+    None for non-sentinel fields.
+    """
     for field in SENTINEL_STRING_FIELDS:
+        assert is_sentinel_field(field) is True, f"{field} should be sentinel"
         assert get_sentinel_value(field) == "", f"{field} sentinel should be ''"
 
     for field in SENTINEL_DATETIME_FIELDS:
+        assert is_sentinel_field(field) is True, f"{field} should be sentinel"
         assert get_sentinel_value(field) is SENTINEL_DATETIME_VALUES[field]
 
     for field in SENTINEL_INT_FIELDS:
+        assert is_sentinel_field(field) is True, f"{field} should be sentinel"
         assert get_sentinel_value(field) == 0, f"{field} sentinel should be 0"
 
     for field in NON_SENTINEL_FIELDS:
+        assert is_sentinel_field(field) is False, f"{field} should not be sentinel"
         assert get_sentinel_value(field) is None, (
             f"{field} should return None (not a sentinel field)"
         )
 
 
-def test_sentinel_ch_type() -> None:
-    """Returns correct CH type strings and raises for non-sentinel fields."""
+def test_sentinel_ch_type_and_literal() -> None:
+    """sentinel_ch_type maps each partition to its CH type and sentinel_ch_literal
+    to its SQL literal; both raise for non-sentinel fields.
+    """
     for field in SENTINEL_STRING_FIELDS:
         assert sentinel_ch_type(field) == "String"
+        assert sentinel_ch_literal(field) == "''"
 
     for field in SENTINEL_DATETIME_FIELDS:
         precision = DATETIME_PRECISION[field]
         assert sentinel_ch_type(field) == f"DateTime64({precision})"
 
-    # Specific precision values per migration schema
+    for field in SENTINEL_INT_FIELDS:
+        assert sentinel_ch_type(field) == "UInt64"
+
+    # Specific precision/literal values per migration schema.
     assert sentinel_ch_type("ended_at") == "DateTime64(6)"
     assert sentinel_ch_type("updated_at") == "DateTime64(3)"
     assert sentinel_ch_type("deleted_at") == "DateTime64(3)"
     assert sentinel_ch_type("expire_at") == "DateTime64(3)"
-
-    for field in SENTINEL_INT_FIELDS:
-        assert sentinel_ch_type(field) == "UInt64"
-
-    for field in NON_SENTINEL_FIELDS:
-        with pytest.raises(ValueError, match=f"Not a sentinel field: {field}"):
-            sentinel_ch_type(field)
-
-
-def test_sentinel_ch_literal() -> None:
-    """Returns SQL literals for sentinel fields; raises for non-sentinel fields."""
-    # String sentinel fields return empty string literal.
     assert sentinel_ch_literal("parent_id") == "''"
-    for field in SENTINEL_STRING_FIELDS:
-        assert sentinel_ch_literal(field) == "''"
-
-    # Datetime sentinel fields return their field-specific sentinel literal.
     assert sentinel_ch_literal("ended_at") == "toDateTime64(0, 6)"
     assert sentinel_ch_literal("updated_at") == "toDateTime64(0, 3)"
     assert sentinel_ch_literal("deleted_at") == "toDateTime64(0, 3)"
     assert sentinel_ch_literal("expire_at") == (
         "toDateTime64('2100-01-01 00:00:00', 3)"
     )
-
-    # Int sentinel fields return 0.
     assert sentinel_ch_literal("wb_run_step") == "0"
     assert sentinel_ch_literal("wb_run_step_end") == "0"
 
-    # Non-sentinel fields raise ValueError.
     for field in NON_SENTINEL_FIELDS:
+        with pytest.raises(ValueError, match=f"Not a sentinel field: {field}"):
+            sentinel_ch_type(field)
         with pytest.raises(ValueError, match=f"Not a sentinel field: {field}"):
             sentinel_ch_literal(field)
 

--- a/tests/trace_server/test_clickhouse_batching.py
+++ b/tests/trace_server/test_clickhouse_batching.py
@@ -6,6 +6,7 @@ ClickHouse insert operation for performance optimization.
 
 import base64
 import datetime
+import gc
 import json
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -22,259 +23,74 @@ from weave.trace_server.errors import (
     handle_server_exception,
 )
 from weave.trace_server.validation_util import CHValidationError
+from weave.trace_server_bindings.caching_middleware_trace_server import (
+    CachingMiddlewareTraceServer,
+)
 
 
-def make_base_64_content(content: str) -> str:
-    """Helper function to create base64 encoded content.
-
-    Args:
-        content (str): The content to encode.
-
-    Returns:
-        str: Base64 encoded content with data URI prefix.
+def test_clickhouse_batching_insert_grouping():
+    """call_start_batch coalesces inserts: 3 distinct base64 contents produce
+    exactly 2 inserts (files + call_parts), and 3 identical contents dedup to a
+    single file pair (content + metadata).
     """
-    return "data:text/plain;base64," + base64.b64encode(content.encode()).decode()
-
-
-string_suffix = "a" * AUTO_CONVERSION_MIN_SIZE
-
-
-def create_file_sized_content(content: str) -> str:
-    """Create base64 content padded to exceed AUTO_CONVERSION_MIN_SIZE.
-
-    This ensures the content is large enough to trigger file-based storage
-    in ClickHouse rather than inline storage.
-    """
-    return make_base_64_content(content + string_suffix)
-
-
-def _make_batch_req_with_contents(project_id: str, contents: list[str]):
-    """Helper to build a CallCreateBatchReq where each call has one base64 input."""
-    return tsi.CallCreateBatchReq(
-        batch=[
-            tsi.CallBatchStartMode(
-                mode="start",
-                req=tsi.CallStartReq(
-                    start=tsi.StartedCallSchemaForInsert(
-                        project_id=project_id,
-                        op_name=f"test_op_{i}",
-                        started_at=datetime.datetime.now(datetime.timezone.utc),
-                        attributes={},
-                        inputs={"input": create_file_sized_content(c)},
-                    )
-                ),
-            )
-            for i, c in enumerate(contents)
+    # Distinct contents -> exactly one files insert + one call_parts insert.
+    distinct = _run_batch_start(
+        [
+            create_file_sized_content("SOME BASE64 CONTENT - 1"),
+            create_file_sized_content("SOME BASE64 CONTENT - 2"),
+            create_file_sized_content("SOME BASE64 CONTENT - 3"),
         ]
     )
+    insert_tables = [call[0][0] for call in distinct.insert.call_args_list]
+    assert distinct.insert.call_count == 2
+    assert set(insert_tables) == {"files", "call_parts"}
+
+    # Identical content across 3 calls -> still only one file pair.
+    same = "IDENTICAL CONTENT"
+    dedup = _run_batch_start([create_file_sized_content(same)] * 3)
+    dedup_tables = [call[0][0] for call in dedup.insert.call_args_list]
+    assert set(dedup_tables) == {"files", "call_parts"}
+    files_insert = next(c for c in dedup.insert.call_args_list if c[0][0] == "files")
+    # Each Content object produces 2 files (content + metadata.json); dedup keeps 1 pair.
+    assert len(files_insert[1]["data"]) == 2
 
 
-def test_clickhouse_batching():
-    """Test that batched calls are properly sent to ClickHouse with correct parameters."""
-    # Create a mock ClickHouse client
-    mock_ch_client = MagicMock()
-
-    # Mock the command method to avoid actual database operations
-    mock_ch_client.command.return_value = None
-
-    # Mock the insert method to track calls
-    mock_ch_client.insert.return_value = MagicMock()
-    # MagicMock is truthy, so get_project_data_residence() returns BOTH, which is incorrect, mock it
-    mock_ch_client.query.return_value.result_rows = []
-
-    # Create a ClickHouseTraceServer instance and patch _mint_client
-    with patch.object(
-        ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
-    ):
-        trace_server = ClickHouseTraceServer(host="test_host")
-
-        # Use properly base64 encoded project_id (entity/project format)
-        project_id = base64.b64encode(b"test_entity/test_project").decode("utf-8")
-
-        # Simulate a legacy project by returning merged-only residence.
-        mock_query_result = MagicMock()
-        mock_query_result.result_rows = [[0, 1]]  # has_complete=0, has_merged=1
-        mock_ch_client.query.return_value = mock_query_result
-
-        # Create a batch of call start requests
-        batch_req = tsi.CallCreateBatchReq(
-            batch=[
-                tsi.CallBatchStartMode(
-                    mode="start",
-                    req=tsi.CallStartReq(
-                        start=tsi.StartedCallSchemaForInsert(
-                            project_id=project_id,
-                            op_name="test_op_1",
-                            started_at=datetime.datetime.now(datetime.timezone.utc),
-                            attributes={},
-                            inputs={
-                                "input": create_file_sized_content(
-                                    "SOME BASE64 CONTENT - 1"
-                                )
-                            },
-                        )
-                    ),
-                ),
-                tsi.CallBatchStartMode(
-                    mode="start",
-                    req=tsi.CallStartReq(
-                        start=tsi.StartedCallSchemaForInsert(
-                            project_id=project_id,
-                            op_name="test_op_2",
-                            started_at=datetime.datetime.now(datetime.timezone.utc),
-                            attributes={},
-                            inputs={
-                                "input": create_file_sized_content(
-                                    "SOME BASE64 CONTENT - 2"
-                                )
-                            },
-                        )
-                    ),
-                ),
-                tsi.CallBatchStartMode(
-                    mode="start",
-                    req=tsi.CallStartReq(
-                        start=tsi.StartedCallSchemaForInsert(
-                            project_id=project_id,
-                            op_name="test_op_3",
-                            started_at=datetime.datetime.now(datetime.timezone.utc),
-                            attributes={},
-                            inputs={
-                                "input": create_file_sized_content(
-                                    "SOME BASE64 CONTENT - 3"
-                                )
-                            },
-                        )
-                    ),
-                ),
-            ]
-        )
-
-        # Execute the batch
-        trace_server.call_start_batch(batch_req)
-
-        # THE KEY ASSERTION:
-        # Verify that there are exactly 2 inserts:
-        # 1 for files and 1 for call_parts (order may vary)
-        insert_call_count = mock_ch_client.insert.call_count
-        assert insert_call_count == 2, (
-            f"Expected exactly 2 ClickHouse insert calls for 3 batched calls "
-            f"(and 3 base64 content objects, which are stored in files), "
-            f"but got {insert_call_count} insert calls"
-        )
-
-        # Check that both files and call_parts were inserted (order may vary)
-        insert_tables = [
-            mock_ch_client.insert.call_args_list[0][0][0],
-            mock_ch_client.insert.call_args_list[1][0][0],
-        ]
-        assert set(insert_tables) == {"files", "call_parts"}, (
-            f"Expected inserts to files and call_parts tables, "
-            f"but got inserts to: {insert_tables}"
-        )
-
-
-def test_clickhouse_batching_deduplicates_identical_files():
-    """Duplicate content in the same batch should only produce one file insert."""
-    mock_ch_client = MagicMock()
-    mock_ch_client.command.return_value = None
-    mock_ch_client.insert.return_value = MagicMock()
-    mock_ch_client.query.return_value.result_rows = []
-
-    with patch.object(
-        ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
-    ):
-        trace_server = ClickHouseTraceServer(host="test_host")
-        project_id = base64.b64encode(b"test_entity/test_project").decode("utf-8")
-
-        mock_query_result = MagicMock()
-        mock_query_result.result_rows = [[0, 1]]
-        mock_ch_client.query.return_value = mock_query_result
-
-        # 3 calls with the SAME content
-        same_content = "IDENTICAL CONTENT"
-        batch_req = _make_batch_req_with_contents(
-            project_id, [same_content, same_content, same_content]
-        )
-        trace_server.call_start_batch(batch_req)
-
-        insert_tables = [call[0][0] for call in mock_ch_client.insert.call_args_list]
-        assert set(insert_tables) == {"files", "call_parts"}
-
-        # The files insert should contain chunks for only 1 unique file
-        # (content + metadata), not 3 copies.
-        files_insert = next(
-            call
-            for call in mock_ch_client.insert.call_args_list
-            if call[0][0] == "files"
-        )
-        file_rows = files_insert[1]["data"]
-        # Each Content object produces 2 files (content + metadata.json).
-        # With dedup, 3 identical calls should still yield only 2 file rows.
-        assert len(file_rows) == 2, (
-            f"Expected 2 file rows (1 content + 1 metadata) for deduplicated batch, "
-            f"got {len(file_rows)}"
-        )
-
-
-def _mk_obj(project_id: str, object_id: str, wb_user_id: str, val: dict[str, Any]):
-    return tsi.ObjSchemaForInsert(
-        project_id=project_id,
-        object_id=object_id,
-        wb_user_id=wb_user_id,
-        val=val,
-    )
-
-
-def _internal_pid() -> str:
-    # Any base64 string is valid for internal project id validation
-    # Reuse the same value as other tests in this module
-    return base64.b64encode(b"test_project").decode()
-
-
-def _internal_wb_user_id() -> str:
-    return base64.b64encode(b"test_user").decode()
-
-
-def test_obj_batch_same_object_id_different_hash(trace_server, client):
-    """Two versions for same object_id with different digests."""
+def test_obj_batch_two_version_scenarios(trace_server, client):
+    """obj_create_batch over two-version inputs: two digests under one
+    object_id yield two versions with exactly one latest; one digest under two
+    object_ids yields two distinct objects.
+    """
     server = trace_server._internal_trace_server
     pid = _internal_pid()
     wb_user_id = _internal_wb_user_id()
-    obj_id = "my_obj"
-    v1 = {"k": 1}
-    v2 = {"k": 2}
 
+    # Same object_id, two distinct values -> two versions, one latest.
+    v1, v2 = {"k": 1}, {"k": 2}
     server.obj_create_batch(
         batch=[
-            _mk_obj(pid, obj_id, wb_user_id, v1),
-            _mk_obj(pid, obj_id, wb_user_id, v2),
+            _mk_obj(pid, "my_obj", wb_user_id, v1),
+            _mk_obj(pid, "my_obj", wb_user_id, v2),
         ]
     )
-
     res = server.objs_query(
         tsi.ObjQueryReq(
             project_id=pid,
-            filter=tsi.ObjectVersionFilter(object_ids=[obj_id], latest_only=False),
+            filter=tsi.ObjectVersionFilter(object_ids=["my_obj"], latest_only=False),
         )
     )
     assert len(res.objs) == 2
-    digests = {o.digest for o in res.objs}
-    assert digests == {str_digest(json.dumps(v1)), str_digest(json.dumps(v2))}
-    # Exactly one latest
+    assert {o.digest for o in res.objs} == {
+        str_digest(json.dumps(v1)),
+        str_digest(json.dumps(v2)),
+    }
     assert sum(o.is_latest for o in res.objs) == 1
 
-
-def test_obj_batch_same_hash_different_object_ids(trace_server, client):
-    """Same digest payload uploaded under different object_ids yields distinct objects."""
-    server = trace_server._internal_trace_server
-    pid = _internal_pid()
-    wb_user_id = _internal_wb_user_id()
-    val = {"shared": True}
+    # Same value, two object_ids -> two distinct objects.
+    shared = {"shared": True}
     server.obj_create_batch(
         batch=[
-            _mk_obj(pid, "obj_1", wb_user_id, val),
-            _mk_obj(pid, "obj_2", wb_user_id, val),
+            _mk_obj(pid, "obj_1", wb_user_id, shared),
+            _mk_obj(pid, "obj_2", wb_user_id, shared),
         ]
     )
     res = server.objs_query(
@@ -287,29 +103,6 @@ def test_obj_batch_same_hash_different_object_ids(trace_server, client):
     )
     assert len(res.objs) == 2
     assert {o.object_id for o in res.objs} == {"obj_1", "obj_2"}
-
-
-def test_obj_batch_identical_same_id_same_hash_deduplicates(trace_server, client):
-    """Duplicate rows (same object_id and digest) are represented once in metadata view."""
-    server = trace_server._internal_trace_server
-    pid = _internal_pid()
-    wb_user_id = _internal_wb_user_id()
-    obj_id = "dup_obj"
-    val = {"x": 1}
-    server.obj_create_batch(
-        batch=[
-            _mk_obj(pid, obj_id, wb_user_id, val),
-            _mk_obj(pid, obj_id, wb_user_id, val),
-        ]
-    )
-    res = server.objs_query(
-        tsi.ObjQueryReq(
-            project_id=pid,
-            filter=tsi.ObjectVersionFilter(object_ids=[obj_id], latest_only=False),
-        )
-    )
-    assert len(res.objs) == 1
-    assert res.objs[0].digest == str_digest(json.dumps(val))
 
 
 def test_obj_batch_four_versions_and_read_path(trace_server, client):
@@ -391,66 +184,50 @@ def test_obj_batch_delete_version_preserves_indices(trace_server, client):
     assert {obj.digest for obj in res.objs} == {pre_del_digests[0], pre_del_digests[2]}
 
 
-def test_str_digest_is_key_order_independent():
-    """str_digest must return the same value regardless of dict key insertion order."""
+def test_digest_key_order_independence(trace_server, client):
+    """Key-order independence at every layer: str_digest is order-invariant only
+    with sort_keys; obj_create_batch collapses key-reordered values (and exact
+    duplicates) to one version; table_create gives reordered rows equal digests.
+    """
+    # str_digest: equal under sort_keys, differs without it.
     val_a = {"b": 1, "a": 2, "c": [{"z": 9, "y": 8}]}
     val_b = {"a": 2, "c": [{"y": 8, "z": 9}], "b": 1}
-
-    digest_a = str_digest(json.dumps(val_a, sort_keys=True))
-    digest_b = str_digest(json.dumps(val_b, sort_keys=True))
-    assert digest_a == digest_b
-
-    # Without sort_keys the digests would differ
+    assert str_digest(json.dumps(val_a, sort_keys=True)) == str_digest(
+        json.dumps(val_b, sort_keys=True)
+    )
     assert str_digest(json.dumps(val_a)) != str_digest(json.dumps(val_b))
 
-
-def test_obj_batch_different_key_order_deduplicates(trace_server, client):
-    """Objects with identical values but different key ordering share the same digest."""
     server = trace_server._internal_trace_server
     pid = _internal_pid()
     wb_user_id = _internal_wb_user_id()
-    obj_id = "key_order_obj"
 
-    val_a = {"b": 1, "a": 2}
-    val_b = {"a": 2, "b": 1}
-
+    # obj_create_batch: key-reordered + exact-duplicate values dedup to one version.
     server.obj_create_batch(
         batch=[
-            _mk_obj(pid, obj_id, wb_user_id, val_a),
-            _mk_obj(pid, obj_id, wb_user_id, val_b),
+            _mk_obj(pid, "dedup_obj", wb_user_id, {"b": 1, "a": 2}),
+            _mk_obj(pid, "dedup_obj", wb_user_id, {"a": 2, "b": 1}),
+            _mk_obj(pid, "dedup_obj", wb_user_id, {"b": 1, "a": 2}),
         ]
     )
-
     res = server.objs_query(
         tsi.ObjQueryReq(
             project_id=pid,
-            filter=tsi.ObjectVersionFilter(object_ids=[obj_id], latest_only=False),
+            filter=tsi.ObjectVersionFilter(object_ids=["dedup_obj"], latest_only=False),
         )
     )
-    # Both values are logically identical, so only one version should exist
     assert len(res.objs) == 1
+    assert res.objs[0].digest == str_digest(json.dumps({"a": 2, "b": 1}))
 
-
-def test_table_create_different_key_order_same_digest(trace_server):
-    """Rows with different key ordering produce the same digest in table_create."""
-    server = trace_server._internal_trace_server
-    pid = _internal_pid()
-
-    row_a = {"b": 1, "a": 2}
-    row_b = {"a": 2, "b": 1}
-
-    res = server.table_create(
+    # table_create: reordered rows produce identical digests.
+    table_res = server.table_create(
         tsi.TableCreateReq(
             table=tsi.TableSchemaForInsert(
-                project_id=pid,
-                rows=[row_a, row_b],
+                project_id=pid, rows=[{"b": 1, "a": 2}, {"a": 2, "b": 1}]
             )
         )
     )
-
-    # Both rows are logically identical so their digests must match
-    assert len(res.row_digests) == 2
-    assert res.row_digests[0] == res.row_digests[1]
+    assert len(table_res.row_digests) == 2
+    assert table_res.row_digests[0] == table_res.row_digests[1]
 
 
 def test_call_start_batch_invalid_trace_id_returns_400():
@@ -522,3 +299,89 @@ def test_obj_batch_mixed_projects_errors(trace_server, client):
         match="obj_create_batch only supports updating a single project.",
     ):
         server.obj_create_batch(batch=batch)
+
+
+def test_caching_middleware_closes_cache_on_gc():
+    """Destroying the caching middleware closes its disk cache (the __del__
+    cleanup path), so a dropped reference does not leak the cache handle.
+    """
+    server = CachingMiddlewareTraceServer(next_trace_server=MagicMock())
+    assert server._cache_recorder == {"hits": 0, "misses": 0, "skips": 0}
+
+    del server
+    gc.collect()
+
+
+def make_base_64_content(content: str) -> str:
+    """Create base64 encoded content with a data URI prefix."""
+    return "data:text/plain;base64," + base64.b64encode(content.encode()).decode()
+
+
+string_suffix = "a" * AUTO_CONVERSION_MIN_SIZE
+
+
+def create_file_sized_content(content: str) -> str:
+    """Create base64 content padded past AUTO_CONVERSION_MIN_SIZE so it is
+    stored as a file rather than inline.
+    """
+    return make_base_64_content(content + string_suffix)
+
+
+def _run_batch_start(contents: list[str]) -> MagicMock:
+    """Run call_start_batch over one base64 input per content against a mocked
+    CH client (legacy merged-only residence) and return that client for insert
+    assertions.
+    """
+    mock_ch_client = MagicMock()
+    mock_ch_client.command.return_value = None
+    mock_ch_client.insert.return_value = MagicMock()
+    mock_ch_client.query.return_value.result_rows = []
+
+    with patch.object(
+        ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+    ):
+        trace_server = ClickHouseTraceServer(host="test_host")
+        project_id = base64.b64encode(b"test_entity/test_project").decode("utf-8")
+
+        # Simulate a legacy project by returning merged-only residence.
+        mock_query_result = MagicMock()
+        mock_query_result.result_rows = [[0, 1]]  # has_complete=0, has_merged=1
+        mock_ch_client.query.return_value = mock_query_result
+
+        batch_req = tsi.CallCreateBatchReq(
+            batch=[
+                tsi.CallBatchStartMode(
+                    mode="start",
+                    req=tsi.CallStartReq(
+                        start=tsi.StartedCallSchemaForInsert(
+                            project_id=project_id,
+                            op_name=f"test_op_{i}",
+                            started_at=datetime.datetime.now(datetime.timezone.utc),
+                            attributes={},
+                            inputs={"input": c},
+                        )
+                    ),
+                )
+                for i, c in enumerate(contents)
+            ]
+        )
+        trace_server.call_start_batch(batch_req)
+
+    return mock_ch_client
+
+
+def _mk_obj(project_id: str, object_id: str, wb_user_id: str, val: dict[str, Any]):
+    return tsi.ObjSchemaForInsert(
+        project_id=project_id,
+        object_id=object_id,
+        wb_user_id=wb_user_id,
+        val=val,
+    )
+
+
+def _internal_pid() -> str:
+    return base64.b64encode(b"test_project").decode()
+
+
+def _internal_wb_user_id() -> str:
+    return base64.b64encode(b"test_user").decode()

--- a/tests/trace_server/test_clickhouse_trace_server_batched.py
+++ b/tests/trace_server/test_clickhouse_trace_server_batched.py
@@ -171,14 +171,14 @@ def test_clickhouse_calls_query_stream_empty_thread_ids_against_real_clickhouse(
     assert result == []
 
 
-def test_clickhouse_storage_size_schema_conversion():
-    """Test that storage size fields are correctly converted in ClickHouse schema."""
-    # Test data with proper datetime structures
+def test_ch_call_dict_to_call_schema_dict_conversions():
+    """ch_call_dict_to_call_schema_dict at the API boundary: storage-size
+    fields pass through populated, are preserved as None, and the far-future
+    expire_at sentinel is hidden as None.
+    """
     started_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     ended_at = datetime(2024, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
-    test_data = {
-        "storage_size_bytes": 1000,
-        "total_storage_size_bytes": 2000,
+    base = {
         "id": "test_id",
         "name": "test_name",
         "project_id": "test_project",
@@ -197,66 +197,28 @@ def test_clickhouse_storage_size_schema_conversion():
         "wb_user_id": None,
     }
 
-    # Test ClickHouse conversion
-    ch_schema = chts.ch_call_dict_to_call_schema_dict(test_data)
-    assert ch_schema["storage_size_bytes"] == 1000
-    assert ch_schema["total_storage_size_bytes"] == 2000
+    populated = chts.ch_call_dict_to_call_schema_dict(
+        {**base, "storage_size_bytes": 1000, "total_storage_size_bytes": 2000}
+    )
+    assert populated["storage_size_bytes"] == 1000
+    assert populated["total_storage_size_bytes"] == 2000
 
+    nulled = chts.ch_call_dict_to_call_schema_dict(
+        {**base, "storage_size_bytes": None, "total_storage_size_bytes": None}
+    )
+    assert nulled["storage_size_bytes"] is None
+    assert nulled["total_storage_size_bytes"] is None
 
-def test_clickhouse_storage_size_null_handling():
-    """Test that NULL values in storage size fields are handled correctly in ClickHouse."""
-    # Test data with NULL values and proper datetime structures
-    started_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    ended_at = datetime(2024, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
-    test_data = {
-        "storage_size_bytes": None,
-        "total_storage_size_bytes": None,
-        "id": "test_id",
-        "name": "test_name",
-        "project_id": "test_project",
-        "trace_id": "test_trace",
-        "parent_id": None,
-        "started_at": started_at,
-        "ended_at": ended_at,
-        "inputs": {},
-        "outputs": {},
-        "error": None,
-        "summary": None,
-        "summary_dump": None,
-        "cost": None,
-        "wb_run_id": None,
-        "wb_run_step": None,
-        "wb_user_id": None,
-    }
-
-    # Test ClickHouse conversion
-    ch_schema = chts.ch_call_dict_to_call_schema_dict(test_data)
-    assert ch_schema["storage_size_bytes"] is None
-    assert ch_schema["total_storage_size_bytes"] is None
-
-
-def test_clickhouse_expire_at_sentinel_converts_to_none():
-    """The DB far-future expire_at sentinel is hidden at the API boundary."""
-    started_at = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-    test_data = {
-        "storage_size_bytes": None,
-        "total_storage_size_bytes": None,
-        "id": "test_id",
-        "project_id": "test_project",
-        "trace_id": "test_trace",
-        "parent_id": None,
-        "started_at": started_at,
-        "ended_at": None,
-        "summary_dump": None,
-        "wb_run_id": None,
-        "wb_run_step": None,
-        "wb_user_id": None,
-        "expire_at": EXPIRE_AT_NEVER,
-    }
-
-    ch_schema = chts.ch_call_dict_to_call_schema_dict(test_data)
-
-    assert ch_schema["expire_at"] is None
+    sentinel = chts.ch_call_dict_to_call_schema_dict(
+        {
+            **base,
+            "ended_at": None,
+            "storage_size_bytes": None,
+            "total_storage_size_bytes": None,
+            "expire_at": EXPIRE_AT_NEVER,
+        }
+    )
+    assert sentinel["expire_at"] is None
 
 
 def test_ch_call_to_row_sentinelizes_expire_at_for_v1_insert_paths():

--- a/tests/trace_server/test_clickhouse_trace_server_migrator.py
+++ b/tests/trace_server/test_clickhouse_trace_server_migrator.py
@@ -449,25 +449,27 @@ def test_initialize_migration_db_adds_heartbeat_column():
     )
 
 
-def test_execute_migration_command(migrator):
-    # Setup
+def test_execute_migration_command_non_replicated(migrator):
+    """Non-replicated mode passes SQL through verbatim and restores the original DB."""
     migrator.ch_client.database = "original_db"
 
-    # Execute
+    # Plain DDL is executed as-is and the client DB is restored afterward.
     migrator._execute_migration_command("test_db", "CREATE TABLE test (id Int32)")
-
-    # Verify
-    assert (
-        migrator.ch_client.database == "original_db"
-    )  # Should restore original database
+    assert migrator.ch_client.database == "original_db"
     migrator.ch_client.command.assert_called_once_with("CREATE TABLE test (id Int32)")
+    migrator.ch_client.command.reset_mock()
 
-
-def test_migration_non_replicated(migrator):
-    # Test that non-replicated mode doesn't transform the SQL
+    # MergeTree engine is not rewritten to ReplicatedMergeTree in non-replicated mode.
     orig = "CREATE TABLE test (id String, project_id String) ENGINE = MergeTree ORDER BY (project_id, id);"
     migrator._execute_migration_command("test_db", orig)
     migrator.ch_client.command.assert_called_once_with(orig)
+    migrator.ch_client.command.reset_mock()
+
+    # Table names are preserved (no _local suffix) in non-replicated mode.
+    no_semicolon = "CREATE TABLE test (id Int32) ENGINE = MergeTree"
+    migrator._execute_migration_command("test_db", no_semicolon)
+    assert migrator.ch_client.command.call_count == 1
+    assert migrator.ch_client.command.call_args_list[0][0][0] == no_semicolon
 
 
 def test_update_migration_status(migrator):
@@ -736,10 +738,15 @@ def test_replicated_engine_discovery_wait_and_timeout(mock_sleep):
             "CREATE TABLE test (id Int32) ENGINE = Log",
             "CREATE TABLE test (id Int32) ENGINE = Log",
         ),
+        # Idempotent: an already-replicated engine is not double-transformed.
+        (
+            "CREATE TABLE test (id Int32) ENGINE = ReplicatedMergeTree",
+            "CREATE TABLE test (id Int32) ENGINE = ReplicatedMergeTree",
+        ),
     ],
 )
 def test_format_replicated_sql(input_sql, expected_sql):
-    """Test MergeTree engine replacement with ReplicatedMergeTree."""
+    """MergeTree engines become ReplicatedMergeTree; non-MergeTree and already-replicated are unchanged."""
     replicated_migrator = ReplicatedClickHouseTraceServerMigrator(
         _make_ch_client(),
         replicated_cluster="test_cluster",
@@ -749,12 +756,14 @@ def test_format_replicated_sql(input_sql, expected_sql):
 
 
 def test_format_replicated_sql_distributed():
-    """Test replicated SQL formatting in distributed mode with explicit paths."""
+    """Distributed ZK paths: bare engine, engine args merged in, and no-arg engine."""
     distributed_migrator = DistributedClickHouseTraceServerMigrator(
         _make_ch_client(),
         replicated_cluster="test_cluster",
         migration_dir=DEFAULT_MIGRATION_DIR,
     )
+
+    # Bare MergeTree gets the ZK path + replica params.
     result = distributed_migrator._format_replicated_sql_distributed(
         "CREATE TABLE test (id Int32) ENGINE = MergeTree", "test_db"
     )
@@ -763,14 +772,7 @@ def test_format_replicated_sql_distributed():
         in result
     )
 
-
-def test_format_replicated_sql_distributed_with_engine_args():
-    """Test that engine args like (created_at) are merged into the ZK path params."""
-    distributed_migrator = DistributedClickHouseTraceServerMigrator(
-        _make_ch_client(),
-        replicated_cluster="test_cluster",
-        migration_dir=DEFAULT_MIGRATION_DIR,
-    )
+    # Engine args like (created_at) are appended after the ZK path params.
     result = distributed_migrator._format_replicated_sql_distributed(
         "CREATE TABLE test (id Int32) ENGINE = ReplacingMergeTree(created_at)",
         "test_db",
@@ -780,7 +782,7 @@ def test_format_replicated_sql_distributed_with_engine_args():
         in result
     )
 
-    # AggregatingMergeTree() should not get extra args
+    # AggregatingMergeTree() should not get extra args.
     result = distributed_migrator._format_replicated_sql_distributed(
         "CREATE TABLE test (id Int32) ENGINE = AggregatingMergeTree()", "test_db"
     )
@@ -829,24 +831,19 @@ def test_rename_table_to_local(sql, table_name, expected_sql):
 
 
 def test_create_distributed_table_sql():
-    """Test distributed table creation SQL."""
+    """Distributed table SQL: rand() sharding by default, sipHash64(trace_id) for ID-sharded."""
     distributed_migrator = DistributedClickHouseTraceServerMigrator(
         _make_ch_client(),
         replicated_cluster="test_cluster",
         migration_dir=DEFAULT_MIGRATION_DIR,
     )
+
+    # Plain table: random sharding.
     sql = distributed_migrator._create_distributed_table_sql("test")
     expected = "CREATE TABLE IF NOT EXISTS test ON CLUSTER test_cluster\n        AS test_local\n        ENGINE = Distributed(test_cluster, currentDatabase(), test_local, rand())"
     assert sql.strip() == expected.strip()
 
-
-def test_create_distributed_table_sql_id_sharded():
-    """Test distributed table creation SQL for ID-sharded tables (default: trace_id)."""
-    distributed_migrator = DistributedClickHouseTraceServerMigrator(
-        _make_ch_client(),
-        replicated_cluster="test_cluster",
-        migration_dir=DEFAULT_MIGRATION_DIR,
-    )
+    # ID-sharded table (default key trace_id): sipHash64(trace_id).
     sql = distributed_migrator._create_distributed_table_sql("calls_complete")
     expected = """
         CREATE TABLE IF NOT EXISTS calls_complete ON CLUSTER test_cluster
@@ -961,29 +958,33 @@ def test_execute_migration_command_with_alter(replicated_migrator):
 
 
 def test_execute_migration_command_with_alter_distributed(distributed_migrator):
-    distributed_migrator._execute_migration_command(
-        "test_db", "ALTER TABLE test ADD COLUMN x Int32"
-    )
-
-    # Should execute ALTER on both local and distributed tables
-    assert distributed_migrator.ch_client.command.call_count == 2
-    assert distributed_migrator.ch_client.database == "original_db"
-
-    # First call: ALTER local table
-    local_alter_sql = distributed_migrator.ch_client.command.call_args_list[0][0][0]
-    assert (
-        local_alter_sql
-        == "ALTER TABLE test_local ON CLUSTER test_cluster ADD COLUMN x Int32"
-    )
-
-    # Second call: ALTER distributed table
-    distributed_alter_sql = distributed_migrator.ch_client.command.call_args_list[1][0][
-        0
+    """ALTER on a distributed table fans out to local then distributed, including complex column types."""
+    cases = [
+        (
+            "ALTER TABLE test ADD COLUMN x Int32",
+            "ALTER TABLE test_local ON CLUSTER test_cluster ADD COLUMN x Int32",
+            "ALTER TABLE test ON CLUSTER test_cluster ADD COLUMN x Int32",
+        ),
+        (
+            "ALTER TABLE object_versions ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL",
+            "ALTER TABLE object_versions_local ON CLUSTER test_cluster ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL",
+            "ALTER TABLE object_versions ON CLUSTER test_cluster ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL",
+        ),
     ]
-    assert (
-        distributed_alter_sql
-        == "ALTER TABLE test ON CLUSTER test_cluster ADD COLUMN x Int32"
-    )
+    for command, expected_local, expected_distributed in cases:
+        distributed_migrator._execute_migration_command("test_db", command)
+
+        # Both the local and distributed tables are altered with ON CLUSTER.
+        assert distributed_migrator.ch_client.command.call_count == 2
+        assert distributed_migrator.ch_client.database == "original_db"
+        local_alter_sql = distributed_migrator.ch_client.command.call_args_list[0][0][0]
+        assert local_alter_sql == expected_local
+        distributed_alter_sql = distributed_migrator.ch_client.command.call_args_list[
+            1
+        ][0][0]
+        assert distributed_alter_sql == expected_distributed
+
+        distributed_migrator.ch_client.command.reset_mock()
 
 
 @pytest.mark.parametrize(
@@ -1028,34 +1029,6 @@ def test_distributed_requires_replicated():
         )
 
 
-def test_format_replicated_sql_idempotent():
-    """Test that formatting is idempotent (doesn't double-transform)."""
-    replicated_migrator = ReplicatedClickHouseTraceServerMigrator(
-        _make_ch_client(),
-        replicated_cluster="test_cluster",
-        migration_dir=DEFAULT_MIGRATION_DIR,
-    )
-    sql = "CREATE TABLE test (id Int32) ENGINE = MergeTree"
-    formatted_once = replicated_migrator._format_replicated_sql(sql)
-    expected = "CREATE TABLE test (id Int32) ENGINE = ReplicatedMergeTree"
-    assert formatted_once == expected
-
-    formatted_twice = replicated_migrator._format_replicated_sql(formatted_once)
-    assert formatted_twice == expected
-
-
-def test_non_replicated_preserves_table_names(migrator):
-    migrator.ch_client.database = "original_db"
-
-    migrator._execute_migration_command(
-        "test_db", "CREATE TABLE test (id Int32) ENGINE = MergeTree"
-    )
-
-    assert migrator.ch_client.command.call_count == 1
-    call_sql = migrator.ch_client.command.call_args_list[0][0][0]
-    assert call_sql == "CREATE TABLE test (id Int32) ENGINE = MergeTree"
-
-
 @pytest.mark.parametrize(
     ("input_sql", "expected_sql"),
     [
@@ -1094,10 +1067,18 @@ def test_non_replicated_preserves_table_names(migrator):
             "RENAME TABLE foo TO bar",
             "RENAME TABLE foo TO bar ON CLUSTER test_cluster",
         ),
+        # Idempotent: already has ON CLUSTER -> unchanged.
+        (
+            "ALTER TABLE test ON CLUSTER existing_cluster ADD COLUMN x Int32",
+            "ALTER TABLE test ON CLUSTER existing_cluster ADD COLUMN x Int32",
+        ),
+        # Non-DDL statements are never modified.
+        ("INSERT INTO test VALUES (1)", "INSERT INTO test VALUES (1)"),
+        ("SELECT * FROM test", "SELECT * FROM test"),
     ],
 )
 def test_add_on_cluster_clause(input_sql, expected_sql):
-    """Test that ON CLUSTER clause is added correctly to various DDL statements."""
+    """ON CLUSTER is added to DDL, left off when already present, and never on non-DDL."""
     replicated_migrator = ReplicatedClickHouseTraceServerMigrator(
         _make_ch_client(),
         replicated_cluster="test_cluster",
@@ -1105,32 +1086,6 @@ def test_add_on_cluster_clause(input_sql, expected_sql):
     )
     result = replicated_migrator._add_on_cluster_clause(input_sql)
     assert result == expected_sql
-
-
-def test_add_on_cluster_clause_idempotent():
-    """Test that ON CLUSTER clause addition is idempotent."""
-    replicated_migrator = ReplicatedClickHouseTraceServerMigrator(
-        _make_ch_client(),
-        replicated_cluster="test_cluster",
-        migration_dir=DEFAULT_MIGRATION_DIR,
-    )
-    already_formatted = (
-        "ALTER TABLE test ON CLUSTER existing_cluster ADD COLUMN x Int32"
-    )
-    result = replicated_migrator._add_on_cluster_clause(already_formatted)
-    # Should not modify if already has ON CLUSTER
-    assert result == already_formatted
-
-
-def test_add_on_cluster_clause_non_ddl():
-    """Test that non-DDL statements are not modified."""
-    replicated_migrator = ReplicatedClickHouseTraceServerMigrator(
-        _make_ch_client(),
-        replicated_cluster="test_cluster",
-        migration_dir=DEFAULT_MIGRATION_DIR,
-    )
-    for sql in ["INSERT INTO test VALUES (1)", "SELECT * FROM test"]:
-        assert replicated_migrator._add_on_cluster_clause(sql) == sql
 
 
 def test_execute_views_in_replicated_and_distributed_modes(
@@ -1212,34 +1167,6 @@ def test_extract_alter_table_name(sql, expected_table):
     """Test extracting table name from ALTER TABLE statements."""
     result = DistributedClickHouseTraceServerMigrator._extract_alter_table_name(sql)
     assert result == expected_table
-
-
-def test_alter_distributed_with_multiple_columns(distributed_migrator):
-    """Test that ALTER TABLE with multiple operations works correctly in distributed mode."""
-    distributed_migrator._execute_migration_command(
-        "test_db",
-        "ALTER TABLE object_versions ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL",
-    )
-
-    # Should execute ALTER on both local and distributed tables
-    assert distributed_migrator.ch_client.command.call_count == 2
-    assert distributed_migrator.ch_client.database == "original_db"
-
-    # First call: ALTER local table
-    local_alter_sql = distributed_migrator.ch_client.command.call_args_list[0][0][0]
-    assert (
-        local_alter_sql
-        == "ALTER TABLE object_versions_local ON CLUSTER test_cluster ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL"
-    )
-
-    # Second call: ALTER distributed table
-    distributed_alter_sql = distributed_migrator.ch_client.command.call_args_list[1][0][
-        0
-    ]
-    assert (
-        distributed_alter_sql
-        == "ALTER TABLE object_versions ON CLUSTER test_cluster ADD COLUMN deleted_at Nullable(DateTime64(3)) DEFAULT NULL"
-    )
 
 
 @pytest.mark.parametrize(
@@ -1367,7 +1294,8 @@ def test_insert_command_distributed(distributed_migrator):
 
 
 def test_rename_table_distributed(distributed_migrator):
-    """Test RENAME TABLE in distributed mode renames local, drops old distributed, creates new."""
+    """RENAME in distributed mode renames local, drops old distributed, recreates with the right shard key."""
+    # Rename away from an ID-sharded name: local rename, drop old distributed, recreate.
     distributed_migrator._execute_migration_command(
         "test_db", "RENAME TABLE calls_complete TO calls_complete_old"
     )
@@ -1375,46 +1303,48 @@ def test_rename_table_distributed(distributed_migrator):
     assert distributed_migrator.ch_client.command.call_count == 3
     assert distributed_migrator.ch_client.database == "original_db"
 
-    # 1. Rename local table
     rename_sql = distributed_migrator.ch_client.command.call_args_list[0][0][0]
     assert (
         rename_sql
         == "RENAME TABLE calls_complete_local TO calls_complete_old_local ON CLUSTER test_cluster"
     )
-
-    # 2. Drop old distributed table
     drop_sql = distributed_migrator.ch_client.command.call_args_list[1][0][0]
     assert drop_sql == "DROP TABLE IF EXISTS calls_complete ON CLUSTER test_cluster"
-
-    # 3. Create new distributed table
     create_sql = distributed_migrator.ch_client.command.call_args_list[2][0][0]
     assert "calls_complete_old" in create_sql
     assert "ON CLUSTER test_cluster" in create_sql
     assert "Distributed" in create_sql
     assert "calls_complete_old_local" in create_sql
 
+    distributed_migrator.ch_client.command.reset_mock()
 
-def test_rename_table_distributed_picks_up_shard_key(distributed_migrator):
-    """Test that RENAME TABLE to a name in ID_SHARDED_TABLES uses the correct shard key."""
+    # Rename INTO an ID_SHARDED_TABLES name: new distributed table picks up sipHash64(trace_id).
     distributed_migrator._execute_migration_command(
         "test_db", "RENAME TABLE calls_complete_new TO calls_complete"
     )
-
     assert distributed_migrator.ch_client.command.call_count == 3
-
-    # The new distributed table should use sipHash64(trace_id) for calls_complete
     create_sql = distributed_migrator.ch_client.command.call_args_list[2][0][0]
     assert "sipHash64(trace_id)" in create_sql
     assert "calls_complete_local" in create_sql
 
 
-def test_rename_table_replicated(replicated_migrator):
-    """Test RENAME TABLE in replicated mode adds ON CLUSTER at the end."""
-    replicated_migrator._execute_migration_command("test_db", "RENAME TABLE foo TO bar")
-
-    assert replicated_migrator.ch_client.command.call_count == 1
-    call_sql = replicated_migrator.ch_client.command.call_args_list[0][0][0]
-    assert call_sql == "RENAME TABLE foo TO bar ON CLUSTER test_cluster"
+def test_rename_and_drop_table_replicated(replicated_migrator):
+    """RENAME and DROP in replicated mode emit a single command with ON CLUSTER appended."""
+    cases = [
+        ("RENAME TABLE foo TO bar", "RENAME TABLE foo TO bar ON CLUSTER test_cluster"),
+        (
+            "DROP TABLE IF EXISTS my_table",
+            "DROP TABLE IF EXISTS my_table ON CLUSTER test_cluster",
+        ),
+    ]
+    for command, expected_sql in cases:
+        replicated_migrator._execute_migration_command("test_db", command)
+        assert replicated_migrator.ch_client.command.call_count == 1
+        assert (
+            replicated_migrator.ch_client.command.call_args_list[0][0][0]
+            == expected_sql
+        )
+        replicated_migrator.ch_client.command.reset_mock()
 
 
 def test_drop_table_distributed(distributed_migrator):
@@ -1431,17 +1361,6 @@ def test_drop_table_distributed(distributed_migrator):
 
     distributed_sql = distributed_migrator.ch_client.command.call_args_list[1][0][0]
     assert "DROP TABLE IF EXISTS my_table ON CLUSTER test_cluster" == distributed_sql
-
-
-def test_drop_table_replicated(replicated_migrator):
-    """Test DROP TABLE in replicated mode adds ON CLUSTER."""
-    replicated_migrator._execute_migration_command(
-        "test_db", "DROP TABLE IF EXISTS my_table"
-    )
-
-    assert replicated_migrator.ch_client.command.call_count == 1
-    call_sql = replicated_migrator.ch_client.command.call_args_list[0][0][0]
-    assert call_sql == "DROP TABLE IF EXISTS my_table ON CLUSTER test_cluster"
 
 
 def test_ddl_adapts_to_database_engine(replicated_migrator, distributed_migrator):
@@ -1555,9 +1474,12 @@ def test_execute_migration_command_restores_database_on_error(
         migrator.ch_client.command.side_effect = None
 
 
-def test_index_operations_only_on_local_tables_distributed(distributed_migrator):
-    """Test that ADD/DROP INDEX operations are only applied to local tables in distributed mode."""
+def test_index_and_ttl_operations_only_on_local_tables_distributed(
+    distributed_migrator,
+):
+    """ADD/DROP INDEX and MODIFY/REMOVE TTL hit only the local table in distributed mode."""
     test_cases = [
+        # ADD/DROP INDEX
         (
             "ALTER TABLE calls_merged ADD INDEX idx_sortable_datetime (sortable_datetime) TYPE minmax GRANULARITY 1",
             "ALTER TABLE calls_merged_local ON CLUSTER test_cluster ADD INDEX idx_sortable_datetime (sortable_datetime) TYPE minmax GRANULARITY 1",
@@ -1566,26 +1488,7 @@ def test_index_operations_only_on_local_tables_distributed(distributed_migrator)
             "ALTER TABLE calls_merged DROP INDEX IF EXISTS idx_sortable_datetime",
             "ALTER TABLE calls_merged_local ON CLUSTER test_cluster DROP INDEX IF EXISTS idx_sortable_datetime",
         ),
-    ]
-
-    for command, expected_local_sql in test_cases:
-        distributed_migrator._execute_migration_command("test_db", command)
-
-        # Should only execute ALTER on local table (1 command, not 2)
-        assert distributed_migrator.ch_client.command.call_count == 1
-        assert distributed_migrator.ch_client.database == "original_db"
-
-        # Verify it was applied to the local table
-        local_alter_sql = distributed_migrator.ch_client.command.call_args_list[0][0][0]
-        assert local_alter_sql == expected_local_sql
-
-        # Reset for next test case
-        distributed_migrator.ch_client.command.reset_mock()
-
-
-def test_ttl_operations_only_on_local_tables_distributed(distributed_migrator):
-    """Test that MODIFY TTL and REMOVE TTL are only applied to local tables in distributed mode."""
-    test_cases = [
+        # MODIFY/REMOVE TTL
         (
             "ALTER TABLE call_parts MODIFY TTL toDateTime(expire_at) DELETE",
             "ALTER TABLE call_parts_local ON CLUSTER test_cluster MODIFY TTL toDateTime(expire_at) DELETE",
@@ -1603,15 +1506,12 @@ def test_ttl_operations_only_on_local_tables_distributed(distributed_migrator):
     for command, expected_local_sql in test_cases:
         distributed_migrator._execute_migration_command("test_db", command)
 
-        # Should only execute ALTER on local table (1 command, not 2)
+        # Only the local table is altered (1 command, not 2).
         assert distributed_migrator.ch_client.command.call_count == 1
         assert distributed_migrator.ch_client.database == "original_db"
-
-        # Verify it was applied to the local table
         local_alter_sql = distributed_migrator.ch_client.command.call_args_list[0][0][0]
         assert local_alter_sql == expected_local_sql
 
-        # Reset for next test case
         distributed_migrator.ch_client.command.reset_mock()
 
 

--- a/tests/trace_server/test_clickhouse_utilities.py
+++ b/tests/trace_server/test_clickhouse_utilities.py
@@ -47,38 +47,30 @@ def test_sanitize_invalid_utf8_surrogates_replaces_lone_surrogates() -> None:
     str(sanitized).encode("utf-8")
 
 
-def test_insert_does_not_sanitize_successful_clean_clickhouse_write() -> None:
-    # Clean inserts should stay on the old hot path: no recursive sanitation
-    # unless clickhouse_connect first reports an encoding failure.
-    data = [["valid \U0001f600"]]
-    mock_ch_client = MagicMock()
-    mock_ch_client.insert.return_value = MagicMock()
+def test_insert_sanitizes_only_after_encode_error() -> None:
+    # Clean inserts stay on the hot path with no sanitation; a UnicodeEncodeError
+    # (direct string columns like `exception`/`display_name` bypass JSON dumps)
+    # triggers exactly one sanitized retry of the same batch.
+    clean_data = [["valid \U0001f600"]]
+    clean_client = MagicMock()
+    clean_client.insert.return_value = MagicMock()
 
     with patch.object(
-        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+        chts.ClickHouseTraceServer, "_mint_client", return_value=clean_client
     ):
         server = chts.ClickHouseTraceServer(host="test_host")
-        server._insert(
-            "call_parts",
-            data=data,
-            column_names=["valid"],
-        )
+        server._insert("call_parts", data=clean_data, column_names=["valid"])
 
-    inserted_data = mock_ch_client.insert.call_args.kwargs["data"]
-    assert inserted_data is data
+    assert clean_client.insert.call_args.kwargs["data"] is clean_data
 
-
-def test_insert_sanitizes_invalid_utf8_surrogates_after_encode_error() -> None:
-    # Direct string columns like `exception` or `display_name` bypass JSON dumps,
-    # so a UnicodeEncodeError should trigger one sanitized retry of the same batch.
-    mock_ch_client = MagicMock()
-    mock_ch_client.insert.side_effect = [
+    retry_client = MagicMock()
+    retry_client.insert.side_effect = [
         UnicodeEncodeError("utf-8", "broken \ud83d", 7, 8, "surrogates not allowed"),
         MagicMock(),
     ]
 
     with patch.object(
-        chts.ClickHouseTraceServer, "_mint_client", return_value=mock_ch_client
+        chts.ClickHouseTraceServer, "_mint_client", return_value=retry_client
     ):
         server = chts.ClickHouseTraceServer(host="test_host")
         server._insert(
@@ -87,10 +79,9 @@ def test_insert_sanitizes_invalid_utf8_surrogates_after_encode_error() -> None:
             column_names=["valid", "broken"],
         )
 
-    first_insert = mock_ch_client.insert.call_args_list[0].kwargs["data"]
-    retried_insert = mock_ch_client.insert.call_args_list[1].kwargs["data"]
+    first_insert = retry_client.insert.call_args_list[0].kwargs["data"]
+    retried_insert = retry_client.insert.call_args_list[1].kwargs["data"]
     assert first_insert == [["valid \U0001f600", "broken \ud83d"]]
     assert retried_insert is not first_insert
-    inserted_data = retried_insert
-    assert inserted_data == [["valid \U0001f600", "broken \ufffd"]]
-    str(inserted_data).encode("utf-8")
+    assert retried_insert == [["valid \U0001f600", "broken \ufffd"]]
+    str(retried_insert).encode("utf-8")

--- a/tests/trace_server/test_container_management.py
+++ b/tests/trace_server/test_container_management.py
@@ -15,7 +15,9 @@ def _mock_client_with_get_side_effect(side_effect):
 
 
 @patch("tests.trace_server.conftest_lib.container_management.time.sleep")
-def test_check_server_health_retries_transient_httpx_errors_and_statuses(mock_sleep):
+def test_check_server_health_retries_recovers_and_reports_last_error(
+    mock_sleep, capsys
+):
     # Transient protocol error during startup, then success.
     client_factory = _mock_client_with_get_side_effect(
         [
@@ -46,9 +48,9 @@ def test_check_server_health_retries_transient_httpx_errors_and_statuses(mock_sl
         assert _check_server_health("http://localhost:8123/", "ping", num_retries=2)
     assert mock_sleep.call_count == 1
 
+    mock_sleep.reset_mock()
 
-@patch("tests.trace_server.conftest_lib.container_management.time.sleep")
-def test_check_server_health_reports_last_httpx_error(mock_sleep, capsys):
+    # Exhausting retries returns False and reports the last error.
     client_factory = _mock_client_with_get_side_effect(
         [
             httpx.RemoteProtocolError("server disconnected without sending a response"),

--- a/tests/trace_server/test_custom_provider.py
+++ b/tests/trace_server/test_custom_provider.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import datetime
 from unittest.mock import patch
 
+import pytest
 from litellm.types.utils import ModelResponse
 
 from weave.trace.settings import override_settings
@@ -249,58 +250,103 @@ def test_custom_provider_model_classes():
     )
 
 
-def test_custom_provider_completions_create(client):
-    """Test the completions_create endpoint with a custom provider.
+@pytest.mark.parametrize(
+    (
+        "provider_id_prefix",
+        "model_id",
+        "model_name_part",
+        "base_url",
+        "api_key_name",
+        "extra_headers",
+        "response_model_name",
+        "expected_litellm_model",
+        "expected_api_base",
+    ),
+    [
+        # openai provider with custom extra headers and default base_url.
+        (
+            "test-provider",
+            "test-model",
+            "test-model",
+            "https://api.example.com",
+            "EXAMPLE_API_KEY",
+            {"X-Custom-Header": "value"},
+            None,
+            "openai/test-model",
+            "https://api.example.com",
+        ),
+        # ollama model gets the ollama/ prefix instead of openai/.
+        (
+            "test-ollama",
+            "llama2",
+            "llama2",
+            "http://my-ollama-server.example.com:11434",
+            "OLLAMA_API_KEY",
+            {},
+            "ollama/llama2",
+            "ollama/llama2",
+            "http://my-ollama-server.example.com:11434",
+        ),
+        # trailing slash in base_url is stripped to avoid redirect-induced POST->GET.
+        (
+            "test-trailing-slash",
+            "test-model",
+            "test-model",
+            "http://my-ollama-server.example.com:11434/",
+            "TEST_API_KEY",
+            {},
+            None,
+            "openai/test-model",
+            "http://my-ollama-server.example.com:11434",
+        ),
+    ],
+    ids=["openai", "ollama", "trailing-slash"],
+)
+def test_custom_provider_completions_create(
+    client,
+    provider_id_prefix,
+    model_id,
+    model_name_part,
+    base_url,
+    api_key_name,
+    extra_headers,
+    response_model_name,
+    expected_litellm_model,
+    expected_api_base,
+):
+    """Test the completions_create endpoint across custom provider variants.
 
-    This test verifies the complete flow of creating a completion using a custom provider:
-    1. Provider and model object creation with correct configuration
-    2. Proper request handling and parameter passing to LiteLLM
-    3. Response transformation and validation
-    4. Usage tracking and logging of the completion call
-
-    The test mocks:
-    - Object read operations to simulate provider/model configuration
-    - LiteLLM completion call to simulate API response
-    - Secret fetching for API keys
-
-    Args:
-        client: The test client fixture providing access to the completion endpoint
+    Verifies the full flow (provider/model config, litellm param passing, response
+    transformation, span creation) for: openai prefixing with extra headers, ollama
+    prefixing, and trailing-slash normalization in base_url.
     """
-    # Create unique provider ID and model ID for test isolation
-    provider_id = f"test-provider-{uuid.uuid4()}"
-    model_id = "test-model"
+    provider_id = f"{provider_id_prefix}-{uuid.uuid4()}"
     model_name = f"custom::{provider_id}::{model_id}"
 
-    # Create a Provider object with test configuration
     provider_obj = create_provider_obj(
         project_id=client.project_id,
         provider_id=provider_id,
-        extra_headers={"X-Custom-Header": "value"},
+        base_url=base_url,
+        api_key_name=api_key_name,
+        extra_headers=extra_headers,
     )
-
-    # Create a ProviderModel object with test configuration
     provider_model_obj = create_provider_model_obj(
         project_id=client.project_id,
         provider_id=provider_id,
         model_id=model_id,
-        model_name=model_id,  # Use the actual model name part only
+        model_name=model_name_part,
     )
-
-    # Mock responses for obj_read calls to return our test configurations
     mock_obj_read = create_mock_obj_read(provider_obj, provider_model_obj)
 
-    # Create test input with a simple chat message
     inputs = {
         "model": model_name,
         "messages": [{"role": "user", "content": "Hello, world!"}],
     }
+    mock_response = create_mock_completion_response(
+        model_name=response_model_name or model_name
+    )
 
-    # Mock response from LiteLLM to simulate successful API call
-    mock_response = create_mock_completion_response(model_name=model_name)
-
-    # Run test with tracing disabled to avoid interference
     with override_settings(disabled=True):
-        # Set up the secret fetcher
         mock_secret_fetcher, token = setup_test_environment()
         try:
             with patch(
@@ -311,7 +357,6 @@ def test_custom_provider_completions_create(client):
                     mock_completion.return_value = ModelResponse.model_validate(
                         mock_response
                     )
-
                     res = client.server.completions_create(
                         tsi.CompletionsCreateReq.model_validate(
                             {
@@ -321,17 +366,12 @@ def test_custom_provider_completions_create(client):
                         )
                     )
 
-            # Verify the response matches our mock
             assert res.response == mock_response, (
                 f"Response mismatch. Expected {mock_response}, got {res.response}"
             )
 
-            # Verify LiteLLM was called with correct parameters
             mock_completion.assert_called_once()
             call_args = mock_completion.call_args[1]
-            expected_litellm_model = (
-                f"openai/{model_id}"  # Implementation prefixes with "openai/"
-            )
             assert call_args["model"] == expected_litellm_model, (
                 f"Model name mismatch. Expected '{expected_litellm_model}', got '{call_args['model']}'"
             )
@@ -343,171 +383,19 @@ def test_custom_provider_completions_create(client):
                 f"API key mismatch. Expected 'DUMMY_SECRET_VALUE', "
                 f"got '{call_args['api_key']}'"
             )
-            assert call_args["api_base"] == "https://api.example.com", (
-                f"API base URL mismatch. Expected 'https://api.example.com', "
+            assert call_args["api_base"] == expected_api_base, (
+                f"API base URL mismatch. Expected '{expected_api_base}', "
                 f"got '{call_args['api_base']}'"
             )
-            assert call_args["extra_headers"] == {"X-Custom-Header": "value"}, (
-                f"Extra headers mismatch. Expected {{'X-Custom-Header': 'value'}}, "
+            assert call_args["extra_headers"] == extra_headers, (
+                f"Extra headers mismatch. Expected {extra_headers}, "
                 f"got {call_args['extra_headers']}"
             )
 
-            # Completions now write to the spans table, not calls.
-            # Verify the span was created with correct identifiers.
+            # Completions write to the spans table; verify span identifiers exist.
             assert res.weave_call_id is not None, "Expected a span_id in response"
             assert res.span_id is not None, "Expected span_id in response"
             assert res.trace_id is not None, "Expected trace_id in response"
-        finally:
-            _secret_fetcher_context.reset(token)
-
-
-def test_custom_provider_ollama_model(client):
-    """Test handling of ollama models that need special prefixing."""
-    # Create provider ID and model ID for testing
-    provider_id = f"test-ollama-{uuid.uuid4()}"
-    model_id = "llama2"
-    model_name = f"custom::{provider_id}::{model_id}"
-
-    # Create a Provider object with Ollama-specific configuration
-    provider_obj = create_provider_obj(
-        project_id=client.project_id,
-        provider_id=provider_id,
-        base_url="http://my-ollama-server.example.com:11434",
-        api_key_name="OLLAMA_API_KEY",
-        extra_headers={},
-    )
-
-    # Create a ProviderModel object with Ollama-specific configuration
-    provider_model_obj = create_provider_model_obj(
-        project_id=client.project_id,
-        provider_id=provider_id,
-        model_id=model_id,
-        model_name="llama2",  # Note: this will be prefixed with ollama/
-    )
-
-    # Mock responses for obj_read calls
-    mock_obj_read = create_mock_obj_read(provider_obj, provider_model_obj)
-
-    # Create test input
-    inputs = {
-        "model": model_name,
-        "messages": [{"role": "user", "content": "Hello, world!"}],
-    }
-
-    # Mock response from LiteLLM with Ollama-specific details
-    mock_response = create_mock_completion_response(
-        model_name="ollama/llama2",
-        content="Hello from Ollama!",
-        completion_tokens=4,
-        prompt_tokens=11,
-    )
-
-    with override_settings(disabled=True):
-        # Set up the secret fetcher
-        mock_secret_fetcher, token = setup_test_environment()
-        try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
-                with patch("litellm.completion") as mock_completion:
-                    mock_completion.return_value = ModelResponse.model_validate(
-                        mock_response
-                    )
-                    res = client.server.completions_create(
-                        tsi.CompletionsCreateReq.model_validate(
-                            {
-                                "project_id": client.project_id,
-                                "inputs": inputs,
-                            }
-                        )
-                    )
-
-            # Verify the correct response is returned
-            assert res.response == mock_response
-
-            # Verify the litellm.completion was called with the right parameters
-            mock_completion.assert_called_once()
-            call_args = mock_completion.call_args[1]
-            assert call_args["model"] == "ollama/llama2"  # Should add ollama/ prefix
-            assert call_args["api_key"] == "DUMMY_SECRET_VALUE"
-            assert call_args["api_base"] == "http://my-ollama-server.example.com:11434"
-        finally:
-            _secret_fetcher_context.reset(token)
-
-
-def test_custom_provider_trailing_slash_normalization(client):
-    """Test that trailing slashes in base_url are stripped to prevent redirect issues.
-
-    When a base_url has a trailing slash, HTTP servers often redirect to the
-    canonical URL without the slash using 301/302. These redirects cause most
-    HTTP clients to change POST to GET, breaking the API call.
-
-    This test verifies that trailing slashes are stripped before making the request.
-    """
-    # Create provider ID and model ID for testing
-    provider_id = f"test-trailing-slash-{uuid.uuid4()}"
-    model_id = "test-model"
-    model_name = f"custom::{provider_id}::{model_id}"
-
-    # Create a Provider object with a trailing slash in base_url
-    provider_obj = create_provider_obj(
-        project_id=client.project_id,
-        provider_id=provider_id,
-        base_url="http://my-ollama-server.example.com:11434/",  # Note the trailing slash
-        api_key_name="TEST_API_KEY",
-        extra_headers={},
-    )
-
-    # Create a ProviderModel object
-    provider_model_obj = create_provider_model_obj(
-        project_id=client.project_id,
-        provider_id=provider_id,
-        model_id=model_id,
-        model_name=model_id,
-    )
-
-    # Mock responses for obj_read calls
-    mock_obj_read = create_mock_obj_read(provider_obj, provider_model_obj)
-
-    # Create test input
-    inputs = {
-        "model": model_name,
-        "messages": [{"role": "user", "content": "Hello, world!"}],
-    }
-
-    # Mock response from LiteLLM
-    mock_response = create_mock_completion_response(
-        model_name=model_id,
-        content="Hello!",
-    )
-
-    with override_settings(disabled=True):
-        mock_secret_fetcher, token = setup_test_environment()
-        try:
-            with patch(
-                "weave.trace_server.clickhouse_trace_server_batched.ClickHouseTraceServer.obj_read"
-            ) as mock_read:
-                mock_read.side_effect = mock_obj_read
-                with patch("litellm.completion") as mock_completion:
-                    mock_completion.return_value = ModelResponse.model_validate(
-                        mock_response
-                    )
-                    client.server.completions_create(
-                        tsi.CompletionsCreateReq.model_validate(
-                            {
-                                "project_id": client.project_id,
-                                "inputs": inputs,
-                            }
-                        )
-                    )
-
-            # Verify the trailing slash was stripped from api_base
-            mock_completion.assert_called_once()
-            call_args = mock_completion.call_args[1]
-            assert (
-                call_args["api_base"] == "http://my-ollama-server.example.com:11434"
-            ), f"Expected trailing slash to be stripped. Got '{call_args['api_base']}'"
         finally:
             _secret_fetcher_context.reset(token)
 

--- a/tests/trace_server/test_dataset_v2_api.py
+++ b/tests/trace_server/test_dataset_v2_api.py
@@ -10,507 +10,345 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 
 
-def test_dataset_create_basic(trace_server):
-    """Test creating a basic dataset object."""
-    project_id = f"{TEST_ENTITY}/test_dataset_create_basic"
+def test_dataset_create_shapes(trace_server):
+    """dataset_create across row shapes: with/without description, empty, large.
 
-    # Create a dataset
-    rows = [
-        {"id": 1, "value": "a"},
-        {"id": 2, "value": "b"},
-        {"id": 3, "value": "c"},
+    Every create returns a digest, echoes object_id, and starts at version 0.
+    """
+    project_id = f"{TEST_ENTITY}/test_dataset_create_shapes"
+    cases = [
+        (
+            "with_desc",
+            "A test dataset",
+            [{"id": 1, "value": "a"}, {"id": 2, "value": "b"}],
+        ),
+        ("no_desc", None, [{"x": 1, "y": 2}]),
+        ("empty_rows", "A dataset with no rows", []),
+        (
+            "large_rows",
+            "100 rows",
+            [{"id": i, "value": f"value_{i}"} for i in range(100)],
+        ),
     ]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="my_dataset",
-        description="A test dataset",
-        rows=rows,
+    for name, description, rows in cases:
+        res = trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id, name=name, description=description, rows=rows
+            )
+        )
+        assert res.digest is not None
+        assert res.object_id == name
+        assert res.version_index == 0
+
+
+def test_dataset_read_round_trip_and_not_found(trace_server):
+    """dataset_read returns full metadata and a `weave:///` rows reference (never
+    inline data); reading a missing dataset raises NotFoundError.
+    """
+    project_id = f"{TEST_ENTITY}/test_dataset_read"
+    create_res = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id,
+            name="people",
+            description="A dataset of people",
+            rows=[{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}],
+        )
     )
-    create_res = trace_server.dataset_create(create_req)
 
-    assert create_res.digest is not None
-    assert create_res.object_id == "my_dataset"
-    assert create_res.version_index == 0
-
-
-def test_dataset_create_without_description(trace_server):
-    """Test creating a dataset without providing a description."""
-    project_id = f"{TEST_ENTITY}/test_dataset_create_no_desc"
-
-    # Create a dataset without description
-    rows = [{"x": 1, "y": 2}]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="dataset_no_desc",
-        description=None,
-        rows=rows,
+    read_res = trace_server.dataset_read(
+        tsi.DatasetReadReq(
+            project_id=project_id, object_id="people", digest=create_res.digest
+        )
     )
-    create_res = trace_server.dataset_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "dataset_no_desc"
-    assert create_res.version_index == 0
-
-
-def test_dataset_read_basic(trace_server):
-    """Test reading a specific dataset object."""
-    project_id = f"{TEST_ENTITY}/test_dataset_read_basic"
-
-    # Create a dataset
-    rows = [
-        {"name": "Alice", "age": 30},
-        {"name": "Bob", "age": 25},
-    ]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="people",
-        description="A dataset of people",
-        rows=rows,
-    )
-    create_res = trace_server.dataset_create(create_req)
-
-    # Read the dataset back
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="people",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.dataset_read(read_req)
-
     assert read_res.object_id == "people"
     assert read_res.digest == create_res.digest
     assert read_res.version_index == 0
     assert read_res.name == "people"
     assert read_res.description == "A dataset of people"
     assert read_res.created_at is not None
-    # Verify rows is a string reference, not the actual data
+    # Rows are a reference, not the actual data.
     assert isinstance(read_res.rows, str)
     assert read_res.rows.startswith("weave:///")
 
-
-def test_dataset_read_not_found(trace_server):
-    """Test reading a non-existent dataset raises NotFoundError."""
-    project_id = f"{TEST_ENTITY}/test_dataset_read_not_found"
-
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="nonexistent_dataset",
-        digest="fake_digest_1234567890",
+    # Version-like digest "v0" resolves to the same first version (int parse path);
+    # a "v"-prefixed non-integer digest falls back to a digest lookup (NotFound).
+    by_version = trace_server.dataset_read(
+        tsi.DatasetReadReq(project_id=project_id, object_id="people", digest="v0")
     )
+    assert by_version.digest == create_res.digest
+    with pytest.raises(NotFoundError):
+        trace_server.dataset_read(
+            tsi.DatasetReadReq(
+                project_id=project_id, object_id="people", digest="vnotanint"
+            )
+        )
 
     with pytest.raises(NotFoundError):
-        trace_server.dataset_read(read_req)
-
-
-def test_dataset_list_basic(trace_server):
-    """Test listing all datasets in a project."""
-    project_id = f"{TEST_ENTITY}/test_dataset_list_basic"
-
-    # Create multiple datasets
-    dataset_names = ["dataset_a", "dataset_b", "dataset_c"]
-    for name in dataset_names:
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name=name,
-            description=f"Dataset {name}",
-            rows=[{"id": 1, "name": name}],
+        trace_server.dataset_read(
+            tsi.DatasetReadReq(
+                project_id=project_id,
+                object_id="nonexistent_dataset",
+                digest="fake_digest_1234567890",
+            )
         )
-        trace_server.dataset_create(create_req)
 
-    # List all datasets
-    list_req = tsi.DatasetListReq(project_id=project_id)
-    datasets = list(trace_server.dataset_list(list_req))
 
-    assert len(datasets) == 3
-    dataset_names_returned = {ds.name for ds in datasets}
-    assert dataset_names_returned == {"dataset_a", "dataset_b", "dataset_c"}
+def test_dataset_metadata_preserves_special_and_unicode(trace_server):
+    """Special characters and unicode in name/description survive the create ->
+    read round-trip; rows remain a reference.
+    """
+    project_id = f"{TEST_ENTITY}/test_dataset_special_unicode"
 
-    # Verify all datasets have rows references (not actual data)
-    for ds in datasets:
+    special_res = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id,
+            name="special_chars",
+            description='Dataset with "special" characters',
+            rows=[
+                {"text": "This has \"quotes\" and 'apostrophes'"},
+                {"text": "Line breaks:\n\tand tabs"},
+                {"text": "Unicode: 你好世界 🚀"},
+            ],
+        )
+    )
+    special_read = trace_server.dataset_read(
+        tsi.DatasetReadReq(
+            project_id=project_id, object_id="special_chars", digest=special_res.digest
+        )
+    )
+    assert special_read.name == "special_chars"
+    assert special_read.description == 'Dataset with "special" characters'
+    assert isinstance(special_read.rows, str)
+    assert special_read.rows.startswith("weave:///")
+
+    unicode_res = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id,
+            name="unicode_dataset",
+            description="Unicode greetings 🌍",
+            rows=[
+                {"language": "Chinese", "greeting": "你好世界"},
+                {"language": "Japanese", "greeting": "こんにちは"},
+                {"language": "Emoji", "greeting": "🚀 🌟 ✨"},
+            ],
+        )
+    )
+    unicode_read = trace_server.dataset_read(
+        tsi.DatasetReadReq(
+            project_id=project_id,
+            object_id="unicode_dataset",
+            digest=unicode_res.digest,
+        )
+    )
+    assert unicode_read.name == "unicode_dataset"
+    assert unicode_read.description == "Unicode greetings 🌍"
+    assert "🌍" in unicode_read.description
+
+
+def test_dataset_versioning_increments_and_distinct_digests(trace_server):
+    """Re-creating the same dataset name increments version_index and yields a
+    distinct digest per version.
+    """
+    project_id = f"{TEST_ENTITY}/test_dataset_versioning"
+    versions = [
+        trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id,
+                name="versioned_dataset",
+                description=f"Version {i}",
+                rows=[{"value": i}],
+            )
+        )
+        for i in range(3)
+    ]
+
+    assert [v.version_index for v in versions] == [0, 1, 2]
+    assert len({v.digest for v in versions}) == 3
+
+
+def test_dataset_list_pagination_and_empty(trace_server):
+    """dataset_list: empty project -> 0; basic list returns all names with rows
+    references; limit, offset, and limit+offset paginate without overlap.
+    """
+    empty_project = f"{TEST_ENTITY}/test_dataset_list_empty"
+    assert (
+        list(trace_server.dataset_list(tsi.DatasetListReq(project_id=empty_project)))
+        == []
+    )
+
+    # Basic list: three named datasets, each with a rows reference.
+    basic_project = f"{TEST_ENTITY}/test_dataset_list_basic"
+    for name in ("dataset_a", "dataset_b", "dataset_c"):
+        trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=basic_project,
+                name=name,
+                description=f"Dataset {name}",
+                rows=[{"id": 1, "name": name}],
+            )
+        )
+    basic = list(
+        trace_server.dataset_list(tsi.DatasetListReq(project_id=basic_project))
+    )
+    assert len(basic) == 3
+    assert {ds.name for ds in basic} == {"dataset_a", "dataset_b", "dataset_c"}
+    for ds in basic:
         assert isinstance(ds.rows, str)
         assert ds.rows.startswith("weave:///")
         assert ds.created_at is not None
 
-
-def test_dataset_list_with_limit(trace_server):
-    """Test listing datasets with a limit."""
-    project_id = f"{TEST_ENTITY}/test_dataset_list_limit"
-
-    # Create multiple datasets
-    for i in range(5):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name=f"dataset_{i}",
-            description=None,
-            rows=[{"value": i}],
-        )
-        trace_server.dataset_create(create_req)
-
-    # List with a limit
-    list_req = tsi.DatasetListReq(project_id=project_id, limit=3)
-    datasets = list(trace_server.dataset_list(list_req))
-
-    assert len(datasets) == 3
-
-
-def test_dataset_list_with_offset(trace_server):
-    """Test listing datasets with an offset."""
-    project_id = f"{TEST_ENTITY}/test_dataset_list_offset"
-
-    # Create multiple datasets
-    for i in range(5):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name=f"dataset_{i}",
-            description=None,
-            rows=[{"value": i}],
-        )
-        trace_server.dataset_create(create_req)
-
-    # List with an offset
-    list_req = tsi.DatasetListReq(project_id=project_id, offset=2)
-    datasets = list(trace_server.dataset_list(list_req))
-
-    assert len(datasets) == 3
-
-
-def test_dataset_list_with_limit_and_offset(trace_server):
-    """Test listing datasets with both limit and offset for pagination."""
-    project_id = f"{TEST_ENTITY}/test_dataset_list_pagination"
-
-    # Create multiple datasets
+    # Pagination: 10 datasets, exercise limit, offset, and limit+offset.
+    page_project = f"{TEST_ENTITY}/test_dataset_list_pagination"
     for i in range(10):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name=f"dataset_{i}",
-            description=None,
-            rows=[{"value": i}],
+        trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=page_project,
+                name=f"dataset_{i}",
+                description=None,
+                rows=[{"value": i}],
+            )
         )
-        trace_server.dataset_create(create_req)
-
-    # First page
-    list_req1 = tsi.DatasetListReq(project_id=project_id, limit=3, offset=0)
-    datasets1 = list(trace_server.dataset_list(list_req1))
-    assert len(datasets1) == 3
-
-    # Second page
-    list_req2 = tsi.DatasetListReq(project_id=project_id, limit=3, offset=3)
-    datasets2 = list(trace_server.dataset_list(list_req2))
-    assert len(datasets2) == 3
-
-    # Verify different datasets on different pages
-    datasets1_names = {ds.name for ds in datasets1}
-    datasets2_names = {ds.name for ds in datasets2}
-    assert len(datasets1_names & datasets2_names) == 0  # No overlap
-
-
-def test_dataset_list_empty_project(trace_server):
-    """Test listing datasets in a project with no datasets."""
-    project_id = f"{TEST_ENTITY}/test_dataset_list_empty"
-
-    list_req = tsi.DatasetListReq(project_id=project_id)
-    datasets = list(trace_server.dataset_list(list_req))
-
-    assert len(datasets) == 0
-
-
-def test_dataset_delete_single_version(trace_server):
-    """Test deleting a single version of a dataset."""
-    project_id = f"{TEST_ENTITY}/test_dataset_delete_single"
-
-    # Create a dataset
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="delete_test",
-        description=None,
-        rows=[{"id": 1}],
+    assert (
+        len(
+            list(
+                trace_server.dataset_list(
+                    tsi.DatasetListReq(project_id=page_project, limit=3)
+                )
+            )
+        )
+        == 3
     )
-    create_res = trace_server.dataset_create(create_req)
-
-    # Delete the specific version
-    delete_req = tsi.DatasetDeleteReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digests=[create_res.digest],
+    assert (
+        len(
+            list(
+                trace_server.dataset_list(
+                    tsi.DatasetListReq(project_id=page_project, offset=7)
+                )
+            )
+        )
+        == 3
     )
-    delete_res = trace_server.dataset_delete(delete_req)
-
-    assert delete_res.num_deleted == 1
-
-    # Verify the dataset is deleted (should raise ObjectDeletedError)
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digest=create_res.digest,
+    page1 = list(
+        trace_server.dataset_list(
+            tsi.DatasetListReq(project_id=page_project, limit=3, offset=0)
+        )
     )
+    page2 = list(
+        trace_server.dataset_list(
+            tsi.DatasetListReq(project_id=page_project, limit=3, offset=3)
+        )
+    )
+    assert len(page1) == 3
+    assert len(page2) == 3
+    assert {ds.name for ds in page1} & {ds.name for ds in page2} == set()
+
+
+def test_dataset_delete_variants(trace_server):
+    """dataset_delete: single version, all versions (digests=None), a specific
+    subset, and a missing dataset (NotFoundError). Deleted versions raise
+    ObjectDeletedError on read; surviving versions still read.
+    """
+    project_id = f"{TEST_ENTITY}/test_dataset_delete_variants"
+
+    # Single version: delete then read raises ObjectDeletedError.
+    single = trace_server.dataset_create(
+        tsi.DatasetCreateReq(
+            project_id=project_id, name="single", description=None, rows=[{"id": 1}]
+        )
+    )
+    single_del = trace_server.dataset_delete(
+        tsi.DatasetDeleteReq(
+            project_id=project_id, object_id="single", digests=[single.digest]
+        )
+    )
+    assert single_del.num_deleted == 1
     with pytest.raises(ObjectDeletedError):
-        trace_server.dataset_read(read_req)
+        trace_server.dataset_read(
+            tsi.DatasetReadReq(
+                project_id=project_id, object_id="single", digest=single.digest
+            )
+        )
 
-
-def test_dataset_delete_all_versions(trace_server):
-    """Test deleting all versions of a dataset (no digests specified)."""
-    project_id = f"{TEST_ENTITY}/test_dataset_delete_all"
-
-    # Create multiple versions of the same dataset
-    digests = []
+    # All versions: digests=None deletes every version.
     for i in range(3):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name="versioned_dataset",
-            description=None,
-            rows=[{"version": i}],
+        trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id,
+                name="all_versions",
+                description=None,
+                rows=[{"version": i}],
+            )
         )
-        create_res = trace_server.dataset_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete all versions (no digests specified)
-    delete_req = tsi.DatasetDeleteReq(
-        project_id=project_id,
-        object_id="versioned_dataset",
-        digests=None,
+    all_del = trace_server.dataset_delete(
+        tsi.DatasetDeleteReq(
+            project_id=project_id, object_id="all_versions", digests=None
+        )
     )
-    delete_res = trace_server.dataset_delete(delete_req)
+    assert all_del.num_deleted == 3
 
-    assert delete_res.num_deleted == 3
-
-
-def test_dataset_delete_multiple_versions(trace_server):
-    """Test deleting multiple specific versions of a dataset."""
-    project_id = f"{TEST_ENTITY}/test_dataset_delete_multiple"
-
-    # Create multiple versions
-    digests = []
-    for i in range(4):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name="multi_version_dataset",
-            description=None,
-            rows=[{"version": i}],
+    # Subset: delete the first two of four; the last two still read.
+    multi_digests = [
+        trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id,
+                name="multi",
+                description=None,
+                rows=[{"version": i}],
+            )
+        ).digest
+        for i in range(4)
+    ]
+    multi_del = trace_server.dataset_delete(
+        tsi.DatasetDeleteReq(
+            project_id=project_id, object_id="multi", digests=multi_digests[:2]
         )
-        create_res = trace_server.dataset_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete the first two versions
-    delete_req = tsi.DatasetDeleteReq(
-        project_id=project_id,
-        object_id="multi_version_dataset",
-        digests=digests[:2],
     )
-    delete_res = trace_server.dataset_delete(delete_req)
-
-    assert delete_res.num_deleted == 2
-
-    # Verify the first two are deleted
-    for digest in digests[:2]:
-        read_req = tsi.DatasetReadReq(
-            project_id=project_id,
-            object_id="multi_version_dataset",
-            digest=digest,
-        )
+    assert multi_del.num_deleted == 2
+    for digest in multi_digests[:2]:
         with pytest.raises(ObjectDeletedError):
-            trace_server.dataset_read(read_req)
-
-    # Verify the last two still exist
-    for digest in digests[2:]:
-        read_req = tsi.DatasetReadReq(
-            project_id=project_id,
-            object_id="multi_version_dataset",
-            digest=digest,
+            trace_server.dataset_read(
+                tsi.DatasetReadReq(
+                    project_id=project_id, object_id="multi", digest=digest
+                )
+            )
+    for digest in multi_digests[2:]:
+        assert (
+            trace_server.dataset_read(
+                tsi.DatasetReadReq(
+                    project_id=project_id, object_id="multi", digest=digest
+                )
+            ).digest
+            == digest
         )
-        read_res = trace_server.dataset_read(read_req)
-        assert read_res.digest == digest
 
-
-def test_dataset_delete_not_found(trace_server):
-    """Test deleting a non-existent dataset raises NotFoundError."""
-    project_id = f"{TEST_ENTITY}/test_dataset_delete_not_found"
-
-    delete_req = tsi.DatasetDeleteReq(
-        project_id=project_id,
-        object_id="nonexistent_dataset",
-        digests=["fake_digest"],
-    )
-
+    # Missing dataset raises NotFoundError.
     with pytest.raises(NotFoundError):
-        trace_server.dataset_delete(delete_req)
-
-
-def test_dataset_versioning(trace_server):
-    """Test that creating multiple versions of a dataset increments version_index."""
-    project_id = f"{TEST_ENTITY}/test_dataset_versioning"
-
-    # Create multiple versions of the same dataset
-    versions = []
-    for i in range(3):
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name="versioned_dataset",
-            description=f"Version {i}",
-            rows=[{"value": i}],
+        trace_server.dataset_delete(
+            tsi.DatasetDeleteReq(
+                project_id=project_id,
+                object_id="nonexistent_dataset",
+                digests=["fake_digest"],
+            )
         )
-        create_res = trace_server.dataset_create(create_req)
-        versions.append(create_res)
-
-    # Verify version indices increment
-    assert versions[0].version_index == 0
-    assert versions[1].version_index == 1
-    assert versions[2].version_index == 2
-
-    # Verify all versions are distinct
-    assert len({v.digest for v in versions}) == 3
 
 
-def test_dataset_with_special_characters(trace_server):
-    """Test creating and reading a dataset with special characters in data."""
-    project_id = f"{TEST_ENTITY}/test_dataset_special_chars"
-
-    # Create a dataset with special characters
-    rows = [
-        {"text": "This has \"quotes\" and 'apostrophes'"},
-        {"text": "Line breaks:\n\tand tabs"},
-        {"text": "Unicode: 你好世界 🚀"},
-    ]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="special_chars",
-        description='Dataset with "special" characters',
-        rows=rows,
-    )
-    create_res = trace_server.dataset_create(create_req)
-
-    # Read it back and verify metadata is preserved
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="special_chars",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.dataset_read(read_req)
-
-    assert read_res.name == "special_chars"
-    assert read_res.description == 'Dataset with "special" characters'
-    # The rows should still be a reference
-    assert isinstance(read_res.rows, str)
-    assert read_res.rows.startswith("weave:///")
-
-
-def test_dataset_with_unicode(trace_server):
-    """Test creating and reading a dataset with unicode characters."""
-    project_id = f"{TEST_ENTITY}/test_dataset_unicode"
-
-    # Create a dataset with unicode
-    rows = [
-        {"language": "Chinese", "greeting": "你好世界"},
-        {"language": "Japanese", "greeting": "こんにちは"},
-        {"language": "Emoji", "greeting": "🚀 🌟 ✨"},
-    ]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="unicode_dataset",
-        description="Unicode greetings 🌍",
-        rows=rows,
-    )
-    create_res = trace_server.dataset_create(create_req)
-
-    # Read it back and verify metadata is preserved
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="unicode_dataset",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.dataset_read(read_req)
-
-    assert read_res.name == "unicode_dataset"
-    assert read_res.description == "Unicode greetings 🌍"
-    assert "🌍" in read_res.description
-
-
-def test_dataset_list_after_deletion(trace_server):
-    """Test that deleted datasets don't appear in list results."""
+def test_dataset_list_excludes_deleted(trace_server):
+    """A deleted dataset disappears from dataset_list while siblings remain."""
     project_id = f"{TEST_ENTITY}/test_dataset_list_after_deletion"
-
-    # Create three datasets
-    dataset_names = ["keep_1", "delete_me", "keep_2"]
-    digests = {}
-    for name in dataset_names:
-        create_req = tsi.DatasetCreateReq(
-            project_id=project_id,
-            name=name,
-            description=None,
-            rows=[{"id": 1}],
+    for name in ("keep_1", "delete_me", "keep_2"):
+        trace_server.dataset_create(
+            tsi.DatasetCreateReq(
+                project_id=project_id, name=name, description=None, rows=[{"id": 1}]
+            )
         )
-        create_res = trace_server.dataset_create(create_req)
-        digests[name] = create_res.digest
 
-    # Delete one dataset
-    delete_req = tsi.DatasetDeleteReq(
-        project_id=project_id,
-        object_id="delete_me",
-        digests=None,
+    trace_server.dataset_delete(
+        tsi.DatasetDeleteReq(project_id=project_id, object_id="delete_me", digests=None)
     )
-    trace_server.dataset_delete(delete_req)
 
-    # List datasets - should only see the two that weren't deleted
-    list_req = tsi.DatasetListReq(project_id=project_id)
-    datasets = list(trace_server.dataset_list(list_req))
-
-    dataset_names_returned = {ds.name for ds in datasets}
-    assert dataset_names_returned == {"keep_1", "keep_2"}
-    assert "delete_me" not in dataset_names_returned
-
-
-def test_dataset_empty_rows(trace_server):
-    """Test creating a dataset with empty rows."""
-    project_id = f"{TEST_ENTITY}/test_dataset_empty_rows"
-
-    # Create a dataset with empty rows
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="empty_dataset",
-        description="A dataset with no rows",
-        rows=[],
-    )
-    create_res = trace_server.dataset_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "empty_dataset"
-
-    # Read it back
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="empty_dataset",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.dataset_read(read_req)
-
-    assert read_res.name == "empty_dataset"
-    assert isinstance(read_res.rows, str)
-
-
-def test_dataset_large_rows(trace_server):
-    """Test creating a dataset with many rows."""
-    project_id = f"{TEST_ENTITY}/test_dataset_large_rows"
-
-    # Create a dataset with 100 rows
-    rows = [{"id": i, "value": f"value_{i}", "data": i * 2} for i in range(100)]
-    create_req = tsi.DatasetCreateReq(
-        project_id=project_id,
-        name="large_dataset",
-        description="A dataset with 100 rows",
-        rows=rows,
-    )
-    create_res = trace_server.dataset_create(create_req)
-
-    assert create_res.digest is not None
-
-    # Read it back
-    read_req = tsi.DatasetReadReq(
-        project_id=project_id,
-        object_id="large_dataset",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.dataset_read(read_req)
-
-    assert read_res.name == "large_dataset"
-    # The rows should still be a reference (not the actual 100 rows)
-    assert isinstance(read_res.rows, str)
-    assert read_res.rows.startswith("weave:///")
+    names = {
+        ds.name
+        for ds in trace_server.dataset_list(tsi.DatasetListReq(project_id=project_id))
+    }
+    assert names == {"keep_1", "keep_2"}
+    assert "delete_me" not in names

--- a/tests/trace_server/test_digest_validation.py
+++ b/tests/trace_server/test_digest_validation.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import pytest
 
+from weave.shared.digest import compute_file_digest
 from weave.trace_server.digest_validation import validate_expected_digest
 from weave.trace_server.errors import DigestMismatchError
 from weave.trace_server.trace_server_interface import (
@@ -19,110 +20,90 @@ from weave.trace_server.trace_server_interface import (
 )
 
 
-def test_validate_expected_digest_match() -> None:
-    """No error when expected matches actual."""
+def test_validate_expected_digest() -> None:
+    """Matching/None digests pass; mismatches raise DigestMismatchError."""
     validate_expected_digest(expected="abc123", actual="abc123", label="test")
-
-
-def test_validate_expected_digest_none_skips() -> None:
-    """None expected (fallback path) never raises."""
     validate_expected_digest(expected=None, actual="abc123", label="test")
-
-
-def test_validate_expected_digest_mismatch_raises() -> None:
-    """Mismatched digests raise DigestMismatchError."""
     with pytest.raises(DigestMismatchError, match="(?i)client.*!=.*server"):
         validate_expected_digest(expected="wrong", actual="abc123", label="test")
 
 
 @pytest.mark.trace_server
-class TestFileCreateExpectedDigest:
-    def test_no_expected_digest(self, client) -> None:
-        """file_create without expected_digest succeeds (fallback path)."""
-        req = FileCreateReq(
-            project_id=client.project_id,
-            name="test.txt",
-            content=b"hello world",
-        )
-        res = client.server.file_create(req)
-        assert res.digest is not None
+def test_file_create_expected_digest(client) -> None:
+    """file_create: fallback (none) and correct digests succeed, wrong raises."""
+    content = b"hello world"
+    no_digest = client.server.file_create(
+        FileCreateReq(project_id=client.project_id, name="test.txt", content=content)
+    )
+    assert no_digest.digest is not None
 
-    def test_correct_expected_digest(self, client) -> None:
-        """file_create with correct expected_digest succeeds."""
-        from weave.shared.digest import compute_file_digest
-
-        content = b"hello world"
-        digest = compute_file_digest(content)
-        req = FileCreateReq(
+    digest = compute_file_digest(content)
+    correct = client.server.file_create(
+        FileCreateReq(
             project_id=client.project_id,
             name="test.txt",
             content=content,
             expected_digest=digest,
         )
-        res = client.server.file_create(req)
-        assert res.digest == digest
+    )
+    assert correct.digest == digest
 
-    def test_wrong_expected_digest(self, client) -> None:
-        """file_create with wrong expected_digest raises DigestMismatchError."""
-        req = FileCreateReq(
-            project_id=client.project_id,
-            name="test.txt",
-            content=b"hello world",
-            expected_digest="wrong_digest",
+    with pytest.raises(DigestMismatchError):
+        client.server.file_create(
+            FileCreateReq(
+                project_id=client.project_id,
+                name="test.txt",
+                content=content,
+                expected_digest="wrong_digest",
+            )
         )
-        with pytest.raises(DigestMismatchError):
-            client.server.file_create(req)
 
 
 @pytest.mark.trace_server
-class TestObjCreateExpectedDigest:
-    def test_no_expected_digest(self, client) -> None:
-        """obj_create without expected_digest succeeds (fallback path)."""
-        req = ObjCreateReq(
+def test_obj_create_expected_digest(client) -> None:
+    """obj_create: fallback (none) succeeds, wrong digest raises."""
+    no_digest = client.server.obj_create(
+        ObjCreateReq(
             obj=ObjSchemaForInsert(
                 project_id=client.project_id,
                 object_id="test_obj",
                 val={"key": "value"},
             )
         )
-        res = client.server.obj_create(req)
-        assert res.digest is not None
+    )
+    assert no_digest.digest is not None
 
-    def test_wrong_expected_digest(self, client) -> None:
-        """obj_create with wrong expected_digest raises DigestMismatchError."""
-        req = ObjCreateReq(
-            obj=ObjSchemaForInsert(
-                project_id=client.project_id,
-                object_id="test_obj",
-                val={"key": "value"},
-                expected_digest="wrong_digest",
+    with pytest.raises(DigestMismatchError):
+        client.server.obj_create(
+            ObjCreateReq(
+                obj=ObjSchemaForInsert(
+                    project_id=client.project_id,
+                    object_id="test_obj",
+                    val={"key": "value"},
+                    expected_digest="wrong_digest",
+                )
             )
         )
-        with pytest.raises(DigestMismatchError):
-            client.server.obj_create(req)
 
 
 @pytest.mark.trace_server
-class TestTableCreateExpectedDigest:
-    def test_no_expected_digest(self, client) -> None:
-        """table_create without expected_digest succeeds (fallback path)."""
-        req = TableCreateReq(
-            table=TableSchemaForInsert(
-                project_id=client.project_id,
-                rows=[{"val": {"a": 1}}, {"val": {"a": 2}}],
-            )
+def test_table_create_expected_digest(client) -> None:
+    """table_create: fallback (none) succeeds, wrong digest raises."""
+    rows = [{"val": {"a": 1}}, {"val": {"a": 2}}]
+    no_digest = client.server.table_create(
+        TableCreateReq(
+            table=TableSchemaForInsert(project_id=client.project_id, rows=rows)
         )
-        res = client.server.table_create(req)
-        assert res.digest is not None
+    )
+    assert no_digest.digest is not None
 
-    def test_wrong_expected_digest(self, client) -> None:
-        """table_create with wrong expected_digest raises DigestMismatchError."""
-        req = TableCreateReq(
-            table=TableSchemaForInsert(
-                project_id=client.project_id,
-                rows=[{"val": {"a": 1}}, {"val": {"a": 2}}],
-                expected_digest="wrong_digest",
+    with pytest.raises(DigestMismatchError):
+        client.server.table_create(
+            TableCreateReq(
+                table=TableSchemaForInsert(
+                    project_id=client.project_id,
+                    rows=rows,
+                    expected_digest="wrong_digest",
+                )
             )
         )
-        with pytest.raises(DigestMismatchError):
-            client.server.table_create(req)

--- a/tests/trace_server/test_emoji_util.py
+++ b/tests/trace_server/test_emoji_util.py
@@ -17,14 +17,16 @@ SENTENCE_TONES = f"The {EMOJI_JUDGE_TONE} had us {EMOJI_HANDSHAKE_TONES}."
 SENTENCE_NO_TONES = f"The {EMOJI_JUDGE_NO_TONE} had us {EMOJI_HANDSHAKE_NO_TONES}."
 
 
-def test_detone_shortcode() -> None:
+def test_detone_shortcode_and_emojis() -> None:
+    """Skin-tone removal across both surfaces: shortcodes (no-tone passthrough,
+    single tone, ZWJ single/multi tones) and raw emoji (no-tone passthrough,
+    single tone, ZWJ single/multi tones, and tones embedded in a sentence).
+    """
     assert detone_shortcode(SHORTCODE_NO_ZWJ_NO_TONE) == ":pool_8_ball:"
     assert detone_shortcode(SHORTCODE_NO_ZWJ_TONE) == ":thumbs_up:"
     assert detone_shortcode(SHORTCODE_ZWJ_ONE_TONE) == ":judge:"
     assert detone_shortcode(SHORTCODE_ZWJ_MULTIPLE_TONES) == ":handshake:"
 
-
-def test_detone_emoji() -> None:
     assert detone_emojis(EMOJI_8_BALL) == EMOJI_8_BALL
     assert detone_emojis(EMOJI_THUMBS_UP_TONE) == EMOJI_THUMBS_UP_NO_TONE
     assert detone_emojis(EMOJI_JUDGE_TONE) == EMOJI_JUDGE_NO_TONE

--- a/tests/trace_server/test_environment.py
+++ b/tests/trace_server/test_environment.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Callable
 
 import pytest
 
@@ -25,6 +26,7 @@ from weave.trace_server.environment import (
 
 @pytest.mark.disable_logging_error_check
 def test_kafka_producer_max_buffer_size():
+    """Optional positive int: unset/empty/non-int -> None, else parsed value."""
     assert kafka_producer_max_buffer_size() is None
     os.environ["KAFKA_PRODUCER_MAX_BUFFER_SIZE"] = "10000"
     assert kafka_producer_max_buffer_size() == 10000
@@ -40,19 +42,57 @@ def test_kafka_producer_max_buffer_size():
 
 
 @pytest.mark.disable_logging_error_check
-def test_wf_scoring_worker_check_cancellation():
-    assert wf_scoring_worker_check_cancellation() is False
-    os.environ["SCORING_WORKER_CHECK_CANCELLATION"] = "true"
-    assert wf_scoring_worker_check_cancellation() is True
-    os.environ["SCORING_WORKER_CHECK_CANCELLATION"] = "True"
-    assert wf_scoring_worker_check_cancellation() is True
-    os.environ["SCORING_WORKER_CHECK_CANCELLATION"] = "false"
-    assert wf_scoring_worker_check_cancellation() is False
-    os.environ["SCORING_WORKER_CHECK_CANCELLATION"] = ""
-    assert wf_scoring_worker_check_cancellation() is False
-    os.environ["SCORING_WORKER_CHECK_CANCELLATION"] = "invalid"
-    assert wf_scoring_worker_check_cancellation() is False
-    del os.environ["SCORING_WORKER_CHECK_CANCELLATION"]
+@pytest.mark.parametrize(
+    ("getter", "env_key", "default", "true_values", "false_values"),
+    [
+        (
+            wf_scoring_worker_check_cancellation,
+            "SCORING_WORKER_CHECK_CANCELLATION",
+            False,
+            ["true", "True"],
+            ["false", "", "invalid"],
+        ),
+        (
+            wf_scoring_worker_remote_scorer_enabled,
+            "WF_SCORING_WORKER_REMOTE_SCORING_ENABLED",
+            False,
+            ["true", "True"],
+            ["false", "", "1"],
+        ),
+        (
+            wf_scoring_worker_remote_scorer_allow_insecure_http,
+            REMOTE_SCORER_ALLOW_INSECURE_HTTP_ENV,
+            False,
+            ["true", "True"],
+            ["false", "", "1"],
+        ),
+        (
+            wf_scoring_worker_remote_scorer_validate_hosts,
+            REMOTE_SCORER_VALIDATE_HOSTS_ENV,
+            True,
+            ["true", ""],
+            ["false", "False"],
+        ),
+    ],
+)
+def test_boolean_env_flags(
+    getter: Callable[[], bool],
+    env_key: str,
+    default: bool,
+    true_values: list[str],
+    false_values: list[str],
+    monkeypatch,
+):
+    """Boolean env flags: case-insensitive ``true`` toggles; unset yields the default."""
+    monkeypatch.delenv(env_key, raising=False)
+    assert getter() is default
+
+    for value in true_values:
+        monkeypatch.setenv(env_key, value)
+        assert getter() is True, f"{env_key}={value!r} should be True"
+    for value in false_values:
+        monkeypatch.setenv(env_key, value)
+        assert getter() is False, f"{env_key}={value!r} should be False"
 
 
 @pytest.mark.disable_logging_error_check
@@ -109,6 +149,7 @@ def test_wf_scoring_worker_debounced_scoring_max_call_history(monkeypatch):
 
 @pytest.mark.disable_logging_error_check
 def test_wf_scoring_worker_kafka_consumer_group_id_override():
+    """Optional string override: unset -> None, otherwise the verbatim value (incl. empty)."""
     assert wf_scoring_worker_kafka_consumer_group_id_override() is None
     os.environ["SCORING_WORKER_KAFKA_CONSUMER_GROUP_ID"] = "test-group-id"
     assert wf_scoring_worker_kafka_consumer_group_id_override() == "test-group-id"
@@ -165,26 +206,6 @@ def test_wf_scoring_worker_remote_scorer_bearer_token(monkeypatch):
 
 
 @pytest.mark.disable_logging_error_check
-def test_wf_scoring_worker_remote_scorer_enabled(monkeypatch):
-    """Remote scoring is off by default; only a case-insensitive ``true`` enables it."""
-    key = "WF_SCORING_WORKER_REMOTE_SCORING_ENABLED"
-    monkeypatch.delenv(key, raising=False)
-    assert wf_scoring_worker_remote_scorer_enabled() is False
-
-    monkeypatch.setenv(key, "true")
-    assert wf_scoring_worker_remote_scorer_enabled() is True
-    monkeypatch.setenv(key, "True")
-    assert wf_scoring_worker_remote_scorer_enabled() is True
-
-    monkeypatch.setenv(key, "false")
-    assert wf_scoring_worker_remote_scorer_enabled() is False
-    monkeypatch.setenv(key, "")
-    assert wf_scoring_worker_remote_scorer_enabled() is False
-    monkeypatch.setenv(key, "1")
-    assert wf_scoring_worker_remote_scorer_enabled() is False
-
-
-@pytest.mark.disable_logging_error_check
 def test_wf_scoring_worker_remote_scorer_http_timeout_seconds(monkeypatch):
     """Timeout defaults to 30s; parses positive floats; invalid or non-positive -> default."""
     key = "WF_SCORING_WORKER_REMOTE_HTTP_TIMEOUT_SECONDS"
@@ -229,43 +250,3 @@ def test_wf_scoring_worker_remote_scorer_allowed_hosts(monkeypatch):
         "api.example.com:8443",
         "localhost",
     ]
-
-
-@pytest.mark.disable_logging_error_check
-def test_wf_scoring_worker_remote_scorer_validate_hosts(monkeypatch):
-    """Host validation is enabled by default; only case-insensitive false disables it."""
-    key = REMOTE_SCORER_VALIDATE_HOSTS_ENV
-    monkeypatch.delenv(key, raising=False)
-    assert wf_scoring_worker_remote_scorer_validate_hosts() is True
-
-    monkeypatch.setenv(key, "false")
-    assert wf_scoring_worker_remote_scorer_validate_hosts() is False
-    monkeypatch.setenv(key, "False")
-    assert wf_scoring_worker_remote_scorer_validate_hosts() is False
-
-    monkeypatch.setenv(key, "true")
-    assert wf_scoring_worker_remote_scorer_validate_hosts() is True
-    monkeypatch.setenv(key, "")
-    assert wf_scoring_worker_remote_scorer_validate_hosts() is True
-    monkeypatch.setenv(key, "0")
-    assert wf_scoring_worker_remote_scorer_validate_hosts() is True
-
-
-@pytest.mark.disable_logging_error_check
-def test_wf_scoring_worker_remote_scorer_allow_insecure_http(monkeypatch):
-    """Insecure HTTP is disabled by default; only case-insensitive true enables it."""
-    key = REMOTE_SCORER_ALLOW_INSECURE_HTTP_ENV
-    monkeypatch.delenv(key, raising=False)
-    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is False
-
-    monkeypatch.setenv(key, "true")
-    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is True
-    monkeypatch.setenv(key, "True")
-    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is True
-
-    monkeypatch.setenv(key, "false")
-    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is False
-    monkeypatch.setenv(key, "")
-    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is False
-    monkeypatch.setenv(key, "1")
-    assert wf_scoring_worker_remote_scorer_allow_insecure_http() is False

--- a/tests/trace_server/test_errors.py
+++ b/tests/trace_server/test_errors.py
@@ -11,63 +11,63 @@ from weave.trace_server.errors import (
 )
 
 
-@pytest.mark.parametrize("code", [400, 401, 403, 404, 429])
-def test_transport_server_error_preserves_4xx_status_code(code: int):
-    """TransportServerError should preserve 4xx HTTP status codes from gorilla."""
+@pytest.mark.parametrize(
+    ("code", "expected_status"),
+    [
+        # 4xx from gorilla is preserved; 5xx or None falls back to 500.
+        (400, 400),
+        (401, 401),
+        (403, 403),
+        (404, 404),
+        (429, 429),
+        (None, 500),
+        (500, 500),
+        (502, 500),
+        (503, 500),
+    ],
+)
+def test_transport_server_error_status_code(code: int | None, expected_status: int):
+    """TransportServerError preserves 4xx codes, falls back to 500 for 5xx/None."""
     exc = TransportServerError(f"{code} Error", code=code)
     result = handle_server_exception(exc)
-    assert result.status_code == code
-    assert result.message == {"reason": f"{code} Error"}
+    assert result.status_code == expected_status
+    if expected_status < 500:
+        assert result.message == {"reason": f"{code} Error"}
 
 
-@pytest.mark.parametrize("code", [None, 500, 502, 503])
-def test_transport_server_error_5xx_or_none_returns_500(code: int | None):
-    """TransportServerError with 5xx or None should fall back to 500."""
-    exc = TransportServerError("Server error", code=code)
-    result = handle_server_exception(exc)
-    assert result.status_code == 500
+def test_exception_status_code_mapping() -> None:
+    """Each domain error maps to its actionable HTTP status, never a bare 500/403.
 
-
-def test_clickhouse_type_mismatch_returns_400() -> None:
-    """TYPE_MISMATCH errors (e.g. wrong date format in filter) should be 400, not 502."""
-    error_msg = (
+    - TYPE_MISMATCH (e.g. bad date filter) -> InvalidRequest -> 400, not 502.
+    - InvalidFieldError (unprocessable input) -> 422, not 403 or 500.
+    - ObjectNameTypeCollision (fixable user error) -> 400 with actionable reason.
+    """
+    type_mismatch_msg = (
         "Code: 53. DB::Exception: Cannot convert string '2026-03-31T15:38:50.164Z' "
         "to type DateTime64(6): while executing 'FUNCTION greaterOrEquals("
         "any(__table1.started_at) : 0, '2026-03-31T15:38:50.164Z'_String :: 1) -> "
         "greaterOrEquals(any(__table1.started_at), '2026-03-31T15:38:50.164Z'_String) "
         "Nullable(UInt8) : 2'. (TYPE_MISMATCH)"
     )
-    exc = CHDatabaseError(error_msg)
-
     with pytest.raises(InvalidRequest, match="Cannot convert"):
-        handle_clickhouse_query_error(exc)
+        handle_clickhouse_query_error(CHDatabaseError(type_mismatch_msg))
+    assert handle_server_exception(InvalidRequest(type_mismatch_msg)).status_code == 400
 
-    result = handle_server_exception(InvalidRequest(error_msg))
-    assert result.status_code == 400
-
-
-def test_invalid_field_error_maps_to_422() -> None:
-    """Unsupported/unselectable fields are well-formed but unprocessable input -> 422,
-    not 403 (Forbidden, which implies an authz failure) or 500.
-    """
-    result = handle_server_exception(InvalidFieldError("Field 'foo' is not allowed"))
-    assert result.status_code == 422
-
-
-def test_object_name_type_collision_maps_to_400() -> None:
-    """Name+type collision is a fixable user error -> 400 with an actionable reason,
-    not 500. The registry matches by exact type, so the InvalidRequest subclass must
-    be registered explicitly.
-    """
-    exc = ObjectNameTypeCollision(
-        object_id="my-object",
-        kind="object",
-        new_base_object_class="Prompt",
-        existing_base_object_classes=[None],
+    field_result = handle_server_exception(
+        InvalidFieldError("Field 'foo' is not allowed")
     )
-    result = handle_server_exception(exc)
-    assert result.status_code == 400
-    assert result.message == {
+    assert field_result.status_code == 422
+
+    collision_result = handle_server_exception(
+        ObjectNameTypeCollision(
+            object_id="my-object",
+            kind="object",
+            new_base_object_class="Prompt",
+            existing_base_object_classes=[None],
+        )
+    )
+    assert collision_result.status_code == 400
+    assert collision_result.message == {
         "reason": (
             "Cannot publish 'my-object' as a Prompt: that name is already used "
             "by a generic (untyped) object in this project. Object versions "

--- a/tests/trace_server/test_eval_results_genai_span_ref.py
+++ b/tests/trace_server/test_eval_results_genai_span_ref.py
@@ -111,14 +111,11 @@ def test_build_trial_combines_prediction_and_parent_genai_span_refs() -> None:
     ]
 
 
-def test_extract_genai_span_refs_ignores_malformed_refs() -> None:
+def test_extract_genai_span_refs_filters_malformed_refs() -> None:
+    # All-malformed lists (missing trace_id or span_id) yield None.
     for raw_refs in (
-        [
-            {"span_id": "missing-trace-id"},
-        ],
-        [
-            {"trace_id": "missing-span-id"},
-        ],
+        [{"span_id": "missing-trace-id"}],
+        [{"trace_id": "missing-span-id"}],
     ):
         call = _call(
             attributes={
@@ -127,11 +124,9 @@ def test_extract_genai_span_refs_ignores_malformed_refs() -> None:
                 }
             }
         )
-
         assert eval_helpers.extract_genai_span_refs(call) is None
 
-
-def test_extract_genai_span_refs_skips_invalid_items() -> None:
+    # Mixed lists keep only the valid refs, dropping invalid items.
     call = _call(
         attributes={
             constants.WEAVE_ATTRIBUTES_NAMESPACE: {
@@ -144,7 +139,6 @@ def test_extract_genai_span_refs_skips_invalid_items() -> None:
             }
         }
     )
-
     assert eval_helpers.extract_genai_span_refs(call) == [
         tsi.GenAISpanRef.model_validate(_genai_span_ref("valid-trace"))
     ]

--- a/tests/trace_server/test_genai_agent_queries.py
+++ b/tests/trace_server/test_genai_agent_queries.py
@@ -1487,128 +1487,108 @@ def test_conversation_chat_includes_child_spans_without_conversation_id(ch_serve
 
 
 def test_message_search(ch_server):
-    """End-to-end search against the `messages` table.
-
-    Spans are inserted and the ClickHouse MV populates the search index
-    automatically; no Python-side extraction runs. Verifies that content
-    LIKE + span-level filters return the expected hits.
+    """End-to-end search against the `messages` table populated by the MV:
+    content LIKE hits/misses, shared content_digest for identical content,
+    and tool-call argument/result indexing (incl. the "tool" role alias).
     """
-    project_id = _make_project_id("search")
     now = datetime.datetime.now(tz=datetime.timezone.utc)
 
-    spans = [
-        _make_span(
-            project_id,
-            conversation_id="search-conv-1",
-            conversation_name="Search Test",
-            output_messages=[
-                NormalizedMessage(
-                    role="assistant",
-                    content="The quantum entanglement hypothesis is fascinating.",
-                ),
-            ],
-            started_at=now,
-        ),
-        _make_span(
-            project_id,
-            conversation_id="search-conv-1",
-            conversation_name="Search Test",
-            output_messages=[
-                NormalizedMessage(
-                    role="assistant",
-                    content="Classical mechanics still has many applications.",
-                ),
-            ],
-            started_at=now + datetime.timedelta(seconds=1),
-        ),
-    ]
-    _insert_spans(ch_server.ch_client, spans)
-
-    # Search for "quantum" — should match 1 message
-    res = ch_server.agent_search(AgentSearchReq(project_id=project_id, query="quantum"))
+    # Basic content match/miss in one project.
+    basic_project = _make_project_id("search")
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                basic_project,
+                conversation_id="search-conv-1",
+                conversation_name="Search Test",
+                output_messages=[
+                    NormalizedMessage(
+                        role="assistant",
+                        content="The quantum entanglement hypothesis is fascinating.",
+                    ),
+                ],
+                started_at=now,
+            ),
+            _make_span(
+                basic_project,
+                conversation_id="search-conv-1",
+                conversation_name="Search Test",
+                output_messages=[
+                    NormalizedMessage(
+                        role="assistant",
+                        content="Classical mechanics still has many applications.",
+                    ),
+                ],
+                started_at=now + datetime.timedelta(seconds=1),
+            ),
+        ],
+    )
+    res = ch_server.agent_search(
+        AgentSearchReq(project_id=basic_project, query="quantum")
+    )
     assert len(res.results) >= 1
-    matched = res.results[0]
-    assert "quantum" in matched.matched_messages[0].content_preview.lower()
-
-    # Search for "xyznonexistent" — should match nothing
+    assert "quantum" in res.results[0].matched_messages[0].content_preview.lower()
     res_empty = ch_server.agent_search(
-        AgentSearchReq(project_id=project_id, query="xyznonexistent")
+        AgentSearchReq(project_id=basic_project, query="xyznonexistent")
     )
     assert res_empty.results == []
 
-
-def test_message_search_shared_digest_across_spans(ch_server):
-    """Two spans carrying identical output message content should produce
-    two rows in `messages` that share a single content_digest — enabling
-    read-side dedup via GROUP BY content_digest when desired.
-    """
-    project_id = _make_project_id("search_dedup")
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-
+    # Identical content across two spans -> two rows sharing one content_digest.
+    dedup_project = _make_project_id("search_dedup")
     repeated = "Identical assistant response across two different spans."
-    spans = [
-        _make_span(
-            project_id,
-            conversation_id="dedup-conv-1",
-            output_messages=[NormalizedMessage(role="assistant", content=repeated)],
-            started_at=now,
-        ),
-        _make_span(
-            project_id,
-            conversation_id="dedup-conv-2",
-            output_messages=[NormalizedMessage(role="assistant", content=repeated)],
-            started_at=now + datetime.timedelta(seconds=1),
-        ),
-    ]
-    _insert_spans(ch_server.ch_client, spans)
-
-    res = ch_server.agent_search(
-        AgentSearchReq(project_id=project_id, query="Identical assistant")
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                dedup_project,
+                conversation_id="dedup-conv-1",
+                output_messages=[NormalizedMessage(role="assistant", content=repeated)],
+                started_at=now,
+            ),
+            _make_span(
+                dedup_project,
+                conversation_id="dedup-conv-2",
+                output_messages=[NormalizedMessage(role="assistant", content=repeated)],
+                started_at=now + datetime.timedelta(seconds=1),
+            ),
+        ],
     )
-    # One row per occurrence across two conversations
-    total_matches = sum(len(r.matched_messages) for r in res.results)
-    assert total_matches == 2
-    # Both occurrences share a single content_digest
-    digests = {m.content_digest for r in res.results for m in r.matched_messages}
+    res_dedup = ch_server.agent_search(
+        AgentSearchReq(project_id=dedup_project, query="Identical assistant")
+    )
+    assert sum(len(r.matched_messages) for r in res_dedup.results) == 2
+    digests = {m.content_digest for r in res_dedup.results for m in r.matched_messages}
     assert len(digests) == 1
 
-
-def test_message_search_indexes_tool_calls(ch_server):
-    """tool_call_arguments and tool_call_result should each produce a
-    searchable occurrence with role 'tool_call' / 'tool_result'.
-    """
-    project_id = _make_project_id("search_tools")
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-
-    spans = [
-        _make_span(
-            project_id,
-            conversation_id="tool-conv-1",
-            operation_name="execute_tool",
-            tool_call_arguments='{"city":"Reykjavík"}',
-            tool_call_result='{"temperature":5,"condition":"snowy"}',
-            started_at=now,
-        ),
-    ]
-    _insert_spans(ch_server.ch_client, spans)
-
-    # Hit on the arguments side
+    # Tool-call arguments and results each produce a searchable occurrence.
+    tool_project = _make_project_id("search_tools")
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(
+                tool_project,
+                conversation_id="tool-conv-1",
+                operation_name="execute_tool",
+                tool_call_arguments='{"city":"Reykjavík"}',
+                tool_call_result='{"temperature":5,"condition":"snowy"}',
+                started_at=now,
+            ),
+        ],
+    )
     res_args = ch_server.agent_search(
-        AgentSearchReq(project_id=project_id, query="Reykjavík")
+        AgentSearchReq(project_id=tool_project, query="Reykjavík")
     )
     assert len(res_args.results) == 1
     assert res_args.results[0].matched_messages[0].role == "tool_call"
-
-    # Hit on the result side
     res_result = ch_server.agent_search(
-        AgentSearchReq(project_id=project_id, query="snowy")
+        AgentSearchReq(project_id=tool_project, query="snowy")
     )
     assert len(res_result.results) == 1
     assert res_result.results[0].matched_messages[0].role == "tool_result"
-
     # UI/back-compat alias: "tool" should include both persisted tool roles.
     res_tool_alias = ch_server.agent_search(
-        AgentSearchReq(project_id=project_id, query="Reykjavík", roles=["tool"])
+        AgentSearchReq(project_id=tool_project, query="Reykjavík", roles=["tool"])
     )
     assert len(res_tool_alias.results) == 1
     assert res_tool_alias.results[0].matched_messages[0].role == "tool_call"
@@ -1619,48 +1599,46 @@ def test_message_search_indexes_tool_calls(ch_server):
 # ---------------------------------------------------------------------------
 
 
-def test_query_dsl_combines_semconv_column_and_custom_attr(ch_server):
-    """Compile and execute a Mongo-style query mixing a semconv-mapped column
-    and an unprefixed custom_attrs_string key dispatched via sibling-literal type.
+def test_query_dsl_compiles_typed_custom_attr_predicates(ch_server):
+    """Mongo-style queries route unprefixed keys to the typed custom_attrs map
+    via sibling-literal type: a string `env` -> custom_attrs_string (combined
+    with a semconv column), and an int `retries` -> custom_attrs_int numeric `$gt`.
     """
-    project_id = _make_project_id("dsl")
     now = datetime.datetime.now(tz=datetime.timezone.utc)
 
-    spans = [
-        # alpha / prod — matches
-        _make_span(
-            project_id,
-            agent_name="alpha",
-            custom_attrs_string={"env": "prod"},
-            started_at=now,
-        ),
-        # alpha / staging — agent matches but env doesn't
-        _make_span(
-            project_id,
-            agent_name="alpha",
-            custom_attrs_string={"env": "staging"},
-            started_at=now + datetime.timedelta(seconds=1),
-        ),
-        # beta / prod — env matches but agent doesn't
-        _make_span(
-            project_id,
-            agent_name="beta",
-            custom_attrs_string={"env": "prod"},
-            started_at=now + datetime.timedelta(seconds=2),
-        ),
-    ]
-    _insert_spans(ch_server.ch_client, spans)
-
-    q = Query.model_validate(
+    # String custom attr combined with a semconv-mapped column.
+    str_project = _make_project_id("dsl")
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            # alpha / prod — matches
+            _make_span(
+                str_project,
+                agent_name="alpha",
+                custom_attrs_string={"env": "prod"},
+                started_at=now,
+            ),
+            # alpha / staging — agent matches but env doesn't
+            _make_span(
+                str_project,
+                agent_name="alpha",
+                custom_attrs_string={"env": "staging"},
+                started_at=now + datetime.timedelta(seconds=1),
+            ),
+            # beta / prod — env matches but agent doesn't
+            _make_span(
+                str_project,
+                agent_name="beta",
+                custom_attrs_string={"env": "prod"},
+                started_at=now + datetime.timedelta(seconds=2),
+            ),
+        ],
+    )
+    str_q = Query.model_validate(
         {
             "$expr": {
                 "$and": [
-                    {
-                        "$eq": [
-                            {"$getField": "agent.name"},
-                            {"$literal": "alpha"},
-                        ]
-                    },
+                    {"$eq": [{"$getField": "agent.name"}, {"$literal": "alpha"}]},
                     # `env` is unknown -> falls through to custom_attrs_string
                     # (sibling literal is a str, so the String map).
                     {"$eq": [{"$getField": "env"}, {"$literal": "prod"}]},
@@ -1668,47 +1646,32 @@ def test_query_dsl_combines_semconv_column_and_custom_attr(ch_server):
             }
         }
     )
-    res = ch_server.agent_spans_query(
-        AgentSpansQueryReq(project_id=project_id, query=q)
+    str_res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=str_project, query=str_q)
     )
-    assert res.total_count == 1
-    assert len(res.spans) == 1
-    assert res.spans[0].agent_name == "alpha"
+    assert str_res.total_count == 1
+    assert len(str_res.spans) == 1
+    assert str_res.spans[0].agent_name == "alpha"
 
-
-def test_query_dsl_typed_custom_attr_comparison(ch_server):
-    """Int-typed custom attributes route to `custom_attrs_int` via the
-    sibling-literal type and compare numerically.
-    """
-    project_id = _make_project_id("dsl_int")
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-
-    spans = [
-        # retries=5 — matches > 3
-        _make_span(
-            project_id,
-            custom_attrs_int={"retries": 5},
-            started_at=now,
-        ),
-        # retries=1 — doesn't match
-        _make_span(
-            project_id,
-            custom_attrs_int={"retries": 1},
-            started_at=now + datetime.timedelta(seconds=1),
-        ),
-        # no retries attr — doesn't match
-        _make_span(
-            project_id,
-            started_at=now + datetime.timedelta(seconds=2),
-        ),
-    ]
-    _insert_spans(ch_server.ch_client, spans)
-
-    q = Query.model_validate(
+    # Int custom attr -> custom_attrs_int numeric comparison.
+    int_project = _make_project_id("dsl_int")
+    _insert_spans(
+        ch_server.ch_client,
+        [
+            _make_span(int_project, custom_attrs_int={"retries": 5}, started_at=now),
+            _make_span(
+                int_project,
+                custom_attrs_int={"retries": 1},
+                started_at=now + datetime.timedelta(seconds=1),
+            ),
+            _make_span(int_project, started_at=now + datetime.timedelta(seconds=2)),
+        ],
+    )
+    int_q = Query.model_validate(
         {"$expr": {"$gt": [{"$getField": "retries"}, {"$literal": 3}]}}
     )
-    res = ch_server.agent_spans_query(
-        AgentSpansQueryReq(project_id=project_id, query=q)
+    int_res = ch_server.agent_spans_query(
+        AgentSpansQueryReq(project_id=int_project, query=int_q)
     )
-    assert res.total_count == 1
-    assert len(res.spans) == 1
+    assert int_res.total_count == 1
+    assert len(int_res.spans) == 1

--- a/tests/trace_server/test_genai_chat_view.py
+++ b/tests/trace_server/test_genai_chat_view.py
@@ -232,8 +232,13 @@ def test_full_agent_turn() -> None:
     assert _assistant_payload(by_type["assistant_message"]).output_tokens == 105
 
 
-def test_agent_start_uses_agent_id_when_name_missing() -> None:
-    messages = build_chat_messages(
+def test_agent_start_emission_rules() -> None:
+    """agent_start identity falls back to agent_id; it still emits (anonymous)
+    when only model/instructions/tools metadata is present; and it is skipped
+    entirely for an anonymous invoke_agent carrying no useful metadata.
+    """
+    # agent_id stands in for a missing agent_name on both messages.
+    by_id = build_chat_messages(
         [
             _span(
                 span_id="agent",
@@ -243,15 +248,14 @@ def test_agent_start_uses_agent_id_when_name_missing() -> None:
             )
         ]
     )
+    assert next(m for m in by_id if m.type == "agent_start").agent_name == "agent-123"
+    assert (
+        next(m for m in by_id if m.type == "assistant_message").agent_name
+        == "agent-123"
+    )
 
-    agent_start = next(m for m in messages if m.type == "agent_start")
-    assistant = next(m for m in messages if m.type == "assistant_message")
-    assert agent_start.agent_name == "agent-123"
-    assert assistant.agent_name == "agent-123"
-
-
-def test_agent_start_emits_useful_metadata_without_agent_identity() -> None:
-    messages = build_chat_messages(
+    # No identity but useful metadata -> anonymous agent_start still emitted.
+    meta = build_chat_messages(
         [
             _span(
                 span_id="agent",
@@ -263,17 +267,15 @@ def test_agent_start_emits_useful_metadata_without_agent_identity() -> None:
             )
         ]
     )
-
-    assert [m.type for m in messages] == ["agent_start"]
-    assert messages[0].agent_name is None
-    agent_start = _agent_start_payload(messages[0])
+    assert [m.type for m in meta] == ["agent_start"]
+    assert meta[0].agent_name is None
+    agent_start = _agent_start_payload(meta[0])
     assert agent_start.model == "gpt-4o"
     assert agent_start.system_instructions == "You are helpful."
     assert agent_start.tool_definitions == '[{"name":"search"}]'
 
-
-def test_anonymous_invoke_without_metadata_skips_empty_agent_start() -> None:
-    messages = build_chat_messages(
+    # No identity and no metadata -> empty agent_start is skipped.
+    anon = build_chat_messages(
         [
             _span(
                 span_id="agent",
@@ -283,9 +285,8 @@ def test_anonymous_invoke_without_metadata_skips_empty_agent_start() -> None:
             )
         ]
     )
-
-    assert [m.type for m in messages] == ["assistant_message"]
-    assert messages[0].agent_name is None
+    assert [m.type for m in anon] == ["assistant_message"]
+    assert anon[0].agent_name is None
 
 
 def test_build_span_tree_handles_null_started_at() -> None:
@@ -393,13 +394,10 @@ def test_build_trace_chat_uses_latest_ended_span_when_root_missing() -> None:
     assert res.provider == "openai"
 
 
-def test_invoke_agent_mirrors_child_llm_output_messages() -> None:
-    """When an invoke_agent span and its inner LLM span both carry the same
-    final `output_messages` (OpenAI Agents SDK / Google ADK single-call
-    turn), we should emit exactly one `assistant_message`, not two.
-
-    The inner LLM span is the canonical content source; the parent
-    invoke_agent only emits if no descendant did.
+def test_invoke_agent_assistant_message_dedup_guard() -> None:
+    """The assistant_message guard is "did a descendant already emit?": when an
+    inner LLM span mirrors the parent's final output we emit once (from the
+    child), but a solo invoke_agent with no descendant LLM span still emits.
     """
 
     def at(seconds: int) -> datetime.datetime:
@@ -407,64 +405,51 @@ def test_invoke_agent_mirrors_child_llm_output_messages() -> None:
             2026, 1, 1, 0, 0, seconds, tzinfo=datetime.timezone.utc
         )
 
+    # Parent + inner LLM carry the same final output -> exactly one message,
+    # sourced from the child chat span (not duplicated from invoke_agent).
     final_text = [{"role": "assistant", "content": "It's 72°F."}]
+    mirrored = build_chat_messages(
+        [
+            _span(
+                span_id="agent",
+                operation_name="invoke_agent",
+                agent_name="my-bot",
+                input_messages=[{"role": "user", "content": "What's the weather?"}],
+                output_messages=final_text,  # mirrored onto the parent
+                input_tokens=10,
+                output_tokens=5,
+                started_at=at(0),
+            ),
+            _span(
+                span_id="llm",
+                parent_span_id="agent",
+                operation_name="chat",
+                output_messages=final_text,  # same text on the inner LLM call
+                input_tokens=200,
+                output_tokens=100,
+                started_at=at(1),
+            ),
+        ]
+    )
+    mirrored_assistant = [m for m in mirrored if m.type == "assistant_message"]
+    assert len(mirrored_assistant) == 1
+    assert _assistant_payload(mirrored_assistant[0]).text == "It's 72°F."
 
-    spans = [
-        _span(
-            span_id="agent",
-            operation_name="invoke_agent",
-            agent_name="my-bot",
-            input_messages=[{"role": "user", "content": "What's the weather?"}],
-            output_messages=final_text,  # mirrored onto the parent
-            input_tokens=10,
-            output_tokens=5,
-            started_at=at(0),
-        ),
-        _span(
-            span_id="llm",
-            parent_span_id="agent",
-            operation_name="chat",
-            output_messages=final_text,  # same text on the inner LLM call
-            input_tokens=200,
-            output_tokens=100,
-            started_at=at(1),
-        ),
-    ]
-
-    messages = build_chat_messages(spans)
-    agent_messages = [m for m in messages if m.type == "assistant_message"]
-
-    # Exactly one assistant_message, sourced from the child chat span (not
-    # duplicated from the parent invoke_agent).
-    assert len(agent_messages) == 1
-    assert _assistant_payload(agent_messages[0]).text == "It's 72°F."
-
-
-def test_invoke_agent_emits_when_no_descendant_llm_span() -> None:
-    """If an invoke_agent has output_messages but no descendant LLM span
-    carries them, the parent still emits — the guard is "child emitted
-    already?", not a blanket "never emit from invoke_agent".
-    """
-
-    def at(seconds: int) -> datetime.datetime:
-        return datetime.datetime(
-            2026, 1, 1, 0, 0, seconds, tzinfo=datetime.timezone.utc
-        )
-
-    spans = [
-        _span(
-            span_id="agent",
-            operation_name="invoke_agent",
-            agent_name="solo-bot",
-            output_messages=[{"role": "assistant", "content": "hi there"}],
-            started_at=at(0),
-        ),
-    ]
-
-    messages = build_chat_messages(spans)
-    agent_messages = [m for m in messages if m.type == "assistant_message"]
-    assert len(agent_messages) == 1
-    assert _assistant_payload(agent_messages[0]).text == "hi there"
+    # Solo invoke_agent with no descendant LLM span -> parent still emits.
+    solo = build_chat_messages(
+        [
+            _span(
+                span_id="agent",
+                operation_name="invoke_agent",
+                agent_name="solo-bot",
+                output_messages=[{"role": "assistant", "content": "hi there"}],
+                started_at=at(0),
+            ),
+        ]
+    )
+    solo_assistant = [m for m in solo if m.type == "assistant_message"]
+    assert len(solo_assistant) == 1
+    assert _assistant_payload(solo_assistant[0]).text == "hi there"
 
 
 def test_subagent_spans_render_inline_with_agent_label_inheritance() -> None:
@@ -528,132 +513,128 @@ def test_system_message_not_used_as_user_prompt_fallback() -> None:
     assert [m.type for m in messages] == ["assistant_message"]
 
 
-def test_input_media_attaches_to_user_message_not_assistant() -> None:
-    """Regression: media supplied with the user prompt renders on the user
-    bubble, not the assistant.
-
-    Mirrors the session SDK shape — `attach_media` records media on the
-    LLM/chat span as a `uri` part on the user input message (external form)
-    and, separately, in the span-level `content_refs` (internal,
-    int<->ext-convertible form). The user text comes from the enclosing
-    invoke_agent span. The ref *value* surfaced is the internal `content_refs`
-    one (so the response's int->ext adapter can round-trip it); its *direction*
-    comes from the input part, matched by digest. So the audio lands on the
-    user message and the assistant stays clean.
+def test_media_content_refs_attach_by_part_direction() -> None:
+    """A `content_refs` ref surfaces the internal (round-trippable) value but
+    its direction is matched by digest to an inline message part: input media
+    lands on the user bubble, output media on the assistant bubble, and an
+    orphan ref with no matching part attaches to neither.
     """
+    # Input media: audio on the user prompt -> user bubble, assistant clean.
     audio_internal = "weave-trace-internal:///PID/object/Content:AUDIODIGEST"
     audio_external = "weave:///e/p/object/Content:AUDIODIGEST"
-    spans = [
-        _span(
-            span_id="agent",
-            operation_name="invoke_agent",
-            agent_name="audio-agent",
-            input_messages=[
-                {"role": "user", "content": _parts(_text_part("Describe the audio."))}
-            ],
-        ),
-        _span(
-            span_id="chat",
-            parent_span_id="agent",
-            operation_name="chat",
-            input_messages=[
-                {
-                    "role": "user",
-                    "content": _parts(
-                        _text_part("Describe the audio."), _uri_part(audio_external)
-                    ),
-                }
-            ],
-            output_messages=[
-                {"role": "assistant", "content": _parts(_text_part("Chiptune music."))}
-            ],
-            # Round-trippable internal-form ref; same object digest as the part.
-            content_refs=[audio_internal],
-        ),
-    ]
-
-    messages = build_chat_messages(spans)
-    user = next(m for m in messages if m.type == "user_message")
-    assistant = next(m for m in messages if m.type == "assistant_message")
-
-    # Value is the internal (convertible) ref; direction is from the input part.
+    input_msgs = build_chat_messages(
+        [
+            _span(
+                span_id="agent",
+                operation_name="invoke_agent",
+                agent_name="audio-agent",
+                input_messages=[
+                    {
+                        "role": "user",
+                        "content": _parts(_text_part("Describe the audio.")),
+                    }
+                ],
+            ),
+            _span(
+                span_id="chat",
+                parent_span_id="agent",
+                operation_name="chat",
+                input_messages=[
+                    {
+                        "role": "user",
+                        "content": _parts(
+                            _text_part("Describe the audio."),
+                            _uri_part(audio_external),
+                        ),
+                    }
+                ],
+                output_messages=[
+                    {
+                        "role": "assistant",
+                        "content": _parts(_text_part("Chiptune music.")),
+                    }
+                ],
+                # Round-trippable internal-form ref; same object digest as the part.
+                content_refs=[audio_internal],
+            ),
+        ]
+    )
+    user = next(m for m in input_msgs if m.type == "user_message")
+    assistant = next(m for m in input_msgs if m.type == "assistant_message")
     assert _user_payload(user).content_refs == [audio_internal]
     assert _assistant_payload(assistant).content_refs == []
 
-
-def test_output_media_attaches_to_assistant_message() -> None:
-    """Model-generated media is a part on the output message and renders on
-    the assistant bubble (mirror image of the input case).
-    """
+    # Output media: model-generated image on the output -> assistant bubble.
     image_internal = "weave-trace-internal:///PID/object/Content:GENIMG"
     image_external = "weave:///e/p/object/Content:GENIMG"
-    spans = [
-        _span(
-            span_id="agent",
-            operation_name="invoke_agent",
-            agent_name="image-gen",
-            input_messages=[
-                {"role": "user", "content": _parts(_text_part("Draw a cat."))}
-            ],
-        ),
-        _span(
-            span_id="chat",
-            parent_span_id="agent",
-            operation_name="chat",
-            input_messages=[
-                {"role": "user", "content": _parts(_text_part("Draw a cat."))}
-            ],
-            output_messages=[
-                {
-                    "role": "assistant",
-                    "content": _parts(
-                        _text_part("Here you go."),
-                        _uri_part(
-                            image_external, mime_type="image/png", modality="image"
+    output_msgs = build_chat_messages(
+        [
+            _span(
+                span_id="agent",
+                operation_name="invoke_agent",
+                agent_name="image-gen",
+                input_messages=[
+                    {"role": "user", "content": _parts(_text_part("Draw a cat."))}
+                ],
+            ),
+            _span(
+                span_id="chat",
+                parent_span_id="agent",
+                operation_name="chat",
+                input_messages=[
+                    {"role": "user", "content": _parts(_text_part("Draw a cat."))}
+                ],
+                output_messages=[
+                    {
+                        "role": "assistant",
+                        "content": _parts(
+                            _text_part("Here you go."),
+                            _uri_part(
+                                image_external,
+                                mime_type="image/png",
+                                modality="image",
+                            ),
                         ),
-                    ),
-                }
-            ],
-            content_refs=[image_internal],
-        ),
-    ]
-
-    messages = build_chat_messages(spans)
-    user = next(m for m in messages if m.type == "user_message")
-    assistant = next(m for m in messages if m.type == "assistant_message")
-
+                    }
+                ],
+                content_refs=[image_internal],
+            ),
+        ]
+    )
+    user = next(m for m in output_msgs if m.type == "user_message")
+    assistant = next(m for m in output_msgs if m.type == "assistant_message")
     assert _user_payload(user).content_refs == []
     assert _assistant_payload(assistant).content_refs == [image_internal]
 
-
-def test_content_ref_without_inline_part_is_not_attached() -> None:
-    """A `content_refs` entry with no matching inline message part has no
-    direction signal, so it attaches to neither bubble — only refs anchored to
-    an input/output part are surfaced (documents the deliberate pre-GA break
-    away from the undirected flat list).
-    """
-    spans = [
-        _span(
-            span_id="agent",
-            operation_name="invoke_agent",
-            agent_name="bot",
-            input_messages=[{"role": "user", "content": "hello"}],
-            output_messages=[{"role": "assistant", "content": "hi"}],
-            content_refs=["weave-trace-internal:///PID/object/Content:ORPHAN"],
-        ),
-    ]
-
-    messages = build_chat_messages(spans)
-    user = next(m for m in messages if m.type == "user_message")
-    assistant = next(m for m in messages if m.type == "assistant_message")
+    # Orphan ref with no matching inline part attaches to neither bubble.
+    orphan_msgs = build_chat_messages(
+        [
+            _span(
+                span_id="agent",
+                operation_name="invoke_agent",
+                agent_name="bot",
+                input_messages=[{"role": "user", "content": "hello"}],
+                output_messages=[{"role": "assistant", "content": "hi"}],
+                content_refs=["weave-trace-internal:///PID/object/Content:ORPHAN"],
+            ),
+        ]
+    )
+    user = next(m for m in orphan_msgs if m.type == "user_message")
+    assistant = next(m for m in orphan_msgs if m.type == "assistant_message")
     assert _user_payload(user).content_refs == []
     assert _assistant_payload(assistant).content_refs == []
 
 
-def test_build_span_tree_sort_is_stable_on_equal_timestamps() -> None:
-    """Siblings with equal started_at must sort deterministically by span_id."""
+def test_build_span_tree_sort_tiebreakers() -> None:
+    """Equal-started siblings sort by latest end first (enclosing spans lead),
+    then deterministically by span_id when end times also tie.
+    """
     t0 = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
-    spans = [
+    t1 = datetime.datetime(2026, 1, 1, 0, 0, 1, tzinfo=datetime.timezone.utc)
+    t2 = datetime.datetime(2026, 1, 1, 0, 0, 2, tzinfo=datetime.timezone.utc)
+
+    # Equal started_at and equal ended_at -> deterministic span_id order.
+    equal_end = [
         AgentSpanSchema(
             project_id="p1",
             trace_id="t1",
@@ -666,16 +647,10 @@ def test_build_span_tree_sort_is_stable_on_equal_timestamps() -> None:
         # Intentionally out of order to exercise the tiebreaker.
         for sid in ("c", "a", "b")
     ]
-    roots = build_span_tree(spans)
-    assert [r.span.span_id for r in roots] == ["a", "b", "c"]
+    assert [r.span.span_id for r in build_span_tree(equal_end)] == ["a", "b", "c"]
 
-
-def test_build_span_tree_sorts_equal_starts_by_latest_end_first() -> None:
-    """Enclosing spans often share child start times and should sort first."""
-    t0 = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
-    t1 = datetime.datetime(2026, 1, 1, 0, 0, 1, tzinfo=datetime.timezone.utc)
-    t2 = datetime.datetime(2026, 1, 1, 0, 0, 2, tzinfo=datetime.timezone.utc)
-    spans = [
+    # Equal started_at, differing ended_at -> latest end first.
+    mixed_end = [
         AgentSpanSchema(
             project_id="p1",
             trace_id="t1",
@@ -704,5 +679,8 @@ def test_build_span_tree_sorts_equal_starts_by_latest_end_first() -> None:
             ended_at=t1,
         ),
     ]
-    roots = build_span_tree(spans)
-    assert [r.span.span_id for r in roots] == ["z-long", "a-short", "b-short"]
+    assert [r.span.span_id for r in build_span_tree(mixed_end)] == [
+        "z-long",
+        "a-short",
+        "b-short",
+    ]

--- a/tests/trace_server/test_genai_extraction.py
+++ b/tests/trace_server/test_genai_extraction.py
@@ -1,17 +1,14 @@
-"""Unit tests for genai_extraction.py — OTel span → schema extraction.
-
-Per griffin's review: the per-helper tests (TestExtractProvider,
-TestExtractOperationName, etc.) duplicated what one comprehensive
-`extract_genai_span` test already covers. Collapsed into a single
-success-path test that exercises every extractor plus one error-status
-test since that's a separate code path (Status object vs attributes).
-"""
+"""Unit tests for genai_extraction.py — OTel span → schema extraction."""
 
 import datetime
 import json
 from typing import Any
 
 from weave.trace_server.agents import semconv
+from weave.trace_server.agents.constants import (
+    MAX_CUSTOM_ATTR_VALUE_CHARS,
+    MAX_CUSTOM_ATTRS_PER_SPAN,
+)
 from weave.trace_server.opentelemetry.genai_extraction import extract_genai_span
 from weave.trace_server.opentelemetry.python_spans import (
     Resource,
@@ -20,28 +17,6 @@ from weave.trace_server.opentelemetry.python_spans import (
     Status,
     StatusCode,
 )
-
-
-def _make_span(
-    attrs: dict[str, Any] | None = None,
-    name: str = "test-span",
-    events: list | None = None,
-    status: Status | None = None,
-) -> Span:
-    """Build a minimal Span for testing."""
-    now_ns = int(datetime.datetime.now().timestamp() * 1_000_000_000)
-    return Span(
-        resource=Resource(attributes={}),
-        name=name,
-        trace_id="abc123",
-        span_id="def456",
-        start_time_unix_nano=now_ns,
-        end_time_unix_nano=now_ns + 100_000_000,
-        attributes=attrs or {},
-        kind=SpanKind.CLIENT,
-        status=status or Status(code=StatusCode.OK),
-        events=events or [],
-    )
 
 
 def test_extract_genai_span_comprehensive() -> None:
@@ -181,207 +156,101 @@ def test_extract_genai_span_comprehensive() -> None:
     assert result.attributes_dump != ""
 
 
-def test_extract_genai_span_error_status() -> None:
-    """ERROR status code comes from the Span's Status object, not attributes —
-    different code path than the OK case.
+def test_extract_genai_span_status_code_variants() -> None:
+    """status_code/message/error_type come from the Span's Status object (a
+    separate code path from attributes): ERROR carries a message + error.type,
+    while UNSET is preserved verbatim.
     """
-    span = _make_span(
-        attrs={"error.type": "RateLimitError"},
-        status=Status(code=StatusCode.ERROR, message="rate limited"),
+    error_result = extract_genai_span(
+        _make_span(
+            attrs={"error.type": "RateLimitError"},
+            status=Status(code=StatusCode.ERROR, message="rate limited"),
+        ),
+        project_id="p1",
     )
-    result = extract_genai_span(span, project_id="p1")
+    assert error_result.status_code == "ERROR"
+    assert error_result.status_message == "rate limited"
+    assert error_result.error_type == "RateLimitError"
 
-    assert result.status_code == "ERROR"
-    assert result.status_message == "rate limited"
-    assert result.error_type == "RateLimitError"
-
-
-def test_extract_genai_span_preserves_unset_status() -> None:
-    span = _make_span(status=Status(code=StatusCode.UNSET))
-    result = extract_genai_span(span, project_id="p1")
-
-    assert result.status_code == "UNSET"
-
-
-def test_normalize_message_missing_role_and_finish_reason() -> None:
-    span = _make_span(
-        attrs={
-            "gen_ai.output.messages": [
-                {"content": "hello", "finish_reason": None},
-            ],
-        },
+    unset_result = extract_genai_span(
+        _make_span(status=Status(code=StatusCode.UNSET)), project_id="p1"
     )
-    result = extract_genai_span(span, project_id="p1")
-
-    assert result.output_messages[0].role == "assistant"
-    assert result.output_messages[0].finish_reason == ""
+    assert unset_result.status_code == "UNSET"
 
 
-def test_normalize_input_messages_without_role_uses_user_role() -> None:
-    result = extract_genai_span(
+def test_message_and_instruction_normalization() -> None:
+    """Message/instruction normalization across forms: missing role/finish_reason
+    defaults (output -> assistant/'', input -> user), the legacy gen_ai.prompt
+    string becomes a user message and is also kept as a custom attr, and
+    system_instructions accept content/text/plain JSON block shapes.
+    """
+    # Output message missing role/finish_reason: defaults to assistant / "".
+    out = extract_genai_span(
+        _make_span(
+            attrs={
+                "gen_ai.output.messages": [{"content": "hello", "finish_reason": None}]
+            }
+        ),
+        project_id="p1",
+    )
+    assert out.output_messages[0].role == "assistant"
+    assert out.output_messages[0].finish_reason == ""
+
+    # Input messages without role default to user, plain string or dict.
+    inp = extract_genai_span(
         _make_span(
             attrs={
                 "gen_ai.input.messages": [
                     "plain prompt",
                     {"content": "structured prompt"},
-                ],
-            },
+                ]
+            }
         ),
         project_id="p1",
     )
-
-    assert [(m.role, m.content) for m in result.input_messages] == [
+    assert [(m.role, m.content) for m in inp.input_messages] == [
         ("user", "plain prompt"),
         ("user", "structured prompt"),
     ]
 
-
-def test_genai_prompt_attr_becomes_user_message() -> None:
-    result = extract_genai_span(
-        _make_span(attrs={"gen_ai.prompt": "hello"}),
-        project_id="p1",
+    # Legacy gen_ai.prompt becomes a user message and stays in custom attrs.
+    prompt = extract_genai_span(
+        _make_span(attrs={"gen_ai.prompt": "hello"}), project_id="p1"
     )
+    assert [(m.role, m.content) for m in prompt.input_messages] == [("user", "hello")]
+    assert prompt.custom_attrs_string["gen_ai.prompt"] == "hello"
 
-    assert [(m.role, m.content) for m in result.input_messages] == [("user", "hello")]
-    assert result.custom_attrs_string["gen_ai.prompt"] == "hello"
-
-
-def test_system_instructions_support_json_blocks() -> None:
-    result = extract_genai_span(
+    # system_instructions support content / text / plain block shapes.
+    sys = extract_genai_span(
         _make_span(
             attrs={
                 "gen_ai.system_instructions": [
                     {"content": "content instruction"},
                     {"text": "text instruction"},
                     "plain instruction",
-                ],
+                ]
             }
         ),
         project_id="p1",
     )
-
-    assert result.system_instructions == [
+    assert sys.system_instructions == [
         "content instruction",
         "text instruction",
         "plain instruction",
     ]
 
 
-def test_extract_custom_attrs_caps_total_entries() -> None:
-    """A span with more than MAX_CUSTOM_ATTRS_PER_SPAN attributes has the
-    excess silently dropped so a single misbehaving client can't blow up the
-    insert.
-    """
-    from weave.trace_server.agents.constants import MAX_CUSTOM_ATTRS_PER_SPAN
-
-    attrs = {
-        f"lorem.key_{i:05d}": f"val_{i}" for i in range(MAX_CUSTOM_ATTRS_PER_SPAN + 500)
-    }
-    result = extract_genai_span(_make_span(attrs=attrs), project_id="p1")
-
-    total = (
-        len(result.custom_attrs_string)
-        + len(result.custom_attrs_int)
-        + len(result.custom_attrs_float)
-    )
-    assert total == MAX_CUSTOM_ATTRS_PER_SPAN
-
-
-def test_extract_custom_attrs_skips_empty_strings() -> None:
-    result = extract_genai_span(
-        _make_span(attrs={"lorem.empty": "", "lorem.nonempty": "x"}),
-        project_id="p1",
-    )
-
-    assert "lorem.empty" not in result.custom_attrs_string
-    assert result.custom_attrs_string["lorem.nonempty"] == "x"
-
-
-def test_extract_custom_attrs_truncates_large_string_values() -> None:
-    """String values larger than MAX_CUSTOM_ATTR_VALUE_CHARS are truncated
-    with a marker suffix so downstream tools can tell truncation happened.
-    """
-    from weave.trace_server.agents.constants import MAX_CUSTOM_ATTR_VALUE_CHARS
-
-    huge = "x" * (MAX_CUSTOM_ATTR_VALUE_CHARS + 50_000)
-    result = extract_genai_span(
-        _make_span(attrs={"lorem.big_string": huge}),
-        project_id="p1",
-    )
-
-    stored = result.custom_attrs_string["lorem.big_string"]
-    assert len(stored) <= MAX_CUSTOM_ATTR_VALUE_CHARS
-    assert stored.endswith("chars]")
-    assert "truncated from" in stored
-
-
-def test_extract_custom_attrs_truncates_large_json_values() -> None:
-    """Non-primitive, non-dict values (e.g. lists) get JSON-encoded then
-    truncated the same way. Dicts get flattened by `_flatten_attrs` so
-    they never hit the JSON-encoding branch.
-    """
-    from weave.trace_server.agents.constants import MAX_CUSTOM_ATTR_VALUE_CHARS
-
-    huge_list = ["x" * 100] * 5000  # JSON encoding ~500KB
-    result = extract_genai_span(
-        _make_span(attrs={"lorem.big_list": huge_list}),
-        project_id="p1",
-    )
-
-    stored = result.custom_attrs_string["lorem.big_list"]
-    assert len(stored) <= MAX_CUSTOM_ATTR_VALUE_CHARS
-    assert "truncated from" in stored
-
-
-def test_extract_custom_attrs_routes_bool_to_bool_map() -> None:
-    """Bool values land in custom_attrs_bool, not custom_attrs_string or
-    custom_attrs_int.
-
-    Ordering matters: Python `bool` is a subclass of `int`, so the
-    extractor's bool check must come before the int check (otherwise
-    `isinstance(True, int)` matches first and the value ends up in
-    custom_attrs_int).
-    """
-    result = extract_genai_span(
-        _make_span(
-            attrs={
-                "lorem.is_active": True,
-                "lorem.is_cached": False,
-                "lorem.int_looks_like_bool": 1,
-            }
-        ),
-        project_id="p1",
-    )
-
-    assert result.custom_attrs_bool["lorem.is_active"] is True
-    assert result.custom_attrs_bool["lorem.is_cached"] is False
-    # A plain int stays in custom_attrs_int even though 0/1 look bool-ish.
-    assert result.custom_attrs_int["lorem.int_looks_like_bool"] == 1
-    # Bools don't leak into the other maps.
-    assert "lorem.is_active" not in result.custom_attrs_string
-    assert "lorem.is_active" not in result.custom_attrs_int
-    assert "lorem.is_active" not in result.custom_attrs_float
-
-
-def test_multi_alias_extraction_recognises_every_form() -> None:
-    """For any attribute with multiple OTel aliases, the extractor must
-    populate its column from a span carrying the value under any recognised
-    key — canonical weave.* form, primary OTel alias, or any parallel /
-    historical alias. ``USAGE_REASONING_TOKENS`` is used here as a concrete
-    example; the same contract applies to any multi-alias semconv attribute.
+def test_multi_alias_extraction() -> None:
+    """For a multi-alias semconv attribute (USAGE_REASONING_TOKENS as the
+    example), the column populates from a span carrying the value under any
+    recognised key, and the canonical weave.* key wins over parallel OTel
+    aliases when both are present.
     """
     for key in semconv.USAGE_REASONING_TOKENS.lookup_keys:
         result = extract_genai_span(_make_span(attrs={key: 42}), project_id="p1")
         assert result.reasoning_tokens == 42, f"key {key!r} did not populate column"
 
-
-def test_multi_alias_extraction_canonical_weave_key_wins() -> None:
-    """When a span carries both the canonical weave.* key and parallel OTel
-    aliases, the weave.* value wins (extractor probes lookup_keys in order).
-    ``USAGE_REASONING_TOKENS`` is used here as a concrete example; the same
-    contract applies to any multi-alias semconv attribute.
-    """
-    result = extract_genai_span(
+    both = extract_genai_span(
         _make_span(
             attrs={
                 semconv.USAGE_REASONING_TOKENS.key: 99,
@@ -390,16 +259,23 @@ def test_multi_alias_extraction_canonical_weave_key_wins() -> None:
         ),
         project_id="p1",
     )
-    assert result.reasoning_tokens == 99
+    assert both.reasoning_tokens == 99
 
 
-def test_extract_custom_attrs_skips_non_finite_floats() -> None:
-    """NaN and +/-Inf must not reach custom_attrs_float — they break JSON
-    serialization and have no aggregation semantics.
+def test_extract_custom_attrs_routing_and_limits() -> None:
+    """Custom-attr handling in one span: empty strings dropped; bools route to
+    custom_attrs_bool (checked before int, since bool subclasses int); plain
+    ints stay int; non-finite floats (NaN/+-Inf) skipped while finite floats
+    land in custom_attrs_float.
     """
     result = extract_genai_span(
         _make_span(
             attrs={
+                "lorem.empty": "",
+                "lorem.nonempty": "x",
+                "lorem.is_active": True,
+                "lorem.is_cached": False,
+                "lorem.int_looks_like_bool": 1,
                 "lorem.nan": float("nan"),
                 "lorem.pos_inf": float("inf"),
                 "lorem.neg_inf": float("-inf"),
@@ -409,9 +285,77 @@ def test_extract_custom_attrs_skips_non_finite_floats() -> None:
         project_id="p1",
     )
 
-    assert "lorem.finite" in result.custom_attrs_float
+    assert "lorem.empty" not in result.custom_attrs_string
+    assert result.custom_attrs_string["lorem.nonempty"] == "x"
+
+    assert result.custom_attrs_bool["lorem.is_active"] is True
+    assert result.custom_attrs_bool["lorem.is_cached"] is False
+    assert result.custom_attrs_int["lorem.int_looks_like_bool"] == 1
+    for key in ("lorem.is_active", "lorem.is_cached"):
+        assert key not in result.custom_attrs_string
+        assert key not in result.custom_attrs_int
+        assert key not in result.custom_attrs_float
+
     assert result.custom_attrs_float["lorem.finite"] == 3.14
     for key in ("lorem.nan", "lorem.pos_inf", "lorem.neg_inf"):
         assert key not in result.custom_attrs_float
         assert key not in result.custom_attrs_string
         assert key not in result.custom_attrs_int
+
+
+def test_extract_custom_attrs_caps_and_truncation() -> None:
+    """A span over MAX_CUSTOM_ATTRS_PER_SPAN drops the excess; oversized string
+    and JSON-encoded (list) values are truncated to MAX_CUSTOM_ATTR_VALUE_CHARS
+    with a `truncated from ... chars]` marker. Dicts are flattened by
+    `_flatten_attrs` and never hit the JSON branch.
+    """
+    over_cap = {
+        f"lorem.key_{i:05d}": f"val_{i}" for i in range(MAX_CUSTOM_ATTRS_PER_SPAN + 500)
+    }
+    capped = extract_genai_span(_make_span(attrs=over_cap), project_id="p1")
+    total = (
+        len(capped.custom_attrs_string)
+        + len(capped.custom_attrs_int)
+        + len(capped.custom_attrs_float)
+    )
+    assert total == MAX_CUSTOM_ATTRS_PER_SPAN
+
+    huge_string = "x" * (MAX_CUSTOM_ATTR_VALUE_CHARS + 50_000)
+    huge_list = ["x" * 100] * 5000  # JSON encoding ~500KB
+    truncated = extract_genai_span(
+        _make_span(
+            attrs={"lorem.big_string": huge_string, "lorem.big_list": huge_list}
+        ),
+        project_id="p1",
+    )
+
+    stored_string = truncated.custom_attrs_string["lorem.big_string"]
+    assert len(stored_string) <= MAX_CUSTOM_ATTR_VALUE_CHARS
+    assert stored_string.endswith("chars]")
+    assert "truncated from" in stored_string
+
+    stored_list = truncated.custom_attrs_string["lorem.big_list"]
+    assert len(stored_list) <= MAX_CUSTOM_ATTR_VALUE_CHARS
+    assert "truncated from" in stored_list
+
+
+def _make_span(
+    attrs: dict[str, Any] | None = None,
+    name: str = "test-span",
+    events: list | None = None,
+    status: Status | None = None,
+) -> Span:
+    """Build a minimal Span for testing."""
+    now_ns = int(datetime.datetime.now().timestamp() * 1_000_000_000)
+    return Span(
+        resource=Resource(attributes={}),
+        name=name,
+        trace_id="abc123",
+        span_id="def456",
+        start_time_unix_nano=now_ns,
+        end_time_unix_nano=now_ns + 100_000_000,
+        attributes=attrs or {},
+        kind=SpanKind.CLIENT,
+        status=status or Status(code=StatusCode.OK),
+        events=events or [],
+    )

--- a/tests/trace_server/test_genai_helpers.py
+++ b/tests/trace_server/test_genai_helpers.py
@@ -28,7 +28,7 @@ def test_genai_span_to_row_converts_messages_to_named_tuples() -> None:
     assert row[input_messages_idx] == [("user", "hi", "")]
 
 
-def test_normalize_span_row_returns_new_dict() -> None:
+def test_normalize_span_row_expands_tuples_immutably_and_validates_shape() -> None:
     row = {
         "input_messages": [("user", "hi", "")],
         "output_messages": [],
@@ -42,8 +42,6 @@ def test_normalize_span_row_returns_new_dict() -> None:
         {"role": "user", "content": "hi", "finish_reason": ""}
     ]
 
-
-def test_normalize_span_row_rejects_invalid_message_shape() -> None:
     with pytest.raises(ValueError, match="tuple must have 3 values"):
         normalize_span_row({"input_messages": [("user", "hi")]})
 

--- a/tests/trace_server/test_genai_schema.py
+++ b/tests/trace_server/test_genai_schema.py
@@ -8,50 +8,35 @@ from pydantic import ValidationError
 from weave.trace_server.agents.schema import AgentSpanCHInsertable, NormalizedMessage
 
 
-def test_normalized_message_requires_content_and_defaults_missing_role() -> None:
+def test_normalized_message_validation() -> None:
+    """NormalizedMessage requires content; role defaults to "" when omitted (but
+    cannot stand alone without content); finish_reason defaults to "".
+    """
     with pytest.raises(ValidationError):
         NormalizedMessage()
     with pytest.raises(ValidationError):
         NormalizedMessage(role="user")
 
     assert NormalizedMessage(content="hello").role == ""
-
-    msg = NormalizedMessage(role="assistant", content="")
-    assert msg.finish_reason == ""
+    assert NormalizedMessage(role="assistant", content="").finish_reason == ""
 
 
-def test_agent_span_defaults_created_at_to_utc() -> None:
-    span = AgentSpanCHInsertable(
-        project_id="p1",
-        trace_id="t1",
-        span_id="s1",
-        span_name="chat",
-        started_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-    )
+def test_agent_span_defaults_and_output_type_literal() -> None:
+    """AgentSpanCHInsertable: created_at defaults to a tz-aware UTC value;
+    output_type accepts the "json" literal but rejects an unknown value.
+    """
+    base = {
+        "project_id": "p1",
+        "trace_id": "t1",
+        "span_id": "s1",
+        "span_name": "chat",
+        "started_at": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
+    }
 
+    span = AgentSpanCHInsertable(**base)
     assert span.created_at.tzinfo is not None
 
-
-def test_agent_span_output_type_is_literal() -> None:
-    AgentSpanCHInsertable(
-        project_id="p1",
-        trace_id="t1",
-        span_id="s1",
-        span_name="chat",
-        started_at=datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        output_type="json",
-    )
+    AgentSpanCHInsertable(**base, output_type="json")
 
     with pytest.raises(ValidationError):
-        AgentSpanCHInsertable.model_validate(
-            {
-                "project_id": "p1",
-                "trace_id": "t1",
-                "span_id": "s1",
-                "span_name": "chat",
-                "started_at": datetime.datetime(
-                    2026, 1, 1, tzinfo=datetime.timezone.utc
-                ),
-                "output_type": "pdf",
-            }
-        )
+        AgentSpanCHInsertable.model_validate({**base, "output_type": "pdf"})

--- a/tests/trace_server/test_genai_semconv.py
+++ b/tests/trace_server/test_genai_semconv.py
@@ -3,20 +3,19 @@
 from weave.trace_server.agents import semconv
 
 
-def test_all_attribute_constants_are_registered() -> None:
+def test_semconv_registry_invariants() -> None:
+    """Every defined Attribute is registered, exposed, and filterable columns
+    only reference registered attributes.
+    """
     defined_attrs = {
         value.key
         for name, value in vars(semconv).items()
         if name.isupper() and isinstance(value, semconv.Attribute)
     }
-
     registered_attrs = {attr.key for attr in semconv._DEFS}
 
     assert registered_attrs == defined_attrs
     assert set(semconv.ATTRIBUTES) == defined_attrs
-
-
-def test_filterable_columns_reference_registered_attributes() -> None:
     assert set(semconv.CANONICAL_KEY_TO_COLUMN).issubset(set(semconv.ATTRIBUTES))
 
 

--- a/tests/trace_server/test_ids.py
+++ b/tests/trace_server/test_ids.py
@@ -5,66 +5,37 @@ import time
 from weave.trace_server.ids import generate_id
 
 
-def test_uuid_format():
-    """Test that UUIDs are in the correct format."""
+def test_generate_id_structure() -> None:
+    """A generated id is a lowercase-hex 8-4-4-4-12 UUID with the v7 version
+    bits (7) and RFC-4122 variant bits (10b) set.
+    """
     uuid_str = generate_id()
 
-    # Check format (8-4-4-4-12)
+    # Format: 8-4-4-4-12, all hex.
     parts = uuid_str.split("-")
-    assert len(parts) == 5, f"Expected 5 parts, got {len(parts)}"
-    assert len(parts[0]) == 8, f"Part 1 should be 8 chars, got {len(parts[0])}"
-    assert len(parts[1]) == 4, f"Part 2 should be 4 chars, got {len(parts[1])}"
-    assert len(parts[2]) == 4, f"Part 3 should be 4 chars, got {len(parts[2])}"
-    assert len(parts[3]) == 4, f"Part 4 should be 4 chars, got {len(parts[3])}"
-    assert len(parts[4]) == 12, f"Part 5 should be 12 chars, got {len(parts[4])}"
-
-    # Check that all parts are hex
+    assert [len(p) for p in parts] == [8, 4, 4, 4, 12]
     for part in parts:
-        int(part, 16)  # Will raise if not valid hex
+        int(part, 16)  # raises if not valid hex
 
-
-def test_uuid_version():
-    """Test that the version bits are set correctly for UUIDv7."""
-    uuid_str = generate_id()
-
-    # Remove hyphens and convert to bytes
-    hex_str = uuid_str.replace("-", "")
-    uuid_bytes = bytes.fromhex(hex_str)
-
-    # Check version (should be 7, stored in bits 12-15 of byte 6)
-    version = (uuid_bytes[6] >> 4) & 0xF
-    assert version == 7, f"Expected version 7, got {version}"
-
-    # Check variant (should be 10b, stored in bits 0-1 of byte 8)
-    variant = (uuid_bytes[8] >> 6) & 0x3
-    assert variant == 2, f"Expected variant 2 (10b), got {variant}"
-
-
-def test_uuid_timestamp_ordering():
-    """Test that UUIDs generated later have higher timestamps."""
-    uuid1 = generate_id()
-    time.sleep(0.01)  # Sleep for 10ms
-    uuid2 = generate_id()
-
-    # Since UUIDv7 has timestamp prefix, uuid2 should be lexicographically greater
-    assert uuid2 > uuid1, f"UUID2 ({uuid2}) should be greater than UUID1 ({uuid1})"
-
-
-def test_uuid_uniqueness():
-    """Test that we generate unique UUIDs."""
-    uuids = set()
-    count = 1000
-
-    for _ in range(count):
-        uuid_str = generate_id()
-        uuids.add(uuid_str)
-
-    assert len(uuids) == count, f"Expected {count} unique UUIDs, got {len(uuids)}"
-
-
-def test_uuid_hex_lowercase():
-    """Test that UUIDs use lowercase hex characters."""
-    uuid_str = generate_id()
-    # Remove hyphens for checking
+    # Lowercase hex only.
     hex_chars = uuid_str.replace("-", "")
     assert hex_chars == hex_chars.lower(), "UUID should use lowercase hex characters"
+
+    # Version 7 (bits 12-15 of byte 6) and variant 10b (bits 0-1 of byte 8).
+    uuid_bytes = bytes.fromhex(hex_chars)
+    assert (uuid_bytes[6] >> 4) & 0xF == 7
+    assert (uuid_bytes[8] >> 6) & 0x3 == 2
+
+
+def test_generate_id_ordering_and_uniqueness() -> None:
+    """The timestamp prefix makes later ids lexicographically greater, and bulk
+    generation yields all-distinct ids.
+    """
+    uuid1 = generate_id()
+    time.sleep(0.01)  # 10ms so the millisecond timestamp prefix advances
+    uuid2 = generate_id()
+    assert uuid2 > uuid1, f"UUID2 ({uuid2}) should be greater than UUID1 ({uuid1})"
+
+    count = 1000
+    uuids = {generate_id() for _ in range(count)}
+    assert len(uuids) == count, f"Expected {count} unique UUIDs, got {len(uuids)}"

--- a/tests/trace_server/test_image_completion.py
+++ b/tests/trace_server/test_image_completion.py
@@ -20,373 +20,285 @@ from weave.trace_server.image_completion import (
 )
 
 
-class TestProcessImageDataItem:
-    """Tests for _process_image_data_item function."""
+def test_process_url_image_success():
+    """URL-based image data is fetched via Content.from_url and stored."""
+    with (
+        patch("weave.trace_server.image_completion.Content.from_url") as mock_from_url,
+        patch("weave.trace_server.image_completion.store_content_object") as mock_store,
+    ):
+        mock_content = Mock()
+        mock_from_url.return_value = mock_content
+        mock_store.return_value = {"type": "Content", "digest": "abc123"}
 
-    def test_process_url_image_success(self):
-        """Test successful processing of URL-based image data."""
-        # Mock Content.from_url to return a mock content object
-        with (
-            patch(
-                "weave.trace_server.image_completion.Content.from_url"
-            ) as mock_from_url,
-            patch(
-                "weave.trace_server.image_completion.store_content_object"
-            ) as mock_store,
-        ):
-            mock_content = Mock()
-            mock_from_url.return_value = mock_content
-            mock_store.return_value = {"type": "Content", "digest": "abc123"}
-
-            data_item = {"url": "https://example.com/image.png"}
-            trace_server = Mock()
-            project_id = "test-project"
-
-            result = _process_image_data_item(
-                data_item, 0, trace_server, project_id, "user123"
-            )
-
-            # Verify Content.from_url was called with correct parameters
-            mock_from_url.assert_called_once_with(
-                "https://example.com/image.png",
-                metadata={"source_index": 0, "_original_schema": "url"},
-            )
-
-            # Verify store_content_object was called
-            mock_store.assert_called_once_with(mock_content, project_id, trace_server)
-
-            # Verify the result contains the content dict
-            assert result["url"] == {"type": "Content", "digest": "abc123"}
-            assert "error" not in result
-
-    def test_process_base64_image_success(self):
-        """Test successful processing of base64 image data."""
-        # Create valid base64 image data
-        test_image_data = b"fake image data"
-        b64_data = base64.b64encode(test_image_data).decode("ascii")
-
-        with (
-            patch(
-                "weave.trace_server.image_completion.Content.from_base64"
-            ) as mock_from_base64,
-            patch(
-                "weave.trace_server.image_completion.store_content_object"
-            ) as mock_store,
-        ):
-            mock_content = Mock()
-            mock_from_base64.return_value = mock_content
-            mock_store.return_value = {"type": "Content", "digest": "def456"}
-
-            data_item = {"b64_json": b64_data}
-            trace_server = Mock()
-            project_id = "test-project"
-
-            result = _process_image_data_item(
-                data_item, 1, trace_server, project_id, "user123"
-            )
-
-            # Verify Content.from_base64 was called with correct parameters
-            mock_from_base64.assert_called_once_with(
-                b64_data,
-                mimetype="image/png",
-                metadata={"source_index": 1, "_original_schema": "b64_json"},
-            )
-
-            # Verify store_content_object was called
-            mock_store.assert_called_once_with(mock_content, project_id, trace_server)
-
-            # Verify the result contains the content dict
-            assert result["b64_json"] == {"type": "Content", "digest": "def456"}
-            assert "error" not in result
-
-    def test_process_no_trace_server(self):
-        """Test that no processing occurs when trace_server is None."""
-        data_item = {"url": "https://example.com/image.png"}
-
-        result = _process_image_data_item(data_item, 0, None, "test-project", "user123")
-
-        # Should return original data unchanged
-        assert result == {"url": "https://example.com/image.png"}
-        assert "error" not in result
-
-    def test_process_no_project_id(self):
-        """Test that no processing occurs when project_id is None."""
-        data_item = {"url": "https://example.com/image.png"}
         trace_server = Mock()
+        result = _process_image_data_item(
+            {"url": "https://example.com/image.png"},
+            0,
+            trace_server,
+            "test-project",
+            "user123",
+        )
 
-        result = _process_image_data_item(data_item, 0, trace_server, None, "user123")
-
-        # Should return original data unchanged
-        assert result == {"url": "https://example.com/image.png"}
+        mock_from_url.assert_called_once_with(
+            "https://example.com/image.png",
+            metadata={"source_index": 0, "_original_schema": "url"},
+        )
+        mock_store.assert_called_once_with(mock_content, "test-project", trace_server)
+        assert result["url"] == {"type": "Content", "digest": "abc123"}
         assert "error" not in result
 
-    def test_process_url_error(self):
-        """Test handling of errors when fetching URL-based images."""
-        with patch(
-            "weave.trace_server.image_completion.Content.from_url"
-        ) as mock_from_url:
-            mock_from_url.side_effect = Exception("Connection failed")
 
-            data_item = {"url": "https://example.com/image.png"}
-            trace_server = Mock()
-            project_id = "test-project"
-
-            result = _process_image_data_item(
-                data_item, 0, trace_server, project_id, "user123"
-            )
-
-            # Should contain error information
-            assert "error" in result
-            assert result["error"] == "Connection failed"  # Returns str(e) directly
-            # Original URL should still be present
-            assert result["url"] == "https://example.com/image.png"
-
-    def test_process_base64_decode_error(self):
-        """Test handling of base64 decoding errors."""
-        with patch(
+def test_process_base64_image_success():
+    """Base64 image data is decoded via Content.from_base64 and stored."""
+    b64_data = base64.b64encode(b"fake image data").decode("ascii")
+    with (
+        patch(
             "weave.trace_server.image_completion.Content.from_base64"
-        ) as mock_from_base64:
-            mock_from_base64.side_effect = ValueError("Invalid base64 data")
+        ) as mock_from_base64,
+        patch("weave.trace_server.image_completion.store_content_object") as mock_store,
+    ):
+        mock_content = Mock()
+        mock_from_base64.return_value = mock_content
+        mock_store.return_value = {"type": "Content", "digest": "def456"}
 
-            data_item = {"b64_json": "invalid_base64_data!@#"}
-            trace_server = Mock()
-            project_id = "test-project"
+        trace_server = Mock()
+        result = _process_image_data_item(
+            {"b64_json": b64_data}, 1, trace_server, "test-project", "user123"
+        )
 
-            result = _process_image_data_item(
-                data_item, 0, trace_server, project_id, "user123"
-            )
-
-            # Should contain error information
-            assert "error" in result
-            assert result["error"] == "Invalid base64 data"  # Returns str(e) directly
-            # Original b64_json should still be present
-            assert result["b64_json"] == "invalid_base64_data!@#"
-
-    def test_process_unexpected_error(self):
-        """Test handling of unexpected errors during processing."""
-        with patch(
-            "weave.trace_server.image_completion.Content.from_url"
-        ) as mock_from_url:
-            mock_from_url.side_effect = RuntimeError("Unexpected error")
-
-            data_item = {"url": "https://example.com/image.png"}
-            trace_server = Mock()
-            project_id = "test-project"
-
-            result = _process_image_data_item(
-                data_item, 0, trace_server, project_id, "user123"
-            )
-
-            # Should contain generic error message
-            assert "error" in result
-            assert result["error"] == "Unexpected error"  # Returns str(e) directly
+        mock_from_base64.assert_called_once_with(
+            b64_data,
+            mimetype="image/png",
+            metadata={"source_index": 1, "_original_schema": "b64_json"},
+        )
+        mock_store.assert_called_once_with(mock_content, "test-project", trace_server)
+        assert result["b64_json"] == {"type": "Content", "digest": "def456"}
+        assert "error" not in result
 
 
-class TestLiteLLMImageGeneration:
-    """Tests for lite_llm_image_generation function."""
+@pytest.mark.parametrize(
+    ("trace_server", "project_id"),
+    [(None, "test-project"), (Mock(), None)],
+    ids=["no_trace_server", "no_project_id"],
+)
+def test_process_no_processing_when_unconfigured(trace_server, project_id):
+    """Without both a trace server and project id, the data item is returned unchanged."""
+    data_item = {"url": "https://example.com/image.png"}
+    result = _process_image_data_item(data_item, 0, trace_server, project_id, "user123")
+    assert result == {"url": "https://example.com/image.png"}
+    assert "error" not in result
 
-    def test_dalle3_successful_generation(self):
-        """Test successful image generation with DALL-E 3."""
-        mock_response = Mock()
-        mock_response.model_dump.return_value = {
-            "data": [
-                {"url": "https://example.com/generated1.png"},
-                {"b64_json": "base64encodeddata"},
-            ],
-            "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
-        }
 
-        with (
-            patch("litellm.image_generation") as mock_image_gen,
-            patch(
-                "weave.trace_server.image_completion._process_image_data_item"
-            ) as mock_process,
-        ):
-            mock_image_gen.return_value = mock_response
-            mock_process.side_effect = [
-                {
-                    "url": "https://example.com/generated1.png",
-                    "content": {"digest": "abc123"},
-                },
-                {"b64_json": "base64encodeddata", "content": {"digest": "def456"}},
-            ]
+@pytest.mark.parametrize(
+    ("patch_target", "data_item", "exc", "preserved_key"),
+    [
+        (
+            "Content.from_url",
+            {"url": "https://example.com/image.png"},
+            Exception("Connection failed"),
+            "url",
+        ),
+        (
+            "Content.from_base64",
+            {"b64_json": "invalid_base64_data!@#"},
+            ValueError("Invalid base64 data"),
+            "b64_json",
+        ),
+        (
+            "Content.from_url",
+            {"url": "https://example.com/image.png"},
+            RuntimeError("Unexpected error"),
+            "url",
+        ),
+    ],
+    ids=["url_error", "base64_decode_error", "unexpected_error"],
+)
+def test_process_errors_return_str_and_preserve_original(
+    patch_target, data_item, exc, preserved_key
+):
+    """Any failure surfaces ``str(exc)`` as ``error`` and leaves the original value in place."""
+    original = data_item[preserved_key]
+    with patch(f"weave.trace_server.image_completion.{patch_target}") as mock_fn:
+        mock_fn.side_effect = exc
+        result = _process_image_data_item(
+            dict(data_item), 0, Mock(), "test-project", "user123"
+        )
+    assert result["error"] == str(exc)
+    assert result[preserved_key] == original
 
-            inputs = {"model": "dall-e-3", "prompt": "A beautiful sunset", "n": 2}
 
-            result = lite_llm_image_generation(
-                api_key="sk-test-key",
-                inputs=inputs,
-                trace_server=Mock(),
-                project_id="test-project",
-                wb_user_id="user123",
-            )
+def test_dalle3_successful_generation():
+    """DALL-E 3 is pinned to n=1 with style/quality defaults and url response_format."""
+    mock_response = Mock()
+    mock_response.model_dump.return_value = {
+        "data": [
+            {"url": "https://example.com/generated1.png"},
+            {"b64_json": "base64encodeddata"},
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 0, "total_tokens": 10},
+    }
+    with (
+        patch("litellm.image_generation") as mock_image_gen,
+        patch(
+            "weave.trace_server.image_completion._process_image_data_item"
+        ) as mock_process,
+    ):
+        mock_image_gen.return_value = mock_response
+        mock_process.side_effect = [
+            {
+                "url": "https://example.com/generated1.png",
+                "content": {"digest": "abc123"},
+            },
+            {"b64_json": "base64encodeddata", "content": {"digest": "def456"}},
+        ]
 
-            # Verify the API call was made with correct parameters
-            mock_image_gen.assert_called_once_with(
-                model="dall-e-3",
-                prompt="A beautiful sunset",
-                api_key="sk-test-key",
-                n=1,  # DALL-E 3 only supports n=1
-                quality="standard",
-                style="natural",
-                size="1024x1024",
-                response_format="url",
-            )
+        result = lite_llm_image_generation(
+            api_key="sk-test-key",
+            inputs={"model": "dall-e-3", "prompt": "A beautiful sunset", "n": 2},
+            trace_server=Mock(),
+            project_id="test-project",
+            wb_user_id="user123",
+        )
 
-            # Verify the response structure
-            assert isinstance(result, tsi.ImageGenerationCreateRes)
-            assert result.response["model"] == "dall-e-3"
-            assert "data" in result.response
-            assert len(result.response["data"]) == 2
+        mock_image_gen.assert_called_once_with(
+            model="dall-e-3",
+            prompt="A beautiful sunset",
+            api_key="sk-test-key",
+            n=1,  # DALL-E 3 only supports n=1
+            quality="standard",
+            style="natural",
+            size="1024x1024",
+            response_format="url",
+        )
+        assert isinstance(result, tsi.ImageGenerationCreateRes)
+        assert result.response["model"] == "dall-e-3"
+        assert "data" in result.response
+        assert len(result.response["data"]) == 2
 
-    def test_other_model_successful_generation(self):
-        """Test successful image generation with non-DALL-E model."""
-        mock_response = Mock()
-        mock_response.model_dump.return_value = {
-            "data": [{"url": "https://example.com/generated.png"}],
-            "usage": {"input_tokens": 8, "output_tokens": 1, "total_tokens": 9},
-        }
 
-        with patch("litellm.image_generation") as mock_image_gen:
-            mock_image_gen.return_value = mock_response
-
-            inputs = {
+def test_other_model_successful_generation():
+    """Non-DALL-E models honor n and normalize input/output token usage keys."""
+    mock_response = Mock()
+    mock_response.model_dump.return_value = {
+        "data": [{"url": "https://example.com/generated.png"}],
+        "usage": {"input_tokens": 8, "output_tokens": 1, "total_tokens": 9},
+    }
+    with patch("litellm.image_generation") as mock_image_gen:
+        mock_image_gen.return_value = mock_response
+        result = lite_llm_image_generation(
+            api_key="test-key",
+            inputs={
                 "model": "stable-diffusion-xl",
                 "prompt": "A cat wearing a hat",
                 "n": 3,
-            }
-
-            result = lite_llm_image_generation(api_key="test-key", inputs=inputs)
-
-            # Verify the API call was made with correct parameters
-            mock_image_gen.assert_called_once_with(
-                model="stable-diffusion-xl",
-                prompt="A cat wearing a hat",
-                api_key="test-key",
-                n=3,  # Non-DALL-E 3 can support multiple images
-                size="1024x1024",
-                response_format="url",
-            )
-
-            # Verify usage token normalization
-            assert result.response["usage"]["prompt_tokens"] == 8
-            assert result.response["usage"]["completion_tokens"] == 1
-            assert result.response["usage"]["total_tokens"] == 9
-
-    def test_gpt_image_1_generation(self):
-        """Test image generation with gpt-image-1 model (no response_format parameter)."""
-        mock_response = Mock()
-        mock_response.model_dump.return_value = {
-            "data": [{"url": "https://example.com/generated.png"}]
-        }
-
-        with patch("litellm.image_generation") as mock_image_gen:
-            mock_image_gen.return_value = mock_response
-
-            inputs = {"model": "gpt-image-1", "prompt": "A robot painting"}
-
-            result = lite_llm_image_generation(api_key="test-key", inputs=inputs)
-
-            # Verify the API call was made without response_format parameter
-            mock_image_gen.assert_called_once_with(
-                model="gpt-image-1",
-                prompt="A robot painting",
-                api_key="test-key",
-                n=1,
-                quality="high",  # gpt-image-1 gets high quality
-                size="1024x1024",
-                # Note: no response_format parameter for gpt-image-1
-            )
-
-    def test_missing_model_error(self):
-        """Test error handling when model is not specified."""
-        inputs = {"prompt": "A test image"}
-
-        with pytest.raises(InvalidRequest, match="Model name is required"):
-            lite_llm_image_generation(api_key="test-key", inputs=inputs)
-
-    def test_litellm_exception_handling(self):
-        """Test error handling when LiteLLM raises an exception."""
-        with patch("litellm.image_generation") as mock_image_gen:
-            mock_image_gen.side_effect = Exception("litellm.APIError: Invalid API key")
-
-            inputs = {"model": "dall-e-3", "prompt": "Test prompt"}
-
-            result = lite_llm_image_generation(api_key="invalid-key", inputs=inputs)
-
-            # Should return error response with cleaned error message
-            assert isinstance(result, tsi.ImageGenerationCreateRes)
-            assert "error" in result.response
-            assert "APIError: Invalid API key" in result.response["error"]
-            assert "litellm." not in result.response["error"]  # Should be stripped
-
-
-class TestRequestResponseTypes:
-    """Tests for request and response type validation."""
-
-    def test_image_generation_request_creation(self):
-        """Test creating ImageGenerationCreateReq with valid inputs."""
-        req = tsi.ImageGenerationCreateReq(
-            project_id="test-project",
-            inputs=tsi.ImageGenerationRequestInputs(
-                model="dall-e-3", prompt="A beautiful sunset", n=1
-            ),
-            track_llm_call=True,
+            },
         )
 
-        assert req.project_id == "test-project"
-        assert req.inputs.model == "dall-e-3"
-        assert req.inputs.prompt == "A beautiful sunset"
-        assert req.inputs.n == 1
-        assert req.track_llm_call is True
+        mock_image_gen.assert_called_once_with(
+            model="stable-diffusion-xl",
+            prompt="A cat wearing a hat",
+            api_key="test-key",
+            n=3,  # Non-DALL-E 3 can support multiple images
+            size="1024x1024",
+            response_format="url",
+        )
+        assert result.response["usage"]["prompt_tokens"] == 8
+        assert result.response["usage"]["completion_tokens"] == 1
+        assert result.response["usage"]["total_tokens"] == 9
 
-    def test_image_generation_response_creation(self):
-        """Test creating ImageGenerationCreateRes with response data."""
-        response_data = {
-            "data": [{"url": "https://example.com/image.png"}],
-            "model": "dall-e-3",
-            "usage": {"prompt_tokens": 10, "total_tokens": 10},
-        }
 
-        res = tsi.ImageGenerationCreateRes(
-            response=response_data, weave_call_id="call_123"
+def test_gpt_image_1_generation():
+    """gpt-image-1 uses high quality and omits the response_format parameter."""
+    mock_response = Mock()
+    mock_response.model_dump.return_value = {
+        "data": [{"url": "https://example.com/generated.png"}]
+    }
+    with patch("litellm.image_generation") as mock_image_gen:
+        mock_image_gen.return_value = mock_response
+        lite_llm_image_generation(
+            api_key="test-key",
+            inputs={"model": "gpt-image-1", "prompt": "A robot painting"},
         )
 
-        assert res.response == response_data
-        assert res.weave_call_id == "call_123"
+        mock_image_gen.assert_called_once_with(
+            model="gpt-image-1",
+            prompt="A robot painting",
+            api_key="test-key",
+            n=1,
+            quality="high",  # gpt-image-1 gets high quality
+            size="1024x1024",
+        )
 
 
-class TestProcessImageDataItemRejectsUnsafeURLs:
+def test_missing_model_error():
+    """A missing model name raises InvalidRequest."""
+    with pytest.raises(InvalidRequest, match="Model name is required"):
+        lite_llm_image_generation(api_key="test-key", inputs={"prompt": "A test image"})
+
+
+def test_litellm_exception_handling():
+    """LiteLLM exceptions become an error response with the ``litellm.`` prefix stripped."""
+    with patch("litellm.image_generation") as mock_image_gen:
+        mock_image_gen.side_effect = Exception("litellm.APIError: Invalid API key")
+        result = lite_llm_image_generation(
+            api_key="invalid-key", inputs={"model": "dall-e-3", "prompt": "Test prompt"}
+        )
+        assert isinstance(result, tsi.ImageGenerationCreateRes)
+        assert "error" in result.response
+        assert "APIError: Invalid API key" in result.response["error"]
+        assert "litellm." not in result.response["error"]
+
+
+def test_image_generation_request_and_response_types():
+    """ImageGenerationCreateReq/Res round-trip their fields."""
+    req = tsi.ImageGenerationCreateReq(
+        project_id="test-project",
+        inputs=tsi.ImageGenerationRequestInputs(
+            model="dall-e-3", prompt="A beautiful sunset", n=1
+        ),
+        track_llm_call=True,
+    )
+    assert req.project_id == "test-project"
+    assert req.inputs.model == "dall-e-3"
+    assert req.inputs.prompt == "A beautiful sunset"
+    assert req.inputs.n == 1
+    assert req.track_llm_call is True
+
+    response_data = {
+        "data": [{"url": "https://example.com/image.png"}],
+        "model": "dall-e-3",
+        "usage": {"prompt_tokens": 10, "total_tokens": 10},
+    }
+    res = tsi.ImageGenerationCreateRes(response=response_data, weave_call_id="call_123")
+    assert res.response == response_data
+    assert res.weave_call_id == "call_123"
+
+
+@pytest.mark.parametrize(
+    "unsafe_url",
+    [
+        "http://169.254.169.254/latest/meta-data/",
+        "http://127.0.0.1:6379/",
+        "http://localhost:8123/",
+        "file:///etc/passwd",
+    ],
+)
+def test_unsafe_url_skips_from_url(unsafe_url):
     """Non-publicly-routable URLs in the provider response must not be fetched.
 
     URL classification itself is covered in tests/trace_server/test_url_safety.py;
     this checks that `_process_image_data_item` is wired to that gate.
     """
-
-    @pytest.mark.parametrize(
-        "unsafe_url",
-        [
-            "http://169.254.169.254/latest/meta-data/",
-            "http://127.0.0.1:6379/",
-            "http://localhost:8123/",
-            "file:///etc/passwd",
-        ],
-    )
-    def test_unsafe_url_skips_from_url(self, unsafe_url):
-        with (
-            patch(
-                "weave.trace_server.image_completion.Content.from_url"
-            ) as mock_from_url,
-            patch(
-                "weave.trace_server.image_completion.store_content_object"
-            ) as mock_store,
-        ):
-            result = _process_image_data_item(
-                {"url": unsafe_url}, 0, Mock(), "test-project", "user123"
-            )
-            mock_from_url.assert_not_called()
-            mock_store.assert_not_called()
-            assert "error" in result
+    with (
+        patch("weave.trace_server.image_completion.Content.from_url") as mock_from_url,
+        patch("weave.trace_server.image_completion.store_content_object") as mock_store,
+    ):
+        result = _process_image_data_item(
+            {"url": unsafe_url}, 0, Mock(), "test-project", "user123"
+        )
+        mock_from_url.assert_not_called()
+        mock_store.assert_not_called()
+        assert "error" in result
 
 
 if __name__ == "__main__":

--- a/tests/trace_server/test_llm_completion.py
+++ b/tests/trace_server/test_llm_completion.py
@@ -1,5 +1,5 @@
 import datetime
-import unittest
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,10 +14,24 @@ from weave.trace_server.errors import (
     NotFoundError,
 )
 from weave.trace_server.interface.builtin_object_classes.provider import Provider
-from weave.trace_server.llm_completion import get_custom_provider_info
-from weave.trace_server.secret_fetcher_context import (
-    _secret_fetcher_context,
+from weave.trace_server.llm_completion import (
+    get_custom_provider_info,
+    resolve_and_apply_prompt,
+    resolve_prompt_messages,
 )
+from weave.trace_server.secret_fetcher_context import _secret_fetcher_context
+
+LITELLM_STREAM = (
+    "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion_stream"
+)
+LITELLM_COMPLETION = (
+    "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion"
+)
+AGENT_WRITER = "weave.trace_server.clickhouse_trace_server_batched.AgentWriteHandler"
+
+
+class StreamingException(Exception):
+    """Sentinel exception raised by a mocked litellm stream."""
 
 
 @pytest.fixture(autouse=True)
@@ -27,1305 +41,738 @@ def _clear_custom_provider_cache():
         llm_mod._custom_provider_cache.clear()
 
 
-class MockObjectReadError(Exception):
-    """Custom exception for mock object read failures."""
-
-    pass
+# --- get_custom_provider_info --------------------------------------------------
 
 
-class TestGetCustomProviderInfo(unittest.TestCase):
-    """Tests for the get_custom_provider_info function in llm_completion.py.
+def test_successful_provider_info_fetch():
+    """Provider + model objects and API key are resolved into a populated ProviderInfo."""
+    project_id = "test-project"
+    provider_id = "test-provider"
+    model_name = f"{provider_id}/test-model"
+    provider_obj = _provider_obj(project_id, provider_id)
+    model_obj = _provider_model_obj(
+        project_id, f"{provider_id}-test-model", provider_id
+    )
 
-    This test suite verifies the functionality of retrieving and validating custom provider
-    information for LLM completions. It tests:
-    1. Successful retrieval of provider and model information
-    2. Error handling for missing or invalid configurations
-    3. Secret fetching and validation
-    4. Type checking for provider and model objects
-
-    The suite uses mock objects to simulate database interactions and secret fetching,
-    allowing for controlled testing of various scenarios and edge cases.
-    """
-
-    def setUp(self):
-        """Set up test fixtures before each test.
-
-        Creates mock objects and test data including:
-        - Project and provider IDs
-        - Provider configuration with API endpoints and headers
-        - Provider model configuration with model parameters
-        - Mock secret fetcher for API key management
-        """
-        self.project_id = "test-project"
-
-        # Provider data with complete configuration
-        self.provider_id = "test-provider"
-        self.provider_obj = tsi.ObjSchema(
-            project_id=self.project_id,
-            object_id=self.provider_id,
-            digest="digest-1",
-            base_object_class="Provider",
-            leaf_object_class="Provider",
-            val={
-                "base_url": "https://api.example.com",
-                "api_key_name": "TEST_API_KEY",
-                "extra_headers": {"X-Header": "value"},
-                "return_type": "openai",
-            },
-            created_at=datetime.datetime.now(),
-            version_index=1,
-            is_latest=1,
-            kind="object",
-            deleted_at=None,
+    obj_read = MagicMock(
+        side_effect=_obj_read_router({provider_id: provider_obj, model_name: model_obj})
+    )
+    secret_fetcher = _secret_fetcher({"TEST_API_KEY": "test-api-key-value"})
+    token = _secret_fetcher_context.set(secret_fetcher)
+    try:
+        info = get_custom_provider_info(
+            project_id=project_id,
+            provider_name=provider_id,
+            model_name=model_name,
+            obj_read_func=obj_read,
         )
+        assert info.base_url == "https://api.example.com"
+        assert info.api_key == "test-api-key-value"
+        assert info.extra_headers == {"X-Header": "value"}
+        assert info.return_type == "openai"
+        assert info.actual_model_name == "actual-model-name"
+        obj_read.assert_called()
+        secret_fetcher.fetch.assert_called_with("TEST_API_KEY")
+    finally:
+        _secret_fetcher_context.reset(token)
 
-        # Provider model data with model-specific settings
-        self.model_id = "test-model"
-        self.provider_model_obj = tsi.ObjSchema(
-            project_id=self.project_id,
-            object_id=f"{self.provider_id}-{self.model_id}",
-            digest="digest-2",
-            base_object_class="ProviderModel",
-            leaf_object_class="ProviderModel",
-            val={
-                "name": "actual-model-name",
-                "provider": self.provider_id,
-                "max_tokens": 4096,
-                "mode": "chat",
-            },
-            created_at=datetime.datetime.now(),
-            version_index=1,
-            is_latest=1,
-            kind="object",
-            deleted_at=None,
+
+@pytest.mark.parametrize(
+    ("scenario", "expected_message"),
+    [
+        ("missing_secret_fetcher", "No secret fetcher found"),
+        ("provider_not_found", "Failed to fetch provider model information"),
+        ("wrong_provider_type", "Could not find Provider"),
+        ("wrong_provider_model_type", "Could not find Provider"),
+    ],
+)
+def test_get_custom_provider_info_error_paths(scenario, expected_message):
+    """Missing fetcher, unreadable objects, and wrong object types each raise InvalidRequest."""
+    project_id = "test-project"
+    provider_id = "test-provider"
+    model_name = f"{provider_id}/test-model"
+    provider_obj = _provider_obj(project_id, provider_id)
+    model_obj = _provider_model_obj(
+        project_id, f"{provider_id}-test-model", provider_id
+    )
+    secret_fetcher = _secret_fetcher({"TEST_API_KEY": "test-api-key-value"})
+
+    if scenario == "missing_secret_fetcher":
+        obj_read: Callable[[tsi.ObjReadReq], tsi.ObjReadRes] = MagicMock()
+        fetcher = None
+    elif scenario == "provider_not_found":
+        obj_read = MagicMock(side_effect=NotFoundError("Provider not found"))
+        fetcher = secret_fetcher
+    elif scenario == "wrong_provider_type":
+        wrong = provider_obj.model_copy()
+        wrong.base_object_class = "NotAProvider"
+        obj_read = MagicMock(
+            side_effect=_obj_read_router({provider_id: wrong}, default=model_obj)
         )
+        fetcher = secret_fetcher
+    elif scenario == "wrong_provider_model_type":
+        wrong = model_obj.model_copy()
+        wrong.base_object_class = "NotAProviderModel"
+        obj_read = MagicMock(
+            side_effect=_obj_read_router({provider_id: provider_obj}, default=wrong)
+        )
+        fetcher = secret_fetcher
+    else:
+        raise AssertionError(f"unhandled scenario: {scenario}")
 
-        # Model name in format provider_id/model_id for API calls
-        self.model_name = f"{self.provider_id}/{self.model_id}"
-
-        # Mock secret fetcher for API key management
-        self.mock_secret_fetcher = MagicMock()
-        self.mock_secret_fetcher.fetch.return_value = {
-            "secrets": {"TEST_API_KEY": "test-api-key-value"}
-        }
-
-        # Mock object read function for database interactions
-        self.mock_obj_read_func = MagicMock()
-
-    def test_successful_provider_info_fetch(self):
-        """Test successful retrieval of provider information.
-
-        Verifies that:
-        1. Provider and model information are correctly retrieved
-        2. API credentials are properly fetched
-        3. All configuration parameters are returned as expected
-        4. Object read and secret fetch calls are made correctly
-        """
-
-        def mock_obj_read(req):
-            if req.object_id == self.provider_id:
-                return tsi.ObjReadRes(obj=self.provider_obj)
-            elif req.object_id == self.model_name:
-                return tsi.ObjReadRes(obj=self.provider_model_obj)
-            raise NotFoundError(f"Unknown object_id: {req.object_id}")
-
-        self.mock_obj_read_func.side_effect = mock_obj_read
-
-        # Set up the secret fetcher context
-        token = _secret_fetcher_context.set(self.mock_secret_fetcher)
-        try:
-            # Call the function under test
-            provider_info = get_custom_provider_info(
-                project_id=self.project_id,
-                provider_name=self.provider_id,
-                model_name=self.model_name,
-                obj_read_func=self.mock_obj_read_func,
+    token = _secret_fetcher_context.set(fetcher)
+    try:
+        with pytest.raises(InvalidRequest, match=expected_message):
+            get_custom_provider_info(
+                project_id=project_id,
+                provider_name=provider_id,
+                model_name=model_name,
+                obj_read_func=obj_read,
             )
+    finally:
+        _secret_fetcher_context.reset(token)
 
-            # Verify the results
-            assert provider_info.base_url == "https://api.example.com", (
-                f"Base URL mismatch. Expected 'https://api.example.com', "
-                f"got '{provider_info.base_url}'"
-            )
-            assert provider_info.api_key == "test-api-key-value", (
-                f"API key mismatch. Expected 'test-api-key-value', "
-                f"got '{provider_info.api_key}'"
-            )
-            assert provider_info.extra_headers == {"X-Header": "value"}, (
-                f"Extra headers mismatch. Expected {{'X-Header': 'value'}}, "
-                f"got {provider_info.extra_headers}"
-            )
-            assert provider_info.return_type == "openai", (
-                f"Return type mismatch. Expected 'openai', "
-                f"got '{provider_info.return_type}'"
-            )
-            assert provider_info.actual_model_name == "actual-model-name", (
-                f"Actual model name mismatch. Expected 'actual-model-name', "
-                f"got '{provider_info.actual_model_name}'"
-            )
 
-            # Verify the mock calls
-            self.mock_obj_read_func.assert_called()
-            self.mock_secret_fetcher.fetch.assert_called_with("TEST_API_KEY")
-        finally:
-            _secret_fetcher_context.reset(token)
+# --- streaming completions -----------------------------------------------------
 
-    def test_missing_secret_fetcher(self):
-        """Test error handling when secret fetcher is not configured.
 
-        Verifies that appropriate error is raised when attempting to
-        fetch provider information without a configured secret fetcher.
-        """
-        # Set the context to None to simulate missing secret fetcher
-        token = _secret_fetcher_context.set(None)
-        try:
-            with pytest.raises(InvalidRequest) as context:
-                get_custom_provider_info(
-                    project_id=self.project_id,
-                    provider_name=self.provider_id,
-                    model_name=self.model_name,
-                    obj_read_func=self.mock_obj_read_func,
+def test_basic_streaming_completion(streaming_server):
+    """Content deltas and the terminal usage chunk pass through verbatim."""
+    chunks_in = [
+        _delta_chunk("Hello"),
+        _delta_chunk(" world"),
+        _stop_chunk({"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}),
+    ]
+    with patch(LITELLM_STREAM, return_value=_iter_mock(chunks_in)):
+        chunks = list(
+            streaming_server.completions_create_stream(
+                _completion_req("test_project", track=False)
+            )
+        )
+    assert len(chunks) == 3
+    assert chunks[0]["choices"][0]["delta"]["content"] == "Hello"
+    assert chunks[1]["choices"][0]["delta"]["content"] == " world"
+    assert chunks[2]["choices"][0]["finish_reason"] == "stop"
+    assert "usage" in chunks[2]
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        StreamingException("Test error"),
+        MissingLLMApiKeyError("No API key found", api_key_name="TEST_API_KEY"),
+    ],
+    ids=["generic_error", "missing_api_key"],
+)
+def test_streaming_propagates_litellm_errors(streaming_server, exc):
+    """Errors raised by the litellm stream propagate out of the generator."""
+    with patch(LITELLM_STREAM, side_effect=exc):
+        with pytest.raises(type(exc)):
+            list(
+                streaming_server.completions_create_stream(
+                    _completion_req("test_project", track=False)
                 )
-
-            assert "No secret fetcher found" in str(context.value), (
-                "Expected error message about missing secret fetcher not found"
-            )
-        finally:
-            _secret_fetcher_context.reset(token)
-
-    def test_provider_not_found(self):
-        """Test error handling when provider object cannot be found.
-
-        Verifies that appropriate error is raised when the provider
-        object cannot be retrieved from the database.
-        """
-        # Make obj_read_func raise an exception to simulate missing provider
-        self.mock_obj_read_func.side_effect = NotFoundError("Provider not found")
-
-        token = _secret_fetcher_context.set(self.mock_secret_fetcher)
-        try:
-            with pytest.raises(InvalidRequest) as context:
-                get_custom_provider_info(
-                    project_id=self.project_id,
-                    provider_name=self.provider_id,
-                    model_name=self.model_name,
-                    obj_read_func=self.mock_obj_read_func,
-                )
-
-            assert "Failed to fetch provider model information" in str(context.value), (
-                "Expected error message about failed provider fetch not found"
-            )
-        finally:
-            _secret_fetcher_context.reset(token)
-
-    def test_wrong_provider_type(self):
-        """Test error handling when provider object has incorrect type.
-
-        Verifies that appropriate error is raised when the retrieved
-        provider object is not of the expected Provider type.
-        """
-        # Create provider object with incorrect type
-        wrong_type_provider = self.provider_obj.model_copy()
-        wrong_type_provider.base_object_class = "NotAProvider"
-
-        def mock_obj_read(req):
-            if req.object_id == self.provider_id:
-                return tsi.ObjReadRes(obj=wrong_type_provider)
-            else:
-                return tsi.ObjReadRes(obj=self.provider_model_obj)
-
-        self.mock_obj_read_func.side_effect = mock_obj_read
-
-        token = _secret_fetcher_context.set(self.mock_secret_fetcher)
-        try:
-            with pytest.raises(InvalidRequest) as context:
-                get_custom_provider_info(
-                    project_id=self.project_id,
-                    provider_name=self.provider_id,
-                    model_name=self.model_name,
-                    obj_read_func=self.mock_obj_read_func,
-                )
-
-            assert "Could not find Provider" in str(context.value), (
-                "Expected error message about incorrect provider type not found"
-            )
-        finally:
-            _secret_fetcher_context.reset(token)
-
-    def test_wrong_provider_model_type(self):
-        """Test error handling when provider model object has incorrect type.
-
-        Verifies that appropriate error is raised when the retrieved
-        provider model object is not of the expected ProviderModel type.
-        """
-        # Create provider model object with incorrect type
-        wrong_type_model = self.provider_model_obj.model_copy()
-        wrong_type_model.base_object_class = "NotAProviderModel"
-
-        def mock_obj_read(req):
-            if req.object_id == self.provider_id:
-                return tsi.ObjReadRes(obj=self.provider_obj)
-            else:
-                return tsi.ObjReadRes(obj=wrong_type_model)
-
-        self.mock_obj_read_func.side_effect = mock_obj_read
-
-        token = _secret_fetcher_context.set(self.mock_secret_fetcher)
-        try:
-            with pytest.raises(InvalidRequest) as context:
-                get_custom_provider_info(
-                    project_id=self.project_id,
-                    provider_name=self.provider_id,
-                    model_name=self.model_name,
-                    obj_read_func=self.mock_obj_read_func,
-                )
-
-            assert "Could not find Provider" in str(context.value), (
-                "Expected error message about incorrect provider model type not found"
-            )
-        finally:
-            _secret_fetcher_context.reset(token)
-
-
-class TestLLMCompletionStreaming(unittest.TestCase):
-    """Tests for LLM completion streaming functionality."""
-
-    def setUp(self):
-        """Set up test fixtures before each test."""
-        self.server = chts.ClickHouseTraceServer(host="test_host")
-        mock_ch_client = MagicMock()
-        mock_ch_client.query.return_value = MagicMock(result_rows=[[0, 0]])
-        # ch_client is lazy; pre-populating _thread_local.ch_client bypasses _mint_client.
-        self.server._thread_local.ch_client = mock_ch_client
-        self.mock_secret_fetcher = MagicMock()
-        self.mock_secret_fetcher.fetch.return_value = {
-            "secrets": {
-                "OPENAI_API_KEY": "test-api-key-value",
-                "CUSTOM_API_KEY": "test-api-key-value",
-                "TEST_API_KEY": "test-api-key-value",
-            }
-        }
-        self.token = _secret_fetcher_context.set(self.mock_secret_fetcher)
-
-    def tearDown(self):
-        _secret_fetcher_context.reset(self.token)
-
-    def test_basic_streaming_completion(self):
-        """Test basic streaming completion functionality."""
-        # Mock the litellm completion stream
-        mock_chunks = [
-            {
-                "choices": [
-                    {
-                        "delta": {"content": "Hello"},
-                        "finish_reason": None,
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "test-model",
-                "created": 1234567890,
-            },
-            {
-                "choices": [
-                    {
-                        "delta": {"content": " world"},
-                        "finish_reason": None,
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "test-model",
-                "created": 1234567890,
-            },
-            {
-                "choices": [
-                    {
-                        "delta": {},
-                        "finish_reason": "stop",
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "test-model",
-                "created": 1234567890,
-                "usage": {
-                    "prompt_tokens": 10,
-                    "completion_tokens": 2,
-                    "total_tokens": 12,
-                },
-            },
-        ]
-
-        with patch(
-            "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion_stream"
-        ) as mock_litellm:
-            # Mock the litellm completion stream
-            mock_stream = MagicMock()
-            mock_stream.__iter__.return_value = mock_chunks
-            mock_litellm.return_value = mock_stream
-
-            # Create test request
-            req = tsi.CompletionsCreateReq(
-                project_id="test_project",
-                inputs=tsi.CompletionsCreateRequestInputs(
-                    model="gpt-3.5-turbo",
-                    messages=[{"role": "user", "content": "Say hello"}],
-                ),
-                track_llm_call=False,
             )
 
-            # Get the stream
-            stream = self.server.completions_create_stream(req)
 
-            # Collect all chunks
-            chunks = list(stream)
-
-            # Verify the chunks
-            assert len(chunks) == 3
-            assert chunks[0]["choices"][0]["delta"]["content"] == "Hello"
-            assert chunks[1]["choices"][0]["delta"]["content"] == " world"
-            assert chunks[2]["choices"][0]["finish_reason"] == "stop"
-            assert "usage" in chunks[2]
-
-    def test_streaming_error_handling(self):
-        """Test error handling in streaming completion."""
-
-        class StreamingException(Exception): ...
-
-        with patch(
-            "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion_stream"
-        ) as mock_litellm:
-            # Mock litellm to raise an exception
-            mock_litellm.side_effect = StreamingException("Test error")
-
-            # Create test request
-            req = tsi.CompletionsCreateReq(
-                project_id="test_project",
-                inputs=tsi.CompletionsCreateRequestInputs(
-                    model="gpt-3.5-turbo",
-                    messages=[{"role": "user", "content": "Say hello"}],
-                ),
-                track_llm_call=False,
+def test_streaming_with_call_tracking(streaming_server):
+    """Tracking emits a leading _meta chunk and writes open + completed spans."""
+    chunks_in = [
+        _delta_chunk("Hello"),
+        _stop_chunk({"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11}),
+    ]
+    with (
+        patch(LITELLM_STREAM, return_value=_iter_mock(chunks_in)),
+        patch(AGENT_WRITER) as writer_cls,
+    ):
+        writer = writer_cls.return_value
+        chunks = list(
+            streaming_server.completions_create_stream(
+                _completion_req("dGVzdF9wcm9qZWN0", track=True)
             )
-
-            # Get the stream and expect an exception
-            with pytest.raises(StreamingException):
-                list(self.server.completions_create_stream(req))
-
-    def test_streaming_with_call_tracking(self):
-        """Test streaming completion with call tracking enabled."""
-        mock_chunks = [
-            {
-                "choices": [
-                    {
-                        "delta": {"content": "Hello"},
-                        "finish_reason": None,
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "test-model",
-                "created": 1234567890,
-            },
-            {
-                "choices": [
-                    {
-                        "delta": {},
-                        "finish_reason": "stop",
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "test-model",
-                "created": 1234567890,
-                "usage": {
-                    "prompt_tokens": 10,
-                    "completion_tokens": 1,
-                    "total_tokens": 11,
-                },
-            },
-        ]
-
-        with (
-            patch(
-                "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion_stream"
-            ) as mock_litellm,
-            patch(
-                "weave.trace_server.clickhouse_trace_server_batched.AgentWriteHandler"
-            ) as mock_agent_writer_cls,
-        ):
-            mock_agent_writer = MagicMock()
-            mock_agent_writer_cls.return_value = mock_agent_writer
-
-            mock_stream = MagicMock()
-            mock_stream.__iter__.return_value = mock_chunks
-            mock_litellm.return_value = mock_stream
-
-            req = tsi.CompletionsCreateReq(
-                project_id="dGVzdF9wcm9qZWN0",
-                inputs=tsi.CompletionsCreateRequestInputs(
-                    model="gpt-3.5-turbo",
-                    messages=[{"role": "user", "content": "Say hello"}],
-                ),
-                track_llm_call=True,
-            )
-
-            stream = self.server.completions_create_stream(req)
-            chunks = list(stream)
-
-            assert len(chunks) == 3  # Meta chunk + 2 content chunks
-            assert "_meta" in chunks[0]
-            assert "weave_call_id" in chunks[0]["_meta"]
-            assert chunks[1]["choices"][0]["delta"]["content"] == "Hello"
-            assert chunks[2]["choices"][0]["finish_reason"] == "stop"
-
-            # Open span + completed span = 2 insert_span calls
-            assert mock_agent_writer.insert_span.call_count == 2
-            completed_span = mock_agent_writer.insert_span.call_args_list[1][0][0]
-            assert completed_span.project_id == "dGVzdF9wcm9qZWN0"
-
-    def test_custom_provider_streaming(self):
-        """Test streaming completion with a custom provider."""
-        # Mock the litellm completion stream
-        mock_chunks = [
-            {
-                "choices": [
-                    {
-                        "delta": {"content": "Custom"},
-                        "finish_reason": None,
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "custom-model",
-                "created": 1234567890,
-            },
-            {
-                "choices": [
-                    {
-                        "delta": {},
-                        "finish_reason": "stop",
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "custom-model",
-                "created": 1234567890,
-                "usage": {
-                    "prompt_tokens": 5,
-                    "completion_tokens": 1,
-                    "total_tokens": 6,
-                },
-            },
-        ]
-
-        with (
-            patch(
-                "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion_stream"
-            ) as mock_litellm,
-            patch.object(chts.ClickHouseTraceServer, "obj_read") as mock_obj_read,
-        ):
-            # Mock the litellm completion stream
-            mock_stream = MagicMock()
-            mock_stream.__iter__.return_value = mock_chunks
-            mock_litellm.return_value = mock_stream
-
-            # Mock provider and model objects
-            mock_provider = tsi.ObjSchema(
-                project_id="test_project",
-                object_id="custom-provider",
-                digest="digest-1",
-                base_object_class="Provider",
-                leaf_object_class="Provider",
-                val={
-                    "base_url": "https://api.custom.com",
-                    "api_key_name": "CUSTOM_API_KEY",
-                    "extra_headers": {"X-Custom": "value"},
-                    "return_type": "openai",
-                    "api_base": "https://api.custom.com",
-                },
-                created_at=datetime.datetime.now(),
-                version_index=1,
-                is_latest=1,
-                kind="object",
-                deleted_at=None,
-            )
-
-            mock_model = tsi.ObjSchema(
-                project_id="test_project",
-                object_id="custom-provider-model",
-                digest="digest-2",
-                base_object_class="ProviderModel",
-                leaf_object_class="ProviderModel",
-                val={
-                    "name": "custom-model",
-                    "provider": "custom-provider",
-                    "max_tokens": 4096,
-                    "mode": "chat",
-                },
-                created_at=datetime.datetime.now(),
-                version_index=1,
-                is_latest=1,
-                kind="object",
-                deleted_at=None,
-            )
-
-            def mock_obj_read_func(req):
-                if req.object_id == "custom-provider":
-                    return tsi.ObjReadRes(obj=mock_provider)
-                elif req.object_id == "custom-provider-model":
-                    return tsi.ObjReadRes(obj=mock_model)
-                raise MockObjectReadError(f"Unknown object_id: {req.object_id}")
-
-            mock_obj_read.side_effect = mock_obj_read_func
-
-            # Create test request
-            req = tsi.CompletionsCreateReq(
-                project_id="dGVzdF9wcm9qZWN0",
-                inputs=tsi.CompletionsCreateRequestInputs(
-                    model="custom::custom-provider::model",
-                    messages=[{"role": "user", "content": "Say hello"}],
-                ),
-                track_llm_call=False,
-            )
-
-            # Get the stream
-            stream = self.server.completions_create_stream(req)
-
-            # Collect all chunks
-            chunks = list(stream)
-
-            # Verify the chunks
-            assert len(chunks) == 2
-            assert chunks[0]["choices"][0]["delta"]["content"] == "Custom"
-            assert chunks[1]["choices"][0]["finish_reason"] == "stop"
-
-            # Verify litellm was called with correct parameters
-            mock_litellm.assert_called_once()
-            call_args = mock_litellm.call_args[1]
-            assert (
-                call_args.get("api_base") or call_args.get("base_url")
-            ) == "https://api.custom.com"
-            assert call_args["extra_headers"] == {"X-Custom": "value"}
-
-    def test_missing_api_key(self):
-        """Test handling of missing API key in streaming completion."""
-        with patch(
-            "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion_stream"
-        ) as mock_litellm:
-            # Mock litellm to raise MissingLLMApiKeyError
-            mock_litellm.side_effect = MissingLLMApiKeyError(
-                "No API key found", api_key_name="TEST_API_KEY"
-            )
-
-            # Create test request
-            req = tsi.CompletionsCreateReq(
-                project_id="test_project",
-                inputs=tsi.CompletionsCreateRequestInputs(
-                    model="gpt-3.5-turbo",
-                    messages=[{"role": "user", "content": "Say hello"}],
-                ),
-                track_llm_call=False,
-            )
-
-            # Get the stream and expect an exception
-            with pytest.raises(MissingLLMApiKeyError):
-                list(self.server.completions_create_stream(req))
+        )
+    assert len(chunks) == 3
+    assert "_meta" in chunks[0]
+    assert "weave_call_id" in chunks[0]["_meta"]
+    assert chunks[1]["choices"][0]["delta"]["content"] == "Hello"
+    assert chunks[2]["choices"][0]["finish_reason"] == "stop"
+    assert writer.insert_span.call_count == 2
+    completed_span = writer.insert_span.call_args_list[1][0][0]
+    assert completed_span.project_id == "dGVzdF9wcm9qZWN0"
 
 
-class TestPromptResolution(unittest.TestCase):
-    """Tests for prompt resolution and template variable substitution."""
+def test_custom_provider_streaming(streaming_server):
+    """A custom:: model resolves provider config and forwards base_url + extra_headers."""
+    chunks_in = [
+        _delta_chunk("Custom", model="custom-model"),
+        _stop_chunk(
+            {"prompt_tokens": 5, "completion_tokens": 1, "total_tokens": 6},
+            model="custom-model",
+        ),
+    ]
+    provider = _provider_obj(
+        "test_project",
+        "custom-provider",
+        base_url="https://api.custom.com",
+        api_key_name="CUSTOM_API_KEY",
+        extra_headers={"X-Custom": "value"},
+        extra_val={"api_base": "https://api.custom.com"},
+    )
+    model = _provider_model_obj(
+        "test_project", "custom-provider-model", "custom-provider", name="custom-model"
+    )
+    with (
+        patch(LITELLM_STREAM, return_value=_iter_mock(chunks_in)) as mock_litellm,
+        patch.object(
+            chts.ClickHouseTraceServer,
+            "obj_read",
+            side_effect=_obj_read_router(
+                {"custom-provider": provider, "custom-provider-model": model}
+            ),
+        ),
+    ):
+        req = _completion_req(
+            "dGVzdF9wcm9qZWN0", track=False, model="custom::custom-provider::model"
+        )
+        chunks = list(streaming_server.completions_create_stream(req))
+    assert len(chunks) == 2
+    assert chunks[0]["choices"][0]["delta"]["content"] == "Custom"
+    assert chunks[1]["choices"][0]["finish_reason"] == "stop"
+    mock_litellm.assert_called_once()
+    call_args = mock_litellm.call_args[1]
+    assert (
+        call_args.get("api_base") or call_args.get("base_url")
+    ) == "https://api.custom.com"
+    assert call_args["extra_headers"] == {"X-Custom": "value"}
 
-    def setUp(self):
-        """Set up test fixtures before each test."""
-        self.project_id = "test-project"
-        self.mock_secret_fetcher = MagicMock()
-        self.mock_secret_fetcher.fetch.return_value = {
-            "secrets": {"OPENAI_API_KEY": "test-api-key"}
-        }
-        self.token = _secret_fetcher_context.set(self.mock_secret_fetcher)
 
-    def tearDown(self):
-        _secret_fetcher_context.reset(self.token)
+# --- prompt resolution ---------------------------------------------------------
 
-    def test_resolve_prompt_messages(self):
-        """Test resolving prompt messages from a MessagesPrompt object."""
-        from weave.trace_server.llm_completion import resolve_prompt_messages
 
-        # Create a mock MessagesPrompt object
-        mock_prompt_obj = tsi.ObjSchema(
-            project_id=self.project_id,
-            object_id="test-prompt",
-            digest="digest-1",
-            base_object_class="MessagesPrompt",
-            leaf_object_class="MessagesPrompt",
-            val={
-                "messages": [
-                    {"role": "system", "content": "You are {assistant_name}."},
-                    {"role": "user", "content": "Hello!"},
-                ]
-            },
-            created_at=datetime.datetime.now(),
-            version_index=1,
-            is_latest=1,
-            kind="object",
-            deleted_at=None,
+def test_resolve_prompt_messages():
+    """resolve_prompt_messages returns prompt messages without substituting template vars."""
+    project_id = "test-project"
+    prompt_obj = _messages_prompt_obj(
+        project_id,
+        [
+            {"role": "system", "content": "You are {assistant_name}."},
+            {"role": "user", "content": "Hello!"},
+        ],
+    )
+    messages = resolve_prompt_messages(
+        prompt=_prompt_uri(project_id, "test-prompt"),
+        project_id=project_id,
+        obj_read_func=lambda req: tsi.ObjReadRes(obj=prompt_obj),
+    )
+    assert messages == [
+        {"role": "system", "content": "You are {assistant_name}."},
+        {"role": "user", "content": "Hello!"},
+    ]
+
+
+def test_resolve_prompt_messages_invalid_prompt():
+    """A non-Prompt object raises InvalidRequest."""
+    project_id = "test-project"
+    not_prompt = _model_obj(project_id, "test-obj")
+    with pytest.raises(InvalidRequest, match="is not a Prompt or MessagesPrompt"):
+        resolve_prompt_messages(
+            prompt=_prompt_uri(project_id, "test-obj"),
+            project_id=project_id,
+            obj_read_func=lambda req: tsi.ObjReadRes(obj=not_prompt),
         )
 
-        def mock_obj_read(req):
-            return tsi.ObjReadRes(obj=mock_prompt_obj)
 
-        prompt_uri = (
-            f"weave-trace-internal:///{self.project_id}/object/test-prompt:digest-1"
+def test_streaming_with_prompt_resolution(streaming_server):
+    """A prompt reference is resolved via obj_read before streaming."""
+    project_id = "test-project"
+    prompt_obj = _messages_prompt_obj(
+        project_id, [{"role": "system", "content": "You are a helpful assistant."}]
+    )
+    chunks_in = [
+        _delta_chunk("Hello"),
+        _stop_chunk({"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11}),
+    ]
+    with (
+        patch(LITELLM_STREAM, return_value=_iter_mock(chunks_in)),
+        patch.object(
+            chts.ClickHouseTraceServer,
+            "obj_read",
+            return_value=tsi.ObjReadRes(obj=prompt_obj),
+        ) as mock_obj_read,
+    ):
+        req = _completion_req(
+            project_id, track=False, prompt=_prompt_uri(project_id, "test-prompt")
         )
+        chunks = list(streaming_server.completions_create_stream(req))
+    assert len(chunks) == 2
+    assert chunks[0]["choices"][0]["delta"]["content"] == "Hello"
+    assert chunks[1]["choices"][0]["finish_reason"] == "stop"
+    mock_obj_read.assert_called_once()
 
-        # Test resolving messages (without template var substitution)
-        messages = resolve_prompt_messages(
-            prompt=prompt_uri,
-            project_id=self.project_id,
-            obj_read_func=mock_obj_read,
+
+def test_streaming_with_prompt_and_template_vars(streaming_server):
+    """Template vars are substituted into the resolved prompt before the litellm call."""
+    project_id = "test-project"
+    prompt_obj = _messages_prompt_obj(
+        project_id,
+        [
+            {"role": "system", "content": "You are {assistant_name}."},
+            {"role": "user", "content": "Tell me about {topic}."},
+        ],
+    )
+    chunks_in = [
+        _delta_chunk("Mathematics"),
+        _stop_chunk({"prompt_tokens": 15, "completion_tokens": 1, "total_tokens": 16}),
+    ]
+    with (
+        patch(LITELLM_STREAM, return_value=_iter_mock(chunks_in)) as mock_litellm,
+        patch.object(
+            chts.ClickHouseTraceServer,
+            "obj_read",
+            return_value=tsi.ObjReadRes(obj=prompt_obj),
+        ),
+    ):
+        req = tsi.CompletionsCreateReq(
+            project_id=project_id,
+            inputs=tsi.CompletionsCreateRequestInputs(
+                model="gpt-3.5-turbo",
+                messages=[],
+                prompt=_prompt_uri(project_id, "test-prompt"),
+                template_vars={"assistant_name": "MathBot", "topic": "mathematics"},
+            ),
+            track_llm_call=False,
         )
+        chunks = list(streaming_server.completions_create_stream(req))
+    assert len(chunks) == 2
+    assert chunks[0]["choices"][0]["delta"]["content"] == "Mathematics"
+    mock_litellm.assert_called_once()
+    messages = mock_litellm.call_args[1]["inputs"].messages
+    assert messages == [
+        {"role": "system", "content": "You are MathBot."},
+        {"role": "user", "content": "Tell me about mathematics."},
+    ]
 
-        # Template variables should NOT be substituted (that's handled separately)
-        assert len(messages) == 2
-        assert messages[0]["role"] == "system"
-        assert messages[0]["content"] == "You are {assistant_name}."
-        assert messages[1]["role"] == "user"
-        assert messages[1]["content"] == "Hello!"
 
-    def test_resolve_prompt_messages_invalid_prompt(self):
-        """Test error handling when prompt object is not a Prompt or MessagesPrompt."""
-        from weave.trace_server.errors import InvalidRequest
-        from weave.trace_server.llm_completion import resolve_prompt_messages
-
-        # Create a mock object that is NOT a MessagesPrompt
-        mock_not_prompt = tsi.ObjSchema(
-            project_id=self.project_id,
-            object_id="test-obj",
-            digest="digest-1",
-            base_object_class="Model",
-            leaf_object_class="Model",
-            val={"name": "test"},
-            created_at=datetime.datetime.now(),
-            version_index=1,
-            is_latest=1,
-            kind="object",
-            deleted_at=None,
+@pytest.mark.disable_logging_error_check
+def test_streaming_with_prompt_error(streaming_server):
+    """A failed prompt resolution yields a single error chunk instead of raising."""
+    project_id = "test-project"
+    with patch.object(
+        chts.ClickHouseTraceServer,
+        "obj_read",
+        side_effect=NotFoundError("Prompt not found"),
+    ):
+        req = _completion_req(
+            project_id, track=False, prompt=_prompt_uri(project_id, "missing-prompt")
         )
-
-        def mock_obj_read(req):
-            return tsi.ObjReadRes(obj=mock_not_prompt)
-
-        prompt_uri = (
-            f"weave-trace-internal:///{self.project_id}/object/test-obj:digest-1"
-        )
-
-        # Should raise InvalidRequest when object is not a Prompt or MessagesPrompt
-        with pytest.raises(InvalidRequest) as context:
-            resolve_prompt_messages(
-                prompt=prompt_uri,
-                project_id=self.project_id,
-                obj_read_func=mock_obj_read,
-            )
-
-        assert "is not a Prompt or MessagesPrompt" in str(context.value)
+        chunks = list(streaming_server.completions_create_stream(req))
+    assert len(chunks) == 1
+    assert "error" in chunks[0]
+    assert "Failed to resolve and apply prompt" in chunks[0]["error"]
 
 
-class TestStreamingWithPrompts(unittest.TestCase):
-    """Tests for streaming completions with prompt resolution and template variables."""
-
-    def setUp(self):
-        """Set up test fixtures before each test."""
-        self.server = chts.ClickHouseTraceServer(host="test_host")
-        self.project_id = "test-project"
-        self.mock_secret_fetcher = MagicMock()
-        self.mock_secret_fetcher.fetch.return_value = {
-            "secrets": {"OPENAI_API_KEY": "test-api-key"}
-        }
-        self.token = _secret_fetcher_context.set(self.mock_secret_fetcher)
-
-    def tearDown(self):
-        _secret_fetcher_context.reset(self.token)
-
-    def test_streaming_with_prompt_resolution(self):
-        """Test streaming completion with prompt resolution."""
-        # Mock the MessagesPrompt object
-        mock_prompt_obj = tsi.ObjSchema(
-            project_id=self.project_id,
-            object_id="test-prompt",
-            digest="digest-1",
-            base_object_class="MessagesPrompt",
-            leaf_object_class="MessagesPrompt",
-            val={
-                "messages": [
-                    {"role": "system", "content": "You are a helpful assistant."},
-                ]
-            },
-            created_at=datetime.datetime.now(),
-            version_index=1,
-            is_latest=1,
-            kind="object",
-            deleted_at=None,
-        )
-
-        # Mock response chunks
-        mock_chunks = [
-            {
-                "choices": [
-                    {
-                        "delta": {"content": "Hello"},
-                        "finish_reason": None,
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "gpt-3.5-turbo",
-                "created": 1234567890,
-            },
-            {
-                "choices": [
-                    {
-                        "delta": {},
-                        "finish_reason": "stop",
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "gpt-3.5-turbo",
-                "created": 1234567890,
-                "usage": {
-                    "prompt_tokens": 10,
-                    "completion_tokens": 1,
-                    "total_tokens": 11,
-                },
-            },
-        ]
-
-        with (
-            patch(
-                "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion_stream"
-            ) as mock_litellm,
-            patch.object(chts.ClickHouseTraceServer, "obj_read") as mock_obj_read,
-        ):
-            # Mock the litellm completion stream
-            mock_stream = MagicMock()
-            mock_stream.__iter__.return_value = mock_chunks
-            mock_litellm.return_value = mock_stream
-
-            # Mock obj_read to return the prompt
-            mock_obj_read.return_value = tsi.ObjReadRes(obj=mock_prompt_obj)
-
-            prompt_uri = (
-                f"weave-trace-internal:///{self.project_id}/object/test-prompt:digest-1"
-            )
-
-            # Create test request with prompt
-            req = tsi.CompletionsCreateReq(
-                project_id=self.project_id,
-                inputs=tsi.CompletionsCreateRequestInputs(
-                    model="gpt-3.5-turbo",
-                    messages=[{"role": "user", "content": "Hi there"}],
-                    prompt=prompt_uri,
-                ),
-                track_llm_call=False,
-            )
-
-            # Get the stream
-            stream = self.server.completions_create_stream(req)
-
-            # Collect all chunks
-            chunks = list(stream)
-
-            # Verify the chunks
-            assert len(chunks) == 2
-            assert chunks[0]["choices"][0]["delta"]["content"] == "Hello"
-            assert chunks[1]["choices"][0]["finish_reason"] == "stop"
-
-            # Verify obj_read was called to resolve the prompt
-            mock_obj_read.assert_called_once()
-
-    def test_streaming_with_prompt_and_template_vars(self):
-        """Test streaming completion with prompt resolution and template variables."""
-        # Mock the MessagesPrompt object with template variables
-        mock_prompt_obj = tsi.ObjSchema(
-            project_id=self.project_id,
-            object_id="test-prompt",
-            digest="digest-1",
-            base_object_class="MessagesPrompt",
-            leaf_object_class="MessagesPrompt",
-            val={
-                "messages": [
-                    {"role": "system", "content": "You are {assistant_name}."},
-                    {"role": "user", "content": "Tell me about {topic}."},
-                ]
-            },
-            created_at=datetime.datetime.now(),
-            version_index=1,
-            is_latest=1,
-            kind="object",
-            deleted_at=None,
-        )
-
-        # Mock response chunks
-        mock_chunks = [
-            {
-                "choices": [
-                    {
-                        "delta": {"content": "Mathematics"},
-                        "finish_reason": None,
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "gpt-3.5-turbo",
-                "created": 1234567890,
-            },
-            {
-                "choices": [
-                    {
-                        "delta": {},
-                        "finish_reason": "stop",
-                        "index": 0,
-                    }
-                ],
-                "id": "test-id",
-                "model": "gpt-3.5-turbo",
-                "created": 1234567890,
-                "usage": {
-                    "prompt_tokens": 15,
-                    "completion_tokens": 1,
-                    "total_tokens": 16,
-                },
-            },
-        ]
-
-        with (
-            patch(
-                "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion_stream"
-            ) as mock_litellm,
-            patch.object(chts.ClickHouseTraceServer, "obj_read") as mock_obj_read,
-        ):
-            # Mock the litellm completion stream
-            mock_stream = MagicMock()
-            mock_stream.__iter__.return_value = mock_chunks
-            mock_litellm.return_value = mock_stream
-
-            # Mock obj_read to return the prompt
-            mock_obj_read.return_value = tsi.ObjReadRes(obj=mock_prompt_obj)
-
-            prompt_uri = (
-                f"weave-trace-internal:///{self.project_id}/object/test-prompt:digest-1"
-            )
-
-            # Create test request with prompt and template_vars
-            req = tsi.CompletionsCreateReq(
-                project_id=self.project_id,
-                inputs=tsi.CompletionsCreateRequestInputs(
-                    model="gpt-3.5-turbo",
-                    messages=[],
-                    prompt=prompt_uri,
-                    template_vars={"assistant_name": "MathBot", "topic": "mathematics"},
-                ),
-                track_llm_call=False,
-            )
-
-            # Get the stream
-            stream = self.server.completions_create_stream(req)
-
-            # Collect all chunks
-            chunks = list(stream)
-
-            # Verify the chunks
-            assert len(chunks) == 2
-            assert chunks[0]["choices"][0]["delta"]["content"] == "Mathematics"
-            assert chunks[1]["choices"][0]["finish_reason"] == "stop"
-
-            # Verify litellm was called with substituted messages
-            mock_litellm.assert_called_once()
-            call_kwargs = mock_litellm.call_args[1]
-            messages = call_kwargs["inputs"].messages
-
-            # Should have 2 messages with template vars replaced
-            assert len(messages) == 2
-            assert messages[0]["content"] == "You are MathBot."
-            assert messages[1]["content"] == "Tell me about mathematics."
-
-    @pytest.mark.disable_logging_error_check
-    def test_streaming_with_prompt_error(self):
-        """Test error handling when prompt resolution fails during streaming."""
-        with patch.object(chts.ClickHouseTraceServer, "obj_read") as mock_obj_read:
-            # Mock obj_read to raise an error
-            from weave.trace_server.errors import NotFoundError
-
-            mock_obj_read.side_effect = NotFoundError("Prompt not found")
-
-            prompt_uri = f"weave-trace-internal:///{self.project_id}/object/missing-prompt:digest-1"
-
-            # Create test request with non-existent prompt
-            req = tsi.CompletionsCreateReq(
-                project_id=self.project_id,
-                inputs=tsi.CompletionsCreateRequestInputs(
-                    model="gpt-3.5-turbo",
-                    messages=[{"role": "user", "content": "Hi"}],
-                    prompt=prompt_uri,
-                ),
-                track_llm_call=False,
-            )
-
-            # Get the stream
-            stream = self.server.completions_create_stream(req)
-
-            # Collect all chunks - should get error chunk
-            chunks = list(stream)
-
-            # Should have exactly one error chunk
-            assert len(chunks) == 1
-            assert "error" in chunks[0]
-            assert "Failed to resolve and apply prompt" in chunks[0]["error"]
+# --- resolve_and_apply_prompt --------------------------------------------------
 
 
-class TestResolveAndApplyPrompt(unittest.TestCase):
-    """Tests for the resolve_and_apply_prompt helper function.
-
-    This test suite verifies the consolidated helper that:
-    1. Resolves prompt references to messages
-    2. Combines prompt messages with user messages
-    3. Applies template variable substitution to combined messages
-    """
-
-    def setUp(self):
-        """Set up test fixtures before each test."""
-        self.project_id = "test-project"
-
-    def test_resolve_and_apply_prompt_with_all_params(self):
-        """Test with prompt, messages, and template vars all provided."""
-        from weave.trace_server.llm_completion import resolve_and_apply_prompt
-
-        # Mock prompt object
-        mock_prompt_obj = tsi.ObjSchema(
-            project_id=self.project_id,
-            object_id="test-prompt",
-            digest="digest-1",
-            base_object_class="MessagesPrompt",
-            leaf_object_class="MessagesPrompt",
-            val={
-                "messages": [
-                    {"role": "system", "content": "You are {assistant_name}."},
-                    {"role": "user", "content": "Answer in {language}."},
-                ]
-            },
-            created_at=datetime.datetime.now(),
-            version_index=1,
-            is_latest=1,
-            kind="object",
-            deleted_at=None,
-        )
-
-        def mock_obj_read(req):
-            return tsi.ObjReadRes(obj=mock_prompt_obj)
-
-        prompt_uri = (
-            f"weave-trace-internal:///{self.project_id}/object/test-prompt:digest-1"
-        )
-        messages = [{"role": "user", "content": "My question: {question}"}]
-        template_vars = {
+def test_resolve_and_apply_prompt_with_all_params():
+    """Prompt + user messages combine and all non-assistant messages get template vars."""
+    project_id = "test-project"
+    prompt_obj = _messages_prompt_obj(
+        project_id,
+        [
+            {"role": "system", "content": "You are {assistant_name}."},
+            {"role": "user", "content": "Answer in {language}."},
+        ],
+    )
+    combined, initial = resolve_and_apply_prompt(
+        prompt=_prompt_uri(project_id, "test-prompt"),
+        messages=[{"role": "user", "content": "My question: {question}"}],
+        template_vars={
             "assistant_name": "TestBot",
             "language": "Spanish",
             "question": "What is 2+2?",
-        }
+        },
+        project_id=project_id,
+        obj_read_func=lambda req: tsi.ObjReadRes(obj=prompt_obj),
+    )
+    assert combined == [
+        {"role": "system", "content": "You are TestBot."},
+        {"role": "user", "content": "Answer in Spanish."},
+        {"role": "user", "content": "My question: What is 2+2?"},
+    ]
+    assert initial == [{"role": "user", "content": "My question: {question}"}]
 
-        combined, initial = resolve_and_apply_prompt(
-            prompt=prompt_uri,
-            messages=messages,
-            template_vars=template_vars,
-            project_id=self.project_id,
-            obj_read_func=mock_obj_read,
-        )
 
-        # Check combined messages (prompt + user, with template vars applied)
-        assert len(combined) == 3
-        assert combined[0]["role"] == "system"
-        assert combined[0]["content"] == "You are TestBot."
-        assert combined[1]["role"] == "user"
-        assert combined[1]["content"] == "Answer in Spanish."
-        assert combined[2]["role"] == "user"
-        assert combined[2]["content"] == "My question: What is 2+2?"
+def test_resolve_and_apply_prompt_only_prompt_no_template_vars():
+    """A prompt with no user messages or vars passes its messages through unchanged."""
+    project_id = "test-project"
+    prompt_obj = _messages_prompt_obj(
+        project_id, [{"role": "system", "content": "You are a helpful assistant."}]
+    )
+    combined, initial = resolve_and_apply_prompt(
+        prompt=_prompt_uri(project_id, "test-prompt"),
+        messages=None,
+        template_vars=None,
+        project_id=project_id,
+        obj_read_func=lambda req: tsi.ObjReadRes(obj=prompt_obj),
+    )
+    assert combined == [{"role": "system", "content": "You are a helpful assistant."}]
+    assert initial == []
 
-        # Check initial messages (original user messages before template vars)
-        assert len(initial) == 1
-        assert initial[0]["content"] == "My question: {question}"
 
-    def test_resolve_and_apply_prompt_only_prompt_no_template_vars(self):
-        """Test with only prompt, no user messages or template vars."""
-        from weave.trace_server.llm_completion import resolve_and_apply_prompt
-
-        mock_prompt_obj = tsi.ObjSchema(
-            project_id=self.project_id,
-            object_id="test-prompt",
-            digest="digest-1",
-            base_object_class="MessagesPrompt",
-            leaf_object_class="MessagesPrompt",
-            val={
-                "messages": [
-                    {"role": "system", "content": "You are a helpful assistant."},
-                ]
-            },
-            created_at=datetime.datetime.now(),
-            version_index=1,
-            is_latest=1,
-            kind="object",
-            deleted_at=None,
-        )
-
-        def mock_obj_read(req):
-            return tsi.ObjReadRes(obj=mock_prompt_obj)
-
-        prompt_uri = (
-            f"weave-trace-internal:///{self.project_id}/object/test-prompt:digest-1"
-        )
-
-        combined, initial = resolve_and_apply_prompt(
-            prompt=prompt_uri,
-            messages=None,
-            template_vars=None,
-            project_id=self.project_id,
-            obj_read_func=mock_obj_read,
-        )
-
-        # Should just have the prompt messages
-        assert len(combined) == 1
-        assert combined[0]["content"] == "You are a helpful assistant."
-
-        # No initial messages
-        assert len(initial) == 0
-
-    def test_resolve_and_apply_prompt_only_messages_and_template_vars(self):
-        """Test with only user messages and template vars, no prompt."""
-        from weave.trace_server.llm_completion import resolve_and_apply_prompt
-
-        def mock_obj_read(req):
-            raise NotImplementedError("Should not be called")
-
-        messages = [
+def test_resolve_and_apply_prompt_only_messages_and_template_vars():
+    """With no prompt, user messages get vars applied while initial stays raw."""
+    combined, initial = resolve_and_apply_prompt(
+        prompt=None,
+        messages=[
             {"role": "system", "content": "You are {assistant_name}."},
             {"role": "user", "content": "Hello {user_name}!"},
-        ]
-        template_vars = {
-            "assistant_name": "ChatBot",
-            "user_name": "Alice",
-        }
+        ],
+        template_vars={"assistant_name": "ChatBot", "user_name": "Alice"},
+        project_id="test-project",
+        obj_read_func=_unused_obj_read,
+    )
+    assert combined == [
+        {"role": "system", "content": "You are ChatBot."},
+        {"role": "user", "content": "Hello Alice!"},
+    ]
+    assert initial[0]["content"] == "You are {assistant_name}."
 
-        combined, initial = resolve_and_apply_prompt(
-            prompt=None,
-            messages=messages,
-            template_vars=template_vars,
-            project_id=self.project_id,
-            obj_read_func=mock_obj_read,
-        )
 
-        # Should have messages with template vars applied
-        assert len(combined) == 2
-        assert combined[0]["content"] == "You are ChatBot."
-        assert combined[1]["content"] == "Hello Alice!"
+def test_resolve_and_apply_prompt_only_messages_no_template_vars():
+    """User messages with no prompt or vars pass through unchanged."""
+    user_messages = [{"role": "user", "content": "Hello!"}]
+    combined, initial = resolve_and_apply_prompt(
+        prompt=None,
+        messages=user_messages,
+        template_vars=None,
+        project_id="test-project",
+        obj_read_func=_unused_obj_read,
+    )
+    assert combined == [{"role": "user", "content": "Hello!"}]
+    assert initial == user_messages
 
-        # Initial messages should be untouched
-        assert len(initial) == 2
-        assert initial[0]["content"] == "You are {assistant_name}."
 
-    def test_resolve_and_apply_prompt_only_messages_no_template_vars(self):
-        """Test with only user messages, no prompt or template vars."""
-        from weave.trace_server.llm_completion import resolve_and_apply_prompt
+@pytest.mark.parametrize(
+    "template_vars",
+    [None, {"name": "Alice"}],
+    ids=["empty_inputs", "template_vars_no_messages"],
+)
+def test_resolve_and_apply_prompt_empty_message_set(template_vars):
+    """No prompt and no messages yields empty output even when template vars are present."""
+    combined, initial = resolve_and_apply_prompt(
+        prompt=None,
+        messages=None,
+        template_vars=template_vars,
+        project_id="test-project",
+        obj_read_func=_unused_obj_read,
+    )
+    assert combined == []
+    assert initial == []
 
-        def mock_obj_read(req):
-            raise NotImplementedError("Should not be called")
 
-        user_messages = [
-            {"role": "user", "content": "Hello!"},
-        ]
-
-        combined, initial = resolve_and_apply_prompt(
-            prompt=None,
-            messages=user_messages,
-            template_vars=None,
-            project_id=self.project_id,
-            obj_read_func=mock_obj_read,
-        )
-
-        # Should just pass through the messages unchanged
-        assert len(combined) == 1
-        assert combined[0]["content"] == "Hello!"
-        assert initial == user_messages
-
-    def test_resolve_and_apply_prompt_empty_inputs(self):
-        """Test with all inputs empty/None."""
-        from weave.trace_server.llm_completion import resolve_and_apply_prompt
-
-        def mock_obj_read(req):
-            raise NotImplementedError("Should not be called")
-
-        combined, initial = resolve_and_apply_prompt(
-            prompt=None,
-            messages=None,
-            template_vars=None,
-            project_id=self.project_id,
-            obj_read_func=mock_obj_read,
-        )
-
-        # Should return empty lists
-        assert len(combined) == 0
-        assert len(initial) == 0
-
-    def test_resolve_and_apply_prompt_prompt_not_found(self):
-        """Test error handling when prompt reference cannot be found."""
-        from weave.trace_server.llm_completion import resolve_and_apply_prompt
-
-        def mock_obj_read(req):
-            # Raise NotFoundError directly (simulating obj_read behavior when object doesn't exist)
-            raise NotFoundError(f"Object not found: {req.object_id}")
-
-        prompt_uri = (
-            f"weave-trace-internal:///{self.project_id}/object/missing-prompt:digest-1"
-        )
-
-        with pytest.raises(NotFoundError) as context:
-            resolve_and_apply_prompt(
-                prompt=prompt_uri,
-                messages=None,
-                template_vars=None,
-                project_id=self.project_id,
-                obj_read_func=mock_obj_read,
-            )
-
-        assert "Object not found" in str(context.value)
-
-    def test_resolve_and_apply_prompt_invalid_prompt_type(self):
-        """Test error handling when prompt reference is not a Prompt object."""
-        from weave.trace_server.llm_completion import resolve_and_apply_prompt
-
-        # Mock an object that's not a MessagesPrompt
-        mock_obj = tsi.ObjSchema(
-            project_id=self.project_id,
-            object_id="test-obj",
-            digest="digest-1",
-            base_object_class="Model",
-            leaf_object_class="Model",
-            val={"name": "test"},
-            created_at=datetime.datetime.now(),
-            version_index=1,
-            is_latest=1,
-            kind="object",
-            deleted_at=None,
-        )
-
-        def mock_obj_read(req):
-            return tsi.ObjReadRes(obj=mock_obj)
-
-        prompt_uri = (
-            f"weave-trace-internal:///{self.project_id}/object/test-obj:digest-1"
-        )
-
-        with pytest.raises(InvalidRequest) as context:
-            resolve_and_apply_prompt(
-                prompt=prompt_uri,
-                messages=None,
-                template_vars=None,
-                project_id=self.project_id,
-                obj_read_func=mock_obj_read,
-            )
-
-        assert "is not a Prompt or MessagesPrompt" in str(context.value)
-
-    def test_resolve_and_apply_prompt_template_vars_with_empty_messages(self):
-        """Test that template vars are skipped when there are no messages."""
-        from weave.trace_server.llm_completion import resolve_and_apply_prompt
-
-        def mock_obj_read(req):
-            raise NotImplementedError("Should not be called")
-
-        # Template vars provided but no messages
-        template_vars = {"name": "Alice"}
-
-        combined, initial = resolve_and_apply_prompt(
-            prompt=None,
-            messages=None,
-            template_vars=template_vars,
-            project_id=self.project_id,
-            obj_read_func=mock_obj_read,
-        )
-
-        # Should return empty lists (template vars skipped when no messages)
-        assert len(combined) == 0
-        assert len(initial) == 0
-
-    def test_resolve_and_apply_prompt_skips_assistant_messages(self):
-        """Test that template variable substitution is skipped for assistant messages."""
-        from weave.trace_server.llm_completion import resolve_and_apply_prompt
-
-        def mock_obj_read(req):
-            raise NotImplementedError("Should not be called")
-
-        # Messages including an assistant message with template-like content
-        # If for example we specified a JSON response format, the assistant message would be a JSON object.
-        messages = [
+def test_resolve_and_apply_prompt_skips_assistant_messages():
+    """Template substitution applies to system/user messages but never assistant ones."""
+    combined, _ = resolve_and_apply_prompt(
+        prompt=None,
+        messages=[
             {"role": "system", "content": "You are {assistant_name}."},
             {"role": "user", "content": "Hello {user_name}!"},
             {"role": "assistant", "content": '{"response": "My name is ChatBot."}'},
             {"role": "user", "content": "Yes, my name is {user_name}."},
-        ]
-        template_vars = {
-            "assistant_name": "ChatBot",
-            "user_name": "Alice",
-        }
+        ],
+        template_vars={"assistant_name": "ChatBot", "user_name": "Alice"},
+        project_id="test-project",
+        obj_read_func=_unused_obj_read,
+    )
+    assert combined == [
+        {"role": "system", "content": "You are ChatBot."},
+        {"role": "user", "content": "Hello Alice!"},
+        {"role": "assistant", "content": '{"response": "My name is ChatBot."}'},
+        {"role": "user", "content": "Yes, my name is Alice."},
+    ]
 
-        combined, initial = resolve_and_apply_prompt(
-            prompt=None,
-            messages=messages,
-            template_vars=template_vars,
-            project_id=self.project_id,
-            obj_read_func=mock_obj_read,
+
+def test_resolve_and_apply_prompt_prompt_not_found():
+    """A missing prompt reference raises NotFoundError."""
+    project_id = "test-project"
+
+    def obj_read(req: tsi.ObjReadReq) -> tsi.ObjReadRes:
+        raise NotFoundError(f"Object not found: {req.object_id}")
+
+    with pytest.raises(NotFoundError, match="Object not found"):
+        resolve_and_apply_prompt(
+            prompt=_prompt_uri(project_id, "missing-prompt"),
+            messages=None,
+            template_vars=None,
+            project_id=project_id,
+            obj_read_func=obj_read,
         )
 
-        # Should have 4 messages
-        assert len(combined) == 4
 
-        # System message should have template vars applied
-        assert combined[0]["role"] == "system"
-        assert combined[0]["content"] == "You are ChatBot."
+def test_resolve_and_apply_prompt_invalid_prompt_type():
+    """A non-Prompt prompt reference raises InvalidRequest."""
+    project_id = "test-project"
+    obj = _model_obj(project_id, "test-obj")
+    with pytest.raises(InvalidRequest, match="is not a Prompt or MessagesPrompt"):
+        resolve_and_apply_prompt(
+            prompt=_prompt_uri(project_id, "test-obj"),
+            messages=None,
+            template_vars=None,
+            project_id=project_id,
+            obj_read_func=lambda req: tsi.ObjReadRes(obj=obj),
+        )
 
-        # First user message should have template vars applied
-        assert combined[1]["role"] == "user"
-        assert combined[1]["content"] == "Hello Alice!"
 
-        # Assistant message should NOT have template vars applied (kept as-is)
-        assert combined[2]["role"] == "assistant"
-        assert combined[2]["content"] == '{"response": "My name is ChatBot."}'
+# --- non-streaming completions write agent spans -------------------------------
 
-        # Second user message should have template vars applied
-        assert combined[3]["role"] == "user"
-        assert combined[3]["content"] == "Yes, my name is Alice."
+
+def test_completions_writes_agent_span(
+    completions_mock_server, completions_secret_fetcher, completions_mock_response
+):
+    """completions_create writes one span carrying model, tokens, OK status, and ids."""
+    with (
+        patch(
+            LITELLM_COMPLETION,
+            return_value=MagicMock(response=completions_mock_response),
+        ),
+        patch(AGENT_WRITER) as writer_cls,
+    ):
+        writer = writer_cls.return_value
+        result = completions_mock_server.completions_create(
+            _completion_req("dGVzdF9wcm9qZWN0", track=True)
+        )
+    writer.insert_span.assert_called_once()
+    assert result.weave_call_id is not None
+    assert result.span_id is not None
+    assert result.trace_id is not None
+    assert result.response["choices"][0]["message"]["content"] == "Hello!"
+    span = writer.insert_span.call_args[0][0]
+    assert span.project_id == "dGVzdF9wcm9qZWN0"
+    assert span.request_model == "gpt-3.5-turbo"
+    assert span.input_tokens == 10
+    assert span.output_tokens == 5
+    assert span.status_code == "OK"
+
+
+def test_completions_handles_error_response(
+    completions_mock_server, completions_secret_fetcher
+):
+    """An error response is surfaced and recorded as an ERROR span."""
+    error_response = {"error": "Rate limit exceeded", "choices": []}
+    with (
+        patch(LITELLM_COMPLETION, return_value=MagicMock(response=error_response)),
+        patch(AGENT_WRITER) as writer_cls,
+    ):
+        writer = writer_cls.return_value
+        result = completions_mock_server.completions_create(
+            _completion_req("dGVzdF9wcm9qZWN0", track=True)
+        )
+    assert result.response["error"] == "Rate limit exceeded"
+    writer.insert_span.assert_called_once()
+    span = writer.insert_span.call_args[0][0]
+    assert span.status_code == "ERROR"
+    assert span.status_message == "Rate limit exceeded"
+
+
+def test_streaming_completions_writes_agent_spans(
+    completions_mock_server, completions_secret_fetcher
+):
+    """Streaming with tracking writes an open (UNSET) span then a completed (OK) span."""
+    chunks_in = [
+        _delta_chunk("Hi"),
+        _stop_chunk({"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11}),
+    ]
+    with (
+        patch(LITELLM_STREAM, return_value=_iter_mock(chunks_in)),
+        patch(AGENT_WRITER) as writer_cls,
+    ):
+        writer = writer_cls.return_value
+        chunks = list(
+            completions_mock_server.completions_create_stream(
+                _completion_req("dGVzdF9wcm9qZWN0", track=True)
+            )
+        )
+    assert "_meta" in chunks[0]
+    assert "weave_call_id" in chunks[0]["_meta"]
+    assert "span_id" in chunks[0]["_meta"]
+    assert "trace_id" in chunks[0]["_meta"]
+    assert writer.insert_span.call_count == 2
+    assert writer.insert_span.call_args_list[0][0][0].status_code == "UNSET"
+    completed_span = writer.insert_span.call_args_list[1][0][0]
+    assert completed_span.status_code == "OK"
+    assert completed_span.project_id == "dGVzdF9wcm9qZWN0"
+
+
+def test_streaming_completions_error_writes_error_span(
+    completions_mock_server, completions_secret_fetcher
+):
+    """A mid-stream exception is captured in the completed span as an ERROR."""
+
+    def _error_stream():
+        yield _delta_chunk("Hi")
+        raise RuntimeError("stream died")
+
+    with (
+        patch(LITELLM_STREAM, return_value=_error_stream()),
+        patch(AGENT_WRITER) as writer_cls,
+    ):
+        writer = writer_cls.return_value
+        list(
+            completions_mock_server.completions_create_stream(
+                _completion_req("dGVzdF9wcm9qZWN0", track=True)
+            )
+        )
+    assert writer.insert_span.call_count == 2
+    completed_span = writer.insert_span.call_args_list[1][0][0]
+    assert completed_span.status_code == "ERROR"
+    assert "stream died" in completed_span.status_message
+
+
+# --- provider base_url / header validation -------------------------------------
+
+
+def test_provider_base_url_validation():
+    """Provider.base_url only accepts well-formed, public HTTP(S) URLs and safe headers."""
+    assert (
+        _make_provider("https://api.openai.com/v1").base_url
+        == "https://api.openai.com/v1"
+    )
+    assert (
+        _make_provider("http://my-ollama-server.example.com:11434").base_url
+        == "http://my-ollama-server.example.com:11434"
+    )
+
+    for bad_url in (
+        "ftp://bad.example.com",
+        "file:///etc/passwd",
+        "https://api.example.com/v1?foo=bar",
+        "https://api.example.com/v1#section",
+        "http://10.0.0.1/path?",
+    ):
+        with pytest.raises(ValidationError):
+            _make_provider(bad_url)
+
+    for hostname in (
+        "metadata.google.internal",
+        "metadata.google.internal.",
+        "foo.metadata.google.internal",
+        "169.254.169.254",
+    ):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{hostname}/v1")
+
+    for addr in ("10.0.0.1", "172.16.0.1", "192.168.1.1", "127.0.0.1"):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{addr}/v1")
+
+    for alt_ip in ("0xa9fea9fe", "2852039166", "0x7f000001", "0"):
+        with pytest.raises(ValidationError):
+            _make_provider(f"http://{alt_ip}/v1")
+
+    with pytest.raises(ValidationError):
+        _make_provider("http://[::1]/v1")
+    with pytest.raises(ValidationError):
+        _make_provider("http://[::ffff:169.254.169.254]/v1")
+
+    for blocked in ("Metadata-Flavor", "METADATA-FLAVOR", "X-aws-ec2-metadata-token"):
+        with pytest.raises(ValidationError):
+            _make_provider("https://api.example.com", extra_headers={blocked: "val"})
+
+    allowed = _make_provider(
+        "https://api.example.com",
+        extra_headers={"X-Custom-Header": "value", "Authorization": "Bearer tok"},
+    )
+    assert "X-Custom-Header" in allowed.extra_headers
+
+    # Validation also runs on assignment, not just init.
+    p = _make_provider("https://api.example.com")
+    with pytest.raises(ValidationError):
+        p.base_url = "http://169.254.169.254/v1"
+    with pytest.raises(ValidationError):
+        p.extra_headers = {"Metadata-Flavor": "Google"}
+
+
+# --- custom provider cache -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    (
+        "override_project",
+        "expected_obj_reads",
+        "expected_secret_fetches",
+        "same_instance",
+    ),
+    [
+        (False, 2, 1, True),  # same key on second call -> cache hit
+        (True, 4, 2, False),  # distinct project_id -> distinct cache key
+    ],
+    ids=["cache_hit_within_ttl", "distinct_keys_isolate"],
+)
+def test_get_custom_provider_info_cache_behavior(
+    custom_provider_fixture,
+    override_project,
+    expected_obj_reads,
+    expected_secret_fetches,
+    same_instance,
+):
+    """Cache hits within TTL skip resolution; distinct keys do not collide."""
+    project_id, provider_id, model_object_id, obj_read, secret_fetcher = (
+        custom_provider_fixture
+    )
+    first = get_custom_provider_info(project_id, provider_id, model_object_id, obj_read)
+    second_project = "other-project" if override_project else project_id
+    second = get_custom_provider_info(
+        second_project, provider_id, model_object_id, obj_read
+    )
+    assert (first is second) is same_instance
+    assert obj_read.call_count == expected_obj_reads
+    assert secret_fetcher.fetch.call_count == expected_secret_fetches
+
+
+def test_get_custom_provider_info_requires_secret_fetcher_on_cache_hit(
+    custom_provider_fixture,
+):
+    """A cache hit must not bypass the secret_fetcher-required guard."""
+    project_id, provider_id, model_object_id, obj_read, _ = custom_provider_fixture
+    get_custom_provider_info(project_id, provider_id, model_object_id, obj_read)
+
+    _secret_fetcher_context.set(None)
+    with pytest.raises(InvalidRequest, match="No secret fetcher found"):
+        get_custom_provider_info(project_id, provider_id, model_object_id, obj_read)
+
+
+# --- fixtures ------------------------------------------------------------------
+
+
+@pytest.fixture
+def streaming_server():
+    """ClickHouseTraceServer with a stubbed CH client and an OPENAI/CUSTOM/TEST key fetcher."""
+    server = _mock_ch_server()
+    fetcher = _secret_fetcher(
+        {
+            "OPENAI_API_KEY": "test-api-key-value",
+            "CUSTOM_API_KEY": "test-api-key-value",
+            "TEST_API_KEY": "test-api-key-value",
+        }
+    )
+    token = _secret_fetcher_context.set(fetcher)
+    yield server
+    _secret_fetcher_context.reset(token)
 
 
 @pytest.fixture
 def completions_mock_server():
-    """Create a mock ClickHouseTraceServer for completions tests."""
-    server = chts.ClickHouseTraceServer(host="test_host")
-    mock_ch_client = MagicMock()
-    mock_ch_client.query.return_value = MagicMock(result_rows=[[0, 0]])
-    # ch_client is lazy; pre-populating _thread_local.ch_client bypasses _mint_client.
-    server._thread_local.ch_client = mock_ch_client
-    return server
+    """ClickHouseTraceServer with a stubbed CH client for completions tests."""
+    return _mock_ch_server()
 
 
 @pytest.fixture
 def completions_secret_fetcher():
-    """Set up mock secret fetcher with test API key."""
-    mock_fetcher = MagicMock()
-    mock_fetcher.fetch.return_value = {
-        "secrets": {"OPENAI_API_KEY": "test-api-key-value"}
-    }
-    token = _secret_fetcher_context.set(mock_fetcher)
-    yield mock_fetcher
+    """Set up a mock secret fetcher with the OPENAI test key."""
+    fetcher = _secret_fetcher({"OPENAI_API_KEY": "test-api-key-value"})
+    token = _secret_fetcher_context.set(fetcher)
+    yield fetcher
     _secret_fetcher_context.reset(token)
 
 
@@ -1344,446 +791,212 @@ def completions_mock_response():
                 "finish_reason": "stop",
             }
         ],
-        "usage": {
-            "prompt_tokens": 10,
-            "completion_tokens": 5,
-            "total_tokens": 15,
-        },
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     }
 
 
-def test_completions_writes_agent_span(
-    completions_mock_server,
-    completions_secret_fetcher,
-    completions_mock_response,
-):
-    """Verify completions_create writes an agent span via AgentWriteHandler."""
-    with (
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion"
-        ) as mock_litellm,
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.AgentWriteHandler"
-        ) as mock_agent_writer_cls,
-    ):
-        mock_agent_writer = MagicMock()
-        mock_agent_writer_cls.return_value = mock_agent_writer
-        mock_litellm.return_value = MagicMock(response=completions_mock_response)
+@pytest.fixture
+def custom_provider_fixture():
+    """Provider/model/secret fixture for cache tests.
 
-        req = tsi.CompletionsCreateReq(
-            project_id="dGVzdF9wcm9qZWN0",
-            inputs=tsi.CompletionsCreateRequestInputs(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "user", "content": "Say hello"}],
-            ),
-            track_llm_call=True,
+    Yields (project_id, provider_id, model_object_id, mock_obj_read, mock_secret_fetcher).
+    """
+    project_id = "p"
+    provider_id = "prov"
+    model_object_id = f"{provider_id}-mdl"
+    provider_obj = _provider_obj(project_id, provider_id, digest="d1", extra_headers={})
+    model_obj = _provider_model_obj(
+        project_id, model_object_id, provider_id, digest="d2", name="actual-model"
+    )
+    obj_read = MagicMock(
+        side_effect=_obj_read_router(
+            {provider_id: provider_obj, model_object_id: model_obj}
         )
-
-        result = completions_mock_server.completions_create(req)
-
-        mock_agent_writer.insert_span.assert_called_once()
-        assert result.weave_call_id is not None
-        assert result.span_id is not None
-        assert result.trace_id is not None
-        assert result.response["choices"][0]["message"]["content"] == "Hello!"
-
-        span = mock_agent_writer.insert_span.call_args[0][0]
-        assert span.project_id == "dGVzdF9wcm9qZWN0"
-        assert span.request_model == "gpt-3.5-turbo"
-        assert span.input_tokens == 10
-        assert span.output_tokens == 5
-        assert span.status_code == "OK"
+    )
+    secret_fetcher = _secret_fetcher({"TEST_API_KEY": "k"})
+    token = _secret_fetcher_context.set(secret_fetcher)
+    try:
+        yield project_id, provider_id, model_object_id, obj_read, secret_fetcher
+    finally:
+        _secret_fetcher_context.reset(token)
 
 
-def test_completions_handles_error_response(
-    completions_mock_server,
-    completions_secret_fetcher,
-):
-    """Verify error responses are properly captured in the agent span."""
-    error_response = {"error": "Rate limit exceeded", "choices": []}
-
-    with (
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion"
-        ) as mock_litellm,
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.AgentWriteHandler"
-        ) as mock_agent_writer_cls,
-    ):
-        mock_agent_writer = MagicMock()
-        mock_agent_writer_cls.return_value = mock_agent_writer
-        mock_litellm.return_value = MagicMock(response=error_response)
-
-        req = tsi.CompletionsCreateReq(
-            project_id="dGVzdF9wcm9qZWN0",
-            inputs=tsi.CompletionsCreateRequestInputs(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "user", "content": "Say hello"}],
-            ),
-            track_llm_call=True,
-        )
-
-        result = completions_mock_server.completions_create(req)
-
-        assert result.response["error"] == "Rate limit exceeded"
-
-        mock_agent_writer.insert_span.assert_called_once()
-        span = mock_agent_writer.insert_span.call_args[0][0]
-        assert span.status_code == "ERROR"
-        assert span.status_message == "Rate limit exceeded"
+# --- helpers -------------------------------------------------------------------
 
 
-def test_completions_usage_captured_in_span(
-    completions_mock_server, completions_secret_fetcher, completions_mock_response
-):
-    """Verify usage data is properly captured in the agent span token fields."""
-    with (
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion"
-        ) as mock_litellm,
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.AgentWriteHandler"
-        ) as mock_agent_writer_cls,
-    ):
-        mock_agent_writer = MagicMock()
-        mock_agent_writer_cls.return_value = mock_agent_writer
-        mock_litellm.return_value = MagicMock(response=completions_mock_response)
-
-        req = tsi.CompletionsCreateReq(
-            project_id="dGVzdF9wcm9qZWN0",
-            inputs=tsi.CompletionsCreateRequestInputs(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "user", "content": "Say hello"}],
-            ),
-            track_llm_call=True,
-        )
-
-        completions_mock_server.completions_create(req)
-
-        mock_agent_writer.insert_span.assert_called_once()
-        span = mock_agent_writer.insert_span.call_args[0][0]
-
-        assert span.input_tokens == 10
-        assert span.output_tokens == 5
-        assert span.request_model == "gpt-3.5-turbo"
+def _mock_ch_server() -> chts.ClickHouseTraceServer:
+    server = chts.ClickHouseTraceServer(host="test_host")
+    mock_ch_client = MagicMock()
+    mock_ch_client.query.return_value = MagicMock(result_rows=[[0, 0]])
+    # ch_client is lazy; pre-populating _thread_local.ch_client bypasses _mint_client.
+    server._thread_local.ch_client = mock_ch_client
+    return server
 
 
-def test_streaming_completions_writes_agent_spans(
-    completions_mock_server,
-    completions_secret_fetcher,
-):
-    """Verify completions_create_stream writes open + completed agent spans."""
-    mock_chunks = [
-        {
-            "choices": [
-                {"delta": {"content": "Hi"}, "finish_reason": None, "index": 0}
-            ],
-            "id": "test-id",
-            "model": "gpt-3.5-turbo",
-            "created": 1234567890,
-        },
-        {
-            "choices": [{"delta": {}, "finish_reason": "stop", "index": 0}],
-            "id": "test-id",
-            "model": "gpt-3.5-turbo",
-            "created": 1234567890,
-            "usage": {"prompt_tokens": 10, "completion_tokens": 1, "total_tokens": 11},
-        },
-    ]
-
-    with (
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion_stream"
-        ) as mock_litellm,
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.AgentWriteHandler"
-        ) as mock_agent_writer_cls,
-    ):
-        mock_agent_writer = MagicMock()
-        mock_agent_writer_cls.return_value = mock_agent_writer
-
-        mock_stream = MagicMock()
-        mock_stream.__iter__.return_value = mock_chunks
-        mock_litellm.return_value = mock_stream
-
-        req = tsi.CompletionsCreateReq(
-            project_id="dGVzdF9wcm9qZWN0",
-            inputs=tsi.CompletionsCreateRequestInputs(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "user", "content": "Say hello"}],
-            ),
-            track_llm_call=True,
-        )
-
-        stream = completions_mock_server.completions_create_stream(req)
-        chunks = list(stream)
-
-        assert "_meta" in chunks[0]
-        assert "weave_call_id" in chunks[0]["_meta"]
-        assert "span_id" in chunks[0]["_meta"]
-        assert "trace_id" in chunks[0]["_meta"]
-
-        # Open span + completed span = 2 insert_span calls
-        assert mock_agent_writer.insert_span.call_count == 2
-
-        open_span = mock_agent_writer.insert_span.call_args_list[0][0][0]
-        assert open_span.status_code == "UNSET"
-
-        completed_span = mock_agent_writer.insert_span.call_args_list[1][0][0]
-        assert completed_span.status_code == "OK"
-        assert completed_span.project_id == "dGVzdF9wcm9qZWN0"
+def _secret_fetcher(secrets: dict[str, str]) -> MagicMock:
+    fetcher = MagicMock()
+    fetcher.fetch.return_value = {"secrets": secrets}
+    return fetcher
 
 
-def test_streaming_completions_error_writes_error_span(
-    completions_mock_server,
-    completions_secret_fetcher,
-):
-    """Verify streaming errors are captured in the completed agent span."""
+def _obj_read_router(
+    objs: dict[str, tsi.ObjSchema], default: tsi.ObjSchema | None = None
+) -> Callable[[tsi.ObjReadReq], tsi.ObjReadRes]:
+    """Return an obj_read side-effect that maps object_id -> ObjReadRes."""
 
-    def _error_stream():
-        yield {
-            "choices": [
-                {"delta": {"content": "Hi"}, "finish_reason": None, "index": 0}
-            ],
-            "id": "test-id",
-            "model": "gpt-3.5-turbo",
-            "created": 1234567890,
-        }
-        raise RuntimeError("stream died")
+    def _read(req: tsi.ObjReadReq) -> tsi.ObjReadRes:
+        obj = objs.get(req.object_id)
+        if obj is not None:
+            return tsi.ObjReadRes(obj=obj)
+        if default is not None:
+            return tsi.ObjReadRes(obj=default)
+        raise NotFoundError(f"Unknown object_id: {req.object_id}")
 
-    with (
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.lite_llm_completion_stream"
-        ) as mock_litellm,
-        patch(
-            "weave.trace_server.clickhouse_trace_server_batched.AgentWriteHandler"
-        ) as mock_agent_writer_cls,
-    ):
-        mock_agent_writer = MagicMock()
-        mock_agent_writer_cls.return_value = mock_agent_writer
-        mock_litellm.return_value = _error_stream()
-
-        req = tsi.CompletionsCreateReq(
-            project_id="dGVzdF9wcm9qZWN0",
-            inputs=tsi.CompletionsCreateRequestInputs(
-                model="gpt-3.5-turbo",
-                messages=[{"role": "user", "content": "Say hello"}],
-            ),
-            track_llm_call=True,
-        )
-
-        stream = completions_mock_server.completions_create_stream(req)
-        # The new wrapper catches the error and records it in the span
-        chunks = list(stream)
-
-        # Open span + completed (error) span
-        assert mock_agent_writer.insert_span.call_count == 2
-        completed_span = mock_agent_writer.insert_span.call_args_list[1][0][0]
-        assert completed_span.status_code == "ERROR"
-        assert "stream died" in completed_span.status_message
+    return _read
 
 
-def _make_provider(base_url: str, extra_headers: dict | None = None):
+def _unused_obj_read(req: tsi.ObjReadReq) -> tsi.ObjReadRes:
+    raise NotImplementedError("Should not be called")
+
+
+def _obj_schema(project_id: str, object_id: str, **kwargs) -> tsi.ObjSchema:
+    base = {
+        "project_id": project_id,
+        "object_id": object_id,
+        "created_at": datetime.datetime.now(),
+        "version_index": 1,
+        "is_latest": 1,
+        "kind": "object",
+        "deleted_at": None,
+    }
+    base.update(kwargs)
+    return tsi.ObjSchema(**base)
+
+
+def _provider_obj(
+    project_id: str,
+    object_id: str,
+    *,
+    digest: str = "digest-1",
+    base_url: str = "https://api.example.com",
+    api_key_name: str = "TEST_API_KEY",
+    extra_headers: dict | None = None,
+    extra_val: dict | None = None,
+) -> tsi.ObjSchema:
+    val = {
+        "base_url": base_url,
+        "api_key_name": api_key_name,
+        "extra_headers": {"X-Header": "value"}
+        if extra_headers is None
+        else extra_headers,
+        "return_type": "openai",
+    }
+    if extra_val:
+        val.update(extra_val)
+    return _obj_schema(
+        project_id,
+        object_id,
+        digest=digest,
+        base_object_class="Provider",
+        leaf_object_class="Provider",
+        val=val,
+    )
+
+
+def _provider_model_obj(
+    project_id: str,
+    object_id: str,
+    provider_id: str,
+    *,
+    digest: str = "digest-2",
+    name: str = "actual-model-name",
+) -> tsi.ObjSchema:
+    return _obj_schema(
+        project_id,
+        object_id,
+        digest=digest,
+        base_object_class="ProviderModel",
+        leaf_object_class="ProviderModel",
+        val={"name": name, "provider": provider_id, "max_tokens": 4096, "mode": "chat"},
+    )
+
+
+def _messages_prompt_obj(project_id: str, messages: list[dict]) -> tsi.ObjSchema:
+    return _obj_schema(
+        project_id,
+        "test-prompt",
+        digest="digest-1",
+        base_object_class="MessagesPrompt",
+        leaf_object_class="MessagesPrompt",
+        val={"messages": messages},
+    )
+
+
+def _model_obj(project_id: str, object_id: str) -> tsi.ObjSchema:
+    return _obj_schema(
+        project_id,
+        object_id,
+        digest="digest-1",
+        base_object_class="Model",
+        leaf_object_class="Model",
+        val={"name": "test"},
+    )
+
+
+def _prompt_uri(project_id: str, object_id: str) -> str:
+    return f"weave-trace-internal:///{project_id}/object/{object_id}:digest-1"
+
+
+def _completion_req(
+    project_id: str,
+    *,
+    track: bool,
+    model: str = "gpt-3.5-turbo",
+    prompt: str | None = None,
+) -> tsi.CompletionsCreateReq:
+    inputs_kwargs: dict[str, object] = {
+        "model": model,
+        "messages": [{"role": "user", "content": "Say hello"}],
+    }
+    if prompt is not None:
+        inputs_kwargs["messages"] = [{"role": "user", "content": "Hi"}]
+        inputs_kwargs["prompt"] = prompt
+    return tsi.CompletionsCreateReq(
+        project_id=project_id,
+        inputs=tsi.CompletionsCreateRequestInputs(**inputs_kwargs),
+        track_llm_call=track,
+    )
+
+
+def _delta_chunk(content: str, *, model: str = "test-model") -> dict:
+    return {
+        "choices": [{"delta": {"content": content}, "finish_reason": None, "index": 0}],
+        "id": "test-id",
+        "model": model,
+        "created": 1234567890,
+    }
+
+
+def _stop_chunk(usage: dict, *, model: str = "test-model") -> dict:
+    return {
+        "choices": [{"delta": {}, "finish_reason": "stop", "index": 0}],
+        "id": "test-id",
+        "model": model,
+        "created": 1234567890,
+        "usage": usage,
+    }
+
+
+def _iter_mock(chunks: list[dict]) -> MagicMock:
+    stream = MagicMock()
+    stream.__iter__.return_value = chunks
+    return stream
+
+
+def _make_provider(base_url: str, extra_headers: dict | None = None) -> Provider:
     return Provider(
         name="test",
         base_url=base_url,
         api_key_name="MY_KEY",
         extra_headers=extra_headers or {},
     )
-
-
-def test_provider_base_url_validation():
-    """Verify that Provider.base_url only accepts well-formed, public HTTP(S) URLs."""
-    # Valid URLs accepted
-    p = _make_provider("https://api.openai.com/v1")
-    assert p.base_url == "https://api.openai.com/v1"
-    p = _make_provider("http://my-ollama-server.example.com:11434")
-    assert p.base_url == "http://my-ollama-server.example.com:11434"
-
-    # Non-http schemes rejected
-    with pytest.raises(ValidationError):
-        _make_provider("ftp://bad.example.com")
-    with pytest.raises(ValidationError):
-        _make_provider("file:///etc/passwd")
-
-    # Query strings, bare '?', and fragments rejected
-    with pytest.raises(ValidationError):
-        _make_provider("https://api.example.com/v1?foo=bar")
-    with pytest.raises(ValidationError):
-        _make_provider("https://api.example.com/v1#section")
-    with pytest.raises(ValidationError):
-        _make_provider("http://10.0.0.1/path?")
-
-    # Blocked hostnames rejected
-    for hostname in (
-        "metadata.google.internal",
-        "metadata.google.internal.",
-        "foo.metadata.google.internal",
-        "169.254.169.254",
-    ):
-        with pytest.raises(ValidationError):
-            _make_provider(f"http://{hostname}/v1")
-
-    # Non-globally-routable IPs rejected
-    for addr in ("10.0.0.1", "172.16.0.1", "192.168.1.1", "127.0.0.1"):
-        with pytest.raises(ValidationError):
-            _make_provider(f"http://{addr}/v1")
-
-    # Alternative IP encodings rejected
-    for alt_ip in ("0xa9fea9fe", "2852039166", "0x7f000001", "0"):
-        with pytest.raises(ValidationError):
-            _make_provider(f"http://{alt_ip}/v1")
-
-    # IPv6 non-global addresses rejected
-    with pytest.raises(ValidationError):
-        _make_provider("http://[::1]/v1")
-    with pytest.raises(ValidationError):
-        _make_provider("http://[::ffff:169.254.169.254]/v1")
-
-    # Blocked extra_headers rejected
-    for blocked in ("Metadata-Flavor", "METADATA-FLAVOR", "X-aws-ec2-metadata-token"):
-        with pytest.raises(ValidationError):
-            _make_provider("https://api.example.com", extra_headers={blocked: "val"})
-
-    # Allowed headers accepted
-    p = _make_provider(
-        "https://api.example.com",
-        extra_headers={"X-Custom-Header": "value", "Authorization": "Bearer tok"},
-    )
-    assert "X-Custom-Header" in p.extra_headers
-
-    # Validation also runs on assignment, not just init
-    p = _make_provider("https://api.example.com")
-    with pytest.raises(ValidationError):
-        p.base_url = "http://169.254.169.254/v1"
-    with pytest.raises(ValidationError):
-        p.extra_headers = {"Metadata-Flavor": "Google"}
-
-
-@pytest.fixture
-def custom_provider_fixture():
-    """Build a provider/model/secret fixture and clear the module-level cache.
-
-    Yields a tuple of (project_id, provider_id, model_object_id, mock_obj_read,
-    mock_secret_fetcher). The autouse fixture clears the module-level cache.
-    """
-    project_id = "p"
-    provider_id = "prov"
-    model_object_id = f"{provider_id}-mdl"
-
-    provider_obj = tsi.ObjSchema(
-        project_id=project_id,
-        object_id=provider_id,
-        digest="d1",
-        base_object_class="Provider",
-        leaf_object_class="Provider",
-        val={
-            "base_url": "https://api.example.com",
-            "api_key_name": "TEST_API_KEY",
-            "extra_headers": {},
-            "return_type": "openai",
-        },
-        created_at=datetime.datetime.now(),
-        version_index=1,
-        is_latest=1,
-        kind="object",
-        deleted_at=None,
-    )
-    model_obj = tsi.ObjSchema(
-        project_id=project_id,
-        object_id=model_object_id,
-        digest="d2",
-        base_object_class="ProviderModel",
-        leaf_object_class="ProviderModel",
-        val={
-            "name": "actual-model",
-            "provider": provider_id,
-            "max_tokens": 4096,
-            "mode": "chat",
-        },
-        created_at=datetime.datetime.now(),
-        version_index=1,
-        is_latest=1,
-        kind="object",
-        deleted_at=None,
-    )
-
-    def mock_obj_read(req):
-        if req.object_id == provider_id:
-            return tsi.ObjReadRes(obj=provider_obj)
-        if req.object_id == model_object_id:
-            return tsi.ObjReadRes(obj=model_obj)
-        raise NotFoundError(req.object_id)
-
-    mock_obj_read_func = MagicMock(side_effect=mock_obj_read)
-    mock_secret_fetcher = MagicMock()
-    mock_secret_fetcher.fetch.return_value = {"secrets": {"TEST_API_KEY": "k"}}
-
-    token = _secret_fetcher_context.set(mock_secret_fetcher)
-    try:
-        yield (
-            project_id,
-            provider_id,
-            model_object_id,
-            mock_obj_read_func,
-            mock_secret_fetcher,
-        )
-    finally:
-        _secret_fetcher_context.reset(token)
-
-
-@pytest.mark.parametrize(
-    (
-        "override_project",
-        "expected_obj_reads",
-        "expected_secret_fetches",
-        "same_instance",
-    ),
-    [
-        # Same key on the second call -> cache hit; only the first call resolves.
-        (False, 2, 1, True),
-        # Different project_id -> distinct cache key; both calls resolve.
-        (True, 4, 2, False),
-    ],
-    ids=["cache_hit_within_ttl", "distinct_keys_isolate"],
-)
-def test_get_custom_provider_info_cache_behavior(
-    custom_provider_fixture,
-    override_project,
-    expected_obj_reads,
-    expected_secret_fetches,
-    same_instance,
-):
-    """Cache hits within TTL skip resolution; distinct keys do not collide."""
-    project_id, provider_id, model_object_id, obj_read, secret_fetcher = (
-        custom_provider_fixture
-    )
-
-    first = get_custom_provider_info(project_id, provider_id, model_object_id, obj_read)
-    second_project = "other-project" if override_project else project_id
-    second = get_custom_provider_info(
-        second_project, provider_id, model_object_id, obj_read
-    )
-
-    assert (first is second) is same_instance
-    assert obj_read.call_count == expected_obj_reads
-    assert secret_fetcher.fetch.call_count == expected_secret_fetches
-
-
-def test_get_custom_provider_info_requires_secret_fetcher_on_cache_hit(
-    custom_provider_fixture,
-):
-    """A cache hit must not bypass the secret_fetcher-required guard."""
-    project_id, provider_id, model_object_id, obj_read, _ = custom_provider_fixture
-
-    # Populate the cache while the fixture's fetcher is in context.
-    get_custom_provider_info(project_id, provider_id, model_object_id, obj_read)
-
-    # Drop the fetcher; a subsequent call must still raise rather than serve cache.
-    _secret_fetcher_context.set(None)
-    with pytest.raises(InvalidRequest, match="No secret fetcher found"):
-        get_custom_provider_info(project_id, provider_id, model_object_id, obj_read)
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/trace_server/test_migration_lock.py
+++ b/tests/trace_server/test_migration_lock.py
@@ -22,32 +22,6 @@ from weave.trace_server.migration_lock import (
 MANAGEMENT_DB = "db_management"
 
 
-def _make_ch_client(
-    initial_rows: list | None = None,
-    verify_rows: list | None = None,
-) -> Mock:
-    """Create a mock CH client.
-
-    initial_rows: rows returned by the first query (lock check).
-    verify_rows: rows returned by the second query (post-insert verify).
-    If only initial_rows is provided, both queries return that value.
-    """
-    ch_client = Mock()
-
-    if verify_rows is not None:
-        initial_result = Mock()
-        initial_result.result_rows = initial_rows or []
-        verify_result = Mock()
-        verify_result.result_rows = verify_rows
-        ch_client.query.side_effect = [initial_result, verify_result]
-    else:
-        query_result = Mock()
-        query_result.result_rows = initial_rows or []
-        ch_client.query.return_value = query_result
-
-    return ch_client
-
-
 # ---------------------------------------------------------------------------
 # try_acquire — all outcomes
 # ---------------------------------------------------------------------------
@@ -261,17 +235,19 @@ def test_migration_lock_thread_lifecycle():
     assert ch_client.command.call_args[0][0].startswith("DELETE FROM")
 
 
-def test_acquire_with_retry_times_out_when_lock_held():
-    other_holder = _generate_holder_id()
-    ch_client = _make_ch_client(initial_rows=[(other_holder, "2026-01-01 00:00:00")])
-
+def test_acquire_with_retry_outcomes():
+    """acquire_with_retry: times out under a held lock, retries through a
+    transient error, and surfaces a persistent error as MigrationLockError.
+    """
+    # Held by another holder for the whole window -> timeout.
+    held_client = _make_ch_client(
+        initial_rows=[(_generate_holder_id(), "2026-01-01 00:00:00")]
+    )
     with pytest.raises(MigrationLockError, match="Could not acquire migration lock"):
-        acquire_with_retry(ch_client, MANAGEMENT_DB, timeout_seconds=1.0)
+        acquire_with_retry(held_client, MANAGEMENT_DB, timeout_seconds=1.0)
 
-
-def test_acquire_with_retry_recovers_from_transient_error():
-    """Transient OperationalError should retry, not fail fast."""
-    ch_client = Mock()
+    # Transient OperationalError on the first query, then a normal acquire.
+    transient_client = Mock()
     empty_result = Mock()
     empty_result.result_rows = []
     call_count = 0
@@ -279,30 +255,24 @@ def test_acquire_with_retry_recovers_from_transient_error():
     def _query_side_effect(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        # First call on first attempt: raise transient error.
-        # Subsequent calls: behave like a normal successful acquire.
         if call_count == 1:
             raise OperationalError("connection reset")
-        if ch_client.insert.call_count == 0:
+        if transient_client.insert.call_count == 0:
             return empty_result
         result = Mock()
-        result.result_rows = [(ch_client.insert.call_args.kwargs["data"][0][1],)]
+        result.result_rows = [(transient_client.insert.call_args.kwargs["data"][0][1],)]
         return result
 
-    ch_client.query.side_effect = _query_side_effect
-
-    holder = acquire_with_retry(ch_client, MANAGEMENT_DB, timeout_seconds=5.0)
+    transient_client.query.side_effect = _query_side_effect
+    holder = acquire_with_retry(transient_client, MANAGEMENT_DB, timeout_seconds=5.0)
     assert len(holder) == 12
     assert call_count >= 2  # proves we retried
 
-
-def test_acquire_with_retry_surfaces_persistent_error():
-    """Persistent OperationalError should raise MigrationLockError, not bubble raw."""
-    ch_client = Mock()
-    ch_client.query.side_effect = OperationalError("clickhouse down")
-
+    # Persistent OperationalError -> MigrationLockError, not the raw error.
+    down_client = Mock()
+    down_client.query.side_effect = OperationalError("clickhouse down")
     with pytest.raises(MigrationLockError, match="Could not acquire migration lock"):
-        acquire_with_retry(ch_client, MANAGEMENT_DB, timeout_seconds=1.0)
+        acquire_with_retry(down_client, MANAGEMENT_DB, timeout_seconds=1.0)
 
 
 # ---------------------------------------------------------------------------
@@ -360,3 +330,26 @@ def test_lock_acquire_release_real_clickhouse(real_ch_lock):
     result = acquire_with_retry(client, mgmt_db, holder=holder_b, timeout_seconds=10.0)
     assert result == holder_b
     release(client, mgmt_db, holder_b)
+
+
+def _make_ch_client(
+    initial_rows: list | None = None,
+    verify_rows: list | None = None,
+) -> Mock:
+    """Mock CH client.
+
+    initial_rows back the first query (lock check); verify_rows back the second
+    (post-insert verify). With only initial_rows, both queries return it.
+    """
+    ch_client = Mock()
+    if verify_rows is not None:
+        initial_result = Mock()
+        initial_result.result_rows = initial_rows or []
+        verify_result = Mock()
+        verify_result.result_rows = verify_rows
+        ch_client.query.side_effect = [initial_result, verify_result]
+    else:
+        query_result = Mock()
+        query_result.result_rows = initial_rows or []
+        ch_client.query.return_value = query_result
+    return ch_client

--- a/tests/trace_server/test_op_v2_api.py
+++ b/tests/trace_server/test_op_v2_api.py
@@ -10,431 +10,312 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 
 
-def test_op_create_basic(trace_server):
-    """Test creating a basic op object."""
-    project_id = f"{TEST_ENTITY}/test_op_create_basic"
+def test_op_create_with_and_without_source_code(trace_server):
+    """op_create returns a digest + object_id at version 0, whether or not
+    source code is supplied (None falls back to a placeholder body).
+    """
+    project_id = f"{TEST_ENTITY}/test_op_create"
 
-    # Create an op
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="my_function",
-        description=None,
-        source_code="def my_function(x: int) -> int:\n    return x * 2",
+    with_source = trace_server.op_create(
+        tsi.OpCreateReq(
+            project_id=project_id,
+            name="my_function",
+            description=None,
+            source_code="def my_function(x: int) -> int:\n    return x * 2",
+        )
     )
-    create_res = trace_server.op_create(create_req)
+    assert with_source.digest is not None
+    assert with_source.object_id == "my_function"
+    assert with_source.version_index == 0
 
-    assert create_res.digest is not None
-    assert create_res.object_id == "my_function"
-    assert create_res.version_index == 0
-
-
-def test_op_create_without_source_code(trace_server):
-    """Test creating an op without providing source code (uses placeholder)."""
-    project_id = f"{TEST_ENTITY}/test_op_create_no_source"
-
-    # Create an op without source code
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="my_op_no_source",
-        description=None,
-        source_code=None,
+    without_source = trace_server.op_create(
+        tsi.OpCreateReq(
+            project_id=project_id,
+            name="my_op_no_source",
+            description=None,
+            source_code=None,
+        )
     )
-    create_res = trace_server.op_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "my_op_no_source"
-    assert create_res.version_index == 0
+    assert without_source.digest is not None
+    assert without_source.object_id == "my_op_no_source"
+    assert without_source.version_index == 0
 
 
-def test_op_read_basic(trace_server):
-    """Test reading a specific op object."""
-    project_id = f"{TEST_ENTITY}/test_op_read_basic"
+@pytest.mark.parametrize(
+    ("name", "source_code", "extra_substrings"),
+    [
+        (
+            "read_test",
+            "def read_test(x: int) -> int:\n    return x + 1",
+            [],
+        ),
+        (
+            "special_function",
+            "def special_function(x: str) -> str:\n"
+            "    '''This function has \"quotes\" and 'apostrophes'.'''\n"
+            '    return f"Result: {x} with special chars: \n\t\r"\n',
+            [],
+        ),
+        (
+            "unicode_function",
+            "def unicode_function():\n"
+            "    '''This function has unicode: 你好世界 🚀 café'''\n"
+            '    return "unicode test"\n',
+            ["你好世界", "🚀", "café"],
+        ),
+    ],
+    ids=["plain", "special_chars", "unicode"],
+)
+def test_op_read_roundtrip(trace_server, name, source_code, extra_substrings):
+    """op_read returns the created op with its source code preserved verbatim,
+    including special characters and unicode.
+    """
+    project_id = f"{TEST_ENTITY}/test_op_read_{name}"
 
-    # Create an op
-    source_code = "def read_test(x: int) -> int:\n    return x + 1"
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="read_test",
-        description=None,
-        source_code=source_code,
+    create_res = trace_server.op_create(
+        tsi.OpCreateReq(
+            project_id=project_id,
+            name=name,
+            description=None,
+            source_code=source_code,
+        )
     )
-    create_res = trace_server.op_create(create_req)
-
-    # Read the op back
-    read_req = tsi.OpReadReq(
-        project_id=project_id,
-        object_id="read_test",
-        digest=create_res.digest,
+    read_res = trace_server.op_read(
+        tsi.OpReadReq(project_id=project_id, object_id=name, digest=create_res.digest)
     )
-    read_res = trace_server.op_read(read_req)
 
-    assert read_res.object_id == "read_test"
+    assert read_res.object_id == name
     assert read_res.digest == create_res.digest
     assert read_res.version_index == 0
     assert read_res.code == source_code
     assert read_res.created_at is not None
+    for substring in extra_substrings:
+        assert substring in read_res.code
 
 
 def test_op_read_not_found(trace_server):
-    """Test reading a non-existent op raises NotFoundError."""
+    """Reading a non-existent op raises NotFoundError."""
     project_id = f"{TEST_ENTITY}/test_op_read_not_found"
-
-    read_req = tsi.OpReadReq(
-        project_id=project_id,
-        object_id="nonexistent_op",
-        digest="fake_digest_1234567890",
-    )
-
     with pytest.raises(NotFoundError):
-        trace_server.op_read(read_req)
-
-
-def test_op_list_basic(trace_server):
-    """Test listing all ops in a project."""
-    project_id = f"{TEST_ENTITY}/test_op_list_basic"
-
-    # Create multiple ops
-    op_names = ["op_a", "op_b", "op_c"]
-    for name in op_names:
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name=name,
-            description=None,
-            source_code=f"def {name}():\n    pass",
+        trace_server.op_read(
+            tsi.OpReadReq(
+                project_id=project_id,
+                object_id="nonexistent_op",
+                digest="fake_digest_1234567890",
+            )
         )
-        trace_server.op_create(create_req)
 
-    # List all ops
-    list_req = tsi.OpListReq(project_id=project_id)
-    ops = list(trace_server.op_list(list_req))
 
-    assert len(ops) == 3
-    op_names_returned = {op.object_id for op in ops}
-    assert op_names_returned == {"op_a", "op_b", "op_c"}
+def test_op_list_content_and_filtering(trace_server):
+    """op_list returns every op with code + created_at loaded, an empty project
+    yields nothing, and deleted ops drop out of subsequent listings.
+    """
+    # Empty project -> no ops.
+    empty_project = f"{TEST_ENTITY}/test_op_list_empty"
+    assert list(trace_server.op_list(tsi.OpListReq(project_id=empty_project))) == []
 
-    # Verify all ops have code loaded
+    # Three ops, all carry loaded code + created_at.
+    project_id = f"{TEST_ENTITY}/test_op_list_basic"
+    for name in ("op_a", "op_b", "op_c"):
+        trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=project_id,
+                name=name,
+                description=None,
+                source_code=f"def {name}():\n    pass",
+            )
+        )
+    ops = list(trace_server.op_list(tsi.OpListReq(project_id=project_id)))
+    assert {op.object_id for op in ops} == {"op_a", "op_b", "op_c"}
     for op in ops:
         assert op.code
         assert "def " in op.code
         assert op.created_at is not None
 
-
-def test_op_list_with_limit(trace_server):
-    """Test listing ops with a limit."""
-    project_id = f"{TEST_ENTITY}/test_op_list_limit"
-
-    # Create multiple ops
-    for i in range(5):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name=f"op_{i}",
-            description=None,
-            source_code=f"def op_{i}():\n    pass",
+    # Deleting an op removes it from the listing.
+    del_project = f"{TEST_ENTITY}/test_op_list_after_deletion"
+    for name in ("op_keep_1", "op_delete", "op_keep_2"):
+        trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=del_project,
+                name=name,
+                description=None,
+                source_code=f"def {name}():\n    pass",
+            )
         )
-        trace_server.op_create(create_req)
-
-    # List with a limit
-    list_req = tsi.OpListReq(project_id=project_id, limit=3)
-    ops = list(trace_server.op_list(list_req))
-
-    assert len(ops) == 3
+    trace_server.op_delete(
+        tsi.OpDeleteReq(project_id=del_project, object_id="op_delete", digests=None)
+    )
+    remaining = list(trace_server.op_list(tsi.OpListReq(project_id=del_project)))
+    assert {op.object_id for op in remaining} == {"op_keep_1", "op_keep_2"}
 
 
-def test_op_list_with_offset(trace_server):
-    """Test listing ops with an offset."""
-    project_id = f"{TEST_ENTITY}/test_op_list_offset"
-
-    # Create multiple ops
-    for i in range(5):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name=f"op_{i}",
-            description=None,
-            source_code=f"def op_{i}():\n    pass",
-        )
-        trace_server.op_create(create_req)
-
-    # List with an offset
-    list_req = tsi.OpListReq(project_id=project_id, offset=2)
-    ops = list(trace_server.op_list(list_req))
-
-    assert len(ops) == 3
-
-
-def test_op_list_with_limit_and_offset(trace_server):
-    """Test listing ops with both limit and offset for pagination."""
+@pytest.mark.parametrize(
+    ("limit", "offset", "expected_count"),
+    [(3, None, 3), (None, 2, 3)],
+    ids=["limit", "offset"],
+)
+def test_op_list_pagination(trace_server, limit, offset, expected_count):
+    """Limit and offset each slice the op listing over a 5-op project."""
     project_id = f"{TEST_ENTITY}/test_op_list_pagination"
+    for i in range(5):
+        trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=project_id,
+                name=f"op_{i}",
+                description=None,
+                source_code=f"def op_{i}():\n    pass",
+            )
+        )
+    req_kwargs = {"project_id": project_id}
+    if limit is not None:
+        req_kwargs["limit"] = limit
+    if offset is not None:
+        req_kwargs["offset"] = offset
+    ops = list(trace_server.op_list(tsi.OpListReq(**req_kwargs)))
+    assert len(ops) == expected_count
 
-    # Create multiple ops
+
+def test_op_list_pagination_pages_are_disjoint(trace_server):
+    """Successive limit/offset pages over the same project never overlap."""
+    project_id = f"{TEST_ENTITY}/test_op_list_pages_disjoint"
     for i in range(10):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name=f"op_{i}",
-            description=None,
-            source_code=f"def op_{i}():\n    pass",
+        trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=project_id,
+                name=f"op_{i}",
+                description=None,
+                source_code=f"def op_{i}():\n    pass",
+            )
         )
-        trace_server.op_create(create_req)
-
-    # First page
-    list_req1 = tsi.OpListReq(project_id=project_id, limit=3, offset=0)
-    ops1 = list(trace_server.op_list(list_req1))
-    assert len(ops1) == 3
-
-    # Second page
-    list_req2 = tsi.OpListReq(project_id=project_id, limit=3, offset=3)
-    ops2 = list(trace_server.op_list(list_req2))
-    assert len(ops2) == 3
-
-    # Verify different ops on different pages
-    ops1_ids = {op.object_id for op in ops1}
-    ops2_ids = {op.object_id for op in ops2}
-    assert len(ops1_ids & ops2_ids) == 0  # No overlap
-
-
-def test_op_list_empty_project(trace_server):
-    """Test listing ops in a project with no ops."""
-    project_id = f"{TEST_ENTITY}/test_op_list_empty"
-
-    list_req = tsi.OpListReq(project_id=project_id)
-    ops = list(trace_server.op_list(list_req))
-
-    assert len(ops) == 0
-
-
-def test_op_delete_single_version(trace_server):
-    """Test deleting a single version of an op."""
-    project_id = f"{TEST_ENTITY}/test_op_delete_single"
-
-    # Create an op
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="delete_test",
-        description=None,
-        source_code="def delete_test():\n    pass",
+    page1 = list(
+        trace_server.op_list(tsi.OpListReq(project_id=project_id, limit=3, offset=0))
     )
-    create_res = trace_server.op_create(create_req)
-
-    # Delete the specific version
-    delete_req = tsi.OpDeleteReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digests=[create_res.digest],
+    page2 = list(
+        trace_server.op_list(tsi.OpListReq(project_id=project_id, limit=3, offset=3))
     )
-    delete_res = trace_server.op_delete(delete_req)
+    assert len(page1) == 3
+    assert len(page2) == 3
+    assert {op.object_id for op in page1} & {op.object_id for op in page2} == set()
 
-    assert delete_res.num_deleted == 1
 
-    # Verify the op is deleted (should raise ObjectDeletedError)
-    read_req = tsi.OpReadReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digest=create_res.digest,
+def test_op_delete_versions(trace_server):
+    """op_delete handles a single version, a specific subset (survivors remain),
+    all versions (digests=None), and raises NotFoundError for a missing op.
+    """
+    # Single version: deleted op then reads as ObjectDeletedError.
+    single_project = f"{TEST_ENTITY}/test_op_delete_single"
+    single = trace_server.op_create(
+        tsi.OpCreateReq(
+            project_id=single_project,
+            name="delete_test",
+            description=None,
+            source_code="def delete_test():\n    pass",
+        )
     )
+    single_del = trace_server.op_delete(
+        tsi.OpDeleteReq(
+            project_id=single_project,
+            object_id="delete_test",
+            digests=[single.digest],
+        )
+    )
+    assert single_del.num_deleted == 1
     with pytest.raises(ObjectDeletedError):
-        trace_server.op_read(read_req)
-
-
-def test_op_delete_all_versions(trace_server):
-    """Test deleting all versions of an op (no digests specified)."""
-    project_id = f"{TEST_ENTITY}/test_op_delete_all"
-
-    # Create multiple versions of the same op
-    digests = []
-    for i in range(3):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name="versioned_op",
-            description=None,
-            source_code=f"def versioned_op():\n    return {i}",
+        trace_server.op_read(
+            tsi.OpReadReq(
+                project_id=single_project,
+                object_id="delete_test",
+                digest=single.digest,
+            )
         )
-        create_res = trace_server.op_create(create_req)
-        digests.append(create_res.digest)
 
-    # Delete all versions (no digests specified)
-    delete_req = tsi.OpDeleteReq(
-        project_id=project_id,
-        object_id="versioned_op",
-        digests=None,
-    )
-    delete_res = trace_server.op_delete(delete_req)
-
-    assert delete_res.num_deleted == 3
-
-
-def test_op_delete_multiple_versions(trace_server):
-    """Test deleting multiple specific versions of an op."""
-    project_id = f"{TEST_ENTITY}/test_op_delete_multiple"
-
-    # Create multiple versions
-    digests = []
-    for i in range(4):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name="multi_version_op",
-            description=None,
-            source_code=f"def multi_version_op():\n    return {i}",
+    # Subset of versions: first two deleted, last two still readable.
+    multi_project = f"{TEST_ENTITY}/test_op_delete_multiple"
+    digests = [
+        trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=multi_project,
+                name="multi_version_op",
+                description=None,
+                source_code=f"def multi_version_op():\n    return {i}",
+            )
+        ).digest
+        for i in range(4)
+    ]
+    multi_del = trace_server.op_delete(
+        tsi.OpDeleteReq(
+            project_id=multi_project,
+            object_id="multi_version_op",
+            digests=digests[:2],
         )
-        create_res = trace_server.op_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete the first two versions
-    delete_req = tsi.OpDeleteReq(
-        project_id=project_id,
-        object_id="multi_version_op",
-        digests=digests[:2],
     )
-    delete_res = trace_server.op_delete(delete_req)
-
-    assert delete_res.num_deleted == 2
-
-    # Verify the first two are deleted
+    assert multi_del.num_deleted == 2
     for digest in digests[:2]:
-        read_req = tsi.OpReadReq(
-            project_id=project_id,
-            object_id="multi_version_op",
-            digest=digest,
-        )
         with pytest.raises(ObjectDeletedError):
-            trace_server.op_read(read_req)
-
-    # Verify the last two still exist
+            trace_server.op_read(
+                tsi.OpReadReq(
+                    project_id=multi_project,
+                    object_id="multi_version_op",
+                    digest=digest,
+                )
+            )
     for digest in digests[2:]:
-        read_req = tsi.OpReadReq(
-            project_id=project_id,
-            object_id="multi_version_op",
-            digest=digest,
+        read_res = trace_server.op_read(
+            tsi.OpReadReq(
+                project_id=multi_project,
+                object_id="multi_version_op",
+                digest=digest,
+            )
         )
-        read_res = trace_server.op_read(read_req)
         assert read_res.digest == digest
 
-
-def test_op_delete_not_found(trace_server):
-    """Test deleting a non-existent op raises NotFoundError."""
-    project_id = f"{TEST_ENTITY}/test_op_delete_not_found"
-
-    delete_req = tsi.OpDeleteReq(
-        project_id=project_id,
-        object_id="nonexistent_op",
-        digests=["fake_digest"],
+    # All versions: digests=None deletes every version.
+    all_project = f"{TEST_ENTITY}/test_op_delete_all"
+    for i in range(3):
+        trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=all_project,
+                name="versioned_op",
+                description=None,
+                source_code=f"def versioned_op():\n    return {i}",
+            )
+        )
+    all_del = trace_server.op_delete(
+        tsi.OpDeleteReq(project_id=all_project, object_id="versioned_op", digests=None)
     )
+    assert all_del.num_deleted == 3
 
+    # Missing op raises NotFoundError.
+    nf_project = f"{TEST_ENTITY}/test_op_delete_not_found"
     with pytest.raises(NotFoundError):
-        trace_server.op_delete(delete_req)
+        trace_server.op_delete(
+            tsi.OpDeleteReq(
+                project_id=nf_project,
+                object_id="nonexistent_op",
+                digests=["fake_digest"],
+            )
+        )
 
 
 def test_op_versioning(trace_server):
-    """Test that creating multiple versions of an op increments version_index."""
+    """Creating multiple versions of an op increments version_index and yields
+    distinct digests.
+    """
     project_id = f"{TEST_ENTITY}/test_op_versioning"
-
-    # Create multiple versions of the same op
-    versions = []
-    for i in range(3):
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name="versioned_function",
-            description=None,
-            source_code=f"def versioned_function():\n    return {i}",
+    versions = [
+        trace_server.op_create(
+            tsi.OpCreateReq(
+                project_id=project_id,
+                name="versioned_function",
+                description=None,
+                source_code=f"def versioned_function():\n    return {i}",
+            )
         )
-        create_res = trace_server.op_create(create_req)
-        versions.append(create_res)
+        for i in range(3)
+    ]
 
-    # Verify version indices increment
     assert versions[0].version_index == 0
     assert versions[1].version_index == 1
     assert versions[2].version_index == 2
-
-    # Verify all versions are distinct
     assert len({v.digest for v in versions}) == 3
-
-
-def test_op_code_with_special_characters(trace_server):
-    """Test creating and reading an op with special characters in source code."""
-    project_id = f"{TEST_ENTITY}/test_op_special_chars"
-
-    # Create an op with special characters
-    source_code = """def special_function(x: str) -> str:
-    '''This function has "quotes" and 'apostrophes'.'''
-    return f"Result: {x} with special chars: \n\t\r"
-"""
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="special_function",
-        description=None,
-        source_code=source_code,
-    )
-    create_res = trace_server.op_create(create_req)
-
-    # Read it back and verify the code is preserved
-    read_req = tsi.OpReadReq(
-        project_id=project_id,
-        object_id="special_function",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.op_read(read_req)
-
-    assert read_res.code == source_code
-
-
-def test_op_code_with_unicode(trace_server):
-    """Test creating and reading an op with unicode characters in source code."""
-    project_id = f"{TEST_ENTITY}/test_op_unicode"
-
-    # Create an op with unicode
-    source_code = """def unicode_function():
-    '''This function has unicode: 你好世界 🚀 café'''
-    return "unicode test"
-"""
-    create_req = tsi.OpCreateReq(
-        project_id=project_id,
-        name="unicode_function",
-        description=None,
-        source_code=source_code,
-    )
-    create_res = trace_server.op_create(create_req)
-
-    # Read it back and verify the unicode is preserved
-    read_req = tsi.OpReadReq(
-        project_id=project_id,
-        object_id="unicode_function",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.op_read(read_req)
-
-    assert read_res.code == source_code
-    assert "你好世界" in read_res.code
-    assert "🚀" in read_res.code
-    assert "café" in read_res.code
-
-
-def test_op_list_after_deletion(trace_server):
-    """Test that deleted ops don't appear in list results."""
-    project_id = f"{TEST_ENTITY}/test_op_list_after_deletion"
-
-    # Create three ops
-    op_names = ["op_keep_1", "op_delete", "op_keep_2"]
-    digests = {}
-    for name in op_names:
-        create_req = tsi.OpCreateReq(
-            project_id=project_id,
-            name=name,
-            description=None,
-            source_code=f"def {name}():\n    pass",
-        )
-        create_res = trace_server.op_create(create_req)
-        digests[name] = create_res.digest
-
-    # Delete one op
-    delete_req = tsi.OpDeleteReq(
-        project_id=project_id,
-        object_id="op_delete",
-        digests=None,
-    )
-    trace_server.op_delete(delete_req)
-
-    # List ops - should only see the two that weren't deleted
-    list_req = tsi.OpListReq(project_id=project_id)
-    ops = list(trace_server.op_list(list_req))
-
-    op_names_returned = {op.object_id for op in ops}
-    assert op_names_returned == {"op_keep_1", "op_keep_2"}
-    assert "op_delete" not in op_names_returned

--- a/tests/trace_server/test_opentelemetry.py
+++ b/tests/trace_server/test_opentelemetry.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any
 
 import pytest
+from openinference.semconv.trace import SpanAttributes as OISpanAttr
 from opentelemetry.proto.common.v1.common_pb2 import (
     AnyValue,
     InstrumentationScope,
@@ -374,1432 +375,1137 @@ def test_otel_export_with_turn_no_thread(client: weave_client.WeaveClient):
     )
 
 
-class TestPythonSpans:
-    def test_span_from_proto(self):
-        """Test converting a protobuf Span to a Python Span."""
-        pb_span = create_test_span()
-        py_span = PySpan.from_proto(pb_span)
+def test_span_from_proto() -> None:
+    """Test converting a protobuf Span to a Python Span."""
+    pb_span = create_test_span()
+    py_span = PySpan.from_proto(pb_span)
 
-        assert py_span.name == pb_span.name
-        assert py_span.trace_id == pb_span.trace_id.hex()
-        assert py_span.span_id == pb_span.span_id.hex()
-        assert py_span.start_time_unix_nano == pb_span.start_time_unix_nano
-        assert py_span.end_time_unix_nano == pb_span.end_time_unix_nano
-        assert py_span.kind == SpanKind.INTERNAL
-        assert py_span.status.code == StatusCode.OK
-        assert py_span.status.message == pb_span.status.message
+    assert py_span.name == pb_span.name
+    assert py_span.trace_id == pb_span.trace_id.hex()
+    assert py_span.span_id == pb_span.span_id.hex()
+    assert py_span.start_time_unix_nano == pb_span.start_time_unix_nano
+    assert py_span.end_time_unix_nano == pb_span.end_time_unix_nano
+    assert py_span.kind == SpanKind.INTERNAL
+    assert py_span.status.code == StatusCode.OK
+    assert py_span.status.message == pb_span.status.message
 
-        # Verify attributes were correctly converted
-        assert get_attribute(py_span.attributes, "test.attribute") == "test_value"
-        assert get_attribute(py_span.attributes, "test.number") == 42
-        assert (
-            get_attribute(py_span.attributes, "test.nested.value")
-            == "nested_test_value"
+    # Verify attributes were correctly converted
+    assert get_attribute(py_span.attributes, "test.attribute") == "test_value"
+    assert get_attribute(py_span.attributes, "test.number") == 42
+    assert get_attribute(py_span.attributes, "test.nested.value") == "nested_test_value"
+    array_value = get_attribute(py_span.attributes, "test.array")
+    assert isinstance(array_value, list)
+    assert len(array_value) == 2
+    assert array_value[0] == "value1"
+    assert array_value[1] == "value2"
+
+
+def test_span_from_proto_parent_id_normalization() -> None:
+    """Test that empty and all-zero parent_span_id values normalize to None."""
+    # All-zero parent_span_id is the OTel invalid-id sentinel; must mean no parent.
+    pb_span = create_test_span()
+    pb_span.parent_span_id = b"\x00" * 8
+    assert PySpan.from_proto(pb_span).parent_id is None, (
+        "all-zero parent_span_id should yield parent_id=None"
+    )
+
+    pb_span = create_test_span()
+    pb_span.parent_span_id = b""
+    assert PySpan.from_proto(pb_span).parent_id is None, (
+        "empty parent_span_id should yield parent_id=None"
+    )
+
+    pb_span = create_test_span()
+    pb_span.parent_span_id = bytes.fromhex("0123456789abcdef")
+    assert PySpan.from_proto(pb_span).parent_id == "0123456789abcdef", (
+        "real parent_span_id should hex-encode to parent_id"
+    )
+
+
+def test_span_to_call() -> None:
+    """Test converting a Python Span to Weave Calls."""
+    pb_span = create_test_span()
+    py_span = PySpan.from_proto(pb_span)
+
+    start_call, _ = py_span.to_call("test_project")
+
+    # Verify start call
+    assert isinstance(start_call, tsi.StartedCallSchemaForInsert)
+    assert start_call.project_id == "test_project"
+    assert start_call.id == py_span.span_id
+    assert (
+        start_call.op_name == py_span.name
+    )  # This should be using the shortened name if necessary
+    assert start_call.trace_id == py_span.trace_id
+    assert start_call.started_at == py_span.start_time
+
+
+def test_span_to_call_long_name() -> None:
+    """Test that span names are properly shortened when too long."""
+    # Create a test span with a very long name
+    pb_span = create_test_span()
+    long_name = "a" * (MAX_OP_NAME_LENGTH + 10)
+    pb_span.name = long_name
+
+    py_span = PySpan.from_proto(pb_span)
+    start_call, end_call = py_span.to_call("test_project")
+
+    # Verify that the op_name was shortened
+    identifier = hashlib.sha256(long_name.encode("utf-8")).hexdigest()[:4]
+    shortened_name = shorten_name(
+        long_name,
+        MAX_OP_NAME_LENGTH,
+        abbrv=f":{identifier}",
+        use_delimiter_in_abbr=False,
+    )
+    assert start_call.op_name == shortened_name
+    assert len(start_call.op_name) <= MAX_OP_NAME_LENGTH
+
+    # Verify attributes in start call
+    assert "test" in start_call.attributes
+    assert "attribute" in start_call.attributes["test"]
+    assert start_call.attributes["test"]["attribute"] == "test_value"
+    assert start_call.attributes["test"]["number"] == 42
+    assert "nested" in start_call.attributes["test"]
+    assert start_call.attributes["test"]["nested"]["value"] == "nested_test_value"
+    assert "array" in start_call.attributes["test"]
+    assert start_call.attributes["test"]["array"] == ["value1", "value2"]
+
+    # Verify otel_dump is included in the call (otel_span is now in otel_dump)
+    assert start_call.otel_dump is not None
+    assert start_call.otel_dump["name"] == long_name
+    assert start_call.otel_dump["context"]["trace_id"] == py_span.trace_id
+    assert start_call.otel_dump["context"]["span_id"] == py_span.span_id
+
+    # Verify end call
+    assert isinstance(end_call, tsi.EndedCallSchemaForInsert)
+    assert end_call.project_id == "test_project"
+    assert end_call.id == py_span.span_id
+    assert end_call.ended_at == py_span.end_time
+    assert end_call.exception is None
+
+
+def test_span_to_call_with_turn_and_thread() -> None:
+    """Test that turn_id equals thread_id when is_turn is True."""
+    # Create a test span with turn and thread attributes
+    pb_span = create_test_span()
+    test_thread_id = str(uuid.uuid4())
+
+    # Add wandb.is_turn and wandb.thread_id attributes
+    kv_is_turn = KeyValue()
+    kv_is_turn.key = "wandb.is_turn"
+    kv_is_turn.value.bool_value = True
+    pb_span.attributes.append(kv_is_turn)
+
+    kv_thread = KeyValue()
+    kv_thread.key = "wandb.thread_id"
+    kv_thread.value.string_value = test_thread_id
+    pb_span.attributes.append(kv_thread)
+
+    py_span = PySpan.from_proto(pb_span)
+    start_call, end_call = py_span.to_call("test_project")
+
+    # Verify turn_id equals call.id (span_id) when is_turn is True
+    assert start_call.turn_id == py_span.span_id
+    # Verify thread_id is passed through
+    assert start_call.thread_id == test_thread_id
+
+    # Test with is_turn = False
+    pb_span_false = create_test_span()
+    kv_is_turn_false = KeyValue()
+    kv_is_turn_false.key = "wandb.is_turn"
+    kv_is_turn_false.value.bool_value = False
+    pb_span_false.attributes.append(kv_is_turn_false)
+
+    kv_thread_false = KeyValue()
+    kv_thread_false.key = "wandb.thread_id"
+    kv_thread_false.value.string_value = test_thread_id
+    pb_span_false.attributes.append(kv_thread_false)
+
+    py_span_false = PySpan.from_proto(pb_span_false)
+    start_call_false, _ = py_span_false.to_call("test_project")
+
+    # Verify turn_id is None when is_turn is False
+    assert start_call_false.turn_id is None
+    assert start_call_false.thread_id == test_thread_id
+
+    # Test without is_turn (should default to None)
+    pb_span_no_turn = create_test_span()
+    kv_thread_only = KeyValue()
+    kv_thread_only.key = "wandb.thread_id"
+    kv_thread_only.value.string_value = test_thread_id
+    pb_span_no_turn.attributes.append(kv_thread_only)
+
+    py_span_no_turn = PySpan.from_proto(pb_span_no_turn)
+    start_call_no_turn, _ = py_span_no_turn.to_call("test_project")
+
+    # Verify turn_id is None when is_turn is not present
+    assert start_call_no_turn.turn_id is None
+    assert start_call_no_turn.thread_id == test_thread_id
+
+    # Test with is_turn = True but no thread_id
+    pb_span_turn_no_thread = create_test_span()
+    kv_is_turn_only = KeyValue()
+    kv_is_turn_only.key = "wandb.is_turn"
+    kv_is_turn_only.value.bool_value = True
+    pb_span_turn_no_thread.attributes.append(kv_is_turn_only)
+
+    py_span_turn_no_thread = PySpan.from_proto(pb_span_turn_no_thread)
+    start_call_turn_no_thread, _ = py_span_turn_no_thread.to_call("test_project")
+
+    # Verify turn_id is None when is_turn is True but thread_id is missing
+    assert start_call_turn_no_thread.turn_id is None
+    assert start_call_turn_no_thread.thread_id is None
+
+    # gen_ai.conversation.id sets thread_id and (being truthy) turn_id.
+    pb_span_conv = create_test_span()
+    kv_conv = KeyValue()
+    kv_conv.key = "gen_ai.conversation.id"
+    kv_conv.value.string_value = "conv-xyz"
+    pb_span_conv.attributes.append(kv_conv)
+
+    py_span_conv = PySpan.from_proto(pb_span_conv)
+    start_call_conv, _ = py_span_conv.to_call("test_project")
+    assert start_call_conv.thread_id == "conv-xyz"
+    assert start_call_conv.turn_id == py_span_conv.span_id
+
+
+def test_span_to_call_with_cache_tokens() -> None:
+    """Test that cache token usage attributes flow through to_call summary."""
+    pb_span = create_test_span()
+
+    # Add cache token usage attributes
+    kv_cache_creation = KeyValue()
+    kv_cache_creation.key = "gen_ai.usage.cache_creation.input_tokens"
+    kv_cache_creation.value.int_value = 500
+    pb_span.attributes.append(kv_cache_creation)
+
+    kv_cache_read = KeyValue()
+    kv_cache_read.key = "gen_ai.usage.cache_read.input_tokens"
+    kv_cache_read.value.int_value = 200
+    pb_span.attributes.append(kv_cache_read)
+
+    kv_input = KeyValue()
+    kv_input.key = "gen_ai.usage.input_tokens"
+    kv_input.value.int_value = 100
+    pb_span.attributes.append(kv_input)
+
+    kv_output = KeyValue()
+    kv_output.key = "gen_ai.usage.output_tokens"
+    kv_output.value.int_value = 50
+    pb_span.attributes.append(kv_output)
+
+    py_span = PySpan.from_proto(pb_span)
+    _, end_call = py_span.to_call("test_project")
+
+    # Usage is keyed by model name or "usage" when no model is set
+    usage = end_call.summary["usage"]["usage"]  # type: ignore
+    assert usage["cache_creation_input_tokens"] == 500
+    assert usage["cache_read_input_tokens"] == 200
+    assert usage["input_tokens"] == 100
+    assert usage["output_tokens"] == 50
+
+
+def test_traces_data_from_proto() -> None:
+    """Test converting protobuf TracesData to Python TracesData."""
+    export_req = create_test_export_request()
+    resource_spans_list = [ps.resource_spans for ps in export_req.processed_spans]
+    traces_data = PyTracesData.from_proto(
+        TracesData(resource_spans=resource_spans_list)
+    )
+
+    assert len(traces_data.resource_spans) == 1
+    resource_spans = traces_data.resource_spans[0]
+    assert len(resource_spans.scope_spans) == 1
+    scope_spans = resource_spans.scope_spans[0]
+    assert len(scope_spans.spans) == 1
+    span = scope_spans.spans[0]
+
+    assert span.name == "test_span"
+    assert span.kind == SpanKind.INTERNAL
+
+
+def test_to_json_serializable() -> None:
+    """to_json_serializable handles primitives, containers, and stdlib types."""
+    from dataclasses import dataclass
+    from datetime import date, time, timedelta
+    from decimal import Decimal
+
+    # Primitives, lists/tuples, dicts, nested structures, datetime, enums.
+    assert to_json_serializable("string") == "string"
+    assert to_json_serializable(42) == 42
+    assert to_json_serializable(3.14) == 3.14
+    assert to_json_serializable(True) == True
+    assert to_json_serializable(None) is None
+    assert to_json_serializable(["a", 1, True]) == ["a", 1, True]
+    assert to_json_serializable(("a", 1, True)) == ["a", 1, True]
+    assert to_json_serializable({"a": 1, "b": "two"}) == {"a": 1, "b": "two"}
+    nested = {"a": [1, 2, {"b": "c"}], "d": {"e": [3, 4]}}
+    assert to_json_serializable(nested) == nested
+    assert to_json_serializable(datetime(2023, 1, 1, 12, 0, 0)) == "2023-01-01T12:00:00"
+    assert to_json_serializable(SpanKind.INTERNAL) == 1
+
+    # Special floats serialize to their string form.
+    assert to_json_serializable(float("nan")) == "nan"
+    assert to_json_serializable(float("inf")) == "inf"
+    assert to_json_serializable(float("-inf")) == "-inf"
+
+    # date / time.
+    assert to_json_serializable(date(2023, 1, 1)) == "2023-01-01"
+    assert to_json_serializable(time(12, 30, 45)) == "12:30:45"
+
+    # timedelta -> total seconds.
+    assert to_json_serializable(timedelta(days=1)) == 86400.0
+    assert (
+        to_json_serializable(timedelta(days=1, hours=2, minutes=30, seconds=15))
+        == (1 * 24 * 60 * 60) + (2 * 60 * 60) + (30 * 60) + 15
+    )
+
+    # UUID -> str.
+    assert (
+        to_json_serializable(uuid.UUID("12345678-1234-5678-1234-567812345678"))
+        == "12345678-1234-5678-1234-567812345678"
+    )
+
+    # Decimal -> float.
+    assert to_json_serializable(Decimal("10.5")) == 10.5
+    assert (
+        to_json_serializable(Decimal("3.14159265358979323846"))
+        == 3.14159265358979323846
+    )
+    assert to_json_serializable(Decimal("0")) == 0.0
+
+    # set / frozenset -> unordered list.
+    set_result = to_json_serializable({1, 2, 3, "test"})
+    assert isinstance(set_result, list)
+    assert len(set_result) == 4
+    assert {1, 2, 3, "test"} == set(set_result)
+    frozen_result = to_json_serializable(frozenset([4, 5, 6, "frozen"]))
+    assert isinstance(frozen_result, list)
+    assert len(frozen_result) == 4
+    assert {4, 5, 6, "frozen"} == set(frozen_result)
+
+    # complex -> {real, imag}.
+    assert to_json_serializable(complex(3, 4)) == {"real": 3.0, "imag": 4.0}
+    assert to_json_serializable(complex(1, -2)) == {"real": 1.0, "imag": -2.0}
+
+    # bytes / bytearray -> base64.
+    assert to_json_serializable(b"hello world") == "aGVsbG8gd29ybGQ="
+    assert to_json_serializable(bytearray(b"hello world")) == "aGVsbG8gd29ybGQ="
+
+    # dataclass -> dict (including nested dataclasses).
+    @dataclass
+    class Person:
+        name: str
+        age: int
+
+    assert to_json_serializable(Person(name="John", age=30)) == {
+        "name": "John",
+        "age": 30,
+    }
+
+    @dataclass
+    class Department:
+        name: str
+        head: Person
+
+    assert to_json_serializable(
+        Department(name="Engineering", head=Person(name="Jane", age=35))
+    ) == {"name": "Engineering", "head": {"name": "Jane", "age": 35}}
+
+
+def test_unflatten_key_values() -> None:
+    """Test unflattening key-value pairs into nested structure."""
+    kv1 = KeyValue(key="a.b.c", value=AnyValue(string_value="value1"))
+    kv2 = KeyValue(key="a.b.d", value=AnyValue(int_value=42))
+    kv3 = KeyValue(key="a.e", value=AnyValue(bool_value=True))
+    kv4 = KeyValue(key="f.0", value=AnyValue(string_value="item0"))
+    kv5 = KeyValue(key="f.1", value=AnyValue(string_value="item1"))
+
+    result = unflatten_key_values([kv1, kv2, kv3, kv4, kv5])
+
+    assert result == {
+        "a": {"b": {"c": "value1", "d": 42}, "e": True},
+        "f": {"0": "item0", "1": "item1"},
+    }
+
+
+def test_get_attribute() -> None:
+    """Test getting attributes from nested structures."""
+    nested = {"a": {"b": {"c": "value1"}}, "d": [1, 2, 3]}
+
+    assert get_attribute(nested, "a.b.c") == "value1"
+    assert get_attribute(nested, "a.b") == {"c": "value1"}
+    assert get_attribute(nested, "d") == [1, 2, 3]
+    assert get_attribute(nested, "d.0") == 1
+    assert get_attribute(nested, "nonexistent") is None
+
+
+def test_expand_and_flatten_attributes() -> None:
+    """expand_attributes nests, convert_numeric_keys_to_list lists, flatten reverses."""
+    flat_attrs = [
+        ("a.b.c", "value1"),
+        ("a.b.d", 42),
+        ("a.e", True),
+        ("f.0", "item0"),
+        ("f.1", "item1"),
+    ]
+
+    expanded = expand_attributes(flat_attrs)
+    assert expanded == {
+        "a": {"b": {"c": "value1", "d": 42}, "e": True},
+        "f": {"0": "item0", "1": "item1"},
+    }
+
+    listed = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
+    assert listed == {
+        "a": {"b": {"c": "value1", "d": 42}, "e": True},
+        "f": ["item0", "item1"],
+    }
+
+    assert flatten_attributes(listed) == {
+        "a.b.c": "value1",
+        "a.b.d": 42,
+        "a.e": True,
+        "f.0": "item0",
+        "f.1": "item1",
+    }
+
+
+def test_expand_attributes_parent_child_primitive_conflict_raises() -> None:
+    """A parent primitive and a nested subkey for the same path conflict either order."""
+    # parent primitive set first, then a nested subkey.
+    try:
+        expand_attributes([("gen_ai.prompt", True), ("gen_ai.prompt.content", "Hello")])
+        raise AssertionError("Expected AttributePathConflictError")
+    except AttributePathConflictError as e:
+        msg = str(e)
+        assert "gen_ai.prompt" in msg
+        assert "content" in msg
+        assert "Do not" in msg or "Invalid attribute structure" in msg
+
+    # nested subkey set first, then the parent primitive.
+    try:
+        expand_attributes([("gen_ai.prompt.content", "Hello"), ("gen_ai.prompt", True)])
+        raise AssertionError("Expected AttributePathConflictError")
+    except AttributePathConflictError as e:
+        msg = str(e)
+        assert "gen_ai.prompt" in msg
+        assert "Do not" in msg or "Invalid attribute structure" in msg
+
+
+def test_expand_attributes_json_string_and_dotted_subkeys_merge() -> None:
+    """A JSON-string blob and dotted subkeys for the same path merge across orderings."""
+    # JSON string first, then a matching dotted subkey -> single merged element.
+    result = convert_numeric_keys_to_list(
+        expand_attributes(
+            [
+                ("gen_ai.completion", '[{"role": "assistant", "content": "hello"}]'),
+                ("gen_ai.completion.0.role", "assistant"),
+            ]
         )
-        array_value = get_attribute(py_span.attributes, "test.array")
-        assert isinstance(array_value, list)
-        assert len(array_value) == 2
-        assert array_value[0] == "value1"
-        assert array_value[1] == "value2"
+    )
+    assert result["gen_ai"]["completion"] == [{"role": "assistant", "content": "hello"}]
 
-    def test_span_from_proto_parent_id_normalization(self):
-        """Test that empty and all-zero parent_span_id values normalize to None."""
-        # All-zero parent_span_id is the OTel invalid-id sentinel; must mean no parent.
-        pb_span = create_test_span()
-        pb_span.parent_span_id = b"\x00" * 8
-        assert PySpan.from_proto(pb_span).parent_id is None, (
-            "all-zero parent_span_id should yield parent_id=None"
+    # Dotted subkeys first, then JSON string (reversed ordering) -> same merge.
+    result = convert_numeric_keys_to_list(
+        expand_attributes(
+            [
+                ("gen_ai.completion.0.role", "assistant"),
+                ("gen_ai.completion.0.content", "hello"),
+                ("gen_ai.completion", '[{"role": "assistant", "content": "hello"}]'),
+            ]
         )
+    )
+    assert result["gen_ai"]["completion"] == [{"role": "assistant", "content": "hello"}]
 
-        pb_span = create_test_span()
-        pb_span.parent_span_id = b""
-        assert PySpan.from_proto(pb_span).parent_id is None, (
-            "empty parent_span_id should yield parent_id=None"
+    # Dotted subkeys arriving after JSON string win at the leaves.
+    result = convert_numeric_keys_to_list(
+        expand_attributes(
+            [
+                ("gen_ai.completion", '[{"role": "assistant", "content": "original"}]'),
+                ("gen_ai.completion.0.content", "overridden"),
+            ]
         )
+    )
+    assert result["gen_ai"]["completion"] == [
+        {"role": "assistant", "content": "overridden"}
+    ]
 
-        pb_span = create_test_span()
-        pb_span.parent_span_id = bytes.fromhex("0123456789abcdef")
-        assert PySpan.from_proto(pb_span).parent_id == "0123456789abcdef", (
-            "real parent_span_id should hex-encode to parent_id"
+    # JSON string arriving after dotted subkeys merges in extra fields.
+    result = convert_numeric_keys_to_list(
+        expand_attributes(
+            [
+                ("gen_ai.completion.0.role", "assistant"),
+                (
+                    "gen_ai.completion",
+                    '[{"role": "assistant", "content": "hello", "extra": true}]',
+                ),
+            ]
         )
+    )
+    assert result["gen_ai"]["completion"] == [
+        {"role": "assistant", "content": "hello", "extra": True}
+    ]
 
-    def test_span_to_call(self):
-        """Test converting a Python Span to Weave Calls."""
-        pb_span = create_test_span()
-        py_span = PySpan.from_proto(pb_span)
-
-        start_call, _ = py_span.to_call("test_project")
-
-        # Verify start call
-        assert isinstance(start_call, tsi.StartedCallSchemaForInsert)
-        assert start_call.project_id == "test_project"
-        assert start_call.id == py_span.span_id
-        assert (
-            start_call.op_name == py_span.name
-        )  # This should be using the shortened name if necessary
-        assert start_call.trace_id == py_span.trace_id
-        assert start_call.started_at == py_span.start_time
-
-    def test_span_to_call_long_name(self):
-        """Test that span names are properly shortened when too long."""
-        # Create a test span with a very long name
-        pb_span = create_test_span()
-        long_name = "a" * (MAX_OP_NAME_LENGTH + 10)
-        pb_span.name = long_name
-
-        py_span = PySpan.from_proto(pb_span)
-        start_call, end_call = py_span.to_call("test_project")
-
-        # Verify that the op_name was shortened
-        identifier = hashlib.sha256(long_name.encode("utf-8")).hexdigest()[:4]
-        shortened_name = shorten_name(
-            long_name,
-            MAX_OP_NAME_LENGTH,
-            abbrv=f":{identifier}",
-            use_delimiter_in_abbr=False,
+    # A nested-list element present only in dotted attrs must survive a later JSON blob:
+    # top-level completion lists are index-merged, but _deep_merge clobbers nested lists,
+    # so a second tool_call sent only via dotted keys must not vanish.
+    result = convert_numeric_keys_to_list(
+        expand_attributes(
+            [
+                ("gen_ai.completion.0.tool_calls.0.id", "call_0"),
+                ("gen_ai.completion.0.tool_calls.1.id", "call_1"),
+                ("gen_ai.completion.0.tool_calls.1.type", "function"),
+                (
+                    "gen_ai.completion",
+                    '[{"role": "assistant", "tool_calls": [{"id": "call_0", "type": "function"}]}]',
+                ),
+            ]
         )
-        assert start_call.op_name == shortened_name
-        assert len(start_call.op_name) <= MAX_OP_NAME_LENGTH
-
-        # Verify attributes in start call
-        assert "test" in start_call.attributes
-        assert "attribute" in start_call.attributes["test"]
-        assert start_call.attributes["test"]["attribute"] == "test_value"
-        assert start_call.attributes["test"]["number"] == 42
-        assert "nested" in start_call.attributes["test"]
-        assert start_call.attributes["test"]["nested"]["value"] == "nested_test_value"
-        assert "array" in start_call.attributes["test"]
-        assert start_call.attributes["test"]["array"] == ["value1", "value2"]
-
-        # Verify otel_dump is included in the call (otel_span is now in otel_dump)
-        assert start_call.otel_dump is not None
-        assert start_call.otel_dump["name"] == long_name
-        assert start_call.otel_dump["context"]["trace_id"] == py_span.trace_id
-        assert start_call.otel_dump["context"]["span_id"] == py_span.span_id
-
-        # Verify end call
-        assert isinstance(end_call, tsi.EndedCallSchemaForInsert)
-        assert end_call.project_id == "test_project"
-        assert end_call.id == py_span.span_id
-        assert end_call.ended_at == py_span.end_time
-        assert end_call.exception is None
-
-    def test_span_to_call_with_turn_and_thread(self):
-        """Test that turn_id equals thread_id when is_turn is True."""
-        # Create a test span with turn and thread attributes
-        pb_span = create_test_span()
-        test_thread_id = str(uuid.uuid4())
-
-        # Add wandb.is_turn and wandb.thread_id attributes
-        kv_is_turn = KeyValue()
-        kv_is_turn.key = "wandb.is_turn"
-        kv_is_turn.value.bool_value = True
-        pb_span.attributes.append(kv_is_turn)
-
-        kv_thread = KeyValue()
-        kv_thread.key = "wandb.thread_id"
-        kv_thread.value.string_value = test_thread_id
-        pb_span.attributes.append(kv_thread)
-
-        py_span = PySpan.from_proto(pb_span)
-        start_call, end_call = py_span.to_call("test_project")
-
-        # Verify turn_id equals call.id (span_id) when is_turn is True
-        assert start_call.turn_id == py_span.span_id
-        # Verify thread_id is passed through
-        assert start_call.thread_id == test_thread_id
-
-        # Test with is_turn = False
-        pb_span_false = create_test_span()
-        kv_is_turn_false = KeyValue()
-        kv_is_turn_false.key = "wandb.is_turn"
-        kv_is_turn_false.value.bool_value = False
-        pb_span_false.attributes.append(kv_is_turn_false)
-
-        kv_thread_false = KeyValue()
-        kv_thread_false.key = "wandb.thread_id"
-        kv_thread_false.value.string_value = test_thread_id
-        pb_span_false.attributes.append(kv_thread_false)
-
-        py_span_false = PySpan.from_proto(pb_span_false)
-        start_call_false, _ = py_span_false.to_call("test_project")
-
-        # Verify turn_id is None when is_turn is False
-        assert start_call_false.turn_id is None
-        assert start_call_false.thread_id == test_thread_id
-
-        # Test without is_turn (should default to None)
-        pb_span_no_turn = create_test_span()
-        kv_thread_only = KeyValue()
-        kv_thread_only.key = "wandb.thread_id"
-        kv_thread_only.value.string_value = test_thread_id
-        pb_span_no_turn.attributes.append(kv_thread_only)
-
-        py_span_no_turn = PySpan.from_proto(pb_span_no_turn)
-        start_call_no_turn, _ = py_span_no_turn.to_call("test_project")
-
-        # Verify turn_id is None when is_turn is not present
-        assert start_call_no_turn.turn_id is None
-        assert start_call_no_turn.thread_id == test_thread_id
-
-        # Test with is_turn = True but no thread_id
-        pb_span_turn_no_thread = create_test_span()
-        kv_is_turn_only = KeyValue()
-        kv_is_turn_only.key = "wandb.is_turn"
-        kv_is_turn_only.value.bool_value = True
-        pb_span_turn_no_thread.attributes.append(kv_is_turn_only)
-
-        py_span_turn_no_thread = PySpan.from_proto(pb_span_turn_no_thread)
-        start_call_turn_no_thread, _ = py_span_turn_no_thread.to_call("test_project")
-
-        # Verify turn_id is None when is_turn is True but thread_id is missing
-        assert start_call_turn_no_thread.turn_id is None
-        assert start_call_turn_no_thread.thread_id is None
-
-    def test_span_to_call_with_cache_tokens(self):
-        """Test that cache token usage attributes flow through to_call summary."""
-        pb_span = create_test_span()
-
-        # Add cache token usage attributes
-        kv_cache_creation = KeyValue()
-        kv_cache_creation.key = "gen_ai.usage.cache_creation.input_tokens"
-        kv_cache_creation.value.int_value = 500
-        pb_span.attributes.append(kv_cache_creation)
-
-        kv_cache_read = KeyValue()
-        kv_cache_read.key = "gen_ai.usage.cache_read.input_tokens"
-        kv_cache_read.value.int_value = 200
-        pb_span.attributes.append(kv_cache_read)
-
-        kv_input = KeyValue()
-        kv_input.key = "gen_ai.usage.input_tokens"
-        kv_input.value.int_value = 100
-        pb_span.attributes.append(kv_input)
-
-        kv_output = KeyValue()
-        kv_output.key = "gen_ai.usage.output_tokens"
-        kv_output.value.int_value = 50
-        pb_span.attributes.append(kv_output)
-
-        py_span = PySpan.from_proto(pb_span)
-        _, end_call = py_span.to_call("test_project")
-
-        # Usage is keyed by model name or "usage" when no model is set
-        usage = end_call.summary["usage"]["usage"]  # type: ignore
-        assert usage["cache_creation_input_tokens"] == 500
-        assert usage["cache_read_input_tokens"] == 200
-        assert usage["input_tokens"] == 100
-        assert usage["output_tokens"] == 50
-
-    def test_span_to_call_with_genai_conversation_id(self):
-        """Test that gen_ai.conversation.id sets thread_id and turn_id."""
-        pb_span = create_test_span()
-
-        kv_conv = KeyValue()
-        kv_conv.key = "gen_ai.conversation.id"
-        kv_conv.value.string_value = "conv-xyz"
-        pb_span.attributes.append(kv_conv)
-
-        py_span = PySpan.from_proto(pb_span)
-        start_call, _ = py_span.to_call("test_project")
-
-        assert start_call.thread_id == "conv-xyz"
-        # is_turn is truthy via conversation.id, so turn_id should be set
-        assert start_call.turn_id == py_span.span_id
-
-    def test_traces_data_from_proto(self):
-        """Test converting protobuf TracesData to Python TracesData."""
-        export_req = create_test_export_request()
-        resource_spans_list = [ps.resource_spans for ps in export_req.processed_spans]
-        traces_data = PyTracesData.from_proto(
-            TracesData(resource_spans=resource_spans_list)
-        )
-
-        assert len(traces_data.resource_spans) == 1
-        resource_spans = traces_data.resource_spans[0]
-        assert len(resource_spans.scope_spans) == 1
-        scope_spans = resource_spans.scope_spans[0]
-        assert len(scope_spans.spans) == 1
-        span = scope_spans.spans[0]
-
-        assert span.name == "test_span"
-        assert span.kind == SpanKind.INTERNAL
-
-
-class TestAttributes:
-    def test_to_json_serializable(self):
-        """Test converting various types to JSON serializable values."""
-        # Test primitive types
-        assert to_json_serializable("string") == "string"
-        assert to_json_serializable(42) == 42
-        assert to_json_serializable(3.14) == 3.14
-        assert to_json_serializable(True) == True
-        assert to_json_serializable(None) is None
-
-        # Test lists and tuples
-        assert to_json_serializable(["a", 1, True]) == ["a", 1, True]
-        assert to_json_serializable(("a", 1, True)) == ["a", 1, True]
-
-        # Test dictionaries
-        assert to_json_serializable({"a": 1, "b": "two"}) == {"a": 1, "b": "two"}
-
-        # Test nested structures
-        nested = {"a": [1, 2, {"b": "c"}], "d": {"e": [3, 4]}}
-        assert to_json_serializable(nested) == nested
-
-        # Test datetime
-        dt = datetime(2023, 1, 1, 12, 0, 0)
-        assert to_json_serializable(dt) == "2023-01-01T12:00:00"
-
-        # Test enums
-        assert to_json_serializable(SpanKind.INTERNAL) == 1
-
-    def test_to_json_serializable_special_floats(self):
-        """Test converting special float values (NaN, Infinity)."""
-        # Test NaN
-        assert to_json_serializable(float("nan")) == "nan"
-
-        # Test positive infinity
-        assert to_json_serializable(float("inf")) == "inf"
-
-        # Test negative infinity
-        assert to_json_serializable(float("-inf")) == "-inf"
-
-    def test_to_json_serializable_date_time(self):
-        """Test converting date and time objects."""
-        from datetime import date, time
-
-        # Test date
-        d = date(2023, 1, 1)
-        assert to_json_serializable(d) == "2023-01-01"
-
-        # Test time
-        t = time(12, 30, 45)
-        assert to_json_serializable(t) == "12:30:45"
-
-    def test_to_json_serializable_timedelta(self):
-        """Test converting timedelta objects."""
-        from datetime import timedelta
-
-        # Test one day
-        td = timedelta(days=1)
-        assert to_json_serializable(td) == 86400.0  # 24 * 60 * 60 seconds
-
-        # Test complex timedelta
-        td = timedelta(days=1, hours=2, minutes=30, seconds=15)
-        expected_seconds = (1 * 24 * 60 * 60) + (2 * 60 * 60) + (30 * 60) + 15
-        assert to_json_serializable(td) == expected_seconds
-
-    def test_to_json_serializable_uuid(self):
-        """Test converting UUID objects."""
-        import uuid
-
-        # Create a UUID with a known value
-        test_uuid = uuid.UUID("12345678-1234-5678-1234-567812345678")
-        assert to_json_serializable(test_uuid) == "12345678-1234-5678-1234-567812345678"
-
-    def test_to_json_serializable_decimal(self):
-        """Test converting Decimal objects."""
-        from decimal import Decimal
-
-        # Test simple decimal
-        assert to_json_serializable(Decimal("10.5")) == 10.5
-
-        # Test high precision decimal
-        assert (
-            to_json_serializable(Decimal("3.14159265358979323846"))
-            == 3.14159265358979323846
-        )
-
-        # Test zero
-        assert to_json_serializable(Decimal("0")) == 0.0
-
-    def test_to_json_serializable_sets(self):
-        """Test converting set and frozenset objects."""
-        # Test set
-        s = {1, 2, 3, "test"}
-        result = to_json_serializable(s)
-        assert isinstance(result, list)
-        assert len(result) == 4
-        assert 1 in result
-        assert 2 in result
-        assert 3 in result
-        assert "test" in result
-
-        # Test frozenset
-        fs = frozenset([4, 5, 6, "frozen"])
-        result = to_json_serializable(fs)
-        assert isinstance(result, list)
-        assert len(result) == 4
-        assert 4 in result
-        assert 5 in result
-        assert 6 in result
-        assert "frozen" in result
-
-    def test_to_json_serializable_complex(self):
-        """Test converting complex numbers."""
-        c = complex(3, 4)
-        result = to_json_serializable(c)
-        assert isinstance(result, dict)
-        assert result == {"real": 3.0, "imag": 4.0}
-
-        # Test complex with negative imaginary part
-        c = complex(1, -2)
-        assert to_json_serializable(c) == {"real": 1.0, "imag": -2.0}
-
-    def test_to_json_serializable_bytes(self):
-        """Test converting bytes and bytearray objects."""
-        # Test bytes
-        b = b"hello world"
-        assert to_json_serializable(b) == "aGVsbG8gd29ybGQ="  # Base64 encoded
-
-        # Test bytearray
-        ba = bytearray(b"hello world")
-        assert to_json_serializable(ba) == "aGVsbG8gd29ybGQ="  # Base64 encoded
-
-    def test_to_json_serializable_dataclass(self):
-        """Test converting dataclass objects."""
-        from dataclasses import dataclass
-
-        @dataclass
-        class Person:
-            name: str
-            age: int
-
-        person = Person(name="John", age=30)
-        result = to_json_serializable(person)
-        assert isinstance(result, dict)
-        assert result == {"name": "John", "age": 30}
-
-        # Nested dataclass
-        @dataclass
-        class Department:
-            name: str
-            head: Person
-
-        dept = Department(name="Engineering", head=Person(name="Jane", age=35))
-        result = to_json_serializable(dept)
-        assert result == {"name": "Engineering", "head": {"name": "Jane", "age": 35}}
-
-    def test_unflatten_key_values(self):
-        """Test unflattening key-value pairs into nested structure."""
-        # Create key-value pairs
-        kv1 = KeyValue(key="a.b.c", value=AnyValue(string_value="value1"))
-        kv2 = KeyValue(key="a.b.d", value=AnyValue(int_value=42))
-        kv3 = KeyValue(key="a.e", value=AnyValue(bool_value=True))
-        kv4 = KeyValue(key="f.0", value=AnyValue(string_value="item0"))
-        kv5 = KeyValue(key="f.1", value=AnyValue(string_value="item1"))
-
-        # Unflatten key-values
-        result = unflatten_key_values([kv1, kv2, kv3, kv4, kv5])
-
-        # Verify the result
-        assert result == {
-            "a": {"b": {"c": "value1", "d": 42}, "e": True},
-            "f": {"0": "item0", "1": "item1"},
-        }
-
-    def test_get_attribute(self):
-        """Test getting attributes from nested structures."""
-        nested = {"a": {"b": {"c": "value1"}}, "d": [1, 2, 3]}
-
-        assert get_attribute(nested, "a.b.c") == "value1"
-        assert get_attribute(nested, "a.b") == {"c": "value1"}
-        assert get_attribute(nested, "d") == [1, 2, 3]
-
-        assert get_attribute(nested, "d.0") == 1
-
-        assert get_attribute(nested, "nonexistent") is None
-
-    def test_expand_attributes(self):
-        """Test expanding flattened attributes into nested structure."""
-        flat_attrs = [
-            ("a.b.c", "value1"),
-            ("a.b.d", 42),
-            ("a.e", True),
-            ("f.0", "item0"),
-            ("f.1", "item1"),
-        ]
-
-        result = expand_attributes(flat_attrs)
-
-        assert result == {
-            "a": {"b": {"c": "value1", "d": 42}, "e": True},
-            "f": {"0": "item0", "1": "item1"},
-        }
-
-    def test_expand_attributes_convert_numeric_to_list(self):
-        """Test expanding flattened attributes into nested structure."""
-        flat_attrs = [
-            ("a.b.c", "value1"),
-            ("a.b.d", 42),
-            ("a.e", True),
-            ("f.0", "item0"),
-            ("f.1", "item1"),
-        ]
-
-        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
-
-        assert result == {
-            "a": {"b": {"c": "value1", "d": 42}, "e": True},
-            "f": ["item0", "item1"],
-        }
-
-    def test_flatten_attributes(self):
-        """Test flattening nested attributes into key-value pairs."""
-        nested = {
-            "a": {"b": {"c": "value1", "d": 42}, "e": True},
-            "f": ["item0", "item1"],
-        }
-
-        result = flatten_attributes(nested)
-
-        expected = {
-            "a.b.c": "value1",
-            "a.b.d": 42,
-            "a.e": True,
-            "f.0": "item0",
-            "f.1": "item1",
-        }
-
-        assert result == expected
-
-    def test_expand_attributes_conflict_parent_then_child(self):
-        """Setting a parent primitive then a nested subkey should raise a clear error."""
-        flat_attrs = [
-            ("gen_ai.prompt", True),
-            ("gen_ai.prompt.content", "Hello"),
-        ]
-
-        try:
-            expand_attributes(flat_attrs)
-            raise AssertionError("Expected AttributePathConflictError")
-        except AttributePathConflictError as e:
-            msg = str(e)
-            assert "gen_ai.prompt" in msg
-            assert "content" in msg
-            assert "Do not" in msg or "Invalid attribute structure" in msg
-
-    def test_expand_attributes_conflict_child_then_parent(self):
-        """Setting nested subkeys then a parent primitive should raise a clear error."""
-        flat_attrs = [
-            ("gen_ai.prompt.content", "Hello"),
-            ("gen_ai.prompt", True),
-        ]
-
-        try:
-            expand_attributes(flat_attrs)
-            raise AssertionError("Expected AttributePathConflictError")
-        except AttributePathConflictError as e:
-            msg = str(e)
-            assert "gen_ai.prompt" in msg
-            assert "Do not" in msg or "Invalid attribute structure" in msg
-
-    def test_expand_attributes_json_string_and_dotted_subkeys_coexist(self):
-        """JSON string + dotted subkeys for the same path should merge, not conflict."""
-        flat_attrs = [
-            ("gen_ai.completion", '[{"role": "assistant", "content": "hello"}]'),
-            ("gen_ai.completion.0.role", "assistant"),
-        ]
-        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
-        assert result["gen_ai"]["completion"] == [
-            {"role": "assistant", "content": "hello"}
-        ]
-
-    def test_expand_attributes_dotted_subkeys_then_json_string_coexist(self):
-        """Same merge but with reversed attribute ordering."""
-        flat_attrs = [
-            ("gen_ai.completion.0.role", "assistant"),
-            ("gen_ai.completion.0.content", "hello"),
-            ("gen_ai.completion", '[{"role": "assistant", "content": "hello"}]'),
-        ]
-        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
-        assert result["gen_ai"]["completion"] == [
-            {"role": "assistant", "content": "hello"}
-        ]
-
-    def test_expand_attributes_dotted_subkeys_override_json_string(self):
-        """Dotted subkeys arriving after JSON string should win at leaves."""
-        flat_attrs = [
-            ("gen_ai.completion", '[{"role": "assistant", "content": "original"}]'),
-            ("gen_ai.completion.0.content", "overridden"),
-        ]
-        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
-        assert result["gen_ai"]["completion"] == [
-            {"role": "assistant", "content": "overridden"}
-        ]
-
-    def test_expand_attributes_json_string_adds_fields_to_dotted(self):
-        """JSON string arriving after dotted subkeys should merge in extra fields."""
-        flat_attrs = [
-            ("gen_ai.completion.0.role", "assistant"),
-            (
-                "gen_ai.completion",
-                '[{"role": "assistant", "content": "hello", "extra": true}]',
-            ),
-        ]
-        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
-        assert result["gen_ai"]["completion"] == [
-            {"role": "assistant", "content": "hello", "extra": True}
-        ]
-
-    def test_expand_attributes_nested_list_merge_preserves_dotted_only_elements(self):
-        """A nested-list element present only in dotted attrs must survive a later JSON blob.
-
-        Top-level completion lists are index-merged, but _deep_merge clobbers nested
-        lists (base[key] = value), so a second tool_call sent only via dotted keys is
-        silently dropped when the gen_ai.completion JSON blob is emitted after the
-        dotted attributes. Same data, different OTel emission order -> a tool call
-        vanishes from the stored call.
-        """
-        flat_attrs = [
-            ("gen_ai.completion.0.tool_calls.0.id", "call_0"),
-            ("gen_ai.completion.0.tool_calls.1.id", "call_1"),
-            ("gen_ai.completion.0.tool_calls.1.type", "function"),
-            (
-                "gen_ai.completion",
-                '[{"role": "assistant", "tool_calls": [{"id": "call_0", "type": "function"}]}]',
-            ),
-        ]
-        result = convert_numeric_keys_to_list(expand_attributes(flat_attrs))
-        tool_calls = result["gen_ai"]["completion"][0]["tool_calls"]
-        assert [tc["id"] for tc in tool_calls] == ["call_0", "call_1"]
+    )
+    tool_calls = result["gen_ai"]["completion"][0]["tool_calls"]
+    assert [tc["id"] for tc in tool_calls] == ["call_0", "call_1"]
 
 
 def create_attributes(d: dict[str, Any]):
     return expand_attributes(d.items())
 
 
-class TestSemanticConventionParsing:
-    """Test the semantic convention parsing functionality in attributes.py."""
+def test_openinference_attributes_extraction() -> None:
+    """Test extracting attributes from OpenInference attributes."""
+    attributes = create_attributes(
+        {
+            OISpanAttr.LLM_SYSTEM: "This is a system prompt",
+            OISpanAttr.LLM_PROVIDER: "test-provider",
+            OISpanAttr.LLM_MODEL_NAME: "test-model",
+            OISpanAttr.OPENINFERENCE_SPAN_KIND: "llm",
+            OISpanAttr.LLM_INVOCATION_PARAMETERS: json.dumps(
+                {"temperature": 0.7, "max_tokens": 100}
+            ),
+        }
+    )
 
-    def test_openinference_attributes_extraction(self):
-        """Test extracting attributes from OpenInference attributes."""
-        from openinference.semconv.trace import SpanAttributes as OISpanAttr
+    extracted = get_weave_attributes(attributes)
+    assert extracted["system"] == "This is a system prompt"
+    assert extracted["provider"] == "test-provider"
+    assert extracted["model"] == "test-model"
+    assert extracted["kind"] == "llm"
+    assert extracted["model_parameters"]["max_tokens"] == 100
+    assert extracted["model_parameters"]["temperature"] == 0.7
 
-        # Create attribute dictionary with OpenInference attributes
-        attributes = create_attributes(
-            {
-                OISpanAttr.LLM_SYSTEM: "This is a system prompt",
-                OISpanAttr.LLM_PROVIDER: "test-provider",
-                OISpanAttr.LLM_MODEL_NAME: "test-model",
-                OISpanAttr.OPENINFERENCE_SPAN_KIND: "llm",
-                OISpanAttr.LLM_INVOCATION_PARAMETERS: json.dumps(
-                    {"temperature": 0.7, "max_tokens": 100}
-                ),
-            }
+
+def test_opentelemetry_attributes_extraction() -> None:
+    """Test extracting attributes from OpenTelemetry attributes."""
+    attributes = create_attributes(
+        {
+            OTSpanAttr.LLM_SYSTEM: "You are a helpful assistant",
+            OTSpanAttr.LLM_REQUEST_MAX_TOKENS: 150,
+            OTSpanAttr.TRACELOOP_SPAN_KIND: "llm",
+            OTSpanAttr.LLM_RESPONSE_MODEL: "gpt-4",
+        }
+    )
+
+    extracted = get_weave_attributes(attributes)
+    assert extracted["system"] == "You are a helpful assistant"
+    assert extracted["model_parameters"]["max_tokens"] == 150
+    assert extracted["kind"] == "llm"
+    assert extracted["model"] == "gpt-4"
+
+
+def test_wandb_attributes_extraction() -> None:
+    """Test extracting wandb-specific attributes (flat, empty, partial, nested)."""
+    extracted = get_wandb_attributes(
+        create_attributes({"wandb.display_name": "My Custom Display Name"})
+    )
+    assert extracted["display_name"] == "My Custom Display Name"
+
+    assert get_wandb_attributes(create_attributes({})) == {}
+
+    extracted = get_wandb_attributes(
+        create_attributes({"wandb.display_name": "Only Display Name"})
+    )
+    assert extracted["display_name"] == "Only Display Name"
+    assert "project_id" not in extracted
+
+    extracted = get_wandb_attributes(
+        create_attributes({"wandb": {"display_name": "Nested Display Name"}})
+    )
+    assert extracted["display_name"] == "Nested Display Name"
+
+
+def test_wandb_turn_and_thread_attributes() -> None:
+    """is_turn is only kept when truthy; thread_id is always passed through."""
+    test_thread_id = str(uuid.uuid4())
+
+    extracted = get_wandb_attributes(
+        create_attributes({"wandb.is_turn": True, "wandb.thread_id": test_thread_id})
+    )
+    assert extracted["is_turn"] is True
+    assert extracted["thread_id"] == test_thread_id
+
+    extracted_false = get_wandb_attributes(
+        create_attributes({"wandb.is_turn": False, "wandb.thread_id": test_thread_id})
+    )
+    assert "is_turn" not in extracted_false.keys()
+    assert extracted_false["thread_id"] == test_thread_id
+
+    extracted_thread_only = get_wandb_attributes(
+        create_attributes({"wandb.thread_id": test_thread_id})
+    )
+    assert "is_turn" not in extracted_thread_only
+    assert extracted_thread_only["thread_id"] == test_thread_id
+
+    extracted_turn_only = get_wandb_attributes(
+        create_attributes({"wandb.is_turn": True})
+    )
+    assert extracted_turn_only["is_turn"] is True
+    assert "thread_id" not in extracted_turn_only
+
+
+@pytest.mark.skip(reason="wb_run_id extraction not yet implemented")
+def test_wandb_wb_run_id_extraction() -> None:
+    """Test extracting wb_run_id from both wb_run_id and wandb.wb_run_id attributes."""
+    extracted_top_level = get_wandb_attributes(
+        create_attributes({"wb_run_id": "run_top_123"})
+    )
+    assert extracted_top_level["wb_run_id"] == "run_top_123"
+
+    extracted_namespaced = get_wandb_attributes(
+        create_attributes({"wandb.wb_run_id": "run_ns_456"})
+    )
+    assert extracted_namespaced["wb_run_id"] == "run_ns_456"
+
+    # Both present: top-level takes precedence.
+    extracted_both = get_wandb_attributes(
+        create_attributes(
+            {"wb_run_id": "preferred_top", "wandb.wb_run_id": "fallback_ns"}
         )
+    )
+    assert extracted_both["wb_run_id"] == "preferred_top"
 
-        # Test get_weave_attributes
-        extracted = get_weave_attributes(attributes)
-        assert extracted["system"] == "This is a system prompt"
-        assert extracted["provider"] == "test-provider"
-        assert extracted["model"] == "test-model"
-        assert extracted["kind"] == "llm"
-        assert extracted["model_parameters"]["max_tokens"] == 100
-        assert extracted["model_parameters"]["temperature"] == 0.7
 
-    def test_wandb_attributes_extraction(self):
-        """Test extracting wandb-specific attributes."""
-        # Create attribute dictionary with W&B specific attributes
-        attributes = create_attributes(
-            {
-                "wandb.display_name": "My Custom Display Name",
-            }
-        )
-
-        # Test get_wandb_attributes
-        extracted = get_wandb_attributes(attributes)
-        assert extracted["display_name"] == "My Custom Display Name"
-
-        # Test with missing attributes
-        empty_attributes = create_attributes({})
-        extracted = get_wandb_attributes(empty_attributes)
-        assert extracted == {}
-
-        # Test with partial attributes
-        partial_attributes = create_attributes(
-            {
-                "wandb.display_name": "Only Display Name",
-            }
-        )
-        extracted = get_wandb_attributes(partial_attributes)
-        assert extracted["display_name"] == "Only Display Name"
-        assert "project_id" not in extracted
-
-        # Test with nested attributes format
-        nested_attributes = create_attributes(
-            {
-                "wandb": {
-                    "display_name": "Nested Display Name",
-                }
-            }
-        )
-        extracted = get_wandb_attributes(nested_attributes)
-        assert extracted["display_name"] == "Nested Display Name"
-
-    def test_wandb_turn_and_thread_attributes(self):
-        """Test extracting turn and thread attributes from wandb attributes."""
-        # Test with is_turn = True and thread_id
-        test_thread_id = str(uuid.uuid4())
-        attributes = create_attributes(
-            {
-                "wandb.is_turn": True,
-                "wandb.thread_id": test_thread_id,
-            }
-        )
-
-        extracted = get_wandb_attributes(attributes)
-        assert extracted["is_turn"] is True
-        assert extracted["thread_id"] == test_thread_id
-
-        # Test with is_turn = False
-        attributes_false = create_attributes(
-            {
-                "wandb.is_turn": False,
-                "wandb.thread_id": test_thread_id,
-            }
-        )
-        extracted_false = get_wandb_attributes(attributes_false)
-        assert "is_turn" not in extracted_false.keys()
-        assert extracted_false["thread_id"] == test_thread_id
-
-        # Test with only thread_id
-        attributes_thread_only = create_attributes(
-            {
-                "wandb.thread_id": test_thread_id,
-            }
-        )
-        extracted_thread_only = get_wandb_attributes(attributes_thread_only)
-        assert "is_turn" not in extracted_thread_only
-        assert extracted_thread_only["thread_id"] == test_thread_id
-
-        # Test with only is_turn
-        attributes_turn_only = create_attributes(
-            {
-                "wandb.is_turn": True,
-            }
-        )
-        extracted_turn_only = get_wandb_attributes(attributes_turn_only)
-        assert extracted_turn_only["is_turn"] is True
-        assert "thread_id" not in extracted_turn_only
-
-    @pytest.mark.skip(reason="wb_run_id extraction not yet implemented")
-    def test_wandb_wb_run_id_extraction(self):
-        """Test extracting wb_run_id from both wb_run_id and wandb.wb_run_id attributes."""
-        # Case 1: Only top-level wb_run_id present
-        attributes_top_level = create_attributes(
-            {
-                "wb_run_id": "run_top_123",
-            }
-        )
-        extracted_top_level = get_wandb_attributes(attributes_top_level)
-        assert extracted_top_level["wb_run_id"] == "run_top_123"
-
-        # Case 2: Only namespaced wandb.wb_run_id present
-        attributes_namespaced = create_attributes(
-            {
-                "wandb.wb_run_id": "run_ns_456",
-            }
-        )
-        extracted_namespaced = get_wandb_attributes(attributes_namespaced)
-        assert extracted_namespaced["wb_run_id"] == "run_ns_456"
-
-        # Case 3: Both present, top-level should take precedence
-        attributes_both = create_attributes(
-            {
-                "wb_run_id": "preferred_top",
-                "wandb.wb_run_id": "fallback_ns",
-            }
-        )
-        extracted_both = get_wandb_attributes(attributes_both)
-        assert extracted_both["wb_run_id"] == "preferred_top"
-
-    def test_openinference_inputs_extraction(self):
-        """Test extracting inputs from OpenInference attributes."""
-        from openinference.semconv.trace import SpanAttributes as OISpanAttr
-
-        # Create attribute dictionary with OpenInference input value and mime type
-        attributes = create_attributes(
+def test_openinference_inputs_extraction() -> None:
+    """get_weave_inputs handles OpenInference text and JSON input values."""
+    inputs = get_weave_inputs(
+        [],
+        create_attributes(
             {
                 OISpanAttr.INPUT_VALUE: "What is machine learning?",
                 OISpanAttr.INPUT_MIME_TYPE: "text/plain",
             }
-        )
+        ),
+    )
+    assert inputs == {"input.value": "What is machine learning?"}
 
-        # Test get_weave_inputs with text input
-        inputs = get_weave_inputs([], attributes)
-        assert inputs == {
-            "input.value": "What is machine learning?",
+    json_input = json.dumps(
+        {
+            "messages": [
+                {"role": "system", "content": "You are an assistant"},
+                {"role": "user", "content": "What is machine learning?"},
+            ]
         }
-
-        # Test with JSON input
-        json_input = json.dumps(
-            {
-                "messages": [
-                    {"role": "system", "content": "You are an assistant"},
-                    {"role": "user", "content": "What is machine learning?"},
-                ]
-            }
-        )
-        attributes = create_attributes(
+    )
+    inputs = get_weave_inputs(
+        [],
+        create_attributes(
             {
                 OISpanAttr.INPUT_VALUE: json_input,
                 OISpanAttr.INPUT_MIME_TYPE: "application/json",
             }
-        )
-        inputs = get_weave_inputs([], attributes)
-        assert inputs == {
-            "input.value": {
-                "messages": [
-                    {"role": "system", "content": "You are an assistant"},
-                    {"role": "user", "content": "What is machine learning?"},
-                ]
-            },
-        }
+        ),
+    )
+    assert inputs == {
+        "input.value": {
+            "messages": [
+                {"role": "system", "content": "You are an assistant"},
+                {"role": "user", "content": "What is machine learning?"},
+            ]
+        },
+    }
 
-    def test_openinference_outputs_extraction(self):
-        """Test extracting outputs from OpenInference attributes."""
-        from openinference.semconv.trace import SpanAttributes as OISpanAttr
 
-        # Create attribute dictionary with OpenInference output value and mime type
-        attributes = create_attributes(
+def test_openinference_outputs_extraction() -> None:
+    """get_weave_outputs handles OpenInference text and JSON output values."""
+    outputs = get_weave_outputs(
+        [],
+        create_attributes(
             {
                 OISpanAttr.OUTPUT_VALUE: "Machine learning is a field of AI...",
                 OISpanAttr.OUTPUT_MIME_TYPE: "text/plain",
             }
-        )
+        ),
+    )
+    assert outputs == {"output.value": "Machine learning is a field of AI..."}
 
-        # Test get_weave_outputs with text output
-        outputs = get_weave_outputs([], attributes)
-        assert outputs == {
-            "output.value": "Machine learning is a field of AI...",
-        }
-
-        # Test with JSON output
-        json_output = json.dumps(
-            {
-                "response": {
-                    "role": "assistant",
-                    "content": "Machine learning is a field of AI...",
-                }
+    json_output = json.dumps(
+        {
+            "response": {
+                "role": "assistant",
+                "content": "Machine learning is a field of AI...",
             }
-        )
-        attributes = create_attributes(
+        }
+    )
+    outputs = get_weave_outputs(
+        [],
+        create_attributes(
             {
                 OISpanAttr.OUTPUT_VALUE: json_output,
                 OISpanAttr.OUTPUT_MIME_TYPE: "application/json",
             }
-        )
-        outputs = get_weave_outputs([], attributes)
-        assert outputs == {
-            "output.value": {
-                "response": {
-                    "role": "assistant",
-                    "content": "Machine learning is a field of AI...",
-                }
-            },
+        ),
+    )
+    assert outputs == {
+        "output.value": {
+            "response": {
+                "role": "assistant",
+                "content": "Machine learning is a field of AI...",
+            }
+        },
+    }
+
+
+def test_opentelemetry_inputs_extraction() -> None:
+    """get_weave_inputs expands OpenTelemetry prompts into a message list."""
+    attributes = create_attributes(
+        {
+            OTSpanAttr.LLM_PROMPTS: {
+                "0": {"role": "user", "content": "Tell me about quantum computing"}
+            }
         }
+    )
+    inputs = get_weave_inputs([], attributes)
+    assert inputs == {
+        "gen_ai.prompt": [
+            {"role": "user", "content": "Tell me about quantum computing"}
+        ]
+    }
 
-    def test_openinference_usage_extraction(self):
-        """Test extracting usage from OpenInference attributes."""
-        from openinference.semconv.trace import SpanAttributes as OISpanAttr
 
-        # Create attribute dictionary with OpenInference token counts
-        attributes = create_attributes(
+def test_opentelemetry_outputs_extraction() -> None:
+    """get_weave_outputs expands OpenTelemetry completions into a message list."""
+    attributes = create_attributes(
+        {
+            OTSpanAttr.LLM_COMPLETIONS: {
+                "0": {
+                    "role": "assistant",
+                    "content": "Quantum computing uses quantum mechanics...",
+                }
+            }
+        }
+    )
+    outputs = get_weave_outputs([], attributes)
+    assert outputs == {
+        "gen_ai.completion": [
+            {
+                "role": "assistant",
+                "content": "Quantum computing uses quantum mechanics...",
+            }
+        ]
+    }
+
+
+def test_usage_token_extraction() -> None:
+    """get_weave_usage parses token counts across OpenInference, OTel, gen_ai, and cache."""
+    # OpenInference token counts.
+    usage = get_weave_usage(
+        create_attributes(
             {
                 OISpanAttr.LLM_TOKEN_COUNT_PROMPT: 10,
                 OISpanAttr.LLM_TOKEN_COUNT_COMPLETION: 20,
                 OISpanAttr.LLM_TOKEN_COUNT_TOTAL: 30,
             }
         )
+    )
+    assert usage.get("prompt_tokens") == 10
+    assert usage.get("completion_tokens") == 20
+    assert usage.get("total_tokens") == 30
 
-        # Test get_weave_usage
-        usage = get_weave_usage(attributes)
-        assert usage.get("prompt_tokens") == 10
-        assert usage.get("completion_tokens") == 20
-        assert usage.get("total_tokens") == 30
-
-    def test_opentelemetry_attributes_extraction(self):
-        """Test extracting attributes from OpenTelemetry attributes."""
-        from opentelemetry.semconv_ai import SpanAttributes as OTSpanAttr
-
-        # Create attribute dictionary with OpenTelemetry attributes
-        attributes = create_attributes(
-            {
-                OTSpanAttr.LLM_SYSTEM: "You are a helpful assistant",
-                OTSpanAttr.LLM_REQUEST_MAX_TOKENS: 150,
-                OTSpanAttr.TRACELOOP_SPAN_KIND: "llm",
-                OTSpanAttr.LLM_RESPONSE_MODEL: "gpt-4",
-            }
-        )
-
-        # Test get_weave_attributes
-        extracted = get_weave_attributes(attributes)
-        assert extracted["system"] == "You are a helpful assistant"
-        assert extracted["model_parameters"]["max_tokens"] == 150
-        assert extracted["kind"] == "llm"
-        assert extracted["model"] == "gpt-4"
-
-    def test_opentelemetry_inputs_extraction(self):
-        """Test extracting inputs from OpenTelemetry attributes."""
-        from opentelemetry.semconv_ai import SpanAttributes as OTSpanAttr
-
-        # Create attribute dictionary with OpenTelemetry prompts
-        prompts = {"0": {"role": "user", "content": "Tell me about quantum computing"}}
-        attributes = create_attributes(
-            {
-                OTSpanAttr.LLM_PROMPTS: prompts,
-            }
-        )
-
-        # Test get_weave_inputs
-        inputs = get_weave_inputs([], attributes)
-        assert inputs == {
-            "gen_ai.prompt": [
-                {"role": "user", "content": "Tell me about quantum computing"}
-            ]
-        }
-
-    def test_opentelemetry_outputs_extraction(self):
-        """Test extracting outputs from OpenTelemetry attributes."""
-        from opentelemetry.semconv_ai import SpanAttributes as OTSpanAttr
-
-        # Create attribute dictionary with OpenTelemetry completions
-        completions = {
-            "0": {
-                "role": "assistant",
-                "content": "Quantum computing uses quantum mechanics...",
-            }
-        }
-        attributes = create_attributes(
-            {
-                OTSpanAttr.LLM_COMPLETIONS: completions,
-            }
-        )
-
-        # Create OpenTelemetry attributes object
-
-        # Test get_weave_outputs
-        outputs = get_weave_outputs([], attributes)
-        assert outputs == {
-            "gen_ai.completion": [
+    # OpenTelemetry token counts.
+    usage = (
+        get_weave_usage(
+            create_attributes(
                 {
-                    "role": "assistant",
-                    "content": "Quantum computing uses quantum mechanics...",
+                    OTSpanAttr.LLM_USAGE_PROMPT_TOKENS: 15,
+                    OTSpanAttr.LLM_USAGE_COMPLETION_TOKENS: 25,
+                    OTSpanAttr.LLM_USAGE_TOTAL_TOKENS: 40,
                 }
-            ]
-        }
-
-    def test_opentelemetry_usage_extraction(self):
-        """Test extracting usage from OpenTelemetry attributes."""
-        from opentelemetry.semconv_ai import SpanAttributes as OTSpanAttr
-
-        # Create attribute dictionary with OpenTelemetry token usage
-        attributes = create_attributes(
-            {
-                OTSpanAttr.LLM_USAGE_PROMPT_TOKENS: 15,
-                OTSpanAttr.LLM_USAGE_COMPLETION_TOKENS: 25,
-                OTSpanAttr.LLM_USAGE_TOTAL_TOKENS: 40,
-            }
+            )
         )
+        or {}
+    )
+    assert usage.get("prompt_tokens") == 15
+    assert usage.get("completion_tokens") == 25
+    assert usage.get("total_tokens") == 40
 
-        # Create OpenTelemetry attributes object
-        usage = get_weave_usage(attributes) or {}
-
-        assert usage.get("prompt_tokens") == 15
-        assert usage.get("completion_tokens") == 25
-        assert usage.get("total_tokens") == 40
-
-    def test_opentelemetry_usage_output_tokens_extraction(self):
-        """Test that gen_ai.usage.output_tokens is properly parsed and combined with input_tokens."""
-        # Test with gen_ai.usage.input_tokens and gen_ai.usage.output_tokens
-        attributes = create_attributes(
-            {
-                "gen_ai.usage.input_tokens": 10,
-                "gen_ai.usage.output_tokens": 20,
-            }
+    # gen_ai input/output tokens: total is computed when not provided.
+    usage = (
+        get_weave_usage(
+            create_attributes(
+                {"gen_ai.usage.input_tokens": 10, "gen_ai.usage.output_tokens": 20}
+            )
         )
+        or {}
+    )
+    assert usage.get("input_tokens") == 10
+    assert usage.get("output_tokens") == 20
+    assert usage.get("total_tokens") == 30
 
-        usage = get_weave_usage(attributes) or {}
-
-        # Verify individual tokens are parsed
-        assert usage.get("input_tokens") == 10
-        assert usage.get("output_tokens") == 20
-        # Verify total_tokens is calculated when not provided
-        assert usage.get("total_tokens") == 30
-
-    def test_opentelemetry_usage_output_tokens_with_explicit_total(self):
-        """Test that explicit total_tokens takes precedence over calculated value."""
-        # Test with explicit total_tokens provided
-        attributes = create_attributes(
-            {
-                "gen_ai.usage.input_tokens": 10,
-                "gen_ai.usage.output_tokens": 20,
-                "llm.usage.total_tokens": 35,  # Explicit total (might include overhead)
-            }
+    # An explicit total_tokens takes precedence over the computed value.
+    usage = (
+        get_weave_usage(
+            create_attributes(
+                {
+                    "gen_ai.usage.input_tokens": 10,
+                    "gen_ai.usage.output_tokens": 20,
+                    "llm.usage.total_tokens": 35,
+                }
+            )
         )
+        or {}
+    )
+    assert usage.get("input_tokens") == 10
+    assert usage.get("output_tokens") == 20
+    assert usage.get("total_tokens") == 35
 
-        usage = get_weave_usage(attributes) or {}
+    # cache_creation / cache_read token usage rolls into the total.
+    usage = (
+        get_weave_usage(
+            create_attributes(
+                {
+                    "gen_ai.usage.input_tokens": 100,
+                    "gen_ai.usage.output_tokens": 50,
+                    "gen_ai.usage.cache_creation.input_tokens": 80,
+                    "gen_ai.usage.cache_read.input_tokens": 20,
+                }
+            )
+        )
+        or {}
+    )
+    assert usage.get("input_tokens") == 100
+    assert usage.get("output_tokens") == 50
+    assert usage.get("cache_creation_input_tokens") == 80
+    assert usage.get("cache_read_input_tokens") == 20
+    assert usage.get("total_tokens") == 150
 
-        # Verify individual tokens are parsed
-        assert usage.get("input_tokens") == 10
-        assert usage.get("output_tokens") == 20
-        # Verify explicit total_tokens is used instead of calculated value
-        assert usage.get("total_tokens") == 35
 
-    def test_genai_semconv_system_instructions(self):
-        """Test that gen_ai.system_instructions takes priority over gen_ai.system."""
-        # gen_ai.system_instructions (new semconv) should take priority
-        attributes = create_attributes(
+def test_genai_semconv_attribute_priority_and_fallback() -> None:
+    """get_weave_attributes prefers new gen_ai semconv keys, falling back to legacy."""
+    # gen_ai.system_instructions takes priority over gen_ai.system.
+    extracted = get_weave_attributes(
+        create_attributes(
             {
                 "gen_ai.system_instructions": "You are a new-style assistant",
                 "gen_ai.system": "You are a legacy assistant",
             }
         )
-        extracted = get_weave_attributes(attributes)
-        assert extracted["system"] == "You are a new-style assistant"
+    )
+    assert extracted["system"] == "You are a new-style assistant"
+    extracted_legacy = get_weave_attributes(
+        create_attributes({"gen_ai.system": "You are a legacy assistant"})
+    )
+    assert extracted_legacy["system"] == "You are a legacy assistant"
 
-        # gen_ai.system still works when system_instructions is absent
-        attributes_legacy = create_attributes(
-            {
-                "gen_ai.system": "You are a legacy assistant",
-            }
-        )
-        extracted_legacy = get_weave_attributes(attributes_legacy)
-        assert extracted_legacy["system"] == "You are a legacy assistant"
-
-    def test_genai_semconv_request_model_fallback(self):
-        """Test that gen_ai.request.model is used when gen_ai.response.model is absent."""
-        # response.model takes priority
-        attributes_both = create_attributes(
+    # gen_ai.response.model takes priority over gen_ai.request.model (fallback).
+    extracted = get_weave_attributes(
+        create_attributes(
             {
                 "gen_ai.response.model": "gpt-4-actual",
                 "gen_ai.request.model": "gpt-4-requested",
             }
         )
-        extracted = get_weave_attributes(attributes_both)
-        assert extracted["model"] == "gpt-4-actual"
+    )
+    assert extracted["model"] == "gpt-4-actual"
+    extracted_request = get_weave_attributes(
+        create_attributes({"gen_ai.request.model": "gpt-4-requested"})
+    )
+    assert extracted_request["model"] == "gpt-4-requested"
 
-        # request.model used as fallback
-        attributes_request_only = create_attributes(
-            {
-                "gen_ai.request.model": "gpt-4-requested",
-            }
+    # gen_ai.provider.name takes priority over llm.provider (fallback).
+    extracted = get_weave_attributes(
+        create_attributes(
+            {"gen_ai.provider.name": "anthropic", "llm.provider": "legacy-provider"}
         )
-        extracted_request = get_weave_attributes(attributes_request_only)
-        assert extracted_request["model"] == "gpt-4-requested"
+    )
+    assert extracted["provider"] == "anthropic"
+    extracted_legacy = get_weave_attributes(
+        create_attributes({"llm.provider": "legacy-provider"})
+    )
+    assert extracted_legacy["provider"] == "legacy-provider"
 
-    def test_genai_semconv_provider_name(self):
-        """Test that gen_ai.provider.name takes priority over llm.provider."""
-        attributes = create_attributes(
-            {
-                "gen_ai.provider.name": "anthropic",
-                "llm.provider": "legacy-provider",
-            }
+
+def test_genai_semconv_scalar_attribute_extraction() -> None:
+    """get_weave_attributes maps single gen_ai semconv keys to their weave fields."""
+    extracted = get_weave_attributes(
+        create_attributes({"gen_ai.operation.name": "chat"})
+    )
+    assert extracted["operation_name"] == "chat"
+
+    extracted = get_weave_attributes(
+        create_attributes({"gen_ai.response.id": "chatcmpl-abc123"})
+    )
+    assert extracted["response_id"] == "chatcmpl-abc123"
+
+    extracted = get_weave_attributes(
+        create_attributes({"gen_ai.response.finish_reasons": ["stop", "length"]})
+    )
+    assert extracted["finish_reasons"] == ["stop", "length"]
+
+    extracted = get_weave_attributes(
+        create_attributes(
+            {"gen_ai.agent.name": "my-agent", "gen_ai.agent.id": "agent-42"}
         )
-        extracted = get_weave_attributes(attributes)
-        assert extracted["provider"] == "anthropic"
+    )
+    assert extracted["agent_name"] == "my-agent"
+    assert extracted["agent_id"] == "agent-42"
 
-        # llm.provider still works as fallback
-        attributes_legacy = create_attributes(
-            {
-                "llm.provider": "legacy-provider",
-            }
-        )
-        extracted_legacy = get_weave_attributes(attributes_legacy)
-        assert extracted_legacy["provider"] == "legacy-provider"
 
-    def test_genai_semconv_operation_name(self):
-        """Test extraction of gen_ai.operation.name attribute."""
-        attributes = create_attributes(
-            {
-                "gen_ai.operation.name": "chat",
-            }
-        )
-        extracted = get_weave_attributes(attributes)
-        assert extracted["operation_name"] == "chat"
+def test_genai_semconv_conversation_id_thread_and_priority() -> None:
+    """gen_ai.conversation.id sets thread_id + is_turn and outranks wandb.thread_id."""
+    extracted = get_wandb_attributes(
+        create_attributes({"gen_ai.conversation.id": "conv-abc-123"})
+    )
+    assert extracted["thread_id"] == "conv-abc-123"
+    assert extracted["is_turn"]
 
-    def test_genai_semconv_response_id(self):
-        """Test extraction of gen_ai.response.id attribute."""
-        attributes = create_attributes(
-            {
-                "gen_ai.response.id": "chatcmpl-abc123",
-            }
-        )
-        extracted = get_weave_attributes(attributes)
-        assert extracted["response_id"] == "chatcmpl-abc123"
-
-    def test_genai_semconv_finish_reasons(self):
-        """Test extraction of gen_ai.response.finish_reasons attribute."""
-        attributes = create_attributes(
-            {
-                "gen_ai.response.finish_reasons": ["stop", "length"],
-            }
-        )
-        extracted = get_weave_attributes(attributes)
-        assert extracted["finish_reasons"] == ["stop", "length"]
-
-    def test_genai_semconv_agent_attributes(self):
-        """Test extraction of gen_ai.agent.name and gen_ai.agent.id attributes."""
-        attributes = create_attributes(
-            {
-                "gen_ai.agent.name": "my-agent",
-                "gen_ai.agent.id": "agent-42",
-            }
-        )
-        extracted = get_weave_attributes(attributes)
-        assert extracted["agent_name"] == "my-agent"
-        assert extracted["agent_id"] == "agent-42"
-
-    def test_genai_semconv_cache_token_usage(self):
-        """Test extraction of cache_creation and cache_read token usage."""
-        attributes = create_attributes(
-            {
-                "gen_ai.usage.input_tokens": 100,
-                "gen_ai.usage.output_tokens": 50,
-                "gen_ai.usage.cache_creation.input_tokens": 80,
-                "gen_ai.usage.cache_read.input_tokens": 20,
-            }
-        )
-        usage = get_weave_usage(attributes) or {}
-        assert usage.get("input_tokens") == 100
-        assert usage.get("output_tokens") == 50
-        assert usage.get("cache_creation_input_tokens") == 80
-        assert usage.get("cache_read_input_tokens") == 20
-        assert usage.get("total_tokens") == 150
-
-    def test_genai_semconv_conversation_id_as_thread_and_turn(self):
-        """Test that gen_ai.conversation.id maps to both thread_id and is_turn."""
-        test_conversation_id = "conv-abc-123"
-        attributes = create_attributes(
-            {
-                "gen_ai.conversation.id": test_conversation_id,
-            }
-        )
-        extracted = get_wandb_attributes(attributes)
-        assert extracted["thread_id"] == test_conversation_id
-        # is_turn should be truthy (the conversation id itself)
-        assert extracted["is_turn"]
-
-    def test_genai_semconv_conversation_id_priority_over_wandb(self):
-        """Test that gen_ai.conversation.id takes priority over wandb.thread_id."""
-        attributes = create_attributes(
+    extracted = get_wandb_attributes(
+        create_attributes(
             {
                 "gen_ai.conversation.id": "conv-from-semconv",
                 "wandb.thread_id": "thread-from-wandb",
             }
         )
-        extracted = get_wandb_attributes(attributes)
-        assert extracted["thread_id"] == "conv-from-semconv"
+    )
+    assert extracted["thread_id"] == "conv-from-semconv"
 
-    def test_opentelemetry_cost_calculation(self, client: weave_client.WeaveClient):
-        """Test that costs are properly calculated for OTEL spans with usage at query time."""
-        project_id = client.project_id
 
-        # Create span with gpt-4 model and usage
-        span_gpt4 = create_test_span()
-        span_gpt4.name = "llm_call_gpt4"
+def test_opentelemetry_cost_calculation(client: weave_client.WeaveClient) -> None:
+    """Test that costs are properly calculated for OTEL spans with usage at query time."""
+    project_id = client.project_id
 
-        # Add model attribute
-        kv_model = KeyValue()
-        kv_model.key = "gen_ai.request.model"
-        kv_model.value.string_value = "gpt-4"
-        span_gpt4.attributes.append(kv_model)
+    # Create span with gpt-4 model and usage
+    span_gpt4 = create_test_span()
+    span_gpt4.name = "llm_call_gpt4"
 
-        # Add usage attributes
-        kv_prompt = KeyValue()
-        kv_prompt.key = "gen_ai.usage.prompt_tokens"
-        kv_prompt.value.int_value = 1000000
-        span_gpt4.attributes.append(kv_prompt)
+    # Add model attribute
+    kv_model = KeyValue()
+    kv_model.key = "gen_ai.request.model"
+    kv_model.value.string_value = "gpt-4"
+    span_gpt4.attributes.append(kv_model)
 
-        kv_completion = KeyValue()
-        kv_completion.key = "gen_ai.usage.completion_tokens"
-        kv_completion.value.int_value = 2000000
-        span_gpt4.attributes.append(kv_completion)
+    # Add usage attributes
+    kv_prompt = KeyValue()
+    kv_prompt.key = "gen_ai.usage.prompt_tokens"
+    kv_prompt.value.int_value = 1000000
+    span_gpt4.attributes.append(kv_prompt)
 
-        # Create export request
-        export_req = create_test_export_request(project_id=project_id)
-        # Materialize processed_spans to avoid iterator exhaustion
-        processed_spans_list = export_req.processed_spans
-        processed_spans_list[0].resource_spans.scope_spans[0].spans[0].CopyFrom(
-            span_gpt4
+    kv_completion = KeyValue()
+    kv_completion.key = "gen_ai.usage.completion_tokens"
+    kv_completion.value.int_value = 2000000
+    span_gpt4.attributes.append(kv_completion)
+
+    # Create export request
+    export_req = create_test_export_request(project_id=project_id)
+    # Materialize processed_spans to avoid iterator exhaustion
+    processed_spans_list = export_req.processed_spans
+    processed_spans_list[0].resource_spans.scope_spans[0].spans[0].CopyFrom(span_gpt4)
+    export_req.processed_spans = processed_spans_list
+    export_req.wb_user_id = "test_user"
+
+    # Export the trace
+    client.server.otel_export(export_req)
+
+    # Query with costs
+    res_with_cost = client.server.calls_query(
+        tsi.CallsQueryReq(
+            project_id=project_id,
+            include_costs=True,
         )
-        export_req.processed_spans = processed_spans_list
-        export_req.wb_user_id = "test_user"
+    )
 
-        # Export the trace
-        client.server.otel_export(export_req)
-
-        # Query with costs
-        res_with_cost = client.server.calls_query(
-            tsi.CallsQueryReq(
-                project_id=project_id,
-                include_costs=True,
-            )
+    # Query without costs
+    res_no_cost = client.server.calls_query(
+        tsi.CallsQueryReq(
+            project_id=project_id,
+            include_costs=False,
         )
+    )
 
-        # Query without costs
-        res_no_cost = client.server.calls_query(
-            tsi.CallsQueryReq(
-                project_id=project_id,
-                include_costs=False,
-            )
-        )
+    assert len(res_with_cost.calls) == 1
+    assert len(res_no_cost.calls) == 1
 
-        assert len(res_with_cost.calls) == 1
-        assert len(res_no_cost.calls) == 1
+    call_with_cost = res_with_cost.calls[0]
+    call_no_cost = res_no_cost.calls[0]
+    assert call_with_cost.summary is not None
 
-        call_with_cost = res_with_cost.calls[0]
-        call_no_cost = res_no_cost.calls[0]
-        assert call_with_cost.summary is not None
+    # Verify model cost information is present when requested
+    assert "gpt-4" in call_with_cost.summary["weave"]["costs"]  # type: ignore
 
-        # Verify model cost information is present when requested
-        assert "gpt-4" in call_with_cost.summary["weave"]["costs"]  # type: ignore
+    gpt4_cost = call_with_cost.summary["weave"]["costs"]["gpt-4"]  # type: ignore
+    del gpt4_cost["effective_date"]  # type: ignore
+    del gpt4_cost["created_at"]  # type: ignore
+    # Verify cost calculation matches expected values
+    assert (
+        gpt4_cost
+        == {
+            "prompt_tokens": 1000000,
+            "completion_tokens": 2000000,
+            "requests": 0,  # OTEL doesn't track requests separately
+            "total_tokens": 3000000,  # Now properly calculated from prompt + completion tokens
+            "prompt_tokens_total_cost": pytest.approx(30),
+            "completion_tokens_total_cost": pytest.approx(120),
+            "prompt_token_cost": 3e-05,
+            "completion_token_cost": 6e-05,
+            "prompt_token_cost_unit": "USD",
+            "completion_token_cost_unit": "USD",
+            "provider_id": "openai",
+            "pricing_level": "default",
+            "pricing_level_id": "default",
+            "created_by": "system",
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens_total_cost": 0,
+            "cache_creation_input_tokens_total_cost": 0,
+            "cache_read_input_token_cost": 0,
+            "cache_creation_input_token_cost": 0,
+        }
+    )
 
-        gpt4_cost = call_with_cost.summary["weave"]["costs"]["gpt-4"]  # type: ignore
-        del gpt4_cost["effective_date"]  # type: ignore
-        del gpt4_cost["created_at"]  # type: ignore
-        # Verify cost calculation matches expected values
-        assert (
-            gpt4_cost
-            == {
-                "prompt_tokens": 1000000,
-                "completion_tokens": 2000000,
-                "requests": 0,  # OTEL doesn't track requests separately
-                "total_tokens": 3000000,  # Now properly calculated from prompt + completion tokens
-                "prompt_tokens_total_cost": pytest.approx(30),
-                "completion_tokens_total_cost": pytest.approx(120),
-                "prompt_token_cost": 3e-05,
-                "completion_token_cost": 6e-05,
-                "prompt_token_cost_unit": "USD",
-                "completion_token_cost_unit": "USD",
-                "provider_id": "openai",
-                "pricing_level": "default",
-                "pricing_level_id": "default",
-                "created_by": "system",
-                "cache_read_input_tokens": 0,
-                "cache_creation_input_tokens": 0,
-                "cache_read_input_tokens_total_cost": 0,
-                "cache_creation_input_tokens_total_cost": 0,
-                "cache_read_input_token_cost": 0,
-                "cache_creation_input_token_cost": 0,
-            }
-        )
-
-        # Verify no cost information when not requested
-        assert "costs" not in call_no_cost.summary.get("weave", {})  # type: ignore
+    # Verify no cost information when not requested
+    assert "costs" not in call_no_cost.summary.get("weave", {})  # type: ignore
 
 
-class TestHelpers:
-    def test_capture_parts(self):
-        """Test capturing parts of a string split by delimiters."""
-        # Test with a single delimiter
-        assert capture_parts("part1.part2") == ["part1", ".", "part2"]
+def test_capture_parts() -> None:
+    """Test capturing parts of a string split by delimiters."""
+    assert capture_parts("part1.part2") == ["part1", ".", "part2"]
+    assert capture_parts("part1.part2,part3") == [
+        "part1",
+        ".",
+        "part2",
+        ",",
+        "part3",
+    ]
+    assert capture_parts("nodelimiters") == ["nodelimiters"]
+    assert capture_parts("") == [""]
+    assert capture_parts("a-b-c", delimiters=["-"]) == ["a", "-", "b", "-", "c"]
+    assert capture_parts("part1..part2") == ["part1", ".", ".", "part2"]
 
-        # Test with multiple delimiters
-        assert capture_parts("part1.part2,part3") == [
-            "part1",
-            ".",
-            "part2",
-            ",",
-            "part3",
-        ]
 
-        # Test with delimiters that don't appear in the string
-        assert capture_parts("nodelimiters") == ["nodelimiters"]
+def test_shorten_name() -> None:
+    """shorten_name truncates on delimiter boundaries respecting max_len and abbrev."""
+    # No delimiters: short names pass through, long names get an ellipsis.
+    assert shorten_name("short", 10) == "short"
+    assert shorten_name("abcdefghijklmnopqrstuvwxyz", 10) == "abcdefg..."
 
-        # Test with an empty string
-        assert capture_parts("") == [""]
+    # Delimiters: truncate on a boundary, or keep whole when it fits.
+    assert shorten_name("part1.part2", 10) == "part1..."
+    assert shorten_name("a.b.c", 10) == "a.b.c"
+    assert shorten_name("part1.part2.part3", 12) == "part1..."
 
-        # Test with custom delimiters
-        assert capture_parts("a-b-c", delimiters=["-"]) == ["a", "-", "b", "-", "c"]
+    # First part already too long.
+    assert shorten_name("verylongfirstpart.second", 10) == "verylon..."
 
-        # Test with adjacent delimiters
-        assert capture_parts("part1..part2") == ["part1", ".", ".", "part2"]
+    # Custom and empty abbreviations.
+    assert shorten_name("part1.part2.part3", 10, "***") == "part1.***"
+    assert shorten_name("part1.part2.part3", 10, "") == "part1"
 
-    def test_shorten_name_no_delimiters(self):
-        """Test shortening a name with no delimiters."""
-        # Test a string shorter than max_len - the function always adds ellipsis
-        assert shorten_name("short", 10) == "short"
+    # Different delimiter types (space, slash, mixed, question mark).
+    assert shorten_name("word1 word2 word3", 12) == "word1 ..."
+    assert shorten_name("path/to/file", 8) == "path/..."
+    assert shorten_name("user.name@example.com", 12) == "user..."
+    assert shorten_name("api/endpoint?param=value", 15) == "api/..."
 
-        # Test a string longer than max_len with no delimiters
-        long_name = "abcdefghijklmnopqrstuvwxyz"
-        assert shorten_name(long_name, 10) == "abcdefg..."
+    # '-' is not a default delimiter, so it is treated as part of the string.
+    result = shorten_name("part1-part2-part3", 10)
+    assert result.startswith("part1-")
+    assert result.endswith("...")
+    assert len(result) == 10
 
-    def test_shorten_name_with_delimiters(self):
-        """Test shortening a name with delimiters."""
-        # Test with a single delimiter
-        assert shorten_name("part1.part2", 10) == "part1..."
 
-        # Test with multiple delimiters where it fits within the max_len
-        assert shorten_name("a.b.c", 10) == "a.b.c"
+def test_long_url_regression() -> None:
+    # A modified version of the URL that caused failed traces due to op_name length.
+    actual = shorten_name(
+        "GET /api/trpc/lambda/organization.getActiveOrganization,account.getSubscription,checkout.getPrices,user.getUserToolGroupsConfig?batch=1&input=%8A%220%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%221%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%222%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%223%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%8D",
+        128,
+    )
+    assert actual.startswith("GET /")
+    assert actual.endswith("...")
+    assert len(actual) <= 128
 
-        # Test with multiple delimiters where it needs truncation
-        assert shorten_name("part1.part2.part3", 12) == "part1..."
 
-    def test_shorten_name_first_part_too_long(self):
-        """Test shortening a name where first part is already too long."""
-        # First part already exceeds max_len
-        assert shorten_name("verylongfirstpart.second", 10) == "verylon..."
+def test_try_parse_timestamp() -> None:
+    """Test parsing timestamps from various formats."""
+    # ISO 8601 string.
+    result = try_parse_timestamp("2023-01-01T12:00:00")
+    assert isinstance(result, datetime)
+    assert (result.year, result.month, result.day) == (2023, 1, 1)
+    assert (result.hour, result.minute, result.second) == (12, 0, 0)
 
-    def test_shorten_name_custom_abbreviation(self):
-        """Test shortening a name with custom abbreviation."""
-        assert shorten_name("part1.part2.part3", 10, "***") == "part1.***"
-
-        # Test with empty abbreviation
-        assert shorten_name("part1.part2.part3", 10, "") == "part1"
-
-    def test_shorten_name_different_delimiters(self):
-        """Test shortening a name with different types of delimiters."""
-        # Test with a space delimiter
-        assert shorten_name("word1 word2 word3", 12) == "word1 ..."
-
-        # Test with a slash delimiter
-        assert shorten_name("path/to/file", 8) == "path/..."
-
-        # Test with mixed delimiters
-        assert shorten_name("user.name@example.com", 12) == "user..."
-
-        # Test with a delimiter not in the default list
-        # Since '-' is not in the default delimiters list, it's treated as part of the string
-        result = shorten_name("part1-part2-part3", 10)
-        assert result.startswith("part1-")
-        assert result.endswith("...")
-        assert len(result) == 10
-
-        # Test with a question mark delimiter
-        assert shorten_name("api/endpoint?param=value", 15) == "api/..."
-
-    def test_long_url_regression(self):
-        # Test for a modified version of the URL which caused failed traces due to op_name length
-        actual = shorten_name(
-            "GET /api/trpc/lambda/organization.getActiveOrganization,account.getSubscription,checkout.getPrices,user.getUserToolGroupsConfig?batch=1&input=%8A%220%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%221%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%222%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%2P%223%22%3Z%8A%22json%22%3Znull%2P%22meta%22%3Z%8A%22values%22%3Z%5X%22undefined%22%5D%8D%8D%8D",
-            128,
-        )
-        # The new implementation shortens the URL differently, so we check that it has the correct format
-        # and doesn't exceed the maximum length
-        assert actual.startswith("GET /")
-        assert actual.endswith("...")
-        assert len(actual) <= 128
-
-    def test_try_parse_timestamp(self):
-        """Test parsing timestamps from various formats."""
-        from datetime import datetime
-
-        # Test parsing ISO 8601 format string
-        iso_timestamp = "2023-01-01T12:00:00"
-        result = try_parse_timestamp(iso_timestamp)
+    # Nanoseconds since epoch (int) and seconds since epoch (float).
+    # Hour is not checked due to timezone differences.
+    for ts in (1672574400000000000, 1672574400.0):
+        result = try_parse_timestamp(ts)
         assert isinstance(result, datetime)
-        assert result.year == 2023
-        assert result.month == 1
-        assert result.day == 1
-        assert result.hour == 12
-        assert result.minute == 0
-        assert result.second == 0
+        assert (result.year, result.month, result.day) == (2023, 1, 1)
 
-        # Test parsing nanoseconds since epoch (int)
-        ns_timestamp = 1672574400000000000  # 2023-01-01T12:00:00 in nanoseconds
-        result = try_parse_timestamp(ns_timestamp)
-        assert isinstance(result, datetime)
-        assert result.year == 2023
-        assert result.month == 1
-        assert result.day == 1
-        # Hour may vary based on timezone, so we don't check it
-
-        # Test parsing seconds since epoch (float)
-        seconds_timestamp = 1672574400.0  # 2023-01-01T12:00:00 in seconds
-        result = try_parse_timestamp(seconds_timestamp)
-        assert isinstance(result, datetime)
-        assert result.year == 2023
-        assert result.month == 1
-        assert result.day == 1
-        # Hour may vary based on timezone, so we don't check it
-
-        # Test with invalid string format
-        invalid_string = "not-a-timestamp"
-        assert try_parse_timestamp(invalid_string) is None
-
-        # Test with other types
-        assert try_parse_timestamp(None) is None
-        assert try_parse_timestamp({}) is None
-        assert try_parse_timestamp([]) is None
+    # Invalid string and unsupported types return None.
+    assert try_parse_timestamp("not-a-timestamp") is None
+    assert try_parse_timestamp(None) is None
+    assert try_parse_timestamp({}) is None
+    assert try_parse_timestamp([]) is None
 
 
-class TestSpanOverrides:
-    """Test the functionality for span overrides in opentelemetry attributes."""
-
-    def test_get_span_overrides(self):
-        """Test extracting span overrides from attributes."""
-        # Create attribute dictionary with timestamp overrides in ISO format
-        iso_start = "2023-01-01T10:00:00"
-        iso_end = "2023-01-01T10:01:30"
-        attributes = expand_attributes(
+def test_get_span_overrides() -> None:
+    """get_span_overrides parses ISO + epoch timestamps and tolerates missing ones."""
+    # ISO format timestamps round-trip exactly.
+    iso_start = "2023-01-01T10:00:00"
+    iso_end = "2023-01-01T10:01:30"
+    overrides = get_span_overrides(
+        expand_attributes(
             [
                 ("langfuse.startTime", iso_start),
                 ("langfuse.endTime", iso_end),
                 ("other.attribute", "value"),
             ]
         )
+    )
+    assert len(overrides) == 2
+    assert isinstance(overrides["start_time"], datetime)
+    assert isinstance(overrides["end_time"], datetime)
+    assert overrides["start_time"].isoformat() == iso_start
+    assert overrides["end_time"].isoformat() == iso_end
 
-        # Test extracting the overrides
-        overrides = get_span_overrides(attributes)
-        assert len(overrides) == 2
-        assert isinstance(overrides["start_time"], datetime)
-        assert isinstance(overrides["end_time"], datetime)
-        assert overrides["start_time"].isoformat() == iso_start
-        assert overrides["end_time"].isoformat() == iso_end
-
-    def test_get_span_overrides_with_timestamps(self):
-        """Test extracting span overrides with different timestamp formats."""
-        from datetime import datetime
-
-        # Create attribute dictionary with epoch timestamps
-        start_ns = 1672574400000000000  # 2023-01-01T12:00:00 in nanoseconds
-        end_seconds = 1672574460.0  # 2023-01-01T12:01:00 in seconds
-
-        attributes = expand_attributes(
+    # Epoch timestamps (nanoseconds int + seconds float). Hour is timezone-dependent.
+    overrides = get_span_overrides(
+        expand_attributes(
             [
-                ("langfuse.startTime", start_ns),
-                ("langfuse.endTime", end_seconds),
+                ("langfuse.startTime", 1672574400000000000),
+                ("langfuse.endTime", 1672574460.0),
             ]
         )
+    )
+    assert len(overrides) == 2
+    assert isinstance(overrides["start_time"], datetime)
+    assert isinstance(overrides["end_time"], datetime)
+    assert (overrides["start_time"].year, overrides["start_time"].month) == (2023, 1)
+    assert overrides["start_time"].day == 1
+    assert (overrides["end_time"].year, overrides["end_time"].month) == (2023, 1)
+    assert overrides["end_time"].day == 1
+    delta = overrides["end_time"] - overrides["start_time"]
+    assert abs(delta.total_seconds() - 60) < 1
 
-        # Test extracting the overrides
-        overrides = get_span_overrides(attributes)
-        assert len(overrides) == 2
-        assert isinstance(overrides["start_time"], datetime)
-        assert isinstance(overrides["end_time"], datetime)
-
-        # Check the year/month/day to ensure timestamps were parsed correctly
-        # (not checking hour due to timezone differences)
-        assert overrides["start_time"].year == 2023
-        assert overrides["start_time"].month == 1
-        assert overrides["start_time"].day == 1
-
-        assert overrides["end_time"].year == 2023
-        assert overrides["end_time"].month == 1
-        assert overrides["end_time"].day == 1
-
-        # End time should be 60 seconds after start time
-        delta = overrides["end_time"] - overrides["start_time"]
-        assert (
-            abs(delta.total_seconds() - 60) < 1
-        )  # Allow small difference due to float precision
-
-    def test_get_span_overrides_with_missing_attributes(self):
-        """Test get_span_overrides when no override attributes are present."""
-        # Create attribute dictionary without overrides
-        attributes = expand_attributes(
-            [
-                ("some.attribute", "value"),
-                ("other.attribute", 123),
-            ]
+    # No override attributes -> empty dict.
+    assert (
+        get_span_overrides(
+            expand_attributes(
+                [
+                    ("some.attribute", "value"),
+                    ("other.attribute", 123),
+                ]
+            )
         )
-
-        # Test extracting the overrides
-        overrides = get_span_overrides(attributes)
-        assert overrides == {}
+        == {}
+    )
 
 
 def test_otel_export_partial_success_on_attribute_conflict(

--- a/tests/trace_server/test_orm.py
+++ b/tests/trace_server/test_orm.py
@@ -121,157 +121,59 @@ def test_map_string_float_column_round_trip():
     }
 
 
-def test_select_basic():
-    table = Table(
-        "users",
-        [
-            Column("id", "string"),
-            Column("creator", "string", nullable=True),
-            Column("payload", "json", db_name="payload_dump"),
-        ],
-    )
-    select = table.select()
-    select = select.limit(10)
-    prepared = select.prepare()
+def test_select_basic_and_json_field_projection():
+    """Default select projects all db columns; explicit fields can pull a
+    JSON path, which compiles to JSON_VALUE with a parameterized path.
+    """
+    basic = _users_table().select().limit(10).prepare()
     assert (
-        prepared.sql
+        basic.sql
         == """SELECT id, creator, payload_dump
 FROM users
 LIMIT {limit:UInt64}"""
     )
-    assert prepared.parameters == {"limit": 10}
-    assert prepared.fields == ["id", "creator", "payload_dump"]
+    assert basic.parameters == {"limit": 10}
+    assert basic.fields == ["id", "creator", "payload_dump"]
 
-
-def test_select_fields():
-    table = Table(
-        "users",
-        [
-            Column("id", "string"),
-            Column("creator", "string", nullable=True),
-            Column("payload", "json", db_name="payload_dump"),
-        ],
-    )
-    select = table.select()
-    select = select.fields(["id", "payload.address"])
-
+    select = _users_table().select().fields(["id", "payload.address"])
     # More complicated than normal usage to fix the ParamBuilder prefix.
-    pb = ParamBuilder(prefix="pb")
-    prepared = select.prepare(param_builder=pb)
+    fielded = select.prepare(param_builder=ParamBuilder(prefix="pb"))
     assert (
-        prepared.sql
+        fielded.sql
         == """SELECT id, toString(JSON_VALUE(payload_dump, {pb_0:String}))
 FROM users"""
     )
-    assert prepared.parameters == {"pb_0": '$."address"'}
-    assert prepared.fields == ["id", "payload.address"]
+    assert fielded.parameters == {"pb_0": '$."address"'}
+    assert fielded.fields == ["id", "payload.address"]
 
 
-def test_join():
-    table1 = Table(
-        "users",
-        [
-            Column("id", "string"),
-            Column("creator", "string", nullable=True),
-            Column("payload", "json", db_name="payload_dump"),
-        ],
+@pytest.mark.parametrize(
+    ("join_type", "join_clause"),
+    [
+        (None, "JOIN roles ON (table1.id = table2.id)"),
+        ("inner", "inner JOIN roles ON (table1.id = table2.id)"),
+    ],
+)
+def test_join(join_type, join_clause):
+    """Join emits the default `JOIN` or a typed join prefix when one is given."""
+    table1 = _users_table()
+    table2 = Table("roles", [Column("id", "string"), Column("name", "string")])
+    join_cond = tsi.Query(
+        **{"$expr": {"$eq": [{"$getField": "table1.id"}, {"$getField": "table2.id"}]}}
     )
-    table2 = Table(
-        "roles",
-        [
-            Column("id", "string"),
-            Column("name", "string"),
-        ],
+    join_args = (
+        (table2, join_cond) if join_type is None else (table2, join_cond, join_type)
     )
-
-    select = (
-        table1.select()
-        .fields(["id", "name"])
-        .join(
-            table2,
-            tsi.Query(
-                **{
-                    "$expr": {
-                        "$eq": [
-                            {"$getField": "table1.id"},
-                            {"$getField": "table2.id"},
-                        ]
-                    }
-                }
-            ),
-        )
-    )
-
+    select = table1.select().fields(["id", "name"]).join(*join_args)
     prepared = select.prepare()
-
-    assert (
-        prepared.sql
-        == """SELECT id, name
-FROM users
-JOIN roles ON (table1.id = table2.id)"""
-    )
-
-
-def test_join_with_join_type():
-    table1 = Table(
-        "users",
-        [
-            Column("id", "string"),
-            Column("creator", "string", nullable=True),
-            Column("payload", "json", db_name="payload_dump"),
-        ],
-    )
-    table2 = Table(
-        "roles",
-        [
-            Column("id", "string"),
-            Column("name", "string"),
-        ],
-    )
-
-    select = (
-        table1.select()
-        .fields(["id", "name"])
-        .join(
-            table2,
-            tsi.Query(
-                **{
-                    "$expr": {
-                        "$eq": [
-                            {"$getField": "table1.id"},
-                            {"$getField": "table2.id"},
-                        ]
-                    }
-                }
-            ),
-            "inner",
-        )
-    )
-
-    prepared = select.prepare()
-
-    assert (
-        prepared.sql
-        == """SELECT id, name
-FROM users
-inner JOIN roles ON (table1.id = table2.id)"""
-    )
+    assert prepared.sql == f"SELECT id, name\nFROM users\n{join_clause}"
 
 
 def test_group_by():
-    table = Table(
-        "users",
-        [
-            Column("id", "string"),
-            Column("creator", "string", nullable=True),
-            Column("payload", "json", db_name="payload_dump"),
-        ],
+    select = (
+        _users_table().select().fields(["id", "creator"]).group_by(["id", "creator"])
     )
-
-    select = table.select().fields(["id", "creator"]).group_by(["id", "creator"])
-
     prepared = select.prepare()
-
     assert (
         prepared.sql
         == """SELECT id, creator
@@ -320,6 +222,17 @@ def test_split_escaped_field_path() -> None:
 
     # Edge case: leading dot (unescaped)
     assert split_escaped_field_path(".output") == ["", "output"]
+
+
+def _users_table() -> Table:
+    return Table(
+        "users",
+        [
+            Column("id", "string"),
+            Column("creator", "string", nullable=True),
+            Column("payload", "json", db_name="payload_dump"),
+        ],
+    )
 
 
 def _feedback_table() -> Table:
@@ -411,125 +324,69 @@ def test_feedback_query_infers_cast_from_literal(
     }
 
 
-def test_feedback_query_string_literal_keeps_uncast_path() -> None:
-    """String literals must keep the existing toString(JSON_VALUE(...)) path.
-
-    Inferring a cast for strings would break legitimate JSON-string
-    comparisons (e.g. category fields).
+@pytest.mark.parametrize(
+    ("expr", "expected_where"),
+    [
+        # String literals keep the existing toString(JSON_VALUE(...)) path;
+        # inferring a cast would break legitimate JSON-string comparisons.
+        (
+            {"$eq": [{"$getField": "payload.label"}, {"$literal": "ok"}]},
+            "(toString(JSON_VALUE(payload_dump, {pb_0:String})) = {pb_1:String})",
+        ),
+        # An explicit $convert wins over inference and is not double-cast: the
+        # inferred field cast is a no-op so the outer toUInt8OrNull wins.
+        (
+            {
+                "$eq": [
+                    {
+                        "$convert": {
+                            "input": {"$getField": "payload.is_positive"},
+                            "to": "bool",
+                        }
+                    },
+                    {"$literal": True},
+                ]
+            },
+            "(toUInt8OrNull(toString(JSON_VALUE(payload_dump, {pb_0:String}))) = {pb_1:Bool})",
+        ),
+        # Inference works regardless of which side carries the literal.
+        (
+            {"$gt": [{"$literal": 3}, {"$getField": "payload.score"}]},
+            "({pb_0:Int64} > toInt64OrNull(JSON_VALUE(payload_dump, {pb_1:String})))",
+        ),
+        # $in with a homogeneous numeric list infers a single cast for the field.
+        (
+            {
+                "$in": [
+                    {"$getField": "payload.score"},
+                    [{"$literal": 1}, {"$literal": 2}, {"$literal": 3}],
+                ]
+            },
+            "(toInt64OrNull(JSON_VALUE(payload_dump, {pb_0:String})) "
+            "IN ({pb_1:Int64},{pb_2:Int64},{pb_3:Int64}))",
+        ),
+        # A heterogeneous $in list cannot share a single cast and falls back.
+        (
+            {
+                "$in": [
+                    {"$getField": "payload.value"},
+                    [{"$literal": 1}, {"$literal": "two"}],
+                ]
+            },
+            "(toString(JSON_VALUE(payload_dump, {pb_0:String})) "
+            "IN ({pb_1:Int64},{pb_2:String}))",
+        ),
+    ],
+)
+def test_feedback_query_cast_inference_paths(expr, expected_where) -> None:
+    """The peer literal's type drives the field-side cast (or the uncast
+    fallback) across eq/gt/in shapes and explicit $convert.
     """
     select = (
-        _feedback_table()
-        .select()
-        .fields(["id"])
-        .where(
-            tsi.Query(
-                **{
-                    "$expr": {
-                        "$eq": [
-                            {"$getField": "payload.label"},
-                            {"$literal": "ok"},
-                        ]
-                    }
-                }
-            )
-        )
+        _feedback_table().select().fields(["id"]).where(tsi.Query(**{"$expr": expr}))
     )
     prepared = _prepare_clickhouse(select)
-    assert prepared.sql == (
-        "SELECT id\n"
-        "FROM feedback\n"
-        "WHERE (toString(JSON_VALUE(payload_dump, {pb_0:String})) = {pb_1:String})"
-    )
-
-
-def test_feedback_query_explicit_convert_overrides_inference() -> None:
-    """An explicit $convert wins over inference and is not double-cast."""
-    select = (
-        _feedback_table()
-        .select()
-        .fields(["id"])
-        .where(
-            tsi.Query(
-                **{
-                    "$expr": {
-                        "$eq": [
-                            {
-                                "$convert": {
-                                    "input": {"$getField": "payload.is_positive"},
-                                    "to": "bool",
-                                },
-                            },
-                            {"$literal": True},
-                        ]
-                    }
-                }
-            )
-        )
-    )
-    prepared = _prepare_clickhouse(select)
-    # ConvertOperation runs after process_operand for the field, so the cast
-    # we infer for the field side has no effect (the inner JSON_VALUE
-    # already wears toString from the default), and the outer cast wins.
-    assert prepared.sql == (
-        "SELECT id\n"
-        "FROM feedback\n"
-        "WHERE (toUInt8OrNull(toString(JSON_VALUE(payload_dump, {pb_0:String}))) = {pb_1:Bool})"
-    )
-
-
-def test_feedback_query_literal_on_lhs_casts_field_on_rhs() -> None:
-    """Inference works regardless of which side carries the literal."""
-    select = (
-        _feedback_table()
-        .select()
-        .fields(["id"])
-        .where(
-            tsi.Query(
-                **{
-                    "$expr": {
-                        "$gt": [
-                            {"$literal": 3},
-                            {"$getField": "payload.score"},
-                        ]
-                    }
-                }
-            )
-        )
-    )
-    prepared = _prepare_clickhouse(select)
-    assert prepared.sql == (
-        "SELECT id\n"
-        "FROM feedback\n"
-        "WHERE ({pb_0:Int64} > toInt64OrNull(JSON_VALUE(payload_dump, {pb_1:String})))"
-    )
-
-
-def test_feedback_query_in_homogeneous_literal_list_casts_field() -> None:
-    """$in with a homogeneous numeric list infers a single cast for the field."""
-    select = (
-        _feedback_table()
-        .select()
-        .fields(["id"])
-        .where(
-            tsi.Query(
-                **{
-                    "$expr": {
-                        "$in": [
-                            {"$getField": "payload.score"},
-                            [{"$literal": 1}, {"$literal": 2}, {"$literal": 3}],
-                        ]
-                    }
-                }
-            )
-        )
-    )
-    prepared = _prepare_clickhouse(select)
-    assert prepared.sql == (
-        "SELECT id\n"
-        "FROM feedback\n"
-        "WHERE (toInt64OrNull(JSON_VALUE(payload_dump, {pb_0:String})) "
-        "IN ({pb_1:Int64},{pb_2:Int64},{pb_3:Int64}))"
-    )
+    assert prepared.sql == f"SELECT id\nFROM feedback\nWHERE {expected_where}"
 
 
 def test_feedback_query_inference_threads_through_and_or_not() -> None:
@@ -593,34 +450,6 @@ def test_feedback_query_inference_threads_through_and_or_not() -> None:
         f"WHERE (({bool_field} = {{pb_1:Bool}}) "
         f"AND (({score_field} > {{pb_3:Float64}}) "
         f"OR (NOT (({rank_field} = {{pb_5:Int64}})))))"
-    )
-
-
-def test_feedback_query_in_mixed_literal_list_keeps_uncast_path() -> None:
-    """A heterogeneous $in list cannot share a single cast and falls back."""
-    select = (
-        _feedback_table()
-        .select()
-        .fields(["id"])
-        .where(
-            tsi.Query(
-                **{
-                    "$expr": {
-                        "$in": [
-                            {"$getField": "payload.value"},
-                            [{"$literal": 1}, {"$literal": "two"}],
-                        ]
-                    }
-                }
-            )
-        )
-    )
-    prepared = _prepare_clickhouse(select)
-    assert prepared.sql == (
-        "SELECT id\n"
-        "FROM feedback\n"
-        "WHERE (toString(JSON_VALUE(payload_dump, {pb_0:String})) "
-        "IN ({pb_1:Int64},{pb_2:String}))"
     )
 
 

--- a/tests/trace_server/test_otel_calls_complete.py
+++ b/tests/trace_server/test_otel_calls_complete.py
@@ -16,6 +16,7 @@ These tests should FAIL when the OTel calls_complete write path is disabled
 import datetime
 import uuid
 from binascii import hexlify
+from collections import defaultdict
 
 import pytest
 from cachetools import TTLCache
@@ -272,8 +273,8 @@ def test_otel_export_establishes_residence_for_subsequent_calls(
     )
     assert complete_after_v2 == 2, "V2 call should go to calls_complete"
 
-    # V1 API should raise error since project is now calls_complete mode
-    with pytest.raises(CallsCompleteModeRequired):
+    # V1 call_start should raise since project is now calls_complete mode.
+    with pytest.raises(CallsCompleteModeRequired) as exc_info:
         trace_server.call_start(
             tsi.CallStartReq(
                 start=tsi.StartedCallSchemaForInsert(
@@ -284,6 +285,20 @@ def test_otel_export_establishes_residence_for_subsequent_calls(
                     started_at=datetime.datetime.now(datetime.timezone.utc),
                     attributes={},
                     inputs={},
+                )
+            )
+        )
+    assert "complete" in str(exc_info.value).lower()
+
+    # V1 call_end should also raise for the same reason.
+    with pytest.raises(CallsCompleteModeRequired):
+        trace_server.call_end(
+            tsi.CallEndReq(
+                end=tsi.EndedCallSchemaForInsert(
+                    project_id=project_id,
+                    id=str(uuid.uuid4()),
+                    ended_at=datetime.datetime.now(datetime.timezone.utc),
+                    summary={"usage": {}, "status_counts": {}},
                 )
             )
         )
@@ -461,52 +476,6 @@ def test_otel_export_reuses_existing_real_op(trace_server, clickhouse_trace_serv
     assert objs[0].digest == real_op.digest
 
 
-def test_v1_api_raises_error_for_otel_established_project(
-    trace_server, clickhouse_trace_server
-):
-    """V1 call_start and call_end raise CallsCompleteModeRequired for OTel projects.
-
-    When OTel has established a project as calls_complete mode, legacy V1 APIs
-    should fail with a clear error message directing users to upgrade.
-    """
-    project_id = f"{TEST_ENTITY}/otel_v1_error"
-
-    # OTel establishes project in calls_complete mode
-    req = _create_otel_export_req(project_id)
-    trace_server.otel_export(req)
-
-    # This will only fail if OTel wrote to calls_complete (not calls_merged)
-    # V1 call_start should raise
-    with pytest.raises(CallsCompleteModeRequired) as exc_info:
-        trace_server.call_start(
-            tsi.CallStartReq(
-                start=tsi.StartedCallSchemaForInsert(
-                    project_id=project_id,
-                    id=str(uuid.uuid4()),
-                    trace_id=str(uuid.uuid4()),
-                    op_name="v1_op",
-                    started_at=datetime.datetime.now(datetime.timezone.utc),
-                    attributes={},
-                    inputs={},
-                )
-            )
-        )
-    assert "complete" in str(exc_info.value).lower()
-
-    # V1 call_end should also raise
-    with pytest.raises(CallsCompleteModeRequired):
-        trace_server.call_end(
-            tsi.CallEndReq(
-                end=tsi.EndedCallSchemaForInsert(
-                    project_id=project_id,
-                    id=str(uuid.uuid4()),
-                    ended_at=datetime.datetime.now(datetime.timezone.utc),
-                    summary={"usage": {}, "status_counts": {}},
-                )
-            )
-        )
-
-
 def test_otel_export_null_sentinel_fields_to_calls_complete(
     trace_server, clickhouse_trace_server
 ):
@@ -591,61 +560,57 @@ def test_otel_and_calls_complete_api_interoperability(
 # =============================================================================
 
 
-def test_otel_op_ref_cached_across_batches(
+def test_otel_op_ref_cache_hits_mixed_and_many(
     trace_server, clickhouse_trace_server, monkeypatch
 ):
-    """Op ref URIs are cached: the same op name across two batches resolves identically."""
-    project_id = f"{TEST_ENTITY}/otel_cache_across_batches"
+    """Op ref cache: repeat ops hit cache (no obj_create_batch), mixed cached/new resolve, many distinct ops stay unique and stable across batches."""
+    project_id = f"{TEST_ENTITY}/otel_op_ref_cache"
+    op_names = [f"op_{i}" for i in range(20)]
 
-    # Batch 1: export span with op "foo"
-    span1 = _create_otel_span("foo")
-    req1 = _create_otel_export_req(project_id, [span1])
-    trace_server.otel_export(req1)
+    # Batch 1: 20 distinct ops, each gets a unique ref URI.
+    spans = [_create_otel_span(name) for name in op_names]
+    trace_server.otel_export(_create_otel_export_req(project_id, spans))
+    calls = _fetch_calls_stream(trace_server, project_id)
+    assert len(calls) == 20
+    assert len({c.op_name for c in calls}) == 20
 
-    def fail_obj_create_batch(_batch):
-        raise AssertionError("obj_create_batch should not be called for cached ops")
+    # Batch 2: re-export the same 20 cached ops plus one brand-new op.
+    # The 20 cached ops must NOT trigger obj_create_batch; only the new op may.
+    new_op = "brand_new_op"
+    created_op_names: list[str] = []
+    original_obj_create_batch = clickhouse_trace_server.obj_create_batch
+
+    def tracking_obj_create_batch(batch):
+        for obj in batch:
+            created_op_names.append(obj.object_id)
+        return original_obj_create_batch(batch)
 
     monkeypatch.setattr(
-        clickhouse_trace_server, "obj_create_batch", fail_obj_create_batch
+        clickhouse_trace_server, "obj_create_batch", tracking_obj_create_batch
     )
 
-    # Batch 2: export another span with op "foo"
-    span2 = _create_otel_span("foo")
-    req2 = _create_otel_export_req(project_id, [span2])
-    trace_server.otel_export(req2)
+    spans2 = [_create_otel_span(name) for name in op_names]
+    spans2.append(_create_otel_span(new_op))
+    trace_server.otel_export(_create_otel_export_req(project_id, spans2))
 
-    calls = _fetch_calls_stream(trace_server, project_id)
-    assert len(calls) == 2
-    # Both should resolve to the same op ref URI
-    assert calls[0].op_name == calls[1].op_name
-    assert "foo" in calls[0].op_name
+    # Only the brand-new op required an obj_create_batch write; cached ops did not.
+    assert created_op_names == [new_op]
 
+    calls_after = _fetch_calls_stream(trace_server, project_id)
+    assert len(calls_after) == 41
+    assert len([c for c in calls_after if f"/op/{new_op}:" in c.op_name]) == 1
 
-def test_otel_mixed_cached_and_new_ops(trace_server, clickhouse_trace_server):
-    """A batch with both cached and uncached ops resolves all correctly."""
-    project_id = f"{TEST_ENTITY}/otel_mixed_cache"
-
-    # Batch 1: establish "existing_op" in cache
-    span1 = _create_otel_span("existing_op")
-    req1 = _create_otel_export_req(project_id, [span1])
-    trace_server.otel_export(req1)
-
-    # Batch 2: mix of cached "existing_op" and new "brand_new_op"
-    span2 = _create_otel_span("existing_op")
-    span3 = _create_otel_span("brand_new_op")
-    req2 = _create_otel_export_req(project_id, [span2, span3])
-    trace_server.otel_export(req2)
-
-    calls = _fetch_calls_stream(trace_server, project_id)
-    assert len(calls) == 3
-
-    op_names = [c.op_name for c in calls]
-    existing_refs = [n for n in op_names if "existing_op" in n]
-    new_refs = [n for n in op_names if "brand_new_op" in n]
-    assert len(existing_refs) == 2
-    assert len(new_refs) == 1
-    # All "existing_op" refs should be identical
-    assert len(set(existing_refs)) == 1
+    # Every op name resolves to exactly one ref URI across both batches.
+    by_op: dict[str, set[str]] = defaultdict(set)
+    all_op_names = sorted([*op_names, new_op], key=len, reverse=True)
+    for c in calls_after:
+        for name in all_op_names:
+            if f"/op/{name}:" in c.op_name:
+                by_op[name].add(c.op_name)
+                break
+    assert len(by_op) == 21
+    for name, uri_set in by_op.items():
+        assert len(uri_set) == 1, f"Op {name} has inconsistent refs: {uri_set}"
 
 
 def test_otel_same_op_name_different_projects(trace_server, clickhouse_trace_server):
@@ -671,44 +636,6 @@ def test_otel_same_op_name_different_projects(trace_server, clickhouse_trace_ser
     assert "shared_op" in calls_b[0].op_name
     # URIs differ because they reference different project_ids
     assert calls_a[0].op_name != calls_b[0].op_name
-
-
-def test_otel_many_unique_ops_in_batch(trace_server, clickhouse_trace_server):
-    """A single batch with many distinct ops resolves all, and a repeat batch uses cache."""
-    project_id = f"{TEST_ENTITY}/otel_many_ops"
-    op_names = [f"op_{i}" for i in range(20)]
-
-    # Batch 1: 20 distinct ops
-    spans = [_create_otel_span(name) for name in op_names]
-    req1 = _create_otel_export_req(project_id, spans)
-    trace_server.otel_export(req1)
-
-    calls = _fetch_calls_stream(trace_server, project_id)
-    assert len(calls) == 20
-
-    # Each op should have a unique ref URI
-    refs = {c.op_name for c in calls}
-    assert len(refs) == 20
-
-    # Batch 2: re-export the same 20 ops (all should come from cache)
-    spans2 = [_create_otel_span(name) for name in op_names]
-    req2 = _create_otel_export_req(project_id, spans2)
-    trace_server.otel_export(req2)
-
-    calls_after = _fetch_calls_stream(trace_server, project_id)
-    assert len(calls_after) == 40
-
-    # All refs for the same op name should be identical across batches
-    from collections import defaultdict
-
-    by_op: dict[str, set[str]] = defaultdict(set)
-    for c in calls_after:
-        for name in sorted(op_names, key=len, reverse=True):
-            if f"/op/{name}:" in c.op_name:
-                by_op[name].add(c.op_name)
-                break
-    for name, uri_set in by_op.items():
-        assert len(uri_set) == 1, f"Op {name} has inconsistent refs: {uri_set}"
 
 
 def test_placeholder_file_created_at_most_once_per_project(

--- a/tests/trace_server/test_parallel_bucket_uploads.py
+++ b/tests/trace_server/test_parallel_bucket_uploads.py
@@ -22,44 +22,31 @@ def _req(content: bytes, name: str = "f.bin") -> FileCreateReq:
     return FileCreateReq(project_id="entity/project", name=name, content=content)
 
 
-def test_stage_dedup_raises_on_duplicate_key() -> None:
-    batch = BucketUploadBatch()
-    batch.stage(_req(b"hello"), digest="d1")
+def test_stage_size_guard_and_dedup() -> None:
+    """stage() enforces dedup and the cumulative byte budget."""
+    # Duplicate key raises and does not consume budget (raise precedes counter bump).
+    batch = BucketUploadBatch(max_bytes=1024)
+    batch.stage(_req(b"x" * 600), digest="d1")
     with pytest.raises(ValueError, match="called twice"):
-        batch.stage(_req(b"hello"), digest="d1")
+        batch.stage(_req(b"x" * 600), digest="d1")
+    batch.stage(_req(b"y" * 400), digest="d2")  # budget still allows 400 more
 
-
-def test_stage_rejects_when_total_exceeds_max_bytes() -> None:
-    """One oversized payload trips the guard immediately."""
+    # One oversized payload trips the guard immediately; nothing is staged.
     batch = BucketUploadBatch(max_bytes=1024)
     with pytest.raises(RequestTooLarge, match="max_bytes=1024"):
         batch.stage(_req(b"x" * 2048), digest="d1")
-    # Nothing was staged after the rejection.
     assert not batch
     assert not batch.has("entity/project", "d1")
 
-
-def test_stage_rejects_when_cumulative_exceeds_max_bytes() -> None:
-    """The guard accumulates across items, not just per-item."""
+    # The guard accumulates across items, not just per-item.
     batch = BucketUploadBatch(max_bytes=1024)
     batch.stage(_req(b"x" * 600), digest="d1")
     batch.stage(_req(b"y" * 400), digest="d2")
     with pytest.raises(RequestTooLarge):
         batch.stage(_req(b"z" * 100), digest="d3")
-    # First two items remain staged; the rejected third is not.
     assert batch.has("entity/project", "d1")
     assert batch.has("entity/project", "d2")
     assert not batch.has("entity/project", "d3")
-
-
-def test_duplicate_stage_does_not_consume_budget() -> None:
-    """Dedup hits raise ValueError before incrementing the byte counter."""
-    batch = BucketUploadBatch(max_bytes=1024)
-    batch.stage(_req(b"x" * 600), digest="d1")
-    with pytest.raises(ValueError, match="called twice"):
-        batch.stage(_req(b"x" * 600), digest="d1")
-    # Budget should still allow another 400 bytes.
-    batch.stage(_req(b"y" * 400), digest="d2")
 
 
 def test_flush_resets_byte_counter(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/trace_server/test_project_version.py
+++ b/tests/trace_server/test_project_version.py
@@ -138,31 +138,51 @@ def test_version_resolution_by_table_contents(
         )
 
 
-def test_caching_behavior(client, trace_server):
+def test_resolver_caching_and_trace_server_integration(client, trace_server):
+    """Resolver is a lazily-initialized singleton; non-empty resolutions cache, empty don't."""
     ch_server = trace_server._internal_trace_server
-    resolver = ch_server.table_routing_resolver
-    resolver._mode = CallsStorageServerMode.AUTO
 
+    assert ch_server._table_routing_resolver is None
+    resolver1 = ch_server.table_routing_resolver
+    assert resolver1 is not None
+    resolver2 = ch_server.table_routing_resolver
+    assert resolver1 is resolver2
+
+    resolver1._mode = CallsStorageServerMode.AUTO
+
+    # Non-empty project: first resolve queries, subsequent resolves (even via the
+    # other handle to the same singleton) hit the cache.
     cached_proj = make_project_id("cached_project")
     insert_call(ch_server.ch_client, "calls_complete", cached_proj)
-
     with count_queries(ch_server.ch_client) as get_count:
-        table1 = resolver.resolve_read_table(cached_proj, ch_server.ch_client)
-        assert table1 == ReadTable.CALLS_COMPLETE
+        assert (
+            resolver1.resolve_read_table(cached_proj, ch_server.ch_client)
+            == ReadTable.CALLS_COMPLETE
+        )
+        assert get_count() == 1
+        assert (
+            resolver1.resolve_read_table(cached_proj, ch_server.ch_client)
+            == ReadTable.CALLS_COMPLETE
+        )
+        assert get_count() == 1
+        assert (
+            resolver2.resolve_read_table(cached_proj, ch_server.ch_client)
+            == ReadTable.CALLS_COMPLETE
+        )
         assert get_count() == 1
 
-        table2 = resolver.resolve_read_table(cached_proj, ch_server.ch_client)
-        assert table2 == ReadTable.CALLS_COMPLETE
-        assert get_count() == 1
-
+    # Empty project resolves to COMPLETE but is not cached: each call re-queries.
     empty_proj = make_project_id("empty_not_cached")
     with count_queries(ch_server.ch_client) as get_count:
-        table1 = resolver.resolve_read_table(empty_proj, ch_server.ch_client)
-        assert table1 == ReadTable.CALLS_COMPLETE
+        assert (
+            resolver1.resolve_read_table(empty_proj, ch_server.ch_client)
+            == ReadTable.CALLS_COMPLETE
+        )
         assert get_count() == 1
-
-        table2 = resolver.resolve_read_table(empty_proj, ch_server.ch_client)
-        assert table2 == ReadTable.CALLS_COMPLETE
+        assert (
+            resolver1.resolve_read_table(empty_proj, ch_server.ch_client)
+            == ReadTable.CALLS_COMPLETE
+        )
         assert get_count() == 2
 
 
@@ -199,37 +219,6 @@ def test_clickhouse_provider_directly(client, trace_server):
     residence = get_project_data_residence(project_id, ch_server.ch_client)
 
     assert residence == ProjectDataResidence.MERGED_ONLY
-
-
-def test_resolver_as_trace_server_member(client, trace_server):
-    """Test that the resolver is properly integrated as a trace server member."""
-    ch_server = trace_server._internal_trace_server
-
-    # Test that the resolver is lazily initialized
-    assert ch_server._table_routing_resolver is None
-    resolver1 = ch_server.table_routing_resolver
-    assert resolver1 is not None
-
-    resolver2 = ch_server.table_routing_resolver
-    assert resolver1 is resolver2
-
-    project_id = make_project_id("trace_server_member")
-    insert_call(ch_server.ch_client, "calls_complete", project_id)
-
-    with count_queries(ch_server.ch_client) as get_count:
-        resolver1._mode = CallsStorageServerMode.AUTO
-        table = resolver1.resolve_read_table(project_id, ch_server.ch_client)
-        assert table == ReadTable.CALLS_COMPLETE
-        assert get_count() == 1
-
-        # Subsequent requests hit the cache
-        table2 = resolver1.resolve_read_table(project_id, ch_server.ch_client)
-        assert table2 == ReadTable.CALLS_COMPLETE
-        assert get_count() == 1
-
-        table3 = resolver2.resolve_read_table(project_id, ch_server.ch_client)
-        assert table3 == ReadTable.CALLS_COMPLETE
-        assert get_count() == 1
 
 
 def test_project_version_mode_from_env():

--- a/tests/trace_server/test_redis_client.py
+++ b/tests/trace_server/test_redis_client.py
@@ -14,18 +14,17 @@ def clear_cached_redis_client():
     redis_client.get_redis_client.cache_clear()
 
 
-def test_no_url_returns_none(monkeypatch):
-    redis_client.get_redis_client.cache_clear()
-    monkeypatch.delenv("WEAVE_REDIS_URL", raising=False)
-    assert redis_client.get_redis_client() is None
-
-
 def test_client_resolution_from_url(monkeypatch):
-    """Direct URL -> redis.from_url; ?master= URL -> Sentinel.master_for (port defaults to 26379)."""
+    """No URL -> None; direct URL -> redis.from_url; ?master= URL -> Sentinel.master_for (port defaults to 26379)."""
     timeouts = {
         "socket_connect_timeout": redis_client.REDIS_CONNECT_TIMEOUT_SECS,
         "socket_timeout": redis_client.REDIS_SOCKET_TIMEOUT_SECS,
     }
+
+    # Unset URL path -> no client.
+    redis_client.get_redis_client.cache_clear()
+    monkeypatch.delenv("WEAVE_REDIS_URL", raising=False)
+    assert redis_client.get_redis_client() is None
 
     # Direct URL path.
     with patch.object(redis_client.redis, "from_url") as mock_from_url:

--- a/tests/trace_server/test_rescore_evaluation.py
+++ b/tests/trace_server/test_rescore_evaluation.py
@@ -30,11 +30,12 @@ from weave.utils.project_id import from_project_id
 # ---------------------------------------------------------------------------
 
 
-def test_evaluation_run_create_stores_source_evaluation_run_id(client):
-    """source_evaluation_run_id written at create time must survive a read."""
+def test_evaluation_run_source_id_round_trip(client):
+    """source_evaluation_run_id written at create time survives a read; a run
+    created without one reads back None.
+    """
     project_id = client.project_id
 
-    # Create the source run
     source_run = client.server.evaluation_run_create(
         EvaluationRunCreateReq(
             project_id=project_id,
@@ -42,8 +43,7 @@ def test_evaluation_run_create_stores_source_evaluation_run_id(client):
             model="model://source",
         )
     )
-
-    # Create a new run that is a rescore of the source
+    # A run that is a rescore of the source preserves the link.
     rescore_run = client.server.evaluation_run_create(
         EvaluationRunCreateReq(
             project_id=project_id,
@@ -52,35 +52,22 @@ def test_evaluation_run_create_stores_source_evaluation_run_id(client):
             source_evaluation_run_id=source_run.evaluation_run_id,
         )
     )
-
-    # Read back and verify source_evaluation_run_id is preserved
-    read_res = client.server.evaluation_run_read(
+    rescore_read = client.server.evaluation_run_read(
         EvaluationRunReadReq(
             project_id=project_id,
             evaluation_run_id=rescore_run.evaluation_run_id,
         )
     )
-    assert read_res.source_evaluation_run_id == source_run.evaluation_run_id
+    assert rescore_read.source_evaluation_run_id == source_run.evaluation_run_id
 
-
-def test_evaluation_run_without_source_has_none(client):
-    """evaluation_run_read returns source_evaluation_run_id=None for normal runs."""
-    project_id = client.project_id
-
-    run = client.server.evaluation_run_create(
-        EvaluationRunCreateReq(
-            project_id=project_id,
-            evaluation="eval://plain",
-            model="model://plain",
-        )
-    )
-    read_res = client.server.evaluation_run_read(
+    # The source run itself has no source -> None on read.
+    source_read = client.server.evaluation_run_read(
         EvaluationRunReadReq(
             project_id=project_id,
-            evaluation_run_id=run.evaluation_run_id,
+            evaluation_run_id=source_run.evaluation_run_id,
         )
     )
-    assert read_res.source_evaluation_run_id is None
+    assert source_read.source_evaluation_run_id is None
 
 
 # ---------------------------------------------------------------------------
@@ -189,8 +176,10 @@ def test_rescore_without_wb_user_id_raises(client):
 # ---------------------------------------------------------------------------
 
 
-def test_prediction_list_filters_by_evaluation_run_id(client):
-    """prediction_list(evaluation_run_id=X) must return only predictions for run X."""
+def test_prediction_list_filters_by_run_and_paginates(client):
+    """prediction_list returns only the requested run's predictions and honors
+    limit/offset (non-overlapping pages) within that run.
+    """
     project_id = client.project_id
 
     run_a = client.server.evaluation_run_create(
@@ -208,110 +197,74 @@ def test_prediction_list_filters_by_evaluation_run_id(client):
         )
     )
 
-    # 2 predictions for run_a, 1 for run_b
-    for i in range(2):
-        pred = client.server.prediction_create(
-            PredictionCreateReq(
-                project_id=project_id,
-                model="model://list-a",
-                inputs={"i": i},
-                output=f"out-{i}",
-                evaluation_run_id=run_a.evaluation_run_id,
-            )
+    # 5 predictions for run_a (enough to paginate), 1 for run_b.
+    for i in range(5):
+        _create_finished_prediction(
+            client, project_id, "model://list-a", run_a.evaluation_run_id, i
         )
-        client.server.prediction_finish(
-            PredictionFinishReq(project_id=project_id, prediction_id=pred.prediction_id)
-        )
-
-    pred_b = client.server.prediction_create(
-        PredictionCreateReq(
-            project_id=project_id,
-            model="model://list-b",
-            inputs={"i": 99},
-            output="out-99",
-            evaluation_run_id=run_b.evaluation_run_id,
-        )
-    )
-    client.server.prediction_finish(
-        PredictionFinishReq(project_id=project_id, prediction_id=pred_b.prediction_id)
+    _create_finished_prediction(
+        client, project_id, "model://list-b", run_b.evaluation_run_id, 99
     )
 
+    # Filtering: each run sees only its own predictions.
     preds_a = list(
         client.server.prediction_list(
             PredictionListReq(
-                project_id=project_id,
-                evaluation_run_id=run_a.evaluation_run_id,
+                project_id=project_id, evaluation_run_id=run_a.evaluation_run_id
             )
         )
     )
-    assert len(preds_a) == 2
-    for p in preds_a:
-        assert p.evaluation_run_id == run_a.evaluation_run_id
+    assert len(preds_a) == 5
+    assert all(p.evaluation_run_id == run_a.evaluation_run_id for p in preds_a)
 
     preds_b = list(
         client.server.prediction_list(
             PredictionListReq(
-                project_id=project_id,
-                evaluation_run_id=run_b.evaluation_run_id,
+                project_id=project_id, evaluation_run_id=run_b.evaluation_run_id
             )
         )
     )
     assert len(preds_b) == 1
     assert preds_b[0].evaluation_run_id == run_b.evaluation_run_id
 
-
-def test_prediction_list_pagination(client):
-    """prediction_list respects limit and offset."""
-    project_id = client.project_id
-
-    run = client.server.evaluation_run_create(
-        EvaluationRunCreateReq(
-            project_id=project_id,
-            evaluation="eval://page-test",
-            model="model://page-test",
-        )
-    )
-
-    # Create 5 predictions
-    for i in range(5):
-        pred = client.server.prediction_create(
-            PredictionCreateReq(
-                project_id=project_id,
-                model="model://page-test",
-                inputs={"i": i},
-                output=f"out-{i}",
-                evaluation_run_id=run.evaluation_run_id,
-            )
-        )
-        client.server.prediction_finish(
-            PredictionFinishReq(project_id=project_id, prediction_id=pred.prediction_id)
-        )
-
+    # Pagination over run_a: limit/offset return non-overlapping pages.
     page1 = list(
         client.server.prediction_list(
             PredictionListReq(
                 project_id=project_id,
-                evaluation_run_id=run.evaluation_run_id,
+                evaluation_run_id=run_a.evaluation_run_id,
                 limit=3,
                 offset=0,
             )
         )
     )
     assert len(page1) == 3
-
     page2 = list(
         client.server.prediction_list(
             PredictionListReq(
                 project_id=project_id,
-                evaluation_run_id=run.evaluation_run_id,
+                evaluation_run_id=run_a.evaluation_run_id,
                 limit=3,
                 offset=3,
             )
         )
     )
     assert len(page2) == 2
+    assert {p.prediction_id for p in page1}.isdisjoint({p.prediction_id for p in page2})
 
-    # No overlap between pages
-    ids_page1 = {p.prediction_id for p in page1}
-    ids_page2 = {p.prediction_id for p in page2}
-    assert ids_page1.isdisjoint(ids_page2)
+
+def _create_finished_prediction(
+    client, project_id: str, model: str, evaluation_run_id: str, i: int
+) -> None:
+    pred = client.server.prediction_create(
+        PredictionCreateReq(
+            project_id=project_id,
+            model=model,
+            inputs={"i": i},
+            output=f"out-{i}",
+            evaluation_run_id=evaluation_run_id,
+        )
+    )
+    client.server.prediction_finish(
+        PredictionFinishReq(project_id=project_id, prediction_id=pred.prediction_id)
+    )

--- a/tests/trace_server/test_scorer_v2_api.py
+++ b/tests/trace_server/test_scorer_v2_api.py
@@ -10,514 +10,295 @@ from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.errors import NotFoundError, ObjectDeletedError
 
 
-def test_scorer_create_basic(trace_server):
-    """Test creating a basic scorer object."""
-    project_id = f"{TEST_ENTITY}/test_scorer_create_basic"
-
-    # Create a scorer
-    op_source_code = """
-def score(output: str, target: str) -> dict:
-    return {"correct": output == target}
-"""
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="exact_match",
-        description="A simple exact match scorer",
-        op_source_code=op_source_code,
+@pytest.mark.parametrize(
+    ("object_id", "description", "op_source_code"),
+    [
+        (
+            "exact_match",
+            "A simple exact match scorer",
+            'def score(output: str, target: str) -> dict:\n    return {"correct": output == target}',
+        ),
+        (
+            "length_scorer",
+            None,
+            'def score(output: str) -> dict:\n    return {"length": len(output)}',
+        ),
+        (
+            "json_similarity",
+            "Complex JSON similarity scorer",
+            "import json\nfrom typing import Any\n\n"
+            "def score(output: str, target: str) -> dict:\n"
+            "    '''Complex scoring function.'''\n"
+            "    try:\n"
+            "        output_data = json.loads(output)\n"
+            "        target_data = json.loads(target)\n"
+            "    except json.JSONDecodeError:\n"
+            '        return {"error": "Invalid JSON", "score": 0.0}\n'
+            "    matches = sum(1 for k, v in target_data.items() if output_data.get(k) == v)\n"
+            "    total = len(target_data)\n"
+            '    return {"score": matches / total if total else 0.0, "matches": matches, "total": total}',
+        ),
+    ],
+    ids=["basic", "no_description", "complex_source_code"],
+)
+def test_scorer_create_and_read_round_trip(
+    trace_server, object_id, description, op_source_code
+):
+    """Creating a scorer yields a v0 weave ref and reads back the same metadata."""
+    project_id = f"{TEST_ENTITY}/test_scorer_create_{object_id}"
+    create_res = trace_server.scorer_create(
+        tsi.ScorerCreateReq(
+            project_id=project_id,
+            name=object_id,
+            description=description,
+            op_source_code=op_source_code,
+        )
     )
-    create_res = trace_server.scorer_create(create_req)
-
     assert create_res.digest is not None
-    assert create_res.object_id == "exact_match"
+    assert create_res.object_id == object_id
     assert create_res.version_index == 0
-    # Verify scorer returns a reference string
     assert isinstance(create_res.scorer, str)
     assert create_res.scorer.startswith("weave:///")
 
-
-def test_scorer_create_without_description(trace_server):
-    """Test creating a scorer without providing a description."""
-    project_id = f"{TEST_ENTITY}/test_scorer_create_no_desc"
-
-    # Create a scorer without description
-    op_source_code = """
-def score(output: str) -> dict:
-    return {"length": len(output)}
-"""
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="length_scorer",
-        description=None,
-        op_source_code=op_source_code,
+    read_res = trace_server.scorer_read(
+        tsi.ScorerReadReq(
+            project_id=project_id, object_id=object_id, digest=create_res.digest
+        )
     )
-    create_res = trace_server.scorer_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "length_scorer"
-    assert create_res.version_index == 0
-    assert isinstance(create_res.scorer, str)
-
-
-def test_scorer_read_basic(trace_server):
-    """Test reading a specific scorer object."""
-    project_id = f"{TEST_ENTITY}/test_scorer_read_basic"
-
-    # Create a scorer
-    op_source_code = """
-def score(output: str, target: str) -> dict:
-    return {"correct": output.lower() == target.lower()}
-"""
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="case_insensitive_match",
-        description="Case insensitive match scorer",
-        op_source_code=op_source_code,
-    )
-    create_res = trace_server.scorer_create(create_req)
-
-    # Read the scorer back
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="case_insensitive_match",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.scorer_read(read_req)
-
-    assert read_res.object_id == "case_insensitive_match"
+    assert read_res.object_id == object_id
     assert read_res.digest == create_res.digest
     assert read_res.version_index == 0
-    assert read_res.name == "case_insensitive_match"
-    assert read_res.description == "Case insensitive match scorer"
+    assert read_res.name == object_id
+    assert read_res.description == description
     assert read_res.created_at is not None
-    # Verify score_op is a reference string
     assert isinstance(read_res.score_op, str)
-    assert read_res.score_op.startswith("weave:///") or len(read_res.score_op) > 0
+    assert read_res.score_op
+
+
+@pytest.mark.parametrize(
+    ("object_id", "description", "op_source_code", "expected_substring"),
+    [
+        (
+            "special_chars",
+            'Scorer with "special" characters',
+            "def score(output: str) -> dict:\n"
+            "    '''This scorer has \"quotes\" and 'apostrophes'.'''\n"
+            '    return {"result": f"Output: {output} with special chars: \\n\\t"}',
+            '"special"',
+        ),
+        (
+            "unicode_scorer",
+            "Unicode scorer 🌍",
+            "def score(output: str) -> dict:\n"
+            "    '''This scorer has unicode: 你好世界 🚀'''\n"
+            '    return {"greeting": "你好世界"}',
+            "🌍",
+        ),
+    ],
+    ids=["special_characters", "unicode"],
+)
+def test_scorer_metadata_round_trip_with_exotic_text(
+    trace_server, object_id, description, op_source_code, expected_substring
+):
+    """Special and unicode characters in code/description survive create + read."""
+    project_id = f"{TEST_ENTITY}/test_scorer_{object_id}"
+    create_res = trace_server.scorer_create(
+        tsi.ScorerCreateReq(
+            project_id=project_id,
+            name=object_id,
+            description=description,
+            op_source_code=op_source_code,
+        )
+    )
+    read_res = trace_server.scorer_read(
+        tsi.ScorerReadReq(
+            project_id=project_id, object_id=object_id, digest=create_res.digest
+        )
+    )
+    assert read_res.name == object_id
+    assert read_res.description == description
+    assert read_res.score_op
+    assert expected_substring in read_res.description
 
 
 def test_scorer_read_not_found(trace_server):
-    """Test reading a non-existent scorer raises NotFoundError."""
+    """Reading a non-existent scorer raises NotFoundError."""
     project_id = f"{TEST_ENTITY}/test_scorer_read_not_found"
+    with pytest.raises(NotFoundError):
+        trace_server.scorer_read(
+            tsi.ScorerReadReq(
+                project_id=project_id,
+                object_id="nonexistent_scorer",
+                digest="fake_digest_1234567890",
+            )
+        )
 
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="nonexistent_scorer",
-        digest="fake_digest_1234567890",
+
+def test_scorer_list_contents_and_pagination(trace_server):
+    """List returns full metadata, respects limit/offset, paginates without overlap."""
+    project_id = f"{TEST_ENTITY}/test_scorer_list"
+
+    # Empty project lists nothing.
+    assert (
+        list(trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id))) == []
     )
 
-    with pytest.raises(NotFoundError):
-        trace_server.scorer_read(read_req)
+    for i in range(10):
+        _create_scorer(trace_server, project_id, f"scorer_{i}")
 
-
-def test_scorer_list_basic(trace_server):
-    """Test listing all scorers in a project."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_basic"
-
-    # Create multiple scorers
-    scorer_names = ["scorer_a", "scorer_b", "scorer_c"]
-    for name in scorer_names:
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name=name,
-            description=f"Scorer {name}",
-            op_source_code=f'def score():\n    return {{"score": "{name}"}}',
-        )
-        trace_server.scorer_create(create_req)
-
-    # List all scorers
-    list_req = tsi.ScorerListReq(project_id=project_id)
-    scorers = list(trace_server.scorer_list(list_req))
-
-    assert len(scorers) == 3
-    scorer_names_returned = {s.name for s in scorers}
-    assert scorer_names_returned == {"scorer_a", "scorer_b", "scorer_c"}
-
-    # Verify all scorers have score_op references
-    for scorer in scorers:
+    all_scorers = list(
+        trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id))
+    )
+    assert len(all_scorers) == 10
+    assert {s.name for s in all_scorers} == {f"scorer_{i}" for i in range(10)}
+    for scorer in all_scorers:
         assert scorer.score_op
         assert scorer.created_at is not None
 
-
-def test_scorer_list_with_limit(trace_server):
-    """Test listing scorers with a limit."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_limit"
-
-    # Create multiple scorers
-    for i in range(5):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name=f"scorer_{i}",
-            description=None,
-            op_source_code=f'def score():\n    return {{"value": {i}}}',
+    assert (
+        len(
+            list(
+                trace_server.scorer_list(
+                    tsi.ScorerListReq(project_id=project_id, limit=3)
+                )
+            )
         )
-        trace_server.scorer_create(create_req)
-
-    # List with a limit
-    list_req = tsi.ScorerListReq(project_id=project_id, limit=3)
-    scorers = list(trace_server.scorer_list(list_req))
-
-    assert len(scorers) == 3
-
-
-def test_scorer_list_with_offset(trace_server):
-    """Test listing scorers with an offset."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_offset"
-
-    # Create multiple scorers
-    for i in range(5):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name=f"scorer_{i}",
-            description=None,
-            op_source_code=f'def score():\n    return {{"value": {i}}}',
+        == 3
+    )
+    assert (
+        len(
+            list(
+                trace_server.scorer_list(
+                    tsi.ScorerListReq(project_id=project_id, offset=7)
+                )
+            )
         )
-        trace_server.scorer_create(create_req)
+        == 3
+    )
 
-    # List with an offset
-    list_req = tsi.ScorerListReq(project_id=project_id, offset=2)
-    scorers = list(trace_server.scorer_list(list_req))
-
-    assert len(scorers) == 3
-
-
-def test_scorer_list_with_limit_and_offset(trace_server):
-    """Test listing scorers with both limit and offset for pagination."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_pagination"
-
-    # Create multiple scorers
-    for i in range(10):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name=f"scorer_{i}",
-            description=None,
-            op_source_code=f'def score():\n    return {{"value": {i}}}',
+    page1 = list(
+        trace_server.scorer_list(
+            tsi.ScorerListReq(project_id=project_id, limit=3, offset=0)
         )
-        trace_server.scorer_create(create_req)
-
-    # First page
-    list_req1 = tsi.ScorerListReq(project_id=project_id, limit=3, offset=0)
-    scorers1 = list(trace_server.scorer_list(list_req1))
-    assert len(scorers1) == 3
-
-    # Second page
-    list_req2 = tsi.ScorerListReq(project_id=project_id, limit=3, offset=3)
-    scorers2 = list(trace_server.scorer_list(list_req2))
-    assert len(scorers2) == 3
-
-    # Verify different scorers on different pages
-    scorers1_names = {s.name for s in scorers1}
-    scorers2_names = {s.name for s in scorers2}
-    assert len(scorers1_names & scorers2_names) == 0  # No overlap
-
-
-def test_scorer_list_empty_project(trace_server):
-    """Test listing scorers in a project with no scorers."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_empty"
-
-    list_req = tsi.ScorerListReq(project_id=project_id)
-    scorers = list(trace_server.scorer_list(list_req))
-
-    assert len(scorers) == 0
-
-
-def test_scorer_delete_single_version(trace_server):
-    """Test deleting a single version of a scorer."""
-    project_id = f"{TEST_ENTITY}/test_scorer_delete_single"
-
-    # Create a scorer
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="delete_test",
-        description=None,
-        op_source_code='def score():\n    return {"score": 1}',
     )
-    create_res = trace_server.scorer_create(create_req)
-
-    # Delete the specific version
-    delete_req = tsi.ScorerDeleteReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digests=[create_res.digest],
-    )
-    delete_res = trace_server.scorer_delete(delete_req)
-
-    assert delete_res.num_deleted == 1
-
-    # Verify the scorer is deleted (should raise ObjectDeletedError)
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="delete_test",
-        digest=create_res.digest,
-    )
-    with pytest.raises(ObjectDeletedError):
-        trace_server.scorer_read(read_req)
-
-
-def test_scorer_delete_all_versions(trace_server):
-    """Test deleting all versions of a scorer (no digests specified)."""
-    project_id = f"{TEST_ENTITY}/test_scorer_delete_all"
-
-    # Create multiple versions of the same scorer
-    digests = []
-    for i in range(3):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name="versioned_scorer",
-            description=None,
-            op_source_code=f'def score():\n    return {{"version": {i}}}',
+    page2 = list(
+        trace_server.scorer_list(
+            tsi.ScorerListReq(project_id=project_id, limit=3, offset=3)
         )
-        create_res = trace_server.scorer_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete all versions (no digests specified)
-    delete_req = tsi.ScorerDeleteReq(
-        project_id=project_id,
-        object_id="versioned_scorer",
-        digests=None,
     )
-    delete_res = trace_server.scorer_delete(delete_req)
+    assert len(page1) == 3
+    assert len(page2) == 3
+    assert {s.name for s in page1} & {s.name for s in page2} == set()
 
-    assert delete_res.num_deleted == 3
+
+def test_scorer_list_excludes_deleted(trace_server):
+    """Deleted scorers disappear from list results."""
+    project_id = f"{TEST_ENTITY}/test_scorer_list_after_deletion"
+    for name in ["keep_1", "delete_me", "keep_2"]:
+        _create_scorer(trace_server, project_id, name)
+
+    trace_server.scorer_delete(
+        tsi.ScorerDeleteReq(project_id=project_id, object_id="delete_me", digests=None)
+    )
+
+    scorers = list(trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id)))
+    assert {s.name for s in scorers} == {"keep_1", "keep_2"}
 
 
-def test_scorer_delete_multiple_versions(trace_server):
-    """Test deleting multiple specific versions of a scorer."""
-    project_id = f"{TEST_ENTITY}/test_scorer_delete_multiple"
-
-    # Create multiple versions
-    digests = []
-    for i in range(4):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name="multi_version_scorer",
-            description=None,
-            op_source_code=f'def score():\n    return {{"version": {i}}}',
+def test_scorer_delete_selective_and_all(trace_server):
+    """Deleting specific digests removes only those; ``digests=None`` removes every version."""
+    # Selective delete: first two of four versions go, last two remain readable.
+    selective_proj = f"{TEST_ENTITY}/test_scorer_delete_multiple"
+    digests = [
+        _create_scorer(
+            trace_server, selective_proj, "multi_version_scorer", f'{{"version": {i}}}'
+        ).digest
+        for i in range(4)
+    ]
+    del_res = trace_server.scorer_delete(
+        tsi.ScorerDeleteReq(
+            project_id=selective_proj,
+            object_id="multi_version_scorer",
+            digests=digests[:2],
         )
-        create_res = trace_server.scorer_create(create_req)
-        digests.append(create_res.digest)
-
-    # Delete the first two versions
-    delete_req = tsi.ScorerDeleteReq(
-        project_id=project_id,
-        object_id="multi_version_scorer",
-        digests=digests[:2],
     )
-    delete_res = trace_server.scorer_delete(delete_req)
-
-    assert delete_res.num_deleted == 2
-
-    # Verify the first two are deleted
+    assert del_res.num_deleted == 2
     for digest in digests[:2]:
-        read_req = tsi.ScorerReadReq(
-            project_id=project_id,
-            object_id="multi_version_scorer",
-            digest=digest,
-        )
         with pytest.raises(ObjectDeletedError):
-            trace_server.scorer_read(read_req)
-
-    # Verify the last two still exist
+            trace_server.scorer_read(
+                tsi.ScorerReadReq(
+                    project_id=selective_proj,
+                    object_id="multi_version_scorer",
+                    digest=digest,
+                )
+            )
     for digest in digests[2:]:
-        read_req = tsi.ScorerReadReq(
-            project_id=project_id,
-            object_id="multi_version_scorer",
-            digest=digest,
+        read_res = trace_server.scorer_read(
+            tsi.ScorerReadReq(
+                project_id=selective_proj,
+                object_id="multi_version_scorer",
+                digest=digest,
+            )
         )
-        read_res = trace_server.scorer_read(read_req)
         assert read_res.digest == digest
+
+    # Delete-all: a single version, then a multi-version object.
+    single_proj = f"{TEST_ENTITY}/test_scorer_delete_single"
+    single_digest = _create_scorer(trace_server, single_proj, "delete_test").digest
+    single_res = trace_server.scorer_delete(
+        tsi.ScorerDeleteReq(
+            project_id=single_proj, object_id="delete_test", digests=[single_digest]
+        )
+    )
+    assert single_res.num_deleted == 1
+    with pytest.raises(ObjectDeletedError):
+        trace_server.scorer_read(
+            tsi.ScorerReadReq(
+                project_id=single_proj, object_id="delete_test", digest=single_digest
+            )
+        )
+
+    all_proj = f"{TEST_ENTITY}/test_scorer_delete_all"
+    for i in range(3):
+        _create_scorer(
+            trace_server, all_proj, "versioned_scorer", f'{{"version": {i}}}'
+        )
+    all_res = trace_server.scorer_delete(
+        tsi.ScorerDeleteReq(
+            project_id=all_proj, object_id="versioned_scorer", digests=None
+        )
+    )
+    assert all_res.num_deleted == 3
 
 
 def test_scorer_delete_not_found(trace_server):
-    """Test deleting a non-existent scorer raises NotFoundError."""
+    """Deleting a non-existent scorer raises NotFoundError."""
     project_id = f"{TEST_ENTITY}/test_scorer_delete_not_found"
-
-    delete_req = tsi.ScorerDeleteReq(
-        project_id=project_id,
-        object_id="nonexistent_scorer",
-        digests=["fake_digest"],
-    )
-
     with pytest.raises(NotFoundError):
-        trace_server.scorer_delete(delete_req)
+        trace_server.scorer_delete(
+            tsi.ScorerDeleteReq(
+                project_id=project_id,
+                object_id="nonexistent_scorer",
+                digests=["fake_digest"],
+            )
+        )
 
 
 def test_scorer_versioning(trace_server):
-    """Test that creating multiple versions of a scorer increments version_index."""
+    """Creating multiple versions of a scorer increments version_index with distinct digests."""
     project_id = f"{TEST_ENTITY}/test_scorer_versioning"
-
-    # Create multiple versions of the same scorer
-    versions = []
-    for i in range(3):
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name="versioned_scorer",
-            description=f"Version {i}",
-            op_source_code=f'def score():\n    return {{"version": {i}}}',
+    versions = [
+        _create_scorer(
+            trace_server,
+            project_id,
+            "versioned_scorer",
+            f'{{"version": {i}}}',
+            f"Version {i}",
         )
-        create_res = trace_server.scorer_create(create_req)
-        versions.append(create_res)
-
-    # Verify version indices increment
-    assert versions[0].version_index == 0
-    assert versions[1].version_index == 1
-    assert versions[2].version_index == 2
-
-    # Verify all versions are distinct
+        for i in range(3)
+    ]
+    assert [v.version_index for v in versions] == [0, 1, 2]
     assert len({v.digest for v in versions}) == 3
-
-
-def test_scorer_with_special_characters(trace_server):
-    """Test creating and reading a scorer with special characters in code."""
-    project_id = f"{TEST_ENTITY}/test_scorer_special_chars"
-
-    # Create a scorer with special characters
-    op_source_code = """
-def score(output: str) -> dict:
-    '''This scorer has "quotes" and 'apostrophes'.'''
-    return {"result": f"Output: {output} with special chars: \\n\\t"}
-"""
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="special_chars",
-        description='Scorer with "special" characters',
-        op_source_code=op_source_code,
-    )
-    create_res = trace_server.scorer_create(create_req)
-
-    # Read it back and verify metadata is preserved
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="special_chars",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.scorer_read(read_req)
-
-    assert read_res.name == "special_chars"
-    assert read_res.description == 'Scorer with "special" characters'
-    assert read_res.score_op  # Should have a reference
-
-
-def test_scorer_with_unicode(trace_server):
-    """Test creating and reading a scorer with unicode characters."""
-    project_id = f"{TEST_ENTITY}/test_scorer_unicode"
-
-    # Create a scorer with unicode
-    op_source_code = """
-def score(output: str) -> dict:
-    '''This scorer has unicode: 你好世界 🚀'''
-    return {"greeting": "你好世界"}
-"""
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="unicode_scorer",
-        description="Unicode scorer 🌍",
-        op_source_code=op_source_code,
-    )
-    create_res = trace_server.scorer_create(create_req)
-
-    # Read it back and verify metadata is preserved
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="unicode_scorer",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.scorer_read(read_req)
-
-    assert read_res.name == "unicode_scorer"
-    assert read_res.description == "Unicode scorer 🌍"
-    assert "🌍" in read_res.description
-
-
-def test_scorer_list_after_deletion(trace_server):
-    """Test that deleted scorers don't appear in list results."""
-    project_id = f"{TEST_ENTITY}/test_scorer_list_after_deletion"
-
-    # Create three scorers
-    scorer_names = ["keep_1", "delete_me", "keep_2"]
-    digests = {}
-    for name in scorer_names:
-        create_req = tsi.ScorerCreateReq(
-            project_id=project_id,
-            name=name,
-            description=None,
-            op_source_code='def score():\n    return {"score": 1}',
-        )
-        create_res = trace_server.scorer_create(create_req)
-        digests[name] = create_res.digest
-
-    # Delete one scorer
-    delete_req = tsi.ScorerDeleteReq(
-        project_id=project_id,
-        object_id="delete_me",
-        digests=None,
-    )
-    trace_server.scorer_delete(delete_req)
-
-    # List scorers - should only see the two that weren't deleted
-    list_req = tsi.ScorerListReq(project_id=project_id)
-    scorers = list(trace_server.scorer_list(list_req))
-
-    scorer_names_returned = {s.name for s in scorers}
-    assert scorer_names_returned == {"keep_1", "keep_2"}
-    assert "delete_me" not in scorer_names_returned
-
-
-def test_scorer_complex_source_code(trace_server):
-    """Test creating a scorer with complex multi-line source code."""
-    project_id = f"{TEST_ENTITY}/test_scorer_complex_code"
-
-    # Create a scorer with complex code
-    op_source_code = """
-import json
-from typing import Any
-
-def score(output: str, target: str) -> dict:
-    '''
-    Complex scoring function with multiple operations.
-    '''
-    # Parse outputs
-    try:
-        output_data = json.loads(output)
-        target_data = json.loads(target)
-    except json.JSONDecodeError:
-        return {"error": "Invalid JSON", "score": 0.0}
-
-    # Calculate similarity
-    matches = 0
-    total = len(target_data)
-
-    for key, value in target_data.items():
-        if key in output_data and output_data[key] == value:
-            matches += 1
-
-    score = matches / total if total > 0 else 0.0
-
-    return {
-        "score": score,
-        "matches": matches,
-        "total": total
-    }
-"""
-    create_req = tsi.ScorerCreateReq(
-        project_id=project_id,
-        name="json_similarity",
-        description="Complex JSON similarity scorer",
-        op_source_code=op_source_code,
-    )
-    create_res = trace_server.scorer_create(create_req)
-
-    assert create_res.digest is not None
-    assert create_res.object_id == "json_similarity"
-
-    # Read it back
-    read_req = tsi.ScorerReadReq(
-        project_id=project_id,
-        object_id="json_similarity",
-        digest=create_res.digest,
-    )
-    read_res = trace_server.scorer_read(read_req)
-
-    assert read_res.name == "json_similarity"
-    assert read_res.description == "Complex JSON similarity scorer"
 
 
 def test_scorer_list_with_missing_name_in_val(trace_server):
@@ -528,29 +309,41 @@ def test_scorer_list_with_missing_name_in_val(trace_server):
     back to using object_id as the name.
     """
     project_id = f"{TEST_ENTITY}/test_scorer_list_missing_name"
-
-    # Directly create a Scorer object whose val dict has no "name" key.
-    obj_create_req = tsi.ObjCreateReq(
-        obj=tsi.ObjSchemaForInsert(
-            project_id=project_id,
-            object_id="nameless_scorer",
-            val={
-                "_type": "Scorer",
-                "_class_name": "Scorer",
-                "_bases": ["Scorer", "Object", "BaseModel"],
-                "description": "A scorer with no name in val",
-                "score": "",
-            },
-            set_base_object_class="Scorer",
+    trace_server.obj_create(
+        tsi.ObjCreateReq(
+            obj=tsi.ObjSchemaForInsert(
+                project_id=project_id,
+                object_id="nameless_scorer",
+                val={
+                    "_type": "Scorer",
+                    "_class_name": "Scorer",
+                    "_bases": ["Scorer", "Object", "BaseModel"],
+                    "description": "A scorer with no name in val",
+                    "score": "",
+                },
+                set_base_object_class="Scorer",
+            )
         )
     )
-    trace_server.obj_create(obj_create_req)
-
-    # List scorers - should not raise ValidationError
-    list_req = tsi.ScorerListReq(project_id=project_id)
-    scorers = list(trace_server.scorer_list(list_req))
-
+    scorers = list(trace_server.scorer_list(tsi.ScorerListReq(project_id=project_id)))
     assert len(scorers) == 1
-    # name should fall back to object_id
     assert scorers[0].name == "nameless_scorer"
     assert scorers[0].object_id == "nameless_scorer"
+
+
+def _create_scorer(
+    trace_server,
+    project_id: str,
+    name: str,
+    body: str = '{"score": 1}',
+    description: str | None = None,
+) -> tsi.ScorerCreateRes:
+    """Create a minimal scorer whose `score` returns `body`; returns the create response."""
+    return trace_server.scorer_create(
+        tsi.ScorerCreateReq(
+            project_id=project_id,
+            name=name,
+            description=description,
+            op_source_code=f"def score():\n    return {body}",
+        )
+    )

--- a/tests/trace_server/test_service_interface.py
+++ b/tests/trace_server/test_service_interface.py
@@ -2,36 +2,37 @@
 
 from __future__ import annotations
 
+import pytest
+
 from weave.trace_server.fake_service import FakeService
 from weave.trace_server.service_interface import (
     ProjectsInfoReq,
 )
 
 
-def test_server_info() -> None:
+def test_server_info_and_ensure_project_exists() -> None:
     svc = FakeService()
-    res = svc.server_info()
-    assert res.min_required_weave_python_version == "0.0.0"
-    assert res.trace_server_version == "test"
+
+    info = svc.server_info()
+    assert info.min_required_weave_python_version == "0.0.0"
+    assert info.trace_server_version == "test"
+
+    ensured = svc.ensure_project_exists("my-entity", "my-project")
+    assert ensured.project_name == "my-project"
 
 
-def test_ensure_project_exists() -> None:
+@pytest.mark.parametrize(
+    ("project_ids", "expected"),
+    [
+        (
+            ["entity-a/project-a", "entity-b/project-b"],
+            ["entity-a/project-a", "entity-b/project-b"],
+        ),
+        ([], []),
+    ],
+    ids=["populated", "empty"],
+)
+def test_projects_info(project_ids: list[str], expected: list[str]) -> None:
     svc = FakeService()
-    res = svc.ensure_project_exists("my-entity", "my-project")
-    assert res.project_name == "my-project"
-
-
-def test_projects_info() -> None:
-    svc = FakeService()
-    req = ProjectsInfoReq(project_ids=["entity-a/project-a", "entity-b/project-b"])
-    res = svc.projects_info(req)
-    assert len(res) == 2
-    assert res[0].external_project_id == "entity-a/project-a"
-    assert res[1].external_project_id == "entity-b/project-b"
-
-
-def test_projects_info_empty() -> None:
-    svc = FakeService()
-    req = ProjectsInfoReq(project_ids=[])
-    res = svc.projects_info(req)
-    assert res == []
+    res = svc.projects_info(ProjectsInfoReq(project_ids=project_ids))
+    assert [p.external_project_id for p in res] == expected

--- a/tests/trace_server/test_trace_server_converter.py
+++ b/tests/trace_server/test_trace_server_converter.py
@@ -95,43 +95,36 @@ def test_universal_ext_to_int_ref_converter_reuses_models_and_untouched_branches
     assert original_payload == ["plain", external_ref]
 
 
-def test_universal_ext_to_int_ref_converter_handles_aliased_query_models():
-    """Query models with `$`-prefixed aliases still serialize via by_alias."""
-    project_id = "entity/project"
+def test_universal_ext_to_int_ref_converter_variant_payloads():
+    """Converter handles aliased Query models, `Any`-field dataclass roundtrips,
+    and refs stored in `extra='allow'` model extras.
+    """
     internal_project_id = "internal-project"
-    external_ref = f"weave:///{project_id}/object/name:digest"
+    external_ref = "weave:///entity/project/object/name:digest"
     internal_ref = f"weave-trace-internal:///{internal_project_id}/object/name:digest"
 
+    # `$`-prefixed query aliases still serialize via by_alias; the rewritten
+    # literal rebuilds while the untouched literal keeps identity.
     query = Query.model_validate(
-        {
-            "$expr": {
-                "$eq": [
-                    {"$literal": external_ref},
-                    {"$literal": "plain"},
-                ]
-            }
-        }
+        {"$expr": {"$eq": [{"$literal": external_ref}, {"$literal": "plain"}]}}
     )
     original_expr = query.expr_
     original_eq = query.expr_.eq_
     original_left_literal = query.expr_.eq_[0]
 
-    converted = universal_ext_to_int_ref_converter(
+    converted_query = universal_ext_to_int_ref_converter(
         query, lambda project: internal_project_id
     )
-
-    assert converted is query
-    assert converted.expr_ is original_expr
-    assert converted.expr_.eq_ is not original_eq
-    assert converted.expr_.eq_[0] is original_left_literal
-    aliased_query = converted.model_dump(by_alias=True)
+    assert converted_query is query
+    assert converted_query.expr_ is original_expr
+    assert converted_query.expr_.eq_ is not original_eq
+    assert converted_query.expr_.eq_[0] is original_left_literal
+    aliased_query = converted_query.model_dump(by_alias=True)
     assert aliased_query["$expr"]["$eq"][0]["$literal"] == internal_ref
     assert aliased_query["$expr"]["$eq"][1]["$literal"] == "plain"
 
-
-def test_universal_ext_to_int_ref_converter_roundtrips_models_with_any_payloads():
-    """Nested dataclasses inside an `Any` field force the legacy roundtrip path."""
-    req = ObjCreateReq(
+    # Nested dataclasses inside an `Any` field force the legacy roundtrip path.
+    any_req = ObjCreateReq(
         obj=ObjSchemaForInsert(
             project_id="entity/project",
             object_id="thing",
@@ -145,51 +138,29 @@ def test_universal_ext_to_int_ref_converter_roundtrips_models_with_any_payloads(
             },
         )
     )
-
-    converted = universal_ext_to_int_ref_converter(
-        req, lambda project: "internal-project"
+    converted_any = universal_ext_to_int_ref_converter(
+        any_req, lambda project: "internal-project"
     )
+    assert isinstance(converted_any.obj.val["ref"], dict)
+    json.dumps(converted_any.obj.val)
 
-    assert isinstance(converted.obj.val["ref"], dict)
-    json.dumps(converted.obj.val)
-
-
-def test_universal_ext_to_int_ref_converter_rewrites_refs_in_model_extras():
-    """Refs stored on a `extra='allow'` BaseModel must still be rewritten.
-
-    The legacy converter walked the `model_dump(by_alias=True)` output,
-    which includes fields collected into `model_extra`. The COW fast path
-    iterates `model_fields` only, so extras are silently skipped unless
-    `_walk_model` also walks them.
-    """
-    project_id = "entity/project"
-    internal_project_id = "internal-project"
-    external_ref = f"weave:///{project_id}/op/some-op:latest"
-    internal_ref = f"weave-trace-internal:///{internal_project_id}/op/some-op:latest"
-
-    class ExtraAllowed(BaseModel):
-        model_config = ConfigDict(extra="allow")
-        declared: str
-
-    model = ExtraAllowed.model_validate(
-        {"declared": "plain", "extra_ref": external_ref}
+    # Refs collected into `model_extra` must still be rewritten.
+    op_external = "weave:///entity/project/op/some-op:latest"
+    op_internal = f"weave-trace-internal:///{internal_project_id}/op/some-op:latest"
+    model = _ExtraAllowed.model_validate(
+        {"declared": "plain", "extra_ref": op_external}
     )
-
-    converted = universal_ext_to_int_ref_converter(
+    converted_extra = universal_ext_to_int_ref_converter(
         model, lambda project: internal_project_id
     )
+    assert converted_extra.declared == "plain"
+    extras = converted_extra.model_extra or {}
+    assert extras.get("extra_ref") == op_internal
 
-    assert converted.declared == "plain"
-    extras = converted.model_extra or {}
-    assert extras.get("extra_ref") == internal_ref
 
-
-def test_replace_external_weave_ref_uses_cache():
-    """Shared cache amortizes ext→int_project_id lookups across calls.
-
-    Callers that walk many refs (e.g. an OTel batch with the same
-    entity/project on every span) pass a per-request dict so the
-    underlying converter runs once per distinct project_key.
+def test_replace_external_weave_ref_cache_and_rejections():
+    """Shared cache amortizes ext->int lookups; non-external scheme and
+    malformed tails are contract violations that raise.
     """
     calls: list[str] = []
 
@@ -198,7 +169,6 @@ def test_replace_external_weave_ref_uses_cache():
         return f"internal:{project_key}"
 
     cache: dict[str, str] = {}
-
     a = replace_external_weave_ref("weave:///ent/proj/object/a:v1", converter, cache)
     b = replace_external_weave_ref("weave:///ent/proj/object/b:v1", converter, cache)
     c = replace_external_weave_ref("weave:///other/proj/object/c:v1", converter, cache)
@@ -209,21 +179,15 @@ def test_replace_external_weave_ref_uses_cache():
     # Same entity/project resolves once, distinct one resolves again.
     assert calls == ["ent/proj", "other/proj"]
 
-
-def test_replace_external_weave_ref_rejects_non_external_scheme():
-    """Inputs not on the external scheme are a contract violation; the
-    caller must precheck `startswith(weave_prefix)` before invoking.
-    """
     with pytest.raises(ValueError, match="Invalid URI"):
         replace_external_weave_ref(
             "weave-trace-internal:///proj/object/a:v1", lambda p: p
         )
 
-
-def test_replace_external_weave_ref_rejects_malformed_tail():
-    """Refs missing the `entity/project/tail` triplet trip InvalidExternalRef
-    so the caller surfaces the bad payload rather than silently passing it
-    through.
-    """
     with pytest.raises(InvalidExternalRef):
         replace_external_weave_ref("weave:///just-entity", lambda p: p)
+
+
+class _ExtraAllowed(BaseModel):
+    model_config = ConfigDict(extra="allow")
+    declared: str

--- a/tests/trace_server/test_trace_server_evaluation_apis.py
+++ b/tests/trace_server/test_trace_server_evaluation_apis.py
@@ -543,7 +543,10 @@ def test_evaluate_model_rejects_op_ref_as_eval_or_model_ref(client, op_arg):
         )
 
 
-def test_eval_results_query_basic(client):
+def test_eval_results_query_basic_and_children(client):
+    """A scored prediction is queryable; include_predict_and_score_children
+    toggles child call ids while the scores stay populated either way.
+    """
     project_id = client.project_id
     entity, project = from_project_id(project_id)
 
@@ -596,12 +599,37 @@ def test_eval_results_query_basic(client):
             evaluation_call_ids=[run.evaluation_run_id],
         )
     )
-
     assert res.total_rows == 1
     assert len(res.rows) == 1
     trial = res.rows[0].evaluations[0].trials[0]
     assert "basic_scorer" in trial.scores
     assert trial.scores["basic_scorer"] == 0.9
+
+    # Children included (default): predict_call_id + scorer_call_ids populated.
+    res_with = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[run.evaluation_run_id],
+            include_predict_and_score_children=True,
+        )
+    )
+    trial_with = res_with.rows[0].evaluations[0].trials[0]
+    assert trial_with.predict_call_id is not None
+    assert trial_with.scorer_call_ids != {}
+    assert trial_with.scores["basic_scorer"] == 0.9
+
+    # Children excluded: ids drop out but scores remain.
+    res_without = client.server.eval_results_query(
+        EvalResultsQueryReq(
+            project_id=project_id,
+            evaluation_call_ids=[run.evaluation_run_id],
+            include_predict_and_score_children=False,
+        )
+    )
+    trial_without = res_without.rows[0].evaluations[0].trials[0]
+    assert trial_without.predict_call_id is None
+    assert trial_without.scorer_call_ids == {}
+    assert trial_without.scores["basic_scorer"] == 0.9
 
 
 def test_eval_results_query_returns_genai_span_ref_without_children(client):
@@ -769,81 +797,6 @@ def test_eval_results_resolve_refs_only_for_paginated_rows(client):
     for call in refs_read_batch_calls:
         # only resolve refs for the paginated slice, not all rows
         assert len(call.refs) <= 2
-
-
-def test_eval_results_include_predict_and_score_children(client):
-    """Verify include_predict_and_score_children controls child call data."""
-    project_id = client.project_id
-    entity, project = from_project_id(project_id)
-
-    scorer_res = client.server.scorer_create(
-        ScorerCreateReq(
-            project_id=project_id,
-            name="children_test_scorer",
-            op_source_code="def score(output):\n    return 1",
-        )
-    )
-    scorer_ref = (
-        f"weave:///{entity}/{project}/object/{scorer_res.object_id}:{scorer_res.digest}"
-    )
-
-    run = client.server.evaluation_run_create(
-        EvaluationRunCreateReq(
-            project_id=project_id,
-            evaluation="eval://children-test",
-            model="model://children-test",
-        )
-    )
-    pred = client.server.prediction_create(
-        PredictionCreateReq(
-            project_id=project_id,
-            model="model://children-test",
-            inputs={"x": 1},
-            output="result",
-            evaluation_run_id=run.evaluation_run_id,
-        )
-    )
-    client.server.score_create(
-        ScoreCreateReq(
-            project_id=project_id,
-            prediction_id=pred.prediction_id,
-            scorer=scorer_ref,
-            value=0.8,
-            evaluation_run_id=run.evaluation_run_id,
-        )
-    )
-    client.server.prediction_finish(
-        PredictionFinishReq(
-            project_id=project_id,
-            prediction_id=pred.prediction_id,
-        )
-    )
-
-    # With children included (default) — predict_call_id and scorer_call_ids populated
-    res_with = client.server.eval_results_query(
-        EvalResultsQueryReq(
-            project_id=project_id,
-            evaluation_call_ids=[run.evaluation_run_id],
-            include_predict_and_score_children=True,
-        )
-    )
-    trial_with = res_with.rows[0].evaluations[0].trials[0]
-    assert trial_with.predict_call_id is not None
-    assert trial_with.scorer_call_ids != {}
-    assert trial_with.scores["children_test_scorer"] == 0.8
-
-    # scores should still be present.
-    res_without = client.server.eval_results_query(
-        EvalResultsQueryReq(
-            project_id=project_id,
-            evaluation_call_ids=[run.evaluation_run_id],
-            include_predict_and_score_children=False,
-        )
-    )
-    trial_without = res_without.rows[0].evaluations[0].trials[0]
-    assert trial_without.predict_call_id is None
-    assert trial_without.scorer_call_ids == {}
-    assert trial_without.scores["children_test_scorer"] == 0.8
 
 
 def test_eval_results_resolved_inputs_inline(client):
@@ -1066,43 +1019,28 @@ def test_eval_results_excludes_deleted_calls(client):
     assert res.total_rows == 2
 
 
-def test_eval_results_sort_by_score_desc(client):
-    """Sort by scores.accuracy DESC should return highest-scoring row first."""
+@pytest.mark.parametrize(
+    ("direction", "expected"),
+    [("desc", [0.9, 0.6, 0.3]), ("asc", [0.3, 0.6, 0.9])],
+)
+def test_eval_results_sort_by_score(client, direction, expected):
+    """Sort by scores.accuracy orders rows by score in the requested direction."""
     eval_id, _ = _create_eval_with_scores(
         client,
         [{"accuracy": 0.3}, {"accuracy": 0.9}, {"accuracy": 0.6}],
-        eval_name="sort-desc",
+        eval_name=f"sort-{direction}",
     )
     res = client.server.eval_results_query(
         EvalResultsQueryReq(
             project_id=client.project_id,
             evaluation_call_ids=[eval_id],
             include_raw_data_rows=True,
-            sort_by=[EvalResultsSortBy(field="scores.accuracy", direction="desc")],
+            sort_by=[EvalResultsSortBy(field="scores.accuracy", direction=direction)],
         )
     )
     assert res.total_rows == 3
     accuracies = [row.evaluations[0].trials[0].scores["accuracy"] for row in res.rows]
-    assert accuracies == [0.9, 0.6, 0.3]
-
-
-def test_eval_results_sort_by_score_asc(client):
-    """Sort by scores.accuracy ASC should return lowest-scoring row first."""
-    eval_id, _ = _create_eval_with_scores(
-        client,
-        [{"accuracy": 0.3}, {"accuracy": 0.9}, {"accuracy": 0.6}],
-        eval_name="sort-asc",
-    )
-    res = client.server.eval_results_query(
-        EvalResultsQueryReq(
-            project_id=client.project_id,
-            evaluation_call_ids=[eval_id],
-            include_raw_data_rows=True,
-            sort_by=[EvalResultsSortBy(field="scores.accuracy", direction="asc")],
-        )
-    )
-    accuracies = [row.evaluations[0].trials[0].scores["accuracy"] for row in res.rows]
-    assert accuracies == [0.3, 0.6, 0.9]
+    assert accuracies == expected
 
 
 def test_eval_results_filter_score_gte(client):

--- a/tests/trace_server/test_trace_server_interface_util.py
+++ b/tests/trace_server/test_trace_server_interface_util.py
@@ -234,47 +234,60 @@ def _ref_attr_values(
     raise AssertionError(f"no values for {attr_key}")
 
 
-def test_genai_otel_export_rewrites_flat_ref_attrs() -> None:
-    """Flat-dotted `weave.object_refs` array values are rewritten to
-    internal form before reaching the inner trace server.
+def test_genai_otel_export_rewrites_ref_attrs() -> None:
+    """ext->int rewriting of typed `weave.*_refs` OTel arrays: flat-dotted keys
+    (object_refs + content_refs) and the nested `weave` kvlist form both get
+    rewritten, while non-external array elements (already-internal, non-ref
+    strings) pass through unchanged.
     """
     internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
-    req = _make_otel_export_req_with_ref_attrs(
-        {
-            "weave.object_refs": [
-                "weave:///ent/proj/object/a:v1",
-                "weave:///ent/proj/object/b:v1",
-            ],
-            "weave.content_refs": ["weave:///ent/proj/content/c"],
-        }
+
+    flat = _capture_genai_otel_export_req(
+        _make_otel_export_req_with_ref_attrs(
+            {
+                "weave.object_refs": [
+                    "weave:///ent/proj/object/a:v1",
+                    "weave:///ent/proj/object/b:v1",
+                ],
+                "weave.content_refs": ["weave:///ent/proj/content/c"],
+            }
+        )
     )
-
-    forwarded = _capture_genai_otel_export_req(req)
-
-    assert _ref_attr_values(forwarded, "weave.object_refs") == [
+    assert _ref_attr_values(flat, "weave.object_refs") == [
         f"weave-trace-internal:///{internal_proj}/object/a:v1",
         f"weave-trace-internal:///{internal_proj}/object/b:v1",
     ]
-    assert _ref_attr_values(forwarded, "weave.content_refs") == [
+    assert _ref_attr_values(flat, "weave.content_refs") == [
         f"weave-trace-internal:///{internal_proj}/content/c"
     ]
 
-
-def test_genai_otel_export_rewrites_nested_kvlist_ref_attrs() -> None:
-    """The nested `weave` → `object_refs` kvlist form is rewritten too;
-    the walker descends through kvlist children and matches the dotted
-    full key.
-    """
-    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
-    req = _make_otel_export_req_with_ref_attrs(
-        {"object_refs": ["weave:///ent/proj/object/a:v1"]},
-        nest_under_kvlist=True,
+    # Nested `weave` -> `object_refs` kvlist: walker descends and matches the dotted key.
+    nested = _capture_genai_otel_export_req(
+        _make_otel_export_req_with_ref_attrs(
+            {"object_refs": ["weave:///ent/proj/object/a:v1"]},
+            nest_under_kvlist=True,
+        )
     )
-
-    forwarded = _capture_genai_otel_export_req(req)
-
-    assert _ref_attr_values(forwarded, "weave.object_refs") == [
+    assert _ref_attr_values(nested, "weave.object_refs") == [
         f"weave-trace-internal:///{internal_proj}/object/a:v1"
+    ]
+
+    # Only matching external `weave:///` prefixes convert; others pass through.
+    mixed = _capture_genai_otel_export_req(
+        _make_otel_export_req_with_ref_attrs(
+            {
+                "weave.object_refs": [
+                    "weave:///ent/proj/object/a:v1",
+                    "weave-trace-internal:///already-internal/object/b:v1",
+                    "not-a-ref-at-all",
+                ]
+            }
+        )
+    )
+    assert _ref_attr_values(mixed, "weave.object_refs") == [
+        f"weave-trace-internal:///{internal_proj}/object/a:v1",
+        "weave-trace-internal:///already-internal/object/b:v1",
+        "not-a-ref-at-all",
     ]
 
 
@@ -291,29 +304,6 @@ def test_genai_otel_export_leaves_non_ref_attrs_untouched() -> None:
     span = forwarded.processed_spans[0].resource_spans.scope_spans[0].spans[0]
     dump_kv = next(kv for kv in span.attributes if kv.key == "weave.raw_span_dump")
     assert dump_kv.value.string_value == "weave:///should/not/be/rewritten"
-
-
-def test_genai_otel_export_skips_non_external_refs_in_array() -> None:
-    """Array elements that aren't on the external `weave:///` scheme pass
-    through unchanged; only matching prefixes are converted.
-    """
-    internal_proj = _EncodingIdConverter().ext_to_int_project_id("ent/proj")
-    req = _make_otel_export_req_with_ref_attrs(
-        {
-            "weave.object_refs": [
-                "weave:///ent/proj/object/a:v1",
-                "weave-trace-internal:///already-internal/object/b:v1",
-                "not-a-ref-at-all",
-            ]
-        }
-    )
-
-    forwarded = _capture_genai_otel_export_req(req)
-    assert _ref_attr_values(forwarded, "weave.object_refs") == [
-        f"weave-trace-internal:///{internal_proj}/object/a:v1",
-        "weave-trace-internal:///already-internal/object/b:v1",
-        "not-a-ref-at-all",
-    ]
 
 
 def test_genai_otel_export_caches_project_id_lookup_across_batch() -> None:

--- a/tests/trace_server/test_trace_usage.py
+++ b/tests/trace_server/test_trace_usage.py
@@ -175,6 +175,32 @@ def _usage_totals(
     return (prompt_tokens, completion_tokens, total_tokens, requests)
 
 
+def _query_usage(
+    client: weave_client.WeaveClient,
+    api: str,
+    trace_id: str,
+    call_ids: list[str],
+    include_costs: bool = False,
+) -> tsi.TraceUsageRes | tsi.CallsUsageRes:
+    if api == "trace_usage":
+        return client.server.trace_usage(
+            tsi.TraceUsageReq(
+                project_id=client.project_id,
+                filter=tsi.CallsFilter(trace_ids=[trace_id]),
+                include_costs=include_costs,
+            )
+        )
+    if api == "calls_usage":
+        return client.server.calls_usage(
+            tsi.CallsUsageReq(
+                project_id=client.project_id,
+                call_ids=call_ids,
+                include_costs=include_costs,
+            )
+        )
+    raise ValueError(f"unknown usage api: {api}")
+
+
 def test_aggregate_usage_with_descendants_rolls_up() -> None:
     root_id = "root"
     child_a_id = "child-a"
@@ -494,8 +520,8 @@ def test_trace_usage_rolls_up_descendants(client: weave_client.WeaveClient) -> N
     assert child_usage.total_tokens == 7
 
 
-def test_trace_usage_include_costs_flag(client: weave_client.WeaveClient) -> None:
-    project_id = client.project_id
+@pytest.mark.parametrize("api", ["trace_usage", "calls_usage"])
+def test_usage_include_costs_flag(client: weave_client.WeaveClient, api: str) -> None:
     trace_id = str(uuid.uuid4())
     now = datetime.datetime.now(datetime.timezone.utc)
 
@@ -509,38 +535,28 @@ def test_trace_usage_include_costs_flag(client: weave_client.WeaveClient) -> Non
         {"gpt-4": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}},
     )
 
-    res_no_costs = client.server.trace_usage(
-        tsi.TraceUsageReq(
-            project_id=project_id,
-            filter=tsi.CallsFilter(trace_ids=[trace_id]),
-            include_costs=False,
-        )
-    )
+    res_no_costs = _query_usage(client, api, trace_id, [call_id], include_costs=False)
     usage_no_costs = res_no_costs.call_usage[call_id]["gpt-4"]
     assert usage_no_costs.prompt_tokens_total_cost is None
     assert usage_no_costs.completion_tokens_total_cost is None
 
-    res_with_costs = client.server.trace_usage(
-        tsi.TraceUsageReq(
-            project_id=project_id,
-            filter=tsi.CallsFilter(trace_ids=[trace_id]),
-            include_costs=True,
-        )
-    )
+    res_with_costs = _query_usage(client, api, trace_id, [call_id], include_costs=True)
     usage_with_costs = res_with_costs.call_usage[call_id]["gpt-4"]
     assert usage_with_costs.prompt_tokens_total_cost is not None
     assert usage_with_costs.completion_tokens_total_cost is not None
 
 
-def test_trace_usage_returns_unfinished_call_ids(
-    client: weave_client.WeaveClient,
+@pytest.mark.parametrize("api", ["trace_usage", "calls_usage"])
+def test_usage_returns_unfinished_call_ids(
+    client: weave_client.WeaveClient, api: str
 ) -> None:
-    project_id = client.project_id
     trace_id = str(uuid.uuid4())
+    trace_id_two = str(uuid.uuid4())
     now = datetime.datetime.now(datetime.timezone.utc)
 
     root_id = str(uuid.uuid4())
     unfinished_child_id = str(uuid.uuid4())
+    root_id_two = str(uuid.uuid4())
 
     _create_call(
         client,
@@ -557,13 +573,17 @@ def test_trace_usage_returns_unfinished_call_ids(
         root_id,
         now + datetime.timedelta(seconds=2),
     )
-
-    res = client.server.trace_usage(
-        tsi.TraceUsageReq(
-            project_id=project_id,
-            filter=tsi.CallsFilter(trace_ids=[trace_id]),
-        )
+    # calls_usage queries by call_ids, so include a second finished root to query.
+    _create_call(
+        client,
+        root_id_two,
+        trace_id_two,
+        None,
+        now + datetime.timedelta(seconds=4),
+        {"gpt-4": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}},
     )
+
+    res = _query_usage(client, api, trace_id, [root_id, root_id_two])
 
     assert set(res.unfinished_call_ids) == {unfinished_child_id}
 
@@ -628,90 +648,6 @@ def test_calls_usage_rolls_up_descendants(client: weave_client.WeaveClient) -> N
     assert root_two_usage.prompt_tokens == 2
     assert root_two_usage.completion_tokens == 1
     assert root_two_usage.total_tokens == 3
-
-
-def test_calls_usage_include_costs_flag(client: weave_client.WeaveClient) -> None:
-    project_id = client.project_id
-    trace_id = str(uuid.uuid4())
-    now = datetime.datetime.now(datetime.timezone.utc)
-
-    call_id = str(uuid.uuid4())
-    _create_call(
-        client,
-        call_id,
-        trace_id,
-        None,
-        now,
-        {"gpt-4": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}},
-    )
-
-    res_no_costs = client.server.calls_usage(
-        tsi.CallsUsageReq(
-            project_id=project_id,
-            call_ids=[call_id],
-            include_costs=False,
-        )
-    )
-    usage_no_costs = res_no_costs.call_usage[call_id]["gpt-4"]
-    assert usage_no_costs.prompt_tokens_total_cost is None
-    assert usage_no_costs.completion_tokens_total_cost is None
-
-    res_with_costs = client.server.calls_usage(
-        tsi.CallsUsageReq(
-            project_id=project_id,
-            call_ids=[call_id],
-            include_costs=True,
-        )
-    )
-    usage_with_costs = res_with_costs.call_usage[call_id]["gpt-4"]
-    assert usage_with_costs.prompt_tokens_total_cost is not None
-    assert usage_with_costs.completion_tokens_total_cost is not None
-
-
-def test_calls_usage_returns_unfinished_call_ids(
-    client: weave_client.WeaveClient,
-) -> None:
-    project_id = client.project_id
-    trace_id = str(uuid.uuid4())
-    trace_id_two = str(uuid.uuid4())
-    now = datetime.datetime.now(datetime.timezone.utc)
-
-    root_id = str(uuid.uuid4())
-    unfinished_child_id = str(uuid.uuid4())
-    root_id_two = str(uuid.uuid4())
-
-    _create_call(
-        client,
-        root_id,
-        trace_id,
-        None,
-        now,
-        {"gpt-4": {"prompt_tokens": 5, "completion_tokens": 5, "total_tokens": 10}},
-    )
-    _create_unfinished_call(
-        client,
-        unfinished_child_id,
-        trace_id,
-        root_id,
-        now + datetime.timedelta(seconds=2),
-    )
-    _create_call(
-        client,
-        root_id_two,
-        trace_id_two,
-        None,
-        now + datetime.timedelta(seconds=4),
-        {"gpt-4": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3}},
-    )
-
-    res = client.server.calls_usage(
-        tsi.CallsUsageReq(
-            project_id=project_id,
-            call_ids=[root_id, root_id_two],
-        )
-    )
-
-    assert set(res.unfinished_call_ids) == {unfinished_child_id}
 
 
 @pytest.mark.parametrize(

--- a/tests/trace_server/test_url_safety.py
+++ b/tests/trace_server/test_url_safety.py
@@ -8,138 +8,75 @@ from weave.trace_server.helpers.url_safety import is_publicly_routable_url
 
 
 @pytest.mark.parametrize(
-    "url",
+    ("url", "expected"),
     [
-        "https://api.openai.com/v1",
-        "http://my-ollama-server.example.com:11434",
-        "https://cdn.openai.com/foo/bar.png",
-        "https://oaidalleapiprodscus.blob.core.windows.net/private/image.png",
-        "http://images.example.org/x.jpg",
-        "https://example.com:8443/path",
-        "https://example.com./trailing-dot",
-        "http://user:pass@example.com/",
-        "HTTPS://Example.Com/Path",
-        "https://evil.example.com/",
+        # public http(s) urls -> accepted
+        ("https://api.openai.com/v1", True),
+        ("http://my-ollama-server.example.com:11434", True),
+        ("https://cdn.openai.com/foo/bar.png", True),
+        ("https://oaidalleapiprodscus.blob.core.windows.net/private/image.png", True),
+        ("http://images.example.org/x.jpg", True),
+        ("https://example.com:8443/path", True),
+        ("https://example.com./trailing-dot", True),
+        ("http://user:pass@example.com/", True),
+        ("HTTPS://Example.Com/Path", True),
+        ("https://evil.example.com/", True),
+        # non-http schemes -> rejected
+        ("ftp://files.example.com", False),
+        ("file:///etc/passwd", False),
+        ("gopher://internal.svc/", False),
+        ("ws://example.com/", False),
+        ("wss://example.com/", False),
+        ("javascript:alert(1)", False),
+        ("data:text/plain,hello", False),
+        # malformed / hostless -> rejected
+        ("", False),
+        ("not a url", False),
+        ("http:///no-host", False),
+        ("http://", False),
+        ("https://", False),
+        # localhost variants -> rejected
+        ("http://localhost/", False),
+        ("http://localhost", False),
+        ("http://LOCALHOST/path", False),
+        ("http://localhost.localdomain/", False),
+        ("http://ip6-localhost/", False),
+        ("http://ip6-loopback/", False),
+        ("http://foo.localhost/", False),
+        ("http://a.b.localhost/", False),
+        # cloud metadata hostnames -> rejected
+        ("http://metadata.google.internal/", False),
+        ("http://metadata.google.internal./", False),
+        ("http://foo.metadata.google.internal/", False),
+        ("http://metadata.goog/", False),
+        ("http://metadata.internal/", False),
+        ("http://metadata.azure.com/", False),
+        ("http://METADATA.GOOGLE.INTERNAL/", False),
+        # non-global ipv4 (loopback, RFC1918, link-local/IMDS, unspecified/multicast/broadcast)
+        ("http://127.0.0.1/", False),
+        ("http://127.0.0.1:6379/", False),
+        ("http://10.0.0.1/", False),
+        ("http://172.16.0.1/", False),
+        ("http://192.168.1.1/", False),
+        ("http://169.254.169.254/latest/meta-data/", False),
+        ("http://0.0.0.0/", False),
+        ("http://224.0.0.1/", False),
+        ("http://255.255.255.255/", False),
+        # non-global ipv6
+        ("http://[::1]/", False),
+        ("http://[fe80::1]/", False),
+        ("http://[fc00::1]/", False),
+        ("http://[ff00::1]/", False),
+        ("http://[::ffff:169.254.169.254]/", False),
+        ("http://[::ffff:10.0.0.1]/", False),
+        # alternative ipv4 encodings: socket.inet_aton accepts hex/decimal forms that a
+        # naive ipaddress.ip_address check would let through; they must not bypass the check.
+        ("http://0x7f000001/", False),  # hex 127.0.0.1
+        ("http://0xa9fea9fe/", False),  # hex 169.254.169.254
+        ("http://2130706433/", False),  # decimal 127.0.0.1
+        ("http://2852039166/", False),  # decimal 169.254.169.254
+        ("http://0/", False),  # decimal 0.0.0.0
     ],
 )
-def test_accepts_public_http_urls(url: str) -> None:
-    assert is_publicly_routable_url(url) is True
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "ftp://files.example.com",
-        "file:///etc/passwd",
-        "gopher://internal.svc/",
-        "ws://example.com/",
-        "wss://example.com/",
-        "javascript:alert(1)",
-        "data:text/plain,hello",
-    ],
-)
-def test_rejects_non_http_schemes(url: str) -> None:
-    assert is_publicly_routable_url(url) is False
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "",
-        "not a url",
-        "http:///no-host",
-        "http://",
-        "https://",
-    ],
-)
-def test_rejects_malformed_or_hostless(url: str) -> None:
-    assert is_publicly_routable_url(url) is False
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "http://localhost/",
-        "http://localhost",
-        "http://LOCALHOST/path",
-        "http://localhost.localdomain/",
-        "http://ip6-localhost/",
-        "http://ip6-loopback/",
-        "http://foo.localhost/",
-        "http://a.b.localhost/",
-    ],
-)
-def test_rejects_localhost_variants(url: str) -> None:
-    assert is_publicly_routable_url(url) is False
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "http://metadata.google.internal/",
-        "http://metadata.google.internal./",
-        "http://foo.metadata.google.internal/",
-        "http://metadata.goog/",
-        "http://metadata.internal/",
-        "http://metadata.azure.com/",
-        "http://METADATA.GOOGLE.INTERNAL/",
-    ],
-)
-def test_rejects_cloud_metadata_hostnames(url: str) -> None:
-    assert is_publicly_routable_url(url) is False
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        # loopback
-        "http://127.0.0.1/",
-        "http://127.0.0.1:6379/",
-        # private RFC1918
-        "http://10.0.0.1/",
-        "http://172.16.0.1/",
-        "http://192.168.1.1/",
-        # link-local (incl. IMDS)
-        "http://169.254.169.254/latest/meta-data/",
-        # unspecified / multicast / broadcast
-        "http://0.0.0.0/",
-        "http://224.0.0.1/",
-        "http://255.255.255.255/",
-    ],
-)
-def test_rejects_non_global_ipv4(url: str) -> None:
-    assert is_publicly_routable_url(url) is False
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "http://[::1]/",
-        "http://[fe80::1]/",
-        "http://[fc00::1]/",
-        "http://[ff00::1]/",
-        "http://[::ffff:169.254.169.254]/",
-        "http://[::ffff:10.0.0.1]/",
-    ],
-)
-def test_rejects_non_global_ipv6(url: str) -> None:
-    assert is_publicly_routable_url(url) is False
-
-
-@pytest.mark.parametrize(
-    "url",
-    [
-        "http://0x7f000001/",  # hex 127.0.0.1
-        "http://0xa9fea9fe/",  # hex 169.254.169.254
-        "http://2130706433/",  # decimal 127.0.0.1
-        "http://2852039166/",  # decimal 169.254.169.254
-        "http://0/",  # decimal 0.0.0.0
-    ],
-)
-def test_rejects_alt_ipv4_encodings(url: str) -> None:
-    """Alternative IPv4 encodings (hex/decimal) must not bypass the IP check.
-
-    socket.inet_aton accepts these forms; a naive ipaddress.ip_address check
-    would let them through.
-    """
-    assert is_publicly_routable_url(url) is False
+def test_is_publicly_routable_url(url: str, expected: bool) -> None:
+    assert is_publicly_routable_url(url) is expected


### PR DESCRIPTION
## Summary
- Split from #7235. Densify `tests/trace_server` tests into fewer, denser parametrized / multi-assert functions: 43 files, +4923/-8101.

## Testing
per-file coverage-superset gate (each touched file's executed weave/ lines+branches after >= before); tests/trace_server dir run shows no new failures vs master.