### PR TITLE
test(weave): densify tests/trace_server/query_builder suite

### DIFF
--- a/tests/trace_server/query_builder/test_agent_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_query_builder.py
@@ -7,6 +7,7 @@ formatted SQL + param dict against an expected value, matching the style of
 """
 
 import datetime
+from collections.abc import Callable
 
 import pytest
 import sqlparse
@@ -33,6 +34,7 @@ from weave.trace_server.orm import ParamBuilder
 from weave.trace_server.query_builder.agent_query_builder import (
     CHAT_VIEW_COLS,
     SPAN_SORTABLE_COLS,
+    SPANS_DETAILS_COLS,
     SPANS_LIST_COLS,
     build_order_by,
     make_agent_versions_count_query,
@@ -51,269 +53,6 @@ from weave.trace_server.query_builder.agent_query_builder import (
     make_trace_detail_spans_query,
     resolve_group_by,
 )
-
-
-def assert_sql(
-    expected_query: str, expected_params: dict, query: str, params: dict
-) -> None:
-    expected_formatted = sqlparse.format(expected_query, reindent=True).strip()
-    found_formatted = sqlparse.format(query, reindent=True).strip()
-
-    assert expected_formatted == found_formatted, (
-        f"\nExpected:\n{expected_formatted}\n\nGot:\n{found_formatted}"
-    )
-    assert expected_params == params, (
-        f"\nExpected params: {expected_params}\n\nGot params: {params}"
-    )
-
-
-# ============================================================================
-# make_spans_count_query (ungrouped)
-# ============================================================================
-
-
-class TestMakeSpansCountQuery:
-    def test_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_count_query(pb, AgentSpansQueryReq(project_id="p1"))
-
-        expected = "SELECT count() FROM spans s WHERE s.project_id = {genai_0:String}"
-        assert_sql(expected, {"genai_0": "p1"}, query, pb.get_params())
-
-    def test_with_query_and_time(self) -> None:
-        pb = ParamBuilder("genai")
-        start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
-        end = datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc)
-        query = make_spans_count_query(
-            pb,
-            AgentSpansQueryReq(
-                project_id="p1",
-                query=Query.model_validate(
-                    {
-                        "$expr": {
-                            "$and": [
-                                {
-                                    "$eq": [
-                                        {"$getField": "agent.name"},
-                                        {"$literal": "bot"},
-                                    ]
-                                },
-                                {
-                                    "$eq": [
-                                        {"$getField": "custom_attrs_string.env"},
-                                        {"$literal": "prod"},
-                                    ]
-                                },
-                            ]
-                        }
-                    }
-                ),
-                started_after=start,
-                started_before=end,
-            ),
-        )
-
-        expected = """
-            SELECT count() FROM spans s
-            WHERE s.project_id = {genai_0:String}
-              AND s.started_at >= {genai_1:DateTime64(6)}
-              AND s.started_at < {genai_2:DateTime64(6)}
-            AND ((s.agent_name = {genai_3:String}) AND (if(mapContains(s.custom_attrs_string, {genai_4:String}), s.custom_attrs_string[{genai_4:String}], NULL) = {genai_5:String}))
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": start,
-            "genai_2": end,
-            "genai_3": "bot",
-            "genai_4": "env",
-            "genai_5": "prod",
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_rejects_empty_not(self) -> None:
-        pb = ParamBuilder("genai")
-        query = Query.model_construct(
-            expr_=tsi_query.NotOperation.model_construct(not_=())
-        )
-
-        with pytest.raises(ValueError, match="Empty \\$not"):
-            make_spans_count_query(pb, AgentSpansQueryReq(project_id="p1", query=query))
-
-    def test_rejects_null_non_eq_comparison(self) -> None:
-        pb = ParamBuilder("genai")
-        query = Query.model_validate(
-            {
-                "$expr": {
-                    "$gt": [
-                        {"$getField": "input_tokens"},
-                        {"$literal": None},
-                    ]
-                }
-            }
-        )
-
-        with pytest.raises(ValueError, match="Null values are not allowed"):
-            make_spans_count_query(pb, AgentSpansQueryReq(project_id="p1", query=query))
-
-    def test_rejects_mixed_in_literal_types(self) -> None:
-        pb = ParamBuilder("genai")
-        query = Query.model_validate(
-            {
-                "$expr": {
-                    "$in": [
-                        {"$getField": "agent_name"},
-                        [{"$literal": "bot"}, {"$literal": 1}],
-                    ]
-                }
-            }
-        )
-
-        with pytest.raises(ValueError, match="same type"):
-            make_spans_count_query(pb, AgentSpansQueryReq(project_id="p1", query=query))
-
-
-# ============================================================================
-# make_spans_list_query (ungrouped)
-# ============================================================================
-
-
-class TestMakeSpansListQuery:
-    def test_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_list_query(pb, AgentSpansQueryReq(project_id="p1"))
-
-        expected = f"""
-            SELECT {SPANS_LIST_COLS}
-            FROM spans s
-            WHERE s.project_id = {{genai_0:String}}
-            ORDER BY started_at DESC
-            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
-        """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_with_custom_sort(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_list_query(
-            pb,
-            AgentSpansQueryReq(
-                project_id="p1",
-                sort_by=[AgentSortBy(field="input_tokens", direction="asc")],
-            ),
-        )
-
-        expected = f"""
-            SELECT {SPANS_LIST_COLS}
-            FROM spans s
-            WHERE s.project_id = {{genai_0:String}}
-            ORDER BY input_tokens asc
-            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
-        """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_projects_and_sorts_selected_custom_attr_columns(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_list_query(
-            pb,
-            AgentSpansQueryReq(
-                project_id="p1",
-                custom_attr_columns=[
-                    AgentSpanValueRef(source="custom_attrs_float", key="score")
-                ],
-                sort_by=[
-                    AgentSortBy(field="custom_attrs_float.score", direction="desc")
-                ],
-            ),
-        )
-
-        expected = f"""
-            SELECT {SPANS_LIST_COLS}, mapFilter((k, v) -> has({{genai_4:Array(String)}}, k), s.custom_attrs_float) AS custom_attrs_float
-            FROM spans s
-            WHERE s.project_id = {{genai_0:String}}
-            ORDER BY if(mapContains(s.custom_attrs_float, {{genai_3:String}}), toFloat64(s.custom_attrs_float[{{genai_3:String}}]), NULL) desc
-            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": 100,
-            "genai_2": 0,
-            "genai_3": "score",
-            "genai_4": ["score"],
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_limit_rejected_when_above_max(self) -> None:
-        with pytest.raises(ValidationError):
-            AgentSpansQueryReq(project_id="p1", limit=99999)
-
-    def test_limit_rejected_when_negative(self) -> None:
-        with pytest.raises(ValidationError):
-            AgentSpansQueryReq(project_id="p1", limit=-1)
-
-    def test_offset_rejected_when_negative(self) -> None:
-        with pytest.raises(ValidationError):
-            AgentSpansQueryReq(project_id="p1", offset=-1)
-
-    def test_limit_zero_is_honored(self) -> None:
-        pb = ParamBuilder("genai")
-        make_spans_list_query(pb, AgentSpansQueryReq(project_id="p1", limit=0))
-        assert pb.get_params()["genai_1"] == 0
-
-    def test_custom_attr_columns_rejected_with_group_by(self) -> None:
-        """custom_attr_columns project per-span maps and are silently dropped in
-        the grouped path. The validator should reject this combination instead
-        of accepting it and quietly ignoring the projection, symmetric with
-        the existing rule that grouped-only fields (measures, group_filters)
-        require group_by.
-        """
-        with pytest.raises(ValidationError):
-            AgentSpansQueryReq(
-                project_id="p1",
-                group_by=[AgentGroupByRef(source="column", key="agent_name")],
-                custom_attr_columns=[
-                    AgentSpanValueRef(source="custom_attrs_string", key="env")
-                ],
-            )
-
-    def test_include_details_projects_detail_columns(self) -> None:
-        from weave.trace_server.query_builder.agent_query_builder import (
-            SPANS_DETAILS_COLS,
-        )
-
-        pb = ParamBuilder("genai")
-        query = make_spans_list_query(
-            pb, AgentSpansQueryReq(project_id="p1", include_details=True)
-        )
-
-        expected = f"""
-            SELECT {SPANS_LIST_COLS}, {SPANS_DETAILS_COLS}
-            FROM spans s
-            WHERE s.project_id = {{genai_0:String}}
-            ORDER BY started_at DESC
-            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
-        """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_include_details_rejected_with_group_by(self) -> None:
-        """SPANS_DETAILS_COLS is only projected on the ungrouped path. The
-        grouped branch ignores `include_details`, so the validator rejects
-        the combination instead of accepting it and quietly dropping the
-        heavy-fields projection.
-        """
-        with pytest.raises(ValidationError):
-            AgentSpansQueryReq(
-                project_id="p1",
-                group_by=[AgentGroupByRef(source="column", key="agent_name")],
-                include_details=True,
-            )
-
-
-# ============================================================================
-# make_spans_count_query (grouped)
-# ============================================================================
-
 
 #: The fixed aggregate tail emitted by the grouped list query, as it would
 #: appear after ``SELECT <group_cols>,``. Used to keep test expected SQL
@@ -336,78 +75,374 @@ _GROUPED_AGG_TAIL = """count() AS span_count,
                min(s.started_at) AS first_seen,
                max(s.started_at) AS last_seen"""
 
-
-class TestMakeConversationPreviewsQuery:
-    def test_scoped_to_conversation_ids(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_conversation_previews_query(pb, "p1", ["conv-a", "conv-b"])
-        expected = """
-            SELECT s.conversation_id AS conversation_id,
-                   argMinIf(s.input_messages, s.started_at, length(s.input_messages) > 0) AS first_input_messages,
-                   argMaxIf(s.output_messages, s.ended_at, length(s.output_messages) > 0) AS last_output_messages
-            FROM spans s
-            WHERE s.project_id = {genai_0:String} AND s.conversation_id IN {genai_1:Array(String)}
-            GROUP BY conversation_id
-        """
-        assert_sql(
-            expected,
-            {"genai_0": "p1", "genai_1": ["conv-a", "conv-b"]},
-            query,
-            pb.get_params(),
-        )
-
-    def test_applies_time_range(self) -> None:
-        pb = ParamBuilder("genai")
-        start = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-        end = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
-        query = make_conversation_previews_query(
-            pb, "p1", ["conv-a"], started_after=start, started_before=end
-        )
-        # Time bounds let ClickHouse prune partitions / primary-key ranges so the
-        # wide message columns are read for an even smaller slice.
-        assert "s.started_at >= {genai_2:DateTime64(6)}" in query
-        assert "s.started_at < {genai_3:DateTime64(6)}" in query
+_START = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+_END = datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc)
+_MESSAGE_SEARCH_SELECT = """SELECT conversation_id, conversation_name, agent_name,
+                   span_id, trace_id, role,
+                   substring(content, 1, 500) AS content,
+                   lower(hex(content_digest)) AS content_digest, started_at"""
+_CUSTOM_ATTRS_SCHEMA_SELECT = """SELECT tupleElement(attr, 1) AS source,
+                   tupleElement(attr, 2) AS key,
+                   tupleElement(attr, 3) AS value_type,
+                   count() AS span_count"""
+_CUSTOM_ATTRS_SCHEMA_ARRAY_JOIN = """ARRAY JOIN arrayConcat(
+                arrayMap(k -> tuple('custom_attrs_string', k, 'string'), filtered.custom_attrs_string_keys),
+                arrayMap(k -> tuple('custom_attrs_int', k, 'int'), filtered.custom_attrs_int_keys),
+                arrayMap(k -> tuple('custom_attrs_float', k, 'float'), filtered.custom_attrs_float_keys),
+                arrayMap(k -> tuple('custom_attrs_bool', k, 'bool'), filtered.custom_attrs_bool_keys)
+            ) AS attr
+            GROUP BY source, key, value_type
+            ORDER BY span_count DESC, key ASC, source ASC"""
 
 
-class TestMakeGroupedSpansCountQuery:
-    def test_group_by_column(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_count_query(
-            pb,
+# ============================================================================
+# make_spans_count_query (ungrouped)
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    ("req", "expected", "expected_params"),
+    [
+        pytest.param(
+            AgentSpansQueryReq(project_id="p1"),
+            "SELECT count() FROM spans s WHERE s.project_id = {genai_0:String}",
+            {"genai_0": "p1"},
+            id="basic",
+        ),
+        pytest.param(
             AgentSpansQueryReq(
                 project_id="p1",
-                group_by=[AgentGroupByRef(source="column", key="trace_id")],
+                query=Query.model_validate(
+                    {
+                        "$expr": {
+                            "$and": [
+                                {
+                                    "$eq": [
+                                        {"$getField": "agent.name"},
+                                        {"$literal": "bot"},
+                                    ]
+                                },
+                                {
+                                    "$eq": [
+                                        {"$getField": "custom_attrs_string.env"},
+                                        {"$literal": "prod"},
+                                    ]
+                                },
+                            ]
+                        }
+                    }
+                ),
+                started_after=_START,
+                started_before=_END,
             ),
+            """
+            SELECT count() FROM spans s
+            WHERE s.project_id = {genai_0:String}
+              AND s.started_at >= {genai_1:DateTime64(6)}
+              AND s.started_at < {genai_2:DateTime64(6)}
+            AND ((s.agent_name = {genai_3:String}) AND (if(mapContains(s.custom_attrs_string, {genai_4:String}), s.custom_attrs_string[{genai_4:String}], NULL) = {genai_5:String}))
+        """,
+            {
+                "genai_0": "p1",
+                "genai_1": _START,
+                "genai_2": _END,
+                "genai_3": "bot",
+                "genai_4": "env",
+                "genai_5": "prod",
+            },
+            id="with_query_and_time",
+        ),
+    ],
+)
+def test_make_spans_count_query(
+    req: AgentSpansQueryReq, expected: str, expected_params: dict
+) -> None:
+    pb = ParamBuilder("genai")
+    query = make_spans_count_query(pb, req)
+    assert_sql(expected, expected_params, query, pb.get_params())
+
+
+@pytest.mark.parametrize(
+    ("query", "expected_match"),
+    [
+        pytest.param(
+            Query.model_construct(
+                expr_=tsi_query.NotOperation.model_construct(not_=())
+            ),
+            "Empty \\$not",
+            id="empty_not",
+        ),
+        pytest.param(
+            Query.model_validate(
+                {
+                    "$expr": {
+                        "$gt": [
+                            {"$getField": "input_tokens"},
+                            {"$literal": None},
+                        ]
+                    }
+                }
+            ),
+            "Null values are not allowed",
+            id="null_non_eq_comparison",
+        ),
+        pytest.param(
+            Query.model_validate(
+                {
+                    "$expr": {
+                        "$in": [
+                            {"$getField": "agent_name"},
+                            [{"$literal": "bot"}, {"$literal": 1}],
+                        ]
+                    }
+                }
+            ),
+            "same type",
+            id="mixed_in_literal_types",
+        ),
+    ],
+)
+def test_make_spans_count_query_rejects_bad_filter(
+    query: Query, expected_match: str
+) -> None:
+    pb = ParamBuilder("genai")
+    with pytest.raises(ValueError, match=expected_match):
+        make_spans_count_query(pb, AgentSpansQueryReq(project_id="p1", query=query))
+
+
+# ============================================================================
+# make_spans_list_query (ungrouped)
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    ("req", "expected", "expected_params"),
+    [
+        pytest.param(
+            AgentSpansQueryReq(project_id="p1"),
+            f"""
+            SELECT {SPANS_LIST_COLS}
+            FROM spans s
+            WHERE s.project_id = {{genai_0:String}}
+            ORDER BY started_at DESC
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """,
+            {"genai_0": "p1", "genai_1": 100, "genai_2": 0},
+            id="basic",
+        ),
+        pytest.param(
+            AgentSpansQueryReq(
+                project_id="p1",
+                sort_by=[AgentSortBy(field="input_tokens", direction="asc")],
+            ),
+            f"""
+            SELECT {SPANS_LIST_COLS}
+            FROM spans s
+            WHERE s.project_id = {{genai_0:String}}
+            ORDER BY input_tokens asc
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """,
+            {"genai_0": "p1", "genai_1": 100, "genai_2": 0},
+            id="custom_sort",
+        ),
+        pytest.param(
+            AgentSpansQueryReq(
+                project_id="p1",
+                custom_attr_columns=[
+                    AgentSpanValueRef(source="custom_attrs_float", key="score")
+                ],
+                sort_by=[
+                    AgentSortBy(field="custom_attrs_float.score", direction="desc")
+                ],
+            ),
+            f"""
+            SELECT {SPANS_LIST_COLS}, mapFilter((k, v) -> has({{genai_4:Array(String)}}, k), s.custom_attrs_float) AS custom_attrs_float
+            FROM spans s
+            WHERE s.project_id = {{genai_0:String}}
+            ORDER BY if(mapContains(s.custom_attrs_float, {{genai_3:String}}), toFloat64(s.custom_attrs_float[{{genai_3:String}}]), NULL) desc
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """,
+            {
+                "genai_0": "p1",
+                "genai_1": 100,
+                "genai_2": 0,
+                "genai_3": "score",
+                "genai_4": ["score"],
+            },
+            id="custom_attr_columns_projected_and_sorted",
+        ),
+        pytest.param(
+            AgentSpansQueryReq(project_id="p1", include_details=True),
+            f"""
+            SELECT {SPANS_LIST_COLS}, {SPANS_DETAILS_COLS}
+            FROM spans s
+            WHERE s.project_id = {{genai_0:String}}
+            ORDER BY started_at DESC
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """,
+            {"genai_0": "p1", "genai_1": 100, "genai_2": 0},
+            id="include_details_projects_detail_columns",
+        ),
+        pytest.param(
+            AgentSpansQueryReq(project_id="p1", limit=0),
+            f"""
+            SELECT {SPANS_LIST_COLS}
+            FROM spans s
+            WHERE s.project_id = {{genai_0:String}}
+            ORDER BY started_at DESC
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """,
+            {"genai_0": "p1", "genai_1": 0, "genai_2": 0},
+            id="limit_zero_is_honored",
+        ),
+    ],
+)
+def test_make_spans_list_query(
+    req: AgentSpansQueryReq, expected: str, expected_params: dict
+) -> None:
+    pb = ParamBuilder("genai")
+    query = make_spans_list_query(pb, req)
+    assert_sql(expected, expected_params, query, pb.get_params())
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"limit": 99999}, id="limit_above_max"),
+        pytest.param({"limit": -1}, id="limit_negative"),
+        pytest.param({"offset": -1}, id="offset_negative"),
+    ],
+)
+def test_spans_query_req_rejects_limit_offset(kwargs: dict) -> None:
+    with pytest.raises(ValidationError):
+        AgentSpansQueryReq(project_id="p1", **kwargs)
+
+
+@pytest.mark.parametrize(
+    "extra_kwargs",
+    [
+        pytest.param(
+            {
+                "custom_attr_columns": [
+                    AgentSpanValueRef(source="custom_attrs_string", key="env")
+                ]
+            },
+            id="custom_attr_columns_with_group_by",
+        ),
+        pytest.param({"include_details": True}, id="include_details_with_group_by"),
+    ],
+)
+def test_spans_query_req_rejects_ungrouped_only_fields_with_group_by(
+    extra_kwargs: dict,
+) -> None:
+    """custom_attr_columns and include_details only project on the ungrouped
+    path; the validator rejects pairing them with group_by instead of silently
+    dropping the projection.
+    """
+    with pytest.raises(ValidationError):
+        AgentSpansQueryReq(
+            project_id="p1",
+            group_by=[AgentGroupByRef(source="column", key="agent_name")],
+            **extra_kwargs,
         )
 
-        expected = """
+
+# ============================================================================
+# make_conversation_previews_query
+# ============================================================================
+
+
+def test_conversation_previews_scoped_to_conversation_ids() -> None:
+    pb = ParamBuilder("genai")
+    query = make_conversation_previews_query(pb, "p1", ["conv-a", "conv-b"])
+    expected = """
+        SELECT s.conversation_id AS conversation_id,
+               argMinIf(s.input_messages, s.started_at, length(s.input_messages) > 0) AS first_input_messages,
+               argMaxIf(s.output_messages, s.ended_at, length(s.output_messages) > 0) AS last_output_messages
+        FROM spans s
+        WHERE s.project_id = {genai_0:String} AND s.conversation_id IN {genai_1:Array(String)}
+        GROUP BY conversation_id
+    """
+    assert_sql(
+        expected,
+        {"genai_0": "p1", "genai_1": ["conv-a", "conv-b"]},
+        query,
+        pb.get_params(),
+    )
+
+
+def test_conversation_previews_applies_time_range() -> None:
+    pb = ParamBuilder("genai")
+    start = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+    end = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+    query = make_conversation_previews_query(
+        pb, "p1", ["conv-a"], started_after=start, started_before=end
+    )
+    expected = """
+        SELECT s.conversation_id AS conversation_id,
+               argMinIf(s.input_messages, s.started_at, length(s.input_messages) > 0) AS first_input_messages,
+               argMaxIf(s.output_messages, s.ended_at, length(s.output_messages) > 0) AS last_output_messages
+        FROM spans s
+        WHERE s.project_id = {genai_0:String} AND s.conversation_id IN {genai_1:Array(String)}
+          AND s.started_at >= {genai_2:DateTime64(6)}
+          AND s.started_at < {genai_3:DateTime64(6)}
+        GROUP BY conversation_id
+    """
+    assert_sql(
+        expected,
+        {
+            "genai_0": "p1",
+            "genai_1": ["conv-a"],
+            "genai_2": start,
+            "genai_3": end,
+        },
+        query,
+        pb.get_params(),
+    )
+
+
+# ============================================================================
+# make_spans_count_query (grouped)
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    ("group_by", "expected", "expected_params"),
+    [
+        pytest.param(
+            AgentGroupByRef(source="column", key="trace_id"),
+            """
             SELECT count() FROM (
                 SELECT s.trace_id FROM spans s
                 WHERE s.project_id = {genai_0:String}
                 GROUP BY s.trace_id
             )
-        """
-        assert_sql(expected, {"genai_0": "p1"}, query, pb.get_params())
-
-    def test_group_by_custom_attr(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_count_query(
-            pb,
-            AgentSpansQueryReq(
-                project_id="p1",
-                group_by=[AgentGroupByRef(source="custom_attrs_string", key="env")],
-            ),
-        )
-
-        expected = """
+        """,
+            {"genai_0": "p1"},
+            id="group_by_column",
+        ),
+        pytest.param(
+            AgentGroupByRef(source="custom_attrs_string", key="env"),
+            """
             SELECT count() FROM (
                 SELECT if(mapContains(s.custom_attrs_string, {genai_1:String}), s.custom_attrs_string[{genai_1:String}], NULL) FROM spans s
                 WHERE s.project_id = {genai_0:String}
                 GROUP BY if(mapContains(s.custom_attrs_string, {genai_1:String}), s.custom_attrs_string[{genai_1:String}], NULL)
             )
-        """
-        expected_params = {"genai_0": "p1", "genai_1": "env"}
-        assert_sql(expected, expected_params, query, pb.get_params())
+        """,
+            {"genai_0": "p1", "genai_1": "env"},
+            id="group_by_custom_attr",
+        ),
+    ],
+)
+def test_make_grouped_spans_count_query(
+    group_by: AgentGroupByRef, expected: str, expected_params: dict
+) -> None:
+    pb = ParamBuilder("genai")
+    query = make_spans_count_query(
+        pb, AgentSpansQueryReq(project_id="p1", group_by=[group_by])
+    )
+    assert_sql(expected, expected_params, query, pb.get_params())
 
 
 # ============================================================================
@@ -415,18 +450,15 @@ class TestMakeGroupedSpansCountQuery:
 # ============================================================================
 
 
-class TestMakeGroupedSpansListQuery:
-    def test_group_by_trace_id(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_list_query(
-            pb,
+@pytest.mark.parametrize(
+    ("req", "expected", "expected_params"),
+    [
+        pytest.param(
             AgentSpansQueryReq(
                 project_id="p1",
                 group_by=[AgentGroupByRef(source="column", key="trace_id")],
             ),
-        )
-
-        expected = f"""
+            f"""
             SELECT s.trace_id AS trace_id,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
@@ -434,27 +466,18 @@ class TestMakeGroupedSpansListQuery:
             GROUP BY trace_id
             ORDER BY last_seen DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
-        """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_group_by_conversation_id_with_time(self) -> None:
-        pb = ParamBuilder("genai")
-        start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
-        end = datetime.datetime(2026, 2, 1, tzinfo=datetime.timezone.utc)
-        query = make_spans_list_query(
-            pb,
+        """,
+            {"genai_0": "p1", "genai_1": 100, "genai_2": 0},
+            id="group_by_trace_id",
+        ),
+        pytest.param(
             AgentSpansQueryReq(
                 project_id="p1",
-                group_by=[
-                    AgentGroupByRef(source="column", key="conversation_id"),
-                ],
-                started_after=start,
-                started_before=end,
+                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+                started_after=_START,
+                started_before=_END,
             ),
-        )
-
-        expected = f"""
+            f"""
             SELECT s.conversation_id AS conversation_id,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
@@ -464,29 +487,22 @@ class TestMakeGroupedSpansListQuery:
             GROUP BY conversation_id
             ORDER BY last_seen DESC
             LIMIT {{genai_3:UInt64}} OFFSET {{genai_4:UInt64}}
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": start,
-            "genai_2": end,
-            "genai_3": 100,
-            "genai_4": 0,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_group_by_custom_attr(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_list_query(
-            pb,
+        """,
+            {
+                "genai_0": "p1",
+                "genai_1": _START,
+                "genai_2": _END,
+                "genai_3": 100,
+                "genai_4": 0,
+            },
+            id="group_by_conversation_id_with_time",
+        ),
+        pytest.param(
             AgentSpansQueryReq(
                 project_id="p1",
-                group_by=[
-                    AgentGroupByRef(source="custom_attrs_string", key="env"),
-                ],
+                group_by=[AgentGroupByRef(source="custom_attrs_string", key="env")],
             ),
-        )
-
-        expected = f"""
+            f"""
             SELECT if(mapContains(s.custom_attrs_string, {{genai_3:String}}), s.custom_attrs_string[{{genai_3:String}}], NULL) AS env,
                    {_GROUPED_AGG_TAIL}
             FROM spans s
@@ -494,19 +510,16 @@ class TestMakeGroupedSpansListQuery:
             GROUP BY env
             ORDER BY last_seen DESC
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": 100,
-            "genai_2": 0,
-            "genai_3": "env",
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_group_by_multi_column_and_sort_by_alias(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_list_query(
-            pb,
+        """,
+            {
+                "genai_0": "p1",
+                "genai_1": 100,
+                "genai_2": 0,
+                "genai_3": "env",
+            },
+            id="group_by_custom_attr",
+        ),
+        pytest.param(
             AgentSpansQueryReq(
                 project_id="p1",
                 group_by=[
@@ -515,9 +528,7 @@ class TestMakeGroupedSpansListQuery:
                 ],
                 sort_by=[AgentSortBy(field="agent_name", direction="asc")],
             ),
-        )
-
-        expected = f"""
+            f"""
             SELECT s.agent_name AS agent_name,
                    s.request_model AS request_model,
                    {_GROUPED_AGG_TAIL}
@@ -526,14 +537,11 @@ class TestMakeGroupedSpansListQuery:
             GROUP BY agent_name, request_model
             ORDER BY agent_name asc
             LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
-        """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_group_by_with_dynamic_measures_filter_and_sort(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_list_query(
-            pb,
+        """,
+            {"genai_0": "p1", "genai_1": 100, "genai_2": 0},
+            id="group_by_multi_column_and_sort_by_alias",
+        ),
+        pytest.param(
             AgentSpansQueryReq(
                 project_id="p1",
                 group_by=[AgentGroupByRef(source="column", key="conversation_id")],
@@ -579,9 +587,7 @@ class TestMakeGroupedSpansListQuery:
                 ],
                 sort_by=[AgentSortBy(field="avg_score", direction="desc")],
             ),
-        )
-
-        expected = """
+            """
             SELECT s.conversation_id AS conversation_id,
                    {_GROUPED_AGG_TAIL},
                    count() AS spans,
@@ -593,44 +599,19 @@ class TestMakeGroupedSpansListQuery:
             HAVING avgOrNull(if((mapContains(s.custom_attrs_float, {genai_5:String})), toFloat64(s.custom_attrs_float[{genai_5:String}]), NULL)) >= {genai_6:Float64}
             ORDER BY avg_score desc
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
-        """
-        expected = expected.replace("{_GROUPED_AGG_TAIL}", _GROUPED_AGG_TAIL)
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": 100,
-            "genai_2": 0,
-            "genai_3": "execute_tool",
-            "genai_4": "score",
-            "genai_5": "score",
-            "genai_6": 0.5,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_dynamic_measure_rejects_invalid_resolved_aggregation(self) -> None:
-        pb = ParamBuilder("genai")
-        with pytest.raises(ValueError, match="not valid for value_type 'string'"):
-            make_spans_list_query(
-                pb,
-                AgentSpansQueryReq(
-                    project_id="p1",
-                    group_by=[AgentGroupByRef(source="column", key="conversation_id")],
-                    measures=[
-                        AgentSpanMeasureSpec(
-                            alias="bad_sum",
-                            aggregation="sum",
-                            value=AgentSpanValueRef(
-                                source="custom_attrs_string",
-                                key="score",
-                            ),
-                        )
-                    ],
-                ),
-            )
-
-    def test_dynamic_measure_infers_boolean_count_true(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_spans_list_query(
-            pb,
+        """,
+            {
+                "genai_0": "p1",
+                "genai_1": 100,
+                "genai_2": 0,
+                "genai_3": "execute_tool",
+                "genai_4": "score",
+                "genai_5": "score",
+                "genai_6": 0.5,
+            },
+            id="dynamic_measures_filter_and_sort",
+        ),
+        pytest.param(
             AgentSpansQueryReq(
                 project_id="p1",
                 group_by=[AgentGroupByRef(source="column", key="conversation_id")],
@@ -645,9 +626,7 @@ class TestMakeGroupedSpansListQuery:
                     )
                 ],
             ),
-        )
-
-        expected = """
+            """
             SELECT s.conversation_id AS conversation_id,
                    {_GROUPED_AGG_TAIL},
                    countIf((mapContains(s.custom_attrs_bool, {genai_3:String})) AND s.custom_attrs_bool[{genai_3:String}] = 1) AS flagged_count
@@ -656,99 +635,128 @@ class TestMakeGroupedSpansListQuery:
             GROUP BY conversation_id
             ORDER BY flagged_count DESC
             LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
-        """
-        expected = expected.replace("{_GROUPED_AGG_TAIL}", _GROUPED_AGG_TAIL)
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": 100,
-            "genai_2": 0,
-            "genai_3": "flagged",
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
+        """,
+            {
+                "genai_0": "p1",
+                "genai_1": 100,
+                "genai_2": 0,
+                "genai_3": "flagged",
+            },
+            id="dynamic_measure_infers_boolean_count_true",
+        ),
+    ],
+)
+def test_make_grouped_spans_list_query(
+    req: AgentSpansQueryReq, expected: str, expected_params: dict
+) -> None:
+    pb = ParamBuilder("genai")
+    query = make_spans_list_query(pb, req)
+    expected = expected.replace("{_GROUPED_AGG_TAIL}", _GROUPED_AGG_TAIL)
+    assert_sql(expected, expected_params, query, pb.get_params())
 
-    def test_dynamic_measure_rejects_fixed_field_alias_collision(self) -> None:
-        with pytest.raises(
-            ValidationError,
-            match="measure aliases collide with grouped row fields: \\['span_count'\\]",
-        ):
+
+@pytest.mark.parametrize(
+    ("measures", "expected_match"),
+    [
+        pytest.param(
+            [
+                AgentSpanMeasureSpec(
+                    alias="span_count",
+                    aggregation="count",
+                )
+            ],
+            "measure aliases collide with grouped row fields: \\['span_count'\\]",
+            id="alias_collides_with_fixed_field",
+        ),
+        pytest.param(
+            [
+                AgentSpanMeasureSpec(
+                    alias="conversation_id",
+                    aggregation="count",
+                )
+            ],
+            "measure aliases collide with grouped row fields: \\['conversation_id'\\]",
+            id="alias_collides_with_group_key",
+        ),
+    ],
+)
+def test_spans_query_req_rejects_measure_alias_collision(
+    measures: list[AgentSpanMeasureSpec], expected_match: str
+) -> None:
+    with pytest.raises(ValidationError, match=expected_match):
+        AgentSpansQueryReq(
+            project_id="p1",
+            group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+            measures=measures,
+        )
+
+
+@pytest.mark.parametrize(
+    ("req", "expected_match"),
+    [
+        pytest.param(
             AgentSpansQueryReq(
                 project_id="p1",
                 group_by=[AgentGroupByRef(source="column", key="conversation_id")],
                 measures=[
                     AgentSpanMeasureSpec(
-                        alias="span_count",
-                        aggregation="count",
+                        alias="bad_sum",
+                        aggregation="sum",
+                        value=AgentSpanValueRef(
+                            source="custom_attrs_string",
+                            key="score",
+                        ),
                     )
                 ],
-            )
-
-    def test_dynamic_measure_rejects_group_key_alias_collision(self) -> None:
-        with pytest.raises(
-            ValidationError,
-            match=(
-                "measure aliases collide with grouped row fields: "
-                "\\['conversation_id'\\]"
             ),
-        ):
+            "not valid for value_type 'string'",
+            id="invalid_resolved_aggregation",
+        ),
+        pytest.param(
             AgentSpansQueryReq(
                 project_id="p1",
                 group_by=[AgentGroupByRef(source="column", key="conversation_id")],
-                measures=[
-                    AgentSpanMeasureSpec(
-                        alias="conversation_id",
-                        aggregation="count",
+                measures=[AgentSpanMeasureSpec(alias="spans", aggregation="count")],
+                group_filters=[
+                    AgentSpanGroupFilter(
+                        measure=AgentSpanMeasureSpec(
+                            alias="spans",
+                            aggregation="count",
+                        ),
+                        min=datetime.datetime(2026, 1, 1),
                     )
                 ],
-            )
-
-    def test_group_filter_rejects_mismatched_datetime_bound(self) -> None:
-        pb = ParamBuilder("genai")
-        with pytest.raises(
-            ValueError,
-            match="datetime group filter bounds require a datetime measure",
-        ):
-            make_spans_list_query(
-                pb,
-                AgentSpansQueryReq(
-                    project_id="p1",
-                    group_by=[AgentGroupByRef(source="column", key="conversation_id")],
-                    measures=[AgentSpanMeasureSpec(alias="spans", aggregation="count")],
-                    group_filters=[
-                        AgentSpanGroupFilter(
-                            measure=AgentSpanMeasureSpec(
-                                alias="spans",
-                                aggregation="count",
-                            ),
-                            min=datetime.datetime(2026, 1, 1),
-                        )
-                    ],
-                ),
-            )
-
-    def test_group_filter_rejects_mismatched_group_by(self) -> None:
-        pb = ParamBuilder("genai")
-        with pytest.raises(
-            ValueError,
-            match="spans list group_filters must use the same group_by",
-        ):
-            make_spans_list_query(
-                pb,
-                AgentSpansQueryReq(
-                    project_id="p1",
-                    group_by=[AgentGroupByRef(source="column", key="conversation_id")],
-                    measures=[AgentSpanMeasureSpec(alias="spans", aggregation="count")],
-                    group_filters=[
-                        AgentSpanGroupFilter(
-                            group_by=[AgentGroupByRef(source="column", key="trace_id")],
-                            measure=AgentSpanMeasureSpec(
-                                alias="spans",
-                                aggregation="count",
-                            ),
-                            min=1,
-                        )
-                    ],
-                ),
-            )
+            ),
+            "datetime group filter bounds require a datetime measure",
+            id="mismatched_datetime_bound",
+        ),
+        pytest.param(
+            AgentSpansQueryReq(
+                project_id="p1",
+                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+                measures=[AgentSpanMeasureSpec(alias="spans", aggregation="count")],
+                group_filters=[
+                    AgentSpanGroupFilter(
+                        group_by=[AgentGroupByRef(source="column", key="trace_id")],
+                        measure=AgentSpanMeasureSpec(
+                            alias="spans",
+                            aggregation="count",
+                        ),
+                        min=1,
+                    )
+                ],
+            ),
+            "spans list group_filters must use the same group_by",
+            id="mismatched_group_by",
+        ),
+    ],
+)
+def test_make_grouped_spans_list_query_builder_errors(
+    req: AgentSpansQueryReq, expected_match: str
+) -> None:
+    pb = ParamBuilder("genai")
+    with pytest.raises(ValueError, match=expected_match):
+        make_spans_list_query(pb, req)
 
 
 # ============================================================================
@@ -756,197 +764,197 @@ class TestMakeGroupedSpansListQuery:
 # ============================================================================
 
 
-class TestMakeSpanGroupDistributionQueries:
-    def test_numeric_distributions_query_batches_specs(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_span_group_numeric_distributions_query(
-            pb,
-            AgentSpansQueryReq(
-                project_id="p1",
-                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+def test_numeric_distributions_query_batches_specs() -> None:
+    pb = ParamBuilder("genai")
+    query = make_span_group_numeric_distributions_query(
+        pb,
+        AgentSpansQueryReq(
+            project_id="p1",
+            group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+        ),
+        ["conv-a", None, 12],
+        [
+            AgentSpanGroupDistributionSpec(
+                alias="score_distribution",
+                value=AgentSpanValueRef(source="custom_attrs_float", key="score"),
+                bins=4,
             ),
-            ["conv-a", None, 12],
-            [
-                AgentSpanGroupDistributionSpec(
-                    alias="score_distribution",
-                    value=AgentSpanValueRef(source="custom_attrs_float", key="score"),
-                    bins=4,
-                ),
-                AgentSpanGroupDistributionSpec(
-                    alias="latency_distribution",
-                    value=AgentSpanValueRef(source="custom_attrs_int", key="latency"),
-                    bins=3,
-                ),
-            ],
-        )
-
-        expected = """
-            WITH
-              value_rows AS (
-                SELECT group_key,
-                       alias,
-                       bins,
-                       value
-                FROM (
-                  SELECT toString(s.conversation_id) AS group_key,
-                         tupleElement(spec, 1) AS alias,
-                         tupleElement(spec, 4) AS bins,
-                         multiIf(tupleElement(spec, 2) = 'custom_attrs_int', toFloat64(s.custom_attrs_int[tupleElement(spec, 3)]), tupleElement(spec, 2) = 'custom_attrs_float', toFloat64(s.custom_attrs_float[tupleElement(spec, 3)]), NULL) AS value
-                  FROM spans s
-                  ARRAY JOIN array(tuple({genai_2:String}, {genai_3:String}, {genai_4:String}, {genai_5:UInt64}), tuple({genai_6:String}, {genai_7:String}, {genai_8:String}, {genai_9:UInt64})) AS spec
-                  WHERE s.project_id = {genai_0:String}
-                    AND toString(s.conversation_id) IN {genai_1:Array(String)}
-                    AND multiIf(tupleElement(spec, 2) = 'custom_attrs_int', mapContains(s.custom_attrs_int, tupleElement(spec, 3)), tupleElement(spec, 2) = 'custom_attrs_float', mapContains(s.custom_attrs_float, tupleElement(spec, 3)), false)
-                )
-                WHERE isNotNull(value)
-                  AND isFinite(value)
-              ),
-              bounds AS (
-                SELECT group_key,
-                       alias,
-                       bins,
-                       min(value) AS min_value,
-                       max(value) AS max_value,
-                       count() AS present_count
-                FROM value_rows
-                GROUP BY group_key, alias, bins
-              ),
-              all_buckets AS (
-                SELECT group_key,
-                       alias,
-                       bins,
-                       toUInt64(bucket_index) AS bucket_index
-                FROM bounds
-                ARRAY JOIN range(bins) AS bucket_index
-              ),
-              aggregated AS (
-                SELECT value_rows.group_key AS group_key,
-                       value_rows.alias AS alias,
-                       if(bounds.max_value = bounds.min_value, toUInt64(0), toUInt64(least(toFloat64(bounds.bins) - 1.0, floor((value_rows.value - bounds.min_value) / if(bounds.max_value > bounds.min_value, (bounds.max_value - bounds.min_value) / toFloat64(bounds.bins), 1.0))))) AS bucket_index,
-                       count() AS bin_count
-                FROM value_rows
-                INNER JOIN bounds
-                  ON value_rows.group_key = bounds.group_key
-                 AND value_rows.alias = bounds.alias
-                GROUP BY group_key, alias, bucket_index
-              )
-            SELECT bounds.group_key AS group_key,
-                   bounds.alias AS alias,
-                   all_buckets.bucket_index AS bucket_index,
-                   if(bounds.max_value = bounds.min_value, bounds.min_value, bounds.min_value + toFloat64(all_buckets.bucket_index) * if(bounds.max_value > bounds.min_value, (bounds.max_value - bounds.min_value) / toFloat64(bounds.bins), 1.0)) AS bucket_min,
-                   if(bounds.max_value = bounds.min_value, bounds.max_value, if(all_buckets.bucket_index = bounds.bins - toUInt64(1), bounds.max_value, bounds.min_value + toFloat64(all_buckets.bucket_index + 1) * if(bounds.max_value > bounds.min_value, (bounds.max_value - bounds.min_value) / toFloat64(bounds.bins), 1.0))) AS bucket_max,
-                   ifNull(aggregated.bin_count, 0) AS count,
-                   bounds.present_count AS present_count
-            FROM bounds
-            INNER JOIN all_buckets
-              ON all_buckets.group_key = bounds.group_key
-             AND all_buckets.alias = bounds.alias
-            LEFT JOIN aggregated
-              ON aggregated.group_key = bounds.group_key
-             AND aggregated.alias = bounds.alias
-             AND aggregated.bucket_index = all_buckets.bucket_index
-            WHERE bounds.present_count > 0
-              AND (
-                bounds.max_value > bounds.min_value
-                OR all_buckets.bucket_index = 0
-              )
-            ORDER BY group_key ASC, alias ASC, bucket_index ASC
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": ["conv-a", "", "12"],
-            "genai_2": "score_distribution",
-            "genai_3": "custom_attrs_float",
-            "genai_4": "score",
-            "genai_5": 4,
-            "genai_6": "latency_distribution",
-            "genai_7": "custom_attrs_int",
-            "genai_8": "latency",
-            "genai_9": 3,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_categorical_distributions_query_batches_specs(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_span_group_categorical_distributions_query(
-            pb,
-            AgentSpansQueryReq(
-                project_id="p1",
-                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+            AgentSpanGroupDistributionSpec(
+                alias="latency_distribution",
+                value=AgentSpanValueRef(source="custom_attrs_int", key="latency"),
+                bins=3,
             ),
-            ["conv-a"],
-            [
-                AgentSpanGroupDistributionSpec(
-                    alias="env_distribution",
-                    value=AgentSpanValueRef(source="custom_attrs_string", key="env"),
-                    top_n=2,
-                ),
-                AgentSpanGroupDistributionSpec(
-                    alias="cached_distribution",
-                    value=AgentSpanValueRef(source="custom_attrs_bool", key="cached"),
-                    top_n=2,
-                ),
-            ],
-        )
+        ],
+    )
 
-        expected = """
-            WITH
-              value_counts AS (
-                SELECT group_key,
-                       alias,
-                       raw_value,
-                       top_n,
-                       count() AS value_count
-                FROM (
-                  SELECT toString(s.conversation_id) AS group_key,
-                         tupleElement(spec, 1) AS alias,
-                         tupleElement(spec, 4) AS top_n,
-                         multiIf(tupleElement(spec, 2) = 'custom_attrs_bool', if(s.custom_attrs_bool[tupleElement(spec, 3)] = 1, 'true', 'false'), tupleElement(spec, 2) = 'custom_attrs_string', toString(s.custom_attrs_string[tupleElement(spec, 3)]), '') AS raw_value
-                  FROM spans s
-                  ARRAY JOIN array(tuple({genai_2:String}, {genai_3:String}, {genai_4:String}, {genai_5:UInt64}), tuple({genai_6:String}, {genai_7:String}, {genai_8:String}, {genai_9:UInt64})) AS spec
-                  WHERE s.project_id = {genai_0:String}
-                    AND toString(s.conversation_id) IN {genai_1:Array(String)}
-                    AND multiIf(tupleElement(spec, 2) = 'custom_attrs_string', mapContains(s.custom_attrs_string, tupleElement(spec, 3)), tupleElement(spec, 2) = 'custom_attrs_bool', mapContains(s.custom_attrs_bool, tupleElement(spec, 3)), false)
-                )
-                GROUP BY group_key, alias, raw_value, top_n
-              ),
-              ranked AS (
-                SELECT group_key,
-                       alias,
-                       raw_value,
-                       top_n,
-                       value_count,
-                       sum(value_count) OVER (
-                         PARTITION BY group_key, alias
-                       ) AS present_count,
-                       row_number() OVER (
-                         PARTITION BY group_key, alias
-                         ORDER BY value_count DESC, raw_value ASC
-                       ) AS value_rank
-                FROM value_counts
-              )
+    expected = """
+        WITH
+          value_rows AS (
             SELECT group_key,
                    alias,
-                   substring(raw_value, 1, 256) AS value,
-                   value_count AS count,
-                   present_count
-            FROM ranked
-            WHERE value_rank <= top_n
-            ORDER BY group_key ASC, alias ASC, count DESC, raw_value ASC
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": ["conv-a"],
-            "genai_2": "env_distribution",
-            "genai_3": "custom_attrs_string",
-            "genai_4": "env",
-            "genai_5": 2,
-            "genai_6": "cached_distribution",
-            "genai_7": "custom_attrs_bool",
-            "genai_8": "cached",
-            "genai_9": 2,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
+                   bins,
+                   value
+            FROM (
+              SELECT toString(s.conversation_id) AS group_key,
+                     tupleElement(spec, 1) AS alias,
+                     tupleElement(spec, 4) AS bins,
+                     multiIf(tupleElement(spec, 2) = 'custom_attrs_int', toFloat64(s.custom_attrs_int[tupleElement(spec, 3)]), tupleElement(spec, 2) = 'custom_attrs_float', toFloat64(s.custom_attrs_float[tupleElement(spec, 3)]), NULL) AS value
+              FROM spans s
+              ARRAY JOIN array(tuple({genai_2:String}, {genai_3:String}, {genai_4:String}, {genai_5:UInt64}), tuple({genai_6:String}, {genai_7:String}, {genai_8:String}, {genai_9:UInt64})) AS spec
+              WHERE s.project_id = {genai_0:String}
+                AND toString(s.conversation_id) IN {genai_1:Array(String)}
+                AND multiIf(tupleElement(spec, 2) = 'custom_attrs_int', mapContains(s.custom_attrs_int, tupleElement(spec, 3)), tupleElement(spec, 2) = 'custom_attrs_float', mapContains(s.custom_attrs_float, tupleElement(spec, 3)), false)
+            )
+            WHERE isNotNull(value)
+              AND isFinite(value)
+          ),
+          bounds AS (
+            SELECT group_key,
+                   alias,
+                   bins,
+                   min(value) AS min_value,
+                   max(value) AS max_value,
+                   count() AS present_count
+            FROM value_rows
+            GROUP BY group_key, alias, bins
+          ),
+          all_buckets AS (
+            SELECT group_key,
+                   alias,
+                   bins,
+                   toUInt64(bucket_index) AS bucket_index
+            FROM bounds
+            ARRAY JOIN range(bins) AS bucket_index
+          ),
+          aggregated AS (
+            SELECT value_rows.group_key AS group_key,
+                   value_rows.alias AS alias,
+                   if(bounds.max_value = bounds.min_value, toUInt64(0), toUInt64(least(toFloat64(bounds.bins) - 1.0, floor((value_rows.value - bounds.min_value) / if(bounds.max_value > bounds.min_value, (bounds.max_value - bounds.min_value) / toFloat64(bounds.bins), 1.0))))) AS bucket_index,
+                   count() AS bin_count
+            FROM value_rows
+            INNER JOIN bounds
+              ON value_rows.group_key = bounds.group_key
+             AND value_rows.alias = bounds.alias
+            GROUP BY group_key, alias, bucket_index
+          )
+        SELECT bounds.group_key AS group_key,
+               bounds.alias AS alias,
+               all_buckets.bucket_index AS bucket_index,
+               if(bounds.max_value = bounds.min_value, bounds.min_value, bounds.min_value + toFloat64(all_buckets.bucket_index) * if(bounds.max_value > bounds.min_value, (bounds.max_value - bounds.min_value) / toFloat64(bounds.bins), 1.0)) AS bucket_min,
+               if(bounds.max_value = bounds.min_value, bounds.max_value, if(all_buckets.bucket_index = bounds.bins - toUInt64(1), bounds.max_value, bounds.min_value + toFloat64(all_buckets.bucket_index + 1) * if(bounds.max_value > bounds.min_value, (bounds.max_value - bounds.min_value) / toFloat64(bounds.bins), 1.0))) AS bucket_max,
+               ifNull(aggregated.bin_count, 0) AS count,
+               bounds.present_count AS present_count
+        FROM bounds
+        INNER JOIN all_buckets
+          ON all_buckets.group_key = bounds.group_key
+         AND all_buckets.alias = bounds.alias
+        LEFT JOIN aggregated
+          ON aggregated.group_key = bounds.group_key
+         AND aggregated.alias = bounds.alias
+         AND aggregated.bucket_index = all_buckets.bucket_index
+        WHERE bounds.present_count > 0
+          AND (
+            bounds.max_value > bounds.min_value
+            OR all_buckets.bucket_index = 0
+          )
+        ORDER BY group_key ASC, alias ASC, bucket_index ASC
+    """
+    expected_params = {
+        "genai_0": "p1",
+        "genai_1": ["conv-a", "", "12"],
+        "genai_2": "score_distribution",
+        "genai_3": "custom_attrs_float",
+        "genai_4": "score",
+        "genai_5": 4,
+        "genai_6": "latency_distribution",
+        "genai_7": "custom_attrs_int",
+        "genai_8": "latency",
+        "genai_9": 3,
+    }
+    assert_sql(expected, expected_params, query, pb.get_params())
+
+
+def test_categorical_distributions_query_batches_specs() -> None:
+    pb = ParamBuilder("genai")
+    query = make_span_group_categorical_distributions_query(
+        pb,
+        AgentSpansQueryReq(
+            project_id="p1",
+            group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+        ),
+        ["conv-a"],
+        [
+            AgentSpanGroupDistributionSpec(
+                alias="env_distribution",
+                value=AgentSpanValueRef(source="custom_attrs_string", key="env"),
+                top_n=2,
+            ),
+            AgentSpanGroupDistributionSpec(
+                alias="cached_distribution",
+                value=AgentSpanValueRef(source="custom_attrs_bool", key="cached"),
+                top_n=2,
+            ),
+        ],
+    )
+
+    expected = """
+        WITH
+          value_counts AS (
+            SELECT group_key,
+                   alias,
+                   raw_value,
+                   top_n,
+                   count() AS value_count
+            FROM (
+              SELECT toString(s.conversation_id) AS group_key,
+                     tupleElement(spec, 1) AS alias,
+                     tupleElement(spec, 4) AS top_n,
+                     multiIf(tupleElement(spec, 2) = 'custom_attrs_bool', if(s.custom_attrs_bool[tupleElement(spec, 3)] = 1, 'true', 'false'), tupleElement(spec, 2) = 'custom_attrs_string', toString(s.custom_attrs_string[tupleElement(spec, 3)]), '') AS raw_value
+              FROM spans s
+              ARRAY JOIN array(tuple({genai_2:String}, {genai_3:String}, {genai_4:String}, {genai_5:UInt64}), tuple({genai_6:String}, {genai_7:String}, {genai_8:String}, {genai_9:UInt64})) AS spec
+              WHERE s.project_id = {genai_0:String}
+                AND toString(s.conversation_id) IN {genai_1:Array(String)}
+                AND multiIf(tupleElement(spec, 2) = 'custom_attrs_string', mapContains(s.custom_attrs_string, tupleElement(spec, 3)), tupleElement(spec, 2) = 'custom_attrs_bool', mapContains(s.custom_attrs_bool, tupleElement(spec, 3)), false)
+            )
+            GROUP BY group_key, alias, raw_value, top_n
+          ),
+          ranked AS (
+            SELECT group_key,
+                   alias,
+                   raw_value,
+                   top_n,
+                   value_count,
+                   sum(value_count) OVER (
+                     PARTITION BY group_key, alias
+                   ) AS present_count,
+                   row_number() OVER (
+                     PARTITION BY group_key, alias
+                     ORDER BY value_count DESC, raw_value ASC
+                   ) AS value_rank
+            FROM value_counts
+          )
+        SELECT group_key,
+               alias,
+               substring(raw_value, 1, 256) AS value,
+               value_count AS count,
+               present_count
+        FROM ranked
+        WHERE value_rank <= top_n
+        ORDER BY group_key ASC, alias ASC, count DESC, raw_value ASC
+    """
+    expected_params = {
+        "genai_0": "p1",
+        "genai_1": ["conv-a"],
+        "genai_2": "env_distribution",
+        "genai_3": "custom_attrs_string",
+        "genai_4": "env",
+        "genai_5": 2,
+        "genai_6": "cached_distribution",
+        "genai_7": "custom_attrs_bool",
+        "genai_8": "cached",
+        "genai_9": 2,
+    }
+    assert_sql(expected, expected_params, query, pb.get_params())
 
 
 # ============================================================================
@@ -954,61 +962,63 @@ class TestMakeSpanGroupDistributionQueries:
 # ============================================================================
 
 
-class TestResolveGroupBy:
-    def test_rejects_non_allowlisted_column(self) -> None:
-        pb = ParamBuilder("genai")
-        with pytest.raises(ValueError, match="not in the allowlist"):
-            resolve_group_by(
-                pb, [AgentGroupByRef(source="column", key="raw_span_dump")]
-            )
+@pytest.mark.parametrize(
+    ("refs", "expected_match"),
+    [
+        pytest.param(
+            [AgentGroupByRef(source="column", key="raw_span_dump")],
+            "not in the allowlist",
+            id="non_allowlisted_column",
+        ),
+        pytest.param(
+            [
+                AgentGroupByRef(source="field", key="agent.name"),
+                AgentGroupByRef(source="column", key="agent_name"),
+            ],
+            "duplicate group_by alias",
+            id="duplicate_alias",
+        ),
+        pytest.param(
+            [
+                AgentGroupByRef(
+                    source="custom_attrs_string",
+                    key="has spaces",
+                    alias="bad alias",
+                )
+            ],
+            "must match",
+            id="invalid_alias",
+        ),
+    ],
+)
+def test_resolve_group_by_rejects(
+    refs: list[AgentGroupByRef], expected_match: str
+) -> None:
+    pb = ParamBuilder("genai")
+    with pytest.raises(ValueError, match=expected_match):
+        resolve_group_by(pb, refs)
 
-    def test_rejects_duplicate_alias(self) -> None:
-        pb = ParamBuilder("genai")
-        with pytest.raises(ValueError, match="duplicate group_by alias"):
-            resolve_group_by(
-                pb,
-                [
-                    AgentGroupByRef(source="field", key="agent.name"),
-                    AgentGroupByRef(source="column", key="agent_name"),
-                ],
-            )
 
-    def test_field_source_resolves_semconv_key(self) -> None:
-        pb = ParamBuilder("genai")
-        out = resolve_group_by(pb, [AgentGroupByRef(source="field", key="agent.name")])
-        assert out == [("s.agent_name", "agent_name")]
-
-    def test_rejects_invalid_alias(self) -> None:
-        pb = ParamBuilder("genai")
-        with pytest.raises(ValueError, match="must match"):
-            resolve_group_by(
-                pb,
-                [
-                    AgentGroupByRef(
-                        source="custom_attrs_string",
-                        key="has spaces",
-                        alias="bad alias",
-                    )
-                ],
-            )
-
-    def test_defaults_alias_to_key_when_valid(self) -> None:
-        pb = ParamBuilder("genai")
-        out = resolve_group_by(
-            pb, [AgentGroupByRef(source="custom_attrs_string", key="env")]
-        )
-        assert out == [
-            (
-                "if(mapContains(s.custom_attrs_string, {genai_0:String}), "
-                "s.custom_attrs_string[{genai_0:String}], NULL)",
-                "env",
-            )
-        ]
-
-    def test_custom_alias_used_when_key_non_identifier(self) -> None:
-        pb = ParamBuilder("genai")
-        out = resolve_group_by(
-            pb,
+@pytest.mark.parametrize(
+    ("refs", "expected"),
+    [
+        pytest.param(
+            [AgentGroupByRef(source="field", key="agent.name")],
+            [("s.agent_name", "agent_name")],
+            id="field_source_resolves_semconv_key",
+        ),
+        pytest.param(
+            [AgentGroupByRef(source="custom_attrs_string", key="env")],
+            [
+                (
+                    "if(mapContains(s.custom_attrs_string, {genai_0:String}), "
+                    "s.custom_attrs_string[{genai_0:String}], NULL)",
+                    "env",
+                )
+            ],
+            id="defaults_alias_to_key_when_valid",
+        ),
+        pytest.param(
             [
                 AgentGroupByRef(
                     source="custom_attrs_string",
@@ -1016,14 +1026,22 @@ class TestResolveGroupBy:
                     alias="spaced_attr",
                 )
             ],
-        )
-        assert out == [
-            (
-                "if(mapContains(s.custom_attrs_string, {genai_0:String}), "
-                "s.custom_attrs_string[{genai_0:String}], NULL)",
-                "spaced_attr",
-            )
-        ]
+            [
+                (
+                    "if(mapContains(s.custom_attrs_string, {genai_0:String}), "
+                    "s.custom_attrs_string[{genai_0:String}], NULL)",
+                    "spaced_attr",
+                )
+            ],
+            id="custom_alias_used_when_key_non_identifier",
+        ),
+    ],
+)
+def test_resolve_group_by_success(
+    refs: list[AgentGroupByRef], expected: list[tuple[str, str]]
+) -> None:
+    pb = ParamBuilder("genai")
+    assert resolve_group_by(pb, refs) == expected
 
 
 # ============================================================================
@@ -1031,101 +1049,103 @@ class TestResolveGroupBy:
 # ============================================================================
 
 
-class TestMakeTraceDetailSpansQuery:
-    def test_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_trace_detail_spans_query(pb, "p1", "t1")
+def test_make_trace_detail_spans_query() -> None:
+    pb = ParamBuilder("genai")
+    query = make_trace_detail_spans_query(pb, "p1", "t1")
 
-        expected = f"""
-            SELECT {CHAT_VIEW_COLS} FROM spans s
-            WHERE s.project_id = {{genai_0:String}}
-            AND s.trace_id = {{genai_1:String}}
-            ORDER BY s.started_at ASC
-        """
-        assert_sql(
-            expected,
-            {"genai_0": "p1", "genai_1": "t1"},
-            query,
-            pb.get_params(),
-        )
+    expected = f"""
+        SELECT {CHAT_VIEW_COLS} FROM spans s
+        WHERE s.project_id = {{genai_0:String}}
+        AND s.trace_id = {{genai_1:String}}
+        ORDER BY s.started_at ASC
+    """
+    assert_sql(
+        expected,
+        {"genai_0": "p1", "genai_1": "t1"},
+        query,
+        pb.get_params(),
+    )
 
 
 # ============================================================================
 # make_agents_count_query / make_agents_list_query
 # ============================================================================
 
+_AGENTS_LIST_SELECT = """SELECT agent_name,
+               sum(invocation_count) AS invocation_count,
+               sum(span_count) AS span_count,
+               sum(total_input_tokens) AS total_input_tokens,
+               sum(total_output_tokens) AS total_output_tokens,
+               sum(total_duration_ms) AS total_duration_ms,
+               sum(error_count) AS error_count,
+               min(first_seen) AS first_seen,
+               max(last_seen) AS last_seen"""
 
-class TestMakeAgentsQueries:
-    def test_count_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_agents_count_query(pb, AgentsQueryReq(project_id="p1"))
 
-        expected = """
+@pytest.mark.parametrize(
+    ("builder", "req", "expected", "expected_params"),
+    [
+        pytest.param(
+            make_agents_count_query,
+            AgentsQueryReq(project_id="p1"),
+            """
             SELECT count() FROM (
                 SELECT agent_name FROM agents
                 WHERE project_id = {genai_0:String}
                 GROUP BY agent_name
             )
-        """
-        assert_sql(expected, {"genai_0": "p1"}, query, pb.get_params())
-
-    def test_list_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_agents_list_query(pb, AgentsQueryReq(project_id="p1"))
-
-        expected = """
-            SELECT agent_name,
-                   sum(invocation_count) AS invocation_count,
-                   sum(span_count) AS span_count,
-                   sum(total_input_tokens) AS total_input_tokens,
-                   sum(total_output_tokens) AS total_output_tokens,
-                   sum(total_duration_ms) AS total_duration_ms,
-                   sum(error_count) AS error_count,
-                   min(first_seen) AS first_seen,
-                   max(last_seen) AS last_seen
+        """,
+            {"genai_0": "p1"},
+            id="count_basic",
+        ),
+        pytest.param(
+            make_agents_list_query,
+            AgentsQueryReq(project_id="p1"),
+            f"""
+            {_AGENTS_LIST_SELECT}
             FROM agents
-            WHERE project_id = {genai_0:String}
+            WHERE project_id = {{genai_0:String}}
             GROUP BY agent_name
             ORDER BY last_seen DESC, agent_name
-            LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
-        """
-        expected_params = {"genai_0": "p1", "genai_1": 100, "genai_2": 0}
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_list_with_filter(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_agents_list_query(
-            pb,
+            LIMIT {{genai_1:UInt64}} OFFSET {{genai_2:UInt64}}
+        """,
+            {"genai_0": "p1", "genai_1": 100, "genai_2": 0},
+            id="list_basic",
+        ),
+        pytest.param(
+            make_agents_list_query,
             AgentsQueryReq(
                 project_id="p1",
                 filters=AgentsQueryFilters(agent_name="my-agent"),
             ),
-        )
-
-        expected = """
-            SELECT agent_name,
-                   sum(invocation_count) AS invocation_count,
-                   sum(span_count) AS span_count,
-                   sum(total_input_tokens) AS total_input_tokens,
-                   sum(total_output_tokens) AS total_output_tokens,
-                   sum(total_duration_ms) AS total_duration_ms,
-                   sum(error_count) AS error_count,
-                   min(first_seen) AS first_seen,
-                   max(last_seen) AS last_seen
+            f"""
+            {_AGENTS_LIST_SELECT}
             FROM agents
-            WHERE project_id = {genai_0:String}
-            AND agent_name = {genai_1:String}
+            WHERE project_id = {{genai_0:String}}
+            AND agent_name = {{genai_1:String}}
             GROUP BY agent_name
             ORDER BY last_seen DESC, agent_name
-            LIMIT {genai_2:UInt64} OFFSET {genai_3:UInt64}
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": "my-agent",
-            "genai_2": 100,
-            "genai_3": 0,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
+            LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
+        """,
+            {
+                "genai_0": "p1",
+                "genai_1": "my-agent",
+                "genai_2": 100,
+                "genai_3": 0,
+            },
+            id="list_with_filter",
+        ),
+    ],
+)
+def test_make_agents_queries(
+    builder: Callable[[ParamBuilder, AgentsQueryReq], str],
+    req: AgentsQueryReq,
+    expected: str,
+    expected_params: dict,
+) -> None:
+    pb = ParamBuilder("genai")
+    query = builder(pb, req)
+    assert_sql(expected, expected_params, query, pb.get_params())
 
 
 # ============================================================================
@@ -1133,49 +1153,16 @@ class TestMakeAgentsQueries:
 # ============================================================================
 
 
-class TestMakeCustomAttrsSchemaQuery:
-    def test_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_custom_attrs_schema_query(
-            pb,
+@pytest.mark.parametrize(
+    ("req", "where_clause", "expected_params"),
+    [
+        pytest.param(
             AgentCustomAttrsSchemaReq(project_id="p1"),
-        )
-
-        expected = """
-            SELECT tupleElement(attr, 1) AS source,
-                   tupleElement(attr, 2) AS key,
-                   tupleElement(attr, 3) AS value_type,
-                   count() AS span_count
-            FROM (
-                SELECT s.custom_attrs_string.keys AS custom_attrs_string_keys,
-                       s.custom_attrs_int.keys AS custom_attrs_int_keys,
-                       s.custom_attrs_float.keys AS custom_attrs_float_keys,
-                       s.custom_attrs_bool.keys AS custom_attrs_bool_keys
-                FROM spans s
-                WHERE s.project_id = {genai_0:String}
-            ) filtered
-            ARRAY JOIN arrayConcat(
-                arrayMap(k -> tuple('custom_attrs_string', k, 'string'), filtered.custom_attrs_string_keys),
-                arrayMap(k -> tuple('custom_attrs_int', k, 'int'), filtered.custom_attrs_int_keys),
-                arrayMap(k -> tuple('custom_attrs_float', k, 'float'), filtered.custom_attrs_float_keys),
-                arrayMap(k -> tuple('custom_attrs_bool', k, 'bool'), filtered.custom_attrs_bool_keys)
-            ) AS attr
-            GROUP BY source, key, value_type
-            ORDER BY span_count DESC, key ASC, source ASC
-            LIMIT {genai_1:UInt64} OFFSET {genai_2:UInt64}
-        """
-        assert_sql(
-            expected,
+            "WHERE s.project_id = {genai_0:String}",
             {"genai_0": "p1", "genai_1": 201, "genai_2": 0},
-            query,
-            pb.get_params(),
-        )
-
-    def test_reuses_spans_filters(self) -> None:
-        pb = ParamBuilder("genai")
-        start = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
-        query = make_custom_attrs_schema_query(
-            pb,
+            id="basic",
+        ),
+        pytest.param(
             AgentCustomAttrsSchemaReq(
                 project_id="p1",
                 query=Query.model_validate(
@@ -1188,45 +1175,44 @@ class TestMakeCustomAttrsSchemaQuery:
                         }
                     }
                 ),
-                started_after=start,
+                started_after=_START,
                 limit=10,
                 offset=20,
             ),
-        )
-
-        expected = """
-            SELECT tupleElement(attr, 1) AS source,
-                   tupleElement(attr, 2) AS key,
-                   tupleElement(attr, 3) AS value_type,
-                   count() AS span_count
-            FROM (
-                SELECT s.custom_attrs_string.keys AS custom_attrs_string_keys,
-                       s.custom_attrs_int.keys AS custom_attrs_int_keys,
-                       s.custom_attrs_float.keys AS custom_attrs_float_keys,
-                       s.custom_attrs_bool.keys AS custom_attrs_bool_keys
-                FROM spans s
-                WHERE s.project_id = {genai_0:String}
+            """WHERE s.project_id = {genai_0:String}
                 AND s.started_at >= {genai_1:DateTime64(6)}
-                AND (s.agent_name = {genai_2:String})
-            ) filtered
-            ARRAY JOIN arrayConcat(
-                arrayMap(k -> tuple('custom_attrs_string', k, 'string'), filtered.custom_attrs_string_keys),
-                arrayMap(k -> tuple('custom_attrs_int', k, 'int'), filtered.custom_attrs_int_keys),
-                arrayMap(k -> tuple('custom_attrs_float', k, 'float'), filtered.custom_attrs_float_keys),
-                arrayMap(k -> tuple('custom_attrs_bool', k, 'bool'), filtered.custom_attrs_bool_keys)
-            ) AS attr
-            GROUP BY source, key, value_type
-            ORDER BY span_count DESC, key ASC, source ASC
-            LIMIT {genai_3:UInt64} OFFSET {genai_4:UInt64}
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": start,
-            "genai_2": "bot",
-            "genai_3": 11,
-            "genai_4": 20,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
+                AND (s.agent_name = {genai_2:String})""",
+            {
+                "genai_0": "p1",
+                "genai_1": _START,
+                "genai_2": "bot",
+                "genai_3": 11,
+                "genai_4": 20,
+            },
+            id="reuses_spans_filters",
+        ),
+    ],
+)
+def test_make_custom_attrs_schema_query(
+    req: AgentCustomAttrsSchemaReq, where_clause: str, expected_params: dict
+) -> None:
+    pb = ParamBuilder("genai")
+    query = make_custom_attrs_schema_query(pb, req)
+    limit_idx = len(expected_params) - 2
+    expected = f"""
+        {_CUSTOM_ATTRS_SCHEMA_SELECT}
+        FROM (
+            SELECT s.custom_attrs_string.keys AS custom_attrs_string_keys,
+                   s.custom_attrs_int.keys AS custom_attrs_int_keys,
+                   s.custom_attrs_float.keys AS custom_attrs_float_keys,
+                   s.custom_attrs_bool.keys AS custom_attrs_bool_keys
+            FROM spans s
+            {where_clause}
+        ) filtered
+        {_CUSTOM_ATTRS_SCHEMA_ARRAY_JOIN}
+        LIMIT {{genai_{limit_idx}:UInt64}} OFFSET {{genai_{limit_idx + 1}:UInt64}}
+    """
+    assert_sql(expected, expected_params, query, pb.get_params())
 
 
 # ============================================================================
@@ -1234,35 +1220,25 @@ class TestMakeCustomAttrsSchemaQuery:
 # ============================================================================
 
 
-class TestMakeAgentVersionsQueries:
-    def test_count_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_agent_versions_count_query(
-            pb, AgentVersionsQueryReq(project_id="p1", agent_name="a1")
-        )
-
-        expected = """
+@pytest.mark.parametrize(
+    ("builder", "expected", "expected_params"),
+    [
+        pytest.param(
+            make_agent_versions_count_query,
+            """
             SELECT count() FROM (
                 SELECT agent_version FROM agent_versions
                 WHERE project_id = {genai_0:String}
                 AND agent_name = {genai_1:String}
                 GROUP BY agent_version
             )
-        """
-        assert_sql(
-            expected,
+        """,
             {"genai_0": "p1", "genai_1": "a1"},
-            query,
-            pb.get_params(),
-        )
-
-    def test_list_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_agent_versions_list_query(
-            pb, AgentVersionsQueryReq(project_id="p1", agent_name="a1")
-        )
-
-        expected = """
+            id="count_basic",
+        ),
+        pytest.param(
+            make_agent_versions_list_query,
+            """
             SELECT agent_version,
                    sum(invocation_count) AS invocation_count,
                    sum(span_count) AS span_count,
@@ -1278,14 +1254,25 @@ class TestMakeAgentVersionsQueries:
             GROUP BY agent_version
             ORDER BY last_seen DESC
             LIMIT {genai_2:UInt64} OFFSET {genai_3:UInt64}
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": "a1",
-            "genai_2": 100,
-            "genai_3": 0,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
+        """,
+            {
+                "genai_0": "p1",
+                "genai_1": "a1",
+                "genai_2": 100,
+                "genai_3": 0,
+            },
+            id="list_basic",
+        ),
+    ],
+)
+def test_make_agent_versions_queries(
+    builder: Callable[[ParamBuilder, AgentVersionsQueryReq], str],
+    expected: str,
+    expected_params: dict,
+) -> None:
+    pb = ParamBuilder("genai")
+    query = builder(pb, AgentVersionsQueryReq(project_id="p1", agent_name="a1"))
+    assert_sql(expected, expected_params, query, pb.get_params())
 
 
 # ============================================================================
@@ -1293,36 +1280,21 @@ class TestMakeAgentVersionsQueries:
 # ============================================================================
 
 
-class TestMakeMessageSearchQuery:
-    def test_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_message_search_query(
-            pb, AgentSearchReq(project_id="p1", query="hello")
-        )
-
-        expected = """
-            SELECT conversation_id, conversation_name, agent_name,
-                   span_id, trace_id, role,
-                   substring(content, 1, 500) AS content,
-                   lower(hex(content_digest)) AS content_digest, started_at
-            FROM messages
-            WHERE project_id = {genai_0:String}
-            AND content LIKE {genai_1:String}
-            ORDER BY started_at DESC
-            LIMIT {genai_2:UInt64} OFFSET {genai_3:UInt64}
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": "%hello%",
-            "genai_2": 20,
-            "genai_3": 0,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_with_filters(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_message_search_query(
-            pb,
+@pytest.mark.parametrize(
+    ("req", "where_tail", "expected_params"),
+    [
+        pytest.param(
+            AgentSearchReq(project_id="p1", query="hello"),
+            "AND content LIKE {genai_1:String}",
+            {
+                "genai_0": "p1",
+                "genai_1": "%hello%",
+                "genai_2": 20,
+                "genai_3": 0,
+            },
+            id="basic",
+        ),
+        pytest.param(
             AgentSearchReq(
                 project_id="p1",
                 query="test",
@@ -1330,80 +1302,73 @@ class TestMakeMessageSearchQuery:
                 agent_name="bot",
                 conversation_id="conv-1",
             ),
-        )
-
-        expected = """
-            SELECT conversation_id, conversation_name, agent_name,
-                   span_id, trace_id, role,
-                   substring(content, 1, 500) AS content,
-                   lower(hex(content_digest)) AS content_digest, started_at
-            FROM messages
-            WHERE project_id = {genai_0:String}
-            AND content LIKE {genai_1:String}
+            """AND content LIKE {genai_1:String}
               AND role IN {genai_2:Array(String)}
               AND agent_name = {genai_3:String}
-              AND conversation_id = {genai_4:String}
-            ORDER BY started_at DESC
-            LIMIT {genai_5:UInt64} OFFSET {genai_6:UInt64}
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": "%test%",
-            "genai_2": ["user", "assistant"],
-            "genai_3": "bot",
-            "genai_4": "conv-1",
-            "genai_5": 20,
-            "genai_6": 0,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
-
-    def test_tool_role_alias_expands_to_tool_message_roles(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_message_search_query(
-            pb,
+              AND conversation_id = {genai_4:String}""",
+            {
+                "genai_0": "p1",
+                "genai_1": "%test%",
+                "genai_2": ["user", "assistant"],
+                "genai_3": "bot",
+                "genai_4": "conv-1",
+                "genai_5": 20,
+                "genai_6": 0,
+            },
+            id="with_filters",
+        ),
+        pytest.param(
             AgentSearchReq(project_id="p1", query="test", roles=["tool"]),
-        )
+            """AND content LIKE {genai_1:String}
+              AND role IN {genai_2:Array(String)}""",
+            {
+                "genai_0": "p1",
+                "genai_1": "%test%",
+                "genai_2": ["tool_call", "tool_result"],
+                "genai_3": 20,
+                "genai_4": 0,
+            },
+            id="tool_role_alias_expands_to_tool_message_roles",
+        ),
+    ],
+)
+def test_make_message_search_query(
+    req: AgentSearchReq, where_tail: str, expected_params: dict
+) -> None:
+    pb = ParamBuilder("genai")
+    query = make_message_search_query(pb, req)
+    limit_idx = len(expected_params) - 2
+    expected = f"""
+        {_MESSAGE_SEARCH_SELECT}
+        FROM messages
+        WHERE project_id = {{genai_0:String}}
+        {where_tail}
+        ORDER BY started_at DESC
+        LIMIT {{genai_{limit_idx}:UInt64}} OFFSET {{genai_{limit_idx + 1}:UInt64}}
+    """
+    assert_sql(expected, expected_params, query, pb.get_params())
 
-        expected = """
-            SELECT conversation_id, conversation_name, agent_name,
-                   span_id, trace_id, role,
-                   substring(content, 1, 500) AS content,
-                   lower(hex(content_digest)) AS content_digest, started_at
-            FROM messages
-            WHERE project_id = {genai_0:String}
-            AND content LIKE {genai_1:String}
-              AND role IN {genai_2:Array(String)}
-            ORDER BY started_at DESC
-            LIMIT {genai_3:UInt64} OFFSET {genai_4:UInt64}
-        """
-        expected_params = {
-            "genai_0": "p1",
-            "genai_1": "%test%",
-            "genai_2": ["tool_call", "tool_result"],
-            "genai_3": 20,
-            "genai_4": 0,
-        }
-        assert_sql(expected, expected_params, query, pb.get_params())
 
-    def test_escapes_like_wildcards(self) -> None:
-        pb = ParamBuilder("genai")
-        make_message_search_query(
-            pb, AgentSearchReq(project_id="p1", query=r"88%_off\sale")
-        )
+def test_message_search_escapes_like_wildcards() -> None:
+    pb = ParamBuilder("genai")
+    make_message_search_query(
+        pb, AgentSearchReq(project_id="p1", query=r"88%_off\sale")
+    )
 
-        assert pb.get_params()["genai_1"] == r"%88\%\_off\\sale%"
+    assert pb.get_params()["genai_1"] == r"%88\%\_off\\sale%"
 
-    def test_limit_rejected_when_above_max(self) -> None:
-        with pytest.raises(ValidationError):
-            AgentSearchReq(project_id="p1", query="x", limit=5000)
 
-    def test_limit_rejected_when_negative(self) -> None:
-        with pytest.raises(ValidationError):
-            AgentSearchReq(project_id="p1", query="x", limit=-1)
-
-    def test_offset_rejected_when_negative(self) -> None:
-        with pytest.raises(ValidationError):
-            AgentSearchReq(project_id="p1", query="x", offset=-1)
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"limit": 5000}, id="limit_above_max"),
+        pytest.param({"limit": -1}, id="limit_negative"),
+        pytest.param({"offset": -1}, id="offset_negative"),
+    ],
+)
+def test_agent_search_req_rejects_limit_offset(kwargs: dict) -> None:
+    with pytest.raises(ValidationError):
+        AgentSearchReq(project_id="p1", query="x", **kwargs)
 
 
 # ============================================================================
@@ -1411,99 +1376,80 @@ class TestMakeMessageSearchQuery:
 # ============================================================================
 
 
-class TestMakeConversationChatSpansQuery:
-    def test_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_conversation_chat_spans_query(
-            pb,
+@pytest.mark.parametrize(
+    ("req", "expected_params"),
+    [
+        pytest.param(
             AgentConversationChatReq(project_id="p1", conversation_id="c1"),
-        )
-
-        expected = f"""
-            SELECT {", ".join(f"s.{c} AS {c}" for c in CHAT_VIEW_COLS.split(", "))}
-            FROM spans s
-            INNER JOIN (
-                SELECT trace_id, min(started_at) AS turn_started_at
-                FROM spans
-                WHERE project_id = {{genai_0:String}}
-                AND conversation_id = {{genai_1:String}}
-                GROUP BY trace_id
-                ORDER BY turn_started_at DESC, trace_id DESC
-                LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
-            ) t ON s.trace_id = t.trace_id
-            WHERE s.project_id = {{genai_0:String}}
-            ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
-        """
-        assert_sql(
-            expected,
             {"genai_0": "p1", "genai_1": "c1", "genai_2": 50, "genai_3": 0},
-            query,
-            pb.get_params(),
-        )
-
-    def test_with_pagination(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_conversation_chat_spans_query(
-            pb,
+            id="basic",
+        ),
+        pytest.param(
             AgentConversationChatReq(
                 project_id="p1", conversation_id="c1", limit=10, offset=20
             ),
-        )
-
-        expected = f"""
-            SELECT {", ".join(f"s.{c} AS {c}" for c in CHAT_VIEW_COLS.split(", "))}
-            FROM spans s
-            INNER JOIN (
-                SELECT trace_id, min(started_at) AS turn_started_at
-                FROM spans
-                WHERE project_id = {{genai_0:String}}
-                AND conversation_id = {{genai_1:String}}
-                GROUP BY trace_id
-                ORDER BY turn_started_at DESC, trace_id DESC
-                LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
-            ) t ON s.trace_id = t.trace_id
-            WHERE s.project_id = {{genai_0:String}}
-            ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
-        """
-        assert_sql(
-            expected,
             {"genai_0": "p1", "genai_1": "c1", "genai_2": 10, "genai_3": 20},
-            query,
-            pb.get_params(),
+            id="with_pagination",
+        ),
+    ],
+)
+def test_make_conversation_chat_spans_query(
+    req: AgentConversationChatReq, expected_params: dict
+) -> None:
+    pb = ParamBuilder("genai")
+    query = make_conversation_chat_spans_query(pb, req)
+    expected = f"""
+        SELECT {", ".join(f"s.{c} AS {c}" for c in CHAT_VIEW_COLS.split(", "))}
+        FROM spans s
+        INNER JOIN (
+            SELECT trace_id, min(started_at) AS turn_started_at
+            FROM spans
+            WHERE project_id = {{genai_0:String}}
+            AND conversation_id = {{genai_1:String}}
+            GROUP BY trace_id
+            ORDER BY turn_started_at DESC, trace_id DESC
+            LIMIT {{genai_2:UInt64}} OFFSET {{genai_3:UInt64}}
+        ) t ON s.trace_id = t.trace_id
+        WHERE s.project_id = {{genai_0:String}}
+        ORDER BY t.turn_started_at ASC, t.trace_id ASC, s.started_at ASC
+    """
+    assert_sql(expected, expected_params, query, pb.get_params())
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"limit": 51}, id="limit_above_max_turns"),
+        pytest.param({"offset": -1}, id="offset_negative"),
+    ],
+)
+def test_conversation_chat_req_rejects_limit_offset(kwargs: dict) -> None:
+    with pytest.raises(ValidationError):
+        AgentConversationChatReq(project_id="p1", conversation_id="c1", **kwargs)
+
+
+def test_make_conversation_chat_turns_count_query() -> None:
+    pb = ParamBuilder("genai")
+    query = make_conversation_chat_turns_count_query(
+        pb,
+        AgentConversationChatReq(project_id="p1", conversation_id="c1"),
+    )
+
+    expected = """
+        SELECT count() FROM (
+            SELECT trace_id
+            FROM spans s
+            WHERE s.project_id = {genai_0:String}
+            AND s.conversation_id = {genai_1:String}
+            GROUP BY trace_id
         )
-
-    def test_limit_rejected_above_max_turns(self) -> None:
-        with pytest.raises(ValidationError):
-            AgentConversationChatReq(project_id="p1", conversation_id="c1", limit=51)
-
-    def test_offset_rejected_when_negative(self) -> None:
-        with pytest.raises(ValidationError):
-            AgentConversationChatReq(project_id="p1", conversation_id="c1", offset=-1)
-
-
-class TestMakeConversationChatTurnsCountQuery:
-    def test_basic(self) -> None:
-        pb = ParamBuilder("genai")
-        query = make_conversation_chat_turns_count_query(
-            pb,
-            AgentConversationChatReq(project_id="p1", conversation_id="c1"),
-        )
-
-        expected = """
-            SELECT count() FROM (
-                SELECT trace_id
-                FROM spans s
-                WHERE s.project_id = {genai_0:String}
-                AND s.conversation_id = {genai_1:String}
-                GROUP BY trace_id
-            )
-        """
-        assert_sql(
-            expected,
-            {"genai_0": "p1", "genai_1": "c1"},
-            query,
-            pb.get_params(),
-        )
+    """
+    assert_sql(
+        expected,
+        {"genai_0": "p1", "genai_1": "c1"},
+        query,
+        pb.get_params(),
+    )
 
 
 # ============================================================================
@@ -1511,35 +1457,59 @@ class TestMakeConversationChatTurnsCountQuery:
 # ============================================================================
 
 
-class TestBuildOrderBy:
-    def test_default(self) -> None:
-        assert (
-            build_order_by(None, SPAN_SORTABLE_COLS, "started_at DESC")
-            == "started_at DESC"
-        )
+@pytest.mark.parametrize(
+    ("sort", "expected"),
+    [
+        pytest.param(None, "started_at DESC", id="default"),
+        pytest.param(
+            [AgentSortBy(field="input_tokens", direction="asc")],
+            "input_tokens asc",
+            id="valid_single",
+        ),
+        pytest.param(
+            [
+                AgentSortBy(field="started_at", direction="desc"),
+                AgentSortBy(field="input_tokens", direction="asc"),
+            ],
+            "started_at desc, input_tokens asc",
+            id="valid_multiple",
+        ),
+    ],
+)
+def test_build_order_by_success(sort: list[AgentSortBy] | None, expected: str) -> None:
+    fallback = "started_at DESC" if sort is None else "fallback"
+    assert build_order_by(sort, SPAN_SORTABLE_COLS, fallback) == expected
 
-    def test_valid_single(self) -> None:
-        sort = [AgentSortBy(field="input_tokens", direction="asc")]
-        assert (
-            build_order_by(sort, SPAN_SORTABLE_COLS, "fallback") == "input_tokens asc"
-        )
 
-    def test_rejects_invalid_field(self) -> None:
-        sort = [AgentSortBy(field="'; DROP TABLE--", direction="asc")]
-        with pytest.raises(ValueError, match="Invalid sort field"):
-            build_order_by(sort, SPAN_SORTABLE_COLS, "started_at DESC")
+@pytest.mark.parametrize(
+    ("sort", "expected_match"),
+    [
+        pytest.param(
+            [AgentSortBy(field="'; DROP TABLE--", direction="asc")],
+            "Invalid sort field",
+            id="invalid_field_injection_guard",
+        ),
+        pytest.param(
+            [AgentSortBy.model_construct(field="input_tokens", direction="sideways")],
+            "Invalid sort direction",
+            id="invalid_direction",
+        ),
+    ],
+)
+def test_build_order_by_rejects(sort: list[AgentSortBy], expected_match: str) -> None:
+    with pytest.raises(ValueError, match=expected_match):
+        build_order_by(sort, SPAN_SORTABLE_COLS, "started_at DESC")
 
-    def test_rejects_invalid_direction(self) -> None:
-        sort = [AgentSortBy.model_construct(field="input_tokens", direction="sideways")]
-        with pytest.raises(ValueError, match="Invalid sort direction"):
-            build_order_by(sort, SPAN_SORTABLE_COLS, "started_at DESC")
 
-    def test_valid_multiple(self) -> None:
-        sort = [
-            AgentSortBy(field="started_at", direction="desc"),
-            AgentSortBy(field="input_tokens", direction="asc"),
-        ]
-        assert (
-            build_order_by(sort, SPAN_SORTABLE_COLS, "fallback")
-            == "started_at desc, input_tokens asc"
-        )
+def assert_sql(
+    expected_query: str, expected_params: dict, query: str, params: dict
+) -> None:
+    expected_formatted = sqlparse.format(expected_query, reindent=True).strip()
+    found_formatted = sqlparse.format(query, reindent=True).strip()
+
+    assert expected_formatted == found_formatted, (
+        f"\nExpected:\n{expected_formatted}\n\nGot:\n{found_formatted}"
+    )
+    assert expected_params == params, (
+        f"\nExpected params: {expected_params}\n\nGot params: {params}"
+    )

--- a/tests/trace_server/query_builder/test_agent_query_compiler.py
+++ b/tests/trace_server/query_builder/test_agent_query_compiler.py
@@ -16,126 +16,136 @@ from weave.trace_server.query_builder.agent_query_compiler import (
     compile_agent_query,
 )
 
-
-def _compile(expr: dict) -> tuple[str, dict]:
-    """Compile ``{"$expr": <op>}`` and return (condition, params)."""
-    pb = ParamBuilder("genai")
-    condition = compile_agent_query(Query.model_validate({"$expr": expr}), pb)
-    return condition, pb.get_params()
-
-
 # ---------------------------------------------------------------------------
 # Field resolution
 # ---------------------------------------------------------------------------
 
 
-class TestFieldResolution:
-    def test_semconv_canonical_key(self) -> None:
-        sql, params = _compile(
-            {"$eq": [{"$getField": "weave.agent.name"}, {"$literal": "bot"}]}
-        )
-        assert sql == "(s.agent_name = {genai_0:String})"
-        assert params == {"genai_0": "bot"}
+@pytest.mark.parametrize(
+    ("expr", "expected_sql", "expected_params"),
+    [
+        (
+            {"$eq": [{"$getField": "weave.agent.name"}, {"$literal": "bot"}]},
+            "(s.agent_name = {genai_0:String})",
+            {"genai_0": "bot"},
+        ),
+        (
+            {"$eq": [{"$getField": "gen_ai.agent.name"}, {"$literal": "bot"}]},
+            "(s.agent_name = {genai_0:String})",
+            {"genai_0": "bot"},
+        ),
+        (
+            {"$eq": [{"$getField": "agent.name"}, {"$literal": "bot"}]},
+            "(s.agent_name = {genai_0:String})",
+            {"genai_0": "bot"},
+        ),
+        (
+            {"$eq": [{"$getField": "trace_id"}, {"$literal": "t1"}]},
+            "(s.trace_id = {genai_0:String})",
+            {"genai_0": "t1"},
+        ),
+        # `input_tokens` isn't a semconv key (canonical is `weave.usage.input_tokens`)
+        # but resolves because the column is a semconv target.
+        (
+            {"$gt": [{"$getField": "input_tokens"}, {"$literal": 100}]},
+            "(s.input_tokens > {genai_0:Int64})",
+            {"genai_0": 100},
+        ),
+    ],
+)
+def test_field_resolution_semconv(
+    expr: dict, expected_sql: str, expected_params: dict
+) -> None:
+    sql, params = _compile(expr)
+    assert sql == expected_sql
+    assert params == expected_params
 
-    def test_semconv_gen_ai_alias(self) -> None:
-        sql, _ = _compile(
-            {"$eq": [{"$getField": "gen_ai.agent.name"}, {"$literal": "bot"}]}
-        )
-        assert "s.agent_name" in sql
 
-    def test_semconv_short_form(self) -> None:
-        sql, _ = _compile({"$eq": [{"$getField": "agent.name"}, {"$literal": "bot"}]})
-        assert "s.agent_name" in sql
-
-    def test_direct_column_name(self) -> None:
-        sql, _ = _compile({"$eq": [{"$getField": "trace_id"}, {"$literal": "t1"}]})
-        assert "s.trace_id" in sql
-
-    def test_semconv_target_column_by_name(self) -> None:
-        # `input_tokens` isn't a semconv key — the canonical key is
-        # `weave.usage.input_tokens` — but the column should still resolve
-        # because the compiler accepts any column that's a semconv target.
-        sql, _ = _compile({"$gt": [{"$getField": "input_tokens"}, {"$literal": 100}]})
-        assert "s.input_tokens" in sql
-
-    def test_custom_attr_explicit_prefix_string(self) -> None:
-        sql, params = _compile(
-            {"$eq": [{"$getField": "custom_attrs_string.env"}, {"$literal": "prod"}]}
-        )
-        # key param added before value param
-        assert (
-            "if(mapContains(s.custom_attrs_string, {genai_0:String}), "
-            "s.custom_attrs_string[{genai_0:String}], NULL) = {genai_1:String}"
-        ) in sql
-        assert params == {"genai_0": "env", "genai_1": "prod"}
-
-    def test_custom_attr_explicit_prefix_int(self) -> None:
-        sql, params = _compile(
-            {"$gt": [{"$getField": "custom_attrs_int.retries"}, {"$literal": 3}]}
-        )
-        assert (
-            "if(mapContains(s.custom_attrs_int, {genai_0:String}), "
-            "s.custom_attrs_int[{genai_0:String}], NULL) > {genai_1:Int64}"
-        ) in sql
-        assert params == {"genai_0": "retries", "genai_1": 3}
-
-    def test_custom_attr_explicit_prefix_float(self) -> None:
-        sql, params = _compile(
-            {
-                "$lt": [
-                    {"$getField": "custom_attrs_float.latency"},
-                    {"$literal": 1.5},
-                ]
-            }
-        )
-        assert (
-            "if(mapContains(s.custom_attrs_float, {genai_0:String}), "
-            "s.custom_attrs_float[{genai_0:String}], NULL) < {genai_1:Float64}"
-        ) in sql
-        assert params == {"genai_0": "latency", "genai_1": 1.5}
-
-    def test_custom_attr_unprefixed_sibling_int(self) -> None:
-        sql, params = _compile({"$gt": [{"$getField": "retries"}, {"$literal": 3}]})
-        # Unknown name + int sibling -> custom_attrs_int map
-        assert (
-            "if(mapContains(s.custom_attrs_int, {genai_0:String}), "
-            "s.custom_attrs_int[{genai_0:String}], NULL) > {genai_1:Int64}"
-        ) in sql
-        assert params == {"genai_0": "retries", "genai_1": 3}
-
-    def test_custom_attr_unprefixed_sibling_float(self) -> None:
-        sql, _ = _compile({"$gt": [{"$getField": "latency_ms"}, {"$literal": 1.5}]})
-        assert "s.custom_attrs_float[" in sql
-
-    def test_custom_attr_unprefixed_sibling_str(self) -> None:
-        sql, _ = _compile({"$eq": [{"$getField": "env"}, {"$literal": "prod"}]})
-        assert "s.custom_attrs_string[" in sql
-
-    def test_custom_attr_explicit_prefix_bool(self) -> None:
-        sql, params = _compile(
+@pytest.mark.parametrize(
+    ("expr", "expected_sql", "expected_params"),
+    [
+        (
+            {"$eq": [{"$getField": "custom_attrs_string.env"}, {"$literal": "prod"}]},
+            "(if(mapContains(s.custom_attrs_string, {genai_0:String}), "
+            "s.custom_attrs_string[{genai_0:String}], NULL) = {genai_1:String})",
+            {"genai_0": "env", "genai_1": "prod"},
+        ),
+        (
+            {"$gt": [{"$getField": "custom_attrs_int.retries"}, {"$literal": 3}]},
+            "(if(mapContains(s.custom_attrs_int, {genai_0:String}), "
+            "s.custom_attrs_int[{genai_0:String}], NULL) > {genai_1:Int64})",
+            {"genai_0": "retries", "genai_1": 3},
+        ),
+        (
+            {"$lt": [{"$getField": "custom_attrs_float.latency"}, {"$literal": 1.5}]},
+            "(if(mapContains(s.custom_attrs_float, {genai_0:String}), "
+            "s.custom_attrs_float[{genai_0:String}], NULL) < {genai_1:Float64})",
+            {"genai_0": "latency", "genai_1": 1.5},
+        ),
+        (
             {
                 "$eq": [
                     {"$getField": "custom_attrs_bool.is_streaming"},
                     {"$literal": True},
                 ]
-            }
-        )
-        assert (
-            "if(mapContains(s.custom_attrs_bool, {genai_0:String}), "
-            "s.custom_attrs_bool[{genai_0:String}], NULL) = {genai_1:Bool}"
-        ) in sql
-        assert params == {"genai_0": "is_streaming", "genai_1": True}
+            },
+            "(if(mapContains(s.custom_attrs_bool, {genai_0:String}), "
+            "s.custom_attrs_bool[{genai_0:String}], NULL) = {genai_1:Bool})",
+            {"genai_0": "is_streaming", "genai_1": True},
+        ),
+    ],
+)
+def test_field_resolution_custom_attr_explicit_prefix(
+    expr: dict, expected_sql: str, expected_params: dict
+) -> None:
+    sql, params = _compile(expr)
+    assert sql == expected_sql
+    assert params == expected_params
 
-    def test_custom_attr_unprefixed_sibling_bool(self) -> None:
-        # Bool sibling -> custom_attrs_bool (not custom_attrs_int, which
-        # Python's isinstance(True, int) would suggest if ordering were wrong).
-        sql, _ = _compile({"$eq": [{"$getField": "is_cached"}, {"$literal": False}]})
-        assert "s.custom_attrs_bool[" in sql
 
-    def test_custom_attr_rejected_field_vs_field(self) -> None:
-        # No literal operand => no sibling hint => rejection.
-        with pytest.raises(InvalidAgentFilterFieldError, match="cannot resolve"):
-            _compile({"$eq": [{"$getField": "foo"}, {"$getField": "bar"}]})
+@pytest.mark.parametrize(
+    ("expr", "expected_sql", "expected_params"),
+    [
+        (
+            {"$gt": [{"$getField": "retries"}, {"$literal": 3}]},
+            "(if(mapContains(s.custom_attrs_int, {genai_0:String}), "
+            "s.custom_attrs_int[{genai_0:String}], NULL) > {genai_1:Int64})",
+            {"genai_0": "retries", "genai_1": 3},
+        ),
+        (
+            {"$gt": [{"$getField": "latency_ms"}, {"$literal": 1.5}]},
+            "(if(mapContains(s.custom_attrs_float, {genai_0:String}), "
+            "s.custom_attrs_float[{genai_0:String}], NULL) > {genai_1:Float64})",
+            {"genai_0": "latency_ms", "genai_1": 1.5},
+        ),
+        (
+            {"$eq": [{"$getField": "env"}, {"$literal": "prod"}]},
+            "(if(mapContains(s.custom_attrs_string, {genai_0:String}), "
+            "s.custom_attrs_string[{genai_0:String}], NULL) = {genai_1:String})",
+            {"genai_0": "env", "genai_1": "prod"},
+        ),
+        # Bool sibling -> custom_attrs_bool, NOT custom_attrs_int (isinstance(True,
+        # int) would mis-route here if literal-type ordering were wrong).
+        (
+            {"$eq": [{"$getField": "is_cached"}, {"$literal": False}]},
+            "(if(mapContains(s.custom_attrs_bool, {genai_0:String}), "
+            "s.custom_attrs_bool[{genai_0:String}], NULL) = {genai_1:Bool})",
+            {"genai_0": "is_cached", "genai_1": False},
+        ),
+    ],
+)
+def test_field_resolution_unprefixed_sibling(
+    expr: dict, expected_sql: str, expected_params: dict
+) -> None:
+    sql, params = _compile(expr)
+    assert sql == expected_sql
+    assert params == expected_params
+
+
+def test_custom_attr_rejected_field_vs_field() -> None:
+    # No literal operand => no sibling hint => rejection.
+    with pytest.raises(InvalidAgentFilterFieldError, match="cannot resolve"):
+        _compile({"$eq": [{"$getField": "foo"}, {"$getField": "bar"}]})
 
 
 # ---------------------------------------------------------------------------
@@ -143,135 +153,142 @@ class TestFieldResolution:
 # ---------------------------------------------------------------------------
 
 
-class TestOperatorShapes:
-    def test_eq_with_null(self) -> None:
-        sql, _ = _compile({"$eq": [{"$getField": "agent_name"}, {"$literal": None}]})
-        assert sql == "(s.agent_name IS NULL)"
+def test_eq_with_null() -> None:
+    sql, _ = _compile({"$eq": [{"$getField": "agent_name"}, {"$literal": None}]})
+    assert sql == "(s.agent_name IS NULL)"
 
-    def test_rejects_invalid_table_alias(self) -> None:
-        pb = ParamBuilder("genai")
-        query = Query.model_validate(
-            {"$expr": {"$eq": [{"$getField": "agent_name"}, {"$literal": "bot"}]}}
-        )
 
-        with pytest.raises(ValueError, match="Invalid SQL identifier"):
-            compile_agent_query(query, pb, table_alias="s; DROP TABLE spans")
+def test_in_with_literal_list() -> None:
+    sql, params = _compile(
+        {
+            "$in": [
+                {"$getField": "status_code"},
+                [{"$literal": "OK"}, {"$literal": "ERROR"}],
+            ]
+        }
+    )
+    assert sql == "(s.status_code IN ({genai_0:String}, {genai_1:String}))"
+    assert params == {"genai_0": "OK", "genai_1": "ERROR"}
 
-    def test_rejects_empty_not(self) -> None:
-        pb = ParamBuilder("genai")
-        query = Query.model_construct(
-            expr_=tsi_query.NotOperation.model_construct(not_=())
-        )
 
-        with pytest.raises(ValueError, match="Empty \\$not"):
-            compile_agent_query(query, pb)
-
-    def test_not_wraps_in_negation(self) -> None:
-        sql, _ = _compile(
-            {"$not": [{"$eq": [{"$getField": "agent.name"}, {"$literal": "a"}]}]}
-        )
-        assert sql.startswith("(NOT (")
-
-    def test_and_joins_with_and(self) -> None:
-        sql, _ = _compile(
+@pytest.mark.parametrize(
+    ("expr", "expected_sql"),
+    [
+        (
+            {"$not": [{"$eq": [{"$getField": "agent.name"}, {"$literal": "a"}]}]},
+            "(NOT ((s.agent_name = {genai_0:String})))",
+        ),
+        (
             {
                 "$and": [
                     {"$eq": [{"$getField": "agent.name"}, {"$literal": "a"}]},
                     {"$gt": [{"$getField": "input_tokens"}, {"$literal": 10}]},
                 ]
-            }
-        )
-        assert " AND " in sql
-
-    def test_or_joins_with_or(self) -> None:
-        sql, _ = _compile(
+            },
+            "((s.agent_name = {genai_0:String}) AND (s.input_tokens > {genai_1:Int64}))",
+        ),
+        (
             {
                 "$or": [
                     {"$eq": [{"$getField": "agent.name"}, {"$literal": "a"}]},
                     {"$eq": [{"$getField": "agent.name"}, {"$literal": "b"}]},
                 ]
-            }
-        )
-        assert " OR " in sql
+            },
+            "((s.agent_name = {genai_0:String}) OR (s.agent_name = {genai_1:String}))",
+        ),
+    ],
+)
+def test_operator_shapes_boolean_join(expr: dict, expected_sql: str) -> None:
+    sql, _ = _compile(expr)
+    assert sql == expected_sql
 
-    def test_in_with_literal_list(self) -> None:
-        sql, params = _compile(
+
+@pytest.mark.parametrize(
+    ("case_insensitive", "expected_sql"),
+    [
+        (False, "position(s.reasoning_content, {genai_0:String}) > 0"),
+        (True, "positionCaseInsensitive(s.reasoning_content, {genai_0:String}) > 0"),
+    ],
+)
+def test_operator_shapes_contains(case_insensitive: bool, expected_sql: str) -> None:
+    sql, params = _compile(
+        {
+            "$contains": {
+                "input": {"$getField": "reasoning_content"},
+                "substr": {"$literal": "thought"},
+                "case_insensitive": case_insensitive,
+            }
+        }
+    )
+    assert sql == expected_sql
+    assert params == {"genai_0": "thought"}
+
+
+def test_convert_forces_custom_attr_map() -> None:
+    # ``to: "int"`` on a custom_attrs_string field routes to custom_attrs_int
+    # and wraps in toInt64OrNull.
+    sql, params = _compile(
+        {
+            "$gt": [
+                {"$convert": {"input": {"$getField": "retries"}, "to": "int"}},
+                {"$literal": 5},
+            ]
+        }
+    )
+    assert "toInt64OrNull(if(mapContains(s.custom_attrs_int" in sql
+    assert params["genai_0"] == "retries"
+
+
+@pytest.mark.parametrize(
+    ("expr", "expected_error"),
+    [
+        (
+            {"$gt": [{"$getField": "input_tokens"}, {"$literal": None}]},
+            "Null values are not allowed",
+        ),
+        (
             {
                 "$in": [
-                    {"$getField": "status_code"},
-                    [{"$literal": "OK"}, {"$literal": "ERROR"}],
+                    {"$getField": "agent_name"},
+                    [{"$literal": "bot"}, {"$literal": 1}],
                 ]
-            }
-        )
-        assert "s.status_code IN (" in sql
-        assert params == {"genai_0": "OK", "genai_1": "ERROR"}
-
-    def test_rejects_null_non_eq_comparison(self) -> None:
-        with pytest.raises(ValueError, match="Null values are not allowed"):
-            _compile({"$gt": [{"$getField": "input_tokens"}, {"$literal": None}]})
-
-    def test_rejects_mixed_in_literal_types(self) -> None:
-        with pytest.raises(ValueError, match="same type"):
-            _compile(
-                {
-                    "$in": [
-                        {"$getField": "agent_name"},
-                        [{"$literal": "bot"}, {"$literal": 1}],
-                    ]
-                }
-            )
-
-    def test_rejects_null_in_literal_list(self) -> None:
-        with pytest.raises(ValueError, match="Null values are not allowed"):
-            _compile(
-                {
-                    "$in": [
-                        {"$getField": "agent_name"},
-                        [{"$literal": "bot"}, {"$literal": None}],
-                    ]
-                }
-            )
-
-    def test_contains_emits_position_gt_zero(self) -> None:
-        sql, _ = _compile(
+            },
+            "same type",
+        ),
+        (
             {
-                "$contains": {
-                    "input": {"$getField": "reasoning_content"},
-                    "substr": {"$literal": "thought"},
-                    "case_insensitive": False,
-                }
-            }
-        )
-        assert "position(s.reasoning_content, " in sql
-        assert sql.endswith(") > 0")
-
-    def test_contains_case_insensitive(self) -> None:
-        sql, _ = _compile(
-            {
-                "$contains": {
-                    "input": {"$getField": "reasoning_content"},
-                    "substr": {"$literal": "thought"},
-                    "case_insensitive": True,
-                }
-            }
-        )
-        assert "positionCaseInsensitive(" in sql
-
-    def test_convert_forces_custom_attr_map(self) -> None:
-        # ``to: "int"`` on a custom_attrs_string field routes to custom_attrs_int
-        # and wraps in toInt64OrNull.
-        sql, params = _compile(
-            {
-                "$gt": [
-                    {
-                        "$convert": {
-                            "input": {"$getField": "retries"},
-                            "to": "int",
-                        }
-                    },
-                    {"$literal": 5},
+                "$in": [
+                    {"$getField": "agent_name"},
+                    [{"$literal": "bot"}, {"$literal": None}],
                 ]
-            }
-        )
-        assert "toInt64OrNull(if(mapContains(s.custom_attrs_int" in sql
-        assert params["genai_0"] == "retries"
+            },
+            "Null values are not allowed",
+        ),
+    ],
+)
+def test_operator_shapes_rejects_compilable(expr: dict, expected_error: str) -> None:
+    with pytest.raises(ValueError, match=expected_error):
+        _compile(expr)
+
+
+def test_rejects_invalid_table_alias() -> None:
+    pb = ParamBuilder("genai")
+    query = Query.model_validate(
+        {"$expr": {"$eq": [{"$getField": "agent_name"}, {"$literal": "bot"}]}}
+    )
+    with pytest.raises(ValueError, match="Invalid SQL identifier"):
+        compile_agent_query(query, pb, table_alias="s; DROP TABLE spans")
+
+
+def test_rejects_empty_not() -> None:
+    pb = ParamBuilder("genai")
+    query = Query.model_construct(expr_=tsi_query.NotOperation.model_construct(not_=()))
+    with pytest.raises(ValueError, match="Empty \\$not"):
+        compile_agent_query(query, pb)
+
+
+def _compile(expr: dict) -> tuple[str, dict]:
+    """Compile ``{"$expr": <op>}`` and return (condition, params)."""
+    pb = ParamBuilder("genai")
+    condition = compile_agent_query(Query.model_validate({"$expr": expr}), pb)
+    return condition, pb.get_params()

--- a/tests/trace_server/query_builder/test_agent_stats_query_builder.py
+++ b/tests/trace_server/query_builder/test_agent_stats_query_builder.py
@@ -1,4 +1,5 @@
 import datetime
+from collections.abc import Callable
 
 import pytest
 import sqlparse
@@ -20,29 +21,18 @@ from weave.trace_server.query_builder.agent_stats_query_builder import (
     build_agent_span_stats_query,
 )
 
-
-def assert_sql(
-    expected_query: str,
-    expected_params: dict,
-    query: str,
-    params: dict,
-) -> None:
-    expected_formatted = sqlparse.format(expected_query, reindent=True).strip()
-    found_formatted = sqlparse.format(query, reindent=True).strip()
-
-    assert expected_formatted == found_formatted, (
-        f"\nExpected:\n{expected_formatted}\n\nGot:\n{found_formatted}"
-    )
-    assert expected_params == params, (
-        f"\nExpected params: {expected_params}\n\nGot params: {params}"
-    )
+_START = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+_END = datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc)
+_AGENT_NAME_FILTER = Query.model_validate(
+    {"$expr": {"$eq": [{"$getField": "agent.name"}, {"$literal": "agent-a"}]}}
+)
 
 
 def _req(**kwargs) -> AgentSpanStatsReq:
     defaults = {
         "project_id": "p1",
-        "start": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "end": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
+        "start": _START,
+        "end": _END,
         "granularity": 3600,
         "metrics": [
             AgentSpanStatsMetricSpec(
@@ -63,16 +53,7 @@ def _req(**kwargs) -> AgentSpanStatsReq:
 def test_ungrouped_stats_query_full_sql_shape() -> None:
     pb = ParamBuilder("genai")
     req = _req(
-        query=Query.model_validate(
-            {
-                "$expr": {
-                    "$eq": [
-                        {"$getField": "agent.name"},
-                        {"$literal": "agent-a"},
-                    ]
-                }
-            }
-        ),
+        query=_AGENT_NAME_FILTER,
         metrics=[
             AgentSpanStatsMetricSpec(
                 alias="duration_ms",
@@ -158,8 +139,8 @@ def test_ungrouped_stats_query_full_sql_shape() -> None:
     """
     expected_params = {
         "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
+        "genai_1": _START,
+        "genai_2": _END,
         "genai_3": "agent-a",
         "genai_4": 1767225600.0,
         "genai_5": 1767312000.0,
@@ -175,8 +156,18 @@ def test_ungrouped_stats_query_full_sql_shape() -> None:
     ]
 
 
-def test_grouped_stats_query_full_sql_shape() -> None:
+@pytest.mark.parametrize(
+    ("group_limit", "expected_group_limit_param"),
+    [
+        pytest.param(1000, 400, id="group_limit_capped"),
+        pytest.param(None, 50, id="group_limit_default"),
+    ],
+)
+def test_grouped_stats_query_full_sql_shape(
+    group_limit: int | None, expected_group_limit_param: int
+) -> None:
     pb = ParamBuilder("genai")
+    extra = {} if group_limit is None else {"group_limit": group_limit}
     req = _req(
         group_by=[
             AgentGroupByRef(
@@ -196,7 +187,7 @@ def test_grouped_stats_query_full_sql_shape() -> None:
                 aggregations=["avg", "count"],
             )
         ],
-        group_limit=1000,
+        **extra,
     )
 
     result = build_agent_span_stats_query(req, pb)
@@ -270,126 +261,38 @@ def test_grouped_stats_query_full_sql_shape() -> None:
     """
     expected_params = {
         "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
+        "genai_1": _START,
+        "genai_2": _END,
         "genai_3": "env",
         "genai_4": "score",
         "genai_5": 1767225600.0,
         "genai_6": 1767312000.0,
         "genai_7": "UTC",
         "genai_8": 3600,
-        "genai_9": 400,
+        "genai_9": expected_group_limit_param,
     }
     assert_sql(expected_sql, expected_params, result.sql, result.parameters)
     assert result.columns == ["timestamp", "env", "avg_score", "count_score"]
 
 
-def test_basic_stats_query_uses_query_filter_and_bucket() -> None:
-    pb = ParamBuilder("genai")
-    req = _req(
-        query=Query.model_validate(
-            {
-                "$expr": {
-                    "$eq": [
-                        {"$getField": "agent.name"},
-                        {"$literal": "agent-a"},
-                    ]
-                }
-            }
-        ),
-        metrics=[
-            AgentSpanStatsMetricSpec(
-                alias="duration_ms",
-                value_type="number",
+@pytest.mark.parametrize(
+    ("bucket_by", "metrics", "expected_sql", "extra_params", "expected_columns"),
+    [
+        pytest.param(
+            AgentSpanStatsNumericBucketSpec(
+                type="number",
                 value=AgentSpanValueRef(source="derived", key="duration_ms"),
-                aggregations=["avg"],
-                percentiles=[95],
+                bins=4,
             ),
-            AgentSpanStatsMetricSpec(
-                alias="errors",
-                value_type="boolean",
-                value=AgentSpanValueRef(source="derived", key="is_error"),
-                aggregations=["count_true"],
-            ),
-        ],
-    )
-
-    result = build_agent_span_stats_query(req, pb)
-
-    expected_sql = """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({genai_4:Float64}, {genai_6:String}), INTERVAL 3600 SECOND, {genai_6:String}) + toIntervalSecond(number * {genai_7:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({genai_5:Float64}, {genai_6:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({genai_4:Float64}, {genai_6:String}), INTERVAL 3600 SECOND, {genai_6:String}))) / {genai_7:Float64})))
-           WHERE bucket < toDateTime({genai_5:Float64}, {genai_6:String}) ),
-             filtered_spans AS
-          (SELECT *
-           FROM spans s
-           WHERE s.project_id = {genai_0:String}
-             AND s.started_at >= {genai_1:DateTime64(6)}
-             AND s.started_at < {genai_2:DateTime64(6)}
-           AND (s.agent_name = {genai_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  avgOrNull(if(v_duration_ms, m_duration_ms, NULL)) AS avg_duration_ms,
-                  quantileOrNull(0.95)(if(v_duration_ms, m_duration_ms, NULL)) AS p95_duration_ms,
-                  countIf(v_errors
-                          AND m_errors = 1) AS count_true_errors
-           FROM
-             (SELECT toStartOfInterval(s.started_at, INTERVAL 3600 SECOND, {genai_6:String}) AS bucket,
-                     if(s.ended_at > s.started_at, toFloat64(toUnixTimestamp64Milli(s.ended_at) - toUnixTimestamp64Milli(s.started_at)), NULL) AS m_duration_ms,
-                     toUInt8(s.ended_at > s.started_at) AS v_duration_ms,
-                     s.status_code = 'ERROR' AS m_errors,
-                     toUInt8(1) AS v_errors
-              FROM filtered_spans s)
-           GROUP BY bucket)
-        SELECT all_buckets.bucket AS timestamp,
-               aggregated_data.avg_duration_ms AS avg_duration_ms,
-               aggregated_data.p95_duration_ms AS p95_duration_ms,
-               COALESCE(aggregated_data.count_true_errors, 0) AS count_true_errors
-        FROM all_buckets
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        ORDER BY timestamp
-    """
-    expected_params = {
-        "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
-        "genai_3": "agent-a",
-        "genai_4": 1767225600.0,
-        "genai_5": 1767312000.0,
-        "genai_6": "UTC",
-        "genai_7": 3600,
-    }
-    assert_sql(expected_sql, expected_params, result.sql, result.parameters)
-    assert result.columns == [
-        "timestamp",
-        "avg_duration_ms",
-        "p95_duration_ms",
-        "count_true_errors",
-    ]
-
-
-def test_numeric_bucket_stats_query_uses_value_buckets() -> None:
-    pb = ParamBuilder("genai")
-    req = _req(
-        bucket_by=AgentSpanStatsNumericBucketSpec(
-            type="number",
-            value=AgentSpanValueRef(source="derived", key="duration_ms"),
-            bins=4,
-        ),
-        metrics=[
-            AgentSpanStatsMetricSpec(
-                alias="spans",
-                value_type="boolean",
-                value=AgentSpanValueRef(source="derived", key="is_error"),
-                aggregations=["count"],
-            )
-        ],
-    )
-
-    result = build_agent_span_stats_query(req, pb)
-
-    expected_sql = """
+            [
+                AgentSpanStatsMetricSpec(
+                    alias="spans",
+                    value_type="boolean",
+                    value=AgentSpanValueRef(source="derived", key="is_error"),
+                    aggregations=["count"],
+                )
+            ],
+            """
         WITH filtered_spans AS
           (SELECT *
            FROM spans s
@@ -432,44 +335,25 @@ def test_numeric_bucket_stats_query_uses_value_buckets() -> None:
           AND (bounds.bucket_max_bound > bounds.bucket_min_bound
                OR all_buckets.bucket = 0)
         ORDER BY bucket_index
-    """
-    expected_params = {
-        "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
-        "genai_3": 4,
-    }
-    assert_sql(expected_sql, expected_params, result.sql, result.parameters)
-    assert result.columns == [
-        "bucket_index",
-        "bucket_min",
-        "bucket_max",
-        "count_spans",
-    ]
-    assert result.granularity_seconds is None
-    assert result.bucket_type == "number"
-
-
-def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
-    pb = ParamBuilder("genai")
-    req = _req(
-        bucket_by=AgentSpanStatsNumericBucketSpec(
-            type="number",
-            bins=8,
-            group_by=[AgentGroupByRef(source="column", key="conversation_id")],
-            measure=AgentSpanMeasureSpec(
-                alias="avg_score",
-                aggregation="avg",
-                value=AgentSpanValueRef(source="custom_attrs_float", key="score"),
-                value_type="number",
-            ),
+    """,
+            {"genai_3": 4},
+            ["bucket_index", "bucket_min", "bucket_max", "count_spans"],
+            id="value_buckets",
         ),
-        metrics=[],
-    )
-
-    result = build_agent_span_stats_query(req, pb)
-
-    expected_sql = """
+        pytest.param(
+            AgentSpanStatsNumericBucketSpec(
+                type="number",
+                bins=8,
+                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+                measure=AgentSpanMeasureSpec(
+                    alias="avg_score",
+                    aggregation="avg",
+                    value=AgentSpanValueRef(source="custom_attrs_float", key="score"),
+                    value_type="number",
+                ),
+            ),
+            [],
+            """
         WITH filtered_spans AS
           (SELECT *
            FROM spans s
@@ -508,16 +392,34 @@ def test_numeric_bucket_stats_query_groups_custom_attr_measure() -> None:
           AND (bounds.bucket_max_bound > bounds.bucket_min_bound
                OR all_buckets.bucket = 0)
         ORDER BY bucket_index
-    """
+    """,
+            {"genai_3": 8, "genai_4": "score"},
+            ["bucket_index", "bucket_min", "bucket_max", "count"],
+            id="groups_custom_attr_measure",
+        ),
+    ],
+)
+def test_numeric_bucket_stats_query(
+    bucket_by: AgentSpanStatsNumericBucketSpec,
+    metrics: list[AgentSpanStatsMetricSpec],
+    expected_sql: str,
+    extra_params: dict,
+    expected_columns: list[str],
+) -> None:
+    pb = ParamBuilder("genai")
+    req = _req(bucket_by=bucket_by, metrics=metrics)
+
+    result = build_agent_span_stats_query(req, pb)
+
     expected_params = {
         "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
-        "genai_3": 8,
-        "genai_4": "score",
+        "genai_1": _START,
+        "genai_2": _END,
+        **extra_params,
     }
     assert_sql(expected_sql, expected_params, result.sql, result.parameters)
-    assert result.columns == ["bucket_index", "bucket_min", "bucket_max", "count"]
+    assert result.columns == expected_columns
+    assert result.granularity_seconds is None
     assert result.bucket_type == "number"
 
 
@@ -550,109 +452,6 @@ def test_numeric_bucket_group_filter_rejects_mismatched_group_by() -> None:
         match="numeric bucket group_filters must use the same group_by",
     ):
         build_agent_span_stats_query(req, pb)
-
-
-def test_request_validation_rejects_grouped_numeric_bucket_metrics() -> None:
-    with pytest.raises(
-        ValidationError,
-        match="grouped numeric bucket stats do not support explicit metrics",
-    ):
-        _req(
-            bucket_by=AgentSpanStatsNumericBucketSpec(
-                type="number",
-                group_by=[AgentGroupByRef(source="column", key="conversation_id")],
-                measure=AgentSpanMeasureSpec(alias="spans", aggregation="count"),
-            ),
-            metrics=[
-                AgentSpanStatsMetricSpec(
-                    alias="input_tokens",
-                    value_type="number",
-                    value=AgentSpanValueRef(source="field", key="usage.input_tokens"),
-                    aggregations=["sum"],
-                )
-            ],
-        )
-
-
-def test_group_by_custom_attr_and_metric_custom_attr() -> None:
-    pb = ParamBuilder("genai")
-    req = _req(
-        group_by=[
-            AgentGroupByRef(
-                source="custom_attrs_string",
-                key="env",
-                alias="env",
-            )
-        ],
-        metrics=[
-            AgentSpanStatsMetricSpec(
-                alias="score",
-                value_type="number",
-                value=AgentSpanValueRef(
-                    source="custom_attrs_float",
-                    key="score",
-                ),
-                aggregations=["avg", "count"],
-            )
-        ],
-    )
-
-    result = build_agent_span_stats_query(req, pb)
-
-    expected_sql = """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({genai_5:Float64}, {genai_7:String}), INTERVAL 3600 SECOND, {genai_7:String}) + toIntervalSecond(number * {genai_8:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({genai_6:Float64}, {genai_7:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({genai_5:Float64}, {genai_7:String}), INTERVAL 3600 SECOND, {genai_7:String}))) / {genai_8:Float64})))
-           WHERE bucket < toDateTime({genai_6:Float64}, {genai_7:String}) ),
-             filtered_spans AS
-          (SELECT *
-           FROM spans s
-           WHERE s.project_id = {genai_0:String}
-             AND s.started_at >= {genai_1:DateTime64(6)}
-             AND s.started_at < {genai_2:DateTime64(6)} ),
-             top_groups AS
-          (SELECT if(mapContains(s.custom_attrs_string, {genai_3:String}), s.custom_attrs_string[{genai_3:String}], NULL) AS env
-           FROM filtered_spans s
-           GROUP BY env
-           ORDER BY count() DESC
-           LIMIT {genai_9:UInt64}),
-             aggregated_data AS
-          (SELECT bucket,
-                  env,
-                  avgOrNull(if(v_score, m_score, NULL)) AS avg_score,
-                  countIf(v_score) AS count_score
-           FROM
-             (SELECT toStartOfInterval(s.started_at, INTERVAL 3600 SECOND, {genai_7:String}) AS bucket,
-                     if(mapContains(s.custom_attrs_string, {genai_3:String}), s.custom_attrs_string[{genai_3:String}], NULL) AS env,
-                     toFloat64(s.custom_attrs_float[{genai_4:String}]) AS m_score,
-                     toUInt8(mapContains(s.custom_attrs_float, {genai_4:String})) AS v_score
-              FROM filtered_spans s)
-           GROUP BY bucket,
-                    env)
-        SELECT all_buckets.bucket AS timestamp,
-               top_groups.env AS env,
-               aggregated_data.avg_score AS avg_score,
-               COALESCE(aggregated_data.count_score, 0) AS count_score
-        FROM all_buckets
-        CROSS JOIN top_groups
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND top_groups.env = aggregated_data.env
-        ORDER BY timestamp, env
-    """
-    expected_params = {
-        "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
-        "genai_3": "env",
-        "genai_4": "score",
-        "genai_5": 1767225600.0,
-        "genai_6": 1767312000.0,
-        "genai_7": "UTC",
-        "genai_8": 3600,
-        "genai_9": 50,
-    }
-    assert_sql(expected_sql, expected_params, result.sql, result.parameters)
-    assert result.columns == ["timestamp", "env", "avg_score", "count_score"]
 
 
 def test_time_stats_apply_group_filters() -> None:
@@ -720,8 +519,8 @@ def test_time_stats_apply_group_filters() -> None:
     """
     expected_params = {
         "genai_0": "p1",
-        "genai_1": datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc),
-        "genai_2": datetime.datetime(2026, 1, 2, tzinfo=datetime.timezone.utc),
+        "genai_1": _START,
+        "genai_2": _END,
         "genai_3": 1767225600.0,
         "genai_4": 1767312000.0,
         "genai_5": "UTC",
@@ -762,68 +561,118 @@ def test_request_validation_normalizes_naive_datetimes() -> None:
     assert req.end is None
 
 
-def test_metric_validation_rejects_invalid_type_aggregation() -> None:
-    with pytest.raises(ValidationError):
-        AgentSpanStatsMetricSpec(
-            alias="agent",
-            value_type="string",
-            value=AgentSpanValueRef(source="field", key="agent.name"),
-            aggregations=["sum"],
-        )
-
-
-def test_request_validation_rejects_duplicate_aliases() -> None:
-    with pytest.raises(ValidationError):
-        _req(
-            metrics=[
-                AgentSpanStatsMetricSpec(
-                    alias="tokens",
-                    value_type="number",
-                    value=AgentSpanValueRef(
-                        source="field",
-                        key="usage.input_tokens",
-                    ),
-                    aggregations=["sum"],
+@pytest.mark.parametrize(
+    ("build", "match"),
+    [
+        pytest.param(
+            lambda: _req(
+                bucket_by=AgentSpanStatsNumericBucketSpec(
+                    type="number",
+                    group_by=[AgentGroupByRef(source="column", key="conversation_id")],
+                    measure=AgentSpanMeasureSpec(alias="spans", aggregation="count"),
                 ),
-                AgentSpanStatsMetricSpec(
-                    alias="tokens",
-                    value_type="number",
-                    value=AgentSpanValueRef(
-                        source="field",
-                        key="usage.output_tokens",
-                    ),
-                    aggregations=["sum"],
-                ),
-            ]
-        )
-
-
-def test_numeric_bucket_validation_rejects_non_numeric_derived_field() -> None:
-    with pytest.raises(ValidationError):
-        AgentSpanStatsNumericBucketSpec(
-            type="number",
-            value=AgentSpanValueRef(source="derived", key="is_error"),
-        )
-
-
-def test_request_validation_rejects_numeric_bucket_group_by() -> None:
-    with pytest.raises(ValidationError):
-        _req(
-            bucket_by=AgentSpanStatsNumericBucketSpec(
-                type="number",
-                value=AgentSpanValueRef(source="derived", key="duration_ms"),
+                metrics=[
+                    AgentSpanStatsMetricSpec(
+                        alias="input_tokens",
+                        value_type="number",
+                        value=AgentSpanValueRef(
+                            source="field", key="usage.input_tokens"
+                        ),
+                        aggregations=["sum"],
+                    )
+                ],
             ),
-            group_by=[
-                AgentGroupByRef(
-                    source="field",
-                    key="agent.name",
-                )
-            ],
-        )
+            "grouped numeric bucket stats do not support explicit metrics",
+            id="grouped_numeric_bucket_with_metrics",
+        ),
+        pytest.param(
+            lambda: AgentSpanStatsMetricSpec(
+                alias="agent",
+                value_type="string",
+                value=AgentSpanValueRef(source="field", key="agent.name"),
+                aggregations=["sum"],
+            ),
+            None,
+            id="invalid_type_aggregation",
+        ),
+        pytest.param(
+            lambda: _req(
+                metrics=[
+                    AgentSpanStatsMetricSpec(
+                        alias="tokens",
+                        value_type="number",
+                        value=AgentSpanValueRef(
+                            source="field",
+                            key="usage.input_tokens",
+                        ),
+                        aggregations=["sum"],
+                    ),
+                    AgentSpanStatsMetricSpec(
+                        alias="tokens",
+                        value_type="number",
+                        value=AgentSpanValueRef(
+                            source="field",
+                            key="usage.output_tokens",
+                        ),
+                        aggregations=["sum"],
+                    ),
+                ]
+            ),
+            None,
+            id="duplicate_aliases",
+        ),
+        pytest.param(
+            lambda: AgentSpanStatsNumericBucketSpec(
+                type="number",
+                value=AgentSpanValueRef(source="derived", key="is_error"),
+            ),
+            None,
+            id="non_numeric_derived_field",
+        ),
+        pytest.param(
+            lambda: _req(
+                bucket_by=AgentSpanStatsNumericBucketSpec(
+                    type="number",
+                    value=AgentSpanValueRef(source="derived", key="duration_ms"),
+                ),
+                group_by=[
+                    AgentGroupByRef(
+                        source="field",
+                        key="agent.name",
+                    )
+                ],
+            ),
+            None,
+            id="numeric_bucket_with_group_by",
+        ),
+        pytest.param(
+            lambda: _req(
+                end=datetime.datetime(2026, 2, 15, tzinfo=datetime.timezone.utc),
+            ),
+            None,
+            id="large_range",
+        ),
+    ],
+)
+def test_request_validation_errors(
+    build: Callable[[], object], match: str | None
+) -> None:
+    with pytest.raises(ValidationError, match=match):
+        build()
 
 
-def test_request_validation_rejects_large_range() -> None:
-    with pytest.raises(ValidationError):
-        _req(
-            end=datetime.datetime(2026, 2, 15, tzinfo=datetime.timezone.utc),
-        )
+def assert_sql(
+    expected_query: str,
+    expected_params: dict,
+    query: str,
+    params: dict,
+) -> None:
+    expected_formatted = sqlparse.format(expected_query, reindent=True).strip()
+    found_formatted = sqlparse.format(query, reindent=True).strip()
+
+    assert expected_formatted == found_formatted, (
+        f"\nExpected:\n{expected_formatted}\n\nGot:\n{found_formatted}"
+    )
+    assert expected_params == params, (
+        f"\nExpected params: {expected_params}\n\nGot params: {params}"
+    )

--- a/tests/trace_server/query_builder/test_annotation_queues_query_builder.py
+++ b/tests/trace_server/query_builder/test_annotation_queues_query_builder.py
@@ -1,5 +1,6 @@
 import datetime
 
+import pytest
 import sqlparse
 
 from weave.trace_server.common_interface import AnnotationQueueItemsFilter, SortBy
@@ -11,20 +12,6 @@ from weave.trace_server.query_builder.annotation_queues_query_builder import (
     make_queue_items_query,
     make_queues_query,
 )
-
-
-def assert_sql(
-    expected_query: str, expected_params: dict, query: str, params: dict
-) -> None:
-    expected_formatted = sqlparse.format(expected_query, reindent=True)
-    found_formatted = sqlparse.format(query, reindent=True)
-
-    assert expected_formatted == found_formatted, (
-        f"\nExpected:\n{expected_formatted}\n\nGot:\n{found_formatted}"
-    )
-    assert expected_params == params, (
-        f"\nExpected params: {expected_params}\n\nGot params: {params}"
-    )
 
 
 def test_make_queues_query_with_name_and_pagination() -> None:
@@ -68,21 +55,18 @@ def test_make_queues_query_with_name_and_pagination() -> None:
     assert_sql(expected_query, expected_params, query, params)
 
 
-def test_make_queue_items_query_with_filter_and_annotation_states() -> None:
-    pb = ParamBuilder("pb")
-    query = make_queue_items_query(
-        project_id="project",
-        queue_id="queue-id",
-        pb=pb,
-        filter=AnnotationQueueItemsFilter(
-            call_id="call-id",
-            annotation_states=["completed"],
-        ),
-        sort_by=[SortBy(field="call_started_at", direction="desc")],
-    )
-    params = pb.get_params()
-
-    expected_query = """
+# make_queue_items_query shares one ~16-column SELECT + LEFT JOIN; cases diverge in
+# the WHERE tail, the optional annotation_state outer wrapper, and the ORDER BY.
+@pytest.mark.parametrize(
+    ("filter", "sort_by", "expected_query", "expected_params"),
+    [
+        # annotation_states wraps the base query in an outer SELECT with an IN filter.
+        pytest.param(
+            AnnotationQueueItemsFilter(
+                call_id="call-id", annotation_states=["completed"]
+            ),
+            [SortBy(field="call_started_at", direction="desc")],
+            """
     SELECT * FROM (
         SELECT
             qi.id,
@@ -114,46 +98,19 @@ def test_make_queue_items_query_with_filter_and_annotation_states() -> None:
     )
     WHERE annotation_state IN {pb_3:Array(String)}
     ORDER BY call_started_at DESC, id ASC
-    """
-
-    expected_params = {
-        "pb_0": "project",
-        "pb_1": "queue-id",
-        "pb_2": "call-id",
-        "pb_3": ["completed"],
-    }
-
-    assert_sql(expected_query, expected_params, query, params)
-
-
-def test_annotation_queue_items_filter_accepts_id_field() -> None:
-    """Requirement: AnnotationQueueItemsFilter must support filtering by queue item ID
-    Interface: AnnotationQueueItemsFilter class constructor
-    Given: An id value "item-123"
-    When: AnnotationQueueItemsFilter is instantiated with id="item-123"
-    Then: filter.id equals "item-123"
-    """
-    filter = AnnotationQueueItemsFilter(id="item-123")
-    assert filter.id == "item-123"
-
-
-def test_make_queue_items_query_with_id_filter() -> None:
-    """Requirement: make_queue_items_query must generate SQL filtering by queue item ID
-    Interface: make_queue_items_query function output (SQL string and params)
-    Given: An AnnotationQueueItemsFilter with id="item-id"
-    When: make_queue_items_query is called with the filter
-    Then: Generated SQL contains qi.id = {param} and params include the id value
-    """
-    pb = ParamBuilder("pb")
-    query = make_queue_items_query(
-        project_id="project",
-        queue_id="queue-id",
-        pb=pb,
-        filter=AnnotationQueueItemsFilter(id="item-id"),
-    )
-    params = pb.get_params()
-
-    expected_query = """
+    """,
+            {
+                "pb_0": "project",
+                "pb_1": "queue-id",
+                "pb_2": "call-id",
+                "pb_3": ["completed"],
+            },
+            id="call_id_and_annotation_states",
+        ),
+        pytest.param(
+            AnnotationQueueItemsFilter(id="item-id"),
+            None,
+            """
     SELECT
         qi.id,
         any(qi.project_id) as project_id,
@@ -182,34 +139,14 @@ def test_make_queue_items_query_with_id_filter() -> None:
         AND qi.id = {pb_2:String}
     GROUP BY qi.id
     ORDER BY created_at ASC, id ASC
-    """
-
-    expected_params = {
-        "pb_0": "project",
-        "pb_1": "queue-id",
-        "pb_2": "item-id",
-    }
-
-    assert_sql(expected_query, expected_params, query, params)
-
-
-def test_make_queue_items_query_with_id_and_call_id_filter() -> None:
-    """Requirement: id filter can be combined with other filters like call_id
-    Interface: make_queue_items_query function output (SQL string and params)
-    Given: An AnnotationQueueItemsFilter with id="item-id" and call_id="call-id"
-    When: make_queue_items_query is called with the filter
-    Then: Generated SQL contains both qi.id and qi.call_id conditions
-    """
-    pb = ParamBuilder("pb")
-    query = make_queue_items_query(
-        project_id="project",
-        queue_id="queue-id",
-        pb=pb,
-        filter=AnnotationQueueItemsFilter(id="item-id", call_id="call-id"),
-    )
-    params = pb.get_params()
-
-    expected_query = """
+    """,
+            {"pb_0": "project", "pb_1": "queue-id", "pb_2": "item-id"},
+            id="id_filter",
+        ),
+        pytest.param(
+            AnnotationQueueItemsFilter(id="item-id", call_id="call-id"),
+            None,
+            """
     SELECT
         qi.id,
         any(qi.project_id) as project_id,
@@ -239,16 +176,43 @@ def test_make_queue_items_query_with_id_and_call_id_filter() -> None:
         AND qi.call_id = {pb_3:String}
     GROUP BY qi.id
     ORDER BY created_at ASC, id ASC
+    """,
+            {
+                "pb_0": "project",
+                "pb_1": "queue-id",
+                "pb_2": "item-id",
+                "pb_3": "call-id",
+            },
+            id="id_and_call_id_filter",
+        ),
+    ],
+)
+def test_make_queue_items_query(
+    filter: AnnotationQueueItemsFilter,
+    sort_by: list[SortBy] | None,
+    expected_query: str,
+    expected_params: dict,
+) -> None:
+    pb = ParamBuilder("pb")
+    query = make_queue_items_query(
+        project_id="project",
+        queue_id="queue-id",
+        pb=pb,
+        filter=filter,
+        sort_by=sort_by,
+    )
+    assert_sql(expected_query, expected_params, query, pb.get_params())
+
+
+def test_annotation_queue_items_filter_accepts_id_field() -> None:
+    """Requirement: AnnotationQueueItemsFilter must support filtering by queue item ID
+    Interface: AnnotationQueueItemsFilter class constructor
+    Given: An id value "item-123"
+    When: AnnotationQueueItemsFilter is instantiated with id="item-123"
+    Then: filter.id equals "item-123"
     """
-
-    expected_params = {
-        "pb_0": "project",
-        "pb_1": "queue-id",
-        "pb_2": "item-id",
-        "pb_3": "call-id",
-    }
-
-    assert_sql(expected_query, expected_params, query, params)
+    filter = AnnotationQueueItemsFilter(id="item-123")
+    assert filter.id == "item-123"
 
 
 def test_make_annotator_progress_state_check_query() -> None:
@@ -347,3 +311,17 @@ def test_make_annotator_progress_insert_query() -> None:
     }
 
     assert_sql(expected_query, expected_params, query, params)
+
+
+def assert_sql(
+    expected_query: str, expected_params: dict, query: str, params: dict
+) -> None:
+    expected_formatted = sqlparse.format(expected_query, reindent=True)
+    found_formatted = sqlparse.format(query, reindent=True)
+
+    assert expected_formatted == found_formatted, (
+        f"\nExpected:\n{expected_formatted}\n\nGot:\n{found_formatted}"
+    )
+    assert expected_params == params, (
+        f"\nExpected params: {expected_params}\n\nGot params: {params}"
+    )

--- a/tests/trace_server/query_builder/test_call_metrics_query_builder.py
+++ b/tests/trace_server/query_builder/test_call_metrics_query_builder.py
@@ -6,6 +6,8 @@ These tests verify the SQL generation for call-level metrics
 
 import datetime
 
+import pytest
+
 from tests.trace_server.query_builder.utils import assert_call_metrics_sql
 from weave.trace_server.project_version.types import ReadTable
 from weave.trace_server.trace_server_interface import (
@@ -15,27 +17,33 @@ from weave.trace_server.trace_server_interface import (
     CallStatsReq,
 )
 
+START_DT = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+DAY_END_DT = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
+HOUR_END_DT = datetime.datetime(2024, 12, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
+NOW = datetime.datetime(2024, 12, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
 
-def test_latency_basic():
-    """Test basic latency metric with AVG and MAX aggregations."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        CallMetricSpec(
-            metric="latency_ms",
-            aggregations=[AggregationType.AVG, AggregationType.MAX],
-        )
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
+
+@pytest.mark.parametrize(
+    (
+        "metrics",
+        "granularity",
+        "end_dt",
+        "exp_query",
+        "exp_params",
+        "exp_columns",
+        "exp_granularity",
+    ),
+    [
+        pytest.param(
+            [
+                CallMetricSpec(
+                    metric="latency_ms",
+                    aggregations=[AggregationType.AVG, AggregationType.MAX],
+                )
+            ],
+            3600,
+            DAY_END_DT,
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -70,38 +78,27 @@ def test_latency_basic():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        ["timestamp", "avg_latency_ms", "max_latency_ms", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_call_and_error_counts():
-    """Test call_count and error_count metrics with SUM aggregation."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        CallMetricSpec(metric="call_count", aggregations=[AggregationType.SUM]),
-        CallMetricSpec(metric="error_count", aggregations=[AggregationType.SUM]),
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+            },
+            ["timestamp", "avg_latency_ms", "max_latency_ms", "count"],
+            3600,
+            id="latency_avg_max",
+        ),
+        pytest.param(
+            [
+                CallMetricSpec(metric="call_count", aggregations=[AggregationType.SUM]),
+                CallMetricSpec(
+                    metric="error_count", aggregations=[AggregationType.SUM]
+                ),
+            ],
+            3600,
+            DAY_END_DT,
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -138,46 +135,33 @@ def test_call_and_error_counts():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        ["timestamp", "sum_call_count", "sum_error_count", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_all_aggregation_types():
-    """Test all aggregation types (SUM, AVG, MIN, MAX, COUNT) for latency."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        CallMetricSpec(
-            metric="latency_ms",
-            aggregations=[
-                AggregationType.SUM,
-                AggregationType.AVG,
-                AggregationType.MIN,
-                AggregationType.MAX,
-                AggregationType.COUNT,
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+            },
+            ["timestamp", "sum_call_count", "sum_error_count", "count"],
+            3600,
+            id="call_and_error_counts",
+        ),
+        pytest.param(
+            [
+                CallMetricSpec(
+                    metric="latency_ms",
+                    aggregations=[
+                        AggregationType.SUM,
+                        AggregationType.AVG,
+                        AggregationType.MIN,
+                        AggregationType.MAX,
+                        AggregationType.COUNT,
+                    ],
+                )
             ],
-        )
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=300,
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
+            300,
+            HOUR_END_DT,
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -218,49 +202,36 @@ def test_all_aggregation_types():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733014800.0,
-            "pb_3": "UTC",
-            "pb_4": 300,
-        },
-        [
-            "timestamp",
-            "sum_latency_ms",
-            "avg_latency_ms",
-            "min_latency_ms",
-            "max_latency_ms",
-            "count_latency_ms",
-            "count",
-        ],
-        300,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_latency_percentiles():
-    """Test percentile calculations (p50, p95, p99) for latency."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        CallMetricSpec(
-            metric="latency_ms",
-            aggregations=[],
-            percentiles=[50, 95, 99],
-        )
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=300,
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733014800.0,
+                "pb_3": "UTC",
+                "pb_4": 300,
+            },
+            [
+                "timestamp",
+                "sum_latency_ms",
+                "avg_latency_ms",
+                "min_latency_ms",
+                "max_latency_ms",
+                "count_latency_ms",
+                "count",
+            ],
+            300,
+            id="all_aggregation_types",
+        ),
+        pytest.param(
+            [
+                CallMetricSpec(
+                    metric="latency_ms",
+                    aggregations=[],
+                    percentiles=[50, 95, 99],
+                )
+            ],
+            300,
+            HOUR_END_DT,
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -297,240 +268,37 @@ def test_latency_percentiles():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733014800.0,
-            "pb_3": "UTC",
-            "pb_4": 300,
-        },
-        [
-            "timestamp",
-            "p50_latency_ms",
-            "p95_latency_ms",
-            "p99_latency_ms",
-            "count",
-        ],
-        300,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_op_names_filter():
-    """Test filtering by op_names."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [CallMetricSpec(metric="call_count", aggregations=[AggregationType.SUM])]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(op_names=["openai.chat", "anthropic.messages"]),
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  sumOrNull(m_call_count) AS sum_call_count,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     1 AS m_call_count
-              FROM
-                (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                        anyIf(cm.started_at, cm.started_at IS NOT NULL) AS started_at,
-                        anyIf(cm.ended_at, cm.ended_at IS NOT NULL) AS ended_at,
-                        anyIf(cm.exception, cm.exception IS NOT NULL) AS
-                 exception
-                 FROM calls_merged AS cm
-                 WHERE cm.project_id = {pb_0:String}
-                   AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                   AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                   AND cm.deleted_at IS NULL
-                   AND op_name IN {pb_5:Array(String)}
-                 GROUP BY project_id,
-                          id))
-           GROUP BY bucket)
-        SELECT all_buckets.bucket AS timestamp,
-               COALESCE(aggregated_data.sum_call_count, 0) AS sum_call_count,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        ORDER BY all_buckets.bucket
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-            "pb_5": ["openai.chat", "anthropic.messages"],
-        },
-        ["timestamp", "sum_call_count", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_trace_roots_only_filter():
-    """Test filtering to only trace roots (no parent)."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [CallMetricSpec(metric="latency_ms", aggregations=[AggregationType.AVG])]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(trace_roots_only=True),
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  avgOrNull(m_latency_ms) AS avg_latency_ms,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     dateDiff('millisecond', started_at, ended_at) AS m_latency_ms
-              FROM
-                (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                        anyIf(cm.started_at, cm.started_at IS NOT NULL) AS started_at,
-                        anyIf(cm.ended_at, cm.ended_at IS NOT NULL) AS ended_at,
-                        anyIf(cm.exception, cm.exception IS NOT NULL) AS
-                 exception
-                 FROM calls_merged AS cm
-                 WHERE cm.project_id = {pb_0:String}
-                   AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                   AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                   AND cm.deleted_at IS NULL
-                   AND parent_id IS NULL
-                 GROUP BY project_id,
-                          id))
-           GROUP BY bucket)
-        SELECT all_buckets.bucket AS timestamp,
-               COALESCE(aggregated_data.avg_latency_ms, 0) AS avg_latency_ms,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        ORDER BY all_buckets.bucket
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        ["timestamp", "avg_latency_ms", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_trace_ids_filter():
-    """Test filtering by specific trace_ids."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [CallMetricSpec(metric="error_count", aggregations=[AggregationType.SUM])]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(trace_ids=["trace_abc", "trace_def"]),
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  sumOrNull(m_error_count) AS sum_error_count,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     if(
-                        exception IS NOT NULL, 1, 0) AS m_error_count
-              FROM
-                (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                        anyIf(cm.started_at, cm.started_at IS NOT NULL) AS started_at,
-                        anyIf(cm.ended_at, cm.ended_at IS NOT NULL) AS ended_at,
-                        anyIf(cm.exception, cm.exception IS NOT NULL) AS
-                 exception
-                 FROM calls_merged AS cm
-                 WHERE cm.project_id = {pb_0:String}
-                   AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                   AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                   AND cm.deleted_at IS NULL
-                   AND ifNull(trace_id, '') IN {pb_5:Array(String)}
-                 GROUP BY project_id,
-                          id))
-           GROUP BY bucket)
-        SELECT all_buckets.bucket AS timestamp,
-               COALESCE(aggregated_data.sum_error_count, 0) AS sum_error_count,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        ORDER BY all_buckets.bucket
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-            "pb_5": ["trace_abc", "trace_def"],
-        },
-        ["timestamp", "sum_error_count", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_combined_metrics():
-    """Test requesting multiple different metrics together."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        CallMetricSpec(
-            metric="latency_ms",
-            aggregations=[AggregationType.AVG, AggregationType.MAX],
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733014800.0,
+                "pb_3": "UTC",
+                "pb_4": 300,
+            },
+            [
+                "timestamp",
+                "p50_latency_ms",
+                "p95_latency_ms",
+                "p99_latency_ms",
+                "count",
+            ],
+            300,
+            id="latency_percentiles",
         ),
-        CallMetricSpec(metric="call_count", aggregations=[AggregationType.SUM]),
-        CallMetricSpec(metric="error_count", aggregations=[AggregationType.SUM]),
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
+        pytest.param(
+            [
+                CallMetricSpec(
+                    metric="latency_ms",
+                    aggregations=[AggregationType.AVG, AggregationType.MAX],
+                ),
+                CallMetricSpec(metric="call_count", aggregations=[AggregationType.SUM]),
+                CallMetricSpec(
+                    metric="error_count", aggregations=[AggregationType.SUM]
+                ),
+            ],
+            3600,
+            DAY_END_DT,
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -572,42 +340,238 @@ def test_combined_metrics():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        [
-            "timestamp",
-            "avg_latency_ms",
-            "max_latency_ms",
-            "sum_call_count",
-            "sum_error_count",
-            "count",
-        ],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_granularity_auto_selection():
-    """Test automatic granularity selection based on time range."""
-    now = datetime.datetime(2024, 12, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [CallMetricSpec(metric="call_count")]
-
-    # < 2 hours -> 5 minutes (300 seconds)
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+            },
+            [
+                "timestamp",
+                "avg_latency_ms",
+                "max_latency_ms",
+                "sum_call_count",
+                "sum_error_count",
+                "count",
+            ],
+            3600,
+            id="combined_metrics",
+        ),
+    ],
+)
+def test_calls_merged_metric_shapes(
+    metrics: list[CallMetricSpec],
+    granularity: int,
+    end_dt: datetime.datetime,
+    exp_query: str,
+    exp_params: dict[str, object],
+    exp_columns: list[str],
+    exp_granularity: int,
+):
+    """calls_merged metric/aggregation/percentile SQL shapes."""
     req = CallStatsReq(
-        project_id="p",
-        start=now - datetime.timedelta(hours=1),
-        end=now,
+        project_id="entity/project",
+        start=START_DT,
+        end=end_dt,
+        granularity=granularity,
     )
     assert_call_metrics_sql(
         req,
         metrics,
-        """
+        exp_query,
+        exp_params,
+        exp_columns,
+        exp_granularity,
+        exp_start=START_DT,
+        exp_end=end_dt,
+    )
+
+
+@pytest.mark.parametrize(
+    ("metric", "call_filter", "exp_query", "exp_params", "exp_columns"),
+    [
+        pytest.param(
+            "call_count",
+            CallsFilter(op_names=["openai.chat", "anthropic.messages"]),
+            """
+        WITH all_buckets AS
+          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+             aggregated_data AS
+          (SELECT bucket,
+                  sumOrNull(m_call_count) AS sum_call_count,
+                  count() AS count
+           FROM
+             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
+                     1 AS m_call_count
+              FROM
+                (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
+                        anyIf(cm.started_at, cm.started_at IS NOT NULL) AS started_at,
+                        anyIf(cm.ended_at, cm.ended_at IS NOT NULL) AS ended_at,
+                        anyIf(cm.exception, cm.exception IS NOT NULL) AS
+                 exception
+                 FROM calls_merged AS cm
+                 WHERE cm.project_id = {pb_0:String}
+                   AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
+                   AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                   AND cm.deleted_at IS NULL
+                   AND op_name IN {pb_5:Array(String)}
+                 GROUP BY project_id,
+                          id))
+           GROUP BY bucket)
+        SELECT all_buckets.bucket AS timestamp,
+               COALESCE(aggregated_data.sum_call_count, 0) AS sum_call_count,
+               COALESCE(aggregated_data.count, 0) AS count
+        FROM all_buckets
+        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+        ORDER BY all_buckets.bucket
+        """,
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+                "pb_5": ["openai.chat", "anthropic.messages"],
+            },
+            ["timestamp", "sum_call_count", "count"],
+            id="op_names",
+        ),
+        pytest.param(
+            "latency_ms",
+            CallsFilter(trace_roots_only=True),
+            """
+        WITH all_buckets AS
+          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+             aggregated_data AS
+          (SELECT bucket,
+                  avgOrNull(m_latency_ms) AS avg_latency_ms,
+                  count() AS count
+           FROM
+             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
+                     dateDiff('millisecond', started_at, ended_at) AS m_latency_ms
+              FROM
+                (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
+                        anyIf(cm.started_at, cm.started_at IS NOT NULL) AS started_at,
+                        anyIf(cm.ended_at, cm.ended_at IS NOT NULL) AS ended_at,
+                        anyIf(cm.exception, cm.exception IS NOT NULL) AS
+                 exception
+                 FROM calls_merged AS cm
+                 WHERE cm.project_id = {pb_0:String}
+                   AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
+                   AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                   AND cm.deleted_at IS NULL
+                   AND parent_id IS NULL
+                 GROUP BY project_id,
+                          id))
+           GROUP BY bucket)
+        SELECT all_buckets.bucket AS timestamp,
+               COALESCE(aggregated_data.avg_latency_ms, 0) AS avg_latency_ms,
+               COALESCE(aggregated_data.count, 0) AS count
+        FROM all_buckets
+        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+        ORDER BY all_buckets.bucket
+        """,
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+            },
+            ["timestamp", "avg_latency_ms", "count"],
+            id="trace_roots_only",
+        ),
+        pytest.param(
+            "error_count",
+            CallsFilter(trace_ids=["trace_abc", "trace_def"]),
+            """
+        WITH all_buckets AS
+          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+             aggregated_data AS
+          (SELECT bucket,
+                  sumOrNull(m_error_count) AS sum_error_count,
+                  count() AS count
+           FROM
+             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
+                     if(
+                        exception IS NOT NULL, 1, 0) AS m_error_count
+              FROM
+                (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
+                        anyIf(cm.started_at, cm.started_at IS NOT NULL) AS started_at,
+                        anyIf(cm.ended_at, cm.ended_at IS NOT NULL) AS ended_at,
+                        anyIf(cm.exception, cm.exception IS NOT NULL) AS
+                 exception
+                 FROM calls_merged AS cm
+                 WHERE cm.project_id = {pb_0:String}
+                   AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
+                   AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                   AND cm.deleted_at IS NULL
+                   AND ifNull(trace_id, '') IN {pb_5:Array(String)}
+                 GROUP BY project_id,
+                          id))
+           GROUP BY bucket)
+        SELECT all_buckets.bucket AS timestamp,
+               COALESCE(aggregated_data.sum_error_count, 0) AS sum_error_count,
+               COALESCE(aggregated_data.count, 0) AS count
+        FROM all_buckets
+        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+        ORDER BY all_buckets.bucket
+        """,
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+                "pb_5": ["trace_abc", "trace_def"],
+            },
+            ["timestamp", "sum_error_count", "count"],
+            id="trace_ids",
+        ),
+    ],
+)
+def test_calls_merged_filters(
+    metric: str,
+    call_filter: CallsFilter,
+    exp_query: str,
+    exp_params: dict[str, object],
+    exp_columns: list[str],
+):
+    """calls_merged filter-clause WHERE rewrites (op_names, trace_roots, trace_ids)."""
+    agg = AggregationType.SUM if metric != "latency_ms" else AggregationType.AVG
+    req = CallStatsReq(
+        project_id="entity/project",
+        start=START_DT,
+        end=DAY_END_DT,
+        granularity=3600,
+        filter=call_filter,
+    )
+    assert_call_metrics_sql(
+        req,
+        [CallMetricSpec(metric=metric, aggregations=[agg])],
+        exp_query,
+        exp_params,
+        exp_columns,
+        3600,
+        exp_start=START_DT,
+        exp_end=DAY_END_DT,
+    )
+
+
+@pytest.mark.parametrize(
+    ("delta", "granularity", "exp_query", "exp_params", "exp_granularity"),
+    [
+        pytest.param(
+            datetime.timedelta(hours=1),
+            300,
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -640,27 +604,20 @@ def test_granularity_auto_selection():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "p",
-            "pb_1": 1733050800.0,
-            "pb_2": 1733054400.0,
-            "pb_3": "UTC",
-            "pb_4": 300,
-        },
-        ["timestamp", "sum_call_count", "count"],
-        300,
-    )
-
-    # 2-12 hours -> 1 hour (3600 seconds)
-    req = CallStatsReq(
-        project_id="p",
-        start=now - datetime.timedelta(hours=6),
-        end=now,
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
+            {
+                "pb_0": "p",
+                "pb_1": 1733050800.0,
+                "pb_2": 1733054400.0,
+                "pb_3": "UTC",
+                "pb_4": 300,
+            },
+            300,
+            id="under_2h_300s",
+        ),
+        pytest.param(
+            datetime.timedelta(hours=6),
+            3600,
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -693,15 +650,38 @@ def test_granularity_auto_selection():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "p",
-            "pb_1": 1733032800.0,
-            "pb_2": 1733054400.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
+            {
+                "pb_0": "p",
+                "pb_1": 1733032800.0,
+                "pb_2": 1733054400.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+            },
+            3600,
+            id="2_to_12h_3600s",
+        ),
+    ],
+)
+def test_granularity_auto_selection(
+    delta: datetime.timedelta,
+    granularity: int,
+    exp_query: str,
+    exp_params: dict[str, object],
+    exp_granularity: int,
+):
+    """Automatic granularity selection based on time range (only 2 of 5 ladder steps)."""
+    req = CallStatsReq(
+        project_id="p",
+        start=NOW - delta,
+        end=NOW,
+    )
+    assert_call_metrics_sql(
+        req,
+        [CallMetricSpec(metric="call_count")],
+        exp_query,
+        exp_params,
         ["timestamp", "sum_call_count", "count"],
-        3600,
+        granularity,
     )
 
 
@@ -715,32 +695,18 @@ def test_granularity_auto_selection():
 # =============================================================================
 
 
-def test_calls_complete_latency_basic():
-    """Test basic latency metric query for calls_complete table.
-
-    Key differences from calls_merged:
-    - Uses started_at instead of sortable_datetime
-    - No anyIf aggregation (single row per call)
-    - No GROUP BY project_id, id
-    """
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        CallMetricSpec(
-            metric="latency_ms",
-            aggregations=[AggregationType.AVG, AggregationType.MAX],
-        )
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
+@pytest.mark.parametrize(
+    ("metrics", "call_filter", "exp_query", "exp_params", "exp_columns"),
+    [
+        pytest.param(
+            [
+                CallMetricSpec(
+                    metric="latency_ms",
+                    aggregations=[AggregationType.AVG, AggregationType.MAX],
+                )
+            ],
+            None,
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -773,39 +739,25 @@ def test_calls_complete_latency_basic():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        ["timestamp", "avg_latency_ms", "max_latency_ms", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-        read_table=ReadTable.CALLS_COMPLETE,
-    )
-
-
-def test_calls_complete_call_and_error_counts():
-    """Test call_count and error_count metrics with calls_complete table."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        CallMetricSpec(metric="call_count", aggregations=[AggregationType.SUM]),
-        CallMetricSpec(metric="error_count", aggregations=[AggregationType.SUM]),
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+            },
+            ["timestamp", "avg_latency_ms", "max_latency_ms", "count"],
+            id="latency_basic",
+        ),
+        pytest.param(
+            [
+                CallMetricSpec(metric="call_count", aggregations=[AggregationType.SUM]),
+                CallMetricSpec(
+                    metric="error_count", aggregations=[AggregationType.SUM]
+                ),
+            ],
+            None,
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -840,43 +792,21 @@ def test_calls_complete_call_and_error_counts():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-            "pb_5": "",
-        },
-        ["timestamp", "sum_call_count", "sum_error_count", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-        read_table=ReadTable.CALLS_COMPLETE,
-    )
-
-
-def test_calls_complete_trace_roots_only_filter():
-    """Test trace_roots_only filter uses sentinel check for calls_complete.
-
-    In calls_complete, parent_id is a non-nullable String with '' as the
-    sentinel for NULL, so trace_roots_only must check parent_id = '' instead
-    of parent_id IS NULL.
-    """
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [CallMetricSpec(metric="latency_ms", aggregations=[AggregationType.AVG])]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(trace_roots_only=True),
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+                "pb_5": "",
+            },
+            ["timestamp", "sum_call_count", "sum_error_count", "count"],
+            id="call_and_error_counts",
+        ),
+        pytest.param(
+            [CallMetricSpec(metric="latency_ms", aggregations=[AggregationType.AVG])],
+            CallsFilter(trace_roots_only=True),
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -908,38 +838,21 @@ def test_calls_complete_trace_roots_only_filter():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-            "pb_5": "",
-        },
-        ["timestamp", "avg_latency_ms", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-        read_table=ReadTable.CALLS_COMPLETE,
-    )
-
-
-def test_calls_complete_with_filter():
-    """Test call metrics with op_names filter for calls_complete table."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [CallMetricSpec(metric="call_count", aggregations=[AggregationType.SUM])]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(op_names=["openai.chat"]),
-    )
-    assert_call_metrics_sql(
-        req,
-        metrics,
-        """
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+                "pb_5": "",
+            },
+            ["timestamp", "avg_latency_ms", "count"],
+            id="trace_roots_only_sentinel",
+        ),
+        pytest.param(
+            [CallMetricSpec(metric="call_count", aggregations=[AggregationType.SUM])],
+            CallsFilter(op_names=["openai.chat"]),
+            """
         WITH all_buckets AS
           (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
            FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
@@ -971,17 +884,42 @@ def test_calls_complete_with_filter():
         LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
         ORDER BY all_buckets.bucket
         """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-            "pb_5": ["openai.chat"],
-        },
-        ["timestamp", "sum_call_count", "count"],
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+                "pb_5": ["openai.chat"],
+            },
+            ["timestamp", "sum_call_count", "count"],
+            id="op_names_filter",
+        ),
+    ],
+)
+def test_calls_complete_shapes(
+    metrics: list[CallMetricSpec],
+    call_filter: CallsFilter | None,
+    exp_query: str,
+    exp_params: dict[str, object],
+    exp_columns: list[str],
+):
+    """calls_complete inner-query shape: started_at bucketing, no anyIf/GROUP BY, sentinel branches."""
+    req = CallStatsReq(
+        project_id="entity/project",
+        start=START_DT,
+        end=DAY_END_DT,
+        granularity=3600,
+        filter=call_filter,
+    )
+    assert_call_metrics_sql(
+        req,
+        metrics,
+        exp_query,
+        exp_params,
+        exp_columns,
         3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
+        exp_start=START_DT,
+        exp_end=DAY_END_DT,
         read_table=ReadTable.CALLS_COMPLETE,
     )

--- a/tests/trace_server/query_builder/test_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_calls_query_builder.py
@@ -863,57 +863,96 @@ def test_calls_query_with_predicate_filters() -> None:
     )
 
 
-def test_query_with_summary_weave_status_sort() -> None:
-    """Test sorting by summary.weave.status field."""
-    cq = CallsQuery(project_id="project")
+@pytest.mark.parametrize(
+    ("read_table", "extra_fields", "expected_sql", "expected_params"),
+    [
+        (
+            ReadTable.CALLS_MERGED,
+            ["exception", "ended_at"],
+            """
+            SELECT
+                calls_merged.id AS id,
+                any(calls_merged.exception) AS exception,
+                any(calls_merged.ended_at) AS ended_at
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_5:String}
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((
+                    any(calls_merged.deleted_at) IS NULL
+                ))
+                AND
+                ((
+                   NOT ((
+                      any(calls_merged.op_name) IS NULL
+                   ))
+                ))
+            )
+            ORDER BY CASE
+                WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
+                WHEN IFNULL(
+                    toInt64OrNull(
+                        coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')
+                    ),
+                    0
+                ) > 0 THEN {pb_4:String}
+                WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
+                ELSE {pb_3:String}
+                END ASC
+            """,
+            {
+                "pb_0": '$."status_counts"."error"',
+                "pb_1": "error",
+                "pb_2": "running",
+                "pb_3": "success",
+                "pb_4": "descendant_error",
+                "pb_5": "project",
+            },
+        ),
+        (
+            ReadTable.CALLS_COMPLETE,
+            [],
+            """
+            SELECT calls_complete.id AS id
+            FROM calls_complete PREWHERE calls_complete.project_id = {pb_8:String}
+            WHERE 1
+              AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
+            ORDER BY CASE
+                         WHEN calls_complete.exception != {pb_6:String} THEN {pb_2:String}
+                         WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_1:String}), 'null'), '')), 0) > 0 THEN {pb_5:String}
+                         WHEN calls_complete.ended_at = {pb_7:DateTime64(6)} THEN {pb_3:String}
+                         ELSE {pb_4:String}
+                     END ASC
+            """,
+            {
+                "pb_0": SENTINEL_EPOCH,
+                "pb_1": '$."status_counts"."error"',
+                "pb_2": "error",
+                "pb_3": "running",
+                "pb_4": "success",
+                "pb_5": "descendant_error",
+                "pb_6": "",
+                "pb_7": SENTINEL_EPOCH,
+                "pb_8": "project",
+            },
+        ),
+    ],
+)
+def test_status_sort_by_table(
+    read_table: ReadTable,
+    extra_fields: list[str],
+    expected_sql: str,
+    expected_params: dict,
+) -> None:
+    """Sorting by summary.weave.status: calls_merged uses any()-CASE over a GROUP BY,
+    calls_complete uses sentinel checks (exception != '', ended_at = sentinel) on flat rows.
+    """
+    cq = CallsQuery(project_id="project", read_table=read_table)
     cq.add_field("id")
-    cq.add_field("exception")
-    cq.add_field("ended_at")
+    for field in extra_fields:
+        cq.add_field(field)
     cq.add_order("summary.weave.status", "asc")
-
-    # Assert that the query orders by the computed status field
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_merged.id AS id,
-            any(calls_merged.exception) AS exception,
-            any(calls_merged.ended_at) AS ended_at
-        FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_5:String}
-        GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (
-            ((
-                any(calls_merged.deleted_at) IS NULL
-            ))
-            AND
-            ((
-               NOT ((
-                  any(calls_merged.op_name) IS NULL
-               ))
-            ))
-        )
-        ORDER BY CASE
-            WHEN any(calls_merged.exception) IS NOT NULL THEN {pb_1:String}
-            WHEN IFNULL(
-                toInt64OrNull(
-                    coalesce(nullIf(JSON_VALUE(any(calls_merged.summary_dump), {pb_0:String}), 'null'), '')
-                ),
-                0
-            ) > 0 THEN {pb_4:String}
-            WHEN any(calls_merged.ended_at) IS NULL THEN {pb_2:String}
-            ELSE {pb_3:String}
-            END ASC
-        """,
-        {
-            "pb_0": '$."status_counts"."error"',
-            "pb_1": "error",
-            "pb_2": "running",
-            "pb_3": "success",
-            "pb_4": "descendant_error",
-            "pb_5": "project",
-        },
-    )
+    assert_sql(cq, expected_sql, expected_params)
 
 
 def test_query_with_summary_weave_status_sort_and_filter() -> None:
@@ -1200,244 +1239,189 @@ def test_calls_query_with_complex_heavy_filters() -> None:
     )
 
 
-def test_calls_query_with_like_optimization() -> None:
-    """Test that simple JSON field equality checks use LIKE optimization."""
+_LIKE_EQ_CONDITION = tsi_query.EqOperation.model_validate(
+    {"$eq": [{"$getField": "inputs.param"}, {"$literal": "hello"}]}
+)
+_LIKE_CONTAINS_CONDITION = tsi_query.ContainsOperation.model_validate(
+    {
+        "$contains": {
+            "input": {"$getField": "inputs.param"},
+            "substr": {"$literal": "hello"},
+            "case_insensitive": True,
+        }
+    }
+)
+_LIKE_IN_CONDITION = tsi_query.InOperation.model_validate(
+    {
+        "$in": [
+            {"$getField": "inputs.param"},
+            [{"$literal": "hello"}, {"$literal": "world"}],
+        ]
+    }
+)
+
+
+@pytest.mark.parametrize(
+    ("condition", "expected_sql", "expected_params"),
+    [
+        (
+            _LIKE_EQ_CONDITION,
+            """
+            SELECT
+                calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_3:String}
+            WHERE ((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+            )
+            """,
+            {
+                "pb_3": "project",
+                "pb_2": '%"hello"%',
+                "pb_1": "hello",
+                "pb_0": '$."param"',
+            },
+        ),
+        (
+            _LIKE_CONTAINS_CONDITION,
+            """
+            SELECT
+                calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_3:String}
+            WHERE ((lower(calls_merged.inputs_dump) LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+            )
+            """,
+            {
+                "pb_0": '$."param"',
+                "pb_3": "project",
+                "pb_2": '%"%hello%"%',
+                "pb_1": "hello",
+            },
+        ),
+        (
+            _LIKE_IN_CONDITION,
+            """
+            SELECT
+                calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_5:String}
+            WHERE (((calls_merged.inputs_dump LIKE {pb_3:String} OR calls_merged.inputs_dump LIKE {pb_4:String})
+                    OR calls_merged.inputs_dump IS NULL))
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') IN ({pb_1:String},{pb_2:String})))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+            )
+            """,
+            {
+                "pb_0": '$."param"',
+                "pb_1": "hello",
+                "pb_2": "world",
+                "pb_5": "project",
+                "pb_3": '%"hello"%',
+                "pb_4": '%"world"%',
+            },
+        ),
+    ],
+    ids=["eq", "contains", "in"],
+)
+def test_calls_query_with_like_optimization_calls_merged(
+    condition: object, expected_sql: str, expected_params: dict
+) -> None:
+    """On calls_merged the LIKE prefilter carries `OR ... IS NULL` (unmerged parts)."""
     cq = CallsQuery(project_id="project")
     cq.add_field("id")
-    cq.add_condition(
-        tsi_query.EqOperation.model_validate(
+    cq.add_condition(condition)
+    assert_sql(cq, expected_sql, expected_params)
+
+
+@pytest.mark.parametrize(
+    ("condition", "expected_sql", "expected_params"),
+    [
+        (
+            _LIKE_EQ_CONDITION,
+            """
+            SELECT
+                calls_complete.id AS id
+            FROM calls_complete
+            PREWHERE calls_complete.project_id = {pb_4:String}
+            WHERE (calls_complete.inputs_dump LIKE {pb_3:String})
+            AND
+                (((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), '') = {pb_1:String}))
+                     AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
+            """,
             {
-                "$eq": [
-                    {"$getField": "inputs.param"},
-                    {"$literal": "hello"},
-                ]
-            }
-        )
-    )
-
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_merged.id AS id
-        FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_3:String}
-        WHERE ((calls_merged.inputs_dump LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
-        GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (
-            ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') = {pb_1:String}))
-            AND ((any(calls_merged.deleted_at) IS NULL))
-            AND ((NOT ((any(calls_merged.op_name) IS NULL))))
-        )
-        """,
-        {
-            "pb_3": "project",
-            "pb_2": '%"hello"%',
-            "pb_1": "hello",
-            "pb_0": '$."param"',
-        },
-    )
-
-
-def test_calls_query_with_like_optimization_contains() -> None:
-    """Test that contains operations on JSON fields use LIKE optimization."""
-    cq = CallsQuery(project_id="project")
-    cq.add_field("id")
-    cq.add_condition(
-        tsi_query.ContainsOperation.model_validate(
+                "pb_0": '$."param"',
+                "pb_1": "hello",
+                "pb_2": SENTINEL_EPOCH,
+                "pb_3": '%"hello"%',
+                "pb_4": "project",
+            },
+        ),
+        (
+            _LIKE_CONTAINS_CONDITION,
+            """
+            SELECT
+                calls_complete.id AS id
+            FROM calls_complete
+            PREWHERE calls_complete.project_id = {pb_4:String}
+            WHERE (lower(calls_complete.inputs_dump) LIKE {pb_3:String})
+            AND
+                ((positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
+                     AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
+            """,
             {
-                "$contains": {
-                    "input": {"$getField": "inputs.param"},
-                    "substr": {"$literal": "hello"},
-                    "case_insensitive": True,
-                }
-            }
-        )
-    )
-
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_merged.id AS id
-        FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_3:String}
-        WHERE ((lower(calls_merged.inputs_dump) LIKE {pb_2:String} OR calls_merged.inputs_dump IS NULL))
-        GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (
-            (positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
-            AND ((any(calls_merged.deleted_at) IS NULL))
-            AND ((NOT ((any(calls_merged.op_name) IS NULL))))
-        )
-        """,
-        {
-            "pb_0": '$."param"',
-            "pb_3": "project",
-            "pb_2": '%"%hello%"%',
-            "pb_1": "hello",
-        },
-    )
-
-
-def test_query_with_json_value_in_condition() -> None:
-    """Test that in operations on JSON fields use JSON_VALUE with IN."""
-    cq = CallsQuery(project_id="project")
-    cq.add_field("id")
-    cq.add_condition(
-        tsi_query.InOperation.model_validate(
+                "pb_0": '$."param"',
+                "pb_1": "hello",
+                "pb_2": SENTINEL_EPOCH,
+                "pb_3": '%"%hello%"%',
+                "pb_4": "project",
+            },
+        ),
+        (
+            _LIKE_IN_CONDITION,
+            """
+            SELECT
+                calls_complete.id AS id
+            FROM calls_complete
+            PREWHERE calls_complete.project_id = {pb_6:String}
+            WHERE ((calls_complete.inputs_dump LIKE {pb_4:String} OR calls_complete.inputs_dump LIKE {pb_5:String}))
+            AND
+                (((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), '') IN ({pb_1:String},{pb_2:String})))
+                     AND ((calls_complete.deleted_at = {pb_3:DateTime64(3)})))
+            """,
             {
-                "$in": [
-                    {"$getField": "inputs.param"},
-                    [{"$literal": "hello"}, {"$literal": "world"}],
-                ]
-            }
-        )
-    )
-
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_merged.id AS id
-        FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_5:String}
-        WHERE (((calls_merged.inputs_dump LIKE {pb_3:String} OR calls_merged.inputs_dump LIKE {pb_4:String})
-                OR calls_merged.inputs_dump IS NULL))
-        GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (
-            ((coalesce(nullIf(JSON_VALUE(any(calls_merged.inputs_dump), {pb_0:String}), 'null'), '') IN ({pb_1:String},{pb_2:String})))
-            AND ((any(calls_merged.deleted_at) IS NULL))
-            AND ((NOT ((any(calls_merged.op_name) IS NULL))))
-        )
-        """,
-        {
-            "pb_0": '$."param"',
-            "pb_1": "hello",
-            "pb_2": "world",
-            "pb_5": "project",
-            "pb_3": '%"hello"%',
-            "pb_4": '%"world"%',
-        },
-    )
-
-
-def test_calls_query_with_like_optimization_calls_complete() -> None:
-    """Test that LIKE optimization on calls_complete does NOT include null checks.
-
-    For calls_complete, every row is a complete call, so there are no unmerged
-    call parts with NULL fields. The LIKE condition should be tighter without
-    the OR IS NULL clause.
-    """
+                "pb_0": '$."param"',
+                "pb_1": "hello",
+                "pb_2": "world",
+                "pb_3": SENTINEL_EPOCH,
+                "pb_4": '%"hello"%',
+                "pb_5": '%"world"%',
+                "pb_6": "project",
+            },
+        ),
+    ],
+    ids=["eq", "contains", "in"],
+)
+def test_calls_query_with_like_optimization_calls_complete(
+    condition: object, expected_sql: str, expected_params: dict
+) -> None:
+    """On calls_complete every row is complete, so the LIKE prefilter has no `OR IS NULL`."""
     cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
     cq.add_field("id")
-    cq.add_condition(
-        tsi_query.EqOperation.model_validate(
-            {
-                "$eq": [
-                    {"$getField": "inputs.param"},
-                    {"$literal": "hello"},
-                ]
-            }
-        )
-    )
-
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_complete.id AS id
-        FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_4:String}
-        WHERE (calls_complete.inputs_dump LIKE {pb_3:String})
-        AND
-            (((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), '') = {pb_1:String}))
-                 AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
-        """,
-        {
-            "pb_0": '$."param"',
-            "pb_1": "hello",
-            "pb_2": SENTINEL_EPOCH,
-            "pb_3": '%"hello"%',
-            "pb_4": "project",
-        },
-    )
-
-
-def test_calls_query_with_like_optimization_contains_calls_complete() -> None:
-    """Test that contains LIKE optimization on calls_complete does NOT include null checks."""
-    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
-    cq.add_field("id")
-    cq.add_condition(
-        tsi_query.ContainsOperation.model_validate(
-            {
-                "$contains": {
-                    "input": {"$getField": "inputs.param"},
-                    "substr": {"$literal": "hello"},
-                    "case_insensitive": True,
-                }
-            }
-        )
-    )
-
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_complete.id AS id
-        FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_4:String}
-        WHERE (lower(calls_complete.inputs_dump) LIKE {pb_3:String})
-        AND
-            ((positionCaseInsensitive(coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), ''), {pb_1:String}) > 0)
-                 AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
-        """,
-        {
-            "pb_0": '$."param"',
-            "pb_1": "hello",
-            "pb_2": SENTINEL_EPOCH,
-            "pb_3": '%"%hello%"%',
-            "pb_4": "project",
-        },
-    )
-
-
-def test_calls_query_with_like_optimization_in_calls_complete() -> None:
-    """Test that IN LIKE optimization on calls_complete does NOT include null checks."""
-    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
-    cq.add_field("id")
-    cq.add_condition(
-        tsi_query.InOperation.model_validate(
-            {
-                "$in": [
-                    {"$getField": "inputs.param"},
-                    [{"$literal": "hello"}, {"$literal": "world"}],
-                ]
-            }
-        )
-    )
-
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_complete.id AS id
-        FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_6:String}
-        WHERE ((calls_complete.inputs_dump LIKE {pb_4:String} OR calls_complete.inputs_dump LIKE {pb_5:String}))
-        AND
-            (((coalesce(nullIf(JSON_VALUE(calls_complete.inputs_dump, {pb_0:String}), 'null'), '') IN ({pb_1:String},{pb_2:String})))
-                 AND ((calls_complete.deleted_at = {pb_3:DateTime64(3)})))
-        """,
-        {
-            "pb_0": '$."param"',
-            "pb_1": "hello",
-            "pb_2": "world",
-            "pb_3": SENTINEL_EPOCH,
-            "pb_4": '%"hello"%',
-            "pb_5": '%"world"%',
-            "pb_6": "project",
-        },
-    )
+    cq.add_condition(condition)
+    assert_sql(cq, expected_sql, expected_params)
 
 
 def test_calls_query_with_combined_like_optimizations_and_op_filter() -> None:
@@ -2120,57 +2104,56 @@ def test_query_with_summary_weave_trace_name_filter() -> None:
     )
 
 
-def test_unsupported_summary_field_raises_invalid_field_error() -> None:
-    """Filtering by an unknown summary.weave.* field must surface as InvalidFieldError
-    (mapped to HTTP 403) rather than NotImplementedError (HTTP 500). Regression for
-    WB-34835: clients hitting /calls/query_stats with summary.weave.duration_ms were
-    getting 500s for what is actually invalid input.
-    """
+def _select_field_as_sql(field: str) -> None:
+    cq = CallsQuery(project_id="project")
+    cq.add_field(field)
+    cq.as_sql(ParamBuilder())
+
+
+def _filter_summary_duration_ms_as_sql() -> None:
     cq = CallsQuery(project_id="project")
     cq.add_field("id")
     cq.add_condition(
         tsi_query.GtOperation.model_validate(
-            {
-                "$gt": [
-                    {"$getField": "summary.weave.duration_ms"},
-                    {"$literal": 0},
-                ]
-            }
+            {"$gt": [{"$getField": "summary.weave.duration_ms"}, {"$literal": 0}]}
         )
     )
-    with pytest.raises(InvalidFieldError, match="duration_ms"):
-        cq.as_sql(ParamBuilder())
+    cq.as_sql(ParamBuilder())
 
 
-def test_unselectable_columns_raise_invalid_field_error() -> None:
-    """Selecting columns that the SQL builder can't materialize as a select expression
-    must surface as InvalidFieldError (403), not NotImplementedError (500). Regression
-    for WB-34836: dynamic, feedback, and annotation-queue-item paths all hit the same
-    "implement me!" raise.
-    """
-    # Nested dynamic field (e.g. inputs.foo) - routed through CallsMergedDynamicField
-    cq = CallsQuery(project_id="project")
-    cq.add_field("inputs.foo")
-    with pytest.raises(InvalidFieldError, match="cannot be selected directly"):
-        cq.as_sql(ParamBuilder())
-
-    # Feedback payload column - routed through CallsMergedFeedbackPayloadField
-    cq = CallsQuery(project_id="project")
-    cq.add_field("feedback.[wandb.note].payload.note")
-    with pytest.raises(InvalidFieldError, match="Feedback fields"):
-        cq.as_sql(ParamBuilder())
-
-    # Annotation queue item column - routed through CallsMergedQueueItemField
-    cq = CallsQuery(project_id="project")
-    cq.add_field("annotation_queue_items.queue_id")
-    with pytest.raises(InvalidFieldError, match="queue item fields"):
-        cq.as_sql(ParamBuilder())
-
-    # QueryBuilderDynamicField with extra_path (used by table_query, not CallsQuery,
-    # so we have to construct and select directly).
+def _select_dynamic_field_with_extra_path() -> None:
+    # QueryBuilderDynamicField with extra_path is used by table_query, not CallsQuery,
+    # so construct and select directly.
     field = QueryBuilderDynamicField(field="val_dump", extra_path=["foo", "bar"])
-    with pytest.raises(InvalidFieldError, match="val_dump.foo.bar"):
-        field.as_select_sql(ParamBuilder(), "table")
+    field.as_select_sql(ParamBuilder(), "table")
+
+
+@pytest.mark.parametrize(
+    ("trigger", "match_substr"),
+    [
+        (lambda: _select_field_as_sql("inputs.foo"), "cannot be selected directly"),
+        (
+            lambda: _select_field_as_sql("feedback.[wandb.note].payload.note"),
+            "Feedback fields",
+        ),
+        (
+            lambda: _select_field_as_sql("annotation_queue_items.queue_id"),
+            "queue item fields",
+        ),
+        (_select_dynamic_field_with_extra_path, "val_dump.foo.bar"),
+        (_filter_summary_duration_ms_as_sql, "duration_ms"),
+    ],
+)
+def test_unsupported_field_raises_invalid_field_error(
+    trigger: object, match_substr: str
+) -> None:
+    """Unselectable/unfilterable columns surface as InvalidFieldError (403), not a 500.
+
+    Regression for WB-34835/WB-34836: dynamic, feedback, queue-item, extra-path, and
+    unknown summary.weave.* paths must raise InvalidFieldError rather than NotImplementedError.
+    """
+    with pytest.raises(InvalidFieldError, match=match_substr):
+        trigger()
 
 
 def test_build_calls_complete_update_end_query() -> None:
@@ -2636,50 +2619,54 @@ def test_datetime_optimization_invalid_field() -> None:
     )
 
 
-def test_maybe_convert_datetime_operands() -> None:
-    """Test that _maybe_convert_datetime_operands converts numeric timestamps to datetime strings
-    for DateTime column fields (started_at, ended_at, deleted_at), and leaves other fields unchanged.
+@pytest.mark.parametrize(
+    ("field", "literal_in", "field_first", "expected_literal"),
+    [
+        # numeric int/float against a datetime column -> converted
+        ("started_at", 1709251200, True, "2024-03-01 00:00:00.000000"),
+        ("ended_at", 1709251200.5, True, "2024-03-01 00:00:00.500000"),
+        # numeric/None against a non-datetime column or null -> unchanged
+        ("wb_user_id", 1709251200, True, 1709251200),
+        ("deleted_at", None, True, None),
+        # CH-shaped string unchanged; ISO 8601 + bare-second forms map to CH format
+        (
+            "started_at",
+            "2024-03-01 00:00:00.000000",
+            True,
+            "2024-03-01 00:00:00.000000",
+        ),
+        ("started_at", "2024-03-01 00:00:00", True, "2024-03-01 00:00:00.000000"),
+        ("started_at", "2024-03-01T00:00:00Z", True, "2024-03-01 00:00:00.000000"),
+        # bare date for each datetime column -> midnight CH format
+        ("started_at", "2024-03-01", True, "2024-03-01 00:00:00.000000"),
+        ("ended_at", "2024-03-01", True, "2024-03-01 00:00:00.000000"),
+        ("deleted_at", "2024-03-01", True, "2024-03-01 00:00:00.000000"),
+        # literal-before-field ordering still converts the literal operand
+        ("started_at", "2024-03-01T12:00:00Z", False, "2024-03-01 12:00:00.000000"),
+        # non-datetime field or unparseable string -> unchanged
+        ("display_name", "2024-03-01", True, "2024-03-01"),
+        ("started_at", "not-a-timestamp", True, "not-a-timestamp"),
+    ],
+)
+def test_maybe_convert_datetime_operands(
+    field: str, literal_in: object, field_first: bool, expected_literal: object
+) -> None:
+    """_maybe_convert_datetime_operands canonicalizes numeric/string literals against
+    DateTime columns (started_at, ended_at, deleted_at) and leaves other fields untouched.
     """
-    # Test: numeric int literal compared to started_at → should convert
-    ops = _maybe_convert_datetime_operands(
-        [
-            tsi_query.GetFieldOperator(**{"$getField": "started_at"}),
-            tsi_query.LiteralOperation(**{"$literal": 1709251200}),
-        ]
-    )
-    assert isinstance(ops[1], tsi_query.LiteralOperation)
-    assert ops[1].literal_ == "2024-03-01 00:00:00.000000"
+    field_op = tsi_query.GetFieldOperator(**{"$getField": field})
+    literal_op = tsi_query.LiteralOperation(**{"$literal": literal_in})
+    operands = [field_op, literal_op] if field_first else [literal_op, field_op]
+    literal_index = 1 if field_first else 0
 
-    # Test: numeric float literal compared to ended_at → should convert
-    ops = _maybe_convert_datetime_operands(
-        [
-            tsi_query.GetFieldOperator(**{"$getField": "ended_at"}),
-            tsi_query.LiteralOperation(**{"$literal": 1709251200.5}),
-        ]
-    )
-    assert isinstance(ops[1], tsi_query.LiteralOperation)
-    assert isinstance(ops[1].literal_, str)
-    assert ops[1].literal_.startswith("2024-03-01 00:00:00")
+    ops = _maybe_convert_datetime_operands(operands)
 
-    # Test: numeric literal compared to non-datetime field → should NOT convert
-    ops = _maybe_convert_datetime_operands(
-        [
-            tsi_query.GetFieldOperator(**{"$getField": "wb_user_id"}),
-            tsi_query.LiteralOperation(**{"$literal": 1709251200}),
-        ]
-    )
-    assert ops[1].literal_ == 1709251200
+    assert isinstance(ops[literal_index], tsi_query.LiteralOperation)
+    assert ops[literal_index].literal_ == expected_literal
 
-    # Test: None literal compared to deleted_at → should NOT convert
-    ops = _maybe_convert_datetime_operands(
-        [
-            tsi_query.GetFieldOperator(**{"$getField": "deleted_at"}),
-            tsi_query.LiteralOperation(**{"$literal": None}),
-        ]
-    )
-    assert ops[1].literal_ is None
 
-    # Test: original operands are NOT mutated
+def test_maybe_convert_datetime_operands_does_not_mutate_input() -> None:
+    """Conversion returns new operands; the caller's LiteralOperation is left intact."""
     original_lit = tsi_query.LiteralOperation(**{"$literal": 1709251200})
     _maybe_convert_datetime_operands(
         [
@@ -2688,75 +2675,6 @@ def test_maybe_convert_datetime_operands() -> None:
         ]
     )
     assert original_lit.literal_ == 1709251200
-
-
-@pytest.mark.parametrize(
-    ("literal_in", "expected_literal"),
-    [
-        (
-            "2024-03-01 00:00:00.000000",
-            "2024-03-01 00:00:00.000000",
-        ),
-        (
-            "2024-03-01 00:00:00",
-            "2024-03-01 00:00:00.000000",
-        ),
-        (
-            "2024-03-01T00:00:00Z",
-            "2024-03-01 00:00:00.000000",
-        ),
-    ],
-)
-def test_maybe_convert_string_literal_to_ch_format(
-    literal_in: str, expected_literal: str
-) -> None:
-    """CH-shaped literals are unchanged; ISO 8601 literals map to canonical CH format."""
-    ops = _maybe_convert_datetime_operands(
-        [
-            tsi_query.GetFieldOperator(**{"$getField": "started_at"}),
-            tsi_query.LiteralOperation(**{"$literal": literal_in}),
-        ]
-    )
-    assert ops[1].literal_ == expected_literal
-
-
-@pytest.mark.parametrize("field", ["started_at", "ended_at", "deleted_at"])
-def test_maybe_convert_string_date_for_datetime_columns(field: str) -> None:
-    ops = _maybe_convert_datetime_operands(
-        [
-            tsi_query.GetFieldOperator(**{"$getField": field}),
-            tsi_query.LiteralOperation(**{"$literal": "2024-03-01"}),
-        ]
-    )
-    assert ops[1].literal_ == "2024-03-01 00:00:00.000000"
-
-
-def test_maybe_convert_literal_before_field() -> None:
-    ops = _maybe_convert_datetime_operands(
-        [
-            tsi_query.LiteralOperation(**{"$literal": "2024-03-01T12:00:00Z"}),
-            tsi_query.GetFieldOperator(**{"$getField": "started_at"}),
-        ]
-    )
-    assert ops[0].literal_ == "2024-03-01 12:00:00.000000"
-
-
-def test_maybe_convert_skips_non_datetime_string_field() -> None:
-    original = [
-        tsi_query.GetFieldOperator(**{"$getField": "display_name"}),
-        tsi_query.LiteralOperation(**{"$literal": "2024-03-01"}),
-    ]
-    ops = _maybe_convert_datetime_operands(original)
-    assert ops == original
-
-
-def test_maybe_convert_skips_unparseable_string() -> None:
-    original = [
-        tsi_query.GetFieldOperator(**{"$getField": "started_at"}),
-        tsi_query.LiteralOperation(**{"$literal": "not-a-timestamp"}),
-    ]
-    ops = _maybe_convert_datetime_operands(original)
-    assert ops == original
 
 
 def test_query_with_feedback_filter_and_datetime_and_string_filter() -> None:
@@ -3175,76 +3093,31 @@ def test_all_optimization_filters():
     )
 
 
-def test_filter_length_validation():
-    """Test that filter length validation works."""
-    pb = ParamBuilder()
+@pytest.mark.parametrize(
+    ("filter_key", "value"),
+    [
+        ("op_names", "weave-trace-internal:///%"),
+        ("input_refs", "weave-trace-internal:///%"),
+        ("output_refs", "weave-trace-internal:///%"),
+        ("parent_ids", "weave-trace-internal:///%"),
+        ("trace_ids", "weave-trace-internal:///%"),
+        ("call_ids", "weave-trace-internal:///%"),
+        ("thread_ids", "thread_123"),
+        ("turn_ids", "turn_123"),
+        ("wb_run_ids", "wb_run_123"),
+    ],
+)
+def test_filter_length_validation(filter_key: str, value: str) -> None:
+    """Every length-capped filter key rejects an over-max (1001-element) list."""
     cq = CallsQuery(project_id="test/project")
     cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(
-        filter={"op_names": ["weave-trace-internal:///%"] * 1001}
-    )
+    cq.hardcoded_filter = HardCodedFilter(filter={filter_key: [value] * 1001})
     with pytest.raises(ValueError, match="request length is greater than max length"):
-        cq.as_sql(pb)
+        cq.as_sql(ParamBuilder())
 
-    cq = CallsQuery(project_id="test/project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(
-        filter={"input_refs": ["weave-trace-internal:///%"] * 1001}
-    )
-    with pytest.raises(ValueError, match="request length is greater than max length"):
-        cq.as_sql(pb)
 
-    cq = CallsQuery(project_id="test/project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(
-        filter={"output_refs": ["weave-trace-internal:///%"] * 1001}
-    )
-    with pytest.raises(ValueError, match="request length is greater than max length"):
-        cq.as_sql(pb)
-
-    cq = CallsQuery(project_id="test/project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(
-        filter={"parent_ids": ["weave-trace-internal:///%"] * 1001}
-    )
-    with pytest.raises(ValueError, match="request length is greater than max length"):
-        cq.as_sql(pb)
-
-    cq = CallsQuery(project_id="test/project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(
-        filter={"trace_ids": ["weave-trace-internal:///%"] * 1001}
-    )
-    with pytest.raises(ValueError, match="request length is greater than max length"):
-        cq.as_sql(pb)
-
-    cq = CallsQuery(project_id="test/project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(
-        filter={"call_ids": ["weave-trace-internal:///%"] * 1001}
-    )
-    with pytest.raises(ValueError, match="request length is greater than max length"):
-        cq.as_sql(pb)
-
-    cq = CallsQuery(project_id="test/project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(filter={"thread_ids": ["thread_123"] * 1001})
-    with pytest.raises(ValueError, match="request length is greater than max length"):
-        cq.as_sql(pb)
-
-    cq = CallsQuery(project_id="test/project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(filter={"turn_ids": ["turn_123"] * 1001})
-    with pytest.raises(ValueError, match="request length is greater than max length"):
-        cq.as_sql(pb)
-
-    cq = CallsQuery(project_id="test/project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(filter={"wb_run_ids": ["wb_run_123"] * 1001})
-    with pytest.raises(ValueError, match="request length is greater than max length"):
-        cq.as_sql(pb)
-
-    # Test with too many conditions
+def test_filter_too_many_object_reference_conditions() -> None:
+    """Exceeding MAX_CTES_PER_QUERY object-ref conditions raises a distinct error."""
     cq = CallsQuery(project_id="test/project")
     complex_conditions = {
         "$and": [
@@ -3256,182 +3129,128 @@ def test_filter_length_validation():
     cq.add_condition(complex_conditions)
     cq.set_expand_columns(["inputs"])
     with pytest.raises(ValueError, match="Too many object reference conditions"):
-        s = cq.as_sql(pb)
+        cq.as_sql(ParamBuilder())
 
 
-def test_disallowed_fields():
+def test_disallowed_order_fields() -> None:
+    """Storage-size fields are not orderable; a bogus direction is also rejected."""
     cq = CallsQuery(project_id="test/project")
-    # allowed order field
-    cq.add_order("id", "ASC")
+    cq.add_order("id", "ASC")  # allowed, must not raise
     with pytest.raises(ValueError, match="not allowed in ORDER BY"):
         cq.add_order("storage_size_bytes", "ASC")
     with pytest.raises(ValueError, match="not allowed in ORDER BY"):
         cq.add_order("total_storage_size_bytes", "DESC")
-    # with bogus direction
     with pytest.raises(ValueError, match="not allowed"):
         cq.add_order("storage_size_bytes", "ASCDESC")
-    # now try filtering with disallowed
-    cq = CallsQuery(project_id="test/project")  # reset
-    cq.add_field("id")
-    cq.add_condition(
-        tsi_query.GtOperation.model_validate(
-            {
-                "$gt": [
-                    {"$getField": "storage_size_bytes"},
-                    {"$literal": 1},
-                ]
-            }
-        )
-    )
-    with pytest.raises(InvalidFieldError, match="not allowed"):
-        cq.as_sql(ParamBuilder())
 
-    cq = CallsQuery(project_id="test/project")  # reset
-    cq.add_field("id")
-    cq.add_condition(
-        tsi_query.GteOperation.model_validate(
-            {
-                "$gte": [
-                    {"$getField": "total_storage_size_bytes"},
-                    {"$literal": 1},
-                ]
-            }
-        )
-    )
-    with pytest.raises(InvalidFieldError, match="not allowed"):
-        cq.as_sql(ParamBuilder())
 
-    cq = CallsQuery(project_id="test/project")  # reset
+@pytest.mark.parametrize(
+    ("op_key", "op_class", "field"),
+    [
+        ("$gt", tsi_query.GtOperation, "storage_size_bytes"),
+        ("$gte", tsi_query.GteOperation, "total_storage_size_bytes"),
+        ("$lt", tsi_query.LtOperation, "storage_size_bytes"),
+        ("$lte", tsi_query.LteOperation, "total_storage_size_bytes"),
+    ],
+)
+def test_disallowed_storage_fields_in_filter(
+    op_key: str, op_class: type, field: str
+) -> None:
+    """Storage-size fields cannot be filtered on, across every comparison operator."""
+    cq = CallsQuery(project_id="test/project")
     cq.add_field("id")
     cq.add_condition(
-        tsi_query.LtOperation.model_validate(
-            {
-                "$lt": [
-                    {"$getField": "storage_size_bytes"},
-                    {"$literal": 1},
-                ]
-            }
-        )
-    )
-    with pytest.raises(InvalidFieldError, match="not allowed"):
-        cq.as_sql(ParamBuilder())
-
-    cq = CallsQuery(project_id="test/project")  # reset
-    cq.add_field("id")
-    cq.add_condition(
-        tsi_query.LteOperation.model_validate(
-            {
-                "$lte": [
-                    {"$getField": "total_storage_size_bytes"},
-                    {"$literal": 1},
-                ]
-            }
-        )
+        op_class.model_validate({op_key: [{"$getField": field}, {"$literal": 1}]})
     )
     with pytest.raises(InvalidFieldError, match="not allowed"):
         cq.as_sql(ParamBuilder())
 
 
-def test_thread_id_filter_eq():
-    """Test thread_id filter with single thread ID."""
+@pytest.mark.parametrize(
+    ("filter_dict", "expected_sql", "expected_params"),
+    [
+        (
+            {"thread_ids": ["thread_123"]},
+            """
+            SELECT
+                calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_2:String}
+            WHERE (calls_merged.thread_id = {pb_1:String}
+                    OR calls_merged.thread_id IS NULL)
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                AND (any(calls_merged.thread_id) IN {pb_0:Array(String)}))
+            """,
+            {"pb_0": ["thread_123"], "pb_1": "thread_123", "pb_2": "project"},
+        ),
+        (
+            {"thread_ids": ["thread_123", "thread_456"]},
+            """
+            SELECT
+                calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_2:String}
+            WHERE (calls_merged.thread_id IN {pb_1:Array(String)}
+                    OR calls_merged.thread_id IS NULL)
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                AND (any(calls_merged.thread_id) IN {pb_0:Array(String)}))
+            """,
+            {
+                "pb_0": ["thread_123", "thread_456"],
+                "pb_1": ["thread_123", "thread_456"],
+                "pb_2": "project",
+            },
+        ),
+        (
+            {"turn_ids": ["turn_123"]},
+            """
+            SELECT
+                calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_2:String}
+            WHERE (calls_merged.turn_id = {pb_1:String}
+                    OR calls_merged.turn_id IS NULL)
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                AND (any(calls_merged.turn_id) IN {pb_0:Array(String)}))
+            """,
+            {"pb_0": ["turn_123"], "pb_1": "turn_123", "pb_2": "project"},
+        ),
+        (
+            {"turn_ids": ["turn_123", "turn_456"]},
+            """
+            SELECT
+                calls_merged.id AS id
+            FROM calls_merged
+            PREWHERE calls_merged.project_id = {pb_2:String}
+            WHERE (calls_merged.turn_id IN {pb_1:Array(String)}
+                    OR calls_merged.turn_id IS NULL)
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL))))
+                AND (any(calls_merged.turn_id) IN {pb_0:Array(String)}))
+            """,
+            {
+                "pb_0": ["turn_123", "turn_456"],
+                "pb_1": ["turn_123", "turn_456"],
+                "pb_2": "project",
+            },
+        ),
+    ],
+)
+def test_thread_turn_id_filter(
+    filter_dict: dict, expected_sql: str, expected_params: dict
+) -> None:
+    """thread_ids/turn_ids hardcoded filters render `=` for one value and `IN` for many."""
     cq = CallsQuery(project_id="project")
     cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(filter={"thread_ids": ["thread_123"]})
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_merged.id AS id
-        FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.thread_id = {pb_1:String}
-                OR calls_merged.thread_id IS NULL)
-        GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (((any(calls_merged.deleted_at) IS NULL))
-            AND ((NOT ((any(calls_merged.op_name) IS NULL))))
-            AND (any(calls_merged.thread_id) IN {pb_0:Array(String)}))
-        """,
-        {"pb_0": ["thread_123"], "pb_1": "thread_123", "pb_2": "project"},
-    )
-
-
-def test_thread_id_filter_in():
-    """Test thread_id filter with multiple thread IDs."""
-    cq = CallsQuery(project_id="project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(
-        filter={"thread_ids": ["thread_123", "thread_456"]}
-    )
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_merged.id AS id
-        FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.thread_id IN {pb_1:Array(String)}
-                OR calls_merged.thread_id IS NULL)
-        GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (((any(calls_merged.deleted_at) IS NULL))
-            AND ((NOT ((any(calls_merged.op_name) IS NULL))))
-            AND (any(calls_merged.thread_id) IN {pb_0:Array(String)}))
-        """,
-        {
-            "pb_0": ["thread_123", "thread_456"],
-            "pb_1": ["thread_123", "thread_456"],
-            "pb_2": "project",
-        },
-    )
-
-
-def test_turn_id_filter_eq():
-    """Test turn_id filter with single turn ID."""
-    cq = CallsQuery(project_id="project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(filter={"turn_ids": ["turn_123"]})
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_merged.id AS id
-        FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.turn_id = {pb_1:String}
-                OR calls_merged.turn_id IS NULL)
-        GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (((any(calls_merged.deleted_at) IS NULL))
-            AND ((NOT ((any(calls_merged.op_name) IS NULL))))
-            AND (any(calls_merged.turn_id) IN {pb_0:Array(String)}))
-        """,
-        {"pb_0": ["turn_123"], "pb_1": "turn_123", "pb_2": "project"},
-    )
-
-
-def test_turn_id_filter_in():
-    """Test turn_id filter with multiple turn IDs."""
-    cq = CallsQuery(project_id="project")
-    cq.add_field("id")
-    cq.hardcoded_filter = HardCodedFilter(filter={"turn_ids": ["turn_123", "turn_456"]})
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_merged.id AS id
-        FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_2:String}
-        WHERE (calls_merged.turn_id IN {pb_1:Array(String)}
-                OR calls_merged.turn_id IS NULL)
-        GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (((any(calls_merged.deleted_at) IS NULL))
-            AND ((NOT ((any(calls_merged.op_name) IS NULL))))
-            AND (any(calls_merged.turn_id) IN {pb_0:Array(String)}))
-        """,
-        {
-            "pb_0": ["turn_123", "turn_456"],
-            "pb_1": ["turn_123", "turn_456"],
-            "pb_2": "project",
-        },
-    )
+    cq.hardcoded_filter = HardCodedFilter(filter=filter_dict)
+    assert_sql(cq, expected_sql, expected_params)
 
 
 def test_thread_id_and_turn_id_filter_combined():
@@ -3936,101 +3755,140 @@ def test_query_with_summary_weave_status_filter_calls_complete() -> None:
     )
 
 
-def test_build_calls_complete_delete_query() -> None:
-    """Ensure the delete helper builds the expected query."""
+@pytest.mark.parametrize(
+    ("cluster_name", "expected_query"),
+    [
+        (
+            None,
+            """
+            DELETE FROM calls_complete
+            WHERE project_id = {project_id:String} AND id IN {call_ids:Array(String)}
+            """,
+        ),
+        (
+            "my_cluster",
+            """
+            DELETE FROM calls_complete ON CLUSTER my_cluster
+            WHERE project_id = {project_id:String} AND id IN {call_ids:Array(String)}
+            """,
+        ),
+    ],
+)
+def test_build_calls_complete_delete_query(
+    cluster_name: str | None, expected_query: str
+) -> None:
+    """The delete helper adds `ON CLUSTER` only when a cluster name is supplied."""
     query = build_calls_complete_delete_query(
         table_name="calls_complete",
         project_id_param="project_id",
         call_ids_param="call_ids",
+        cluster_name=cluster_name,
     )
-
-    expected = sqlparse.format(
-        """
-        DELETE FROM calls_complete
-        WHERE project_id = {project_id:String} AND id IN {call_ids:Array(String)}
-        """,
-        reindent=True,
-    )
-
+    expected = sqlparse.format(expected_query, reindent=True)
     assert query == expected, f"\nExpected:\n{expected}\n\nGot:\n{query}"
 
 
-def test_build_calls_complete_delete_query_with_cluster() -> None:
-    """Ensure the delete helper builds the expected query with cluster name.
-
-    _format_table_name_with_cluster only adds ON CLUSTER; the caller is
-    responsible for passing the correct table name (e.g. calls_complete_local
-    in distributed mode via _get_calls_complete_table_name).
-    """
-    query = build_calls_complete_delete_query(
-        table_name="calls_complete",
-        project_id_param="project_id",
-        call_ids_param="call_ids",
-        cluster_name="my_cluster",
-    )
-
-    expected = sqlparse.format(
-        """
-        DELETE FROM calls_complete ON CLUSTER my_cluster
-        WHERE project_id = {project_id:String} AND id IN {call_ids:Array(String)}
-        """,
-        reindent=True,
-    )
-
-    assert query == expected, f"\nExpected:\n{expected}\n\nGot:\n{query}"
-
-
-def test_build_calls_complete_update_query() -> None:
-    """Ensure the update helper builds the expected query."""
+@pytest.mark.parametrize(
+    ("cluster_name", "expected_query"),
+    [
+        (
+            None,
+            """
+            UPDATE calls_complete
+            SET display_name = {display_name:String}
+            WHERE project_id = {project_id:String} AND id = {id:String}
+            """,
+        ),
+        (
+            "my_cluster",
+            """
+            UPDATE calls_complete ON CLUSTER my_cluster
+            SET display_name = {display_name:String}
+            WHERE project_id = {project_id:String} AND id = {id:String}
+            """,
+        ),
+    ],
+)
+def test_build_calls_complete_update_query(
+    cluster_name: str | None, expected_query: str
+) -> None:
+    """The update helper adds `ON CLUSTER` only when a cluster name is supplied."""
     query = build_calls_complete_update_query(
         table_name="calls_complete",
         project_id_param="project_id",
         id_param="id",
         display_name_param="display_name",
+        cluster_name=cluster_name,
     )
-
-    expected = sqlparse.format(
-        """
-        UPDATE calls_complete
-        SET display_name = {display_name:String}
-        WHERE project_id = {project_id:String} AND id = {id:String}
-        """,
-        reindent=True,
-    )
-
+    expected = sqlparse.format(expected_query, reindent=True)
     assert query == expected, f"\nExpected:\n{expected}\n\nGot:\n{query}"
 
 
-def test_build_calls_complete_update_query_with_cluster() -> None:
-    """Ensure the update helper builds the expected query with cluster name.
-
-    _format_table_name_with_cluster only adds ON CLUSTER; the caller is
-    responsible for passing the correct table name (e.g. calls_complete_local
-    in distributed mode via _get_calls_complete_table_name).
-    """
-    query = build_calls_complete_update_query(
-        table_name="calls_complete",
-        project_id_param="project_id",
-        id_param="id",
-        display_name_param="display_name",
-        cluster_name="my_cluster",
-    )
-
-    expected = sqlparse.format(
-        """
-        UPDATE calls_complete ON CLUSTER my_cluster
-        SET display_name = {display_name:String}
-        WHERE project_id = {project_id:String} AND id = {id:String}
-        """,
-        reindent=True,
-    )
-
-    assert query == expected, f"\nExpected:\n{expected}\n\nGot:\n{query}"
-
-
-def test_query_with_queue_filter_calls_merged() -> None:
-    """Test queue filtering with calls_merged table - should use aggregate functions."""
-    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_MERGED)
+@pytest.mark.parametrize(
+    ("read_table", "expected_sql", "expected_params"),
+    [
+        (
+            ReadTable.CALLS_MERGED,
+            """
+            SELECT
+                calls_merged.id AS id
+            FROM
+                calls_merged
+            INNER JOIN (
+                SELECT * FROM annotation_queue_items
+                WHERE annotation_queue_items.project_id = {pb_1:String}
+                  AND annotation_queue_items.deleted_at IS NULL
+                  AND annotation_queue_items.queue_id = {pb_0:String}
+            ) AS annotation_queue_items ON (
+                annotation_queue_items.project_id = calls_merged.project_id
+                AND annotation_queue_items.call_id = calls_merged.id)
+            PREWHERE
+                calls_merged.project_id = {pb_1:String}
+            GROUP BY (calls_merged.project_id, calls_merged.id)
+            HAVING (
+                ((any(annotation_queue_items.queue_id) = {pb_0:String}))
+                AND ((any(calls_merged.deleted_at) IS NULL))
+                AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
+            """,
+            {
+                "pb_0": "test_queue_id",
+                "pb_1": "project",
+            },
+        ),
+        (
+            ReadTable.CALLS_COMPLETE,
+            """
+            SELECT
+                calls_complete.id AS id
+            FROM
+                calls_complete
+            INNER JOIN (
+                SELECT * FROM annotation_queue_items
+                WHERE annotation_queue_items.project_id = {pb_2:String}
+                  AND annotation_queue_items.deleted_at IS NULL
+                  AND annotation_queue_items.queue_id = {pb_0:String}
+            ) AS annotation_queue_items ON (
+                annotation_queue_items.project_id = calls_complete.project_id
+                AND annotation_queue_items.call_id = calls_complete.id)
+            PREWHERE
+                calls_complete.project_id = {pb_2:String}
+            WHERE 1
+              AND (((annotation_queue_items.queue_id = {pb_0:String}))
+           AND ((calls_complete.deleted_at = {pb_1:DateTime64(3)})))
+            """,
+            {
+                "pb_0": "test_queue_id",
+                "pb_1": SENTINEL_EPOCH,
+                "pb_2": "project",
+            },
+        ),
+    ],
+)
+def test_query_with_queue_filter_by_table(
+    read_table: ReadTable, expected_sql: str, expected_params: dict
+) -> None:
+    """calls_merged aggregates queue membership via any()+HAVING; calls_complete is flat."""
+    cq = CallsQuery(project_id="project", read_table=read_table)
     cq.add_field("id")
     cq.add_condition(
         tsi_query.EqOperation.model_validate(
@@ -4042,79 +3900,7 @@ def test_query_with_queue_filter_calls_merged() -> None:
             }
         )
     )
-
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_merged.id AS id
-        FROM
-            calls_merged
-        INNER JOIN (
-            SELECT * FROM annotation_queue_items
-            WHERE annotation_queue_items.project_id = {pb_1:String}
-              AND annotation_queue_items.deleted_at IS NULL
-              AND annotation_queue_items.queue_id = {pb_0:String}
-        ) AS annotation_queue_items ON (
-            annotation_queue_items.project_id = calls_merged.project_id
-            AND annotation_queue_items.call_id = calls_merged.id)
-        PREWHERE
-            calls_merged.project_id = {pb_1:String}
-        GROUP BY (calls_merged.project_id, calls_merged.id)
-        HAVING (
-            ((any(annotation_queue_items.queue_id) = {pb_0:String}))
-            AND ((any(calls_merged.deleted_at) IS NULL))
-            AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
-        """,
-        {
-            "pb_0": "test_queue_id",
-            "pb_1": "project",
-        },
-    )
-
-
-def test_query_with_queue_filter_calls_complete() -> None:
-    """Test queue filtering with calls_complete table - should NOT use aggregate functions."""
-    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
-    cq.add_field("id")
-    cq.add_condition(
-        tsi_query.EqOperation.model_validate(
-            {
-                "$eq": [
-                    {"$getField": "annotation_queue_items.queue_id"},
-                    {"$literal": "test_queue_id"},
-                ]
-            }
-        )
-    )
-
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_complete.id AS id
-        FROM
-            calls_complete
-        INNER JOIN (
-            SELECT * FROM annotation_queue_items
-            WHERE annotation_queue_items.project_id = {pb_2:String}
-              AND annotation_queue_items.deleted_at IS NULL
-              AND annotation_queue_items.queue_id = {pb_0:String}
-        ) AS annotation_queue_items ON (
-            annotation_queue_items.project_id = calls_complete.project_id
-            AND annotation_queue_items.call_id = calls_complete.id)
-        PREWHERE
-            calls_complete.project_id = {pb_2:String}
-        WHERE 1
-          AND (((annotation_queue_items.queue_id = {pb_0:String}))
-       AND ((calls_complete.deleted_at = {pb_1:DateTime64(3)})))
-        """,
-        {
-            "pb_0": "test_queue_id",
-            "pb_1": SENTINEL_EPOCH,
-            "pb_2": "project",
-        },
-    )
+    assert_sql(cq, expected_sql, expected_params)
 
 
 # -----------------------------------------------------------------------------
@@ -4122,28 +3908,20 @@ def test_query_with_queue_filter_calls_complete() -> None:
 # -----------------------------------------------------------------------------
 
 
-def test_hardcoded_filter_is_useful_thread_ids_only() -> None:
-    """Filter with only thread_ids must be considered useful so set_hardcoded_filter applies it."""
-    hcf = HardCodedFilter(filter=tsi.CallsFilter(thread_ids=["thread_1"]))
-    assert hcf.is_useful() is True
-
-
-def test_hardcoded_filter_is_useful_empty_thread_ids_only() -> None:
-    """Filter with only thread_ids must be considered useful, even when the list is empty."""
-    hcf = HardCodedFilter(filter=tsi.CallsFilter(thread_ids=[]))
-    assert hcf.is_useful() is True
-
-
-def test_hardcoded_filter_is_useful_turn_ids_only() -> None:
-    """Filter with only turn_ids must be considered useful."""
-    hcf = HardCodedFilter(filter=tsi.CallsFilter(turn_ids=["turn_1"]))
-    assert hcf.is_useful() is True
-
-
-def test_hardcoded_filter_is_useful_empty_not_useful() -> None:
-    """Filter with no fields set is not useful."""
-    hcf = HardCodedFilter(filter=tsi.CallsFilter())
-    assert hcf.is_useful() is False
+@pytest.mark.parametrize(
+    ("call_filter", "expected_useful"),
+    [
+        (tsi.CallsFilter(thread_ids=["thread_1"]), True),
+        (tsi.CallsFilter(thread_ids=[]), True),
+        (tsi.CallsFilter(turn_ids=["turn_1"]), True),
+        (tsi.CallsFilter(), False),
+    ],
+)
+def test_hardcoded_filter_is_useful(
+    call_filter: tsi.CallsFilter, expected_useful: bool
+) -> None:
+    """thread_ids/turn_ids (even empty) make a filter useful; a fully-empty filter is not."""
+    assert HardCodedFilter(filter=call_filter).is_useful() is expected_useful
 
 
 def test_hardcoded_filter_set_hardcoded_filter_with_thread_ids_only() -> None:
@@ -4160,35 +3938,24 @@ def test_hardcoded_filter_set_hardcoded_filter_with_thread_ids_only() -> None:
 # -----------------------------------------------------------------------------
 
 
-def test_is_minimal_filter_none() -> None:
-    assert _is_minimal_filter(None) is True
-
-
-def test_is_minimal_filter_empty() -> None:
-    assert _is_minimal_filter(tsi.CallsFilter()) is True
-
-
-def test_is_minimal_filter_thread_ids_not_minimal() -> None:
-    """Filter with thread_ids set must not be considered minimal (optimized path must not apply)."""
-    assert _is_minimal_filter(tsi.CallsFilter(thread_ids=["thread_1"])) is False
-
-
-def test_is_minimal_filter_turn_ids_not_minimal() -> None:
-    assert _is_minimal_filter(tsi.CallsFilter(turn_ids=["turn_1"])) is False
-
-
-def test_is_minimal_filter_wb_user_ids_not_minimal() -> None:
-    assert _is_minimal_filter(tsi.CallsFilter(wb_user_ids=["user_1"])) is False
-
-
-def test_is_minimal_filter_empty_thread_ids_not_minimal() -> None:
-    """thread_ids=[] is still a set filter (not None), so not minimal."""
-    assert _is_minimal_filter(tsi.CallsFilter(thread_ids=[])) is False
-
-
-def test_is_minimal_filter_empty_turn_ids_not_minimal() -> None:
-    """turn_ids=[] is still a set filter (not None), so not minimal."""
-    assert _is_minimal_filter(tsi.CallsFilter(turn_ids=[])) is False
+@pytest.mark.parametrize(
+    ("call_filter", "expected_minimal"),
+    [
+        (None, True),
+        (tsi.CallsFilter(), True),
+        (tsi.CallsFilter(thread_ids=["thread_1"]), False),
+        (tsi.CallsFilter(turn_ids=["turn_1"]), False),
+        (tsi.CallsFilter(wb_user_ids=["user_1"]), False),
+        # an empty list is still a set field (not None), so it is not minimal
+        (tsi.CallsFilter(thread_ids=[]), False),
+        (tsi.CallsFilter(turn_ids=[]), False),
+    ],
+)
+def test_is_minimal_filter(
+    call_filter: tsi.CallsFilter | None, expected_minimal: bool
+) -> None:
+    """None/empty filters are minimal; setting thread/turn/user ids (even empty) is not."""
+    assert _is_minimal_filter(call_filter) is expected_minimal
 
 
 # -----------------------------------------------------------------------------
@@ -4707,78 +4474,81 @@ def test_stats_query_calls_merged_no_cap_when_summing_storage() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_latency_ms_sort_calls_complete_uses_sentinel_for_ended_at() -> None:
-    """For calls_complete, latency_ms must check ended_at against the sentinel, not IS NULL.
-
-    Bug: _handle_latency_ms_summary_field used `ended_at IS NULL` which never matches in
-    calls_complete (ended_at is non-nullable with epoch-zero sentinel). This caused
-    unfinished calls to compute garbage latency instead of NULL.
-    """
-    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
-    cq.add_field("id")
-    cq.add_field("started_at")
-    cq.add_field("ended_at")
+def _order_by_latency_ms_desc(cq: CallsQuery) -> None:
     cq.add_order("summary.weave.latency_ms", "desc")
 
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_complete.id AS id,
-            calls_complete.started_at AS started_at,
-            calls_complete.ended_at AS ended_at
-        FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_2:String}
-        WHERE 1
-          AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
-        ORDER BY CASE
-            WHEN calls_complete.ended_at = {pb_1:DateTime64(6)} THEN NULL
-            ELSE (toUnixTimestamp64Milli(calls_complete.ended_at) - toUnixTimestamp64Milli(calls_complete.started_at))
-        END DESC
-        """,
-        {
-            "pb_0": SENTINEL_EPOCH,
-            "pb_1": SENTINEL_EPOCH,
-            "pb_2": "project",
-        },
-    )
 
-
-def test_latency_ms_filter_calls_complete_uses_sentinel_for_ended_at() -> None:
-    """For calls_complete, latency_ms filter must use sentinel check for ended_at."""
-    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
-    cq.add_field("id")
-    cq.add_field("started_at")
-    cq.add_field("ended_at")
+def _filter_latency_ms_gt_1000(cq: CallsQuery) -> None:
     cq.add_condition(
         tsi_query.GtOperation.model_validate(
             {"$gt": [{"$getField": "summary.weave.latency_ms"}, {"$literal": 1000}]}
         )
     )
 
-    assert_sql(
-        cq,
-        """
-        SELECT
-            calls_complete.id AS id,
-            calls_complete.started_at AS started_at,
-            calls_complete.ended_at AS ended_at
-        FROM calls_complete
-        PREWHERE calls_complete.project_id = {pb_3:String}
-        WHERE 1
-          AND (((CASE
-              WHEN calls_complete.ended_at = {pb_0:DateTime64(6)} THEN NULL
-              ELSE (toUnixTimestamp64Milli(calls_complete.ended_at) - toUnixTimestamp64Milli(calls_complete.started_at))
-          END > {pb_1:Int64}))
-       AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
-        """,
-        {
-            "pb_0": SENTINEL_EPOCH,
-            "pb_1": 1000,
-            "pb_2": SENTINEL_EPOCH,
-            "pb_3": "project",
-        },
-    )
+
+@pytest.mark.parametrize(
+    ("apply_latency", "expected_sql", "expected_params"),
+    [
+        (
+            _order_by_latency_ms_desc,
+            """
+            SELECT
+                calls_complete.id AS id,
+                calls_complete.started_at AS started_at,
+                calls_complete.ended_at AS ended_at
+            FROM calls_complete
+            PREWHERE calls_complete.project_id = {pb_2:String}
+            WHERE 1
+              AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
+            ORDER BY CASE
+                WHEN calls_complete.ended_at = {pb_1:DateTime64(6)} THEN NULL
+                ELSE (toUnixTimestamp64Milli(calls_complete.ended_at) - toUnixTimestamp64Milli(calls_complete.started_at))
+            END DESC
+            """,
+            {
+                "pb_0": SENTINEL_EPOCH,
+                "pb_1": SENTINEL_EPOCH,
+                "pb_2": "project",
+            },
+        ),
+        (
+            _filter_latency_ms_gt_1000,
+            """
+            SELECT
+                calls_complete.id AS id,
+                calls_complete.started_at AS started_at,
+                calls_complete.ended_at AS ended_at
+            FROM calls_complete
+            PREWHERE calls_complete.project_id = {pb_3:String}
+            WHERE 1
+              AND (((CASE
+                  WHEN calls_complete.ended_at = {pb_0:DateTime64(6)} THEN NULL
+                  ELSE (toUnixTimestamp64Milli(calls_complete.ended_at) - toUnixTimestamp64Milli(calls_complete.started_at))
+              END > {pb_1:Int64}))
+           AND ((calls_complete.deleted_at = {pb_2:DateTime64(3)})))
+            """,
+            {
+                "pb_0": SENTINEL_EPOCH,
+                "pb_1": 1000,
+                "pb_2": SENTINEL_EPOCH,
+                "pb_3": "project",
+            },
+        ),
+    ],
+    ids=["order", "filter"],
+)
+def test_latency_ms_calls_complete_uses_sentinel_for_ended_at(
+    apply_latency: object, expected_sql: str, expected_params: dict
+) -> None:
+    """On calls_complete, latency_ms checks ended_at against the sentinel (not IS NULL),
+    whether latency is applied as an ORDER BY or as a `> 1000` filter.
+    """
+    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
+    cq.add_field("id")
+    cq.add_field("started_at")
+    cq.add_field("ended_at")
+    apply_latency(cq)
+    assert_sql(cq, expected_sql, expected_params)
 
 
 def test_trace_roots_only_filter_calls_complete() -> None:
@@ -4929,39 +4699,6 @@ def test_hardcoded_filters_calls_complete() -> None:
             "pb_12": "",
             "pb_13": ["call_aaa"],
             "pb_14": "project",
-        },
-    )
-
-
-def test_status_sort_calls_complete_uses_sentinels() -> None:
-    """Verify status computation sort uses sentinel checks on calls_complete."""
-    cq = CallsQuery(project_id="project", read_table=ReadTable.CALLS_COMPLETE)
-    cq.add_field("id")
-    cq.add_order("summary.weave.status", "asc")
-    assert_sql(
-        cq,
-        """
-        SELECT calls_complete.id AS id
-        FROM calls_complete PREWHERE calls_complete.project_id = {pb_8:String}
-        WHERE 1
-          AND (calls_complete.deleted_at = {pb_0:DateTime64(3)})
-        ORDER BY CASE
-                     WHEN calls_complete.exception != {pb_6:String} THEN {pb_2:String}
-                     WHEN IFNULL(toInt64OrNull(coalesce(nullIf(JSON_VALUE(calls_complete.summary_dump, {pb_1:String}), 'null'), '')), 0) > 0 THEN {pb_5:String}
-                     WHEN calls_complete.ended_at = {pb_7:DateTime64(6)} THEN {pb_3:String}
-                     ELSE {pb_4:String}
-                 END ASC
-        """,
-        {
-            "pb_0": SENTINEL_EPOCH,
-            "pb_1": '$."status_counts"."error"',
-            "pb_2": "error",
-            "pb_3": "running",
-            "pb_4": "success",
-            "pb_5": "descendant_error",
-            "pb_6": "",
-            "pb_7": SENTINEL_EPOCH,
-            "pb_8": "project",
         },
     )
 

--- a/tests/trace_server/query_builder/test_costs_query.py
+++ b/tests/trace_server/query_builder/test_costs_query.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.trace_server.query_builder.utils import assert_sql
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.calls_query_builder.calls_query_builder import (
@@ -6,6 +8,9 @@ from weave.trace_server.calls_query_builder.calls_query_builder import (
 )
 from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH
 from weave.trace_server.project_version.types import ReadTable
+
+PROJECT_MERGED = "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc="
+PROJECT_COMPLETE = "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc="
 
 
 def test_query_light_column_with_costs() -> None:
@@ -164,26 +169,16 @@ def test_query_light_column_with_costs() -> None:
     )
 
 
-def test_query_with_costs_and_attributes_order() -> None:
-    """Test ordering by attributes_dump and summary.weave.status fields when costs are enabled.
-
-    This test verifies:
-    1. ordering by attributes_dump propagates through the cost CTEs
-    2. ordering by summary.weave.status uses the alias (not the raw summary_dump
-       expression) in the final SELECT's ORDER BY, since summary_dump is not in
-       the GROUP BY (it's rebuilt with cost data)
-    """
-    cq = CallsQuery(
-        project_id="UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=", include_costs=True
-    )
-    cq.add_field("id")
-    cq.add_field("started_at")
-    cq.add_order("attributes_dump", "ASC")
-    cq.add_order("summary.weave.status", "ASC")
-
-    assert_sql(
-        cq,
-        """WITH filtered_calls AS
+# Each param keeps its OWN complete expected SQL + params: the cost CTE bodies
+# diverge by ORDER BY shape, JSON path, GROUP BY membership, and the feedback
+# LEFT JOIN per CTE, so no string is folded away.
+@pytest.mark.parametrize(
+    ("orders", "expected_sql", "expected_params"),
+    [
+        # Test ordering by attributes_dump and summary.weave.status fields when costs are enabled.
+        pytest.param(
+            [("attributes_dump", "ASC"), ("summary.weave.status", "ASC")],
+            """WITH filtered_calls AS
   (SELECT calls_merged.id AS id
    FROM calls_merged PREWHERE calls_merged.project_id = {pb_5:String}
    GROUP BY (calls_merged.project_id,
@@ -292,39 +287,24 @@ GROUP BY id,
          `summary.weave.status`
 ORDER BY (NOT (JSONType(ranked_prices.attributes_dump) = 'Null'
                OR JSONType(ranked_prices.attributes_dump) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(ranked_prices.attributes_dump, '$'), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(ranked_prices.attributes_dump, '$'), 'null'), '')) ASC, `summary.weave.status` ASC""",
-        {
-            "pb_0": '$."status_counts"."error"',
-            "pb_1": "error",
-            "pb_2": "running",
-            "pb_3": "success",
-            "pb_4": "descendant_error",
-            "pb_5": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
-            "pb_6": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
-            "pb_7": "default",
-            "pb_8": "",
-            "pb_9": 1,
-        },
-    )
-
-
-def test_query_with_costs_and_dynamic_summary_order() -> None:
-    """Test ordering by a user-defined summary field when costs are enabled.
-
-    Regression test for ClickHouse error 215: when ordering by a dynamic summary
-    field like summary.acuracia, the final cost SELECT's ORDER BY must wrap
-    summary_dump in any() since it's not in the GROUP BY (it's rebuilt with cost
-    data).
-    """
-    cq = CallsQuery(
-        project_id="UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=", include_costs=True
-    )
-    cq.add_field("id")
-    cq.add_field("started_at")
-    cq.add_order("summary.acuracia", "DESC")
-
-    assert_sql(
-        cq,
-        """WITH filtered_calls AS
+            {
+                "pb_0": '$."status_counts"."error"',
+                "pb_1": "error",
+                "pb_2": "running",
+                "pb_3": "success",
+                "pb_4": "descendant_error",
+                "pb_5": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
+                "pb_6": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
+                "pb_7": "default",
+                "pb_8": "",
+                "pb_9": 1,
+            },
+            id="test_query_with_costs_and_attributes_order",
+        ),
+        # Test ordering by a user-defined summary field when costs are enabled.
+        pytest.param(
+            [("summary.acuracia", "DESC")],
+            """WITH filtered_calls AS
   (SELECT calls_merged.id AS id
    FROM calls_merged PREWHERE calls_merged.project_id = {pb_2:String}
    GROUP BY (calls_merged.project_id,
@@ -413,37 +393,21 @@ GROUP BY id,
          started_at
 ORDER BY (NOT (JSONType(any(ranked_prices.summary_dump), {pb_0:String}) = 'Null'
                OR JSONType(any(ranked_prices.summary_dump), {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(any(ranked_prices.summary_dump), {pb_1:String}), 'null'), '')) DESC, toString(coalesce(nullIf(JSON_VALUE(any(ranked_prices.summary_dump), {pb_1:String}), 'null'), '')) DESC""",
-        {
-            "pb_0": "acuracia",
-            "pb_1": '$."acuracia"',
-            "pb_2": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
-            "pb_3": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
-            "pb_4": "default",
-            "pb_5": "",
-            "pb_6": 1,
-        },
-    )
-
-
-def test_query_with_costs_and_feedback_order() -> None:
-    """Test ordering by feedback field with costs enabled.
-
-    This is a regression test to ensure that feedback join fields work correctly
-    in the ORDER BY clause when costs are enabled. The OrderField.as_sql method
-    should generate the complex expression needed for feedback fields.
-    """
-    cq = CallsQuery(
-        project_id="UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=", include_costs=True
-    )
-    cq.add_field("id")
-    cq.add_field("started_at")
-    cq.add_order("feedback.[wandb.runnable.my_op].payload.output.score", "desc")
-
-    # The key is that feedback ordering requires LEFT JOIN and complex expressions
-    # that must be preserved through the cost CTEs
-    assert_sql(
-        cq,
-        """
+            {
+                "pb_0": "acuracia",
+                "pb_1": '$."acuracia"',
+                "pb_2": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
+                "pb_3": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
+                "pb_4": "default",
+                "pb_5": "",
+                "pb_6": 1,
+            },
+            id="test_query_with_costs_and_dynamic_summary_order",
+        ),
+        # Test ordering by feedback field with costs enabled.
+        pytest.param(
+            [("feedback.[wandb.runnable.my_op].payload.output.score", "desc")],
+            """
         WITH filtered_calls AS
             (SELECT calls_merged.id AS id
              FROM calls_merged
@@ -535,41 +499,23 @@ def test_query_with_costs_and_feedback_order() -> None:
         ORDER BY (NOT (JSONType(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_1:String}, {pb_2:String}) = 'Null'
                        OR JSONType(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_1:String}, {pb_2:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_3:String}), 'null'), '')) DESC, toString(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_0:String}), {pb_3:String}), 'null'), '')) DESC
         """,
-        {
-            "pb_0": "wandb.runnable.my_op",
-            "pb_1": "output",
-            "pb_2": "score",
-            "pb_3": '$."output"."score"',
-            "pb_4": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
-            "pb_5": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
-            "pb_6": "default",
-            "pb_7": "",
-            "pb_8": 1,
-        },
-    )
-
-
-def test_query_with_costs_and_nested_attributes_order() -> None:
-    """Test ordering by nested attributes field (like attributes.sort_key) with costs enabled.
-
-    This is a regression test for the issue where ordering by attributes_dump fields
-    would fail when costs were enabled because the field wasn't being added to the
-    all_calls CTE, causing "Unknown expression identifier" errors.
-    """
-    cq = CallsQuery(
-        project_id="UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=", include_costs=True
-    )
-    cq.add_field("id")
-    cq.add_field("started_at")
-    cq.add_order("attributes.sort_key", "ASC")
-
-    # The key fix is that attributes_dump must be:
-    # 1. Selected in the all_calls CTE (via select_query.select_fields)
-    # 2. Available for the complex ORDER BY expression in all CTEs
-    # 3. Present in the final GROUP BY and ORDER BY clauses
-    assert_sql(
-        cq,
-        """
+            {
+                "pb_0": "wandb.runnable.my_op",
+                "pb_1": "output",
+                "pb_2": "score",
+                "pb_3": '$."output"."score"',
+                "pb_4": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
+                "pb_5": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
+                "pb_6": "default",
+                "pb_7": "",
+                "pb_8": 1,
+            },
+            id="test_query_with_costs_and_feedback_order",
+        ),
+        # Test ordering by nested attributes field (like attributes.sort_key) with costs enabled.
+        pytest.param(
+            [("attributes.sort_key", "ASC")],
+            """
             WITH filtered_calls AS
                 (SELECT calls_merged.id AS id
                  FROM calls_merged
@@ -661,16 +607,28 @@ def test_query_with_costs_and_nested_attributes_order() -> None:
         ORDER BY (NOT (JSONType(ranked_prices.attributes_dump, {pb_0:String}) = 'Null'
                        OR JSONType(ranked_prices.attributes_dump, {pb_0:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(ranked_prices.attributes_dump, {pb_1:String}), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(ranked_prices.attributes_dump, {pb_1:String}), 'null'), '')) ASC
         """,
-        {
-            "pb_0": "sort_key",
-            "pb_1": '$."sort_key"',
-            "pb_2": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
-            "pb_3": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
-            "pb_4": "default",
-            "pb_5": "",
-            "pb_6": 1,
-        },
-    )
+            {
+                "pb_0": "sort_key",
+                "pb_1": '$."sort_key"',
+                "pb_2": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
+                "pb_3": "UHJvamVjdEludGVybmFsSWQ6NDI3Mjk1MTc=",
+                "pb_4": "default",
+                "pb_5": "",
+                "pb_6": 1,
+            },
+            id="test_query_with_costs_and_nested_attributes_order",
+        ),
+    ],
+)
+def test_query_with_costs_calls_merged_order(
+    orders: list[tuple[str, str]], expected_sql: str, expected_params: dict
+) -> None:
+    cq = CallsQuery(project_id=PROJECT_MERGED, include_costs=True)
+    cq.add_field("id")
+    cq.add_field("started_at")
+    for field, direction in orders:
+        cq.add_order(field, direction)
+    assert_sql(cq, expected_sql, expected_params)
 
 
 def test_query_calls_complete_with_costs_light_fields() -> None:
@@ -782,25 +740,15 @@ def test_query_calls_complete_with_costs_light_fields() -> None:
     )
 
 
-def test_query_calls_complete_with_costs_and_attributes_order() -> None:
-    """Test calls_complete with costs and heavy field ordering skips filtered_calls CTE.
-
-    For calls_complete, ordering by a heavy field (attributes.sort_key) uses direct
-    column access without any() aggregation in the all_calls CTE. The ORDER BY in the
-    final select still uses any() because it operates on ranked_prices (post-JOIN).
-    """
-    cq = CallsQuery(
-        project_id="UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
-        include_costs=True,
-        read_table=ReadTable.CALLS_COMPLETE,
-    )
-    cq.add_field("id")
-    cq.add_field("started_at")
-    cq.add_order("attributes.sort_key", "ASC")
-
-    assert_sql(
-        cq,
-        """
+# calls_complete skips the filtered_calls CTE entirely (direct columns / SELECT
+# DISTINCT / CASE-WHEN trace_name). Each param retains its full expected SQL.
+@pytest.mark.parametrize(
+    ("orders", "expected_sql", "expected_params"),
+    [
+        # Test calls_complete with costs and heavy field ordering skips filtered_calls CTE.
+        pytest.param(
+            [("attributes.sort_key", "ASC")],
+            """
         WITH all_calls AS
           (SELECT calls_complete.id AS id,
                   calls_complete.started_at AS started_at,
@@ -880,38 +828,22 @@ def test_query_calls_complete_with_costs_and_attributes_order() -> None:
         ORDER BY (NOT (JSONType(ranked_prices.attributes_dump, {pb_1:String}) = 'Null'
                        OR JSONType(ranked_prices.attributes_dump, {pb_1:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(ranked_prices.attributes_dump, {pb_2:String}), 'null'), '')) ASC, toString(coalesce(nullIf(JSON_VALUE(ranked_prices.attributes_dump, {pb_2:String}), 'null'), '')) ASC
         """,
-        {
-            "pb_0": SENTINEL_EPOCH,
-            "pb_1": "sort_key",
-            "pb_2": '$."sort_key"',
-            "pb_3": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
-            "pb_4": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
-            "pb_5": "default",
-            "pb_6": "",
-            "pb_7": 1,
-        },
-    )
-
-
-def test_query_calls_complete_with_costs_and_feedback_order() -> None:
-    """Test calls_complete with costs and feedback ordering skips filtered_calls CTE.
-
-    For calls_complete, feedback ordering uses CASE WHEN instead of anyIf() in the
-    all_calls CTE (no aggregation), while the final select on ranked_prices still
-    uses anyIf() because it operates after the cost JOIN.
-    """
-    cq = CallsQuery(
-        project_id="UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
-        include_costs=True,
-        read_table=ReadTable.CALLS_COMPLETE,
-    )
-    cq.add_field("id")
-    cq.add_field("started_at")
-    cq.add_order("feedback.[wandb.runnable.my_op].payload.output.score", "desc")
-
-    assert_sql(
-        cq,
-        """
+            {
+                "pb_0": SENTINEL_EPOCH,
+                "pb_1": "sort_key",
+                "pb_2": '$."sort_key"',
+                "pb_3": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
+                "pb_4": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
+                "pb_5": "default",
+                "pb_6": "",
+                "pb_7": 1,
+            },
+            id="test_query_calls_complete_with_costs_and_attributes_order",
+        ),
+        # Test calls_complete with costs and feedback ordering skips filtered_calls CTE.
+        pytest.param(
+            [("feedback.[wandb.runnable.my_op].payload.output.score", "desc")],
+            """
         WITH all_calls AS
           (SELECT DISTINCT calls_complete.id AS id,
                   calls_complete.started_at AS started_at
@@ -1001,19 +933,138 @@ def test_query_calls_complete_with_costs_and_feedback_order() -> None:
         ORDER BY (NOT (JSONType(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_1:String}), {pb_2:String}, {pb_3:String}) = 'Null'
                        OR JSONType(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_1:String}), {pb_2:String}, {pb_3:String}) IS NULL)) desc, toFloat64OrNull(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_1:String}), {pb_4:String}), 'null'), '')) DESC, toString(coalesce(nullIf(JSON_VALUE(anyIf(feedback.payload_dump, feedback.feedback_type = {pb_1:String}), {pb_4:String}), 'null'), '')) DESC
         """,
-        {
-            "pb_0": SENTINEL_EPOCH,
-            "pb_1": "wandb.runnable.my_op",
-            "pb_2": "output",
-            "pb_3": "score",
-            "pb_4": '$."output"."score"',
-            "pb_5": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
-            "pb_6": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
-            "pb_7": "default",
-            "pb_8": "",
-            "pb_9": 1,
-        },
+            {
+                "pb_0": SENTINEL_EPOCH,
+                "pb_1": "wandb.runnable.my_op",
+                "pb_2": "output",
+                "pb_3": "score",
+                "pb_4": '$."output"."score"',
+                "pb_5": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
+                "pb_6": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
+                "pb_7": "default",
+                "pb_8": "",
+                "pb_9": 1,
+            },
+            id="test_query_calls_complete_with_costs_and_feedback_order",
+        ),
+        # Test calls_complete with costs and summary.weave.trace_name ordering.
+        pytest.param(
+            [("summary.weave.trace_name", "DESC")],
+            """
+        WITH all_calls AS
+          (SELECT calls_complete.id AS id,
+                  calls_complete.started_at AS started_at,
+                  CASE
+                      WHEN calls_complete.display_name != {pb_0:String} THEN calls_complete.display_name
+                      WHEN calls_complete.op_name IS NOT NULL
+                           AND calls_complete.op_name LIKE 'weave-trace-internal:///%' THEN regexpExtract(toString(calls_complete.op_name), '/([^/:]*):', 1)
+                      ELSE calls_complete.op_name
+                  END AS `summary.weave.trace_name`
+           FROM calls_complete PREWHERE calls_complete.project_id = {pb_3:String}
+           WHERE 1
+             AND (calls_complete.deleted_at = {pb_1:DateTime64(3)})
+           ORDER BY CASE
+                        WHEN calls_complete.display_name != {pb_2:String} THEN calls_complete.display_name
+                        WHEN calls_complete.op_name IS NOT NULL
+                             AND calls_complete.op_name LIKE 'weave-trace-internal:///%' THEN regexpExtract(toString(calls_complete.op_name), '/([^/:]*):', 1)
+                        ELSE calls_complete.op_name
+                    END DESC),
+             llm_usage AS
+          (-- From the all_calls we get the usage data for LLMs
+         SELECT *,
+                ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
+                arrayJoin(if(usage_raw != ''
+                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
+                kv.1 AS llm_id,
+                JSONExtractInt(kv.2, 'requests') AS requests,
+                (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
+                (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
+                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
+                JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
+                JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
+           FROM all_calls),
+             ranked_prices AS
+          (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
+         SELECT *,
+                llm_token_prices.id,
+                llm_token_prices.pricing_level,
+                llm_token_prices.pricing_level_id,
+                llm_token_prices.provider_id,
+                llm_token_prices.llm_id,
+                llm_token_prices.effective_date,
+                llm_token_prices.prompt_token_cost,
+                llm_token_prices.completion_token_cost,
+                llm_token_prices.cache_read_input_token_cost,
+                llm_token_prices.cache_creation_input_token_cost,
+                llm_token_prices.prompt_token_cost_unit,
+                llm_token_prices.completion_token_cost_unit,
+                llm_token_prices.created_by,
+                llm_token_prices.created_at,
+                ROW_NUMBER() OVER (PARTITION BY llm_usage.id, llm_usage.llm_id
+                                   ORDER BY CASE -- Order by effective_date
+                                                WHEN llm_usage.started_at >= llm_token_prices.effective_date THEN 1
+                                                ELSE 2
+                                            END, CASE -- Order by pricing level then by effective_date
+                                                 -- WHEN llm_token_prices.pricing_level = 'org' AND llm_token_prices.pricing_level_id = ORG_PARAM THEN 1
+                                                     WHEN llm_token_prices.pricing_level = 'project'
+                                                          AND llm_token_prices.pricing_level_id = 'UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=' THEN 2
+                                                     WHEN llm_token_prices.pricing_level = 'default'
+                                                          AND llm_token_prices.pricing_level_id = 'default' THEN 3
+                                                     ELSE 4
+                                                 END, llm_token_prices.effective_date DESC) AS rank
+           FROM llm_usage
+           LEFT JOIN llm_token_prices ON ((llm_usage.llm_id = llm_token_prices.llm_id)
+                                          AND ((llm_token_prices.pricing_level_id = {pb_4:String})
+                                               OR (llm_token_prices.pricing_level_id = {pb_5:String})
+                                               OR (llm_token_prices.pricing_level_id = {pb_6:String})))) -- Final Select, which just selects the correct fields, and adds a costs object
+        SELECT id,
+               started_at,
+               `summary.weave.trace_name`,
+               if(any(llm_id) = 'weave_dummy_llm_id'
+                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
+                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
+                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
+                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
+                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
+                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
+                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
+                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
+                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
+        FROM ranked_prices
+        WHERE (rank = {pb_7:UInt64})
+        GROUP BY id,
+                 started_at,
+                 `summary.weave.trace_name`
+        ORDER BY `summary.weave.trace_name` DESC
+        """,
+            {
+                "pb_0": "",
+                "pb_1": SENTINEL_EPOCH,
+                "pb_2": "",
+                "pb_3": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
+                "pb_4": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
+                "pb_5": "default",
+                "pb_6": "",
+                "pb_7": 1,
+            },
+            id="test_query_calls_complete_with_costs_and_trace_name_order",
+        ),
+    ],
+)
+def test_query_with_costs_calls_complete_order(
+    orders: list[tuple[str, str]], expected_sql: str, expected_params: dict
+) -> None:
+    cq = CallsQuery(
+        project_id=PROJECT_COMPLETE,
+        include_costs=True,
+        read_table=ReadTable.CALLS_COMPLETE,
     )
+    cq.add_field("id")
+    cq.add_field("started_at")
+    for field, direction in orders:
+        cq.add_order(field, direction)
+    assert_sql(cq, expected_sql, expected_params)
 
 
 def test_query_with_costs_and_summary_weave_trace_name_field() -> None:
@@ -1123,124 +1174,5 @@ def test_query_with_costs_and_summary_weave_trace_name_field() -> None:
             "pb_2": "default",
             "pb_3": "",
             "pb_4": 1,
-        },
-    )
-
-
-def test_query_calls_complete_with_costs_and_trace_name_order() -> None:
-    """Test calls_complete with costs and summary.weave.trace_name ordering.
-
-    Regression test: ordering by summary.weave.trace_name with costs on
-    calls_complete used to fail with UNKNOWN_IDENTIFIER because the computed
-    trace_name column was not included in the all_calls CTE SELECT.
-    """
-    cq = CallsQuery(
-        project_id="UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
-        include_costs=True,
-        read_table=ReadTable.CALLS_COMPLETE,
-    )
-    cq.add_field("id")
-    cq.add_field("started_at")
-    cq.add_order("summary.weave.trace_name", "DESC")
-
-    assert_sql(
-        cq,
-        """
-        WITH all_calls AS
-          (SELECT calls_complete.id AS id,
-                  calls_complete.started_at AS started_at,
-                  CASE
-                      WHEN calls_complete.display_name != {pb_0:String} THEN calls_complete.display_name
-                      WHEN calls_complete.op_name IS NOT NULL
-                           AND calls_complete.op_name LIKE 'weave-trace-internal:///%' THEN regexpExtract(toString(calls_complete.op_name), '/([^/:]*):', 1)
-                      ELSE calls_complete.op_name
-                  END AS `summary.weave.trace_name`
-           FROM calls_complete PREWHERE calls_complete.project_id = {pb_3:String}
-           WHERE 1
-             AND (calls_complete.deleted_at = {pb_1:DateTime64(3)})
-           ORDER BY CASE
-                        WHEN calls_complete.display_name != {pb_2:String} THEN calls_complete.display_name
-                        WHEN calls_complete.op_name IS NOT NULL
-                             AND calls_complete.op_name LIKE 'weave-trace-internal:///%' THEN regexpExtract(toString(calls_complete.op_name), '/([^/:]*):', 1)
-                        ELSE calls_complete.op_name
-                    END DESC),
-             llm_usage AS
-          (-- From the all_calls we get the usage data for LLMs
-         SELECT *,
-                ifNull(JSONExtractRaw(summary_dump, 'usage'), '{}') AS usage_raw,
-                arrayJoin(if(usage_raw != ''
-                             and usage_raw != '{}', JSONExtractKeysAndValuesRaw(usage_raw), [('weave_dummy_llm_id', '{\\"requests\\": 0, \\"prompt_tokens\\": 0, \\"completion_tokens\\": 0, \\"total_tokens\\": 0, \\"cache_read_input_tokens\\": 0, \\"cache_creation_input_tokens\\": 0}')])) AS kv,
-                kv.1 AS llm_id,
-                JSONExtractInt(kv.2, 'requests') AS requests,
-                (if(JSONHas(kv.2, 'prompt_tokens'), JSONExtractInt(kv.2, 'prompt_tokens'), 0) + if(JSONHas(kv.2, 'input_tokens'), JSONExtractInt(kv.2, 'input_tokens'), 0)) AS prompt_tokens,
-                (if(JSONHas(kv.2, 'completion_tokens'), JSONExtractInt(kv.2, 'completion_tokens'), 0) + if(JSONHas(kv.2, 'output_tokens'), JSONExtractInt(kv.2, 'output_tokens'), 0)) AS completion_tokens,
-                JSONExtractInt(kv.2, 'total_tokens') AS total_tokens,
-                JSONExtractInt(kv.2, 'cache_read_input_tokens') AS cache_read_input_tokens,
-                JSONExtractInt(kv.2, 'cache_creation_input_tokens') AS cache_creation_input_tokens
-           FROM all_calls),
-             ranked_prices AS
-          (-- based on the llm_ids in the usage data we get all the prices and rank them according to specificity and effective date
-         SELECT *,
-                llm_token_prices.id,
-                llm_token_prices.pricing_level,
-                llm_token_prices.pricing_level_id,
-                llm_token_prices.provider_id,
-                llm_token_prices.llm_id,
-                llm_token_prices.effective_date,
-                llm_token_prices.prompt_token_cost,
-                llm_token_prices.completion_token_cost,
-                llm_token_prices.cache_read_input_token_cost,
-                llm_token_prices.cache_creation_input_token_cost,
-                llm_token_prices.prompt_token_cost_unit,
-                llm_token_prices.completion_token_cost_unit,
-                llm_token_prices.created_by,
-                llm_token_prices.created_at,
-                ROW_NUMBER() OVER (PARTITION BY llm_usage.id, llm_usage.llm_id
-                                   ORDER BY CASE -- Order by effective_date
-                                                WHEN llm_usage.started_at >= llm_token_prices.effective_date THEN 1
-                                                ELSE 2
-                                            END, CASE -- Order by pricing level then by effective_date
-                                                 -- WHEN llm_token_prices.pricing_level = 'org' AND llm_token_prices.pricing_level_id = ORG_PARAM THEN 1
-                                                     WHEN llm_token_prices.pricing_level = 'project'
-                                                          AND llm_token_prices.pricing_level_id = 'UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=' THEN 2
-                                                     WHEN llm_token_prices.pricing_level = 'default'
-                                                          AND llm_token_prices.pricing_level_id = 'default' THEN 3
-                                                     ELSE 4
-                                                 END, llm_token_prices.effective_date DESC) AS rank
-           FROM llm_usage
-           LEFT JOIN llm_token_prices ON ((llm_usage.llm_id = llm_token_prices.llm_id)
-                                          AND ((llm_token_prices.pricing_level_id = {pb_4:String})
-                                               OR (llm_token_prices.pricing_level_id = {pb_5:String})
-                                               OR (llm_token_prices.pricing_level_id = {pb_6:String})))) -- Final Select, which just selects the correct fields, and adds a costs object
-        SELECT id,
-               started_at,
-               `summary.weave.trace_name`,
-               if(any(llm_id) = 'weave_dummy_llm_id'
-                  or any(llm_token_prices.id) == '', any(summary_dump), concat(left(any(summary_dump), length(any(summary_dump)) - 1), ',"weave":{', '"costs":', concat('{', arrayStringConcat(groupUniqArray(concat('"', toString(llm_id), '":{', '"prompt_tokens":', toString(prompt_tokens), ',', '"completion_tokens":', toString(completion_tokens), ',', '"requests":', toString(requests), ',', '"total_tokens":', toString(total_tokens), ',',
-                                        '"cache_read_input_tokens":', toString(cache_read_input_tokens), ',',
-                                        '"cache_creation_input_tokens":', toString(cache_creation_input_tokens), ',',
-                                        '"prompt_token_cost":', toString(prompt_token_cost), ',', '"completion_token_cost":', toString(completion_token_cost), ',',
-                                        '"cache_read_input_token_cost":', toString(cache_read_input_token_cost), ',',
-                                        '"cache_creation_input_token_cost":', toString(cache_creation_input_token_cost), ',',
-                                        '"prompt_tokens_total_cost":', toString((prompt_tokens - cache_read_input_tokens - cache_creation_input_tokens) * prompt_token_cost), ',', '"completion_tokens_total_cost":', toString(completion_tokens * completion_token_cost), ',',
-                                        '"cache_read_input_tokens_total_cost":', toString(cache_read_input_tokens * cache_read_input_token_cost), ',',
-                                        '"cache_creation_input_tokens_total_cost":', toString(cache_creation_input_tokens * cache_creation_input_token_cost), ',',
-                                        '"prompt_token_cost_unit":"', toString(prompt_token_cost_unit), '",', '"completion_token_cost_unit":"', toString(completion_token_cost_unit), '",', '"effective_date":"', toString(effective_date), '",', '"provider_id":"', toString(provider_id), '",', '"pricing_level":"', toString(pricing_level), '",', '"pricing_level_id":"', toString(pricing_level_id), '",', '"created_by":"', toString(created_by), '",', '"created_at":"', toString(created_at), '"}')), ','), '} }'), '}')) AS summary_dump
-        FROM ranked_prices
-        WHERE (rank = {pb_7:UInt64})
-        GROUP BY id,
-                 started_at,
-                 `summary.weave.trace_name`
-        ORDER BY `summary.weave.trace_name` DESC
-        """,
-        {
-            "pb_0": "",
-            "pb_1": SENTINEL_EPOCH,
-            "pb_2": "",
-            "pb_3": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
-            "pb_4": "UHJvamVjdEludGVybmFsSWQ6Mzk1NDg2Mjc=",
-            "pb_5": "default",
-            "pb_6": "",
-            "pb_7": 1,
         },
     )

--- a/tests/trace_server/query_builder/test_eval_results_query_builder.py
+++ b/tests/trace_server/query_builder/test_eval_results_query_builder.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.trace_server.query_builder.utils import assert_raw_sql
 from weave.trace_server import trace_server_interface as tsi
 from weave.trace_server.ch_sentinel_values import SENTINEL_EPOCH
@@ -13,23 +15,32 @@ from weave.trace_server.query_builder.eval_results_query_builder import (
 )
 
 
-def test_cte_chain_calls_merged() -> None:
-    """Full CTE chain for calls_merged with intersection."""
-    pb = ParamBuilder("pb")
-    cte = build_eval_results_cte_chain(
-        project_id="proj-1",
-        eval_root_ids=["eval-1", "eval-2"],
-        sort_by=None,
-        filters=None,
-        require_intersection=True,
-        limit=50,
-        offset=0,
-        pb=pb,
-        read_table="calls_merged",
-    )
-    assert_raw_sql(
-        cte,
-        """
+# Each param keeps its complete expected CTE string + params: merged uses any(...)
+# aggregation + parent-id-NULL OR-branch, complete uses direct columns +
+# deleted_at = SENTINEL_EPOCH, and the sort / multi-filter cases add ROW_NUMBER
+# ordering plus HAVING toFloat64OrNull comparisons.
+@pytest.mark.parametrize(
+    (
+        "read_table",
+        "eval_root_ids",
+        "sort_by",
+        "filters",
+        "require_intersection",
+        "limit",
+        "offset",
+        "expected_sql",
+        "expected_params",
+    ),
+    [
+        pytest.param(
+            "calls_merged",
+            ["eval-1", "eval-2"],
+            None,
+            None,
+            True,
+            50,
+            0,
+            """
             predict_and_score_calls AS (
                 SELECT calls_merged.id AS call_id,
                     any(calls_merged.parent_id) AS eval_call_id,
@@ -100,34 +111,24 @@ def test_cte_chain_calls_merged() -> None:
                 LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
-        pb.get_params(),
-        {
-            "pb_0": "proj-1",
-            "pb_1": ["eval-1", "eval-2"],
-            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
-            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
-            "pb_4": 2,
-        },
-    )
-
-
-def test_cte_chain_calls_complete() -> None:
-    """Full CTE chain for calls_complete with offset."""
-    pb = ParamBuilder("pb")
-    cte = build_eval_results_cte_chain(
-        project_id="proj-1",
-        eval_root_ids=["eval-1"],
-        sort_by=None,
-        filters=None,
-        require_intersection=False,
-        limit=25,
-        offset=10,
-        pb=pb,
-        read_table="calls_complete",
-    )
-    assert_raw_sql(
-        cte,
-        """
+            {
+                "pb_0": "proj-1",
+                "pb_1": ["eval-1", "eval-2"],
+                "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+                "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
+                "pb_4": 2,
+            },
+            id="cte_chain_calls_merged",
+        ),
+        pytest.param(
+            "calls_complete",
+            ["eval-1"],
+            None,
+            None,
+            False,
+            25,
+            10,
+            """
             predict_and_score_calls AS (
                 SELECT calls_complete.id AS call_id,
                     calls_complete.parent_id AS eval_call_id,
@@ -190,79 +191,67 @@ def test_cte_chain_calls_complete() -> None:
                 LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
-        pb.get_params(),
-        {
-            "pb_0": "proj-1",
-            "pb_1": ["eval-1"],
-            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
-            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
-            "pb_4": SENTINEL_EPOCH,
-        },
-    )
-
-
-def test_cte_chain_sort_and_multi_eval_filters() -> None:
-    """Full CTE chain: scoped sort + two per-eval filters + intersection on calls_complete."""
-    pb = ParamBuilder("pb")
-    sort_by = [
-        tsi.EvalResultsSortBy(
-            field="scores.accuracy",
-            direction="desc",
-            evaluation_call_id="eval-1",
-        )
-    ]
-    filters = [
-        tsi.EvalResultsFilter(
-            evaluation_call_id="eval-1",
-            query=Query.model_validate(
-                {
-                    "$expr": {
-                        "$gte": [
-                            {
-                                "$convert": {
-                                    "input": {"$getField": "scores.accuracy"},
-                                    "to": "double",
-                                }
-                            },
-                            {"$literal": 0.5},
-                        ]
-                    }
-                }
-            ),
+            {
+                "pb_0": "proj-1",
+                "pb_1": ["eval-1"],
+                "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+                "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
+                "pb_4": SENTINEL_EPOCH,
+            },
+            id="cte_chain_calls_complete",
         ),
-        tsi.EvalResultsFilter(
-            evaluation_call_id="eval-2",
-            query=Query.model_validate(
-                {
-                    "$expr": {
-                        "$lte": [
-                            {
-                                "$convert": {
-                                    "input": {"$getField": "scores.accuracy"},
-                                    "to": "double",
-                                }
-                            },
-                            {"$literal": 0.9},
-                        ]
-                    }
-                }
-            ),
-        ),
-    ]
-    cte = build_eval_results_cte_chain(
-        project_id="proj-1",
-        eval_root_ids=["eval-1", "eval-2"],
-        sort_by=sort_by,
-        filters=filters,
-        require_intersection=True,
-        limit=100,
-        offset=50,
-        pb=pb,
-        read_table="calls_complete",
-    )
-    assert_raw_sql(
-        cte,
-        """
+        pytest.param(
+            "calls_complete",
+            ["eval-1", "eval-2"],
+            [
+                tsi.EvalResultsSortBy(
+                    field="scores.accuracy",
+                    direction="desc",
+                    evaluation_call_id="eval-1",
+                )
+            ],
+            [
+                tsi.EvalResultsFilter(
+                    evaluation_call_id="eval-1",
+                    query=Query.model_validate(
+                        {
+                            "$expr": {
+                                "$gte": [
+                                    {
+                                        "$convert": {
+                                            "input": {"$getField": "scores.accuracy"},
+                                            "to": "double",
+                                        }
+                                    },
+                                    {"$literal": 0.5},
+                                ]
+                            }
+                        }
+                    ),
+                ),
+                tsi.EvalResultsFilter(
+                    evaluation_call_id="eval-2",
+                    query=Query.model_validate(
+                        {
+                            "$expr": {
+                                "$lte": [
+                                    {
+                                        "$convert": {
+                                            "input": {"$getField": "scores.accuracy"},
+                                            "to": "double",
+                                        }
+                                    },
+                                    {"$literal": 0.9},
+                                ]
+                            }
+                        }
+                    ),
+                ),
+            ],
+            True,
+            100,
+            50,
+            """
             predict_and_score_calls AS (
                 SELECT calls_complete.id AS call_id,
                     calls_complete.parent_id AS eval_call_id,
@@ -328,71 +317,60 @@ def test_cte_chain_sort_and_multi_eval_filters() -> None:
                 LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
-        pb.get_params(),
-        {
-            "pb_0": "proj-1",
-            "pb_1": ["eval-1", "eval-2"],
-            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
-            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
-            "pb_4": SENTINEL_EPOCH,
-            "pb_5": '$."scores"."accuracy"',
-            "pb_6": "eval-1",
-            "pb_7": 2,
-            "pb_8": 0.5,
-            "pb_9": "eval-2",
-            "pb_10": 0.9,
-        },
-    )
-
-
-def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
-    """Red-team for PR #6735: orm.py infers field-side casts from peer
-    literals so feedback / threads / objects don't need an explicit
-    `$convert` to compare a JSON-extracted field against a typed param. The
-    PR promises that any caller of `Select.where(...)` benefits, but
-    `_process_query_to_conditions`'s `GetFieldOperator` branch silently
-    drops the inferred cast when a `field_resolver` is provided. Eval
-    results filtering reaches `_process_query_to_conditions` exactly that
-    way, so a numeric / bool literal without `$convert` should still pick
-    up the typed cast (matching the explicit-`$convert` shape pinned by
-    `test_cte_chain_sort_and_multi_eval_filters`).
-
-    The HAVING clause on `ranked_digests` must wrap the per-eval scores
-    aggregate in `toFloat64OrNull(...)` so the comparison against the
-    `Float64` parameter type-checks in ClickHouse. Without the fix the
-    field comes through as `String` and CH refuses the comparison with
-    `NO_COMMON_TYPE`.
-    """
-    pb = ParamBuilder("pb")
-    filters = [
-        tsi.EvalResultsFilter(
-            evaluation_call_id="eval-1",
-            query=Query.model_validate(
-                {
-                    "$expr": {
-                        "$gte": [
-                            {"$getField": "scores.accuracy"},
-                            {"$literal": 0.5},
-                        ]
-                    }
-                }
-            ),
+            {
+                "pb_0": "proj-1",
+                "pb_1": ["eval-1", "eval-2"],
+                "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+                "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
+                "pb_4": SENTINEL_EPOCH,
+                "pb_5": '$."scores"."accuracy"',
+                "pb_6": "eval-1",
+                "pb_7": 2,
+                "pb_8": 0.5,
+                "pb_9": "eval-2",
+                "pb_10": 0.9,
+            },
+            id="cte_chain_sort_and_multi_eval_filters",
         ),
-    ]
-    cte = build_eval_results_cte_chain(
-        project_id="proj-1",
-        eval_root_ids=["eval-1"],
-        sort_by=None,
-        filters=filters,
-        require_intersection=False,
-        limit=10,
-        offset=0,
-        pb=pb,
-        read_table="calls_merged",
-    )
-    assert_raw_sql(
-        cte,
-        """
+        # Red-team for PR #6735: orm.py infers field-side casts from peer
+        #     literals so feedback / threads / objects don't need an explicit
+        #     `$convert` to compare a JSON-extracted field against a typed param. The
+        #     PR promises that any caller of `Select.where(...)` benefits, but
+        #     `_process_query_to_conditions`'s `GetFieldOperator` branch silently
+        #     drops the inferred cast when a `field_resolver` is provided. Eval
+        #     results filtering reaches `_process_query_to_conditions` exactly that
+        #     way, so a numeric / bool literal without `$convert` should still pick
+        #     up the typed cast (matching the explicit-`$convert` shape pinned by
+        #     `test_cte_chain_sort_and_multi_eval_filters`).
+        #
+        #     The HAVING clause on `ranked_digests` must wrap the per-eval scores
+        #     aggregate in `toFloat64OrNull(...)` so the comparison against the
+        #     `Float64` parameter type-checks in ClickHouse. Without the fix the
+        #     field comes through as `String` and CH refuses the comparison with
+        #     `NO_COMMON_TYPE`.
+        pytest.param(
+            "calls_merged",
+            ["eval-1"],
+            None,
+            [
+                tsi.EvalResultsFilter(
+                    evaluation_call_id="eval-1",
+                    query=Query.model_validate(
+                        {
+                            "$expr": {
+                                "$gte": [
+                                    {"$getField": "scores.accuracy"},
+                                    {"$literal": 0.5},
+                                ]
+                            }
+                        }
+                    ),
+                ),
+            ],
+            False,
+            10,
+            0,
+            """
             predict_and_score_calls AS (
                 SELECT calls_merged.id AS call_id,
                     any(calls_merged.parent_id) AS eval_call_id,
@@ -463,36 +441,54 @@ def test_eval_filter_infers_cast_for_typed_literal_without_convert() -> None:
                 LEFT JOIN page_resolved_inputs ON page_resolved_inputs.digest = predict_and_score_calls_resolved.row_digest
             )
             """,
-        pb.get_params(),
-        {
-            "pb_0": "proj-1",
-            "pb_1": ["eval-1"],
-            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
-            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
-            "pb_4": '$."scores"."accuracy"',
-            "pb_5": "eval-1",
-            "pb_6": 0.5,
-        },
-    )
-
-
-def test_full_query_calls_merged() -> None:
-    """Full SQL: lean CTEs + outer SELECT hydrates from calls_merged."""
+            {
+                "pb_0": "proj-1",
+                "pb_1": ["eval-1"],
+                "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+                "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
+                "pb_4": '$."scores"."accuracy"',
+                "pb_5": "eval-1",
+                "pb_6": 0.5,
+            },
+            id="eval_filter_infers_cast_for_typed_literal_without_convert",
+        ),
+    ],
+)
+def test_cte_chain(
+    read_table: str,
+    eval_root_ids: list[str],
+    sort_by: list[tsi.EvalResultsSortBy] | None,
+    filters: list[tsi.EvalResultsFilter] | None,
+    require_intersection: bool,
+    limit: int,
+    offset: int,
+    expected_sql: str,
+    expected_params: dict,
+) -> None:
     pb = ParamBuilder("pb")
-    sql = build_eval_results_query(
+    cte = build_eval_results_cte_chain(
         project_id="proj-1",
-        eval_root_ids=["eval-1"],
-        sort_by=None,
-        filters=None,
-        require_intersection=False,
-        limit=10,
-        offset=0,
+        eval_root_ids=eval_root_ids,
+        sort_by=sort_by,
+        filters=filters,
+        require_intersection=require_intersection,
+        limit=limit,
+        offset=offset,
         pb=pb,
-        read_table="calls_merged",
+        read_table=read_table,
     )
-    assert_raw_sql(
-        sql,
-        """
+    assert_raw_sql(cte, expected_sql, pb.get_params(), expected_params)
+
+
+# merged vs complete differ only in the page_calls CTE (merged: any(...) + GROUP
+# BY + PREWHERE; complete: direct columns + plain WHERE, no GROUP BY) and the
+# extra project param; the outer SELECT is identical. Both full strings retained.
+@pytest.mark.parametrize(
+    ("read_table", "expected_sql", "expected_params"),
+    [
+        pytest.param(
+            "calls_merged",
+            """
         WITH predict_and_score_calls AS (
                 SELECT calls_merged.id AS call_id,
                     any(calls_merged.parent_id) AS eval_call_id,
@@ -598,34 +594,18 @@ def test_full_query_calls_merged() -> None:
         LEFT JOIN page_calls ON page_calls.call_id = page_rows.call_id
         ORDER BY page_rows.row_order ASC
         """,
-        pb.get_params(),
-        {
-            "pb_0": "proj-1",
-            "pb_1": ["eval-1"],
-            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
-            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
-            "pb_4": "proj-1",
-        },
-    )
-
-
-def test_full_query_calls_complete() -> None:
-    """Full SQL: lean CTEs + page_calls hydration on calls_complete (no GROUP BY)."""
-    pb = ParamBuilder("pb")
-    sql = build_eval_results_query(
-        project_id="proj-1",
-        eval_root_ids=["eval-1"],
-        sort_by=None,
-        filters=None,
-        require_intersection=False,
-        limit=10,
-        offset=0,
-        pb=pb,
-        read_table="calls_complete",
-    )
-    assert_raw_sql(
-        sql,
-        """
+            {
+                "pb_0": "proj-1",
+                "pb_1": ["eval-1"],
+                "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+                "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
+                "pb_4": "proj-1",
+            },
+            id="full_query_calls_merged",
+        ),
+        pytest.param(
+            "calls_complete",
+            """
         WITH predict_and_score_calls AS (
                 SELECT calls_complete.id AS call_id,
                     calls_complete.parent_id AS eval_call_id,
@@ -723,13 +703,29 @@ def test_full_query_calls_complete() -> None:
         LEFT JOIN page_calls ON page_calls.call_id = page_rows.call_id
         ORDER BY page_rows.row_order ASC
         """,
-        pb.get_params(),
-        {
-            "pb_0": "proj-1",
-            "pb_1": ["eval-1"],
-            "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
-            "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
-            "pb_4": SENTINEL_EPOCH,
-            "pb_5": "proj-1",
-        },
+            {
+                "pb_0": "proj-1",
+                "pb_1": ["eval-1"],
+                "pb_2": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME,
+                "pb_3": EVALUATION_RUN_PREDICTION_AND_SCORE_OP_NAME_TS,
+                "pb_4": SENTINEL_EPOCH,
+                "pb_5": "proj-1",
+            },
+            id="full_query_calls_complete",
+        ),
+    ],
+)
+def test_full_query(read_table: str, expected_sql: str, expected_params: dict) -> None:
+    pb = ParamBuilder("pb")
+    sql = build_eval_results_query(
+        project_id="proj-1",
+        eval_root_ids=["eval-1"],
+        sort_by=None,
+        filters=None,
+        require_intersection=False,
+        limit=10,
+        offset=0,
+        pb=pb,
+        read_table=read_table,
     )
+    assert_raw_sql(sql, expected_sql, pb.get_params(), expected_params)

--- a/tests/trace_server/query_builder/test_feedback_stats.py
+++ b/tests/trace_server/query_builder/test_feedback_stats.py
@@ -36,144 +36,118 @@ from weave.trace_server.trace_server_interface import (
     FeedbackStatsReq,
 )
 
+_START = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
+_END = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+
+
 # ---------------------------------------------------------------------------
 # discover_payload_schema
 # ---------------------------------------------------------------------------
 
 
-class TestDiscoverPaths:
-    def test_flat_dict(self):
-        result = _discover_paths({"score": 0.9, "passed": True})
-        assert "score" in result
-        assert float in result["score"]
-        assert "passed" in result
-        assert bool in result["passed"]
-
-    def test_nested_dict(self):
-        result = _discover_paths({"output": {"score": 0.9}})
-        assert "output.score" in result
-        assert float in result["output.score"]
-
-    def test_skips_keys_with_dot(self):
-        result = _discover_paths({"a.b": 1})
-        assert not result
-
-    def test_skips_empty_key(self):
-        result = _discover_paths({"": 1})
-        assert not result
-
-    def test_list_of_scalars(self):
-        # A dict with a list-of-scalars value produces a path keyed by the field name
-        result = _discover_paths({"scores": [0.1, 0.2]})
-        assert "scores" in result
-        assert float in result["scores"]
-
-    def test_none_value(self):
-        result = _discover_paths({"x": None})
-        assert "x" in result
-        assert type(None) in result["x"]
+@pytest.mark.parametrize(
+    ("payload", "path", "expected_type"),
+    [
+        ({"score": 0.9, "passed": True}, "score", float),  # flat float
+        ({"score": 0.9, "passed": True}, "passed", bool),  # flat bool
+        ({"output": {"score": 0.9}}, "output.score", float),  # nested float
+        ({"scores": [0.1, 0.2]}, "scores", float),  # list-of-scalars
+        ({"x": None}, "x", type(None)),  # None value
+    ],
+)
+def test_discover_paths_value_shapes(payload, path, expected_type):
+    result = _discover_paths(payload)
+    assert path in result
+    assert expected_type in result[path]
 
 
-class TestInferValueType:
-    def test_numeric(self):
-        assert _infer_value_type({int, float}) == "numeric"
-        assert _infer_value_type({int}) == "numeric"
-        assert _infer_value_type({float, type(None)}) == "numeric"
-
-    def test_boolean(self):
-        assert _infer_value_type({bool}) == "boolean"
-        assert _infer_value_type({bool, type(None)}) == "boolean"
-
-    def test_categorical_when_mixed(self):
-        assert _infer_value_type({str}) == "categorical"
-        assert _infer_value_type({int, str}) == "categorical"
-
-    def test_empty(self):
-        # No types seen → default to numeric
-        assert _infer_value_type(set()) == "numeric"
-
-    def test_bool_not_confused_with_int(self):
-        # bool is subclass of int; {bool} must resolve to "boolean", not "numeric"
-        assert _infer_value_type({bool}) == "boolean"
-        # Mixed bool+int → categorical (ambiguous)
-        assert _infer_value_type({bool, int}) == "categorical"
+@pytest.mark.parametrize("payload", [{"a.b": 1}, {"": 1}])
+def test_discover_paths_skips_invalid_keys(payload):
+    assert not _discover_paths(payload)
 
 
-class TestDiscoverPayloadSchema:
-    def test_basic(self):
-        paths = discover_payload_schema(['{"output": {"score": 0.9}}'])
-        assert len(paths) == 1
-        assert paths[0].json_path == "output.score"
-        assert paths[0].value_type == "numeric"
+@pytest.mark.parametrize(
+    ("types", "expected"),
+    [
+        ({int, float}, "numeric"),
+        ({int}, "numeric"),
+        ({float, type(None)}, "numeric"),
+        (set(), "numeric"),  # no types seen -> default numeric
+        ({bool}, "boolean"),  # bool is subclass of int, must stay boolean
+        ({bool, type(None)}, "boolean"),
+        ({str}, "categorical"),
+        ({int, str}, "categorical"),
+        ({bool, int}, "categorical"),  # mixed bool+int is ambiguous
+    ],
+)
+def test_infer_value_type(types, expected):
+    assert _infer_value_type(types) == expected
 
-    def test_boolean_field(self):
-        paths = discover_payload_schema(['{"passed": true}'])
-        assert paths[0].json_path == "passed"
-        assert paths[0].value_type == "boolean"
 
-    def test_multiple_payloads_merged(self):
-        payloads = ['{"score": 1.0}', '{"score": 0.5, "label": "good"}']
-        paths = discover_payload_schema(payloads)
-        path_map = {p.json_path: p.value_type for p in paths}
-        assert "score" in path_map
-        assert path_map["score"] == "numeric"
-        assert "label" in path_map
-        assert path_map["label"] == "categorical"
+@pytest.mark.parametrize(
+    ("payloads", "expected_subset", "excluded", "expected_len"),
+    [
+        (['{"output": {"score": 0.9}}'], {"output.score": "numeric"}, [], 1),
+        (['{"passed": true}'], {"passed": "boolean"}, [], 1),
+        (
+            ['{"score": 1.0}', '{"score": 0.5, "label": "good"}'],
+            {"score": "numeric", "label": "categorical"},
+            [],
+            2,
+        ),
+        (['{"items": [1, 2, 3]}'], {}, ["["], None),  # array-index paths filtered
+        (["not json", '{"score": 1.0}'], {"score": "numeric"}, [], 1),
+        (["", "   ", '{"x": 1}'], {"x": "numeric"}, [], 1),  # empty strings skipped
+        (
+            ['{"a b": 1, "c": 2}'],
+            {"a b": "numeric", "c": "numeric"},
+            [],
+            2,
+        ),  # spaces ok
+        (
+            ["""{"a'b": 1, "c": 2}"""],
+            {"c": "numeric"},
+            ["a'b"],
+            1,
+        ),  # unsafe char excluded
+    ],
+)
+def test_discover_payload_schema(payloads, expected_subset, excluded, expected_len):
+    paths = discover_payload_schema(payloads)
+    path_map = {p.json_path: p.value_type for p in paths}
+    for path, value_type in expected_subset.items():
+        assert path_map[path] == value_type
+    for substr in excluded:
+        assert all(substr not in name for name in path_map)
+    if expected_len is not None:
+        assert len(paths) == expected_len
 
-    def test_skips_array_index_paths(self):
-        paths = discover_payload_schema(['{"items": [1, 2, 3]}'])
-        # Array-index paths like "items[0]" are filtered out
-        for p in paths:
-            assert "[" not in p.json_path
 
-    def test_invalid_json_skipped(self):
-        paths = discover_payload_schema(["not json", '{"score": 1.0}'])
-        assert len(paths) == 1
-        assert paths[0].json_path == "score"
+def test_discover_payload_schema_paths_sorted():
+    paths = discover_payload_schema(['{"z": 1, "a": 2, "m": 3}'])
+    names = [p.json_path for p in paths]
+    assert names == sorted(names)
 
-    def test_empty_strings_skipped(self):
-        paths = discover_payload_schema(["", "   ", '{"x": 1}'])
-        assert len(paths) == 1
 
-    def test_paths_sorted(self):
-        payloads = ['{"z": 1, "a": 2, "m": 3}']
-        paths = discover_payload_schema(payloads)
-        names = [p.json_path for p in paths]
-        assert names == sorted(names)
-
-    def test_path_with_spaces_included(self):
-        # Spaces are allowed (classifier monitors use human-readable names as keys)
-        paths = discover_payload_schema(['{"a b": 1, "c": 2}'])
-        names = [p.json_path for p in paths]
-        assert "a b" in names
-        assert "c" in names
-
-    def test_path_with_unsafe_chars_excluded(self):
-        # Special chars like quotes must still be excluded
-        paths = discover_payload_schema(["""{"a'b": 1, "c": 2}"""])
-        names = [p.json_path for p in paths]
-        assert "a'b" not in names
-        assert "c" in names
-
-    def test_classifier_monitor_payload(self):
-        # Classifier monitors use human-readable names as dictionary keys
-        payload = json.dumps(
-            {
-                "output": {
-                    "classifier_tags": "Low quality, Bug",
-                    "classifier_meta": {
-                        "Low quality": {"confidence": 0.95, "reason": "evidence"},
-                        "Bug": {"confidence": 0.80, "reason": "evidence"},
-                    },
-                }
+def test_classifier_monitor_payload():
+    # Classifier monitors use human-readable names as dictionary keys
+    payload = json.dumps(
+        {
+            "output": {
+                "classifier_tags": "Low quality, Bug",
+                "classifier_meta": {
+                    "Low quality": {"confidence": 0.95, "reason": "evidence"},
+                    "Bug": {"confidence": 0.80, "reason": "evidence"},
+                },
             }
-        )
-        paths = discover_payload_schema([payload])
-        path_map = {p.json_path: p.value_type for p in paths}
-        assert "output.classifier_meta.Low quality.confidence" in path_map
-        assert path_map["output.classifier_meta.Low quality.confidence"] == "numeric"
-        assert "output.classifier_meta.Bug.confidence" in path_map
-        assert path_map["output.classifier_meta.Bug.confidence"] == "numeric"
+        }
+    )
+    paths = discover_payload_schema([payload])
+    path_map = {p.json_path: p.value_type for p in paths}
+    assert "output.classifier_meta.Low quality.confidence" in path_map
+    assert path_map["output.classifier_meta.Low quality.confidence"] == "numeric"
+    assert "output.classifier_meta.Bug.confidence" in path_map
+    assert path_map["output.classifier_meta.Bug.confidence"] == "numeric"
 
 
 # ---------------------------------------------------------------------------
@@ -181,56 +155,67 @@ class TestDiscoverPayloadSchema:
 # ---------------------------------------------------------------------------
 
 
-class TestJsonPathHelpers:
-    def test_slug_replaces_dots(self):
-        assert _json_path_to_metric_slug("output.score") == "output_score"
-
-    def test_slug_single_key(self):
-        assert _json_path_to_metric_slug("score") == "score"
-
-    def test_extraction_numeric(self):
-        sql = _json_path_to_extraction_sql("output.score", "numeric")
-        assert sql == "toFloat64OrNull(JSONExtractRaw(payload_dump, 'output', 'score'))"
-
-    def test_extraction_numeric_nested(self):
-        sql = _json_path_to_extraction_sql("a.b.c", "numeric")
-        assert sql == "toFloat64OrNull(JSONExtractRaw(payload_dump, 'a', 'b', 'c'))"
-
-    def test_extraction_boolean(self):
-        sql = _json_path_to_extraction_sql("passed", "boolean")
-        assert (
-            sql
-            == "if(JSONExtractRaw(payload_dump, 'passed') = 'true', 1, if(JSONExtractRaw(payload_dump, 'passed') = 'false', 0, NULL))"
-        )
-
-    def test_extraction_categorical(self):
-        sql = _json_path_to_extraction_sql("label", "categorical")
-        assert sql == "JSONExtractString(payload_dump, 'label')"
-
-    def test_extraction_categorical_nested(self):
-        sql = _json_path_to_extraction_sql("output.label", "categorical")
-        assert sql == "JSONExtractString(payload_dump, 'output', 'label')"
-
-    def test_invalid_path_raises(self):
-        with pytest.raises(ValueError, match="json_path may only contain"):
-            _json_path_to_metric_slug("output'score")
-
-    def test_empty_path_raises(self):
-        with pytest.raises(ValueError, match="cannot be empty"):
-            _json_path_to_metric_slug("")
+@pytest.mark.parametrize(
+    ("json_path", "value_type", "expected_sql"),
+    [
+        (
+            "output.score",
+            "numeric",
+            "toFloat64OrNull(JSONExtractRaw(payload_dump, 'output', 'score'))",
+        ),
+        (
+            "a.b.c",
+            "numeric",
+            "toFloat64OrNull(JSONExtractRaw(payload_dump, 'a', 'b', 'c'))",
+        ),
+        (
+            "passed",
+            "boolean",
+            "if(JSONExtractRaw(payload_dump, 'passed') = 'true', 1, if(JSONExtractRaw(payload_dump, 'passed') = 'false', 0, NULL))",
+        ),
+        ("label", "categorical", "JSONExtractString(payload_dump, 'label')"),
+        (
+            "output.label",
+            "categorical",
+            "JSONExtractString(payload_dump, 'output', 'label')",
+        ),
+    ],
+)
+def test_json_path_to_extraction_sql(json_path, value_type, expected_sql):
+    assert _json_path_to_extraction_sql(json_path, value_type) == expected_sql
 
 
-class TestJsonPathPattern:
-    def test_valid(self):
-        assert JSON_PATH_PATTERN.match("output.score")
-        assert JSON_PATH_PATTERN.match("score")
-        assert JSON_PATH_PATTERN.match("a_b.c_d")
-        assert JSON_PATH_PATTERN.match("output.classifier_meta.Low quality.confidence")
+@pytest.mark.parametrize(
+    ("json_path", "expected_slug"),
+    [("output.score", "output_score"), ("score", "score")],
+)
+def test_json_path_to_metric_slug(json_path, expected_slug):
+    assert _json_path_to_metric_slug(json_path) == expected_slug
 
-    def test_invalid(self):
-        assert not JSON_PATH_PATTERN.match("a[0]")
-        assert not JSON_PATH_PATTERN.match("")
-        assert not JSON_PATH_PATTERN.match("path'injection")
+
+@pytest.mark.parametrize(
+    ("json_path", "error_match"),
+    [("output'score", "json_path may only contain"), ("", "cannot be empty")],
+)
+def test_json_path_to_metric_slug_rejects(json_path, error_match):
+    with pytest.raises(ValueError, match=error_match):
+        _json_path_to_metric_slug(json_path)
+
+
+@pytest.mark.parametrize(
+    ("path", "should_match"),
+    [
+        ("output.score", True),
+        ("score", True),
+        ("a_b.c_d", True),
+        ("output.classifier_meta.Low quality.confidence", True),
+        ("a[0]", False),
+        ("", False),
+        ("path'injection", False),
+    ],
+)
+def test_json_path_pattern(path, should_match):
+    assert bool(JSON_PATH_PATTERN.match(path)) is should_match
 
 
 # ---------------------------------------------------------------------------
@@ -238,18 +223,22 @@ class TestJsonPathPattern:
 # ---------------------------------------------------------------------------
 
 
-class TestTriggerRefWhereClause:
-    def test_exact_match(self):
-        pb = _make_pb()
-        sql = trigger_ref_where_clause("my-monitor:v1", pb)
-        assert sql == "trigger_ref = {pb_0:String}"
-        assert pb.get_params() == {"pb_0": "my-monitor:v1"}
-
-    def test_prefix_match(self):
-        pb = _make_pb()
-        sql = trigger_ref_where_clause("my-monitor:*", pb)
-        assert sql == "startsWith(trigger_ref, {pb_0:String})"
-        assert pb.get_params() == {"pb_0": "my-monitor"}
+@pytest.mark.parametrize(
+    ("trigger_ref", "expected_sql", "expected_params"),
+    [
+        ("my-monitor:v1", "trigger_ref = {pb_0:String}", {"pb_0": "my-monitor:v1"}),
+        (
+            "my-monitor:*",
+            "startsWith(trigger_ref, {pb_0:String})",
+            {"pb_0": "my-monitor"},  # trailing :* stripped
+        ),
+    ],
+)
+def test_trigger_ref_where_clause(trigger_ref, expected_sql, expected_params):
+    pb = _make_pb()
+    sql = trigger_ref_where_clause(trigger_ref, pb)
+    assert sql == expected_sql
+    assert pb.get_params() == expected_params
 
 
 # ---------------------------------------------------------------------------
@@ -257,8 +246,441 @@ class TestTriggerRefWhereClause:
 # ---------------------------------------------------------------------------
 
 
-_START = datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc)
-_END = datetime.datetime(2024, 1, 2, tzinfo=datetime.timezone.utc)
+_NUMERIC_BUCKET_SQL = """
+WITH all_buckets AS
+  (SELECT toStartOfInterval(toDateTime({{pb_1:Float64}}, {{pb_3:String}}), toIntervalSecond({{{idx}:Int64}}), {{pb_3:String}}) + toIntervalSecond(number * {{{idx}:Int64}}) AS bucket
+   FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({{pb_2:Float64}}, {{pb_3:String}})) - toUnixTimestamp(toStartOfInterval(toDateTime({{pb_1:Float64}}, {{pb_3:String}}), toIntervalSecond({{{idx}:Int64}}), {{pb_3:String}}))) / {{{idx}:Float64}})))
+   WHERE bucket < toDateTime({{pb_2:Float64}}, {{pb_3:String}}) ),
+     aggregated_data AS
+  (SELECT bucket,
+          avgOrNull(m_output_score) AS avg_output_score,
+          maxOrNull(m_output_score) AS max_output_score,
+          quantileOrNull(0.05)(m_output_score) AS p5_output_score,
+          quantileOrNull(0.95)(m_output_score) AS p95_output_score,
+          count() AS count
+   FROM
+     (SELECT toStartOfInterval(created_at, toIntervalSecond({{{idx}:Int64}}), {{pb_3:String}}) AS bucket,
+             toFloat64OrNull(JSONExtractRaw(payload_dump, 'output', 'score')) AS m_output_score
+      FROM feedback
+      WHERE project_id = {{pb_0:String}}
+        AND created_at >= toDateTime({{pb_1:Float64}}, {{pb_3:String}})
+        AND created_at < toDateTime({{pb_2:Float64}}, {{pb_3:String}}){filter_clause} )
+   GROUP BY bucket)
+SELECT all_buckets.bucket AS timestamp,
+       COALESCE(aggregated_data.avg_output_score, 0) AS avg_output_score,
+       aggregated_data.max_output_score AS max_output_score,
+       aggregated_data.p5_output_score AS p5_output_score,
+       aggregated_data.p95_output_score AS p95_output_score,
+       COALESCE(aggregated_data.count, 0) AS count
+FROM all_buckets
+LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+ORDER BY all_buckets.bucket
+"""
+
+_BOOLEAN_BUCKET_SQL = """
+WITH all_buckets AS
+  (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_4:Int64}), {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+   FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_4:Int64}), {pb_3:String}))) / {pb_4:Float64})))
+   WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+     aggregated_data AS
+  (SELECT bucket,
+          countIf(m_passed = 1) AS count_true_passed,
+          countIf(m_passed = 0) AS count_false_passed,
+          count() AS count
+   FROM
+     (SELECT toStartOfInterval(created_at, toIntervalSecond({pb_4:Int64}), {pb_3:String}) AS bucket,
+             if(JSONExtractRaw(payload_dump, 'passed') = 'true', 1, if(JSONExtractRaw(payload_dump, 'passed') = 'false', 0, NULL)) AS m_passed
+      FROM feedback
+      WHERE project_id = {pb_0:String}
+        AND created_at >= toDateTime({pb_1:Float64}, {pb_3:String})
+        AND created_at < toDateTime({pb_2:Float64}, {pb_3:String}) )
+   GROUP BY bucket)
+SELECT all_buckets.bucket AS timestamp,
+       COALESCE(aggregated_data.count_true_passed, 0) AS count_true_passed,
+       COALESCE(aggregated_data.count_false_passed, 0) AS count_false_passed,
+       COALESCE(aggregated_data.count, 0) AS count
+FROM all_buckets
+LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+ORDER BY all_buckets.bucket
+"""
+
+_BOOLEAN_METRIC = FeedbackMetricSpec(
+    json_path="passed",
+    value_type="boolean",
+    aggregations=[AggregationType.COUNT_TRUE, AggregationType.COUNT_FALSE],
+)
+
+
+@pytest.mark.parametrize(
+    ("req_kwargs", "expected_sql", "expected_params"),
+    [
+        (
+            {},
+            _NUMERIC_BUCKET_SQL.format(idx="pb_4", filter_clause=""),
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1704067200.0,
+                "pb_2": 1704153600.0,
+                "pb_3": "UTC",
+                "pb_4": 21600,
+            },
+        ),
+        (
+            {"feedback_type": "wandb.runnable.my-scorer"},
+            _NUMERIC_BUCKET_SQL.format(
+                idx="pb_5", filter_clause="\n        AND feedback_type = {pb_4:String}"
+            ),
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1704067200.0,
+                "pb_2": 1704153600.0,
+                "pb_3": "UTC",
+                "pb_4": "wandb.runnable.my-scorer",
+                "pb_5": 21600,
+            },
+        ),
+        (
+            {"trigger_ref": "weave:///entity/project/op/my-op:v1"},
+            _NUMERIC_BUCKET_SQL.format(
+                idx="pb_5", filter_clause="\n        AND trigger_ref = {pb_4:String}"
+            ),
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1704067200.0,
+                "pb_2": 1704153600.0,
+                "pb_3": "UTC",
+                "pb_4": "weave:///entity/project/op/my-op:v1",
+                "pb_5": 21600,
+            },
+        ),
+        (
+            {"trigger_ref": "weave:///entity/project/op/my-op:*"},
+            _NUMERIC_BUCKET_SQL.format(
+                idx="pb_5",
+                filter_clause="\n        AND startsWith(trigger_ref, {pb_4:String})",
+            ),
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1704067200.0,
+                "pb_2": 1704153600.0,
+                "pb_3": "UTC",
+                "pb_4": "weave:///entity/project/op/my-op",  # trailing :* stripped
+                "pb_5": 21600,
+            },
+        ),
+        (
+            {"metrics": [_BOOLEAN_METRIC]},  # boolean swaps projection + extraction
+            _BOOLEAN_BUCKET_SQL,
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1704067200.0,
+                "pb_2": 1704153600.0,
+                "pb_3": "UTC",
+                "pb_4": 21600,
+            },
+        ),
+    ],
+)
+def test_build_feedback_stats_query_sql(req_kwargs, expected_sql, expected_params):
+    req = _make_req(**req_kwargs)
+    pb = _make_pb()
+    result = build_feedback_stats_query(req, pb)
+    _assert_sql_equal(result.sql, expected_sql)
+    assert pb.get_params() == expected_params
+
+
+def test_build_feedback_stats_query_metadata():
+    pb = _make_pb()
+    result = build_feedback_stats_query(_make_req(), pb)
+    assert result.columns == [
+        "timestamp",
+        "avg_output_score",
+        "max_output_score",
+        "p5_output_score",
+        "p95_output_score",
+        "count",
+    ]
+    assert result.start == _START
+    assert result.end == _END
+
+    multi = build_feedback_stats_query(
+        _make_req(
+            metrics=[
+                FeedbackMetricSpec(
+                    json_path="score",
+                    value_type="numeric",
+                    aggregations=[AggregationType.AVG],
+                ),
+                FeedbackMetricSpec(
+                    json_path="passed",
+                    value_type="boolean",
+                    aggregations=[AggregationType.COUNT_TRUE],
+                ),
+            ]
+        ),
+        _make_pb(),
+    )
+    assert "avg_score" in multi.columns
+    assert "count_true_passed" in multi.columns
+
+
+@pytest.mark.parametrize(
+    ("granularity", "predicate"),
+    [
+        (1800, lambda g: g == 1800),  # explicit value honored
+        (None, lambda g: g > 0),  # auto-selected positive
+    ],
+)
+def test_build_feedback_stats_query_granularity(granularity, predicate):
+    pb = _make_pb()
+    result = build_feedback_stats_query(_make_req(granularity=granularity), pb)
+    assert predicate(result.granularity_seconds)
+
+
+# ---------------------------------------------------------------------------
+# build_feedback_stats_window_query
+# ---------------------------------------------------------------------------
+
+
+_WINDOW_SQL = """
+SELECT avgOrNull(m_output_score) AS avg_output_score,
+       maxOrNull(m_output_score) AS max_output_score,
+       quantileOrNull(0.05)(m_output_score) AS p5_output_score,
+       quantileOrNull(0.95)(m_output_score) AS p95_output_score
+FROM
+  (SELECT toFloat64OrNull(JSONExtractRaw(payload_dump, 'output', 'score')) AS m_output_score
+   FROM feedback
+   WHERE project_id = {{pb_0:String}}
+     AND created_at >= toDateTime({{pb_1:Float64}}, {{pb_3:String}})
+     AND created_at < toDateTime({{pb_2:Float64}}, {{pb_3:String}}){filter_clause} )
+"""
+
+
+@pytest.mark.parametrize(
+    ("req_kwargs", "expected_sql", "expected_params"),
+    [
+        (
+            {},
+            _WINDOW_SQL.format(filter_clause=""),
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1704067200.0,
+                "pb_2": 1704153600.0,
+                "pb_3": "UTC",
+            },
+        ),
+        (
+            {"feedback_type": "wandb.runnable.scorer", "trigger_ref": "ref:v1"},
+            _WINDOW_SQL.format(
+                filter_clause="\n     AND feedback_type = {pb_4:String}"
+                "\n     AND trigger_ref = {pb_5:String}"
+            ),
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1704067200.0,
+                "pb_2": 1704153600.0,
+                "pb_3": "UTC",
+                "pb_4": "wandb.runnable.scorer",
+                "pb_5": "ref:v1",
+            },
+        ),
+    ],
+)
+def test_build_window_query_sql(req_kwargs, expected_sql, expected_params):
+    req = _make_req(**req_kwargs)
+    pb = _make_pb()
+    result = build_feedback_stats_window_query(req, pb)
+    assert result is not None
+    _assert_sql_equal(result.sql, expected_sql)
+    assert pb.get_params() == expected_params
+    assert result.columns == [
+        "avg_output_score",
+        "max_output_score",
+        "p5_output_score",
+        "p95_output_score",
+    ]
+
+
+def test_window_query_returns_none_for_empty_metrics():
+    pb = _make_pb()
+    assert build_feedback_stats_window_query(_make_req(metrics=[]), pb) is None
+
+
+# ---------------------------------------------------------------------------
+# _parse_window_stat_col (the count_true/count_false bug fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("column", "expected"),
+    [
+        ("avg_output_score", ("avg", "output_score")),
+        ("sum_output_score", ("sum", "output_score")),
+        ("min_output_score", ("min", "output_score")),
+        ("max_output_score", ("max", "output_score")),
+        ("count_output_score", ("count", "output_score")),
+        # count_true/count_false are the regression anchors: split("_", 1) was the bug
+        ("count_true_output_score", ("count_true", "output_score")),
+        ("count_false_output_score", ("count_false", "output_score")),
+        ("p95_output_score", ("p95", "output_score")),
+        ("p5_output_score", ("p5", "output_score")),
+        ("avg_output_quality_score", ("avg", "output_quality_score")),
+        ("count_true_output_quality_score", ("count_true", "output_quality_score")),
+        ("unknown_col", None),
+        ("timestamp", None),
+        ("count", None),  # no slug portion
+    ],
+)
+def test_parse_window_stat_col(column, expected):
+    assert _parse_window_stat_col(column) == expected
+
+
+# ---------------------------------------------------------------------------
+# FeedbackMetricSpec validation (typed aggregations)
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_metric_spec():
+    explicit = FeedbackMetricSpec(
+        json_path="score",
+        aggregations=[AggregationType.AVG, AggregationType.MAX],
+    )
+    assert explicit.aggregations == [AggregationType.AVG, AggregationType.MAX]
+
+    default = FeedbackMetricSpec(json_path="score")
+    assert len(default.aggregations) > 0
+    assert all(isinstance(a, AggregationType) for a in default.aggregations)
+
+    with_pcts = FeedbackMetricSpec(json_path="score", percentiles=[5, 50, 95])
+    assert with_pcts.percentiles == [5, 50, 95]
+
+
+def test_invalid_aggregation_string_rejected():
+    with pytest.raises(ValueError, match="average"):
+        FeedbackMetricSpec.model_validate(
+            {"json_path": "score", "aggregations": ["average"]}
+        )
+
+
+# ---------------------------------------------------------------------------
+# _extract_window_stats
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("cols", "row", "expected"),
+    [
+        (["avg_output_score"], (0.5,), {"output_score": {"avg": 0.5}}),
+        (
+            ["avg_output_score", "max_output_score", "p95_output_score"],
+            (0.5, 1.0, 0.95),
+            {"output_score": {"avg": 0.5, "max": 1.0, "p95": 0.95}},
+        ),
+        (
+            ["avg_score", "avg_quality"],
+            (0.5, 0.8),
+            {"score": {"avg": 0.5}, "quality": {"avg": 0.8}},
+        ),
+        (["avg_output_score"], (None,), {"output_score": {"avg": None}}),  # None kept
+        (["unknown_col"], (1.0,), {}),  # unknown column skipped
+        (["avg_score", "max_score"], (0.5,), {"score": {"avg": 0.5}}),  # row < cols
+        ([], (), {}),  # empty
+        (
+            ["count_true_passed", "count_false_passed"],
+            (10, 5),
+            {"passed": {"count_true": 10.0, "count_false": 5.0}},  # float-coerced
+        ),
+    ],
+)
+def test_extract_window_stats(cols, row, expected):
+    assert _extract_window_stats(cols, row) == expected
+
+
+# ---------------------------------------------------------------------------
+# feedback_stats (methods module, mocked server)
+# ---------------------------------------------------------------------------
+
+
+def test_feedback_stats_empty_metrics_returns_empty_buckets():
+    server = _make_mock_server()
+    res = feedback_stats(server, _make_req(metrics=[]))
+    assert res.buckets == []
+    assert res.start == _START
+    assert res.granularity == 3600
+    server._query.assert_not_called()
+
+
+def test_feedback_stats_calls_server_and_returns_buckets():
+    ts = datetime.datetime(2024, 1, 1, 6, 0, tzinfo=datetime.timezone.utc)
+    server = _make_mock_server(bucket_rows=[(ts, 0.75, 1.0, 0.1, 0.95, 5)])
+    res = feedback_stats(server, _make_req())
+    assert len(res.buckets) == 1
+    assert res.buckets[0]["avg_output_score"] == 0.75
+    assert res.granularity > 0
+    assert server._query.call_count >= 1
+
+
+@pytest.mark.parametrize(
+    ("window_rows", "expects_window_stats"),
+    [([(0.6, 1.0, 0.05, 0.98)], True), ([], False)],
+)
+def test_feedback_stats_window_stats(window_rows, expects_window_stats):
+    bucket_rows = [(_START, 0.5, 1.0, 0.1, 0.9, 10)]
+    server = _make_mock_server(bucket_rows=bucket_rows, window_rows=window_rows)
+    res = feedback_stats(server, _make_req())
+    if expects_window_stats:
+        assert res.window_stats is not None
+        assert res.window_stats["output_score"]["avg"] == 0.6
+    else:
+        assert res.window_stats is None
+
+
+@pytest.mark.parametrize(
+    ("req_kwargs", "expected_timezone"),
+    [
+        ({"timezone": "America/New_York"}, "America/New_York"),
+        ({}, "UTC"),  # defaults to UTC
+    ],
+)
+def test_feedback_stats_timezone(req_kwargs, expected_timezone):
+    server = _make_mock_server()
+    res = feedback_stats(server, _make_req(metrics=[], **req_kwargs))
+    assert res.timezone == expected_timezone
+
+
+# ---------------------------------------------------------------------------
+# feedback_payload_schema (methods module, mocked server)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("result_rows", "expected_subset", "expected_len"),
+    [
+        (
+            [('{"output": {"score": 0.9}}',), ('{"label": "good"}',)],
+            {"output.score": "numeric", "label": "categorical"},
+            2,
+        ),
+        ([], {}, 0),
+        ([(None,), ("",), ('{"x": 1}',)], {"x": "numeric"}, 1),  # null/empty skipped
+    ],
+)
+def test_feedback_payload_schema(result_rows, expected_subset, expected_len):
+    server = MagicMock()
+    result = MagicMock()
+    result.result_rows = result_rows
+    server._query.return_value = result
+    req = FeedbackPayloadSchemaReq(project_id="entity/project", start=_START, end=_END)
+    res = feedback_payload_schema(server, req)
+    path_map = {p.json_path: p.value_type for p in res.paths}
+    for path, value_type in expected_subset.items():
+        assert path_map[path] == value_type
+    assert len(res.paths) == expected_len
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _make_pb() -> ParamBuilder:
@@ -293,628 +715,22 @@ def _make_req(**kwargs) -> FeedbackStatsReq:
     return FeedbackStatsReq(**defaults)
 
 
-class TestBuildFeedbackStatsQuery:
-    def test_returns_expected_bucket_query_sql(self):
-        req = _make_req()
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        _assert_sql_equal(
-            result.sql,
-            """
-            WITH all_buckets AS
-              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_4:Int64}), {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_4:Int64}), {pb_3:String}))) / {pb_4:Float64})))
-               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-                 aggregated_data AS
-              (SELECT bucket,
-                      avgOrNull(m_output_score) AS avg_output_score,
-                      maxOrNull(m_output_score) AS max_output_score,
-                      quantileOrNull(0.05)(m_output_score) AS p5_output_score,
-                      quantileOrNull(0.95)(m_output_score) AS p95_output_score,
-                      count() AS count
-               FROM
-                 (SELECT toStartOfInterval(created_at, toIntervalSecond({pb_4:Int64}), {pb_3:String}) AS bucket,
-                         toFloat64OrNull(JSONExtractRaw(payload_dump, 'output', 'score')) AS m_output_score
-                  FROM feedback
-                  WHERE project_id = {pb_0:String}
-                    AND created_at >= toDateTime({pb_1:Float64}, {pb_3:String})
-                    AND created_at < toDateTime({pb_2:Float64}, {pb_3:String}) )
-               GROUP BY bucket)
-            SELECT all_buckets.bucket AS timestamp,
-                   COALESCE(aggregated_data.avg_output_score, 0) AS avg_output_score,
-                   aggregated_data.max_output_score AS max_output_score,
-                   aggregated_data.p5_output_score AS p5_output_score,
-                   aggregated_data.p95_output_score AS p95_output_score,
-                   COALESCE(aggregated_data.count, 0) AS count
-            FROM all_buckets
-            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-            ORDER BY all_buckets.bucket
-            """,
-        )
-        assert pb.get_params() == {
-            "pb_0": "entity/project",
-            "pb_1": 1704067200.0,
-            "pb_2": 1704153600.0,
-            "pb_3": "UTC",
-            "pb_4": 21600,
-        }
-
-    def test_columns_include_timestamp_and_count(self):
-        req = _make_req()
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        assert "timestamp" in result.columns
-        assert "count" in result.columns
-
-    def test_columns_include_agg_aliases(self):
-        req = _make_req()
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        assert "avg_output_score" in result.columns
-        assert "max_output_score" in result.columns
-        assert "p5_output_score" in result.columns
-        assert "p95_output_score" in result.columns
-
-    def test_granularity_respected(self):
-        req = _make_req(granularity=1800)
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        assert result.granularity_seconds == 1800
-
-    def test_granularity_auto_selected_when_none(self):
-        req = _make_req(granularity=None)
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        assert result.granularity_seconds > 0
-
-    def test_feedback_type_filter_matches_expected_sql(self):
-        req = _make_req(feedback_type="wandb.runnable.my-scorer")
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        _assert_sql_equal(
-            result.sql,
-            """
-            WITH all_buckets AS
-              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_5:Int64}), {pb_3:String}) + toIntervalSecond(number * {pb_5:Int64}) AS bucket
-               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_5:Int64}), {pb_3:String}))) / {pb_5:Float64})))
-               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-                 aggregated_data AS
-              (SELECT bucket,
-                      avgOrNull(m_output_score) AS avg_output_score,
-                      maxOrNull(m_output_score) AS max_output_score,
-                      quantileOrNull(0.05)(m_output_score) AS p5_output_score,
-                      quantileOrNull(0.95)(m_output_score) AS p95_output_score,
-                      count() AS count
-               FROM
-                 (SELECT toStartOfInterval(created_at, toIntervalSecond({pb_5:Int64}), {pb_3:String}) AS bucket,
-                         toFloat64OrNull(JSONExtractRaw(payload_dump, 'output', 'score')) AS m_output_score
-                  FROM feedback
-                  WHERE project_id = {pb_0:String}
-                    AND created_at >= toDateTime({pb_1:Float64}, {pb_3:String})
-                    AND created_at < toDateTime({pb_2:Float64}, {pb_3:String})
-                    AND feedback_type = {pb_4:String} )
-               GROUP BY bucket)
-            SELECT all_buckets.bucket AS timestamp,
-                   COALESCE(aggregated_data.avg_output_score, 0) AS avg_output_score,
-                   aggregated_data.max_output_score AS max_output_score,
-                   aggregated_data.p5_output_score AS p5_output_score,
-                   aggregated_data.p95_output_score AS p95_output_score,
-                   COALESCE(aggregated_data.count, 0) AS count
-            FROM all_buckets
-            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-            ORDER BY all_buckets.bucket
-            """,
-        )
-        assert pb.get_params()["pb_4"] == "wandb.runnable.my-scorer"
-
-    def test_trigger_ref_exact_filter_matches_expected_sql(self):
-        req = _make_req(trigger_ref="weave:///entity/project/op/my-op:v1")
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        _assert_sql_equal(
-            result.sql,
-            """
-            WITH all_buckets AS
-              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_5:Int64}), {pb_3:String}) + toIntervalSecond(number * {pb_5:Int64}) AS bucket
-               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_5:Int64}), {pb_3:String}))) / {pb_5:Float64})))
-               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-                 aggregated_data AS
-              (SELECT bucket,
-                      avgOrNull(m_output_score) AS avg_output_score,
-                      maxOrNull(m_output_score) AS max_output_score,
-                      quantileOrNull(0.05)(m_output_score) AS p5_output_score,
-                      quantileOrNull(0.95)(m_output_score) AS p95_output_score,
-                      count() AS count
-               FROM
-                 (SELECT toStartOfInterval(created_at, toIntervalSecond({pb_5:Int64}), {pb_3:String}) AS bucket,
-                         toFloat64OrNull(JSONExtractRaw(payload_dump, 'output', 'score')) AS m_output_score
-                  FROM feedback
-                  WHERE project_id = {pb_0:String}
-                    AND created_at >= toDateTime({pb_1:Float64}, {pb_3:String})
-                    AND created_at < toDateTime({pb_2:Float64}, {pb_3:String})
-                    AND trigger_ref = {pb_4:String} )
-               GROUP BY bucket)
-            SELECT all_buckets.bucket AS timestamp,
-                   COALESCE(aggregated_data.avg_output_score, 0) AS avg_output_score,
-                   aggregated_data.max_output_score AS max_output_score,
-                   aggregated_data.p5_output_score AS p5_output_score,
-                   aggregated_data.p95_output_score AS p95_output_score,
-                   COALESCE(aggregated_data.count, 0) AS count
-            FROM all_buckets
-            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-            ORDER BY all_buckets.bucket
-            """,
-        )
-        assert pb.get_params()["pb_4"] == "weave:///entity/project/op/my-op:v1"
-
-    def test_trigger_ref_prefix_filter_matches_expected_sql(self):
-        req = _make_req(trigger_ref="weave:///entity/project/op/my-op:*")
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        _assert_sql_equal(
-            result.sql,
-            """
-            WITH all_buckets AS
-              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_5:Int64}), {pb_3:String}) + toIntervalSecond(number * {pb_5:Int64}) AS bucket
-               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_5:Int64}), {pb_3:String}))) / {pb_5:Float64})))
-               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-                 aggregated_data AS
-              (SELECT bucket,
-                      avgOrNull(m_output_score) AS avg_output_score,
-                      maxOrNull(m_output_score) AS max_output_score,
-                      quantileOrNull(0.05)(m_output_score) AS p5_output_score,
-                      quantileOrNull(0.95)(m_output_score) AS p95_output_score,
-                      count() AS count
-               FROM
-                 (SELECT toStartOfInterval(created_at, toIntervalSecond({pb_5:Int64}), {pb_3:String}) AS bucket,
-                         toFloat64OrNull(JSONExtractRaw(payload_dump, 'output', 'score')) AS m_output_score
-                  FROM feedback
-                  WHERE project_id = {pb_0:String}
-                    AND created_at >= toDateTime({pb_1:Float64}, {pb_3:String})
-                    AND created_at < toDateTime({pb_2:Float64}, {pb_3:String})
-                    AND startsWith(trigger_ref, {pb_4:String}) )
-               GROUP BY bucket)
-            SELECT all_buckets.bucket AS timestamp,
-                   COALESCE(aggregated_data.avg_output_score, 0) AS avg_output_score,
-                   aggregated_data.max_output_score AS max_output_score,
-                   aggregated_data.p5_output_score AS p5_output_score,
-                   aggregated_data.p95_output_score AS p95_output_score,
-                   COALESCE(aggregated_data.count, 0) AS count
-            FROM all_buckets
-            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-            ORDER BY all_buckets.bucket
-            """,
-        )
-        assert pb.get_params()["pb_4"] == "weave:///entity/project/op/my-op"
-
-    def test_start_and_end_resolved(self):
-        req = _make_req()
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        assert result.start == _START
-        assert result.end == _END
-
-    def test_boolean_metric_matches_expected_sql(self):
-        req = _make_req(
-            metrics=[
-                FeedbackMetricSpec(
-                    json_path="passed",
-                    value_type="boolean",
-                    aggregations=[
-                        AggregationType.COUNT_TRUE,
-                        AggregationType.COUNT_FALSE,
-                    ],
-                )
-            ]
-        )
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        assert "count_true_passed" in result.columns
-        assert "count_false_passed" in result.columns
-        _assert_sql_equal(
-            result.sql,
-            """
-            WITH all_buckets AS
-              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_4:Int64}), {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), toIntervalSecond({pb_4:Int64}), {pb_3:String}))) / {pb_4:Float64})))
-               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-                 aggregated_data AS
-              (SELECT bucket,
-                      countIf(m_passed = 1) AS count_true_passed,
-                      countIf(m_passed = 0) AS count_false_passed,
-                      count() AS count
-               FROM
-                 (SELECT toStartOfInterval(created_at, toIntervalSecond({pb_4:Int64}), {pb_3:String}) AS bucket,
-                         if(JSONExtractRaw(payload_dump, 'passed') = 'true', 1, if(JSONExtractRaw(payload_dump, 'passed') = 'false', 0, NULL)) AS m_passed
-                  FROM feedback
-                  WHERE project_id = {pb_0:String}
-                    AND created_at >= toDateTime({pb_1:Float64}, {pb_3:String})
-                    AND created_at < toDateTime({pb_2:Float64}, {pb_3:String}) )
-               GROUP BY bucket)
-            SELECT all_buckets.bucket AS timestamp,
-                   COALESCE(aggregated_data.count_true_passed, 0) AS count_true_passed,
-                   COALESCE(aggregated_data.count_false_passed, 0) AS count_false_passed,
-                   COALESCE(aggregated_data.count, 0) AS count
-            FROM all_buckets
-            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-            ORDER BY all_buckets.bucket
-            """,
-        )
-
-    def test_multiple_metrics(self):
-        req = _make_req(
-            metrics=[
-                FeedbackMetricSpec(
-                    json_path="score",
-                    value_type="numeric",
-                    aggregations=[AggregationType.AVG],
-                ),
-                FeedbackMetricSpec(
-                    json_path="passed",
-                    value_type="boolean",
-                    aggregations=[AggregationType.COUNT_TRUE],
-                ),
-            ]
-        )
-        pb = _make_pb()
-        result = build_feedback_stats_query(req, pb)
-        assert "avg_score" in result.columns
-        assert "count_true_passed" in result.columns
-
-
-# ---------------------------------------------------------------------------
-# build_feedback_stats_window_query
-# ---------------------------------------------------------------------------
-
-
-class TestBuildFeedbackStatsWindowQuery:
-    def test_returns_none_for_empty_metrics(self):
-        req = _make_req(metrics=[])
-        pb = _make_pb()
-        assert build_feedback_stats_window_query(req, pb) is None
-
-    def test_returns_result_with_columns(self):
-        req = _make_req()
-        pb = _make_pb()
-        result = build_feedback_stats_window_query(req, pb)
-        assert result is not None
-        assert "avg_output_score" in result.columns
-        assert "max_output_score" in result.columns
-
-    def test_window_query_matches_expected_sql(self):
-        req = _make_req()
-        pb = _make_pb()
-        result = build_feedback_stats_window_query(req, pb)
-        assert result is not None
-        _assert_sql_equal(
-            result.sql,
-            """
-            SELECT avgOrNull(m_output_score) AS avg_output_score,
-                   maxOrNull(m_output_score) AS max_output_score,
-                   quantileOrNull(0.05)(m_output_score) AS p5_output_score,
-                   quantileOrNull(0.95)(m_output_score) AS p95_output_score
-            FROM
-              (SELECT toFloat64OrNull(JSONExtractRaw(payload_dump, 'output', 'score')) AS m_output_score
-               FROM feedback
-               WHERE project_id = {pb_0:String}
-                 AND created_at >= toDateTime({pb_1:Float64}, {pb_3:String})
-                 AND created_at < toDateTime({pb_2:Float64}, {pb_3:String}) )
-            """,
-        )
-        assert pb.get_params() == {
-            "pb_0": "entity/project",
-            "pb_1": 1704067200.0,
-            "pb_2": 1704153600.0,
-            "pb_3": "UTC",
-        }
-
-    def test_window_query_filters_match_expected_sql(self):
-        req = _make_req(feedback_type="wandb.runnable.scorer", trigger_ref="ref:v1")
-        pb = _make_pb()
-        result = build_feedback_stats_window_query(req, pb)
-        assert result is not None
-        _assert_sql_equal(
-            result.sql,
-            """
-            SELECT avgOrNull(m_output_score) AS avg_output_score,
-                   maxOrNull(m_output_score) AS max_output_score,
-                   quantileOrNull(0.05)(m_output_score) AS p5_output_score,
-                   quantileOrNull(0.95)(m_output_score) AS p95_output_score
-            FROM
-              (SELECT toFloat64OrNull(JSONExtractRaw(payload_dump, 'output', 'score')) AS m_output_score
-               FROM feedback
-               WHERE project_id = {pb_0:String}
-                 AND created_at >= toDateTime({pb_1:Float64}, {pb_3:String})
-                 AND created_at < toDateTime({pb_2:Float64}, {pb_3:String})
-                 AND feedback_type = {pb_4:String}
-                 AND trigger_ref = {pb_5:String} )
-            """,
-        )
-        assert pb.get_params() == {
-            "pb_0": "entity/project",
-            "pb_1": 1704067200.0,
-            "pb_2": 1704153600.0,
-            "pb_3": "UTC",
-            "pb_4": "wandb.runnable.scorer",
-            "pb_5": "ref:v1",
-        }
-
-
-# ---------------------------------------------------------------------------
-# _parse_window_stat_col (the count_true/count_false bug fix)
-# ---------------------------------------------------------------------------
-
-
-class TestParseWindowStatCol:
-    def test_avg(self):
-        assert _parse_window_stat_col("avg_output_score") == ("avg", "output_score")
-
-    def test_sum(self):
-        assert _parse_window_stat_col("sum_output_score") == ("sum", "output_score")
-
-    def test_min(self):
-        assert _parse_window_stat_col("min_output_score") == ("min", "output_score")
-
-    def test_max(self):
-        assert _parse_window_stat_col("max_output_score") == ("max", "output_score")
-
-    def test_count(self):
-        assert _parse_window_stat_col("count_output_score") == ("count", "output_score")
-
-    def test_count_true_multi_word_prefix(self):
-        # This was the bug: split("_", 1) gave ("count", "true_output_score")
-        assert _parse_window_stat_col("count_true_output_score") == (
-            "count_true",
-            "output_score",
-        )
-
-    def test_count_false_multi_word_prefix(self):
-        assert _parse_window_stat_col("count_false_output_score") == (
-            "count_false",
-            "output_score",
-        )
-
-    def test_percentile_p95(self):
-        assert _parse_window_stat_col("p95_output_score") == ("p95", "output_score")
-
-    def test_percentile_p5(self):
-        assert _parse_window_stat_col("p5_output_score") == ("p5", "output_score")
-
-    def test_slug_with_underscores(self):
-        # Metric slugs can contain underscores (converted from dot paths)
-        assert _parse_window_stat_col("avg_output_quality_score") == (
-            "avg",
-            "output_quality_score",
-        )
-
-    def test_count_true_slug_with_underscores(self):
-        assert _parse_window_stat_col("count_true_output_quality_score") == (
-            "count_true",
-            "output_quality_score",
-        )
-
-    def test_unknown_returns_none(self):
-        assert _parse_window_stat_col("unknown_col") is None
-        assert _parse_window_stat_col("timestamp") is None
-        assert _parse_window_stat_col("count") is None  # no slug portion
-
-
-# ---------------------------------------------------------------------------
-# FeedbackMetricSpec validation (typed aggregations)
-# ---------------------------------------------------------------------------
-
-
-class TestFeedbackMetricSpec:
-    def test_valid_aggregation_type(self):
-        spec = FeedbackMetricSpec(
-            json_path="score",
-            aggregations=[AggregationType.AVG, AggregationType.MAX],
-        )
-        assert spec.aggregations == [AggregationType.AVG, AggregationType.MAX]
-
-    def test_invalid_aggregation_string_rejected(self):
-        with pytest.raises(ValueError, match="average"):
-            FeedbackMetricSpec(json_path="score", aggregations=["average"])  # type: ignore[list-item]
-
-    def test_default_aggregations(self):
-        spec = FeedbackMetricSpec(json_path="score")
-        assert len(spec.aggregations) > 0
-        assert all(isinstance(a, AggregationType) for a in spec.aggregations)
-
-    def test_percentiles_accepted(self):
-        spec = FeedbackMetricSpec(json_path="score", percentiles=[5, 50, 95])
-        assert spec.percentiles == [5, 50, 95]
-
-
-# ---------------------------------------------------------------------------
-# _extract_window_stats
-# ---------------------------------------------------------------------------
-
-
-class TestExtractWindowStats:
-    def test_single_metric(self):
-        result = _extract_window_stats(["avg_output_score"], (0.5,))
-        assert result == {"output_score": {"avg": 0.5}}
-
-    def test_multiple_aggs_same_metric(self):
-        cols = ["avg_output_score", "max_output_score", "p95_output_score"]
-        row = (0.5, 1.0, 0.95)
-        result = _extract_window_stats(cols, row)
-        assert result == {
-            "output_score": {"avg": 0.5, "max": 1.0, "p95": 0.95},
-        }
-
-    def test_multiple_metrics(self):
-        cols = ["avg_score", "avg_quality"]
-        row = (0.5, 0.8)
-        result = _extract_window_stats(cols, row)
-        assert result == {"score": {"avg": 0.5}, "quality": {"avg": 0.8}}
-
-    def test_none_values_preserved(self):
-        result = _extract_window_stats(["avg_output_score"], (None,))
-        assert result == {"output_score": {"avg": None}}
-
-    def test_ignores_unknown_columns(self):
-        result = _extract_window_stats(["unknown_col"], (1.0,))
-        assert result == {}
-
-    def test_row_shorter_than_columns(self):
-        result = _extract_window_stats(["avg_score", "max_score"], (0.5,))
-        assert result == {"score": {"avg": 0.5}}
-
-    def test_empty(self):
-        result = _extract_window_stats([], ())
-        assert result == {}
-
-    def test_count_true_false(self):
-        cols = ["count_true_passed", "count_false_passed"]
-        row = (10, 5)
-        result = _extract_window_stats(cols, row)
-        assert result == {"passed": {"count_true": 10.0, "count_false": 5.0}}
-
-
-# ---------------------------------------------------------------------------
-# feedback_stats (methods module, mocked server)
-# ---------------------------------------------------------------------------
-
-
 def _make_mock_server(
     bucket_rows: list[tuple] | None = None,
     window_rows: list[tuple] | None = None,
 ) -> MagicMock:
-    """Create a mock ClickHouseTraceServer that returns canned query results."""
+    """Mock ClickHouseTraceServer returning canned bucket then window results."""
     server = MagicMock()
     call_count = 0
 
     def _query_side_effect(sql: str, parameters: dict) -> MagicMock:
         nonlocal call_count
         result = MagicMock()
-        if call_count == 0:
-            result.result_rows = bucket_rows or []
-        else:
-            result.result_rows = window_rows or []
+        result.result_rows = (
+            (bucket_rows or []) if call_count == 0 else (window_rows or [])
+        )
         call_count += 1
         return result
 
     server._query.side_effect = _query_side_effect
     return server
-
-
-class TestFeedbackStatsMethod:
-    def test_empty_metrics_returns_empty_buckets(self):
-        server = _make_mock_server()
-        req = _make_req(metrics=[])
-        res = feedback_stats(server, req)
-        assert res.buckets == []
-        assert res.start == _START
-        assert res.granularity == 3600
-        server._query.assert_not_called()
-
-    def test_calls_server_and_returns_buckets(self):
-        ts = datetime.datetime(2024, 1, 1, 6, 0, tzinfo=datetime.timezone.utc)
-        bucket_rows = [(ts, 0.75, 1.0, 0.1, 0.95, 5)]
-        server = _make_mock_server(bucket_rows=bucket_rows)
-        req = _make_req()
-        res = feedback_stats(server, req)
-        assert len(res.buckets) == 1
-        assert res.buckets[0]["avg_output_score"] == 0.75
-        assert res.granularity > 0
-        assert server._query.call_count >= 1
-
-    def test_includes_window_stats(self):
-        bucket_rows = [
-            (
-                datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
-                0.5,
-                1.0,
-                0.1,
-                0.9,
-                10,
-            )
-        ]
-        window_rows = [(0.6, 1.0, 0.05, 0.98)]
-        server = _make_mock_server(bucket_rows=bucket_rows, window_rows=window_rows)
-        req = _make_req()
-        res = feedback_stats(server, req)
-        assert res.window_stats is not None
-        assert "output_score" in res.window_stats
-        assert res.window_stats["output_score"]["avg"] == 0.6
-
-    def test_no_window_stats_when_no_rows(self):
-        bucket_rows = [
-            (
-                datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
-                0.5,
-                1.0,
-                0.1,
-                0.9,
-                10,
-            )
-        ]
-        server = _make_mock_server(bucket_rows=bucket_rows, window_rows=[])
-        req = _make_req()
-        res = feedback_stats(server, req)
-        assert res.window_stats is None
-
-    def test_timezone_passed_through(self):
-        server = _make_mock_server()
-        req = _make_req(metrics=[], timezone="America/New_York")
-        res = feedback_stats(server, req)
-        assert res.timezone == "America/New_York"
-
-    def test_defaults_timezone_to_utc(self):
-        server = _make_mock_server()
-        req = _make_req(metrics=[])
-        res = feedback_stats(server, req)
-        assert res.timezone == "UTC"
-
-
-# ---------------------------------------------------------------------------
-# feedback_payload_schema (methods module, mocked server)
-# ---------------------------------------------------------------------------
-
-
-class TestFeedbackPayloadSchemaMethod:
-    def test_returns_discovered_paths(self):
-        server = MagicMock()
-        result = MagicMock()
-        result.result_rows = [('{"output": {"score": 0.9}}',), ('{"label": "good"}',)]
-        server._query.return_value = result
-        req = FeedbackPayloadSchemaReq(
-            project_id="entity/project",
-            start=_START,
-            end=_END,
-        )
-        res = feedback_payload_schema(server, req)
-        path_map = {p.json_path: p.value_type for p in res.paths}
-        assert "output.score" in path_map
-        assert path_map["output.score"] == "numeric"
-        assert "label" in path_map
-        assert path_map["label"] == "categorical"
-
-    def test_empty_result_rows(self):
-        server = MagicMock()
-        result = MagicMock()
-        result.result_rows = []
-        server._query.return_value = result
-        req = FeedbackPayloadSchemaReq(
-            project_id="entity/project",
-            start=_START,
-            end=_END,
-        )
-        res = feedback_payload_schema(server, req)
-        assert res.paths == []
-
-    def test_skips_null_payloads(self):
-        server = MagicMock()
-        result = MagicMock()
-        result.result_rows = [(None,), ("",), ('{"x": 1}',)]
-        server._query.return_value = result
-        req = FeedbackPayloadSchemaReq(
-            project_id="entity/project",
-            start=_START,
-            end=_END,
-        )
-        res = feedback_payload_schema(server, req)
-        assert len(res.paths) == 1
-        assert res.paths[0].json_path == "x"

--- a/tests/trace_server/query_builder/test_obj_tags_query_builder.py
+++ b/tests/trace_server/query_builder/test_obj_tags_query_builder.py
@@ -1,3 +1,6 @@
+from collections.abc import Callable
+
+import pytest
 import sqlparse
 
 from weave.trace_server.query_builder.obj_tags_query_builder import (
@@ -11,23 +14,6 @@ from weave.trace_server.query_builder.obj_tags_query_builder import (
 from weave.trace_server.query_builder.objects_query_builder import (
     ObjectMetadataQueryBuilder,
 )
-
-
-def _assert_sql(
-    expected_query: str,
-    expected_params: dict,
-    actual_query: str,
-    actual_params: dict,
-) -> None:
-    expected_formatted = sqlparse.format(expected_query, reindent=True).strip()
-    actual_formatted = sqlparse.format(actual_query, reindent=True).strip()
-    assert expected_formatted == actual_formatted, (
-        f"\nExpected:\n{expected_formatted}\n\nGot:\n{actual_formatted}"
-    )
-    assert expected_params == actual_params, (
-        f"\nExpected params: {expected_params}\n\nGot params: {actual_params}"
-    )
-
 
 # --- obj_tags_query_builder functions ---
 
@@ -115,14 +101,55 @@ def test_make_resolve_alias_query():
     _assert_sql(expected_query, expected_params, query, params)
 
 
+# --- list queries ---
+
+
+@pytest.mark.parametrize(
+    ("make_query", "expected_query"),
+    [
+        pytest.param(
+            make_list_tags_query,
+            """
+        SELECT tag
+        FROM tags
+        PREWHERE project_id = {project_id: String}
+        GROUP BY project_id, tag
+        HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
+        ORDER BY tag
+    """,
+            id="list_tags",
+        ),
+        pytest.param(
+            make_list_aliases_query,
+            """
+        SELECT alias
+        FROM aliases
+        PREWHERE project_id = {project_id: String}
+        GROUP BY project_id, alias
+        HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
+        ORDER BY alias
+    """,
+            id="list_aliases",
+        ),
+    ],
+)
+def test_make_list_query(
+    make_query: Callable[[str], tuple[str, dict]], expected_query: str
+) -> None:
+    query, params = make_query("proj")
+    _assert_sql(expected_query, {"project_id": "proj"}, query, params)
+
+
 # --- ObjectMetadataQueryBuilder tag/alias conditions ---
 
 
-def test_add_tags_condition():
-    builder = ObjectMetadataQueryBuilder(project_id="test_project")
-    builder.add_tags_condition(["reviewed", "staging"])
-
-    expected_query = """
+@pytest.mark.parametrize(
+    ("method_name", "names", "expected_query", "expected_params"),
+    [
+        pytest.param(
+            "add_tags_condition",
+            ["reviewed", "staging"],
+            """
 WHERE (((main.project_id,
          main.object_id,
          main.digest) IN
@@ -137,22 +164,14 @@ WHERE (((main.project_id,
                     tag
            HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)))
        AND (deleted_at IS NULL))
-    """
-    expected_params = {
-        "project_id": "test_project",
-        "filter_tags": ["reviewed", "staging"],
-    }
-
-    _assert_sql(
-        expected_query, expected_params, builder.conditions_part, builder.parameters
-    )
-
-
-def test_add_aliases_condition():
-    builder = ObjectMetadataQueryBuilder(project_id="test_project")
-    builder.add_aliases_condition(["production", "canary"])
-
-    expected_query = """
+    """,
+            {"project_id": "test_project", "filter_tags": ["reviewed", "staging"]},
+            id="tags",
+        ),
+        pytest.param(
+            "add_aliases_condition",
+            ["production", "canary"],
+            """
 WHERE (((main.project_id,
          main.object_id,
          main.digest) IN
@@ -166,87 +185,27 @@ WHERE (((main.project_id,
                     alias
            HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)))
        AND (deleted_at IS NULL))
-    """
-    expected_params = {
-        "project_id": "test_project",
-        "filter_aliases": ["production", "canary"],
-    }
-
-    _assert_sql(
-        expected_query, expected_params, builder.conditions_part, builder.parameters
-    )
-
-
-def test_add_aliases_condition_latest_only():
-    """Filtering by 'latest' alone routes through the hybrid `is_latest` column.
-
-    The CTE-derived `is_latest` covers both the explicit "latest" alias row
-    and the computed most-recent-surviving fallback for objects whose alias
-    row was tombstoned by obj_delete.
-    """
-    builder = ObjectMetadataQueryBuilder(project_id="test_project")
-    builder.add_aliases_condition(["latest"])
-
-    expected_query = """
+    """,
+            {"project_id": "test_project", "filter_aliases": ["production", "canary"]},
+            id="aliases",
+        ),
+        # 'latest' alone routes through the hybrid `is_latest` column: no subquery,
+        # no filter_aliases param.
+        pytest.param(
+            "add_aliases_condition",
+            ["latest"],
+            """
 WHERE ((is_latest = 1)
    AND (deleted_at IS NULL))
-    """
-    expected_params = {
-        "project_id": "test_project",
-    }
-
-    _assert_sql(
-        expected_query, expected_params, builder.conditions_part, builder.parameters
-    )
-
-
-# --- list queries ---
-
-
-def test_make_list_tags_query():
-    query, params = make_list_tags_query("proj")
-
-    expected_query = """
-        SELECT tag
-        FROM tags
-        PREWHERE project_id = {project_id: String}
-        GROUP BY project_id, tag
-        HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
-        ORDER BY tag
-    """
-    expected_params = {
-        "project_id": "proj",
-    }
-
-    _assert_sql(expected_query, expected_params, query, params)
-
-
-def test_make_list_aliases_query():
-    query, params = make_list_aliases_query("proj")
-
-    expected_query = """
-        SELECT alias
-        FROM aliases
-        PREWHERE project_id = {project_id: String}
-        GROUP BY project_id, alias
-        HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3)
-        ORDER BY alias
-    """
-    expected_params = {
-        "project_id": "proj",
-    }
-
-    _assert_sql(expected_query, expected_params, query, params)
-
-
-def test_add_aliases_condition_with_latest():
-    """Filtering by both 'latest' and a real alias ORs the hybrid `is_latest`
-    column with the aliases-table subquery for the non-latest names.
-    """
-    builder = ObjectMetadataQueryBuilder(project_id="test_project")
-    builder.add_aliases_condition(["latest", "production"])
-
-    expected_query = """
+    """,
+            {"project_id": "test_project"},
+            id="aliases_latest_only",
+        ),
+        # 'latest' plus a real alias ORs the hybrid column with the aliases subquery.
+        pytest.param(
+            "add_aliases_condition",
+            ["latest", "production"],
+            """
 WHERE (((is_latest = 1
          OR (main.project_id,
              main.object_id,
@@ -261,12 +220,36 @@ WHERE (((is_latest = 1
                      alias
             HAVING argMax(deleted_at, created_at) = toDateTime64(0, 3))))
        AND (deleted_at IS NULL))
-    """
-    expected_params = {
-        "project_id": "test_project",
-        "filter_aliases": ["production"],
-    }
-
+    """,
+            {"project_id": "test_project", "filter_aliases": ["production"]},
+            id="aliases_with_latest",
+        ),
+    ],
+)
+def test_metadata_builder_condition(
+    method_name: str,
+    names: list[str],
+    expected_query: str,
+    expected_params: dict,
+) -> None:
+    builder = ObjectMetadataQueryBuilder(project_id="test_project")
+    getattr(builder, method_name)(names)
     _assert_sql(
         expected_query, expected_params, builder.conditions_part, builder.parameters
+    )
+
+
+def _assert_sql(
+    expected_query: str,
+    expected_params: dict,
+    actual_query: str,
+    actual_params: dict,
+) -> None:
+    expected_formatted = sqlparse.format(expected_query, reindent=True).strip()
+    actual_formatted = sqlparse.format(actual_query, reindent=True).strip()
+    assert expected_formatted == actual_formatted, (
+        f"\nExpected:\n{expected_formatted}\n\nGot:\n{actual_formatted}"
+    )
+    assert expected_params == actual_params, (
+        f"\nExpected params: {expected_params}\n\nGot params: {actual_params}"
     )

--- a/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
+++ b/tests/trace_server/query_builder/test_object_ref_calls_query_builder.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.trace_server.query_builder.utils import assert_sql
 from weave.trace_server.calls_query_builder.calls_query_builder import (
     CallsQuery,
@@ -8,30 +10,48 @@ from weave.trace_server.interface import query as tsi_query
 from weave.trace_server.project_version.types import ReadTable
 
 
-def test_object_ref_filter_simple() -> None:
+@pytest.mark.parametrize(
+    ("operation", "op_sql"),
+    [
+        (
+            tsi_query.EqOperation.model_validate(
+                {
+                    "$eq": [
+                        {"$getField": "output.model.temperature"},
+                        {"$literal": 1},
+                    ]
+                }
+            ),
+            "=",
+        ),
+        (
+            tsi_query.LtOperation.model_validate(
+                {
+                    "$lt": [
+                        {"$getField": "output.model.temperature"},
+                        {"$literal": 1},
+                    ]
+                }
+            ),
+            "<",
+        ),
+    ],
+)
+def test_object_ref_filter_simple_operator(operation, op_sql) -> None:
     cq = CallsQuery(project_id="project")
     cq.add_field("id")
-    cq.add_condition(
-        tsi_query.EqOperation.model_validate(
-            {
-                "$eq": [
-                    {"$getField": "output.model.temperature"},
-                    {"$literal": 1},
-                ]
-            }
-        )
-    )
+    cq.add_condition(operation)
     cq.add_order("started_at", "desc")
     cq.set_expand_columns(["output.model"])
     assert_sql(
         cq,
-        """
+        f"""
         WITH obj_filter_0 AS
           (SELECT digest,
                   concat('weave-trace-internal:///', project_id, '/object/', object_id, ':', digest) AS ref
            FROM object_versions
-           WHERE project_id = {pb_0:String}
-             AND JSON_VALUE(val_dump, {pb_1:String}) = {pb_2:Int64}
+           WHERE project_id = {{pb_0:String}}
+             AND JSON_VALUE(val_dump, {{pb_1:String}}) {op_sql} {{pb_2:Int64}}
            GROUP BY project_id,
                     object_id,
                     digest
@@ -41,22 +61,22 @@ def test_object_ref_filter_simple() -> None:
            SELECT digest,
                   digest as ref
            FROM table_rows
-           WHERE project_id = {pb_0:String}
-             AND JSON_VALUE(val_dump, {pb_1:String}) = {pb_2:Int64}
+           WHERE project_id = {{pb_0:String}}
+             AND JSON_VALUE(val_dump, {{pb_1:String}}) {op_sql} {{pb_2:Int64}}
            GROUP BY project_id,
                     digest),
              filtered_calls AS
           (SELECT calls_merged.id AS id
            FROM calls_merged
-           PREWHERE calls_merged.project_id = {pb_0:String}
+           PREWHERE calls_merged.project_id = {{pb_0:String}}
            WHERE (length(calls_merged.output_refs) > 0
                   OR calls_merged.ended_at IS NULL)
            GROUP BY (calls_merged.project_id,
                      calls_merged.id)
-           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), '') GLOBAL IN
+           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {{pb_3:String}}), 'null'), '') GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_0)
-                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
+                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {{pb_3:String}}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
                       (SELECT ref
                        FROM obj_filter_0)))
                    AND ((any(calls_merged.deleted_at) IS NULL))
@@ -64,78 +84,7 @@ def test_object_ref_filter_simple() -> None:
            ORDER BY any(calls_merged.started_at) DESC)
         SELECT calls_merged.id AS id
         FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
-        WHERE (calls_merged.id IN filtered_calls)
-        GROUP BY (calls_merged.project_id,
-                  calls_merged.id)
-        ORDER BY any(calls_merged.started_at) DESC
-        """,
-        {
-            "pb_0": "project",
-            "pb_1": '$."temperature"',
-            "pb_2": 1,
-            "pb_3": '$."model"',
-        },
-    )
-
-
-def test_object_ref_filter_lt() -> None:
-    cq = CallsQuery(project_id="project")
-    cq.add_field("id")
-    cq.add_condition(
-        tsi_query.LtOperation.model_validate(
-            {
-                "$lt": [
-                    {"$getField": "output.model.temperature"},
-                    {"$literal": 1},
-                ]
-            }
-        )
-    )
-    cq.add_order("started_at", "desc")
-    cq.set_expand_columns(["output.model"])
-    assert_sql(
-        cq,
-        """
-        WITH obj_filter_0 AS
-          (SELECT digest,
-                  concat('weave-trace-internal:///', project_id, '/object/', object_id, ':', digest) AS ref
-           FROM object_versions
-           WHERE project_id = {pb_0:String}
-             AND JSON_VALUE(val_dump, {pb_1:String}) < {pb_2:Int64}
-           GROUP BY project_id,
-                    object_id,
-                    digest
-
-           UNION ALL
-
-           SELECT digest,
-                  digest as ref
-           FROM table_rows
-           WHERE project_id = {pb_0:String}
-             AND JSON_VALUE(val_dump, {pb_1:String}) < {pb_2:Int64}
-           GROUP BY project_id,
-                    digest),
-             filtered_calls AS
-          (SELECT calls_merged.id AS id
-           FROM calls_merged
-           PREWHERE calls_merged.project_id = {pb_0:String}
-           WHERE (length(calls_merged.output_refs) > 0
-                  OR calls_merged.ended_at IS NULL)
-           GROUP BY (calls_merged.project_id,
-                     calls_merged.id)
-           HAVING (((coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), '') GLOBAL IN
-                      (SELECT ref
-                       FROM obj_filter_0)
-                   OR regexpExtract(coalesce(nullIf(JSON_VALUE(any(calls_merged.output_dump), {pb_3:String}), 'null'), ''), '/([^/]+)$', 1) GLOBAL IN
-                      (SELECT ref
-                       FROM obj_filter_0)))
-                   AND ((any(calls_merged.deleted_at) IS NULL))
-                   AND ((NOT ((any(calls_merged.op_name) IS NULL)))))
-           ORDER BY any(calls_merged.started_at) DESC)
-        SELECT calls_merged.id AS id
-        FROM calls_merged
-        PREWHERE calls_merged.project_id = {pb_0:String}
+        PREWHERE calls_merged.project_id = {{pb_0:String}}
         WHERE (calls_merged.id IN filtered_calls)
         GROUP BY (calls_merged.project_id,
                   calls_merged.id)

--- a/tests/trace_server/query_builder/test_objects_query_builder.py
+++ b/tests/trace_server/query_builder/test_objects_query_builder.py
@@ -70,29 +70,26 @@ def test_object_query_builder_basic():
     assert builder.parameters["project_id"] == "test_project"
 
 
-def test_object_query_builder_add_digest_condition():
+def test_object_query_builder_mutators():
+    """Each mutator lands its fragment in the right builder part plus any param."""
+    # latest digest -> is_latest condition, no param
     builder = ObjectMetadataQueryBuilder(project_id="test_project")
-
-    # Test latest digest
     builder.add_digests_conditions("latest")
     assert "is_latest = 1" in builder.conditions_part
 
-    # Test specific digest
+    # specific digest -> digest condition + param
     builder = ObjectMetadataQueryBuilder(project_id="test_project")
     builder.add_digests_conditions("abc123")
     assert "digest = {version_digest_0: String}" in builder.conditions_part
     assert builder.parameters["version_digest_0"] == "abc123"
 
-
-def test_object_query_builder_add_object_ids_condition():
+    # single object id -> equality + param
     builder = ObjectMetadataQueryBuilder(project_id="test_project")
-
-    # Test single object ID
     builder.add_object_ids_condition(["obj1"])
     assert "object_id = {object_id: String}" in builder.object_id_conditions_part
     assert builder.parameters["object_id"] == "obj1"
 
-    # Test multiple object IDs
+    # multiple object ids -> IN + param
     builder = ObjectMetadataQueryBuilder(project_id="test_project")
     builder.add_object_ids_condition(["obj1", "obj2"])
     assert (
@@ -100,8 +97,7 @@ def test_object_query_builder_add_object_ids_condition():
     )
     assert builder.parameters["object_ids"] == ["obj1", "obj2"]
 
-
-def test_object_query_builder_add_is_op_condition():
+    # is_op -> is_op condition
     builder = ObjectMetadataQueryBuilder(project_id="test_project")
     builder.add_is_op_condition(True)
     assert "is_op = 1" in builder.conditions_part
@@ -234,79 +230,74 @@ def assert_sql(exp_query, actual_query):
     assert exp_formatted == actual_formatted
 
 
-def test_object_query_builder_metadata_query_basic():
-    builder = ObjectMetadataQueryBuilder(project_id="test_project")
+def _build_metadata_basic(builder: ObjectMetadataQueryBuilder) -> None:
     builder.add_digests_conditions("latest")
 
-    query = builder.make_metadata_query()
-    parameters = builder.parameters
 
-    expected_query = _expected_metadata_query(
-        "ov.project_id = {project_id: String}",
-        """WHERE ((is_latest = 1) AND (deleted_at IS NULL))
-ORDER BY created_at ASC""",
-    )
-
-    assert_sql(query, expected_query)
-    assert parameters == {"project_id": "test_project"}
-
-
-def test_object_query_builder_metadata_query_with_limit_offset_sort():
-    builder = ObjectMetadataQueryBuilder(project_id="test_project")
-
-    limit = 10
-    offset = 5
-
-    builder.set_limit(limit)
-    builder.set_offset(offset)
+def _build_metadata_limit_offset_sort(builder: ObjectMetadataQueryBuilder) -> None:
+    builder.set_limit(10)
+    builder.set_offset(5)
     builder.add_order("created_at", "desc")
     builder.add_object_ids_condition(["object_1"])
     builder.add_digests_conditions("digestttttttttttttttt", "another-one", "v2")
     builder.add_base_object_classes_condition(["Model", "Model2"])
 
-    query = builder.make_metadata_query()
-    parameters = builder.parameters
 
-    expected_query = _expected_metadata_query(
-        "ov.project_id = {project_id: String} AND object_id = {object_id: String}",
-        """WHERE ((((digest = {version_digest_0: String}) OR (digest = {version_digest_1: String}) OR (version_index = {version_index_2: Int64}))) AND (base_object_class IN {base_object_classes: Array(String)}) AND (deleted_at IS NULL))
-ORDER BY created_at DESC
-LIMIT 10
-OFFSET 5""",
-    )
-
-    assert_sql(query, expected_query)
-    assert parameters == {
-        "project_id": "test_project",
-        "object_id": "object_1",
-        "version_digest_0": "digestttttttttttttttt",
-        "version_digest_1": "another-one",
-        "version_index_2": 2,
-        "base_object_classes": ["Model", "Model2"],
-    }
-
-
-def test_objects_query_metadata_op():
-    builder = ObjectMetadataQueryBuilder(project_id="test_project")
+def _build_metadata_op(builder: ObjectMetadataQueryBuilder) -> None:
     builder.add_is_op_condition(True)
     builder.add_object_ids_condition(["my_op"])
     builder.add_digests_conditions("v3")
 
-    query = builder.make_metadata_query()
-    parameters = builder.parameters
 
-    expected_query = _expected_metadata_query(
-        "ov.project_id = {project_id: String} AND object_id = {object_id: String}",
-        """WHERE ((is_op = 1) AND (version_index = {version_index_0: Int64}) AND (deleted_at IS NULL))
+@pytest.mark.parametrize(
+    ("configure", "where_clause", "outer_clauses", "expected_params"),
+    [
+        (
+            _build_metadata_basic,
+            "ov.project_id = {project_id: String}",
+            """WHERE ((is_latest = 1) AND (deleted_at IS NULL))
 ORDER BY created_at ASC""",
-    )
+            {"project_id": "test_project"},
+        ),
+        (
+            _build_metadata_limit_offset_sort,
+            "ov.project_id = {project_id: String} AND object_id = {object_id: String}",
+            """WHERE ((((digest = {version_digest_0: String}) OR (digest = {version_digest_1: String}) OR (version_index = {version_index_2: Int64}))) AND (base_object_class IN {base_object_classes: Array(String)}) AND (deleted_at IS NULL))
+ORDER BY created_at DESC
+LIMIT 10
+OFFSET 5""",
+            {
+                "project_id": "test_project",
+                "object_id": "object_1",
+                "version_digest_0": "digestttttttttttttttt",
+                "version_digest_1": "another-one",
+                "version_index_2": 2,
+                "base_object_classes": ["Model", "Model2"],
+            },
+        ),
+        (
+            _build_metadata_op,
+            "ov.project_id = {project_id: String} AND object_id = {object_id: String}",
+            """WHERE ((is_op = 1) AND (version_index = {version_index_0: Int64}) AND (deleted_at IS NULL))
+ORDER BY created_at ASC""",
+            {
+                "project_id": "test_project",
+                "object_id": "my_op",
+                "version_index_0": 3,
+            },
+        ),
+    ],
+)
+def test_object_query_builder_metadata_query(
+    configure, where_clause, outer_clauses, expected_params
+):
+    builder = ObjectMetadataQueryBuilder(project_id="test_project")
+    configure(builder)
 
-    assert_sql(query, expected_query)
-    assert parameters == {
-        "project_id": "test_project",
-        "object_id": "my_op",
-        "version_index_0": 3,
-    }
+    query = builder.make_metadata_query()
+
+    assert_sql(query, _expected_metadata_query(where_clause, outer_clauses))
+    assert builder.parameters == expected_params
 
 
 def test_make_objects_val_query_and_parameters():

--- a/tests/trace_server/query_builder/test_optimization_builder.py
+++ b/tests/trace_server/query_builder/test_optimization_builder.py
@@ -43,112 +43,111 @@ def test_condition_is_heavy(table_alias: str) -> None:
     assert light_condition.is_heavy(table_alias) is False
 
 
-class TestMaybeUseNullCheck:
-    """Unit tests for _maybe_use_null_check helper."""
-
-    def test_adds_null_check_outside_not(self) -> None:
-        result = _maybe_use_null_check(
-            "x LIKE '%y%'", "attributes_dump", "t", use_null_check=True
-        )
-        assert result == "(x LIKE '%y%' OR t.attributes_dump IS NULL)"
-
-    def test_skips_optimization_inside_not(self) -> None:
+@pytest.mark.parametrize(
+    ("sql", "field", "alias", "use_null_check", "inside_not", "expected"),
+    [
+        (
+            "x LIKE '%y%'",
+            "attributes_dump",
+            "t",
+            True,
+            False,
+            "(x LIKE '%y%' OR t.attributes_dump IS NULL)",
+        ),
+        ("x LIKE '%y%'", "attributes_dump", "t", True, True, None),
+        ("x LIKE '%y%'", "attributes_dump", "t", False, False, "x LIKE '%y%'"),
+        ("x LIKE '%y%'", "op_name", "t", True, False, "x LIKE '%y%'"),
+    ],
+)
+def test_maybe_use_null_check(
+    sql: str,
+    field: str,
+    alias: str,
+    use_null_check: bool,
+    inside_not: bool,
+    expected: str | None,
+) -> None:
+    """Null-check wrapping: applies outside NOT for nullable fields, else passthrough/None."""
+    if inside_not:
         with NotContext.not_context():
             result = _maybe_use_null_check(
-                "x LIKE '%y%'", "attributes_dump", "t", use_null_check=True
+                sql, field, alias, use_null_check=use_null_check
             )
-        assert result is None
+    else:
+        result = _maybe_use_null_check(sql, field, alias, use_null_check=use_null_check)
+    assert result == expected
 
-    def test_passes_through_when_null_check_disabled(self) -> None:
-        result = _maybe_use_null_check(
-            "x LIKE '%y%'", "attributes_dump", "t", use_null_check=False
-        )
-        assert result == "x LIKE '%y%'"
 
-    def test_passes_through_for_non_nullable_field(self) -> None:
-        result = _maybe_use_null_check(
-            "x LIKE '%y%'", "op_name", "t", use_null_check=True
-        )
-        assert result == "x LIKE '%y%'"
+def test_nested_not_context() -> None:
+    """AND nested inside NOT doesn't reset or alter the NOT depth."""
+    and_body = {
+        "$and": [
+            {
+                "$eq": [
+                    {"$getField": "attributes.key_a"},
+                    {"$literal": "val_a"},
+                ]
+            },
+            {
+                "$eq": [
+                    {"$getField": "attributes.key_b"},
+                    {"$literal": "val_b"},
+                ]
+            },
+        ]
+    }
 
-    def test_nested_not_context(self) -> None:
-        """AND nested inside NOT doesn't reset or alter the NOT depth."""
-        and_body = {
-            "$and": [
+    # Bare AND: optimization applies
+    pb = ParamBuilder()
+    processor = HeavyFieldOptimizationProcessor(pb, "calls_merged", use_null_check=True)
+    and_op = tsi_query.AndOperation.model_validate(and_body)
+    assert apply_processor(processor, and_op) is not None
+
+    # NOT(AND(...)): single negation, optimization skipped
+    pb = ParamBuilder()
+    processor = HeavyFieldOptimizationProcessor(pb, "calls_merged", use_null_check=True)
+    not_op = tsi_query.NotOperation.model_validate({"$not": [and_body]})
+    assert apply_processor(processor, not_op) is None
+
+    # NOT(NOT(AND(...))): double negation cancels, optimization applies
+    pb = ParamBuilder()
+    processor = HeavyFieldOptimizationProcessor(pb, "calls_merged", use_null_check=True)
+    double_not_op = tsi_query.NotOperation.model_validate(
+        {"$not": [{"$not": [and_body]}]}
+    )
+    assert apply_processor(processor, double_not_op) is not None
+
+    # NOT(AND(NOT(eq_a), eq_b)): eq_b at depth=1 returns None, so AND
+    # bails entirely rather than producing a too-restrictive pre-filter.
+    pb = ParamBuilder()
+    processor = HeavyFieldOptimizationProcessor(pb, "calls_merged", use_null_check=True)
+    mixed_op = tsi_query.NotOperation.model_validate(
+        {
+            "$not": [
                 {
-                    "$eq": [
-                        {"$getField": "attributes.key_a"},
-                        {"$literal": "val_a"},
+                    "$and": [
+                        {
+                            "$not": [
+                                {
+                                    "$eq": [
+                                        {"$getField": "attributes.a"},
+                                        {"$literal": "x"},
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "$eq": [
+                                {"$getField": "attributes.b"},
+                                {"$literal": "y"},
+                            ]
+                        },
                     ]
-                },
-                {
-                    "$eq": [
-                        {"$getField": "attributes.key_b"},
-                        {"$literal": "val_b"},
-                    ]
-                },
+                }
             ]
         }
-
-        # Bare AND: optimization applies
-        pb = ParamBuilder()
-        processor = HeavyFieldOptimizationProcessor(
-            pb, "calls_merged", use_null_check=True
-        )
-        op = tsi_query.AndOperation.model_validate(and_body)
-        assert apply_processor(processor, op) is not None
-
-        # NOT(AND(...)): single negation, optimization skipped
-        pb = ParamBuilder()
-        processor = HeavyFieldOptimizationProcessor(
-            pb, "calls_merged", use_null_check=True
-        )
-        op = tsi_query.NotOperation.model_validate({"$not": [and_body]})  # type: ignore [assignment]
-        assert apply_processor(processor, op) is None
-
-        # NOT(NOT(AND(...))): double negation cancels, optimization applies
-        pb = ParamBuilder()
-        processor = HeavyFieldOptimizationProcessor(
-            pb, "calls_merged", use_null_check=True
-        )
-        op = tsi_query.NotOperation.model_validate({"$not": [{"$not": [and_body]}]})  # type: ignore [assignment]
-        assert apply_processor(processor, op) is not None
-
-        # NOT(AND(NOT(eq_a), eq_b)): eq_b at depth=1 returns None, so AND
-        # bails entirely rather than producing a too-restrictive pre-filter.
-        pb = ParamBuilder()
-        processor = HeavyFieldOptimizationProcessor(
-            pb, "calls_merged", use_null_check=True
-        )
-        op = tsi_query.NotOperation.model_validate(  # type: ignore [assignment]
-            {
-                "$not": [
-                    {
-                        "$and": [
-                            {
-                                "$not": [
-                                    {
-                                        "$eq": [
-                                            {"$getField": "attributes.a"},
-                                            {"$literal": "x"},
-                                        ]
-                                    }
-                                ]
-                            },
-                            {
-                                "$eq": [
-                                    {"$getField": "attributes.b"},
-                                    {"$literal": "y"},
-                                ]
-                            },
-                        ]
-                    }
-                ]
-            }
-        )
-        # eq_b at depth=1 can't be optimized, and dropping it from the AND
-        # would make the pre-filter too restrictive, so the whole thing bails.
-        assert apply_processor(processor, op) is None
+    )
+    assert apply_processor(processor, mixed_op) is None
 
 
 def test_heavy_field_eq_with_null_check() -> None:
@@ -166,8 +165,35 @@ def test_heavy_field_eq_with_null_check() -> None:
     assert "OR calls_merged.attributes_dump IS NULL" in result
 
 
-def test_heavy_field_eq_inside_not_skips_optimization() -> None:
-    """Eq on a heavy start/end field inside NOT returns None to skip optimization.
+@pytest.mark.parametrize(
+    "inner_op",
+    [
+        pytest.param(
+            {"$eq": [{"$getField": "attributes.some_key"}, {"$literal": "true"}]},
+            id="eq",
+        ),
+        pytest.param(
+            {
+                "$contains": {
+                    "input": {"$getField": "attributes.key"},
+                    "substr": {"$literal": "val"},
+                }
+            },
+            id="contains",
+        ),
+        pytest.param(
+            {
+                "$in": [
+                    {"$getField": "attributes.key"},
+                    [{"$literal": "a"}, {"$literal": "b"}],
+                ]
+            },
+            id="in",
+        ),
+    ],
+)
+def test_heavy_field_inside_not_skips_optimization(inner_op: dict) -> None:
+    """Heavy field ($eq/$contains/$in) inside NOT returns None to skip optimization.
 
     Without this, De Morgan's law turns `NOT(LIKE ... OR IS NULL)` into
     `NOT LIKE ... AND IS NOT NULL`, which excludes unmerged end rows from
@@ -176,16 +202,9 @@ def test_heavy_field_eq_inside_not_skips_optimization() -> None:
     pb = ParamBuilder()
     processor = HeavyFieldOptimizationProcessor(pb, "calls_merged", use_null_check=True)
 
-    op = tsi_query.NotOperation.model_validate(
-        {
-            "$not": [
-                {"$eq": [{"$getField": "attributes.some_key"}, {"$literal": "true"}]}
-            ]
-        }
-    )
+    op = tsi_query.NotOperation.model_validate({"$not": [inner_op]})
     result = apply_processor(processor, op)
 
-    # The optimization should be skipped entirely (returns None → no WHERE clause)
     assert result is None
 
 
@@ -262,47 +281,3 @@ def test_not_heavy_field_skips_pre_filter_on_calls_complete(inner_op: dict) -> N
         f"calls_merged: pre-filter inside NOT would emit a SUBSET and "
         f"over-filter, got: {result_merged.heavy_filter_opt_sql}"
     )
-
-
-def test_heavy_field_contains_inside_not_skips_optimization() -> None:
-    """Contains on a heavy field inside NOT also skips optimization."""
-    pb = ParamBuilder()
-    processor = HeavyFieldOptimizationProcessor(pb, "calls_merged", use_null_check=True)
-
-    op = tsi_query.NotOperation.model_validate(
-        {
-            "$not": [
-                {
-                    "$contains": {
-                        "input": {"$getField": "attributes.key"},
-                        "substr": {"$literal": "val"},
-                    }
-                }
-            ]
-        }
-    )
-    result = apply_processor(processor, op)
-
-    assert result is None
-
-
-def test_heavy_field_in_inside_not_skips_optimization() -> None:
-    """IN on a heavy field inside NOT also skips optimization."""
-    pb = ParamBuilder()
-    processor = HeavyFieldOptimizationProcessor(pb, "calls_merged", use_null_check=True)
-
-    op = tsi_query.NotOperation.model_validate(
-        {
-            "$not": [
-                {
-                    "$in": [
-                        {"$getField": "attributes.key"},
-                        [{"$literal": "a"}, {"$literal": "b"}],
-                    ]
-                }
-            ]
-        }
-    )
-    result = apply_processor(processor, op)
-
-    assert result is None

--- a/tests/trace_server/query_builder/test_project_query_builder.py
+++ b/tests/trace_server/query_builder/test_project_query_builder.py
@@ -13,6 +13,179 @@ from weave.trace_server.query_builder.project_query_builder import (
     make_project_stats_query,
 )
 
+_TRACE_SUBQUERY_MERGED = """(SELECT sum(
+    COALESCE(attributes_size_bytes, 0) +
+    COALESCE(inputs_size_bytes, 0) +
+    COALESCE(output_size_bytes, 0) +
+    COALESCE(summary_size_bytes, 0) +
+    COALESCE(otel_dump_size_bytes, 0)
+    )
+    FROM calls_merged_stats
+    WHERE project_id = {pb_0: String}
+) AS trace_storage_size_bytes"""
+
+_TRACE_SUBQUERY_COMPLETE = """(SELECT sum(
+    COALESCE(attributes_size_bytes, 0) +
+    COALESCE(inputs_size_bytes, 0) +
+    COALESCE(output_size_bytes, 0) +
+    COALESCE(summary_size_bytes, 0) +
+    COALESCE(otel_size_bytes, 0)
+    )
+    FROM calls_complete_stats
+    WHERE project_id = {pb_0: String}
+) AS trace_storage_size_bytes"""
+
+_OBJECTS_SUBQUERY = """(SELECT sum(size_bytes)
+    FROM object_versions_stats
+    WHERE project_id = {pb_0: String}
+) AS objects_storage_size_bytes"""
+
+_TABLES_SUBQUERY = """(SELECT sum(size_bytes)
+    FROM table_rows_stats
+    WHERE project_id = {pb_0: String}
+) AS tables_storage_size_bytes"""
+
+_FILES_SUBQUERY = """(SELECT sum(size_bytes)
+    FROM files_stats
+    WHERE project_id = {pb_0: String}
+) AS files_storage_size_bytes"""
+
+
+@pytest.mark.parametrize(
+    ("include_kwargs", "read_table", "subquery", "columns"),
+    [
+        (
+            {"include_trace_storage_size": True},
+            ReadTable.CALLS_MERGED,
+            _TRACE_SUBQUERY_MERGED,
+            ["trace_storage_size_bytes"],
+        ),
+        (
+            {"include_trace_storage_size": True},
+            ReadTable.CALLS_COMPLETE,
+            _TRACE_SUBQUERY_COMPLETE,
+            ["trace_storage_size_bytes"],
+        ),
+        (
+            {"include_objects_storage_size": True},
+            ReadTable.CALLS_MERGED,
+            _OBJECTS_SUBQUERY,
+            ["objects_storage_size_bytes"],
+        ),
+        (
+            {"include_tables_storage_size": True},
+            ReadTable.CALLS_MERGED,
+            _TABLES_SUBQUERY,
+            ["tables_storage_size_bytes"],
+        ),
+        (
+            {"include_files_storage_size": True},
+            ReadTable.CALLS_MERGED,
+            _FILES_SUBQUERY,
+            ["files_storage_size_bytes"],
+        ),
+        (
+            {"include_objects_storage_size": True},
+            ReadTable.CALLS_COMPLETE,
+            _OBJECTS_SUBQUERY,
+            ["objects_storage_size_bytes"],
+        ),
+    ],
+)
+def test_single_storage_kind(include_kwargs, read_table, subquery, columns) -> None:
+    """Each storage kind selects its own subquery; non-trace kinds ignore read_table."""
+    pb = ParamBuilder("pb")
+    query, found_columns = make_project_stats_query(
+        project_id="test_project",
+        pb=pb,
+        include_trace_storage_size=include_kwargs.get(
+            "include_trace_storage_size", False
+        ),
+        include_objects_storage_size=include_kwargs.get(
+            "include_objects_storage_size", False
+        ),
+        include_tables_storage_size=include_kwargs.get(
+            "include_tables_storage_size", False
+        ),
+        include_files_storage_size=include_kwargs.get(
+            "include_files_storage_size", False
+        ),
+        read_table=read_table,
+    )
+
+    assert_sql(query, f"\nSELECT {subquery}", pb.get_params(), {"pb_0": "test_project"})
+    assert found_columns == columns
+
+
+@pytest.mark.parametrize(
+    ("read_table", "trace_subquery"),
+    [
+        (ReadTable.CALLS_MERGED, _TRACE_SUBQUERY_MERGED),
+        (ReadTable.CALLS_COMPLETE, _TRACE_SUBQUERY_COMPLETE),
+    ],
+)
+def test_all_storage_sizes(read_table, trace_subquery) -> None:
+    """All four kinds appear in fixed column order; trace subquery varies by read_table."""
+    pb = ParamBuilder("pb")
+    query, columns = make_project_stats_query(
+        project_id="test_project",
+        pb=pb,
+        include_trace_storage_size=True,
+        include_objects_storage_size=True,
+        include_tables_storage_size=True,
+        include_files_storage_size=True,
+        read_table=read_table,
+    )
+
+    expected_sql = (
+        f"\nSELECT {trace_subquery},\n"
+        f"{_OBJECTS_SUBQUERY},\n"
+        f"{_TABLES_SUBQUERY},\n"
+        f"{_FILES_SUBQUERY}"
+    )
+    assert_sql(query, expected_sql, pb.get_params(), {"pb_0": "test_project"})
+    assert columns == [
+        "trace_storage_size_bytes",
+        "objects_storage_size_bytes",
+        "tables_storage_size_bytes",
+        "files_storage_size_bytes",
+    ]
+
+
+def test_raises_when_no_storage_sizes_requested() -> None:
+    """Verify ValueError raised when all include_* params are False."""
+    pb = ParamBuilder("pb")
+    with pytest.raises(ValueError, match="At least one of"):
+        make_project_stats_query(
+            project_id="test_project",
+            pb=pb,
+            include_trace_storage_size=False,
+            include_objects_storage_size=False,
+            include_tables_storage_size=False,
+            include_files_storage_size=False,
+        )
+
+
+def test_parameterization_prevents_sql_injection() -> None:
+    """Verify project_id is parameterized for SQL injection safety."""
+    pb = ParamBuilder("pb")
+    query, columns = make_project_stats_query(
+        project_id="malicious'--project",
+        pb=pb,
+        include_trace_storage_size=True,
+        include_objects_storage_size=False,
+        include_tables_storage_size=False,
+        include_files_storage_size=False,
+    )
+
+    assert "malicious" not in query
+    assert_sql(
+        query,
+        f"\nSELECT {_TRACE_SUBQUERY_MERGED}",
+        pb.get_params(),
+        {"pb_0": "malicious'--project"},
+    )
+
 
 def assert_sql(query: str, expected: str, params: dict, expected_params: dict) -> None:
     """Assert SQL matches expected after normalizing whitespace."""
@@ -25,316 +198,3 @@ def assert_sql(query: str, expected: str, params: dict, expected_params: dict) -
     assert expected_params == params, (
         f"\nExpected params: {expected_params}\n\nGot params: {params}"
     )
-
-
-class TestMakeProjectStatsQuery:
-    """Tests for make_project_stats_query function."""
-
-    def test_trace_storage_only_calls_merged(self) -> None:
-        """Verify SQL when only trace storage is requested with calls_merged (default)."""
-        pb = ParamBuilder("pb")
-        query, columns = make_project_stats_query(
-            project_id="test_project",
-            pb=pb,
-            include_trace_storage_size=True,
-            include_objects_storage_size=False,
-            include_tables_storage_size=False,
-            include_files_storage_size=False,
-        )
-
-        expected_sql = """
-            SELECT
-                (SELECT sum(
-                    COALESCE(attributes_size_bytes, 0) +
-                    COALESCE(inputs_size_bytes, 0) +
-                    COALESCE(output_size_bytes, 0) +
-                    COALESCE(summary_size_bytes, 0) +
-                    COALESCE(otel_dump_size_bytes, 0)
-                    )
-                    FROM calls_merged_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS trace_storage_size_bytes
-        """
-        assert_sql(query, expected_sql, pb.get_params(), {"pb_0": "test_project"})
-        assert columns == ["trace_storage_size_bytes"]
-
-    def test_trace_storage_only_calls_complete(self) -> None:
-        """Verify SQL when only trace storage is requested with calls_complete."""
-        pb = ParamBuilder("pb")
-        query, columns = make_project_stats_query(
-            project_id="test_project",
-            pb=pb,
-            include_trace_storage_size=True,
-            include_objects_storage_size=False,
-            include_tables_storage_size=False,
-            include_files_storage_size=False,
-            read_table=ReadTable.CALLS_COMPLETE,
-        )
-
-        expected_sql = """
-            SELECT
-                (SELECT sum(
-                    COALESCE(attributes_size_bytes, 0) +
-                    COALESCE(inputs_size_bytes, 0) +
-                    COALESCE(output_size_bytes, 0) +
-                    COALESCE(summary_size_bytes, 0) +
-                    COALESCE(otel_size_bytes, 0)
-                    )
-                    FROM calls_complete_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS trace_storage_size_bytes
-        """
-        assert_sql(query, expected_sql, pb.get_params(), {"pb_0": "test_project"})
-        assert columns == ["trace_storage_size_bytes"]
-
-    def test_objects_storage_only(self) -> None:
-        """Verify SQL when only objects storage is requested."""
-        pb = ParamBuilder("pb")
-        query, columns = make_project_stats_query(
-            project_id="test_project",
-            pb=pb,
-            include_trace_storage_size=False,
-            include_objects_storage_size=True,
-            include_tables_storage_size=False,
-            include_files_storage_size=False,
-        )
-
-        expected_sql = """
-            SELECT
-                (SELECT sum(size_bytes)
-                    FROM object_versions_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS objects_storage_size_bytes
-        """
-        assert_sql(query, expected_sql, pb.get_params(), {"pb_0": "test_project"})
-        assert columns == ["objects_storage_size_bytes"]
-
-    def test_tables_storage_only(self) -> None:
-        """Verify SQL when only tables storage is requested."""
-        pb = ParamBuilder("pb")
-        query, columns = make_project_stats_query(
-            project_id="test_project",
-            pb=pb,
-            include_trace_storage_size=False,
-            include_objects_storage_size=False,
-            include_tables_storage_size=True,
-            include_files_storage_size=False,
-        )
-
-        expected_sql = """
-            SELECT
-                (SELECT sum(size_bytes)
-                    FROM table_rows_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS tables_storage_size_bytes
-        """
-        assert_sql(query, expected_sql, pb.get_params(), {"pb_0": "test_project"})
-        assert columns == ["tables_storage_size_bytes"]
-
-    def test_files_storage_only(self) -> None:
-        """Verify SQL when only files storage is requested."""
-        pb = ParamBuilder("pb")
-        query, columns = make_project_stats_query(
-            project_id="test_project",
-            pb=pb,
-            include_trace_storage_size=False,
-            include_objects_storage_size=False,
-            include_tables_storage_size=False,
-            include_files_storage_size=True,
-        )
-
-        expected_sql = """
-            SELECT
-                (SELECT sum(size_bytes)
-                    FROM files_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS files_storage_size_bytes
-        """
-        assert_sql(query, expected_sql, pb.get_params(), {"pb_0": "test_project"})
-        assert columns == ["files_storage_size_bytes"]
-
-    def test_all_storage_sizes_calls_merged(self) -> None:
-        """Verify SQL when all storage sizes are requested with calls_merged."""
-        pb = ParamBuilder("pb")
-        query, columns = make_project_stats_query(
-            project_id="test_project",
-            pb=pb,
-            include_trace_storage_size=True,
-            include_objects_storage_size=True,
-            include_tables_storage_size=True,
-            include_files_storage_size=True,
-            read_table=ReadTable.CALLS_MERGED,
-        )
-
-        expected_sql = """
-            SELECT
-                (SELECT sum(
-                    COALESCE(attributes_size_bytes, 0) +
-                    COALESCE(inputs_size_bytes, 0) +
-                    COALESCE(output_size_bytes, 0) +
-                    COALESCE(summary_size_bytes, 0) +
-                    COALESCE(otel_dump_size_bytes, 0)
-                    )
-                    FROM calls_merged_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS trace_storage_size_bytes,
-                (SELECT sum(size_bytes)
-                    FROM object_versions_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS objects_storage_size_bytes,
-                (SELECT sum(size_bytes)
-                    FROM table_rows_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS tables_storage_size_bytes,
-                (SELECT sum(size_bytes)
-                    FROM files_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS files_storage_size_bytes
-        """
-        assert_sql(query, expected_sql, pb.get_params(), {"pb_0": "test_project"})
-        assert columns == [
-            "trace_storage_size_bytes",
-            "objects_storage_size_bytes",
-            "tables_storage_size_bytes",
-            "files_storage_size_bytes",
-        ]
-
-    def test_all_storage_sizes_calls_complete(self) -> None:
-        """Verify SQL when all storage sizes are requested with calls_complete."""
-        pb = ParamBuilder("pb")
-        query, columns = make_project_stats_query(
-            project_id="test_project",
-            pb=pb,
-            include_trace_storage_size=True,
-            include_objects_storage_size=True,
-            include_tables_storage_size=True,
-            include_files_storage_size=True,
-            read_table=ReadTable.CALLS_COMPLETE,
-        )
-
-        expected_sql = """
-            SELECT
-                (SELECT sum(
-                    COALESCE(attributes_size_bytes, 0) +
-                    COALESCE(inputs_size_bytes, 0) +
-                    COALESCE(output_size_bytes, 0) +
-                    COALESCE(summary_size_bytes, 0) +
-                    COALESCE(otel_size_bytes, 0)
-                    )
-                    FROM calls_complete_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS trace_storage_size_bytes,
-                (SELECT sum(size_bytes)
-                    FROM object_versions_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS objects_storage_size_bytes,
-                (SELECT sum(size_bytes)
-                    FROM table_rows_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS tables_storage_size_bytes,
-                (SELECT sum(size_bytes)
-                    FROM files_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS files_storage_size_bytes
-        """
-        assert_sql(query, expected_sql, pb.get_params(), {"pb_0": "test_project"})
-        assert columns == [
-            "trace_storage_size_bytes",
-            "objects_storage_size_bytes",
-            "tables_storage_size_bytes",
-            "files_storage_size_bytes",
-        ]
-
-    def test_raises_when_no_storage_sizes_requested(self) -> None:
-        """Verify ValueError raised when all include_* params are False."""
-        pb = ParamBuilder("pb")
-        with pytest.raises(ValueError, match="At least one of"):
-            make_project_stats_query(
-                project_id="test_project",
-                pb=pb,
-                include_trace_storage_size=False,
-                include_objects_storage_size=False,
-                include_tables_storage_size=False,
-                include_files_storage_size=False,
-            )
-
-    def test_parameterization_prevents_sql_injection(self) -> None:
-        """Verify project_id is parameterized for SQL injection safety."""
-        pb = ParamBuilder("pb")
-        query, columns = make_project_stats_query(
-            project_id="malicious'--project",
-            pb=pb,
-            include_trace_storage_size=True,
-            include_objects_storage_size=False,
-            include_tables_storage_size=False,
-            include_files_storage_size=False,
-        )
-
-        expected_sql = """
-            SELECT
-                (SELECT sum(
-                    COALESCE(attributes_size_bytes, 0) +
-                    COALESCE(inputs_size_bytes, 0) +
-                    COALESCE(output_size_bytes, 0) +
-                    COALESCE(summary_size_bytes, 0) +
-                    COALESCE(otel_dump_size_bytes, 0)
-                    )
-                    FROM calls_merged_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS trace_storage_size_bytes
-        """
-        # Project ID should be parameterized, not directly in query
-        assert "malicious" not in query
-        assert_sql(
-            query, expected_sql, pb.get_params(), {"pb_0": "malicious'--project"}
-        )
-
-    def test_trace_storage_includes_otel_bytes_regression(self) -> None:
-        """trace_storage_size_bytes must sum OTEL bytes for both stats tables.
-
-        Dropping OTEL underreports project storage (the calls_merged_stats column
-        is `otel_dump_size_bytes`, calls_complete_stats is `otel_size_bytes`).
-        """
-        for read_table, expected_otel_col, other_otel_col in [
-            (ReadTable.CALLS_MERGED, "otel_dump_size_bytes", "otel_size_bytes"),
-            (ReadTable.CALLS_COMPLETE, "otel_size_bytes", "otel_dump_size_bytes"),
-        ]:
-            pb = ParamBuilder("pb")
-            query, _ = make_project_stats_query(
-                project_id="test_project",
-                pb=pb,
-                include_trace_storage_size=True,
-                include_objects_storage_size=False,
-                include_tables_storage_size=False,
-                include_files_storage_size=False,
-                read_table=read_table,
-            )
-            assert f"COALESCE({expected_otel_col}, 0)" in query, (
-                f"trace_storage sum missing OTEL bytes for {read_table}"
-            )
-            assert other_otel_col not in query, (
-                f"wrong OTEL column {other_otel_col} used for {read_table}"
-            )
-
-    def test_only_objects_storage_with_calls_complete(self) -> None:
-        """Verify non-trace storage works without including calls stats table."""
-        pb = ParamBuilder("pb")
-        query, columns = make_project_stats_query(
-            project_id="test_project",
-            pb=pb,
-            include_trace_storage_size=False,
-            include_objects_storage_size=True,
-            include_tables_storage_size=False,
-            include_files_storage_size=False,
-            read_table=ReadTable.CALLS_COMPLETE,
-        )
-
-        expected_sql = """
-            SELECT
-                (SELECT sum(size_bytes)
-                    FROM object_versions_stats
-                    WHERE project_id = {pb_0: String}
-                ) AS objects_storage_size_bytes
-        """
-        assert_sql(query, expected_sql, pb.get_params(), {"pb_0": "test_project"})
-        assert columns == ["objects_storage_size_bytes"]

--- a/tests/trace_server/query_builder/test_threads_query_builder.py
+++ b/tests/trace_server/query_builder/test_threads_query_builder.py
@@ -11,19 +11,9 @@ from weave.trace_server.threads_query_builder import (
     make_threads_query,
 )
 
-# Basic Functionality Tests
 
-
-@pytest.mark.parametrize(
-    ("read_table", "expected_table"),
-    [
-        (ReadTable.CALLS_MERGED, "calls_merged"),
-        (ReadTable.CALLS_COMPLETE, "calls_complete"),
-    ],
-)
-def test_clickhouse_basic_query(read_table: ReadTable, expected_table: str):
-    """Test basic ClickHouse threads query uses correct table and full query shape."""
-    expected_query = f"""
+def _basic_query(table: str) -> str:
+    return f"""
         SELECT
             aggregated_thread_id AS thread_id,
             COUNT(*) AS turn_count,
@@ -44,7 +34,7 @@ def test_clickhouse_basic_query(read_table: ReadTable, expected_table: str):
                     THEN dateDiff('millisecond', call_start_time, call_end_time)
                     ELSE NULL
                 END AS call_duration
-            FROM {expected_table}
+            FROM {table}
             WHERE project_id = {{pb_0: String}}
 
             GROUP BY (project_id, id)
@@ -53,25 +43,30 @@ def test_clickhouse_basic_query(read_table: ReadTable, expected_table: str):
         GROUP BY aggregated_thread_id
         ORDER BY last_updated DESC
     """
-    assert_clickhouse_sql(
-        expected_query,
+
+
+# Each row asserts the COMPLETE ClickHouse query so every WHERE/ORDER BY/LIMIT/
+# OFFSET/thread-id branch keeps full-SQL coverage.
+_CLICKHOUSE_CASES = [
+    pytest.param(
+        {"read_table": ReadTable.CALLS_MERGED},
+        _basic_query("calls_merged"),
         {"pb_0": "test_project"},
-        project_id="test_project",
-        read_table=read_table,
-    )
-
-
-# Sorting Tests
-
-
-def test_clickhouse_custom_sorting():
-    """Test ClickHouse query with custom sorting."""
-    sort_by = [
-        SortBy(field="turn_count", direction="asc"),
-        SortBy(field="start_time", direction="desc"),
-    ]
-
-    assert_clickhouse_sql(
+        id="basic_calls_merged",
+    ),
+    pytest.param(
+        {"read_table": ReadTable.CALLS_COMPLETE},
+        _basic_query("calls_complete"),
+        {"pb_0": "test_project"},
+        id="basic_calls_complete",
+    ),
+    pytest.param(
+        {
+            "sort_by": [
+                SortBy(field="turn_count", direction="asc"),
+                SortBy(field="start_time", direction="desc"),
+            ]
+        },
         """
         SELECT
             aggregated_thread_id AS thread_id,
@@ -103,17 +98,10 @@ def test_clickhouse_custom_sorting():
         ORDER BY turn_count ASC, start_time DESC
         """,
         {"pb_0": "test_project"},
-        project_id="test_project",
-        sort_by=sort_by,
-    )
-
-
-# Pagination Tests
-
-
-def test_clickhouse_with_limit():
-    """Test ClickHouse query with limit."""
-    assert_clickhouse_sql(
+        id="custom_sorting",
+    ),
+    pytest.param(
+        {"limit": 50},
         """
         SELECT
             aggregated_thread_id AS thread_id,
@@ -146,14 +134,10 @@ def test_clickhouse_with_limit():
         LIMIT {pb_1: Int64}
         """,
         {"pb_0": "test_project", "pb_1": 50},
-        project_id="test_project",
-        limit=50,
-    )
-
-
-def test_clickhouse_with_limit_and_offset():
-    """Test ClickHouse query with limit and offset."""
-    assert_clickhouse_sql(
+        id="limit",
+    ),
+    pytest.param(
+        {"limit": 25, "offset": 100},
         """
         SELECT
             aggregated_thread_id AS thread_id,
@@ -187,21 +171,13 @@ def test_clickhouse_with_limit_and_offset():
         OFFSET {pb_2: Int64}
         """,
         {"pb_0": "test_project", "pb_1": 25, "pb_2": 100},
-        project_id="test_project",
-        limit=25,
-        offset=100,
-    )
-
-
-# Date Filtering Tests
-
-
-def test_clickhouse_with_date_filters():
-    """Test ClickHouse query with sortable_datetime filters."""
-    after_date = datetime.datetime(2024, 1, 1, 12, 0, 0)
-    before_date = datetime.datetime(2024, 12, 31, 23, 59, 59)
-
-    assert_clickhouse_sql(
+        id="limit_and_offset",
+    ),
+    pytest.param(
+        {
+            "sortable_datetime_after": datetime.datetime(2024, 1, 1, 12, 0, 0),
+            "sortable_datetime_before": datetime.datetime(2024, 12, 31, 23, 59, 59),
+        },
         """
         SELECT
             aggregated_thread_id AS thread_id,
@@ -237,22 +213,51 @@ def test_clickhouse_with_date_filters():
             "pb_1": "2024-01-01 12:00:00.000000",
             "pb_2": "2024-12-31 23:59:59.000000",
         },
-        project_id="test_project",
-        sortable_datetime_after=after_date,
-        sortable_datetime_before=before_date,
-    )
-
-
-# Complex Scenarios
-
-
-def test_clickhouse_full_featured_query():
-    """Test ClickHouse query with all features: custom sorting, pagination, and date filtering."""
-    after_date = datetime.datetime(2024, 1, 1)
-    before_date = datetime.datetime(2024, 12, 31)
-    sort_by = [SortBy(field="turn_count", direction="desc")]
-
-    assert_clickhouse_sql(
+        id="date_filters",
+    ),
+    pytest.param(
+        {"sortable_datetime_after": datetime.datetime(2024, 1, 1, 0, 0, 0)},
+        """
+        SELECT
+            aggregated_thread_id AS thread_id,
+            COUNT(*) AS turn_count,
+            min(call_start_time) AS start_time,
+            max(call_end_time) AS last_updated,
+            argMin(id, call_start_time) AS first_turn_id,
+            argMax(id, call_end_time) AS last_turn_id,
+            quantile(0.5)(call_duration) AS p50_turn_duration_ms,
+            quantile(0.99)(call_duration) AS p99_turn_duration_ms
+        FROM (
+            SELECT
+                id,
+                any(thread_id) AS aggregated_thread_id,
+                min(started_at) AS call_start_time,
+                max(ended_at) AS call_end_time,
+                CASE
+                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
+                    THEN dateDiff('millisecond', call_start_time, call_end_time)
+                    ELSE NULL
+                END AS call_duration
+            FROM calls_merged
+            WHERE project_id = {pb_0: String}
+                AND sortable_datetime > {pb_1: String}
+            GROUP BY (project_id, id)
+            HAVING id = any(turn_id) AND aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''
+        ) AS properly_merged_calls
+        GROUP BY aggregated_thread_id
+        ORDER BY last_updated DESC
+        """,
+        {"pb_0": "test_project", "pb_1": "2024-01-01 00:00:00.000000"},
+        id="only_after_date",
+    ),
+    pytest.param(
+        {
+            "sortable_datetime_after": datetime.datetime(2024, 1, 1),
+            "sortable_datetime_before": datetime.datetime(2024, 12, 31),
+            "sort_by": [SortBy(field="turn_count", direction="desc")],
+            "limit": 15,
+            "offset": 30,
+        },
         """
         SELECT
             aggregated_thread_id AS thread_id,
@@ -292,144 +297,10 @@ def test_clickhouse_full_featured_query():
             "pb_3": 15,
             "pb_4": 30,
         },
-        project_id="test_project",
-        sortable_datetime_after=after_date,
-        sortable_datetime_before=before_date,
-        sort_by=sort_by,
-        limit=15,
-        offset=30,
-    )
-
-
-# Edge Cases
-
-
-def test_clickhouse_only_after_date():
-    """Test ClickHouse query with only after date filter."""
-    after_date = datetime.datetime(2024, 1, 1, 0, 0, 0)
-
-    assert_clickhouse_sql(
-        """
-        SELECT
-            aggregated_thread_id AS thread_id,
-            COUNT(*) AS turn_count,
-            min(call_start_time) AS start_time,
-            max(call_end_time) AS last_updated,
-            argMin(id, call_start_time) AS first_turn_id,
-            argMax(id, call_end_time) AS last_turn_id,
-            quantile(0.5)(call_duration) AS p50_turn_duration_ms,
-            quantile(0.99)(call_duration) AS p99_turn_duration_ms
-        FROM (
-            SELECT
-                id,
-                any(thread_id) AS aggregated_thread_id,
-                min(started_at) AS call_start_time,
-                max(ended_at) AS call_end_time,
-                CASE
-                    WHEN call_end_time IS NOT NULL AND call_start_time IS NOT NULL
-                    THEN dateDiff('millisecond', call_start_time, call_end_time)
-                    ELSE NULL
-                END AS call_duration
-            FROM calls_merged
-            WHERE project_id = {pb_0: String}
-                AND sortable_datetime > {pb_1: String}
-            GROUP BY (project_id, id)
-            HAVING id = any(turn_id) AND aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''
-        ) AS properly_merged_calls
-        GROUP BY aggregated_thread_id
-        ORDER BY last_updated DESC
-        """,
-        {"pb_0": "test_project", "pb_1": "2024-01-01 00:00:00.000000"},
-        project_id="test_project",
-        sortable_datetime_after=after_date,
-    )
-
-
-# Validation Tests
-
-
-def test_validate_and_map_sort_field():
-    """Test the sort field validation function."""
-    # Test valid fields
-    assert _validate_and_map_sort_field("thread_id") == "thread_id"
-    assert _validate_and_map_sort_field("turn_count") == "turn_count"
-    assert _validate_and_map_sort_field("start_time") == "start_time"
-    assert _validate_and_map_sort_field("last_updated") == "last_updated"
-    assert (
-        _validate_and_map_sort_field("p50_turn_duration_ms") == "p50_turn_duration_ms"
-    )
-    assert (
-        _validate_and_map_sort_field("p99_turn_duration_ms") == "p99_turn_duration_ms"
-    )
-
-    # Test invalid fields - call IDs should not be sortable since they're just identifiers
-    with pytest.raises(
-        ValueError, match="Unsupported sort field: first_turn_id"
-    ) as exc_info:
-        _validate_and_map_sort_field("first_turn_id")
-    assert "Unsupported sort field: first_turn_id" in str(exc_info.value)
-
-    with pytest.raises(
-        ValueError, match="Unsupported sort field: last_turn_id"
-    ) as exc_info:
-        _validate_and_map_sort_field("last_turn_id")
-    assert "Unsupported sort field: last_turn_id" in str(exc_info.value)
-
-    with pytest.raises(
-        ValueError, match="Unsupported sort field: invalid_field"
-    ) as exc_info:
-        _validate_and_map_sort_field("invalid_field")
-    assert "Unsupported sort field: invalid_field" in str(exc_info.value)
-    assert (
-        "Supported fields: ['thread_id', 'turn_count', 'start_time', 'last_updated', 'p50_turn_duration_ms', 'p99_turn_duration_ms']"
-        in str(exc_info.value)
-    )
-
-
-def test_sort_field_validation_in_query():
-    """Test that invalid sort fields raise errors in query generation."""
-    invalid_sort = [SortBy(field="nonexistent_field", direction="asc")]
-    with pytest.raises(ValueError, match="Unsupported sort field"):
-        make_threads_query(
-            project_id="test_project", pb=ParamBuilder("pb"), sort_by=invalid_sort
-        )
-
-
-# Turn-ID Filtering Behavior Tests
-
-
-def test_turn_filtering_explanation():
-    """Test that demonstrates the key behavior: only turn calls are included.
-
-    This test is more about documenting the expected behavior than testing
-    implementation details. It shows that the filtering `id = turn_id` ensures
-    only turn calls are included in thread statistics, not their descendants.
-    """
-    # The key filtering condition: "id = any(turn_id)" in the HAVING clause.
-
-    # This means:
-    # ✅ Turn calls (where call.id == call.turn_id) are included
-    # ❌ Descendant calls (where call.id != call.turn_id) are excluded
-    pb = ParamBuilder("pb")
-    clickhouse_query = make_threads_query(project_id="test", pb=pb)
-
-    # Check that turn filtering is present
-    assert "id = any(turn_id)" in clickhouse_query
-
-    # Check that thread filtering is also present (non-null, non-empty),
-    # in the HAVING clause using aggregated_thread_id
-    assert (
-        "aggregated_thread_id IS NOT NULL AND aggregated_thread_id != ''"
-        in clickhouse_query
-    )
-
-
-# Thread ID Filtering Tests
-
-
-def test_clickhouse_with_thread_id_filter():
-    """Test ClickHouse query with thread_id filter."""
-    assert_clickhouse_sql(
+        id="full_featured",
+    ),
+    pytest.param(
+        {"thread_ids": ["my_specific_thread"]},
         """
         SELECT
             aggregated_thread_id AS thread_id,
@@ -461,17 +332,14 @@ def test_clickhouse_with_thread_id_filter():
          ORDER BY last_updated DESC
         """,
         {"pb_0": "test_project", "pb_1": "my_specific_thread"},
-        project_id="test_project",
-        thread_ids=["my_specific_thread"],
-    )
-
-
-def test_clickhouse_with_thread_id_and_date_filters():
-    """Test ClickHouse query with both thread_id and date filters."""
-    after_date = datetime.datetime(2024, 1, 1, 12, 0, 0)
-    before_date = datetime.datetime(2024, 12, 31, 23, 59, 59)
-
-    assert_clickhouse_sql(
+        id="thread_id_filter",
+    ),
+    pytest.param(
+        {
+            "sortable_datetime_after": datetime.datetime(2024, 1, 1, 12, 0, 0),
+            "sortable_datetime_before": datetime.datetime(2024, 12, 31, 23, 59, 59),
+            "thread_ids": ["thread_with_dates"],
+        },
         """
         SELECT
             aggregated_thread_id AS thread_id,
@@ -509,20 +377,17 @@ def test_clickhouse_with_thread_id_and_date_filters():
             "pb_2": "2024-12-31 23:59:59.000000",
             "pb_3": "thread_with_dates",
         },
-        project_id="test_project",
-        sortable_datetime_after=after_date,
-        sortable_datetime_before=before_date,
-        thread_ids=["thread_with_dates"],
-    )
-
-
-def test_clickhouse_with_thread_id_and_all_options():
-    """Test ClickHouse query with thread_id, dates, sorting, and pagination."""
-    after_date = datetime.datetime(2024, 1, 1)
-    before_date = datetime.datetime(2024, 12, 31)
-    sort_by = [SortBy(field="turn_count", direction="desc")]
-
-    assert_clickhouse_sql(
+        id="thread_id_and_date_filters",
+    ),
+    pytest.param(
+        {
+            "sortable_datetime_after": datetime.datetime(2024, 1, 1),
+            "sortable_datetime_before": datetime.datetime(2024, 12, 31),
+            "sort_by": [SortBy(field="turn_count", direction="desc")],
+            "limit": 15,
+            "offset": 30,
+            "thread_ids": ["full_featured_thread"],
+        },
         """
         SELECT
             aggregated_thread_id AS thread_id,
@@ -564,55 +429,64 @@ def test_clickhouse_with_thread_id_and_all_options():
             "pb_4": 15,
             "pb_5": 30,
         },
-        project_id="test_project",
-        sortable_datetime_after=after_date,
-        sortable_datetime_before=before_date,
-        sort_by=sort_by,
-        limit=15,
-        offset=30,
-        thread_ids=["full_featured_thread"],
+        id="thread_id_and_all_options",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected_query", "expected_params"), _CLICKHOUSE_CASES
+)
+def test_clickhouse_query_shapes(
+    kwargs: dict, expected_query: str, expected_params: dict
+):
+    """Each input combination produces the full expected ClickHouse SQL + params."""
+    assert_clickhouse_sql(
+        expected_query, expected_params, project_id="test_project", **kwargs
     )
 
 
-def test_thread_id_filter_no_match():
-    """Test that thread_id filter doesn't break query even if no threads match."""
-    # This test verifies that the SQL generation doesn't break with thread_id filter
-    pb = ParamBuilder("pb")
-    query = make_threads_query(
-        project_id="test_project", pb=pb, thread_ids=["nonexistent_thread"]
+def test_validate_and_map_sort_field():
+    """Test the sort field validation function."""
+    assert _validate_and_map_sort_field("thread_id") == "thread_id"
+    assert _validate_and_map_sort_field("turn_count") == "turn_count"
+    assert _validate_and_map_sort_field("start_time") == "start_time"
+    assert _validate_and_map_sort_field("last_updated") == "last_updated"
+    assert (
+        _validate_and_map_sort_field("p50_turn_duration_ms") == "p50_turn_duration_ms"
+    )
+    assert (
+        _validate_and_map_sort_field("p99_turn_duration_ms") == "p99_turn_duration_ms"
     )
 
-    # Should contain the thread filter
-    assert "thread_id IN ({pb_1: String})" in query
+    # Call IDs are identifiers, not sortable fields.
+    with pytest.raises(
+        ValueError, match="Unsupported sort field: first_turn_id"
+    ) as exc_info:
+        _validate_and_map_sort_field("first_turn_id")
+    assert "Unsupported sort field: first_turn_id" in str(exc_info.value)
 
-    # Should have the expected parameter
-    params = pb.get_params()
-    assert "pb_1" in params
-    assert params["pb_1"] == "nonexistent_thread"
+    with pytest.raises(
+        ValueError, match="Unsupported sort field: last_turn_id"
+    ) as exc_info:
+        _validate_and_map_sort_field("last_turn_id")
+    assert "Unsupported sort field: last_turn_id" in str(exc_info.value)
+
+    with pytest.raises(
+        ValueError, match="Unsupported sort field: invalid_field"
+    ) as exc_info:
+        _validate_and_map_sort_field("invalid_field")
+    assert "Unsupported sort field: invalid_field" in str(exc_info.value)
+    assert (
+        "Supported fields: ['thread_id', 'turn_count', 'start_time', 'last_updated', 'p50_turn_duration_ms', 'p99_turn_duration_ms']"
+        in str(exc_info.value)
+    )
 
 
-def test_query_structure_documentation():
-    """Test that documents the structure and purpose of the threads query.
-
-    This test serves AS living documentation of what the threads query does
-    and why it's structured the way it is.
-    """
-    pb = ParamBuilder("pb")
-    query = make_threads_query(project_id="test_project", pb=pb)
-
-    # Should be a two-level aggregation for ClickHouse
-    assert "SELECT" in query  # Outer query
-    assert "FROM (" in query  # Inner subquery
-    assert "GROUP BY aggregated_thread_id" in query  # Outer aggregation by thread
-    assert "GROUP BY (project_id, id)" in query  # Inner aggregation by call
-
-    # Should include key aggregations
-    assert "COUNT(*) AS turn_count" in query
-    assert "min(call_start_time) AS start_time" in query
-    assert "max(call_end_time) AS last_updated" in query
-
-    # Should include turn filtering
-    assert "id = any(turn_id)" in query
-
-    # Should have default ordering
-    assert "ORDER BY last_updated DESC" in query
+def test_sort_field_validation_in_query():
+    """Test that invalid sort fields raise errors in query generation."""
+    invalid_sort = [SortBy(field="nonexistent_field", direction="asc")]
+    with pytest.raises(ValueError, match="Unsupported sort field"):
+        make_threads_query(
+            project_id="test_project", pb=ParamBuilder("pb"), sort_by=invalid_sort
+        )

--- a/tests/trace_server/query_builder/test_usage_query_builder.py
+++ b/tests/trace_server/query_builder/test_usage_query_builder.py
@@ -1,5 +1,7 @@
 import datetime
 
+import pytest
+
 from tests.trace_server.query_builder.utils import assert_usage_sql
 from weave.trace_server.project_version.types import ReadTable
 from weave.trace_server.trace_server_interface import (
@@ -9,215 +11,531 @@ from weave.trace_server.trace_server_interface import (
     UsageMetricSpec,
 )
 
-
-def test_explicit_start_end():
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        UsageMetricSpec(
-            metric="total_tokens",
-            aggregations=[AggregationType.SUM, AggregationType.AVG],
-        )
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  avgOrNull(m_total_tokens) AS avg_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.avg_total_tokens, 0) AS avg_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        ["timestamp", "model", "sum_total_tokens", "avg_total_tokens", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
+START_DT = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+END_DT = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
+END_DT_1H = datetime.datetime(2024, 12, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
 
 
-def test_op_names_filter():
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [UsageMetricSpec(metric="total_tokens")]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(op_names=["openai.chat", "anthropic.messages"]),
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                      AND op_name IN {pb_5:Array(String)}
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-            "pb_5": ["openai.chat", "anthropic.messages"],
-        },
-        ["timestamp", "model", "sum_total_tokens", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_all_aggregation_types():
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        UsageMetricSpec(
-            metric="total_tokens",
-            aggregations=[
-                AggregationType.SUM,
-                AggregationType.AVG,
-                AggregationType.MIN,
-                AggregationType.MAX,
-                AggregationType.COUNT,
+@pytest.mark.parametrize(
+    ("metrics", "end_dt", "granularity", "expected_query", "expected_columns"),
+    [
+        pytest.param(
+            [
+                UsageMetricSpec(
+                    metric="total_tokens",
+                    aggregations=[AggregationType.SUM, AggregationType.AVG],
+                )
             ],
-        )
-    ]
+            END_DT,
+            3600,
+            """
+            WITH all_buckets AS
+              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+                 aggregated_data AS
+              (SELECT bucket,
+                      model,
+                      sumOrNull(m_total_tokens) AS sum_total_tokens,
+                      avgOrNull(m_total_tokens) AS avg_total_tokens,
+                      count() AS count
+               FROM
+                 (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
+                         kv.1 AS model,
+                         toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
+                  FROM
+                    (SELECT sortable_datetime,
+                            JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                     FROM
+                       (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
+                               anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
+                        FROM calls_merged AS cm
+                        WHERE cm.project_id = {pb_0:String}
+                          AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
+                          AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                          AND cm.deleted_at IS NULL
+                        GROUP BY project_id,
+                                 id)) ARRAY
+                  JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+               GROUP BY bucket,
+                        model),
+                 all_models AS
+              (SELECT DISTINCT model
+               FROM aggregated_data)
+            SELECT all_buckets.bucket AS timestamp,
+                   all_models.model,
+                   COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
+                   COALESCE(aggregated_data.avg_total_tokens, 0) AS avg_total_tokens,
+                   COALESCE(aggregated_data.count, 0) AS count
+            FROM all_buckets
+            CROSS JOIN all_models
+            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+            AND all_models.model = aggregated_data.model
+            ORDER BY all_buckets.bucket,
+                     all_models.model
+            """,
+            ["timestamp", "model", "sum_total_tokens", "avg_total_tokens", "count"],
+            id="sum_avg",
+        ),
+        pytest.param(
+            [
+                UsageMetricSpec(
+                    metric="total_tokens",
+                    aggregations=[
+                        AggregationType.SUM,
+                        AggregationType.AVG,
+                        AggregationType.MIN,
+                        AggregationType.MAX,
+                        AggregationType.COUNT,
+                    ],
+                )
+            ],
+            END_DT_1H,
+            300,
+            """
+            WITH all_buckets AS
+              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+                 aggregated_data AS
+              (SELECT bucket,
+                      model,
+                      sumOrNull(m_total_tokens) AS sum_total_tokens,
+                      avgOrNull(m_total_tokens) AS avg_total_tokens,
+                      minOrNull(m_total_tokens) AS min_total_tokens,
+                      maxOrNull(m_total_tokens) AS max_total_tokens,
+                      countOrNull(m_total_tokens) AS count_total_tokens,
+                      count() AS count
+               FROM
+                 (SELECT toStartOfInterval(sortable_datetime, INTERVAL 300 SECOND, {pb_3:String}) AS bucket,
+                         kv.1 AS model,
+                         toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
+                  FROM
+                    (SELECT sortable_datetime,
+                            JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                     FROM
+                       (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
+                               anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
+                        FROM calls_merged AS cm
+                        WHERE cm.project_id = {pb_0:String}
+                          AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
+                          AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                          AND cm.deleted_at IS NULL
+                        GROUP BY project_id,
+                                 id)) ARRAY
+                  JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+               GROUP BY bucket,
+                        model),
+                 all_models AS
+              (SELECT DISTINCT model
+               FROM aggregated_data)
+            SELECT all_buckets.bucket AS timestamp,
+                   all_models.model,
+                   COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
+                   COALESCE(aggregated_data.avg_total_tokens, 0) AS avg_total_tokens,
+                   aggregated_data.min_total_tokens AS min_total_tokens,
+                   aggregated_data.max_total_tokens AS max_total_tokens,
+                   COALESCE(aggregated_data.count_total_tokens, 0) AS count_total_tokens,
+                   COALESCE(aggregated_data.count, 0) AS count
+            FROM all_buckets
+            CROSS JOIN all_models
+            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+            AND all_models.model = aggregated_data.model
+            ORDER BY all_buckets.bucket,
+                     all_models.model
+            """,
+            [
+                "timestamp",
+                "model",
+                "sum_total_tokens",
+                "avg_total_tokens",
+                "min_total_tokens",
+                "max_total_tokens",
+                "count_total_tokens",
+                "count",
+            ],
+            id="all_aggregation_types",
+        ),
+        pytest.param(
+            [
+                UsageMetricSpec(
+                    metric="output_tokens",
+                    aggregations=[],
+                    percentiles=[50, 75, 90, 95, 99, 99.9],
+                )
+            ],
+            END_DT_1H,
+            300,
+            """
+            WITH all_buckets AS
+              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+                 aggregated_data AS
+              (SELECT bucket,
+                      model,
+                      quantileOrNull(0.5)(m_output_tokens) AS p50_output_tokens,
+                      quantileOrNull(0.75)(m_output_tokens) AS p75_output_tokens,
+                      quantileOrNull(0.9)(m_output_tokens) AS p90_output_tokens,
+                      quantileOrNull(0.95)(m_output_tokens) AS p95_output_tokens,
+                      quantileOrNull(0.99)(m_output_tokens) AS p99_output_tokens,
+                      quantileOrNull(0.999)(m_output_tokens) AS p99.9_output_tokens,
+                      count() AS count
+               FROM
+                 (SELECT toStartOfInterval(sortable_datetime, INTERVAL 300 SECOND, {pb_3:String}) AS bucket,
+                         kv.1 AS model,
+                         (ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'completion_tokens')), 0) + ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'output_tokens')), 0)) AS m_output_tokens
+                  FROM
+                    (SELECT sortable_datetime,
+                            JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                     FROM
+                       (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
+                               anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
+                        FROM calls_merged AS cm
+                        WHERE cm.project_id = {pb_0:String}
+                          AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
+                          AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                          AND cm.deleted_at IS NULL
+                        GROUP BY project_id,
+                                 id)) ARRAY
+                  JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+               GROUP BY bucket,
+                        model),
+                 all_models AS
+              (SELECT DISTINCT model
+               FROM aggregated_data)
+            SELECT all_buckets.bucket AS timestamp,
+                   all_models.model,
+                   aggregated_data.p50_output_tokens AS p50_output_tokens,
+                   aggregated_data.p75_output_tokens AS p75_output_tokens,
+                   aggregated_data.p90_output_tokens AS p90_output_tokens,
+                   aggregated_data.p95_output_tokens AS p95_output_tokens,
+                   aggregated_data.p99_output_tokens AS p99_output_tokens,
+                   aggregated_data.p99.9_output_tokens AS p99.9_output_tokens,
+                   COALESCE(aggregated_data.count, 0) AS count
+            FROM all_buckets
+            CROSS JOIN all_models
+            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+            AND all_models.model = aggregated_data.model
+            ORDER BY all_buckets.bucket,
+                     all_models.model
+            """,
+            [
+                "timestamp",
+                "model",
+                "p50_output_tokens",
+                "p75_output_tokens",
+                "p90_output_tokens",
+                "p95_output_tokens",
+                "p99_output_tokens",
+                "p99.9_output_tokens",
+                "count",
+            ],
+            id="custom_percentiles",
+        ),
+        pytest.param(
+            [
+                UsageMetricSpec(
+                    metric="input_tokens", aggregations=[AggregationType.SUM]
+                ),
+                UsageMetricSpec(
+                    metric="output_tokens", aggregations=[AggregationType.SUM]
+                ),
+                UsageMetricSpec(
+                    metric="total_tokens", aggregations=[AggregationType.AVG]
+                ),
+            ],
+            END_DT,
+            3600,
+            """
+            WITH all_buckets AS
+              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+                 aggregated_data AS
+              (SELECT bucket,
+                      model,
+                      sumOrNull(m_input_tokens) AS sum_input_tokens,
+                      sumOrNull(m_output_tokens) AS sum_output_tokens,
+                      avgOrNull(m_total_tokens) AS avg_total_tokens,
+                      count() AS count
+               FROM
+                 (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
+                         kv.1 AS model,
+                         (ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'prompt_tokens')), 0) + ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'input_tokens')), 0)) AS m_input_tokens,
+                         (ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'completion_tokens')), 0) + ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'output_tokens')), 0)) AS m_output_tokens,
+                         toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
+                  FROM
+                    (SELECT sortable_datetime,
+                            JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                     FROM
+                       (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
+                               anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
+                        FROM calls_merged AS cm
+                        WHERE cm.project_id = {pb_0:String}
+                          AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
+                          AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                          AND cm.deleted_at IS NULL
+                        GROUP BY project_id,
+                                 id)) ARRAY
+                  JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+               GROUP BY bucket,
+                        model),
+                 all_models AS
+              (SELECT DISTINCT model
+               FROM aggregated_data)
+            SELECT all_buckets.bucket AS timestamp,
+                   all_models.model,
+                   COALESCE(aggregated_data.sum_input_tokens, 0) AS sum_input_tokens,
+                   COALESCE(aggregated_data.sum_output_tokens, 0) AS sum_output_tokens,
+                   COALESCE(aggregated_data.avg_total_tokens, 0) AS avg_total_tokens,
+                   COALESCE(aggregated_data.count, 0) AS count
+            FROM all_buckets
+            CROSS JOIN all_models
+            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+            AND all_models.model = aggregated_data.model
+            ORDER BY all_buckets.bucket,
+                     all_models.model
+            """,
+            [
+                "timestamp",
+                "model",
+                "sum_input_tokens",
+                "sum_output_tokens",
+                "avg_total_tokens",
+                "count",
+            ],
+            id="multiple_metrics",
+        ),
+        pytest.param(
+            [
+                UsageMetricSpec(
+                    metric="total_tokens",
+                    aggregations=[AggregationType.SUM, AggregationType.AVG],
+                    percentiles=[50, 95, 99],
+                )
+            ],
+            END_DT,
+            3600,
+            """
+            WITH all_buckets AS
+              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+                 aggregated_data AS
+              (SELECT bucket,
+                      model,
+                      sumOrNull(m_total_tokens) AS sum_total_tokens,
+                      avgOrNull(m_total_tokens) AS avg_total_tokens,
+                      quantileOrNull(0.5)(m_total_tokens) AS p50_total_tokens,
+                      quantileOrNull(0.95)(m_total_tokens) AS p95_total_tokens,
+                      quantileOrNull(0.99)(m_total_tokens) AS p99_total_tokens,
+                      count() AS count
+               FROM
+                 (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
+                         kv.1 AS model,
+                         toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
+                  FROM
+                    (SELECT sortable_datetime,
+                            JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                     FROM
+                       (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
+                               anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
+                        FROM calls_merged AS cm
+                        WHERE cm.project_id = {pb_0:String}
+                          AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
+                          AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                          AND cm.deleted_at IS NULL
+                        GROUP BY project_id,
+                                 id)) ARRAY
+                  JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+               GROUP BY bucket,
+                        model),
+                 all_models AS
+              (SELECT DISTINCT model
+               FROM aggregated_data)
+            SELECT all_buckets.bucket AS timestamp,
+                   all_models.model,
+                   COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
+                   COALESCE(aggregated_data.avg_total_tokens, 0) AS avg_total_tokens,
+                   aggregated_data.p50_total_tokens AS p50_total_tokens,
+                   aggregated_data.p95_total_tokens AS p95_total_tokens,
+                   aggregated_data.p99_total_tokens AS p99_total_tokens,
+                   COALESCE(aggregated_data.count, 0) AS count
+            FROM all_buckets
+            CROSS JOIN all_models
+            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+            AND all_models.model = aggregated_data.model
+            ORDER BY all_buckets.bucket,
+                     all_models.model
+            """,
+            [
+                "timestamp",
+                "model",
+                "sum_total_tokens",
+                "avg_total_tokens",
+                "p50_total_tokens",
+                "p95_total_tokens",
+                "p99_total_tokens",
+                "count",
+            ],
+            id="mixed_aggregations_and_percentiles",
+        ),
+        pytest.param(
+            [UsageMetricSpec(metric="total_tokens")],
+            END_DT,
+            300,
+            """
+            WITH all_buckets AS
+              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+                 aggregated_data AS
+              (SELECT bucket,
+                      model,
+                      sumOrNull(m_total_tokens) AS sum_total_tokens,
+                      count() AS count
+               FROM
+                 (SELECT toStartOfInterval(sortable_datetime, INTERVAL 300 SECOND, {pb_3:String}) AS bucket,
+                         kv.1 AS model,
+                         toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
+                  FROM
+                    (SELECT sortable_datetime,
+                            JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                     FROM
+                       (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
+                               anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
+                        FROM calls_merged AS cm
+                        WHERE cm.project_id = {pb_0:String}
+                          AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
+                          AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                          AND cm.deleted_at IS NULL
+                        GROUP BY project_id,
+                                 id)) ARRAY
+                  JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+               GROUP BY bucket,
+                        model),
+                 all_models AS
+              (SELECT DISTINCT model
+               FROM aggregated_data)
+            SELECT all_buckets.bucket AS timestamp,
+                   all_models.model,
+                   COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
+                   COALESCE(aggregated_data.count, 0) AS count
+            FROM all_buckets
+            CROSS JOIN all_models
+            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+            AND all_models.model = aggregated_data.model
+            ORDER BY all_buckets.bucket,
+                     all_models.model
+            """,
+            ["timestamp", "model", "sum_total_tokens", "count"],
+            id="explicit_granularity_overrides_auto",
+        ),
+    ],
+)
+def test_calls_merged_aggregation_shapes(
+    metrics: list[UsageMetricSpec],
+    end_dt: datetime.datetime,
+    granularity: int,
+    expected_query: str,
+    expected_columns: list[str],
+) -> None:
     req = CallStatsReq(
         project_id="entity/project",
-        start=start_dt,
+        start=START_DT,
         end=end_dt,
-        granularity=300,
+        granularity=granularity,
     )
     assert_usage_sql(
         req,
         metrics,
-        """
+        expected_query,
+        {
+            "pb_0": "entity/project",
+            "pb_1": 1733011200.0,
+            "pb_2": end_dt.timestamp(),
+            "pb_3": "UTC",
+            "pb_4": granularity,
+        },
+        expected_columns,
+        granularity,
+        exp_start=START_DT,
+        exp_end=end_dt,
+    )
+
+
+@pytest.mark.parametrize(
+    ("call_filter", "where_clause", "pb_5"),
+    [
+        pytest.param(
+            CallsFilter(op_names=["openai.chat", "anthropic.messages"]),
+            "AND op_name IN {pb_5:Array(String)}",
+            ["openai.chat", "anthropic.messages"],
+            id="op_names",
+        ),
+        pytest.param(
+            CallsFilter(trace_roots_only=True),
+            "AND parent_id IS NULL",
+            None,
+            id="trace_roots_only",
+        ),
+        pytest.param(
+            CallsFilter(trace_ids=["trace_abc", "trace_def"]),
+            "AND ifNull(trace_id, '') IN {pb_5:Array(String)}",
+            ["trace_abc", "trace_def"],
+            id="trace_ids",
+        ),
+        pytest.param(
+            CallsFilter(wb_user_ids=["user_123"]),
+            "AND wb_user_id IN {pb_5:Array(String)}",
+            ["user_123"],
+            id="wb_user_ids",
+        ),
+    ],
+)
+def test_calls_merged_filter_clauses(
+    call_filter: CallsFilter,
+    where_clause: str,
+    pb_5: list[str] | None,
+) -> None:
+    metrics = [UsageMetricSpec(metric="total_tokens")]
+    req = CallStatsReq(
+        project_id="entity/project",
+        start=START_DT,
+        end=END_DT,
+        granularity=3600,
+        filter=call_filter,
+    )
+    expected_query = f"""
         WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+          (SELECT toStartOfInterval(toDateTime({{pb_1:Float64}}, {{pb_3:String}}), INTERVAL 3600 SECOND, {{pb_3:String}}) + toIntervalSecond(number * {{pb_4:Int64}}) AS bucket
+           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({{pb_2:Float64}}, {{pb_3:String}})) - toUnixTimestamp(toStartOfInterval(toDateTime({{pb_1:Float64}}, {{pb_3:String}}), INTERVAL 3600 SECOND, {{pb_3:String}}))) / {{pb_4:Float64}})))
+           WHERE bucket < toDateTime({{pb_2:Float64}}, {{pb_3:String}}) ),
              aggregated_data AS
           (SELECT bucket,
                   model,
                   sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  avgOrNull(m_total_tokens) AS avg_total_tokens,
-                  minOrNull(m_total_tokens) AS min_total_tokens,
-                  maxOrNull(m_total_tokens) AS max_total_tokens,
-                  countOrNull(m_total_tokens) AS count_total_tokens,
                   count() AS count
            FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 300 SECOND, {pb_3:String}) AS bucket,
+             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {{pb_3:String}}) AS bucket,
                      kv.1 AS model,
                      toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
               FROM
                 (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                        JSONExtractRaw(ifNull(summary_dump, '{{}}'), 'usage') AS usage_raw
                  FROM
                    (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
                            anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
                     FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                    WHERE cm.project_id = {{pb_0:String}}
+                      AND cm.sortable_datetime >= toDateTime({{pb_1:Float64}}, {{pb_3:String}})
+                      AND cm.sortable_datetime < toDateTime({{pb_2:Float64}}, {{pb_3:String}})
                       AND cm.deleted_at IS NULL
+                      {where_clause}
                     GROUP BY project_id,
                              id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{{}}')) AS kv)
            GROUP BY bucket,
                     model),
              all_models AS
@@ -226,10 +544,6 @@ def test_all_aggregation_types():
         SELECT all_buckets.bucket AS timestamp,
                all_models.model,
                COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.avg_total_tokens, 0) AS avg_total_tokens,
-               aggregated_data.min_total_tokens AS min_total_tokens,
-               aggregated_data.max_total_tokens AS max_total_tokens,
-               COALESCE(aggregated_data.count_total_tokens, 0) AS count_total_tokens,
                COALESCE(aggregated_data.count, 0) AS count
         FROM all_buckets
         CROSS JOIN all_models
@@ -237,352 +551,80 @@ def test_all_aggregation_types():
         AND all_models.model = aggregated_data.model
         ORDER BY all_buckets.bucket,
                  all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733014800.0,
-            "pb_3": "UTC",
-            "pb_4": 300,
-        },
-        [
-            "timestamp",
-            "model",
-            "sum_total_tokens",
-            "avg_total_tokens",
-            "min_total_tokens",
-            "max_total_tokens",
-            "count_total_tokens",
-            "count",
-        ],
-        300,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_custom_percentiles():
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 1, 1, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        UsageMetricSpec(
-            metric="output_tokens",
-            aggregations=[],
-            percentiles=[50, 75, 90, 95, 99, 99.9],
-        )
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=300,
-    )
+        """
+    expected_params = {
+        "pb_0": "entity/project",
+        "pb_1": 1733011200.0,
+        "pb_2": 1733097600.0,
+        "pb_3": "UTC",
+        "pb_4": 3600,
+    }
+    if pb_5 is not None:
+        expected_params["pb_5"] = pb_5
     assert_usage_sql(
         req,
         metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  quantileOrNull(0.5)(m_output_tokens) AS p50_output_tokens,
-                  quantileOrNull(0.75)(m_output_tokens) AS p75_output_tokens,
-                  quantileOrNull(0.9)(m_output_tokens) AS p90_output_tokens,
-                  quantileOrNull(0.95)(m_output_tokens) AS p95_output_tokens,
-                  quantileOrNull(0.99)(m_output_tokens) AS p99_output_tokens,
-                  quantileOrNull(0.999)(m_output_tokens) AS p99.9_output_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 300 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     (ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'completion_tokens')), 0) + ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'output_tokens')), 0)) AS m_output_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               aggregated_data.p50_output_tokens AS p50_output_tokens,
-               aggregated_data.p75_output_tokens AS p75_output_tokens,
-               aggregated_data.p90_output_tokens AS p90_output_tokens,
-               aggregated_data.p95_output_tokens AS p95_output_tokens,
-               aggregated_data.p99_output_tokens AS p99_output_tokens,
-               aggregated_data.p99.9_output_tokens AS p99.9_output_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733014800.0,
-            "pb_3": "UTC",
-            "pb_4": 300,
-        },
-        [
-            "timestamp",
-            "model",
-            "p50_output_tokens",
-            "p75_output_tokens",
-            "p90_output_tokens",
-            "p95_output_tokens",
-            "p99_output_tokens",
-            "p99.9_output_tokens",
-            "count",
-        ],
-        300,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_multiple_metrics():
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        UsageMetricSpec(metric="input_tokens", aggregations=[AggregationType.SUM]),
-        UsageMetricSpec(metric="output_tokens", aggregations=[AggregationType.SUM]),
-        UsageMetricSpec(metric="total_tokens", aggregations=[AggregationType.AVG]),
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_input_tokens) AS sum_input_tokens,
-                  sumOrNull(m_output_tokens) AS sum_output_tokens,
-                  avgOrNull(m_total_tokens) AS avg_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     (ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'prompt_tokens')), 0) + ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'input_tokens')), 0)) AS m_input_tokens,
-                     (ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'completion_tokens')), 0) + ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'output_tokens')), 0)) AS m_output_tokens,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_input_tokens, 0) AS sum_input_tokens,
-               COALESCE(aggregated_data.sum_output_tokens, 0) AS sum_output_tokens,
-               COALESCE(aggregated_data.avg_total_tokens, 0) AS avg_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        [
-            "timestamp",
-            "model",
-            "sum_input_tokens",
-            "sum_output_tokens",
-            "avg_total_tokens",
-            "count",
-        ],
+        expected_query,
+        expected_params,
+        ["timestamp", "model", "sum_total_tokens", "count"],
         3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
+        exp_start=START_DT,
+        exp_end=END_DT,
     )
 
 
-def test_mixed_aggregations_and_percentiles():
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        UsageMetricSpec(
-            metric="total_tokens",
-            aggregations=[AggregationType.SUM, AggregationType.AVG],
-            percentiles=[50, 95, 99],
-        )
-    ]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  avgOrNull(m_total_tokens) AS avg_total_tokens,
-                  quantileOrNull(0.5)(m_total_tokens) AS p50_total_tokens,
-                  quantileOrNull(0.95)(m_total_tokens) AS p95_total_tokens,
-                  quantileOrNull(0.99)(m_total_tokens) AS p99_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.avg_total_tokens, 0) AS avg_total_tokens,
-               aggregated_data.p50_total_tokens AS p50_total_tokens,
-               aggregated_data.p95_total_tokens AS p95_total_tokens,
-               aggregated_data.p99_total_tokens AS p99_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        [
-            "timestamp",
-            "model",
-            "sum_total_tokens",
-            "avg_total_tokens",
-            "p50_total_tokens",
-            "p95_total_tokens",
-            "p99_total_tokens",
-            "count",
-        ],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_granularity_auto_selection():
-    """Test that granularity is automatically selected based on time range."""
+@pytest.mark.parametrize(
+    ("delta", "granularity", "expected_pb_1"),
+    [
+        pytest.param(datetime.timedelta(hours=1), 300, 1733050800.0, id="under_2h_300"),
+        pytest.param(datetime.timedelta(hours=6), 3600, 1733032800.0, id="2h_12h_3600"),
+        pytest.param(
+            datetime.timedelta(days=2), 21600, 1732881600.0, id="12h_3d_21600"
+        ),
+        pytest.param(
+            datetime.timedelta(days=10), 43200, 1732190400.0, id="3d_14d_43200"
+        ),
+        pytest.param(
+            datetime.timedelta(days=30), 86400, 1730462400.0, id="over_14d_86400"
+        ),
+    ],
+)
+def test_granularity_auto_selection(
+    delta: datetime.timedelta,
+    granularity: int,
+    expected_pb_1: float,
+) -> None:
     now = datetime.datetime(2024, 12, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
-
     metrics = [UsageMetricSpec(metric="total_tokens")]
-
-    # < 2 hours -> 5 minutes (300 seconds)
-    req = CallStatsReq(
-        project_id="p",
-        start=now - datetime.timedelta(hours=1),
-        end=now,
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
+    req = CallStatsReq(project_id="p", start=now - delta, end=now)
+    expected_query = f"""
         WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+          (SELECT toStartOfInterval(toDateTime({{pb_1:Float64}}, {{pb_3:String}}), INTERVAL {granularity} SECOND, {{pb_3:String}}) + toIntervalSecond(number * {{pb_4:Int64}}) AS bucket
+           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({{pb_2:Float64}}, {{pb_3:String}})) - toUnixTimestamp(toStartOfInterval(toDateTime({{pb_1:Float64}}, {{pb_3:String}}), INTERVAL {granularity} SECOND, {{pb_3:String}}))) / {{pb_4:Float64}})))
+           WHERE bucket < toDateTime({{pb_2:Float64}}, {{pb_3:String}}) ),
              aggregated_data AS
           (SELECT bucket,
                   model,
                   sumOrNull(m_total_tokens) AS sum_total_tokens,
                   count() AS count
            FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 300 SECOND, {pb_3:String}) AS bucket,
+             (SELECT toStartOfInterval(sortable_datetime, INTERVAL {granularity} SECOND, {{pb_3:String}}) AS bucket,
                      kv.1 AS model,
                      toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
               FROM
                 (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                        JSONExtractRaw(ifNull(summary_dump, '{{}}'), 'usage') AS usage_raw
                  FROM
                    (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
                            anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
                     FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
+                    WHERE cm.project_id = {{pb_0:String}}
+                      AND cm.sortable_datetime >= toDateTime({{pb_1:Float64}}, {{pb_3:String}})
+                      AND cm.sortable_datetime < toDateTime({{pb_2:Float64}}, {{pb_3:String}})
                       AND cm.deleted_at IS NULL
                     GROUP BY project_id,
                              id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{{}}')) AS kv)
            GROUP BY bucket,
                     model),
              all_models AS
@@ -598,564 +640,20 @@ def test_granularity_auto_selection():
         AND all_models.model = aggregated_data.model
         ORDER BY all_buckets.bucket,
                  all_models.model
-        """,
+        """
+    assert_usage_sql(
+        req,
+        metrics,
+        expected_query,
         {
             "pb_0": "p",
-            "pb_1": 1733050800.0,
+            "pb_1": expected_pb_1,
             "pb_2": 1733054400.0,
             "pb_3": "UTC",
-            "pb_4": 300,
+            "pb_4": granularity,
         },
         ["timestamp", "model", "sum_total_tokens", "count"],
-        300,
-    )
-
-    # 2-12 hours -> 1 hour (3600 seconds)
-    req = CallStatsReq(
-        project_id="p",
-        start=now - datetime.timedelta(hours=6),
-        end=now,
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "p",
-            "pb_1": 1733032800.0,
-            "pb_2": 1733054400.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        ["timestamp", "model", "sum_total_tokens", "count"],
-        3600,
-    )
-
-    # 12h - 3 days -> 6 hours (21600 seconds)
-    req = CallStatsReq(
-        project_id="p",
-        start=now - datetime.timedelta(days=2),
-        end=now,
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 21600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 21600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 21600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "p",
-            "pb_1": 1732881600.0,
-            "pb_2": 1733054400.0,
-            "pb_3": "UTC",
-            "pb_4": 21600,
-        },
-        ["timestamp", "model", "sum_total_tokens", "count"],
-        21600,
-    )
-
-    # 3-14 days -> 12 hours (43200 seconds)
-    req = CallStatsReq(
-        project_id="p",
-        start=now - datetime.timedelta(days=10),
-        end=now,
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 43200 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 43200 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 43200 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "p",
-            "pb_1": 1732190400.0,
-            "pb_2": 1733054400.0,
-            "pb_3": "UTC",
-            "pb_4": 43200,
-        },
-        ["timestamp", "model", "sum_total_tokens", "count"],
-        43200,
-    )
-
-    # > 14 days -> 1 day (86400 seconds)
-    req = CallStatsReq(
-        project_id="p",
-        start=now - datetime.timedelta(days=30),
-        end=now,
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 86400 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 86400 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 86400 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "p",
-            "pb_1": 1730462400.0,
-            "pb_2": 1733054400.0,
-            "pb_3": "UTC",
-            "pb_4": 86400,
-        },
-        ["timestamp", "model", "sum_total_tokens", "count"],
-        86400,
-    )
-
-
-def test_explicit_granularity_overrides_auto():
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [UsageMetricSpec(metric="total_tokens")]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=300,
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 300 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 300 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 300,
-        },
-        ["timestamp", "model", "sum_total_tokens", "count"],
-        300,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_trace_roots_only_filter():
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [UsageMetricSpec(metric="total_tokens")]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(trace_roots_only=True),
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                      AND parent_id IS NULL
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        ["timestamp", "model", "sum_total_tokens", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_trace_ids_filter():
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [UsageMetricSpec(metric="total_tokens")]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(trace_ids=["trace_abc", "trace_def"]),
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                      AND ifNull(trace_id, '') IN {pb_5:Array(String)}
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-            "pb_5": ["trace_abc", "trace_def"],
-        },
-        ["timestamp", "model", "sum_total_tokens", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-    )
-
-
-def test_wb_user_ids_filter():
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [UsageMetricSpec(metric="total_tokens")]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(wb_user_ids=["user_123"]),
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(sortable_datetime, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT sortable_datetime,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT anyIf(cm.sortable_datetime, cm.sortable_datetime IS NOT NULL) AS sortable_datetime,
-                           anyIf(cm.summary_dump, cm.summary_dump IS NOT NULL) AS summary_dump
-                    FROM calls_merged AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.sortable_datetime >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.sortable_datetime < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at IS NULL
-                      AND wb_user_id IN {pb_5:Array(String)}
-                    GROUP BY project_id,
-                             id)) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-            "pb_5": ["user_123"],
-        },
-        ["timestamp", "model", "sum_total_tokens", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
+        granularity,
     )
 
 
@@ -1175,238 +673,209 @@ def test_wb_user_ids_filter():
 # =============================================================================
 
 
-def test_calls_complete_basic():
-    """Test basic usage query for calls_complete table.
-
-    Key differences from calls_merged:
-    - Uses started_at instead of sortable_datetime
-    - No anyIf aggregation (single row per call)
-    - No GROUP BY project_id, id
-    """
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [
-        UsageMetricSpec(
-            metric="total_tokens",
-            aggregations=[AggregationType.SUM, AggregationType.AVG],
-        )
-    ]
+@pytest.mark.parametrize(
+    ("metrics", "call_filter", "expected_query", "expected_columns", "expected_params"),
+    [
+        pytest.param(
+            [
+                UsageMetricSpec(
+                    metric="total_tokens",
+                    aggregations=[AggregationType.SUM, AggregationType.AVG],
+                )
+            ],
+            None,
+            """
+            WITH all_buckets AS
+              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+                 aggregated_data AS
+              (SELECT bucket,
+                      model,
+                      sumOrNull(m_total_tokens) AS sum_total_tokens,
+                      avgOrNull(m_total_tokens) AS avg_total_tokens,
+                      count() AS count
+               FROM
+                 (SELECT toStartOfInterval(started_at, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
+                         kv.1 AS model,
+                         toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
+                  FROM
+                    (SELECT started_at,
+                            JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                     FROM
+                       (SELECT cm.started_at AS started_at,
+                               cm.summary_dump AS summary_dump
+                        FROM calls_complete AS cm
+                        WHERE cm.project_id = {pb_0:String}
+                          AND cm.started_at >= toDateTime({pb_1:Float64}, {pb_3:String})
+                          AND cm.started_at < toDateTime({pb_2:Float64}, {pb_3:String})
+                          AND cm.deleted_at = toDateTime64(0, 3) )) ARRAY
+                  JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+               GROUP BY bucket,
+                        model),
+                 all_models AS
+              (SELECT DISTINCT model
+               FROM aggregated_data)
+            SELECT all_buckets.bucket AS timestamp,
+                   all_models.model,
+                   COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
+                   COALESCE(aggregated_data.avg_total_tokens, 0) AS avg_total_tokens,
+                   COALESCE(aggregated_data.count, 0) AS count
+            FROM all_buckets
+            CROSS JOIN all_models
+            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+            AND all_models.model = aggregated_data.model
+            ORDER BY all_buckets.bucket,
+                     all_models.model
+            """,
+            ["timestamp", "model", "sum_total_tokens", "avg_total_tokens", "count"],
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+            },
+            id="basic",
+        ),
+        pytest.param(
+            [UsageMetricSpec(metric="total_tokens")],
+            CallsFilter(trace_roots_only=True),
+            """
+            WITH all_buckets AS
+              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+                 aggregated_data AS
+              (SELECT bucket,
+                      model,
+                      sumOrNull(m_total_tokens) AS sum_total_tokens,
+                      count() AS count
+               FROM
+                 (SELECT toStartOfInterval(started_at, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
+                         kv.1 AS model,
+                         toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
+                  FROM
+                    (SELECT started_at,
+                            JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                     FROM
+                       (SELECT cm.started_at AS started_at,
+                               cm.summary_dump AS summary_dump
+                        FROM calls_complete AS cm
+                        WHERE cm.project_id = {pb_0:String}
+                          AND cm.started_at >= toDateTime({pb_1:Float64}, {pb_3:String})
+                          AND cm.started_at < toDateTime({pb_2:Float64}, {pb_3:String})
+                          AND cm.deleted_at = toDateTime64(0, 3)
+                          AND parent_id = {pb_5:String} )) ARRAY
+                  JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+               GROUP BY bucket,
+                        model),
+                 all_models AS
+              (SELECT DISTINCT model
+               FROM aggregated_data)
+            SELECT all_buckets.bucket AS timestamp,
+                   all_models.model,
+                   COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
+                   COALESCE(aggregated_data.count, 0) AS count
+            FROM all_buckets
+            CROSS JOIN all_models
+            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+            AND all_models.model = aggregated_data.model
+            ORDER BY all_buckets.bucket,
+                     all_models.model
+            """,
+            ["timestamp", "model", "sum_total_tokens", "count"],
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+                "pb_5": "",
+            },
+            id="trace_roots_only_sentinel",
+        ),
+        pytest.param(
+            [UsageMetricSpec(metric="input_tokens")],
+            CallsFilter(op_names=["openai.chat"]),
+            """
+            WITH all_buckets AS
+              (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
+               FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
+               WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
+                 aggregated_data AS
+              (SELECT bucket,
+                      model,
+                      sumOrNull(m_input_tokens) AS sum_input_tokens,
+                      count() AS count
+               FROM
+                 (SELECT toStartOfInterval(started_at, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
+                         kv.1 AS model,
+                         (ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'prompt_tokens')), 0) + ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'input_tokens')), 0)) AS m_input_tokens
+                  FROM
+                    (SELECT started_at,
+                            JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
+                     FROM
+                       (SELECT cm.started_at AS started_at,
+                               cm.summary_dump AS summary_dump
+                        FROM calls_complete AS cm
+                        WHERE cm.project_id = {pb_0:String}
+                          AND cm.started_at >= toDateTime({pb_1:Float64}, {pb_3:String})
+                          AND cm.started_at < toDateTime({pb_2:Float64}, {pb_3:String})
+                          AND cm.deleted_at = toDateTime64(0, 3)
+                          AND op_name IN {pb_5:Array(String)} )) ARRAY
+                  JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
+               GROUP BY bucket,
+                        model),
+                 all_models AS
+              (SELECT DISTINCT model
+               FROM aggregated_data)
+            SELECT all_buckets.bucket AS timestamp,
+                   all_models.model,
+                   COALESCE(aggregated_data.sum_input_tokens, 0) AS sum_input_tokens,
+                   COALESCE(aggregated_data.count, 0) AS count
+            FROM all_buckets
+            CROSS JOIN all_models
+            LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
+            AND all_models.model = aggregated_data.model
+            ORDER BY all_buckets.bucket,
+                     all_models.model
+            """,
+            ["timestamp", "model", "sum_input_tokens", "count"],
+            {
+                "pb_0": "entity/project",
+                "pb_1": 1733011200.0,
+                "pb_2": 1733097600.0,
+                "pb_3": "UTC",
+                "pb_4": 3600,
+                "pb_5": ["openai.chat"],
+            },
+            id="op_names_filter",
+        ),
+    ],
+)
+def test_calls_complete_table_variants(
+    metrics: list[UsageMetricSpec],
+    call_filter: CallsFilter | None,
+    expected_query: str,
+    expected_columns: list[str],
+    expected_params: dict[str, object],
+) -> None:
     req = CallStatsReq(
         project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
+        start=START_DT,
+        end=END_DT,
         granularity=3600,
+        filter=call_filter,
     )
     assert_usage_sql(
         req,
         metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  avgOrNull(m_total_tokens) AS avg_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(started_at, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT started_at,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT cm.started_at AS started_at,
-                           cm.summary_dump AS summary_dump
-                    FROM calls_complete AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.started_at >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.started_at < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at = toDateTime64(0, 3) )) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.avg_total_tokens, 0) AS avg_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-        },
-        ["timestamp", "model", "sum_total_tokens", "avg_total_tokens", "count"],
+        expected_query,
+        expected_params,
+        expected_columns,
         3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-        read_table=ReadTable.CALLS_COMPLETE,
-    )
-
-
-def test_calls_complete_trace_roots_only_filter():
-    """Test trace_roots_only filter uses sentinel check for calls_complete.
-
-    In calls_complete, parent_id is a non-nullable String with '' as the
-    sentinel for NULL, so trace_roots_only must check parent_id = '' instead
-    of parent_id IS NULL.
-    """
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [UsageMetricSpec(metric="total_tokens")]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(trace_roots_only=True),
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_total_tokens) AS sum_total_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(started_at, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     toFloat64OrNull(JSONExtractRaw(kv.2, 'total_tokens')) AS m_total_tokens
-              FROM
-                (SELECT started_at,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT cm.started_at AS started_at,
-                           cm.summary_dump AS summary_dump
-                    FROM calls_complete AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.started_at >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.started_at < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at = toDateTime64(0, 3)
-                      AND parent_id = {pb_5:String} )) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_total_tokens, 0) AS sum_total_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-            "pb_5": "",
-        },
-        ["timestamp", "model", "sum_total_tokens", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
-        read_table=ReadTable.CALLS_COMPLETE,
-    )
-
-
-def test_calls_complete_with_filter():
-    """Test usage query with op_names filter for calls_complete table."""
-    start_dt = datetime.datetime(2024, 12, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    end_dt = datetime.datetime(2024, 12, 2, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    metrics = [UsageMetricSpec(metric="input_tokens")]
-    req = CallStatsReq(
-        project_id="entity/project",
-        start=start_dt,
-        end=end_dt,
-        granularity=3600,
-        filter=CallsFilter(op_names=["openai.chat"]),
-    )
-    assert_usage_sql(
-        req,
-        metrics,
-        """
-        WITH all_buckets AS
-          (SELECT toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}) + toIntervalSecond(number * {pb_4:Int64}) AS bucket
-           FROM numbers(toUInt64(ceil((toUnixTimestamp(toDateTime({pb_2:Float64}, {pb_3:String})) - toUnixTimestamp(toStartOfInterval(toDateTime({pb_1:Float64}, {pb_3:String}), INTERVAL 3600 SECOND, {pb_3:String}))) / {pb_4:Float64})))
-           WHERE bucket < toDateTime({pb_2:Float64}, {pb_3:String}) ),
-             aggregated_data AS
-          (SELECT bucket,
-                  model,
-                  sumOrNull(m_input_tokens) AS sum_input_tokens,
-                  count() AS count
-           FROM
-             (SELECT toStartOfInterval(started_at, INTERVAL 3600 SECOND, {pb_3:String}) AS bucket,
-                     kv.1 AS model,
-                     (ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'prompt_tokens')), 0) + ifNull(toFloat64OrNull(JSONExtractRaw(kv.2, 'input_tokens')), 0)) AS m_input_tokens
-              FROM
-                (SELECT started_at,
-                        JSONExtractRaw(ifNull(summary_dump, '{}'), 'usage') AS usage_raw
-                 FROM
-                   (SELECT cm.started_at AS started_at,
-                           cm.summary_dump AS summary_dump
-                    FROM calls_complete AS cm
-                    WHERE cm.project_id = {pb_0:String}
-                      AND cm.started_at >= toDateTime({pb_1:Float64}, {pb_3:String})
-                      AND cm.started_at < toDateTime({pb_2:Float64}, {pb_3:String})
-                      AND cm.deleted_at = toDateTime64(0, 3)
-                      AND op_name IN {pb_5:Array(String)} )) ARRAY
-              JOIN JSONExtractKeysAndValuesRaw(ifNull(usage_raw, '{}')) AS kv)
-           GROUP BY bucket,
-                    model),
-             all_models AS
-          (SELECT DISTINCT model
-           FROM aggregated_data)
-        SELECT all_buckets.bucket AS timestamp,
-               all_models.model,
-               COALESCE(aggregated_data.sum_input_tokens, 0) AS sum_input_tokens,
-               COALESCE(aggregated_data.count, 0) AS count
-        FROM all_buckets
-        CROSS JOIN all_models
-        LEFT JOIN aggregated_data ON all_buckets.bucket = aggregated_data.bucket
-        AND all_models.model = aggregated_data.model
-        ORDER BY all_buckets.bucket,
-                 all_models.model
-        """,
-        {
-            "pb_0": "entity/project",
-            "pb_1": 1733011200.0,
-            "pb_2": 1733097600.0,
-            "pb_3": "UTC",
-            "pb_4": 3600,
-            "pb_5": ["openai.chat"],
-        },
-        ["timestamp", "model", "sum_input_tokens", "count"],
-        3600,
-        exp_start=start_dt,
-        exp_end=end_dt,
+        exp_start=START_DT,
+        exp_end=END_DT,
         read_table=ReadTable.CALLS_COMPLETE,
     )


### PR DESCRIPTION
## Summary
- Split from #7235. Densify `tests/trace_server/query_builder` tests into fewer, denser parametrized / multi-assert functions: 16 files, +5096/-6762.

## Testing
per-file coverage-superset gate (each touched file's executed weave/ lines+branches after >= before); tests/trace_server/query_builder dir run shows no new failures vs master.