### PR TITLE
test(weave): densify tests/utils suite

### DIFF
--- a/tests/utils/test_dict_utils.py
+++ b/tests/utils/test_dict_utils.py
@@ -1,89 +1,101 @@
+import pytest
+
 from weave.utils.dict_utils import sum_dict_leaves
 
 
-def test_sum_dict_leaves_list_of_dicts():
-    """Test that sum_dict_leaves correctly handles lists of dictionaries."""
-    dicts = [
-        {"a": 1, "b": "hello", "c": 2},
-        {"a": 3, "b": "world", "c": 4},
-        {"a": 5, "b": "!", "c": 6},
-    ]
-    result = sum_dict_leaves(dicts)
-    assert result == {"a": 9, "b": ["hello", "world", "!"], "c": 12}
-
-    # Test with nested dictionaries in the list
-    dicts = [
-        {"a": {"x": 1, "y": 2}, "b": 3},
-        {"a": {"x": 4, "y": 5}, "b": 6},
-        {"a": {"x": 7, "y": 8}, "b": 9},
-    ]
-    result = sum_dict_leaves(dicts)
-    assert result == {"a": {"x": 12, "y": 15}, "b": 18}
-
-    # Test with empty list
-    assert sum_dict_leaves([]) == {}
-
-    # Test with list containing empty dictionaries
-    assert sum_dict_leaves([{}]) == {}
-
-    # Test with None values
-    dicts = [
-        {"a": 1, "b": None, "c": 2},
-        {"a": 3, "b": None, "c": 4},
-        {"a": 5, "b": None, "c": 6},
-    ]
-    result = sum_dict_leaves(dicts)
-    assert result == {"a": 9, "c": 12}
-
-
-def test_sum_dict_leaves_mixed_types():
-    """Test that sum_dict_leaves correctly handles dictionaries where the same key has different types."""
-    dicts = [
-        {"a": 1, "b": "hello", "c": 2},
-        {"a": "world", "b": 3, "c": 4},
-        {"a": 5, "b": "!", "c": "test"},
-    ]
-    result = sum_dict_leaves(dicts)
-    # When a key has mixed types, all values should be collected in a list
-    assert result == {"a": [1, "world", 5], "b": ["hello", 3, "!"], "c": [2, 4, "test"]}
-
-    # Test with nested dictionaries having mixed types
-    dicts = [
-        {"a": {"x": 1, "y": "hello"}, "b": 3},
-        {"a": {"x": "world", "y": 2}, "b": "test"},
-        {"a": {"x": 5, "y": 3}, "b": 6},
-    ]
-    result = sum_dict_leaves(dicts)
-    assert result == {
-        "a": {"x": [1, "world", 5], "y": ["hello", 2, 3]},
-        "b": [3, "test", 6],
-    }
-
-
-def test_sum_dict_leaves_deep_nested():
-    """Test that sum_dict_leaves correctly handles deeply nested dictionaries (2 levels) with mixed types."""
-    dicts = [
-        {
-            "level1": {"level2": {"a": 1, "b": "hello", "c": {"x": 2, "y": "world"}}},
-            "top": 10,
-        },
-        {
-            "level1": {"level2": {"a": "test", "b": 3, "c": {"x": "deep", "y": 4}}},
-            "top": "mixed",
-        },
-        {
-            "level1": {"level2": {"a": 5, "b": "!", "c": {"x": 6, "y": "nested"}}},
-            "top": 20,
-        },
-    ]
-    result = sum_dict_leaves(dicts)
-    assert result == {
-        "level1": {
-            "level2": {
-                "a": [1, "test", 5],
+@pytest.mark.parametrize(
+    ("dicts", "expected"),
+    [
+        # Numbers summed, strings collected into a list.
+        (
+            [
+                {"a": 1, "b": "hello", "c": 2},
+                {"a": 3, "b": "world", "c": 4},
+                {"a": 5, "b": "!", "c": 6},
+            ],
+            {"a": 9, "b": ["hello", "world", "!"], "c": 12},
+        ),
+        # Nested dicts summed leaf-wise.
+        (
+            [
+                {"a": {"x": 1, "y": 2}, "b": 3},
+                {"a": {"x": 4, "y": 5}, "b": 6},
+                {"a": {"x": 7, "y": 8}, "b": 9},
+            ],
+            {"a": {"x": 12, "y": 15}, "b": 18},
+        ),
+        # Empty input and empty member dicts.
+        ([], {}),
+        ([{}], {}),
+        # None values are dropped.
+        (
+            [
+                {"a": 1, "b": None, "c": 2},
+                {"a": 3, "b": None, "c": 4},
+                {"a": 5, "b": None, "c": 6},
+            ],
+            {"a": 9, "c": 12},
+        ),
+        # Mixed types per key collected into a list.
+        (
+            [
+                {"a": 1, "b": "hello", "c": 2},
+                {"a": "world", "b": 3, "c": 4},
+                {"a": 5, "b": "!", "c": "test"},
+            ],
+            {
+                "a": [1, "world", 5],
                 "b": ["hello", 3, "!"],
-                "c": {"x": [2, "deep", 6], "y": ["world", 4, "nested"]},
-            }
-        },
-        "top": [10, "mixed", 20],
-    }
+                "c": [2, 4, "test"],
+            },
+        ),
+        # Nested dicts with mixed types.
+        (
+            [
+                {"a": {"x": 1, "y": "hello"}, "b": 3},
+                {"a": {"x": "world", "y": 2}, "b": "test"},
+                {"a": {"x": 5, "y": 3}, "b": 6},
+            ],
+            {
+                "a": {"x": [1, "world", 5], "y": ["hello", 2, 3]},
+                "b": [3, "test", 6],
+            },
+        ),
+        # Deeply nested (2 levels) with mixed types.
+        (
+            [
+                {
+                    "level1": {
+                        "level2": {"a": 1, "b": "hello", "c": {"x": 2, "y": "world"}}
+                    },
+                    "top": 10,
+                },
+                {
+                    "level1": {
+                        "level2": {"a": "test", "b": 3, "c": {"x": "deep", "y": 4}}
+                    },
+                    "top": "mixed",
+                },
+                {
+                    "level1": {
+                        "level2": {"a": 5, "b": "!", "c": {"x": 6, "y": "nested"}}
+                    },
+                    "top": 20,
+                },
+            ],
+            {
+                "level1": {
+                    "level2": {
+                        "a": [1, "test", 5],
+                        "b": ["hello", 3, "!"],
+                        "c": {"x": [2, "deep", 6], "y": ["world", 4, "nested"]},
+                    }
+                },
+                "top": [10, "mixed", 20],
+            },
+        ),
+    ],
+)
+def test_sum_dict_leaves(dicts, expected):
+    """sum_dict_leaves: sum numbers, collect strings/mixed into lists, drop None, recurse."""
+    assert sum_dict_leaves(dicts) == expected

--- a/tests/utils/test_http_requests.py
+++ b/tests/utils/test_http_requests.py
@@ -28,25 +28,21 @@ def test_client_uses_default_httpx_transport():
     assert isinstance(http_requests._get_client()._transport, httpx.HTTPTransport)
 
 
-def test_request_hook_logs_when_enabled(monkeypatch):
-    monkeypatch.setenv("WEAVE_DEBUG_HTTP", "1")
+@pytest.mark.parametrize("debug_enabled", [True, False])
+def test_request_hook_logs_only_when_debug_enabled(monkeypatch, debug_enabled):
+    if debug_enabled:
+        monkeypatch.setenv("WEAVE_DEBUG_HTTP", "1")
     request = httpx.Request("GET", "https://api.wandb.ai/calls")
 
     with patch.object(http_requests, "pprint_request") as mock_pprint_request:
         http_requests._log_request(request)
 
-    mock_pprint_request.assert_called_once_with(request)
-    assert isinstance(request.extensions.get("weave_start_time"), float)
-
-
-def test_request_hook_noop_when_disabled():
-    request = httpx.Request("GET", "https://api.wandb.ai/calls")
-
-    with patch.object(http_requests, "pprint_request") as mock_pprint_request:
-        http_requests._log_request(request)
-
-    mock_pprint_request.assert_not_called()
-    assert "weave_start_time" not in request.extensions
+    if debug_enabled:
+        mock_pprint_request.assert_called_once_with(request)
+        assert isinstance(request.extensions.get("weave_start_time"), float)
+    else:
+        mock_pprint_request.assert_not_called()
+        assert "weave_start_time" not in request.extensions
 
 
 def test_response_hook_logs_when_enabled(monkeypatch):

--- a/tests/utils/test_invertable_dict.py
+++ b/tests/utils/test_invertable_dict.py
@@ -5,71 +5,68 @@ from weave.utils.invertable_dict import InvertableDict
 pytestmark = pytest.mark.trace_server
 
 
-def test_invertable_dict_construction_and_access():
+def test_invertable_dict_access_and_inverse_roundtrip():
     mapping = InvertableDict({"jpg": "jpeg", "png": "png"})
 
-    # Default mapping -- looks and acts like a regular dict
+    # Forward mapping acts like a regular dict.
     assert len(mapping) == 2
     assert mapping["jpg"] == "jpeg"
     assert mapping["png"] == "png"
     assert sorted(iter(mapping)) == ["jpg", "png"]
 
-    # Inverse mapping -- looks and acts like a regular dict
+    # Inverse mapping acts like a regular dict.
     assert len(mapping.inv) == 2
     assert mapping.inv["jpeg"] == "jpg"
     assert mapping.inv["png"] == "png"
     assert sorted(iter(mapping.inv)) == ["jpeg", "png"]
 
-
-def test_invertable_dict_rejects_duplicate_values_on_init():
-    with pytest.raises(ValueError, match="Duplicate value found: jpeg"):
-        InvertableDict({"jpg": "jpeg", "jpe": "jpeg"})
-
-
-def test_invertable_dict_inverse_roundtrip():
-    mapping = InvertableDict({"a": 1, "b": 2})
-
-    assert mapping.inv[1] == "a"
-    assert mapping.inv[2] == "b"
-    assert mapping.inv.inv["a"] == 1
-    assert mapping.inv.inv["b"] == 2
+    # Double-inverse returns to the forward view.
+    nums = InvertableDict({"a": 1, "b": 2})
+    assert nums.inv[1] == "a"
+    assert nums.inv[2] == "b"
+    assert nums.inv.inv["a"] == 1
+    assert nums.inv.inv["b"] == 2
 
 
-def test_invertable_dict_mutation_updates_inverse_view():
-    mapping = InvertableDict({"a": 1})
-    inverse = mapping.inv
-
-    mapping["b"] = 2
-    mapping["a"] = 3
-
-    assert inverse[2] == "b"
-    assert inverse[3] == "a"
-    assert 1 not in inverse
-
-
-def test_invertable_dict_inverse_mutation_updates_forward_view():
-    mapping = InvertableDict({"a": 1})
-    inverse = mapping.inv
-
-    inverse[2] = "b"
-
-    assert mapping["b"] == 2
-    assert inverse[2] == "b"
-
-
-def test_invertable_dict_delete_updates_inverse_view():
+def test_invertable_dict_mutations_keep_views_in_sync():
     mapping = InvertableDict({"a": 1, "b": 2})
     inverse = mapping.inv
 
-    del mapping["a"]
-
-    assert "a" not in mapping
+    # Forward set adds and reassigns, dropping the stale inverse key.
+    mapping["c"] = 3
+    mapping["a"] = 4
+    assert inverse[3] == "c"
+    assert inverse[4] == "a"
     assert 1 not in inverse
-    assert inverse[2] == "b"
+
+    # Inverse set writes through to the forward view.
+    inverse[5] = "d"
+    assert mapping["d"] == 5
+    assert inverse[5] == "d"
+
+    # Forward delete removes both directions.
+    del mapping["b"]
+    assert "b" not in mapping
+    assert 2 not in inverse
 
 
-def test_invertable_dict_rejects_duplicate_values_on_set():
+def _init_duplicate() -> None:
+    InvertableDict({"jpg": "jpeg", "jpe": "jpeg"})
+
+
+def _set_duplicate() -> None:
     mapping = InvertableDict({"a": 1})
+    mapping["b"] = 1
 
-    with pytest.raises(ValueError, match="Duplicate value found: 1"):
-        mapping["b"] = 1
+
+@pytest.mark.parametrize(
+    ("build", "match"),
+    [
+        (_init_duplicate, "Duplicate value found: jpeg"),
+        (_set_duplicate, "Duplicate value found: 1"),
+    ],
+    ids=["on-init", "on-set"],
+)
+def test_invertable_dict_rejects_duplicate_values(build, match):
+    with pytest.raises(ValueError, match=match):
+        build()

--- a/tests/utils/test_ipython_utils.py
+++ b/tests/utils/test_ipython_utils.py
@@ -1,38 +1,29 @@
 import sys
-from typing import Any, ClassVar
+from typing import ClassVar
 
 import pytest
 
 from weave.utils import ipython as ipy
 
 
-def test_is_running_interactively_without_ipython(monkeypatch):
+def test_is_running_interactively(monkeypatch):
+    """False when IPython is absent, True when a get_ipython shell is present."""
     monkeypatch.delitem(sys.modules, "IPython", raising=False)
     assert ipy.is_running_interactively() is False
 
-
-def test_is_running_interactively_with_stub(monkeypatch):
     sentinel = object()
-
-    def fake_get_ipython():
-        return sentinel
-
-    monkeypatch.setattr(ipy, "_lazy_get_ipython", fake_get_ipython)
+    monkeypatch.setattr(ipy, "_lazy_get_ipython", lambda: sentinel)
     assert ipy.is_running_interactively() is True
 
 
-def test_get_notebook_source_requires_interactive(monkeypatch):
+def test_get_notebook_source(monkeypatch):
+    """Raises outside an interactive env, otherwise joins the shell's `In` cells."""
     monkeypatch.delitem(sys.modules, "IPython", raising=False)
     with pytest.raises(ipy.NotInteractiveEnvironmentError):
         ipy.get_notebook_source()
 
-
-def test_get_notebook_source_reads_cells(monkeypatch):
     class DummyShell:
-        user_ns: ClassVar[dict[str, Any]] = {"In": ["", "a = 1", "", "b = 2"]}
+        user_ns: ClassVar[dict[str, list[str]]] = {"In": ["", "a = 1", "", "b = 2"]}
 
-    def fake_get_ipython():
-        return DummyShell()
-
-    monkeypatch.setattr(ipy, "_lazy_get_ipython", fake_get_ipython)
+    monkeypatch.setattr(ipy, "_lazy_get_ipython", DummyShell)
     assert ipy.get_notebook_source() == "a = 1\n\nb = 2"

--- a/tests/utils/test_iterators.py
+++ b/tests/utils/test_iterators.py
@@ -5,91 +5,86 @@ import pytest
 from weave.utils.iterators import ThreadSafeLazyList, first
 
 
-def test_first_with_list():
-    """Test first() with a list."""
-    assert first([1, 2, 3]) == 1
-    assert first([42]) == 42
-    assert first(["a", "b", "c"]) == "a"
+def _gen():
+    yield 10
+    yield 20
+    yield 30
 
 
-def test_first_with_string():
-    """Test first() with a string."""
-    assert first("hello") == "h"
-    assert first("x") == "x"
+class _CustomIterable:
+    def __iter__(self):
+        return iter([99, 88, 77])
 
 
-def test_first_with_range():
-    """Test first() with range objects."""
-    assert first(range(5)) == 0
-    assert first(range(10, 20)) == 10
-    assert first(range(100, 101)) == 100
+@pytest.mark.parametrize(
+    ("iterable", "expected"),
+    [
+        ([1, 2, 3], 1),
+        ([42], 42),
+        (["a", "b", "c"], "a"),
+        ("hello", "h"),
+        ("x", "x"),
+        (range(5), 0),
+        (range(10, 20), 10),
+        (range(100, 101), 100),
+        (_gen(), 10),
+        (iter([7, 8, 9]), 7),
+        (iter("abc"), "a"),
+        ({42}, 42),
+        ((100, 200, 300), 100),
+        (("x",), "x"),
+        (_CustomIterable(), 99),
+    ],
+)
+def test_first_returns_first_element(iterable, expected):
+    """first() yields the first element across list/str/range/generator/iterator/set/tuple/custom."""
+    assert first(iterable) == expected
 
 
-def test_first_with_generator():
-    """Test first() with a generator."""
-
-    def gen():
-        yield 10
-        yield 20
-        yield 30
-
-    assert first(gen()) == 10
-
-
-def test_first_with_iterator():
-    """Test first() with an iterator."""
-    assert first(iter([7, 8, 9])) == 7
-    assert first(iter("abc")) == "a"
-
-
-def test_first_with_set():
-    """Test first() with a set (order may vary, but should return an element)."""
-    s = {42}
-    assert first(s) == 42
-
-
-def test_first_with_tuple():
-    """Test first() with a tuple."""
-    assert first((100, 200, 300)) == 100
-    assert first(("x",)) == "x"
-
-
-def test_first_with_empty_iterable():
-    """Test first() with empty iterables - should raise StopIteration."""
+@pytest.mark.parametrize("empty", [[], "", range(0), iter([])])
+def test_first_empty_raises(empty):
+    """first() on an empty iterable raises StopIteration."""
     with pytest.raises(StopIteration):
-        first([])
-
-    with pytest.raises(StopIteration):
-        first("")
-
-    with pytest.raises(StopIteration):
-        first(range(0))
-
-    with pytest.raises(StopIteration):
-        first(iter([]))
+        first(empty)
 
 
-def test_first_with_custom_iterable():
-    """Test first() with a custom iterable."""
-
-    class CustomIterable:
-        def __iter__(self):
-            return iter([99, 88, 77])
-
-    assert first(CustomIterable()) == 99
-
-
-def test_basic_sequence_operations():
-    """Test basic sequence operations."""
+def test_lazy_list_sequence_access():
+    """len, indexing, negative index, slicing, and full iteration over a fresh list."""
     iterator = ThreadSafeLazyList(iter(range(10)))
+
     assert len(iterator) == 10
     assert iterator[0] == 0
+    assert iterator[5] == 5
+    assert iterator[9] == 9
+    assert iterator[-1] == 9
     assert iterator[1:3] == [1, 2]
+    assert iterator[2:5] == [2, 3, 4]
+    assert iterator[:3] == [0, 1, 2]
+    assert iterator[7:] == [7, 8, 9]
+    assert iterator[::2] == [0, 2, 4, 6, 8]
+    assert iterator[::-1] == [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
     assert list(iterator) == list(range(10))
 
 
-def test_empty_iterator():
-    """Test behavior with empty iterator."""
+def test_lazy_list_repeated_iteration():
+    """Repeated iteration returns the same data each time."""
+    data = list(range(5))
+    iterator = ThreadSafeLazyList(iter(data))
+
+    assert list(iterator) == data
+    assert list(iterator) == data
+    assert list(iterator) == data
+
+
+def test_lazy_list_known_length():
+    """known_length avoids exhausting the iterator while still allowing access."""
+    iterator = ThreadSafeLazyList(iter(range(5)), known_length=5)
+    assert len(iterator) == 5
+    assert iterator[4] == 4
+
+
+def test_lazy_list_empty():
+    """Empty iterator: zero length, IndexError on access, empty materialization."""
     iterator = ThreadSafeLazyList(iter([]))
     assert len(iterator) == 0
     with pytest.raises(IndexError):
@@ -97,25 +92,17 @@ def test_empty_iterator():
     assert list(iterator) == []
 
 
-def test_known_length():
-    """Test initialization with known length."""
-    iterator = ThreadSafeLazyList(iter(range(5)), known_length=5)
-    assert len(iterator) == 5  # Should not need to exhaust iterator
-    assert iterator[4] == 4  # Access last element
+def test_lazy_list_index_out_of_range():
+    """Out-of-range index raises IndexError; iterator exhaustion is still materializable."""
+    iterator = ThreadSafeLazyList(_CountingIterator())
+    assert len(iterator) == 5
+    with pytest.raises(IndexError):
+        _ = iterator[10]
+    assert list(iterator) == [0, 1, 2, 3, 4]
 
 
-def test_multiple_iterations():
-    """Test multiple iterations return same results."""
-    data = list(range(5))
-    iterator = ThreadSafeLazyList(iter(data))
-
-    assert list(iterator) == data  # First iteration
-    assert list(iterator) == data  # Second iteration
-    assert list(iterator) == data  # Third iteration
-
-
-def test_concurrent_access():
-    """Test thread-safe concurrent access."""
+def test_lazy_list_concurrent_iteration():
+    """Concurrent full iterations from multiple threads see identical data."""
     data = list(range(1000))
     iterator = ThreadSafeLazyList(iter(data))
     results = []
@@ -129,44 +116,18 @@ def test_concurrent_access():
     for t in threads:
         t.join()
 
-    # All threads should see the same data
     assert all(r == data for r in results)
 
 
-def test_slicing():
-    """Test various slicing operations."""
-    iterator = ThreadSafeLazyList(iter(range(10)))
-
-    assert iterator[2:5] == [2, 3, 4]
-    assert iterator[:3] == [0, 1, 2]
-    assert iterator[7:] == [7, 8, 9]
-    assert iterator[::2] == [0, 2, 4, 6, 8]
-    assert iterator[::-1] == [9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-
-
-def test_random_access():
-    """Test random access patterns."""
-    iterator = ThreadSafeLazyList(iter(range(10)))
-
-    assert iterator[5] == 5  # Middle access
-    assert iterator[1] == 1  # Earlier access
-    assert iterator[8] == 8  # Later access
-    assert iterator[0] == 0  # First element
-    assert iterator[9] == 9  # Last element
-
-
-def test_concurrent_mixed_operations():
-    """Test concurrent mixed operations (reads, slices, iterations)."""
+def test_lazy_list_concurrent_mixed_operations():
+    """Concurrent mixed reads/slices/iterations from multiple threads agree."""
     data = list(range(100))
     iterator = ThreadSafeLazyList(iter(data))
     results = []
 
     def mixed_ops_thread():
-        local_results = []
-        local_results.append(iterator[10])  # Single element access
-        local_results.append(list(iterator[20:25]))  # Slice access
-        local_results.append(iterator[50])  # Another single element
-        local_results.extend(iterator[90:])  # End slice
+        local_results = [iterator[10], list(iterator[20:25]), iterator[50]]
+        local_results.extend(iterator[90:])
         results.append(local_results)
 
     threads = [threading.Thread(target=mixed_ops_thread) for _ in range(3)]
@@ -175,43 +136,19 @@ def test_concurrent_mixed_operations():
     for t in threads:
         t.join()
 
-    # Verify all threads got the same results
-    expected = [10, list(range(20, 25)), 50] + list(range(90, 100))
+    expected = [10, list(range(20, 25)), 50, *range(90, 100)]
     assert all(r == expected for r in results)
 
 
-def test_index_out_of_range():
-    """Test index out of range behavior."""
-    iterator = ThreadSafeLazyList(iter(range(5)))
+class _CountingIterator:
+    def __init__(self):
+        self.count = 0
 
-    with pytest.raises(IndexError):
-        _ = iterator[10]
+    def __iter__(self):
+        return self
 
-    assert iterator[-1] == 4  # Negative indices are supported
-
-
-def test_iterator_exhaustion():
-    """Test behavior when iterator is exhausted."""
-
-    class CountingIterator:
-        def __init__(self):
-            self.count = 0
-
-        def __iter__(self):
-            return self
-
-        def __next__(self):
-            if self.count < 5:
-                self.count += 1
-                return self.count - 1
-            raise StopIteration
-
-    iterator = ThreadSafeLazyList(CountingIterator())
-
-    # Access beyond iterator length should raise IndexError
-    assert len(iterator) == 5
-    with pytest.raises(IndexError):
-        _ = iterator[10]
-
-    # Verify original data is still accessible
-    assert list(iterator) == [0, 1, 2, 3, 4]
+    def __next__(self):
+        if self.count < 5:
+            self.count += 1
+            return self.count - 1
+        raise StopIteration

--- a/tests/utils/test_netrc.py
+++ b/tests/utils/test_netrc.py
@@ -22,18 +22,17 @@ def temp_netrc(tmp_path):
 
 
 # Tests for Netrc class
-def test_netrc_init_default_path():
-    """Test initialization with default path."""
-    netrc = Netrc()
-    expected_path = Path.home() / ".netrc"
-    assert netrc.path == expected_path
-
-
-def test_netrc_init_custom_path():
-    """Test initialization with custom path."""
-    custom_path = "/custom/path/.netrc"
-    netrc = Netrc(custom_path)
-    assert netrc.path == Path(custom_path)
+@pytest.mark.parametrize(
+    ("arg", "expected"),
+    [
+        (None, Path.home() / ".netrc"),
+        ("/custom/path/.netrc", Path("/custom/path/.netrc")),
+    ],
+)
+def test_netrc_init_path(arg, expected):
+    """Init resolves both the default and a custom path."""
+    netrc = Netrc() if arg is None else Netrc(arg)
+    assert netrc.path == expected
 
 
 def test_netrc_read_nonexistent_file(temp_netrc):
@@ -148,196 +147,130 @@ def test_netrc_write_permission_error(mock_chmod, temp_netrc):
         temp_netrc.write(credentials)
 
 
-def test_netrc_add_or_update_entry_new_file(temp_netrc):
-    """Test adding entry to a new netrc file."""
+def test_netrc_add_or_update_entry(temp_netrc):
+    """add_or_update creates a new file, appends to an existing one, and updates in place."""
+    # New file: full entry incl. account.
     temp_netrc.add_or_update_entry("example.com", "testuser", "testpass", "testaccount")
-
-    credentials = temp_netrc.read()
-    assert len(credentials) == 1
-    assert credentials["example.com"]["login"] == "testuser"
-    assert credentials["example.com"]["password"] == "testpass"
-    assert credentials["example.com"]["account"] == "testaccount"
-
-
-def test_netrc_add_or_update_entry_existing_file(temp_netrc):
-    """Test adding entry to an existing netrc file."""
-    # Create initial file
-    initial_credentials = {
-        "example.com": {"login": "olduser", "account": "", "password": "oldpass"}
-    }
-    temp_netrc.write(initial_credentials)
-
-    # Add new entry
-    temp_netrc.add_or_update_entry("api.example.com", "apiuser", "apipass")
-
-    credentials = temp_netrc.read()
-    assert len(credentials) == 2
-    assert credentials["example.com"]["login"] == "olduser"
-    assert credentials["api.example.com"]["login"] == "apiuser"
-
-
-def test_netrc_add_or_update_entry_update_existing(temp_netrc):
-    """Test updating an existing entry."""
-    # Create initial file
-    initial_credentials = {
-        "example.com": {"login": "olduser", "account": "", "password": "oldpass"}
-    }
-    temp_netrc.write(initial_credentials)
-
-    # Update existing entry
-    temp_netrc.add_or_update_entry("example.com", "newuser", "newpass", "newaccount")
-
-    credentials = temp_netrc.read()
-    assert len(credentials) == 1
-    assert credentials["example.com"]["login"] == "newuser"
-    assert credentials["example.com"]["password"] == "newpass"
-    assert credentials["example.com"]["account"] == "newaccount"
-
-
-def test_netrc_delete_entry_existing(temp_netrc):
-    """Test deleting an existing entry."""
-    # Create initial file with multiple entries
-    initial_credentials = {
-        "example.com": {"login": "user1", "account": "", "password": "pass1"},
-        "api.example.com": {"login": "user2", "account": "", "password": "pass2"},
-    }
-    temp_netrc.write(initial_credentials)
-
-    # Delete one entry
-    result = temp_netrc.delete_entry("example.com")
-
-    assert result is True
-    credentials = temp_netrc.read()
-    assert len(credentials) == 1
-    assert "example.com" not in credentials
-    assert "api.example.com" in credentials
-
-
-def test_netrc_delete_entry_nonexistent(temp_netrc):
-    """Test deleting a non-existent entry."""
-    # Create initial file
-    initial_credentials = {
-        "example.com": {"login": "user1", "account": "", "password": "pass1"}
-    }
-    temp_netrc.write(initial_credentials)
-
-    # Try to delete non-existent entry
-    result = temp_netrc.delete_entry("nonexistent.com")
-
-    assert result is False
-    credentials = temp_netrc.read()
-    assert len(credentials) == 1
-    assert "example.com" in credentials
-
-
-def test_netrc_delete_entry_no_file(temp_netrc):
-    """Test deleting entry when netrc file doesn't exist."""
-    result = temp_netrc.delete_entry("example.com")
-    assert result is False
-
-
-def test_netrc_get_credentials_existing(temp_netrc):
-    """Test getting credentials for an existing machine."""
-    credentials = {
+    assert temp_netrc.read() == {
         "example.com": {
             "login": "testuser",
             "account": "testaccount",
             "password": "testpass",
         }
     }
-    temp_netrc.write(credentials)
 
-    result = temp_netrc.get_credentials("example.com")
-
-    assert result is not None
-    assert result["login"] == "testuser"
-    assert result["account"] == "testaccount"
-    assert result["password"] == "testpass"
-
-
-def test_netrc_get_credentials_nonexistent(temp_netrc):
-    """Test getting credentials for a non-existent machine."""
-    credentials = {
-        "example.com": {"login": "testuser", "account": "", "password": "testpass"}
+    # Append a second machine (no account) to the existing file.
+    temp_netrc.add_or_update_entry("api.example.com", "apiuser", "apipass")
+    credentials = temp_netrc.read()
+    assert len(credentials) == 2
+    assert credentials["example.com"]["login"] == "testuser"
+    assert credentials["api.example.com"] == {
+        "login": "apiuser",
+        "account": "",
+        "password": "apipass",
     }
-    temp_netrc.write(credentials)
 
-    result = temp_netrc.get_credentials("nonexistent.com")
-    assert result is None
-
-
-def test_netrc_get_credentials_no_file(temp_netrc):
-    """Test getting credentials when netrc file doesn't exist."""
-    result = temp_netrc.get_credentials("example.com")
-    assert result is None
-
-
-def test_netrc_list_machines_with_entries(temp_netrc):
-    """Test listing machines when netrc file has entries."""
-    credentials = {
-        "example.com": {"login": "user1", "account": "", "password": "pass1"},
-        "api.example.com": {"login": "user2", "account": "", "password": "pass2"},
+    # Update the existing machine in place.
+    temp_netrc.add_or_update_entry("example.com", "newuser", "newpass", "newaccount")
+    credentials = temp_netrc.read()
+    assert len(credentials) == 2
+    assert credentials["example.com"] == {
+        "login": "newuser",
+        "account": "newaccount",
+        "password": "newpass",
     }
-    temp_netrc.write(credentials)
 
+
+def test_netrc_delete_entry(temp_netrc):
+    """delete_entry removes a present machine, no-ops on a missing one, and no-ops with no file."""
+    # No file yet -> False.
+    assert temp_netrc.delete_entry("example.com") is False
+
+    temp_netrc.write(
+        {
+            "example.com": {"login": "user1", "account": "", "password": "pass1"},
+            "api.example.com": {"login": "user2", "account": "", "password": "pass2"},
+        }
+    )
+
+    # Delete a present machine -> True, others retained.
+    assert temp_netrc.delete_entry("example.com") is True
+    credentials = temp_netrc.read()
+    assert "example.com" not in credentials
+    assert "api.example.com" in credentials
+
+    # Delete a missing machine -> False, nothing changed.
+    assert temp_netrc.delete_entry("nonexistent.com") is False
+    credentials = temp_netrc.read()
+    assert len(credentials) == 1
+    assert "api.example.com" in credentials
+
+
+def test_netrc_get_credentials(temp_netrc):
+    """get_credentials returns the entry for a present machine, None otherwise."""
+    # No file yet -> None.
+    assert temp_netrc.get_credentials("example.com") is None
+
+    temp_netrc.write(
+        {
+            "example.com": {
+                "login": "testuser",
+                "account": "testaccount",
+                "password": "testpass",
+            }
+        }
+    )
+
+    assert temp_netrc.get_credentials("example.com") == {
+        "login": "testuser",
+        "account": "testaccount",
+        "password": "testpass",
+    }
+    assert temp_netrc.get_credentials("nonexistent.com") is None
+
+
+def test_netrc_list_machines(temp_netrc):
+    """list_machines reflects file entries, empty file, and a missing file."""
+    # No file yet -> empty.
+    assert temp_netrc.list_machines() == []
+
+    temp_netrc.write(
+        {
+            "example.com": {"login": "user1", "account": "", "password": "pass1"},
+            "api.example.com": {"login": "user2", "account": "", "password": "pass2"},
+        }
+    )
     machines = temp_netrc.list_machines()
-
     assert len(machines) == 2
     assert "example.com" in machines
     assert "api.example.com" in machines
 
-
-def test_netrc_list_machines_empty_file(temp_netrc):
-    """Test listing machines when netrc file is empty."""
+    # Empty file -> empty.
     temp_netrc.write({})
-
-    machines = temp_netrc.list_machines()
-    assert len(machines) == 0
-
-
-def test_netrc_list_machines_no_file(temp_netrc):
-    """Test listing machines when netrc file doesn't exist."""
-    machines = temp_netrc.list_machines()
-    assert len(machines) == 0
+    assert temp_netrc.list_machines() == []
 
 
 # Tests for netrc permission checking
-def test_check_netrc_access_nonexistent_file(tmp_path):
-    """Test checking access for a non-existent file."""
+@pytest.mark.parametrize(
+    ("mode", "exists", "read_access", "write_access"),
+    [
+        (None, False, True, True),  # missing file: can create -> read/write True
+        (0o600, True, True, True),  # read-write file
+        (0o400, True, True, False),  # read-only file
+    ],
+)
+def test_check_netrc_access(tmp_path, mode, exists, read_access, write_access):
+    """check_netrc_access reports existence and read/write for missing, rw, and ro files."""
     netrc_path = tmp_path / ".netrc"
-    permissions = check_netrc_access(str(netrc_path))
-
-    assert permissions.exists is False
-    assert permissions.read_access is True  # Can create
-    assert permissions.write_access is True  # Can create
-
-
-def test_check_netrc_access_existing_file(tmp_path):
-    """Test checking access for an existing file."""
-    # Create a test file with specific permissions
-    netrc_path = tmp_path / ".netrc"
-    netrc_path.write_text("test content")
-    os.chmod(netrc_path, 0o600)
-
-    permissions = check_netrc_access(str(netrc_path))
-
-    assert permissions.exists is True
-    assert permissions.read_access is True
-    assert permissions.write_access is True
-
-
-def test_check_netrc_access_read_only_file(tmp_path):
-    """Test checking access for a read-only file."""
-    # Create a test file with read-only permissions
-    netrc_path = tmp_path / ".netrc"
-    netrc_path.write_text("test content")
-    os.chmod(netrc_path, 0o400)
+    if mode is not None:
+        netrc_path.write_text("test content")
+        os.chmod(netrc_path, mode)
 
     permissions = check_netrc_access(str(netrc_path))
 
-    assert permissions.exists is True
-    assert permissions.read_access is True
-    assert permissions.write_access is False
+    assert permissions.exists is exists
+    assert permissions.read_access is read_access
+    assert permissions.write_access is write_access
 
 
 @pytest.mark.disable_logging_error_check(
@@ -357,24 +290,22 @@ def test_check_netrc_access_os_error(mock_stat, tmp_path):
 
 
 # Tests for get_netrc_file_path function
-@patch.dict(os.environ, {"NETRC": "/custom/netrc/path"})
-def test_get_netrc_file_path_from_env():
-    """Test getting netrc file path from environment variable."""
-    path = get_netrc_file_path()
-    assert Path(path) == Path("/custom/netrc/path")
-
-
-@patch.dict(os.environ, {"NETRC": "~/custom/netrc"})
-def test_get_netrc_file_path_expanduser():
-    """Test getting netrc file path with user expansion."""
-    path = get_netrc_file_path()
-    expected = str(Path("~/custom/netrc").expanduser())
-    assert path == expected
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("/custom/netrc/path", Path("/custom/netrc/path")),  # literal env path
+        ("~/custom/netrc", Path("~/custom/netrc").expanduser()),  # tilde expansion
+    ],
+)
+def test_get_netrc_file_path_from_env(env_value, expected):
+    """NETRC env var wins and is user-expanded."""
+    with patch.dict(os.environ, {"NETRC": env_value}):
+        assert Path(get_netrc_file_path()) == expected
 
 
 @patch.dict(os.environ, {}, clear=True)
 def test_get_netrc_file_path_existing_file(tmp_path):
-    """Test getting netrc file path when file exists."""
+    """With no env var, an existing home .netrc is returned."""
     netrc_path = tmp_path / ".netrc"
     netrc_path.write_text("test")
 
@@ -383,19 +314,18 @@ def test_get_netrc_file_path_existing_file(tmp_path):
         assert path == str(netrc_path)
 
 
-@patch.dict(os.environ, {}, clear=True)
-@patch("platform.system", return_value="Linux")
-def test_get_netrc_file_path_default_unix(mock_system):
-    """Test getting default netrc file path on Unix systems."""
-    with patch("pathlib.Path.home", return_value=Path("/home/user")):
-        path = get_netrc_file_path()
-        assert Path(path) == Path("/home/user/.netrc")
-
-
-@patch.dict(os.environ, {}, clear=True)
-@patch("platform.system", return_value="Windows")
-def test_get_netrc_file_path_default_windows(mock_system):
-    """Test getting default netrc file path on Windows systems."""
-    with patch("pathlib.Path.home", return_value=Path("C:/Users/user")):
-        path = get_netrc_file_path()
-        assert Path(path) == Path("C:/Users/user/_netrc")
+@pytest.mark.parametrize(
+    ("system", "home", "expected"),
+    [
+        ("Linux", Path("/home/user"), Path("/home/user/.netrc")),
+        ("Windows", Path("C:/Users/user"), Path("C:/Users/user/_netrc")),
+    ],
+)
+def test_get_netrc_file_path_default(system, home, expected):
+    """With no env var and no existing file, the platform default name is used."""
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        patch("platform.system", return_value=system),
+        patch("pathlib.Path.home", return_value=home),
+    ):
+        assert Path(get_netrc_file_path()) == expected

--- a/tests/utils/test_paginated_iterator.py
+++ b/tests/utils/test_paginated_iterator.py
@@ -9,35 +9,26 @@ from weave.utils.paginated_iterator import PaginatedIterator
 pytestmark = pytest.mark.trace_server
 
 
-def _fetch_numbers(offset: int, limit: int) -> list[int]:
-    numbers = [0, 1, 2, 3, 4]
-    return numbers[offset : offset + limit]
-
-
-def test_paginated_iterator_implements_iterator_protocol() -> None:
+def test_paginated_iterator_protocol_and_restart() -> None:
+    # Implements the iterator protocol, yielding lazily across pages.
     paginated = PaginatedIterator(_fetch_numbers, page_size=2)
-
     assert isinstance(paginated, Iterator)
     assert next(paginated) == 0
     assert next(paginated) == 1
 
-
-def test_paginated_iterator_next_stops_at_end() -> None:
-    paginated = PaginatedIterator(_fetch_numbers, page_size=2, limit=3)
-
-    assert next(paginated) == 0
-    assert next(paginated) == 1
-    assert next(paginated) == 2
+    # `next` stops at the configured limit.
+    bounded = PaginatedIterator(_fetch_numbers, page_size=2, limit=3)
+    assert next(bounded) == 0
+    assert next(bounded) == 1
+    assert next(bounded) == 2
     with pytest.raises(StopIteration):
-        next(paginated)
+        next(bounded)
 
-
-def test_paginated_iterator_iter_remains_restartable() -> None:
-    paginated = PaginatedIterator(_fetch_numbers, page_size=2)
-
-    assert next(paginated) == 0
-    assert list(paginated) == [0, 1, 2, 3, 4]
-    assert list(paginated) == [0, 1, 2, 3, 4]
+    # `iter` is restartable even after a partial `next` consumption.
+    restartable = PaginatedIterator(_fetch_numbers, page_size=2)
+    assert next(restartable) == 0
+    assert list(restartable) == [0, 1, 2, 3, 4]
+    assert list(restartable) == [0, 1, 2, 3, 4]
 
 
 def test_paginated_iterator_limit_bounds_index_and_slice_consistently() -> None:
@@ -53,7 +44,7 @@ def test_paginated_iterator_limit_bounds_index_and_slice_consistently() -> None:
     assert list(paginated) == [0, 1, 2]
 
 
-def test_paginated_iterator_reuses_fetched_pages_within_instance() -> None:
+def test_paginated_iterator_per_instance_cache_reuses_and_releases() -> None:
     fetch_offsets: list[int] = []
 
     def fetch(offset: int, limit: int) -> list[int]:
@@ -71,20 +62,14 @@ def test_paginated_iterator_reuses_fetched_pages_within_instance() -> None:
     assert paginated[10] == 10
     assert fetch_offsets == [0, 10]
 
-
-def test_paginated_iterator_released_when_unreferenced() -> None:
-    # Regression: a method-level functools.lru_cache keys on `self` and lives
-    # for the process lifetime, pinning every iterator (and its fetched pages)
-    # in memory. The per-instance cache must let the iterator be garbage
-    # collected once the caller drops it.
-    def fetch(offset: int, limit: int) -> list[int]:
-        return list(range(100))[offset : offset + limit]
-
-    paginated = PaginatedIterator(fetch, page_size=10)
-    assert paginated[0] == 0  # populate the page cache
-
+    # The per-instance cache must not pin the iterator: dropping the only
+    # reference lets it (and its fetched pages) be garbage collected.
     ref = weakref.ref(paginated)
     del paginated
     gc.collect()
-
     assert ref() is None
+
+
+def _fetch_numbers(offset: int, limit: int) -> list[int]:
+    numbers = [0, 1, 2, 3, 4]
+    return numbers[offset : offset + limit]

--- a/tests/utils/test_project_id.py
+++ b/tests/utils/test_project_id.py
@@ -7,14 +7,10 @@ import pytest
 from weave.utils.project_id import from_project_id, to_project_id
 
 
-def test_to_project_id() -> None:
-    """Test formatting entity and project as project_id."""
-    assert to_project_id("my-entity", "my-project") == "my-entity/my-project"
-
-
 @pytest.mark.parametrize(
     ("entity", "project"),
     [
+        ("my-entity", "my-project"),
         (" my-entity ", " my-project "),
         ("my\tentity", "my\tproject"),
         ("my\nentity", "my\nproject"),
@@ -24,6 +20,7 @@ def test_to_project_id() -> None:
         ("entity!@#$%^&*()[]{}", "project~`+=_-.,:;?"),
     ],
     ids=[
+        "basic",
         "leading-trailing-spaces",
         "tabs",
         "newlines",
@@ -33,11 +30,16 @@ def test_to_project_id() -> None:
         "special-characters",
     ],
 )
-def test_to_project_id_preserves_whitespace_unicode_and_special_characters(
-    entity: str, project: str
-) -> None:
-    """Test to_project_id preserves supported characters exactly."""
-    assert to_project_id(entity, project) == f"{entity}/{project}"
+def test_to_project_id_format_and_round_trip(entity: str, project: str) -> None:
+    """to_project_id joins on '/' preserving all supported chars, and round-trips through from_project_id."""
+    project_id = to_project_id(entity, project)
+    assert project_id == f"{entity}/{project}"
+    assert from_project_id(project_id) == (entity, project)
+
+
+def test_from_project_id() -> None:
+    """from_project_id splits a project_id string into (entity, project)."""
+    assert from_project_id("my-entity/my-project") == ("my-entity", "my-project")
 
 
 @pytest.mark.parametrize(
@@ -58,14 +60,9 @@ def test_to_project_id_preserves_whitespace_unicode_and_special_characters(
 def test_to_project_id_invalid_inputs(
     entity: str, project: str, error_message: str
 ) -> None:
-    """Test to_project_id raises ValueError for invalid inputs."""
+    """to_project_id raises ValueError for empty or slash-containing inputs."""
     with pytest.raises(ValueError, match=re.escape(error_message)):
         to_project_id(entity, project)
-
-
-def test_from_project_id() -> None:
-    """Test parsing project_id string into entity and project."""
-    assert from_project_id("my-entity/my-project") == ("my-entity", "my-project")
 
 
 @pytest.mark.parametrize(
@@ -84,41 +81,6 @@ def test_from_project_id() -> None:
     ],
 )
 def test_from_project_id_invalid_inputs(project_id: str, error_message: str) -> None:
-    """Test from_project_id raises ValueError for invalid inputs."""
+    """from_project_id raises ValueError for malformed project_id strings."""
     with pytest.raises(ValueError, match=re.escape(error_message)):
         from_project_id(project_id)
-
-
-def test_project_id_round_trip() -> None:
-    """Test project IDs can be round-tripped through parser and formatter."""
-    entity = "my-entity"
-    project = "my-project"
-    assert from_project_id(to_project_id(entity, project)) == (entity, project)
-
-
-@pytest.mark.parametrize(
-    ("entity", "project"),
-    [
-        (" my-entity ", " my-project "),
-        ("my\tentity", "my\tproject"),
-        ("my\nentity", "my\nproject"),
-        ("mañana", "café"),
-        ("東京", "项目"),
-        ("team🚀", "proj✨"),
-        ("entity!@#$%^&*()[]{}", "project~`+=_-.,:;?"),
-    ],
-    ids=[
-        "round-trip-leading-trailing-spaces",
-        "round-trip-tabs",
-        "round-trip-newlines",
-        "round-trip-accented-unicode",
-        "round-trip-multiscript-unicode",
-        "round-trip-emoji",
-        "round-trip-special-characters",
-    ],
-)
-def test_project_id_round_trip_with_whitespace_unicode_and_special_characters(
-    entity: str, project: str
-) -> None:
-    """Test round-trip parsing/formatting with non-standard valid strings."""
-    assert from_project_id(to_project_id(entity, project)) == (entity, project)

--- a/tests/utils/test_sanitize.py
+++ b/tests/utils/test_sanitize.py
@@ -3,82 +3,43 @@
 from weave.utils import sanitize
 
 
-def test_add_redact_key() -> None:
-    """Test the add_redact_key API function."""
-    # Store original keys to restore later
+def test_redact_key_api_add_remove_and_case_insensitivity() -> None:
+    """add/remove_redact_key normalize case, should_redact is case-insensitive, and defaults persist."""
     original_keys = sanitize.get_redact_keys()
-
     try:
-        # Add new keys using the API
-        sanitize.add_redact_key("token")
-        sanitize.add_redact_key("CLIENT_ID")  # Test case normalization
+        # Default keys are redacted regardless of case.
+        for default in ("api_key", "auth_headers", "authorization"):
+            assert sanitize.should_redact(default) is True
+        assert sanitize.should_redact("Api_Key") is True
+        assert sanitize.should_redact("API_KEY") is True
+        assert sanitize.should_redact("Authorization") is True
+        assert sanitize.should_redact("AUTHORIZATION") is True
 
-        # Verify keys were added (case normalized to lowercase)
+        # add_redact_key normalizes to lowercase and is case-insensitive on lookup.
+        sanitize.add_redact_key("token")
+        sanitize.add_redact_key("CLIENT_ID")
         current_keys = sanitize.get_redact_keys()
         assert "token" in current_keys
         assert "client_id" in current_keys
-
-        # Test that should_redact works with new keys (case insensitive)
-        assert sanitize.should_redact("token") is True
-        assert sanitize.should_redact("Token") is True
-        assert sanitize.should_redact("TOKEN") is True
-        assert sanitize.should_redact("client_id") is True
-        assert sanitize.should_redact("CLIENT_ID") is True
-
-        # Test that non-redacted keys return False
+        for variant in ("token", "Token", "TOKEN", "client_id", "CLIENT_ID"):
+            assert sanitize.should_redact(variant) is True
         assert sanitize.should_redact("random_key") is False
 
-    finally:
-        # Restore original keys to avoid affecting other tests
-        sanitize._REDACT_KEYS = original_keys
-
-
-def test_remove_redact_key() -> None:
-    """Test the remove_redact_key API function."""
-    # Store original keys to restore later
-    original_keys = sanitize.get_redact_keys()
-
-    try:
-        # Add a test key
-        sanitize.add_redact_key("temporary_key")
-        assert sanitize.should_redact("temporary_key") is True
-
-        # Remove the key
-        sanitize.remove_redact_key("TEMPORARY_KEY")  # Test case normalization
-        assert sanitize.should_redact("temporary_key") is False
-
-        # Verify default keys are still present
+        # remove_redact_key normalizes case and leaves defaults intact.
+        sanitize.remove_redact_key("TOKEN")
+        assert sanitize.should_redact("token") is False
         assert sanitize.should_redact("api_key") is True
-        assert sanitize.should_redact("auth_headers") is True
-        assert sanitize.should_redact("authorization") is True
-
     finally:
-        # Restore original keys
         sanitize._REDACT_KEYS = original_keys
 
 
-def test_get_redact_keys() -> None:
-    """Test that get_redact_keys returns a copy."""
-    # Get a copy of the keys
+def test_get_redact_keys_returns_independent_copy() -> None:
+    """get_redact_keys returns a fresh set; mutating it does not affect the source of truth."""
     keys_copy = sanitize.get_redact_keys()
-
-    # Verify it contains the default keys
     assert "api_key" in keys_copy
     assert "auth_headers" in keys_copy
     assert "authorization" in keys_copy
 
-    # Verify it's a copy (modifying it doesn't affect the original)
     keys_copy.add("test_key")
     assert "test_key" in keys_copy
     assert "test_key" not in sanitize.get_redact_keys()
-
-
-def test_should_redact_case_insensitive() -> None:
-    """Test that should_redact is case insensitive."""
-    # Test with default keys
-    assert sanitize.should_redact("api_key") is True
-    assert sanitize.should_redact("Api_Key") is True
-    assert sanitize.should_redact("API_KEY") is True
-    assert sanitize.should_redact("authorization") is True
-    assert sanitize.should_redact("Authorization") is True
-    assert sanitize.should_redact("AUTHORIZATION") is True

--- a/tests/utils/test_ssl_verification.py
+++ b/tests/utils/test_ssl_verification.py
@@ -6,129 +6,84 @@ from unittest.mock import MagicMock, patch
 
 import gql
 import httpx
+import pytest
 
 from weave.compat.wandb.wandb_thin.internal_api import Api
 from weave.trace.env import WEAVE_INSECURE_DISABLE_SSL, ssl_verify
 from weave.utils import http_requests
 
 
-class TestSslVerifyEnv:
-    """env.ssl_verify() respects WEAVE_INSECURE_DISABLE_SSL."""
-
-    def test_default_is_true(self, monkeypatch):
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        (None, True),
+        ("true", False),
+        ("True", False),
+        ("false", True),
+        ("", True),
+    ],
+)
+def test_ssl_verify_env(monkeypatch, env_value, expected):
+    """env.ssl_verify() is True unless WEAVE_INSECURE_DISABLE_SSL is a true-string (case-insensitive)."""
+    if env_value is None:
         monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
-        assert ssl_verify() is True
-
-    def test_true_string_disables(self, monkeypatch):
-        monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "true")
-        assert ssl_verify() is False
-
-    def test_case_insensitive(self, monkeypatch):
-        monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "True")
-        assert ssl_verify() is False
-
-    def test_other_values_keep_enabled(self, monkeypatch):
-        monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "false")
-        assert ssl_verify() is True
-
-    def test_empty_string_keeps_enabled(self, monkeypatch):
-        monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "")
-        assert ssl_verify() is True
+    else:
+        monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, env_value)
+    assert ssl_verify() is expected
 
 
-class TestHttpxClientSslVerify:
-    """`_get_client()` honors `ssl_verify()` at call time."""
+def test_httpx_client_env_flip_swaps_cached_client(monkeypatch):
+    """`_get_client()` reads ssl_verify() per call, caches by verify flag, and swaps clients on env flip."""
+    monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
+    verifying = http_requests._get_client()
+    assert isinstance(verifying._transport, httpx.HTTPTransport)
+    assert verifying._transport._pool._ssl_context.verify_mode.name != "CERT_NONE"
 
-    def test_client_verify_disabled(self, monkeypatch):
-        monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "true")
-        # httpx bakes the verify flag into an ssl_context on the transport pool;
-        # CERT_NONE means SSL certificate verification is disabled.
-        transport = http_requests._get_client()._transport
-        assert isinstance(transport, httpx.HTTPTransport)
-        assert transport._pool._ssl_context.verify_mode.name == "CERT_NONE"
+    monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "true")
+    insecure = http_requests._get_client()
+    assert isinstance(insecure._transport, httpx.HTTPTransport)
+    assert insecure is not verifying
+    assert insecure._transport._pool._ssl_context.verify_mode.name == "CERT_NONE"
 
-    def test_client_verify_enabled_by_default(self, monkeypatch):
+    # Flipping back returns the original cached client (connection pool preserved).
+    monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
+    assert http_requests._get_client() is verifying
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected_verify"),
+    [("true", False), (None, True)],
+)
+def test_internal_api_passes_ssl_verify_to_gql_transport(
+    monkeypatch, env_value, expected_verify
+):
+    """The wandb thin API client forwards ssl_verify() as the gql httpx transport's `verify`."""
+    if env_value is None:
         monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
-        transport = http_requests._get_client()._transport
-        assert isinstance(transport, httpx.HTTPTransport)
-        assert transport._pool._ssl_context.verify_mode.name != "CERT_NONE"
+    else:
+        monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, env_value)
 
-    def test_env_flip_swaps_cached_client(self, monkeypatch):
-        # _get_client() reads ssl_verify() per call and caches clients keyed
-        # on (verify, timeout). Flipping the env var post-import must surface
-        # a client with the new verify setting on the very next request.
-        monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
-        verifying = http_requests._get_client()
-        assert verifying._transport._pool._ssl_context.verify_mode.name != "CERT_NONE"
+    mock_transport_cls = MagicMock()
+    mock_transport_cls.return_value = MagicMock()
 
-        monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "true")
-        insecure = http_requests._get_client()
-        assert insecure is not verifying
-        assert insecure._transport._pool._ssl_context.verify_mode.name == "CERT_NONE"
+    mock_client = MagicMock()
+    mock_session = MagicMock()
+    mock_session.execute.return_value = {"data": {}}
+    mock_client.connect_sync.return_value = mock_session
 
-        # Flipping back returns the original cached client (connection pool
-        # preserved across env-var toggles).
-        monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
-        assert http_requests._get_client() is verifying
+    with (
+        patch("gql.Client", return_value=mock_client),
+        patch(
+            "weave.compat.wandb.wandb_thin.internal_api.get_wandb_api_context",
+            return_value=None,
+        ),
+        patch.dict(
+            "sys.modules",
+            {"gql.transport.httpx": MagicMock(HTTPXTransport=mock_transport_cls)},
+        ),
+    ):
+        api = Api()
+        api.query(gql.gql("{ viewer { username } }"))
 
-
-class TestInternalApiSslVerify:
-    """The wandb thin API client passes ssl_verify() to gql transports."""
-
-    def test_httpx_transport_gets_verify_false_if_ssl_disabled(self, monkeypatch):
-        monkeypatch.setenv(WEAVE_INSECURE_DISABLE_SSL, "true")
-
-        mock_transport_cls = MagicMock()
-        mock_transport_instance = MagicMock()
-        mock_transport_cls.return_value = mock_transport_instance
-
-        mock_client = MagicMock()
-        mock_session = MagicMock()
-        mock_session.execute.return_value = {"data": {}}
-        mock_client.connect_sync.return_value = mock_session
-
-        with (
-            patch("gql.Client", return_value=mock_client),
-            patch(
-                "weave.compat.wandb.wandb_thin.internal_api.get_wandb_api_context",
-                return_value=None,
-            ),
-            patch.dict(
-                "sys.modules",
-                {"gql.transport.httpx": MagicMock(HTTPXTransport=mock_transport_cls)},
-            ),
-        ):
-            api = Api()
-            api.query(gql.gql("{ viewer { username } }"))
-
-            _, kwargs = mock_transport_cls.call_args
-            assert kwargs["verify"] is False
-
-    def test_httpx_transport_gets_verify_true_by_default(self, monkeypatch):
-        monkeypatch.delenv(WEAVE_INSECURE_DISABLE_SSL, raising=False)
-
-        mock_transport_cls = MagicMock()
-        mock_transport_instance = MagicMock()
-        mock_transport_cls.return_value = mock_transport_instance
-
-        mock_client = MagicMock()
-        mock_session = MagicMock()
-        mock_session.execute.return_value = {"data": {}}
-        mock_client.connect_sync.return_value = mock_session
-
-        with (
-            patch("gql.Client", return_value=mock_client),
-            patch(
-                "weave.compat.wandb.wandb_thin.internal_api.get_wandb_api_context",
-                return_value=None,
-            ),
-            patch.dict(
-                "sys.modules",
-                {"gql.transport.httpx": MagicMock(HTTPXTransport=mock_transport_cls)},
-            ),
-        ):
-            api = Api()
-            api.query(gql.gql("{ viewer { username } }"))
-
-            _, kwargs = mock_transport_cls.call_args
-            assert kwargs["verify"] is True
+        _, kwargs = mock_transport_cls.call_args
+        assert kwargs["verify"] is expected_verify

--- a/tests/utils/test_stream_metrics.py
+++ b/tests/utils/test_stream_metrics.py
@@ -28,74 +28,40 @@ def simple_content_detector(chunk: MockChunk) -> bool:
     return bool(chunk.content)
 
 
-def test_ttft_basic_calculation():
-    """Test that TTFT is calculated correctly for the first content chunk."""
+def test_ttft_computed_once_on_first_content_chunk():
+    """TTFT ignores empty chunks, fires on the first content chunk, and never recalculates."""
     accumulator = MockAccumulator()
     init_stream_tracking(accumulator, 1000.0)
 
-    # First content chunk should calculate TTFT
-    first_content_chunk = MockChunk(content="Hello")
+    # Empty chunks never trigger TTFT.
+    with patch("time.time", return_value=1001.0):
+        assert (
+            calculate_time_to_first_token(
+                accumulator, MockChunk(content=""), simple_content_detector
+            )
+            is None
+        )
+        assert (
+            calculate_time_to_first_token(
+                accumulator, MockChunk(content=""), simple_content_detector
+            )
+            is None
+        )
+    assert extract_time_to_first_token(accumulator) is None
+
+    # First content chunk computes TTFT as now - start.
     with patch("time.time", return_value=1001.5):
         ttft = calculate_time_to_first_token(
-            accumulator, first_content_chunk, simple_content_detector
+            accumulator, MockChunk(content="Hello"), simple_content_detector
         )
-
     assert ttft == 1.5
     assert extract_time_to_first_token(accumulator) == 1.5
 
-
-def test_ttft_ignores_empty_chunks():
-    """Test that TTFT ignores empty chunks and only calculates on first content."""
-    accumulator = MockAccumulator()
-    init_stream_tracking(accumulator, 1000.0)
-
-    # Empty chunks should not trigger TTFT calculation
-    empty_chunk1 = MockChunk(content="")
-    empty_chunk2 = MockChunk(content="")
-
-    with patch("time.time", return_value=1001.0):
-        ttft1 = calculate_time_to_first_token(
-            accumulator, empty_chunk1, simple_content_detector
-        )
-        ttft2 = calculate_time_to_first_token(
-            accumulator, empty_chunk2, simple_content_detector
-        )
-
-    assert ttft1 is None
-    assert ttft2 is None
-    assert extract_time_to_first_token(accumulator) is None
-
-    # First content chunk should calculate TTFT
-    first_content_chunk = MockChunk(content="Hello")
-    with patch("time.time", return_value=1002.5):
-        ttft3 = calculate_time_to_first_token(
-            accumulator, first_content_chunk, simple_content_detector
-        )
-
-    assert ttft3 == 2.5
-    assert extract_time_to_first_token(accumulator) == 2.5
-
-
-def test_ttft_calculated_only_once():
-    """Test that TTFT is only calculated once, even with multiple content chunks."""
-    accumulator = MockAccumulator()
-    init_stream_tracking(accumulator, 1000.0)
-
-    # First content chunk - should calculate TTFT
-    first_content_chunk = MockChunk(content="Hello")
-    with patch("time.time", return_value=1001.5):
-        ttft1 = calculate_time_to_first_token(
-            accumulator, first_content_chunk, simple_content_detector
-        )
-
-    # Second content chunk - should NOT recalculate TTFT
-    second_content_chunk = MockChunk(content=" World")
+    # Subsequent content chunks do not recalculate.
     with patch("time.time", return_value=1002.0):
         ttft2 = calculate_time_to_first_token(
-            accumulator, second_content_chunk, simple_content_detector
+            accumulator, MockChunk(content=" World"), simple_content_detector
         )
-
-    assert ttft1 == 1.5
     assert ttft2 is None
     assert extract_time_to_first_token(accumulator) == 1.5
 


### PR DESCRIPTION
## Summary
- Split from #7235. Densify `tests/utils` tests into fewer, denser parametrized / multi-assert functions: 11 files, +515/-823.

## Testing
per-file coverage-superset gate (each touched file's executed weave/ lines+branches after >= before); tests/utils dir run shows no new failures vs master.